### PR TITLE
Fix fish_config error with python3

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 # Whether we're Python 2
-import sys, os
+import sys
+import os
+import operator
 IS_PY2 = sys.version_info[0] == 2
 
 if IS_PY2:
@@ -489,7 +491,7 @@ class FishConfigHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             result.append([color_name, color_desc, parse_color('')])
 
         # Sort our result (by their keys)
-        result.sort()
+        result.sort(key=operator.itemgetter('name'))
 
         return result
 


### PR DESCRIPTION
fixes #1253 

This fix was originally suggested by @sjdrodge. I tested with both python 2.7.5 and python 3.4.1.

I wasn't able to repro either of the two issues mentioned by @sjdrodge above. Perhaps they've been fixed elsewhere.
