### PR TITLE
Set $CMD_DURATION to milliseconds. Fixes #1585

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -1008,6 +1008,7 @@ values of most of these variables.
 - \c PWD, the current working directory.
 - \c status, the <a href="#variables-status">exit status</a> of the last foreground job to exit. If the job was terminated through a signal, the exit status will be 128 plus the signal number.
 - \c USER, the current username. This variable can only be changed by the root user.
+- \c CMD_DURATION, the runtime of the last command in milliseconds.
 
 The names of these variables are mostly derived from the csh family of
 shells and differ from the ones used by Bourne style shells such as

--- a/reader.cpp
+++ b/reader.cpp
@@ -2495,34 +2495,8 @@ void set_env_cmd_duration(struct timeval *after, struct timeval *before)
         secs -= 1;
     }
 
-    if (secs < 1)
-    {
-        env_remove(ENV_CMD_DURATION, 0);
-    }
-    else
-    {
-        if (secs < 10)   // 10 secs
-        {
-            swprintf(buf, 16, L"%lu.%02us", secs, usecs / 10000);
-        }
-        else if (secs < 60)     // 1 min
-        {
-            swprintf(buf, 16, L"%lu.%01us", secs, usecs / 100000);
-        }
-        else if (secs < 600)     // 10 mins
-        {
-            swprintf(buf, 16, L"%lum %lu.%01us", secs / 60, secs % 60, usecs / 100000);
-        }
-        else if (secs < 5400)     // 1.5 hours
-        {
-            swprintf(buf, 16, L"%lum %lus", secs / 60, secs % 60);
-        }
-        else
-        {
-            swprintf(buf, 16, L"%.1fh", secs / 3600.0);
-        }
-        env_set(ENV_CMD_DURATION, buf, ENV_EXPORT);
-    }
+    swprintf(buf, 16, L"%d", (secs * 1000) + (usecs / 1000));
+    env_set(ENV_CMD_DURATION, buf, ENV_EXPORT);
 }
 
 void reader_run_command(parser_t &parser, const wcstring &cmd)


### PR DESCRIPTION
Changing $CMD_DURATION to be in milliseconds as discussed in #1585
