### PR TITLE
Implement not bound checked ranges $var[..n] and $var[n..]

### DIFF
--- a/builtin_set.cpp
+++ b/builtin_set.cpp
@@ -262,8 +262,11 @@ static int parse_index(std::vector<long> &indexes,
             {
                 l_ind2 = var_count+l_ind2+1;
             }
-            int direction = l_ind2<l_ind ? -1 : 1 ;
-            for (long jjj = l_ind; jjj*direction <= l_ind2*direction; jjj+=direction)
+            if (l_ind2<l_ind)
+            {
+                return 1;
+            }
+            for (long jjj = l_ind; jjj <= l_ind2; jjj+=1)
             {
                 // debug(0, L"Expand range [set]: %i\n", jjj);
                 indexes.push_back(jjj);

--- a/doc_src/tutorial.hdr
+++ b/doc_src/tutorial.hdr
@@ -490,8 +490,8 @@ You can also access ranges of elements, known as "slices:"
 <pre>
 > <b>echo</b> <i>$PATH[1..2]</i>
 /usr/bin /bin
-> <b>echo</b> <i>$PATH[-1..2]</i>
-/usr/local/bin /sbin /usr/sbin /bin
+> <b>echo</b> <i>$PATH[-2..-1]</i>
+/sbin /usr/local/bin
 </pre>
 
 You can iterate over a list (or a slice) with a <i>for loop</i>:

--- a/tests/test8.err
+++ b/tests/test8.err
@@ -1,0 +1,3 @@
+fish: Could not expand string “$test[..-11]”
+/data/programs/fish-shell/tests/test8.in (line 32): count $test[..-11]
+                                                          ^

--- a/tests/test8.in
+++ b/tests/test8.in
@@ -4,22 +4,30 @@ echo Test variable expand
 set n 10
 set test (seq $n)
 echo $test[1..$n]      # normal range
-echo $test[$n..1]      # inverted range
-echo $test[2..5 8..6]  # several ranges
-echo $test[-1..-2]     # range with negative limits
-echo $test[-1..1]      # range with mixed limits
+echo $test[2..5 6..8]  # several ranges
+echo $test[-2..-1]     # range with negative limits
+echo $test[1..-1]      # range with mixed limits
 
 echo Test variable set
 set test1 $test
-set test1[-1..1] $test; echo $test1
 set test1[1..$n] $test; echo $test1
-set test1[$n..1] $test; echo $test1
-set test1[2..4 -2..-4] $test1[4..2 -4..-2]; echo $test1
 
 echo Test command substitution
-echo (seq 5)[-1..1]
-echo (seq $n)[3..5 -2..2]
+echo (seq 5)[1..-1]
+echo (seq $n)[3..5 2..-2]
 
 echo Test more
-echo $test[(count $test)..1]
 echo $test[1..(count $test)]
+
+echo Test unbounded ranges
+echo $test[..5] , $test[6..]
+echo $test[..-5] , $test[-4..]
+
+echo Test unbounded ranges '(out)'
+echo $test[..-11] , $test[-10..]    # empty, full
+echo $test[..11] , $test[12..]      # full, empty
+
+echo Test strange things:
+echo $test[0..] 
+echo $test[..0]
+echo $test[..]

--- a/tests/test8.out
+++ b/tests/test8.out
@@ -1,17 +1,22 @@
 Test variable expand
 1 2 3 4 5 6 7 8 9 10
-10 9 8 7 6 5 4 3 2 1
-2 3 4 5 8 7 6
-10 9
-10 9 8 7 6 5 4 3 2 1
-Test variable set
-10 9 8 7 6 5 4 3 2 1
+2 3 4 5 6 7 8
+9 10
 1 2 3 4 5 6 7 8 9 10
-10 9 8 7 6 5 4 3 2 1
-10 7 8 9 6 5 2 3 4 1
+Test variable set
+1 2 3 4 5 6 7 8 9 10
 Test command substitution
-5 4 3 2 1
-3 4 5 9 8 7 6 5 4 3 2
+1 2 3 4 5
+3 4 5 2 3 4 5 6 7 8 9
 Test more
-10 9 8 7 6 5 4 3 2 1
+1 2 3 4 5 6 7 8 9 10
+Test unbounded ranges
+1 2 3 4 5 , 6 7 8 9 10
+1 2 3 4 5 6 , 7 8 9 10
+Test unbounded ranges (out)
+, 1 2 3 4 5 6 7 8 9 10
+1 2 3 4 5 6 7 8 9 10 ,
+Test strange things:
+1 2 3 4 5 6 7 8 9 10
+
 1 2 3 4 5 6 7 8 9 10


### PR DESCRIPTION
This pull request is a demonstrator of a functionality requested by @GlitchMr in #826.

It implements a possibility to call slicing without bound checking. It is done by passing single bound ranges:
1) n..
2) ..n
3) As a consequence $var[..] is expanded as $var.

Currently only positive indexes are supported.

The usage is the following:
```sh
function atest
    echo Two first: $argv[..2] , others: $argv[3..]
end
for i in ( seq 1 5 )
    atest (seq $i)
end
```

Adding this functionality produces several questions which I do not know what to answer currently:
1) Is more reach functionality needed? I mean being safe to call any range inside a variable? Any index?
2) How to treat the direction? Currently the direction is determined based on left/right difference. In case of not checked bounds it will lead to the situation when $var[4..-4] will be expanded promptly or reversely depending on the var size. The possible option is to allow only  positive direction and return empty list this case of out-of-bounds error.
3) It is possible to add modifiers to the slicing. For example: $var[3] and $var[--silent 3]: first one should issue error if the length of the variable is less than 3, another one should not. Does anybody need such a functionality? Any other syntax solutions?

Thank you for the feedback.
