### PR TITLE
Fixes use-after-free issue in mimedb.cpp

### DIFF
--- a/mimedb.cpp
+++ b/mimedb.cpp
@@ -1190,6 +1190,12 @@ static void launch(char *filter, const string_list_t &files, size_t fileno)
             writer('&');
             writer('\0');
 
+            /*
+              Calling writer might fail in which case launch_buff gets freed.
+            */
+            if (error)
+                return;
+
             if (system(launch_buff) == -1)
             {
                 fprintf(stderr, _(ERROR_SYSTEM), MIMEDB, launch_buff);


### PR DESCRIPTION
Calling writer() might fail in which case launch_buff gets freed.

In detail: the realloc in writer() might return null, in which case the launch_buff gets freed and an error is set appropriately. But on the call site launch_buf was still passed to system().

So either we set launch_buff to null or avoid the invalid memory access.

This patch prevents the subsequent use of memory after it was freed.
