### PR TITLE
Fixes misleading "connect: Connection failed" message on start up

### DIFF
--- a/env_universal.cpp
+++ b/env_universal.cpp
@@ -132,7 +132,12 @@ static int try_get_socket_once(void)
     if (connect(s, (struct sockaddr *)&local, sizeof local) == -1)
     {
         close(s);
-        wperror(L"connect");
+        
+        /* If it fails on first try, it's probably no serious error, but fishd hasn't been launched yet.
+         This happens (at least) on the first concurrent session. */
+        if (get_socket_count > 1)
+            wperror(L"connect");
+        
         return -1;
     }
 


### PR DESCRIPTION
When launching the first instance of fish and fishd is not launched already, this should not be considered an error as long as it can be launched. So ignore the first failure of connect(), as the calling function get_socket() will try again. May need a bit of cleanup.
