### PR TITLE
A case against brace expansion

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -976,8 +976,6 @@ wchar_t *escape( const wchar_t *in_orig, escape_flags_t flags )
 				case L')':
 				case L'[':
 				case L']':
-				case L'{':
-				case L'}':
 				case L'?':
 				case L'*':
 				case L'|':
@@ -1060,7 +1058,6 @@ wchar_t *unescape( const wchar_t * orig, int flags )
 	size_t in_pos;
     size_t len;
 	int c;
-	int bracket_count=0;
 	wchar_t prev=0;	
 	wchar_t *in;
 	int unescape_special = flags & UNESCAPE_SPECIAL;
@@ -1373,47 +1370,6 @@ wchar_t *unescape( const wchar_t * orig, int flags )
 							else
 							{
 								in[out_pos]=in[in_pos];											
-							}
-							break;					
-						}
-
-						case L'{':
-						{
-							if( unescape_special )
-							{
-								bracket_count++;
-								in[out_pos]=BRACKET_BEGIN;
-							}
-							else
-							{
-								in[out_pos]=in[in_pos];						
-							}
-							break;					
-						}
-						
-						case L'}':
-						{
-							if( unescape_special )
-							{
-								bracket_count--;
-								in[out_pos]=BRACKET_END;
-							}
-							else
-							{
-								in[out_pos]=in[in_pos];						
-							}
-							break;					
-						}
-						
-						case L',':
-						{
-							if( unescape_special && bracket_count && prev!=BRACKET_SEP)
-							{
-								in[out_pos]=BRACKET_SEP;
-							}
-							else
-							{
-								in[out_pos]=in[in_pos];						
 							}
 							break;					
 						}

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -594,18 +594,6 @@ end</code> will convert all Jpeg files in the current directory to the
 PNG format.
 
 
-\subsection expand-brace Brace expansion
-
-A comma separated list of characters enclosed in curly braces will be
-expanded so each element of the list becomes a new parameter.
-
-Example:
-
-<code>echo input.{c,h,txt}</code> outputs 'input.c input.h input.txt'
-
-The command <code>mv *.{c,h} src/</code> moves all files with the suffix
-'.c' or '.h' to the subdirectory src.
-
 \subsection expand-variable Variable expansion
 
 A dollar sign followed by a string of characters is expanded into the
@@ -618,28 +606,9 @@ Example:
 <code> echo \$HOME</code> prints the home directory of the current
 user.
 
-If you wish to combine environment variables with text, you can
-encase the variables within braces to embed a variable inside running
-text like <code>echo Konnichiwa {$USER}san</code>, which will print a
-personalized Japanese greeting.
-
-The {$USER}san syntax might need a bit of an elaboration.  Posix
-shells allow you to specify a variable name using '$VARNAME' or
-'${VARNAME}'. Fish supports the former, and has no support whatsoever
-for the latter or anything like it. So what is '{$VARNAME}' then?
-Well, '{WHATEVER}' is <a href='#brace'>brace expansion</a>, e.g. 'a{b,c}d' -> 'abd acd'.
-So '{$VARNAME}' is a bracket-expansion with
-only a single element, i.e.  it becomes expanded to '$VARNAME', which
-will be variable expanded to the value of the variable 'VARNAME'. So
-you might think that the brackets don't actually do anything, and that
-is nearly the truth. The snag is that there once along the way was a
-'}' in there somewhere, and } is not a valid character in a variable
-name.  So anything after the otherwise pointless bracket expansion
-becomes explicitly NOT a part of the variable name, even if it happens
-to be a legal variable name character. That's why '{$USER}san' looks
-for the variable '$USER' and not for the variable '$USERsan'. It's
-simply a case of one syntax lending itself nicely to solving an
-unrelated problem in its spare time.
+If you wish to combine environment variables with text, you can use 'echo' to
+denote the variable boundaries like <code>echo Konnichiwa
+(echo $USER)san</code>, which will print a personalized Japanese greeting.
 
 Variable expansion is the only type of expansion performed on double
 quoted strings. There is, however, an important difference in how
