### PR TITLE
Debian chroot environment in prompt

### DIFF
--- a/share/tools/web_config/sample_prompts/debian_chroot.fish
+++ b/share/tools/web_config/sample_prompts/debian_chroot.fish
@@ -1,0 +1,55 @@
+# name: Debian chroot
+# author: Maurizio De Santis
+
+function fish_prompt --description 'Write out the prompt, prepending the Debian chroot environment if present'
+
+	# Just calculate these once, to save a few cycles when displaying the prompt
+	if not set -q __fish_prompt_hostname
+		set -g __fish_prompt_hostname (hostname|cut -d . -f 1)
+	end
+
+	if not set -q __fish_prompt_normal
+		set -g __fish_prompt_normal (set_color normal)
+	end
+
+	if not set -q __fish_prompt_chroot_env
+		set -g __fish_prompt_chroot_env (set_color yellow)
+	end
+
+	# Set variable identifying the chroot you work in (used in the prompt below)
+	if begin; not set -q debian_chroot; and test -r /etc/debian_chroot; end
+		set debian_chroot (cat /etc/debian_chroot)
+	end
+	if begin; not set -q __fish_debian_chroot_prompt; and set -q debian_chroot; and test -n $debian_chroot; end
+		set -g __fish_debian_chroot_prompt "($debian_chroot)"
+	end
+
+	# Prepend the chroot environment if present
+	if set -q __fish_debian_chroot_prompt
+		echo -n -s "$__fish_prompt_chroot_env" "$__fish_debian_chroot_prompt" "$__fish_prompt_normal" ' '
+	end
+
+	switch $USER
+
+		case root
+
+		if not set -q __fish_prompt_cwd
+			if set -q fish_color_cwd_root
+				set -g __fish_prompt_cwd (set_color $fish_color_cwd_root)
+			else
+				set -g __fish_prompt_cwd (set_color $fish_color_cwd)
+			end
+		end
+
+		echo -n -s "$USER" @ "$__fish_prompt_hostname" ' ' "$__fish_prompt_cwd" (prompt_pwd) "$__fish_prompt_normal" '# '
+
+		case '*'
+
+		if not set -q __fish_prompt_cwd
+			set -g __fish_prompt_cwd (set_color $fish_color_cwd)
+		end
+
+		echo -n -s "$USER" @ "$__fish_prompt_hostname" ' ' "$__fish_prompt_cwd" (prompt_pwd) "$__fish_prompt_normal" '> '
+
+	end
+end


### PR DESCRIPTION
When you chroot in Debian, bash shows the chroot environment in the prompt:

``` bash
# inside /etc/bash.bashrc

...

# set variable identifying the chroot you work in (used in the prompt below)
if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
    debian_chroot=$(cat /etc/debian_chroot)
fi

# set a fancy prompt (non-color, overwrite the one in /etc/profile)
PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '

...
```

This is the effect:

```
(chroot_env)user@host:~#
```

It is useful when chrooting, since usually the hostname remains the same and thus you can't distinguish where you are.

My proposal has the same effect. I tested it and it works.

Feel free to discuss it, I made it on the fly.
