### PR TITLE
Fix rendering of long switches in docs

### DIFF
--- a/doc_src/commandline.txt
+++ b/doc_src/commandline.txt
@@ -16,11 +16,11 @@ the contents of \c CMD.
 
 The following options are available:
 
-- \c -C or \c --cursor set or get the current cursor position, not
+- \c -C or \c `--cursor` set or get the current cursor position, not
   the contents of the buffer. If no argument is given, the current
   cursor position is printed, otherwise the argument is interpreted
   as the new cursor position.
-- \c -f or \c --function inject readline functions into the
+- \c -f or \c `--function` inject readline functions into the
   reader. This option cannot be combined with any other option. It
   will cause any additional arguments to be interpreted as readline
   functions, and these functions will be injected into the reader, so
@@ -30,27 +30,27 @@ The following options are available:
 The following options change the way \c commandline updates the
 command line buffer:
 
-- \c -a or \c --append do not remove the current commandline, append
+- \c -a or \c `--append` do not remove the current commandline, append
   the specified string at the end of it
-- \c -i or \c --insert do not remove the current commandline, insert
+- \c -i or \c `--insert` do not remove the current commandline, insert
   the specified string at the current cursor position
-- \c -r or \c --replace remove the current commandline and replace it
+- \c -r or \c `--replace` remove the current commandline and replace it
   with the specified string (default)
 
 The following options change what part of the commandline is printed
 or updated:
 
-- \c -b or \c --current-buffer select the entire buffer (default)
-- \c -j or \c --current-job select the current job
-- \c -p or \c --current-process select the current process
-- \c -t or \c --current-token select the current token.
+- \c -b or \c `--current-buffer` select the entire buffer (default)
+- \c -j or \c `--current-job` select the current job
+- \c -p or \c `--current-process` select the current process
+- \c -t or \c `--current-token` select the current token.
 
 The following options change the way \c commandline prints the current
 commandline buffer:
 
-- \c -c or \c --cut-at-cursor only print selection up until the
+- \c -c or \c `--cut-at-cursor` only print selection up until the
   current cursor position
-- \c -o or \c --tokenize tokenize the selection and print one string-type token per line
+- \c -o or \c `--tokenize` tokenize the selection and print one string-type token per line
 
 
 If \c commandline is called during a call to complete a given string
@@ -59,11 +59,11 @@ specified string to be the current contents of the command line.
 
 The following options output metadata about the commandline state:
 
-- \c -L or \c --line print the line that the cursor is on, with the topmost
+- \c -L or \c `--line` print the line that the cursor is on, with the topmost
 line starting at 1
-- \c -S or \c --search-mode evaluates to true if the commandline is performing
+- \c -S or \c `--search-mode` evaluates to true if the commandline is performing
 a history search
-- \c -P or \c --paging-mode evaluates to true if the commandline is showing
+- \c -P or \c `--paging-mode` evaluates to true if the commandline is showing
 pager contents, such as tab completions
 
 

--- a/doc_src/contains.txt
+++ b/doc_src/contains.txt
@@ -11,8 +11,8 @@ with status 1.
 
 The following options are available:
 
-- \c -i or \c --index print the word index
-- \c -h or \c --help display this message
+- \c -i or \c `--index` print the word index
+- \c -h or \c `--help` display this message
 
 \subsection contains-example Example
 <pre>

--- a/doc_src/echo.txt
+++ b/doc_src/echo.txt
@@ -13,7 +13,7 @@ The following options are available:
 - \c -s, \c Do not separate arguments with spaces
 - \c -E, \c Disable interpretation of backslash escapes (default)
 - \c -e, \c Enable interpretation of backslash escapes
-- \c -h, \c --help Display this help
+- \c -h, \c `--help` Display this help
 
 \subsection echo-escapes Escape Sequences
 

--- a/doc_src/fish.txt
+++ b/doc_src/fish.txt
@@ -11,14 +11,14 @@ full manual is available <a href='index.html'>in HTML</a> by using the
 
 The following options are available:
 
