### PR TITLE
On short prompts, commands wider than the terminal do not reposition to start on their own line

### DIFF
--- a/screen.cpp
+++ b/screen.cpp
@@ -537,10 +537,6 @@ static void s_desired_append_char(screen_t *s,
                 s->desired.add_line();
                 s->desired.cursor.y++;
                 s->desired.cursor.x=0;
-                for (size_t i=0; i < prompt_width; i++)
-                {
-                    s_desired_append_char(s, L' ', 0, indent, prompt_width);
-                }
             }
 
             line_t &line = s->desired.line(line_no);


### PR DESCRIPTION
Picks up issue #1121 with a relevant branch name and a bug fix
