### PR TITLE
failiure/failure

### DIFF
--- a/doc_src/design.hdr
+++ b/doc_src/design.hdr
@@ -56,7 +56,7 @@ Examples:
 
 Every configuration option in a program is a place where the program
 is too stupid to figure out for itself what the user really wants, and
-should be considered a failiure of both the program and the programmer
+should be considered a failure of both the program and the programmer
 who implemented it.
 
 Rationale:


### PR DESCRIPTION
Fix misspelling of failure in the fish shell design doc
