### PR TITLE
Set up fish_{function,complete}_path properly

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -47,7 +47,7 @@ if not set -q fish_function_path
 end
 
 if not contains $__fish_datadir/functions $fish_function_path
-	set fish_function_path[-1] $__fish_datadir/functions
+	set fish_function_path $fish_function_path $__fish_datadir/functions
 end
 
 if not set -q fish_complete_path
@@ -55,7 +55,7 @@ if not set -q fish_complete_path
 end
 
 if not contains $__fish_datadir/completions $fish_complete_path
-	set fish_complete_path[-1] $__fish_datadir/completions
+	set fish_complete_path $fish_complete_path $__fish_datadir/completions
 end
 
 #


### PR DESCRIPTION
In the base config.fish, fish_function_path and fish_complete_path have
$__fish_datadir/{functions,completions} added to them if not already
present. For some reason they were replacing the final path component
instead of being added on to the end.
