### PR TITLE
More git_prompt changes

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -672,21 +672,12 @@ function __fish_git_prompt_set_color
 		set default_done "$argv[3]"
 	end
 
-	if test (count $user_variable) -eq 2
-		set user_variable_bright $user_variable[2]
-		set user_variable $user_variable[1]
-	end
-
 	set -l variable _$user_variable_name
 	set -l variable_done "$variable"_done
 
 	if not set -q $variable
 		if test -n "$user_variable"
-			if test -n "$user_variable_bright"
-				set -g $variable (set_color --bold $user_variable)
-			else
-				set -g $variable (set_color $user_variable)
-			end
+			set -g $variable (set_color $user_variable)
 			set -g $variable_done (set_color normal)
 		else
 			set -g $variable $default


### PR DESCRIPTION
There are three changes:
1. Grab the "verbose name" feature from git.git
2. Re-add the space character as a default upstream_prefix character but only when showupstream is verbose.  (This matches the original git.git behavior.)
3. Remove the custom handling of the color variables in favor of just passing arguments to set_color.
