### PR TITLE
Revert 1349d12 and properly fix #213: delete autoloaded function

### DIFF
--- a/builtin.cpp
+++ b/builtin.cpp
@@ -1565,7 +1565,7 @@ static int builtin_functions(parser_t &parser, wchar_t **argv)
     {
         int i;
         for (i=woptind; i<argc; i++)
-            function_remove_ignore_autoload(argv[i]);
+            function_remove(argv[i]);
         return STATUS_BUILTIN_OK;
     }
     else if (desc)

--- a/function.h
+++ b/function.h
@@ -105,9 +105,6 @@ void function_init();
 /** Add a function. definition_line_offset is the line number of the function's definition within its source file */
 void function_add(const function_data_t &data, const parser_t &parser, int definition_line_offset = 0);
 
-/** Removes a function from our internal table, returning true if it was found and false if not */
-bool function_remove_ignore_autoload(const wcstring &name);
-
 /**
    Remove the function with the specified name.
 */


### PR DESCRIPTION
As suggested by @ridiculousfish, when removing autoloaded functions, add them
to a tombstones set.  These functions will never be autoloaded again in the
current shell, not even when the timestamp changes.

Tested as per comment 1 of #1033.  `~/.config/fish/functions/ls.fish` contains
the function definition.  `function -e ls` removes the redefined `ls` (and
reverts back to the built-in command).  `touch .../ls.fish` does not cause the
function to be reloaded.