### PR TITLE
vi bindings: add CTRL-C handler in 'default' mode

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -17,6 +17,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
   #
 
   bind \cd exit
+  bind \cc 'commandline ""'
   bind h backward-char
   bind l forward-char
   bind \e\[C forward-char


### PR DESCRIPTION
There is no CTRL-C handler for the default mode in the vi bindings. This makes it difficult to say "never mind" and start a new command line like you can do in bash's vi mode. 

There were CTRL-C handlers for insert and visual modes that go back to default mode, but nothing happens in default mode. I copy-pasted the CTRL-C handler from the default key bindings file.
