### PR TITLE
Support nixos command-not-found handler

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -224,6 +224,11 @@ function __fish_config_interactive -d "Initializations that should be performed 
 			function __fish_command_not_found_handler --on-event fish_command_not_found
 				/usr/lib/command-not-found -- $argv
 			end
+		# Check for NixOS handler
+		else if test -f /run/current-system/sw/bin/command-not-found
+			function __fish_command_not_found_handler --on-event fish_command_not_found
+				/run/current-system/sw/bin/command-not-found $argv
+			end
 		# Ubuntu Feisty places this command in the regular path instead
 		else if type -q -p command-not-found
 			function __fish_command_not_found_handler --on-event fish_command_not_found


### PR DESCRIPTION
NixOS uses non standard path for command-not-found handle without support for empty (--) arguments.
