### PR TITLE
Autotools fixes for darwin, clang.

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -1213,11 +1213,16 @@ EOF
 	echo ${UNAME_MACHINE}-apple-rhapsody${UNAME_RELEASE}
 	exit ;;
     *:Darwin:*:*)
-	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
-	case $UNAME_PROCESSOR in
-	    unknown) UNAME_PROCESSOR=powerpc ;;
-	esac
-	echo ${UNAME_PROCESSOR}-apple-darwin${UNAME_RELEASE}
+  if [ $(uname -p) = i386 ]; then
+    eval $set_cc_for_build
+    if (echo '#ifdef __LP64__'; echo 64BIT; echo '#endif') | (CCOPTS= \
+      $CC_FOR_BUILD $CPPFLAGS $CFLAGS -E - 2>/dev/null) | grep 64BIT >/dev/null
+    then UNAME_PROCESSOR="x86_64"
+    else UNAME_PROCESSOR="i686"
+    fi
+  else UNAME_PROCESSOR=${UNAME_MACHINE}
+  fi
+  echo ${UNAME_PROCESSOR}-apple-darwin${UNAME_RELEASE} | sed -e 's/\..*//'
 	exit ;;
     *:procnto*:*:* | *:QNX:[0123456789]*:*)
 	UNAME_PROCESSOR=`uname -p`

--- a/configure.ac
+++ b/configure.ac
@@ -606,7 +606,7 @@ AC_CHECK_HEADER(
 # conditional definition of __EXTENSIONS__, to avoid redundant tests.
 #
 
-XCFLAGS="$CXXFLAGS"
+XCFLAGS="-x c++ $CXXFLAGS"
 
 echo checking how to use -D_XOPEN_SOURCE=600 and -D_POSIX_C_SOURCE=200112L...
 local_found_posix_switch=no


### PR DESCRIPTION
Fix config.guess to emit correct canonical triples on Darwin.

Fix configure script where it calls `$CC` with  `$CXXFLAGS` —
This causes errors within the script when building with clang, if `-std=c++11` or other C++ specific-flags are set.
