### PR TITLE
Added `export` alias for set global variable, made for sh/bash/zsh compatibility.

### DIFF
--- a/share/functions/export.fish
+++ b/share/functions/export.fish
@@ -1,0 +1,16 @@
+function export --description 'Set global variable. Alias for set -g, made for bash compatibility'
+        if test -z "$argv"
+           set
+           return 0
+        end
+        for arg in $argv
+            set -l v (echo $arg|tr '=' \n)
+            set -l c (count $v)
+            switch $c
+                    case 1
+                            set -gx $v $$v
+                    case 2
+                            set -gx $v[1] $v[2]
+            end
+        end
+end


### PR DESCRIPTION
fish-shell already have `setenv` alias for csh compatibility, hence this is `export` alias for `sh` `bash` `zsh` compatibility.

It's useful for some tools like `ssh-agent` or `boot2docker shellinit` that display `export KEY=VALUE` .

Signed-off-by: Rack Lin racklin@gmail.com
