### PR TITLE
Remove -rdynamic compilation flag for OSX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -275,10 +275,12 @@ if test "$GCC" = yes; then
   CXXFLAGS="$CXXFLAGS -Wall"
 
   #
-  # This is needed in order to get the really cool backtraces
+  # This is needed in order to get the really cool backtraces on Linux
   #
 
-  LDFLAGS_FISH="$LDFLAGS_FISH -rdynamic"
+  if test `uname` != "Darwin"; then
+    LDFLAGS_FISH="$LDFLAGS_FISH -rdynamic"
+  fi
 
 fi
 


### PR DESCRIPTION
I'm using fish on OSX 10.7.5 and have a Linux ported version of gcc/g++ 4.7

For some obscure reasons it does not support the flag "-rdynamic", even if it is specified in the man page.

The man description is the following :
-rdynamic : Pass the flag -export-dynamic to the ELF linker, on targets that support it. This instructs the linker to add all symbols, not only used ones, to the dynamic symbol table. This option is needed for some uses of "dlopen" or to allow obtaining backtraces from within a program.

This flag is obviously here for the backtrace() and backtrace_symbols() system calls in show_stackframe() function in common.cpp:106.

I had never seen this error printed before, but anyway, I wanted to test the result with and without the flag. The result is the same for me on OSX even with the g++ provided by Apple, but the flag is indeed needed on Linux (tested on Fedora 14).

This commit does not add -rdynamic compilation flag on OSX.
