### PR TITLE
Highlight pipe characters correctly

### DIFF
--- a/highlight.cpp
+++ b/highlight.cpp
@@ -1358,6 +1358,7 @@ const highlighter_t::color_array_t & highlighter_t::highlight()
             }
             break;
 
+            case parse_token_type_pipe:
             case parse_token_type_background:
             case parse_token_type_end:
             case symbol_optional_background:


### PR DESCRIPTION
According to `fish_config`'s colors page, the pipe operator `|` is
supposed to be colored the same as a statement terminator.
