### PR TITLE
Enhance/fix `isatty` to actually handle specifed file descriptors.

### DIFF
--- a/share/functions/isatty.fish
+++ b/share/functions/isatty.fish
@@ -1,28 +1,47 @@
 
 function isatty -d "Tests if a file descriptor is a tty"
-	set -l fd 0
-	if count $argv >/dev/null
-		switch $argv[1]
+		switch "$argv"
 
 			case -h --h --he --hel --help
 				__fish_print_help isatty
 				return 0
 
-			case stdin
+			case stdin 0 ''
 				set fd 0
 
-			case stdout
+			case stdout 1
 				set fd 1
 
-			case stderr
+			case stderr 2
 				set fd 2
 
-			case '*'
-				set fd $argv[1]
-
 		end
-	end
 
+  switch "$fd"
+    case 0 1 2
 	eval "tty 0>&$fd >/dev/null"
+       return $status
+  end
 
+ # Everything above this comment shouldn't be necessary with the code below, but
+ # fish's built-in `test` doesn't properly handle the '-c' flag in a pipe here.
+
+ # If you have a POSIX-compliant /bin/test, drop it in here to see the effect.
+
+  if test -z "$argv"
+     test -c /dev/fd/0
+
+  else if test -e "$argv"
+       if test -c "$argv"; eval tty 0>"$argv" >/dev/null; end
+
+  else if test -e /dev/"$argv"
+       if test -c /dev/"$argv"; eval tty 0>/dev/"$argv" >/dev/null; end
+
+  else if test -e /dev/fd/"$argv"
+       if test -c /dev/fd/"$argv"; eval tty 0>/dev/fd/"$argv" >/dev/null; end
+
+  else
+    return 1
+
+  end
 end


### PR DESCRIPTION
Presently, `isatty` only works on a handful of keywords, and uses redirection shorthand (i.e., 0>&2). It is pretty prickly if one doesn't give it an argument that it likes. This change would allow the handling of any normal file path as well, which is how to my intuition at least, a function called _isatty_ should work.

Note that there a bug in fish's built-in `test`, and in order to retain bug-compatible functionality, this is a bit lengthier than it aught to be. See the comments in the commit or issue #1228.
