### PR TITLE
Fixed invalid or outdated function documentation comments.

### DIFF
--- a/autoload.h
+++ b/autoload.h
@@ -105,7 +105,6 @@ public:
        Autoloading one file may unload another.
 
        \param cmd the filename to search for. The suffix '.fish' is always added to this name
-       \param on_unload a callback function to run if a suitable file is found, which has not already been run. unload will also be called for old files which are unloaded.
        \param reload wheter to recheck file timestamps on already loaded files
     */
     int load(const wcstring &cmd, bool reload);
@@ -118,7 +117,6 @@ public:
        is no longer loaded.
 
        \param cmd the filename to search for. The suffix '.fish' is always added to this name
-       \param on_unload a callback function which will be called before (re)loading a file, may be used to unload the previous file.
        \return non-zero if the file was removed, zero if the file had not yet been loaded
     */
     int unload(const wcstring &cmd);

--- a/common.h
+++ b/common.h
@@ -737,7 +737,7 @@ void debug(int level, const wchar_t *msg, ...);
    replaced with \n, etc.
 
    \param in The string to be escaped
-   \param escape_all Whether all characters wich hold special meaning in fish (Pipe, semicolon, etc,) should be escaped, or only unprintable characters
+   \param flags Whether all characters wich hold special meaning in fish (Pipe, semicolon, etc,) should be escaped, or only unprintable characters
    \return The escaped string, or 0 if there is not enough memory
 */
 

--- a/complete.cpp
+++ b/complete.cpp
@@ -1127,9 +1127,7 @@ static wcstring complete_function_desc(const wcstring &fn)
    path, executables defined using an absolute path, functions,
    builtins and directories for implicit cd commands.
 
