### PR TITLE
Fix backward kill line bug

### DIFF
--- a/reader.cpp
+++ b/reader.cpp
@@ -3102,8 +3102,9 @@ const wchar_t *reader_readline()
                     const wchar_t *end = &buff[data->buff_pos];
                     const wchar_t *begin = end;
 
-                    while (begin > buff  && *begin != L'\n')
+                    do
                         begin--;
+                    while (begin > buff && *begin != L'\n');
 
                     if (*begin == L'\n')
                         begin++;


### PR DESCRIPTION
Hello! I fixed a bug where the shell would crash after performing a backward-kill-line with the cursor positioned under a newline character. To reproduce the crash type:

```
$ if 1
      #
```

then move the cursor to the end of the first line and press CTRL-U.

This is my first commit here so apologies if I did anything terribly wrong :)
