### PR TITLE
Math: disable bc multi-line output.

### DIFF
--- a/share/functions/math.fish
+++ b/share/functions/math.fish
@@ -7,7 +7,7 @@ function math --description "Perform math calculations in bc"
 				return 0
 		end
 
-		set -l out (echo $argv|bc)
+		set -l out (echo $argv|env BC_LINE_LENGTH=0 bc)
 		echo $out
 		switch $out
 			case 0


### PR DESCRIPTION
Currently math generates exceptions for large numbers (eg: "2^1288") due to bc wraps it outputs into multiple lines. This disables it.
