### PR TITLE
Introduce an environment variable to set the history location

### DIFF
--- a/history.cpp
+++ b/history.cpp
@@ -32,6 +32,7 @@
 #include "signal.h"
 #include "autoload.h"
 #include "iothread.h"
+#include "env.h"
 #include <map>
 #include <algorithm>
 
@@ -1259,12 +1260,21 @@ static wcstring history_filename(const wcstring &name, const wcstring &suffix)
     if (! path_get_config(path))
         return L"";
 
-    wcstring result = path;
-    result.append(L"/");
-    result.append(name);
-    result.append(L"_history");
-    result.append(suffix);
-    return result;
+    /* If the fish_history_filename environment variable is set, store our history there */
+    const env_var_t history_filename = env_get_string(L"fish_history_filename");
+    if (history_filename.missing_or_empty())
+    {
+        wcstring result = path;
+        result.append(L"/");
+        result.append(name);
+        result.append(L"_history");
+        result.append(suffix);
+        return result;
+    } else {
+        wcstring result = history_filename;
+        result.append(suffix);
+        return result;
+    }
 }
 
 void history_t::clear_file_state()


### PR DESCRIPTION
As discussed in issue #102, I have introduced an environment variable `fish_history_filename`. If it's set, then that path will be used to store the history file. If it's set to `/dev/null`, this would also operate as a solution/workaround for issue #1156.

Thanks in advance for any feedback.

Thanks,
Jay