### PR TITLE
Show first two characters for dotdirs. Fixes #754.

### DIFF
--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -1,10 +1,9 @@
-
 if test (uname) = Darwin
 	function prompt_pwd --description "Print the current working directory, shortend to fit the prompt"
-		echo $PWD | sed -e "s|^$HOME|~|" -e 's|^/private||' -e 's-\(\.\?[^/.]\)[^/]*/-\1/-g'
+		echo $PWD | sed -e "s|^$HOME|~|" -e 's|^/private||' -e 's-\([^/.]\)[^/]*/-\1/-g'
 	end
 else
 	function prompt_pwd --description "Print the current working directory, shortend to fit the prompt"
-		echo $PWD | sed -e "s|^$HOME|~|" -e 's-\(\.\?[^/.]\)[^/]*/-\1/-g'
+		echo $PWD | sed -e "s|^$HOME|~|" -e 's-\([^/.]\)[^/]*/-\1/-g'
 	end
 end


### PR DESCRIPTION
I sort of agree with @dag (`~/.` was never helpful), and decided to make a small patch for it.
