### PR TITLE
Fixes issue #1234

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -16,10 +16,15 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	# Does not match hostnames with @directives specified
 	sgrep -Eoh '^[^#@|, ]*' ~/.ssh/known_hosts{,2} ^/dev/null
 
+	# Print hosts from system wide ssh configuration file
+	if [ -e /etc/ssh/ssh_config ]
+		# Ignore lines containing wildcards
+		sgrep -Eoi '^ *host[^*]*$' /etc/ssh/ssh_config | cut -d '=' -f 2 | tr ' ' '\n'
+	end
+
 	# Print hosts from ssh configuration file
 	if [ -e ~/.ssh/config ]
 		# Ignore lines containing wildcards
 		sgrep -Eoi '^ *host[^*]*$' ~/.ssh/config | cut -d '=' -f 2 | tr ' ' '\n'
 	end
 end
-


### PR DESCRIPTION
Fish now parses system wide ssh configuration file (`/etc/ssh/ssh_config`) in addition to user config file (`~/.ssh/config`).
