### PR TITLE
adding a dockerfile building fish on a centos machine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM centos:latest
+
+# Build dependency
+RUN yum update -y &&\
+  yum install -y autoconf automake clang gcc-c++ make ncurses-devel &&\
+  yum clean all
+
+# Test dependency
+RUN yum install -y expect vim-common
+
+ADD . /src
+WORKDIR /src
+
+# Build fish
+RUN autoreconf &&\
+  ./configure &&\
+  make &&\
+  make install
+


### PR DESCRIPTION
Hey, I created a Dockerfile for fish so users can build/test their feature on their computer on a controlled environment.

```
docker build -t fish-shell .
docker run -t fish-shell make test SHOW_INTERACTIVE_LOG=1
```