### PR TITLE
Fix compilation due to misplaced #endif

### DIFF
--- a/builtin_printf.cpp
+++ b/builtin_printf.cpp
@@ -373,8 +373,8 @@ long builtin_printf_state_t::print_esc(const wchar_t *escstart, bool octal_0)
             this->append_output(uni_value);
 #else
             this->append_format_output(L"%lc", uni_value);
-        }
 #endif
+        }
     }
     else
     {


### PR DESCRIPTION
Fixes compilation with gcc 4.7 on Debian squeeze.
