### PR TITLE
Git prompt tweaks

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -155,8 +155,7 @@
 #
 # The separator before the upstream information can be customized via
 # __fish_git_prompt_char_upstream_prefix.  It is colored like the rest of
-# the upstream information.  It normallly defaults to a space ( ) and defaults
-# to nothing () when __fish_git_prompt_show_informative_status is set.
+# the upstream information.  It defaults to nothing ().
 #
 #
 # Turning on __fish_git_prompt_showcolorhints changes the colors as follows to
@@ -636,7 +635,7 @@ function __fish_git_prompt_validate_chars --description "__fish_git_prompt helpe
 	__fish_git_prompt_set_char __fish_git_prompt_char_upstream_behind   '<' '↓'
 	__fish_git_prompt_set_char __fish_git_prompt_char_upstream_diverged '<>'
 	__fish_git_prompt_set_char __fish_git_prompt_char_upstream_equal    '='
-	__fish_git_prompt_set_char __fish_git_prompt_char_upstream_prefix   ' '
+	__fish_git_prompt_set_char __fish_git_prompt_char_upstream_prefix   ''
 
 end
 


### PR DESCRIPTION
Fix a bad test when `bash.showUntrackedFiles` isn't set.

Default `__fish_git_prompt_char_upstream_prefix` to nothing instead of a space. The bash `__git_ps1` doesn't even have an upstream prefix option, and I don't know why one was added to our `__fish_git_prompt`, but it certainly shouldn't default to a space.
