### PR TITLE
lexicon_filter fix for escaped options

### DIFF
--- a/doc_src/bind.txt
+++ b/doc_src/bind.txt
@@ -116,6 +116,6 @@ Performs a history search when the @key{Page Up} key is pressed.
 
 \fish
 set -g fish_key_bindings fish_vi_key_bindings
-bind -M insert @args{@bksl{cc}} kill-whole-line force-repaint
+bind -M insert \cc kill-whole-line force-repaint
 \endfish
 Turns on Vi key bindings and rebinds @key{Control,C} to clear the input line.

--- a/lexicon_filter.in
+++ b/lexicon_filter.in
@@ -188,14 +188,14 @@ s/@sgst{\([^}]*\)}/\\\
 #.
 # Command/Function options
 # Short options
-s/ -\([A-Za-z][A-Za-z]*\)\([^A-Za-z}]\)/ \\\
-<@opts{-\1}\
-\2/g
+s/\([[( ]\)-\([A-Za-z][A-Za-z]*\)\([^A-Za-z}]\)/\1\\\
+<@opts{-\2}\
+\3/g
 #.
 # Long options
-s/ --\([A-Za-z][A-Za-z0-9=_-]*\)\([^A-Za-z0-9=_-]*\)/ \\\
-<@opts{--\1}\
-\2/g
+s/\([[( ]\)--\([A-Za-z][A-Za-z0-9=_-]*\)\([^A-Za-z0-9=_-]*\)/\1\\\
+<@opts{--\2}\
+\3/g
 #.
 # Prompt
 s/~>_/\\\
@@ -210,6 +210,9 @@ s/___$/@curs/
 s/___\(.\)/\\\
 <@curs{\1}\
 /
+#.
+# Escaped Options
+s/ \\\([A-Za-z0-9][A-Za-z0-9]*\) / @bksl{\1} /g
 #.
 # Trailing Backslash
 s/ \\$/ @bksl{ }/
@@ -447,7 +450,10 @@ s/\( *@redr{|} *\)@bltn/\1@xbln/g
 s/^\( *\)@func/\1@xfnc/
 s/\( *[;()] *\)@func/\1@xfnc/g
 s/\( *@redr{|} *\)@func/\1@xfnc/g
-s/\\@bltn{\([^}]*\)/@args{@bksl{\1}/g
+s/ @bksl{\([^}]*\)} / @args{@bksl{\1}} /g
+s/ @bksl{@bltn{\([^}]*\)}/ @args{@bksl{\1}/g
+s/ @bksl{@func{\([^}]*\)}/ @args{@bksl{\1}/g
+s/ @bksl{@cmnd{\([^}]*\)}/ @args{@bksl{\1}/g
 s/@bltn/@args/g
 s/@func/@args/g
 s/@cmnd/@args/g


### PR DESCRIPTION
Fixes #1703.

Missed that case as the only other escape sequence in the docs previously was `\cd` which had to be trapped differently due to `cd` also being a built-in.

Also, I had been giving a bit of space in the synopsis around short and long options to make them clearer (the effect is more noticeable in the man pages). I've updated the filter to pick up on options tight to `(` or `[`, but it would be better to have a convention one way or the other. I'm happy to run through and update accordingly.
