### PR TITLE
Restore and save colors

### DIFF
--- a/share/functions/fish_load_colors.fish
+++ b/share/functions/fish_load_colors.fish
@@ -1,0 +1,23 @@
+function fish_load_colors --description 'Restore colors'
+	set fish_color_autosuggestion 555 yellow
+	set fish_color_command 005fd7 purple
+	set fish_color_comment red
+	set fish_color_cwd green
+	set fish_color_cwd_root red
+	set fish_color_error red --bold
+	set fish_color_escape cyan
+	set fish_color_history_current cyan
+	set fish_color_match cyan
+	set fish_color_normal normal
+	set fish_color_operator cyan
+	set fish_color_param 00afff cyan
+	set fish_color_quote brown
+	set fish_color_redirection normal
+	set fish_color_search_match --background=purple
+	set fish_color_selection --background=purple
+	set fish_color_valid_path --underline
+	set fish_pager_color_completion normal
+	set fish_pager_color_description 555 yellow
+	set fish_pager_color_prefix cyan
+	set fish_pager_color_progress cyan
+end

--- a/share/functions/fish_save_colors.fish
+++ b/share/functions/fish_save_colors.fish
@@ -1,0 +1,10 @@
+function fish_save_colors --description 'Save current colors'
+	begin
+		echo "function fish_load_colors --description 'Restore colors'"
+		for color in (set -n | grep color)
+			echo set $color $$color
+		end
+		echo end
+	end | fish_indent | source
+	funcsave fish_load_colors
+end


### PR DESCRIPTION
It would be nice to have the option to save and restore colors. This is
my first attempt at this. The default saved `fish_load_colors` is the
output of the `fish_save_colors` on a clean environment running fish.

Any ideas or suggestions to improve on this or is it good enough and a
feature we want?