### PR TITLE
Remove -v flag from set_color synopsis.

### DIFF
--- a/doc_src/set_color.txt
+++ b/doc_src/set_color.txt
@@ -1,7 +1,7 @@
 \section set_color set_color - set the terminal color
 
 \subsection set_color-synopsis Synopsis
- <tt>set_color [-v --version] [-h --help] [-b --background COLOR] [COLOR]</tt>
+ <tt>set_color [-h --help] [-b --background COLOR] [COLOR]</tt>
 
 \subsection set_color-description Description
 


### PR DESCRIPTION
The -v documentation was removed when set_color was made a builtin, but wasn't removed from the synopsis.
