### PR TITLE
add completion support for aliased command

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -46,6 +46,12 @@ function __fish_git_using_command
     if [ $argv[1] = $cmd[2] ]
       return 0
     end
+    
+    # aliased command
+    set aliased (git config --get "alias.$cmd[2]" | sed 's/ .*$//')
+    if [ $argv[1] = "$aliased" ]
+      return 0
+    end
   end
   return 1
 end


### PR DESCRIPTION
current git completion does not support aliased command

eg.

``` sh
git checkout [tab]
```

this will show all object can be checkout

``` sh
master branch1 branch2 ...
```

aliase this command

``` sh
git config alias.co checkout
```

completion does not work

``` sh
git co [tab]
```
