### PR TITLE
Fix wchar_t cast

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -386,7 +386,7 @@ void input_destroy()
 static wint_t input_exec_binding(const input_mapping_t &m, const wcstring &seq)
 {
     wchar_t code = input_function_get_code(m.command);
-    if (code != -1)
+    if (code != (wchar_t)-1)
     {
         switch (code)
         {


### PR DESCRIPTION
(First noted in http://www.mail-archive.com/fish-users@lists.sourceforge.net/msg01751.html)

Fix a wchar_t cast; grep'd the source for more -- and found that builtin_commandline.cpp has been previously fixed.

The grep expression was rather crude: grep -B2 -- -1 _.[ch]_ | grep -e wchar -e ==
