### PR TITLE
Fix completion bug for special fish characters.

### DIFF
--- a/complete.cpp
+++ b/complete.cpp
@@ -1240,7 +1240,7 @@ void completer_t::complete_from_args(const wcstring &str,
     if (! is_autosuggest)
         proc_pop_interactive();
 
-    this->complete_strings(str, desc.c_str(), 0, possible_comp, flags);
+    this->complete_strings(escape_string(str, ESCAPE_ALL), desc.c_str(), 0, possible_comp, flags);
 }
 
 /**


### PR DESCRIPTION
Issue #1108: If there are special characters like '{' in the
completion suggestions, then we fail to parse it successfully
as we are passing an unescaped version of the character to
parser_t::eval_args(...).

This causes us to retun w/o completion suggestions.

This bug was discovered while implementing 'git stash' completion
as the suggestion contained strings like 'stash@{0}'.

Th fix is to properly escape the string before parsing it.
