### PR TITLE
Fix $SHLVL

### DIFF
--- a/env.cpp
+++ b/env.cpp
@@ -443,7 +443,7 @@ void env_init(const struct config_paths_t *paths /* or NULL */)
         L"LINES",
         L"COLUMNS",
         L"PWD",
-        L"SHLVL",
+        //L"SHLVL", // will be inserted a bit lower down
         L"FISH_VERSION",
     };
     for (size_t i=0; i < sizeof ro_keys / sizeof *ro_keys; i++)
@@ -549,6 +549,7 @@ void env_init(const struct config_paths_t *paths /* or NULL */)
         }
     }
     env_set(L"SHLVL", nshlvl_str.c_str(), ENV_GLOBAL | ENV_EXPORT);
+    env_read_only.insert(L"SHLVL");
 
     /* Set up the HOME variable */
     if (env_get_string(L"HOME").missing_or_empty())

--- a/tests/test3.in
+++ b/tests/test3.in
@@ -233,4 +233,8 @@ echo $testu
 echo Missing: $testu
 ../fish -c 'echo Missing: $testu'
 
+# test SHLVL
+# use a subshell to ensure a clean slate
+env SHLVL= ../fish -c 'echo SHLVL: $SHLVL; ../fish -c \'echo SHLVL: $SHLVL\''
+
 true

--- a/tests/test3.out
+++ b/tests/test3.out
@@ -21,3 +21,5 @@ Testing Universal Startup
 2
 Missing:
 Missing:
+SHLVL: 1
+SHLVL: 2


### PR DESCRIPTION
Due to being read-only, SHLVL wasn't being incremented properly for
recursive invocations of fish.
