### PR TITLE
Fixed two small spelling mistakes (probably quite old).

### DIFF
--- a/expand.cpp
+++ b/expand.cpp
@@ -1328,7 +1328,7 @@ static int expand_cmdsubst( parser_t &parser, const wcstring &input, std::vector
 		case -1:
 			parser.error( SYNTAX_ERROR,
                          -1,
-                         L"Mismatched parans" );
+                         L"Mismatched parenthesis" );
 			return 0;
 		case 0:
             outList.push_back(completion_t(input));

--- a/parser.cpp
+++ b/parser.cpp
@@ -2681,7 +2681,7 @@ int parser_t::parser_test_argument( const wchar_t *arg, wcstring *out, const wch
 				{
 					error( SYNTAX_ERROR,
 						   offset,
-						   L"Mismatched parans" );
+						   L"Mismatched parenthesis" );
 					this->print_errors( *out, prefix);
 				}
 				free( arg_cpy );


### PR DESCRIPTION
- Saw these during normal usage today.
  "parens" or "parenthesis" was spelled as "parans".
  Fixed two instances of this to "parenthesis".
