### PR TITLE
Fix: `status --job-control` with invalid parameters causes segmentation fault

### DIFF
--- a/builtin.cpp
+++ b/builtin.cpp
@@ -2670,7 +2670,7 @@ static int builtin_status(parser_t &parser, wchar_t **argv)
                 {
                     append_format(stderr_buffer,
                                   L"%ls: Invalid job control mode '%ls'\n",
-                                  woptarg);
+                                  L"status", woptarg);
                     res = 1;
                 }
                 mode = DONE;


### PR DESCRIPTION
Example:

```
$ status --job-control ""
fish: Job 1, “fish” terminated by signal SIGSEGV (Address boundary error)
```
