### PR TITLE
Changed sorting if the user hit tab only once, or we had no visible completion list

### DIFF
--- a/reader.cpp
+++ b/reader.cpp
@@ -1672,7 +1672,7 @@ static void prioritize_completions(std::vector<completion_t> &comp)
     }
 
     /* Sort the remainder */
-    sort(comp.begin(), comp.end(), compare_completions_by_match_type);
+    sort(comp.begin(), comp.end(), compare_completions_by_alphabet);
 }
 
 /* Given a list of completions, get the completion at an index past *inout_idx, and then increment it. inout_idx should be initialized to (size_t)(-1) for the first call. */
@@ -3963,4 +3963,10 @@ int reader_read(int fd, const io_chain_t &io)
 
     proc_pop_interactive();
     return res;
+}
+
+/* Compares two completions, ordering completions by alphabet */
+bool compare_completions_by_alphabet(const completion_t &a, const completion_t &b)
+{
+    return wcsfilecmp(a.completion.c_str(), b.completion.c_str()) < 0;
 }

--- a/reader.h
+++ b/reader.h
@@ -253,5 +253,6 @@ bool reader_expand_abbreviation_in_command(const wcstring &cmdline, size_t curso
 /* Apply a completion string. Exposed for testing only. */
 wcstring completion_apply_to_command_line(const wcstring &val_str, complete_flags_t flags, const wcstring &command_line, size_t *inout_cursor_pos, bool append_only);
 
-
+/* Compares two completions, ordering completions by alphabet */
+bool compare_completions_by_alphabet(const completion_t &a, const completion_t &b);
 #endif


### PR DESCRIPTION
From by match type to by alphabet.

Why? Because in match type sorting we compare by match type, then by fuzzy match

(see common.cpp line 1863)

I assume we should always return completions in alphabetically sorted order in this case (please correct me if I'm wrong).

This should close the bug #923.

Please, review my commits, I could miss something since it's my first contribution to fish.

All comments are welcome.)
