### PR TITLE
Fix man completion: suppress stderr of aprops

### DIFF
--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -21,7 +21,7 @@ function __fish_complete_man
 		set section $section"[^)]*"
 
 		# Do the actual search
-		apropos (commandline -ct) | sgrep \^(commandline -ct) | sed -n -e 's/\([^ ]*\).*(\('$section'\)) *- */\1'\t'\2: /p'
+		apropos (commandline -ct) ^/dev/null | sgrep \^(commandline -ct) | sed -n -e 's/\([^ ]*\).*(\('$section'\)) *- */\1'\t'\2: /p'
 	end
 end
 


### PR DESCRIPTION
Currently tab completion of man when there is no match results in "nothing appropriate" being displayed.
