### PR TITLE
fix the completion problem of `man` under OS X

### DIFF
--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -23,7 +23,7 @@ function __fish_complete_man
 		# Do the actual search
 		switch (uname)
 		case Darwin
-			apropos (commandline -ct) ^/dev/null | sgrep \^(commandline -ct) | awk -F " - " '
+			apropos (commandline -ct) ^/dev/null | awk -F " - " '
 {
 	split($1, a, ", ");
 	for (i in a) {


### PR DESCRIPTION
The problem is `apropos` under OS X behaves differently from Linux.
1. The format: for command `apropos sudo`, the output under Linux:

```
sudo (8)             - execute a command as another user
```

and the output under OS X:

```
sudo(8)                  - execute a command as another user
```

one-space difference.
1. For some items sharing a same manpage, e.g. for `apropos printf`,

Linux:

```
printf (3)           - formatted output conversion
snprintf (3)         - formatted output conversion
sprintf (3)          - formatted output conversion
vprintf (3)          - formatted output conversion
vsnprintf (3)        - formatted output conversion
vsprintf (3)         - formatted output conversion
```

OS X:

```
printf(3), fprintf(3), sprintf(3), snprintf(3), asprintf(3), dprintf(3), vprintf(3), vfprintf(3), vsprintf(3), vsnprintf(3), vasprintf(3), vdprintf(3) - formatted output conversion
```

OS X puts them in one line.

So, we need special handling here, otherwise, completion with prefix
`man 3 printf` will give the result of "man 3 printf(3),"
