### PR TITLE
Fix non-verbose, non-informative __fish_git_prompt

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -336,11 +336,11 @@ function __fish_git_prompt_show_upstream --description "Helper function for __fi
 		case "0	0" # equal to upstream
 			echo "$___fish_git_prompt_char_upstream_prefix$___fish_git_prompt_char_upstream_equal"
 		case "0	*" # ahead of upstream
-			echo "$___fish_git_prompt_char_upstream_prefix$___fish_git_prompt_char_upstream_ahead$ahead"
+			echo "$___fish_git_prompt_char_upstream_prefix$___fish_git_prompt_char_upstream_ahead"
 		case "*	0" # behind upstream
-			echo "$___fish_git_prompt_char_upstream_prefix$___fish_git_prompt_char_upstream_behind$behind"
+			echo "$___fish_git_prompt_char_upstream_prefix$___fish_git_prompt_char_upstream_behind"
 		case '*' # diverged from upstream
-			echo "$___fish_git_prompt_char_upstream_prefix$___fish_git_prompt_char_upstream_diverged$ahead-$behind"
+			echo "$___fish_git_prompt_char_upstream_prefix$___fish_git_prompt_char_upstream_diverged"
 		end
 	end
 end


### PR DESCRIPTION
At some point the non-verbose, non-informative variant of the prompt
(e.g. the variant that looks like the bash prompt) was modified to try
and show the behind/ahead counts the same way the informative prompt
does. Besides being wrong, it also didn't work because behind/ahead
weren't defined.
