### PR TITLE
Changed paths.bin to respect BINDIR

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -61,7 +61,7 @@ optbindirs = @optbindirs@
 # Various flags
 #
 
-MACROS = -DLOCALEDIR=\"$(localedir)\" -DPREFIX=L\"$(prefix)\" -DDATADIR=L\"$(datadir)\" -DSYSCONFDIR=L\"$(sysconfdir)\"
+MACROS = -DLOCALEDIR=\"$(localedir)\" -DPREFIX=L\"$(prefix)\" -DDATADIR=L\"$(datadir)\" -DSYSCONFDIR=L\"$(sysconfdir)\" -DBINDIR=L\"$(bindir)\"
 CXXFLAGS = @CXXFLAGS@ $(MACROS) $(EXTRA_CXXFLAGS)
 LDFLAGS = @LIBS@ @LDFLAGS@
 LDFLAGS_FISH = ${LDFLAGS} @LIBS_FISH@ @LDFLAGS_FISH@

--- a/fish.cpp
+++ b/fish.cpp
@@ -202,7 +202,7 @@ static struct config_paths_t determine_config_directory_paths(const char *argv0)
         paths.data = L"" DATADIR "/fish";
         paths.sysconf = L"" SYSCONFDIR "/fish";
         paths.doc = L"" DATADIR "/doc/fish";
-        paths.bin = L"" PREFIX "/bin";
+        paths.bin = L"" BINDIR;
 
         done = true;
     }


### PR DESCRIPTION
The compiled-in path to the "bin" directory was not correct; it made the common assumption that `$(bindir)` == `$(prefix)/bin` which is usually true, but not in all cases.
1. [machine specific files](http://www.gnu.org/prep/standards/html_node/Directory-Variables.html#index-exec_005fprefix)  should use `$(exec_prefix)` (`@exec_prefix@` in Makefile.in)  instead of the usual `$(prefix)`.
2. [executable programs](http://www.gnu.org/prep/standards/html_node/Directory-Variables.html#index-bindir) should use the more-specific `$(bindir)` (`@bindir@` in Makefile.in)  instead of assuming `$(exec_prefix)/bin` as this allows the executable install location to be changed with the `--bindir=/foo/bin` option to `./configure`.

Fortunately, the makefile is mostly correct and _installs_ the executable in the correct location. The problem shows up later such as during tab-completion, when fish_pager is run - the compiled-in path it uses was the incorrect `$(prefix)/bin` resulting in an "Unknown command" error, which only required this small fix.
