### PR TITLE
Autogenerate manpage completions in background if they do not exist

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -137,8 +137,11 @@ function __fish_config_interactive -d "Initializations that should be performed 
 
 	end
 
+    #
+    # Generate man page completions if not present
+    #
+
     if not test -d $configdir/fish/generated_completions
-        echo "Man page completions not found on your system. Running 'fish_update_completions' in background. You can continue to use fish while the process is being done."
         #fish_update_completions is a function, so it can not be directly run in background.
         fish -c 'fish_update_completions > /dev/null ^/dev/null' &
     end


### PR DESCRIPTION
Autogenerate manpage completions on interactive startup when generated completions directory does not exist.
