### PR TITLE
$LINES always equal to $COLUMNS

### DIFF
--- a/env.cpp
+++ b/env.cpp
@@ -1076,7 +1076,7 @@ env_var_t env_get_string(const wcstring &key)
     }
     else if (key == L"LINES")
     {
-        return to_string(common_get_width());
+        return to_string(common_get_height());
     }
     else if (key == L"status")
     {


### PR DESCRIPTION
![lines](https://f.cloud.github.com/assets/319/496644/d5e153be-bbe6-11e2-8c07-8560a2be0551.png)

`$COLUMNS` is right, `$LINES` is not.  If I resize the terminal, they both update to the correct value for `$COLUMNS`.

![columns](https://f.cloud.github.com/assets/319/496658/41885310-bbe7-11e2-81d4-e634a5f6d3f3.png)
