### PR TITLE
No reason not to set locales on non-login shells.

### DIFF
--- a/etc/config.fish
+++ b/etc/config.fish
@@ -3,20 +3,18 @@
 #
 
 #
+# Set some value for LANG if nothing was set before
+#
+if not set -q LANG >/dev/null
+	set -gx LANG en_US.UTF-8
+	set -gx LC_ALL en_US.UTF-8
+end
+
+#
 # Some things should only be done for login terminals
 #
 
 if status --is-login
-
-	#
-	# Set some value for LANG if nothing was set before, and this is a
-	# login shell.
-	#
-
-	if not set -q LANG >/dev/null
-		set -gx LANG en_US.UTF-8
-	end
-
 	# Check for i18n information in
 	# /etc/sysconfig/i18n
 


### PR DESCRIPTION
Setting locale only on login shells prevents mosh from working.