### PR TITLE
better host completion

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -13,7 +13,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	end
 
 	# Print hosts with known ssh keys
-	cat ~/.ssh/known_hosts{,2} ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
+	cat ~/.ssh/known_hosts{,2} ^/dev/null | grep -v '^|' | cut -d ' ' -f 1| cut -d , -f 1
 
 	# Print hosts from ssh configuration file
 	if [ -e ~/.ssh/config ]


### PR DESCRIPTION
The ssh/.config file "host" directive is case insensitive. This patch makes fish work properly with my personal ssh config.

Also, add filtering so that we only suggest un-hashed hosts in ssh's known_hosts file.

Signed-off-by: Greg Dietsche Gregory.Dietsche@cuw.edu