@@ -764,17 +733,16 @@ When combining multiple parameter expansions, expansions are performed in the fo
 
 - Command substitutions
 - Variable expansions
-- Bracket expansion
 - Pid expansion
 - Wildcard expansion
 
-Expansions are performed from right to left, nested bracket expansions
+Expansions are performed from right to left, nested command substitutions
 are performed from the inside and out.
 
 Example:
 
 If the current directory contains the files 'foo' and 'bar', the command
-<code>echo a(ls){1,2,3} </code>
+<code>echo a(ls)(quote 1 2 3) </code>
 will output 'abar1 abar2 abar3 afoo1 afoo2 afoo3'.
 
 

--- a/expand.h
+++ b/expand.h
@@ -81,21 +81,9 @@ enum
 	/** Character rpresenting variable expansion into a single element*/
 	VARIABLE_EXPAND_SINGLE,
 
-	/** Character representing the start of a bracket expansion */
-	BRACKET_BEGIN,
-
-	/** Character representing the end of a bracket expansion */
-	BRACKET_END,
-
-	/** Character representing separation between two bracket elements */
-	BRACKET_SEP,
-	/**
-	   Separate subtokens in a token with this character. 
-	*/
+	/** Separate subtokens in a token with this character.  */
 	INTERNAL_SEPARATOR,
