### PR TITLE
Add completion for ruby-build

### DIFF
--- a/share/completions/ruby-build.fish
+++ b/share/completions/ruby-build.fish
@@ -1,0 +1,19 @@
+function __fish_ruby-build_needs_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -eq 1 -a $cmd[1] = 'ruby-build' ]
+    return 0
+  end
+  return 1
+end
+
+function __fish_ruby-build_definitions
+  ruby-build --definitions
+end
+
+complete -f -c ruby-build -n '__fish_ruby-build_needs_command' -a '(__fish_ruby-build_definitions)' -d 'Definition'
+
+complete -f -c ruby-build -n '__fish_ruby-build_needs_command' -l keep -s k -d 'Do not remove source tree after installation'
+complete -f -c ruby-build -n '__fish_ruby-build_needs_command' -l verbose -s v -d 'Verbose mode: print compilation status to stdout'
+complete -f -c ruby-build -n '__fish_ruby-build_needs_command' -l definitions -d 'List all built-in definitions'
+
+complete -f -c ruby-build -n '__fish_ruby-build_needs_command' -l help -s h -d 'Display help information'


### PR DESCRIPTION
This adds completion for ruby-build.

Don't know if fish wants to contain all kinds of completions by default or if we want to limit to some extent?

Otherwise I have a few other completions lying around also.
