### PR TITLE
git prompt: Fix hang on detached head.

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -209,7 +209,7 @@ function __fish_git_prompt --description "Prompt function for Git"
 	test -n "$git_dir"; or return
 
 	set -l r (__fish_git_prompt_current_operation $git_dir)
-	set -l b (__fish_git_prompt_current_branch)
+	set -l b (__fish_git_prompt_current_branch $git_dir)
 	set -l w #dirty working directory
 	set -l i #staged changes
 	set -l s #stashes
@@ -322,6 +322,7 @@ function __fish_git_prompt_current_branch_bare --description "__fish_git_prompt 
 end
 
 function __fish_git_prompt_current_branch --description "__fish_git_prompt helper, returns the current Git branch"
+	set -l git_dir $argv[1]
 	set -l branch
 
 	set -l os


### PR DESCRIPTION
$git_dir was never set in __fish_git_prompt_current_branch, but used
in the case of a detached HEAD.  This caused `cut -c1-7 $git_dir/HEAD`
to expand to `cut -c1-7` which then waited for input.

[Side note:  I find $unset_far/foo expanding to '' instead of '/foo' unexpected]
