### PR TITLE
fixed fish-shell/fish-shell#944

### DIFF
--- a/reader.cpp
+++ b/reader.cpp
@@ -1648,25 +1648,35 @@ bool compare_completions_by_match_type(const completion_t &a, const completion_t
     return wcsfilecmp(a.completion.c_str(), b.completion.c_str()) < 0;
 }
 
-/* Order completions such that case insensitive completions come first. */
-static void prioritize_completions(std::vector<completion_t> &comp)
+/* Determine the best match type */
+fuzzy_match_type_t get_best_match_type(const std::vector<completion_t> &comp)
 {
-    /* Determine the best match type */
-    size_t i;
     fuzzy_match_type_t best_type = fuzzy_match_none;
-    for (i=0; i < comp.size(); i++)
+    for (size_t i=0; i < comp.size(); i++)
     {
         const completion_t &el = comp.at(i);
         if (el.match.type < best_type)
+        {
             best_type = el.match.type;
+        }
     }
+    /* For case exact match as best type, make it to lower level as prefix match,
+       because completions with prefix match cannot stay otherwise while they are
+       also candidates of the input along with completion with exact match. */
     if (best_type == fuzzy_match_exact)
     {
         best_type = fuzzy_match_prefix;
     }
+    return best_type;
+}
 
-    /* Throw out completions whose match types are not the best. */
-    i = comp.size();
+/* Order completions such that case insensitive completions come first. */
+static void prioritize_completions(std::vector<completion_t> &comp)
+{
+    fuzzy_match_type_t best_type = get_best_match_type(comp);
+
+    /* Throw out completions whose match types are less suitable than the best. */
+    size_t i = comp.size();
     while (i--)
     {
         if (comp.at(i).match.type > best_type)
@@ -1784,21 +1794,7 @@ static bool handle_completions(const std::vector<completion_t> &comp)
 
     if (!done)
     {
-
-        /* Determine the type of the best match(es) */
-        fuzzy_match_type_t best_match_type = fuzzy_match_none;
-        for (size_t i=0; i < comp.size(); i++)
-        {
-            const completion_t &el = comp.at(i);
-            if (el.match.type < best_match_type)
-            {
-                best_match_type = el.match.type;
-            }
-        }
-        if (best_match_type == fuzzy_match_exact)
-        {
-            best_match_type = fuzzy_match_prefix;
-        }
+        fuzzy_match_type_t best_match_type = get_best_match_type(comp);
 
         /* Determine whether we are going to replace the token or not. If any commands of the best type do not require replacement, then ignore all those that want to use replacement */
         bool will_replace_token = true;
@@ -1817,7 +1813,7 @@ static bool handle_completions(const std::vector<completion_t> &comp)
         for (size_t i=0; i < comp.size(); i++)
         {
             const completion_t &el = comp.at(i);
-            /* Only use completions with the best match type */
+            /* Ignore completions with less suitable match type than the best. */
             if (el.match.type > best_match_type)
                 continue;
 


### PR DESCRIPTION
When the completion list includes the exact typed string with other
candidates, i.e. completion_t.match.type == fuzzy_match_exact,
the other candidates will be removed from the list, as they are not
the "best type". This is inconvenient for the user who wants to
type and complete commands in the other candidates.

The commit is to make the best_type to fuzzy_match_prefix as highest
priority, also, when comparing to best_type, the same or higher
priority completions can both match.
