### PR TITLE
Random fixes

### DIFF
--- a/share/completions/help.fish
+++ b/share/completions/help.fish
@@ -3,7 +3,7 @@
 #
 
 if test -f "$__fish_help_dir/commands.html"
-	for i in case (sed -n < $__fish_help_dir/commands.html -e "s/.*<h[12]><a class=\"anchor\" name=\"\([^\"]*\)\">.*/\1/p")
+	for i in (sed -n 's/.*<h1><a class="anchor" \(id\|name\)="\([^"]*\)">.*/\2/p' $__fish_help_dir/commands.html)
 		complete -c help -x -a $i --description "Help for the specified command"
 	end
 end

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -97,7 +97,7 @@ function help --description "Show help for the fish shell"
 		# documentation.  It's a bit of a hack, since it relies on the
 		# Doxygen markup format to never change.
 
-		case (sed -n 's/.*<h[12]><a class="anchor" \(id\|name\)="\([^"]*\)">.*/\2/p' $__fish_help_dir/commands.html)
+		case (sed -n 's/.*<h1><a class="anchor" \(id\|name\)="\([^"]*\)">.*/\2/p' $__fish_help_dir/commands.html)
 			set fish_help_page "commands.html\#$fish_help_item"
 		case $help_topics
 			set fish_help_page "index.html\#$fish_help_item"


### PR DESCRIPTION
"drop `<h1>` anchor" should be "drop `<h2>` anchor", which are things like alias-synopsis, etc. I thought it would be useful to keep them but they mess up the completion list, so I dropped them.
