### PR TITLE
Fix check for non-empty argument (= initial tab) in fish_config

### DIFF
--- a/share/functions/fish_config.fish
+++ b/share/functions/fish_config.fish
@@ -1,7 +1,7 @@
 function fish_config --description "Launch fish's web based configuration"
 	# Support passing an initial tab like "colors" or "functions"
 	set -l initial_tab
-	if test (count $argv) > 0
+	if count $argv >/dev/null
 		set initial_tab $argv[1]
 	end
 	eval $__fish_datadir/tools/web_config/webconfig.py $initial_tab


### PR DESCRIPTION
The original version (based on 'test') was creating spurious files named "0" in the current working directory
