### PR TITLE
Don't delete files outside prefix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -510,23 +510,6 @@ check-uninstall:
 .PHONY: check-uninstall
 
 
-# seq used to be a shell script that we would install
-# Now we just look for previously installed seqs, and erase them
-# No big deal if it fails
-# same with set_color, which is now a builtin.
-# Invoke set_color with -v to make sure it's ours.
-cleanup_old_binaries:
-	SEQLOC=`which seq`;\
-	if test -x "$$SEQLOC" && grep -q '\(^#!/.*/fish\|^#!/usr/bin/env fish\)' "$$SEQLOC"; then\
-		rm -f "$$SEQLOC";\
-	fi;\
-	SETCOLOR_LOC=`which set_color`;\
-	if test -x "$$SETCOLOR_LOC" && $$SETCOLOR_LOC -v 2>&1 >/dev/null | grep -q "^set_color, version "; then\
-		rm -f "$$SETCOLOR_LOC";\
-	fi;\
-	true;
-.PHONY: cleanup_old_binaries
-
 #
 # This check makes sure that the install-sh script is executable. The
 # darcs repo doesn't preserve the executable bit, so this needs to be
@@ -542,7 +525,7 @@ install-sh:
 # Try to install after checking for incompatible installed versions.
 #
 
-install: all cleanup_old_binaries install-sh check-uninstall install-force
+install: all install-sh check-uninstall install-force
 .PHONY: install
 
 #


### PR DESCRIPTION
Touching files outside PREFIX is not only a bad practice but causes access violations using portage (Gentoo) build system