-
-}
-	;
+};
 
 
 /**

--- a/fish_tests.cpp
+++ b/fish_tests.cpp
@@ -314,7 +314,7 @@ static void test_tok()
 	
 	{
 
-		const wchar_t *str = L"string <redirection  2>&1 'nested \"quoted\" '(string containing subshells ){and,brackets}$as[$well (as variable arrays)] not_a_redirect^ ^ ^^is_a_redirect";
+		const wchar_t *str = L"string <redirection  2>&1 'nested \"quoted\" '(string containing subshells )(quote and quotes)$as[$well (as variable arrays)] not_a_redirect^ ^ ^^is_a_redirect";
 		const int types[] = 
 		{
 			TOK_STRING, TOK_REDIRECT_IN, TOK_STRING, TOK_REDIRECT_FD, TOK_STRING, TOK_STRING, TOK_STRING, TOK_REDIRECT_OUT, TOK_REDIRECT_APPEND, TOK_STRING, TOK_END
@@ -522,10 +522,7 @@ static int expand_test( const wchar_t *in, int flags, ... )
 	int res=1;
 	wchar_t *arg;
 	
-	if( expand_string( in, output, flags) )
-	{
-		
-	}
+	expand_string( in, output, flags);
 	
 #if 0
     for (size_t idx=0; idx < output.size(); idx++)
@@ -568,11 +565,6 @@ static void test_expand()
 	if( !expand_test( L"foo", 0, L"foo", 0 ))
 	{
 		err( L"Strings do not expand to themselves" );
-	}
-
-	if( !expand_test( L"a{b,c,d}e", 0, L"abe", L"ace", L"ade", 0 ) )
-	{
-		err( L"Bracket expansion is broken" );
 	}
 
 	if( !expand_test( L"a*", EXPAND_SKIP_WILDCARDS, L"a*", 0 ) )

--- a/highlight.cpp
+++ b/highlight.cpp
@@ -151,9 +151,6 @@ bool is_potential_path(const wcstring &const_path, const wcstring_list_t &direct
             case PROCESS_EXPAND:
             case VARIABLE_EXPAND:
             case VARIABLE_EXPAND_SINGLE:
-            case BRACKET_BEGIN:
-            case BRACKET_END:
-            case BRACKET_SEP:
             case ANY_CHAR:
             case ANY_STRING:
             case ANY_STRING_RECURSIVE:
@@ -362,7 +359,6 @@ static void highlight_param( const wcstring &buffstr, std::vector<int> &colors, 
     const wchar_t * const buff = buffstr.c_str();
 	enum {e_unquoted, e_single_quoted, e_double_quoted} mode = e_unquoted;
 	size_t in_pos, len = buffstr.size();
-	int bracket_count=0;
 	int normal_status = colors.at(0);
 	
 	for (in_pos=0; in_pos<len; in_pos++)
@@ -388,15 +384,7 @@ static void highlight_param( const wcstring &buffstr, std::vector<int> &colors, 
 							colors.at(in_pos+1) = normal_status;
 						}
 					}
-					else if( buff[in_pos]==L',' )
-					{
-						if( bracket_count )
-						{
-							colors.at(start_pos) = HIGHLIGHT_ESCAPE;
-							colors.at(in_pos+1) = normal_status;
-						}
-					}
-					else if( wcschr( L"abefnrtv*?$(){}[]'\"<>^ \\#;|&", buff[in_pos] ) )
+					else if( wcschr( L"abefnrtv*?$()[]'\"<>^ \\#;|&", buff[in_pos] ) )
 					{
 						colors.at(start_pos)=HIGHLIGHT_ESCAPE;
 						colors.at(in_pos+1)=normal_status;
@@ -509,33 +497,6 @@ static void highlight_param( const wcstring &buffstr, std::vector<int> &colors, 
 							colors.at(in_pos) = HIGHLIGHT_OPERATOR;
 							colors.at(in_pos+1) = normal_status;
 							break;
-						}
-                            
-						case L'{':
-						{
-							colors.at(in_pos) = HIGHLIGHT_OPERATOR;
-							colors.at(in_pos+1) = normal_status;
-							bracket_count++;
-							break;					
-						}
-                            
-						case L'}':
-						{
-							colors.at(in_pos) = HIGHLIGHT_OPERATOR;
-							colors.at(in_pos+1) = normal_status;
-							bracket_count--;
-							break;						
-						}
-                            
-						case L',':
-						{
-							if( bracket_count )
-							{
-								colors.at(in_pos) = HIGHLIGHT_OPERATOR;
-								colors.at(in_pos+1) = normal_status;
-							}
-                            
-							break;					
 						}
                             
 						case L'\'':

--- a/share/completions/help.fish
+++ b/share/completions/help.fish
@@ -28,7 +28,6 @@ complete -c help -x -a globbing --description "Help on parameter expansion (Glob
 complete -c help -x -a expand --description "Help on parameter expansion (Globbing)"
 complete -c help -x -a expand-variable --description "Help on variable expansion \$VARNAME"
 complete -c help -x -a expand-home --description "Help on home directory expansion ~USER"
-complete -c help -x -a expand-brace --description "Help on brace expansion {a,b,c}"
 complete -c help -x -a expand-wildcard --description "Help on wildcard expansion *.*"
 complete -c help -x -a expand-command-substitution --description "Help on command substitution (SUBCOMMAND)"
 complete -c help -x -a expand-process --description "Help on process expansion %JOB"

--- a/share/completions/ifconfig.fish
+++ b/share/completions/ifconfig.fish
@@ -1,9 +1,9 @@
 complete -x -c ifconfig -a down --description "Stop interface"
 complete -x -c ifconfig -a up --description "Start interface"
 complete -x -c ifconfig -a "
-	{,-}arp
-	{,-}promisc
-	{,-}allmulti
+	(quote '' -)arp
+	(quote '' -)promisc
+	(quote '' -)allmulti
 	metric
 	mtu
 	dstaddr
@@ -15,8 +15,8 @@ complete -x -c ifconfig -a "
 	io_addr
 	mem_start
 	media
-	{,-}broadcast
-	{,-}pointopoint
+	(quote '' -)broadcast
+	(quote '' -)pointopoint
 	hw
 	multicast
 	address

--- a/share/completions/ifconfig.fish
+++ b/share/completions/ifconfig.fish
@@ -1,9 +1,9 @@
 complete -x -c ifconfig -a down --description "Stop interface"
 complete -x -c ifconfig -a up --description "Start interface"
 complete -x -c ifconfig -a "
-	(quote '' -)arp
-	(quote '' -)promisc
-	(quote '' -)allmulti
+	(array '' -)arp
+	(array '' -)promisc
+	(array '' -)allmulti
 	metric
 	mtu
 	dstaddr
@@ -15,8 +15,8 @@ complete -x -c ifconfig -a "
 	io_addr
 	mem_start
 	media
-	(quote '' -)broadcast
-	(quote '' -)pointopoint
+	(array '' -)broadcast
+	(array '' -)pointopoint
 	hw
 	multicast
 	address

--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -12,14 +12,14 @@ complete -c scp -d Hostname -a "
 
 (
 	#Find a suitable hostname from the knownhosts files
-	cat ~/.ssh/known_hosts(quote '' 2) ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
+	cat ~/.ssh/known_hosts(array '' 2) ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
 ):
 
 (
 	#Prepend any username specified in the completion to the hostname
 	echo (commandline -ct)|sed -ne 's/\(.*@\).*/\1/p'
 )(
-	cat ~/.ssh/known_hosts(quote '' 2) ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
+	cat ~/.ssh/known_hosts(array '' 2) ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
 ):
 
 (__fish_print_users)@

