### PR TITLE
__fish_print_hostnames outputs "host" and "hostname"

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -18,13 +18,11 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 
 	# Print hosts from system wide ssh configuration file
 	if [ -e /etc/ssh/ssh_config ]
-		# Ignore lines containing wildcards
-		sgrep -Eoi '^ *host[^*]*$' /etc/ssh/ssh_config | cut -d '=' -f 2 | tr ' ' '\n'
+		sgrep -Eoi '^ *host[^*]*$' /etc/ssh/ssh_config | cut -d ' ' -f 2 | tr ' ' '\n' | sgrep -v '[\*\?\!]'
 	end
 
 	# Print hosts from ssh configuration file
 	if [ -e ~/.ssh/config ]
-		# Ignore lines containing wildcards
-		sgrep -Eoi '^ *host[^*]*$' ~/.ssh/config | cut -d '=' -f 2 | tr ' ' '\n'
+		sgrep -Eoi '^ *host[^*]*$' ~/.ssh/config | cut -d ' ' -f 2 | tr ' ' '\n' | sgrep -v '[\*\?\!]'
 	end
 end


### PR DESCRIPTION
There's some strange code in `__fish_print_hostnames` that tries to split a line on `=` which, as far as I can tell, isn't supported in `ssh_config(5)`. This has the effect that `__fish_print_hostnames` incorrectly outputs "hostnames" of "host" and "hostname", which means that `fish` thinks these are valid completions for a host.

That is, you get something like:

``` sh
$ ssh ho[tab]
Host  (Hostname)  HostName  (Hostname)  Hostname  (Hostname)  
```

This PR fixes this, and also eliminates any wildcarded "hostnames" that might appear in `/etc/ssh/ssh_config` and `~/.ssh/config`.
