### PR TITLE
math requires bc package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
 before_install:
   - sudo apt-get update
 install:
-  - sudo apt-get install --no-install-recommends libncurses5-dev gettext doxygen expect
+  - sudo apt-get install --no-install-recommends bc doxygen expect gettext libncurses5-dev
 script:
   - autoreconf
   - ./configure

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:latest
 
 # Build dependency
 RUN yum update -y &&\
-  yum install -y autoconf automake clang gcc-c++ make ncurses-devel &&\
+  yum install -y autoconf automake bc clang gcc-c++ make ncurses-devel &&\
   yum clean all
 
 # Test dependency


### PR DESCRIPTION
Function math requires `bc` package. Adding it to Dockerfile and travis.