### PR TITLE
Align `fg` and `bg` commands regarding "no argument" behaviour.

### DIFF
--- a/builtin.cpp
+++ b/builtin.cpp
@@ -3502,7 +3502,6 @@ static int builtin_fg(parser_t &parser, wchar_t **argv)
             append_format(stderr_buffer,
                           _(L"%ls: There are no suitable jobs\n"),
                           argv[0]);
-            builtin_print_help(parser, argv[0], stderr_buffer);
         }
     }
     else if (argv[2] != 0)


### PR DESCRIPTION
With no parameters `fg` prints the help.`bg` on the other hand only prints "no job". Now both print "no job".
