### PR TITLE
Abstract getopt handling for GNU vs BSD

### DIFF
--- a/share/functions/__fish_getopt.fish
+++ b/share/functions/__fish_getopt.fish
@@ -1,0 +1,24 @@
+function __fish_getopt
+	set -l shortopt $argv[1]
+	set -e argv[1]
+	set -l gnuopt
+	set -l args
+	while count $argv >/dev/null
+		if test $argv[1] = "--"
+			set args $argv
+			set -e args[1]
+			break
+		else
+			set gnuopt $gnuopt $argv[1]
+			set -e argv[1]
+		end
+	end
+	set -l getopt
+	if not getopt -T >/dev/null
+		set getopt -o $shortopt $gnuopt -- $args
+	else
+		set getopt $shortopt $args
+	end
+	getopt $getopt
+	return $status
+end

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -5,21 +5,14 @@ function psub --description "Read from stdin into a file and output the filename
 	set -l filename
 	set -l funcname
 	set -l use_fifo 1
-	set -l shortopt -o hf
-	set -l longopt -l help,file
+	set -l options hf -l help,file -n psub -- $argv
 
-	if getopt -T >/dev/null
-		set longopt
-	end
-
-	if not getopt -n psub -Q $shortopt $longopt -- $argv >/dev/null
+	if not __fish_getopt $options >/dev/null
 		return 1
 	end
 
-	set -l tmp (getopt $shortopt $longopt -- $argv)
-
-	eval set opt $tmp
-
+	set -l opt
+	eval set opt (__fish_getopt $options)
 	while count $opt >/dev/null
 
 		switch $opt[1]

--- a/share/functions/trap.fish
+++ b/share/functions/trap.fish
@@ -26,33 +26,13 @@ function trap -d 'Perform an action when the shell receives a signal'
 	set -l cmd
 	set -l sig
 
-	set -l options
-	set -l longopt
-	set -l shortopt lph
-	if not getopt -T > /dev/null
-		# GNU getopt
-		set longopt print,help,list-signals
-		set options -o $shortopt -l $longopt --
-		# Verify options
-		if not getopt -n type $options $argv >/dev/null
-			return 1
-		end
-	else
-		# Old getopt, used on OS X
-		set options $shortopt
-		# Verify options
-		if not getopt $options $argv >/dev/null
-			return 1
-		end
+	set -l options lph -l print,help,list-signals -n trap -- $argv
+	if not __fish_getopt $options >/dev/null
+		return 1
 	end
 
-	# Do the real getopt invocation
-	set -l tmp (getopt $options $argv)
-
-	# Break tmp up into an array
 	set -l opt
-	eval set opt $tmp
-
+	eval set opt (__fish_getopt $options)
 	while count $opt >/dev/null
 		switch $opt[1]
 			case -h --help

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -9,32 +9,13 @@ function type --description "Print the type of a command"
 	#
 	# Get options
 	#
-	set -l options
-	set -l shortopt tpPafh
-	if not getopt -T > /dev/null
-		# GNU getopt
-		set -l longopt type,path,force-path,all,no-functions,help
-		set options -o $shortopt -l $longopt --
-		# Verify options
-		if not getopt -n type $options $argv >/dev/null
-			return 1
-		end
-	else
-		# Old getopt, used on OS X
-		set options $shortopt
-		# Verify options
-		if not getopt $options $argv >/dev/null
-			return 1
-		end
+	set -l options tpPafh -l type,path,force-path,all,no-functions,help -n type -- $argv
+	if not __fish_getopt $options >/dev/null
+		return 1
 	end
 
-	# Do the real getopt invocation
-	set -l tmp (getopt $options $argv)
-
-	# Break tmp up into an array
 	set -l opt
-	eval set opt $tmp
-	
+	eval set opt (__fish_getopt $options)
 	for i in $opt
 		switch $i
 			case -t --type

--- a/share/functions/umask.fish
+++ b/share/functions/umask.fish
@@ -139,28 +139,13 @@ function umask --description "Set default file permission mask"
 	set -l as_command 0
 	set -l symbolic 0
 	
-	set -l options
-	set -l shortopt pSh
-	if not getopt -T >/dev/null
-		# GNU getopt
-		set longopt -l as-command,symbolic,help
-		set options -o $shortopt $longopt --
-		# Verify options
-		if not getopt -n umask $options $argv >/dev/null
-			return 1
-		end
-	else
-		# Old getopt, used on OS X
-		set options $shortopt
-		# Verify options
-		if not getopt $options $argv >/dev/null
-			return 1
-		end
+	set -l options pSh -l as-command,symbolic,help -n umask -- $argv
+	if not __fish_getopt $options >/dev/null
+		return 1
 	end
 
-	set -l tmp (getopt $options $argv)
-	eval set opt $tmp
-
+	set -l opt
+	eval set opt (__fish_getopt $options)
 	while count $opt >/dev/null
 
 		switch $opt[1]


### PR DESCRIPTION
I'm hoping this will resolve #715, although I'm not on OSX so I can't easily test it.  As an added bonus, the code is a bit less repetitive and this new function could be reused in future code. I also fixed a typo in the trap function; it was passing `-n type` to GNU getopt.