### PR TITLE
Determine version using git when possible, fixes #890.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 #
 
 # Get version from git, 2.0.0 otherwise
-AC_INIT(fish, m4_esyscmd([git describe --dirty 2> /dev/null | awk '
+AC_INIT(fish, m4_esyscmd([git describe --tags --dirty 2> /dev/null | awk '
   { printf "%s", $0 ? $0 : "2.0.0" }
 ']), fish-users@lists.sf.net)
 


### PR DESCRIPTION
This should end people claiming to use 2.0.0, when they use version from git. If person aren't configuring fish from git, default 2.0.0 appears, just because nothing better could be done. The example version would be `2.0.0-61-g07b7a65`, which is rather obviously `2.0.0`, revision `61`, commit 07b7a65.

This pull request fixes #890, that I haven't noticed, but @Zanchey linked to the issue made a hour ago (coincidence, I guess).
