### PR TITLE
Fix fish_vi_mode.fish

### DIFF
--- a/share/functions/fish_vi_mode.fish
+++ b/share/functions/fish_vi_mode.fish
@@ -1,5 +1,6 @@
-function fish_prompt
-  fish_vi_prompt
+function fish_vi_mode
+  function fish_prompt
+    fish_vi_prompt
+  end
+  set -g fish_key_bindings fish_vi_key_bindings
 end
-set fish_key_bindings fish_vi_key_bindings
-#fish_vi_key_bindings


### PR DESCRIPTION
Currently it does nothing, but setting prompt and errorring out (this file is supposed to contain one top-level function which will be executed, but instead this file is executed and then it is said that there is no such command).

Setting `fish_key_bindings` does not show any result without `-g`.
