### PR TITLE
Completion fix for directories with spaces on CDPATH

### DIFF
--- a/share/functions/__fish_complete_cd.fish
+++ b/share/functions/__fish_complete_cd.fish
@@ -32,7 +32,7 @@ function __fish_complete_cd -d "Completions for the cd command"
 			# in case the CDPATH directory is relative
 
 			builtin cd $wd
-			eval builtin cd $i
+			eval builtin cd \"$i\"
 
 			# What we would really like to do is skip descriptions if all
 			# valid paths are in the same directory, but we don't know how to


### PR DESCRIPTION
It's a really minor fix. I'm not sure why the `builtin cd` command is `eval`'ed here exactly, but using eval breaks the argument list when not properly quoted.
