### PR TITLE
Modify parser to accept 'begin' without ';'

### DIFF
--- a/fish_indent.cpp
+++ b/fish_indent.cpp
@@ -105,11 +105,15 @@ static void prettify_node_recursive(const wcstring &source, const parse_node_tre
         }
     }
 
+    static bool after_begin = false;
     if (node_type == parse_token_type_end)
     {
-        /* Newline */
-        out_result->push_back(L'\n');
-        *has_new_line = true;
+        if (!after_begin) {
+            /* Newline */
+            out_result->push_back(L'\n');
+            *has_new_line = true;
+        }
+        after_begin = false;
     }
     else if ((node_type >= FIRST_PARSE_TOKEN_TYPE && node_type <= LAST_PARSE_TOKEN_TYPE) || node_type == parse_special_type_parse_error)
     {
@@ -118,7 +122,16 @@ static void prettify_node_recursive(const wcstring &source, const parse_node_tre
             /* Some type representing a particular token */
             append_whitespace(node_indent, do_indent, *has_new_line, out_result);
             out_result->append(source, node.source_start, node.source_length);
-            *has_new_line = false;
+            if (node_type == parse_token_type_string &&
+                !wcsncmp(source.c_str() + node.source_start, L"begin",
+                         node.source_length)) {
+                out_result->push_back(L'\n');
+                *has_new_line = true;
+                after_begin = true;
+            } else {
+                *has_new_line = false;
+                after_begin = false;
+            }
         }
     }
 

--- a/fish_tests.cpp
+++ b/fish_tests.cpp
@@ -891,7 +891,9 @@ static void test_indents()
 
     const indent_component_t components7[] =
     {
-        {L"begin; end", 0},
+        {L"begin", 0},
+        {L";", 1},
+        {L"end", 0},
         {L"foo", 0},
         {L"", 0},
         {NULL, -1}

--- a/fish_tests.cpp
+++ b/fish_tests.cpp
@@ -3209,7 +3209,11 @@ static void test_new_parser_correctness(void)
         {L"if end", false},
         {L"end", false},
         {L"for i i", false},
-        {L"for i in a b c ; end", true}
+        {L"for i in a b c ; end", true},
+        {L"begin end", true},
+        {L"begin; end", true},
+        {L"begin if true; end; end;", true},
+        {L"begin if true ; echo hi ; end; end", true},
     };
 
     for (size_t i=0; i < sizeof parser_tests / sizeof *parser_tests; i++)

