### PR TITLE
Silence errors when ack doesn't support --dump

### DIFF
--- a/share/completions/ack.fish
+++ b/share/completions/ack.fish
@@ -84,7 +84,7 @@ complete -c ack -l bar -d 'The warning admiral'
 
 # File types
 if type ack > /dev/null
-	for type in (ack --dump | perl -lne 'print $1 if /^\s+--type-add=([^:]+)/' | uniq)
+	for type in (ack --dump ^/dev/null | perl -lne 'print $1 if /^\s+--type-add=([^:]+)/' | uniq)
 		complete -c ack -l $type -d "Allow $type file type"
 		complete -c ack -l no$type -l no-$type -d "Don't allow $type file type"
 	end


### PR DESCRIPTION
It seems to be new in ack 2.x and with 1.96 I get error messages when the ack completions are loaded.
