### PR TITLE
Add info about branches and stash to robbyrussel fish_prompt

### DIFF
--- a/share/tools/web_config/sample_prompts/robbyrussell.fish
+++ b/share/tools/web_config/sample_prompts/robbyrussell.fish
@@ -8,7 +8,17 @@ function fish_prompt
     function _git_branch_name
       echo (git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
     end
-	
+
+    function _num_branches
+      set -l num (math (git for-each-ref refs/heads | wc -l) - 1)
+      if [ $num != 0 ]; echo " $num"B; else; echo ''; end
+    end
+
+    function _has_stash
+      git rev-parse --verify refs/stash >/dev/null 2>&1
+      if [ $status = 0 ]; echo ' S'; else; echo ''; end
+    end
+
     function _is_git_dirty
       echo (git status -s --ignore-submodules=dirty ^/dev/null)
     end
@@ -25,7 +35,9 @@ function fish_prompt
 
   if [ (_git_branch_name) ]
     set -l git_branch $red(_git_branch_name)
-    set git_info "$blue git:($git_branch$blue)"
+    set -l num_branches $red(_num_branches)
+    set -l has_stash $red(_has_stash)
+    set git_info "$blue git:($git_branch$num_branches$has_stash$blue)"
 
     if [ (_is_git_dirty) ]
       set -l dirty "$yellow ✗"


### PR DESCRIPTION
I always forget whether there are stashed changes or branches I haven't pushed yet. After accidentally blowing away a few important stashed changes, I decided that it would be a good idea to have that info (num of local branches, besides master and a stash flag) in the prompt.

With only the "master" branch and stashed changes it looks the same as before:

```
➜  fish-shell git:(master)
```

Here's how it looks with one local branch, and a stashed change:

```
➜  fish-shell git:(master 1B S)
```

I hope others find it useful.
