### PR TITLE
Fix documentation on variable scopes for `read`

### DIFF
--- a/doc_src/read.txt
+++ b/doc_src/read.txt
@@ -11,7 +11,7 @@ input and stores the result in one or more shell variables.
 The following options are available:
 
 - <tt>-c CMD</tt> or <tt>--command=CMD</tt> sets the initial string in the interactive mode command buffer to <tt>CMD</tt>.
-- <tt>-g</tt> or <tt>--global</tt> makes the variables global (default behaviour).
+- <tt>-g</tt> or <tt>--global</tt> makes the variables global.
 - <tt>-l</tt> or <tt>--local</tt> makes the variables local.
 - <tt>-m NAME</tt> or <tt>--mode-name=NAME</tt> specifies that the name NAME should be used to save/load the history file. If NAME is fish, the regular fish history will be available.
 - <tt>-p PROMPT_CMD</tt> or <tt>--prompt=PROMPT_CMD</tt> uses the output of the shell command \c PROMPT_CMD as the prompt for the interactive mode. The default prompt command is <tt>set_color green; echo read; set_color normal; echo "> "</tt>.
@@ -24,6 +24,9 @@ The following options are available:
 based on the <tt>IFS</tt> shell variable, and then assigns one
 token to each variable specified in <tt>VARIABLES</tt>. If there are more
 tokens than variables, the complete remainder is assigned to the last variable.
+
+See the documentation for \c set for more details on the scoping rules for
+variables.
 
 \subsection read-example Example
 


### PR DESCRIPTION
The `read` docs incorrectly asserted that -g was the default for
variables. In actuality it behaves the same way that `set` does.
