### PR TITLE
Update pythonista.fish

### DIFF
--- a/share/tools/web_config/sample_prompts/pythonista.fish
+++ b/share/tools/web_config/sample_prompts/pythonista.fish
@@ -7,6 +7,7 @@ set yellow (set_color yellow)
 set green (set_color green)
 set gray (set_color -o black)
 
+set -g VIRTUAL_ENV_DISABLE_PROMPT true
 
 function fish_prompt
    set_color yellow


### PR DESCRIPTION
Fix a bug that made the ($VIRTUAL_ENV) string print twice in the prompt.
If the VIRTUAL_ENV_DISABLED_PROMPT env var is not set the ($VIRTUAL_ENV) string is automatically prepended to the prompt by the [activate.fish](https://github.com/pypa/virtualenv/blob/master/virtualenv_embedded/activate.fish) script.
