### PR TITLE
Updated exit.txt reference to source

### DIFF
--- a/doc_src/exit.txt
+++ b/doc_src/exit.txt
@@ -9,4 +9,4 @@ exit [STATUS]
 
 `exit` causes fish to exit. If `STATUS` is supplied, it will be converted to an integer and used as the exit code. Otherwise, the exit code will be that of the last command executed.
 
-If exit is called while sourcing a file (using the <a href="#source">.</a> builtin) the rest of the file will be skipped, but the shell itself will not exit.
+If exit is called while sourcing a file (using the <a href="#source">source</a> builtin) the rest of the file will be skipped, but the shell itself will not exit.


### PR DESCRIPTION
Changed the text referencing 'source' in exit.txt from '.' to 'source.' The '.' command is deprecated in favor of 'source', so the docs that reference it should reflect this.