### PR TITLE
Parse OSC codes in escape_code_length(). 

### DIFF
--- a/fish_tests.cpp
+++ b/fish_tests.cpp
@@ -1209,6 +1209,8 @@ static void test_escape_sequences(void)
     if (escape_code_length(L"\x1b[2J") != 4) err(L"test_escape_sequences failed on line %d\n", __LINE__);
     if (escape_code_length(L"\x1b[38;5;123mABC") != strlen("\x1b[38;5;123m")) err(L"test_escape_sequences failed on line %d\n", __LINE__);
     if (escape_code_length(L"\x1b@") != 2) err(L"test_escape_sequences failed on line %d\n", __LINE__);
+    if (escape_code_length(L"\x1b]blahblahblah\x1b\\") != 16) err(L"test_escape_sequences failed on line %d\n", __LINE__);
+    if (escape_code_length(L"\x1b]blahblahblah\x07") != 15) err(L"test_escape_sequences failed on line %d\n", __LINE__);
 }
 
 class lru_node_test_t : public lru_node_t

--- a/screen.cpp
+++ b/screen.cpp
@@ -291,7 +291,42 @@ size_t escape_code_length(const wchar_t *code)
             resulting_length = cursor;
         }
     }
+    if (! found)
+    {
+        /* OSC code, terminated by <esc>\ or <bel> */
+        if (code[1] == L']')
+        {
+            // Start at 2 to skip over <esc>]
+            size_t cursor = 2;
+            bool backslash_ends = false;
+            for (; code[cursor] != L'\0'; cursor++)
+            {
+                /* Consume a sequence of characters up to <esc>\ or <bel> */
+                wchar_t c = code[cursor];
+                if (c == L'\x1b') {
+                    backslash_ends = true;
+                }
+                else if (c == L'\\' && backslash_ends)
+                {
+                    found = true;
+                    break;
+                }
+                else
+                {
+                    backslash_ends = false;
+                }
 
+                if (c == L'\x07') {
+                    found = true;
+                    break;
+                }
+            }
+            if (found)
+            {
+                resulting_length = cursor + 1;
+            }
+        }
+    }
     if (! found)
     {
         /* Generic VT100 two byte sequence: <esc> followed by something in the range @ through _ */


### PR DESCRIPTION
They begin with _esc_ ] and are terminated with ST (_esc backslash_) or _bel_ (ASCII 7).

OSC codes are useful in prompts. For example, in xterm OSC 50 changes fonts and OSC 0, 1, and 2 are used for setting window and icon title (other terminals interpret this as window and tab title); FinalTerm uses it for its proprietary escape sequences, which enable some really cool features; iTerm2 uses it for its proprietary escape sequences (including [Shell Integration](http://www.iterm2.com/shell_integration.html|), which is what motivates me). 
