### PR TITLE
Set both tab *and* window titles with the fish_title function

### DIFF
--- a/reader.cpp
+++ b/reader.cpp
@@ -608,7 +608,7 @@ void reader_write_title()
 		size_t i;
 		if( lst.size() > 0 )
 		{
-			writestr( L"\x1b]2;" );
+			writestr( L"\x1b];" );
 			for( i=0; i<lst.size(); i++ )
 			{
 				writestr( lst.at(i).c_str() );


### PR DESCRIPTION
This change affects iTerm2 on OSX and is meant to correct [Issue 47](https://github.com/ridiculousfish/fishfish/issues/47).
