### PR TITLE
Code fix for example in contains.txt 

### DIFF
--- a/doc_src/contains.txt
+++ b/doc_src/contains.txt
@@ -16,7 +16,7 @@ yes, 1 otherwise
 <pre>
 for i in ~/bin /usr/local/bin
 	if not contains \$i \$PATH
-		set PATH \$PATH \$i
+		set PATH \$i \$PATH
 	end
 end
 </pre>


### PR DESCRIPTION
The contains.txt example for adding multiple dirs to one's path is broken. I found out the hard way. :P I figured I should fix it. :D 

At first I thought just the $i needed to be tokenized. (Is that what they call making something a variable? Saying "variable" sounds strange. 

I'm not a real™ programmer yet, so this is all I'm able to contribute for now. T_T

An [SU post](http://superuser.com/a/482243) helped me figure out what needed fixing. 

If for some reason this pull request doesn't actually fix the problem, please have a real™ programmer fix the issue. I've made enough of a fool of myself.

![Screen Shot 2013-02-11 at 16 10 37 AN](https://f.cloud.github.com/assets/894466/146894/49e226da-7498-11e2-9e1b-886b73069253.png)
