### PR TITLE
Use \x1B instead of \e.

### DIFF
--- a/builtin.cpp
+++ b/builtin.cpp
@@ -1658,7 +1658,7 @@ static int builtin_echo(parser_t &parser, wchar_t **argv)
                         wc = L'\b';
                         break;
                     case L'e':
-                        wc = L'\e';
+                        wc = L'\x1B';
                         break;
                     case L'f':
                         wc = L'\f';


### PR DESCRIPTION
Currently, `builtin.cpp` seems to use `\e`. However, `\e` is not valid C (but gcc seems to allow it).
