### PR TITLE
Authenticate connections to web_config service

### DIFF
--- a/share/tools/web_config/js/controllers.js
+++ b/share/tools/web_config/js/controllers.js
@@ -83,7 +83,7 @@ controllers.controller("colorsController", function($scope, $http) {
 
 
     $scope.getCurrentTheme = function() {
-        $http.get("/colors/").success(function(data, status, headers, config) {
+        $http.get("colors/").success(function(data, status, headers, config) {
            var currentScheme = { "name": "Current", "colors":[], "preferred_background": "" };
             for (var i in data) {
                 currentScheme[data[i].name] = data[i].color;
@@ -103,7 +103,7 @@ controllers.controller("colorsController", function($scope, $http) {
         var remaining = settingNames.length;
         for (name in settingNames) {
             var postData = "what=" + settingNames[name] + "&color=" + $scope.selectedColorScheme[settingNames[name]] + "&background_color=&bold=&underline=";
-            $http.post("/set_color/", postData, { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }).success(function(data, status, headers, config) {
+            $http.post("set_color/", postData, { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }).success(function(data, status, headers, config) {
             	if (status == 200) {
             		remaining -= 1;
             		if (remaining == 0) {
@@ -124,7 +124,7 @@ controllers.controller("promptController", function($scope, $http) {
     $scope.savePromptButtonTitle = "Set Prompt";
 
     $scope.fetchSamplePrompts= function() {
-        $http.get("/sample_prompts/").success(function(data, status, headers, config) {
+        $http.get("sample_prompts/").success(function(data, status, headers, config) {
             $scope.samplePrompts = data;
             $scope.samplePromptsArrayArray = get_colors_as_nested_array($scope.samplePrompts, 1);
 
@@ -140,7 +140,7 @@ controllers.controller("promptController", function($scope, $http) {
     }
 
     $scope.setNewPrompt = function(selectedPrompt) {
-        $http.post("/set_prompt/","what=" + encodeURIComponent(selectedPrompt.function), { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }).success(function(data, status, headers, config){
+        $http.post("set_prompt/","what=" + encodeURIComponent(selectedPrompt.function), { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }).success(function(data, status, headers, config){
 
             // Update attributes of current prompt and select it
             $scope.samplePrompts[0].demo = selectedPrompt.demo;
@@ -171,7 +171,7 @@ controllers.controller("functionsController", function($scope, $http) {
     }
 
     $scope.fetchFunctions= function() {
-        $http.get("/functions/").success(function(data, status, headers, config) {
+        $http.get("functions/").success(function(data, status, headers, config) {
             $scope.functions = data;
             $scope.selectFunction($scope.functions[0]);
     })};
@@ -195,7 +195,7 @@ controllers.controller("functionsController", function($scope, $http) {
     }
 
     $scope.fetchFunctionDefinition = function(name) {
-         $http.post("/get_function/","what=" + name, { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }).success(function(data, status, headers, config) {
+         $http.post("get_function/","what=" + name, { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }).success(function(data, status, headers, config) {
             $scope.functionDefinition = $scope.cleanupFishFunction(data[0]);
     })};
 
@@ -206,7 +206,7 @@ controllers.controller("variablesController", function($scope, $http) {
     $scope.query = null;
 
     $scope.fetchVariables= function() {
-        $http.get("/variables/").success(function(data, status, headers, config) {
+        $http.get("variables/").success(function(data, status, headers, config) {
         $scope.variables = data;
     })};
 
@@ -247,7 +247,7 @@ controllers.controller("historyController", function($scope, $http, $timeout) {
     }
     // Get history from server
     $scope.fetchHistory = function() {
-        $http.get("/history/").success(function(data, status, headers, config) {
+        $http.get("history/").success(function(data, status, headers, config) {
         $scope.historySize = data.length;
         $scope.remainingItems = data;
 
@@ -257,7 +257,7 @@ controllers.controller("historyController", function($scope, $http, $timeout) {
 
     $scope.deleteHistoryItem = function(item) {
         index = $scope.historyItems.indexOf(item);
-        $http.post("/delete_history_item/","what=" + encodeURIComponent(item), { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }).success(function(data, status, headers, config) {
+        $http.post("delete_history_item/","what=" + encodeURIComponent(item), { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }).success(function(data, status, headers, config) {
         $scope.historyItems.splice(index, 1);
     })};
 
@@ -278,7 +278,7 @@ controllers.controller("historyController", function($scope, $http, $timeout) {
 controllers.controller("bindingsController", function($scope, $http) {
     $scope.bindings = [];
     $scope.fetchBindings = function() {
-        $http.get("/bindings/").success(function(data, status, headers, config) {
+        $http.get("bindings/").success(function(data, status, headers, config) {
             $scope.bindings = data;
     })};
 


### PR DESCRIPTION
This is a fix for CVE-2014-2914 (#1438) which allows us to be more secure in the way we accept web_config requests.

I would appreciate any testing before I merge to master and Integration_2.1.1. I've tried on Debian with Iceweasel 24.7.0 (close to Firefox 24.7.0) and Chrome (36.0.1985.125).

In particular:
- does the web config launch properly?
- if you open the server URL (http://localhost:8001 or whatever) in another browser, do you get "access denied"?
  - can you see any secrets in your process table at any time? Secrets are 32-character hexadecimal strings embedded in `/start/` URLs.
