### PR TITLE
Fix a cd complete error when command starts with a single apostrophe

### DIFF
--- a/share/functions/__fish_complete_cd.fish
+++ b/share/functions/__fish_complete_cd.fish
@@ -17,7 +17,7 @@ function __fish_complete_cd -d "Completions for the cd command"
 	# Note how this works: we evaluate $ctoken*/
 	# That trailing slash ensures that we only expand directories
 
-	set -l ctoken (commandline -ct)
+	set -l ctoken (commandline -ct | sed -r 's/^[\'"]*(.*)/\1/g')
 	if echo $ctoken | sgrep '^/\|^\./\|^\.\./\|^~/' >/dev/null
 		# This is an absolute search path
 		# Squelch descriptions per issue 254


### PR DESCRIPTION
Starting with an apostrophe causes an error in the `eval` on line 45, because there's an uneven amount. It still causes these errors with apostrophes somewhere else in the code, so it should probably be fixed in a better way.