### PR TITLE
Set single-line default prompt

### DIFF
--- a/doc_src/read.txt
+++ b/doc_src/read.txt
@@ -9,8 +9,8 @@ The <tt>read</tt> builtin causes fish to read one line from standard
 input and store the result in one or more environment variables.
 
 - <tt>-c CMD</tt> or <tt>--command=CMD</tt> specifies that the initial string in the interactive mode command buffer should be CMD.
-- <tt>-e</tt> or <tt>--export</tt> specifies that the variables will be exported to subshells.
 - <tt>-g</tt> or <tt>--global</tt> specifies that the variables will be made global.
+- <tt>-l</tt> or <tt>--local</tt> specifies that the variables will be made local.
 - <tt>-m NAME</tt> or <tt>--mode-name=NAME</tt> specifies that the name NAME should be used to save/load the history file. If NAME is fish, the regular fish history will be available.
 - <tt>-p PROMPT_CMD</tt> or <tt>--prompt=PROMPT_CMD</tt> specifies that the output of the shell command PROMPT_CMD should be used as the prompt for the interactive mode prompt. The default prompt command is <tt>set_color green; echo read; set_color normal; echo "> "</tt>.
 - <code>-s</code> or <code>--shell</code> Use syntax highlighting, tab completions and command termination suitable for entering shellscript code

--- a/reader.cpp
+++ b/reader.cpp
@@ -118,7 +118,7 @@ commence.
    fish specific commands, meaning it will work even if fish is not
    installed. This is used by read_i.
 */
-#define DEFAULT_PROMPT L"echo \"$USER@\"; hostname|cut -d . -f 1; echo \" \"; pwd; printf '> ';"
+#define DEFAULT_PROMPT L"echo -n \"$USER@\"(hostname|cut -d . -f 1)' '(pwd)'> '"
 
 /**
    The name of the function that prints the fish prompt


### PR DESCRIPTION
Fish now doesn't join the fish_prompt output. This breaks the default
fish_prompt. Make default fish_prompt single-line. Fixes #203.

Add -l flag to 'read' documentation. Remove ambiguous '-x' description.
Fixes #157.
