### PR TITLE
Link with $CXXFLAGS; disable GCC-specific autoconf check.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2005-2006 Axel Liljencrantz
 #
 # This program is free software; you can redistribute it and/or modify
@@ -742,7 +741,7 @@ uninstall-translations:
 #
 
 fish: $(FISH_OBJS) fish.o
-	$(CXX) $(FISH_OBJS) fish.o $(LDFLAGS_FISH) -o $@
+	$(CXX) $(CXXFLAGS) $(FISH_OBJS) fish.o $(LDFLAGS_FISH) -o $@
 
 
 #
@@ -750,7 +749,7 @@ fish: $(FISH_OBJS) fish.o
 #
 
 fish_pager: $(FISH_PAGER_OBJS)
-	$(CXX) $(FISH_PAGER_OBJS) $(LDFLAGS_FISH_PAGER) -o $@
+	$(CXX) $(CXXFLAGS) $(FISH_PAGER_OBJS) $(LDFLAGS_FISH_PAGER) -o $@
 
 
 #
@@ -758,7 +757,7 @@ fish_pager: $(FISH_PAGER_OBJS)
 #
 
 fishd: $(FISHD_OBJS)
-	$(CXX) $(FISHD_OBJS) $(LDFLAGS_FISHD) -o $@
+	$(CXX) $(CXXFLAGS) $(FISHD_OBJS) $(LDFLAGS_FISHD) -o $@
 
 
 #
@@ -766,7 +765,7 @@ fishd: $(FISHD_OBJS)
 #
 
 fish_tests: $(FISH_TESTS_OBJS)
-	$(CXX) $(FISH_TESTS_OBJS) $(LDFLAGS_FISH) -o $@
+	$(CXX) $(CXXFLAGS) $(FISH_TESTS_OBJS) $(LDFLAGS_FISH) -o $@
 
 
 #
@@ -776,7 +775,7 @@ fish_tests: $(FISH_TESTS_OBJS)
 #
 
 mimedb: $(MIME_OBJS)
-	$(CXX) $(MIME_OBJS) $(LDFLAGS_MIMEDB) -o $@
+	$(CXX) $(CXXFLAGS) $(MIME_OBJS) $(LDFLAGS_MIMEDB) -o $@
 
 
 #
@@ -784,7 +783,7 @@ mimedb: $(MIME_OBJS)
 #
 
 fish_indent: $(FISH_INDENT_OBJS)
-	$(CXX) $(FISH_INDENT_OBJS) $(LDFLAGS_FISH_INDENT) -o $@
+	$(CXX) $(CXXFLAGS) $(FISH_INDENT_OBJS) $(LDFLAGS_FISH_INDENT) -o $@
 
 
 #
@@ -792,7 +791,7 @@ fish_indent: $(FISH_INDENT_OBJS)
 #
 
 key_reader: key_reader.o input_common.o common.o env_universal.o env_universal_common.o wutil.o iothread.o
-	$(CXX) key_reader.o input_common.o common.o env_universal.o env_universal_common.o wutil.o iothread.o $(LDFLAGS_FISH) -o $@
+	$(CXX) $(CXXFLAGS) key_reader.o input_common.o common.o env_universal.o env_universal_common.o wutil.o iothread.o $(LDFLAGS_FISH) -o $@
 
 
 #

--- a/configure.ac
+++ b/configure.ac
@@ -238,56 +238,24 @@ AS_IF([test "$use_doxygen" != "no"],
 
 CXXFLAGS="$CXXFLAGS -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64"
 
+
+# fish does not use exceptions
+# Disabling exceptions saves about 20% (!) of the compiled code size
+CXXFLAGS="$CXXFLAGS -fno-exceptions"
+
+
 #
-# If we are using gcc, set some flags that increase the odds of the
-# compiler producing a working binary...
+# -Wall is there to keep me on my toes
 #
 
-if test "$GCC" = yes; then
+CXXFLAGS="$CXXFLAGS -Wall"
 
-  #
-  # -fno-optimize-sibling-calls seems to work around a bug where
-  # sending a SIGWINCH to fish on NetBSD 3.0 causes fish to exit when
-  # compiled with GCC 3.3.3. This is probably either a compiler bug
-  # or a libc bug, but adding this flag seems to fix things for
-  # now. Long term, the real problem should be tracked down and
-  # truly fixed, at which point we can remove this silly flag. This
-  # bug has been verified to not exist on Linux using GCC 3.3.3.
-  #
+#
+# This is needed in order to get the really cool backtraces on Linux
+#
 
-  GCC_VERSION=$($CC -dumpversion)
-  GCC_VERSION_MAJOR=$(echo $GCC_VERSION | cut -d'.' -f1)
-  GCC_VERSION_MINOR=$(echo $GCC_VERSION | cut -d'.' -f2)
-  GCC_VERSION_PATCH=$(echo $GCC_VERSION | cut -d'.' -f3)
-
-  if test "$GCC_VERSION_MAJOR" -le 3; then
-    if test 0"$GCC_VERSION_MINOR" -le 3; then
-      if test 0"$GCC_VERSION_PATCH" -le 3; then
-        CXXFLAGS="$CXXFLAGS -fno-optimize-sibling-calls"
-      fi
-    fi
-  fi
-
-  # fish does not use exceptions
-  # Disabling exceptions saves about 20% (!) of the compiled code size
-  CXXFLAGS="$CXXFLAGS -fno-exceptions"
-
-
-  #
-  # -Wall is there to keep me on my toes
-  #
-
-  # Some day...
-  CXXFLAGS="$CXXFLAGS -Wall"
-
-  #
-  # This is needed in order to get the really cool backtraces on Linux
-  #
-
-  if test `uname` != "Darwin"; then
-    LDFLAGS_FISH="$LDFLAGS_FISH -rdynamic"
-  fi
-
+if test `uname` != "Darwin"; then
+   LDFLAGS_FISH="$LDFLAGS_FISH -rdynamic"
 fi
 
 


### PR DESCRIPTION
Using CXXFLAGS with LDFLAGS is needed when compiling with `-stdlib=libc++` (necessary if building as C++11 with clang). Otherwise, it will try to link against libstdc++ and fails due to differences in the implementation of some STL functions. `xcodebuild -configuration Release_C++11` already does this.

`if test "$GCC"`... currently prevents `-fno-exceptions` and `-rdynamic` from being used when CXX is not g++. Also, I figured the `-fno-optimize-sibling-calls` bit below probably is no longer necessary. Unless anyone is still building with GCC 3.3.3 on NetBSD 3.0?
