### PR TITLE
Add a variable to make descriptions in tab completions optional

### DIFF
--- a/complete.cpp
+++ b/complete.cpp
@@ -1502,18 +1502,24 @@ void completer_t::complete_param_expand( const wcstring &sstr, bool do_file)
 	{
 		comp_str = str;
 	}
-    
-    expand_flags_t flags = EXPAND_SKIP_CMDSUBST | ACCEPT_INCOMPLETE;
-    
-    if (! do_file)
-        flags |= EXPAND_SKIP_WILDCARDS;
-        
-    if (type == COMPLETE_AUTOSUGGEST)
-        flags |= EXPAND_NO_DESCRIPTIONS;
-	
+
+	expand_flags_t flags = EXPAND_SKIP_CMDSUBST | ACCEPT_INCOMPLETE;
+
+	if (! do_file)
+		flags |= EXPAND_SKIP_WILDCARDS;
+
+	if (type == COMPLETE_AUTOSUGGEST)
+		flags |= EXPAND_NO_DESCRIPTIONS;
+
+	const env_var_t verbose_complete = env_get_string( L"fish_complete_no_descriptions" );
+	if( !verbose_complete.missing() && verbose_complete == env_var_t(L"1"))
+	{
+		flags |= EXPAND_NO_DESCRIPTIONS;
+	}
+
 	if( expand_string( comp_str,
-					   this->completions,
-					   flags | this->expand_flags() ) == EXPAND_ERROR )
+				this->completions,
+				flags | this->expand_flags() ) == EXPAND_ERROR )
 	{
 		debug( 3, L"Error while expanding string '%ls'", comp_str );
 	}	
@@ -1521,9 +1527,9 @@ void completer_t::complete_param_expand( const wcstring &sstr, bool do_file)
 
 void completer_t::debug_print_completions()
 {
-    for (size_t i=0; i < completions.size(); i++) {
-        printf("- Completion: %ls\n", completions.at(i).completion.c_str());
-    }
+	for (size_t i=0; i < completions.size(); i++) {
+		printf("- Completion: %ls\n", completions.at(i).completion.c_str());
+	}
 }
 
 /**

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -917,6 +917,7 @@ certain environment variables.
 - \c BROWSER, which is the users preferred web browser. If this variable is set, fish will use the specified browser instead of the system default browser to display the fish documentation.
 - \c CDPATH, which is an array of directories in which to search for the new directory for the \c cd builtin. The fish init files defined CDPATH to be a universal variable with the values . and ~.
 - A large number of variable starting with the prefixes \c fish_color and \c fish_pager_color. See <a href='#variables-color'>Variables for changing highlighting colors</a> for more information.
+- \c fish_complete_no_descriptions, which controls whether you see descriptions of files on tab completion. Set to '1' to disable descriptions. In all other cases, descriptions will be shown.
 - \c fish_greeting, which is the greeting message printed on startup.
 - \c LANG, \c LC_ALL, \c LC_COLLATE, \c LC_CTYPE, \c LC_MESSAGES, \c LC_MONETARY, \c LC_NUMERIC and \c LC_TIME set the language option for the shell and subprograms. See the section <a href='#variables-locale'>Locale variables</a> for more information.
 - \c PATH, which is an array of directories in which to search for commands

--- a/wildcard.cpp
+++ b/wildcard.cpp
@@ -613,7 +613,7 @@ static void wildcard_completion_allocate( std::vector<completion_t> &list,
 			sz = (long long)buf.st_size;
 		}
 	}
-	
+
 	wcstring desc;
     if (! (expand_flags & EXPAND_NO_DESCRIPTIONS))
         desc = file_get_desc( fullname.c_str(), lstat_res, lbuf, stat_res, buf, stat_errno );
@@ -625,13 +625,13 @@ static void wildcard_completion_allocate( std::vector<completion_t> &list,
         munged_completion.push_back(L'/');
         sb.append(desc);
 	}
-	else
+	else if (! (expand_flags & EXPAND_NO_DESCRIPTIONS))
 	{
         sb.append(desc);
         sb.append(L", ");
         sb.append(format_size(sz));
 	}
-    
+
     const wcstring &completion_to_use = munged_completion.empty() ? completion : munged_completion;
 	wildcard_complete(completion_to_use, wc, sb.c_str(), NULL, list, flags);
 }


### PR DESCRIPTION
The descriptions in the tab completions will be hidden if the variable 'fish_complete_no_descriptions' is set to 1.