-- <code>-c</code> or <code>--command=COMMANDS</code> evaluate the specified commands instead of reading from the commandline
-- <code>-d</code> or <code>--debug-level=DEBUG_LEVEL</code> specify the verbosity level of fish. A higher number means higher verbosity. The default level is 1.
-- <code>-h</code> or <code>--help</code> display help and exit
-- <code>-i</code> or <code>--interactive</code> specify that fish is to run in interactive mode
-- <code>-l</code> or <code>--login</code> specify that fish is to run as a login shell
-- <code>-n</code> or <code>--no-execute</code> do not execute any commands, only perform syntax checking
-- <code>-p</code> or <code>--profile=PROFILE_FILE</code> when fish exits, output timing information on all executed commands to the specified file
-- <code>-v</code> or <code>--version</code> display version and exit
+- <code>-c</code> or `--command=COMMANDS` evaluate the specified commands instead of reading from the commandline
+- <code>-d</code> or `--debug-level=DEBUG_LEVEL` specify the verbosity level of fish. A higher number means higher verbosity. The default level is 1.
+- <code>-h</code> or `--help` display help and exit
+- <code>-i</code> or `--interactive` specify that fish is to run in interactive mode
+- <code>-l</code> or `--login` specify that fish is to run as a login shell
+- <code>-n</code> or `--no-execute` do not execute any commands, only perform syntax checking
+- <code>-p</code> or `--profile=PROFILE_FILE` when fish exits, output timing information on all executed commands to the specified file
+- <code>-v</code> or `--version` display version and exit
 
 The fish exit status is generally the exit status of the last
 foreground command. If fish is exiting because of a parse error, the

--- a/doc_src/funced.txt
+++ b/doc_src/funced.txt
@@ -14,8 +14,8 @@ to edit the function. Otherwise, a built-in editor will be used.
 If there is no function called \c NAME a new function will be created with
 the specified name
 
-- <code>-e command</code> or <code>--editor command</code> Open the function
+- <code>-e command</code> or `--editor command` Open the function
   body inside the text editor given by the command (for example, "vi"). The
   command 'fish' will use the built-in editor.
-- <code>-i</code> or <code>--interactive</code> Open function body in the
+- <code>-i</code> or `--interactive` Open function body in the
   built-in editor.

--- a/doc_src/function.txt
+++ b/doc_src/function.txt
@@ -12,18 +12,18 @@ function is given as a command.
 
 The following options are available:
 
-- <code>-a NAMES</code> or <code>--argument-names NAMES</code> assigns the value of successive command-line arguments to the names given in NAMES.
-- <code>-d DESCRIPTION</code> or \c --description=DESCRIPTION is a description of what the function does, suitable as a completion description.
-- <code>-e</code> or <code>--on-event EVENT_NAME</code> tells fish to run this function when the specified named event is emitted. Fish internally generates named events e.g. when showing the prompt.
-- <code>-j PID</code> or <code> --on-job-exit PID</code> tells fish to run this function when the job with group ID PID exits. Instead of PID, the string 'caller' can be specified. This is only legal when in a command substitution, and will result in the handler being triggered by the exit of the job which created this command substitution.
-- <code>-p PID</code> or <code> --on-process-exit PID</code> tells fish to run this function when the fish child process with process ID PID exits.
-- <code>-s</code> or <code>--on-signal SIGSPEC</code> tells fish to run this function when the signal SIGSPEC is delivered. SIGSPEC can be a signal number, or the signal name, such as SIGHUP (or just HUP).
-- \c -S or \c --no-scope-shadowing allows the function to access the variables of calling functions. Normally, any variables inside the function that have the same name as variables from the calling function are "shadowed", and their contents is independent of the calling function.
-- <code>-v</code> or <code>--on-variable VARIABLE_NAME</code> tells fish to run this function when the variable VARIABLE_NAME changes value.
+- <code>-a NAMES</code> or `--argument-names NAMES` assigns the value of successive command-line arguments to the names given in NAMES.
+- <code>-d DESCRIPTION</code> or \c `--description`=DESCRIPTION is a description of what the function does, suitable as a completion description.
+- <code>-e</code> or `--on-event EVENT_NAME` tells fish to run this function when the specified named event is emitted. Fish internally generates named events e.g. when showing the prompt.
+- <code>-j PID</code> or `--on-job-exit PID` tells fish to run this function when the job with group ID PID exits. Instead of PID, the string 'caller' can be specified. This is only legal when in a command substitution, and will result in the handler being triggered by the exit of the job which created this command substitution.
+- <code>-p PID</code> or `--on-process-exit PID` tells fish to run this function when the fish child process with process ID PID exits.
+- <code>-s</code> or `--on-signal SIGSPEC` tells fish to run this function when the signal SIGSPEC is delivered. SIGSPEC can be a signal number, or the signal name, such as SIGHUP (or just HUP).
+- \c -S or \c `--no-scope-shadowing` allows the function to access the variables of calling functions. Normally, any variables inside the function that have the same name as variables from the calling function are "shadowed", and their contents is independent of the calling function.
+- <code>-v</code> or `--on-variable VARIABLE_NAME` tells fish to run this function when the variable VARIABLE_NAME changes value.
 
 If the user enters any additional arguments after the function, they
 are inserted into the environment <a href="index.html#variables-arrays">variable array</a>
