### PR TITLE
Remove use of str2wcs

### DIFF
--- a/wutil.cpp
+++ b/wutil.cpp
@@ -333,14 +333,13 @@ wchar_t *wrealpath(const wcstring &pathname, wchar_t *resolved_path)
 
     if (resolved_path)
     {
-        wchar_t *tmp2 = str2wcs(narrow_res);
-        wcslcpy(resolved_path, tmp2, PATH_MAX);
-        free(tmp2);
+        wcstring tmp2 = str2wcstring(narrow_res);
+        wcslcpy(resolved_path, tmp2.c_str(), PATH_MAX);
         res = resolved_path;
     }
     else
     {
-        res = str2wcs(narrow_res);
+        res = wcsdup(str2wcstring(narrow_res).c_str());
     }
     return res;
 }


### PR DESCRIPTION
`str2wcs` was removed in https://github.com/fish-shell/fish-shell/commit/644607c29fbb480b0d6fb95bb4ce3b1f9ed81276 but this use was missed out. 
