### PR TITLE
Improve dangerous/undefined PID expansion behavior

### DIFF
--- a/expand.cpp
+++ b/expand.cpp
@@ -585,7 +585,30 @@ static int find_process(const wchar_t *proc,
         ASSERT_IS_MAIN_THREAD();
         const job_t *j;
 
-        if (iswnumeric(proc) || (wcslen(proc)==0))
+        // do the empty param check first, because an empty string passes our 'numeric' check
+        if (wcslen(proc)==0)
+        {
+            /*
+              This is an empty job expansion: '%'
+              It expands to the last job backgrounded.
+            */
+            job_iterator_t jobs;
+            while ((j = jobs.next()))
+            {
+                if (!j->command_is_empty())
+                {
+                    append_completion(out, to_string<long>(j->pgid));
+                    break;
+                }
+            }
+            /*
+              You don't *really* want to flip a coin between killing
+              the last process backgrounded and all processes, do you?
+              Let's not try other match methods with the solo '%' syntax.
+            */
+            found = 1;
+        }
+        else if (iswnumeric(proc))
         {
             /*
               This is a numeric job string, like '%2'
@@ -611,11 +634,9 @@ static int find_process(const wchar_t *proc,
                                           0);
                     }
                 }
-
             }
             else
             {
-
                 int jid;
                 wchar_t *end;
 
@@ -624,15 +645,17 @@ static int find_process(const wchar_t *proc,
                 if (jid > 0 && !errno && !*end)
                 {
                     j = job_get(jid);
-                    if ((j != 0) && (j->command_wcstr() != 0))
+                    if ((j != 0) && (j->command_wcstr() != 0) && (!j->command_is_empty()))
                     {
-                        {
-                            append_completion(out, to_string<long>(j->pgid));
-                            found = 1;
-                        }
+                        append_completion(out, to_string<long>(j->pgid));
                     }
                 }
             }
+            /*
+               Stop here so you can't match a random process name
+               when you're just trying to use job control.
+            */
+            found = 1;
         }
         if (found)
             return 1;


### PR DESCRIPTION
_Backstory_

In Bash, % means something like 'last job backgrounded'. In upstream Fish, it means either "all backgrounded jobs" or "all processes owned by your user" if there are no processes backgrounded.

I usually run `kill -9 %` in Fish if I actually wanted to hard kill the last job backgrounded (useful if it wasn't responding). This actually matched for _all_ jobs backgrounded, but I never noticed until today.

Even further, it turns out `kill -9 %` in Fish kills _all processes owned by your user_ if you ever accidentally run it without backgrounding something first.

Go ahead, `echo %` to get a feel for how it works right now.

---

_Change 1_

Use Bash-like expansion for empty searches (when you just use a '%' by
itself).

'%' will now _only_ match the last valid backgrounded process.
If there are no such processes, an expansion error will be generated.

'%' by itself would previously match either _all_ backgrounded
processes, or failing that, all processes owned by your user. If you
ever tried to run `kill -9 %`, it would either kill all backgrounded
processes or _all_ of your processes. I'm not sure why anyone would ever
want that to be a single keystroke away. You could almost typo it.

As a result of this change, `fg %`, `bg %`, `kill %`, etc will all now operate
on the last process touched by job control (or throw an expansion error).

---

_Change 2_

Don't run 'by-name' matches when the search term is numeric.

This prevents you from running a command like `kill %1` and accidentally
killing a process named something like "1Command". Overloaded behavior
can be dangerous, and we probably shouldn't play fast and loose with
expansion characters that generate process IDs.
