### PR TITLE
Added fish_preexec and fish_postexec event

### DIFF
--- a/reader.cpp
+++ b/reader.cpp
@@ -2961,7 +2961,11 @@ static int read_i(void)
             update_buff_pos(&data->command_line, 0);
             data->command_line.text.clear();
             data->command_line_changed(&data->command_line);
+            wcstring_list_t argv;
+            argv.push_back(command);
+            event_fire_generic(L"fish_preexec", &argv);
             reader_run_command(parser, command);
+            event_fire_generic(L"fish_postexec", &argv);
             if (data->end_loop)
             {
                 handle_end_loop();


### PR DESCRIPTION
Issue: https://github.com/fish-shell/fish-shell/issues/1549
Implemented a solution as event instead of a function call as discussed here: https://github.com/fish-shell/fish-shell/pull/1550
Added a postexec event as well for completeness

Usage:

```
function preexec_test --on-event fish_preexec
  echo preexec handler: $argv
end

function postexec_test --on-event fish_postexec
  echo postexec handler: $argv
end
```
