### PR TITLE
Fix job_or_process_extent with command substitution

### DIFF
--- a/parse_util.cpp
+++ b/parse_util.cpp
@@ -423,14 +423,14 @@ static void job_or_process_extent(const wchar_t *buff,
                     finished=1;
                     if (b)
                     {
-                        *b = (wchar_t *)buff + tok_begin;
+                        *b = (wchar_t *)begin + tok_begin;
                     }
                 }
                 else
                 {
                     if (a)
                     {
-                        *a = (wchar_t *)buff + tok_begin+1;
+                        *a = (wchar_t *)begin + tok_begin+1;
                     }
                 }
 


### PR DESCRIPTION
this fixes #1888.
The resulting positions were calculated from the start of the string.
They are now calculated from the start of the innermost command substitution (if any).