### PR TITLE
Add command-not-found handler for Arch Linux

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -234,6 +234,18 @@ function __fish_config_interactive -d "Initializations that should be performed 
 			function __fish_command_not_found_handler --on-event fish_command_not_found
 				command-not-found -- $argv
 			end
+		# pkgfile is an optional, but official, package on Arch Linux
+		# it ships with example handlers for bash and zsh, so we'll follow that format
+		else if type -p -q pkgfile
+			function __fish_command_not_found_handler --on-event fish_command_not_found
+				set -l __packages (pkgfile --binaries --verbose -- $argv ^/dev/null)
+				if test $status -eq 0
+					printf "%s may be found in the following packages:\n" "$argv"
+					printf "  %s\n" $__packages
+				else
+					__fish_default_command_not_found_handler $argv
+				end
+			end
 		# Use standard fish command not found handler otherwise
 		else
 			function __fish_command_not_found_handler --on-event fish_command_not_found


### PR DESCRIPTION
Arch Linux does not ship with a command-not-found handler, but [pkgfile](https://www.archlinux.org/packages/extra/x86_64/pkgfile/) provides the needed functionality and example command-not-found handlers in Bash.

I thought about adding a check for Arch Linux if `pkgfile` isn't available and recommending installing that package (only once, not every time), but that seems a bit over-the-top for such simple functionality. If you think this would be acceptable and beneficial, I can implement that as well.