### PR TITLE
Make type -a print all executables in PATH

### DIFF
--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -116,23 +116,30 @@ function type --description "Print the type of a command"
 			end
 
 		end
-
-		set -l path (which $i ^/dev/null)
-		if test -x (echo $path)
-			set res 0
-			set found 1
-			switch $mode
-				case normal
-					printf (_ '%s is %s\n') $i $path
+		
+		set -l paths
+		if test $selection != multi
+			set paths (which $i ^/dev/null)
+		else
+			set paths (which -a $i ^/dev/null)
+		end
+		for path in $paths
+			if test -x (echo $path)
+				set res 0
+				set found 1
+				switch $mode
+					case normal
+						printf (_ '%s is %s\n') $i $path
 
 					case type
 						echo (_ 'file')
 
 					case path
 						echo $path
-			end
-			if test $selection != multi
-				continue
+				end
+				if test $selection != multi
+					continue
+				end
 			end
 		end
 
@@ -144,4 +151,3 @@ function type --description "Print the type of a command"
 
 	return $res
 end
-


### PR DESCRIPTION
```
> type -a python
python is /opt/local/Library/Frameworks/Python.framework/Versions/2.7/bin/python
python is /opt/local/bin/python
python is /usr/bin/python
Tyilo:~ > type python
python is /opt/local/Library/Frameworks/Python.framework/Versions/2.7/bin/python
```

Fixed #261
