### PR TITLE
share/functions/__fish_print_service_names : Fix for systemd installed but not PID 1

### DIFF
--- a/share/functions/__fish_print_service_names.fish
+++ b/share/functions/__fish_print_service_names.fish
@@ -1,5 +1,5 @@
 function __fish_print_service_names -d 'All services known to the system'
-    if test -d /run/systemd/system >/dev/null
+    if test -d /run/systemd/system
         command systemctl list-units  -t service | cut -d ' ' -f 1 | grep '\.service$' | sed -e 's/\.service$//'
     else if type -f rc-service
         command rc-service -l


### PR DESCRIPTION
We need to use the /run/systemd/system check to make sure that the system is not something like Ubuntu, where systemd and systemctl are installed but not operating as PID 1.
