### PR TITLE
Added VIRTUAL_ENV_DISABLE_PROMPT

### DIFF
--- a/share/tools/web_config/sample_prompts/pythonista.fish
+++ b/share/tools/web_config/sample_prompts/pythonista.fish
@@ -7,27 +7,29 @@ set yellow (set_color yellow)
 set green (set_color green)
 set gray (set_color -o black)
 
+# venv/bin/activate.fish modifies fish_prompt, unless this variable is set.
+set -xg VIRTUAL_ENV_DISABLE_PROMPT 1
 
 function fish_prompt
-   set_color yellow
-   printf '%s' (whoami)
-   set_color normal
-   printf ' at '
+    set_color yellow
+    printf '%s' (whoami)
+    set_color normal
+    printf ' at '
+    
+    set_color magenta
+    printf '%s' (hostname|cut -d . -f 1)
+    set_color normal
+    printf ' in '
 
-   set_color magenta
-   printf '%s' (hostname|cut -d . -f 1)
-   set_color normal
-   printf ' in '
+    set_color $fish_color_cwd
+    printf '%s' (prompt_pwd)
+    set_color normal
 
-   set_color $fish_color_cwd
-   printf '%s' (prompt_pwd)
-   set_color normal
-
-   # Line 2
-   echo
-   if test $VIRTUAL_ENV
-       printf "(%s) " (set_color blue)(basename $VIRTUAL_ENV)(set_color normal)
-   end
-   printf '↪ '
-   set_color normal
+    # Line 2
+    echo
+    if test $VIRTUAL_ENV
+        printf "(%s) " (set_color blue)(basename $VIRTUAL_ENV)(set_color normal)
+    end
+    printf '↪ '
+    set_color normal
 end


### PR DESCRIPTION
venv/bin/activate.fish modifies the prompt, inserting the (venv) prefix, unless the VIRTUAL_ENV_DISABLE_PROMPT variable is set.

Also fixed indentation of the function
