### PR TITLE
Prevent fish dying if setupterm() fails in builtin_set_color()

### DIFF
--- a/builtin_set_color.cpp
+++ b/builtin_set_color.cpp
@@ -83,6 +83,7 @@ static int builtin_set_color(parser_t &parser, wchar_t **argv)
 
     const wchar_t *bgcolor = NULL;
     bool bold = false, underline=false;
+    int errret;
 
     /* Parse options to obtain the requested operation and the modifiers */
     woptind = 0;
@@ -165,7 +166,7 @@ static int builtin_set_color(parser_t &parser, wchar_t **argv)
     }
 
     /* Make sure that the term exists */
-    if (cur_term == NULL && setupterm(0, STDOUT_FILENO, 0) == ERR)
+    if (cur_term == NULL && setupterm(0, STDOUT_FILENO, &errret) == ERR)
     {
         append_format(stderr_buffer, _(L"%ls: Could not set up terminal\n"), argv[0]);
         return STATUS_BUILTIN_ERROR;


### PR DESCRIPTION
Since set_color was changed to a built-in command, the entire shell will
exit in the event that setupterm() fails for some reason since ncurses
does an exit() if an errret was not passed in.

setupterm() can fail if the TERM environment variable is not set. This can
cause the shell to die prematurely if set_color is called from a startup
file like config.fish (such as vi-mode.fish which caches the results of
set_color when it is loaded) and fish is started without a TERM set
(e.g. when started from .xsession, or when being used as a remote shell
by a command such as rsync, scp or git)

A simple repro case for this issue is:

ian@delenn~ [i]> echo set_color normal > ~/.config/fish/config.fish
ian@delenn~ [i]> scp localhost:test .
TERM environment variable not set.
ian@delenn~ [i]>

This patch passes in an errret variable to setupterm(), which causes
ncurses to return the error to builtin_set_color() rather than calling
exit():

ian@delenn~ [i]> scp localhost:test .
test                                                 100%    0     0.0KB/s   00:00
ian@delenn~ [i]>

Signed-off-by: Ian Munsie darkstarsword@gmail.com
