### PR TITLE
Fix var set in __fish_config_interactive.fish

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -83,7 +83,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
 			set -l line2 (printf (_ 'Type %shelp%s for instructions on how to use fish') (set_color green) (set_color normal))
 			set -U fish_greeting $line1\n$line2
 		end
-		set -U __fish_init_1_23_0
+		set -U __fish_init_1_50_0
 
 		#
 		# Set various defaults using these throwaway functions


### PR DESCRIPTION
__fish_config_interactive.fish uses the presence of __fish_init_1_50_0
to decide whether it should perform a one-time initialization of
universal variables. Unfortunately, it sets the variable
__fish_init_1_23_0. Fix this to set __fish_init_1_50_0 instead.

This fixes #163
