### PR TITLE
Please consider to pull: formatting glitch in doc_src/history.txt makes Doxygen stumble

### DIFF
--- a/doc_src/history.txt
+++ b/doc_src/history.txt
@@ -33,4 +33,4 @@ Interactively delete commands with prefix "foo".
 
 history --delete "foo"
 Delete command "foo" from history.
-<pre>
+</pre>


### PR DESCRIPTION
- Was an opening tag, should have been a closing tag
- Confused Doxygen 1.8.1.1 on my machine (OS X 10.7), resulting in the fish man pages not being installed at all
