### PR TITLE
Allow reading manpages by using F1.

### DIFF
--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -100,7 +100,7 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 	bind \cd delete-or-exit
 
 	# Allow reading manpages by pressing F1
-	bind -k f1 'man (commandline -po; echo)[1] ^/dev/null; or echo -n \a'
+	bind -k f1 'man (basename (commandline -po; echo))[1] ^/dev/null; or echo -n \a'
 
 	# This will make sure the output of the current command is paged using the less pager when you press Meta-p
 	bind \ep '__fish_paginate'


### PR DESCRIPTION
Just a small fun feature I have implemented in order to ease discovering command prompt. Just like in graphical applications, and some text interface programs (like vim, mc, emacs) it allows you to get help, in this case, help for currently typed command by simply pressing F1. I believe it could be helpful in many cases, for example if you want more detailed documentation than what Tab completion provides.

(also, yes, I added this to my personal bindings, and I like this)
