### PR TITLE
Fix "Could not find an iconv implementation, needed to build fish" build error on OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -512,7 +512,7 @@ LIBS="$LIBS_SHARED"
 if test x$local_gettext != xno; then
 	AC_SEARCH_LIBS( gettext, intl,,)
 fi
-AC_SEARCH_LIBS( iconv_open, iconv, , [AC_MSG_ERROR([Could not find an iconv implementation, needed to build fish])] )
+AC_SEARCH_LIBS( iconv_open, iconv, , [AC_SEARCH_LIBS( libiconv_open, iconv, , [AC_MSG_ERROR([Could not find an iconv implementation, needed to build fish])] )] )
 LIBS_FISH_PAGER=$LIBS
 LIBS=$LIBS_COMMON
 
@@ -525,7 +525,7 @@ LIBS="$LIBS_SHARED"
 if test x$local_gettext != xno; then
 	AC_SEARCH_LIBS( gettext, intl,,)
 fi
-AC_SEARCH_LIBS( iconv_open, iconv, , [AC_MSG_ERROR([Could not find an iconv implementation, needed to build fish])] )
+AC_SEARCH_LIBS( iconv_open, iconv, , [AC_SEARCH_LIBS( libiconv_open, iconv, , [AC_MSG_ERROR([Could not find an iconv implementation, needed to build fish])] )] )
 LIBS_FISHD=$LIBS
 LIBS=$LIBS_COMMON
 


### PR DESCRIPTION
Fixes

```
checking for library containing iconv_open... (cached) no
configure: error: Could not find an iconv implementation, needed to build fish
```
