### PR TITLE
Non standard cut options

### DIFF
--- a/share/functions/__fish_print_svn_rev.fish
+++ b/share/functions/__fish_print_svn_rev.fish
@@ -1,5 +1,5 @@
 function __fish_print_svn_rev --description 'Print svn revisions'
-	svn info | grep "Last Changed Rev" | cut --delimiter " " --fields 4
+	svn info | grep "Last Changed Rev" | cut -d " " -f 4
 	echo \{\tRevision at start of the date
 	echo HEAD\tLatest in repository
 	echo BASE\tBase rev of item\'s working copy


### PR DESCRIPTION
Some cut versions don't have `--delimiter` or `--fields` but use the standard options `-d` and `-f`
