### PR TITLE
Replace references to the old site with the new one

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -11,7 +11,7 @@ This is the documentation for \c fish, the friendly interactive
 shell. \c fish is a user friendly commandline shell intended
 mostly for interactive use. A shell is a program used to execute other
 programs. For the latest information on \c fish, please visit the <a
-href="http://www.fishshell.org"><code>fish</code> homepage</a>.
+href="http://ridiculousfish.com/shell/"><code>fish</code> homepage</a>.
 
 \section syntax Syntax overview
 
@@ -1374,7 +1374,7 @@ translated, a future version of fish should also include translated
 manuals.
 
 To make a translation of fish, you will first need the source code,
-available from the <a href='http://www.fishshell.org'>fish
+available from the <a href='http://ridiculousfish.com/shell/'>fish
 homepage</a>. Download the latest version, and then extract it using a
 command like <code>tar -zxf fish-VERSION.tar.gz</code>.
 

--- a/fish.spec.in
+++ b/fish.spec.in
@@ -6,9 +6,9 @@ Release:                0%{?dist}
 
 License:                GPL
 Group:                  System Environment/Shells
-URL:                    http://www.fishshell.org
+URL:                    http://ridiculousfish.com/shell/
 
-Source0:                http://www.fishshell.org/files/%{version}/%{name}-%{version}.tar.bz2
+Source0:                http://ridiculousfish.com/shell/files/%{version}/%{name}-%{version}.tar.bz2
 
 BuildRoot:              %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires:          ncurses-devel gettext groff

--- a/user_doc.head.html
+++ b/user_doc.head.html
@@ -32,7 +32,7 @@ H4
 
 <div class="qindex">
 
- <a class="qindex" href="http://www.fishshell.org"><tt>fish</tt> home</a>
+ <a class="qindex" href="http://ridiculousfish.com/shell/"><tt>fish</tt> home</a>
 |
  <a class="qindex" href="index.html">Main documentation page</a>
 |

--- a/wgetopt.cpp
+++ b/wgetopt.cpp
@@ -9,7 +9,7 @@
 
 	If you want to use this version of getopt in your program,
 	download the fish sourcecode, available at <a
-	href='http://www.fishshell.org'>the fish homepage</a>. Extract
+	href='http://ridiculousfish.com/shell/'>the fish homepage</a>. Extract
 	the sourcode, copy wgetopt.c and wgetopt.h into your program
 	directory, include wgetopt.h in your program, and use all the
 	regular getopt functions, prefixing every function, global

--- a/wgetopt.h
+++ b/wgetopt.h
@@ -9,7 +9,7 @@
 
 	If you want to use this version of getopt in your program,
 	download the fish sourcecode, available at <a
-	href='http://www.fishshell.org'>the fish homepage</a>. Extract
+	href='http://ridiculousfish.com/shell/'>the fish homepage</a>. Extract
 	the sourcode, copy wgetopt.c and wgetopt.h into your program
 	directory, include wgetopt.h in your program, and use all the
 	regular getopt functions, prefixing every function, global


### PR DESCRIPTION
I noticed that the documentation refers to a domain which has been squatted. I've replaced all the references to it to point to the new site (http://ridiculousfish.net/shell/).
