### PR TITLE
Fix fish_config URL generation for python3

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -861,7 +861,10 @@ where = os.path.dirname(sys.argv[0])
 os.chdir(where)
 
 # Generate a 16-byte random key as a hexadecimal string
-authkey = binascii.b2a_hex(os.urandom(16))
+if IS_PY2:
+    authkey = binascii.b2a_hex(os.urandom(16))
+else:
+    authkey = binascii.b2a_hex(os.urandom(16)).decode()
 
 # Try to find a suitable port
 PORT = 8000


### PR DESCRIPTION
In Python3, the following code (line 864) produces a bytes object, not a string:

`authkey = binascii.b2a_hex(os.urandom(16))`

Resulting in fish_config opening a URL like this:

`http://localhost:8000/b'86583ea6eebe3a1c60ca0648f64d9782'/`

This patch properly decodes the bytes object when running Python3, fixing the issue.
