### PR TITLE
changing rendered ordering to: "staged, dirty, untracked, stashed"

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -319,7 +319,7 @@ function __fish_git_prompt --description "Prompt function for Git"
 	if test -n "$u"
 		set u "$___fish_git_prompt_color_untrackedfiles$u$___fish_git_prompt_color_untrackedfiles_done"
 	end
-	set -l f "$w$i$s$u"
+	set -l f "$i$w$u$s"
 	set -l format $argv[1]
 	if test -z "$format"
 		set format " (%s)"


### PR DESCRIPTION
I'm not sure if the original ordering here was based on the bash script, if so then it probably doesn't make sense to change it. I ended up rewriting the function locally to change the ordering and thought maybe it might be worth proposing the change here as well. But it seemingly comes down to preference so I completely understand if this isn't a desired change. Nonetheless I thought I'd see if there was any interest.
