### PR TITLE
[web config] Ajax fix for Firefox

### DIFF
--- a/share/tools/web_config/index.html
+++ b/share/tools/web_config/index.html
@@ -404,6 +404,7 @@ function run_get_request_with_bulk_handler(url, handler) {
 	$.ajax({
 		  type: "GET",
 		  url: url,
+		  dataType: "text",
 		  success: function(data){
 			$('#global_error').text('')
 			handler($.parseJSON(data))
@@ -426,6 +427,7 @@ function run_post_request(url, data_map, handler) {
 	$.ajax({
 		  type: "POST",
 		  url: url,
+		  dataType: "text",
 		  data: data_map,
 		  success: function(data){
 			$('#global_error').text('')


### PR DESCRIPTION
Web config doesn't work in firefox:

http://postimage.org/image/kwza49llj/full/
http://postimage.org/image/n43is6qvr/full/

It's because data type isn't specified. Firefox expect XML. Here is the fix.