--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -12,14 +12,14 @@ complete -c scp -d Hostname -a "
 
 (
 	#Find a suitable hostname from the knownhosts files
-	cat ~/.ssh/known_hosts{,2} ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
+	cat ~/.ssh/known_hosts(quote '' 2) ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
 ):
 
 (
 	#Prepend any username specified in the completion to the hostname
 	echo (commandline -ct)|sed -ne 's/\(.*@\).*/\1/p'
 )(
-	cat ~/.ssh/known_hosts{,2} ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
+	cat ~/.ssh/known_hosts(quote '' 2) ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
 ):
 
 (__fish_print_users)@

--- a/share/functions/__fish_complete_svn.fish
+++ b/share/functions/__fish_complete_svn.fish
@@ -281,7 +281,7 @@ function __fish_complete_svn -d 'Complete svn and its wrappers' --argument-names
     #
     # Complete pget, pset, pedit options with svn props
     #
-    set -l props svn:{ignore,keywords,executable,eol-style,mime-type,externals,need-lock}
+    set -l props svn:(quote ignore keywords executable eol-style mime-type externals need-lock)
     _svn_cmpl_ $propget -a "$props"
     _svn_cmpl_ $propedit -a "$props"
     _svn_cmpl_ $propdel -a "$props"

--- a/share/functions/__fish_complete_svn.fish
+++ b/share/functions/__fish_complete_svn.fish
@@ -281,7 +281,7 @@ function __fish_complete_svn -d 'Complete svn and its wrappers' --argument-names
     #
     # Complete pget, pset, pedit options with svn props
     #
-    set -l props svn:(quote ignore keywords executable eol-style mime-type externals need-lock)
+    set -l props svn:(array ignore keywords executable eol-style mime-type externals need-lock)
     _svn_cmpl_ $propget -a "$props"
     _svn_cmpl_ $propedit -a "$props"
     _svn_cmpl_ $propdel -a "$props"

--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -516,12 +516,12 @@ function __fish_git_prompt_repaint_color $varargs --description "Event handler, 
 	if status --is-interactive
 		set -l var $argv[3]
 		set -e _$var
-		set -e _{$var}_done
+		set -e _(echo $var)_done
 		if test $var = __fish_git_prompt_color
 			# reset all the other colors too
 			for name in prefix suffix bare merging branch dirtystate stagedstate invalidstate stashstate untrackedfiles upstream
 				set -e ___fish_git_prompt_color_$name
-				set -e ___fish_git_prompt_color_{$name}_done
+				set -e ___fish_git_prompt_color_(echo $name)_done
 			end
 		end
 		commandline -f repaint ^/dev/null

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -11,7 +11,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	end
 
 	# Print hosts with known ssh keys
