### PR TITLE
Change fish_paginate to paginate both stdout and stderr.

### DIFF
--- a/share/functions/__fish_paginate.fish
+++ b/share/functions/__fish_paginate.fish
@@ -7,7 +7,7 @@ function __fish_paginate -d "Paginate the current command using the users defaul
 
 	if commandline -j|grep -v "$cmd *\$" >/dev/null
 
-		commandline -aj "|$cmd;"
+		commandline -aj " ^&1 |$cmd;"
 	end
 
 end


### PR DESCRIPTION
The `__fish_paginate` command should redirect both `stdout` and `stderr` to the pager. Otherwise the information is lost and/or not in the right context.
