### PR TITLE
Make a more sensical prompt_pwd

### DIFF
--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -1,22 +1,10 @@
 
 if test (uname) = Darwin
 	function prompt_pwd --description "Print the current working directory, shortend to fit the prompt"
-		if test "$PWD" != "$HOME"
-			printf "%s" (echo $PWD|sed -e 's|^/private\(/.\{1,\}\)|\1|' -e "s|^$HOME|~|" -e 's-/\(\.\{0,1\}[^/]\)\([^/]*\)-/\1-g')
-			echo $PWD|sed -n -e 's-.*/\.\{0,1\}.\([^/]*\)-\1-p'
-		else
-			echo '~'
-		end
+		echo $PWD | sed -e "s|^$HOME|~|" -e 's|^/private||' -e 's-\([^/]\)[^/]*/-\1/-g'
 	end
 else
 	function prompt_pwd --description "Print the current working directory, shortend to fit the prompt"
-		switch "$PWD"
-			case "$HOME"
-			echo '~'
-
-			case '*'
-			printf "%s" (echo $PWD|sed -e "s|^$HOME|~|" -e 's-/\(\.\{0,1\}[^/]\)\([^/]*\)-/\1-g')
-			echo $PWD|sed -n -e 's-.*/\.\{0,1\}.\([^/]*\)-\1-p'
-		end
+		echo $PWD | sed -e "s|^$HOME|~|" -e 's-\([^/]\)[^/]*/-\1/-g'
 	end
 end


### PR DESCRIPTION
In an attempt to make some sense of the prompt_pwd command, I believe I have come up with a more reasonable approach to the shortening of paths. In this new command, I:
- Removed the case statements, which were handled by the sed blocks anyway
- Moved around the '/' character in the regex, so only one regex is needed
- Fixed a bug where '/' is output as '//' because both lines output a '/' upon replacement

I've tested this on a Mac and on Arch Linux, so I'm fairly certain that it works, but more testing couldn't hurt. I hope this helps.
