### PR TITLE
Kill termio.h and sys/termios.h

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -25,10 +25,6 @@ parts of fish.
 #include <dirent.h>
 #include <sys/types.h>
 
-#ifdef HAVE_SYS_TERMIOS_H
-#include <sys/termios.h>
-#endif
-
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
@@ -54,10 +50,6 @@ parts of fish.
 #include <ncurses.h>
 #else
 #include <curses.h>
-#endif
-
-#if HAVE_TERMIO_H
-#include <termio.h>
 #endif
 
 #if HAVE_TERM_H

--- a/configure.ac
+++ b/configure.ac
@@ -537,7 +537,7 @@ LIBS=$LIBS_COMMON
 # Check presense of various header files
 #
 
-AC_CHECK_HEADERS([getopt.h termio.h sys/resource.h term.h ncurses/term.h ncurses.h curses.h stropts.h siginfo.h sys/select.h sys/ioctl.h sys/termios.h execinfo.h spawn.h])
+AC_CHECK_HEADERS([getopt.h termios.h sys/resource.h term.h ncurses/term.h ncurses.h curses.h stropts.h siginfo.h sys/select.h sys/ioctl.h execinfo.h spawn.h])
 
 if test x$local_gettext != xno; then
   AC_CHECK_HEADERS([libintl.h])
@@ -618,13 +618,6 @@ for i in "" "-D_POSIX_C_SOURCE=200112L" "-D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=2
        * For: siginfo_t (also defined by signal.h when in
        * POSIX/extensions mode). */
       #include <siginfo.h>
-      #endif
-
-      #ifdef HAVE_SYS_TERMIOS_H
-      /* Neither POSIX, C89 nor C99: a common extension.
-       * For: TIOCGWINSZ and struct winsize (under at least
-       * Solaris, NetBSD and (dual-listed) FreeBSD). */
-      #include <sys/termios.h>
       #endif
 
       #ifdef HAVE_SYS_IOCTL_H
@@ -750,8 +743,8 @@ AC_LINK_IFELSE(
   [
     AC_LANG_PROGRAM(
       [
-        #ifdef HAVE_SYS_TERMIOS_H
-        #include <sys/termios.h>
+        #ifdef HAVE_TERMIOS_H
+        #include <termios.h>
         #endif
 
         #ifdef HAVE_SYS_IOCTL_H

--- a/env.cpp
+++ b/env.cpp
@@ -25,10 +25,6 @@
 #include <curses.h>
 #endif
 
-#if HAVE_TERMIO_H
-#include <termio.h>
-#endif
-
 #if HAVE_TERM_H
 #include <term.h>
 #elif HAVE_NCURSES_TERM_H

--- a/fallback.cpp
+++ b/fallback.cpp
@@ -33,10 +33,6 @@
 #include <curses.h>
 #endif
 
-#if HAVE_TERMIO_H
-#include <termio.h>
-#endif
-
 #if HAVE_TERM_H
 #include <term.h>
 #elif HAVE_NCURSES_TERM_H

--- a/fish_pager.cpp
+++ b/fish_pager.cpp
@@ -11,9 +11,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifdef HAVE_SYS_TERMIOS_H
-#include <sys/termios.h>
-#endif
 
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
@@ -30,10 +27,6 @@
 #include <ncurses.h>
 #else
 #include <curses.h>
-#endif
-
-#if HAVE_TERMIO_H
-#include <termio.h>
 #endif
 
 #if HAVE_TERM_H

--- a/input.cpp
+++ b/input.cpp
@@ -15,10 +15,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef HAVE_SYS_TERMIOS_H
-#include <sys/termios.h>
-#endif
-
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
@@ -30,11 +26,6 @@
 #include <ncurses.h>
 #else
 #include <curses.h>
-#endif
-
-
-#if HAVE_TERMIO_H
-#include <termio.h>
 #endif
 
 #if HAVE_TERM_H

--- a/io.cpp
+++ b/io.cpp
@@ -15,10 +15,6 @@ Utilities for io redirection.
 #include <set>
 #include <algorithm>
 
-#ifdef HAVE_SYS_TERMIOS_H
-#include <sys/termios.h>
-#endif
-
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
@@ -30,10 +26,6 @@ Utilities for io redirection.
 #include <ncurses.h>
 #else
 #include <curses.h>
-#endif
-
-#if HAVE_TERMIO_H
-#include <termio.h>
 #endif
 
 #if HAVE_TERM_H

--- a/output.cpp
+++ b/output.cpp
@@ -12,10 +12,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef HAVE_SYS_TERMIOS_H
-#include <sys/termios.h>
-#endif
-
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
@@ -28,10 +24,6 @@
 #include <ncurses.h>
 #else
 #include <curses.h>
-#endif
-
-#if HAVE_TERMIO_H
-#include <termio.h>
 #endif
 
 #if HAVE_TERM_H

--- a/proc.cpp
+++ b/proc.cpp
@@ -22,10 +22,6 @@ Some of the code in this file is based on code from the Glibc manual.
 #include <sys/stat.h>
 #include <algorithm>
 
-#ifdef HAVE_SYS_TERMIOS_H
-#include <sys/termios.h>
-#endif
-
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
@@ -39,10 +35,6 @@ Some of the code in this file is based on code from the Glibc manual.
 #include <ncurses.h>
 #else
 #include <curses.h>
-#endif
-
-#if HAVE_TERMIO_H
-#include <termio.h>
 #endif
 
 #if HAVE_TERM_H

--- a/reader.cpp
+++ b/reader.cpp
@@ -30,10 +30,6 @@ commence.
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef HAVE_SYS_TERMIOS_H
-#include <sys/termios.h>
-#endif
-
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
@@ -51,10 +47,6 @@ commence.
 #include <ncurses.h>
 #else
 #include <curses.h>
-#endif
-
-#if HAVE_TERMIO_H
-#include <termio.h>
 #endif
 
 #if HAVE_TERM_H

--- a/screen.cpp
+++ b/screen.cpp
@@ -15,10 +15,6 @@ efficient way for transforming that to the desired screen content.
 #include <termios.h>
 #include <sys/types.h>
 
-#ifdef HAVE_SYS_TERMIOS_H
-#include <sys/termios.h>
-#endif
-
 #include <unistd.h>
 #include <wctype.h>
 
@@ -26,10 +22,6 @@ efficient way for transforming that to the desired screen content.
 #include <ncurses.h>
 #else
 #include <curses.h>
-#endif
-
-#if HAVE_TERMIO_H
-#include <termio.h>
 #endif
 
 #if HAVE_TERM_H


### PR DESCRIPTION
1. On FreeBSD, compilation complains that "this file includes <sys/termios.h> which is deprecated, use <termios.h> instead". On Linux and FreeBSD, <sys/termios.h> literally just pulls in <termios.h>. On OS X and Solaris, <termios.h> pulls in <sys/termios.h>.
2. <termio.h> doesn't exist on FreeBSD or Mac OS X, and on Linux is marked as deprecated and just includes <termios.h>. It does exist on Solaris, but no `struct termio` is ever actually used in the codebase.