-<code>$argv</code>. If the \c --argument-names option is provided, the arguments are
+<code>$argv</code>. If the \c `--argument-names` option is provided, the arguments are
 also assigned to names specified in that option.
 
 By using one of the event handler switches, a function can be made to run automatically at specific events. The user may generate new events using the <a href="#emit">emit</a> builtin. Fish generates the following named events:

--- a/doc_src/functions.txt
+++ b/doc_src/functions.txt
@@ -12,13 +12,13 @@ functions [-eq] FUNCTIONS...</pre>
 
 The following options are available:
 
-- <code>-a</code> or <code>--all</code> lists all functions, even those whose name start with an underscore.
-- <code>-c OLDNAME NEWNAME</code> or <code>--copy OLDNAME NEWNAME</code> creates a new function named NEWNAME, using the definition of the OLDNAME function.
-- <code>-d DESCRIPTION</code> or <code>--description=DESCRIPTION</code> changes the description of this function.
-- <code>-e</code> or <code>--erase</code> causes the specified functions to be erased.
-- <code>-h</code> or <code>--help</code> displays a help message and exits.
-- <code>-n</code> or <code>--names</code> lists the names of all defined functions.
-- <code>-q</code> or <code>--query</code> tests if the specified functions exist.
+- <code>-a</code> or `--all` lists all functions, even those whose name start with an underscore.
+- <code>-c OLDNAME NEWNAME</code> or `--copy OLDNAME NEWNAME` creates a new function named NEWNAME, using the definition of the OLDNAME function.
+- <code>-d DESCRIPTION</code> or `--description=DESCRIPTION` changes the description of this function.
+- <code>-e</code> or `--erase` causes the specified functions to be erased.
+- <code>-h</code> or `--help` displays a help message and exits.
+- <code>-n</code> or `--names` lists the names of all defined functions.
+- <code>-q</code> or `--query` tests if the specified functions exist.
 
 The default behavior of <code>functions</code>, when called with no arguments,
 is to print the names of all defined functions. Unless the \c -a option is

