### PR TITLE
Fixed various Undefined Behavior occurrences.

### DIFF
--- a/autoload.cpp
+++ b/autoload.cpp
@@ -19,7 +19,7 @@ static const int kAutoloadStalenessInterval = 15;
 file_access_attempt_t access_file(const wcstring &path, int mode)
 {
     //printf("Touch %ls\n", path.c_str());
-    file_access_attempt_t result = {0};
+    file_access_attempt_t result = {};
     struct stat statbuf;
     if (wstat(path, &statbuf))
     {

--- a/builtin_commandline.cpp
+++ b/builtin_commandline.cpp
@@ -214,7 +214,7 @@ static int builtin_commandline(parser_t &parser, wchar_t **argv)
     int line_mode = 0;
     int search_mode = 0;
     int paging_mode = 0;
-    const wchar_t *begin, *end;
+    const wchar_t *begin = NULL, *end = NULL;
 
     current_buffer = (wchar_t *)builtin_complete_get_temporary_buffer();
     if (current_buffer)

--- a/common.cpp
+++ b/common.cpp
@@ -599,7 +599,7 @@ bool contains_internal(const wchar_t *a, ...)
 }
 
 /* wcstring variant of contains_internal. The first parameter is a wcstring, the rest are const wchar_t* */
-__sentinel bool contains_internal(const wcstring &needle, ...)
+__sentinel bool contains_internal(const wcstring needle, ...)
 {
     const wchar_t *arg;
     va_list va;

--- a/common.h
+++ b/common.h
@@ -689,7 +689,7 @@ wcstring wsetlocale(int category, const wchar_t *locale);
    \return zero if needle is not found, of if needle is null, non-zero otherwise
 */
 __sentinel bool contains_internal(const wchar_t *needle, ...);
-__sentinel bool contains_internal(const wcstring &needle, ...);
+__sentinel bool contains_internal(const wcstring needle, ...);
 
 /**
    Call read while blocking the SIGCHLD signal. Should only be called

--- a/event.cpp
+++ b/event.cpp
@@ -58,7 +58,7 @@ signal_list_t;
   active, which is the one that new events is written to. The inactive
   one contains the events that are currently beeing performed.
 */
-static signal_list_t sig_list[]= {{0,0},{0,0}};
+static signal_list_t sig_list[]= {{},{}};
 
 /**
    The index of sig_list that is the list of signals currently written to

--- a/expand.cpp
+++ b/expand.cpp
@@ -846,7 +846,7 @@ void expand_variable_error(parser_t &parser, const wcstring &token, size_t token
             *(cpy+token_pos)=0;
             wchar_t *name = &cpy[stop_pos+1];
             wchar_t *end = wcschr(name, BRACKET_END);
-            wchar_t *post;
+            wchar_t *post = NULL;
             int is_var=0;
             if (end)
             {

--- a/parse_util.cpp
+++ b/parse_util.cpp
@@ -1013,7 +1013,7 @@ void parse_util_expand_variable_error(const parse_node_t &node, const wcstring &
             *(cpy+token_pos)=0;
             wchar_t *name = &cpy[stop_pos+1];
             wchar_t *end = wcschr(name, BRACKET_END);
-            wchar_t *post;
+            wchar_t *post = NULL;
             int is_var=0;
             if (end)
             {


### PR DESCRIPTION
There are a few situations in which Undefined Behavior can occur. This pull request fixes mainly three categories: First,conditionally uninitialized variables. Second missing field initializers. And third the usage of references with va_start, which is not allowed, too. The proposed fixes hopefully improve the reliability and portability.

Conditionally uninitialized:
- builtin_commandline.cpp:577
- expand.cpp:869
- parse_util.cpp:1036

Initialization of POD structs:
- event.cpp:61
- autoload.cpp:22

References used with va_start:
- common.cpp:608

Please have a look at it. Thanks.
