### PR TITLE
Fix Makefile.in for building key_reader

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -724,8 +724,8 @@ fish_indent: $(FISH_INDENT_OBJS)
 # Neat little program to show output from terminal
 #
 
-key_reader: key_reader.o input_common.o common.o env_universal.o env_universal_common.o wutil.o iothread.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS_FISH) key_reader.o input_common.o common.o env_universal.o env_universal_common.o wutil.o iothread.o $(LIBS) -o $@
+key_reader: key_reader.o input_common.o common.o env_universal.o env_universal_common.o wutil.o iothread.o utf8.o
+	$(CXX) $(CXXFLAGS) $(LDFLAGS_FISH) key_reader.o input_common.o common.o env_universal.o env_universal_common.o wutil.o iothread.o utf8.o $(LIBS) -o $@
 
 
 #


### PR DESCRIPTION
Could not build key_reader because utf8.o was missing.
