### PR TITLE
Fix path where internal man-pages are installed.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -606,7 +606,7 @@ install-force: all install-translations
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/completions
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/functions
-	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/man
+	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/man/man1
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/tools
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/tools/web_config
 	$(INSTALL) -m 644 etc/config.fish                  $(DESTDIR)$(sysconfdir)/fish/
@@ -620,7 +620,7 @@ install-force: all install-translations
 		true; \
 	done;
 	for i in share/man/*.1; do \
-		$(INSTALL) -m 644 $$i $(DESTDIR)$(datadir)/fish/man/; \
+		$(INSTALL) -m 644 $$i $(DESTDIR)$(datadir)/fish/man/man1/; \
 		true; \
 	done;
 	for i in share/tools/*.py; do\


### PR DESCRIPTION
Change the path where internal man-pages are installed to
/usr/share/fish/man/man1 instead of /usr/share/fish/man, so that tools
like mandb can process it.
