### PR TITLE
Fix, regluarize, and add file comments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.o
 *~
 *.exe
-
+share/doxygen_sqlite3.db
 Makefile
 autom4te.cache/
 build/

--- a/Doxyfile
+++ b/Doxyfile
@@ -176,7 +176,7 @@ ALIASES                =
 # For instance, some of the names that are used will be different. The list
 # of all members will be omitted, etc.
 
-OPTIMIZE_OUTPUT_FOR_C  = YES
+OPTIMIZE_OUTPUT_FOR_C  = NO
 
 # Set the OPTIMIZE_OUTPUT_JAVA tag to YES if your project consists of Java sources
 # only. Doxygen will then generate output that is more tailored for Java.
@@ -422,7 +422,7 @@ INPUT                  =
 # *.c *.cc *.cxx *.cpp *.c++ *.java *.ii *.ixx *.ipp *.i++ *.inl *.h *.hh *.hxx *.hpp
 # *.h++ *.idl *.odl *.cs *.php *.php3 *.inc *.m *.mm
 
-FILE_PATTERNS          =  *.h *.c
+FILE_PATTERNS          =  *.h *.cpp
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories
 # should be searched for input files as well. Possible values are YES and NO.
@@ -434,8 +434,7 @@ RECURSIVE              = NO
 # excluded from the INPUT source files. This way you can easily exclude a
 # subdirectory from a directory tree whose root is specified with the INPUT tag.
 
-EXCLUDE                = print_help.c xdgmimealias.c xdgmimealias.h xdgmime.c xdgmimeglob.c xdgmimeglob.h xdgmime.h xdgmimeint.c xdgmimeint.h xdgmimemagic.c xdgmimemagic.h xdgmimeparent.c xdgmimeparent.h
-
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used select whether or not files or directories
 # that are symbolic links (a Unix filesystem feature) are excluded from the input.

--- a/autoload.cpp
+++ b/autoload.cpp
@@ -1,6 +1,5 @@
 /** \file autoload.cpp
-
-The classes responsible for autoloading functions and completions.
+    The classes responsible for autoloading functions and completions.
 */
 
 #include "config.h"

--- a/autoload.h
+++ b/autoload.h
@@ -1,5 +1,4 @@
 /** \file autoload.h
-
     The classes responsible for autoloading functions and completions.
 */
 

--- a/builtin.cpp
+++ b/builtin.cpp
@@ -1,19 +1,21 @@
-/** \file builtin.c
-	Functions for executing builtin functions.
+/** \file builtin.cpp
+    Functions for executing builtin functions.
+*/
 
-	How to add a new builtin function:
+/**
+    How to add a new builtin function:
 
-	1). Create a function in builtin.c with the following signature:
+    1). Create a function in builtin.cpp with the following signature:
 
-	<tt>static int builtin_NAME( parser_t &parser, wchar_t ** args )</tt>
+    <tt>static int builtin_NAME( parser_t &parser, wchar_t ** args )</tt>
 
-	where NAME is the name of the builtin, and args is a zero-terminated list of arguments.
+    where NAME is the name of the builtin, and args is a zero-terminated list of arguments.
 
-	2). Add a line like { L"NAME", &builtin_NAME, N_(L"Bla bla bla") }, to the builtin_data_t variable. The description is used by the completion system. Note that this array is sorted!
+    2). Add a line like { L"NAME", &builtin_NAME, N_(L"Bla bla bla") }, to the builtin_data_t variable. The description is used by the completion system. Note that this array is sorted!
 
-	3). Create a file doc_src/NAME.txt, containing the manual for the builtin in Doxygen-format. Check the other builtin manuals for proper syntax.
+    3). Create a file doc_src/NAME.txt, containing the manual for the builtin in Doxygen-format. Check the other builtin manuals for proper syntax.
 
-	4). Use 'git add doc_src/NAME.txt' to start tracking changes to the documentation file.
+    4). Use 'git add doc_src/NAME.txt' to start tracking changes to the documentation file.
 
 */
 
@@ -176,9 +178,9 @@ static int builtin_count_args(const wchar_t * const * argv)
 }
 
 /**
-	This function works like wperror, but it prints its result into
-	the sb_err string instead of to stderr. Used by the builtin
-	commands.
+    This function works like wperror, but it prints its result into
+    the sb_err string instead of to stderr. Used by the builtin
+    commands.
 */
 
 static void builtin_wperror(const wchar_t *s)

--- a/builtin.h
+++ b/builtin.h
@@ -1,5 +1,5 @@
 /** \file builtin.h
-  Prototypes for functions for executing builtin functions.
+    Prototypes for functions for executing builtin functions.
 */
 
 #ifndef FISH_BUILTIN_H

--- a/builtin_commandline.cpp
+++ b/builtin_commandline.cpp
@@ -1,8 +1,7 @@
-/** \file builtin_commandline.c Functions defining the commandline builtin
-
-Functions used for implementing the commandline builtin.
-
+/** \file builtin_commandline.cpp
+    Functions used for implementing the commandline builtin.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/builtin_complete.cpp
+++ b/builtin_complete.cpp
@@ -1,8 +1,7 @@
-/** \file builtin_complete.c Functions defining the complete builtin
-
-Functions used for implementing the complete builtin.
-
+/** \file builtin_complete.cpp
+    Functions used for implementing the complete builtin.
 */
+
 #include "config.h"
 
 #include <stdlib.h>
