### PR TITLE
New -n option for read builtin

### DIFF
--- a/doc_src/read.txt
+++ b/doc_src/read.txt
@@ -14,6 +14,7 @@ The following options are available:
 - <tt>-g</tt> or <tt>--global</tt> makes the variables global.
 - <tt>-l</tt> or <tt>--local</tt> makes the variables local.
 - <tt>-m NAME</tt> or <tt>--mode-name=NAME</tt> specifies that the name NAME should be used to save/load the history file. If NAME is fish, the regular fish history will be available.
+- <tt>-n NCHARS</tt> read returns after reading NCHARS characters rather than waiting for a complete line of input
 - <tt>-p PROMPT_CMD</tt> or <tt>--prompt=PROMPT_CMD</tt> uses the output of the shell command \c PROMPT_CMD as the prompt for the interactive mode. The default prompt command is <tt>set_color green; echo read; set_color normal; echo "> "</tt>.
 - <code>-s</code> or <code>--shell</code> enables syntax highlighting, tab completions and command termination suitable for entering shellscript code in the interactive mode.
 - <code>-u</code> or <code>--unexport</code> prevents the variables from being exported to child processes (default behaviour).

--- a/reader.cpp
+++ b/reader.cpp
@@ -2955,7 +2955,7 @@ static int read_i(void)
           during evaluation.
         */
 
-        const wchar_t *tmp = reader_readline();
+        const wchar_t *tmp = reader_readline(0);
 
         if (data->end_loop)
         {
@@ -3044,7 +3044,7 @@ static wchar_t unescaped_quote(const wcstring &str, size_t pos)
 }
 
 
-const wchar_t *reader_readline(void)
+const wchar_t *reader_readline(int nchars)
 {
     wint_t c;
     int last_char=0;
@@ -3054,6 +3054,7 @@ const wchar_t *reader_readline(void)
     std::vector<completion_t> comp;
     int finished=0;
     struct termios old_modes;
+    int num_chars = 0;
 
     /* Coalesce redundant repaints. When we get a repaint, we set this to true, and skip repaints until we get something else. */
     bool coalescing_repaints = false;
@@ -3093,6 +3094,10 @@ const wchar_t *reader_readline(void)
         while (1)
         {
             int was_interactive_read = is_interactive_read;
+
+            if (0 < nchars && nchars <= ++num_chars)
+                finished=1;
+
             is_interactive_read = 1;
             c=input_readch();
             is_interactive_read = was_interactive_read;

--- a/reader.h
+++ b/reader.h
@@ -200,11 +200,12 @@ int reader_reading_interrupted();
 bool reader_thread_job_is_stale();
 
 /**
-   Read one line of input. Before calling this function, reader_push()
-   must have been called in order to set up a valid reader
-   environment.
+   Read one line of input. Before calling this function, reader_push() must have
+   been called in order to set up a valid reader environment. If nchars > 0,
+   return after reading that many characters even if a full line has not yet
+   been read.
 */
-const wchar_t *reader_readline();
+const wchar_t *reader_readline(int nchars);
 
 /**
    Push a new reader environment.


### PR DESCRIPTION
Usage: read -n nchars
Reads maximum of nchars characters. If nchars <= 0, there's no limit which is the default.

As written in #1616, it would be nice to have. Please check the modifications carefully before merging. I'm not an expert.
