### PR TITLE
Issue #265 – Fix webserver arguments handling in python3

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -7,11 +7,11 @@ IS_PY2 = sys.version_info[0] == 2
 if IS_PY2:
     import SimpleHTTPServer
     import SocketServer
-    from urlparse import parse_qs as parse_qs
+    from urlparse import parse_qs
 else:
     import http.server as SimpleHTTPServer
     import socketserver as SocketServer
-    from urllib.parse import parse_qs as parse_qs
+    from urllib.parse import parse_qs
 import webbrowser
 import subprocess
 import re, json, socket, os, sys, cgi, select, time


### PR DESCRIPTION
In both in python2 and python3 parse_qs expects str object. In
python2 it worked ok, because self.rfile was open in binary mode and
str in python2 is actually a string of bytes. However in python3 str is
actually string of unicode literals, not bytes and file was still open
in binary mode. Thus, deleting any file with non-ascii byte inside
filename failed in python3.

Cleaned a lot unnecessary code and fixed some deprecated
dependencies too.

Tests done manually with python2.7 and python3.2.
