### PR TITLE
Improve Mercurial completion.

### DIFF
--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -248,10 +248,11 @@ function __fish_hg_sources
 end
 
 function __fish_hg_mq_enabled
-    set -l val (__fish_hg showconfig extensions.hgext.mq)
+    set -l val (__fish_hg showconfig | grep extensions.hgext.mq)
     if test -z $val
         return 1
     end
+    set -l val (echo $val | cut -d = -f 2)
     switch $val
         case "!*"
             return 1


### PR DESCRIPTION
I've been using my own completion file for Mercurial for a while, and decided to take some time and clean it up and share it with you guys.

One thing that doesn't seem to be behaving properly is path completion.  I was playing with git completion, and I noticed how it only tabbed out one directory at a time.  For my hg completion, it seems that entire file paths show up as a single completion option.  That is, I see:

```
$ hg add <TAB>
something.txt    some/path/to/file.txt
```

But with git I see:

```
$ git add <TAB>
something.txt    some/
```

Any thoughts on what I'm doing wrong?

Also, please let me know what other comments you have.  I'm definitely using this as a chance to learn fish scripting better...

Daniel
