### PR TITLE
Fix python completion to work for pypy

### DIFF
--- a/share/functions/__fish_complete_python.fish
+++ b/share/functions/__fish_complete_python.fish
@@ -18,7 +18,7 @@ function __fish_complete_python -d 'Make completion for python' --argument-names
     complete -c $cmd -a "(__fish_complete_suffix .py)"
     complete -c $cmd -a '-' -d 'Read program from stdin'
 
-    switch (eval $cmd -V 2>| sed 's/^.*\s\(.\).*/\1/')
+    switch (eval $cmd -V 2>&1 | head -n1 | sed 's/^.*\s\([23]\)\..*/\1/')
         case 2
         complete -c $cmd -s 3 -d 'Warn about Python 3.x incompatibilities that 2to3 cannot trivially fix'
         complete -c $cmd -s t --description "Warn on mixed tabs and spaces"


### PR DESCRIPTION
Pypy outputs 2 lines with the -V option, as well as adding a whole lot of stuff that confuses the very general sed regex that was used before.
