### PR TITLE
git prompt improvements (indent, staged, comment)

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -346,7 +346,7 @@ function __fish_git_prompt_current_branch --description "__fish_git_prompt helpe
 		set branch "($branch)"
 	end
 
-	# I honestly don't know when this is relevant
+	# Let user know they're inside the git dir of a non-bare repo
 	if test "true" = (git rev-parse --is-inside-git-dir ^/dev/null)
 		if test "false" = (git rev-parse --is-bare-repository ^/dev/null)
 			set branch "GIT_DIR!"


### PR DESCRIPTION
Started these commits because I noticed it wasn't displaying the staged token even with __fish_git_prompt_showdirtystate set.  Turns out the relevant function wasn't actually outputting the token after figuring out what it should be.

Re-indent patches are annoying, but several nested if statements weren't lined up properly and it used two different kinds of indenting.  I couldn't follow it as is, so I fixed it.

Finally, I replaced a short "what is this" style comment with a short explanation and gave a longer one in the commit.
