### PR TITLE
Move cursor back on insert mode exit.

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -175,8 +175,8 @@ function fish_vi_key_bindings -d "vi-like key bindings for fish"
   bind -M insert -k right forward-char
   bind -M insert -k left backward-char
 
-  bind -M insert -m default \cc force-repaint
-  bind -M insert -m default \e force-repaint
+  bind -M insert -m default \cc backward-char force-repaint
+  bind -M insert -m default \e backward-char force-repaint
 
   bind -M insert \cd exit
 


### PR DESCRIPTION
Make this consistent with vi. Really, the cursor shouldn't be able to go past the end of the line in command mode but I don't know if there is any simple way to fix this.
