### PR TITLE
* Add missing ! to a fallback case where no key mappings are defined

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -350,7 +350,7 @@ int input_init()
     update_fish_term256();
 
 	/* If we have no keybindings, add a few simple defaults */
-	if( mapping_list.size() )
+	if( ! mapping_list.size() )
 	{
 		input_mapping_add( L"", L"self-insert" );
 		input_mapping_add( L"\n", L"execute" );


### PR DESCRIPTION
Fix minor bug in input.cpp, where the code read:

``` c++
       /* If we have no keybindings, add a few simple defaults */
        if( mapping_list.size() )
```

I'm choosing to believe the comment here (it makes sense), so the code is wrong.
