### PR TITLE
Remove grep warning from make target completion

### DIFF
--- a/share/functions/__fish_print_make_targets.fish
+++ b/share/functions/__fish_print_make_targets.fish
@@ -3,6 +3,6 @@ function __fish_print_make_targets
 	# Some seds (e.g. on Mac OS X), don't support \n in the RHS
 	# Use a literal newline instead
 	# http://sed.sourceforge.net/sedfaq4.html#s4.1
-	sgrep -h -E '^[^#%=$[:space:]][^#%=$]*:([^=]|$)' $files | cut -d ":" -f 1 | sed -e 's/^ *//;s/ *$//;s/  */\\
+	sgrep -h -E '^[^#%=$[:space:]][^#%=$]*:([^=]|$)' $files ^/dev/null | cut -d ":" -f 1 | sed -e 's/^ *//;s/ *$//;s/  */\\
 /g' ^/dev/null
 end


### PR DESCRIPTION
grep was throwing warnings when no Makefile was found
