### PR TITLE
Prefer the standard library lzma module if available

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -23,9 +23,9 @@ from deroff import Deroffer
 lzma_available = True
 try:
     try:
-        import backports.lzma as lzma
-    except ImportError:
         import lzma
+    except ImportError:
+        from backports import lzma
 except ImportError:
     lzma_available = False
 


### PR DESCRIPTION
Prefer the standard library lzma module if available.  This change prevents using the backports-lzma when it is installed for a version of Python that already has the lzma module in its standard library.

When I worked on pull request #1015, I remember the [backports-lzma PyPI entry](https://pypi.python.org/pypi/backports.lzma/) explicitly listing support for Python <=3.2, but apparently it also officially supports newer versions of Python, which of course already have the `lzma` module in their standard library. Therefor, it is probably better to prefer the standard library version of the module, as per [backports-lzma usage](https://github.com/peterjc/backports.lzma#usage).

Sorry for missing this in pull request #1015!
