### PR TITLE
Fix `commandline` behavior in bind functions

### DIFF
--- a/input.h
+++ b/input.h
@@ -103,8 +103,12 @@ void input_destroy();
    readch attempts to parse it. If no more input follows after the
    escape key, it is assumed to be an actual escape key press, and is
    returned as such.
+
+   The argument determines whether fish commands are allowed to be run
+   as bindings. If false, when a character is encountered that would
+   invoke a fish command, it is unread and R_NULL is returned.
 */
-wint_t input_readch();
+wint_t input_readch(bool allow_commands = true);
 
 /**
    Push a character or a readline function onto the stack of unread

--- a/reader.cpp
+++ b/reader.cpp
@@ -3117,7 +3117,10 @@ const wchar_t *reader_readline(void)
                             c = 0;
                             break;
                         }
-                        c = input_readch();
+                        // only allow commands on the first key; otherwise, we might
+                        // have data we need to insert on the commandline that the
+                        // commmand might need to be able to see.
+                        c = input_readch(i == 1);
                         if ((!wchar_private(c)) && (c>31) && (c != 127))
                         {
                             arr[i]=c;


### PR DESCRIPTION
When a key is bound to a fish function, if that function invokes
`commandline`, it gets a stale copy of the commandline. This is because
any keys passed to `self-insert` (the default) don't actually get added
to the commandline until a special character is processed, such as the
R_NULL that gets returned after running a binding for a fish command.

To fix this, don't allow fish commands to be run for bindings if we're
processing more than one key. When a key wants to invoke a fish command,
instead we push the invocation sequence back onto the input, followed by
an R_NULL, and return. This causes the input loop to break out and
update the commandline. When it starts up again, it will re-process the
keys and invoke the fish command.

This is primarily an issue with pasting text that includes bound keys in
it. Typed text is slow enough that fish will update the commandline
between each character.

---

I don't know of any way to write a test for this, but the issue can be
reproduced as follows:

```
> bind _ 'commandline -i _'
```

This binds _ to a command that inserts _. Typing the following works:

```
> echo wat_is_it
```

But if you copy that line and paste it instead of typing it, the end
result looks like

```
> _echo wat_isit
```

With this fix in place, the pasted output correctly matches the typed
output.
