### PR TITLE
Fix git completions when aliased command is not found.

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -53,7 +53,7 @@ function __fish_git_using_command
     end
 
     # aliased command
-    set -l aliased (command git config --get "alias.$cmd[2]" | sed 's/ .*$//')
+    set -l aliased (command git config --get "alias.$cmd[2]" ^ /dev/null | sed 's/ .*$//')
     if [ $argv[1] = "$aliased" ]
       return 0
     end


### PR DESCRIPTION
The "__fish_git_using_command" function in "share/completions/git.fish" fetches the complete name of an aliased git command through "git config --get". If the alias is not found, git config prints an error string on stderr instead of stdout. Since __fish_git_using_command is called several times, if the alias is not found the terminal is flooded with those error messages. I redirected stderr to /dev/null to fix this.

In order to reproduce the bug, type something like:
git -n<spacebar><tab>

error: invalid key: alias.-n
error: invalid key: alias.-n
(...)
