### PR TITLE
Remove origin/HEAD lines from __fish_git_branches output.

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1,7 +1,7 @@
 # fish completion for git
 
 function __fish_git_branches
-  git branch --no-color -a 2>/dev/null | sed 's/^..//; s/^remotes\///'
+  git branch --no-color -a ^/dev/null | grep -v ' -> ' | sed -e 's/^..//' -e 's/^remotes\///'
 end
 
 function __fish_git_tags


### PR DESCRIPTION
This patch removed these annoying lines from `git branch` output:

```
origin/HEAD -> origin/master
```

Related discussion:
http://stackoverflow.com/questions/354312/why-is-origin-head-shown-when-running-git-branch-r