--- a/doc_src/history.txt
+++ b/doc_src/history.txt
@@ -12,27 +12,27 @@ history (--search | --delete ) (--prefix "prefix string" | --contains "search st
 
 The following options are available:
 
-- \c --save saves all changes in the history file. The shell automatically
+- \c `--save` saves all changes in the history file. The shell automatically
 saves the history file; this option is provided for internal use.
-- \c --clear clears the history file. A prompt is displayed before the history
+- \c `--clear` clears the history file. A prompt is displayed before the history
 is erased.
-- \c --merge immediately incorporates history changes from other sessions. Ordinarily
+- \c `--merge` immediately incorporates history changes from other sessions. Ordinarily
 fish ignores history changes from sessions started after the current one. This command
 applies those changes immediately.
-- \c --search returns history items in keeping with the \c --prefix or
-\c --contains options.
-- \c --delete deletes history items.
-- \c --prefix searches or deletes items in the history that begin with the
+- \c `--search` returns history items in keeping with the \c `--prefix` or
+\c `--contains` options.
+- \c `--delete` deletes history items.
+- \c `--prefix` searches or deletes items in the history that begin with the
 specified text string.
-- \c --contains searches or deletes items in the history that contain the
+- \c `--contains` searches or deletes items in the history that contain the
 specified text string.
 
-If \c --search is specified without \c --contains or <code>--prefix</code>,
-\c --contains will be assumed.
+If \c `--search` is specified without \c `--contains` or `--prefix`,
+\c `--contains` will be assumed.
 
-If \c --delete is specified without \c --contains or <code>--prefix</code>,
+If \c `--delete` is specified without \c `--contains` or `--prefix`,
 only a history item which exactly matches the parameter will be erased. No
-prompt will be given. If \c --delete is specified with either of these
+prompt will be given. If \c `--delete` is specified with either of these
 parameters, an interactive prompt will be displayed before any items are
 deleted.
 

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -841,13 +841,13 @@ end. The user can specify that a variable should have either global
 or local scope using the \c -g/--global or \c -l/--local switches.
 
 Variables can be explicitly set to be universal with the \c -U or \c
---universal switch, global with the \c -g or \c --global switch, or
-local with the \c -l or \c --local switch.  The scoping rules when
+--universal switch, global with the \c -g or \c `--global` switch, or
+local with the \c -l or \c `--local` switch.  The scoping rules when
 creating or updating a variable are:
 
 -# If a variable is explicitly set to either universal, global or local, that setting will be honored. If a variable of the same name exists in a different scope, that variable will not be changed.
 -# If a variable is not explicitly set to be either universal, global or local, but has been previously defined, the variable scope is not changed.
--# If a variable is not explicitly set to be either universal, global or local and has never before been defined, the variable will be local to the currently executing function. Note that this is different from using the \c -l or \c --local flag. If one of those flags is used, the variable will be local to the most inner currently executing block, while without these the variable will be local to the function. If no function is executing, the variable will be global.
+-# If a variable is not explicitly set to be either universal, global or local and has never before been defined, the variable will be local to the currently executing function. Note that this is different from using the \c -l or \c `--local` flag. If one of those flags is used, the variable will be local to the most inner currently executing block, while without these the variable will be local to the function. If no function is executing, the variable will be global.
 
 There may be many variables with the same name, but different scopes.
 When using a variable, the variable scope will be searched from the
@@ -918,7 +918,7 @@ exported variables are in uppercase and unexported variables are in
 lowercase.
 
 Variables can be explicitly set to be exported with the \c -x or \c
---export switch, or not exported with the \c -u or \c --unexport
+--export switch, or not exported with the \c -u or \c `--unexport`
 switch.  The exporting rules when creating or updating a variable are
 identical to the scoping rules for variables:
 
@@ -1049,7 +1049,7 @@ If a process exits through a signal, the exit status will be 128 plus the number
 The colors used by fish for syntax highlighting can be configured by
 changing the values of a various variables. The value of these
 variables can be one of the colors accepted by the <a
-href='commands.html#set_color'>set_color</a> command. The \c --bold
+href='commands.html#set_color'>set_color</a> command. The \c `--bold`
 or \c -b switches accepted by \c set_color are also accepted.
 
 The following variables are available to change the highlighting colors
@@ -1111,7 +1111,7 @@ actions which cannot be performed by a regular command.
 
 For a list of all builtins, functions and commands shipped with fish,
 see the <a href="#toc-commands">table of contents</a>. The
-documentation is also available by using the <code>--help</code>
+documentation is also available by using the `--help`
 switch of the command.
 
 \section editor Command line editor

--- a/doc_src/jobs.txt
+++ b/doc_src/jobs.txt
@@ -9,11 +9,11 @@ running <a href="index.html#syntax-job-control">jobs</a> and their status.
 
 jobs accepts the following switches:
 
-- <code>-c</code> or <code>--command</code> prints the command name for each process in jobs.
-- <code>-g</code> or <code>--group</code> only prints the group ID of each job.
-- <code>-h</code> or <code>--help</code> displays a help message and exits.
-- <code>-l</code> or <code>--last</code> prints only the last job to be started.
-- <code>-p</code> or <code>--pid</code> prints the process ID for each process in all jobs.
+- <code>-c</code> or `--command` prints the command name for each process in jobs.
+- <code>-g</code> or `--group` only prints the group ID of each job.
+- <code>-h</code> or `--help` displays a help message and exits.
+- <code>-l</code> or `--last` prints only the last job to be started.
+- <code>-p</code> or `--pid` prints the process ID for each process in all jobs.
 
 On systems that supports this feature, jobs will print the CPU usage
 of each job since the last command was executed. The CPU usage is

--- a/doc_src/mimedb.txt
+++ b/doc_src/mimedb.txt
@@ -14,13 +14,13 @@ be used to launch the default action for this file.
 
 The following options are available:
 
-- \c -t, \c --input-file-data determines the files' type both by their filename and by their contents (default behaviour).
-- \c -f, \c --input-filename determines the files' type by their filename.
-- \c -i, \c --input-mime specifies that the arguments are not files, but MIME types.
-- \c -m, \c --output-mime outputs the MIME type of each file (default behaviour).
-- \c -f, \c --output-description outputs the description of each MIME type.
-- \c -a, \c --output-action outputs the default action of each MIME type.
-- \c -l, \c --launch launches the default action for the specified files.
-- \c -h, \c --help displays a help message and exit.
-- \c -v, \c --version displays the version number and exits.
+- \c -t, \c `--input-file-data` determines the files' type both by their filename and by their contents (default behaviour).
+- \c -f, \c `--input-filename` determines the files' type by their filename.
+- \c -i, \c `--input-mime` specifies that the arguments are not files, but MIME types.
+- \c -m, \c `--output-mime` outputs the MIME type of each file (default behaviour).
+- \c -f, \c `--output-description` outputs the description of each MIME type.
+- \c -a, \c `--output-action` outputs the default action of each MIME type.
+- \c -l, \c `--launch` launches the default action for the specified files.
+- \c -h, \c `--help` displays a help message and exit.
+- \c -v, \c `--version` displays the version number and exits.
 

--- a/doc_src/nextd.txt
+++ b/doc_src/nextd.txt
@@ -7,7 +7,7 @@
 <tt>nextd</tt> moves forwards <tt>POS</tt> positions in the history of visited
 directories; if the end of the history has been hit, a warning is printed.
 
-If the <code>-l></code> or <code>--list</code> flag is specified, the current
+If the <code>-l></code> or `--list` flag is specified, the current
 directory history is also displayed.
 
 \subsection nextd-example Example

--- a/doc_src/prevd.txt
+++ b/doc_src/prevd.txt
@@ -9,7 +9,7 @@
 of visited directories; if the beginning of the history has been hit,
 a warning is printed.
 
-If the <code>-l</code> or <code>--list</code> flag is specified, the current
+If the <code>-l</code> or `--list` flag is specified, the current
 history is also displayed.
 
 \subsection prevd-example Example

--- a/doc_src/psub.txt
+++ b/doc_src/psub.txt
@@ -14,7 +14,7 @@ filename of the named pipe sent as an argument to the calling
 program. \c psub combined with a
 regular command substitution provides the same functionality.
 
-If the \c -f or \c --file switch is given to <tt>psub</tt>, \c psub will use a
+If the \c -f or \c `--file` switch is given to <tt>psub</tt>, \c psub will use a
 regular file instead of a named pipe to communicate with the calling
 process. This will cause \c psub to be significantly slower when large
 amounts of data are involved, but has the advantage that the reading

--- a/doc_src/read.txt
+++ b/doc_src/read.txt
@@ -15,10 +15,10 @@ The following options are available:
 - <tt>-l</tt> or <tt>--local</tt> makes the variables local.
 - <tt>-m NAME</tt> or <tt>--mode-name=NAME</tt> specifies that the name NAME should be used to save/load the history file. If NAME is fish, the regular fish history will be available.
 - <tt>-p PROMPT_CMD</tt> or <tt>--prompt=PROMPT_CMD</tt> uses the output of the shell command \c PROMPT_CMD as the prompt for the interactive mode. The default prompt command is <tt>set_color green; echo read; set_color normal; echo "> "</tt>.
-- <code>-s</code> or <code>--shell</code> enables syntax highlighting, tab completions and command termination suitable for entering shellscript code in the interactive mode.
-- <code>-u</code> or <code>--unexport</code> prevents the variables from being exported to child processes (default behaviour).
-- <code>-U</code> or <code>--universal</code> causes the specified shell variable to be made universal.
-- <code>-x</code> or <code>--export</code> exports the variables to child processes.
+- <code>-s</code> or `--shell` enables syntax highlighting, tab completions and command termination suitable for entering shellscript code in the interactive mode.
+- <code>-u</code> or `--unexport` prevents the variables from being exported to child processes (default behaviour).
+- <code>-U</code> or `--universal` causes the specified shell variable to be made universal.
+- <code>-x</code> or `--export` exports the variables to child processes.
 
 \c read reads a single line of input from stdin, breaks it into tokens
 based on the <tt>IFS</tt> shell variable, and then assigns one

--- a/doc_src/set.txt
+++ b/doc_src/set.txt
@@ -24,17 +24,17 @@ With both variable names and values provided, \c set assigns the variable
 <code>VARIABLE_NAME</code> the values <code>VALUES...</code>.
 
 The following options control variable scope:
-- <code>-l</code> or <code>--local</code> forces the specified shell variable to be given a scope that is local to the current block, even if a variable with the given name exists and is non-local
-- <code>-g</code> or <code>--global</code> causes the specified shell variable to be given a global scope. Non-global variables disappear when the block they belong to ends
-- <code>-U</code> or <code>--universal</code> causes the specified shell variable to be given a universal scope. If this option is supplied, the variable will be shared between all the current users fish instances on the current computer, and will be preserved across restarts of the shell.
-- <code>-x</code> or <code>--export</code> causes the specified shell variable to be exported to child processes (making it an "environment variable")
-- <code>-u</code> or <code>--unexport</code> causes the specified shell variable to NOT be exported to child processes
+- <code>-l</code> or `--local` forces the specified shell variable to be given a scope that is local to the current block, even if a variable with the given name exists and is non-local
+- <code>-g</code> or `--global` causes the specified shell variable to be given a global scope. Non-global variables disappear when the block they belong to ends
+- <code>-U</code> or `--universal` causes the specified shell variable to be given a universal scope. If this option is supplied, the variable will be shared between all the current users fish instances on the current computer, and will be preserved across restarts of the shell.
+- <code>-x</code> or `--export` causes the specified shell variable to be exported to child processes (making it an "environment variable")
+- <code>-u</code> or `--unexport` causes the specified shell variable to NOT be exported to child processes
 
 The following options are available:
-- <code>-e</code> or <code>--erase</code> causes the specified shell variable to be erased
-- <code>-q</code> or <code>--query</code> test if the specified variable names are defined. Does not output anything, but the builtins exit status is the number of variables specified that were not defined.
-- <code>-n</code> or <code>--names</code> List only the names of all defined variables, not their value
-- <code>-L</code> or <code>--long</code> do not abbreviate long values when printing set variables
+- <code>-e</code> or `--erase` causes the specified shell variable to be erased
+- <code>-q</code> or `--query` test if the specified variable names are defined. Does not output anything, but the builtins exit status is the number of variables specified that were not defined.
+- <code>-n</code> or `--names` List only the names of all defined variables, not their value
+- <code>-L</code> or `--long` do not abbreviate long values when printing set variables
 
 If a variable is set to more than one value, the variable will be an
 array with the specified elements. If a variable is set to zero
@@ -53,7 +53,7 @@ The scoping rules when creating or updating a variable are:
 
 -# If a variable is explicitly set to either universal, global or local, that setting will be honored. If a variable of the same name exists in a different scope, that variable will not be changed.
 -# If a variable is not explicitly set to be either universal, global or local, but has been previously defined, the previous variable scope is used.
--# If a variable is not explicitly set to be either universal, global or local and has never before been defined, the variable will be local to the currently executing function. Note that this is different from using the \c -l or \c --local flag. If one of those flags is used, the variable will be local to the most inner currently executing block, while without these the variable will be local to the function. If no function is executing, the variable will be global.
+-# If a variable is not explicitly set to be either universal, global or local and has never before been defined, the variable will be local to the currently executing function. Note that this is different from using the \c -l or \c `--local` flag. If one of those flags is used, the variable will be local to the most inner currently executing block, while without these the variable will be local to the function. If no function is executing, the variable will be global.
 
 The exporting rules when creating or updating a variable are identical
 to the scoping rules for variables:

--- a/doc_src/set_color.txt
+++ b/doc_src/set_color.txt
@@ -15,11 +15,11 @@ as A0FF33 or f2f. \c fish will choose the closest supported color.
 
 The following options are available:
 
-- \c -b, \c --background \c COLOR sets the background color.
-- \c -c, \c --print-colors prints a list of all valid color names.
-- \c -h, \c --help displays a help message and exit.
-- \c -o, \c --bold sets bold or extra bright mode.
-- \c -u, \c --underline sets underlined mode.
+- \c -b, \c `--background` \c COLOR sets the background color.
+- \c -c, \c `--print-colors` prints a list of all valid color names.
+- \c -h, \c `--help` displays a help message and exit.
+- \c -o, \c `--bold` sets bold or extra bright mode.
+- \c -u, \c `--underline` sets underlined mode.
 
 Calling <tt>set_color normal</tt> will set the terminal color to
 the default color of the terminal.

--- a/doc_src/trap.txt
+++ b/doc_src/trap.txt
@@ -14,9 +14,9 @@ The following parameters are available:
 
 - \c ARG is the command to be executed on signal delivery.
 - \c SIGSPEC is the name of the signal to trap.
-- \c -h or \c --help displays help and exits.
-- \c -l or \c --list-signals prints a list of signal names.
-- \c -p or \c --print prints all defined signal handlers.
+- \c -h or \c `--help` displays help and exits.
+- \c -l or \c `--list-signals` prints a list of signal names.
+- \c -p or \c `--print` prints all defined signal handlers.
 
 If \c ARG and \c SIGSPEC are both specified, \c ARG is the command to be
 executed when the signal specified by \c SIGSPEC is delivered.

--- a/doc_src/type.txt
+++ b/doc_src/type.txt
@@ -9,12 +9,12 @@ With no options, \c type indicates how each \c NAME would be interpreted if used
 
 The following options are available:
 
-- \c -h or \c --help prints help and then exits.
-- \c -a or \c --all prints all of possible definitions of the specified names.
-- \c -f or \c --no-functions suppresses function and builtin lookup.
-- \c -t or \c --type prints <tt>keyword</tt>, <tt>function</tt>, <tt>builtin</tt>, or <tt>file</tt> if \c NAME is a shell reserved word, function, builtin, or disk file, respectively.
-- \c -p or \c --path returns the name of the disk file that would be executed, or nothing if 'type  -t  name' would not return 'file'.
-- \c -P or \c --force-path returns the name of the disk file that would be executed, or nothing no file with the specified name could be found in the <tt>$PATH</tt>.
+- \c -h or \c `--help` prints help and then exits.
+- \c -a or \c `--all` prints all of possible definitions of the specified names.
+- \c -f or \c `--no-functions` suppresses function and builtin lookup.
+- \c -t or \c `--type` prints <tt>keyword</tt>, <tt>function</tt>, <tt>builtin</tt>, or <tt>file</tt> if \c NAME is a shell reserved word, function, builtin, or disk file, respectively.
+- \c -p or \c `--path` returns the name of the disk file that would be executed, or nothing if 'type  -t  name' would not return 'file'.
+- \c -P or \c `--force-path` returns the name of the disk file that would be executed, or nothing no file with the specified name could be found in the <tt>$PATH</tt>.
 
 \c type sets the exit status to 0 if the specified command was found,
 and 1 if it could not be found.

--- a/doc_src/ulimit.txt
+++ b/doc_src/ulimit.txt
@@ -12,16 +12,16 @@ the specified limit is set to the new value.
 
 Use one of the following switches to specify which resource limit to set or report:
 
-- <code>-c</code> or <code>--core-size</code>: the maximum size of core files created. By setting this limit to zero, core dumps can be disabled.
-- <code>-d</code> or <code>--data-size</code>: the maximum size of a process' data segment.
-- <code>-f</code> or <code>--file-size</code>: the maximum size of files created by the shell.
-- <code>-l</code> or <code>--lock-size</code>: the maximum size that may be locked into memory.
-- <code>-m</code> or <code>--resident-set-size</code>: the maximum resident set size.
-- <code>-n</code> or <code>--file-descriptor-count</code>: the maximum number of open file descriptors (most systems do not allow this value to be set).
-- <code>-s</code> or <code>--stack-size</code>: the maximum stack size.
-- <code>-t</code> or <code>--cpu-time</code>: the maximum amount of CPU time in seconds.
-- <code>-u</code> or <code>--process-count</code>: the maximum number of processes available to a single user.
-- <code>-v</code> or <code>--virtual-memory-size</code> The maximum amount of virtual memory available to the shell.
+- <code>-c</code> or `--core-size`: the maximum size of core files created. By setting this limit to zero, core dumps can be disabled.
+- <code>-d</code> or `--data-size`: the maximum size of a process' data segment.
+- <code>-f</code> or `--file-size`: the maximum size of files created by the shell.
+- <code>-l</code> or `--lock-size`: the maximum size that may be locked into memory.
+- <code>-m</code> or `--resident-set-size`: the maximum resident set size.
+- <code>-n</code> or `--file-descriptor-count`: the maximum number of open file descriptors (most systems do not allow this value to be set).
+- <code>-s</code> or `--stack-size`: the maximum stack size.
+- <code>-t</code> or `--cpu-time`: the maximum amount of CPU time in seconds.
+- <code>-u</code> or `--process-count`: the maximum number of processes available to a single user.
+- <code>-v</code> or `--virtual-memory-size` The maximum amount of virtual memory available to the shell.
 
 Note that not all these limits are available in all operating systems.
 
@@ -39,8 +39,8 @@ supplied, or an error occurs while setting a new limit.
 \c ulimit also accepts the following switches that determine what type of
 limit to set:
 
-- <code>-H</code> or <code>--hard</code> sets hard resource limit
-- <code>-S</code> or <code>--soft</code> sets soft resource limit
+- <code>-H</code> or `--hard` sets hard resource limit
+- <code>-S</code> or `--soft` sets soft resource limit
 
 A hard limit can only be decreased. Once it is set it cannot be
 increased; a soft limit may be increased up to the value of the hard
@@ -50,8 +50,8 @@ limit is used when reporting the current value.
 
 The following additional options are also understood by <tt>ulimit</tt>:
 
-- <code>-a</code> or <code>--all</code> prints all current limits
-- <code>-h</code> or <code>--help</code> displays help and exits.
+- <code>-a</code> or `--all` prints all current limits
+- <code>-h</code> or `--help` displays help and exits.
 
 The \c fish implementation of \c ulimit should behave identically to the
 implementation in bash, except for these differences:

--- a/doc_src/umask.txt
+++ b/doc_src/umask.txt
@@ -17,9 +17,9 @@ Access rights are explained in the manual page for the \c chmod(1) program.
 With no parameters, the current file creation mode mask is printed as
 an octal number.
 
-- <code>-h</code> or <code>--help</code> prints this message.
-- <code>-S</code> or <code>--symbolic</code> prints the umask in symbolic form instead of octal form.
-- <code>-p</code> or <code>--as-command</code> outputs the umask in a form that may be reused as input
+- <code>-h</code> or `--help` prints this message.
+- <code>-S</code> or `--symbolic` prints the umask in symbolic form instead of octal form.
+- <code>-p</code> or `--as-command` outputs the umask in a form that may be reused as input
 
 If a numeric mask is specified as a parameter, the current shell's umask
 will be set to that value, and the rights specified by that mask will be


### PR DESCRIPTION
Render long options with double-dashes (--) rather than n-dashes (–)

fixes #1557
