### PR TITLE
Vim bindings: add Ctrl-[ and Ctrl-] to do prevd/nextd

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -934,6 +934,8 @@ Command mode is also known as normal mode.
 
 - @key{[} and @key{]} search the command history for the previous/next token containing the token under the cursor before the search was started. See the <a href='#history'>history</a> section for more information on history searching.
 
+ - @key{Control,[} and @key{Control,]} moves forward/backward in the directory history
+
 - @key{Control,C} deletes the entire line.
 
 \subsubsection vi-mode-insert Insert mode

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -51,6 +51,9 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
   bind [ history-token-search-backward
   bind ] history-token-search-forward
 
+  bind \x1b prevd force-repaint  # Control-[
+  bind \x1d prevd force-repaint  # Control-]
+
   bind k up-or-search
   bind j down-or-search
   bind \e\[A up-or-search


### PR DESCRIPTION
I was jealous reading in the fish mailing list last week that there was a key code that can do nextd/prevd functionality in the default key bindings. Because I use the vi bindings, I am missing out!

I brought over the 'nextd/prevd' functionality in Command Mode under Option-[ and Option-], which come across as the unicode characters “ and ‘ in OSX. I've used the unicode values of these as the bindings, but I doubt those will port over onto non-OSX? I'm not sure what to do about that, but it works well in OSX! :) I'm certainly open to alternative keys, but these seemed to be the most natural to me.

Note that the default bindings actually implement "nextd-or-forward-word" but I'm suggesting "nextd force-repaint" here. It seems to fit better with the style of vim's Command Mode. 