-	cat ~/.ssh/known_hosts(quote '' 2) ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
+	cat ~/.ssh/known_hosts(array '' 2) ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
 
 	# Print hosts from ssh configuration file
 	if [ -e ~/.ssh/config ]

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -11,7 +11,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	end
 
 	# Print hosts with known ssh keys
-	cat ~/.ssh/known_hosts{,2} ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
+	cat ~/.ssh/known_hosts(quote '' 2) ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
 
 	# Print hosts from ssh configuration file
 	if [ -e ~/.ssh/config ]

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -15,7 +15,7 @@ function help --description "Show help for the fish shell"
 
 	set -l h syntax completion editor job-control todo bugs history killring help
 	set h $h color prompt title variables builtin-overview changes expand
-	set h $h expand-variable expand-home expand-brace expand-wildcard
+	set h $h expand-variable expand-home expand-wildcard
 	set -l help_topics $h expand-command-substitution expand-process
 
 	# 'help -h' should launch 'help help'

--- a/share/functions/quote.fish
+++ b/share/functions/quote.fish
@@ -1,4 +1,4 @@
-function quote -d "Echo a variable in a way that keeps it a list."
+function array -d "Echo a variable in a way that keeps it an array."
 	for arg in $argv
 		echo $arg
 	end

--- a/share/functions/quote.fish
+++ b/share/functions/quote.fish
@@ -1,0 +1,5 @@
+function quote -d "Echo a variable in a way that keeps it a list."
+	for arg in $argv
+		echo $arg
+	end
+end

--- a/share/functions/umask.fish
+++ b/share/functions/umask.fish
@@ -118,15 +118,15 @@ function __fish_umask_print_symbolic
 		set val (echo $umask|cut -c $i)
 
 		if contains $val 0 1 2 3
-			set res {$res}r
+			set res (echo $res)r
 		end
 
 		if contains $val 0 1 4 5
-			set res {$res}w
+			set res (echo $res)w
 		end
 
 		if contains $val 0 2 4 6
-			set res {$res}x
+			set res (echo $res)x
 		end
 
 	end


### PR DESCRIPTION
I think brace expansion should be removed.

I know, I know, it's a cool feature and it's often very convenient. Bear with me for a moment:

First of all, it's inconsistent. Why does it use commas as separators instead of spaces? I thought maybe so you can have spaces in your brace expansion, but that yields a parse error:

    > echo {a b c d}
    fish: could not expand string "{a"

It seems that there's no good reason for this other than compatibility with other shells. Brace expansion is not POSIX. Fish should be consistent with itself first and POSIX second and answer to no one else.  Given all the [recent hoopla](https://github.com/fish-shell/fish-shell/issues/159) about separator consistency I think it's important that we use one separator everywhere. So at the very least, brace expansion should use spaces as a separator.

But if we allow use space separation in brace expansion then we realize that it's exactly the same thing as `(echo ...)`. Check it out:

    > mv file.(echo txt markdown)

works just as well as

    > mv file.{txt,markdown}

This is a super cool side effect of how [lists work together](https://github.com/fish-shell/fish-shell/issues/352). It's five extra characters to use echo. Five. Seems pretty [non-orthogonal](http://ridiculousfish.com/shell/user_doc/html/design.html) to me.

It can be convenient, sometimes, to just have those braces when you want to rename/move a bunch of files. I get it. The terse syntax is nice, and people might expect it coming from other shells.

But before you argue that that five character reduction is good, remember that the brace characters themselves are pretty harmful.

For example, whenever you want to specify a commit in a git command:

    > git reset --soft HEAD@{2}

This blows up unless you use `HEAD@\{2\}`

That costs me two extra characters and a headache. I use commands with braces on *at least* a 3:1 ratio with brace expansion, so brace expansion *actually hurts me as a user*, even if you ignore the headaches that it causes!

It uses inconsistent separator characters, doesn't allow spaces, and saves you five characters. At the same time it dicks you over when you try to use certain git commands and any other commands that want braces.

It's really just `(echo ...)`! It's non-orthogonal! Give it the axe.