### PR TITLE
Allow for customisation of word separator characters

### DIFF
--- a/reader.cpp
+++ b/reader.cpp
@@ -1983,7 +1983,7 @@ public:
         if (state == s_begin){
             if (separator_chars.missing())
             {
-                separator_chars = L" /\t.";
+                separator_chars = L" /\t.\n|;#\r";
             }
             state = (is_separator(c) ? s_separator : s_word);
         }


### PR DESCRIPTION
using the FISH_WORD_SEPARATORS environment variable

This does slightly regress the existing, quite subtle behaviour by not hard-coding special cases like '/' and not knowing about redirection symbols.

New behaviour is that a word is anything matching:  (WORD_CHAR+)(SEPARATOR+)
Where SEPARATOR is defined by the FISH_WORD_SEPARATORS variable, and WORD_CHAR is a set of everything else.

From the examples given in the source code, the only use case that is changed here is the situation where redirections etc, are written without spaces:

`echo 1>/dev/null`
Before, the words were defined as:   `[echo ][1][>][/][dev/][null]`.
Now, the words are:  `[echo ][1>/][dev/][null]`.  
I think both are not ideal, so the loss of functionality isn't so great.
If the line were written:
`echo 1 > /dev/null` then the new behaviour will just 'do the right thing'.

Does allow for the word separator characters to be defined on a per-user basis, if required.  Has sane defaults (imo.)
