### PR TITLE
parsing numbers imho better uses + rather than |

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -1266,7 +1266,7 @@ wchar_t *unescape(const wchar_t * orig, int flags)
                                     break;
                                 }
 
-                                res=(res*base)|d;
+                                res=(res*base)+d;
                             }
 
                             if ((res <= max_val))


### PR DESCRIPTION
small change, both is correct in this case but I find '|' requires more thinking about its correctness. 
