### PR TITLE
Fix __fish_print_packages for rpm

### DIFF
--- a/share/functions/__fish_print_packages.fish
+++ b/share/functions/__fish_print_packages.fish
@@ -67,7 +67,7 @@ function __fish_print_packages
 		end
 
 		# Remove package version information from output and pipe into cache file
-		rpm -qa >$cache_file |sed -e 's/-[^-]*-[^-]*$//' | sed -e 's/$/'\t$package'/' &
+		rpm -qa | sed -e 's/-[^-]*-[^-]*$//' | sed -e 's/$/'\t$package'/' >$cache_file &
 	end
 
 	# This completes the package name from the portage tree.


### PR DESCRIPTION
Small fix, after that rpm packages should be listed properly.
