### PR TITLE
configure.ac: Add --without-local-prefixes, etc to control /usr/local se...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,7 +113,24 @@ echo "CXXFLAGS: $CXXFLAGS"
 #
 # It also helps FreeBSD which puts libiconv in /usr/local/lib
 
-for i in /usr/pkg /sw /opt /opt/local /usr/local; do
+AC_ARG_WITH(
+  [local-prefixes],
+  AS_HELP_STRING(
+    [--without-local-prefixes],
+    [do not automatically check /usr/local, etc.]
+  ),
+  []
+  [])
+
+AS_IF(
+  [test "x$with_local_prefixes" = "xyes" || test "x$with_local_prefixes" = "x"],
+  [local_prefix_dirs="/usr/pkg /sw /opt /opt/local /usr/local"],
+  [test "x$with_local_prefixes" = "xno"],
+  [local_prefix_dirs=],
+  [local_prefix_dirs="$with_local_prefixes"]
+)
+
+for i in $local_prefix_dirs; do
 
   AC_MSG_CHECKING([for $i/include include directory])
   if test -d $i/include; then


### PR DESCRIPTION
...arch

This doesn't change default behavior, but it allows /usr/local to be turned
off.

Closes #1185.
