### PR TITLE
Automatically add include paths for ncurses on Cygwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,6 +213,16 @@ if test `uname` != "Darwin"; then
    LDFLAGS_FISH="$LDFLAGS_FISH -rdynamic"
 fi
 
+#
+# On Cygwin, we need to add some flags for ncurses.
+#
+case `uname` in
+    CYGWIN*)
+        echo "adding flags for ncurses on Cygwin"
+        CXXFLAGS="$CXXFLAGS -I/usr/include -I/usr/include/ncursesw"
+        LDFLAGS_FISH="$LDFLAGS_FISH -L/usr/lib/ncursesw"
+    ;;
+esac
 
 #
 # If we are compiling against glibc, set some flags to work around


### PR DESCRIPTION
See #1453. I'm no expert on build systems, so this should be checked well.
