### PR TITLE
Trim trailing newline on cmdsubst when IFS=''

### DIFF
--- a/tests/read.in
+++ b/tests/read.in
@@ -7,6 +7,11 @@ set -l IFS \t
 count (echo one\ntwo)
 set -l IFS
 count (echo one\ntwo)
+echo [(echo -n one\ntwo)]
+count (echo one\ntwo\n)
+echo [(echo -n one\ntwo\n)]
+count (echo one\ntwo\n\n)
+echo [(echo -n one\ntwo\n\n)]
 set -le IFS
 
 function print_vars --no-scope-shadowing

--- a/tests/read.out
+++ b/tests/read.out
@@ -1,6 +1,15 @@
 2
 2
 1
+[one
+two]
+1
+[one
+two]
+1
+[one
+two
+]
 
 1 'hello' 1 'there'
 1 'hello there'


### PR DESCRIPTION
When $IFS is empty, command substitution no longer splits on newlines.
However we still want to trim off a single trailing newline, as most
commands will emit a trailing newline and it makes it harder to work
with their output.
