### PR TITLE
Fix for issue #419: create_manpage_completions.py fails with UnicodeDecodeError

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -17,7 +17,7 @@ Redistributions in binary form must reproduce the above copyright notice, this l
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import string, sys, re, os.path, gzip, traceback, getopt, errno
+import string, sys, re, os.path, gzip, traceback, getopt, errno, codecs
 from deroff import Deroffer
 
 # Whether we're Python 3
@@ -132,7 +132,7 @@ def builtcommand(options, description):
 
     # Here's what we'll use to truncate if necessary
     max_description_width = 63
-    truncation_suffix = '… [See Man Page]'
+    truncation_suffix = u'… [See Man Page]'
     
     # Try to include as many whole sentences as will fit
     sentences = description.split('.')
@@ -787,7 +787,7 @@ def parse_manpage_at_path(manpage_path, yield_to_dirs, output_directory):
                 fullpath = os.path.join(output_directory, CMDNAME + '.fish')
                 try:
                     if file_missing_or_overwritable(fullpath):
-                        output_file = open(fullpath, 'w')
+                        output_file = codecs.open(fullpath, "w", encoding="utf-8");
                     else:
                         add_diagnostic("Not overwriting the file at '%s'" % fullpath)
 


### PR DESCRIPTION
When running create_manpage_completions.py on system where python sys.getdefaultencoding() is ASCII, the script fails for 2 reasons:
- When truncating a description, it try to append a "…" character using a standard string and not an Unicode string. 
  This character cause an UnicodeDecodeError at
  `"/usr/local/share/fish/tools/create_manpage_completions.py:102": output_list.append(' '.join(comps))`

This patch fix this issue by using an unicode string for the truncation_suffix string.
- When trying to write the resulting string in the .fish file, the write() call raise a UnicodeEncodeError, as the ellipsis character is not an ascii supported character. This patch fix this issue by using the codecs package to open a file in utf-8 mode instead of relying on the default python encoding.
