### PR TITLE
Unexport CMD_DURATION

### DIFF
--- a/reader.cpp
+++ b/reader.cpp
@@ -2508,7 +2508,7 @@ void set_env_cmd_duration(struct timeval *after, struct timeval *before)
     }
 
     swprintf(buf, 16, L"%d", (secs * 1000) + (usecs / 1000));
-    env_set(ENV_CMD_DURATION, buf, ENV_EXPORT);
+    env_set(ENV_CMD_DURATION, buf, ENV_UNEXPORT);
 }
 
 void reader_run_command(parser_t &parser, const wcstring &cmd)


### PR DESCRIPTION
Valid uses of the `CMD_DURATION` environment variable don't seem to include passing
it to subsequent child processes.

I work on the Buck build system at Facebook (http://facebook.github.io/buck/). One of Buck's features is to discard its cache if anything in the calling environment has changed since the last run:

https://github.com/facebook/buck/blob/master/src/com/facebook/buck/parser/Parser.java#L950

For all shells except `fish`, this is no problem. However, since `fish` exports `CMD_DURATION` to all sub-processes with a different value each time, Buck always discards its cache between runs, so it performs terribly.

I confirmed the variable is still available inside the shell by running:

    function fish_prompt
        echo "duration [$CMD_DURATION] "
    end
    
    duration [0] sleep 2
    duration [2002]