### PR TITLE
Rsync Remote Path Completion

### DIFF
--- a/share/completions/rsync.fish
+++ b/share/completions/rsync.fish
@@ -104,3 +104,17 @@ complete -c rsync -s 6 -l ipv6 --description "Prefer IPv6"
 complete -c rsync -l version --description "Display version and exit"
 complete -c rsync -l help --description "Display help and exit"
 
+#
+# Remote path
+#
+complete -c rsync -d "Remote Path" -n "commandline -ct|sgrep -o '.*:'" -a "
+
+(
+	#Prepend any user@host information supplied before the remote completion
+	commandline -ct|sgrep -o '.*:'
+)(
+	#Get the list of remote files from the specified ssh server
+        ssh -o \"BatchMode yes\" (commandline -ct|sed -ne 's/\(.*\):.*/\1/p') ls\ -dp\ (commandline -ct|sed -ne 's/.*://p')\* 2> /dev/null
+)
+
+"

--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -17,7 +17,7 @@ complete -c scp -d Hostname -a "
 
 (
 	#Prepend any username specified in the completion to the hostname
-	echo (commandline -ct)|sed -ne 's/\(.*@\).*/\1/p'
+	commandline -ct |sed -ne 's/\(.*@\).*/\1/p'
 )(
 	cat ~/.ssh/known_hosts{,2} ^/dev/null|cut -d ' ' -f 1| cut -d , -f 1
 ):
@@ -29,14 +29,14 @@ complete -c scp -d Hostname -a "
 #
 # Remote path
 #
-complete -c scp -d "Remote Path" -n "echo (commandline -ct)|sgrep -o '.*:';and true" -a "
+complete -c scp -d "Remote Path" -n "commandline -ct|sgrep -o '.*:'" -a "
 
 (
 	#Prepend any user@host information supplied before the remote completion
-	echo (commandline -ct)|sgrep -o '.*:'
+	commandline -ct|sgrep -o '.*:'
 )(
 	#Get the list of remote files from the specified ssh server
-        ssh -o \"BatchMode yes\" (echo (commandline -ct)|sed -ne 's/\(.*\):.*/\1/p') ls\ -dp\ (echo (commandline -ct)|sed -ne 's/.*://p')\*
+        ssh -o \"BatchMode yes\" (commandline -ct|sed -ne 's/\(.*\):.*/\1/p') ls\ -dp\ (commandline -ct|sed -ne 's/.*://p')\* 2> /dev/null
 )
 
 "


### PR DESCRIPTION
Relevant section lifted from scp.fish to add path completion for rsync.

As an added bonus, scp.fish and rsync.fish now squash stderror to eat ssh banners etc
