### PR TITLE
Fix for building updated docs during Homebrew install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -208,8 +208,8 @@ else
 endif
 
 #
-# Set path to sed, so that Doxygen and lexicon_filter can find it in
-# alternative build environments, such as Hombrew.
+# Set path to sed, so that the Doxygen lexicon filter can find it in
+# alternative build environments, such as Homebrew.
 #
 
 LEXICON_SED_PATH := $(shell which sed)


### PR DESCRIPTION
I noticed that the docs weren't building when trying to `brew install fish --HEAD` due to Homebrew installing inside it's 'superenv' during installation - `which sed` returns a shiv while writing the shebang to `lexicon_filter` which breaks the docs build. 

I submitted a simple fix, but the consensus was that we needed something more robust, so this allows brew to override the `LEXICON_SED_PATH` variable during make. See Homebrew/homebrew#32315. I've got an updated brew formula ready once this is merged.
