### PR TITLE
Fix two clang warnings

### DIFF
--- a/exec.cpp
+++ b/exec.cpp
@@ -1248,7 +1248,7 @@ void exec(parser_t &parser, job_t *j)
                 std::string actual_cmd_str = wcs2string(p->actual_cmd);
                 const char *actual_cmd = actual_cmd_str.c_str();
 
-                const wchar_t *reader_current_filename();
+                const wchar_t *reader_current_filename(void);
                 if (g_log_forks)
                 {
                     const wchar_t *file = reader_current_filename();

--- a/expand.cpp
+++ b/expand.cpp
@@ -753,14 +753,14 @@ static int expand_pid(const wcstring &instr_with_sep,
         if (wcsncmp(in+1, SELF_STR, wcslen(in+1))==0)
         {
             append_completion(out,
-                              SELF_STR+wcslen(in+1),
+                              &SELF_STR[wcslen(in+1)],
                               COMPLETE_SELF_DESC,
                               0);
         }
         else if (wcsncmp(in+1, LAST_STR, wcslen(in+1))==0)
         {
             append_completion(out,
-                              LAST_STR+wcslen(in+1),
+                              &LAST_STR[wcslen(in+1)],
                               COMPLETE_LAST_DESC,
                               0);
         }


### PR DESCRIPTION
The warnings are:

```
exec.cpp:1251:55: warning: empty parentheses interpreted as a function declaration
      [-Wvexing-parse]
                const wchar_t *reader_current_filename();
                                                      ^~
exec.cpp:1251:55: note: replace parentheses with an initializer to declare a variable
                const wchar_t *reader_current_filename();
                                                      ^~
                                                       = NULL
1 warning generated.
```

the suggested fix is wrong though; and

```
expand.cpp:756:39: warning: adding 'size_t' (aka 'unsigned long') to a string does
      not append to the string [-Wstring-plus-int]
                              SELF_STR+wcslen(in+1),
                              ~~~~~~~~^~~~~~~~~~~~~
expand.cpp:756:39: note: use array indexing to silence this warning
                              SELF_STR+wcslen(in+1),
                                      ^
                              &       [            ]
expand.cpp:763:39: warning: adding 'size_t' (aka 'unsigned long') to a string does
      not append to the string [-Wstring-plus-int]
                              LAST_STR+wcslen(in+1),
                              ~~~~~~~~^~~~~~~~~~~~~
expand.cpp:763:39: note: use array indexing to silence this warning
                              LAST_STR+wcslen(in+1),
                                      ^
                              &       [            ]
2 warnings generated.
```
