### PR TITLE
Don't cycle through full completion list if $fish_complete_list == 0

### DIFF
--- a/reader.cpp
+++ b/reader.cpp
@@ -3184,6 +3184,11 @@ const wchar_t *reader_readline(void)
 
                 if (! comp_empty && last_char == R_COMPLETE)
                 {
+                    // if `fish_complete_list is explicitly disabled, don't cycle through the completion list
+                    const env_var_t ENV_ZERO(L"0");
+                    if (env_get_string(L"fish_complete_list") == ENV_ZERO)
+                        break;
+
                     /* The user typed R_COMPLETE more than once in a row. Cycle through our available completions */
                     const completion_t *next_comp = cycle_competions(comp, cycle_command_line, &completion_cycle_idx);
                     if (next_comp != NULL)


### PR DESCRIPTION
I have a habit of pressing `tab` more than once when completing files. I know this is irrational, the reasons are probably some combination of idle habit, impatience, slight OCD, and distrust that the first tab was recognised. I doubt I'm alone, but I don't have any data to back that up.

Anyway, I would love to be able to disable the "start completing full ambiguous matches from the completion list" on tab presses past the first. I have never intentionally triggered this behaviour, but because of the above I do it accidentally quite often. When that happens, I have to remember what I had written and manually backspace the additional stuff fish inserted, since there's no way to undo one of these completions cleanly. I thought I'd grow out of the habit with usage, but I've been using fish full-time for months now, and it still gets me regularly.

This patch disables the full (ambiguous) completion behaviour if `$fish_complete_list` is set to `"0"`