@@ -279,8 +278,8 @@ const wchar_t *builtin_complete_get_temporary_buffer()
 
 /**
    The complete builtin. Used for specifying programmable
-   tab-completions. Calls the functions in complete.c for any heavy
-   lifting. Defined in builtin_complete.c
+   tab-completions. Calls the functions in complete.cpp for any heavy
+   lifting. Defined in builtin_complete.cpp.
 */
 static int builtin_complete(parser_t &parser, wchar_t **argv)
 {

--- a/builtin_jobs.cpp
+++ b/builtin_jobs.cpp
@@ -1,6 +1,7 @@
-/** \file builtin_jobs.c
-  Functions for executing the jobs builtin.
+/** \file builtin_jobs.cpp
+    Functions for executing the jobs builtin.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/builtin_printf.cpp
+++ b/builtin_printf.cpp
@@ -1,3 +1,7 @@
+/** \file builtin_printf.cpp
+    A builtin printf.
+*/
+
 /* printf - format and print data
    Copyright (C) 1990-2007 Free Software Foundation, Inc.
 

--- a/builtin_set.cpp
+++ b/builtin_set.cpp
@@ -1,8 +1,7 @@
-/** \file builtin_set.c Functions defining the set builtin
-
-Functions used for implementing the set builtin.
-
+/** \file builtin_set.cpp
+    Functions used for implementing the set builtin.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/builtin_set_color.cpp
+++ b/builtin_set_color.cpp
@@ -1,8 +1,7 @@
-/** \file builtin_set_color.cpp Functions defining the set_color builtin
-
-Functions used for implementing the set_color builtin.
-
+/** \file builtin_set_color.cpp
+    Functions used for implementing the set_color builtin.
 */
+
 #include "config.h"
 
 #include "builtin.h"

--- a/builtin_test.cpp
+++ b/builtin_test.cpp
@@ -1,8 +1,9 @@
-/** \file builtin_test.cpp Functions defining the test builtin
+/** \file builtin_test.cpp
+    Functions used for implementing the test builtin.
+*/
 
-Functions used for implementing the test builtin.
+/**
 Implemented from scratch (yes, really) by way of IEEE 1003.1 as reference.
-
 */
 
 #include "config.h"

--- a/builtin_ulimit.cpp
+++ b/builtin_ulimit.cpp
@@ -1,8 +1,7 @@
-/** \file builtin_ulimit.c Functions defining the ulimit builtin
-
-Functions used for implementing the ulimit builtin.
-
+/** \file builtin_ulimit.cpp
+    Functions used for implementing the ulimit builtin.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/color.cpp
+++ b/color.cpp
@@ -1,4 +1,5 @@
-/** \file color.cpp Color class implementation
+/** \file color.cpp
+    Color class implementation
 */
 
 #include "color.h"

--- a/color.h
+++ b/color.h
@@ -1,5 +1,7 @@
-/** \file color.h Color class.
-  */
+/** \file color.h
+    Color class.
+*/
+
 #ifndef FISH_COLOR_H
 #define FISH_COLOR_H
 

--- a/common.cpp
+++ b/common.cpp
@@ -1,11 +1,8 @@
-/** \file common.c
-
-Various functions, mostly string utilities, that are used by most
-parts of fish.
+/** \file common.cpp
+    Various functions, mostly string utilities, used by most parts of fish.
 */
 
 #include "config.h"
-
 
 #include <unistd.h>
 

--- a/common.h
+++ b/common.h
@@ -1,11 +1,8 @@
 /** \file common.h
-	Prototypes for various functions, mostly string utilities, that are used by most parts of fish.
+    Prototypes for various functions, used by most parts of fish.
 */
 
 #ifndef FISH_COMMON_H
-/**
-   Header guard
-*/
 #define FISH_COMMON_H
 
 #include <stdlib.h>

--- a/complete.cpp
+++ b/complete.cpp
@@ -1,7 +1,7 @@
-/** \file complete.c Functions related to tab-completion.
-
-  These functions are used for storing and retrieving tab-completion data, as well as for performing tab-completion.
+/** \file complete.cpp
+    Functions related to storing and retrieving tab-completion.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/complete.h
+++ b/complete.h
@@ -1,17 +1,9 @@
 /** \file complete.h
-  Prototypes for functions related to tab-completion.
-
-  These functions are used for storing and retrieving tab-completion
-  data, as well as for performing tab-completion.
+    Prototypes for functions related to storing and performing tab completion.
 */
 
 #ifndef FISH_COMPLETE_H
-
-/**
-   Header guard
-*/
 #define FISH_COMPLETE_H
-
 
 #include <wchar.h>
 #include <stdint.h>

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -627,10 +627,10 @@ expanded so each element of the list becomes a new parameter.
 
 Example:
 
-<code>echo input.{c,h,txt}</code> outputs 'input.c input.h input.txt'
+<code>echo input.{cpp,h,txt}</code> outputs 'input.cpp input.h input.txt'
 
-The command <code>mv *.{c,h} src/</code> moves all files with the suffix
-'.c' or '.h' to the subdirectory src.
+The command <code>mv *.{cpp,h} src/</code> moves all files with the suffix
+'.cpp' or '.h' to the subdirectory src.
 
 \subsection expand-variable Variable expansion
 

--- a/env.cpp
+++ b/env.cpp
@@ -1,6 +1,7 @@
-/** \file env.c
-  Functions for setting and getting environment variables.
+/** \file env.cpp
+    Functions for setting and getting environment variables.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/env.h
+++ b/env.h
@@ -1,5 +1,5 @@
 /** \file env.h
-  Prototypes for functions for setting and getting environment variables.
+    Prototypes for functions for setting and getting environment variables.
 */
 
 #ifndef FISH_ENV_H

--- a/env_universal.cpp
+++ b/env_universal.cpp
@@ -1,5 +1,8 @@
-#include "config.h"
+/** \file env_universal.cpp
+    Universal variable client library.
+*/
 
+#include "config.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/env_universal.h
+++ b/env_universal.h
@@ -1,5 +1,5 @@
 /** \file env_universal.h
-  Universal variable client library.
+    Universal variable client library prototypes.
 */
 
 #ifndef ENV_UNIVERSAL_H

--- a/env_universal_common.cpp
+++ b/env_universal_common.cpp
@@ -1,12 +1,8 @@
-/**
-   \file env_universal_common.c
-
-   The utility library for universal variables. Used both by the
-   client library and by the daemon.
-
+/** \file env_universal_common.cpp
+    Utility library for universal variables. Used by client library, daemon.
 */
-#include "config.h"
 
+#include "config.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/env_universal_common.h
+++ b/env_universal_common.h
@@ -1,3 +1,7 @@
+/** \file env_universal_common.h
+   Common definitions for universal variables. Used by client library, daemon.
+*/
+
 #ifndef FISH_ENV_UNIVERSAL_COMMON_H
 #define FISH_ENV_UNIVERSAL_COMMON_H
 

--- a/event.cpp
+++ b/event.cpp
@@ -1,8 +1,7 @@
-/** \file event.c
-
-  Functions for handling event triggers
-
+/** \file event.cpp
+    Functions for handling event triggers.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/event.h
+++ b/event.h
@@ -1,14 +1,14 @@
 /** \file event.h
+    Functions for handling event triggers.
+*/
 
-  Functions for handling event triggers
-
+/**
   Because most of these functions can be called by signal
   handler, it is important to make it well defined when these
   functions produce output or perform memory allocations, since
   such functions may not be safely called by signal handlers.
-
-
 */
+
 #ifndef FISH_EVENT_H
 #define FISH_EVENT_H
 

--- a/exec.cpp
+++ b/exec.cpp
@@ -1,6 +1,8 @@
-/** \file exec.c
-  Functions for executing a program.
+/** \file exec.cpp
+    Functions for executing a program.
+*/
 
+/**
   Some of the code in this file is based on code from the Glibc
   manual, though the changes performed have been massive.
 */

--- a/exec.h
+++ b/exec.h
@@ -1,11 +1,8 @@
 /** \file exec.h
-  Prototypes for functions for executing a program
+    Prototypes for functions for executing a program.
 */
 
 #ifndef FISH_EXEC_H
-/**
-   Header guard
-*/
 #define FISH_EXEC_H
 
 #include <wchar.h>

--- a/expand.cpp
+++ b/expand.cpp
@@ -1,8 +1,5 @@
-/**\file expand.c
-
-String expansion functions. These functions perform several kinds of
-parameter expansion.
-
+/** \file expand.cpp
+    String expansion functions, performs several kinds of parameter expansion.
 */
 
 #include "config.h"

--- a/expand.h
+++ b/expand.h
@@ -1,18 +1,17 @@
-/**\file expand.h
+/** \file expand.h
+    Prototypes for string expansion functions.
+*/
 
-   Prototypes for string expansion functions. These functions perform
-   several kinds of parameter expansion. There are a lot of issues
-   with regards to memory allocation. Overall, these functions would
-   benefit from using a more clever memory allocation scheme, perhaps
-   an evil combination of talloc, string buffers and reference
-   counting.
-
+/**
+   These functions perform several kinds of parameter expansion.
+   There are a lot of issues with regards to memory allocation.
+   
+   Overall, these functions would benefit from using a more clever memory
+   allocation scheme, perhaps an evil combination of talloc, string buffers
+   and reference counting.
 */
 
 #ifndef FISH_EXPAND_H
-/**
-   Header guard
-*/
 #define FISH_EXPAND_H
 
 #include <wchar.h>

--- a/fallback.cpp
+++ b/fallback.cpp
@@ -1,3 +1,7 @@
+/** \file fallback.cpp
+    Fallback implementations of missing, broken functions found in configure.
+*/
+
 /**
    This file only contains fallback implementations of functions which
    have been found to be missing or broken by the configuration

--- a/fallback.h
+++ b/fallback.h
@@ -1,3 +1,6 @@
+/** \file fallback.h
+    Fallback function prototypes.
+*/
 
 #ifndef FISH_FALLBACK_H
 #define FISH_FALLBACK_H

--- a/fish.cpp
+++ b/fish.cpp
@@ -1,3 +1,7 @@
+/** \file fish.cpp
+    The main loop of fish.
+*/
+
 /*
 Copyright (C) 2005-2008 Axel Liljencrantz
 
@@ -13,11 +17,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
-*/
-
-
-/** \file fish.c
-	The main loop of <tt>fish</tt>.
 */
 
 #include "config.h"

--- a/fish_indent.cpp
+++ b/fish_indent.cpp
@@ -1,3 +1,7 @@
+/** \file fish_indent.cpp
+    The fish_indent program.
+*/
+
 /*
 Copyright (C) 2005-2008 Axel Liljencrantz
 
@@ -15,10 +19,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
 
-
-/** \file fish_indent.cpp
-  The fish_indent proegram.
-*/
 
 #include "config.h"
 

--- a/fish_pager.cpp
+++ b/fish_pager.cpp
@@ -1,3 +1,7 @@
+/** \file fish_pager.cpp
+    The fish_pager program.
+*/
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/fish_tests.cpp
+++ b/fish_tests.cpp
@@ -1,5 +1,5 @@
-/** \file fish_tests.c
-  Various bug and feature tests. Compiled and run by make test.
+/** \file fish_tests.cpp
+    Various bug and feature tests. Compiled and run by make test.
 */
 
 #include "config.h"

--- a/fishd.cpp
+++ b/fishd.cpp
@@ -1,5 +1,8 @@
-/** \file fishd.c
+/** \file fishd.cpp
+    The universal variable server.
+*/
 
+/**
 The universal variable server. fishd is automatically started by fish
 if a fishd server isn't already running. fishd reads any saved
 variables from ~/.fishd, and takes care of communication between fish

--- a/function.cpp
+++ b/function.cpp
@@ -1,6 +1,9 @@
-/** \file function.c
+/** \file function.cpp
+    Prototypes for storing, autoloading, and retrieving function information.
+*/
 
-    Prototypes for functions for storing and retrieving function
+/**
+  Prototypes for functions for storing and retrieving function
   information. These functions also take care of autoloading
   functions in the $fish_function_path. Actual function evaluation
   is taken care of by the parser and to some degree the builtin

--- a/function.h
+++ b/function.h
@@ -1,7 +1,9 @@
 /** \file function.h
+    Prototypes for functions for storing and retrieving functions.
+*/
 
-    Prototypes for functions for storing and retrieving function
-  information. These functions also take care of autoloading
+/**
+  These functions also take care of autoloading
   functions in the $fish_function_path. Actual function evaluation
   is taken care of by the parser and to some degree the builtin
   handling library.

--- a/highlight.cpp
+++ b/highlight.cpp
@@ -1,6 +1,7 @@
-/** \file highlight.c
-  Functions for syntax highlighting
+/** \file highlight.cpp
+    Functions for syntax highlighting.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/highlight.h
+++ b/highlight.h
@@ -1,5 +1,5 @@
 /** \file highlight.h
-  Prototypes for functions for syntax highlighting
+    Prototypes for functions for syntax highlighting.
 */
 
 #ifndef FISH_HIGHLIGHT_H

--- a/history.cpp
+++ b/history.cpp
@@ -1,6 +1,7 @@
-/** \file history.c
-  History functions, part of the user interface.
+/** \file history.cpp
+    History functions, part of the user interface.
 */
+
 #include "config.h"
 
 #include <stdlib.h>
@@ -457,7 +458,7 @@ static size_t offset_of_next_item_fish_2_0(const char *begin, size_t mmap_length
 
 
 // Same as offset_of_next_item_fish_2_0, but for fish 1.x (pre fishfish)
-// Adapted from history_populate_from_mmap in history.c
+// Adapted from history_populate_from_mmap in history.cpp
 static size_t offset_of_next_item_fish_1_x(const char *begin, size_t mmap_length, size_t *inout_cursor, time_t cutoff_timestamp)
 {
     if (mmap_length == 0 || *inout_cursor >= mmap_length)

--- a/history.h
+++ b/history.h
@@ -1,5 +1,5 @@
 /** \file history.h
-  Prototypes for history functions, part of the user interface.
+    Prototypes for history functions, part of the user interface.
 */
 
 #ifndef FISH_HISTORY_H

--- a/input.cpp
+++ b/input.cpp
@@ -1,7 +1,5 @@
-/** \file input.c
-
+/** \file input.cpp
     Functions for reading a character of input from stdin.
-
 */
 
 #include "config.h"

--- a/input.h
+++ b/input.h
@@ -1,8 +1,5 @@
 /** \file input.h
-
-Functions for reading a character of input from stdin, using the
-inputrc information for key bindings.
-
+    Functions for reading a character from stdin, using inputrc key bindings.
 */
 
 #ifndef FISH_INPUT_H

--- a/input_common.cpp
+++ b/input_common.cpp
@@ -1,10 +1,8 @@
-/** \file input_common.c
-
-Implementation file for the low level input library
-
+/** \file input_common.cpp
+    Implementation file for the low level input library.
 */
-#include "config.h"
 
+#include "config.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/input_common.h
+++ b/input_common.h
@@ -1,8 +1,7 @@
 /** \file input_common.h
-
-Header file for the low level input library
-
+    Header file for the low level input library.
 */
+
 #ifndef INPUT_COMMON_H
 #define INPUT_COMMON_H
 

--- a/intern.cpp
+++ b/intern.cpp
@@ -1,10 +1,8 @@
-/** \file intern.c
-
-    Library for pooling common strings
-
+/** \file intern.cpp
+    Library for pooling common strings.
 */
-#include "config.h"
 
+#include "config.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/intern.h
+++ b/intern.h
@@ -1,7 +1,5 @@
 /** \file intern.h
-
-    Library for pooling common strings
-
+    Library for pooling common strings.
 */
 
 #ifndef FISH_INTERN_H

--- a/io.cpp
+++ b/io.cpp
@@ -1,10 +1,8 @@
-/** \file io.c
-
-Utilities for io redirection.
-
+/** \file io.cpp
+    Utilities for io redirection.
 */
-#include "config.h"
 
+#include "config.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/io.h
+++ b/io.h
@@ -1,3 +1,7 @@
+/** \file io.h
+    Prototypes for io redirection.
+*/
+
 #ifndef FISH_IO_H
 #define FISH_IO_H
 

--- a/iothread.cpp
+++ b/iothread.cpp
@@ -1,3 +1,7 @@
+/** \file iothread.cpp
+    Support for io threading.
+*/
+
 #include "config.h"
 #include "iothread.h"
 #include "common.h"

--- a/key_reader.cpp
+++ b/key_reader.cpp
@@ -1,10 +1,7 @@
-/*
-    A small utility to print the resulting key codes from pressing a
-  key. Servers the same function as hitting ^V in bash, but I prefer
-  the way key_reader works.
-
-  Type ^C to exit the program.
+/** key_reader.cpp
+    A small utility to print the resulting key codes from pressing a key.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/kill.cpp
+++ b/kill.cpp
@@ -1,9 +1,5 @@
-/** \file kill.c
-  The killring.
-
-  Works like the killring in emacs and readline. The killring is cut
-  and paste with a memory of previous cuts. It supports integration
-  with the X clipboard.
+/** \file kill.cpp
+    The killring (emacs/readline) style pasteboard functionality.
 */
 
 #include "config.h"

--- a/kill.h
+++ b/kill.h
@@ -1,7 +1,5 @@
 /** \file kill.h
-  Prototypes for the killring.
-
-  Works like the killring in emacs and readline. The killring is cut and paste whith a memory of previous cuts.
+    Prototypes for the killring (like emacs, readline). Pasteboard functions.
 */
 
 #ifndef FISH_KILL_H

--- a/lru.h
+++ b/lru.h
@@ -1,6 +1,5 @@
 /** \file lru.h
-
-    Least-recently-used cache implementation
+    Least-recently-used cache implementation.
 */
 
 #ifndef FISH_LRU_H

--- a/mimedb.cpp
+++ b/mimedb.cpp
@@ -1,5 +1,8 @@
-/** \file mimedb.c
+/** \file mimedb.cpp
+    Multipurpose Internet Mail Extensions database program.
+*/
 
+/**
 mimedb is a program for checking the mimetype, description and
 default action associated with a file or mimetype.  It uses the
 xdgmime library written by the fine folks at freedesktop.org. There does

--- a/mimedb.h
+++ b/mimedb.h
@@ -1,4 +1,7 @@
+/** \file mimedb.h
+    A very important file.
+*/
+
 #ifndef FISH_MIMEDB_H
 #define FISH_MIMEDB_H
-
 #endif

--- a/output.cpp
+++ b/output.cpp
@@ -1,6 +1,6 @@
-/** \file output.c
- Generic output functions
- */
+/** \file output.cpp
+    Generic output functions.
+*/
 
 #include "config.h"
 

--- a/output.h
+++ b/output.h
@@ -1,8 +1,10 @@
 /** \file output.h
-  Generic output functions
+    Generic output functions.
 */
+
 /**
-   Constants for various character classifications. Each character of a command string can be classified as one of the following types.
+   Constants for various character classifications. Each character of a
+   command string can be classified as one of the following types.
 */
 
 #ifndef FISH_OUTPUT_H

--- a/pager.cpp
+++ b/pager.cpp
@@ -1,3 +1,7 @@
+/** \file pager.cpp
+    The "old" pager.
+*/
+
 #include "config.h"
 
 #include "pager.h"

--- a/pager.h
+++ b/pager.h
@@ -1,5 +1,5 @@
 /** \file pager.h
-  Pager support
+    Pager support.
 */
 
 #include "complete.h"

--- a/parse_constants.h
+++ b/parse_constants.h
@@ -1,5 +1,4 @@
-/**\file parse_constants.h
-
+/** \file parse_constants.h
     Constants used in the programmatic representation of fish code.
 */
 

--- a/parse_execution.cpp
+++ b/parse_execution.cpp
@@ -1,5 +1,8 @@
-/**\file parse_execution.cpp
+/** \file parse_execution.cpp
+    Provides linkage between parse_node_tree_t and executions (job_t, etc.).
+*/
 
+/**
    Provides the "linkage" between a parse_node_tree_t and actual execution structures (job_t, etc.)
 
    A note on error handling: fish has two kind of errors, fatal parse errors non-fatal runtime errors. A fatal error prevents execution of the entire file, while a non-fatal error skips that job.
@@ -32,7 +35,7 @@ static wcstring profiling_cmd_name_for_redirectable_block(const parse_node_t &no
 {
     assert(specific_statement_type_is_redirectable_block(node));
     assert(node.has_source());
-    
+
     /* Get the source for the block, and cut it at the next statement terminator. */
     const size_t src_start = node.source_start;
     size_t src_len = node.source_length;
@@ -44,7 +47,7 @@ static wcstring profiling_cmd_name_for_redirectable_block(const parse_node_t &no
         assert(term->source_start >= src_start);
         src_len = term->source_start - src_start;
     }
-    
+
     wcstring result = wcstring(src, src_start, src_len);
     result.append(L"...");
     return result;
@@ -324,7 +327,7 @@ parse_execution_result_t parse_execution_context_t::run_if_statement(const parse
     {
         run_job_list(*job_list_to_execute, ib);
     }
-    
+
     /* It's possible there's a last-minute cancellation, in which case we should not stomp the exit status (#1297) */
     if (should_cancel_execution(ib))
     {
@@ -1302,7 +1305,7 @@ parse_execution_result_t parse_execution_context_t::run_1_job(const parse_node_t
 
     /* Increment the eval_level for the duration of this command */
     scoped_push<int> saved_eval_level(&eval_level, eval_level + 1);
-    
+
     /* Save the node index */
     scoped_push<node_offset_t> saved_node_offset(&executing_node_idx, this->get_offset(job_node));
 
@@ -1339,7 +1342,7 @@ parse_execution_result_t parse_execution_context_t::run_1_job(const parse_node_t
                 PARSER_DIE();
                 break;
         }
-        
+
         if (profile_item != NULL)
         {
             /* Block-types profile a little weird. They have no 'parse' time, and their command is just the block type */
@@ -1350,7 +1353,7 @@ parse_execution_result_t parse_execution_context_t::run_1_job(const parse_node_t
             profile_item->cmd = profiling_cmd_name_for_redirectable_block(specific_statement, this->tree, this->src);
             profile_item->skipped = result != parse_execution_success;
         }
-        
+
         return result;
     }
 
@@ -1543,7 +1546,7 @@ int parse_execution_context_t::get_current_line_number()
     {
         return -1;
     }
-    
+
     /* Count the number of newlines, leveraging our cache */
     const size_t offset = tree.at(this->executing_node_idx).source_start;
     assert(offset <= src.size());
@@ -1553,7 +1556,7 @@ int parse_execution_context_t::get_current_line_number()
     {
         return 1;
     }
-    
+
     /* We want to return (one plus) the number of newlines at offsets less than the given offset. cached_lineno_count is the number of newlines at indexes less than cached_lineno_offset. */
     const wchar_t *str = src.c_str();
     if (offset > cached_lineno_offset)

--- a/parse_execution.h
+++ b/parse_execution.h
@@ -1,6 +1,5 @@
-/**\file parse_execution.h
-
-   Provides the "linkage" between a parse_node_tree_t and actual execution structures (job_t, etc.).
+/** \file parse_execution.h
+   The linkage between parse_node_tree_t and actual executions (job_t, etc.).
 */
 
 #ifndef FISH_PARSE_EXECUTION_H

--- a/parse_productions.cpp
+++ b/parse_productions.cpp
@@ -1,3 +1,7 @@
+/** \file parse_productions.cpp
+    Production generation for the "new" parser.
+*/
+
 #include "parse_productions.h"
 
 using namespace parse_productions;

--- a/parse_productions.h
+++ b/parse_productions.h
@@ -1,6 +1,5 @@
-/**\file parse_tree.h
-
-    Programmatic representation of fish code.
+/** \file parse_productions.h
+    Functions for generating the programmatic representation in "new" parser.
 */
 
 #ifndef FISH_PARSE_TREE_CONSTRUCTION_H

--- a/parse_tree.cpp
+++ b/parse_tree.cpp
@@ -1,3 +1,7 @@
+/** \file parse_tree.cpp
+    Syntax tree for the "new" parser.
+*/
+
 #include "parse_productions.h"
 #include "tokenizer.h"
 #include "fallback.h"

--- a/parse_tree.h
+++ b/parse_tree.h
@@ -1,5 +1,4 @@
-/**\file parse_tree.h
-
+/** \file parse_tree.h
     Programmatic representation of fish code.
 */
 

--- a/parse_util.cpp
+++ b/parse_util.cpp
@@ -1,5 +1,8 @@
-/** \file parse_util.c
+/** \file parse_util.cpp
+    Various utility functions related to parsing with the "new" parser.
+*/
 
+/**
     Various mostly unrelated utility functions related to parsing,
     loading and evaluating fish code.
 

--- a/parse_util.h
+++ b/parse_util.h
@@ -1,7 +1,5 @@
 /** \file parse_util.h
-
-    Various mostly unrelated utility functions related to parsing,
-    loading and evaluating fish code.
+    Various utility functions related to parsing and evaluating fish code.
 */
 
 #ifndef FISH_PARSE_UTIL_H

--- a/parser.cpp
+++ b/parser.cpp
@@ -1,7 +1,5 @@
-/** \file parser.c
-
-The fish parser. Contains functions for parsing and evaluating code.
-
+/** \file parser.cpp
+    The "old" fish parser. Contains functions for parsing and evaluating code.
 */
 
 #include "config.h"

--- a/parser.h
+++ b/parser.h
@@ -1,5 +1,5 @@
 /** \file parser.h
-  The fish parser.
+    The fish parser.
 */
 
 #ifndef FISH_PARSER_H

--- a/parser_keywords.cpp
+++ b/parser_keywords.cpp
@@ -1,6 +1,5 @@
-/** \file parser_keywords.c
-
-Functions having to do with parser keywords, like testing if a function is a block command.
+/** \file parser_keywords.cpp
+    Parser keyword functions, like testing if a function is a block command.
 */
 
 #include "config.h"

--- a/parser_keywords.h
+++ b/parser_keywords.h
@@ -1,6 +1,5 @@
 /** \file parser_keywords.h
-
-Functions having to do with parser keywords, like testing if a function is a block command.
+    Parser keyword functions, like testing if a function is a block command.
 */
 
 #ifndef FISH_PARSER_KEYWORD_H

--- a/path.cpp
+++ b/path.cpp
@@ -1,3 +1,7 @@
+/** \file path.cpp
+    Filepath utities.
+*/
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/path.h
+++ b/path.h
@@ -1,6 +1,9 @@
 /** \file path.h
+    Directory utilities.
+*/
 
-  Directory utilities. This library contains functions for locating
+/**
+  This library contains functions for locating
   configuration directories, for testing if a command with a given
   name can be found in the PATH, and various other path-related
   issues.

--- a/postfork.cpp
+++ b/postfork.cpp
@@ -1,6 +1,5 @@
 /** \file postfork.cpp
-
-  Functions that we may safely call after fork().
+    Functions that we may safely call after fork(). Rare.
 */
 
 #include <fcntl.h>

--- a/postfork.h
+++ b/postfork.h
@@ -1,6 +1,10 @@
 /** \file postfork.h
+    Prototypes for functions that we may safely call after fork(). Rare.
+*/
 
-  Functions that we may safely call after fork(), of which there are very few. In particular we cannot allocate memory, since we're insane enough to call fork from a multithreaded process.
+/**
+    In particular we cannot allocate memory, since we're insane enough to call
+    fork from a multithreaded process.
 */
 
 #ifndef FISH_POSTFORK_H

--- a/print_help.cpp
+++ b/print_help.cpp
@@ -1,6 +1,5 @@
-
-/** \file print_help.c
-  Print help message for the specified command
+/** \file print_help.cpp
+    Print help message for the specified command.
 */
 
 #include <stdlib.h>

--- a/print_help.h
+++ b/print_help.h
@@ -1,14 +1,9 @@
-
 /** \file print_help.h
-  Print help message for the specified command
+    Print help message for the specified command.
 */
 
 #ifndef FISH_PRINT_HELP_H
 #define FISH_PRINT_HELP_H
-
-/**
-  Print help message for the specified command
-*/
 
 void print_help(const char *cmd, int fd);
 

--- a/proc.cpp
+++ b/proc.cpp
@@ -1,5 +1,8 @@
-/** \file proc.c
+/** \file proc.cpp
+    Utilities for keeping track of jobs, processes and subshells.
+*/
 
+/**
 Utilities for keeping track of jobs, processes and subshells, as
 well as signal handling functions for tracking children. These
 functions do not themselves launch new processes, the exec library
@@ -7,7 +10,6 @@ will call proc to create representations of the running jobs as
 needed.
 
 Some of the code in this file is based on code from the Glibc manual.
-
 */
 #include "config.h"
 

--- a/proc.h
+++ b/proc.h
@@ -1,11 +1,12 @@
 /** \file proc.h
+    Prototypes job tracking facilities, processes and subshells, signals.
+*/
 
-    Prototypes for utilities for keeping track of jobs, processes and subshells, as
-  well as signal handling functions for tracking children. These
+/**
+  Also, signal handling functions for tracking children. These
   functions do not themselves launch new processes, the exec library
   will call proc to create representations of the running jobs as
   needed.
-
 */
 
 #ifndef FISH_PROC_H

--- a/reader.cpp
+++ b/reader.cpp
@@ -1,5 +1,8 @@
-/** \file reader.c
+/** \file reader.cpp
+    Functions for reading data from stdin and passing to the parser.
+*/
 
+/**
 Functions for reading data from stdin and passing to the
 parser. If stdin is a keyboard, it supplies a killring, history,
 syntax highlighting, tab-completion and various other interactive features.
@@ -16,7 +19,6 @@ the list is consulted for previous search result, and subsequent
 backwards searches are also handled by consulting the list up until
 the end of the list is reached, at which point regular searching will
 commence.
-
 */
 
 #include "config.h"

--- a/reader.h
+++ b/reader.h
@@ -1,9 +1,10 @@
 /** \file reader.h
+    Prototypes for reading from stdin and passing to the parser.
+*/
 
-    Prototypes for functions for reading data from stdin and passing
-	to the parser. If stdin is a keyboard, it supplies a killring,
-	history, syntax highlighting, tab-completion and various other
-	features.
+/**
+   If stdin is a tty, it supplies a killring, history, syntax highlighting,
+   tab-completion and various other features.
 */
 
 #ifndef FISH_READER_H

--- a/sanity.cpp
+++ b/sanity.cpp
@@ -1,6 +1,7 @@
-/** \file sanity.c
-  Functions for performing sanity checks on the program state
+/** \file sanity.cpp
+    Functions for performing sanity checks on the program state.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/sanity.h
+++ b/sanity.h
@@ -1,5 +1,5 @@
 /** \file sanity.h
-  Prototypes for functions for performing sanity checks on the program state
+    Prototypes for functions for performing sanity checks on program state.
 */
 
 #ifndef FISH_SANITY_H

--- a/screen.cpp
+++ b/screen.cpp
@@ -1,5 +1,8 @@
-/** \file screen.c High level library for handling the terminal screen
+/** \file screen.cpp
+    High level library for handling the terminal screen.
+*/
 
+/**
 The screen library allows the interactive reader to write its
 output to screen efficiently by keeping an internal representation
 of the current screen contents and trying to find the most

--- a/screen.h
+++ b/screen.h
@@ -1,5 +1,8 @@
-/** \file screen.h High level library for handling the terminal screen
+/** \file screen.h
+    High level library for handling terminal (emulator) handling.
+*/
 
+/**
   The screen library allows the interactive reader to write its
   output to screen efficiently by keeping an internal representation
   of the current screen contents and trying to find a reasonably

--- a/signal.cpp
+++ b/signal.cpp
@@ -1,11 +1,8 @@
-/** \file signal.c
-
-The library for various signal related issues
-
+/** \file signal.cpp
+    The library for various signal related issues.
 */
 
 #include "config.h"
-
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -477,7 +474,7 @@ static void handle_int(int sig, siginfo_t *info, void *context)
 }
 
 /**
-   sigchld handler. Does notification and calls the handler in proc.c
+   sigchld handler. Does notification and calls the handler in proc.cpp
 */
 static void handle_chld(int sig, siginfo_t *info, void *context)
 {

--- a/signal.h
+++ b/signal.h
@@ -1,8 +1,7 @@
 /** \file signal.h
-
-The library for various signal related issues
-
+    Prototypes for library for various signal related issues.
 */
+
 #ifndef FISH_SIGNALH
 #define FISH_SIGNALH
 

--- a/tokenizer.cpp
+++ b/tokenizer.cpp
@@ -1,5 +1,8 @@
-/** \file tokenizer.c
+/** \file tokenizer.cpp
+    A specialized tokenizer for tokenizing the fish language.
+*/
 
+/**
 A specialized tokenizer for tokenizing the fish language. In the
 future, the tokenizer should be extended to support marks,
 tokenizing multiple strings and disposing of unused string

--- a/tokenizer.h
+++ b/tokenizer.h
@@ -1,9 +1,10 @@
 /** \file tokenizer.h
+    A specialized tokenizer for tokenizing the fish language.
+*/
 
-    A specialized tokenizer for tokenizing the fish language. In the
-    future, the tokenizer should be extended to support marks,
-    tokenizing multiple strings and disposing of unused string
-    segments.
+/**
+    In the future, the tokenizer should be extended to support marks,
+    tokenizing multiple strings and disposing of unused string segments.
 */
 
 #ifndef FISH_TOKENIZER_H

--- a/util.cpp
+++ b/util.cpp
@@ -1,11 +1,8 @@
-/** \file util.c
-  Generic utilities library.
-
-  Contains datastructures such as automatically growing array lists, priority queues, etc.
+/** \file util.cpp
+    Utilities library for automatically growing arrays, priority queues, etc.
 */
 
 #include "config.h"
-
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/util.h
+++ b/util.h
@@ -1,5 +1,5 @@
 /** \file util.h
-  Generic utilities library.
+    Generic utilities library.
 */
 
 #ifndef FISH_UTIL_H

--- a/wgetopt.cpp
+++ b/wgetopt.cpp
@@ -1,6 +1,8 @@
-/** \file wgetopt.c
-  A version of the getopt library for use with wide character strings.
+/** \file wgetopt.cpp
+    A version of the getopt library for use with wide character strings.
+*/
 
+/**
   This is simply the gnu getopt library, but converted for use with
   wchar_t instead of char. This is not usually useful since the argv
   array is always defined to be of type char**, but in fish, all
@@ -10,7 +12,7 @@
   If you want to use this version of getopt in your program,
   download the fish sourcecode, available at <a
   href='http://fishshell.com'>the fish homepage</a>. Extract
-  the sourcode, copy wgetopt.c and wgetopt.h into your program
+  the sourcode, copy wgetopt.cpp and wgetopt.h into your program
   directory, include wgetopt.h in your program, and use all the
   regular getopt functions, prefixing every function, global
   variable and structure with a 'w', and use only wide character
@@ -18,7 +20,7 @@
   getopt besides using wide character strings.
 
   For examples of how to use wgetopt, see the fish builtin
-  functions, many of which are defined in builtin.c.
+  functions, many of which are defined in builtin.cpp.
 
 */
 

--- a/wgetopt.h
+++ b/wgetopt.h
@@ -1,6 +1,8 @@
 /** \file wgetopt.h
-  A version of the getopt library for use with wide character strings.
+    A version of the getopt library for use with wide character strings.
+*/
 
+/**
   This is simply the gnu getopt library, but converted for use with
   wchar_t instead of char. This is not usually useful since the argv
   array is always defined to be of type char**, but in fish, all
@@ -10,7 +12,7 @@
   If you want to use this version of getopt in your program,
   download the fish sourcecode, available at <a
   href='http://fishshell.com'>the fish homepage</a>. Extract
-  the sourcode, copy wgetopt.c and wgetopt.h into your program
+  the sourcecode, copy wgetopt.cpp and wgetopt.h into your program
   directory, include wgetopt.h in your program, and use all the
   regular getopt functions, prefixing every function, global
   variable and structure with a 'w', and use only wide character
@@ -19,7 +21,6 @@
 
   For examples of how to use wgetopt, see the fish builtin
   functions, many of which are defined in builtin.c.
-
 */
 
 

--- a/wildcard.cpp
+++ b/wildcard.cpp
@@ -1,5 +1,9 @@
-/** \file wildcard.c
+/** \file wildcard.cpp
+    Globbing implementation to support tab-expansion of globbed parameters.
+*/
 
+/**
+Also provides recursive wildcards using **.
 Fish needs it's own globbing implementation to support
 tab-expansion of globbed parameters. Also provides recursive
 wildcards using **.

--- a/wildcard.h
+++ b/wildcard.h
@@ -1,15 +1,14 @@
 /** \file wildcard.h
+    Globbing.
+*/
 
+/**
     My own globbing implementation. Needed to implement this instead
     of using libs globbing to support tab-expansion of globbed
     paramaters.
-
 */
 
 #ifndef FISH_WILDCARD_H
-/**
-   Header guard
-*/
 #define FISH_WILDCARD_H
 
 #include <wchar.h>

--- a/wutil.cpp
+++ b/wutil.cpp
@@ -1,7 +1,7 @@
-/** \file wutil.c
-  Wide character equivalents of various standard unix
-  functions.
+/** \file wutil.cpp
+    Wide character equivalents of various standard POSIX functions.
 */
+
 #include "config.h"
 
 #include <stdlib.h>

--- a/wutil.h
+++ b/wutil.h
@@ -1,8 +1,7 @@
 /** \file wutil.h
-
-  Prototypes for wide character equivalents of various standard unix
-  functions.
+    Prototypes for wide character equivalents of various POSIX functions.
 */
+
 #ifndef FISH_WUTIL_H
 #define FISH_WUTIL_H
 

--- a/xdgmime.cpp
+++ b/xdgmime.cpp
@@ -1,5 +1,8 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
-/* xdgmime.c: XDG Mime Spec mime resolver.  Based on version 0.11 of the spec.
+/** \file xdgmime.cpp
+    X Desktop Group Multipurpose Internet Mail Extensions resolver.
+*/
+
+/* xdgmime.cpp: XDG Mime Spec mime resolver.  Based version 0.11 of the spec.
  *
  * More info can be found at http://www.freedesktop.org/standards/
  *

--- a/xdgmime.h
+++ b/xdgmime.h
@@ -1,4 +1,7 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
+/** \file xdgmime.h
+    X Desktop Group Multipurpose Internet Mail Extensions resolver header.
+*/
+
 /* xdgmime.h: XDG Mime Spec mime resolver.  Based on version 0.11 of the spec.
  *
  * More info can be found at http://www.freedesktop.org/standards/

--- a/xdgmimealias.cpp
+++ b/xdgmimealias.cpp
@@ -1,5 +1,8 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
-/* xdgmimealias.c: Private file.  Datastructure for storing the aliases.
+/** \file xdgmimealias.cpp
+    X Desktop Group Multipurpose Internet Mail Extensions alias storage.
+*/
+
+/* xdgmimealias.cpp: Private file.  Datastructure for storing the aliases.
  *
  * More info can be found at http://www.freedesktop.org/standards/
  *

--- a/xdgmimealias.h
+++ b/xdgmimealias.h
@@ -1,4 +1,7 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
+/** \file xdgmimealias.h
+    X Desktop Group Multipurpose Internet Mail Extensions alias prototypes.
+*/
+
 /* xdgmimealias.h: Private file.  Datastructure for storing the aliases.
  *
  * More info can be found at http://www.freedesktop.org/standards/

--- a/xdgmimeglob.cpp
+++ b/xdgmimeglob.cpp
@@ -1,5 +1,8 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
-/* xdgmimeglob.c: Private file.  Datastructure for storing the globs.
+/** \file xdgmimeglob.cpp
+    X Desktop Group Multipurpose Internet Mail Extensions glob storage.
+*/
+
+/* xdgmimeglob.cpp: Private file.  Datastructure for storing the globs.
  *
  * More info can be found at http://www.freedesktop.org/standards/
  *

--- a/xdgmimeglob.h
+++ b/xdgmimeglob.h
@@ -1,4 +1,7 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
+/** \file xdgmimeglob.h
+    X Desktop Group Multipurpose Internet Mail Extensions glob prototypes.
+*/
+
 /* xdgmimeglob.h: Private file.  Datastructure for storing the globs.
  *
  * More info can be found at http://www.freedesktop.org/standards/

--- a/xdgmimeint.cpp
+++ b/xdgmimeint.cpp
@@ -1,5 +1,8 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
-/* xdgmimeint.c: Internal defines and functions.
+/** \file xdgmimeint.cpp
+    X Desktop Group Multipurpose Internet Mail Extensions int[ernal|ergers].
+*/
+
+/* xdgmimeint.cpp: Internal defines and functions.
  *
  * More info can be found at http://www.freedesktop.org/standards/
  *

--- a/xdgmimeint.h
+++ b/xdgmimeint.h
@@ -1,4 +1,7 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
+/** \file xdgmimeint.h
+    X Desktop Group Multipurpose Internet Mail Extensions int header.
+*/
+
 /* xdgmimeint.h: Internal defines and functions.
  *
  * More info can be found at http://www.freedesktop.org/standards/

--- a/xdgmimemagic.cpp
+++ b/xdgmimemagic.cpp
@@ -1,5 +1,8 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
-/* xdgmimemagic.: Private file.  Datastructure for storing magic files.
+/** \file xdgmimemagic.cpp
+    X Desktop Group Multipurpose Internet Mail Extensions magic (5) handling.
+*/
+
+/* xdgmimemagic.cpp: Private file.  Datastructure for storing magic files.
  *
  * More info can be found at http://www.freedesktop.org/standards/
  *

--- a/xdgmimemagic.h
+++ b/xdgmimemagic.h
@@ -1,4 +1,7 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
+/** \file xdgmimemagic.h
+    X Desktop Group Multipurpose Internet Mail Extensions magic (5) header.
+*/
+
 /* xdgmimemagic.h: Private file.  Datastructure for storing the magic files.
  *
  * More info can be found at http://www.freedesktop.org/standards/

--- a/xdgmimeparent.cpp
+++ b/xdgmimeparent.cpp
@@ -1,4 +1,7 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
+/** \file xdgmimeparent.cpp
+    X Desktop Group Multipurpose Internet Mail Extensions heirarchy.
+*/
+
 /* xdgmimealias.c: Private file.  Datastructure for storing the hierarchy.
  *
  * More info can be found at http://www.freedesktop.org/standards/

--- a/xdgmimeparent.h
+++ b/xdgmimeparent.h
@@ -1,4 +1,7 @@
-/* -*- mode: C; c-file-style: "gnu" -*- */
+/** \file xdgmimeparent.h
+    X Desktop Group Multipurpose Internet Mail Extensions heirarchy header.
+*/
+
 /* xdgmimeparent.h: Private file.  Datastructure for storing the hierarchy.
  *
  * More info can be found at http://www.freedesktop.org/standards/


### PR DESCRIPTION
Second go at comment fixes from #1317.

No intended functionality change or changes to code (besides documentation generation, obviously).
Done by hand (with a little bit of help from `grep` and `sed`). But *please* review before merge.

Introductory comments have been regularized to:
```
/** \file foobar.[cpp|h]
    Four spaces, one line not longer than 78 characters, ending in a period.
*/

(^ Newline. ^)
```
- Many files lacked these entirely; I have done my best to summarize these files accurately.
- `Doxyfile` has been changed to properly account for C++ classes: `OPTIMIZE_OUTPUT_FOR_C = NO`.
- The database generated when doxygen 1.8.5+ is linked to sqlite has been added to `.gitignore`.
- A few other minor changes to comments and whitespace: typos, etc. No removals except for these:
`#ifndef FISH_HEADER_H`  
__`/**`__  
__`   Header guard`__  
__`*/`__  
`#define FISH_HEADER_H`  

Also:
- Note that _many_ comments lack javadoc style `/**`s, and therefore do not appear in documentation.
- Much of the code does not conform to `CONTRIBUTING.md`: in particular, use of hard tabs.
- Not sure it really matters, but the includes are all still in C `stdlib.h` form rather than `cstdlib`, etc.
- The current HEAD has disassociated from the 2.1.0 release tag, and this causes 
  `FISH_BUILD_VERSION`  (for me, at least) to be generated as `1.23.1-1996-XXXXXX`.  
   Someone maybe should push a new tag to (2.1.X, 2.2.0, or whatnot) to rectify this?

Since the last time I tried to use clang tooling it caused a serious regression, it won't be me, but I'd strongly urge the consideration of a pass or two through `clang-tidy`, `clang-format`, and/or `clang-modernize` to help clean up some.