### PR TITLE
'seq' should return 1, not exit 1, on bad arglist

### DIFF
--- a/share/functions/seq.fish
+++ b/share/functions/seq.fish
@@ -29,14 +29,14 @@ if begin ; not test -x /usr/bin/seq ; and not type -f seq > /dev/null; end
 		
 			case '*'
 				printf (_ "%s: Expected 1, 2 or 3 arguments, got %d\n") seq (count $argv)
-				exit 1
+				return 1
 		
 		end
 		
 		for i in $from $step $to
 			if not echo $i | grep -E '^-?[0-9]*([0-9]*|\.[0-9]+)$' >/dev/null
 				printf (_ "%s: '%s' is not a number\n") seq $i
-				exit 1
+				return 1
 			end
 		end
 		


### PR DESCRIPTION
Try running `seq a`.  Since seq is a fish function, not a program, it calling "exit" causes the entire fish shell to exit.  This is a problem and probably not intended behavior.  This commit fixes it.  (No other fish functions use exit, except delete-or-exit, which is obviously intentional, and tests/test.fish, which I'm not sure about, but which appears to work.)
