### PR TITLE
`cd` autocompletion for paths with spaces is broken bug #191 Fix

### DIFF
--- a/highlight.cpp
+++ b/highlight.cpp
@@ -257,7 +257,27 @@ bool is_potential_path(const wcstring &const_path, const wcstring_list_t &direct
                                     if (! string_suffixes_string(L"/", *out_path))
                                         out_path->push_back(L'/');
                                 }
-                                out_path->append(ent);
+                                
+				unescaped = ent.c_str();
+	    
+				for(in = unescaped; *in; in++ )
+				{
+					switch( *in )
+					{
+						case L' ':
+						{
+							out_path->append(L"\\ ");
+							break;
+						}
+						default:
+						{
+							out_path->append(in, 1);
+							break;
+						}
+					}
+					
+				}
+
                                 /* We actually do want a trailing / for directories, since it makes autosuggestion a bit nicer */
                                 if (is_dir)
                                     out_path->push_back(L'/');


### PR DESCRIPTION
Hey guys this is a really simple fix for the auto completion issues. I am just following the form that you guys have set further up in the function. Hopefully this works for you!

Instead of appending straight away I just loop through and clean up the spaces. It may be better to use the escape function in common.cpp, but I did not want to break the system we had going so far. 
