### PR TITLE
Add setfacl completions

### DIFF
--- a/share/completions/setfacl.fish
+++ b/share/completions/setfacl.fish
@@ -7,15 +7,15 @@ function __fish_facl_list_spec_keyword
 end
 
 function __fish_facl_starts_with_spec_user
-  echo (commandline -ct) | grep -q -E 'u(ser)?:'
+  echo (commandline -ct) | sgrep -q -E 'u(ser)?:'
 end
 
 function __fish_facl_starts_with_spec_group
-  echo (commandline -ct) | grep -q -E 'g(roup)?:'
+  echo (commandline -ct) | sgrep -q -E 'g(roup)?:'
 end
 
 function __fish_facl_extract_acl
-  echo (commandline -ct) | grep -o -E '\w*:'
+  echo (commandline -ct) | sgrep -o -E '\w*:'
 end
 
 complete -c setfacl    -s m -s x -l modify -l remove -l set -n '__fish_facl_starts_with_spec_user'  -a '(__fish_facl_extract_acl)(__fish_complete_users  | sed "s/\t/:\t/g")'


### PR DESCRIPTION
Due to some reasons `setfacl --modify TAB` doesn't work. fish version is 2.1.0. Is this a bug or my misunderstanding of `complete` function?

Is there better way to add several arguments completion to several options?
