### PR TITLE
Add newline before listing current token.

### DIFF
--- a/share/functions/__fish_list_current_token.fish
+++ b/share/functions/__fish_list_current_token.fish
@@ -6,6 +6,7 @@
 
 function __fish_list_current_token -d "List contents of token under the cursor if it is a directory, otherwise list the contents of the current directory"
 	set val (eval echo (commandline -t))
+	printf "\n"
 	if test -d $val
 		ls $val
 	else


### PR DESCRIPTION
Hi, I hope not to be annoying since I already submitted another slightly useless pull request some minutes ago, but I noticed that when __fish_list_current_token is called (with alt-l keybinding), the ls command starts to print immediately after the prompt, and this is a bit ugly.
