### PR TITLE
Add travis continuous integration support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+before_install:
+  - sudo apt-get update
+install:
+  - sudo apt-get install --no-install-recommends libncurses5-dev gettext doxygen
+script:
+  - autoreconf
+  - ./configure
+  - make
+  - sudo make install
+  - make test
+notifications:
+  irc:
+    channels:
+      - "irc.oftc.net#fish"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[fish](http://fishshell.com/) - the friendly interactive shell
+[fish](http://fishshell.com/) - the friendly interactive shell [![Build Status](https://travis-ci.org/fish-shell/fish-shell.png?branch=travis)](https://travis-ci.org/zanchey/fish-shell)
 ================================================
 
 fish is a smart and user-friendly command line shell for OS X, Linux, and the rest of the family. fish includes features like syntax highlighting, autosuggest-as-you-type, and fancy tab completions that just work, with no configuration required.


### PR DESCRIPTION
This commit adds support for continuous integration on clang and GCC using http://travis-ci.org/ (a free service).

In order to enable this, someone with repository admin permissions (@ridiculousfish, not sure about anyone else) needs to follow steps 1 and 2 from [the getting started guide](http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in); then this commit (which implements step 3) can be merged.

The benefit is that all commits and pull requests are built to make sure they compile and that the unit tests run.
