### PR TITLE
Fix broken links in tutorial

### DIFF
--- a/doc_src/tutorial.hdr
+++ b/doc_src/tutorial.hdr
@@ -721,7 +721,7 @@ function fish_prompt
 end
 </pre>
 
-<p>See the documentation for <a href="docs/current/commands.html#funced">funced</a> and <a href="docs/current/commands.html#funcsave">funcsave</a> for ways to create these files automatically.
+<p>See the documentation for <a href="commands.html#funced">funced</a> and <a href="commands.html#funcsave">funcsave</a> for ways to create these files automatically.
 
 <h3>Universal Variables</h2>
 
@@ -740,7 +740,7 @@ vim
 
 <h3>Ready for more?</h2>
 
-<p>If you want to learn more about fish, there is <a href="docs/current/">lots of detailed documentation</a>, an <a href="https://lists.sourceforge.net/lists/listinfo/fish-users">official mailing list</a>, the IRC channel <tt>#fish</tt> on <tt>irc.oftc.net</tt>, and the <a href="http://github.com/fish-shell/fish-shell/">github page</a>.
+<p>If you want to learn more about fish, there is <a href="index.html">lots of detailed documentation</a>, an <a href="https://lists.sourceforge.net/lists/listinfo/fish-users">official mailing list</a>, the IRC channel <tt>#fish</tt> on <tt>irc.oftc.net</tt>, and the <a href="http://github.com/fish-shell/fish-shell/">github page</a>.
 
 </div>
  \endhtmlonly


### PR DESCRIPTION
There were 3 broken links at the end of the tutorial, just below the [Startup](http://fishshell.com/docs/current/tutorial.html#tut_startup) section.

These links erroneously go to http://fishshell.com/docs/current/docs/current/.
