### PR TITLE
service name completion for systemd

### DIFF
--- a/share/completions/service.fish
+++ b/share/completions/service.fish
@@ -1,6 +1,13 @@
+function print_service_names
+	if type -f systemctl >/dev/null
+        command systemctl list-units  -t service | cut -d ' ' -f 1 | grep '\.service$' | sed -e 's/\.service$//'
+    end
+
+    command ls /etc/init.d
+end
 
 # Fist argument is the names of the service, i.e. a file in /etc/init.d
-complete -c service -n "test (count (commandline -poc)) = 1" -xa "(command ls /etc/init.d)" --description "Service name"
+complete -c service -n "test (count (commandline -poc)) = 1" -xa "(print_service_names)" --description "Service name"
 
 #The second argument is what action to take with the service
 complete -c service -n "test (count (commandline -poc)) -gt 1" -xa '$__fish_service_commands'


### PR DESCRIPTION
some linux systems have moved from "init sctipt" to "systemd" for service management.

this commit adds support for completing service name is these systems

[Systemd in wikipedia](http://en.wikipedia.org/wiki/Systemd)
