### PR TITLE
Bind 0 to beginning-of-line in vi mode

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -33,6 +33,7 @@ function fish_vi_key_bindings -d "vi-like key bindings for fish"
 
   bind \x24 end-of-line
   bind \x5e beginning-of-line
+  bind 0 beginning-of-line
   bind g\x24 end-of-line
   bind g\x5e beginning-of-line
   bind \e\[H beginning-of-line


### PR DESCRIPTION
This is consistent with zsh.