-   \param cmd the command string to find completions for
-
-   \param comp the list to add all completions to
+   \param str_cmd the command string to find completions for
 */
 void completer_t::complete_cmd(const wcstring &str_cmd, bool use_function, bool use_builtin, bool use_command)
 {
@@ -1231,8 +1229,8 @@ void completer_t::complete_cmd(const wcstring &str_cmd, bool use_function, bool 
 
    \param str The string to complete.
    \param args The list of option arguments to be evaluated.
-   \param desc Description of the completion
-   \param comp_out The list into which the results will be inserted
+   \param desc Description of the completion.
+   \param flags Completion flags.
 */
 void completer_t::complete_from_args(const wcstring &str,
                                      const wcstring &args,

--- a/complete.h
+++ b/complete.h
@@ -170,7 +170,7 @@ wcstring_list_t completions_to_wcstring_list(const std::vector<completion_t> &co
 
 
   \param cmd Command to complete.
-  \param cmd_type If cmd_type is PATH, cmd will be interpreted as the absolute
+  \param cmd_is_path If cmd_is_path is true, cmd will be interpreted as the absolute
       path of the program (optionally containing wildcards), otherwise it
       will be interpreted as the command name.
   \param short_opt The single character name of an option. (-a is a short option,

--- a/env_universal.h
+++ b/env_universal.h
@@ -56,7 +56,7 @@ int env_universal_read_all();
 /**
    Get the names of all universal variables
 
-   \param l the list to insert the names into
+   \param list the list to insert the names into
    \param show_exported whether exported variables should be shown
    \param show_unexported whether unexported variables should be shown
 */

--- a/exec.cpp
+++ b/exec.cpp
@@ -500,7 +500,7 @@ static bool io_transmogrify(const io_chain_t &in_chain, io_chain_t *out_chain, s
    \param def the code to evaluate, or the empty string if none
    \param node_offset the offset of the node to evalute, or NODE_OFFSET_INVALID
    \param block_type the type of block to push on evaluation
-   \param io the io redirections to be performed on this block
+   \param ios the io redirections to be performed on this block
 */
 
 static void internal_exec_helper(parser_t &parser,

--- a/expand.h
+++ b/expand.h
@@ -145,7 +145,7 @@ class parser_t;
 
    \param input The parameter to expand
    \param output The list to which the result will be appended.
-   \param flag Specifies if any expansion pass should be skipped. Legal values are any combination of EXPAND_SKIP_CMDSUBST EXPAND_SKIP_VARIABLES and EXPAND_SKIP_WILDCARDS
+   \param flags Specifies if any expansion pass should be skipped. Legal values are any combination of EXPAND_SKIP_CMDSUBST EXPAND_SKIP_VARIABLES and EXPAND_SKIP_WILDCARDS
    \return One of EXPAND_OK, EXPAND_ERROR, EXPAND_WILDCARD_MATCH and EXPAND_WILDCARD_NO_MATCH. EXPAND_WILDCARD_NO_MATCH and EXPAND_WILDCARD_MATCH are normal exit conditions used only on strings containing wildcards to tell if the wildcard produced any matches.
 */
 __warn_unused int expand_string(const wcstring &input, std::vector<completion_t> &output, expand_flags_t flags);
@@ -157,7 +157,7 @@ __warn_unused int expand_string(const wcstring &input, std::vector<completion_t>
    names.
 
    \param inout_str The parameter to expand in-place
-   \param flag Specifies if any expansion pass should be skipped. Legal values are any combination of EXPAND_SKIP_CMDSUBST EXPAND_SKIP_VARIABLES and EXPAND_SKIP_WILDCARDS
+   \param flags Specifies if any expansion pass should be skipped. Legal values are any combination of EXPAND_SKIP_CMDSUBST EXPAND_SKIP_VARIABLES and EXPAND_SKIP_WILDCARDS
    \return Whether expansion succeded
 */
 bool expand_one(wcstring &inout_str, expand_flags_t flags);

--- a/fish_pager.cpp
+++ b/fish_pager.cpp
@@ -459,7 +459,7 @@ static void completion_print_item(const wchar_t *prefix, comp_t *c, int width, b
    Print the specified part of the completion list, using the
    specified column offsets and quoting style.
 
-   \param l The list of completions to print
+   \param lst The list of completions to print
    \param cols number of columns to print in
    \param width An array specifying the width of each column
    \param row_start The first row to print
@@ -516,7 +516,7 @@ static void completion_print(int cols,
    \param cols the number of columns to try to fit onto the screen
    \param prefix the character string to prefix each completion with
    \param is_quoted whether the completions should be quoted
-   \param l the list of completions
+   \param lst the list of completions
 
    \return one of PAGER_RETRY, PAGER_DONE and PAGER_RESIZE
 */

--- a/highlight.h
+++ b/highlight.h
@@ -69,7 +69,7 @@ struct file_detection_context_t;
    stored in the color array as a color_code from the HIGHLIGHT_ enum
    for each character in buff.
 
-   \param buff The buffer on which to perform syntax highlighting
+   \param buffstr The buffer on which to perform syntax highlighting
    \param color The array in wchich to store the color codes. The first 8 bits are used for fg color, the next 8 bits for bg color.
    \param pos the cursor position. Used for quote matching, etc.
    \param error a list in which a description of each error will be inserted. May be 0, in whcich case no error descriptions will be generated.
@@ -82,7 +82,7 @@ void highlight_shell_new_parser(const wcstring &buffstr, std::vector<highlight_s
    stored in the color array as a color_code from the HIGHLIGHT_ enum
    for each character in buff.
 
-   \param buff The buffer on which to perform syntax highlighting
+   \param buffstr The buffer on which to perform syntax highlighting
    \param color The array in wchich to store the color codes. The first 8 bits are used for fg color, the next 8 bits for bg color.
    \param pos the cursor position. Used for quote matching, etc.
    \param error a list in which a description of each error will be inserted. May be 0, in whcich case no error descriptions will be generated.

--- a/pager.cpp
+++ b/pager.cpp
@@ -164,9 +164,9 @@ line_t pager_t::completion_print_item(const wcstring &prefix, const comp_t *c, s
    Print the specified part of the completion list, using the
    specified column offsets and quoting style.
 
-   \param l The list of completions to print
+   \param lst The list of completions to print
    \param cols number of columns to print in
-   \param width An array specifying the width of each column
+   \param width_per_column An array specifying the width of each column
    \param row_start The first row to print
    \param row_stop the row after the last row to print
    \param prefix The string to print before each completion

--- a/parser.cpp
+++ b/parser.cpp
@@ -669,7 +669,7 @@ void parser_t::emit_profiling(const char *path) const
    Print error message to string if an error has occured while parsing
 
    \param target the buffer to write to
-   \param prefix: The string token to prefix the each line with. Usually the name of the command trying to parse something.
+   \param prefix The string token to prefix the each line with. Usually the name of the command trying to parse something.
 */
 void parser_t::print_errors(wcstring &target, const wchar_t *prefix)
 {
@@ -1254,7 +1254,7 @@ profile_item_t *parser_t::create_profile_item()
    \param j the job to which the process belongs to
    \param tok the tokenizer to read options from
    \param args the argument list to insert options into
-   \param args unskip whether we should ignore current_block()->skip. Big hack because of our dumb handling of if statements.
+   \param unskip whether we should ignore current_block()->skip. Big hack because of our dumb handling of if statements.
 */
 void parser_t::parse_job_argument_list(process_t *p,
                                        job_t *j,

--- a/parser.h
+++ b/parser.h
@@ -371,7 +371,7 @@ public:
     /**
       Evaluate the expressions contained in cmd.
 
-      \param cmd the string to evaluate
+      \param cmd_str the string to evaluate
       \param io io redirections to perform on all started jobs
       \param block_type The type of block to push on the block stack
 
@@ -387,10 +387,6 @@ public:
       Evaluate line as a list of parameters, i.e. tokenize it and perform parameter expansion and cmdsubst execution on the tokens.
       The output is inserted into output.
 
-      \param line Line to evaluate
-      \param output List to insert output to
-    */
-    /**
       \param line Line to evaluate
       \param output List to insert output to
     */

--- a/postfork.cpp
+++ b/postfork.cpp
@@ -162,7 +162,7 @@ static void free_redirected_fds_from_pipes(const io_chain_t &io_chain)
    server file descriptor. It then goes on to perform all the
    redirections described by \c io.
 
-   \param io the list of IO redirections for the child
+   \param io_chain the list of IO redirections for the child
 
    \return 0 on sucess, -1 on failiure
 */

--- a/reader.cpp
+++ b/reader.cpp
@@ -1217,7 +1217,7 @@ static bool insert_char(editable_line_t *el, wchar_t c, bool should_expand_abbre
    Insert the string in the given command line at the given cursor
    position. The function checks if the string is quoted or not and
    correctly escapes the string.
-   \param val the string to insert
+   \param val_str the string to insert
    \param flags A union of all flags describing the completion to insert. See the completion_t struct for more information on possible values.
    \param command_line The command line into which we will insert
    \param inout_cursor_pos On input, the location of the cursor within the command line. On output, the new desired position.
@@ -2884,7 +2884,6 @@ static int threaded_highlight(background_highlight_context_t *ctx)
    maykes characters under the sursor unreadable.
 
    \param match_highlight_pos_adjust the adjustment to the position to use for bracket matching. This is added to the current cursor position and may be negative.
-   \param error if non-null, any possible errors in the buffer are further descibed by the strings inserted into the specified arraylist
 */
 static void reader_super_highlight_me_plenty(int match_highlight_pos_adjust)
 {

--- a/wildcard.cpp
+++ b/wildcard.cpp
@@ -609,7 +609,7 @@ static wcstring file_get_desc(const wcstring &filename,
    \param fullname the full filename of the file
    \param completion the completion part of the file name
    \param wc the wildcard to match against
-   \param is_cmd whether we are performing command completion
+   \param expand_flags expansion flags
 */
 static void wildcard_completion_allocate(std::vector<completion_t> &list,
         const wcstring &fullname,


### PR DESCRIPTION
I checked the available documentation comments for consistency in respect to the respective function's signature. Mostly param tags had to be fixed to reflect function signature changes from code refactoring.

There are a few situations where I'm not sure how to fix it in a correct way, for example in parser.h:484-495: It seems like the comment block has to be moved a function down and slightly adapted.

Please have a look at it. Thanks.