### PR TITLE
Fix "command not found" handler behaviour.

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -222,12 +222,12 @@ function __fish_config_interactive -d "Initializations that should be performed 
 		# First check in /usr/lib, this is where modern Ubuntus place this command
 		if test -f /usr/lib/command-not-found
 			function fish_command_not_found_handler --on-event fish_command_not_found
-				/usr/lib/command-not-found $argv
+				/usr/lib/command-not-found -- $argv
 			end
 		# Ubuntu Feisty places this command in the regular path instead
 		else if type -p command-not-found > /dev/null 2> /dev/null
 			function fish_command_not_found_handler --on-event fish_command_not_found
-				command-not-found $argv
+				command-not-found -- $argv
 			end
 		# Use standard fish command not found handler otherwise
 		else


### PR DESCRIPTION
I noticed that typing "--help" on the prompt returns the help message of the command-not-found program instead of the expected message "--help: command not found" (it also works with the other available flags, like --version). This happens because "fish_command_not_found_handler" calls "/usr/lib/command-not-found $argv", so that if $argv contains a valid flag like "--help", it's interpreted as an option by the program. Adding a double hypen before $argv prevents the program to evaluate the following arguments as options and passes them literally. (This is the way the command-not-found handle is set in bash and zsh)
