### PR TITLE
"webconfig.py: Don't allow NoneType as buffer, fallback to bytes.

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -287,7 +287,7 @@ class BindingParser:
     def set_buffer(self, buffer):
         """ Sets code to parse """
 
-        self.buffer = buffer
+        self.buffer = buffer or b''
         self.index = 0
 
     def get_char(self):


### PR DESCRIPTION
Fixes TypeErrors when using bindings tab"