--- a/parse_execution.cpp
+++ b/parse_execution.cpp
@@ -413,7 +413,7 @@ parse_execution_result_t parse_execution_context_t::run_block_statement(const pa
 
     const parse_node_t &block_header = *get_child(statement, 0, symbol_block_header); //block header
     const parse_node_t &header = *get_child(block_header, 0); //specific header type (e.g. for loop)
-    const parse_node_t &contents = *get_child(statement, 2, symbol_job_list); //block contents
+    const parse_node_t &contents = *get_child(statement, 1, symbol_job_list); //block contents
 
     parse_execution_result_t ret = parse_execution_success;
     switch (header.type)
@@ -428,7 +428,7 @@ parse_execution_result_t parse_execution_context_t::run_block_statement(const pa
 
         case symbol_function_header:
         {
-            const parse_node_t &function_end = *get_child(statement, 3, symbol_end_command); //the 'end' associated with the block
+            const parse_node_t &function_end = *get_child(statement, 2, symbol_end_command); //the 'end' associated with the block
             ret = run_function_statement(header, function_end);
             break;
         }

--- a/parse_productions.cpp
+++ b/parse_productions.cpp
@@ -298,7 +298,7 @@ RESOLVE(freestanding_argument_list)
 
 PRODUCTIONS(block_statement) =
 {
-    {symbol_block_header, parse_token_type_end, symbol_job_list, symbol_end_command, symbol_arguments_or_redirections_list}
+    {symbol_block_header, symbol_job_list, symbol_end_command, symbol_arguments_or_redirections_list}
 };
 RESOLVE_ONLY(block_statement)
 
@@ -328,25 +328,35 @@ RESOLVE(block_header)
 
 PRODUCTIONS(for_header) =
 {
-    {KEYWORD(parse_keyword_for), parse_token_type_string, KEYWORD(parse_keyword_in), symbol_argument_list}
+    {KEYWORD(parse_keyword_for), parse_token_type_string, KEYWORD
+        (parse_keyword_in), symbol_argument_list, parse_token_type_end}
 };
 RESOLVE_ONLY(for_header)
 
 PRODUCTIONS(while_header) =
 {
-    {KEYWORD(parse_keyword_while), symbol_job}
+    {KEYWORD(parse_keyword_while), symbol_job, parse_token_type_end}
 };
 RESOLVE_ONLY(while_header)
 
 PRODUCTIONS(begin_header) =
 {
+    {KEYWORD(parse_keyword_begin), parse_token_type_end},
     {KEYWORD(parse_keyword_begin)}
 };
-RESOLVE_ONLY(begin_header)
+RESOLVE(begin_header)
+{
+    switch (token2.type) {
+        case parse_token_type_end:
+            return 0;
+        default:
+            return 1;
+    }
+}
 
 PRODUCTIONS(function_header) =
 {
-    {KEYWORD(parse_keyword_function), symbol_argument, symbol_argument_list}
+    {KEYWORD(parse_keyword_function), symbol_argument, symbol_argument_list, parse_token_type_end}
 };
 RESOLVE_ONLY(function_header)
 

--- a/parse_productions.cpp
+++ b/parse_productions.cpp
@@ -341,18 +341,9 @@ RESOLVE_ONLY(while_header)
 
 PRODUCTIONS(begin_header) =
 {
-    {KEYWORD(parse_keyword_begin), parse_token_type_end},
     {KEYWORD(parse_keyword_begin)}
 };
-RESOLVE(begin_header)
-{
-    switch (token2.type) {
-        case parse_token_type_end:
-            return 0;
-        default:
-            return 1;
-    }
-}
+RESOLVE_ONLY(begin_header)
 
 PRODUCTIONS(function_header) =
 {

--- a/parse_tree.h
+++ b/parse_tree.h
@@ -249,14 +249,14 @@ bool parse_tree_from_string(const wcstring &str, parse_tree_flags_t flags, parse
 
     case_item = CASE argument_list <TOK_END> job_list
 
-    block_statement = block_header <TOK_END> job_list end_command arguments_or_redirections_list
-    block_header = for_header | while_header | function_header | begin_header
-    for_header = FOR var_name IN argument_list
-    while_header = WHILE job
-    begin_header = BEGIN
+    block_statement = block_header  job_list end_command arguments_or_redirections_list
+    block_header = for_header | while_header  | function_header | begin_header
+    for_header = FOR var_name IN argument_list <TOK_END>
+    while_header = WHILE job <TOK_END>
+    begin_header = BEGIN | BEGIN <TOK_END>
 
 # Functions take arguments, and require at least one (the name). No redirections allowed.
-    function_header = FUNCTION argument argument_list
+    function_header = FUNCTION argument argument_list <TOK_END>
 
 # A boolean statement is AND or OR or NOT
 

--- a/parse_tree.h
+++ b/parse_tree.h
@@ -253,7 +253,7 @@ bool parse_tree_from_string(const wcstring &str, parse_tree_flags_t flags, parse
     block_header = for_header | while_header  | function_header | begin_header
     for_header = FOR var_name IN argument_list <TOK_END>
     while_header = WHILE job <TOK_END>
-    begin_header = BEGIN | BEGIN <TOK_END>
+    begin_header = BEGIN
 
 # Functions take arguments, and require at least one (the name). No redirections allowed.
     function_header = FUNCTION argument argument_list <TOK_END>


### PR DESCRIPTION
Modify parser to accept 'begin' without ';'

Examples that work as expected (even completions don't get confused):

$ begin true; end;
$ begin if true; end; end
$ begin if true; echo hi; end

The last example correctly expects another 'end' to match 'begin'.

Fixes #1248, includes tests.