### PR TITLE
Re-enable alias redefinition

### DIFF
--- a/share/functions/alias.fish
+++ b/share/functions/alias.fish
@@ -40,9 +40,6 @@ function alias --description "Legacy function for creating shellscript functions
 			set prefix command
 		case builtin
 			set prefix builtin
-		case function
-			printf ( _ "%s: A function with the name '%s' already exists. Use the 'functions' or 'funced' commands to edit it.") alias "$name"
-			return 1
 	end
 
 	eval "function $name; $prefix $body \$argv; end"


### PR DESCRIPTION
alias modification introduced in a4c646f prevents to redefine already defined functions by using alias.

I find it disturbing because most of the time for simple functions (like "ll" for "ls -l") it is way faster to just redefine it instead of finding which of "functions" or "funced" must be used (I never know which one applies for which case), after that find the good option,...

I think fish should just overwrite the existing function, just like it was before and like every other shell does.
