### PR TITLE
Lists and IFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ po/*.gmo
 fish
 fish_indent
 fish_tests
-fishd
 fish.pc
 mimedb
 seq

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -1016,14 +1016,9 @@ Note that functions cannot be started in the background. Functions that are stop
 
 \section initialization Initialization files
 
-On startup, `fish` evaluates the files listed below, in order. Some of the exact paths may be different depending on how fish has been installed.
+On startup, `fish` evaluates the files `/usr/share/fish/config.fish` (Or `/usr/local/fish...` if you installed fish in `/usr/local`), `/etc/fish/config.fish` (Or `~/etc/fish/...` if you installed fish in your home directory) and `~/.config/fish/config.fish` (Or any other directory specified by the `$XDG_CONFIG_HOME` variable), in that order.
 
-- `/usr/share/fish/config.fish`, which sets up the default behaviour of `fish`. Editing this file is discouraged.
-- `/etc/profile.d/*.fish` - all files matching this pattern are evaluated. Third-party packages should install snippets as separate files in this directory.
-- `/etc/fish/config.fish`, which contains system-wide configuration.
-- `$XDG_CONFIG_HOME/fish/config.fish` (usually `~/.config/fish/config.fish`), which contains configuration specific to your user account.
-
-If you want to run a command only on starting an interactive shell, use the exit status of the command `status --is-interactive` to determine if the shell is interactive. If you want to run a command only when using a login shell, use `status --is-login` instead.
+The first file should not be directly edited, the second one is meant for systemwide configuration and the last one is meant for user configuration. If you want to run a command only on starting an interactive shell, use the exit status of the command `status --is-interactive` to determine if the shell is interactive. If you want to run a command only when using a login shell, use `status --is-login` instead.
 
 Examples:
 

--- a/env.cpp
+++ b/env.cpp
@@ -420,7 +420,7 @@ wcstring env_get_pwd_slash(void)
 /* Here is the whitelist of variables that we colon-delimit, both incoming from the environment and outgoing back to it. This is deliberately very short - we don't want to add language-specific values like CLASSPATH. */
 static bool variable_is_colon_delimited_array(const wcstring &str)
 {
-    return contains(str, L"PATH", L"MANPATH", L"CDPATH");
+    return contains(str, L"PATH", L"MANPATH", L"CDPATH", L"LD_LIBRARY_PATH");
 }
 
 void env_init(const struct config_paths_t *paths /* or NULL */)

--- a/fish_tests.cpp
+++ b/fish_tests.cpp
@@ -891,7 +891,9 @@ static void test_indents()
 
     const indent_component_t components7[] =
     {
-        {L"begin; end", 0},
+        {L"begin", 0},
+        {L";", 1},
+        {L"end", 0},
         {L"foo", 0},
         {L"", 0},
         {NULL, -1}

--- a/fish_tests.cpp
+++ b/fish_tests.cpp
@@ -3209,7 +3209,11 @@ static void test_new_parser_correctness(void)
         {L"if end", false},
         {L"end", false},
         {L"for i i", false},
-        {L"for i in a b c ; end", true}
+        {L"for i in a b c ; end", true},
+        {L"begin end", true},
+        {L"begin; end", true},
+        {L"begin if true; end; end;", true},
+        {L"begin if true ; echo hi ; end; end", true},
     };
 
     for (size_t i=0; i < sizeof parser_tests / sizeof *parser_tests; i++)

--- a/parse_execution.cpp
+++ b/parse_execution.cpp
@@ -413,7 +413,7 @@ parse_execution_result_t parse_execution_context_t::run_block_statement(const pa
 
     const parse_node_t &block_header = *get_child(statement, 0, symbol_block_header); //block header
     const parse_node_t &header = *get_child(block_header, 0); //specific header type (e.g. for loop)
-    const parse_node_t &contents = *get_child(statement, 2, symbol_job_list); //block contents
+    const parse_node_t &contents = *get_child(statement, 1, symbol_job_list); //block contents
 
     parse_execution_result_t ret = parse_execution_success;
     switch (header.type)
@@ -428,7 +428,7 @@ parse_execution_result_t parse_execution_context_t::run_block_statement(const pa
 
         case symbol_function_header:
         {
-            const parse_node_t &function_end = *get_child(statement, 3, symbol_end_command); //the 'end' associated with the block
+            const parse_node_t &function_end = *get_child(statement, 2, symbol_end_command); //the 'end' associated with the block
             ret = run_function_statement(header, function_end);
             break;
         }

--- a/parse_productions.cpp
+++ b/parse_productions.cpp
@@ -298,7 +298,7 @@ RESOLVE(freestanding_argument_list)
 
 PRODUCTIONS(block_statement) =
 {
-    {symbol_block_header, parse_token_type_end, symbol_job_list, symbol_end_command, symbol_arguments_or_redirections_list}
+    {symbol_block_header, symbol_job_list, symbol_end_command, symbol_arguments_or_redirections_list}
 };
 RESOLVE_ONLY(block_statement)
 
@@ -328,25 +328,35 @@ RESOLVE(block_header)
 
 PRODUCTIONS(for_header) =
 {
-    {KEYWORD(parse_keyword_for), parse_token_type_string, KEYWORD(parse_keyword_in), symbol_argument_list}
+    {KEYWORD(parse_keyword_for), parse_token_type_string, KEYWORD
+        (parse_keyword_in), symbol_argument_list, parse_token_type_end}
 };
 RESOLVE_ONLY(for_header)
 
 PRODUCTIONS(while_header) =
 {
-    {KEYWORD(parse_keyword_while), symbol_job}
+    {KEYWORD(parse_keyword_while), symbol_job, parse_token_type_end}
 };
 RESOLVE_ONLY(while_header)
 
 PRODUCTIONS(begin_header) =
 {
+    {KEYWORD(parse_keyword_begin), parse_token_type_end},
     {KEYWORD(parse_keyword_begin)}
 };
-RESOLVE_ONLY(begin_header)
+RESOLVE(begin_header)
+{
+    switch (token2.type) {
+        case parse_token_type_end:
+            return 0;
+        default:
+            return 1;
+    }
+}
 
 PRODUCTIONS(function_header) =
 {
-    {KEYWORD(parse_keyword_function), symbol_argument, symbol_argument_list}
+    {KEYWORD(parse_keyword_function), symbol_argument, symbol_argument_list, parse_token_type_end}
 };
 RESOLVE_ONLY(function_header)
 

--- a/parse_productions.cpp
+++ b/parse_productions.cpp
@@ -341,18 +341,9 @@ RESOLVE_ONLY(while_header)
 
 PRODUCTIONS(begin_header) =
 {
-    {KEYWORD(parse_keyword_begin), parse_token_type_end},
     {KEYWORD(parse_keyword_begin)}
 };
-RESOLVE(begin_header)
-{
-    switch (token2.type) {
-        case parse_token_type_end:
-            return 0;
-        default:
-            return 1;
-    }
-}
+RESOLVE_ONLY(begin_header)
 
 PRODUCTIONS(function_header) =
 {

--- a/parse_tree.h
+++ b/parse_tree.h
@@ -249,14 +249,14 @@ bool parse_tree_from_string(const wcstring &str, parse_tree_flags_t flags, parse
 
     case_item = CASE argument_list <TOK_END> job_list
 
-    block_statement = block_header <TOK_END> job_list end_command arguments_or_redirections_list
-    block_header = for_header | while_header | function_header | begin_header
-    for_header = FOR var_name IN argument_list
-    while_header = WHILE job
-    begin_header = BEGIN
+    block_statement = block_header  job_list end_command arguments_or_redirections_list
+    block_header = for_header | while_header  | function_header | begin_header
+    for_header = FOR var_name IN argument_list <TOK_END>
+    while_header = WHILE job <TOK_END>
+    begin_header = BEGIN | BEGIN <TOK_END>
 
 # Functions take arguments, and require at least one (the name). No redirections allowed.
-    function_header = FUNCTION argument argument_list
+    function_header = FUNCTION argument argument_list <TOK_END>
 
 # A boolean statement is AND or OR or NOT
 

--- a/parse_tree.h
+++ b/parse_tree.h
@@ -253,7 +253,7 @@ bool parse_tree_from_string(const wcstring &str, parse_tree_flags_t flags, parse
     block_header = for_header | while_header  | function_header | begin_header
     for_header = FOR var_name IN argument_list <TOK_END>
     while_header = WHILE job <TOK_END>
-    begin_header = BEGIN | BEGIN <TOK_END>
+    begin_header = BEGIN
 
 # Functions take arguments, and require at least one (the name). No redirections allowed.
     function_header = FUNCTION argument argument_list <TOK_END>

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-03-13 21:29+0800\n"
+"POT-Creation-Date: 2015-04-13 22:15+0800\n"
 "PO-Revision-Date: 2013-11-01 18:36+0100\n"
 "Last-Translator: Benjamin\n"
 "Language-Team: deutsch <de@li.org>\n"
@@ -23,111 +23,116 @@ msgstr ""
 msgid "Could not autoload item '%ls', it is already being autoloaded. "
 msgstr ""
 
-#: builtin.cpp:83
+#: builtin.cpp:84
 #, c-format
 msgid "Send job %d, '%ls' to foreground\n"
 msgstr "Job %d, '%ls' in den Vordergrund schicken\n"
 
-#: builtin.cpp:344
+#: builtin.cpp:352
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
 "\n"
 msgstr ""
 
-#: builtin.cpp:484
+#: builtin.cpp:531
 #, c-format
 msgid "%ls: No key with name '%ls' found\n"
 msgstr ""
 
-#: builtin.cpp:490
+#: builtin.cpp:537
 #, fuzzy, c-format
 msgid "%ls: Key with name '%ls' does not have any mapping\n"
 msgstr "%ls: Funktion '%ls' existiert nicht\n"
 
-#: builtin.cpp:496
+#: builtin.cpp:543
 #, fuzzy, c-format
 msgid "%ls: Unknown error trying to bind to key named '%ls'\n"
 msgstr "%ls: Unbekannte Option '%ls'\n"
 
-#: builtin.cpp:668
+#: builtin.cpp:794
 #, fuzzy, c-format
-msgid "%ls: Expected zero or two parameters, got %d\n"
-msgstr "%ls: Erwartete kein oder ein Argument, erhielt %d\n"
+msgid "%ls: No binding found for key '%ls'\n"
+msgstr "Beschreibung des mime-Typs ausgeben"
 
-#: builtin.cpp:692
+#: builtin.cpp:798
+#, c-format
+msgid "%ls: No binding found for sequence '%ls'\n"
+msgstr ""
+
+#: builtin.cpp:834
 #, fuzzy, c-format
 msgid "%ls: Invalid state\n"
 msgstr "%ls: Ungültiger Indexstart bei '%ls'\n"
 
-#: builtin.cpp:796
+#: builtin.cpp:939
 #, c-format
 msgid "%ls: Can not specify scope when removing block\n"
 msgstr "%ls: Bei Blocklöschung kann kein Bereich angegeben werden\n"
 
-#: builtin.cpp:802
+#: builtin.cpp:945
 #, c-format
 msgid "%ls: No blocks defined\n"
 msgstr "%ls: Keine Blöcke definiert\n"
 
-#: builtin.cpp:1312 builtin.h:32
+#: builtin.cpp:1556 builtin.h:32
 #, c-format
 msgid "%ls: Invalid combination of options\n"
 msgstr "%ls: Ungültige Kombination der Optionen\n"
 
-#: builtin.cpp:1334
+#: builtin.cpp:1578
 #, c-format
 msgid "%ls: Expected exactly one function name\n"
 msgstr "%ls: Erwartete genau einen Funktionsnamen\n"
 
-#: builtin.cpp:1344 builtin.cpp:1406
+#: builtin.cpp:1588 builtin.cpp:1650
 #, c-format
 msgid "%ls: Function '%ls' does not exist\n"
 msgstr "%ls: Funktion '%ls' existiert nicht\n"
 
-#: builtin.cpp:1394
+#: builtin.cpp:1638
 #, fuzzy, c-format
 msgid ""
 "%ls: Expected exactly two names (current function name, and new function "
 "name)\n"
 msgstr "%ls: Erwartete genau einen Funktionsnamen\n"
 
-#: builtin.cpp:1417 builtin.cpp:1952 builtin.cpp:2259
+#: builtin.cpp:1661 builtin.cpp:2230
 #, c-format
 msgid "%ls: Illegal function name '%ls'\n"
 msgstr "%ls: Ungültiger Funktionsname '%ls'\n"
 
-#: builtin.cpp:1428
+#: builtin.cpp:1672
 #, fuzzy, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy '%ls'\n"
 msgstr "%ls: Funktion '%ls' existiert nicht\n"
 
-#: builtin.cpp:1809 builtin.cpp:2114
+#: builtin.cpp:2070
 #, c-format
 msgid "%ls: Unknown signal '%ls'\n"
 msgstr "%ls: Unbekanntes Signal '%ls'\n"
 
-#: builtin.cpp:1824 builtin.cpp:1984 builtin.cpp:2129 builtin.cpp:2291
+#: builtin.cpp:2085 builtin.cpp:2195 builtin.cpp:2263
 #, c-format
 msgid "%ls: Invalid variable name '%ls'\n"
 msgstr "%ls: Ungültiger Variablenname '%ls'\n"
 
-#: builtin.cpp:1877 builtin.cpp:2182
+#: builtin.cpp:2138
 #, c-format
 msgid "%ls: Cannot find calling job for event handler\n"
 msgstr "%ls: Kann aufrufenden Job zur Ereignisbehandlung nicht finden\n"
 
-#: builtin.cpp:1895 builtin.cpp:2200
+#: builtin.cpp:2156
 #, c-format
 msgid "%ls: Invalid process id %ls\n"
 msgstr "%ls: Ungültige Prozesskennung %ls\n"
 
-#: builtin.cpp:1945 builtin.cpp:2252
+#: builtin.cpp:2223
 #, fuzzy, c-format
 msgid "%ls: Expected function name\n"
 msgstr "%ls: Erwartete genau einen Funktionsnamen\n"
 
-#: builtin.cpp:1962 builtin.cpp:2269
+#: builtin.cpp:2240
 #, c-format
 msgid ""
 "%ls: The name '%ls' is reserved,\n"
@@ -136,396 +141,386 @@ msgstr ""
 "%ls: Der Name '%ls' ist reserviert,\n"
 "und kann nicht als Funktionsname benutzt werden\n"
 
-#: builtin.cpp:1970 builtin.cpp:2277 builtin.cpp:3824
+#: builtin.cpp:2248
 #, fuzzy, c-format
 msgid "%ls: No function name given\n"
 msgstr "%ls: Ungültiger Funktionsname '%ls'\n"
 
-#: builtin.cpp:1997 builtin.cpp:2304
+#: builtin.cpp:2276
 #, c-format
 msgid "%ls: Expected one argument, got %d\n"
 msgstr "%ls: Erwartete ein Argument, erhielt %d\n"
 
-#: builtin.cpp:2319
-msgid "Current functions are: "
-msgstr "Aktuelle Funktionen sind: "
-
-#: builtin.cpp:2459
+#: builtin.cpp:2412
 #, c-format
 msgid "%ls: Seed value '%ls' is not a valid number\n"
 msgstr "%ls: Seed-Wert '%ls' ist keine gültige Zahl\n"
 
-#: builtin.cpp:2473
+#: builtin.cpp:2426
 #, c-format
 msgid "%ls: Expected zero or one argument, got %d\n"
 msgstr "%ls: Erwartete kein oder ein Argument, erhielt %d\n"
 
-#: builtin.cpp:2981 fish.cpp:518 parser.cpp:1095
-#, fuzzy
-msgid "Standard input"
-msgstr "Standardmodus"
+#: builtin.cpp:2593
+#, fuzzy, c-format
+msgid "%ls: Argument '%ls' is out of range\n"
+msgstr "%ls: Argument '%ls' muss eine Ganzzahl sein\n"
 
-#: builtin.cpp:3024
-#, fuzzy
-msgid "This is a login shell\n"
-msgstr "Login-Shell erstellen"
-
-#: builtin.cpp:3026
-#, fuzzy
-msgid "This is not a login shell\n"
-msgstr "Login-Shell erstellen"
-
-#: builtin.cpp:3028
-#, c-format
-msgid "Job control: %ls\n"
-msgstr ""
-
-#: builtin.cpp:3029
-#, fuzzy
-msgid "Only on interactive jobs"
-msgstr "Ausführung im interaktiven Modus"
-
-#: builtin.cpp:3030
-msgid "Never"
-msgstr ""
-
-#: builtin.cpp:3030
-msgid "Always"
-msgstr ""
-
-#: builtin.cpp:3066 builtin.cpp:3995
+#: builtin.cpp:2601 builtin.cpp:3150 builtin.cpp:3817
 #, c-format
 msgid "%ls: Argument '%ls' must be an integer\n"
 msgstr "%ls: Argument '%ls' muss eine Ganzzahl sein\n"
 
+#: builtin.cpp:2656
+#, fuzzy, c-format
+msgid "%ls: --array option requires a single variable name.\n"
+msgstr ""
+"%ls: Erase benötigt einen Variablennamen\n"
+"%ls\n"
+
+#: builtin.cpp:3065 fish.cpp:620 parser.cpp:764
+#, fuzzy
+msgid "Standard input"
+msgstr "Standardmodus"
+
 #: builtin.cpp:3108
+#, fuzzy
+msgid "This is a login shell\n"
+msgstr "Login-Shell erstellen"
+
+#: builtin.cpp:3110
+#, fuzzy
+msgid "This is not a login shell\n"
+msgstr "Login-Shell erstellen"
+
+#: builtin.cpp:3112
+#, c-format
+msgid "Job control: %ls\n"
+msgstr ""
+
+#: builtin.cpp:3113
+#, fuzzy
+msgid "Only on interactive jobs"
+msgstr "Ausführung im interaktiven Modus"
+
+#: builtin.cpp:3114
+msgid "Never"
+msgstr ""
+
+#: builtin.cpp:3114
+msgid "Always"
+msgstr ""
+
+#: builtin.cpp:3192
 #, c-format
 msgid "%ls: Could not find home directory\n"
 msgstr "%ls: Konnte Startverzeichnis nicht finden\n"
 
-#: builtin.cpp:3128 builtin.cpp:3182
+#: builtin.cpp:3212 builtin.cpp:3266
 #, c-format
 msgid "%ls: '%ls' is not a directory\n"
 msgstr "%ls: '%ls' ist kein Verzeichnis\n"
 
-#: builtin.cpp:3135
+#: builtin.cpp:3219
 #, fuzzy, c-format
 msgid "%ls: The directory '%ls' does not exist\n"
 msgstr "%ls: Funktion '%ls' existiert nicht\n"
 
-#: builtin.cpp:3142
+#: builtin.cpp:3226
 #, fuzzy, c-format
 msgid "%ls: '%ls' is a rotten symlink\n"
 msgstr "%ls: '%ls' ist keine Datei\n"
 
-#: builtin.cpp:3150
+#: builtin.cpp:3234
 #, fuzzy, c-format
 msgid "%ls: Unknown error trying to locate directory '%ls'\n"
 msgstr "%ls: Unbekannte Option '%ls'\n"
 
-#: builtin.cpp:3173
+#: builtin.cpp:3257
 #, fuzzy, c-format
 msgid "%ls: Permission denied: '%ls'\n"
 msgstr "%ls: Ungültiger Funktionsname '%ls'\n"
 
-#: builtin.cpp:3197
+#: builtin.cpp:3281
 #, c-format
 msgid "%ls: Could not set PWD variable\n"
 msgstr "%ls: Konnte PWD-Variable nicht festlegen\n"
 
-#: builtin.cpp:3284
+#: builtin.cpp:3368
 #, fuzzy, c-format
 msgid "%ls: Key not specified\n"
 msgstr "%s: Schlüssel nicht angegeben\\n"
 
-#: builtin.cpp:3328 builtin.cpp:3336
+#: builtin.cpp:3412 builtin.cpp:3420
 #, fuzzy, c-format
 msgid "%ls: Error encountered while sourcing file '%ls':\n"
 msgstr "%ls: Fehler beim Lesen der Datei '%ls'\n"
 
-#: builtin.cpp:3344
+#: builtin.cpp:3428
 #, c-format
 msgid "%ls: '%ls' is not a file\n"
 msgstr "%ls: '%ls' ist keine Datei\n"
 
-#: builtin.cpp:3363
+#: builtin.cpp:3447
 #, c-format
 msgid "%ls: Error while reading file '%ls'\n"
 msgstr "%ls: Fehler beim Lesen der Datei '%ls'\n"
 
-#: builtin.cpp:3419 builtin.cpp:3599
+#: builtin.cpp:3503 builtin.cpp:3682
 #, fuzzy, c-format
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls: Es gibt keine Jobs\n"
 
-#: builtin.cpp:3448
+#: builtin.cpp:3531
 #, c-format
 msgid "%ls: Ambiguous job\n"
 msgstr "%ls: Mehrdeutiger Job\n"
 
-#: builtin.cpp:3454 builtin.cpp:3622 builtin_jobs.cpp:301
+#: builtin.cpp:3537 builtin.cpp:3705 builtin_jobs.cpp:301
 #, c-format
 msgid "%ls: '%ls' is not a job\n"
 msgstr "%ls: '%ls' ist kein Job\n"
 
-#: builtin.cpp:3485 builtin_jobs.cpp:316
+#: builtin.cpp:3568 builtin_jobs.cpp:316
 #, c-format
 msgid "%ls: No suitable job: %d\n"
 msgstr "%ls: Kein passender Job: %d\n"
 
-#: builtin.cpp:3494
+#: builtin.cpp:3577
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to foreground because it is not under job "
 "control\n"
 msgstr ""
 
-#: builtin.cpp:3547
+#: builtin.cpp:3630
 #, c-format
 msgid "%ls: Unknown job '%ls'\n"
 msgstr "%ls: Unbekannter Job '%ls'\n"
 
-#: builtin.cpp:3556
+#: builtin.cpp:3639
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to background because it is not under job "
 "control\n"
 msgstr ""
 
-#: builtin.cpp:3566
+#: builtin.cpp:3649
 #, c-format
 msgid "Send job %d '%ls' to background\n"
 msgstr "Sende Job %d '%ls' in den Hintergrund\n"
 
-#: builtin.cpp:3605
+#: builtin.cpp:3688
 msgid "(default)"
 msgstr "(Standard)"
 
-#: builtin.cpp:3737
-#, c-format
-msgid "%ls: Not inside of block\n"
-msgstr "%ls: Nicht innerhalb eines Blocks\n"
-
-#: builtin.cpp:3884
-#, c-format
-msgid "%ls: Not inside of 'if' block\n"
-msgstr "%ls: Nicht innerhalb eines 'if'-Blocks\n"
-
-#: builtin.cpp:3938
+#: builtin.cpp:3760
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls: Nicht innerhalb einer Schleife\n"
 
-#: builtin.cpp:4005 builtin_complete.cpp:539 builtin_set_color.cpp:140
-#: builtin.h:83
+#: builtin.cpp:3827 builtin_complete.cpp:551 builtin.h:83
 #, c-format
 msgid "%ls: Too many arguments\n"
 msgstr "%ls: Zu viele Argumente\n"
 
-#: builtin.cpp:4023
+#: builtin.cpp:3845
 #, c-format
 msgid "%ls: Not inside of function\n"
 msgstr "%ls: Nicht innerhalb einer Funktion\n"
 
-#: builtin.cpp:4059
-#, c-format
-msgid "%ls: Expected exactly one argument, got %d\n"
-msgstr "%ls: Erwartete genau ein Argument, erhielt %d\n"
-
-#: builtin.cpp:4090
-#, c-format
-msgid "%ls: 'case' command while not in switch block\n"
-msgstr "%ls: 'case'-Befehl außerhalb eines switch-Blocks\n"
-
-#: builtin.cpp:4317 builtin.cpp:4360
+#: builtin.cpp:4069 builtin.cpp:4113
 #, fuzzy
 msgid "Test a condition"
 msgstr "Konfigurationsoption festlegen"
 
-#: builtin.cpp:4318
+#: builtin.cpp:4070
 msgid "Try out the new parser"
 msgstr ""
 
-#: builtin.cpp:4319
+#: builtin.cpp:4071
 msgid "Execute command if previous command suceeded"
 msgstr "Befehl ausführen, wenn vorheriger Befehl fehlerfrei war"
 
-#: builtin.cpp:4320
+#: builtin.cpp:4072
 msgid "Create a block of code"
 msgstr "Codeblock erstellen"
 
-#: builtin.cpp:4321
+#: builtin.cpp:4073
 msgid "Send job to background"
 msgstr "Job in Hintergrund schicken"
 
-#: builtin.cpp:4322
+#: builtin.cpp:4074
 msgid "Handle fish key bindings"
 msgstr "Fish-Tastenbelegungen bearbeiten"
 
-#: builtin.cpp:4323
+#: builtin.cpp:4075
 msgid "Temporarily block delivery of events"
 msgstr "Ereignisweitergabe vorübergehend blockieren"
 
-#: builtin.cpp:4324
+#: builtin.cpp:4076
 msgid "Stop the innermost loop"
 msgstr "Innerste Schleife beenden"
 
-#: builtin.cpp:4325
+#: builtin.cpp:4077
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 
-#: builtin.cpp:4326
+#: builtin.cpp:4078
 msgid "Run a builtin command instead of a function"
 msgstr "Internen Befehl anstatt einer Funktion ausführen"
 
-#: builtin.cpp:4327 builtin.cpp:4359
+#: builtin.cpp:4079 builtin.cpp:4112
 msgid "Conditionally execute a block of commands"
 msgstr "Befehlsblock bedingt ausführen"
 
-#: builtin.cpp:4328
+#: builtin.cpp:4080
 msgid "Change working directory"
 msgstr "Arbeitsverzeichnis wechseln"
 
-#: builtin.cpp:4329
+#: builtin.cpp:4081
 msgid "Run a program instead of a function or builtin"
 msgstr "Programm statt Funktion oder internem Befehl ausführen"
 
-#: builtin.cpp:4330
+#: builtin.cpp:4082
 msgid "Set or get the commandline"
 msgstr "Festlegen oder Abrufen der Befehlszeile"
 
-#: builtin.cpp:4331
+#: builtin.cpp:4083
 msgid "Edit command specific completions"
 msgstr "Befehlsspezifische Erweiterungen bearbeiten"
 
-#: builtin.cpp:4332
+#: builtin.cpp:4084
 msgid "Search for a specified string in a list"
 msgstr ""
 
-#: builtin.cpp:4333
+#: builtin.cpp:4085
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "Rest des aktuellen Durchlaufs der innersten Schleife überspringen"
 
-#: builtin.cpp:4334
+#: builtin.cpp:4086
 #, fuzzy
 msgid "Count the number of arguments"
 msgstr "Anzahl der Vorkommen ausgeben"
 
-#: builtin.cpp:4335
+#: builtin.cpp:4087
 #, fuzzy
 msgid "Print arguments"
 msgstr "Wortzählung ausgeben"
 
-#: builtin.cpp:4336
+#: builtin.cpp:4088
 msgid "Evaluate block if condition is false"
 msgstr "Werte Block aus, wenn die Bedingung falsch ist"
 
-#: builtin.cpp:4337
+#: builtin.cpp:4089
 #, fuzzy
 msgid "Emit an event"
 msgstr "Debian-Version auslassen"
 
-#: builtin.cpp:4338
+#: builtin.cpp:4090
 msgid "End a block of commands"
 msgstr "Befehlsblock beenden"
 
-#: builtin.cpp:4339
+#: builtin.cpp:4091
 msgid "Run command in current process"
 msgstr "Befehl im aktuellen Prozess ausführen"
 
-#: builtin.cpp:4340
+#: builtin.cpp:4092
 msgid "Exit the shell"
 msgstr "Shell verlassen"
 
-#: builtin.cpp:4341
+#: builtin.cpp:4093
+msgid "Return an unsuccessful result"
+msgstr ""
+
+#: builtin.cpp:4094
 msgid "Send job to foreground"
 msgstr "Job in Vordergrund schicken"
 
-#: builtin.cpp:4342
+#: builtin.cpp:4095
 msgid "Perform a set of commands multiple times"
 msgstr "Eine Befehlsfolge mehrmals ausführen"
 
-#: builtin.cpp:4343
+#: builtin.cpp:4096
 msgid "Define a new function"
 msgstr "Neue Funktion definieren"
 
-#: builtin.cpp:4344
+#: builtin.cpp:4097
 msgid "List or remove functions"
 msgstr "Funktionen auflisten oder entfernen"
 
-#: builtin.cpp:4345
+#: builtin.cpp:4098
 msgid "History of commands executed by user"
 msgstr ""
 
-#: builtin.cpp:4346
+#: builtin.cpp:4099
 msgid "Evaluate block if condition is true"
 msgstr "Block auswerten, wenn Bedingung wahr ist"
 
-#: builtin.cpp:4347
+#: builtin.cpp:4100
 msgid "Print currently running jobs"
 msgstr "Derzeit laufende Jobs ausgeben"
 
-#: builtin.cpp:4348
+#: builtin.cpp:4101
 msgid "Negate exit status of job"
 msgstr "Exit-Status des Jobs verneinen"
 
-#: builtin.cpp:4349
+#: builtin.cpp:4102
 msgid "Execute command if previous command failed"
 msgstr "Befehl ausführen, wenn vorheriger Befehl fehlerhaft war"
 
-#: builtin.cpp:4350
+#: builtin.cpp:4103
 #, fuzzy
 msgid "Prints formatted text"
 msgstr "Befehlstyp ausgeben"
 
-#: builtin.cpp:4351
+#: builtin.cpp:4104
 #, fuzzy
 msgid "Print the working directory"
 msgstr "Arbeitsverzeichnis ausgeben"
 
-#: builtin.cpp:4352
+#: builtin.cpp:4105
 msgid "Generate random number"
 msgstr "Zufallszahl generieren"
 
-#: builtin.cpp:4353
+#: builtin.cpp:4106
 msgid "Read a line of input into variables"
 msgstr "Eine Eingabezeile in Variablen einlesen"
 
-#: builtin.cpp:4354
+#: builtin.cpp:4107
 msgid "Stop the currently evaluated function"
 msgstr "Derzeit ausgewertete Funktion stoppen"
 
-#: builtin.cpp:4355
+#: builtin.cpp:4108
 msgid "Handle environment variables"
 msgstr "Behandlung von Umgebungsvariablen"
 
-#: builtin.cpp:4356
+#: builtin.cpp:4109
 msgid "Set the terminal color"
 msgstr ""
 
-#: builtin.cpp:4357
+#: builtin.cpp:4110
 msgid "Evaluate contents of file"
 msgstr "Inhalt einer Datei auswerten"
 
-#: builtin.cpp:4358
+#: builtin.cpp:4111
 msgid "Return status information about fish"
 msgstr "Statusinformation über Fish zurückgeben"
 
-#: builtin.cpp:4361
+#: builtin.cpp:4114
+msgid "Return a successful result"
+msgstr ""
+
+#: builtin.cpp:4115
 msgid "Set or get the shells resource usage limits"
 msgstr "Die Ressourcengrenzen der Shell festlegen/abrufen"
 
-#: builtin.cpp:4362
+#: builtin.cpp:4116
 msgid "Perform a command multiple times"
 msgstr "Einen Befehl mehrmals ausführen"
 
-#: builtin.cpp:4442 parser.cpp:53
-#, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "unbekannter interner Befehl '%ls'"
-
-#: builtin_commandline.cpp:411
+#: builtin_commandline.cpp:466
 #, fuzzy, c-format
 msgid "%ls: Unknown input function '%ls'\n"
 msgstr "%ls: Unbekannte Option '%ls'\n"
@@ -542,7 +537,7 @@ msgstr "CPU\t"
 msgid "State\tCommand\n"
 msgstr "Status\tBefehl\n"
 
-#: builtin_jobs.cpp:99 proc.cpp:751
+#: builtin_jobs.cpp:99 proc.cpp:843
 msgid "stopped"
 msgstr "gestoppt"
 
@@ -588,31 +583,31 @@ msgstr ""
 msgid "missing hexadecimal number in escape"
 msgstr ""
 
-#: builtin_printf.cpp:387
+#: builtin_printf.cpp:388
 msgid "Missing hexadecimal number in Unicode escape"
 msgstr ""
 
-#: builtin_printf.cpp:401
+#: builtin_printf.cpp:402
 #, c-format
 msgid "Unicode character out of range: \\%c%0*x"
 msgstr ""
 
-#: builtin_printf.cpp:668
+#: builtin_printf.cpp:670
 #, c-format
 msgid "invalid field width: %ls"
 msgstr ""
 
-#: builtin_printf.cpp:706
+#: builtin_printf.cpp:708
 #, fuzzy, c-format
 msgid "invalid precision: %ls"
 msgstr "%ls: Ungültige Prozesskennung %ls\n"
 
-#: builtin_printf.cpp:737
+#: builtin_printf.cpp:739
 #, fuzzy, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%ls: Ungültige Kombination der Optionen\n"
 
-#: builtin_printf.cpp:769
+#: builtin_printf.cpp:771
 #, fuzzy
 msgid "printf: not enough arguments"
 msgstr "Dateiargumente nicht sortieren"
@@ -624,58 +619,64 @@ msgstr "%ls: Fehler beim Lesen der Datei '%ls'\n"
 
 #: builtin_set.cpp:162
 #, fuzzy, c-format
-msgid "%ls: Unknown error"
-msgstr "%ls: Unbekannter Job '%ls'\n"
+msgid "%ls: Tried to set the special variable '%ls' with the wrong scope\n"
+msgstr "%ls: Fehler beim Lesen der Datei '%ls'\n"
 
-#: builtin_set.cpp:214
+#: builtin_set.cpp:169
+#, fuzzy, c-format
+msgid "%ls: Tried to set the special variable '%ls' to an invalid value\n"
+msgstr "%ls: Fehler beim Lesen der Datei '%ls'\n"
+
+#: builtin_set.cpp:221
 #, c-format
 msgid "%ls: Multiple variable names specified in single call (%ls and %.*ls)\n"
 msgstr ""
 
-#: builtin_set.cpp:241
+#: builtin_set.cpp:248
 #, c-format
 msgid "%ls: Invalid index starting at '%ls'\n"
 msgstr "%ls: Ungültiger Indexstart bei '%ls'\n"
 
-#: builtin_set.cpp:640
+#: builtin_set.cpp:647
 #, fuzzy, c-format
 msgid "%ls: Erase needs a variable name\n"
 msgstr ""
 "%ls: Erase benötigt einen Variablennamen\n"
 "%ls\n"
 
-#: builtin_set.cpp:684
-#, fuzzy, c-format
-msgid "%ls: Can not specify scope when erasing array slice\n"
-msgstr "%ls: Bei Blocklöschung kann kein Bereich angegeben werden\n"
-
-#: builtin_set.cpp:783
+#: builtin_set.cpp:791
 #, fuzzy, c-format
 msgid "%ls: Values cannot be specfied with erase\n"
 msgstr ""
 "%ls: Bei erase können keine Werte angegeben werden\n"
 "%ls\n"
 
-#: builtin_set_color.cpp:149
-#, fuzzy, c-format
-msgid "%ls: Expected an argument\n"
-msgstr "%ls: Argument erwartet\n"
+#: builtin_set.cpp:817
+#, c-format
+msgid ""
+"%ls: Warning: universal scope selected, but a global variable '%ls' exists.\n"
+msgstr ""
 
-#: builtin_set_color.cpp:157 builtin_set_color.cpp:164
+#: builtin_set_color.cpp:144 builtin_set_color.cpp:166
 #, fuzzy, c-format
 msgid "%ls: Unknown color '%ls'\n"
 msgstr "%ls: Unbekannter Job '%ls'\n"
 
-#: builtin_set_color.cpp:171
+#: builtin_set_color.cpp:153
+#, fuzzy, c-format
+msgid "%ls: Expected an argument\n"
+msgstr "%ls: Argument erwartet\n"
+
+#: builtin_set_color.cpp:173
 #, fuzzy, c-format
 msgid "%ls: Could not set up terminal\n"
 msgstr "Konnte Terminal nicht einrichten"
 
-#: common.cpp:1882
+#: common.cpp:1917
 msgid "This is a bug. Break on bugreport to debug."
 msgstr ""
 
-#: common.cpp:1901
+#: common.cpp:1936
 msgid "empty"
 msgstr "leer"
 
@@ -689,72 +690,70 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variable: "
 
-#: complete.cpp:907 complete.cpp:925
+#: complete.cpp:901 complete.cpp:919
 msgid "Unknown option: "
 msgstr "Unbekannte Option: "
 
-#: complete.cpp:929
+#: complete.cpp:923
 msgid "Multiple matches for option: "
 msgstr "Mehrere Treffer für Option: "
 
-#: env.cpp:251
-msgid "Could not get user information"
-msgstr "Kann Benutzerinformation nicht abrufen"
-
-#: env.cpp:362
+#: env.cpp:315
 msgid "Changing language to English"
 msgstr "Sprachwechsel zu Deutsch"
 
-#: env.cpp:1252
+#: env.cpp:1180
 msgid "Tried to pop empty environment stack."
 msgstr "Versuchte, einen leeren Umgebungsstack zu poppen."
 
-#: env_universal_common.cpp:529
-#, c-format
-msgid "Could not convert message '%s' to wide character string"
+#: env_universal_common.cpp:617 path.cpp:279
+msgid ""
+"Unable to create a configuration directory for fish. Your personal settings "
+"will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
+"where the current user has write access."
 msgstr ""
 
-#: event.cpp:168
+#: event.cpp:178
 #, c-format
 msgid "signal handler for %ls (%ls)"
 msgstr ""
 
-#: event.cpp:172
+#: event.cpp:182
 #, fuzzy, c-format
 msgid "handler for variable '%ls'"
 msgstr "Behandlung von Umgebungsvariablen"
 
-#: event.cpp:178
+#: event.cpp:188
 #, c-format
 msgid "exit handler for process %d"
 msgstr ""
 
-#: event.cpp:184 event.cpp:195
+#: event.cpp:194 event.cpp:205
 #, c-format
 msgid "exit handler for job %d, '%ls'"
 msgstr ""
 
-#: event.cpp:186
+#: event.cpp:196
 #, c-format
 msgid "exit handler for job with process group %d"
 msgstr ""
 
-#: event.cpp:197
+#: event.cpp:207
 #, c-format
 msgid "exit handler for job with job id %d"
 msgstr ""
 
-#: event.cpp:203
+#: event.cpp:213
 #, c-format
 msgid "handler for generic event '%ls'"
 msgstr ""
 
-#: event.cpp:207
+#: event.cpp:217
 #, fuzzy, c-format
 msgid "Unknown event type '0x%x'"
 msgstr "Unbekannter Typ %d bei Eingabeumleitung "
 
-#: event.cpp:621
+#: event.cpp:613
 msgid "Signal list overflow. Signals have been ignored."
 msgstr "Signallistenüberlauf. Signale wurden ignoriert."
 
@@ -773,12 +772,12 @@ msgstr "Fehler beim Einrichten der Pipe aufgetreten"
 msgid "An error occurred while redirecting file '%s'"
 msgstr "Fehler beim Umleiten der Datei '%ls'"
 
-#: exec.cpp:912
+#: exec.cpp:795
 #, c-format
 msgid "Unknown function '%ls'"
 msgstr "Unbekannte Funktion '%ls'"
 
-#: exec.cpp:1063
+#: exec.cpp:943
 #, c-format
 msgid "Unknown input redirection type %d"
 msgstr "Unbekannter Typ %d bei Eingabeumleitung "
@@ -812,176 +811,160 @@ msgstr "Preprozessoren"
 msgid "Last background job"
 msgstr "In Hintergrund verzweigen"
 
-#: expand.cpp:1306
+#: expand.cpp:1419
 #, fuzzy
 msgid "Mismatched brackets"
 msgstr "Unpassendes Anführungszeichen"
 
-#: fish.cpp:320
+#: fish.cpp:330
+msgid ""
+"Old versions of fish appear to be running. You will not be able to share "
+"variable values between old and new fish sessions. For best results, restart "
+"all running instances of fish."
+msgstr ""
+
+#: fish.cpp:420
 #, c-format
 msgid "Invalid value '%s' for debug level switch"
 msgstr ""
 
-#: fish.cpp:361 mimedb.cpp:1335
+#: fish.cpp:461 mimedb.cpp:1343
 #, c-format
 msgid "%s, version %s\n"
 msgstr ""
 
-#: fish.cpp:416
+#: fish.cpp:516
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr ""
 
-#: fish.cpp:517
+#: fish.cpp:619
 #, fuzzy, c-format
 msgid "Error while reading file %ls\n"
 msgstr "%ls: Fehler beim Lesen der Datei '%ls'\n"
 
-#: fish_indent.cpp:345
+#: fish_indent.cpp:332
 #, c-format
 msgid "%ls, version %s\n"
 msgstr ""
 
-#: fish_pager.cpp:113
-#, fuzzy, c-format
-msgid "%ls: Argument '%s' is not a valid file descriptor\n"
-msgstr "%ls: '%ls' ist kein gültiger Variablenname\n"
-
-#: fish_pager.cpp:703
-#, c-format
-msgid " %d to %d of %d"
-msgstr ""
-
-#: fish_pager.cpp:1012
-msgid "Could not set up output file descriptors for pager"
-msgstr ""
-
-#: fish_pager.cpp:1018
-#, fuzzy
-msgid "Could not set up input file descriptors for pager"
-msgstr "Konnte Terminalmodus für neue Shell nicht festlegen"
-
-#: fish_pager.cpp:1024
-#, fuzzy
-msgid "Could not open tty for pager"
-msgstr "Konnte Shell nicht wieder in Vordergrund zurückholen"
-
-#: fish_pager.cpp:1031
-msgid "Could not initialize result pipe"
-msgstr ""
-
-#: fish_pager.cpp:1075 input.cpp:384 input.cpp:394
+#: input.cpp:483 input.cpp:493
 msgid "Could not set up terminal"
 msgstr "Konnte Terminal nicht einrichten"
 
-#: fish_pager.cpp:1110 input.cpp:436
-#, fuzzy
-msgid "Error while closing terminfo"
-msgstr "Fehler beim Schließen des Eingabestroms"
-
-#: fish_pager.cpp:1306
-#, fuzzy
-msgid "Unspecified file descriptors"
-msgstr "Datei-Deskriptoren beobachten"
-
-#: fish_pager.cpp:1318
-#, fuzzy
-msgid "Could not read completions"
-msgstr "Befehl, bei dem Vervollständigung genutzt werden soll"
-
-#: fishd.cpp:766 path.cpp:358
-msgid ""
-"Unable to create a configuration directory for fish. Your personal settings "
-"will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
-"where the current user has write access."
-msgstr ""
-
-#: input.cpp:387
+#: input.cpp:486
 #, c-format
 msgid "Check that your terminal type, '%ls', is supported on this system"
 msgstr ""
 
-#: input.cpp:389
+#: input.cpp:488
 #, c-format
 msgid "Attempting to use '%ls' instead"
 msgstr ""
 
-#: io.cpp:110
+#: input.cpp:535
+#, fuzzy
+msgid "Error while closing terminfo"
+msgstr "Fehler beim Schließen des Eingabestroms"
+
+#: io.cpp:112
 #, c-format
 msgid ""
 "An error occured while reading output from code block on file descriptor %d"
 msgstr "Fehler beim Lesen der Ausgabe des Codeblocks auf Dateideskriptor %d"
 
-#: mimedb.cpp:173 mimedb.cpp:187 mimedb.cpp:1177
+#: mimedb.cpp:174 mimedb.cpp:188 mimedb.cpp:1179
 #, c-format
 msgid "%s: Out of memory\n"
 msgstr ""
 
-#: mimedb.cpp:462
+#: mimedb.cpp:463
 #, fuzzy, c-format
 msgid "%s: Unknown error in munge()\n"
 msgstr "%ls: Unbekannte Option '%ls'\n"
 
-#: mimedb.cpp:480
+#: mimedb.cpp:481
 #, fuzzy, c-format
 msgid "%s: Locale string too long\n"
 msgstr "%ls: Parameter '%ls' ist zu lang\n"
 
-#: mimedb.cpp:550 mimedb.cpp:558
+#: mimedb.cpp:551 mimedb.cpp:559
 #, c-format
 msgid "%s: Could not compile regular expressions %s with error %s\n"
 msgstr ""
 
-#: mimedb.cpp:674
+#: mimedb.cpp:676
 #, fuzzy, c-format
 msgid "%s: No description for type %s\n"
 msgstr "Beschreibung des mime-Typs ausgeben"
 
-#: mimedb.cpp:742
+#: mimedb.cpp:744
 #, fuzzy, c-format
 msgid "%s: Could not parse launcher string '%s'\n"
 msgstr "Konnte Zeichenkette '%ls' nicht erweitern"
 
-#: mimedb.cpp:778
+#: mimedb.cpp:780
 #, c-format
 msgid "%s: Default launcher '%s' does not specify how to start\n"
 msgstr ""
 
-#: mimedb.cpp:1156
+#: mimedb.cpp:1158
 #, c-format
 msgid "%s: Unsupported switch '%c' in launch string '%s'\n"
 msgstr ""
 
-#: mimedb.cpp:1346
+#: mimedb.cpp:1354
 #, c-format
 msgid "%s: Can not launch a mimetype\n"
 msgstr ""
 
-#: mimedb.cpp:1374
+#: mimedb.cpp:1382
 #, fuzzy, c-format
 msgid "%s: Could not parse mimetype from argument '%s'\n"
 msgstr "Konnte Sequenz '%ls' nicht auswerten"
 
-#: mimedb.cpp:1394 signal.cpp:407 signal.cpp:422
+#: mimedb.cpp:1402 signal.cpp:407 signal.cpp:422
 #, fuzzy
 msgid "Unknown"
 msgstr "unbekannt"
+
+#: output.cpp:608
+#, c-format
+msgid ""
+"Tried to use terminfo string %s on line %ld of %s, which is undefined in "
+"terminal of type \"%ls\". Please report this error to %s"
+msgstr ""
 
 #: pager.cpp:24
 #, fuzzy
 msgid "search: "
 msgstr "Architektur festlegen"
 
-#: parse_execution.cpp:526 parse_execution.cpp:961 parser.cpp:1404
+#: pager.cpp:562
 #, c-format
-msgid "Could not expand string '%ls'"
-msgstr "Konnte Zeichenkette '%ls' nicht erweitern"
+msgid "%lsand 1 more row"
+msgstr ""
 
-#: parse_execution.cpp:549
+#: pager.cpp:566
+#, c-format
+msgid "%lsand %lu more rows"
+msgstr ""
+
+#: pager.cpp:571
+#, c-format
+msgid "rows %lu to %lu of %lu"
+msgstr ""
+
+#: pager.cpp:576
+#, fuzzy
+msgid "(no matches)"
+msgstr "Dateibeobachtungen festlegen"
+
+#: parse_execution.cpp:555
 #, fuzzy, c-format
 msgid "switch: Expected exactly one argument, got %lu\n"
 msgstr "%ls: Erwartete genau ein Argument, erhielt %d\n"
 
-#: parse_execution.cpp:749 parser.cpp:2053
+#: parse_execution.cpp:799
 #, fuzzy, c-format
 msgid ""
 "Unknown command '%ls'. Did you mean to run %ls with a modified environment? "
@@ -992,7 +975,7 @@ msgstr ""
 "zum Festlegen von Variablenwerten schauen Sie in der Hilfe zum set-Befehl "
 "nach oder geben Sie 'help set' ein."
 
-#: parse_execution.cpp:774 parser.cpp:2078
+#: parse_execution.cpp:824
 #, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function like "
@@ -1001,7 +984,7 @@ msgid ""
 "function'."
 msgstr ""
 
-#: parse_execution.cpp:783 parser.cpp:2087
+#: parse_execution.cpp:833
 #, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function or use the "
@@ -1009,7 +992,7 @@ msgid ""
 "command by typing 'help function'."
 msgstr ""
 
-#: parse_execution.cpp:791 parser.cpp:2095
+#: parse_execution.cpp:841
 #, fuzzy, c-format
 msgid ""
 "Commands may not contain variables. Use the eval builtin instead, like 'eval "
@@ -1019,390 +1002,308 @@ msgstr ""
 "zum Festlegen von Variablenwerten schauen Sie in der Hilfe zum set-Befehl "
 "nach oder geben Sie 'help set' ein."
 
-#: parse_execution.cpp:798 parser.cpp:2102
+#: parse_execution.cpp:848
 #, c-format
 msgid "The file '%ls' is not executable by this user"
 msgstr ""
 
-#: parse_execution.cpp:1029
+#: parse_execution.cpp:1057
 #, fuzzy, c-format
 msgid "Invalid redirection target: %ls"
 msgstr "Ungültige Umleitung"
 
-#: parse_execution.cpp:1053
+#: parse_execution.cpp:1081
 #, fuzzy, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
 msgstr "Angeforderte Umleitung auf etwas, das kein Dateideskriptor ist %ls"
 
-#: parse_util.cpp:47
+#: parse_util.cpp:46
 #, fuzzy, c-format
 msgid "The '%ls' command can not be used in a pipeline"
 msgstr "Dieser Befehl kann nicht in einer Pipe benutzt werden"
 
-#: parser.cpp:58
-msgid "This command can not be used in a pipeline"
+#: parse_util.cpp:49
+#, fuzzy, c-format
+msgid "The '%ls' command can not be used immediately after a backgrounded job"
 msgstr "Dieser Befehl kann nicht in einer Pipe benutzt werden"
 
-#: parser.cpp:64
+#: parse_util.cpp:52
+#, fuzzy
+msgid "Backgrounded commands can not be used as conditionals"
+msgstr "Dieser Befehl kann nicht in einer Pipe benutzt werden"
+
+#: parser.cpp:52
 #, c-format
 msgid "Tokenizer error: '%ls'"
 msgstr "Tokenizer-Fehler: '%ls'"
 
-#: parser.cpp:69
-msgid "An additional command is required"
-msgstr ""
-
-#: parser.cpp:74
-msgid ""
-"The function calls itself immediately, which would result in an infinite "
-"loop."
-msgstr ""
-
-#: parser.cpp:79
-msgid ""
-"Could not locate end of block. The 'end' command is missing, misspelled or a "
-"';' is missing."
-msgstr ""
-"Konnte Blockende nicht finden, Der 'end'-Befehl fehlt, ist falsch "
-"geschriebenoder ein ':' fehlt."
-
-#: parser.cpp:82
-#, c-format
-msgid "Expected a command name, got token of type '%ls'"
-msgstr "Erwartete einen Befehlsnamen, bekam Zeichen des Typs '%ls'"
-
-#: parser.cpp:87 parse_constants.h:158
-#, c-format
-msgid "Illegal command name '%ls'"
-msgstr "Ungültiger Befehlsname '%ls'"
-
-#: parser.cpp:92 parse_constants.h:164
-#, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
-msgstr ""
-
-#: parser.cpp:97 parse_constants.h:167
-#, c-format
-msgid "No matches for wildcard '%ls'."
-msgstr ""
-
-#: parser.cpp:102
-msgid "'case' builtin not inside of switch block"
-msgstr "eingebauter Befehl 'case' nicht innerhalb eines switch-Blocks"
-
-#: parser.cpp:107
-msgid "Loop control command while not inside of loop"
-msgstr "Schleifensteuerungsbefehl 'while' nicht innerhalb einer Schleife"
-
-#: parser.cpp:112 parse_constants.h:176
-#, fuzzy
-msgid "'return' builtin command outside of function definition"
-msgstr "Internen Befehl anstatt einer Funktion ausführen"
-
-#: parser.cpp:117
-#, fuzzy, c-format
-msgid "'%ls' builtin not inside of if block"
-msgstr "eingebauter Befehl 'else' nicht innerhalb eines if-Blocks"
-
-#: parser.cpp:122
-#, c-format
-msgid "'%ls' used past terminating 'else'"
-msgstr ""
-
-#: parser.cpp:127
-msgid "'end' command outside of block"
-msgstr "'end'-Befehl außerhalb eines Blocks"
-
-#: parser.cpp:132 parse_constants.h:179
-#, fuzzy, c-format
-msgid ""
-"Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
-"the set command by typing 'help set'."
-msgstr ""
-"Unbekannter Befehl '%ls'. Meinten Sie 'set VARIABLE WERT'? Zu Informationen "
-"zum Festlegen von Variablenwerten schauen Sie in der Hilfe zum set-Befehl "
-"nach oder geben Sie 'help set' ein."
-
-#: parser.cpp:137
-#, c-format
-msgid "Expected redirection specification, got token of type '%ls'"
-msgstr "Erwartete Umleitungsspezifikation, erhielt Zeichen vom Typ '%ls'"
-
-#: parser.cpp:142
-msgid ""
-"Encountered redirection when expecting a command name. Fish does not allow a "
-"redirection operation before a command."
-msgstr ""
-"Umleitung anstelle eines Befehlsnamens. Fish erlaubt keine Umleitung vor "
-"einem Befehl."
-
-#: parser.cpp:147
+#: parser.cpp:57
 #, c-format
 msgid "Tried to evaluate commands using invalid block type '%ls'"
 msgstr "Versuchte, Befehle mittels des ungültigen Blocktyps '%ls' auszuwerten"
 
-#: parser.cpp:153
+#: parser.cpp:62
 #, c-format
 msgid "Unexpected token of type '%ls'"
 msgstr "Unerwartetes Zeichen des Typs '%ls'"
 
-#: parser.cpp:158 parse_constants.h:209
+#: parser.cpp:67 parse_constants.h:255
 msgid "'while' block"
 msgstr "'while'-Block"
 
-#: parser.cpp:163 parse_constants.h:214
+#: parser.cpp:72 parse_constants.h:260
 msgid "'for' block"
 msgstr "'for'-Block"
 
-#: parser.cpp:168 parse_constants.h:219
+#: parser.cpp:77 parse_constants.h:265
 msgid "Block created by breakpoint"
 msgstr ""
 
-#: parser.cpp:175 parse_constants.h:226
+#: parser.cpp:82 parse_constants.h:272
 msgid "'if' conditional block"
 msgstr "'if'-Bedingungsblock"
 
-#: parser.cpp:181 parse_constants.h:232
+#: parser.cpp:87 parse_constants.h:278
 msgid "function definition block"
 msgstr "Funktionsdefinitonsblock"
 
-#: parser.cpp:187 parse_constants.h:238
+#: parser.cpp:92 parse_constants.h:284
 msgid "function invocation block"
 msgstr "Funktionsausführungsblock"
 
-#: parser.cpp:192 parse_constants.h:243
+#: parser.cpp:97 parse_constants.h:289
 #, fuzzy
 msgid "function invocation block with no variable shadowing"
 msgstr "Funktionsausführungsblock"
 
-#: parser.cpp:198 parse_constants.h:249
+#: parser.cpp:102 parse_constants.h:295
 msgid "'switch' block"
 msgstr "'switch'-Block"
 
-#: parser.cpp:204 parse_constants.h:255
+#: parser.cpp:107 parse_constants.h:301
 msgid "unexecutable block"
 msgstr "nicht ausführbarer Block"
 
-#: parser.cpp:210 parse_constants.h:261
+#: parser.cpp:112 parse_constants.h:307
 msgid "global root block"
 msgstr "globaler Root-Block"
 
-#: parser.cpp:216 parse_constants.h:267
+#: parser.cpp:117 parse_constants.h:313
 msgid "command substitution block"
 msgstr "Befehlsersetzungsblock"
 
-#: parser.cpp:222 parse_constants.h:273
+#: parser.cpp:122 parse_constants.h:319
 msgid "'begin' unconditional block"
 msgstr "'begin' unbedingter Block"
 
-#: parser.cpp:228 parse_constants.h:279
+#: parser.cpp:127 parse_constants.h:325
 msgid "Block created by the . builtin"
 msgstr ""
 
-#: parser.cpp:233 parse_constants.h:284
+#: parser.cpp:132 parse_constants.h:330
 #, fuzzy
 msgid "event handler block"
 msgstr "nicht ausführbarer Block"
 
-#: parser.cpp:239 parse_constants.h:290
+#: parser.cpp:137 parse_constants.h:336
 msgid "unknown/invalid block"
 msgstr "unbekannter/ungültiger Block"
 
-#: parser.cpp:645
+#: parser.cpp:474
 #, c-format
 msgid "Could not write profiling information to file '%s'"
 msgstr "Konnte Profilierungsinformationen nicht in Datei '%s' schreiben"
 
-#: parser.cpp:651
+#: parser.cpp:480
 msgid "Time\tSum\tCommand\n"
 msgstr "Zeit\tSum\tBefehl\n"
 
-#: parser.cpp:811
+#: parser.cpp:562
 #, c-format
 msgid "in event handler: %ls\n"
 msgstr ""
 
-#: parser.cpp:839
+#: parser.cpp:590
 #, c-format
 msgid "from sourcing file %ls\n"
 msgstr ""
 
-#: parser.cpp:845
+#: parser.cpp:597
 #, fuzzy, c-format
 msgid "in function '%ls'\n"
 msgstr "Unbekannte Funktion '%ls'"
 
-#: parser.cpp:850
+#: parser.cpp:602
 #, fuzzy
 msgid "in command substitution\n"
 msgstr "Befehlsersetzungsblock"
 
-#: parser.cpp:863
+#: parser.cpp:615
 #, c-format
 msgid "\tcalled on line %d of file %ls\n"
 msgstr ""
 
-#: parser.cpp:869
+#: parser.cpp:621
 msgid "\tcalled during startup\n"
 msgstr ""
 
-#: parser.cpp:873
+#: parser.cpp:625
 msgid "\tcalled on standard input\n"
 msgstr ""
 
-#: parser.cpp:890
+#: parser.cpp:642
 #, c-format
 msgid "\twith parameter list '%ls'\n"
 msgstr ""
 
-#: parser.cpp:1087
+#: parser.cpp:756
 #, c-format
 msgid "%ls (line %d): "
 msgstr "%ls (Zeile %d): "
 
-#: parser.cpp:1091
+#: parser.cpp:760
 msgid "Startup"
 msgstr ""
 
-#: parser.cpp:1197
+#: parser.cpp:803
 msgid "Job inconsistency"
 msgstr "Jobinkonsistenz"
 
-#: parser.cpp:1520
-msgid "Invalid IO redirection"
-msgstr "Ungültige E/A-Umleitung"
-
-#: parser.cpp:1541
-#, c-format
-msgid "Requested redirection to something that is not a file descriptor %ls"
-msgstr "Angeforderte Umleitung auf etwas, das kein Dateideskriptor ist %ls"
-
-#: parser.cpp:2667 parser.cpp:2750
+#: parser.cpp:956
 msgid "End of block mismatch. Program terminating."
 msgstr "Unpassendes Blockende. Programm wird beendet."
 
-#: parser.cpp:3034
+#: parser.cpp:1047
 #, fuzzy, c-format
 msgid "%ls (line %lu): "
 msgstr "%ls (Zeile %d): "
+
+#: parser.cpp:1051
+#, c-format
+msgid "%ls: "
+msgstr ""
 
 #: path.cpp:24
 #, c-format
 msgid "Error while searching for command '%ls'"
 msgstr "Fehler beim Suchen des Befehls '%ls'"
 
-#: proc.cpp:615
+#: proc.cpp:690
+#, fuzzy, c-format
+msgid "'%ls' has %ls"
+msgstr "Job %d, '%ls' hat %ls"
+
+#: proc.cpp:694
 #, c-format
 msgid "Job %d, '%ls' has %ls"
 msgstr "Job %d, '%ls' hat %ls"
 
-#: proc.cpp:699
-#, c-format
-msgid "%ls: Job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:786
+#, fuzzy, c-format
+msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Job %d, '%ls' durch Signal %ls (%ls) beendet"
 
-#: proc.cpp:707
-#, c-format
-msgid ""
-"%ls: Process %d, '%ls' from job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:797
+#, fuzzy, c-format
+msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 "%ls: Prozess %d, '%ls' aus job %d, '%ls' durch Signal %ls (%ls) beendet"
 
-#: proc.cpp:736
+#: proc.cpp:828
 msgid "ended"
 msgstr "beendet"
 
-#: proc.cpp:969
+#: proc.cpp:1065
 msgid "An error occured while reading output from code block"
 msgstr "Fehler während des Lesens der Ausgabe aus Codeblock"
 
-#: proc.cpp:998 proc.cpp:1010
+#: proc.cpp:1094 proc.cpp:1106
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Konnte Job %d ('%ls') nicht in den Vordergrund schicken"
 
-#: proc.cpp:1030 proc.cpp:1040 proc.cpp:1055
+#: proc.cpp:1126 proc.cpp:1136 proc.cpp:1151
 msgid "Could not return shell to foreground"
 msgstr "Konnte Shell nicht wieder in Vordergrund zurückholen"
 
-#: proc.cpp:1280 proc.cpp:1304
+#: proc.cpp:1354 proc.cpp:1380
 msgid "Process list pointer"
 msgstr "Zeiger auf Prozessliste"
 
-#: proc.cpp:1291
+#: proc.cpp:1365
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "Mehr als ein Job im Vordergrund: Job 1: '%ls' Job 2: '%ls'"
 
-#: proc.cpp:1302
+#: proc.cpp:1378
 msgid "Process argument list"
 msgstr "Prozessargumentliste"
 
-#: proc.cpp:1303
+#: proc.cpp:1379
 msgid "Process name"
 msgstr "Prozessname"
 
-#: proc.cpp:1309
+#: proc.cpp:1385
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Job '%ls', Prozess '%ls' hat inkonsistenten Status 'stopped'=%d"
 
-#: proc.cpp:1319
+#: proc.cpp:1395
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr "Job '%ls', Prozess '%ls' hat inkonsistenten Status 'completed'=%d"
 
-#: reader.cpp:453
+#: reader.cpp:478
 msgid "Could not set terminal mode for new job"
 msgstr "Konnte Terminalmodus für neuen Job nicht festlegen"
 
-#: reader.cpp:477
+#: reader.cpp:525
 msgid "Could not set terminal mode for shell"
 msgstr "Konnte Terminalmodus für neue Shell nicht festlegen"
 
-#: reader.cpp:2133
+#: reader.cpp:2059
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr ""
 
-#: reader.cpp:2148
+#: reader.cpp:2074
 #, c-format
 msgid ""
 "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr ""
 
-#: reader.cpp:2179
+#: reader.cpp:2105
 msgid "Couldn't put the shell in its own process group"
 msgstr "Konnte Shell nicht in ihre eigene Prozessgruppe verschieben"
 
-#: reader.cpp:2189
+#: reader.cpp:2115
 msgid "Couldn't grab control of terminal"
 msgstr "Konnte Terminalsteuerung nicht übernehmen"
 
-#: reader.cpp:2703
+#: reader.cpp:2616
 msgid "Pop null reader block"
 msgstr ""
 
-#: reader.cpp:2956
+#: reader.cpp:2882
 msgid ""
 "There are stopped jobs. A second attempt to exit will enforce their "
 "termination.\n"
 msgstr ""
 
-#: reader.cpp:4069
+#: reader.cpp:4115
 #, c-format
 msgid "Unknown keybinding %d"
 msgstr "Unbekannte Tastenkombination %d"
 
-#: reader.cpp:4210
+#: reader.cpp:4226
 #, fuzzy
 msgid "Error while reading from file descriptor"
 msgstr "Fehler beim Lesen der Befehle"
 
-#: reader.cpp:4227
+#: reader.cpp:4243
 msgid "Error while closing input stream"
 msgstr "Fehler beim Schließen des Eingabestroms"
 
-#: reader.cpp:4248
+#: reader.cpp:4270
 msgid "Error while opening input stream"
 msgstr "Fehler beim Öffnen des Eingabestroms"
 
@@ -1638,7 +1539,7 @@ msgstr "Job im Hintergrund ausführen"
 msgid "Comment"
 msgstr "Kommentar"
 
-#: tokenizer.cpp:602
+#: tokenizer.cpp:561
 #, fuzzy
 msgid "Invalid token type"
 msgstr "Ungültiges Zeichen"
@@ -1683,7 +1584,7 @@ msgstr "%ls: Ungültiger Funktionsname '%ls'\n"
 msgid "%ls: Invalid option -- %lc\n"
 msgstr "%ls: Ungültige Prozesskennung %ls\n"
 
-#: wgetopt.cpp:673
+#: wgetopt.cpp:676
 #, fuzzy, c-format
 msgid "%ls: Option requires an argument -- %lc\n"
 msgstr "%ls: Erwartete ein Argument, erhielt %d\n"
@@ -1696,7 +1597,7 @@ msgstr "Programm"
 msgid "Executable link"
 msgstr "Programmlink"
 
-#: wildcard.cpp:67 share/completions/git.fish:146
+#: wildcard.cpp:67 share/completions/git.fish:178
 msgid "File"
 msgstr "Datei"
 
@@ -1829,31 +1730,24 @@ msgstr "%ls: Argument '%ls' muss eine Ganzzahl sein\n"
 msgid "An error occurred while setting up pipe"
 msgstr "Fehler beim Einrichten der Pipe aufgetreten"
 
-#: expand.h:132
+#: expand.h:135
 msgid "Array index out of bounds"
 msgstr ""
 
-#: output.h:91
-#, c-format
-msgid ""
-"Tried to use terminfo string %s on line %d of %s, which is undefined in "
-"terminal of type \"%ls\". Please report this error to %s"
-msgstr ""
-
-#: parse_constants.h:145
+#: parse_constants.h:185
 #, c-format
 msgid ""
 "The function '%ls' calls itself immediately, which would result in an "
 "infinite loop."
 msgstr ""
 
-#: parse_constants.h:149
+#: parse_constants.h:189
 msgid ""
 "The function call stack limit has been exceeded. Do you have an accidental "
 "infinite loop?"
 msgstr ""
 
-#: parse_constants.h:152
+#: parse_constants.h:192
 #, fuzzy
 msgid ""
 "Expected a command, but instead found a pipe. Did you mean 'COMMAND; or "
@@ -1864,10 +1758,10 @@ msgstr ""
 "'Befehl; or Befehl'? Zu weiteren Informationen über den eingebauten Befehl "
 "'or' schauen Sie in der Hilfe zu 'or' nach oder geben Sie 'help or' ein."
 
-#: parse_constants.h:155
+#: parse_constants.h:195
 #, fuzzy
 msgid ""
-"Expected a command, but instead found a '&'. Did you mean 'COMMAND; and "
+"Expected a command, but instead found an '&'. Did you mean 'COMMAND; and "
 "COMMAND'? See the help section for the 'and' builtin command by typing 'help "
 "and'."
 msgstr ""
@@ -1875,22 +1769,62 @@ msgstr ""
 "'Befehl; and Befehl'? Zu weiteren Informationen über den eingebauten Befehl "
 "'and' schauen Sie in der Hilfe zu 'and' nach oder geben Sie 'help and' ein."
 
-#: parse_constants.h:161
+#: parse_constants.h:198
+#, c-format
+msgid "Illegal command name '%ls'"
+msgstr "Ungültiger Befehlsname '%ls'"
+
+#: parse_constants.h:201
+#, c-format
+msgid "Unknown builtin '%ls'"
+msgstr "unbekannter interner Befehl '%ls'"
+
+#: parse_constants.h:204
 #, fuzzy, c-format
 msgid "Unable to expand variable name '%ls'"
 msgstr "%ls: Ungültiger Variablenname '%ls'\n"
 
-#: parse_constants.h:170
+#: parse_constants.h:207
+#, fuzzy, c-format
+msgid "Unable to find a process '%ls'"
+msgstr "Konnte Prozess '%ls' nicht ausführen"
+
+#: parse_constants.h:210
+#, c-format
+msgid "Illegal file descriptor in redirection '%ls'"
+msgstr ""
+
+#: parse_constants.h:213
+#, c-format
+msgid "No matches for wildcard '%ls'."
+msgstr ""
+
+#: parse_constants.h:216
 #, fuzzy
 msgid "break command while not inside of loop"
 msgstr "Schleifensteuerungsbefehl 'while' nicht innerhalb einer Schleife"
 
-#: parse_constants.h:173
+#: parse_constants.h:219
 #, fuzzy
 msgid "continue command while not inside of loop"
 msgstr "Schleifensteuerungsbefehl 'while' nicht innerhalb einer Schleife"
 
-#: parse_constants.h:184
+#: parse_constants.h:222
+#, fuzzy
+msgid "'return' builtin command outside of function definition"
+msgstr "Internen Befehl anstatt einer Funktion ausführen"
+
+#: parse_constants.h:225
+#, fuzzy, c-format
+msgid ""
+"Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
+"the set command by typing 'help set'."
+msgstr ""
+"Unbekannter Befehl '%ls'. Meinten Sie 'set VARIABLE WERT'? Zu Informationen "
+"zum Festlegen von Variablenwerten schauen Sie in der Hilfe zum set-Befehl "
+"nach oder geben Sie 'help set' ein."
+
+#: parse_constants.h:230
 #, c-format
 msgid ""
 "The '$' character begins a variable name. The character '%lc', which "
@@ -1899,20 +1833,20 @@ msgid ""
 "expansion in fish, type 'help expand-variable'."
 msgstr ""
 
-#: parse_constants.h:189
+#: parse_constants.h:235
 msgid ""
 "$? is not a valid variable in fish. If you want the exit status of the last "
 "command, try $status."
 msgstr ""
 
-#: parse_constants.h:194
+#: parse_constants.h:240
 msgid ""
 "The '$' begins a variable name. It was given at the end of an argument. "
 "Variable names may not be zero characters long. To learn more about variable "
 "expansion in fish, type 'help expand-variable'."
 msgstr ""
 
-#: parse_constants.h:199
+#: parse_constants.h:245
 #, c-format
 msgid ""
 "Did you mean %ls{$%ls}%ls? The '$' character begins a variable name. A "
@@ -1921,7 +1855,7 @@ msgid ""
 "more about variable expansion in fish, type 'help expand-variable'."
 msgstr ""
 
-#: parse_constants.h:204
+#: parse_constants.h:250
 msgid ""
 "Did you mean (COMMAND)? In fish, the '$' character is only used for "
 "accessing variables. To learn more about command substitution in fish, type "
@@ -3059,221 +2993,316 @@ msgstr "Test, ob an apt noch ein Unterbefehl gegeben werden muss"
 msgid "Test if bundle has been given a specific subcommand"
 msgstr "Test, ob an apt noch ein Unterbefehl gegeben werden muss"
 
-#: share/completions/bundle.fish:30
+#: share/completions/bundle.fish:31
 #, fuzzy
 msgid "Display a help page"
 msgstr "Handbuchseite anzeigen"
 
-#: share/completions/bundle.fish:38 share/completions/bundle.fish:65
+#: share/completions/bundle.fish:39 share/completions/bundle.fish:83
 msgid "Install the gems specified by the Gemfile or Gemfile.lock"
 msgstr ""
 
-#: share/completions/bundle.fish:39 share/completions/bundle.fish:87
-msgid "The location of the Gemfile bundler should use."
-msgstr ""
-
-#: share/completions/bundle.fish:40
-msgid "The location to install the gems in the bundle to."
+#: share/completions/bundle.fish:40 share/completions/bundle.fish:106
+msgid "The location of the Gemfile bundler should use"
 msgstr ""
 
 #: share/completions/bundle.fish:41
-msgid "Installs the gems in the bundle to the system location."
-msgstr ""
+#, fuzzy
+msgid "The location to install the gems in the bundle to"
+msgstr "Prozesskennung jedes Prozesses im Job anzeigen"
 
 #: share/completions/bundle.fish:42
-msgid "A space-separated list of groups to skip installing."
-msgstr ""
+#, fuzzy
+msgid "Installs the gems in the bundle to the system location"
+msgstr "Dateien in das Paketdepot übertragen"
 
 #: share/completions/bundle.fish:43
-msgid "Use cached gems instead of connecting to rubygems.org."
+msgid "A space-separated list of groups to skip installing"
 msgstr ""
 
 #: share/completions/bundle.fish:44
-msgid "Switches bundler's defaults into deployment mode."
+msgid "Use cached gems instead of connecting to rubygems.org"
 msgstr ""
 
 #: share/completions/bundle.fish:45
-msgid ""
-"Create a directory containing executabes that run in the context of the "
-"bundle."
+msgid "Switches bundler's defaults into deployment mode."
 msgstr ""
 
 #: share/completions/bundle.fish:46
-msgid "Specify a ruby executable to use with generated binstubs."
+msgid ""
+"Create a directory containing executabes that run in the context of the "
+"bundle"
 msgstr ""
 
 #: share/completions/bundle.fish:47
-msgid "Make a bundle that can work without RubyGems or Bundler at run-time."
+msgid "Specify a ruby executable to use with generated binstubs"
 msgstr ""
 
 #: share/completions/bundle.fish:48
-msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
+msgid "Make a bundle that can work without RubyGems or Bundler at run-time"
 msgstr ""
 
 #: share/completions/bundle.fish:49
-msgid "Do not update the cache in vendor/cache with the newly bundled gems."
+msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
 msgstr ""
 
 #: share/completions/bundle.fish:50
+msgid "Install  gems parallely by starting size number of parallel workers"
+msgstr ""
+
+#: share/completions/bundle.fish:51
+msgid "Do not update the cache in vendor/cache with the newly bundled gems"
+msgstr ""
+
+#: share/completions/bundle.fish:52
 #, fuzzy
-msgid "Do not print progress information to stdout."
+msgid "Do not print progress information to stdout"
 msgstr "Keine Gruppeninformation ausgeben"
 
-#: share/completions/bundle.fish:53 share/completions/bundle.fish:66
+#: share/completions/bundle.fish:53
+#, fuzzy
+msgid "Run bundle clean automatically after install"
+msgstr "Paket aktualisieren, wenn es bereits installiert ist"
+
+#: share/completions/bundle.fish:54 share/completions/bundle.fish:63
+msgid "Use the rubygems modern index instead of the API endpoint"
+msgstr ""
+
+#: share/completions/bundle.fish:55 share/completions/bundle.fish:164
+#, fuzzy
+msgid "Do not remove stale gems from the cache"
+msgstr "Alle gz-Dateien aus dem Zwischenspeicher entfernen"
+
+#: share/completions/bundle.fish:56
+msgid "Do not allow the Gemfile.lock to be updated after this install"
+msgstr ""
+
+#: share/completions/bundle.fish:59 share/completions/bundle.fish:84
 #, fuzzy
 msgid "Update dependencies to their latest versions"
 msgstr "Abhängigkeiten an makefile anhängen"
 
-#: share/completions/bundle.fish:54
-msgid "The name of a :git or :path source used in the Gemfile."
+#: share/completions/bundle.fish:60
+msgid "The name of a :git or :path source used in the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:58
+#: share/completions/bundle.fish:61
+msgid "Do not attempt to fetch gems remotely and use the gem cache instead"
+msgstr ""
+
+#: share/completions/bundle.fish:62
+msgid "Only output warnings and errors"
+msgstr ""
+
+#: share/completions/bundle.fish:64
+#, fuzzy
+msgid "Specify the number of jobs to run in parallel"
+msgstr "Gibt die Anzahl zu sendender Bytes an"
+
+#: share/completions/bundle.fish:65
+msgid "Update a specific group"
+msgstr ""
+
+#: share/completions/bundle.fish:69
 msgid ""
 "Package the .gem files required by your application into the vendor/cache "
 "directory"
 msgstr ""
 
-#: share/completions/bundle.fish:61 share/completions/bundle.fish:68
+#: share/completions/bundle.fish:72
+#, fuzzy
+msgid "Install the binstubs of the listed gem"
+msgstr "Namen aller Signale anzeigen"
+
+#: share/completions/bundle.fish:73
+#, fuzzy
+msgid "Binstub destination directory (default bin)"
+msgstr "Dokumentationsdateien installieren (Standard)"
+
+#: share/completions/bundle.fish:74
+msgid "Overwrite existing binstubs if they exist"
+msgstr ""
+
+#: share/completions/bundle.fish:78 share/completions/bundle.fish:86
 msgid "Execute a script in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:64
+#: share/completions/bundle.fish:79
+msgid "Exec runs a command, providing it access to the gems in the bundle"
+msgstr ""
+
+#: share/completions/bundle.fish:82
 msgid "Describe available tasks or one specific task"
 msgstr ""
 
-#: share/completions/bundle.fish:67
+#: share/completions/bundle.fish:85
 #, fuzzy
 msgid "Package .gem files into the vendor/cache directory"
 msgstr "Dateien in das Paketdepot übertragen"
 
-#: share/completions/bundle.fish:69
+#: share/completions/bundle.fish:87
+#, fuzzy
+msgid "Specify and read configuration options for bundler"
+msgstr "Eine Konfigurationsdatei angeben"
+
+#: share/completions/bundle.fish:88
 msgid "Check bundler requirements for your application"
 msgstr ""
 
-#: share/completions/bundle.fish:70 share/completions/bundle.fish:92
+#: share/completions/bundle.fish:89
 msgid "Show all of the gems in the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:71 share/completions/bundle.fish:96
+#: share/completions/bundle.fish:90
 #, fuzzy
 msgid "Show the source location of a particular gem in the bundle"
 msgstr "Prozesskennung jedes Prozesses im Job anzeigen"
 
-#: share/completions/bundle.fish:72 share/completions/bundle.fish:100
+#: share/completions/bundle.fish:91 share/completions/bundle.fish:121
 msgid "Show all of the outdated gems in the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:73 share/completions/bundle.fish:107
+#: share/completions/bundle.fish:92 share/completions/bundle.fish:129
 msgid "Start an IRB session in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:74 share/completions/bundle.fish:110
+#: share/completions/bundle.fish:93 share/completions/bundle.fish:132
 #, sh-format
 msgid "Open an installed gem in your $EDITOR"
 msgstr ""
 
-#: share/completions/bundle.fish:75 share/completions/bundle.fish:114
+#: share/completions/bundle.fish:94 share/completions/bundle.fish:136
 msgid "Generate a visual representation of your dependencies"
 msgstr ""
 
-#: share/completions/bundle.fish:76
+#: share/completions/bundle.fish:95
 #, fuzzy
 msgid "Generate a simple Gemfile"
 msgstr "Masterdatei erstellen"
 
-#: share/completions/bundle.fish:77 share/completions/bundle.fish:125
+#: share/completions/bundle.fish:96 share/completions/bundle.fish:147
 msgid "Create a simple gem, suitable for development with bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:78 share/completions/bundle.fish:131
+#: share/completions/bundle.fish:97 share/completions/bundle.fish:154
 msgid "Displays platform compatibility information"
 msgstr ""
 
-#: share/completions/bundle.fish:79 share/completions/bundle.fish:135
+#: share/completions/bundle.fish:98 share/completions/bundle.fish:158
 msgid "Cleans up unused gems in your bundler directory"
 msgstr ""
 
-#: share/completions/bundle.fish:86
+#: share/completions/bundle.fish:105
 msgid ""
 "Determine whether the requirements for your application are installed and "
 "available to bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:88
-msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)."
+#: share/completions/bundle.fish:107
+msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)"
 msgstr ""
 
-#: share/completions/bundle.fish:89
+#: share/completions/bundle.fish:108
 #, fuzzy
 msgid "Lock the Gemfile"
 msgstr "Log in Datei schreiben"
 
-#: share/completions/bundle.fish:93
+#: share/completions/bundle.fish:111 share/completions/bundle.fish:116
+msgid ""
+"Show lists the names and versions of all gems that are required by your "
+"Gemfile"
+msgstr ""
+
+#: share/completions/bundle.fish:112 share/completions/bundle.fish:117
 msgid "List the paths of all gems required by your Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:101
+#: share/completions/bundle.fish:122
 #, fuzzy
 msgid "Check for newer pre-release gems"
 msgstr "Test auf Speicher-Lecks"
 
-#: share/completions/bundle.fish:102
+#: share/completions/bundle.fish:123
 msgid "Check against a specific source"
 msgstr ""
 
-#: share/completions/bundle.fish:103
+#: share/completions/bundle.fish:124
 msgid "Use cached gems instead of attempting to fetch gems remotely"
 msgstr ""
 
-#: share/completions/bundle.fish:115
+#: share/completions/bundle.fish:125
+msgid "Only list newer versions allowed by your Gemfile requirements"
+msgstr ""
+
+#: share/completions/bundle.fish:137
 msgid "The name to use for the generated file (see format option)"
 msgstr ""
 
-#: share/completions/bundle.fish:116
+#: share/completions/bundle.fish:138
 #, fuzzy
 msgid "Show each gem version"
 msgstr "Version des Quellenbaumes"
 
-#: share/completions/bundle.fish:117
+#: share/completions/bundle.fish:139
 msgid "Show the version of each required dependency"
 msgstr ""
 
-#: share/completions/bundle.fish:118
+#: share/completions/bundle.fish:140
 msgid "Output a specific format (png, jpg, svg, dot, ...)"
 msgstr ""
 
-#: share/completions/bundle.fish:121
+#: share/completions/bundle.fish:143
 #, fuzzy
 msgid "Generate a simple Gemfile, placed in the current directory"
 msgstr "Nie ins übergeordnete Verzeichnis wechseln"
 
-#: share/completions/bundle.fish:122
+#: share/completions/bundle.fish:144
 msgid "Use a specified .gemspec to create the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:126
+#: share/completions/bundle.fish:148
 msgid "Generate a binary for your library"
 msgstr ""
 
-#: share/completions/bundle.fish:127
+#: share/completions/bundle.fish:149
 msgid "Generate a test directory for your library (rspec or minitest)"
 msgstr ""
 
-#: share/completions/bundle.fish:128
+#: share/completions/bundle.fish:150
 msgid "Path to your editor"
 msgstr ""
 
-#: share/completions/bundle.fish:132
+#: share/completions/bundle.fish:151
+msgid "Generate the boilerplate for C extension code"
+msgstr ""
+
+#: share/completions/bundle.fish:155
 msgid "Only display Ruby directive information"
 msgstr ""
 
-#: share/completions/bundle.fish:136
+#: share/completions/bundle.fish:159
 msgid "Only print out changes, do not actually clean gems"
 msgstr ""
 
-#: share/completions/bundle.fish:137
+#: share/completions/bundle.fish:160
 msgid "Forces clean even if --path is not set"
+msgstr ""
+
+#: share/completions/bundle.fish:163
+msgid "Cache all the gems to vendor/cache"
+msgstr ""
+
+#: share/completions/bundle.fish:165
+msgid "Include all sources (including path and git)"
+msgstr ""
+
+#: share/completions/bundle.fish:168
+#, fuzzy
+msgid "Prints the license of all gems in the bundle"
+msgstr "Prozesskennung jedes Prozesses im Job anzeigen"
+
+#: share/completions/bundle.fish:171
+msgid "Print information about the environment Bundler is running under"
 msgstr ""
 
 #: share/completions/configure.fish:1
@@ -3288,21 +3317,15 @@ msgstr "Hilfe anzeigen und beenden"
 msgid "Cache test results in specified file"
 msgstr "Testergebnisse in angegebener Datei zwischenspeichern"
 
-#: share/completions/cp.fish:10 share/completions/mv.fish:6
+#: share/completions/cp.fish:11 share/completions/mv.fish:6
 msgid "Backup suffix"
 msgstr "Endung für Sicherung"
 
 #: share/completions/cp.fish:20
-#, fuzzy
-msgid "Don't preserve the specified attributes"
-msgstr "Grössen-Attribute nicht prüfen"
+msgid "Preserve ATTRIBUTES if possible"
+msgstr ""
 
-#: share/completions/cp.fish:24
-#, fuzzy
-msgid "Control creation of sparse files"
-msgstr "Sparse-Dateien bearbeiten"
-
-#: share/completions/cp.fish:28
+#: share/completions/cp.fish:29
 msgid "Set security context of copy to CONTEXT"
 msgstr ""
 
@@ -3929,6 +3952,33 @@ msgstr "Dateisysteme des angegebenen Typs anzeigen"
 msgid "Block size"
 msgstr "Blockgrösse"
 
+#: share/completions/docker.fish:19
+#, fuzzy
+msgid "Show all containers"
+msgstr "Arp-Einträge anzeigen"
+
+#: share/completions/docker.fish:24
+#, fuzzy
+msgid "Show the running containers"
+msgstr "Versteckte Funktionen anzeigen"
+
+#: share/completions/docker.fish:28
+#, fuzzy
+msgid "Show the exited containers"
+msgstr "Zeige Zeit"
+
+#: share/completions/docker.fish:70 share/completions/docker.fish:92
+msgid "Docker container"
+msgstr ""
+
+#: share/completions/docker.fish:82
+msgid "Stopped container"
+msgstr ""
+
+#: share/completions/docker.fish:87
+msgid "Container running"
+msgstr ""
+
 #: share/completions/du.fish:15
 #, fuzzy
 msgid "Exclude files that match pattern in file"
@@ -3942,96 +3992,96 @@ msgstr "Dem Muster entsprechende Dateien ausschliessen"
 msgid "Recursion limit"
 msgstr "Rekursionsgrenze"
 
-#: share/completions/duply.fish:5
+#: share/completions/duply.fish:3
 #, fuzzy
 msgid "Profile"
 msgstr "Datei"
 
-#: share/completions/duply.fish:6
+#: share/completions/duply.fish:4
 msgid "Get usage help text"
 msgstr ""
 
-#: share/completions/duply.fish:9
+#: share/completions/duply.fish:7
 #, fuzzy
 msgid "Creates a configuration profile"
 msgstr "Konfigurationsdatei festlegen"
 
-#: share/completions/duply.fish:10
+#: share/completions/duply.fish:8
 msgid "Backup with pre/post script execution"
 msgstr ""
 
-#: share/completions/duply.fish:11
+#: share/completions/duply.fish:9
 #, fuzzy
 msgid "Backup without executing pre/post scripts"
 msgstr "Keine post-Skripte ausführen"
 
-#: share/completions/duply.fish:12
+#: share/completions/duply.fish:10
 #, fuzzy
 msgid "Execute <profile>/pre script"
 msgstr "Keine pre-Skripte ausführen"
 
-#: share/completions/duply.fish:13
+#: share/completions/duply.fish:11
 #, fuzzy
 msgid "Execute <profile>/post script"
 msgstr "Keine post-Skripte ausführen"
 
-#: share/completions/duply.fish:14
+#: share/completions/duply.fish:12
 msgid "Force full backup"
 msgstr ""
 
-#: share/completions/duply.fish:15
+#: share/completions/duply.fish:13
 msgid "Force incremental backup"
 msgstr ""
 
-#: share/completions/duply.fish:16
+#: share/completions/duply.fish:14
 msgid "List all files in backup (as it was at <age>, default: now)"
 msgstr ""
 
-#: share/completions/duply.fish:17
+#: share/completions/duply.fish:15
 msgid "Prints backup sets and chains currently in repository"
 msgstr ""
 
-#: share/completions/duply.fish:18
+#: share/completions/duply.fish:16
 msgid "List files changed since latest backup"
 msgstr ""
 
-#: share/completions/duply.fish:19
+#: share/completions/duply.fish:17
 msgid "Shows outdated backup archives [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:20
+#: share/completions/duply.fish:18
 msgid "Shows outdated backups [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:21
+#: share/completions/duply.fish:19
 msgid "Shows broken backup archives [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:22
+#: share/completions/duply.fish:20
 msgid "Restore the backup to <target_path> [as it was at <age>]"
 msgstr ""
 
-#: share/completions/duply.fish:23
+#: share/completions/duply.fish:21
 msgid "Restore single file/folder from backup [as it was at <age>]"
 msgstr ""
 
-#: share/completions/duply.fish:26
+#: share/completions/duply.fish:24
 msgid "Really execute the commands: purge, purge-full, cleanup"
 msgstr ""
 
-#: share/completions/duply.fish:27
+#: share/completions/duply.fish:25
 msgid "Do nothing but print out generated duplicity command lines"
 msgstr ""
 
-#: share/completions/duply.fish:28
+#: share/completions/duply.fish:26
 msgid "Calculate what would be done, but dont perform any actions"
 msgstr ""
 
-#: share/completions/duply.fish:29
+#: share/completions/duply.fish:27
 msgid "Dont abort when backup different dirs to the same backend"
 msgstr ""
 
-#: share/completions/duply.fish:30
+#: share/completions/duply.fish:28
 #, fuzzy
 msgid "Output verbosity level"
 msgstr "Ausführlichkeitswert auf 0 zurücksetzen"
@@ -4041,12 +4091,12 @@ msgid ""
 "Prints completions for installed packages on the system from /var/db/pkg"
 msgstr ""
 
-#: share/completions/emerge.fish:12 share/completions/equery.fish:12
+#: share/completions/emerge.fish:13 share/completions/equery.fish:12
 msgid ""
 "Prints completions for all available packages on the system from /usr/portage"
 msgstr ""
 
-#: share/completions/emerge.fish:19
+#: share/completions/emerge.fish:22
 #, fuzzy
 msgid ""
 "Tests if emerge command should have an installed package as potential "
@@ -4054,62 +4104,11 @@ msgid ""
 msgstr ""
 "Testen, ob der apt-Befehl Pakete zur möglichen Fertigstellung haben sollte"
 
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-#, fuzzy
-msgid "All base system packages"
-msgstr "Erstellte Pakete löschen"
-
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-#, fuzzy
-msgid "All packages in world"
-msgstr "Installierte Pakete synchronisieren"
-
-#: share/completions/emerge.fish:30
-#, fuzzy
-msgid "Installed package"
-msgstr "Neues Paket installieren"
-
-#: share/completions/emerge.fish:31
-#: share/functions/__fish_print_packages.fish:13
-msgid "Package"
-msgstr "Paket"
-
-#: share/completions/emerge.fish:35
-msgid "Usage overview of emerge"
+#: share/completions/emerge.fish:32
+msgid ""
+"Print completions for all packages including the version compare if that is "
+"already typed"
 msgstr ""
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject system"
-msgstr ""
-
-#: share/completions/emerge.fish:35
-#, fuzzy
-msgid "Help on subject config"
-msgstr "Hilfeabschnitt zu %s"
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject sync"
-msgstr ""
-
-#: share/completions/emerge.fish:57
-#, fuzzy
-msgid "Use colors in output"
-msgstr "Farben benutzen"
-
-#: share/completions/emerge.fish:57
-#, fuzzy
-msgid "Don't use colors in output"
-msgstr "Keine ausführliche Ausgabe"
-
-#: share/completions/emerge.fish:81
-#, fuzzy
-msgid "Pull in build time dependencies"
-msgstr "Erstellungsabhängigkeiten anzeigen"
-
-#: share/completions/emerge.fish:81
-#, fuzzy
-msgid "Don't pull in build time dependencies"
-msgstr "Nicht automatisch Abhängigkeiten erfüllen"
 
 #: share/completions/env.fish:2
 #, fuzzy
@@ -4639,11 +4638,16 @@ msgstr ""
 msgid "Update the RubyGems system software"
 msgstr ""
 
-#: share/completions/git.fish:121 share/completions/git.fish:144
+#: share/completions/git.fish:98
+#, fuzzy
+msgid "name"
+msgstr "Benutzername"
+
+#: share/completions/git.fish:153 share/completions/git.fish:176
 msgid "Branch"
 msgstr ""
 
-#: share/completions/git.fish:145
+#: share/completions/git.fish:177
 #, fuzzy
 msgid "Tag"
 msgstr "Ziel"
@@ -4904,586 +4908,6 @@ msgstr "Hilfe zu Befehlsersetzungen (SUBCOMMAND)"
 msgid "Help on process expansion %JOB"
 msgstr "Hilfe zur Prozess-Expansion %JOB"
 
-#: share/completions/hg.fish:17
-#, fuzzy
-msgid "add the specified files on the next commit"
-msgstr "Angegebene Datei zur aktuellen Schlüsselringliste hinzufügen"
-
-#: share/completions/hg.fish:18
-msgid "add all new files, delete all missing files"
-msgstr ""
-
-#: share/completions/hg.fish:19
-#, fuzzy
-msgid "show changeset information by line for each file"
-msgstr "Zeigt Änderungsinformationen zu dem Paket an"
-
-#: share/completions/hg.fish:20
-msgid "create an unversioned archive of a repository revision"
-msgstr ""
-
-#: share/completions/hg.fish:21
-msgid "reverse effect of earlier changeset"
-msgstr ""
-
-#: share/completions/hg.fish:22
-msgid "subdivision search of changesets"
-msgstr ""
-
-#: share/completions/hg.fish:23
-msgid "track a line of development with movable markers"
-msgstr ""
-
-#: share/completions/hg.fish:24
-msgid "set or show the current branch name"
-msgstr ""
-
-#: share/completions/hg.fish:25
-msgid "list repository named branches"
-msgstr ""
-
-#: share/completions/hg.fish:26
-#, fuzzy
-msgid "create a changegroup file"
-msgstr "Paket aus Datei lesen"
-
-#: share/completions/hg.fish:27
-msgid "output the current or given revision of files"
-msgstr ""
-
-#: share/completions/hg.fish:28
-#, fuzzy
-msgid "make a copy of an existing repository"
-msgstr "Eine lokale Kopie eines weiteren Paketdepots erstellen"
-
-#: share/completions/hg.fish:29
-#, fuzzy
-msgid "commit the specified files or all outstanding changes"
-msgstr "Angegebene Datei oder Standardeingabe entschlüsseln"
-
-#: share/completions/hg.fish:30
-msgid "mark files as copied for the next commit"
-msgstr ""
-
-#: share/completions/hg.fish:31
-msgid "diff repository (or selected files)"
-msgstr ""
-
-#: share/completions/hg.fish:32
-msgid "dump the header and diffs for one or more changesets"
-msgstr ""
-
-#: share/completions/hg.fish:33
-msgid "forget the specified files on the next commit"
-msgstr ""
-
-#: share/completions/hg.fish:34
-msgid "copy changes from other branches onto the current branch"
-msgstr ""
-
-#: share/completions/hg.fish:35
-msgid "search for a pattern in specified files and revisions"
-msgstr ""
-
-#: share/completions/hg.fish:36
-msgid "show current repository heads or show branch heads"
-msgstr ""
-
-#: share/completions/hg.fish:37
-msgid "show help for a given topic or a help overview"
-msgstr ""
-
-#: share/completions/hg.fish:38
-msgid "identify the working copy or specified revision"
-msgstr ""
-
-#: share/completions/hg.fish:39
-#, fuzzy
-msgid "import an ordered set of patches"
-msgstr "Byte-Offset von Treffern ausgeben"
-
-#: share/completions/hg.fish:40
-msgid "show new changesets found in source"
-msgstr ""
-
-#: share/completions/hg.fish:41
-#, fuzzy
-msgid "create a new repository in the given directory"
-msgstr "CVS-Paketdepot erstellen, wenn es nicht existiert"
-
-#: share/completions/hg.fish:42
-#, fuzzy
-msgid "locate files matching specific patterns"
-msgstr "Dem Muster entsprechende Dateien ausschliessen"
-
-#: share/completions/hg.fish:43
-msgid "show revision history of entire repository or files"
-msgstr ""
-
-#: share/completions/hg.fish:44
-msgid "output the current or given revision of the project manifest"
-msgstr ""
-
-#: share/completions/hg.fish:45
-msgid "merge working directory with another revision"
-msgstr ""
-
-#: share/completions/hg.fish:46
-msgid "show changesets not found in the destination"
-msgstr ""
-
-#: share/completions/hg.fish:47
-msgid "show the parents of the working directory or revision"
-msgstr ""
-
-#: share/completions/hg.fish:48
-#, fuzzy
-msgid "show aliases for remote repositories"
-msgstr "Einträge in .cvspass für entferntes Paketdepot entfernen"
-
-#: share/completions/hg.fish:49
-msgid "set or show the current phase name"
-msgstr ""
-
-#: share/completions/hg.fish:50
-#, fuzzy
-msgid "pull changes from the specified source"
-msgstr "Pakete mit der angegebenen Gruppe abfragen"
-
-#: share/completions/hg.fish:51
-#, fuzzy
-msgid "push changes to the specified destination"
-msgstr "Pakete mit der angegebenen Gruppe abfragen"
-
-#: share/completions/hg.fish:52
-msgid "roll back an interrupted transaction"
-msgstr ""
-
-#: share/completions/hg.fish:53
-#, fuzzy
-msgid "remove the specified files on the next commit"
-msgstr "Die auf der Befehlszeile angegebene Datei verschieben"
-
-#: share/completions/hg.fish:54
-msgid "rename files; equivalent of copy + remove"
-msgstr ""
-
-#: share/completions/hg.fish:55
-msgid "redo merges or set/view the merge status of files"
-msgstr ""
-
-#: share/completions/hg.fish:56
-msgid "restore files to their checkout state"
-msgstr ""
-
-#: share/completions/hg.fish:57
-msgid "roll back the last transaction (dangerous)"
-msgstr ""
-
-#: share/completions/hg.fish:58
-msgid "print the root (top) of the current working directory"
-msgstr ""
-
-#: share/completions/hg.fish:59
-msgid "start stand-alone webserver"
-msgstr ""
-
-#: share/completions/hg.fish:60
-msgid "show combined config settings from all hgrc files"
-msgstr ""
-
-#: share/completions/hg.fish:61
-#, fuzzy
-msgid "show changed files in the working directory"
-msgstr "Arbeitsverzeichnis wechseln"
-
-#: share/completions/hg.fish:62
-#, fuzzy
-msgid "summarize working directory state"
-msgstr "Arbeitsverzeichnis ausgeben"
-
-#: share/completions/hg.fish:63
-msgid "add one or more tags for the current or given revision"
-msgstr ""
-
-#: share/completions/hg.fish:64
-#, fuzzy
-msgid "list repository tags"
-msgstr "Depot deaktivieren"
-
-#: share/completions/hg.fish:65
-#, fuzzy
-msgid "show the tip revision"
-msgstr "Zeige Zeit"
-
-#: share/completions/hg.fish:66
-#, fuzzy
-msgid "apply one or more changegroup files"
-msgstr "Ein oder mehrere Paket(e) installieren"
-
-#: share/completions/hg.fish:67
-msgid "update working directory (or switch revisions)"
-msgstr ""
-
-#: share/completions/hg.fish:68
-#, fuzzy
-msgid "verify the integrity of the repository"
-msgstr "Einen Eintrag aus dem Paketdepot entfernen"
-
-#: share/completions/hg.fish:69
-#, fuzzy
-msgid "output version and copyright information"
-msgstr "Magische Versionsinformation ignorieren"
-
-#: share/completions/hg.fish:70
-#, fuzzy
-msgid "Configuration Files"
-msgstr "Konfigurationsdatei"
-
-#: share/completions/hg.fish:71
-#, fuzzy
-msgid "Date Formats"
-msgstr "Format festlegen"
-
-#: share/completions/hg.fish:72
-#, fuzzy
-msgid "Diff Formats"
-msgstr "Listenformat"
-
-#: share/completions/hg.fish:73
-#, fuzzy
-msgid "Environment Variables"
-msgstr "Behandlung von Umgebungsvariablen"
-
-#: share/completions/hg.fish:74
-msgid "Using Additional Features"
-msgstr ""
-
-#: share/completions/hg.fish:75
-#, fuzzy
-msgid "Specifying File Sets"
-msgstr "Konfigurationsdatei angeben"
-
-#: share/completions/hg.fish:76
-msgid "Glossary"
-msgstr ""
-
-#: share/completions/hg.fish:77
-msgid "Syntax for Mercurial Ignore Files"
-msgstr ""
-
-#: share/completions/hg.fish:78
-#, fuzzy
-msgid "Configuring hgweb"
-msgstr "Konfigurationsdatei"
-
-#: share/completions/hg.fish:79
-#, fuzzy
-msgid "Merge Tools"
-msgstr "Sortierte Dateien mischen"
-
-#: share/completions/hg.fish:80
-msgid "Specifying Multiple Revisions"
-msgstr ""
-
-#: share/completions/hg.fish:81
-msgid "File Name Patterns"
-msgstr ""
-
-#: share/completions/hg.fish:82
-msgid "Working with Phases"
-msgstr ""
-
-#: share/completions/hg.fish:83
-#, fuzzy
-msgid "Specifying Single Revisions"
-msgstr "Kernel-Version angeben"
-
-#: share/completions/hg.fish:84
-#, fuzzy
-msgid "Specifying Revision Sets"
-msgstr "Optionen angeben"
-
-#: share/completions/hg.fish:85
-#, fuzzy
-msgid "Subrepositories"
-msgstr "Depot aktivieren"
-
-#: share/completions/hg.fish:86
-msgid "Template Usage"
-msgstr ""
-
-#: share/completions/hg.fish:87
-msgid "URL Paths"
-msgstr ""
-
-#: share/completions/hg.fish:94 share/completions/hg.fish:433
-#: share/completions/hg.fish:458 share/completions/hg.fish:569
-#: share/completions/hg.fish:579 share/completions/hg.fish:594
-#: share/completions/hg.fish:606 share/completions/hg.fish:671
-#, fuzzy
-msgid "[+] include names matching the given patterns"
-msgstr "Module einfügen, die den angegebenen Mustern entsprechen"
-
-#: share/completions/hg.fish:95 share/completions/hg.fish:434
-#: share/completions/hg.fish:459 share/completions/hg.fish:570
-#: share/completions/hg.fish:580 share/completions/hg.fish:595
-#: share/completions/hg.fish:607 share/completions/hg.fish:672
-#, fuzzy
-msgid "[+] exclude names matching the given patterns"
-msgstr "Alle Module auflisten, die den angegebenen Mustern entsprechen"
-
-#: share/completions/hg.fish:104 share/completions/hg.fish:391
-msgid "Guess renamed files by similarity (0<=s<=100)"
-msgstr ""
-
-#: share/completions/hg.fish:105
-#, fuzzy
-msgid "[+]   include names matching the given patterns"
-msgstr "Module einfügen, die den angegebenen Mustern entsprechen"
-
-#: share/completions/hg.fish:106
-#, fuzzy
-msgid "[+]   exclude names matching the given patterns"
-msgstr "Alle Module auflisten, die den angegebenen Mustern entsprechen"
-
-#: share/completions/hg.fish:114
-msgid "Annotate the specified revision"
-msgstr ""
-
-#: share/completions/hg.fish:387
-msgid "Use text as commit message"
-msgstr ""
-
-#: share/completions/hg.fish:388
-#, fuzzy
-msgid "Read commit message from file"
-msgstr "Paket aus Datei lesen"
-
-#: share/completions/hg.fish:389 share/completions/hg.fish:693
-#, fuzzy
-msgid "Record the specified date as commit date"
-msgstr "Angegebene Zeichenkette als Kommentar verwenden"
-
-#: share/completions/hg.fish:390 share/completions/hg.fish:694
-#, fuzzy
-msgid "Record the specified user as committer"
-msgstr "Angegebene Zeichenkette als Kommentar verwenden"
-
-#: share/completions/hg.fish:400
-#, fuzzy
-msgid "File to store the bundles into"
-msgstr "Beschreibung des Patchpaketes editieren"
-
-#: share/completions/hg.fish:401 share/completions/hg.fish:446
-#: share/completions/hg.fish:448 share/completions/hg.fish:450
-#: share/completions/hg.fish:485 share/completions/hg.fish:534
-#: share/completions/hg.fish:536 share/completions/hg.fish:548
-#: share/completions/hg.fish:550 share/completions/hg.fish:669
-msgid "[+]"
-msgstr ""
-
-#: share/completions/hg.fish:403
-msgid "[+] a specific branch you would like to pull"
-msgstr ""
-
-#: share/completions/hg.fish:406 share/completions/hg.fish:453
-#: share/completions/hg.fish:491
-msgid "Limit number of changes displayed"
-msgstr ""
-
-#: share/completions/hg.fish:409 share/completions/hg.fish:456
-#: share/completions/hg.fish:494 share/completions/hg.fish:507
-#: share/completions/hg.fish:709
-msgid "Display using template map file"
-msgstr ""
-
-#: share/completions/hg.fish:410 share/completions/hg.fish:457
-#: share/completions/hg.fish:495 share/completions/hg.fish:508
-#: share/completions/hg.fish:710
-#, fuzzy
-msgid "Display with template"
-msgstr "Alle Übereinstimmungen anzeigen"
-
-#: share/completions/hg.fish:411 share/completions/hg.fish:421
-#: share/completions/hg.fish:496 share/completions/hg.fish:537
-#: share/completions/hg.fish:552
-#, fuzzy
-msgid "Specify ssh command to use"
-msgstr "Befehl an die Shell übergeben"
-
-#: share/completions/hg.fish:412 share/completions/hg.fish:422
-#: share/completions/hg.fish:497 share/completions/hg.fish:538
-#: share/completions/hg.fish:553
-msgid "Specify hg command to run on the remote side"
-msgstr ""
-
-#: share/completions/hg.fish:430
-#, fuzzy
-msgid "Search the repository as it is in REV"
-msgstr "Das Paketdepotverzeichnis angeben, in dem gearbeitet wird"
-
-#: share/completions/hg.fish:441
-msgid "A filename will only show ancestors or"
-msgstr ""
-
-#: share/completions/hg.fish:443
-#, fuzzy
-msgid "Show revisions matching date spec"
-msgstr "Nur zutreffenden Teil anzeigen"
-
-#: share/completions/hg.fish:445
-msgid "[+]    do case-insensitive search for a given text"
-msgstr ""
-
-#: share/completions/hg.fish:449
-msgid "[+]   show changesets within the given named branch"
-msgstr ""
-
-#: share/completions/hg.fish:466
-#, fuzzy
-msgid "Revision to display"
-msgstr "Grafikanzeige auswählen"
-
-#: share/completions/hg.fish:475
-msgid "Revision to merge"
-msgstr ""
-
-#: share/completions/hg.fish:477 share/completions/hg.fish:593
-#, fuzzy
-msgid "Specify merge tool"
-msgstr "Kernel-Version angeben"
-
-#: share/completions/hg.fish:488
-msgid "[+] a specific branch you would like to push"
-msgstr ""
-
-#: share/completions/hg.fish:506
-#, fuzzy
-msgid "Show parents of the specified revision"
-msgstr "Dateisysteme des angegebenen Typs anzeigen"
-
-#: share/completions/hg.fish:525
-msgid "[+] target revision"
-msgstr ""
-
-#: share/completions/hg.fish:535
-msgid "[+] bookmark to pull"
-msgstr ""
-
-#: share/completions/hg.fish:546
-msgid "You want to allow push to create a new named branch"
-msgstr ""
-
-#: share/completions/hg.fish:549
-msgid "[+] bookmark to push"
-msgstr ""
-
-#: share/completions/hg.fish:603 share/completions/hg.fish:726
-#, fuzzy
-msgid "Tipmost revision matching date"
-msgstr "Dem Muster entsprechende Einträge übergehen"
-
-#: share/completions/hg.fish:604
-#, fuzzy
-msgid "Revert to the specified revision"
-msgstr "Fenster auf der angegebenen Anzeige erstellen"
-
-#: share/completions/hg.fish:615
-msgid "Not perform actions, just print output"
-msgstr ""
-
-#: share/completions/hg.fish:629
-msgid "Name of access log file to write to"
-msgstr ""
-
-#: share/completions/hg.fish:631
-msgid "Used internally by daemon mode"
-msgstr ""
-
-#: share/completions/hg.fish:632
-msgid "Name of error log file to write to"
-msgstr ""
-
-#: share/completions/hg.fish:633
-msgid "Port to listen on (default: 8000)"
-msgstr ""
-
-#: share/completions/hg.fish:634
-msgid "Address to listen on (default: all interfaces)"
-msgstr ""
-
-#: share/completions/hg.fish:635
-msgid "Prefix path to serve from (default: server root)"
-msgstr ""
-
-#: share/completions/hg.fish:636
-msgid "Name to show in web pages (default: working"
-msgstr ""
-
-#: share/completions/hg.fish:637
-msgid "Name of the hgweb config file (see \"hg help hgweb\")"
-msgstr ""
-
-#: share/completions/hg.fish:638
-msgid "Name of file to write process ID to"
-msgstr ""
-
-#: share/completions/hg.fish:640
-#, fuzzy
-msgid "For remote clients"
-msgstr "Funktionen auflisten oder entfernen"
-
-#: share/completions/hg.fish:641
-msgid "Web templates to use"
-msgstr ""
-
-#: share/completions/hg.fish:642
-msgid "Template style to use"
-msgstr ""
-
-#: share/completions/hg.fish:644
-#, fuzzy
-msgid "SSL certificate file"
-msgstr "Zertifikatsregeln festlegen"
-
-#: share/completions/hg.fish:651
-#, fuzzy
-msgid "Untrusted configuration options"
-msgstr "Konfigurationsoptionen festlegen"
-
-#: share/completions/hg.fish:670
-msgid "List the changed files of a revision"
-msgstr ""
-
-#: share/completions/hg.fish:680
-msgid "For push and pull"
-msgstr ""
-
-#: share/completions/hg.fish:689
-msgid "Revision to tag"
-msgstr ""
-
-#: share/completions/hg.fish:692
-msgid "Use <text> as commit message"
-msgstr ""
-
-#: share/completions/hg.fish:717
-msgid "To new branch head if changesets were unbundled"
-msgstr ""
-
-#: share/completions/hg.fish:727
-msgid "Revision"
-msgstr ""
-
-#: share/completions/hg.fish:844
-msgid "Or select an existing template-style (--style)"
-msgstr ""
-
-#: share/completions/hg.fish:845
-msgid "Is set"
-msgstr ""
-
 #: share/completions/history.fish:1
 msgid "Match history items that start with the given prefix"
 msgstr ""
@@ -5504,6 +4928,11 @@ msgstr "Schnittstelle starten"
 #: share/completions/ifup.fish:1
 msgid "Network interface"
 msgstr "Netzwerkschnittstelle"
+
+#: share/completions/kitchen.fish:3
+#, fuzzy
+msgid "Test if kitchen has yet to be given the main command"
+msgstr "Test, ob an apt noch ein Unterbefehl gegeben werden muss"
 
 #: share/completions/less.fish:3
 msgid "Buffer space"
@@ -5721,6 +5150,454 @@ msgstr "Geben Sie einen Titel für rss an"
 #: share/completions/mv.fish:4
 msgid "Answer for overwrite questions"
 msgstr "Antwort für Überschreib-Fragen"
+
+#: share/completions/node.fish:9
+#, fuzzy
+msgid "Print node's version"
+msgstr "Kernel-Version ausgeben"
+
+#: share/completions/node.fish:10
+#, fuzzy
+msgid "Evaluate script"
+msgstr "Datei auswerten"
+
+#: share/completions/node.fish:11
+#, fuzzy
+msgid "Print result of --eval"
+msgstr "Flaches Profil ausgeben"
+
+#: share/completions/obnam.fish:9
+#, fuzzy
+msgid "Adds an encryption key to the repository"
+msgstr "Neue/s Datei/Verzeichnis zum Paketdepot hinzufügen"
+
+#: share/completions/obnam.fish:11
+msgid "Lists the keys associated with each client"
+msgstr ""
+
+#: share/completions/obnam.fish:12
+#, fuzzy
+msgid "Lists the clients in the repository"
+msgstr "Paketdepot aktualisieren"
+
+#: share/completions/obnam.fish:13
+#, fuzzy
+msgid "Compares two generations"
+msgstr "Saloppe Einhäng-Optionen tolerieren"
+
+#: share/completions/obnam.fish:14
+#, fuzzy
+msgid "Dumps the repository"
+msgstr "Paketdepot aktualisieren"
+
+#: share/completions/obnam.fish:15
+#, fuzzy
+msgid "Removes a lock file for a client"
+msgstr "Alle gz-Dateien aus dem Zwischenspeicher entfernen"
+
+#: share/completions/obnam.fish:16
+#, fuzzy
+msgid "Removes backup generations"
+msgstr "Vervollständigung entfernen"
+
+#: share/completions/obnam.fish:17
+#, fuzzy
+msgid "Checks the consistency of the repository"
+msgstr "Das ganze Paketdepot prüfen"
+
+#: share/completions/obnam.fish:18
+msgid "Lists every backup generation"
+msgstr ""
+
+#: share/completions/obnam.fish:19
+msgid "Lists the identifier for every generation"
+msgstr ""
+
+#: share/completions/obnam.fish:20
+#, fuzzy
+msgid "Lists the keys"
+msgstr "Vertraute Schlüssel auflisten"
+
+#: share/completions/obnam.fish:21
+#, fuzzy
+msgid "Lists the toplevel keys"
+msgstr "Vertraute Schlüssel auflisten"
+
+#: share/completions/obnam.fish:22
+#, fuzzy
+msgid "Lists the contents of a given generation"
+msgstr "Startverzeichnis festlegen"
+
+#: share/completions/obnam.fish:23
+#, fuzzy
+msgid "Makes the repository available via FUSE"
+msgstr "Das Paketdepotverzeichnis angeben, in dem gearbeitet wird"
+
+#: share/completions/obnam.fish:24
+msgid "Check if a backup age exceeds a threshold"
+msgstr ""
+
+#: share/completions/obnam.fish:25
+#, fuzzy
+msgid "Removes a client from the repository"
+msgstr "Einen Eintrag aus dem Paketdepot entfernen"
+
+#: share/completions/obnam.fish:26
+#, fuzzy
+msgid "Removes a key from the repository"
+msgstr "Einen Eintrag aus dem Paketdepot entfernen"
+
+#: share/completions/obnam.fish:27
+#, fuzzy
+msgid "Restore files from the repository"
+msgstr "Dateien in das Paketdepot übertragen"
+
+#: share/completions/obnam.fish:28
+#, fuzzy
+msgid "Verifies files in the repository"
+msgstr "Dateien in das Paketdepot übertragen"
+
+#: share/completions/obnam.fish:30
+msgid "Restore setuid/setgid bits in restored files"
+msgstr ""
+
+#: share/completions/obnam.fish:31
+msgid "Do not restore setuid/setgid bits in restored files"
+msgstr ""
+
+#: share/completions/obnam.fish:32
+#, fuzzy
+msgid "Name of client"
+msgstr "Name des Patch"
+
+#: share/completions/obnam.fish:33
+#, fuzzy
+msgid "Compress repository with"
+msgstr "Auf Standardausgabe komprimieren"
+
+#: share/completions/obnam.fish:34
+msgid "For --nagios-last-backup-age: maximum age"
+msgstr ""
+
+#: share/completions/obnam.fish:35
+msgid "Dump metadata about files"
+msgstr ""
+
+#: share/completions/obnam.fish:36
+#, fuzzy
+msgid "Do not dump metadata about files"
+msgstr "Erstellte Dateien nicht löschen"
+
+#: share/completions/obnam.fish:37
+#, fuzzy
+msgid "Generate man page"
+msgstr "Ein neues Schlüsselpaar erstellen"
+
+#: share/completions/obnam.fish:38
+msgid "Which generation to restore"
+msgstr ""
+
+#: share/completions/obnam.fish:39
+#, fuzzy
+msgid "Show this help message and exit"
+msgstr "Hilfe anzeigen und beenden"
+
+#: share/completions/obnam.fish:40
+msgid "Policy for what generations to keep when forgetting."
+msgstr ""
+
+#: share/completions/obnam.fish:41
+msgid "Wait TIMEOUT seconds for an existing lock"
+msgstr ""
+
+#: share/completions/obnam.fish:43
+#, fuzzy
+msgid "Do not actually change anything"
+msgstr "Nichts schreiben"
+
+#: share/completions/obnam.fish:44
+#, fuzzy
+msgid "Actually commit changes"
+msgstr "Änderungen zusammenfassen"
+
+#: share/completions/obnam.fish:45
+msgid "Show only errors, no progress updates"
+msgstr ""
+
+#: share/completions/obnam.fish:46
+msgid "Show errors and progress updates"
+msgstr ""
+
+#: share/completions/obnam.fish:49
+#, fuzzy
+msgid "Simulate failures for files that match REGEXP"
+msgstr "Dem REGEXP entsprechende Patche auswählen"
+
+#: share/completions/obnam.fish:52
+msgid "Be more verbose"
+msgstr ""
+
+#: share/completions/obnam.fish:53
+#, fuzzy
+msgid "Do not be verbose"
+msgstr "Nicht überschreiben"
+
+#: share/completions/obnam.fish:54
+msgid "Verify N files randomly from the backup"
+msgstr ""
+
+#: share/completions/obnam.fish:55
+#, fuzzy
+msgid "Show version number and exit"
+msgstr "Version anzeigen und beenden"
+
+#: share/completions/obnam.fish:57
+msgid "Make a checkpoint after a given SIZE"
+msgstr ""
+
+#: share/completions/obnam.fish:58
+#, fuzzy
+msgid "Deduplicate mode"
+msgstr "Lese-/Schreib-Modus"
+
+#: share/completions/obnam.fish:60
+#, fuzzy
+msgid "Exclude directories tagged as cache"
+msgstr "Verzeichnisse nach Quelle durchsuchen"
+
+#: share/completions/obnam.fish:61
+#, fuzzy
+msgid "Include directories tagged as cache"
+msgstr "include-Verzeichnis"
+
+#: share/completions/obnam.fish:63
+msgid "Leave checkpoint generations at the end of backup"
+msgstr ""
+
+#: share/completions/obnam.fish:64
+msgid "Omit checkpoint generations at the end of backup"
+msgstr ""
+
+#: share/completions/obnam.fish:65
+#, fuzzy
+msgid "Do not follow mount points"
+msgstr "Lange Zeilen nicht umbrechen"
+
+#: share/completions/obnam.fish:66
+#, fuzzy
+msgid "Follow mount points"
+msgstr "Einhängepunkt"
+
+#: share/completions/obnam.fish:67
+msgid "Put small files directly into the B-tree"
+msgstr ""
+
+#: share/completions/obnam.fish:68
+msgid "No not put small files into the B-tree"
+msgstr ""
+
+#: share/completions/obnam.fish:70
+#, fuzzy
+msgid "Write out the current configuration"
+msgstr "Dienstkonfiguration neu laden"
+
+#: share/completions/obnam.fish:71
+#, fuzzy
+msgid "Write out setting names"
+msgstr "Prompt ausgeben"
+
+#: share/completions/obnam.fish:72
+#, fuzzy
+msgid "Show all options"
+msgstr "Hilfe- und Debug-Optionen anzeigen"
+
+#: share/completions/obnam.fish:73
+#, fuzzy
+msgid "List config files"
+msgstr "Konfigurationsdatei benutzen"
+
+#: share/completions/obnam.fish:74
+#, fuzzy
+msgid "Clear list of configuration files to read"
+msgstr "Liste der rpm-Konfigurationsdateien"
+
+#: share/completions/obnam.fish:75
+msgid "PGP key with which to encrypt"
+msgstr ""
+
+#: share/completions/obnam.fish:76
+msgid "Show additional user IDs"
+msgstr ""
+
+#: share/completions/obnam.fish:77
+#, fuzzy
+msgid "Do not show additional user IDs"
+msgstr "Verzeichnisnamen nicht speichern"
+
+#: share/completions/obnam.fish:78
+msgid "PGP key id"
+msgstr ""
+
+#: share/completions/obnam.fish:79
+msgid "Size of symmetric key"
+msgstr ""
+
+#: share/completions/obnam.fish:80
+#, fuzzy
+msgid "Use /dev/urandom instead of /dev/random"
+msgstr "purge anstelle von remove verwenden"
+
+#: share/completions/obnam.fish:81
+msgid "Use default /dev/random"
+msgstr ""
+
+#: share/completions/obnam.fish:83
+msgid "fsck should try to fix problems"
+msgstr ""
+
+#: share/completions/obnam.fish:84
+msgid "fsck should not try to fix problems"
+msgstr ""
+
+#: share/completions/obnam.fish:85
+#, fuzzy
+msgid "Ignore chunks when checking integrity"
+msgstr "Groß-/Kleinschreibung beim Dateinamenvergleich ignorieren"
+
+#: share/completions/obnam.fish:86
+msgid "Check chunks when checking integrity"
+msgstr ""
+
+#: share/completions/obnam.fish:87
+msgid "Do not check data for cient NAME."
+msgstr ""
+
+#: share/completions/obnam.fish:88
+#, fuzzy
+msgid "Check only the last generation"
+msgstr "Inhaltsgenerierung durchführen"
+
+#: share/completions/obnam.fish:89 share/completions/obnam.fish:95
+#, fuzzy
+msgid "Check all generations"
+msgstr "Installierte Pakete abfragen"
+
+#: share/completions/obnam.fish:90
+#, fuzzy
+msgid "Do not check directories"
+msgstr "Verzeichnisnamen nicht speichern"
+
+#: share/completions/obnam.fish:91
+#, fuzzy
+msgid "Check directories"
+msgstr "Verzeichnisse rekursiv durchlaufen"
+
+#: share/completions/obnam.fish:92
+#, fuzzy
+msgid "Do not check files"
+msgstr "Quelldateien nicht löschen"
+
+#: share/completions/obnam.fish:93
+#, fuzzy
+msgid "Check files"
+msgstr "Installierte Pakete abfragen"
+
+#: share/completions/obnam.fish:94
+#, fuzzy
+msgid "Do not check any generations"
+msgstr "Überprüfungsstatus von Schlüsselsignaturen nicht zwischenspeichern"
+
+#: share/completions/obnam.fish:96
+msgid "Do not check per-client B-trees"
+msgstr ""
+
+#: share/completions/obnam.fish:97
+msgid "Check per-client B-trees"
+msgstr ""
+
+#: share/completions/obnam.fish:98
+#, fuzzy
+msgid "Do not check shared B-trees"
+msgstr "Quelldateien nicht löschen"
+
+#: share/completions/obnam.fish:99
+#, fuzzy
+msgid "Check shared B-trees"
+msgstr "Installierte Pakete abfragen"
+
+#: share/completions/obnam.fish:102
+msgid "Keep last N logs (10)"
+msgstr ""
+
+#: share/completions/obnam.fish:103
+msgid "Log at LEVEL"
+msgstr ""
+
+#: share/completions/obnam.fish:104
+msgid "Rotate logs larger than SIZE"
+msgstr ""
+
+#: share/completions/obnam.fish:105
+msgid "Set permissions of logfiles to MODE"
+msgstr ""
+
+#: share/completions/obnam.fish:106
+msgid "Options to pass to FUSE"
+msgstr ""
+
+#: share/completions/obnam.fish:107
+msgid "Make memory profiling dumps using METHOD"
+msgstr ""
+
+#: share/completions/obnam.fish:108
+msgid "Make memory profiling dumps at SECONDS"
+msgstr ""
+
+#: share/completions/obnam.fish:109
+msgid "Size of chunks of file data"
+msgstr ""
+
+#: share/completions/obnam.fish:110
+msgid "Encode NUM chunk ids per group"
+msgstr ""
+
+#: share/completions/obnam.fish:111
+msgid "Chunk id level size"
+msgstr ""
+
+#: share/completions/obnam.fish:112
+#, fuzzy
+msgid "Depth of chunk id mapping"
+msgstr "Tiefe der Aufrufkette"
+
+#: share/completions/obnam.fish:113
+msgid "Chunk id mapping lowest bits skip"
+msgstr ""
+
+#: share/completions/obnam.fish:114
+msgid "Size of LRU cache for B-tree nodes"
+msgstr ""
+
+#: share/completions/obnam.fish:115
+msgid "Size of B-tree nodes on disk"
+msgstr ""
+
+#: share/completions/obnam.fish:116
+msgid "Length of upload queue for B-tree nodes"
+msgstr ""
+
+#: share/completions/obnam.fish:117
+msgid "Use only paramiko, no openssh"
+msgstr ""
+
+#: share/completions/obnam.fish:118
+#, fuzzy
+msgid "Use openssh if available"
+msgstr "Index erstellen, wenn nicht vorhanden"
+
+#: share/completions/obnam.fish:120
+msgid "ssh host key check"
+msgstr ""
 
 #: share/completions/perl.fish:6
 msgid "Specify record separator"
@@ -6359,15 +6236,15 @@ msgstr "Hintergrundfarbe ändern"
 msgid "Locale"
 msgstr "Locale"
 
-#: share/completions/sort.fish:12
+#: share/completions/sort.fish:16
 msgid "Write to file"
 msgstr "In Datei schreiben"
 
-#: share/completions/sort.fish:14
+#: share/completions/sort.fish:18
 msgid "Set memory buffer size"
 msgstr "Speicherpuffergröße festlegen"
 
-#: share/completions/sort.fish:16
+#: share/completions/sort.fish:20
 msgid "Set temporary directory"
 msgstr "Temporäres Verzeichnis festlegen"
 
@@ -6635,7 +6512,7 @@ msgstr ""
 msgid "Test if vagrant has yet to be given the main command"
 msgstr "Test, ob an apt noch ein Unterbefehl gegeben werden muss"
 
-#: share/completions/vagrant.fish:34
+#: share/completions/vagrant.fish:23
 #, fuzzy
 msgid "Lists all available Vagrant boxes"
 msgstr "Namen der verfügbaren Signale auflisten"
@@ -7881,6 +7758,11 @@ msgstr "MAC-Markierung jeder Datei anzeigen"
 msgid "Include the file flags in a long (-l) output"
 msgstr "Datei-Kennungen in langer (-l) Ausgabe einfügen"
 
+#: share/functions/__fish_complete_path.fish:1
+#, fuzzy
+msgid "Complete using path"
+msgstr "Saloppe Einhäng-Optionen tolerieren"
+
 #: share/functions/__fish_complete_ppp_peer.fish:1
 msgid "Complete isp name for pon/poff"
 msgstr ""
@@ -8458,63 +8340,50 @@ msgstr ""
 msgid "Complete md5sum sha1 etc"
 msgstr ""
 
-#: share/functions/__fish_config_interactive.fish:65
-#, sh-format
-msgid ""
-"\\nWARNING\\n\\nThe location for fish configuration files has changed to %s."
-"\\nYour old files have been moved to this location.\\nYou can change to a "
-"different location by changing the value of the variable $XDG_CONFIG_HOME.\\n"
-"\\n"
-msgstr ""
-
-#: share/functions/__fish_config_interactive.fish:82
+#: share/functions/__fish_config_interactive.fish:34
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Willkommen zu fish, der freundlichen interaktiven Shell"
 
-#: share/functions/__fish_config_interactive.fish:83
+#: share/functions/__fish_config_interactive.fish:35
 msgid "Type %shelp%s for instructions on how to use fish"
 msgstr "Anweisungen zur fish-Benutzung erhalten Sie über %shelp%s"
 
-#: share/functions/__fish_config_interactive.fish:173
+#: share/functions/__fish_config_interactive.fish:130
 msgid "Event handler, repaints the prompt when fish_color_cwd changes"
 msgstr ""
 
-#: share/functions/__fish_config_interactive.fish:180
+#: share/functions/__fish_config_interactive.fish:137
 msgid "Event handler, repaints the prompt when fish_color_cwd_root changes"
 msgstr ""
 
-#: share/functions/__fish_config_interactive.fish:192
+#: share/functions/__fish_config_interactive.fish:149
 msgid "Start service"
 msgstr "Dienst starten"
 
-#: share/functions/__fish_config_interactive.fish:193
+#: share/functions/__fish_config_interactive.fish:150
 msgid "Stop service"
 msgstr "Dienst anhalten"
 
-#: share/functions/__fish_config_interactive.fish:194
+#: share/functions/__fish_config_interactive.fish:151
 #, fuzzy
 msgid "Print service status"
 msgstr "Dienststatus ausgeben"
 
-#: share/functions/__fish_config_interactive.fish:195
+#: share/functions/__fish_config_interactive.fish:152
 msgid "Stop and then start service"
 msgstr "Stoppe und starte Dienst"
 
-#: share/functions/__fish_config_interactive.fish:196
+#: share/functions/__fish_config_interactive.fish:153
 msgid "Reload service configuration"
 msgstr "Dienstkonfiguration neu laden"
 
-#: share/functions/__fish_config_interactive.fish:228
+#: share/functions/__fish_config_interactive.fish:193
 #, sh-format
 msgid "Notify VTE of change to $PWD"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:173
 msgid "Helper function for __fish_git_prompt"
-msgstr ""
-
-#: share/functions/__fish_git_prompt.fish:244
-msgid "svn_upstream"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:348
@@ -8558,6 +8427,11 @@ msgstr ""
 msgid "Event handler, repaints prompt when any char changes"
 msgstr ""
 
+#: share/functions/__fish_hg_prompt.fish:23
+#, fuzzy
+msgid "Write out the hg prompt"
+msgstr "Prompt ausgeben"
+
 #: share/functions/__fish_is_token_n.fish:1
 msgid "Test if current token is on Nth place"
 msgstr ""
@@ -8595,7 +8469,7 @@ msgstr "Liste laufender screen-Sitzungen ausgeben"
 msgid "Prints services installed"
 msgstr "Dienststatus ausgeben"
 
-#: share/functions/__fish_print_help.fish:2
+#: share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr ""
 
@@ -8623,6 +8497,10 @@ msgstr "Verfügbare Liste ausgeben"
 #, fuzzy
 msgid "Print mounted devices"
 msgstr "Wichtige Abhängigkeiten ausgeben"
+
+#: share/functions/__fish_print_packages.fish:13
+msgid "Package"
+msgstr "Paket"
 
 #: share/functions/__fish_print_svn_rev.fish:1
 #, fuzzy
@@ -8677,15 +8555,64 @@ msgstr "Standardeingabe umbenennen"
 msgid "Write out the git prompt"
 msgstr "Prompt ausgeben"
 
+#: share/functions/abbr.fish:1
+#, fuzzy
+msgid "Manage abbreviations"
+msgstr "Handbuch-Sektionen"
+
+#: share/functions/abbr.fish:40
+#, fuzzy
+msgid "%s: invalid option -- %s\\n"
+msgstr "%ls: Ungültige Prozesskennung %ls\n"
+
+#: share/functions/abbr.fish:47
+#, fuzzy
+msgid "%s: %s cannot be specified along with %s\\n"
+msgstr ""
+"%ls: Bei erase können keine Werte angegeben werden\n"
+"%ls\n"
+
+#: share/functions/abbr.fish:56
+#, fuzzy
+msgid "%s: option requires an argument -- %s\\n"
+msgstr "%ls: Erwartete ein Argument, erhielt %d\n"
+
+#: share/functions/abbr.fish:62
+#, fuzzy
+msgid "%s: Unexpected argument -- %s\\n"
+msgstr "%ls: Argument erwartet\n"
+
+#: share/functions/abbr.fish:75
+msgid "%s: abbreviation must have a non-empty key\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:79
+msgid "%s: abbreviation must have a value\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:101
+#, fuzzy
+msgid "%s: no such abbreviation '%s'\\n"
+msgstr "Unbekannte Funktion '%ls'"
+
 #: share/functions/alias.fish:2
 msgid ""
 "Legacy function for creating shellscript functions using an alias-like syntax"
 msgstr ""
 
-#: share/functions/alias.fish:34
+#: share/functions/alias.fish:36
 #, fuzzy
 msgid "%s: Expected one or two arguments, got %d\\n"
 msgstr "%ls: Erwartete ein Argument, erhielt %d\n"
+
+#: share/functions/alias.fish:42
+#, fuzzy
+msgid "%s: Name cannot be empty\\n"
+msgstr "%ls: Variablenname kann nicht leer sein\n"
+
+#: share/functions/alias.fish:45
+msgid "%s: Body cannot be empty\\n"
+msgstr ""
 
 #: share/functions/contains_seq.fish:1
 msgid "Return true if array contains a sequence"
@@ -8699,6 +8626,10 @@ msgstr ""
 #, fuzzy
 msgid "Print directory stack"
 msgstr "Verzeichnisnamen ausgeben"
+
+#: share/functions/export.fish:1
+msgid "Set global variable. Alias for set -g, made for bash compatibility"
+msgstr ""
 
 #: share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
@@ -8717,6 +8648,20 @@ msgstr "Prompt ausgeben"
 msgid "Update man-page based completions"
 msgstr "Befehlsspezifische Erweiterungen bearbeiten"
 
+#: share/functions/fish_vi_key_bindings.fish:1
+#, fuzzy
+msgid "vi-like key bindings for fish"
+msgstr "Datei mit Tastaturbindungen angeben"
+
+#: share/functions/fish_vi_prompt.fish:1
+#, fuzzy
+msgid "Displays the current mode"
+msgstr "Version anzeigen und beenden"
+
+#: share/functions/fish_vi_prompt.fish:17
+msgid "Simple vi prompt"
+msgstr ""
+
 #: share/functions/funced.fish:1
 #, fuzzy
 msgid "Edit function definition"
@@ -8733,6 +8678,19 @@ msgstr "%ls: Unbekannte Option '%ls'\n"
 msgid "funced: You must specify one function name\n"
 msgstr "%ls: Erwartete genau einen Funktionsnamen\n"
 
+#: share/functions/funced.fish:96
+msgid "Editing failed or was cancelled"
+msgstr ""
+
+#: share/functions/funced.fish:103
+msgid "Edit the file again\\? [Y/n]"
+msgstr ""
+
+#: share/functions/funced.fish:110
+#, fuzzy
+msgid "Cancelled function editing"
+msgstr "Funktionsdefinitonsblock"
+
 #: share/functions/funcsave.fish:2
 msgid "Save the current definition of all specified functions to file"
 msgstr ""
@@ -8747,7 +8705,7 @@ msgstr "%ls: Erwartete genau einen Funktionsnamen\n"
 msgid "%s: Could not create configuration directory\\n"
 msgstr "%ls: Konnte Startverzeichnis nicht finden\n"
 
-#: share/functions/funcsave.fish:37
+#: share/functions/funcsave.fish:36
 #, fuzzy
 msgid "%s: Unknown function '%s'\\n"
 msgstr "Unbekannte Funktion '%ls'"
@@ -8795,7 +8753,7 @@ msgstr ""
 msgid "List contents of directory using long format"
 msgstr ""
 
-#: share/functions/ls.fish:7 share/functions/ls.fish:24
+#: share/functions/ls.fish:7 share/functions/ls.fish:32
 #, fuzzy
 msgid "List contents of directory"
 msgstr "Startverzeichnis festlegen"
@@ -8846,7 +8804,6 @@ msgid "The number of positions to skip must be a non-negative integer\\n"
 msgstr ""
 "Anzahl zu überspringender Positionen muss eine positive Ganzzahl sein\\n"
 
-#: share/functions/prompt_pwd.fish:3 share/functions/prompt_pwd.fish:7
 #: share/functions/prompt_pwd.fish:11
 msgid "Print the current working directory, shortened to fit the prompt"
 msgstr ""
@@ -8890,32 +8847,32 @@ msgstr ""
 msgid "Print the type of a command"
 msgstr "Pfad zu Befehl ausgeben"
 
-#: share/functions/type.fish:84
+#: share/functions/type.fish:90
 msgid "%s is a function with definition\\n"
 msgstr "%s ist eine Funktion mit der Definition\\n"
 
-#: share/functions/type.fish:88
+#: share/functions/type.fish:94
 msgid "function"
 msgstr "Funktion"
 
-#: share/functions/type.fish:105
+#: share/functions/type.fish:107
 msgid "%s is a builtin\\n"
 msgstr "%s ist ein eingebauter Befehl\\n"
 
-#: share/functions/type.fish:108
+#: share/functions/type.fish:110
 #, fuzzy
 msgid "builtin"
 msgstr "eingebauter Befehl\\n"
 
-#: share/functions/type.fish:132
+#: share/functions/type.fish:130
 msgid "%s is %s\\n"
 msgstr "%s ist %s\\n"
 
-#: share/functions/type.fish:135
+#: share/functions/type.fish:133
 msgid "file"
 msgstr "Datei"
 
-#: share/functions/type.fish:147
+#: share/functions/type.fish:144
 #, fuzzy
 msgid "%s: Could not find '%s'\\n"
 msgstr "%s: Konnte '%s' nicht finden"
@@ -8939,16 +8896,16 @@ msgstr "%s: Zu viele Argumente\\n"
 msgid "Edit variable value"
 msgstr "Verfügbare Liste ausgeben"
 
-#: share/functions/vared.fish:41
+#: share/functions/vared.fish:40
 #, fuzzy
 msgid ""
-"%s: %s is an array variable. Use %svared%s %s[n] to edit the n:th element of "
-"%s\\n"
+"%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element "
+"of %s\\n"
 msgstr ""
 "vared: %s ist eine Feldvariable. Benutzen Sie %svared%s %s[n] zum Editieren "
 "den n. Elementes von %s\\n"
 
-#: share/functions/vared.fish:45
+#: share/functions/vared.fish:44
 #, fuzzy
 msgid ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
@@ -8956,6 +8913,330 @@ msgid ""
 msgstr ""
 "vared: Erwartete genau ein Argument, erhielt %s.\\n\\nSynopsis:\\n\\t%svared"
 "%s VARIABLE\\n"
+
+#, fuzzy
+#~ msgid "%ls: Expected zero or two parameters, got %d\n"
+#~ msgstr "%ls: Erwartete kein oder ein Argument, erhielt %d\n"
+
+#~ msgid "Current functions are: "
+#~ msgstr "Aktuelle Funktionen sind: "
+
+#~ msgid "%ls: Not inside of block\n"
+#~ msgstr "%ls: Nicht innerhalb eines Blocks\n"
+
+#~ msgid "%ls: Not inside of 'if' block\n"
+#~ msgstr "%ls: Nicht innerhalb eines 'if'-Blocks\n"
+
+#~ msgid "%ls: Expected exactly one argument, got %d\n"
+#~ msgstr "%ls: Erwartete genau ein Argument, erhielt %d\n"
+
+#~ msgid "%ls: 'case' command while not in switch block\n"
+#~ msgstr "%ls: 'case'-Befehl außerhalb eines switch-Blocks\n"
+
+#, fuzzy
+#~ msgid "%ls: Unknown error"
+#~ msgstr "%ls: Unbekannter Job '%ls'\n"
+
+#, fuzzy
+#~ msgid "%ls: Can not specify scope when erasing array slice\n"
+#~ msgstr "%ls: Bei Blocklöschung kann kein Bereich angegeben werden\n"
+
+#~ msgid "Could not get user information"
+#~ msgstr "Kann Benutzerinformation nicht abrufen"
+
+#, fuzzy
+#~ msgid "%ls: Argument '%s' is not a valid file descriptor\n"
+#~ msgstr "%ls: '%ls' ist kein gültiger Variablenname\n"
+
+#, fuzzy
+#~ msgid "Could not set up input file descriptors for pager"
+#~ msgstr "Konnte Terminalmodus für neue Shell nicht festlegen"
+
+#, fuzzy
+#~ msgid "Could not open tty for pager"
+#~ msgstr "Konnte Shell nicht wieder in Vordergrund zurückholen"
+
+#, fuzzy
+#~ msgid "Unspecified file descriptors"
+#~ msgstr "Datei-Deskriptoren beobachten"
+
+#, fuzzy
+#~ msgid "Could not read completions"
+#~ msgstr "Befehl, bei dem Vervollständigung genutzt werden soll"
+
+#~ msgid "Could not expand string '%ls'"
+#~ msgstr "Konnte Zeichenkette '%ls' nicht erweitern"
+
+#~ msgid ""
+#~ "Could not locate end of block. The 'end' command is missing, misspelled "
+#~ "or a ';' is missing."
+#~ msgstr ""
+#~ "Konnte Blockende nicht finden, Der 'end'-Befehl fehlt, ist falsch "
+#~ "geschriebenoder ein ':' fehlt."
+
+#~ msgid "Expected a command name, got token of type '%ls'"
+#~ msgstr "Erwartete einen Befehlsnamen, bekam Zeichen des Typs '%ls'"
+
+#~ msgid "'case' builtin not inside of switch block"
+#~ msgstr "eingebauter Befehl 'case' nicht innerhalb eines switch-Blocks"
+
+#~ msgid "Loop control command while not inside of loop"
+#~ msgstr "Schleifensteuerungsbefehl 'while' nicht innerhalb einer Schleife"
+
+#, fuzzy
+#~ msgid "'%ls' builtin not inside of if block"
+#~ msgstr "eingebauter Befehl 'else' nicht innerhalb eines if-Blocks"
+
+#~ msgid "'end' command outside of block"
+#~ msgstr "'end'-Befehl außerhalb eines Blocks"
+
+#~ msgid "Expected redirection specification, got token of type '%ls'"
+#~ msgstr "Erwartete Umleitungsspezifikation, erhielt Zeichen vom Typ '%ls'"
+
+#~ msgid ""
+#~ "Encountered redirection when expecting a command name. Fish does not "
+#~ "allow a redirection operation before a command."
+#~ msgstr ""
+#~ "Umleitung anstelle eines Befehlsnamens. Fish erlaubt keine Umleitung vor "
+#~ "einem Befehl."
+
+#~ msgid "Invalid IO redirection"
+#~ msgstr "Ungültige E/A-Umleitung"
+
+#~ msgid "Requested redirection to something that is not a file descriptor %ls"
+#~ msgstr "Angeforderte Umleitung auf etwas, das kein Dateideskriptor ist %ls"
+
+#, fuzzy
+#~ msgid "Don't preserve the specified attributes"
+#~ msgstr "Grössen-Attribute nicht prüfen"
+
+#, fuzzy
+#~ msgid "Control creation of sparse files"
+#~ msgstr "Sparse-Dateien bearbeiten"
+
+#, fuzzy
+#~ msgid "All base system packages"
+#~ msgstr "Erstellte Pakete löschen"
+
+#, fuzzy
+#~ msgid "All packages in world"
+#~ msgstr "Installierte Pakete synchronisieren"
+
+#, fuzzy
+#~ msgid "Installed package"
+#~ msgstr "Neues Paket installieren"
+
+#, fuzzy
+#~ msgid "Help on subject config"
+#~ msgstr "Hilfeabschnitt zu %s"
+
+#, fuzzy
+#~ msgid "Use colors in output"
+#~ msgstr "Farben benutzen"
+
+#, fuzzy
+#~ msgid "Don't use colors in output"
+#~ msgstr "Keine ausführliche Ausgabe"
+
+#, fuzzy
+#~ msgid "Pull in build time dependencies"
+#~ msgstr "Erstellungsabhängigkeiten anzeigen"
+
+#, fuzzy
+#~ msgid "Don't pull in build time dependencies"
+#~ msgstr "Nicht automatisch Abhängigkeiten erfüllen"
+
+#, fuzzy
+#~ msgid "add the specified files on the next commit"
+#~ msgstr "Angegebene Datei zur aktuellen Schlüsselringliste hinzufügen"
+
+#, fuzzy
+#~ msgid "show changeset information by line for each file"
+#~ msgstr "Zeigt Änderungsinformationen zu dem Paket an"
+
+#, fuzzy
+#~ msgid "create a changegroup file"
+#~ msgstr "Paket aus Datei lesen"
+
+#, fuzzy
+#~ msgid "make a copy of an existing repository"
+#~ msgstr "Eine lokale Kopie eines weiteren Paketdepots erstellen"
+
+#, fuzzy
+#~ msgid "commit the specified files or all outstanding changes"
+#~ msgstr "Angegebene Datei oder Standardeingabe entschlüsseln"
+
+#, fuzzy
+#~ msgid "import an ordered set of patches"
+#~ msgstr "Byte-Offset von Treffern ausgeben"
+
+#, fuzzy
+#~ msgid "create a new repository in the given directory"
+#~ msgstr "CVS-Paketdepot erstellen, wenn es nicht existiert"
+
+#, fuzzy
+#~ msgid "locate files matching specific patterns"
+#~ msgstr "Dem Muster entsprechende Dateien ausschliessen"
+
+#, fuzzy
+#~ msgid "show aliases for remote repositories"
+#~ msgstr "Einträge in .cvspass für entferntes Paketdepot entfernen"
+
+#, fuzzy
+#~ msgid "pull changes from the specified source"
+#~ msgstr "Pakete mit der angegebenen Gruppe abfragen"
+
+#, fuzzy
+#~ msgid "push changes to the specified destination"
+#~ msgstr "Pakete mit der angegebenen Gruppe abfragen"
+
+#, fuzzy
+#~ msgid "remove the specified files on the next commit"
+#~ msgstr "Die auf der Befehlszeile angegebene Datei verschieben"
+
+#, fuzzy
+#~ msgid "show changed files in the working directory"
+#~ msgstr "Arbeitsverzeichnis wechseln"
+
+#, fuzzy
+#~ msgid "summarize working directory state"
+#~ msgstr "Arbeitsverzeichnis ausgeben"
+
+#, fuzzy
+#~ msgid "list repository tags"
+#~ msgstr "Depot deaktivieren"
+
+#, fuzzy
+#~ msgid "show the tip revision"
+#~ msgstr "Zeige Zeit"
+
+#, fuzzy
+#~ msgid "apply one or more changegroup files"
+#~ msgstr "Ein oder mehrere Paket(e) installieren"
+
+#, fuzzy
+#~ msgid "verify the integrity of the repository"
+#~ msgstr "Einen Eintrag aus dem Paketdepot entfernen"
+
+#, fuzzy
+#~ msgid "output version and copyright information"
+#~ msgstr "Magische Versionsinformation ignorieren"
+
+#, fuzzy
+#~ msgid "Configuration Files"
+#~ msgstr "Konfigurationsdatei"
+
+#, fuzzy
+#~ msgid "Date Formats"
+#~ msgstr "Format festlegen"
+
+#, fuzzy
+#~ msgid "Diff Formats"
+#~ msgstr "Listenformat"
+
+#, fuzzy
+#~ msgid "Environment Variables"
+#~ msgstr "Behandlung von Umgebungsvariablen"
+
+#, fuzzy
+#~ msgid "Specifying File Sets"
+#~ msgstr "Konfigurationsdatei angeben"
+
+#, fuzzy
+#~ msgid "Configuring hgweb"
+#~ msgstr "Konfigurationsdatei"
+
+#, fuzzy
+#~ msgid "Merge Tools"
+#~ msgstr "Sortierte Dateien mischen"
+
+#, fuzzy
+#~ msgid "Specifying Single Revisions"
+#~ msgstr "Kernel-Version angeben"
+
+#, fuzzy
+#~ msgid "Specifying Revision Sets"
+#~ msgstr "Optionen angeben"
+
+#, fuzzy
+#~ msgid "Subrepositories"
+#~ msgstr "Depot aktivieren"
+
+#, fuzzy
+#~ msgid "[+] include names matching the given patterns"
+#~ msgstr "Module einfügen, die den angegebenen Mustern entsprechen"
+
+#, fuzzy
+#~ msgid "[+] exclude names matching the given patterns"
+#~ msgstr "Alle Module auflisten, die den angegebenen Mustern entsprechen"
+
+#, fuzzy
+#~ msgid "[+]   include names matching the given patterns"
+#~ msgstr "Module einfügen, die den angegebenen Mustern entsprechen"
+
+#, fuzzy
+#~ msgid "[+]   exclude names matching the given patterns"
+#~ msgstr "Alle Module auflisten, die den angegebenen Mustern entsprechen"
+
+#, fuzzy
+#~ msgid "Read commit message from file"
+#~ msgstr "Paket aus Datei lesen"
+
+#, fuzzy
+#~ msgid "Record the specified date as commit date"
+#~ msgstr "Angegebene Zeichenkette als Kommentar verwenden"
+
+#, fuzzy
+#~ msgid "Record the specified user as committer"
+#~ msgstr "Angegebene Zeichenkette als Kommentar verwenden"
+
+#, fuzzy
+#~ msgid "File to store the bundles into"
+#~ msgstr "Beschreibung des Patchpaketes editieren"
+
+#, fuzzy
+#~ msgid "Display with template"
+#~ msgstr "Alle Übereinstimmungen anzeigen"
+
+#, fuzzy
+#~ msgid "Specify ssh command to use"
+#~ msgstr "Befehl an die Shell übergeben"
+
+#, fuzzy
+#~ msgid "Show revisions matching date spec"
+#~ msgstr "Nur zutreffenden Teil anzeigen"
+
+#, fuzzy
+#~ msgid "Revision to display"
+#~ msgstr "Grafikanzeige auswählen"
+
+#, fuzzy
+#~ msgid "Specify merge tool"
+#~ msgstr "Kernel-Version angeben"
+
+#, fuzzy
+#~ msgid "Show parents of the specified revision"
+#~ msgstr "Dateisysteme des angegebenen Typs anzeigen"
+
+#, fuzzy
+#~ msgid "Tipmost revision matching date"
+#~ msgstr "Dem Muster entsprechende Einträge übergehen"
+
+#, fuzzy
+#~ msgid "Revert to the specified revision"
+#~ msgstr "Fenster auf der angegebenen Anzeige erstellen"
+
+#, fuzzy
+#~ msgid "For remote clients"
+#~ msgstr "Funktionen auflisten oder entfernen"
+
+#, fuzzy
+#~ msgid "SSL certificate file"
+#~ msgstr "Zertifikatsregeln festlegen"
+
+#, fuzzy
+#~ msgid "Untrusted configuration options"
+#~ msgstr "Konfigurationsoptionen festlegen"
 
 #~ msgid ""
 #~ "Current function definitions are:\n"
@@ -8983,9 +9264,6 @@ msgstr ""
 
 #~ msgid "Could not create child process - exiting"
 #~ msgstr "Konnte Kindprozess nicht starten - Abbruch"
-
-#~ msgid "Failed to execute process '%ls'"
-#~ msgstr "Konnte Prozess '%ls' nicht ausführen"
 
 #~ msgid "Could not send process %d from group %d to group %d"
 #~ msgstr "Konnte Prozess %d nicht von Gruppe %d an Gruppe %d senden"
@@ -9116,9 +9394,6 @@ msgstr ""
 
 #~ msgid "Prefix to strip on patch"
 #~ msgstr "Präfix zum Entfernen des Patch"
-
-#~ msgid "Use purge instead of remove"
-#~ msgstr "purge anstelle von remove verwenden"
 
 #~ msgid "Do not run update"
 #~ msgstr "Aktualisierung nicht durchführen"
@@ -9371,9 +9646,6 @@ msgstr ""
 #~ msgid "Overwrite"
 #~ msgstr "Überschreiben"
 
-#~ msgid "Do not overwrite"
-#~ msgstr "Nicht überschreiben"
-
 #~ msgid "Reduce memory usage"
 #~ msgstr "Speicherbedarf reduzieren"
 
@@ -9382,9 +9654,6 @@ msgstr ""
 
 #~ msgid "Print license"
 #~ msgstr "Lizenz ausgeben"
-
-#~ msgid "Compress to stdout"
-#~ msgstr "Auf Standardausgabe komprimieren"
 
 #~ msgid "Compress file"
 #~ msgstr "Datei komprimieren"
@@ -9503,9 +9772,6 @@ msgstr ""
 #~ msgid "Option list is not complete"
 #~ msgstr "Optionsliste ist nicht vollständig"
 
-#~ msgid "Remove completion"
-#~ msgstr "Vervollständigung entfernen"
-
 #~ msgid "Cache test results in file config.cache"
 #~ msgstr "Testergebnisse in Datei config.cache zwischenspeichern"
 
@@ -9564,9 +9830,6 @@ msgstr ""
 
 #~ msgid "Bring work tree in sync with repository"
 #~ msgstr "Arbeitsbaum mit Paketdepot synchronisieren"
-
-#~ msgid "Set watches"
-#~ msgstr "Dateibeobachtungen festlegen"
 
 #~ msgid "See who is watching a file"
 #~ msgstr "Anzeigen, wer eine Datei beobachtet"
@@ -9692,9 +9955,6 @@ msgstr ""
 #~ "Nicht nach Dateien und Verzeichnissen suchen, die hinzugefügt werden "
 #~ "sollen und diese nicht automatisch hinzufügen "
 
-#~ msgid "Summarize changes"
-#~ msgstr "Änderungen zusammenfassen"
-
 #~ msgid "Suppress informational output"
 #~ msgstr "Informationelle Ausgabe unterdrücken"
 
@@ -9739,9 +9999,6 @@ msgstr ""
 
 #~ msgid "Forward unsigned messages without extra header"
 #~ msgstr "Unsignierte Nachrichten ohne zusätzliche Kopfzeile weiterleiten"
-
-#~ msgid "Check the entire repository"
-#~ msgstr "Das ganze Paketdepot prüfen"
 
 #~ msgid "Check patches since latest checkpoint"
 #~ msgstr "Patches seit letztem Prüfpunkt prüfen"
@@ -9908,9 +10165,6 @@ msgstr ""
 
 #~ msgid "Erase function"
 #~ msgstr "Funktion löschen"
-
-#~ msgid "Show hidden functions"
-#~ msgstr "Versteckte Funktionen anzeigen"
 
 #~ msgid "Language"
 #~ msgstr "Sprache"
@@ -10119,9 +10373,6 @@ msgstr ""
 
 #~ msgid "List all keys with their fingerprints"
 #~ msgstr "Alle Schlüssel mit ihren Fingerabdrücken ausgeben"
-
-#~ msgid "Generate a new key pair"
-#~ msgstr "Ein neues Schlüsselpaar erstellen"
 
 #~ msgid "Present a menu which enables you to do all key related tasks"
 #~ msgstr ""
@@ -10670,9 +10921,6 @@ msgstr ""
 #~ msgid "No annotated source"
 #~ msgstr "Keine kommentierte Quelle"
 
-#~ msgid "Print flat profile"
-#~ msgstr "Flaches Profil ausgeben"
-
 #~ msgid "No flat profile"
 #~ msgstr "Kein flaches Profil"
 
@@ -10747,9 +10995,6 @@ msgstr ""
 
 #~ msgid "Save/restore filename"
 #~ msgstr "Dateiname (zurück)sichern"
-
-#~ msgid "Recurse directories"
-#~ msgstr "Verzeichnisse rekursiv durchlaufen"
 
 #~ msgid "Display compression ratios"
 #~ msgstr "Kompressionsrate anzeigen"
@@ -10832,9 +11077,6 @@ msgstr ""
 #~ msgid "Display status column"
 #~ msgstr "Statusspalte anzeigen"
 
-#~ msgid "Specify key bindings file"
-#~ msgstr "Datei mit Tastaturbindungen angeben"
-
 #~ msgid "Verbose prompt"
 #~ msgstr "Ausführlicher Prompt"
 
@@ -10870,9 +11112,6 @@ msgstr ""
 
 #~ msgid "Multiple blank lines sqeezed"
 #~ msgstr "Mehrere Leerzeilen zusammengefasst"
-
-#~ msgid "Do not fold long lines"
-#~ msgstr "Lange Zeilen nicht umbrechen"
 
 #~ msgid "Edit tag"
 #~ msgstr "Kennzeichnung bearbeiten"
@@ -11012,9 +11251,6 @@ msgstr ""
 #~ msgid "Pager"
 #~ msgstr "Anzeigeprogramm"
 
-#~ msgid "Manual sections"
-#~ msgstr "Handbuch-Sektionen"
-
 #~ msgid "Always reformat"
 #~ msgstr "immer neuformatieren"
 
@@ -11115,9 +11351,6 @@ msgstr ""
 #~ msgid "Do not write mtab"
 #~ msgstr "keine mtab schreiben"
 
-#~ msgid "Read/Write mode"
-#~ msgstr "Lese-/Schreib-Modus"
-
 #~ msgid "Dynamically change postprocessing"
 #~ msgstr "Nachverarbeitung dynamisch ändern"
 
@@ -11159,9 +11392,6 @@ msgstr ""
 
 #~ msgid "Override framerate"
 #~ msgstr "Frame-Rate überschreiben"
-
-#~ msgid "Build index if unavailable"
-#~ msgstr "Index erstellen, wenn nicht vorhanden"
 
 #~ msgid "Load index from file"
 #~ msgstr "Index aus Datei laden"
@@ -11318,9 +11548,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Normale Routing-Tabellen umgehen und direkt zu einem Rechner an einer "
 #~ "angeschlossenen Schnittstelle senden"
-
-#~ msgid "Specifies the number of data bytes to be sent"
-#~ msgstr "Gibt die Anzahl zu sendender Bytes an"
 
 #~ msgid "Set socket buffer size"
 #~ msgstr "Socketpuffergröße festlegen"
@@ -11497,9 +11724,6 @@ msgstr ""
 
 #~ msgid "Explain what is done"
 #~ msgstr "Erläutere was geschieht"
-
-#~ msgid "List of rpm configuration files"
-#~ msgstr "Liste der rpm-Konfigurationsdateien"
 
 #~ msgid "Pipe output through specified command"
 #~ msgstr "Ausgabe durch angegebenen Befehl schicken"
@@ -11971,9 +12195,6 @@ msgstr ""
 
 #~ msgid "Print kernel release"
 #~ msgstr "Kernel-Release ausgeben"
-
-#~ msgid "Print kernel version"
-#~ msgstr "Kernel-Version ausgeben"
 
 #~ msgid "Print machine name"
 #~ msgstr "Maschinenname ausgeben"
@@ -12468,9 +12689,6 @@ msgstr ""
 
 #~ msgid "Move into zipfile (delete files)"
 #~ msgstr "In Zip-Datei verschieben (Dateien löschen)"
-
-#~ msgid "Do not store directory names"
-#~ msgstr "Verzeichnisnamen nicht speichern"
 
 #~ msgid "Do not compress at all"
 #~ msgstr "Nicht komprimieren"

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-25 15:37+0800\n"
+"POT-Creation-Date: 2015-04-13 22:15+0800\n"
 "PO-Revision-Date: 2014-11-15 09:00+0800\n"
 "Last-Translator: David Adam <zanchey@ucc.gu.uwa.edu.au>\n"
 "Language-Team: English <fish-users@lists.sf.net>\n"
@@ -179,7 +179,7 @@ msgstr "%ls: Argument “%ls” must be an integer\n"
 msgid "%ls: --array option requires a single variable name.\n"
 msgstr "%ls: --array option requires a single variable name.\n"
 
-#: builtin.cpp:3065 fish.cpp:519 parser.cpp:765
+#: builtin.cpp:3065 fish.cpp:620 parser.cpp:764
 msgid "Standard input"
 msgstr "Standard input"
 
@@ -533,7 +533,7 @@ msgstr "CPU\t"
 msgid "State\tCommand\n"
 msgstr "State\tCommand\n"
 
-#: builtin_jobs.cpp:99 proc.cpp:847
+#: builtin_jobs.cpp:99 proc.cpp:843
 msgid "stopped"
 msgstr "stopped"
 
@@ -579,31 +579,31 @@ msgstr "%ls: value not completely converted"
 msgid "missing hexadecimal number in escape"
 msgstr "missing hexadecimal number in escape"
 
-#: builtin_printf.cpp:387
+#: builtin_printf.cpp:388
 msgid "Missing hexadecimal number in Unicode escape"
 msgstr "Missing hexadecimal number in Unicode escape"
 
-#: builtin_printf.cpp:401
+#: builtin_printf.cpp:402
 #, c-format
 msgid "Unicode character out of range: \\%c%0*x"
 msgstr "Unicode character out of range: \\%c%0*x"
 
-#: builtin_printf.cpp:669
+#: builtin_printf.cpp:670
 #, c-format
 msgid "invalid field width: %ls"
 msgstr "invalid field width: %ls"
 
-#: builtin_printf.cpp:707
+#: builtin_printf.cpp:708
 #, c-format
 msgid "invalid precision: %ls"
 msgstr "invalid precision: %ls"
 
-#: builtin_printf.cpp:738
+#: builtin_printf.cpp:739
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: invalid conversion specification"
 
-#: builtin_printf.cpp:770
+#: builtin_printf.cpp:771
 msgid "printf: not enough arguments"
 msgstr "printf: not enough arguments"
 
@@ -650,17 +650,17 @@ msgid ""
 msgstr ""
 "%ls: Warning: universal scope selected, but a global variable “%ls” exists.\n"
 
-#: builtin_set_color.cpp:142 builtin_set_color.cpp:164
+#: builtin_set_color.cpp:144 builtin_set_color.cpp:166
 #, c-format
 msgid "%ls: Unknown color '%ls'\n"
 msgstr "%ls: Unknown color “%ls”\n"
 
-#: builtin_set_color.cpp:151
+#: builtin_set_color.cpp:153
 #, c-format
 msgid "%ls: Expected an argument\n"
 msgstr "%ls: Expected an argument\n"
 
-#: builtin_set_color.cpp:171
+#: builtin_set_color.cpp:173
 #, c-format
 msgid "%ls: Could not set up terminal\n"
 msgstr "%ls: Could not set up terminal\n"
@@ -691,15 +691,15 @@ msgstr "Unknown option: "
 msgid "Multiple matches for option: "
 msgstr "Multiple matches for option: "
 
-#: env.cpp:313
+#: env.cpp:315
 msgid "Changing language to English"
 msgstr "Changing language to English"
 
-#: env.cpp:1182
+#: env.cpp:1180
 msgid "Tried to pop empty environment stack."
 msgstr "Tried to pop empty environment stack."
 
-#: env_universal_common.cpp:610 path.cpp:279
+#: env_universal_common.cpp:617 path.cpp:279
 msgid ""
 "Unable to create a configuration directory for fish. Your personal settings "
 "will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
@@ -709,47 +709,47 @@ msgstr ""
 "will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
 "where the current user has write access."
 
-#: event.cpp:168
+#: event.cpp:178
 #, c-format
 msgid "signal handler for %ls (%ls)"
 msgstr "signal handler for %ls (%ls)"
 
-#: event.cpp:172
+#: event.cpp:182
 #, c-format
 msgid "handler for variable '%ls'"
 msgstr "handler for variable “%ls”"
 
-#: event.cpp:178
+#: event.cpp:188
 #, c-format
 msgid "exit handler for process %d"
 msgstr "exit handler for process %d"
 
-#: event.cpp:184 event.cpp:195
+#: event.cpp:194 event.cpp:205
 #, c-format
 msgid "exit handler for job %d, '%ls'"
 msgstr "exit handler for job %d, “%ls”"
 
-#: event.cpp:186
+#: event.cpp:196
 #, c-format
 msgid "exit handler for job with process group %d"
 msgstr "exit handler for job with process group %d"
 
-#: event.cpp:197
+#: event.cpp:207
 #, c-format
 msgid "exit handler for job with job id %d"
 msgstr "exit handler for job with job id %d"
 
-#: event.cpp:203
+#: event.cpp:213
 #, c-format
 msgid "handler for generic event '%ls'"
 msgstr "handler for generic event “%ls”"
 
-#: event.cpp:207
+#: event.cpp:217
 #, c-format
 msgid "Unknown event type '0x%x'"
 msgstr "Unknown event type '0x%x'"
 
-#: event.cpp:621
+#: event.cpp:613
 msgid "Signal list overflow. Signals have been ignored."
 msgstr "Signal list overflow. Signals have been ignored."
 
@@ -767,12 +767,12 @@ msgstr "An error occurred while writing output"
 msgid "An error occurred while redirecting file '%s'"
 msgstr "An error occurred while redirecting file “%s”"
 
-#: exec.cpp:867
+#: exec.cpp:795
 #, c-format
 msgid "Unknown function '%ls'"
 msgstr "Unknown function “%ls”"
 
-#: exec.cpp:1011
+#: exec.cpp:943
 #, c-format
 msgid "Unknown input redirection type %d"
 msgstr "Unknown input redirection type %d"
@@ -806,49 +806,56 @@ msgstr "Last background job"
 msgid "Mismatched brackets"
 msgstr "Mismatched brackets"
 
-#: fish.cpp:321
+#: fish.cpp:330
+msgid ""
+"Old versions of fish appear to be running. You will not be able to share "
+"variable values between old and new fish sessions. For best results, restart "
+"all running instances of fish."
+msgstr ""
+
+#: fish.cpp:420
 #, c-format
 msgid "Invalid value '%s' for debug level switch"
 msgstr "Invalid value “%s” for debug level switch"
 
-#: fish.cpp:362 mimedb.cpp:1343
+#: fish.cpp:461 mimedb.cpp:1343
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, version %s\n"
 
-#: fish.cpp:417
+#: fish.cpp:516
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "Can not use the no-execute mode when running an interactive session"
 
-#: fish.cpp:518
+#: fish.cpp:619
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Error while reading file %ls\n"
 
-#: fish_indent.cpp:346
+#: fish_indent.cpp:332
 #, c-format
 msgid "%ls, version %s\n"
 msgstr "%ls, version %s\n"
 
-#: input.cpp:481 input.cpp:491
+#: input.cpp:483 input.cpp:493
 msgid "Could not set up terminal"
 msgstr "Could not set up terminal"
 
-#: input.cpp:484
+#: input.cpp:486
 #, c-format
 msgid "Check that your terminal type, '%ls', is supported on this system"
 msgstr "Check that your terminal type, “%ls”, is supported on this system"
 
-#: input.cpp:486
+#: input.cpp:488
 #, c-format
 msgid "Attempting to use '%ls' instead"
 msgstr "Attempting to use “%ls” instead"
 
-#: input.cpp:533
+#: input.cpp:535
 msgid "Error while closing terminfo"
 msgstr "Error while closing terminfo"
 
-#: io.cpp:110
+#: io.cpp:112
 #, c-format
 msgid ""
 "An error occured while reading output from code block on file descriptor %d"
@@ -909,7 +916,7 @@ msgstr "%s: Could not parse mimetype from argument “%s”\n"
 msgid "Unknown"
 msgstr "Unknown"
 
-#: output.cpp:606
+#: output.cpp:608
 #, c-format
 msgid ""
 "Tried to use terminfo string %s on line %ld of %s, which is undefined in "
@@ -1019,150 +1026,150 @@ msgstr "The “%ls” command can not be used immediately after a backgrounded j
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr "Backgrounded commands can not be used as conditionals"
 
-#: parser.cpp:53
+#: parser.cpp:52
 #, c-format
 msgid "Tokenizer error: '%ls'"
 msgstr "Tokenizer error: “%ls”"
 
-#: parser.cpp:58
+#: parser.cpp:57
 #, c-format
 msgid "Tried to evaluate commands using invalid block type '%ls'"
 msgstr "Tried to evaluate commands using invalid block type “%ls”"
 
-#: parser.cpp:63
+#: parser.cpp:62
 #, c-format
 msgid "Unexpected token of type '%ls'"
 msgstr "Unexpected token of type “%ls”"
 
-#: parser.cpp:68 parse_constants.h:253
+#: parser.cpp:67 parse_constants.h:255
 msgid "'while' block"
 msgstr "“while” block"
 
-#: parser.cpp:73 parse_constants.h:258
+#: parser.cpp:72 parse_constants.h:260
 msgid "'for' block"
 msgstr "“for” block"
 
-#: parser.cpp:78 parse_constants.h:263
+#: parser.cpp:77 parse_constants.h:265
 msgid "Block created by breakpoint"
 msgstr "Block created by breakpoint"
 
-#: parser.cpp:83 parse_constants.h:270
+#: parser.cpp:82 parse_constants.h:272
 msgid "'if' conditional block"
 msgstr "“if” conditional block"
 
-#: parser.cpp:88 parse_constants.h:276
+#: parser.cpp:87 parse_constants.h:278
 msgid "function definition block"
 msgstr "function definition block"
 
-#: parser.cpp:93 parse_constants.h:282
+#: parser.cpp:92 parse_constants.h:284
 msgid "function invocation block"
 msgstr "function invocation block"
 
-#: parser.cpp:98 parse_constants.h:287
+#: parser.cpp:97 parse_constants.h:289
 msgid "function invocation block with no variable shadowing"
 msgstr "function invocation block with no variable shadowing"
 
-#: parser.cpp:103 parse_constants.h:293
+#: parser.cpp:102 parse_constants.h:295
 msgid "'switch' block"
 msgstr "“switch” block"
 
-#: parser.cpp:108 parse_constants.h:299
+#: parser.cpp:107 parse_constants.h:301
 msgid "unexecutable block"
 msgstr "unexecutable block"
 
-#: parser.cpp:113 parse_constants.h:305
+#: parser.cpp:112 parse_constants.h:307
 msgid "global root block"
 msgstr "global root block"
 
-#: parser.cpp:118 parse_constants.h:311
+#: parser.cpp:117 parse_constants.h:313
 msgid "command substitution block"
 msgstr "command substitution block"
 
-#: parser.cpp:123 parse_constants.h:317
+#: parser.cpp:122 parse_constants.h:319
 msgid "'begin' unconditional block"
 msgstr "“begin” unconditional block"
 
-#: parser.cpp:128 parse_constants.h:323
+#: parser.cpp:127 parse_constants.h:325
 msgid "Block created by the . builtin"
 msgstr "Block created by the . builtin"
 
-#: parser.cpp:133 parse_constants.h:328
+#: parser.cpp:132 parse_constants.h:330
 msgid "event handler block"
 msgstr "event handler block"
 
-#: parser.cpp:138 parse_constants.h:334
+#: parser.cpp:137 parse_constants.h:336
 msgid "unknown/invalid block"
 msgstr "unknown/invalid block"
 
-#: parser.cpp:475
+#: parser.cpp:474
 #, c-format
 msgid "Could not write profiling information to file '%s'"
 msgstr "Could not write profiling information to file “%s”"
 
-#: parser.cpp:481
+#: parser.cpp:480
 msgid "Time\tSum\tCommand\n"
 msgstr "Time\tSum\tCommand\n"
 
-#: parser.cpp:563
+#: parser.cpp:562
 #, c-format
 msgid "in event handler: %ls\n"
 msgstr "in event handler: %ls\n"
 
-#: parser.cpp:591
+#: parser.cpp:590
 #, c-format
 msgid "from sourcing file %ls\n"
 msgstr "from sourcing file %ls\n"
 
-#: parser.cpp:598
+#: parser.cpp:597
 #, c-format
 msgid "in function '%ls'\n"
 msgstr "in function “%ls”\n"
 
-#: parser.cpp:603
+#: parser.cpp:602
 msgid "in command substitution\n"
 msgstr "in command substitution\n"
 
-#: parser.cpp:616
+#: parser.cpp:615
 #, c-format
 msgid "\tcalled on line %d of file %ls\n"
 msgstr "\tcalled on line %d of file %ls\n"
 
-#: parser.cpp:622
+#: parser.cpp:621
 msgid "\tcalled during startup\n"
 msgstr "\tcalled during startup\n"
 
-#: parser.cpp:626
+#: parser.cpp:625
 msgid "\tcalled on standard input\n"
 msgstr "\tcalled on standard input\n"
 
-#: parser.cpp:643
+#: parser.cpp:642
 #, c-format
 msgid "\twith parameter list '%ls'\n"
 msgstr "\twith parameter list “%ls”\n"
 
-#: parser.cpp:757
+#: parser.cpp:756
 #, c-format
 msgid "%ls (line %d): "
 msgstr "%ls (line %d): "
 
-#: parser.cpp:761
+#: parser.cpp:760
 msgid "Startup"
 msgstr "Startup"
 
-#: parser.cpp:804
+#: parser.cpp:803
 msgid "Job inconsistency"
 msgstr "Job inconsistency"
 
-#: parser.cpp:960
+#: parser.cpp:956
 msgid "End of block mismatch. Program terminating."
 msgstr "End of block mismatch. Program terminating."
 
-#: parser.cpp:1051
+#: parser.cpp:1047
 #, c-format
 msgid "%ls (line %lu): "
 msgstr "%ls (line %lu): "
 
-#: parser.cpp:1055
+#: parser.cpp:1051
 #, c-format
 msgid "%ls: "
 msgstr "%ls: "
@@ -1172,102 +1179,102 @@ msgstr "%ls: "
 msgid "Error while searching for command '%ls'"
 msgstr "Error while searching for command “%ls”"
 
-#: proc.cpp:694
+#: proc.cpp:690
 #, c-format
 msgid "'%ls' has %ls"
 msgstr "“%ls” has %ls"
 
-#: proc.cpp:698
+#: proc.cpp:694
 #, c-format
 msgid "Job %d, '%ls' has %ls"
 msgstr "Job %d, “%ls” has %ls"
 
-#: proc.cpp:790
+#: proc.cpp:786
 #, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: %ls“%ls” terminated by signal %ls (%ls)"
 
-#: proc.cpp:801
+#: proc.cpp:797
 #, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Process %d, “%ls” %ls“%ls” terminated by signal %ls (%ls)"
 
-#: proc.cpp:832
+#: proc.cpp:828
 msgid "ended"
 msgstr "ended"
 
-#: proc.cpp:1066
+#: proc.cpp:1065
 msgid "An error occured while reading output from code block"
 msgstr "An error occured while reading output from code block"
 
-#: proc.cpp:1095 proc.cpp:1107
+#: proc.cpp:1094 proc.cpp:1106
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Could not send job %d (“%ls”) to foreground"
 
-#: proc.cpp:1127 proc.cpp:1137 proc.cpp:1152
+#: proc.cpp:1126 proc.cpp:1136 proc.cpp:1151
 msgid "Could not return shell to foreground"
 msgstr "Could not return shell to foreground"
 
-#: proc.cpp:1380 proc.cpp:1406
+#: proc.cpp:1354 proc.cpp:1380
 msgid "Process list pointer"
 msgstr "Process list pointer"
 
-#: proc.cpp:1391
+#: proc.cpp:1365
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "More than one job in foreground: job 1: “%ls” job 2: “%ls”"
 
-#: proc.cpp:1404
+#: proc.cpp:1378
 msgid "Process argument list"
 msgstr "Process argument list"
 
-#: proc.cpp:1405
+#: proc.cpp:1379
 msgid "Process name"
 msgstr "Process name"
 
-#: proc.cpp:1411
+#: proc.cpp:1385
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Job “%ls”, process “%ls” has inconsistent state “stopped”=%d"
 
-#: proc.cpp:1421
+#: proc.cpp:1395
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr "Job “%ls”, process “%ls” has inconsistent state “completed”=%d"
 
-#: reader.cpp:476
+#: reader.cpp:478
 msgid "Could not set terminal mode for new job"
 msgstr "Could not set terminal mode for new job"
 
-#: reader.cpp:523
+#: reader.cpp:525
 msgid "Could not set terminal mode for shell"
 msgstr "Could not set terminal mode for shell"
 
-#: reader.cpp:2054
+#: reader.cpp:2059
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "No TTY for interactive shell (tcgetpgrp failed)"
 
-#: reader.cpp:2069
+#: reader.cpp:2074
 #, c-format
 msgid ""
 "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr ""
 "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 
-#: reader.cpp:2100
+#: reader.cpp:2105
 msgid "Couldn't put the shell in its own process group"
 msgstr "Couldn't put the shell in its own process group"
 
-#: reader.cpp:2110
+#: reader.cpp:2115
 msgid "Couldn't grab control of terminal"
 msgstr "Couldn't grab control of terminal"
 
-#: reader.cpp:2611
+#: reader.cpp:2616
 msgid "Pop null reader block"
 msgstr "Pop null reader block"
 
-#: reader.cpp:2877
+#: reader.cpp:2882
 msgid ""
 "There are stopped jobs. A second attempt to exit will enforce their "
 "termination.\n"
@@ -1275,20 +1282,20 @@ msgstr ""
 "There are stopped jobs. A second attempt to exit will enforce their "
 "termination.\n"
 
-#: reader.cpp:4090
+#: reader.cpp:4115
 #, c-format
 msgid "Unknown keybinding %d"
 msgstr "Unknown keybinding %d"
 
-#: reader.cpp:4201
+#: reader.cpp:4226
 msgid "Error while reading from file descriptor"
 msgstr "Error while reading from file descriptor"
 
-#: reader.cpp:4218
+#: reader.cpp:4243
 msgid "Error while closing input stream"
 msgstr "Error while closing input stream"
 
-#: reader.cpp:4245
+#: reader.cpp:4270
 msgid "Error while opening input stream"
 msgstr "Error while opening input stream"
 
@@ -1518,7 +1525,7 @@ msgstr "Run job in background"
 msgid "Comment"
 msgstr "Comment"
 
-#: tokenizer.cpp:560
+#: tokenizer.cpp:561
 msgid "Invalid token type"
 msgstr "Invalid token type"
 
@@ -1707,7 +1714,7 @@ msgstr "An error occurred while setting up pipe"
 msgid "Array index out of bounds"
 msgstr "Array index out of bounds"
 
-#: parse_constants.h:183
+#: parse_constants.h:185
 #, c-format
 msgid ""
 "The function '%ls' calls itself immediately, which would result in an "
@@ -1716,7 +1723,7 @@ msgstr ""
 "The function “%ls” calls itself immediately, which would result in an "
 "infinite loop."
 
-#: parse_constants.h:187
+#: parse_constants.h:189
 msgid ""
 "The function call stack limit has been exceeded. Do you have an accidental "
 "infinite loop?"
@@ -1724,7 +1731,7 @@ msgstr ""
 "The function call stack limit has been exceeded. Do you have an accidental "
 "infinite loop?"
 
-#: parse_constants.h:190
+#: parse_constants.h:192
 msgid ""
 "Expected a command, but instead found a pipe. Did you mean 'COMMAND; or "
 "COMMAND'? See the help section for the 'or' builtin command by typing 'help "
@@ -1734,7 +1741,7 @@ msgstr ""
 "COMMAND”? See the help section for the “or” builtin command by typing “help "
 "or”."
 
-#: parse_constants.h:193
+#: parse_constants.h:195
 msgid ""
 "Expected a command, but instead found an '&'. Did you mean 'COMMAND; and "
 "COMMAND'? See the help section for the 'and' builtin command by typing 'help "
@@ -1744,49 +1751,49 @@ msgstr ""
 "COMMAND”? See the help section for the “and” builtin command by typing “help "
 "and”."
 
-#: parse_constants.h:196
+#: parse_constants.h:198
 #, c-format
 msgid "Illegal command name '%ls'"
 msgstr "Illegal command name “%ls”"
 
-#: parse_constants.h:199
+#: parse_constants.h:201
 #, c-format
 msgid "Unknown builtin '%ls'"
 msgstr "Unknown builtin “%ls”"
 
-#: parse_constants.h:202
+#: parse_constants.h:204
 #, c-format
 msgid "Unable to expand variable name '%ls'"
 msgstr "Unable to expand variable name “%ls”"
 
-#: parse_constants.h:205
+#: parse_constants.h:207
 #, c-format
 msgid "Unable to find a process '%ls'"
 msgstr "Unable to find a process “%ls”"
 
-#: parse_constants.h:208
+#: parse_constants.h:210
 #, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr "Illegal file descriptor in redirection “%ls”"
 
-#: parse_constants.h:211
+#: parse_constants.h:213
 #, c-format
 msgid "No matches for wildcard '%ls'."
 msgstr "No matches for wildcard “%ls”."
 
-#: parse_constants.h:214
+#: parse_constants.h:216
 msgid "break command while not inside of loop"
 msgstr "break command while not inside of loop"
 
-#: parse_constants.h:217
+#: parse_constants.h:219
 msgid "continue command while not inside of loop"
 msgstr "continue command while not inside of loop"
 
-#: parse_constants.h:220
+#: parse_constants.h:222
 msgid "'return' builtin command outside of function definition"
 msgstr "“return” builtin command outside of function definition"
 
-#: parse_constants.h:223
+#: parse_constants.h:225
 #, c-format
 msgid ""
 "Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
@@ -1795,7 +1802,7 @@ msgstr ""
 "Unknown command “%ls”. Did you mean “set %ls %ls”? See the help section on "
 "the set command by typing 'help set'."
 
-#: parse_constants.h:228
+#: parse_constants.h:230
 #, c-format
 msgid ""
 "The '$' character begins a variable name. The character '%lc', which "
@@ -1808,7 +1815,7 @@ msgstr ""
 "variable names may not be zero characters long. To learn more about variable "
 "expansion in fish, type “help expand-variable”."
 
-#: parse_constants.h:233
+#: parse_constants.h:235
 msgid ""
 "$? is not a valid variable in fish. If you want the exit status of the last "
 "command, try $status."
@@ -1816,7 +1823,7 @@ msgstr ""
 "$? is not a valid variable in fish. If you want the exit status of the last "
 "command, try $status."
 
-#: parse_constants.h:238
+#: parse_constants.h:240
 msgid ""
 "The '$' begins a variable name. It was given at the end of an argument. "
 "Variable names may not be zero characters long. To learn more about variable "
@@ -1826,7 +1833,7 @@ msgstr ""
 "Variable names may not be zero characters long. To learn more about variable "
 "expansion in fish, type “help expand-variable”."
 
-#: parse_constants.h:243
+#: parse_constants.h:245
 #, c-format
 msgid ""
 "Did you mean %ls{$%ls}%ls? The '$' character begins a variable name. A "
@@ -1839,7 +1846,7 @@ msgstr ""
 "variable name, and variable names may not be zero characters long. To learn "
 "more about variable expansion in fish, type “help expand-variable”."
 
-#: parse_constants.h:248
+#: parse_constants.h:250
 msgid ""
 "Did you mean (COMMAND)? In fish, the '$' character is only used for "
 "accessing variables. To learn more about command substitution in fish, type "
@@ -3979,13 +3986,13 @@ msgid ""
 msgstr ""
 "Prints completions for installed packages on the system from /var/db/pkg"
 
-#: share/completions/emerge.fish:12 share/completions/equery.fish:12
+#: share/completions/emerge.fish:13 share/completions/equery.fish:12
 msgid ""
 "Prints completions for all available packages on the system from /usr/portage"
 msgstr ""
 "Prints completions for all available packages on the system from /usr/portage"
 
-#: share/completions/emerge.fish:19
+#: share/completions/emerge.fish:22
 msgid ""
 "Tests if emerge command should have an installed package as potential "
 "completion"
@@ -3993,54 +4000,13 @@ msgstr ""
 "Tests if emerge command should have an installed package as potential "
 "completion"
 
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-msgid "All base system packages"
-msgstr "All base system packages"
-
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-msgid "All packages in world"
-msgstr "All packages in world"
-
-#: share/completions/emerge.fish:30
-msgid "Installed package"
-msgstr "Installed package"
-
-#: share/completions/emerge.fish:31
-#: share/functions/__fish_print_packages.fish:13
-msgid "Package"
-msgstr "Package"
-
-#: share/completions/emerge.fish:35
-msgid "Usage overview of emerge"
-msgstr "Usage overview of emerge"
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject system"
-msgstr "Help on subject system"
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject config"
-msgstr "Help on subject config"
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject sync"
-msgstr "Help on subject sync"
-
-#: share/completions/emerge.fish:57
-msgid "Use colors in output"
-msgstr "Use colors in output"
-
-#: share/completions/emerge.fish:57
-msgid "Don't use colors in output"
-msgstr "Don't use colors in output"
-
-#: share/completions/emerge.fish:81
-msgid "Pull in build time dependencies"
-msgstr "Pull in build time dependencies"
-
-#: share/completions/emerge.fish:81
-msgid "Don't pull in build time dependencies"
-msgstr "Don't pull in build time dependencies"
+#: share/completions/emerge.fish:32
+#, fuzzy
+msgid ""
+"Print completions for all packages including the version compare if that is "
+"already typed"
+msgstr ""
+"Prints completions for installed packages on the system from /var/db/pkg"
 
 #: share/completions/env.fish:2
 msgid "Redefine variable"
@@ -4798,6 +4764,11 @@ msgstr "Start interface"
 #: share/completions/ifup.fish:1
 msgid "Network interface"
 msgstr "Network interface"
+
+#: share/completions/kitchen.fish:3
+#, fuzzy
+msgid "Test if kitchen has yet to be given the main command"
+msgstr "Test if vagrant has yet to be given the main command"
 
 #: share/completions/less.fish:3
 msgid "Buffer space"
@@ -8042,6 +8013,11 @@ msgstr "Event handler, repaints prompt when any color changes"
 msgid "Event handler, repaints prompt when any char changes"
 msgstr "Event handler, repaints prompt when any char changes"
 
+#: share/functions/__fish_hg_prompt.fish:23
+#, fuzzy
+msgid "Write out the hg prompt"
+msgstr "Write out the git prompt"
+
 #: share/functions/__fish_is_token_n.fish:1
 msgid "Test if current token is on Nth place"
 msgstr "Test if current token is on Nth place"
@@ -8098,6 +8074,10 @@ msgstr "Print available lsblk columns"
 msgid "Print mounted devices"
 msgstr "Print mounted devices"
 
+#: share/functions/__fish_print_packages.fish:13
+msgid "Package"
+msgstr "Package"
+
 #: share/functions/__fish_print_svn_rev.fish:1
 msgid "Print svn revisions"
 msgstr "Print svn revisions"
@@ -8146,31 +8126,31 @@ msgstr "Write out the git prompt"
 msgid "Manage abbreviations"
 msgstr "Manage abbreviations"
 
-#: share/functions/abbr.fish:36
+#: share/functions/abbr.fish:40
 msgid "%s: invalid option -- %s\\n"
 msgstr "%s: invalid option -- %s\\n"
 
-#: share/functions/abbr.fish:43
+#: share/functions/abbr.fish:47
 msgid "%s: %s cannot be specified along with %s\\n"
 msgstr "%s: %s cannot be specified along with %s\\n"
 
-#: share/functions/abbr.fish:52
+#: share/functions/abbr.fish:56
 msgid "%s: option requires an argument -- %s\\n"
 msgstr "%s: option requires an argument -- %s\\n"
 
-#: share/functions/abbr.fish:58
+#: share/functions/abbr.fish:62
 msgid "%s: Unexpected argument -- %s\\n"
 msgstr "%s: Unexpected argument -- %s\\n"
 
-#: share/functions/abbr.fish:71
+#: share/functions/abbr.fish:75
 msgid "%s: abbreviation must have a non-empty key\\n"
 msgstr "%s: abbreviation must have a non-empty key\\n"
 
-#: share/functions/abbr.fish:75
+#: share/functions/abbr.fish:79
 msgid "%s: abbreviation must have a value\\n"
 msgstr "%s: abbreviation must have a value\\n"
 
-#: share/functions/abbr.fish:97
+#: share/functions/abbr.fish:101
 msgid "%s: no such abbreviation '%s'\\n"
 msgstr "%s: no such abbreviation “%s”\\n"
 
@@ -8203,6 +8183,11 @@ msgstr "Print the current directory history (the back- and fwd- lists)"
 #: share/functions/dirs.fish:1
 msgid "Print directory stack"
 msgstr "Print directory stack"
+
+#: share/functions/export.fish:1
+#, fuzzy
+msgid "Set global variable. Alias for set -g, made for bash compatibility"
+msgstr "Set global variable. Alias for set -g, made for csh compatibility"
 
 #: share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
@@ -8269,7 +8254,7 @@ msgstr "%s: Expected function name\\n"
 msgid "%s: Could not create configuration directory\\n"
 msgstr "%s: Could not create configuration directory\\n"
 
-#: share/functions/funcsave.fish:37
+#: share/functions/funcsave.fish:36
 msgid "%s: Unknown function '%s'\\n"
 msgstr "%s: Unknown function “%s”\\n"
 
@@ -8460,6 +8445,39 @@ msgid ""
 msgstr ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
 "VARIABLE\\n"
+
+#~ msgid "All base system packages"
+#~ msgstr "All base system packages"
+
+#~ msgid "All packages in world"
+#~ msgstr "All packages in world"
+
+#~ msgid "Installed package"
+#~ msgstr "Installed package"
+
+#~ msgid "Usage overview of emerge"
+#~ msgstr "Usage overview of emerge"
+
+#~ msgid "Help on subject system"
+#~ msgstr "Help on subject system"
+
+#~ msgid "Help on subject config"
+#~ msgstr "Help on subject config"
+
+#~ msgid "Help on subject sync"
+#~ msgstr "Help on subject sync"
+
+#~ msgid "Use colors in output"
+#~ msgstr "Use colors in output"
+
+#~ msgid "Don't use colors in output"
+#~ msgstr "Don't use colors in output"
+
+#~ msgid "Pull in build time dependencies"
+#~ msgstr "Pull in build time dependencies"
+
+#~ msgid "Don't pull in build time dependencies"
+#~ msgstr "Don't pull in build time dependencies"
 
 #~ msgid "%ls: Expected zero or two parameters, got %d\n"
 #~ msgstr "%ls: Expected zero or two parameters, got %d\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.2.8POT-Creation-Date: 2006-07-10 13:44-0400\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-03-13 21:29+0800\n"
+"POT-Creation-Date: 2015-04-13 22:15+0800\n"
 "PO-Revision-Date: 2006-07-25 20:16-0400\n"
 "Last-Translator: Xavier Douville <fish-fr@douville.org>\n"
 "Language-Team: Français <traduc@traduc.org>\n"
@@ -24,113 +24,118 @@ msgstr ""
 msgid "Could not autoload item '%ls', it is already being autoloaded. "
 msgstr ""
 
-#: builtin.cpp:83
+#: builtin.cpp:84
 #, c-format
 msgid "Send job %d, '%ls' to foreground\n"
 msgstr "Mettre la tâche %d, '%ls' en premier plan\n"
 
-#: builtin.cpp:344
+#: builtin.cpp:352
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
 "\n"
 msgstr ""
 
-#: builtin.cpp:484
+#: builtin.cpp:531
 #, c-format
 msgid "%ls: No key with name '%ls' found\n"
 msgstr ""
 
-#: builtin.cpp:490
+#: builtin.cpp:537
 #, fuzzy, c-format
 msgid "%ls: Key with name '%ls' does not have any mapping\n"
 msgstr "%ls: La fonction '%ls' n'existe pas\n"
 
-#: builtin.cpp:496
+#: builtin.cpp:543
 #, fuzzy, c-format
 msgid "%ls: Unknown error trying to bind to key named '%ls'\n"
 msgstr "%ls: Option '%ls' inconnue\n"
 
-#: builtin.cpp:668
+#: builtin.cpp:794
 #, fuzzy, c-format
-msgid "%ls: Expected zero or two parameters, got %d\n"
-msgstr "%ls: Zéro ou un argument attendu, %d obtenu(s)\n"
+msgid "%ls: No binding found for key '%ls'\n"
+msgstr "%s: Aucune description pour le type %s\n"
 
-#: builtin.cpp:692
+#: builtin.cpp:798
+#, c-format
+msgid "%ls: No binding found for sequence '%ls'\n"
+msgstr ""
+
+#: builtin.cpp:834
 #, fuzzy, c-format
 msgid "%ls: Invalid state\n"
 msgstr "%ls: Option invalide -- %lc\n"
 
-#: builtin.cpp:796
+#: builtin.cpp:939
 #, c-format
 msgid "%ls: Can not specify scope when removing block\n"
 msgstr "%ls: Ne peut pas indiquer la portée en enlevant le bloc\n"
 
-#: builtin.cpp:802
+#: builtin.cpp:945
 #, c-format
 msgid "%ls: No blocks defined\n"
 msgstr "%ls: Aucun bloc défini\n"
 
-#: builtin.cpp:1312 builtin.h:32
+#: builtin.cpp:1556 builtin.h:32
 #, c-format
 msgid "%ls: Invalid combination of options\n"
 msgstr "%ls: Combinaison d'options invalide\n"
 
-#: builtin.cpp:1334
+#: builtin.cpp:1578
 #, c-format
 msgid "%ls: Expected exactly one function name\n"
 msgstr "%ls: Exactement un nom de fonction est attendu\n"
 
-#: builtin.cpp:1344 builtin.cpp:1406
+#: builtin.cpp:1588 builtin.cpp:1650
 #, c-format
 msgid "%ls: Function '%ls' does not exist\n"
 msgstr "%ls: La fonction '%ls' n'existe pas\n"
 
-#: builtin.cpp:1394
+#: builtin.cpp:1638
 #, fuzzy, c-format
 msgid ""
 "%ls: Expected exactly two names (current function name, and new function "
 "name)\n"
 msgstr "%ls: Exactement un nom de fonction est attendu\n"
 
-#: builtin.cpp:1417 builtin.cpp:1952 builtin.cpp:2259
+#: builtin.cpp:1661 builtin.cpp:2230
 #, c-format
 msgid "%ls: Illegal function name '%ls'\n"
 msgstr "%ls: Nom de fonction illégal '%ls'\n"
 
-#: builtin.cpp:1428
+#: builtin.cpp:1672
 #, fuzzy, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy '%ls'\n"
 msgstr "%ls: La fonction '%ls' n'existe pas\n"
 
-#: builtin.cpp:1809 builtin.cpp:2114
+#: builtin.cpp:2070
 #, c-format
 msgid "%ls: Unknown signal '%ls'\n"
 msgstr "%ls: Signal inconnu '%ls'\n"
 
-#: builtin.cpp:1824 builtin.cpp:1984 builtin.cpp:2129 builtin.cpp:2291
+#: builtin.cpp:2085 builtin.cpp:2195 builtin.cpp:2263
 #, c-format
 msgid "%ls: Invalid variable name '%ls'\n"
 msgstr "%ls: Nom de variable invalide '%ls'\n"
 
-#: builtin.cpp:1877 builtin.cpp:2182
+#: builtin.cpp:2138
 #, c-format
 msgid "%ls: Cannot find calling job for event handler\n"
 msgstr ""
 "%ls: Impossible de trouver la tâche parente pour le gestionnaire "
 "d'événements\n"
 
-#: builtin.cpp:1895 builtin.cpp:2200
+#: builtin.cpp:2156
 #, c-format
 msgid "%ls: Invalid process id %ls\n"
 msgstr "%ls: id de processus invalide %ls\n"
 
-#: builtin.cpp:1945 builtin.cpp:2252
+#: builtin.cpp:2223
 #, fuzzy, c-format
 msgid "%ls: Expected function name\n"
 msgstr "%ls: Exactement un nom de fonction est attendu\n"
 
-#: builtin.cpp:1962 builtin.cpp:2269
+#: builtin.cpp:2240
 #, c-format
 msgid ""
 "%ls: The name '%ls' is reserved,\n"
@@ -139,140 +144,148 @@ msgstr ""
 "%ls: Le nom '%ls' est réservé,\n"
 "et ne peut pas être utilisé comme nom de fonction\n"
 
-#: builtin.cpp:1970 builtin.cpp:2277 builtin.cpp:3824
+#: builtin.cpp:2248
 #, fuzzy, c-format
 msgid "%ls: No function name given\n"
 msgstr "%ls: Nom de fonction illégal '%ls'\n"
 
-#: builtin.cpp:1997 builtin.cpp:2304
+#: builtin.cpp:2276
 #, c-format
 msgid "%ls: Expected one argument, got %d\n"
 msgstr "%ls: Un argument attendu, %d obtenu(s)\n"
 
-#: builtin.cpp:2319
-msgid "Current functions are: "
-msgstr "Les fonctions courantes sont: "
-
-#: builtin.cpp:2459
+#: builtin.cpp:2412
 #, c-format
 msgid "%ls: Seed value '%ls' is not a valid number\n"
 msgstr "%ls: La valeur germe '%ls' n'est pas un nombre valide\n"
 
-#: builtin.cpp:2473
+#: builtin.cpp:2426
 #, c-format
 msgid "%ls: Expected zero or one argument, got %d\n"
 msgstr "%ls: Zéro ou un argument attendu, %d obtenu(s)\n"
 
-#: builtin.cpp:2981 fish.cpp:518 parser.cpp:1095
-msgid "Standard input"
-msgstr "Entrée standard"
+#: builtin.cpp:2593
+#, fuzzy, c-format
+msgid "%ls: Argument '%ls' is out of range\n"
+msgstr "%ls: L'argument '%ls' doit être un entier\n"
 
-#: builtin.cpp:3024
-msgid "This is a login shell\n"
-msgstr "Ceci est un shell de connexion\n"
-
-#: builtin.cpp:3026
-msgid "This is not a login shell\n"
-msgstr "Ceci n'est pas un shell de connexion\n"
-
-#: builtin.cpp:3028
-#, c-format
-msgid "Job control: %ls\n"
-msgstr "Contrôle des tâches: %ls\n"
-
-#: builtin.cpp:3029
-msgid "Only on interactive jobs"
-msgstr "Seulement sur les tâches interactives"
-
-#: builtin.cpp:3030
-msgid "Never"
-msgstr "Jamais"
-
-#: builtin.cpp:3030
-msgid "Always"
-msgstr "Toujours"
-
-#: builtin.cpp:3066 builtin.cpp:3995
+#: builtin.cpp:2601 builtin.cpp:3150 builtin.cpp:3817
 #, c-format
 msgid "%ls: Argument '%ls' must be an integer\n"
 msgstr "%ls: L'argument '%ls' doit être un entier\n"
 
+#: builtin.cpp:2656
+#, fuzzy, c-format
+msgid "%ls: --array option requires a single variable name.\n"
+msgstr ""
+"%ls: 'Erase' requiert un nom de variable\n"
+"%ls\n"
+
+#: builtin.cpp:3065 fish.cpp:620 parser.cpp:764
+msgid "Standard input"
+msgstr "Entrée standard"
+
 #: builtin.cpp:3108
+msgid "This is a login shell\n"
+msgstr "Ceci est un shell de connexion\n"
+
+#: builtin.cpp:3110
+msgid "This is not a login shell\n"
+msgstr "Ceci n'est pas un shell de connexion\n"
+
+#: builtin.cpp:3112
+#, c-format
+msgid "Job control: %ls\n"
+msgstr "Contrôle des tâches: %ls\n"
+
+#: builtin.cpp:3113
+msgid "Only on interactive jobs"
+msgstr "Seulement sur les tâches interactives"
+
+#: builtin.cpp:3114
+msgid "Never"
+msgstr "Jamais"
+
+#: builtin.cpp:3114
+msgid "Always"
+msgstr "Toujours"
+
+#: builtin.cpp:3192
 #, c-format
 msgid "%ls: Could not find home directory\n"
 msgstr "%ls: Répertoire personnel introuvable\n"
 
-#: builtin.cpp:3128 builtin.cpp:3182
+#: builtin.cpp:3212 builtin.cpp:3266
 #, c-format
 msgid "%ls: '%ls' is not a directory\n"
 msgstr "%ls: '%ls' n'est pas un répertoire\n"
 
-#: builtin.cpp:3135
+#: builtin.cpp:3219
 #, fuzzy, c-format
 msgid "%ls: The directory '%ls' does not exist\n"
 msgstr "%ls: La fonction '%ls' n'existe pas\n"
 
-#: builtin.cpp:3142
+#: builtin.cpp:3226
 #, fuzzy, c-format
 msgid "%ls: '%ls' is a rotten symlink\n"
 msgstr "%ls: '%ls' n'est pas un fichier\n"
 
-#: builtin.cpp:3150
+#: builtin.cpp:3234
 #, fuzzy, c-format
 msgid "%ls: Unknown error trying to locate directory '%ls'\n"
 msgstr "%ls: Option '%ls' inconnue\n"
 
-#: builtin.cpp:3173
+#: builtin.cpp:3257
 #, fuzzy, c-format
 msgid "%ls: Permission denied: '%ls'\n"
 msgstr "%ls: Nom de fonction illégal '%ls'\n"
 
-#: builtin.cpp:3197
+#: builtin.cpp:3281
 #, c-format
 msgid "%ls: Could not set PWD variable\n"
 msgstr "%ls: Définition de la variable PWD impossible\n"
 
-#: builtin.cpp:3284
+#: builtin.cpp:3368
 #, fuzzy, c-format
 msgid "%ls: Key not specified\n"
 msgstr "Utiliser une étiquette spécifiée"
 
-#: builtin.cpp:3328 builtin.cpp:3336
+#: builtin.cpp:3412 builtin.cpp:3420
 #, fuzzy, c-format
 msgid "%ls: Error encountered while sourcing file '%ls':\n"
 msgstr "%ls: Erreur de lecture sur le fichier '%ls'\n"
 
-#: builtin.cpp:3344
+#: builtin.cpp:3428
 #, c-format
 msgid "%ls: '%ls' is not a file\n"
 msgstr "%ls: '%ls' n'est pas un fichier\n"
 
-#: builtin.cpp:3363
+#: builtin.cpp:3447
 #, c-format
 msgid "%ls: Error while reading file '%ls'\n"
 msgstr "%ls: Erreur de lecture sur le fichier '%ls'\n"
 
-#: builtin.cpp:3419 builtin.cpp:3599
+#: builtin.cpp:3503 builtin.cpp:3682
 #, c-format
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls: Aucune tâche appropriée\n"
 
-#: builtin.cpp:3448
+#: builtin.cpp:3531
 #, c-format
 msgid "%ls: Ambiguous job\n"
 msgstr "%ls: Tâche ambiguë\n"
 
-#: builtin.cpp:3454 builtin.cpp:3622 builtin_jobs.cpp:301
+#: builtin.cpp:3537 builtin.cpp:3705 builtin_jobs.cpp:301
 #, c-format
 msgid "%ls: '%ls' is not a job\n"
 msgstr "%ls: '%ls' n'est pas une tâche\n"
 
-#: builtin.cpp:3485 builtin_jobs.cpp:316
+#: builtin.cpp:3568 builtin_jobs.cpp:316
 #, c-format
 msgid "%ls: No suitable job: %d\n"
 msgstr "%ls: Aucune tâche appropriée: %d\n"
 
-#: builtin.cpp:3494
+#: builtin.cpp:3577
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to foreground because it is not under job "
@@ -281,12 +294,12 @@ msgstr ""
 "%ls: Ne peut mettre la tâche %d, '%ls' en premier plan parce qu'elle n'est "
 "pas gérée par le contrôleur de tâches\n"
 
-#: builtin.cpp:3547
+#: builtin.cpp:3630
 #, c-format
 msgid "%ls: Unknown job '%ls'\n"
 msgstr "%ls: Tâche inconnue: '%ls'\n"
 
-#: builtin.cpp:3556
+#: builtin.cpp:3639
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to background because it is not under job "
@@ -295,239 +308,221 @@ msgstr ""
 "%ls: Ne peut mettre la tâche %d, '%ls' en arrière-plan parce qu'elle n'est "
 "pas gérée par le contrôleur de tâches\n"
 
-#: builtin.cpp:3566
+#: builtin.cpp:3649
 #, c-format
 msgid "Send job %d '%ls' to background\n"
 msgstr "Envoyer la tâche %d '%ls' en arrière-plan\n"
 
-#: builtin.cpp:3605
+#: builtin.cpp:3688
 msgid "(default)"
 msgstr "(défaut)"
 
-#: builtin.cpp:3737
-#, c-format
-msgid "%ls: Not inside of block\n"
-msgstr "%ls: À l'extérieur du bloc\n"
-
-#: builtin.cpp:3884
-#, c-format
-msgid "%ls: Not inside of 'if' block\n"
-msgstr "%ls: À l'extérieur du bloc 'if'\n"
-
-#: builtin.cpp:3938
+#: builtin.cpp:3760
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls: À l'extérieur de la boucle\n"
 
-#: builtin.cpp:4005 builtin_complete.cpp:539 builtin_set_color.cpp:140
-#: builtin.h:83
+#: builtin.cpp:3827 builtin_complete.cpp:551 builtin.h:83
 #, c-format
 msgid "%ls: Too many arguments\n"
 msgstr "%ls: Trop d'arguments\n"
 
-#: builtin.cpp:4023
+#: builtin.cpp:3845
 #, c-format
 msgid "%ls: Not inside of function\n"
 msgstr "%ls: À l'extérieur de la fonction\n"
 
-#: builtin.cpp:4059
-#, c-format
-msgid "%ls: Expected exactly one argument, got %d\n"
-msgstr "%ls: Exactement un argument attendu, %d obtenu(s)\n"
-
-#: builtin.cpp:4090
-#, c-format
-msgid "%ls: 'case' command while not in switch block\n"
-msgstr "%ls: commande 'case' sans bloc 'switch'\n"
-
-#: builtin.cpp:4317 builtin.cpp:4360
+#: builtin.cpp:4069 builtin.cpp:4113
 #, fuzzy
 msgid "Test a condition"
 msgstr "Définir une option de config"
 
-#: builtin.cpp:4318
+#: builtin.cpp:4070
 msgid "Try out the new parser"
 msgstr ""
 
-#: builtin.cpp:4319
+#: builtin.cpp:4071
 msgid "Execute command if previous command suceeded"
 msgstr "Exécuter la commande si la précédente a réussi"
 
-#: builtin.cpp:4320
+#: builtin.cpp:4072
 msgid "Create a block of code"
 msgstr "Créer un bloc de code"
 
-#: builtin.cpp:4321
+#: builtin.cpp:4073
 msgid "Send job to background"
 msgstr "Mettre la tâche en arrière-plan"
 
-#: builtin.cpp:4322
+#: builtin.cpp:4074
 msgid "Handle fish key bindings"
 msgstr "Gérer les raccourcis clavier de fish"
 
-#: builtin.cpp:4323
+#: builtin.cpp:4075
 msgid "Temporarily block delivery of events"
 msgstr "Bloquer temporairement la distribution des événements"
 
-#: builtin.cpp:4324
+#: builtin.cpp:4076
 msgid "Stop the innermost loop"
 msgstr "Arrêter la boucle interne"
 
-#: builtin.cpp:4325
+#: builtin.cpp:4077
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 
-#: builtin.cpp:4326
+#: builtin.cpp:4078
 msgid "Run a builtin command instead of a function"
 msgstr "Exécuter une commande interne au lieu d'une fonction"
 
-#: builtin.cpp:4327 builtin.cpp:4359
+#: builtin.cpp:4079 builtin.cpp:4112
 msgid "Conditionally execute a block of commands"
 msgstr "Exécuter conditionnellement un bloc de commandes"
 
-#: builtin.cpp:4328
+#: builtin.cpp:4080
 msgid "Change working directory"
 msgstr "Changer le répertoire de travail"
 
-#: builtin.cpp:4329
+#: builtin.cpp:4081
 msgid "Run a program instead of a function or builtin"
 msgstr "Exécuter un programme au lieu d'une fonction ou d'une commande interne"
 
-#: builtin.cpp:4330
+#: builtin.cpp:4082
 msgid "Set or get the commandline"
 msgstr "Définir ou obtenir la ligne de commande"
 
-#: builtin.cpp:4331
+#: builtin.cpp:4083
 msgid "Edit command specific completions"
 msgstr "Éditer les complétions spécifiques aux commandes"
 
-#: builtin.cpp:4332
+#: builtin.cpp:4084
 msgid "Search for a specified string in a list"
 msgstr ""
 
-#: builtin.cpp:4333
+#: builtin.cpp:4085
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "Sauter le reste de la boucle interne"
 
-#: builtin.cpp:4334
+#: builtin.cpp:4086
 #, fuzzy
 msgid "Count the number of arguments"
 msgstr "Finir après un nombre de serveurs"
 
-#: builtin.cpp:4335
+#: builtin.cpp:4087
 #, fuzzy
 msgid "Print arguments"
 msgstr "Liste des arguments du processus"
 
-#: builtin.cpp:4336
+#: builtin.cpp:4088
 msgid "Evaluate block if condition is false"
 msgstr "Évalue le bloc si la condition est fausse"
 
-#: builtin.cpp:4337
+#: builtin.cpp:4089
 #, fuzzy
 msgid "Emit an event"
 msgstr "Omettre la version Debian"
 
-#: builtin.cpp:4338
+#: builtin.cpp:4090
 msgid "End a block of commands"
 msgstr "Termine un bloc de commandes"
 
-#: builtin.cpp:4339
+#: builtin.cpp:4091
 msgid "Run command in current process"
 msgstr "Exécuter la commande dans le processus courant"
 
-#: builtin.cpp:4340
+#: builtin.cpp:4092
 msgid "Exit the shell"
 msgstr "Quitter le shell"
 
-#: builtin.cpp:4341
+#: builtin.cpp:4093
+msgid "Return an unsuccessful result"
+msgstr ""
+
+#: builtin.cpp:4094
 msgid "Send job to foreground"
 msgstr "Mettre la tâche en premier plan"
 
-#: builtin.cpp:4342
+#: builtin.cpp:4095
 msgid "Perform a set of commands multiple times"
 msgstr "Exécuter un ensemble de commandes plusieurs fois"
 
-#: builtin.cpp:4343
+#: builtin.cpp:4096
 msgid "Define a new function"
 msgstr "Définir une nouvelle fonction"
 
-#: builtin.cpp:4344
+#: builtin.cpp:4097
 msgid "List or remove functions"
 msgstr "Lister ou enlever des fonctions"
 
-#: builtin.cpp:4345
+#: builtin.cpp:4098
 msgid "History of commands executed by user"
 msgstr ""
 
-#: builtin.cpp:4346
+#: builtin.cpp:4099
 msgid "Evaluate block if condition is true"
 msgstr "Évaluer le bloc si la condition est vraie"
 
-#: builtin.cpp:4347
+#: builtin.cpp:4100
 msgid "Print currently running jobs"
 msgstr "Afficher les tâches en cours d'exécution"
 
-#: builtin.cpp:4348
+#: builtin.cpp:4101
 msgid "Negate exit status of job"
 msgstr "Inverser l'état de sortie de la tâche"
 
-#: builtin.cpp:4349
+#: builtin.cpp:4102
 msgid "Execute command if previous command failed"
 msgstr "Exécuter la commande si la précédente a échoué"
 
-#: builtin.cpp:4350
+#: builtin.cpp:4103
 msgid "Prints formatted text"
 msgstr ""
 
-#: builtin.cpp:4351
+#: builtin.cpp:4104
 #, fuzzy
 msgid "Print the working directory"
 msgstr "Changer le répertoire de travail"
 
-#: builtin.cpp:4352
+#: builtin.cpp:4105
 msgid "Generate random number"
 msgstr "Génère un nombre aléatoire"
 
-#: builtin.cpp:4353
+#: builtin.cpp:4106
 msgid "Read a line of input into variables"
 msgstr "Lire une ligne d'entrée dans des variables"
 
-#: builtin.cpp:4354
+#: builtin.cpp:4107
 msgid "Stop the currently evaluated function"
 msgstr "Arrêter la fonction en évaluation"
 
-#: builtin.cpp:4355
+#: builtin.cpp:4108
 msgid "Handle environment variables"
 msgstr "Gérer les variables d'environnement"
 
-#: builtin.cpp:4356
+#: builtin.cpp:4109
 msgid "Set the terminal color"
 msgstr ""
 
-#: builtin.cpp:4357
+#: builtin.cpp:4110
 msgid "Evaluate contents of file"
 msgstr "Évaluer le contenu d'un fichier"
 
-#: builtin.cpp:4358
+#: builtin.cpp:4111
 msgid "Return status information about fish"
 msgstr "Retourner l'information sur l'état de fish"
 
-#: builtin.cpp:4361
+#: builtin.cpp:4114
+msgid "Return a successful result"
+msgstr ""
+
+#: builtin.cpp:4115
 msgid "Set or get the shells resource usage limits"
 msgstr "Définir ou obtenir les limites d'utilisation des ressources du shell"
 
-#: builtin.cpp:4362
+#: builtin.cpp:4116
 msgid "Perform a command multiple times"
 msgstr "Exécuter une commande plusieurs fois"
 
-#: builtin.cpp:4442 parser.cpp:53
-#, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "Commande interne inconnue '%ls'"
-
-#: builtin_commandline.cpp:411
+#: builtin_commandline.cpp:466
 #, fuzzy, c-format
 msgid "%ls: Unknown input function '%ls'\n"
 msgstr "%ls: Option '%ls' inconnue\n"
@@ -544,7 +539,7 @@ msgstr "CPU\t"
 msgid "State\tCommand\n"
 msgstr "État\tCommande\n"
 
-#: builtin_jobs.cpp:99 proc.cpp:751
+#: builtin_jobs.cpp:99 proc.cpp:843
 msgid "stopped"
 msgstr "arrêtée"
 
@@ -590,31 +585,31 @@ msgstr ""
 msgid "missing hexadecimal number in escape"
 msgstr ""
 
-#: builtin_printf.cpp:387
+#: builtin_printf.cpp:388
 msgid "Missing hexadecimal number in Unicode escape"
 msgstr ""
 
-#: builtin_printf.cpp:401
+#: builtin_printf.cpp:402
 #, c-format
 msgid "Unicode character out of range: \\%c%0*x"
 msgstr ""
 
-#: builtin_printf.cpp:668
+#: builtin_printf.cpp:670
 #, c-format
 msgid "invalid field width: %ls"
 msgstr ""
 
-#: builtin_printf.cpp:706
+#: builtin_printf.cpp:708
 #, fuzzy, c-format
 msgid "invalid precision: %ls"
 msgstr "%ls: id de processus invalide %ls\n"
 
-#: builtin_printf.cpp:737
+#: builtin_printf.cpp:739
 #, fuzzy, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%ls: Combinaison d'options invalide\n"
 
-#: builtin_printf.cpp:769
+#: builtin_printf.cpp:771
 msgid "printf: not enough arguments"
 msgstr ""
 
@@ -626,60 +621,68 @@ msgstr ""
 
 #: builtin_set.cpp:162
 #, fuzzy, c-format
-msgid "%ls: Unknown error"
-msgstr "%s: Erreur inconnue\n"
+msgid "%ls: Tried to set the special variable '%ls' with the wrong scope\n"
+msgstr ""
+"%ls: Impossible de changer la valeur de la variable en lecture seule '%ls'\n"
 
-#: builtin_set.cpp:214
+#: builtin_set.cpp:169
+#, fuzzy, c-format
+msgid "%ls: Tried to set the special variable '%ls' to an invalid value\n"
+msgstr ""
+"%ls: Impossible de changer la valeur de la variable en lecture seule '%ls'\n"
+
+#: builtin_set.cpp:221
 #, c-format
 msgid "%ls: Multiple variable names specified in single call (%ls and %.*ls)\n"
 msgstr ""
 "%ls: Plusieurs noms de variable spécifiés dans un seul appel (%ls and "
 "%.*ls)\n"
 
-#: builtin_set.cpp:241
+#: builtin_set.cpp:248
 #, c-format
 msgid "%ls: Invalid index starting at '%ls'\n"
 msgstr "%ls: Index invalide commençant à '%ls'\n"
 
-#: builtin_set.cpp:640
+#: builtin_set.cpp:647
 #, fuzzy, c-format
 msgid "%ls: Erase needs a variable name\n"
 msgstr ""
 "%ls: 'Erase' requiert un nom de variable\n"
 "%ls\n"
 
-#: builtin_set.cpp:684
-#, fuzzy, c-format
-msgid "%ls: Can not specify scope when erasing array slice\n"
-msgstr "%ls: Ne peut pas indiquer la portée en enlevant le bloc\n"
-
-#: builtin_set.cpp:783
+#: builtin_set.cpp:791
 #, fuzzy, c-format
 msgid "%ls: Values cannot be specfied with erase\n"
 msgstr ""
 "%ls: 'erase' ne peut pas spécifier des valeurs\n"
 "%ls\n"
 
-#: builtin_set_color.cpp:149
-#, fuzzy, c-format
-msgid "%ls: Expected an argument\n"
-msgstr "%s: Un argument attendu\n"
+#: builtin_set.cpp:817
+#, c-format
+msgid ""
+"%ls: Warning: universal scope selected, but a global variable '%ls' exists.\n"
+msgstr ""
 
-#: builtin_set_color.cpp:157 builtin_set_color.cpp:164
+#: builtin_set_color.cpp:144 builtin_set_color.cpp:166
 #, fuzzy, c-format
 msgid "%ls: Unknown color '%ls'\n"
 msgstr "%s: Couleur inconnue '%s'\n"
 
-#: builtin_set_color.cpp:171
+#: builtin_set_color.cpp:153
+#, fuzzy, c-format
+msgid "%ls: Expected an argument\n"
+msgstr "%s: Un argument attendu\n"
+
+#: builtin_set_color.cpp:173
 #, fuzzy, c-format
 msgid "%ls: Could not set up terminal\n"
 msgstr "Paramétrage du terminal impossible"
 
-#: common.cpp:1882
+#: common.cpp:1917
 msgid "This is a bug. Break on bugreport to debug."
 msgstr ""
 
-#: common.cpp:1901
+#: common.cpp:1936
 msgid "empty"
 msgstr "vide"
 
@@ -693,72 +696,70 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variable: "
 
-#: complete.cpp:907 complete.cpp:925
+#: complete.cpp:901 complete.cpp:919
 msgid "Unknown option: "
 msgstr "Option inconnue: "
 
-#: complete.cpp:929
+#: complete.cpp:923
 msgid "Multiple matches for option: "
 msgstr "Plusieurs correspondances pour l'option: "
 
-#: env.cpp:251
-msgid "Could not get user information"
-msgstr "Obtention des informations utilisateur impossible."
-
-#: env.cpp:362
+#: env.cpp:315
 msgid "Changing language to English"
 msgstr "Changement de langue à français"
 
-#: env.cpp:1252
+#: env.cpp:1180
 msgid "Tried to pop empty environment stack."
 msgstr "Impossible de dépiler une pile d'environnement vide"
 
-#: env_universal_common.cpp:529
-#, c-format
-msgid "Could not convert message '%s' to wide character string"
+#: env_universal_common.cpp:617 path.cpp:279
+msgid ""
+"Unable to create a configuration directory for fish. Your personal settings "
+"will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
+"where the current user has write access."
 msgstr ""
 
-#: event.cpp:168
+#: event.cpp:178
 #, c-format
 msgid "signal handler for %ls (%ls)"
 msgstr "gestionnaire de signaux pour %ls (%ls)"
 
-#: event.cpp:172
+#: event.cpp:182
 #, c-format
 msgid "handler for variable '%ls'"
 msgstr "gestionnaire pour la variable '%ls'"
 
-#: event.cpp:178
+#: event.cpp:188
 #, c-format
 msgid "exit handler for process %d"
 msgstr "gestionnaire de sortie pour le processus %d"
 
-#: event.cpp:184 event.cpp:195
+#: event.cpp:194 event.cpp:205
 #, c-format
 msgid "exit handler for job %d, '%ls'"
 msgstr "gestionnaire de sortie pour la tâche %d, '%ls'"
 
-#: event.cpp:186
+#: event.cpp:196
 #, c-format
 msgid "exit handler for job with process group %d"
 msgstr "gestionnaire de sortie pour la tâche avec le groupe de processus %d"
 
-#: event.cpp:197
+#: event.cpp:207
 #, c-format
 msgid "exit handler for job with job id %d"
 msgstr "gestionnaire de sortie pour la tâche %d"
 
-#: event.cpp:203
+#: event.cpp:213
 #, fuzzy, c-format
 msgid "handler for generic event '%ls'"
 msgstr "gestionnaire pour la variable '%ls'"
 
-#: event.cpp:207
+#: event.cpp:217
 #, fuzzy, c-format
 msgid "Unknown event type '0x%x'"
 msgstr "Type de redirection d'entrée inconnu: %d"
 
-#: event.cpp:621
+#: event.cpp:613
 msgid "Signal list overflow. Signals have been ignored."
 msgstr "Débordement de la liste des signaux. Des signaux ont été ignorés."
 
@@ -778,12 +779,12 @@ msgstr "Une erreur est survenue lors du paramétrage du tube"
 msgid "An error occurred while redirecting file '%s'"
 msgstr "Une erreur est survenue pendant la redirection du fichier '%ls'"
 
-#: exec.cpp:912
+#: exec.cpp:795
 #, c-format
 msgid "Unknown function '%ls'"
 msgstr "Fonction inconnue '%ls'"
 
-#: exec.cpp:1063
+#: exec.cpp:943
 #, c-format
 msgid "Unknown input redirection type %d"
 msgstr "Type de redirection d'entrée inconnu: %d"
@@ -813,100 +814,62 @@ msgstr "Processus shell"
 msgid "Last background job"
 msgstr "Dernière tâche mise en arrière-plan"
 
-#: expand.cpp:1306
+#: expand.cpp:1419
 msgid "Mismatched brackets"
 msgstr "Les crochets ne concordent pas"
 
-#: fish.cpp:320
+#: fish.cpp:330
+msgid ""
+"Old versions of fish appear to be running. You will not be able to share "
+"variable values between old and new fish sessions. For best results, restart "
+"all running instances of fish."
+msgstr ""
+
+#: fish.cpp:420
 #, c-format
 msgid "Invalid value '%s' for debug level switch"
 msgstr "Valeur '%s' invalide comme interrupteur au niveau de débogage"
 
-#: fish.cpp:361 mimedb.cpp:1335
+#: fish.cpp:461 mimedb.cpp:1343
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, version %s\n"
 
-#: fish.cpp:416
+#: fish.cpp:516
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr ""
 "Le mode no-execute ne peut pas être utilisé dans une session interactive"
 
-#: fish.cpp:517
+#: fish.cpp:619
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Erreur lors de la lecture du fichier %ls\n"
 
-#: fish_indent.cpp:345
+#: fish_indent.cpp:332
 #, fuzzy, c-format
 msgid "%ls, version %s\n"
 msgstr "%s, version %s\n"
 
-#: fish_pager.cpp:113
-#, fuzzy, c-format
-msgid "%ls: Argument '%s' is not a valid file descriptor\n"
-msgstr "%ls: '%ls' est un nom de variable invalide\n"
-
-#: fish_pager.cpp:703
-#, c-format
-msgid " %d to %d of %d"
-msgstr ""
-
-#: fish_pager.cpp:1012
-msgid "Could not set up output file descriptors for pager"
-msgstr ""
-
-#: fish_pager.cpp:1018
-#, fuzzy
-msgid "Could not set up input file descriptors for pager"
-msgstr "Impossible de définir le mode du terminal pour le shell"
-
-#: fish_pager.cpp:1024
-#, fuzzy
-msgid "Could not open tty for pager"
-msgstr "Impossible de remettre le shell en premier plan"
-
-#: fish_pager.cpp:1031
-msgid "Could not initialize result pipe"
-msgstr ""
-
-#: fish_pager.cpp:1075 input.cpp:384 input.cpp:394
+#: input.cpp:483 input.cpp:493
 msgid "Could not set up terminal"
 msgstr "Paramétrage du terminal impossible"
 
-#: fish_pager.cpp:1110 input.cpp:436
-#, fuzzy
-msgid "Error while closing terminfo"
-msgstr "Erreur lors de la fermeture du flux d'entrée"
-
-#: fish_pager.cpp:1306
-#, fuzzy
-msgid "Unspecified file descriptors"
-msgstr "Redirige vers un descripteur de fichier"
-
-#: fish_pager.cpp:1318
-#, fuzzy
-msgid "Could not read completions"
-msgstr "Commande à ajouter une complétion"
-
-#: fishd.cpp:766 path.cpp:358
-msgid ""
-"Unable to create a configuration directory for fish. Your personal settings "
-"will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
-"where the current user has write access."
-msgstr ""
-
-#: input.cpp:387
+#: input.cpp:486
 #, c-format
 msgid "Check that your terminal type, '%ls', is supported on this system"
 msgstr ""
 
-#: input.cpp:389
+#: input.cpp:488
 #, c-format
 msgid "Attempting to use '%ls' instead"
 msgstr ""
 
-#: io.cpp:110
+#: input.cpp:535
+#, fuzzy
+msgid "Error while closing terminfo"
+msgstr "Erreur lors de la fermeture du flux d'entrée"
+
+#: io.cpp:112
 #, c-format
 msgid ""
 "An error occured while reading output from code block on file descriptor %d"
@@ -914,76 +877,98 @@ msgstr ""
 "Une erreur est survenue lors de la lecture de la sortie du bloc de code sur "
 "le descripteur de fichier %d"
 
-#: mimedb.cpp:173 mimedb.cpp:187 mimedb.cpp:1177
+#: mimedb.cpp:174 mimedb.cpp:188 mimedb.cpp:1179
 #, c-format
 msgid "%s: Out of memory\n"
 msgstr "%s: Mémoire pleine\n"
 
-#: mimedb.cpp:462
+#: mimedb.cpp:463
 #, c-format
 msgid "%s: Unknown error in munge()\n"
 msgstr "%s: Erreur inconnue dans munge()\n"
 
-#: mimedb.cpp:480
+#: mimedb.cpp:481
 #, c-format
 msgid "%s: Locale string too long\n"
 msgstr "%s: Chaîne de caractères de locale trop longue\n"
 
-#: mimedb.cpp:550 mimedb.cpp:558
+#: mimedb.cpp:551 mimedb.cpp:559
 #, fuzzy, c-format
 msgid "%s: Could not compile regular expressions %s with error %s\n"
 msgstr "%s: Compilation impossible de l'expression régulière\n"
 
-#: mimedb.cpp:674
+#: mimedb.cpp:676
 #, c-format
 msgid "%s: No description for type %s\n"
 msgstr "%s: Aucune description pour le type %s\n"
 
-#: mimedb.cpp:742
+#: mimedb.cpp:744
 #, c-format
 msgid "%s: Could not parse launcher string '%s'\n"
 msgstr "%s: Analyse impossible de la chaîne de lancement '%s'\n"
 
-#: mimedb.cpp:778
+#: mimedb.cpp:780
 #, c-format
 msgid "%s: Default launcher '%s' does not specify how to start\n"
 msgstr "%s: Le lanceur par défaut '%s' ne spécifie pas comment démarrer\n"
 
-#: mimedb.cpp:1156
+#: mimedb.cpp:1158
 #, c-format
 msgid "%s: Unsupported switch '%c' in launch string '%s'\n"
 msgstr "%s: Commutateur '%c' non supporté dans la chaîne de démarrage '%s'\n"
 
-#: mimedb.cpp:1346
+#: mimedb.cpp:1354
 #, c-format
 msgid "%s: Can not launch a mimetype\n"
 msgstr "%s: Impossible de lancer un type Mime\n"
 
-#: mimedb.cpp:1374
+#: mimedb.cpp:1382
 #, c-format
 msgid "%s: Could not parse mimetype from argument '%s'\n"
 msgstr "%s: Analyse impossible du type Mime à partir de l'argument '%s'\n"
 
-#: mimedb.cpp:1394 signal.cpp:407 signal.cpp:422
+#: mimedb.cpp:1402 signal.cpp:407 signal.cpp:422
 msgid "Unknown"
 msgstr "Inconnu"
+
+#: output.cpp:608
+#, c-format
+msgid ""
+"Tried to use terminfo string %s on line %ld of %s, which is undefined in "
+"terminal of type \"%ls\". Please report this error to %s"
+msgstr ""
 
 #: pager.cpp:24
 #, fuzzy
 msgid "search: "
 msgstr "Définir l'architecture"
 
-#: parse_execution.cpp:526 parse_execution.cpp:961 parser.cpp:1404
+#: pager.cpp:562
 #, c-format
-msgid "Could not expand string '%ls'"
-msgstr "Développement de la chaîne '%ls' impossible"
+msgid "%lsand 1 more row"
+msgstr ""
 
-#: parse_execution.cpp:549
+#: pager.cpp:566
+#, c-format
+msgid "%lsand %lu more rows"
+msgstr ""
+
+#: pager.cpp:571
+#, c-format
+msgid "rows %lu to %lu of %lu"
+msgstr ""
+
+#: pager.cpp:576
+#, fuzzy
+msgid "(no matches)"
+msgstr "Surveiller des fichiers"
+
+#: parse_execution.cpp:555
 #, fuzzy, c-format
 msgid "switch: Expected exactly one argument, got %lu\n"
 msgstr "%ls: Exactement un argument attendu, %d obtenu(s)\n"
 
-#: parse_execution.cpp:749 parser.cpp:2053
+#: parse_execution.cpp:799
 #, fuzzy, c-format
 msgid ""
 "Unknown command '%ls'. Did you mean to run %ls with a modified environment? "
@@ -994,7 +979,7 @@ msgstr ""
 "l'information sur l'attribution de valeurs à des variables, lisez l'aide sur "
 "la commande 'set' en tapant 'help set'."
 
-#: parse_execution.cpp:774 parser.cpp:2078
+#: parse_execution.cpp:824
 #, fuzzy, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function like "
@@ -1006,7 +991,7 @@ msgstr ""
 "définissez une fonction 'function %ls; %ls $argv; end'. Lisez l'aide pour la "
 "commande 'function' en tapant 'help function'."
 
-#: parse_execution.cpp:783 parser.cpp:2087
+#: parse_execution.cpp:833
 #, fuzzy, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function or use the "
@@ -1017,7 +1002,7 @@ msgstr ""
 "définissez une fonction. Lisez l'aide pour la commande 'function' en tapant "
 "'help function'."
 
-#: parse_execution.cpp:791 parser.cpp:2095
+#: parse_execution.cpp:841
 #, c-format
 msgid ""
 "Commands may not contain variables. Use the eval builtin instead, like 'eval "
@@ -1027,397 +1012,313 @@ msgstr ""
 "interne 'eval', comme 'eval %ls'. Lisez l'aide sur la commande 'eval' en "
 "tapant 'help eval'."
 
-#: parse_execution.cpp:798 parser.cpp:2102
+#: parse_execution.cpp:848
 #, c-format
 msgid "The file '%ls' is not executable by this user"
 msgstr ""
 
-#: parse_execution.cpp:1029
+#: parse_execution.cpp:1057
 #, fuzzy, c-format
 msgid "Invalid redirection target: %ls"
 msgstr "Redirection invalide"
 
-#: parse_execution.cpp:1053
+#: parse_execution.cpp:1081
 #, fuzzy, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
 msgstr ""
 "Redirection demandée à quelque chose qui n'est pas un descripteur de fichier "
 "%ls"
 
-#: parse_util.cpp:47
+#: parse_util.cpp:46
 #, fuzzy, c-format
 msgid "The '%ls' command can not be used in a pipeline"
 msgstr "Cette commande ne peut pas être utilisée dans un pipeline"
 
-#: parser.cpp:58
-msgid "This command can not be used in a pipeline"
+#: parse_util.cpp:49
+#, fuzzy, c-format
+msgid "The '%ls' command can not be used immediately after a backgrounded job"
 msgstr "Cette commande ne peut pas être utilisée dans un pipeline"
 
-#: parser.cpp:64
+#: parse_util.cpp:52
+#, fuzzy
+msgid "Backgrounded commands can not be used as conditionals"
+msgstr "Cette commande ne peut pas être utilisée dans un pipeline"
+
+#: parser.cpp:52
 #, c-format
 msgid "Tokenizer error: '%ls'"
 msgstr "Erreur d'analyseur lexical: '%ls'"
 
-#: parser.cpp:69
-msgid "An additional command is required"
-msgstr ""
-
-#: parser.cpp:74
-msgid ""
-"The function calls itself immediately, which would result in an infinite "
-"loop."
-msgstr ""
-
-#: parser.cpp:79
-msgid ""
-"Could not locate end of block. The 'end' command is missing, misspelled or a "
-"';' is missing."
-msgstr ""
-"Fin de bloc introuvable. La commande 'end' est manquante, mal écrite ou un "
-"';' est manquant."
-
-#: parser.cpp:82
-#, c-format
-msgid "Expected a command name, got token of type '%ls'"
-msgstr "Un nom de commande était attendu, un jeton de type '%ls' a été obtenu"
-
-#: parser.cpp:87 parse_constants.h:158
-#, c-format
-msgid "Illegal command name '%ls'"
-msgstr "Nom de commande illégal '%ls'"
-
-#: parser.cpp:92 parse_constants.h:164
-#, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
-msgstr ""
-
-#: parser.cpp:97 parse_constants.h:167
-#, c-format
-msgid "No matches for wildcard '%ls'."
-msgstr ""
-
-#: parser.cpp:102
-msgid "'case' builtin not inside of switch block"
-msgstr "Commande interne 'case' à l'extérieur d'un bloc 'switch'"
-
-#: parser.cpp:107
-msgid "Loop control command while not inside of loop"
-msgstr "Commande de contrôle de boucle à l'extérieur d'une boucle"
-
-#: parser.cpp:112 parse_constants.h:176
-#, fuzzy
-msgid "'return' builtin command outside of function definition"
-msgstr "Exécuter une commande interne au lieu d'une fonction"
-
-#: parser.cpp:117
-#, fuzzy, c-format
-msgid "'%ls' builtin not inside of if block"
-msgstr "Commande interne 'else' à l'extérieur d'un bloc 'if'"
-
-#: parser.cpp:122
-#, c-format
-msgid "'%ls' used past terminating 'else'"
-msgstr ""
-
-#: parser.cpp:127
-msgid "'end' command outside of block"
-msgstr "Commande interne 'end' à l'extérieur d'un bloc"
-
-#: parser.cpp:132 parse_constants.h:179
-#, fuzzy, c-format
-msgid ""
-"Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
-"the set command by typing 'help set'."
-msgstr ""
-"Commande '%ls' inconnue. Vouliez-vous dire 'set VARIABLE VALEUR'? Pour de "
-"l'information sur l'attribution de valeurs à des variables, lisez l'aide sur "
-"la commande 'set' en tapant 'help set'."
-
-#: parser.cpp:137
-#, c-format
-msgid "Expected redirection specification, got token of type '%ls'"
-msgstr "Spécification de redirection attendue, jeton de type '%ls' obtenu"
-
-#: parser.cpp:142
-msgid ""
-"Encountered redirection when expecting a command name. Fish does not allow a "
-"redirection operation before a command."
-msgstr ""
-"Redirection obtenue alors qu'un nom de commande était attendu. Fish ne "
-"permet pas une opération de redirection avant une commande."
-
-#: parser.cpp:147
+#: parser.cpp:57
 #, c-format
 msgid "Tried to evaluate commands using invalid block type '%ls'"
 msgstr "Évaluation de commandes en utilisant un type de bloc invalide '%ls'"
 
-#: parser.cpp:153
+#: parser.cpp:62
 #, c-format
 msgid "Unexpected token of type '%ls'"
 msgstr "Jeton de type '%ls' inattendu"
 
-#: parser.cpp:158 parse_constants.h:209
+#: parser.cpp:67 parse_constants.h:255
 msgid "'while' block"
 msgstr "bloc 'while'"
 
-#: parser.cpp:163 parse_constants.h:214
+#: parser.cpp:72 parse_constants.h:260
 msgid "'for' block"
 msgstr "bloc 'for'"
 
-#: parser.cpp:168 parse_constants.h:219
+#: parser.cpp:77 parse_constants.h:265
 #, fuzzy
 msgid "Block created by breakpoint"
 msgstr "bloc créé par la commande interne '.'"
 
-#: parser.cpp:175 parse_constants.h:226
+#: parser.cpp:82 parse_constants.h:272
 msgid "'if' conditional block"
 msgstr "bloc conditionnel 'if'"
 
-#: parser.cpp:181 parse_constants.h:232
+#: parser.cpp:87 parse_constants.h:278
 msgid "function definition block"
 msgstr "bloc de définition de fonction"
 
-#: parser.cpp:187 parse_constants.h:238
+#: parser.cpp:92 parse_constants.h:284
 msgid "function invocation block"
 msgstr "bloc d'invocation de fonction"
 
-#: parser.cpp:192 parse_constants.h:243
+#: parser.cpp:97 parse_constants.h:289
 #, fuzzy
 msgid "function invocation block with no variable shadowing"
 msgstr "bloc d'invocation de fonction"
 
-#: parser.cpp:198 parse_constants.h:249
+#: parser.cpp:102 parse_constants.h:295
 msgid "'switch' block"
 msgstr "bloc 'switch'"
 
-#: parser.cpp:204 parse_constants.h:255
+#: parser.cpp:107 parse_constants.h:301
 msgid "unexecutable block"
 msgstr "bloc inexécutable"
 
-#: parser.cpp:210 parse_constants.h:261
+#: parser.cpp:112 parse_constants.h:307
 msgid "global root block"
 msgstr "bloc racine global"
 
-#: parser.cpp:216 parse_constants.h:267
+#: parser.cpp:117 parse_constants.h:313
 msgid "command substitution block"
 msgstr "bloc de substitution de commande"
 
-#: parser.cpp:222 parse_constants.h:273
+#: parser.cpp:122 parse_constants.h:319
 msgid "'begin' unconditional block"
 msgstr "bloc inconditionnel 'begin'"
 
-#: parser.cpp:228 parse_constants.h:279
+#: parser.cpp:127 parse_constants.h:325
 msgid "Block created by the . builtin"
 msgstr "bloc créé par la commande interne '.'"
 
-#: parser.cpp:233 parse_constants.h:284
+#: parser.cpp:132 parse_constants.h:330
 msgid "event handler block"
 msgstr "bloc de gestion d'événement"
 
-#: parser.cpp:239 parse_constants.h:290
+#: parser.cpp:137 parse_constants.h:336
 msgid "unknown/invalid block"
 msgstr "bloc inconnu/invalide"
 
-#: parser.cpp:645
+#: parser.cpp:474
 #, c-format
 msgid "Could not write profiling information to file '%s'"
 msgstr "Écriture des informations de profilage dans le fichier '%s' impossible"
 
-#: parser.cpp:651
+#: parser.cpp:480
 msgid "Time\tSum\tCommand\n"
 msgstr "Temps\tSomme\tCommande\n"
 
-#: parser.cpp:811
+#: parser.cpp:562
 #, c-format
 msgid "in event handler: %ls\n"
 msgstr "dans le gestionnaire d'événement: %ls\n"
 
-#: parser.cpp:839
+#: parser.cpp:590
 #, fuzzy, c-format
 msgid "from sourcing file %ls\n"
 msgstr "Erreur lors de la lecture du fichier %ls\n"
 
-#: parser.cpp:845
+#: parser.cpp:597
 #, fuzzy, c-format
 msgid "in function '%ls'\n"
 msgstr "dans la fonction '%ls',\n"
 
-#: parser.cpp:850
+#: parser.cpp:602
 msgid "in command substitution\n"
 msgstr "dans la substitution de commande\n"
 
-#: parser.cpp:863
+#: parser.cpp:615
 #, fuzzy, c-format
 msgid "\tcalled on line %d of file %ls\n"
 msgstr "\tappelé à la ligne %d du fichier '%ls',\n"
 
-#: parser.cpp:869
+#: parser.cpp:621
 #, fuzzy
 msgid "\tcalled during startup\n"
 msgstr "\tappelé sur l'entrée standard,\n"
 
-#: parser.cpp:873
+#: parser.cpp:625
 #, fuzzy
 msgid "\tcalled on standard input\n"
 msgstr "\tappelé sur l'entrée standard,\n"
 
-#: parser.cpp:890
+#: parser.cpp:642
 #, c-format
 msgid "\twith parameter list '%ls'\n"
 msgstr "\tavec la liste de paramètres '%ls'\n"
 
-#: parser.cpp:1087
+#: parser.cpp:756
 #, c-format
 msgid "%ls (line %d): "
 msgstr "%ls (ligne %d): "
 
-#: parser.cpp:1091
+#: parser.cpp:760
 msgid "Startup"
 msgstr ""
 
-#: parser.cpp:1197
+#: parser.cpp:803
 msgid "Job inconsistency"
 msgstr "Inconsistance de tâche"
 
-#: parser.cpp:1520
-msgid "Invalid IO redirection"
-msgstr "Redirection E/S invalide"
-
-#: parser.cpp:1541
-#, c-format
-msgid "Requested redirection to something that is not a file descriptor %ls"
-msgstr ""
-"Redirection demandée à quelque chose qui n'est pas un descripteur de fichier "
-"%ls"
-
-#: parser.cpp:2667 parser.cpp:2750
+#: parser.cpp:956
 msgid "End of block mismatch. Program terminating."
 msgstr "Fin du bloc incohérente. Fin du programme."
 
-#: parser.cpp:3034
+#: parser.cpp:1047
 #, fuzzy, c-format
 msgid "%ls (line %lu): "
 msgstr "%ls (ligne %d): "
+
+#: parser.cpp:1051
+#, c-format
+msgid "%ls: "
+msgstr ""
 
 #: path.cpp:24
 #, c-format
 msgid "Error while searching for command '%ls'"
 msgstr "Erreur lors de la recherche de la commande '%ls'"
 
-#: proc.cpp:615
+#: proc.cpp:690
+#, fuzzy, c-format
+msgid "'%ls' has %ls"
+msgstr "La tâche %d, '%ls' a %ls"
+
+#: proc.cpp:694
 #, c-format
 msgid "Job %d, '%ls' has %ls"
 msgstr "La tâche %d, '%ls' a %ls"
 
-#: proc.cpp:699
-#, c-format
-msgid "%ls: Job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:786
+#, fuzzy, c-format
+msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Tâche %d, '%ls' terminée par le signal %ls (%ls)"
 
-#: proc.cpp:707
-#, c-format
-msgid ""
-"%ls: Process %d, '%ls' from job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:797
+#, fuzzy, c-format
+msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 "%ls: Processus %d, '%ls' de la tâche %d, '%ls' terminé par le signal %ls "
 "(%ls)"
 
-#: proc.cpp:736
+#: proc.cpp:828
 msgid "ended"
 msgstr "terminé"
 
-#: proc.cpp:969
+#: proc.cpp:1065
 msgid "An error occured while reading output from code block"
 msgstr ""
 "Une erreur est survenue lors de la lecture de la sortie du bloc de code"
 
-#: proc.cpp:998 proc.cpp:1010
+#: proc.cpp:1094 proc.cpp:1106
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Mise en premier plan de la tâche %d ('%ls') impossible"
 
-#: proc.cpp:1030 proc.cpp:1040 proc.cpp:1055
+#: proc.cpp:1126 proc.cpp:1136 proc.cpp:1151
 msgid "Could not return shell to foreground"
 msgstr "Impossible de remettre le shell en premier plan"
 
-#: proc.cpp:1280 proc.cpp:1304
+#: proc.cpp:1354 proc.cpp:1380
 msgid "Process list pointer"
 msgstr "Pointeur de la liste des processus"
 
-#: proc.cpp:1291
+#: proc.cpp:1365
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "Plus d'une tâche en premier plan: tâche 1: '%ls' tâche 2: '%ls'"
 
-#: proc.cpp:1302
+#: proc.cpp:1378
 msgid "Process argument list"
 msgstr "Liste des arguments du processus"
 
-#: proc.cpp:1303
+#: proc.cpp:1379
 msgid "Process name"
 msgstr "Nom du processus"
 
-#: proc.cpp:1309
+#: proc.cpp:1385
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Tâche '%ls', le processus '%ls' a un état inconsistant 'arrêté'=%d"
 
-#: proc.cpp:1319
+#: proc.cpp:1395
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr "Tâche '%ls', le processus '%ls' a un état inconsistant 'complété'=%d"
 
-#: reader.cpp:453
+#: reader.cpp:478
 msgid "Could not set terminal mode for new job"
 msgstr "Impossible de définir le mode du terminal pour la nouvelle tâche"
 
-#: reader.cpp:477
+#: reader.cpp:525
 msgid "Could not set terminal mode for shell"
 msgstr "Impossible de définir le mode du terminal pour le shell"
 
-#: reader.cpp:2133
+#: reader.cpp:2059
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr ""
 
-#: reader.cpp:2148
+#: reader.cpp:2074
 #, c-format
 msgid ""
 "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr ""
 
-#: reader.cpp:2179
+#: reader.cpp:2105
 msgid "Couldn't put the shell in its own process group"
 msgstr "Mise impossible du shell dans son propre groupe de processus"
 
-#: reader.cpp:2189
+#: reader.cpp:2115
 msgid "Couldn't grab control of terminal"
 msgstr "Ne peut pas saisir le contrôle du terminal"
 
-#: reader.cpp:2703
+#: reader.cpp:2616
 msgid "Pop null reader block"
 msgstr "Pop null reader block"
 
-#: reader.cpp:2956
+#: reader.cpp:2882
 msgid ""
 "There are stopped jobs. A second attempt to exit will enforce their "
 "termination.\n"
 msgstr ""
 
-#: reader.cpp:4069
+#: reader.cpp:4115
 #, c-format
 msgid "Unknown keybinding %d"
 msgstr "Raccourci clavier inconnu %d"
 
-#: reader.cpp:4210
+#: reader.cpp:4226
 #, fuzzy
 msgid "Error while reading from file descriptor"
 msgstr "Erreur lors de la lecture du fichier %ls\n"
 
-#: reader.cpp:4227
+#: reader.cpp:4243
 msgid "Error while closing input stream"
 msgstr "Erreur lors de la fermeture du flux d'entrée"
 
-#: reader.cpp:4248
+#: reader.cpp:4270
 msgid "Error while opening input stream"
 msgstr "Erreur d'ouverture du flux d'entrée"
 
@@ -1652,7 +1553,7 @@ msgstr "Exécuter la tâche en arrière-plan"
 msgid "Comment"
 msgstr "Commentaire"
 
-#: tokenizer.cpp:602
+#: tokenizer.cpp:561
 #, fuzzy
 msgid "Invalid token type"
 msgstr "Jeton invalide"
@@ -1697,7 +1598,7 @@ msgstr "%ls: Option illégale -- %lc\n"
 msgid "%ls: Invalid option -- %lc\n"
 msgstr "%ls: Option invalide -- %lc\n"
 
-#: wgetopt.cpp:673
+#: wgetopt.cpp:676
 #, c-format
 msgid "%ls: Option requires an argument -- %lc\n"
 msgstr "%ls: L'option exige un argument -- %lc\n"
@@ -1710,7 +1611,7 @@ msgstr "Exécutable"
 msgid "Executable link"
 msgstr "Lien exécutable"
 
-#: wildcard.cpp:67 share/completions/git.fish:146
+#: wildcard.cpp:67 share/completions/git.fish:178
 msgid "File"
 msgstr "Fichier"
 
@@ -1844,31 +1745,24 @@ msgstr "%ls: L'argument '%ls' doit être un entier\n"
 msgid "An error occurred while setting up pipe"
 msgstr "Une erreur est survenue lors du paramétrage du tube"
 
-#: expand.h:132
+#: expand.h:135
 msgid "Array index out of bounds"
 msgstr ""
 
-#: output.h:91
-#, c-format
-msgid ""
-"Tried to use terminfo string %s on line %d of %s, which is undefined in "
-"terminal of type \"%ls\". Please report this error to %s"
-msgstr ""
-
-#: parse_constants.h:145
+#: parse_constants.h:185
 #, c-format
 msgid ""
 "The function '%ls' calls itself immediately, which would result in an "
 "infinite loop."
 msgstr ""
 
-#: parse_constants.h:149
+#: parse_constants.h:189
 msgid ""
 "The function call stack limit has been exceeded. Do you have an accidental "
 "infinite loop?"
 msgstr ""
 
-#: parse_constants.h:152
+#: parse_constants.h:192
 #, fuzzy
 msgid ""
 "Expected a command, but instead found a pipe. Did you mean 'COMMAND; or "
@@ -1879,10 +1773,10 @@ msgstr ""
 "Vouliez-vous dire 'COMMANDE; or COMMANDE'? Lisez l'aide pour la commande "
 "interne 'or' en tapant 'help or'."
 
-#: parse_constants.h:155
+#: parse_constants.h:195
 #, fuzzy
 msgid ""
-"Expected a command, but instead found a '&'. Did you mean 'COMMAND; and "
+"Expected a command, but instead found an '&'. Did you mean 'COMMAND; and "
 "COMMAND'? See the help section for the 'and' builtin command by typing 'help "
 "and'."
 msgstr ""
@@ -1890,22 +1784,62 @@ msgstr ""
 "Vouliez-vous dire 'COMMANDE; and COMMANDE'? Lisez l'aide pour la commande "
 "interne 'and' en tapant 'help and'."
 
-#: parse_constants.h:161
+#: parse_constants.h:198
+#, c-format
+msgid "Illegal command name '%ls'"
+msgstr "Nom de commande illégal '%ls'"
+
+#: parse_constants.h:201
+#, c-format
+msgid "Unknown builtin '%ls'"
+msgstr "Commande interne inconnue '%ls'"
+
+#: parse_constants.h:204
 #, fuzzy, c-format
 msgid "Unable to expand variable name '%ls'"
 msgstr "%ls: Nom de variable invalide '%ls'\n"
 
-#: parse_constants.h:170
+#: parse_constants.h:207
+#, fuzzy, c-format
+msgid "Unable to find a process '%ls'"
+msgstr "L'exécution du processus '%ls' a échoué"
+
+#: parse_constants.h:210
+#, c-format
+msgid "Illegal file descriptor in redirection '%ls'"
+msgstr ""
+
+#: parse_constants.h:213
+#, c-format
+msgid "No matches for wildcard '%ls'."
+msgstr ""
+
+#: parse_constants.h:216
 #, fuzzy
 msgid "break command while not inside of loop"
 msgstr "Commande de contrôle de boucle à l'extérieur d'une boucle"
 
-#: parse_constants.h:173
+#: parse_constants.h:219
 #, fuzzy
 msgid "continue command while not inside of loop"
 msgstr "Commande de contrôle de boucle à l'extérieur d'une boucle"
 
-#: parse_constants.h:184
+#: parse_constants.h:222
+#, fuzzy
+msgid "'return' builtin command outside of function definition"
+msgstr "Exécuter une commande interne au lieu d'une fonction"
+
+#: parse_constants.h:225
+#, fuzzy, c-format
+msgid ""
+"Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
+"the set command by typing 'help set'."
+msgstr ""
+"Commande '%ls' inconnue. Vouliez-vous dire 'set VARIABLE VALEUR'? Pour de "
+"l'information sur l'attribution de valeurs à des variables, lisez l'aide sur "
+"la commande 'set' en tapant 'help set'."
+
+#: parse_constants.h:230
 #, c-format
 msgid ""
 "The '$' character begins a variable name. The character '%lc', which "
@@ -1918,13 +1852,13 @@ msgstr ""
 "variables ne peuvent pas avoir une taille de 0. Pour en apprendre plus sur "
 "le développement de variables dans fish, tapez 'help expand-variable'."
 
-#: parse_constants.h:189
+#: parse_constants.h:235
 msgid ""
 "$? is not a valid variable in fish. If you want the exit status of the last "
 "command, try $status."
 msgstr ""
 
-#: parse_constants.h:194
+#: parse_constants.h:240
 msgid ""
 "The '$' begins a variable name. It was given at the end of an argument. "
 "Variable names may not be zero characters long. To learn more about variable "
@@ -1935,7 +1869,7 @@ msgstr ""
 "en apprendre plus sur le développement de variables dans fish, tapez 'help "
 "expand-variable'."
 
-#: parse_constants.h:199
+#: parse_constants.h:245
 #, fuzzy, c-format
 msgid ""
 "Did you mean %ls{$%ls}%ls? The '$' character begins a variable name. A "
@@ -1949,7 +1883,7 @@ msgstr ""
 "apprendre plus sur le développement de variables dans fish, tapez 'help "
 "expand-variable'."
 
-#: parse_constants.h:204
+#: parse_constants.h:250
 msgid ""
 "Did you mean (COMMAND)? In fish, the '$' character is only used for "
 "accessing variables. To learn more about command substitution in fish, type "
@@ -3082,216 +3016,307 @@ msgstr "Tester si apt doit se faire donner la sous-commande"
 msgid "Test if bundle has been given a specific subcommand"
 msgstr "Tester si apt doit se faire donner la sous-commande"
 
-#: share/completions/bundle.fish:30
+#: share/completions/bundle.fish:31
 #, fuzzy
 msgid "Display a help page"
 msgstr "Afficher la page de manuel"
 
-#: share/completions/bundle.fish:38 share/completions/bundle.fish:65
+#: share/completions/bundle.fish:39 share/completions/bundle.fish:83
 msgid "Install the gems specified by the Gemfile or Gemfile.lock"
 msgstr ""
 
-#: share/completions/bundle.fish:39 share/completions/bundle.fish:87
-msgid "The location of the Gemfile bundler should use."
-msgstr ""
-
-#: share/completions/bundle.fish:40
-msgid "The location to install the gems in the bundle to."
+#: share/completions/bundle.fish:40 share/completions/bundle.fish:106
+msgid "The location of the Gemfile bundler should use"
 msgstr ""
 
 #: share/completions/bundle.fish:41
-msgid "Installs the gems in the bundle to the system location."
+msgid "The location to install the gems in the bundle to"
 msgstr ""
 
 #: share/completions/bundle.fish:42
-msgid "A space-separated list of groups to skip installing."
-msgstr ""
+#, fuzzy
+msgid "Installs the gems in the bundle to the system location"
+msgstr "Appliquer les modifications au référentiel"
 
 #: share/completions/bundle.fish:43
-msgid "Use cached gems instead of connecting to rubygems.org."
+msgid "A space-separated list of groups to skip installing"
 msgstr ""
 
 #: share/completions/bundle.fish:44
-msgid "Switches bundler's defaults into deployment mode."
+msgid "Use cached gems instead of connecting to rubygems.org"
 msgstr ""
 
 #: share/completions/bundle.fish:45
-msgid ""
-"Create a directory containing executabes that run in the context of the "
-"bundle."
+msgid "Switches bundler's defaults into deployment mode."
 msgstr ""
 
 #: share/completions/bundle.fish:46
-msgid "Specify a ruby executable to use with generated binstubs."
+msgid ""
+"Create a directory containing executabes that run in the context of the "
+"bundle"
 msgstr ""
 
 #: share/completions/bundle.fish:47
-msgid "Make a bundle that can work without RubyGems or Bundler at run-time."
+msgid "Specify a ruby executable to use with generated binstubs"
 msgstr ""
 
 #: share/completions/bundle.fish:48
-msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
+msgid "Make a bundle that can work without RubyGems or Bundler at run-time"
 msgstr ""
 
 #: share/completions/bundle.fish:49
-msgid "Do not update the cache in vendor/cache with the newly bundled gems."
+msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
 msgstr ""
 
 #: share/completions/bundle.fish:50
+msgid "Install  gems parallely by starting size number of parallel workers"
+msgstr ""
+
+#: share/completions/bundle.fish:51
+msgid "Do not update the cache in vendor/cache with the newly bundled gems"
+msgstr ""
+
+#: share/completions/bundle.fish:52
 #, fuzzy
-msgid "Do not print progress information to stdout."
+msgid "Do not print progress information to stdout"
 msgstr "Écriture des informations de profilage dans le fichier '%s' impossible"
 
-#: share/completions/bundle.fish:53 share/completions/bundle.fish:66
+#: share/completions/bundle.fish:53
+#, fuzzy
+msgid "Run bundle clean automatically after install"
+msgstr "Liste des paquets à installer"
+
+#: share/completions/bundle.fish:54 share/completions/bundle.fish:63
+msgid "Use the rubygems modern index instead of the API endpoint"
+msgstr ""
+
+#: share/completions/bundle.fish:55 share/completions/bundle.fish:164
+#, fuzzy
+msgid "Do not remove stale gems from the cache"
+msgstr "Supprimer tous les fichiers gz de la cache"
+
+#: share/completions/bundle.fish:56
+msgid "Do not allow the Gemfile.lock to be updated after this install"
+msgstr ""
+
+#: share/completions/bundle.fish:59 share/completions/bundle.fish:84
 msgid "Update dependencies to their latest versions"
 msgstr ""
 
-#: share/completions/bundle.fish:54
-msgid "The name of a :git or :path source used in the Gemfile."
+#: share/completions/bundle.fish:60
+msgid "The name of a :git or :path source used in the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:58
+#: share/completions/bundle.fish:61
+msgid "Do not attempt to fetch gems remotely and use the gem cache instead"
+msgstr ""
+
+#: share/completions/bundle.fish:62
+msgid "Only output warnings and errors"
+msgstr ""
+
+#: share/completions/bundle.fish:64
+#, fuzzy
+msgid "Specify the number of jobs to run in parallel"
+msgstr "Liste des paquets à installer"
+
+#: share/completions/bundle.fish:65
+msgid "Update a specific group"
+msgstr ""
+
+#: share/completions/bundle.fish:69
 msgid ""
 "Package the .gem files required by your application into the vendor/cache "
 "directory"
 msgstr ""
 
-#: share/completions/bundle.fish:61 share/completions/bundle.fish:68
+#: share/completions/bundle.fish:72
+msgid "Install the binstubs of the listed gem"
+msgstr ""
+
+#: share/completions/bundle.fish:73
+msgid "Binstub destination directory (default bin)"
+msgstr ""
+
+#: share/completions/bundle.fish:74
+msgid "Overwrite existing binstubs if they exist"
+msgstr ""
+
+#: share/completions/bundle.fish:78 share/completions/bundle.fish:86
 msgid "Execute a script in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:64
+#: share/completions/bundle.fish:79
+msgid "Exec runs a command, providing it access to the gems in the bundle"
+msgstr ""
+
+#: share/completions/bundle.fish:82
 msgid "Describe available tasks or one specific task"
 msgstr ""
 
-#: share/completions/bundle.fish:67
+#: share/completions/bundle.fish:85
 #, fuzzy
 msgid "Package .gem files into the vendor/cache directory"
 msgstr "Appliquer les modifications au référentiel"
 
-#: share/completions/bundle.fish:69
+#: share/completions/bundle.fish:87
+#, fuzzy
+msgid "Specify and read configuration options for bundler"
+msgstr "Spécifier un fichier de configuration"
+
+#: share/completions/bundle.fish:88
 msgid "Check bundler requirements for your application"
 msgstr ""
 
-#: share/completions/bundle.fish:70 share/completions/bundle.fish:92
+#: share/completions/bundle.fish:89
 msgid "Show all of the gems in the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:71 share/completions/bundle.fish:96
+#: share/completions/bundle.fish:90
 msgid "Show the source location of a particular gem in the bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:72 share/completions/bundle.fish:100
+#: share/completions/bundle.fish:91 share/completions/bundle.fish:121
 msgid "Show all of the outdated gems in the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:73 share/completions/bundle.fish:107
+#: share/completions/bundle.fish:92 share/completions/bundle.fish:129
 msgid "Start an IRB session in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:74 share/completions/bundle.fish:110
+#: share/completions/bundle.fish:93 share/completions/bundle.fish:132
 #, sh-format
 msgid "Open an installed gem in your $EDITOR"
 msgstr ""
 
-#: share/completions/bundle.fish:75 share/completions/bundle.fish:114
+#: share/completions/bundle.fish:94 share/completions/bundle.fish:136
 msgid "Generate a visual representation of your dependencies"
 msgstr ""
 
-#: share/completions/bundle.fish:76
+#: share/completions/bundle.fish:95
 #, fuzzy
 msgid "Generate a simple Gemfile"
 msgstr "Générer un fichier maître"
 
-#: share/completions/bundle.fish:77 share/completions/bundle.fish:125
+#: share/completions/bundle.fish:96 share/completions/bundle.fish:147
 msgid "Create a simple gem, suitable for development with bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:78 share/completions/bundle.fish:131
+#: share/completions/bundle.fish:97 share/completions/bundle.fish:154
 msgid "Displays platform compatibility information"
 msgstr ""
 
-#: share/completions/bundle.fish:79 share/completions/bundle.fish:135
+#: share/completions/bundle.fish:98 share/completions/bundle.fish:158
 msgid "Cleans up unused gems in your bundler directory"
 msgstr ""
 
-#: share/completions/bundle.fish:86
+#: share/completions/bundle.fish:105
 msgid ""
 "Determine whether the requirements for your application are installed and "
 "available to bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:88
-msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)."
+#: share/completions/bundle.fish:107
+msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)"
 msgstr ""
 
-#: share/completions/bundle.fish:89
+#: share/completions/bundle.fish:108
 msgid "Lock the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:93
+#: share/completions/bundle.fish:111 share/completions/bundle.fish:116
+msgid ""
+"Show lists the names and versions of all gems that are required by your "
+"Gemfile"
+msgstr ""
+
+#: share/completions/bundle.fish:112 share/completions/bundle.fish:117
 msgid "List the paths of all gems required by your Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:101
+#: share/completions/bundle.fish:122
 msgid "Check for newer pre-release gems"
 msgstr ""
 
-#: share/completions/bundle.fish:102
+#: share/completions/bundle.fish:123
 msgid "Check against a specific source"
 msgstr ""
 
-#: share/completions/bundle.fish:103
+#: share/completions/bundle.fish:124
 msgid "Use cached gems instead of attempting to fetch gems remotely"
 msgstr ""
 
-#: share/completions/bundle.fish:115
+#: share/completions/bundle.fish:125
+msgid "Only list newer versions allowed by your Gemfile requirements"
+msgstr ""
+
+#: share/completions/bundle.fish:137
 msgid "The name to use for the generated file (see format option)"
 msgstr ""
 
-#: share/completions/bundle.fish:116
+#: share/completions/bundle.fish:138
 #, fuzzy
 msgid "Show each gem version"
 msgstr "Version de l'arbre source"
 
-#: share/completions/bundle.fish:117
+#: share/completions/bundle.fish:139
 msgid "Show the version of each required dependency"
 msgstr ""
 
-#: share/completions/bundle.fish:118
+#: share/completions/bundle.fish:140
 msgid "Output a specific format (png, jpg, svg, dot, ...)"
 msgstr ""
 
-#: share/completions/bundle.fish:121
+#: share/completions/bundle.fish:143
 msgid "Generate a simple Gemfile, placed in the current directory"
 msgstr ""
 
-#: share/completions/bundle.fish:122
+#: share/completions/bundle.fish:144
 msgid "Use a specified .gemspec to create the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:126
+#: share/completions/bundle.fish:148
 msgid "Generate a binary for your library"
 msgstr ""
 
-#: share/completions/bundle.fish:127
+#: share/completions/bundle.fish:149
 msgid "Generate a test directory for your library (rspec or minitest)"
 msgstr ""
 
-#: share/completions/bundle.fish:128
+#: share/completions/bundle.fish:150
 msgid "Path to your editor"
 msgstr ""
 
-#: share/completions/bundle.fish:132
+#: share/completions/bundle.fish:151
+msgid "Generate the boilerplate for C extension code"
+msgstr ""
+
+#: share/completions/bundle.fish:155
 msgid "Only display Ruby directive information"
 msgstr ""
 
-#: share/completions/bundle.fish:136
+#: share/completions/bundle.fish:159
 msgid "Only print out changes, do not actually clean gems"
 msgstr ""
 
-#: share/completions/bundle.fish:137
+#: share/completions/bundle.fish:160
 msgid "Forces clean even if --path is not set"
+msgstr ""
+
+#: share/completions/bundle.fish:163
+msgid "Cache all the gems to vendor/cache"
+msgstr ""
+
+#: share/completions/bundle.fish:165
+msgid "Include all sources (including path and git)"
+msgstr ""
+
+#: share/completions/bundle.fish:168
+msgid "Prints the license of all gems in the bundle"
+msgstr ""
+
+#: share/completions/bundle.fish:171
+msgid "Print information about the environment Bundler is running under"
 msgstr ""
 
 #: share/completions/configure.fish:1
@@ -3306,20 +3331,15 @@ msgstr "Afficher l'aide et quitter"
 msgid "Cache test results in specified file"
 msgstr ""
 
-#: share/completions/cp.fish:10 share/completions/mv.fish:6
+#: share/completions/cp.fish:11 share/completions/mv.fish:6
 msgid "Backup suffix"
 msgstr ""
 
 #: share/completions/cp.fish:20
-msgid "Don't preserve the specified attributes"
+msgid "Preserve ATTRIBUTES if possible"
 msgstr ""
 
-#: share/completions/cp.fish:24
-#, fuzzy
-msgid "Control creation of sparse files"
-msgstr "Ne pas créer de fichiers de sortie"
-
-#: share/completions/cp.fish:28
+#: share/completions/cp.fish:29
 msgid "Set security context of copy to CONTEXT"
 msgstr ""
 
@@ -3921,6 +3941,33 @@ msgstr ""
 msgid "Block size"
 msgstr ""
 
+#: share/completions/docker.fish:19
+#, fuzzy
+msgid "Show all containers"
+msgstr "Afficher les entrées ARP"
+
+#: share/completions/docker.fish:24
+#, fuzzy
+msgid "Show the running containers"
+msgstr "Afficher le temps"
+
+#: share/completions/docker.fish:28
+#, fuzzy
+msgid "Show the exited containers"
+msgstr "Afficher le temps"
+
+#: share/completions/docker.fish:70 share/completions/docker.fish:92
+msgid "Docker container"
+msgstr ""
+
+#: share/completions/docker.fish:82
+msgid "Stopped container"
+msgstr ""
+
+#: share/completions/docker.fish:87
+msgid "Container running"
+msgstr ""
+
 #: share/completions/du.fish:15
 msgid "Exclude files that match pattern in file"
 msgstr ""
@@ -3933,93 +3980,93 @@ msgstr ""
 msgid "Recursion limit"
 msgstr ""
 
-#: share/completions/duply.fish:5
+#: share/completions/duply.fish:3
 #, fuzzy
 msgid "Profile"
 msgstr "Fichier de config"
 
-#: share/completions/duply.fish:6
+#: share/completions/duply.fish:4
 msgid "Get usage help text"
 msgstr ""
 
-#: share/completions/duply.fish:9
+#: share/completions/duply.fish:7
 #, fuzzy
 msgid "Creates a configuration profile"
 msgstr "Spécifier un fichier de configuration"
 
-#: share/completions/duply.fish:10
+#: share/completions/duply.fish:8
 msgid "Backup with pre/post script execution"
 msgstr ""
 
-#: share/completions/duply.fish:11
+#: share/completions/duply.fish:9
 msgid "Backup without executing pre/post scripts"
 msgstr ""
 
-#: share/completions/duply.fish:12
+#: share/completions/duply.fish:10
 msgid "Execute <profile>/pre script"
 msgstr ""
 
-#: share/completions/duply.fish:13
+#: share/completions/duply.fish:11
 msgid "Execute <profile>/post script"
 msgstr ""
 
-#: share/completions/duply.fish:14
+#: share/completions/duply.fish:12
 msgid "Force full backup"
 msgstr ""
 
-#: share/completions/duply.fish:15
+#: share/completions/duply.fish:13
 msgid "Force incremental backup"
 msgstr ""
 
-#: share/completions/duply.fish:16
+#: share/completions/duply.fish:14
 msgid "List all files in backup (as it was at <age>, default: now)"
 msgstr ""
 
-#: share/completions/duply.fish:17
+#: share/completions/duply.fish:15
 msgid "Prints backup sets and chains currently in repository"
 msgstr ""
 
-#: share/completions/duply.fish:18
+#: share/completions/duply.fish:16
 msgid "List files changed since latest backup"
 msgstr ""
 
-#: share/completions/duply.fish:19
+#: share/completions/duply.fish:17
 msgid "Shows outdated backup archives [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:20
+#: share/completions/duply.fish:18
 msgid "Shows outdated backups [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:21
+#: share/completions/duply.fish:19
 msgid "Shows broken backup archives [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:22
+#: share/completions/duply.fish:20
 msgid "Restore the backup to <target_path> [as it was at <age>]"
 msgstr ""
 
-#: share/completions/duply.fish:23
+#: share/completions/duply.fish:21
 msgid "Restore single file/folder from backup [as it was at <age>]"
 msgstr ""
 
-#: share/completions/duply.fish:26
+#: share/completions/duply.fish:24
 msgid "Really execute the commands: purge, purge-full, cleanup"
 msgstr ""
 
-#: share/completions/duply.fish:27
+#: share/completions/duply.fish:25
 msgid "Do nothing but print out generated duplicity command lines"
 msgstr ""
 
-#: share/completions/duply.fish:28
+#: share/completions/duply.fish:26
 msgid "Calculate what would be done, but dont perform any actions"
 msgstr ""
 
-#: share/completions/duply.fish:29
+#: share/completions/duply.fish:27
 msgid "Dont abort when backup different dirs to the same backend"
 msgstr ""
 
-#: share/completions/duply.fish:30
+#: share/completions/duply.fish:28
 #, fuzzy
 msgid "Output verbosity level"
 msgstr "Fichier sources.list de sortie"
@@ -4029,12 +4076,12 @@ msgid ""
 "Prints completions for installed packages on the system from /var/db/pkg"
 msgstr ""
 
-#: share/completions/emerge.fish:12 share/completions/equery.fish:12
+#: share/completions/emerge.fish:13 share/completions/equery.fish:12
 msgid ""
 "Prints completions for all available packages on the system from /usr/portage"
 msgstr ""
 
-#: share/completions/emerge.fish:19
+#: share/completions/emerge.fish:22
 #, fuzzy
 msgid ""
 "Tests if emerge command should have an installed package as potential "
@@ -4043,59 +4090,11 @@ msgstr ""
 "Tester si la commande apt devrait avoir les paquets comme complétion "
 "potentielle"
 
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-#, fuzzy
-msgid "All base system packages"
-msgstr "Efface les paquets construits"
-
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-#, fuzzy
-msgid "All packages in world"
-msgstr "Synchroniser les paquets installés"
-
-#: share/completions/emerge.fish:30
-#, fuzzy
-msgid "Installed package"
-msgstr "Installer des paquets source"
-
-#: share/completions/emerge.fish:31
-#: share/functions/__fish_print_packages.fish:13
-msgid "Package"
-msgstr "Paquet"
-
-#: share/completions/emerge.fish:35
-msgid "Usage overview of emerge"
+#: share/completions/emerge.fish:32
+msgid ""
+"Print completions for all packages including the version compare if that is "
+"already typed"
 msgstr ""
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject system"
-msgstr ""
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject config"
-msgstr ""
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject sync"
-msgstr ""
-
-#: share/completions/emerge.fish:57
-msgid "Use colors in output"
-msgstr ""
-
-#: share/completions/emerge.fish:57
-msgid "Don't use colors in output"
-msgstr ""
-
-#: share/completions/emerge.fish:81
-#, fuzzy
-msgid "Pull in build time dependencies"
-msgstr "Afficher les dépendances de construction"
-
-#: share/completions/emerge.fish:81
-#, fuzzy
-msgid "Don't pull in build time dependencies"
-msgstr "Afficher les dépendances de construction"
 
 #: share/completions/env.fish:2
 #, fuzzy
@@ -4596,11 +4595,16 @@ msgstr ""
 msgid "Update the RubyGems system software"
 msgstr ""
 
-#: share/completions/git.fish:121 share/completions/git.fish:144
+#: share/completions/git.fish:98
+#, fuzzy
+msgid "name"
+msgstr "Nom d'utilisateur"
+
+#: share/completions/git.fish:153 share/completions/git.fish:176
 msgid "Branch"
 msgstr ""
 
-#: share/completions/git.fish:145
+#: share/completions/git.fish:177
 msgid "Tag"
 msgstr ""
 
@@ -4836,560 +4840,6 @@ msgstr ""
 msgid "Help on process expansion %JOB"
 msgstr ""
 
-#: share/completions/hg.fish:17
-msgid "add the specified files on the next commit"
-msgstr ""
-
-#: share/completions/hg.fish:18
-msgid "add all new files, delete all missing files"
-msgstr ""
-
-#: share/completions/hg.fish:19
-msgid "show changeset information by line for each file"
-msgstr ""
-
-#: share/completions/hg.fish:20
-msgid "create an unversioned archive of a repository revision"
-msgstr ""
-
-#: share/completions/hg.fish:21
-msgid "reverse effect of earlier changeset"
-msgstr ""
-
-#: share/completions/hg.fish:22
-msgid "subdivision search of changesets"
-msgstr ""
-
-#: share/completions/hg.fish:23
-msgid "track a line of development with movable markers"
-msgstr ""
-
-#: share/completions/hg.fish:24
-msgid "set or show the current branch name"
-msgstr ""
-
-#: share/completions/hg.fish:25
-msgid "list repository named branches"
-msgstr ""
-
-#: share/completions/hg.fish:26
-#, fuzzy
-msgid "create a changegroup file"
-msgstr "Lire le paquet depuis un fichier"
-
-#: share/completions/hg.fish:27
-msgid "output the current or given revision of files"
-msgstr ""
-
-#: share/completions/hg.fish:28
-msgid "make a copy of an existing repository"
-msgstr ""
-
-#: share/completions/hg.fish:29
-msgid "commit the specified files or all outstanding changes"
-msgstr ""
-
-#: share/completions/hg.fish:30
-msgid "mark files as copied for the next commit"
-msgstr ""
-
-#: share/completions/hg.fish:31
-msgid "diff repository (or selected files)"
-msgstr ""
-
-#: share/completions/hg.fish:32
-msgid "dump the header and diffs for one or more changesets"
-msgstr ""
-
-#: share/completions/hg.fish:33
-msgid "forget the specified files on the next commit"
-msgstr ""
-
-#: share/completions/hg.fish:34
-msgid "copy changes from other branches onto the current branch"
-msgstr ""
-
-#: share/completions/hg.fish:35
-msgid "search for a pattern in specified files and revisions"
-msgstr ""
-
-#: share/completions/hg.fish:36
-msgid "show current repository heads or show branch heads"
-msgstr ""
-
-#: share/completions/hg.fish:37
-msgid "show help for a given topic or a help overview"
-msgstr ""
-
-#: share/completions/hg.fish:38
-msgid "identify the working copy or specified revision"
-msgstr ""
-
-#: share/completions/hg.fish:39
-msgid "import an ordered set of patches"
-msgstr ""
-
-#: share/completions/hg.fish:40
-msgid "show new changesets found in source"
-msgstr ""
-
-#: share/completions/hg.fish:41
-#, fuzzy
-msgid "create a new repository in the given directory"
-msgstr "Créer un référentiel CVS s'il n'existe pas"
-
-#: share/completions/hg.fish:42
-msgid "locate files matching specific patterns"
-msgstr ""
-
-#: share/completions/hg.fish:43
-msgid "show revision history of entire repository or files"
-msgstr ""
-
-#: share/completions/hg.fish:44
-msgid "output the current or given revision of the project manifest"
-msgstr ""
-
-#: share/completions/hg.fish:45
-msgid "merge working directory with another revision"
-msgstr ""
-
-#: share/completions/hg.fish:46
-msgid "show changesets not found in the destination"
-msgstr ""
-
-#: share/completions/hg.fish:47
-msgid "show the parents of the working directory or revision"
-msgstr ""
-
-#: share/completions/hg.fish:48
-msgid "show aliases for remote repositories"
-msgstr ""
-
-#: share/completions/hg.fish:49
-msgid "set or show the current phase name"
-msgstr ""
-
-#: share/completions/hg.fish:50
-msgid "pull changes from the specified source"
-msgstr ""
-
-#: share/completions/hg.fish:51
-msgid "push changes to the specified destination"
-msgstr ""
-
-#: share/completions/hg.fish:52
-msgid "roll back an interrupted transaction"
-msgstr ""
-
-#: share/completions/hg.fish:53
-#, fuzzy
-msgid "remove the specified files on the next commit"
-msgstr "Déplacer le fichier spécifier dans la ligne de commande"
-
-#: share/completions/hg.fish:54
-msgid "rename files; equivalent of copy + remove"
-msgstr ""
-
-#: share/completions/hg.fish:55
-msgid "redo merges or set/view the merge status of files"
-msgstr ""
-
-#: share/completions/hg.fish:56
-msgid "restore files to their checkout state"
-msgstr ""
-
-#: share/completions/hg.fish:57
-msgid "roll back the last transaction (dangerous)"
-msgstr ""
-
-#: share/completions/hg.fish:58
-msgid "print the root (top) of the current working directory"
-msgstr ""
-
-#: share/completions/hg.fish:59
-msgid "start stand-alone webserver"
-msgstr ""
-
-#: share/completions/hg.fish:60
-msgid "show combined config settings from all hgrc files"
-msgstr ""
-
-#: share/completions/hg.fish:61
-#, fuzzy
-msgid "show changed files in the working directory"
-msgstr "Changer le répertoire de travail"
-
-#: share/completions/hg.fish:62
-#, fuzzy
-msgid "summarize working directory state"
-msgstr "Changer le répertoire de travail"
-
-#: share/completions/hg.fish:63
-msgid "add one or more tags for the current or given revision"
-msgstr ""
-
-#: share/completions/hg.fish:64
-msgid "list repository tags"
-msgstr ""
-
-#: share/completions/hg.fish:65
-#, fuzzy
-msgid "show the tip revision"
-msgstr "Afficher le temps"
-
-#: share/completions/hg.fish:66
-#, fuzzy
-msgid "apply one or more changegroup files"
-msgstr "Installer un ou des paquets"
-
-#: share/completions/hg.fish:67
-msgid "update working directory (or switch revisions)"
-msgstr ""
-
-#: share/completions/hg.fish:68
-#, fuzzy
-msgid "verify the integrity of the repository"
-msgstr "Enlever un fichier du référentiel"
-
-#: share/completions/hg.fish:69
-msgid "output version and copyright information"
-msgstr ""
-
-#: share/completions/hg.fish:70
-#, fuzzy
-msgid "Configuration Files"
-msgstr "Spécifier un fichier de configuration"
-
-#: share/completions/hg.fish:71
-msgid "Date Formats"
-msgstr ""
-
-#: share/completions/hg.fish:72
-msgid "Diff Formats"
-msgstr ""
-
-#: share/completions/hg.fish:73
-#, fuzzy
-msgid "Environment Variables"
-msgstr "Gérer les variables d'environnement"
-
-#: share/completions/hg.fish:74
-msgid "Using Additional Features"
-msgstr ""
-
-#: share/completions/hg.fish:75
-#, fuzzy
-msgid "Specifying File Sets"
-msgstr "Spécifier le fichier de config"
-
-#: share/completions/hg.fish:76
-msgid "Glossary"
-msgstr ""
-
-#: share/completions/hg.fish:77
-msgid "Syntax for Mercurial Ignore Files"
-msgstr ""
-
-#: share/completions/hg.fish:78
-msgid "Configuring hgweb"
-msgstr ""
-
-#: share/completions/hg.fish:79
-#, fuzzy
-msgid "Merge Tools"
-msgstr "Fusionner les révisions"
-
-#: share/completions/hg.fish:80
-msgid "Specifying Multiple Revisions"
-msgstr ""
-
-#: share/completions/hg.fish:81
-msgid "File Name Patterns"
-msgstr ""
-
-#: share/completions/hg.fish:82
-msgid "Working with Phases"
-msgstr ""
-
-#: share/completions/hg.fish:83
-msgid "Specifying Single Revisions"
-msgstr ""
-
-#: share/completions/hg.fish:84
-#, fuzzy
-msgid "Specifying Revision Sets"
-msgstr "Spécifier les options"
-
-#: share/completions/hg.fish:85
-msgid "Subrepositories"
-msgstr ""
-
-#: share/completions/hg.fish:86
-msgid "Template Usage"
-msgstr ""
-
-#: share/completions/hg.fish:87
-msgid "URL Paths"
-msgstr ""
-
-#: share/completions/hg.fish:94 share/completions/hg.fish:433
-#: share/completions/hg.fish:458 share/completions/hg.fish:569
-#: share/completions/hg.fish:579 share/completions/hg.fish:594
-#: share/completions/hg.fish:606 share/completions/hg.fish:671
-msgid "[+] include names matching the given patterns"
-msgstr ""
-
-#: share/completions/hg.fish:95 share/completions/hg.fish:434
-#: share/completions/hg.fish:459 share/completions/hg.fish:570
-#: share/completions/hg.fish:580 share/completions/hg.fish:595
-#: share/completions/hg.fish:607 share/completions/hg.fish:672
-msgid "[+] exclude names matching the given patterns"
-msgstr ""
-
-#: share/completions/hg.fish:104 share/completions/hg.fish:391
-msgid "Guess renamed files by similarity (0<=s<=100)"
-msgstr ""
-
-#: share/completions/hg.fish:105
-msgid "[+]   include names matching the given patterns"
-msgstr ""
-
-#: share/completions/hg.fish:106
-msgid "[+]   exclude names matching the given patterns"
-msgstr ""
-
-#: share/completions/hg.fish:114
-msgid "Annotate the specified revision"
-msgstr ""
-
-#: share/completions/hg.fish:387
-msgid "Use text as commit message"
-msgstr ""
-
-#: share/completions/hg.fish:388
-msgid "Read commit message from file"
-msgstr ""
-
-#: share/completions/hg.fish:389 share/completions/hg.fish:693
-msgid "Record the specified date as commit date"
-msgstr ""
-
-#: share/completions/hg.fish:390 share/completions/hg.fish:694
-msgid "Record the specified user as committer"
-msgstr ""
-
-#: share/completions/hg.fish:400
-msgid "File to store the bundles into"
-msgstr ""
-
-#: share/completions/hg.fish:401 share/completions/hg.fish:446
-#: share/completions/hg.fish:448 share/completions/hg.fish:450
-#: share/completions/hg.fish:485 share/completions/hg.fish:534
-#: share/completions/hg.fish:536 share/completions/hg.fish:548
-#: share/completions/hg.fish:550 share/completions/hg.fish:669
-msgid "[+]"
-msgstr ""
-
-#: share/completions/hg.fish:403
-msgid "[+] a specific branch you would like to pull"
-msgstr ""
-
-#: share/completions/hg.fish:406 share/completions/hg.fish:453
-#: share/completions/hg.fish:491
-msgid "Limit number of changes displayed"
-msgstr ""
-
-#: share/completions/hg.fish:409 share/completions/hg.fish:456
-#: share/completions/hg.fish:494 share/completions/hg.fish:507
-#: share/completions/hg.fish:709
-msgid "Display using template map file"
-msgstr ""
-
-#: share/completions/hg.fish:410 share/completions/hg.fish:457
-#: share/completions/hg.fish:495 share/completions/hg.fish:508
-#: share/completions/hg.fish:710
-#, fuzzy
-msgid "Display with template"
-msgstr "Afficher la page de manuel"
-
-#: share/completions/hg.fish:411 share/completions/hg.fish:421
-#: share/completions/hg.fish:496 share/completions/hg.fish:537
-#: share/completions/hg.fish:552
-#, fuzzy
-msgid "Specify ssh command to use"
-msgstr "Spécifier le type d'enregistrement"
-
-#: share/completions/hg.fish:412 share/completions/hg.fish:422
-#: share/completions/hg.fish:497 share/completions/hg.fish:538
-#: share/completions/hg.fish:553
-msgid "Specify hg command to run on the remote side"
-msgstr ""
-
-#: share/completions/hg.fish:430
-msgid "Search the repository as it is in REV"
-msgstr ""
-
-#: share/completions/hg.fish:441
-msgid "A filename will only show ancestors or"
-msgstr ""
-
-#: share/completions/hg.fish:443
-#, fuzzy
-msgid "Show revisions matching date spec"
-msgstr "Voir qui surveille un fichier"
-
-#: share/completions/hg.fish:445
-msgid "[+]    do case-insensitive search for a given text"
-msgstr ""
-
-#: share/completions/hg.fish:449
-msgid "[+]   show changesets within the given named branch"
-msgstr ""
-
-#: share/completions/hg.fish:466
-#, fuzzy
-msgid "Revision to display"
-msgstr "Choisir l'affichage"
-
-#: share/completions/hg.fish:475
-msgid "Revision to merge"
-msgstr ""
-
-#: share/completions/hg.fish:477 share/completions/hg.fish:593
-#, fuzzy
-msgid "Specify merge tool"
-msgstr "Spécifier le type d'enregistrement"
-
-#: share/completions/hg.fish:488
-msgid "[+] a specific branch you would like to push"
-msgstr ""
-
-#: share/completions/hg.fish:506
-#, fuzzy
-msgid "Show parents of the specified revision"
-msgstr "Afficher les différences entre les révisions"
-
-#: share/completions/hg.fish:525
-#, fuzzy
-msgid "[+] target revision"
-msgstr "Fusionner les révisions"
-
-#: share/completions/hg.fish:535
-msgid "[+] bookmark to pull"
-msgstr ""
-
-#: share/completions/hg.fish:546
-msgid "You want to allow push to create a new named branch"
-msgstr ""
-
-#: share/completions/hg.fish:549
-msgid "[+] bookmark to push"
-msgstr ""
-
-#: share/completions/hg.fish:603 share/completions/hg.fish:726
-msgid "Tipmost revision matching date"
-msgstr ""
-
-#: share/completions/hg.fish:604
-msgid "Revert to the specified revision"
-msgstr ""
-
-#: share/completions/hg.fish:615
-msgid "Not perform actions, just print output"
-msgstr ""
-
-#: share/completions/hg.fish:629
-msgid "Name of access log file to write to"
-msgstr ""
-
-#: share/completions/hg.fish:631
-msgid "Used internally by daemon mode"
-msgstr ""
-
-#: share/completions/hg.fish:632
-msgid "Name of error log file to write to"
-msgstr ""
-
-#: share/completions/hg.fish:633
-msgid "Port to listen on (default: 8000)"
-msgstr ""
-
-#: share/completions/hg.fish:634
-msgid "Address to listen on (default: all interfaces)"
-msgstr ""
-
-#: share/completions/hg.fish:635
-msgid "Prefix path to serve from (default: server root)"
-msgstr ""
-
-#: share/completions/hg.fish:636
-msgid "Name to show in web pages (default: working"
-msgstr ""
-
-#: share/completions/hg.fish:637
-msgid "Name of the hgweb config file (see \"hg help hgweb\")"
-msgstr ""
-
-#: share/completions/hg.fish:638
-msgid "Name of file to write process ID to"
-msgstr ""
-
-#: share/completions/hg.fish:640
-#, fuzzy
-msgid "For remote clients"
-msgstr "Lister ou enlever des fonctions"
-
-#: share/completions/hg.fish:641
-msgid "Web templates to use"
-msgstr ""
-
-#: share/completions/hg.fish:642
-msgid "Template style to use"
-msgstr ""
-
-#: share/completions/hg.fish:644
-msgid "SSL certificate file"
-msgstr ""
-
-#: share/completions/hg.fish:651
-#, fuzzy
-msgid "Untrusted configuration options"
-msgstr "Définir les options de config"
-
-#: share/completions/hg.fish:670
-msgid "List the changed files of a revision"
-msgstr ""
-
-#: share/completions/hg.fish:680
-msgid "For push and pull"
-msgstr ""
-
-#: share/completions/hg.fish:689
-msgid "Revision to tag"
-msgstr ""
-
-#: share/completions/hg.fish:692
-msgid "Use <text> as commit message"
-msgstr ""
-
-#: share/completions/hg.fish:717
-msgid "To new branch head if changesets were unbundled"
-msgstr ""
-
-#: share/completions/hg.fish:727
-#, fuzzy
-msgid "Revision"
-msgstr "Verrouiller une révision"
-
-#: share/completions/hg.fish:844
-msgid "Or select an existing template-style (--style)"
-msgstr ""
-
-#: share/completions/hg.fish:845
-msgid "Is set"
-msgstr ""
-
 #: share/completions/history.fish:1
 msgid "Match history items that start with the given prefix"
 msgstr ""
@@ -5410,6 +4860,11 @@ msgstr ""
 #: share/completions/ifup.fish:1
 msgid "Network interface"
 msgstr ""
+
+#: share/completions/kitchen.fish:3
+#, fuzzy
+msgid "Test if kitchen has yet to be given the main command"
+msgstr "Tester si apt doit se faire donner la sous-commande"
 
 #: share/completions/less.fish:3
 msgid "Buffer space"
@@ -5625,6 +5080,442 @@ msgstr "Spécifier le titre du rss"
 
 #: share/completions/mv.fish:4
 msgid "Answer for overwrite questions"
+msgstr ""
+
+#: share/completions/node.fish:9
+#, fuzzy
+msgid "Print node's version"
+msgstr "Afficher la version des paquets"
+
+#: share/completions/node.fish:10
+msgid "Evaluate script"
+msgstr ""
+
+#: share/completions/node.fish:11
+msgid "Print result of --eval"
+msgstr ""
+
+#: share/completions/obnam.fish:9
+#, fuzzy
+msgid "Adds an encryption key to the repository"
+msgstr "Ajouter un fichier/répertoire au référentiel"
+
+#: share/completions/obnam.fish:11
+msgid "Lists the keys associated with each client"
+msgstr ""
+
+#: share/completions/obnam.fish:12
+#, fuzzy
+msgid "Lists the clients in the repository"
+msgstr "Mettre à jour le référentiel"
+
+#: share/completions/obnam.fish:13
+#, fuzzy
+msgid "Compares two generations"
+msgstr "Définir les options de config"
+
+#: share/completions/obnam.fish:14
+#, fuzzy
+msgid "Dumps the repository"
+msgstr "Mettre à jour le référentiel"
+
+#: share/completions/obnam.fish:15
+#, fuzzy
+msgid "Removes a lock file for a client"
+msgstr "Supprimer tous les fichiers gz de la cache"
+
+#: share/completions/obnam.fish:16
+#, fuzzy
+msgid "Removes backup generations"
+msgstr "Enlever la complétion"
+
+#: share/completions/obnam.fish:17
+#, fuzzy
+msgid "Checks the consistency of the repository"
+msgstr "Appliquer les modifications au référentiel"
+
+#: share/completions/obnam.fish:18
+msgid "Lists every backup generation"
+msgstr ""
+
+#: share/completions/obnam.fish:19
+msgid "Lists the identifier for every generation"
+msgstr ""
+
+#: share/completions/obnam.fish:20
+#, fuzzy
+msgid "Lists the keys"
+msgstr "Lister les clés de confiance"
+
+#: share/completions/obnam.fish:21
+#, fuzzy
+msgid "Lists the toplevel keys"
+msgstr "Lister les clés de confiance"
+
+#: share/completions/obnam.fish:22
+#, fuzzy
+msgid "Lists the contents of a given generation"
+msgstr "Générer le contenu"
+
+#: share/completions/obnam.fish:23
+msgid "Makes the repository available via FUSE"
+msgstr ""
+
+#: share/completions/obnam.fish:24
+msgid "Check if a backup age exceeds a threshold"
+msgstr ""
+
+#: share/completions/obnam.fish:25
+#, fuzzy
+msgid "Removes a client from the repository"
+msgstr "Enlever un fichier du référentiel"
+
+#: share/completions/obnam.fish:26
+#, fuzzy
+msgid "Removes a key from the repository"
+msgstr "Enlever un fichier du référentiel"
+
+#: share/completions/obnam.fish:27
+#, fuzzy
+msgid "Restore files from the repository"
+msgstr "Appliquer les modifications au référentiel"
+
+#: share/completions/obnam.fish:28
+#, fuzzy
+msgid "Verifies files in the repository"
+msgstr "Appliquer les modifications au référentiel"
+
+#: share/completions/obnam.fish:30
+msgid "Restore setuid/setgid bits in restored files"
+msgstr ""
+
+#: share/completions/obnam.fish:31
+msgid "Do not restore setuid/setgid bits in restored files"
+msgstr ""
+
+#: share/completions/obnam.fish:32
+msgid "Name of client"
+msgstr ""
+
+#: share/completions/obnam.fish:33
+#, fuzzy
+msgid "Compress repository with"
+msgstr "Compresser vers stdout"
+
+#: share/completions/obnam.fish:34
+msgid "For --nagios-last-backup-age: maximum age"
+msgstr ""
+
+#: share/completions/obnam.fish:35
+msgid "Dump metadata about files"
+msgstr ""
+
+#: share/completions/obnam.fish:36
+#, fuzzy
+msgid "Do not dump metadata about files"
+msgstr "Ne pas suppr. les fichiers construits"
+
+#: share/completions/obnam.fish:37
+#, fuzzy
+msgid "Generate man page"
+msgstr "Génère un nombre aléatoire"
+
+#: share/completions/obnam.fish:38
+msgid "Which generation to restore"
+msgstr ""
+
+#: share/completions/obnam.fish:39
+#, fuzzy
+msgid "Show this help message and exit"
+msgstr "Charger le média et quitter"
+
+#: share/completions/obnam.fish:40
+msgid "Policy for what generations to keep when forgetting."
+msgstr ""
+
+#: share/completions/obnam.fish:41
+msgid "Wait TIMEOUT seconds for an existing lock"
+msgstr ""
+
+#: share/completions/obnam.fish:43
+#, fuzzy
+msgid "Do not actually change anything"
+msgstr "Ne pas modifier aucun fichier"
+
+#: share/completions/obnam.fish:44
+msgid "Actually commit changes"
+msgstr ""
+
+#: share/completions/obnam.fish:45
+msgid "Show only errors, no progress updates"
+msgstr ""
+
+#: share/completions/obnam.fish:46
+msgid "Show errors and progress updates"
+msgstr ""
+
+#: share/completions/obnam.fish:49
+msgid "Simulate failures for files that match REGEXP"
+msgstr ""
+
+#: share/completions/obnam.fish:52
+msgid "Be more verbose"
+msgstr ""
+
+#: share/completions/obnam.fish:53
+#, fuzzy
+msgid "Do not be verbose"
+msgstr "Ne pas écraser"
+
+#: share/completions/obnam.fish:54
+msgid "Verify N files randomly from the backup"
+msgstr ""
+
+#: share/completions/obnam.fish:55
+#, fuzzy
+msgid "Show version number and exit"
+msgstr "Afficher la version et quitter"
+
+#: share/completions/obnam.fish:57
+msgid "Make a checkpoint after a given SIZE"
+msgstr ""
+
+#: share/completions/obnam.fish:58
+#, fuzzy
+msgid "Deduplicate mode"
+msgstr "Mode silencieux"
+
+#: share/completions/obnam.fish:60
+msgid "Exclude directories tagged as cache"
+msgstr ""
+
+#: share/completions/obnam.fish:61
+msgid "Include directories tagged as cache"
+msgstr ""
+
+#: share/completions/obnam.fish:63
+msgid "Leave checkpoint generations at the end of backup"
+msgstr ""
+
+#: share/completions/obnam.fish:64
+msgid "Omit checkpoint generations at the end of backup"
+msgstr ""
+
+#: share/completions/obnam.fish:65
+msgid "Do not follow mount points"
+msgstr ""
+
+#: share/completions/obnam.fish:66
+#, fuzzy
+msgid "Follow mount points"
+msgstr "Point de montage"
+
+#: share/completions/obnam.fish:67
+msgid "Put small files directly into the B-tree"
+msgstr ""
+
+#: share/completions/obnam.fish:68
+msgid "No not put small files into the B-tree"
+msgstr ""
+
+#: share/completions/obnam.fish:70
+#, fuzzy
+msgid "Write out the current configuration"
+msgstr "Recharger la configuration du service"
+
+#: share/completions/obnam.fish:71
+msgid "Write out setting names"
+msgstr ""
+
+#: share/completions/obnam.fish:72
+#, fuzzy
+msgid "Show all options"
+msgstr "Afficher les entrées ARP"
+
+#: share/completions/obnam.fish:73
+#, fuzzy
+msgid "List config files"
+msgstr "Utiliser le fichier de config"
+
+#: share/completions/obnam.fish:74
+#, fuzzy
+msgid "Clear list of configuration files to read"
+msgstr "Spécifier un fichier de configuration"
+
+#: share/completions/obnam.fish:75
+msgid "PGP key with which to encrypt"
+msgstr ""
+
+#: share/completions/obnam.fish:76
+#, fuzzy
+msgid "Show additional user IDs"
+msgstr "Afficher l'historique de tous les utilisateurs"
+
+#: share/completions/obnam.fish:77
+msgid "Do not show additional user IDs"
+msgstr ""
+
+#: share/completions/obnam.fish:78
+msgid "PGP key id"
+msgstr ""
+
+#: share/completions/obnam.fish:79
+msgid "Size of symmetric key"
+msgstr ""
+
+#: share/completions/obnam.fish:80
+#, fuzzy
+msgid "Use /dev/urandom instead of /dev/random"
+msgstr "Purger au lieu de supprimer"
+
+#: share/completions/obnam.fish:81
+msgid "Use default /dev/random"
+msgstr ""
+
+#: share/completions/obnam.fish:83
+msgid "fsck should try to fix problems"
+msgstr ""
+
+#: share/completions/obnam.fish:84
+msgid "fsck should not try to fix problems"
+msgstr ""
+
+#: share/completions/obnam.fish:85
+#, fuzzy
+msgid "Ignore chunks when checking integrity"
+msgstr "Ignorer les changements correspondants à la regexp"
+
+#: share/completions/obnam.fish:86
+msgid "Check chunks when checking integrity"
+msgstr ""
+
+#: share/completions/obnam.fish:87
+msgid "Do not check data for cient NAME."
+msgstr ""
+
+#: share/completions/obnam.fish:88
+#, fuzzy
+msgid "Check only the last generation"
+msgstr "Générer le contenu"
+
+#: share/completions/obnam.fish:89 share/completions/obnam.fish:95
+#, fuzzy
+msgid "Check all generations"
+msgstr "Réinstaller les paquets"
+
+#: share/completions/obnam.fish:90
+#, fuzzy
+msgid "Do not check directories"
+msgstr "Nettoyer les répertoires source"
+
+#: share/completions/obnam.fish:91
+#, fuzzy
+msgid "Check directories"
+msgstr "Nettoyer les répertoires source"
+
+#: share/completions/obnam.fish:92
+#, fuzzy
+msgid "Do not check files"
+msgstr "Ne pas modifier aucun fichier"
+
+#: share/completions/obnam.fish:93
+#, fuzzy
+msgid "Check files"
+msgstr "Réinstaller les paquets"
+
+#: share/completions/obnam.fish:94
+#, fuzzy
+msgid "Do not check any generations"
+msgstr "Ne pas modifier aucun fichier"
+
+#: share/completions/obnam.fish:96
+msgid "Do not check per-client B-trees"
+msgstr ""
+
+#: share/completions/obnam.fish:97
+msgid "Check per-client B-trees"
+msgstr ""
+
+#: share/completions/obnam.fish:98
+#, fuzzy
+msgid "Do not check shared B-trees"
+msgstr "Ne pas modifier aucun fichier"
+
+#: share/completions/obnam.fish:99
+#, fuzzy
+msgid "Check shared B-trees"
+msgstr "Réinstaller les paquets"
+
+#: share/completions/obnam.fish:102
+msgid "Keep last N logs (10)"
+msgstr ""
+
+#: share/completions/obnam.fish:103
+msgid "Log at LEVEL"
+msgstr ""
+
+#: share/completions/obnam.fish:104
+msgid "Rotate logs larger than SIZE"
+msgstr ""
+
+#: share/completions/obnam.fish:105
+msgid "Set permissions of logfiles to MODE"
+msgstr ""
+
+#: share/completions/obnam.fish:106
+msgid "Options to pass to FUSE"
+msgstr ""
+
+#: share/completions/obnam.fish:107
+msgid "Make memory profiling dumps using METHOD"
+msgstr ""
+
+#: share/completions/obnam.fish:108
+msgid "Make memory profiling dumps at SECONDS"
+msgstr ""
+
+#: share/completions/obnam.fish:109
+msgid "Size of chunks of file data"
+msgstr ""
+
+#: share/completions/obnam.fish:110
+msgid "Encode NUM chunk ids per group"
+msgstr ""
+
+#: share/completions/obnam.fish:111
+msgid "Chunk id level size"
+msgstr ""
+
+#: share/completions/obnam.fish:112
+msgid "Depth of chunk id mapping"
+msgstr ""
+
+#: share/completions/obnam.fish:113
+msgid "Chunk id mapping lowest bits skip"
+msgstr ""
+
+#: share/completions/obnam.fish:114
+msgid "Size of LRU cache for B-tree nodes"
+msgstr ""
+
+#: share/completions/obnam.fish:115
+msgid "Size of B-tree nodes on disk"
+msgstr ""
+
+#: share/completions/obnam.fish:116
+msgid "Length of upload queue for B-tree nodes"
+msgstr ""
+
+#: share/completions/obnam.fish:117
+msgid "Use only paramiko, no openssh"
+msgstr ""
+
+#: share/completions/obnam.fish:118
+msgid "Use openssh if available"
+msgstr ""
+
+#: share/completions/obnam.fish:120
+msgid "ssh host key check"
 msgstr ""
 
 #: share/completions/perl.fish:6
@@ -6221,15 +6112,15 @@ msgstr ""
 msgid "Locale"
 msgstr ""
 
-#: share/completions/sort.fish:12
+#: share/completions/sort.fish:16
 msgid "Write to file"
 msgstr ""
 
-#: share/completions/sort.fish:14
+#: share/completions/sort.fish:18
 msgid "Set memory buffer size"
 msgstr ""
 
-#: share/completions/sort.fish:16
+#: share/completions/sort.fish:20
 msgid "Set temporary directory"
 msgstr ""
 
@@ -6490,7 +6381,7 @@ msgstr ""
 msgid "Test if vagrant has yet to be given the main command"
 msgstr "Tester si apt doit se faire donner la sous-commande"
 
-#: share/completions/vagrant.fish:34
+#: share/completions/vagrant.fish:23
 msgid "Lists all available Vagrant boxes"
 msgstr ""
 
@@ -7706,6 +7597,11 @@ msgstr ""
 msgid "Include the file flags in a long (-l) output"
 msgstr ""
 
+#: share/functions/__fish_complete_path.fish:1
+#, fuzzy
+msgid "Complete using path"
+msgstr "Définir les options de config"
+
 #: share/functions/__fish_complete_ppp_peer.fish:1
 msgid "Complete isp name for pon/poff"
 msgstr ""
@@ -8252,62 +8148,49 @@ msgstr ""
 msgid "Complete md5sum sha1 etc"
 msgstr ""
 
-#: share/functions/__fish_config_interactive.fish:65
-#, sh-format
-msgid ""
-"\\nWARNING\\n\\nThe location for fish configuration files has changed to %s."
-"\\nYour old files have been moved to this location.\\nYou can change to a "
-"different location by changing the value of the variable $XDG_CONFIG_HOME.\\n"
-"\\n"
-msgstr ""
-
-#: share/functions/__fish_config_interactive.fish:82
+#: share/functions/__fish_config_interactive.fish:34
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Bienvenue dans fish, le shell amical et interactif"
 
-#: share/functions/__fish_config_interactive.fish:83
+#: share/functions/__fish_config_interactive.fish:35
 msgid "Type %shelp%s for instructions on how to use fish"
 msgstr "Tappez %shelp%s pour des instructions sur l'utilisation de fish"
 
-#: share/functions/__fish_config_interactive.fish:173
+#: share/functions/__fish_config_interactive.fish:130
 msgid "Event handler, repaints the prompt when fish_color_cwd changes"
 msgstr ""
 
-#: share/functions/__fish_config_interactive.fish:180
+#: share/functions/__fish_config_interactive.fish:137
 msgid "Event handler, repaints the prompt when fish_color_cwd_root changes"
 msgstr ""
 
-#: share/functions/__fish_config_interactive.fish:192
+#: share/functions/__fish_config_interactive.fish:149
 msgid "Start service"
 msgstr "Démarrer le service"
 
-#: share/functions/__fish_config_interactive.fish:193
+#: share/functions/__fish_config_interactive.fish:150
 msgid "Stop service"
 msgstr "Arrêter le service"
 
-#: share/functions/__fish_config_interactive.fish:194
+#: share/functions/__fish_config_interactive.fish:151
 msgid "Print service status"
 msgstr "Afficher l'état du service"
 
-#: share/functions/__fish_config_interactive.fish:195
+#: share/functions/__fish_config_interactive.fish:152
 msgid "Stop and then start service"
 msgstr "Redémarrer le service"
 
-#: share/functions/__fish_config_interactive.fish:196
+#: share/functions/__fish_config_interactive.fish:153
 msgid "Reload service configuration"
 msgstr "Recharger la configuration du service"
 
-#: share/functions/__fish_config_interactive.fish:228
+#: share/functions/__fish_config_interactive.fish:193
 #, sh-format
 msgid "Notify VTE of change to $PWD"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:173
 msgid "Helper function for __fish_git_prompt"
-msgstr ""
-
-#: share/functions/__fish_git_prompt.fish:244
-msgid "svn_upstream"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:348
@@ -8351,6 +8234,10 @@ msgstr ""
 msgid "Event handler, repaints prompt when any char changes"
 msgstr ""
 
+#: share/functions/__fish_hg_prompt.fish:23
+msgid "Write out the hg prompt"
+msgstr ""
+
 #: share/functions/__fish_is_token_n.fish:1
 msgid "Test if current token is on Nth place"
 msgstr ""
@@ -8386,7 +8273,7 @@ msgstr ""
 msgid "Prints services installed"
 msgstr "Afficher l'état du service"
 
-#: share/functions/__fish_print_help.fish:2
+#: share/functions/__fish_print_help.fish:1
 #, fuzzy
 msgid "Print help message for the specified fish function or builtin"
 msgstr "Afficher toutes les complétions pour la commande spécifiée"
@@ -8414,6 +8301,10 @@ msgstr "Afficher la liste disponible"
 #, fuzzy
 msgid "Print mounted devices"
 msgstr "Afficher les dépendances importantes"
+
+#: share/functions/__fish_print_packages.fish:13
+msgid "Package"
+msgstr "Paquet"
 
 #: share/functions/__fish_print_svn_rev.fish:1
 #, fuzzy
@@ -8463,15 +8354,63 @@ msgstr ""
 msgid "Write out the git prompt"
 msgstr ""
 
+#: share/functions/abbr.fish:1
+msgid "Manage abbreviations"
+msgstr ""
+
+#: share/functions/abbr.fish:40
+#, fuzzy
+msgid "%s: invalid option -- %s\\n"
+msgstr "%ls: Option invalide -- %lc\n"
+
+#: share/functions/abbr.fish:47
+#, fuzzy
+msgid "%s: %s cannot be specified along with %s\\n"
+msgstr ""
+"%ls: 'erase' ne peut pas spécifier des valeurs\n"
+"%ls\n"
+
+#: share/functions/abbr.fish:56
+#, fuzzy
+msgid "%s: option requires an argument -- %s\\n"
+msgstr "%ls: L'option exige un argument -- %lc\n"
+
+#: share/functions/abbr.fish:62
+#, fuzzy
+msgid "%s: Unexpected argument -- %s\\n"
+msgstr "%ls: Argument attendu\n"
+
+#: share/functions/abbr.fish:75
+msgid "%s: abbreviation must have a non-empty key\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:79
+msgid "%s: abbreviation must have a value\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:101
+#, fuzzy
+msgid "%s: no such abbreviation '%s'\\n"
+msgstr "Fonction inconnue '%ls'"
+
 #: share/functions/alias.fish:2
 msgid ""
 "Legacy function for creating shellscript functions using an alias-like syntax"
 msgstr ""
 
-#: share/functions/alias.fish:34
+#: share/functions/alias.fish:36
 #, fuzzy
 msgid "%s: Expected one or two arguments, got %d\\n"
 msgstr "%ls: Un argument attendu, %d obtenu(s)\n"
+
+#: share/functions/alias.fish:42
+#, fuzzy
+msgid "%s: Name cannot be empty\\n"
+msgstr "%ls: Le nom de variable ne peut pas être une chaîne vide\n"
+
+#: share/functions/alias.fish:45
+msgid "%s: Body cannot be empty\\n"
+msgstr ""
 
 #: share/functions/contains_seq.fish:1
 msgid "Return true if array contains a sequence"
@@ -8483,6 +8422,10 @@ msgstr ""
 
 #: share/functions/dirs.fish:1
 msgid "Print directory stack"
+msgstr ""
+
+#: share/functions/export.fish:1
+msgid "Set global variable. Alias for set -g, made for bash compatibility"
 msgstr ""
 
 #: share/functions/fish_config.fish:1
@@ -8502,6 +8445,19 @@ msgstr ""
 msgid "Update man-page based completions"
 msgstr "Éditer les complétions spécifiques aux commandes"
 
+#: share/functions/fish_vi_key_bindings.fish:1
+msgid "vi-like key bindings for fish"
+msgstr ""
+
+#: share/functions/fish_vi_prompt.fish:1
+#, fuzzy
+msgid "Displays the current mode"
+msgstr "Afficher la version et quitter"
+
+#: share/functions/fish_vi_prompt.fish:17
+msgid "Simple vi prompt"
+msgstr ""
+
 #: share/functions/funced.fish:1
 #, fuzzy
 msgid "Edit function definition"
@@ -8517,6 +8473,19 @@ msgstr ""
 msgid "funced: You must specify one function name\n"
 msgstr "%ls: Exactement un nom de fonction est attendu\n"
 
+#: share/functions/funced.fish:96
+msgid "Editing failed or was cancelled"
+msgstr ""
+
+#: share/functions/funced.fish:103
+msgid "Edit the file again\\? [Y/n]"
+msgstr ""
+
+#: share/functions/funced.fish:110
+#, fuzzy
+msgid "Cancelled function editing"
+msgstr "bloc de définition de fonction"
+
 #: share/functions/funcsave.fish:2
 msgid "Save the current definition of all specified functions to file"
 msgstr ""
@@ -8531,7 +8500,7 @@ msgstr "%ls: Exactement un nom de fonction est attendu\n"
 msgid "%s: Could not create configuration directory\\n"
 msgstr "%ls: Répertoire personnel introuvable\n"
 
-#: share/functions/funcsave.fish:37
+#: share/functions/funcsave.fish:36
 #, fuzzy
 msgid "%s: Unknown function '%s'\\n"
 msgstr "Fonction inconnue '%ls'"
@@ -8577,7 +8546,7 @@ msgstr ""
 msgid "List contents of directory using long format"
 msgstr ""
 
-#: share/functions/ls.fish:7 share/functions/ls.fish:24
+#: share/functions/ls.fish:7 share/functions/ls.fish:32
 msgid "List contents of directory"
 msgstr ""
 
@@ -8622,7 +8591,6 @@ msgstr ""
 msgid "The number of positions to skip must be a non-negative integer\\n"
 msgstr ""
 
-#: share/functions/prompt_pwd.fish:3 share/functions/prompt_pwd.fish:7
 #: share/functions/prompt_pwd.fish:11
 msgid "Print the current working directory, shortened to fit the prompt"
 msgstr ""
@@ -8662,34 +8630,34 @@ msgstr ""
 msgid "Print the type of a command"
 msgstr ""
 
-#: share/functions/type.fish:84
+#: share/functions/type.fish:90
 msgid "%s is a function with definition\\n"
 msgstr ""
 
-#: share/functions/type.fish:88
+#: share/functions/type.fish:94
 #, fuzzy
 msgid "function"
 msgstr "Fonction"
 
-#: share/functions/type.fish:105
+#: share/functions/type.fish:107
 msgid "%s is a builtin\\n"
 msgstr ""
 
-#: share/functions/type.fish:108
+#: share/functions/type.fish:110
 #, fuzzy
 msgid "builtin"
 msgstr "Commande interne"
 
-#: share/functions/type.fish:132
+#: share/functions/type.fish:130
 msgid "%s is %s\\n"
 msgstr ""
 
-#: share/functions/type.fish:135
+#: share/functions/type.fish:133
 #, fuzzy
 msgid "file"
 msgstr "Fichier de config"
 
-#: share/functions/type.fish:147
+#: share/functions/type.fish:144
 msgid "%s: Could not find '%s'\\n"
 msgstr ""
 
@@ -8710,17 +8678,228 @@ msgstr ""
 msgid "Edit variable value"
 msgstr ""
 
-#: share/functions/vared.fish:41
+#: share/functions/vared.fish:40
 msgid ""
-"%s: %s is an array variable. Use %svared%s %s[n] to edit the n:th element of "
-"%s\\n"
+"%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element "
+"of %s\\n"
 msgstr ""
 
-#: share/functions/vared.fish:45
+#: share/functions/vared.fish:44
 msgid ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
 "VARIABLE\\n"
 msgstr ""
+
+#, fuzzy
+#~ msgid "%ls: Expected zero or two parameters, got %d\n"
+#~ msgstr "%ls: Zéro ou un argument attendu, %d obtenu(s)\n"
+
+#~ msgid "Current functions are: "
+#~ msgstr "Les fonctions courantes sont: "
+
+#~ msgid "%ls: Not inside of block\n"
+#~ msgstr "%ls: À l'extérieur du bloc\n"
+
+#~ msgid "%ls: Not inside of 'if' block\n"
+#~ msgstr "%ls: À l'extérieur du bloc 'if'\n"
+
+#~ msgid "%ls: Expected exactly one argument, got %d\n"
+#~ msgstr "%ls: Exactement un argument attendu, %d obtenu(s)\n"
+
+#~ msgid "%ls: 'case' command while not in switch block\n"
+#~ msgstr "%ls: commande 'case' sans bloc 'switch'\n"
+
+#, fuzzy
+#~ msgid "%ls: Unknown error"
+#~ msgstr "%s: Erreur inconnue\n"
+
+#, fuzzy
+#~ msgid "%ls: Can not specify scope when erasing array slice\n"
+#~ msgstr "%ls: Ne peut pas indiquer la portée en enlevant le bloc\n"
+
+#~ msgid "Could not get user information"
+#~ msgstr "Obtention des informations utilisateur impossible."
+
+#, fuzzy
+#~ msgid "%ls: Argument '%s' is not a valid file descriptor\n"
+#~ msgstr "%ls: '%ls' est un nom de variable invalide\n"
+
+#, fuzzy
+#~ msgid "Could not set up input file descriptors for pager"
+#~ msgstr "Impossible de définir le mode du terminal pour le shell"
+
+#, fuzzy
+#~ msgid "Could not open tty for pager"
+#~ msgstr "Impossible de remettre le shell en premier plan"
+
+#, fuzzy
+#~ msgid "Unspecified file descriptors"
+#~ msgstr "Redirige vers un descripteur de fichier"
+
+#, fuzzy
+#~ msgid "Could not read completions"
+#~ msgstr "Commande à ajouter une complétion"
+
+#~ msgid "Could not expand string '%ls'"
+#~ msgstr "Développement de la chaîne '%ls' impossible"
+
+#~ msgid ""
+#~ "Could not locate end of block. The 'end' command is missing, misspelled "
+#~ "or a ';' is missing."
+#~ msgstr ""
+#~ "Fin de bloc introuvable. La commande 'end' est manquante, mal écrite ou "
+#~ "un ';' est manquant."
+
+#~ msgid "Expected a command name, got token of type '%ls'"
+#~ msgstr ""
+#~ "Un nom de commande était attendu, un jeton de type '%ls' a été obtenu"
+
+#~ msgid "'case' builtin not inside of switch block"
+#~ msgstr "Commande interne 'case' à l'extérieur d'un bloc 'switch'"
+
+#~ msgid "Loop control command while not inside of loop"
+#~ msgstr "Commande de contrôle de boucle à l'extérieur d'une boucle"
+
+#, fuzzy
+#~ msgid "'%ls' builtin not inside of if block"
+#~ msgstr "Commande interne 'else' à l'extérieur d'un bloc 'if'"
+
+#~ msgid "'end' command outside of block"
+#~ msgstr "Commande interne 'end' à l'extérieur d'un bloc"
+
+#~ msgid "Expected redirection specification, got token of type '%ls'"
+#~ msgstr "Spécification de redirection attendue, jeton de type '%ls' obtenu"
+
+#~ msgid ""
+#~ "Encountered redirection when expecting a command name. Fish does not "
+#~ "allow a redirection operation before a command."
+#~ msgstr ""
+#~ "Redirection obtenue alors qu'un nom de commande était attendu. Fish ne "
+#~ "permet pas une opération de redirection avant une commande."
+
+#~ msgid "Invalid IO redirection"
+#~ msgstr "Redirection E/S invalide"
+
+#~ msgid "Requested redirection to something that is not a file descriptor %ls"
+#~ msgstr ""
+#~ "Redirection demandée à quelque chose qui n'est pas un descripteur de "
+#~ "fichier %ls"
+
+#, fuzzy
+#~ msgid "Control creation of sparse files"
+#~ msgstr "Ne pas créer de fichiers de sortie"
+
+#, fuzzy
+#~ msgid "All base system packages"
+#~ msgstr "Efface les paquets construits"
+
+#, fuzzy
+#~ msgid "All packages in world"
+#~ msgstr "Synchroniser les paquets installés"
+
+#, fuzzy
+#~ msgid "Installed package"
+#~ msgstr "Installer des paquets source"
+
+#, fuzzy
+#~ msgid "Pull in build time dependencies"
+#~ msgstr "Afficher les dépendances de construction"
+
+#, fuzzy
+#~ msgid "Don't pull in build time dependencies"
+#~ msgstr "Afficher les dépendances de construction"
+
+#, fuzzy
+#~ msgid "create a changegroup file"
+#~ msgstr "Lire le paquet depuis un fichier"
+
+#, fuzzy
+#~ msgid "create a new repository in the given directory"
+#~ msgstr "Créer un référentiel CVS s'il n'existe pas"
+
+#, fuzzy
+#~ msgid "remove the specified files on the next commit"
+#~ msgstr "Déplacer le fichier spécifier dans la ligne de commande"
+
+#, fuzzy
+#~ msgid "show changed files in the working directory"
+#~ msgstr "Changer le répertoire de travail"
+
+#, fuzzy
+#~ msgid "summarize working directory state"
+#~ msgstr "Changer le répertoire de travail"
+
+#, fuzzy
+#~ msgid "show the tip revision"
+#~ msgstr "Afficher le temps"
+
+#, fuzzy
+#~ msgid "apply one or more changegroup files"
+#~ msgstr "Installer un ou des paquets"
+
+#, fuzzy
+#~ msgid "verify the integrity of the repository"
+#~ msgstr "Enlever un fichier du référentiel"
+
+#, fuzzy
+#~ msgid "Configuration Files"
+#~ msgstr "Spécifier un fichier de configuration"
+
+#, fuzzy
+#~ msgid "Environment Variables"
+#~ msgstr "Gérer les variables d'environnement"
+
+#, fuzzy
+#~ msgid "Specifying File Sets"
+#~ msgstr "Spécifier le fichier de config"
+
+#, fuzzy
+#~ msgid "Merge Tools"
+#~ msgstr "Fusionner les révisions"
+
+#, fuzzy
+#~ msgid "Specifying Revision Sets"
+#~ msgstr "Spécifier les options"
+
+#, fuzzy
+#~ msgid "Display with template"
+#~ msgstr "Afficher la page de manuel"
+
+#, fuzzy
+#~ msgid "Specify ssh command to use"
+#~ msgstr "Spécifier le type d'enregistrement"
+
+#, fuzzy
+#~ msgid "Show revisions matching date spec"
+#~ msgstr "Voir qui surveille un fichier"
+
+#, fuzzy
+#~ msgid "Revision to display"
+#~ msgstr "Choisir l'affichage"
+
+#, fuzzy
+#~ msgid "Specify merge tool"
+#~ msgstr "Spécifier le type d'enregistrement"
+
+#, fuzzy
+#~ msgid "Show parents of the specified revision"
+#~ msgstr "Afficher les différences entre les révisions"
+
+#, fuzzy
+#~ msgid "[+] target revision"
+#~ msgstr "Fusionner les révisions"
+
+#, fuzzy
+#~ msgid "For remote clients"
+#~ msgstr "Lister ou enlever des fonctions"
+
+#, fuzzy
+#~ msgid "Untrusted configuration options"
+#~ msgstr "Définir les options de config"
+
+#, fuzzy
+#~ msgid "Revision"
+#~ msgstr "Verrouiller une révision"
 
 #~ msgid ""
 #~ "Current function definitions are:\n"
@@ -8752,9 +8931,6 @@ msgstr ""
 
 #~ msgid "Could not create child process - exiting"
 #~ msgstr "Impossible de créer le processus fils - fermeture"
-
-#~ msgid "Failed to execute process '%ls'"
-#~ msgstr "L'exécution du processus '%ls' a échoué"
 
 #~ msgid "Could not send process %d from group %d to group %d"
 #~ msgstr "Déplacement du processus %d du groupe %d au groupe %d impossible"
@@ -8895,9 +9071,6 @@ msgstr ""
 
 #~ msgid "Prefix to strip on patch"
 #~ msgstr "Préfixe à sauter dans la patch"
-
-#~ msgid "Use purge instead of remove"
-#~ msgstr "Purger au lieu de supprimer"
 
 #~ msgid "Do not run update"
 #~ msgstr "Ne pas lancer de mise à jour"
@@ -9048,17 +9221,11 @@ msgstr ""
 #~ msgid "Overwrite"
 #~ msgstr "Écraser"
 
-#~ msgid "Do not overwrite"
-#~ msgstr "Ne pas écraser"
-
 #~ msgid "Reduce memory usage"
 #~ msgstr "Réduire l'utilisation de la mémoire"
 
 #~ msgid "Print compression ratios"
 #~ msgstr "Afficher les ratios de compression"
-
-#~ msgid "Compress to stdout"
-#~ msgstr "Compresser vers stdout"
 
 #~ msgid "Compress file"
 #~ msgstr "Compresser le fichier"
@@ -9245,9 +9412,6 @@ msgstr ""
 #~ msgid "Option list is not complete"
 #~ msgstr "Liste d'options incomplète"
 
-#~ msgid "Remove completion"
-#~ msgstr "Enlever la complétion"
-
 #~ msgid ""
 #~ "The completion should only be used if the specified command has a zero "
 #~ "exit status"
@@ -9288,17 +9452,11 @@ msgstr ""
 #~ msgid "Bring work tree in sync with repository"
 #~ msgstr "Synchroniser le répertoire de travail avec le référentiel"
 
-#~ msgid "Set watches"
-#~ msgstr "Surveiller des fichiers"
-
 #~ msgid "Authenticate all net traffic"
 #~ msgstr "Authentifier tout le trafic réseau"
 
 #~ msgid "Do not use the ~/.cvsrc file"
 #~ msgstr "ne pas utiliser ~/.cvsrc"
-
-#~ msgid "Do not change any files"
-#~ msgstr "Ne pas modifier aucun fichier"
 
 #~ msgid "Cause CVS to be really quiet"
 #~ msgstr "Forcer le plus grand silence"
@@ -9425,9 +9583,6 @@ msgstr ""
 
 #~ msgid "Report on all tags"
 #~ msgstr "Rapporter les étiquettes"
-
-#~ msgid "Show history for all users"
-#~ msgstr "Afficher l'historique de tous les utilisateurs"
 
 #~ msgid "Show only records for this directory"
 #~ msgstr "Afficher seulement les enregistrements pour ce répertoire"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-08-24 21:41-0300\n"
+"POT-Creation-Date: 2015-04-13 22:15+0800\n"
 "PO-Revision-Date: 2014-08-25 08:37-0300\n"
 "Last-Translator: Iuri Rezende Souza <riuri@rocketmail.com>\n"
 "Language-Team: Português Brasileiro <>\n"
@@ -25,23 +25,12 @@ msgstr ""
 "Não pôde carregar item “%ls” automaticamente, ele já está sendo carregado "
 "automaticamente. "
 
-#: builtin_commandline.cpp:466
-#, fuzzy, c-format
-msgid "%ls: Unknown input function '%ls'\n"
-msgstr "%ls: Unknown input function “%ls”\n"
-
-#: builtin_complete.cpp:536 builtin.cpp:3632 builtin_set_color.cpp:146
-#: builtin.h:83
-#, c-format
-msgid "%ls: Too many arguments\n"
-msgstr "%ls: Argumentos demais\n"
-
-#: builtin.cpp:83
+#: builtin.cpp:84
 #, c-format
 msgid "Send job %d, '%ls' to foreground\n"
 msgstr "Enviando job %d, “%ls” para foreground\n"
 
-#: builtin.cpp:344
+#: builtin.cpp:352
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
@@ -50,57 +39,62 @@ msgstr ""
 "%ls: Digite “help %ls” para documentação relacionada\n"
 "\n"
 
-#: builtin.cpp:507
+#: builtin.cpp:531
 #, fuzzy, c-format
 msgid "%ls: No key with name '%ls' found\n"
 msgstr "%ls: No key with name “%ls” found\n"
 
-#: builtin.cpp:513
+#: builtin.cpp:537
 #, fuzzy, c-format
 msgid "%ls: Key with name '%ls' does not have any mapping\n"
 msgstr "%ls: Key with name “%ls” does not have any mapping\n"
 
-#: builtin.cpp:519
+#: builtin.cpp:543
 #, fuzzy, c-format
 msgid "%ls: Unknown error trying to bind to key named '%ls'\n"
 msgstr "%ls: Unknown error trying to bind to key named “%ls”\n"
 
-#: builtin.cpp:705
+#: builtin.cpp:794
 #, fuzzy, c-format
-msgid "%ls: Expected zero or at least two parameters, got %d"
-msgstr "%ls: Esperava zero ou dois parâmetros, obteve %d\n"
+msgid "%ls: No binding found for key '%ls'\n"
+msgstr "%s: No description for type %s\n"
 
-#: builtin.cpp:736
+#: builtin.cpp:798
+#, c-format
+msgid "%ls: No binding found for sequence '%ls'\n"
+msgstr ""
+
+#: builtin.cpp:834
 #, c-format
 msgid "%ls: Invalid state\n"
 msgstr "%ls: Estado inválido\n"
 
-#: builtin.cpp:841
+#: builtin.cpp:939
 #, c-format
 msgid "%ls: Can not specify scope when removing block\n"
 msgstr "%ls: Não pode especificar escopo ao remover bloco\n"
 
-#: builtin.cpp:847
+#: builtin.cpp:945
 #, c-format
 msgid "%ls: No blocks defined\n"
 msgstr "%ls: Não há blocos definidos\n"
 
-#: builtin.cpp:1438 builtin.h:32
+#: builtin.cpp:1556 builtin.h:32
 #, c-format
 msgid "%ls: Invalid combination of options\n"
 msgstr "%ls: Combinação inválida de opções\n"
 
-#: builtin.cpp:1460
+#: builtin.cpp:1578
 #, c-format
 msgid "%ls: Expected exactly one function name\n"
 msgstr "%ls: Esperava exatamente um nome de função\n"
 
-#: builtin.cpp:1470 builtin.cpp:1532
+#: builtin.cpp:1588 builtin.cpp:1650
 #, c-format
 msgid "%ls: Function '%ls' does not exist\n"
 msgstr "%ls: Função “%ls” não existe\n"
 
-#: builtin.cpp:1520
+#: builtin.cpp:1638
 #, c-format
 msgid ""
 "%ls: Expected exactly two names (current function name, and new function "
@@ -109,42 +103,42 @@ msgstr ""
 "%ls: Esperava exatamente dois nomes (nome atual da função, e novo nome da "
 "função)\n"
 
-#: builtin.cpp:1543 builtin.cpp:2097
+#: builtin.cpp:1661 builtin.cpp:2230
 #, c-format
 msgid "%ls: Illegal function name '%ls'\n"
 msgstr "%ls: Nome de função ilegal “%ls”\n"
 
-#: builtin.cpp:1554
+#: builtin.cpp:1672
 #, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy '%ls'\n"
 msgstr "%ls: Função “%ls” já existe. Não pode criar cópia “%ls”\n"
 
-#: builtin.cpp:1950
+#: builtin.cpp:2070
 #, c-format
 msgid "%ls: Unknown signal '%ls'\n"
 msgstr "%ls: Sinal desconhecido “%ls”\n"
 
-#: builtin.cpp:1965 builtin.cpp:2130
+#: builtin.cpp:2085 builtin.cpp:2195 builtin.cpp:2263
 #, c-format
 msgid "%ls: Invalid variable name '%ls'\n"
 msgstr "%ls: Nome inválido de variável “%ls”\n"
 
-#: builtin.cpp:2018
+#: builtin.cpp:2138
 #, fuzzy, c-format
 msgid "%ls: Cannot find calling job for event handler\n"
 msgstr "%ls: Cannot find calling job for event handler\n"
 
-#: builtin.cpp:2036
+#: builtin.cpp:2156
 #, c-format
 msgid "%ls: Invalid process id %ls\n"
 msgstr "%ls: ID de processo inválido %ls\n"
 
-#: builtin.cpp:2090
+#: builtin.cpp:2223
 #, c-format
 msgid "%ls: Expected function name\n"
 msgstr "%ls: Esperava nome de função\n"
 
-#: builtin.cpp:2107
+#: builtin.cpp:2240
 #, c-format
 msgid ""
 "%ls: The name '%ls' is reserved,\n"
@@ -153,143 +147,148 @@ msgstr ""
 "%ls: O nome “%ls” é reservado,\n"
 "e não pode ser usado como nome de função\n"
 
-#: builtin.cpp:2115
+#: builtin.cpp:2248
 #, c-format
 msgid "%ls: No function name given\n"
 msgstr "%ls: Esperava nome de função\n"
 
-#: builtin.cpp:2143
+#: builtin.cpp:2276
 #, c-format
 msgid "%ls: Expected one argument, got %d\n"
 msgstr "%ls: Esperava um argumento, obteve %d\n"
 
-#: builtin.cpp:2278
+#: builtin.cpp:2412
 #, fuzzy, c-format
 msgid "%ls: Seed value '%ls' is not a valid number\n"
 msgstr "%ls: Valor semeado “%ls” não é um número válido\n"
 
-#: builtin.cpp:2292
+#: builtin.cpp:2426
 #, c-format
 msgid "%ls: Expected zero or one argument, got %d\n"
 msgstr "%ls: Esperava zero ou um argumento, obteve %d\n"
 
-#: builtin.cpp:2473
+#: builtin.cpp:2593
+#, fuzzy, c-format
+msgid "%ls: Argument '%ls' is out of range\n"
+msgstr "%ls: Argumento “%ls” não é número\n"
+
+#: builtin.cpp:2601 builtin.cpp:3150 builtin.cpp:3817
+#, c-format
+msgid "%ls: Argument '%ls' must be an integer\n"
+msgstr "%ls: Argumento “%ls” deve ser um inteiro\n"
+
+#: builtin.cpp:2656
 #, fuzzy, c-format
 msgid "%ls: --array option requires a single variable name.\n"
 msgstr ""
 "%ls: Erase needs a variable name\n"
 "%ls\n"
 
-#: builtin.cpp:2869 fish.cpp:519 parser.cpp:746
+#: builtin.cpp:3065 fish.cpp:620 parser.cpp:764
 msgid "Standard input"
 msgstr "Entrada padrão"
 
-#: builtin.cpp:2912
+#: builtin.cpp:3108
 msgid "This is a login shell\n"
 msgstr "Este é um shell de login\n"
 
-#: builtin.cpp:2914
+#: builtin.cpp:3110
 msgid "This is not a login shell\n"
 msgstr "Este não é um shell de login\n"
 
-#: builtin.cpp:2916
+#: builtin.cpp:3112
 #, fuzzy, c-format
 msgid "Job control: %ls\n"
 msgstr "Controle de job: %ls\n"
 
-#: builtin.cpp:2917
+#: builtin.cpp:3113
 msgid "Only on interactive jobs"
 msgstr "Somente em jobs interativos"
 
-#: builtin.cpp:2918
+#: builtin.cpp:3114
 msgid "Never"
 msgstr "Nunca"
 
-#: builtin.cpp:2918
+#: builtin.cpp:3114
 msgid "Always"
 msgstr "Sempre"
 
-#: builtin.cpp:2954 builtin.cpp:3622
-#, c-format
-msgid "%ls: Argument '%ls' must be an integer\n"
-msgstr "%ls: Argumento “%ls” deve ser um inteiro\n"
-
-#: builtin.cpp:2996
+#: builtin.cpp:3192
 #, c-format
 msgid "%ls: Could not find home directory\n"
 msgstr "%ls: Não pôde encontrar diretório home\n"
 
-#: builtin.cpp:3016 builtin.cpp:3070
+#: builtin.cpp:3212 builtin.cpp:3266
 #, c-format
 msgid "%ls: '%ls' is not a directory\n"
 msgstr "%ls: “%ls” não é um diretório\n"
 
-#: builtin.cpp:3023
+#: builtin.cpp:3219
 #, c-format
 msgid "%ls: The directory '%ls' does not exist\n"
 msgstr "%ls: O diretório “%ls” não existe\n"
 
-#: builtin.cpp:3030
+#: builtin.cpp:3226
 #, c-format
 msgid "%ls: '%ls' is a rotten symlink\n"
 msgstr "%ls: “%ls” é um symlink quebrado\n"
 
-#: builtin.cpp:3038
+#: builtin.cpp:3234
 #, c-format
 msgid "%ls: Unknown error trying to locate directory '%ls'\n"
 msgstr "%ls: Erro desconhecido ao tentar localizar diretório “%ls”\n"
 
-#: builtin.cpp:3061
+#: builtin.cpp:3257
 #, c-format
 msgid "%ls: Permission denied: '%ls'\n"
 msgstr "%ls: Permissão negada: “%ls”\n"
 
-#: builtin.cpp:3085
+#: builtin.cpp:3281
 #, c-format
 msgid "%ls: Could not set PWD variable\n"
 msgstr "%ls: Não pôde modificar variável PWD\n"
 
-#: builtin.cpp:3172
+#: builtin.cpp:3368
 #, fuzzy, c-format
 msgid "%ls: Key not specified\n"
 msgstr "%ls: Key not specified\n"
 
-#: builtin.cpp:3216 builtin.cpp:3224
+#: builtin.cpp:3412 builtin.cpp:3420
 #, fuzzy, c-format
 msgid "%ls: Error encountered while sourcing file '%ls':\n"
 msgstr "%ls: Erro encontrado ao interpretar arquivo “%ls”:\n"
 
-#: builtin.cpp:3232
+#: builtin.cpp:3428
 #, c-format
 msgid "%ls: '%ls' is not a file\n"
 msgstr "%ls: “%ls” não é um arquivo\n"
 
-#: builtin.cpp:3251
+#: builtin.cpp:3447
 #, c-format
 msgid "%ls: Error while reading file '%ls'\n"
 msgstr "%ls: Erro ao ler arquivo “%ls”\n"
 
-#: builtin.cpp:3307 builtin.cpp:3487
+#: builtin.cpp:3503 builtin.cpp:3682
 #, c-format
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls: Não há jobs adequados\n"
 
-#: builtin.cpp:3336
+#: builtin.cpp:3531
 #, c-format
 msgid "%ls: Ambiguous job\n"
 msgstr "%ls: Job ambíguo\n"
 
-#: builtin.cpp:3342 builtin.cpp:3510 builtin_jobs.cpp:301
+#: builtin.cpp:3537 builtin.cpp:3705 builtin_jobs.cpp:301
 #, c-format
 msgid "%ls: '%ls' is not a job\n"
 msgstr "%ls: “%ls” não é um job\n"
 
-#: builtin.cpp:3373 builtin_jobs.cpp:316
+#: builtin.cpp:3568 builtin_jobs.cpp:316
 #, c-format
 msgid "%ls: No suitable job: %d\n"
 msgstr "%ls: Não é trabalho adequado: %d\n"
 
-#: builtin.cpp:3382
+#: builtin.cpp:3577
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to foreground because it is not under job "
@@ -298,12 +297,12 @@ msgstr ""
 "%ls: Não pôde colocar job %d, “%ls” em foreground porque não está sob "
 "controle de jobs\n"
 
-#: builtin.cpp:3435
+#: builtin.cpp:3630
 #, c-format
 msgid "%ls: Unknown job '%ls'\n"
 msgstr "%ls: Job desconhecido “%ls”\n"
 
-#: builtin.cpp:3444
+#: builtin.cpp:3639
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to background because it is not under job "
@@ -312,204 +311,222 @@ msgstr ""
 "%ls: Não pôde colocar job %d, “%ls” em background porque não está sob "
 "controle de jobs\n"
 
-#: builtin.cpp:3454
+#: builtin.cpp:3649
 #, c-format
 msgid "Send job %d '%ls' to background\n"
 msgstr "Enviando job %d “%ls” para background\n"
 
-#: builtin.cpp:3493
+#: builtin.cpp:3688
 #, fuzzy
 msgid "(default)"
 msgstr "(default)"
 
-#: builtin.cpp:3565
+#: builtin.cpp:3760
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls: Não está dentro de laço\n"
 
-#: builtin.cpp:3650
+#: builtin.cpp:3827 builtin_complete.cpp:551 builtin.h:83
+#, c-format
+msgid "%ls: Too many arguments\n"
+msgstr "%ls: Argumentos demais\n"
+
+#: builtin.cpp:3845
 #, c-format
 msgid "%ls: Not inside of function\n"
 msgstr "%ls: Não está dentro de função\n"
 
-#: builtin.cpp:3867 builtin.cpp:3910
+#: builtin.cpp:4069 builtin.cpp:4113
 msgid "Test a condition"
 msgstr "Testa uma condição"
 
-#: builtin.cpp:3868
+#: builtin.cpp:4070
 msgid "Try out the new parser"
 msgstr "Tenta o novo interpretador"
 
-#: builtin.cpp:3869
+#: builtin.cpp:4071
 msgid "Execute command if previous command suceeded"
 msgstr "Executa comando se o comando anterior obteve sucesso"
 
-#: builtin.cpp:3870
+#: builtin.cpp:4072
 msgid "Create a block of code"
 msgstr "Cria um bloco de código"
 
-#: builtin.cpp:3871
+#: builtin.cpp:4073
 msgid "Send job to background"
 msgstr "Envia job para background"
 
-#: builtin.cpp:3872
+#: builtin.cpp:4074
 msgid "Handle fish key bindings"
 msgstr "Gerencia atalhos de teclado"
 
-#: builtin.cpp:3873
+#: builtin.cpp:4075
 msgid "Temporarily block delivery of events"
 msgstr "Bloqueia temporariamente a entrega de eventos"
 
-#: builtin.cpp:3874
+#: builtin.cpp:4076
 msgid "Stop the innermost loop"
 msgstr "Pára o laço mais interno"
 
-#: builtin.cpp:3875
+#: builtin.cpp:4077
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 "Interrompe temporariamente a execução de um script e abre um prompt de debug "
 "interativo"
 
-#: builtin.cpp:3876
+#: builtin.cpp:4078
 msgid "Run a builtin command instead of a function"
 msgstr "Executa um comando builtin em vez de uma função"
 
-#: builtin.cpp:3877 builtin.cpp:3909
+#: builtin.cpp:4079 builtin.cpp:4112
 msgid "Conditionally execute a block of commands"
 msgstr "Executa condicionalmente um bloco de comandos"
 
-#: builtin.cpp:3878
+#: builtin.cpp:4080
 msgid "Change working directory"
 msgstr "Muda diretório de trabalho"
 
-#: builtin.cpp:3879
+#: builtin.cpp:4081
 msgid "Run a program instead of a function or builtin"
 msgstr "Executa um programa em vez de uma função ou builtin"
 
-#: builtin.cpp:3880
+#: builtin.cpp:4082
 msgid "Set or get the commandline"
 msgstr "Obtém ou altera o buffer da linha de comando"
 
-#: builtin.cpp:3881
+#: builtin.cpp:4083
 msgid "Edit command specific completions"
 msgstr "Edita compleções específicas para um comando"
 
-#: builtin.cpp:3882
+#: builtin.cpp:4084
 msgid "Search for a specified string in a list"
 msgstr "Procura uma string especificada em uma lista"
 
-#: builtin.cpp:3883
+#: builtin.cpp:4085
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "Pula o restante da iteração atual do laço mais interno"
 
-#: builtin.cpp:3884
+#: builtin.cpp:4086
 msgid "Count the number of arguments"
 msgstr "Conta o número de argumentos"
 
-#: builtin.cpp:3885
+#: builtin.cpp:4087
 msgid "Print arguments"
 msgstr "Imprime os argumentos"
 
-#: builtin.cpp:3886
+#: builtin.cpp:4088
 msgid "Evaluate block if condition is false"
 msgstr "Executa bloco se a condição é falsa"
 
-#: builtin.cpp:3887
+#: builtin.cpp:4089
 msgid "Emit an event"
 msgstr "Emite um evento"
 
-#: builtin.cpp:3888
+#: builtin.cpp:4090
 msgid "End a block of commands"
 msgstr "Finaliza um bloco de comandos"
 
-#: builtin.cpp:3889
+#: builtin.cpp:4091
 msgid "Run command in current process"
 msgstr "Executa um comando como o processo atual"
 
-#: builtin.cpp:3890
+#: builtin.cpp:4092
 msgid "Exit the shell"
 msgstr "Sai do shell"
 
-#: builtin.cpp:3891
+#: builtin.cpp:4093
+msgid "Return an unsuccessful result"
+msgstr ""
+
+#: builtin.cpp:4094
 msgid "Send job to foreground"
 msgstr "Envia job para foreground"
 
-#: builtin.cpp:3892
+#: builtin.cpp:4095
 msgid "Perform a set of commands multiple times"
 msgstr "Executa um conjunto de comandos várias vezes"
 
-#: builtin.cpp:3893
+#: builtin.cpp:4096
 msgid "Define a new function"
 msgstr "Define uma nova função"
 
-#: builtin.cpp:3894
+#: builtin.cpp:4097
 msgid "List or remove functions"
 msgstr "Lista ou remove funções"
 
-#: builtin.cpp:3895
+#: builtin.cpp:4098
 msgid "History of commands executed by user"
 msgstr "Histórico de funções executadas pelo usuário"
 
-#: builtin.cpp:3896
+#: builtin.cpp:4099
 msgid "Evaluate block if condition is true"
 msgstr "Executa bloco se a condição é verdadeira"
 
-#: builtin.cpp:3897
+#: builtin.cpp:4100
 msgid "Print currently running jobs"
 msgstr "Imprime os jobs em execução"
 
-#: builtin.cpp:3898
+#: builtin.cpp:4101
 msgid "Negate exit status of job"
 msgstr "Nega estado de saída do job"
 
-#: builtin.cpp:3899
+#: builtin.cpp:4102
 msgid "Execute command if previous command failed"
 msgstr "Executa comando se o comando anterior falhou"
 
-#: builtin.cpp:3900
+#: builtin.cpp:4103
 msgid "Prints formatted text"
 msgstr "Imprime texto formatado"
 
-#: builtin.cpp:3901
+#: builtin.cpp:4104
 msgid "Print the working directory"
 msgstr "Imprime o diretório de trabalho"
 
-#: builtin.cpp:3902
+#: builtin.cpp:4105
 msgid "Generate random number"
 msgstr "Gera um número aleatório"
 
-#: builtin.cpp:3903
+#: builtin.cpp:4106
 msgid "Read a line of input into variables"
 msgstr "Lê uma linha de entrada e a coloca em variáveis"
 
-#: builtin.cpp:3904
+#: builtin.cpp:4107
 msgid "Stop the currently evaluated function"
 msgstr "Pára a função em execução"
 
-#: builtin.cpp:3905
+#: builtin.cpp:4108
 msgid "Handle environment variables"
 msgstr "Modifica variáveis de ambiente"
 
-#: builtin.cpp:3906
+#: builtin.cpp:4109
 msgid "Set the terminal color"
 msgstr "Muda a cor do terminal"
 
-#: builtin.cpp:3907
+#: builtin.cpp:4110
 msgid "Evaluate contents of file"
 msgstr "Executa conteúdo do arquivo"
 
-#: builtin.cpp:3908
+#: builtin.cpp:4111
 msgid "Return status information about fish"
 msgstr "Retorna informação de estado do fish"
 
-#: builtin.cpp:3911
+#: builtin.cpp:4114
+msgid "Return a successful result"
+msgstr ""
+
+#: builtin.cpp:4115
 msgid "Set or get the shells resource usage limits"
 msgstr "Modifica ou obtém limites de uso de recursos pelo shell"
 
-#: builtin.cpp:3912
+#: builtin.cpp:4116
 msgid "Perform a command multiple times"
 msgstr "Executa um comando várias vezes"
+
+#: builtin_commandline.cpp:466
+#, fuzzy, c-format
+msgid "%ls: Unknown input function '%ls'\n"
+msgstr "%ls: Unknown input function “%ls”\n"
 
 #: builtin_jobs.cpp:87
 msgid "Job\tGroup\t"
@@ -523,7 +540,7 @@ msgstr "CPU\t"
 msgid "State\tCommand\n"
 msgstr "Estado\tComando\n"
 
-#: builtin_jobs.cpp:99 proc.cpp:749
+#: builtin_jobs.cpp:99 proc.cpp:843
 msgid "stopped"
 msgstr "parado"
 
@@ -569,48 +586,33 @@ msgstr "%ls: valor não convertido completamente"
 msgid "missing hexadecimal number in escape"
 msgstr "falta número hexadecimal no escape"
 
-#: builtin_printf.cpp:387
+#: builtin_printf.cpp:388
 msgid "Missing hexadecimal number in Unicode escape"
 msgstr "falta número hexadecimal no escape Unicode"
 
-#: builtin_printf.cpp:401
+#: builtin_printf.cpp:402
 #, c-format
 msgid "Unicode character out of range: \\%c%0*x"
 msgstr "Caracter Unicode fora dos limites: \\%c%0*x"
 
-#: builtin_printf.cpp:668
+#: builtin_printf.cpp:670
 #, c-format
 msgid "invalid field width: %ls"
 msgstr "tamanho de campo inválido: %ls"
 
-#: builtin_printf.cpp:706
+#: builtin_printf.cpp:708
 #, c-format
 msgid "invalid precision: %ls"
 msgstr "precisão inválida: %ls"
 
-#: builtin_printf.cpp:737
+#: builtin_printf.cpp:739
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: especificação de conversão inválida"
 
-#: builtin_printf.cpp:769
+#: builtin_printf.cpp:771
 msgid "printf: not enough arguments"
 msgstr "printf: argumentos insuficientes"
-
-#: builtin_set_color.cpp:155
-#, c-format
-msgid "%ls: Expected an argument\n"
-msgstr "%s: Esperava um argumento\n"
-
-#: builtin_set_color.cpp:163 builtin_set_color.cpp:170
-#, c-format
-msgid "%ls: Unknown color '%ls'\n"
-msgstr "%s: Cor desconhecida “%s”\n"
-
-#: builtin_set_color.cpp:177
-#, fuzzy, c-format
-msgid "%ls: Could not set up terminal\n"
-msgstr "Could not set up terminal"
 
 #: builtin_set.cpp:155
 #, c-format
@@ -651,6 +653,27 @@ msgstr ""
 msgid "%ls: Values cannot be specfied with erase\n"
 msgstr "%ls: Values cannot be specfied with erase\n"
 
+#: builtin_set.cpp:817
+#, c-format
+msgid ""
+"%ls: Warning: universal scope selected, but a global variable '%ls' exists.\n"
+msgstr ""
+
+#: builtin_set_color.cpp:144 builtin_set_color.cpp:166
+#, c-format
+msgid "%ls: Unknown color '%ls'\n"
+msgstr "%s: Cor desconhecida “%s”\n"
+
+#: builtin_set_color.cpp:153
+#, c-format
+msgid "%ls: Expected an argument\n"
+msgstr "%s: Esperava um argumento\n"
+
+#: builtin_set_color.cpp:173
+#, fuzzy, c-format
+msgid "%ls: Could not set up terminal\n"
+msgstr "Could not set up terminal"
+
 #: common.cpp:1917
 msgid "This is a bug. Break on bugreport to debug."
 msgstr ""
@@ -670,24 +693,24 @@ msgstr "Diretório de usuário para %ls"
 msgid "Variable: %ls"
 msgstr "Variável: %ls"
 
-#: complete.cpp:907 complete.cpp:925
+#: complete.cpp:901 complete.cpp:919
 msgid "Unknown option: "
 msgstr "Opção desconhecida: "
 
-#: complete.cpp:929
+#: complete.cpp:923
 msgid "Multiple matches for option: "
 msgstr "Várias possibilidades para opção: "
 
-#: env.cpp:313
+#: env.cpp:315
 msgid "Changing language to English"
 msgstr "Mudando língua para Português"
 
-#: env.cpp:1187
+#: env.cpp:1180
 #, fuzzy
 msgid "Tried to pop empty environment stack."
 msgstr "Tentou tirar de uma pilha de ambiente vazia."
 
-#: env_universal_common.cpp:598 path.cpp:358
+#: env_universal_common.cpp:617 path.cpp:279
 msgid ""
 "Unable to create a configuration directory for fish. Your personal settings "
 "will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
@@ -697,47 +720,47 @@ msgstr ""
 "configurações pessoais não serão salvas. Por favor modifique a variável "
 "$XDG_CONFIG_HOME para um diretório onde o usuário atual pode escrever."
 
-#: event.cpp:168
+#: event.cpp:178
 #, fuzzy, c-format
 msgid "signal handler for %ls (%ls)"
 msgstr "signal handler for %ls (%ls)"
 
-#: event.cpp:172
+#: event.cpp:182
 #, fuzzy, c-format
 msgid "handler for variable '%ls'"
 msgstr "handler for variable “%ls”"
 
-#: event.cpp:178
+#: event.cpp:188
 #, fuzzy, c-format
 msgid "exit handler for process %d"
 msgstr "exit handler for process %d"
 
-#: event.cpp:184 event.cpp:195
+#: event.cpp:194 event.cpp:205
 #, fuzzy, c-format
 msgid "exit handler for job %d, '%ls'"
 msgstr "exit handler for job %d, “%ls”"
 
-#: event.cpp:186
+#: event.cpp:196
 #, fuzzy, c-format
 msgid "exit handler for job with process group %d"
 msgstr "exit handler for job with process group %d"
 
-#: event.cpp:197
+#: event.cpp:207
 #, fuzzy, c-format
 msgid "exit handler for job with job id %d"
 msgstr "exit handler for job with job id %d"
 
-#: event.cpp:203
+#: event.cpp:213
 #, fuzzy, c-format
 msgid "handler for generic event '%ls'"
 msgstr "handler for generic event “%ls”"
 
-#: event.cpp:207
+#: event.cpp:217
 #, fuzzy, c-format
 msgid "Unknown event type '0x%x'"
 msgstr "Unknown event type"
 
-#: event.cpp:621
+#: event.cpp:613
 #, fuzzy
 msgid "Signal list overflow. Signals have been ignored."
 msgstr "Signal list overflow. Signals have been ignored."
@@ -756,12 +779,12 @@ msgstr "Um erro ocorreu ao escrever na saída"
 msgid "An error occurred while redirecting file '%s'"
 msgstr "Um erro ocorreu ao redirecionar arquivo “%ls”"
 
-#: exec.cpp:873
+#: exec.cpp:795
 #, c-format
 msgid "Unknown function '%ls'"
 msgstr "Função desconhecida “%ls”"
 
-#: exec.cpp:1024
+#: exec.cpp:943
 #, c-format
 msgid "Unknown input redirection type %d"
 msgstr "Tipo de redireção desconhecida %d"
@@ -792,54 +815,61 @@ msgstr "Processo shell"
 msgid "Last background job"
 msgstr "Último job em background"
 
-#: expand.cpp:1414
+#: expand.cpp:1419
 #, fuzzy
 msgid "Mismatched brackets"
 msgstr "Erro de parênteses"
 
-#: fish.cpp:321
+#: fish.cpp:330
+msgid ""
+"Old versions of fish appear to be running. You will not be able to share "
+"variable values between old and new fish sessions. For best results, restart "
+"all running instances of fish."
+msgstr ""
+
+#: fish.cpp:420
 #, fuzzy, c-format
 msgid "Invalid value '%s' for debug level switch"
 msgstr "Invalid value “%s” for debug level switch"
 
-#: fish.cpp:362 mimedb.cpp:1343
+#: fish.cpp:461 mimedb.cpp:1343
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, versão %s\n"
 
-#: fish.cpp:417
+#: fish.cpp:516
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "Não pode usar o modo não-executar durante uma sessão interativa"
 
-#: fish.cpp:518
+#: fish.cpp:619
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Erro ao ler arquivo %ls\n"
 
-#: fish_indent.cpp:346
+#: fish_indent.cpp:332
 #, c-format
 msgid "%ls, version %s\n"
 msgstr "%ls, versão %s\n"
 
-#: input.cpp:475 input.cpp:485
+#: input.cpp:483 input.cpp:493
 msgid "Could not set up terminal"
 msgstr "Não pôde preparar terminal"
 
-#: input.cpp:478
+#: input.cpp:486
 #, c-format
 msgid "Check that your terminal type, '%ls', is supported on this system"
 msgstr "Verifique se seu tipo de terminal, “%ls”, é suportado neste sistema"
 
-#: input.cpp:480
+#: input.cpp:488
 #, c-format
 msgid "Attempting to use '%ls' instead"
 msgstr "Tentando usar “%ls” no lugar"
 
-#: input.cpp:527
+#: input.cpp:535
 msgid "Error while closing terminfo"
 msgstr "Erro ao fechar terminfo"
 
-#: io.cpp:110
+#: io.cpp:112
 #, c-format
 msgid ""
 "An error occured while reading output from code block on file descriptor %d"
@@ -900,7 +930,7 @@ msgstr "%s: Could not parse mimetype from argument “%s”\n"
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: output.cpp:730
+#: output.cpp:608
 #, c-format
 msgid ""
 "Tried to use terminfo string %s on line %ld of %s, which is undefined in "
@@ -911,31 +941,31 @@ msgstr ""
 msgid "search: "
 msgstr "procurar: "
 
-#: pager.cpp:609
+#: pager.cpp:562
 #, c-format
 msgid "%lsand 1 more row"
 msgstr "%lse mais 1 linha"
 
-#: pager.cpp:613
+#: pager.cpp:566
 #, c-format
 msgid "%lsand %lu more rows"
 msgstr "%lse mais %lu linhas"
 
-#: pager.cpp:618
+#: pager.cpp:571
 #, c-format
 msgid "rows %lu to %lu of %lu"
 msgstr "linhas %lu a %lu de %lu"
 
-#: pager.cpp:623
+#: pager.cpp:576
 msgid "(no matches)"
 msgstr "(não encontrado)"
 
-#: parse_execution.cpp:551
+#: parse_execution.cpp:555
 #, c-format
 msgid "switch: Expected exactly one argument, got %lu\n"
 msgstr "switch: Esperava exatamente um argumento, obteve %d\n"
 
-#: parse_execution.cpp:772
+#: parse_execution.cpp:799
 #, c-format
 msgid ""
 "Unknown command '%ls'. Did you mean to run %ls with a modified environment? "
@@ -946,7 +976,7 @@ msgstr ""
 "modificado? Tente “env %ls=%ls %ls%ls”. Veja a seção de ajuda no comando set "
 "digitando “help set”."
 
-#: parse_execution.cpp:797
+#: parse_execution.cpp:824
 #, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function like "
@@ -959,7 +989,7 @@ msgstr ""
 "como “eval %ls”. Veja a seção de ajuda para o comando function digitando "
 "“help function”."
 
-#: parse_execution.cpp:806
+#: parse_execution.cpp:833
 #, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function or use the "
@@ -970,7 +1000,7 @@ msgstr ""
 "função ou use o builtin eval no lugar, como “eval %ls”. Veja a seção de "
 "ajuda para o comando function digitando “help function”."
 
-#: parse_execution.cpp:814
+#: parse_execution.cpp:841
 #, c-format
 msgid ""
 "Commands may not contain variables. Use the eval builtin instead, like 'eval "
@@ -979,7 +1009,7 @@ msgstr ""
 "Comandos não podem conter variáveis. Em vez disso, use o builtin eval, como "
 "“eval %ls”. Veja a seção de ajuda para o comando eval digitando “help eval”."
 
-#: parse_execution.cpp:821
+#: parse_execution.cpp:848
 #, c-format
 msgid "The file '%ls' is not executable by this user"
 msgstr "O arquivo “%ls” não é executável por este usuário"
@@ -995,198 +1025,212 @@ msgid "Requested redirection to '%ls', which is not a valid file descriptor"
 msgstr ""
 "Requeriu redireção para “%ls”, que não é um descritor de arquivo válido"
 
-#: parser.cpp:53
+#: parse_util.cpp:46
+#, c-format
+msgid "The '%ls' command can not be used in a pipeline"
+msgstr "O comand “%ls” não pode ser usado em pipe"
+
+#: parse_util.cpp:49
+#, fuzzy, c-format
+msgid "The '%ls' command can not be used immediately after a backgrounded job"
+msgstr "O comand “%ls” não pode ser usado em pipe"
+
+#: parse_util.cpp:52
+#, fuzzy
+msgid "Backgrounded commands can not be used as conditionals"
+msgstr "This command can not be used in a pipeline"
+
+#: parser.cpp:52
 #, fuzzy, c-format
 msgid "Tokenizer error: '%ls'"
 msgstr "Tokenizer error: “%ls”"
 
-#: parser.cpp:58
+#: parser.cpp:57
 #, c-format
 msgid "Tried to evaluate commands using invalid block type '%ls'"
 msgstr "Tentou executar comandos usando tipo de bloco inválido “%ls”"
 
-#: parser.cpp:63
+#: parser.cpp:62
 #, c-format
 msgid "Unexpected token of type '%ls'"
 msgstr "Tipo inesperado de token “%ls”"
 
-#: parser.cpp:68 parse_constants.h:245
+#: parser.cpp:67 parse_constants.h:255
 msgid "'while' block"
 msgstr "bloco “while”"
 
-#: parser.cpp:73 parse_constants.h:250
+#: parser.cpp:72 parse_constants.h:260
 msgid "'for' block"
 msgstr "bloco “for”"
 
-#: parser.cpp:78 parse_constants.h:255
+#: parser.cpp:77 parse_constants.h:265
 msgid "Block created by breakpoint"
 msgstr "Bloco criado por breakpoint"
 
-#: parser.cpp:83 parse_constants.h:262
+#: parser.cpp:82 parse_constants.h:272
 msgid "'if' conditional block"
 msgstr "bloco condicional “if”"
 
-#: parser.cpp:88 parse_constants.h:268
+#: parser.cpp:87 parse_constants.h:278
 msgid "function definition block"
 msgstr "bloco de definição de função"
 
-#: parser.cpp:93 parse_constants.h:274
+#: parser.cpp:92 parse_constants.h:284
 msgid "function invocation block"
 msgstr "bloco de chamada de função"
 
-#: parser.cpp:98 parse_constants.h:279
+#: parser.cpp:97 parse_constants.h:289
 #, fuzzy
 msgid "function invocation block with no variable shadowing"
 msgstr "bloco de chamada de função sem mascaramento de variáveis"
 
-#: parser.cpp:103 parse_constants.h:285
+#: parser.cpp:102 parse_constants.h:295
 msgid "'switch' block"
 msgstr "bloco “switch”"
 
-#: parser.cpp:108 parse_constants.h:291
+#: parser.cpp:107 parse_constants.h:301
 msgid "unexecutable block"
 msgstr "bloco não executável"
 
-#: parser.cpp:113 parse_constants.h:297
+#: parser.cpp:112 parse_constants.h:307
 msgid "global root block"
 msgstr "bloco raiz global"
 
-#: parser.cpp:118 parse_constants.h:303
+#: parser.cpp:117 parse_constants.h:313
 msgid "command substitution block"
 msgstr "bloco de substituição de comandos"
 
-#: parser.cpp:123 parse_constants.h:309
+#: parser.cpp:122 parse_constants.h:319
 msgid "'begin' unconditional block"
 msgstr "bloco não condicional “begin”"
 
-#: parser.cpp:128 parse_constants.h:315
+#: parser.cpp:127 parse_constants.h:325
 msgid "Block created by the . builtin"
 msgstr "Bloco criado pelo builtin ."
 
-#: parser.cpp:133 parse_constants.h:320
+#: parser.cpp:132 parse_constants.h:330
 #, fuzzy
 msgid "event handler block"
 msgstr "bloco gerenciador de evento"
 
-#: parser.cpp:138 parse_constants.h:326
+#: parser.cpp:137 parse_constants.h:336
 msgid "unknown/invalid block"
 msgstr "bloco desconhecido/inválido"
 
-#: parser.cpp:456
+#: parser.cpp:474
 #, fuzzy, c-format
 msgid "Could not write profiling information to file '%s'"
 msgstr "Could not write profiling information to file “%s”"
 
-#: parser.cpp:462
+#: parser.cpp:480
 msgid "Time\tSum\tCommand\n"
 msgstr "Tempo\tSoma\tComando\n"
 
-#: parser.cpp:544
+#: parser.cpp:562
 #, fuzzy, c-format
 msgid "in event handler: %ls\n"
 msgstr "no gerenciador de evento: %ls\n"
 
-#: parser.cpp:572
+#: parser.cpp:590
 #, c-format
 msgid "from sourcing file %ls\n"
 msgstr "do arquivo %ls\n"
 
-#: parser.cpp:579
+#: parser.cpp:597
 #, c-format
 msgid "in function '%ls'\n"
 msgstr "na função “%ls”\n"
 
-#: parser.cpp:584
+#: parser.cpp:602
 msgid "in command substitution\n"
 msgstr "na substituição de comando\n"
 
-#: parser.cpp:597
+#: parser.cpp:615
 #, c-format
 msgid "\tcalled on line %d of file %ls\n"
 msgstr "\tchamado na linha %d do arquivo “%ls”\n"
 
-#: parser.cpp:603
+#: parser.cpp:621
 msgid "\tcalled during startup\n"
 msgstr "\tchamado durante inicialização\n"
 
-#: parser.cpp:607
+#: parser.cpp:625
 msgid "\tcalled on standard input\n"
 msgstr "\tchamado na entrada padrão\n"
 
-#: parser.cpp:624
+#: parser.cpp:642
 #, c-format
 msgid "\twith parameter list '%ls'\n"
 msgstr "\tcom lista de parâmetros “%ls”\n"
 
-#: parser.cpp:738
+#: parser.cpp:756
 #, c-format
 msgid "%ls (line %d): "
 msgstr "%ls (linha %d): "
 
-#: parser.cpp:742
+#: parser.cpp:760
 msgid "Startup"
 msgstr "Inicialização"
 
-#: parser.cpp:785
+#: parser.cpp:803
 msgid "Job inconsistency"
 msgstr "Inconsistência de job"
 
-#: parser.cpp:930
+#: parser.cpp:956
 #, fuzzy
 msgid "End of block mismatch. Program terminating."
 msgstr "Fim de bloco desencontrado. Terminando programa."
 
-#: parser.cpp:1028
+#: parser.cpp:1047
 #, c-format
 msgid "%ls (line %lu): "
 msgstr "%ls (linha %d): "
 
-#: parser.cpp:1032
+#: parser.cpp:1051
 #, c-format
 msgid "%ls: "
 msgstr "%ls: "
-
-#: parse_util.cpp:48
-#, c-format
-msgid "The '%ls' command can not be used in a pipeline"
-msgstr "O comand “%ls” não pode ser usado em pipe"
 
 #: path.cpp:24
 #, c-format
 msgid "Error while searching for command '%ls'"
 msgstr "Erro ao procurar por comando “%ls”"
 
-#: proc.cpp:613
+#: proc.cpp:690
+#, fuzzy, c-format
+msgid "'%ls' has %ls"
+msgstr "Job %d, “%ls” está %ls"
+
+#: proc.cpp:694
 #, c-format
 msgid "Job %d, '%ls' has %ls"
 msgstr "Job %d, “%ls” está %ls"
 
-#: proc.cpp:697
-#, c-format
-msgid "%ls: Job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:786
+#, fuzzy, c-format
+msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Job %d, “%ls” terminado pelo sinal %ls (%ls)"
 
-#: proc.cpp:705
-#, c-format
-msgid ""
-"%ls: Process %d, '%ls' from job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:797
+#, fuzzy, c-format
+msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 "%ls: Processo %d, “%ls” do job %d, “%ls” terminado pelo sinal %ls (%ls)"
 
-#: proc.cpp:734
+#: proc.cpp:828
 msgid "ended"
 msgstr ""
 
-#: proc.cpp:968
+#: proc.cpp:1065
 msgid "An error occured while reading output from code block"
 msgstr "Ocorreu um erro ao ler saída de bloco de código"
 
-#: proc.cpp:997 proc.cpp:1009
+#: proc.cpp:1094 proc.cpp:1106
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Não pôde enviar job %d (“%ls”) para foreground"
 
-#: proc.cpp:1029 proc.cpp:1039 proc.cpp:1054
+#: proc.cpp:1126 proc.cpp:1136 proc.cpp:1151
 msgid "Could not return shell to foreground"
 msgstr "Não pôde retornar shell ao foreground"
 
@@ -1196,84 +1240,84 @@ msgstr "Não pôde retornar shell ao foreground"
 # Caminhos:
 # proc.cpp:1279
 # proc.cpp:1305
-#: proc.cpp:1279 proc.cpp:1305
+#: proc.cpp:1354 proc.cpp:1380
 msgid "Process list pointer"
 msgstr "Ponteiro de lista de processo"
 
-#: proc.cpp:1290
+#: proc.cpp:1365
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "Mais de um job no foreground: job 1: “%ls” job 2: “%ls”"
 
-#: proc.cpp:1303
+#: proc.cpp:1378
 msgid "Process argument list"
 msgstr "Lista de argumentos de processo"
 
-#: proc.cpp:1304
+#: proc.cpp:1379
 msgid "Process name"
 msgstr "Nome de processo"
 
-#: proc.cpp:1310
+#: proc.cpp:1385
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Job “%ls”, processo “%ls” está em estado inconsistente “parado”=%d"
 
-#: proc.cpp:1320
+#: proc.cpp:1395
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr "Job “%ls”, processo “%ls” está em estado inconsistente “completo”=%d"
 
-#: reader.cpp:476
+#: reader.cpp:478
 msgid "Could not set terminal mode for new job"
 msgstr "Não pôde preparar modo do terminal para novo job"
 
-#: reader.cpp:523
+#: reader.cpp:525
 msgid "Could not set terminal mode for shell"
 msgstr "Não pôde preparar modo do terminal para shell"
 
-#: reader.cpp:2052
+#: reader.cpp:2059
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "Não há TTY para shell interativo (falha em tcgetpgrp)"
 
-#: reader.cpp:2067
+#: reader.cpp:2074
 #, c-format
 msgid ""
 "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr ""
 "Pareço um processo órfão, então estou saindo educadamente. Meu pid é %d."
 
-#: reader.cpp:2098
+#: reader.cpp:2105
 msgid "Couldn't put the shell in its own process group"
 msgstr "Não pôde colocar o shell em seu próprio grupo de processos"
 
-#: reader.cpp:2108
+#: reader.cpp:2115
 msgid "Couldn't grab control of terminal"
 msgstr "Não pôde pegar controle do terminal"
 
-#: reader.cpp:2609
+#: reader.cpp:2616
 msgid "Pop null reader block"
 msgstr ""
 
-#: reader.cpp:2875
+#: reader.cpp:2882
 msgid ""
 "There are stopped jobs. A second attempt to exit will enforce their "
 "termination.\n"
 msgstr "Há jobs parados. Uma segunda tentativa de sair forçará seu término.\n"
 
-#: reader.cpp:4064
+#: reader.cpp:4115
 #, c-format
 msgid "Unknown keybinding %d"
 msgstr "Atalho desconhecido %d"
 
-#: reader.cpp:4205
+#: reader.cpp:4226
 msgid "Error while reading from file descriptor"
 msgstr "Erro ao ler do descritor de arquivo"
 
-#: reader.cpp:4222
+#: reader.cpp:4243
 msgid "Error while closing input stream"
 msgstr "Erro ao fechar stream de entrada"
 
-#: reader.cpp:4243
+#: reader.cpp:4270
 msgid "Error while opening input stream"
 msgstr "Erro ao abrir stream de entrada"
 
@@ -1509,7 +1553,7 @@ msgstr "Executar job em background"
 msgid "Comment"
 msgstr "Comentário"
 
-#: tokenizer.cpp:602
+#: tokenizer.cpp:561
 #, fuzzy
 msgid "Invalid token type"
 msgstr "Tipo de token inválido"
@@ -1567,7 +1611,7 @@ msgstr "Executável"
 msgid "Executable link"
 msgstr "Link para executável"
 
-#: wildcard.cpp:67 share/completions/git.fish:146
+#: wildcard.cpp:67 share/completions/git.fish:178
 msgid "File"
 msgstr "Arquivo"
 
@@ -1695,11 +1739,11 @@ msgstr "%ls: Argumento “%ls” não é número\n"
 msgid "An error occurred while setting up pipe"
 msgstr "Ocorreu um erro ao preparar pipe"
 
-#: expand.h:138
+#: expand.h:135
 msgid "Array index out of bounds"
 msgstr "Índice do array fora dos limites"
 
-#: parse_constants.h:175
+#: parse_constants.h:185
 #, c-format
 msgid ""
 "The function '%ls' calls itself immediately, which would result in an "
@@ -1707,7 +1751,7 @@ msgid ""
 msgstr ""
 "A função “%ls” se chama imediatamente, o que causaria um loop infinito."
 
-#: parse_constants.h:179
+#: parse_constants.h:189
 msgid ""
 "The function call stack limit has been exceeded. Do you have an accidental "
 "infinite loop?"
@@ -1715,7 +1759,7 @@ msgstr ""
 "O limite de tamanho da pilha de chamada de funções foi excedido. Você está "
 "com um loop infinito acidental?"
 
-#: parse_constants.h:182
+#: parse_constants.h:192
 msgid ""
 "Expected a command, but instead found a pipe. Did you mean 'COMMAND; or "
 "COMMAND'? See the help section for the 'or' builtin command by typing 'help "
@@ -1724,58 +1768,59 @@ msgstr ""
 "Esperava comando, obteve pipe. Você quis dizer “COMANDO; or COMANDO”? Veja a "
 "seção de ajuda para o comando builtin “or” digitando “help or”."
 
-#: parse_constants.h:185
+#: parse_constants.h:195
+#, fuzzy
 msgid ""
-"Expected a command, but instead found a '&'. Did you mean 'COMMAND; and "
+"Expected a command, but instead found an '&'. Did you mean 'COMMAND; and "
 "COMMAND'? See the help section for the 'and' builtin command by typing 'help "
 "and'."
 msgstr ""
 "Esperava comando, obteve “&”. Você quis dizer “COMANDO; and COMANDO”? Veja a "
 "seção de ajuda para o comando builtin “and” digitando “help and”."
 
-#: parse_constants.h:188
+#: parse_constants.h:198
 #, c-format
 msgid "Illegal command name '%ls'"
 msgstr "Nome de comando ilegal “%ls”"
 
-#: parse_constants.h:191
+#: parse_constants.h:201
 #, c-format
 msgid "Unknown builtin '%ls'"
 msgstr "Builtin desconhecida “%ls”"
 
-#: parse_constants.h:194
+#: parse_constants.h:204
 #, c-format
 msgid "Unable to expand variable name '%ls'"
 msgstr "Incapaz de expandir o nome da variável “%ls”"
 
-#: parse_constants.h:197
+#: parse_constants.h:207
 #, c-format
 msgid "Unable to find a process '%ls'"
 msgstr "Incapaz de encontrar um processo “%ls”"
 
-#: parse_constants.h:200
+#: parse_constants.h:210
 #, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr "Descritor de arquivo ilegal na redireção “%ls”"
 
-#: parse_constants.h:203
+#: parse_constants.h:213
 #, c-format
 msgid "No matches for wildcard '%ls'."
 msgstr "Não há combinações para curinga “%ls”."
 
-#: parse_constants.h:206
+#: parse_constants.h:216
 msgid "break command while not inside of loop"
 msgstr "Comando break fora de loop"
 
-#: parse_constants.h:209
+#: parse_constants.h:219
 msgid "continue command while not inside of loop"
 msgstr "Comando continue fora de loop"
 
-#: parse_constants.h:212
+#: parse_constants.h:222
 msgid "'return' builtin command outside of function definition"
 msgstr "Comando builtin “return” fora de definição de função"
 
-#: parse_constants.h:215
+#: parse_constants.h:225
 #, c-format
 msgid ""
 "Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
@@ -1784,7 +1829,7 @@ msgstr ""
 "Comando desconhecido “%ls”. Você quis dizer “set %ls %ls”? Veja a seção de "
 "ajuda para o comando set digitando “help set”."
 
-#: parse_constants.h:220
+#: parse_constants.h:230
 #, c-format
 msgid ""
 "The '$' character begins a variable name. The character '%lc', which "
@@ -1797,7 +1842,7 @@ msgstr ""
 "podem ter tamanho nulo. Para saber mais sobre expansão de variáveis no fish, "
 "digite “help expand-variable”."
 
-#: parse_constants.h:225
+#: parse_constants.h:235
 msgid ""
 "$? is not a valid variable in fish. If you want the exit status of the last "
 "command, try $status."
@@ -1805,7 +1850,7 @@ msgstr ""
 "$? não é uma variável válida no fish. Se você quer o código de saída do "
 "último comando, tente $status."
 
-#: parse_constants.h:230
+#: parse_constants.h:240
 msgid ""
 "The '$' begins a variable name. It was given at the end of an argument. "
 "Variable names may not be zero characters long. To learn more about variable "
@@ -1815,7 +1860,7 @@ msgstr ""
 "Nomes de variáveis não podem ter comprimento nulo. Para saber mais sobre "
 "expansão de variáveis no fish, digite “help expand-variable”."
 
-#: parse_constants.h:235
+#: parse_constants.h:245
 #, c-format
 msgid ""
 "Did you mean %ls{$%ls}%ls? The '$' character begins a variable name. A "
@@ -1828,7 +1873,7 @@ msgstr ""
 "nomes de variáveis não podem ter comprimento nulo. Para saber mais sobre "
 "expansão de variáveis no fish, digite “help expand-variable”."
 
-#: parse_constants.h:240
+#: parse_constants.h:250
 msgid ""
 "Did you mean (COMMAND)? In fish, the '$' character is only used for "
 "accessing variables. To learn more about command substitution in fish, type "
@@ -2435,117 +2480,6 @@ msgstr "Specify a config file"
 msgid "Set a config option"
 msgstr "Set a config option"
 
-#: share/completions/aptitude.fish:3
-#, fuzzy
-msgid "Test if aptitude has yet to be given the subcommand"
-msgstr "Test if aptitude has yet to be given the subcommand"
-
-#: share/completions/aptitude.fish:12
-#, fuzzy
-msgid "Test if aptitude command should have packages as potential completion"
-msgstr "Test if aptitude command should have packages as potential completion"
-
-#: share/completions/aptitude.fish:24
-#, fuzzy
-msgid "Remove any cached packages which can no longer be downloaded"
-msgstr "Clean packages no longer be downloaded"
-
-#: share/completions/aptitude.fish:25
-msgid "Remove all downloaded .deb files from the package cache directory"
-msgstr ""
-
-#: share/completions/aptitude.fish:26
-msgid "Forget all internal information about what packages are \\new"
-msgstr ""
-
-#: share/completions/aptitude.fish:27
-msgid "Cancel all scheduled actions on all packages"
-msgstr ""
-
-#: share/completions/aptitude.fish:28
-msgid "Update the list of available packages from the apt sources"
-msgstr ""
-
-#: share/completions/aptitude.fish:29
-#, fuzzy
-msgid "Upgrade installed packages to their most recent version"
-msgstr "Updates packages to the best version available"
-
-#: share/completions/aptitude.fish:30
-#, fuzzy
-msgid "Download and displays the Debian changelog for the packages"
-msgstr "Display change information for the package"
-
-#: share/completions/aptitude.fish:31
-#, fuzzy
-msgid "Upgrade, removing or installing packages as necessary"
-msgstr "Upgrade or install newest packages"
-
-#: share/completions/aptitude.fish:32
-#, fuzzy
-msgid "Download the packages to the current directory"
-msgstr "Do not ever ascend to the parent directory"
-
-#: share/completions/aptitude.fish:33
-msgid "Forbid the upgrade to a particular version"
-msgstr ""
-
-#: share/completions/aptitude.fish:34
-msgid "Ignore the packages by future upgrade commands"
-msgstr ""
-
-#: share/completions/aptitude.fish:35
-#, fuzzy
-msgid "Install the packages"
-msgstr "Install new package"
-
-#: share/completions/aptitude.fish:36
-#, fuzzy
-msgid "Cancel any scheduled actions on the packages"
-msgstr "Display change information for the package"
-
-#: share/completions/aptitude.fish:37
-#, fuzzy
-msgid "Mark packages as automatically installed"
-msgstr "Upgrade package if already installed"
-
-#: share/completions/aptitude.fish:38
-msgid "Remove and delete all associated configuration and data files"
-msgstr ""
-
-#: share/completions/aptitude.fish:39
-#, fuzzy
-msgid "Reinstall the packages"
-msgstr "Reinstall packages"
-
-#: share/completions/aptitude.fish:40
-#, fuzzy
-msgid "Remove the packages"
-msgstr "Remove packages"
-
-#: share/completions/aptitude.fish:41
-#, fuzzy
-msgid "Display detailed information about the packages"
-msgstr "Display change information for the package"
-
-#: share/completions/aptitude.fish:42
-msgid "Consider the packages by future upgrade commands"
-msgstr ""
-
-#: share/completions/aptitude.fish:43
-#, fuzzy
-msgid "Mark packages as manually installed"
-msgstr "Upgrade package if already installed"
-
-#: share/completions/aptitude.fish:44
-#, fuzzy
-msgid "Search for packages matching one of the patterns"
-msgstr "Search package containing pattern"
-
-#: share/completions/aptitude.fish:45
-msgid "Display brief summary of the available commands and options"
-msgstr ""
-
 #: share/completions/apt-key.fish:2
 #, fuzzy
 msgid "Add a new key"
@@ -3091,6 +3025,117 @@ msgstr "Select an action"
 msgid "Fix broken option"
 msgstr "Fix broken option"
 
+#: share/completions/aptitude.fish:3
+#, fuzzy
+msgid "Test if aptitude has yet to be given the subcommand"
+msgstr "Test if aptitude has yet to be given the subcommand"
+
+#: share/completions/aptitude.fish:12
+#, fuzzy
+msgid "Test if aptitude command should have packages as potential completion"
+msgstr "Test if aptitude command should have packages as potential completion"
+
+#: share/completions/aptitude.fish:24
+#, fuzzy
+msgid "Remove any cached packages which can no longer be downloaded"
+msgstr "Clean packages no longer be downloaded"
+
+#: share/completions/aptitude.fish:25
+msgid "Remove all downloaded .deb files from the package cache directory"
+msgstr ""
+
+#: share/completions/aptitude.fish:26
+msgid "Forget all internal information about what packages are \\new"
+msgstr ""
+
+#: share/completions/aptitude.fish:27
+msgid "Cancel all scheduled actions on all packages"
+msgstr ""
+
+#: share/completions/aptitude.fish:28
+msgid "Update the list of available packages from the apt sources"
+msgstr ""
+
+#: share/completions/aptitude.fish:29
+#, fuzzy
+msgid "Upgrade installed packages to their most recent version"
+msgstr "Updates packages to the best version available"
+
+#: share/completions/aptitude.fish:30
+#, fuzzy
+msgid "Download and displays the Debian changelog for the packages"
+msgstr "Display change information for the package"
+
+#: share/completions/aptitude.fish:31
+#, fuzzy
+msgid "Upgrade, removing or installing packages as necessary"
+msgstr "Upgrade or install newest packages"
+
+#: share/completions/aptitude.fish:32
+#, fuzzy
+msgid "Download the packages to the current directory"
+msgstr "Do not ever ascend to the parent directory"
+
+#: share/completions/aptitude.fish:33
+msgid "Forbid the upgrade to a particular version"
+msgstr ""
+
+#: share/completions/aptitude.fish:34
+msgid "Ignore the packages by future upgrade commands"
+msgstr ""
+
+#: share/completions/aptitude.fish:35
+#, fuzzy
+msgid "Install the packages"
+msgstr "Install new package"
+
+#: share/completions/aptitude.fish:36
+#, fuzzy
+msgid "Cancel any scheduled actions on the packages"
+msgstr "Display change information for the package"
+
+#: share/completions/aptitude.fish:37
+#, fuzzy
+msgid "Mark packages as automatically installed"
+msgstr "Upgrade package if already installed"
+
+#: share/completions/aptitude.fish:38
+msgid "Remove and delete all associated configuration and data files"
+msgstr ""
+
+#: share/completions/aptitude.fish:39
+#, fuzzy
+msgid "Reinstall the packages"
+msgstr "Reinstall packages"
+
+#: share/completions/aptitude.fish:40
+#, fuzzy
+msgid "Remove the packages"
+msgstr "Remove packages"
+
+#: share/completions/aptitude.fish:41
+#, fuzzy
+msgid "Display detailed information about the packages"
+msgstr "Display change information for the package"
+
+#: share/completions/aptitude.fish:42
+msgid "Consider the packages by future upgrade commands"
+msgstr ""
+
+#: share/completions/aptitude.fish:43
+#, fuzzy
+msgid "Mark packages as manually installed"
+msgstr "Upgrade package if already installed"
+
+#: share/completions/aptitude.fish:44
+#, fuzzy
+msgid "Search for packages matching one of the patterns"
+msgstr "Search package containing pattern"
+
+#: share/completions/aptitude.fish:45
+msgid "Display brief summary of the available commands and options"
+msgstr ""
+
 #: share/completions/arp.fish:4
 #, fuzzy
 msgid "Class of hw type"
@@ -3120,26 +3165,6 @@ msgstr "Manually create ARP address"
 #, fuzzy
 msgid "Take addr from filename, default /etc/ethers"
 msgstr "Take addr from filename, default /etc/ethers"
-
-#: share/completions/atd.fish:2
-#, fuzzy
-msgid "Limiting load factor"
-msgstr "Limiting load factor"
-
-#: share/completions/atd.fish:3
-#, fuzzy
-msgid "Minimum interval in seconds"
-msgstr "Minimum interval in seconds"
-
-#: share/completions/atd.fish:4
-#, fuzzy
-msgid "Debug mode"
-msgstr "Debug mode"
-
-#: share/completions/atd.fish:5
-#, fuzzy
-msgid "Process at queue only once"
-msgstr "Process at queue only once"
 
 #: share/completions/at.fish:3 share/completions/atq.fish:3
 #, fuzzy
@@ -3176,6 +3201,26 @@ msgstr "Show the time"
 msgid "Print the jobs listed"
 msgstr "Print the jobs listed"
 
+#: share/completions/atd.fish:2
+#, fuzzy
+msgid "Limiting load factor"
+msgstr "Limiting load factor"
+
+#: share/completions/atd.fish:3
+#, fuzzy
+msgid "Minimum interval in seconds"
+msgstr "Minimum interval in seconds"
+
+#: share/completions/atd.fish:4
+#, fuzzy
+msgid "Debug mode"
+msgstr "Debug mode"
+
+#: share/completions/atd.fish:5
+#, fuzzy
+msgid "Process at queue only once"
+msgstr "Process at queue only once"
+
 #: share/completions/bundle.fish:3
 #, fuzzy
 msgid "Test if bundle has been given no subcommand"
@@ -3186,227 +3231,324 @@ msgstr "Test if aptitude has yet to be given the subcommand"
 msgid "Test if bundle has been given a specific subcommand"
 msgstr "Test if aptitude has yet to be given the subcommand"
 
-#: share/completions/bundle.fish:30
+#: share/completions/bundle.fish:31
 #, fuzzy
 msgid "Display a help page"
 msgstr "Display man page"
 
-#: share/completions/bundle.fish:38 share/completions/bundle.fish:65
+#: share/completions/bundle.fish:39 share/completions/bundle.fish:83
 msgid "Install the gems specified by the Gemfile or Gemfile.lock"
 msgstr ""
 
-#: share/completions/bundle.fish:39 share/completions/bundle.fish:87
-msgid "The location of the Gemfile bundler should use."
-msgstr ""
-
-#: share/completions/bundle.fish:40
+#: share/completions/bundle.fish:40 share/completions/bundle.fish:106
 #, fuzzy
-msgid "The location to install the gems in the bundle to."
+msgid "The location of the Gemfile bundler should use"
 msgstr "Commit an unversioned file or tree into the repository"
 
 #: share/completions/bundle.fish:41
-msgid "Installs the gems in the bundle to the system location."
-msgstr ""
+#, fuzzy
+msgid "The location to install the gems in the bundle to"
+msgstr "Commit an unversioned file or tree into the repository"
 
 #: share/completions/bundle.fish:42
-msgid "A space-separated list of groups to skip installing."
-msgstr ""
+#, fuzzy
+msgid "Installs the gems in the bundle to the system location"
+msgstr "Commit an unversioned file or tree into the repository"
 
 #: share/completions/bundle.fish:43
-msgid "Use cached gems instead of connecting to rubygems.org."
+msgid "A space-separated list of groups to skip installing"
 msgstr ""
 
 #: share/completions/bundle.fish:44
-msgid "Switches bundler's defaults into deployment mode."
+msgid "Use cached gems instead of connecting to rubygems.org"
 msgstr ""
 
 #: share/completions/bundle.fish:45
-msgid ""
-"Create a directory containing executabes that run in the context of the "
-"bundle."
+msgid "Switches bundler's defaults into deployment mode."
 msgstr ""
 
 #: share/completions/bundle.fish:46
-msgid "Specify a ruby executable to use with generated binstubs."
+msgid ""
+"Create a directory containing executabes that run in the context of the "
+"bundle"
 msgstr ""
 
 #: share/completions/bundle.fish:47
-msgid "Make a bundle that can work without RubyGems or Bundler at run-time."
+msgid "Specify a ruby executable to use with generated binstubs"
 msgstr ""
 
 #: share/completions/bundle.fish:48
-msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
+msgid "Make a bundle that can work without RubyGems or Bundler at run-time"
 msgstr ""
 
 #: share/completions/bundle.fish:49
-msgid "Do not update the cache in vendor/cache with the newly bundled gems."
+msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
 msgstr ""
 
 #: share/completions/bundle.fish:50
+msgid "Install  gems parallely by starting size number of parallel workers"
+msgstr ""
+
+#: share/completions/bundle.fish:51
+msgid "Do not update the cache in vendor/cache with the newly bundled gems"
+msgstr ""
+
+#: share/completions/bundle.fish:52
 #, fuzzy
-msgid "Do not print progress information to stdout."
+msgid "Do not print progress information to stdout"
 msgstr "Don't print group information"
 
-#: share/completions/bundle.fish:53 share/completions/bundle.fish:66
+#: share/completions/bundle.fish:53
+#, fuzzy
+msgid "Run bundle clean automatically after install"
+msgstr "Upgrade package if already installed"
+
+#: share/completions/bundle.fish:54 share/completions/bundle.fish:63
+msgid "Use the rubygems modern index instead of the API endpoint"
+msgstr ""
+
+#: share/completions/bundle.fish:55 share/completions/bundle.fish:164
+#, fuzzy
+msgid "Do not remove stale gems from the cache"
+msgstr "Remove all gz files from cache"
+
+#: share/completions/bundle.fish:56
+msgid "Do not allow the Gemfile.lock to be updated after this install"
+msgstr ""
+
+#: share/completions/bundle.fish:59 share/completions/bundle.fish:84
 #, fuzzy
 msgid "Update dependencies to their latest versions"
 msgstr "Updates packages to the best version available"
 
-#: share/completions/bundle.fish:54
-msgid "The name of a :git or :path source used in the Gemfile."
+#: share/completions/bundle.fish:60
+msgid "The name of a :git or :path source used in the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:58
+#: share/completions/bundle.fish:61
+msgid "Do not attempt to fetch gems remotely and use the gem cache instead"
+msgstr ""
+
+#: share/completions/bundle.fish:62
+msgid "Only output warnings and errors"
+msgstr ""
+
+#: share/completions/bundle.fish:64
+#, fuzzy
+msgid "Specify the number of jobs to run in parallel"
+msgstr "Specifies the number of data bytes to be sent"
+
+#: share/completions/bundle.fish:65
+#, fuzzy
+msgid "Update a specific group"
+msgstr "Use a specified tag"
+
+#: share/completions/bundle.fish:69
 msgid ""
 "Package the .gem files required by your application into the vendor/cache "
 "directory"
 msgstr ""
 
-#: share/completions/bundle.fish:61 share/completions/bundle.fish:68
+#: share/completions/bundle.fish:72
+#, fuzzy
+msgid "Install the binstubs of the listed gem"
+msgstr "Display the pretend output in a tabular form"
+
+#: share/completions/bundle.fish:73
+#, fuzzy
+msgid "Binstub destination directory (default bin)"
+msgstr "Install documentation files (default)"
+
+#: share/completions/bundle.fish:74
+msgid "Overwrite existing binstubs if they exist"
+msgstr ""
+
+#: share/completions/bundle.fish:78 share/completions/bundle.fish:86
 msgid "Execute a script in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:64
+#: share/completions/bundle.fish:79
+msgid "Exec runs a command, providing it access to the gems in the bundle"
+msgstr ""
+
+#: share/completions/bundle.fish:82
 msgid "Describe available tasks or one specific task"
 msgstr ""
 
-#: share/completions/bundle.fish:67
+#: share/completions/bundle.fish:85
 #, fuzzy
 msgid "Package .gem files into the vendor/cache directory"
 msgstr "Change working directory"
 
-#: share/completions/bundle.fish:69
+#: share/completions/bundle.fish:87
+#, fuzzy
+msgid "Specify and read configuration options for bundler"
+msgstr "Specify a configuration file"
+
+#: share/completions/bundle.fish:88
 msgid "Check bundler requirements for your application"
 msgstr ""
 
-#: share/completions/bundle.fish:70 share/completions/bundle.fish:92
+#: share/completions/bundle.fish:89
 #, fuzzy
 msgid "Show all of the gems in the current bundle"
 msgstr "Do not ever ascend to the parent directory"
 
-#: share/completions/bundle.fish:71 share/completions/bundle.fish:96
+#: share/completions/bundle.fish:90
 #, fuzzy
 msgid "Show the source location of a particular gem in the bundle"
 msgstr "Show the process id of each process in the job"
 
-#: share/completions/bundle.fish:72 share/completions/bundle.fish:100
+#: share/completions/bundle.fish:91 share/completions/bundle.fish:121
 msgid "Show all of the outdated gems in the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:73 share/completions/bundle.fish:107
+#: share/completions/bundle.fish:92 share/completions/bundle.fish:129
 msgid "Start an IRB session in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:74 share/completions/bundle.fish:110
+#: share/completions/bundle.fish:93 share/completions/bundle.fish:132
 #, sh-format
 msgid "Open an installed gem in your $EDITOR"
 msgstr ""
 
-#: share/completions/bundle.fish:75 share/completions/bundle.fish:114
+#: share/completions/bundle.fish:94 share/completions/bundle.fish:136
 msgid "Generate a visual representation of your dependencies"
 msgstr ""
 
-#: share/completions/bundle.fish:76
+#: share/completions/bundle.fish:95
 #, fuzzy
 msgid "Generate a simple Gemfile"
 msgstr "Generate master file"
 
-#: share/completions/bundle.fish:77 share/completions/bundle.fish:125
+#: share/completions/bundle.fish:96 share/completions/bundle.fish:147
 msgid "Create a simple gem, suitable for development with bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:78 share/completions/bundle.fish:131
+#: share/completions/bundle.fish:97 share/completions/bundle.fish:154
 #, fuzzy
 msgid "Displays platform compatibility information"
 msgstr "Display update information"
 
-#: share/completions/bundle.fish:79 share/completions/bundle.fish:135
+#: share/completions/bundle.fish:98 share/completions/bundle.fish:158
 msgid "Cleans up unused gems in your bundler directory"
 msgstr ""
 
-#: share/completions/bundle.fish:86
+#: share/completions/bundle.fish:105
 msgid ""
 "Determine whether the requirements for your application are installed and "
 "available to bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:88
-msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)."
+#: share/completions/bundle.fish:107
+msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)"
 msgstr ""
 
-#: share/completions/bundle.fish:89
+#: share/completions/bundle.fish:108
 #, fuzzy
 msgid "Lock the Gemfile"
 msgstr "Log to tracefile"
 
-#: share/completions/bundle.fish:93
+#: share/completions/bundle.fish:111 share/completions/bundle.fish:116
+msgid ""
+"Show lists the names and versions of all gems that are required by your "
+"Gemfile"
+msgstr ""
+
+#: share/completions/bundle.fish:112 share/completions/bundle.fish:117
 msgid "List the paths of all gems required by your Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:101
+#: share/completions/bundle.fish:122
 #, fuzzy
 msgid "Check for newer pre-release gems"
 msgstr "Check for memory leaks"
 
-#: share/completions/bundle.fish:102
+#: share/completions/bundle.fish:123
 msgid "Check against a specific source"
 msgstr ""
 
-#: share/completions/bundle.fish:103
+#: share/completions/bundle.fish:124
 msgid "Use cached gems instead of attempting to fetch gems remotely"
 msgstr ""
 
-#: share/completions/bundle.fish:115
+#: share/completions/bundle.fish:125
+msgid "Only list newer versions allowed by your Gemfile requirements"
+msgstr ""
+
+#: share/completions/bundle.fish:137
 msgid "The name to use for the generated file (see format option)"
 msgstr ""
 
-#: share/completions/bundle.fish:116
+#: share/completions/bundle.fish:138
 #, fuzzy
 msgid "Show each gem version"
 msgstr "Source tree version"
 
-#: share/completions/bundle.fish:117
+#: share/completions/bundle.fish:139
 msgid "Show the version of each required dependency"
 msgstr ""
 
-#: share/completions/bundle.fish:118
+#: share/completions/bundle.fish:140
 msgid "Output a specific format (png, jpg, svg, dot, ...)"
 msgstr ""
 
-#: share/completions/bundle.fish:121
+#: share/completions/bundle.fish:143
 #, fuzzy
 msgid "Generate a simple Gemfile, placed in the current directory"
 msgstr "Do not ever ascend to the parent directory"
 
-#: share/completions/bundle.fish:122
+#: share/completions/bundle.fish:144
 msgid "Use a specified .gemspec to create the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:126
+#: share/completions/bundle.fish:148
 msgid "Generate a binary for your library"
 msgstr ""
 
-#: share/completions/bundle.fish:127
+#: share/completions/bundle.fish:149
 msgid "Generate a test directory for your library (rspec or minitest)"
 msgstr ""
 
-#: share/completions/bundle.fish:128
+#: share/completions/bundle.fish:150
 #, fuzzy
 msgid "Path to your editor"
 msgstr "Set source directory"
 
-#: share/completions/bundle.fish:132
+#: share/completions/bundle.fish:151
+msgid "Generate the boilerplate for C extension code"
+msgstr ""
+
+#: share/completions/bundle.fish:155
 #, fuzzy
 msgid "Only display Ruby directive information"
 msgstr "Display update information"
 
-#: share/completions/bundle.fish:136
+#: share/completions/bundle.fish:159
 msgid "Only print out changes, do not actually clean gems"
 msgstr ""
 
-#: share/completions/bundle.fish:137
+#: share/completions/bundle.fish:160
 msgid "Forces clean even if --path is not set"
 msgstr ""
+
+#: share/completions/bundle.fish:163
+msgid "Cache all the gems to vendor/cache"
+msgstr ""
+
+#: share/completions/bundle.fish:165
+msgid "Include all sources (including path and git)"
+msgstr ""
+
+#: share/completions/bundle.fish:168
+#, fuzzy
+msgid "Prints the license of all gems in the bundle"
+msgstr "Commit an unversioned file or tree into the repository"
+
+#: share/completions/bundle.fish:171
+#, fuzzy
+msgid "Print information about the environment Bundler is running under"
+msgstr "Output extra information about the work being done"
 
 #: share/completions/configure.fish:1
 #: share/functions/__fish_complete_diff.fish:27
@@ -4242,77 +4384,27 @@ msgid ""
 msgstr ""
 "Prints completions for installed packages on the system from /var/db/pkg"
 
-#: share/completions/emerge.fish:12 share/completions/equery.fish:12
+#: share/completions/emerge.fish:13 share/completions/equery.fish:12
 #, fuzzy
 msgid ""
 "Prints completions for all available packages on the system from /usr/portage"
 msgstr ""
 "Prints completions for installed packages on the system from /var/db/pkg"
 
-#: share/completions/emerge.fish:19
+#: share/completions/emerge.fish:22
 #, fuzzy
 msgid ""
 "Tests if emerge command should have an installed package as potential "
 "completion"
 msgstr "Test if emerge command should have packages as potential completion"
 
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
+#: share/completions/emerge.fish:32
 #, fuzzy
-msgid "All base system packages"
-msgstr "Erase built packages"
-
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-#, fuzzy
-msgid "All packages in world"
-msgstr "Sync packages installed"
-
-#: share/completions/emerge.fish:30
-#, fuzzy
-msgid "Installed package"
-msgstr "Install new package"
-
-#: share/completions/emerge.fish:31
-#: share/functions/__fish_print_packages.fish:13
-#, fuzzy
-msgid "Package"
-msgstr "Package"
-
-#: share/completions/emerge.fish:35
-msgid "Usage overview of emerge"
+msgid ""
+"Print completions for all packages including the version compare if that is "
+"already typed"
 msgstr ""
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject system"
-msgstr ""
-
-#: share/completions/emerge.fish:35
-#, fuzzy
-msgid "Help on subject config"
-msgstr "Help section"
-
-#: share/completions/emerge.fish:35
-#, fuzzy
-msgid "Help on subject sync"
-msgstr "Help section"
-
-#: share/completions/emerge.fish:57
-#, fuzzy
-msgid "Use colors in output"
-msgstr "Use colors"
-
-#: share/completions/emerge.fish:57
-msgid "Don't use colors in output"
-msgstr ""
-
-#: share/completions/emerge.fish:81
-#, fuzzy
-msgid "Pull in build time dependencies"
-msgstr "Show build dependencies"
-
-#: share/completions/emerge.fish:81
-#, fuzzy
-msgid "Don't pull in build time dependencies"
-msgstr "Don't automatically fulfill dependencies"
+"Prints completions for installed packages on the system from /var/db/pkg"
 
 #: share/completions/env.fish:2
 #, fuzzy
@@ -4849,11 +4941,16 @@ msgstr ""
 msgid "Update the RubyGems system software"
 msgstr ""
 
-#: share/completions/git.fish:121 share/completions/git.fish:144
+#: share/completions/git.fish:98
+#, fuzzy
+msgid "name"
+msgstr "Username"
+
+#: share/completions/git.fish:153 share/completions/git.fish:176
 msgid "Branch"
 msgstr ""
 
-#: share/completions/git.fish:145
+#: share/completions/git.fish:177
 #, fuzzy
 msgid "Tag"
 msgstr "Target"
@@ -5149,6 +5246,11 @@ msgstr "Start interface"
 msgid "Network interface"
 msgstr "Network interface"
 
+#: share/completions/kitchen.fish:3
+#, fuzzy
+msgid "Test if kitchen has yet to be given the main command"
+msgstr "Test if apt has yet to be given the subcommand"
+
 #: share/completions/less.fish:3
 #, fuzzy
 msgid "Buffer space"
@@ -5157,6 +5259,36 @@ msgstr "Buffer space"
 #: share/completions/lsusb.fish:2
 msgid "Show only devices with specified device and/or bus numbers (in decimal)"
 msgstr ""
+
+#: share/completions/make.fish:12
+#, fuzzy
+msgid "Target"
+msgstr "Target"
+
+#: share/completions/make.fish:13
+#, fuzzy
+msgid "Use file as makefile"
+msgstr "Use file as makefile"
+
+#: share/completions/make.fish:18
+#, fuzzy
+msgid "Search directory for makefile"
+msgstr "Search directory for makefile"
+
+#: share/completions/make.fish:19
+#, fuzzy
+msgid "Number of concurrent jobs"
+msgstr "Number of concurrent jobs"
+
+#: share/completions/make.fish:23
+#, fuzzy
+msgid "Ignore specified file"
+msgstr "Ignore specified file"
+
+#: share/completions/make.fish:32
+#, fuzzy
+msgid "Pretend file is modified"
+msgstr "Pretend file is modified"
 
 #: share/completions/makedepend.fish:1
 #, fuzzy
@@ -5202,36 +5334,6 @@ msgstr "Starting string delimiter"
 #, fuzzy
 msgid "Line width"
 msgstr "Line width"
-
-#: share/completions/make.fish:12
-#, fuzzy
-msgid "Target"
-msgstr "Target"
-
-#: share/completions/make.fish:13
-#, fuzzy
-msgid "Use file as makefile"
-msgstr "Use file as makefile"
-
-#: share/completions/make.fish:18
-#, fuzzy
-msgid "Search directory for makefile"
-msgstr "Search directory for makefile"
-
-#: share/completions/make.fish:19
-#, fuzzy
-msgid "Number of concurrent jobs"
-msgstr "Number of concurrent jobs"
-
-#: share/completions/make.fish:23
-#, fuzzy
-msgid "Ignore specified file"
-msgstr "Ignore specified file"
-
-#: share/completions/make.fish:32
-#, fuzzy
-msgid "Pretend file is modified"
-msgstr "Pretend file is modified"
 
 #: share/completions/mosh.fish:20
 msgid "Controls use of speculative local echo"
@@ -6544,12 +6646,12 @@ msgstr "Evalute file"
 msgid "Specify line-length"
 msgstr "Specify line-length"
 
-#: share/completions/set_color.fish:1 share/completions/set.fish:73
+#: share/completions/set.fish:73 share/completions/set_color.fish:1
 #, fuzzy
 msgid "Color"
 msgstr "Color"
 
-#: share/completions/set_color.fish:2 share/completions/set.fish:74
+#: share/completions/set.fish:74 share/completions/set_color.fish:2
 #, fuzzy
 msgid "Change background color"
 msgstr "Change background color"
@@ -6856,7 +6958,7 @@ msgstr ""
 msgid "Test if vagrant has yet to be given the main command"
 msgstr "Test if apt has yet to be given the subcommand"
 
-#: share/completions/vagrant.fish:34
+#: share/completions/vagrant.fish:23
 #, fuzzy
 msgid "Lists all available Vagrant boxes"
 msgstr "List names of available signals"
@@ -6890,6 +6992,11 @@ msgstr "Profiling output format"
 #, fuzzy
 msgid "Test if vim-addons has yet to be given the subcommand"
 msgstr "Test if apt has yet to be given the subcommand"
+
+#: share/completions/w.fish:6
+#, fuzzy
+msgid "Username"
+msgstr "Username"
 
 #: share/completions/wajig.fish:1
 #, fuzzy
@@ -7076,11 +7183,6 @@ msgstr "Synonym for -i"
 #: share/completions/wajig.fish:139
 msgid "Find the package that supplies the given command or file"
 msgstr ""
-
-#: share/completions/w.fish:6
-#, fuzzy
-msgid "Username"
-msgstr "Username"
 
 #: share/completions/wpa_cli.fish:3
 msgid "get current WPA/EAPOL/EAP status"
@@ -7624,38 +7726,9 @@ msgstr ""
 msgid "Download source rpms for all installed packages to a local directory"
 msgstr "Do not ever ascend to the parent directory"
 
-#: share/functions/alias.fish:2
-msgid ""
-"Legacy function for creating shellscript functions using an alias-like syntax"
+#: share/functions/N_.fish:3
+msgid "No-op"
 msgstr ""
-
-#: share/functions/alias.fish:36
-#, fuzzy
-msgid "%s: Expected one or two arguments, got %d\\n"
-msgstr "%s: Expected 1, 2 or 3 arguments, got %d\\n"
-
-#: share/functions/alias.fish:42
-#, fuzzy
-msgid "%s: Name cannot be empty\\n"
-msgstr "%ls: Nome da variável não pode ser a string vazia\n"
-
-#: share/functions/alias.fish:45
-msgid "%s: Body cannot be empty\\n"
-msgstr ""
-
-#: share/functions/contains_seq.fish:1
-msgid "Return true if array contains a sequence"
-msgstr ""
-
-#: share/functions/dirh.fish:2
-#, fuzzy
-msgid "Print the current directory history (the back- and fwd- lists)"
-msgstr "Print the current directory history (the back- and fwd- lists)"
-
-#: share/functions/dirs.fish:1
-#, fuzzy
-msgid "Print directory stack"
-msgstr "Print directory stack"
 
 #: share/functions/_.fish:8 share/functions/_.fish:12
 #, fuzzy
@@ -7671,14 +7744,14 @@ msgstr "fish"
 msgid "Complete abook formats"
 msgstr ""
 
+#: share/functions/__fish_complete_atool.fish:1
+msgid "Complete atool"
+msgstr ""
+
 #: share/functions/__fish_complete_atool_archive_contents.fish:1
 #, fuzzy
 msgid "List archive contents"
 msgstr "List archive"
-
-#: share/functions/__fish_complete_atool.fish:1
-msgid "Complete atool"
-msgstr ""
 
 #: share/functions/__fish_complete_bittorrent.fish:9
 #, fuzzy
@@ -8203,6 +8276,11 @@ msgstr "Mostra etiqueta MAC para cada arquivo"
 msgid "Include the file flags in a long (-l) output"
 msgstr "Inclu"
 
+#: share/functions/__fish_complete_path.fish:1
+#, fuzzy
+msgid "Complete using path"
+msgstr "Tolerate sloppy mount options"
+
 #: share/functions/__fish_complete_ppp_peer.fish:1
 msgid "Complete isp name for pon/poff"
 msgstr ""
@@ -8273,11 +8351,6 @@ msgstr "Arquivo de identificação"
 #: share/functions/__fish_complete_ssh.fish:12
 msgid "Options"
 msgstr "Opções"
-
-#: share/functions/__fish_complete_svn_diff.fish:1
-#, fuzzy
-msgid "Complete \"svn diff\" arguments"
-msgstr "Count the number of arguments"
 
 #: share/functions/__fish_complete_svn.fish:48
 msgid ""
@@ -8613,6 +8686,11 @@ msgstr "Use strict semantics"
 msgid "Relocate via URL-rewriting"
 msgstr "Relocate VIA URL-rewriting"
 
+#: share/functions/__fish_complete_svn_diff.fish:1
+#, fuzzy
+msgid "Complete \"svn diff\" arguments"
+msgstr "Count the number of arguments"
+
 #: share/functions/__fish_complete_tar.fish:14
 #: share/functions/__fish_complete_tar.fish:21
 #: share/functions/__fish_complete_tar.fish:28
@@ -8806,73 +8884,56 @@ msgstr ""
 msgid "Complete md5sum sha1 etc"
 msgstr ""
 
-#: share/functions/fish_config.fish:1
-msgid "Launch fish's web based configuration"
-msgstr ""
-
-#: share/functions/__fish_config_interactive.fish:65
-#, sh-format
-msgid ""
-"\\nWARNING\\n\\nThe location for fish configuration files has changed to %s."
-"\\nYour old files have been moved to this location.\\nYou can change to a "
-"different location by changing the value of the variable $XDG_CONFIG_HOME.\\n"
-"\\n"
-msgstr ""
-
-#: share/functions/__fish_config_interactive.fish:82
+#: share/functions/__fish_config_interactive.fish:34
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Bem-vindo ao fish, ou friendly interactive shell"
 
-#: share/functions/__fish_config_interactive.fish:83
+#: share/functions/__fish_config_interactive.fish:35
 msgid "Type %shelp%s for instructions on how to use fish"
 msgstr "Digite %shelp%s para instruções sobre como usar o fish"
 
-#: share/functions/__fish_config_interactive.fish:176
+#: share/functions/__fish_config_interactive.fish:130
 #, fuzzy
 msgid "Event handler, repaints the prompt when fish_color_cwd changes"
 msgstr "Event handler, repaints the prompt when fish_color_cwd changes"
 
-#: share/functions/__fish_config_interactive.fish:183
+#: share/functions/__fish_config_interactive.fish:137
 #, fuzzy
 msgid "Event handler, repaints the prompt when fish_color_cwd_root changes"
 msgstr "Event handler, repaints the prompt when fish_color_cwd changes"
 
-#: share/functions/__fish_config_interactive.fish:195
+#: share/functions/__fish_config_interactive.fish:149
 #, fuzzy
 msgid "Start service"
 msgstr "Start service"
 
-#: share/functions/__fish_config_interactive.fish:196
+#: share/functions/__fish_config_interactive.fish:150
 #, fuzzy
 msgid "Stop service"
 msgstr "Stop service"
 
-#: share/functions/__fish_config_interactive.fish:197
+#: share/functions/__fish_config_interactive.fish:151
 #, fuzzy
 msgid "Print service status"
 msgstr "Print service status"
 
-#: share/functions/__fish_config_interactive.fish:198
+#: share/functions/__fish_config_interactive.fish:152
 #, fuzzy
 msgid "Stop and then start service"
 msgstr "Stop and then start service"
 
-#: share/functions/__fish_config_interactive.fish:199
+#: share/functions/__fish_config_interactive.fish:153
 #, fuzzy
 msgid "Reload service configuration"
 msgstr "Reload service configuration"
 
-#: share/functions/__fish_config_interactive.fish:231
+#: share/functions/__fish_config_interactive.fish:193
 #, sh-format
 msgid "Notify VTE of change to $PWD"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:173
 msgid "Helper function for __fish_git_prompt"
-msgstr ""
-
-#: share/functions/__fish_git_prompt.fish:244
-msgid "svn_upstream"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:348
@@ -8919,9 +8980,10 @@ msgstr "Event handler, repaints the prompt when fish_color_cwd changes"
 msgid "Event handler, repaints prompt when any char changes"
 msgstr "Event handler, repaints the prompt when fish_color_cwd changes"
 
-#: share/functions/fish_indent.fish:1
-msgid "Indenter and prettifier for fish code"
-msgstr ""
+#: share/functions/__fish_hg_prompt.fish:23
+#, fuzzy
+msgid "Write out the hg prompt"
+msgstr "Write out the prompt"
 
 #: share/functions/__fish_is_token_n.fish:1
 msgid "Test if current token is on Nth place"
@@ -8961,7 +9023,7 @@ msgstr "Print a list of all accepted color names"
 msgid "Prints services installed"
 msgstr "Print service status"
 
-#: share/functions/__fish_print_help.fish:2
+#: share/functions/__fish_print_help.fish:1
 #, fuzzy
 msgid "Print help message for the specified fish function or builtin"
 msgstr "Print all completions for the specified commandline"
@@ -8990,6 +9052,11 @@ msgstr "Print available list"
 #, fuzzy
 msgid "Print mounted devices"
 msgstr "Print important dependencies"
+
+#: share/functions/__fish_print_packages.fish:13
+#, fuzzy
+msgid "Package"
+msgstr "Package"
 
 #: share/functions/__fish_print_svn_rev.fish:1
 #, fuzzy
@@ -9025,11 +9092,6 @@ msgstr "Print word counts"
 msgid "Print X windows"
 msgstr "Print APM info"
 
-#: share/functions/fish_prompt.fish:5
-#, fuzzy
-msgid "Write out the prompt"
-msgstr "Write out the prompt"
-
 #: share/functions/__fish_pwd.fish:3 share/functions/__fish_pwd.fish:7
 #, fuzzy
 msgid "Show current path"
@@ -9039,15 +9101,108 @@ msgstr "Show source package"
 msgid "Test if the token under the cursor matches the specified wildcard"
 msgstr ""
 
-#: share/functions/fish_update_completions.fish:1
-#, fuzzy
-msgid "Update man-page based completions"
-msgstr "Edit command specific completions"
-
 #: share/functions/__fish_urlencode.fish:1
 #, fuzzy
 msgid "URL-encode stdin"
 msgstr "Rename stdin"
+
+#: share/functions/__terlar_git_prompt.fish:23
+#, fuzzy
+msgid "Write out the git prompt"
+msgstr "Write out the prompt"
+
+#: share/functions/abbr.fish:1
+#, fuzzy
+msgid "Manage abbreviations"
+msgstr "Manual sections"
+
+#: share/functions/abbr.fish:40
+#, fuzzy
+msgid "%s: invalid option -- %s\\n"
+msgstr "%ls: Opção inválida -- %lc\n"
+
+#: share/functions/abbr.fish:47
+#, fuzzy
+msgid "%s: %s cannot be specified along with %s\\n"
+msgstr "%ls: Values cannot be specfied with erase\n"
+
+#: share/functions/abbr.fish:56
+#, fuzzy
+msgid "%s: option requires an argument -- %s\\n"
+msgstr "%ls: Opção requer argumento -- %lc\n"
+
+#: share/functions/abbr.fish:62
+#, fuzzy
+msgid "%s: Unexpected argument -- %s\\n"
+msgstr "%ls: Esperava argumento\n"
+
+#: share/functions/abbr.fish:75
+msgid "%s: abbreviation must have a non-empty key\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:79
+msgid "%s: abbreviation must have a value\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:101
+#, fuzzy
+msgid "%s: no such abbreviation '%s'\\n"
+msgstr "%s: Unknown option “%s”\\n"
+
+#: share/functions/alias.fish:2
+msgid ""
+"Legacy function for creating shellscript functions using an alias-like syntax"
+msgstr ""
+
+#: share/functions/alias.fish:36
+#, fuzzy
+msgid "%s: Expected one or two arguments, got %d\\n"
+msgstr "%s: Expected 1, 2 or 3 arguments, got %d\\n"
+
+#: share/functions/alias.fish:42
+#, fuzzy
+msgid "%s: Name cannot be empty\\n"
+msgstr "%ls: Nome da variável não pode ser a string vazia\n"
+
+#: share/functions/alias.fish:45
+msgid "%s: Body cannot be empty\\n"
+msgstr ""
+
+#: share/functions/contains_seq.fish:1
+msgid "Return true if array contains a sequence"
+msgstr ""
+
+#: share/functions/dirh.fish:2
+#, fuzzy
+msgid "Print the current directory history (the back- and fwd- lists)"
+msgstr "Print the current directory history (the back- and fwd- lists)"
+
+#: share/functions/dirs.fish:1
+#, fuzzy
+msgid "Print directory stack"
+msgstr "Print directory stack"
+
+#: share/functions/export.fish:1
+msgid "Set global variable. Alias for set -g, made for bash compatibility"
+msgstr ""
+
+#: share/functions/fish_config.fish:1
+msgid "Launch fish's web based configuration"
+msgstr ""
+
+#: share/functions/fish_indent.fish:1
+msgid "Indenter and prettifier for fish code"
+msgstr ""
+
+#: share/functions/fish_prompt.fish:5
+#, fuzzy
+msgid "Write out the prompt"
+msgstr "Write out the prompt"
+
+#: share/functions/fish_update_completions.fish:1
+#, fuzzy
+msgid "Update man-page based completions"
+msgstr "Edit command specific completions"
 
 #: share/functions/fish_vi_key_bindings.fish:1
 #, fuzzy
@@ -9076,6 +9231,19 @@ msgstr "%s: Opção desconhecida %s\\n"
 msgid "funced: You must specify one function name\n"
 msgstr "funced: Você deve especificar um nome de função\n"
 
+#: share/functions/funced.fish:96
+msgid "Editing failed or was cancelled"
+msgstr ""
+
+#: share/functions/funced.fish:103
+msgid "Edit the file again\\? [Y/n]"
+msgstr ""
+
+#: share/functions/funced.fish:110
+#, fuzzy
+msgid "Cancelled function editing"
+msgstr "Editar definição de função"
+
 #: share/functions/funcsave.fish:2
 msgid "Save the current definition of all specified functions to file"
 msgstr ""
@@ -9090,7 +9258,7 @@ msgstr "%ls: Expected function name\n"
 msgid "%s: Could not create configuration directory\\n"
 msgstr "%ls: Could not find home directory\n"
 
-#: share/functions/funcsave.fish:37
+#: share/functions/funcsave.fish:36
 #, fuzzy
 msgid "%s: Unknown function '%s'\\n"
 msgstr "%s: Unknown option “%s”\\n"
@@ -9142,7 +9310,7 @@ msgstr ""
 msgid "List contents of directory using long format"
 msgstr "List contents of directory using long format"
 
-#: share/functions/ls.fish:7 share/functions/ls.fish:24
+#: share/functions/ls.fish:7 share/functions/ls.fish:32
 #, fuzzy
 msgid "List contents of directory"
 msgstr "List contents of directory"
@@ -9171,10 +9339,6 @@ msgstr "Move forward in the directory history"
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
 msgstr "%s: The number of positions to skip must be a non-negative integer\\n"
 
-#: share/functions/N_.fish:3
-msgid "No-op"
-msgstr ""
-
 #: share/functions/open.fish:8
 #, fuzzy
 msgid "Open file in default application"
@@ -9200,7 +9364,6 @@ msgstr "Move back in the directory history"
 msgid "The number of positions to skip must be a non-negative integer\\n"
 msgstr "The number of positions to skip must be a non-negative integer\\n"
 
-#: share/functions/prompt_pwd.fish:3 share/functions/prompt_pwd.fish:7
 #: share/functions/prompt_pwd.fish:11
 #, fuzzy
 msgid "Print the current working directory, shortened to fit the prompt"
@@ -9242,46 +9405,41 @@ msgstr "%s: “%s” não é um número\\n"
 msgid "Set global variable. Alias for set -g, made for csh compatibility"
 msgstr ""
 
-#: share/functions/__terlar_git_prompt.fish:23
-#, fuzzy
-msgid "Write out the git prompt"
-msgstr "Write out the prompt"
-
 #: share/functions/type.fish:2
 #, fuzzy
 msgid "Print the type of a command"
 msgstr "Print the type of a command"
 
-#: share/functions/type.fish:89
+#: share/functions/type.fish:90
 #, fuzzy
 msgid "%s is a function with definition\\n"
 msgstr "%ls: Missing function definition information."
 
-#: share/functions/type.fish:93
+#: share/functions/type.fish:94
 #, fuzzy
 msgid "function"
 msgstr "function\\n"
 
-#: share/functions/type.fish:106
+#: share/functions/type.fish:107
 #, fuzzy
 msgid "%s is a builtin\\n"
 msgstr "%s is a builtin\\n"
 
-#: share/functions/type.fish:109
+#: share/functions/type.fish:110
 #, fuzzy
 msgid "builtin"
 msgstr "builtin\\n"
 
-#: share/functions/type.fish:129
+#: share/functions/type.fish:130
 #, fuzzy
 msgid "%s is %s\\n"
 msgstr "%s is %s\\n"
 
-#: share/functions/type.fish:132
+#: share/functions/type.fish:133
 msgid "file"
 msgstr "arquivo"
 
-#: share/functions/type.fish:143
+#: share/functions/type.fish:144
 #, fuzzy
 msgid "%s: Could not find '%s'\\n"
 msgstr "%s: Could not find “%s”\\n"
@@ -9307,16 +9465,16 @@ msgstr "%s: Too many arguments\\n"
 msgid "Edit variable value"
 msgstr "Edit variable value"
 
-#: share/functions/vared.fish:41
+#: share/functions/vared.fish:40
 #, fuzzy
 msgid ""
-"%s: %s is an array variable. Use %svared%s %s[n] to edit the n:th element of "
-"%s\\n"
+"%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element "
+"of %s\\n"
 msgstr ""
 "%s: %s is an array variable. Use %svared%s %s[n] to edit the n:th element of "
 "%s\\n"
 
-#: share/functions/vared.fish:45
+#: share/functions/vared.fish:44
 #, fuzzy
 msgid ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
@@ -9324,6 +9482,42 @@ msgid ""
 msgstr ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
 "VARIABLE\\n"
+
+#, fuzzy
+#~ msgid "%ls: Expected zero or at least two parameters, got %d"
+#~ msgstr "%ls: Esperava zero ou dois parâmetros, obteve %d\n"
+
+#, fuzzy
+#~ msgid "All base system packages"
+#~ msgstr "Erase built packages"
+
+#, fuzzy
+#~ msgid "All packages in world"
+#~ msgstr "Sync packages installed"
+
+#, fuzzy
+#~ msgid "Installed package"
+#~ msgstr "Install new package"
+
+#, fuzzy
+#~ msgid "Help on subject config"
+#~ msgstr "Help section"
+
+#, fuzzy
+#~ msgid "Help on subject sync"
+#~ msgstr "Help section"
+
+#, fuzzy
+#~ msgid "Use colors in output"
+#~ msgstr "Use colors"
+
+#, fuzzy
+#~ msgid "Pull in build time dependencies"
+#~ msgstr "Show build dependencies"
+
+#, fuzzy
+#~ msgid "Don't pull in build time dependencies"
+#~ msgstr "Don't automatically fulfill dependencies"
 
 #~ msgid "Encrypt for specified user id"
 #~ msgstr "Criptografa para o id de usuário especificado"
@@ -9376,10 +9570,6 @@ msgstr ""
 
 #~ msgid "Could not expand string '%ls'"
 #~ msgstr "Não pôde expandir string “%ls”"
-
-#, fuzzy
-#~ msgid "This command can not be used in a pipeline"
-#~ msgstr "This command can not be used in a pipeline"
 
 #~ msgid "An additional command is required"
 #~ msgstr "Requer um comando adicional"
@@ -9867,10 +10057,6 @@ msgstr ""
 
 #~ msgid "Use pattern from file"
 #~ msgstr "Use pattern from file"
-
-#, fuzzy
-#~ msgid "print information about the working copy"
-#~ msgstr "Output extra information about the work being done"
 
 #~ msgid "Debug option"
 #~ msgstr "Debug option"
@@ -10798,9 +10984,6 @@ msgstr ""
 
 #~ msgid "Process directories recursively"
 #~ msgstr "Process directories recursively"
-
-#~ msgid "Use a specified tag"
-#~ msgstr "Use a specified tag"
 
 #~ msgid "Specify filenames to be filtered"
 #~ msgstr "Specify filenames to be filtered"
@@ -12529,9 +12712,6 @@ msgstr ""
 #~ msgid "Pager"
 #~ msgstr "Pager"
 
-#~ msgid "Manual sections"
-#~ msgstr "Manual sections"
-
 #~ msgid "Always reformat"
 #~ msgstr "Always reformat"
 
@@ -12951,9 +13131,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Bypass the normal routing tables and send directly to a host on an "
 #~ "attached interface"
-
-#~ msgid "Specifies the number of data bytes to be sent"
-#~ msgstr "Specifies the number of data bytes to be sent"
 
 #~ msgid "Set socket buffer size"
 #~ msgstr "Set socket buffer size"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.22.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-03-13 21:29+0800\n"
+"POT-Creation-Date: 2015-04-13 22:15+0800\n"
 "PO-Revision-Date: 2006-03-13 18:06+0100\n"
 "Last-Translator: Axel Liljencrantz <liljencrantz@gmail.com>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -21,12 +21,12 @@ msgstr ""
 msgid "Could not autoload item '%ls', it is already being autoloaded. "
 msgstr "Kunde inte automatiskt ladda elementet ”%ls”, det autoladdas redan. "
 
-#: builtin.cpp:83
+#: builtin.cpp:84
 #, c-format
 msgid "Send job %d, '%ls' to foreground\n"
 msgstr "Skicka job %d, ”%ls” till förgrunden\n"
 
-#: builtin.cpp:344
+#: builtin.cpp:352
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
@@ -35,100 +35,105 @@ msgstr ""
 "%ls: Skriv 'help %ls' för relaterad dokumnetation\n"
 "\n"
 
-#: builtin.cpp:484
+#: builtin.cpp:531
 #, c-format
 msgid "%ls: No key with name '%ls' found\n"
 msgstr "%ls: Ingen tangent med namn ”%ls” kunde hittas\n"
 
-#: builtin.cpp:490
+#: builtin.cpp:537
 #, c-format
 msgid "%ls: Key with name '%ls' does not have any mapping\n"
 msgstr "%ls: Tangent mad namn “%ls“ har ingen mappning\n"
 
-#: builtin.cpp:496
+#: builtin.cpp:543
 #, c-format
 msgid "%ls: Unknown error trying to bind to key named '%ls'\n"
 msgstr ""
 "%ls: Okänt fel inträffade vid försök att binda till tangen med namn ”%ls”\n"
 
-#: builtin.cpp:668
+#: builtin.cpp:794
 #, fuzzy, c-format
-msgid "%ls: Expected zero or two parameters, got %d\n"
-msgstr "%ls: Förväntade noll eller två argument, fick %d"
+msgid "%ls: No binding found for key '%ls'\n"
+msgstr "%s: Beskrivning saknas för typ %s\n"
 
-#: builtin.cpp:692
+#: builtin.cpp:798
+#, c-format
+msgid "%ls: No binding found for sequence '%ls'\n"
+msgstr ""
+
+#: builtin.cpp:834
 #, c-format
 msgid "%ls: Invalid state\n"
 msgstr "%ls: Ogiltigt tillstånd\n"
 
-#: builtin.cpp:796
+#: builtin.cpp:939
 #, c-format
 msgid "%ls: Can not specify scope when removing block\n"
 msgstr "%ls: Kan inte ange definitionsområde vid blockradering\n"
 
-#: builtin.cpp:802
+#: builtin.cpp:945
 #, c-format
 msgid "%ls: No blocks defined\n"
 msgstr "%ls: Inga block definerade\n"
 
-#: builtin.cpp:1312 builtin.h:32
+#: builtin.cpp:1556 builtin.h:32
 #, c-format
 msgid "%ls: Invalid combination of options\n"
 msgstr "%ls: Ogiltig kombination av flaggor\n"
 
-#: builtin.cpp:1334
+#: builtin.cpp:1578
 #, c-format
 msgid "%ls: Expected exactly one function name\n"
 msgstr "%ls: Förväntade exakt ett funktionsnamn\n"
 
-#: builtin.cpp:1344 builtin.cpp:1406
+#: builtin.cpp:1588 builtin.cpp:1650
 #, c-format
 msgid "%ls: Function '%ls' does not exist\n"
 msgstr "%ls: Funktionen ”%ls” existerar inte\n"
 
-#: builtin.cpp:1394
+#: builtin.cpp:1638
 #, fuzzy, c-format
 msgid ""
 "%ls: Expected exactly two names (current function name, and new function "
 "name)\n"
 msgstr "%ls: Förväntade exakt ett funktionsnamn\n"
 
-#: builtin.cpp:1417 builtin.cpp:1952 builtin.cpp:2259
+#: builtin.cpp:1661 builtin.cpp:2230
 #, c-format
 msgid "%ls: Illegal function name '%ls'\n"
 msgstr "%ls: Ogiltigt funktionsnamn ”%ls”\n"
 
-#: builtin.cpp:1428
+#: builtin.cpp:1672
 #, fuzzy, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy '%ls'\n"
 msgstr "%ls: Funktionen ”%ls” existerar inte\n"
 
-#: builtin.cpp:1809 builtin.cpp:2114
+#: builtin.cpp:2070
 #, c-format
 msgid "%ls: Unknown signal '%ls'\n"
 msgstr "%ls: Okänd signal ”%ls”\n"
 
-#: builtin.cpp:1824 builtin.cpp:1984 builtin.cpp:2129 builtin.cpp:2291
+#: builtin.cpp:2085 builtin.cpp:2195 builtin.cpp:2263
 #, c-format
 msgid "%ls: Invalid variable name '%ls'\n"
 msgstr "%ls: Ogiltigt variabelnamn ”%ls”\n"
 
-#: builtin.cpp:1877 builtin.cpp:2182
+#: builtin.cpp:2138
 #, c-format
 msgid "%ls: Cannot find calling job for event handler\n"
 msgstr "%ls: Kan inte hitta anropande job för händelsehanterare\n"
 
-#: builtin.cpp:1895 builtin.cpp:2200
+#: builtin.cpp:2156
 #, c-format
 msgid "%ls: Invalid process id %ls\n"
 msgstr "%ls: Ogiltigt processid %ls\n"
 
-#: builtin.cpp:1945 builtin.cpp:2252
+#: builtin.cpp:2223
 #, c-format
 msgid "%ls: Expected function name\n"
 msgstr "%ls: Förväntade ett funktionsnamn\n"
 
-#: builtin.cpp:1962 builtin.cpp:2269
+#: builtin.cpp:2240
 #, c-format
 msgid ""
 "%ls: The name '%ls' is reserved,\n"
@@ -137,140 +142,148 @@ msgstr ""
 "%ls: Namnet ”%ls” är reserverat,\n"
 " och kan inte användas som funktionsnamn\n"
 
-#: builtin.cpp:1970 builtin.cpp:2277 builtin.cpp:3824
+#: builtin.cpp:2248
 #, fuzzy, c-format
 msgid "%ls: No function name given\n"
 msgstr "%ls: Förväntade ett funktionsnamn\n"
 
-#: builtin.cpp:1997 builtin.cpp:2304
+#: builtin.cpp:2276
 #, c-format
 msgid "%ls: Expected one argument, got %d\n"
 msgstr "%ls: Förväntade ett argument, fick %d\n"
 
-#: builtin.cpp:2319
-msgid "Current functions are: "
-msgstr "Nuvarande funktioner är: "
-
-#: builtin.cpp:2459
+#: builtin.cpp:2412
 #, c-format
 msgid "%ls: Seed value '%ls' is not a valid number\n"
 msgstr "%ls: Slumpfrö ”%ls” är inte ett giltigt nummer\n"
 
-#: builtin.cpp:2473
+#: builtin.cpp:2426
 #, c-format
 msgid "%ls: Expected zero or one argument, got %d\n"
 msgstr "%ls: Förväntade noll eller ett argument, fick %d\n"
 
-#: builtin.cpp:2981 fish.cpp:518 parser.cpp:1095
-msgid "Standard input"
-msgstr "Standard in"
+#: builtin.cpp:2593
+#, fuzzy, c-format
+msgid "%ls: Argument '%ls' is out of range\n"
+msgstr "%ls: Argumentet ”%ls” är inte ett nummer\n"
 
-#: builtin.cpp:3024
-msgid "This is a login shell\n"
-msgstr "Detta är ett login-skal\n"
-
-#: builtin.cpp:3026
-msgid "This is not a login shell\n"
-msgstr "Detta är inte ett login-skal\n"
-
-#: builtin.cpp:3028
-#, c-format
-msgid "Job control: %ls\n"
-msgstr "Jobkontroll: %ls\n"
-
-#: builtin.cpp:3029
-msgid "Only on interactive jobs"
-msgstr "Bara för interaktiva jobb"
-
-#: builtin.cpp:3030
-msgid "Never"
-msgstr "Aldrig"
-
-#: builtin.cpp:3030
-msgid "Always"
-msgstr "Alltid"
-
-#: builtin.cpp:3066 builtin.cpp:3995
+#: builtin.cpp:2601 builtin.cpp:3150 builtin.cpp:3817
 #, c-format
 msgid "%ls: Argument '%ls' must be an integer\n"
 msgstr "%ls: Argumentet ”%ls” måste vara ett heltal\n"
 
+#: builtin.cpp:2656
+#, fuzzy, c-format
+msgid "%ls: --array option requires a single variable name.\n"
+msgstr ""
+"%ls: Radering kräver ett variabelnamn\n"
+"%ls\n"
+
+#: builtin.cpp:3065 fish.cpp:620 parser.cpp:764
+msgid "Standard input"
+msgstr "Standard in"
+
 #: builtin.cpp:3108
+msgid "This is a login shell\n"
+msgstr "Detta är ett login-skal\n"
+
+#: builtin.cpp:3110
+msgid "This is not a login shell\n"
+msgstr "Detta är inte ett login-skal\n"
+
+#: builtin.cpp:3112
+#, c-format
+msgid "Job control: %ls\n"
+msgstr "Jobkontroll: %ls\n"
+
+#: builtin.cpp:3113
+msgid "Only on interactive jobs"
+msgstr "Bara för interaktiva jobb"
+
+#: builtin.cpp:3114
+msgid "Never"
+msgstr "Aldrig"
+
+#: builtin.cpp:3114
+msgid "Always"
+msgstr "Alltid"
+
+#: builtin.cpp:3192
 #, c-format
 msgid "%ls: Could not find home directory\n"
 msgstr "%ls: Kunde inte hitta hemkatalogen\n"
 
-#: builtin.cpp:3128 builtin.cpp:3182
+#: builtin.cpp:3212 builtin.cpp:3266
 #, c-format
 msgid "%ls: '%ls' is not a directory\n"
 msgstr "%ls: ”%ls” är inte en katalog\n"
 
-#: builtin.cpp:3135
+#: builtin.cpp:3219
 #, c-format
 msgid "%ls: The directory '%ls' does not exist\n"
 msgstr "%ls: Katalogen ”%ls” existerar inte\n"
 
-#: builtin.cpp:3142
+#: builtin.cpp:3226
 #, c-format
 msgid "%ls: '%ls' is a rotten symlink\n"
 msgstr "%ls: ”%ls” är en rutten symbolisk länk\n"
 
-#: builtin.cpp:3150
+#: builtin.cpp:3234
 #, c-format
 msgid "%ls: Unknown error trying to locate directory '%ls'\n"
 msgstr "%ls: Okänd fel inträffade under lokalisering av katalogen ”%ls”\n"
 
-#: builtin.cpp:3173
+#: builtin.cpp:3257
 #, c-format
 msgid "%ls: Permission denied: '%ls'\n"
 msgstr "%ls: Åtkomst nekad till katalogen ”%ls”\n"
 
-#: builtin.cpp:3197
+#: builtin.cpp:3281
 #, c-format
 msgid "%ls: Could not set PWD variable\n"
 msgstr "%ls: Kunde inte sätta variableln PWD\n"
 
-#: builtin.cpp:3284
+#: builtin.cpp:3368
 #, c-format
 msgid "%ls: Key not specified\n"
 msgstr "%ls: Ingen nyckel angiven\n"
 
-#: builtin.cpp:3328 builtin.cpp:3336
+#: builtin.cpp:3412 builtin.cpp:3420
 #, c-format
 msgid "%ls: Error encountered while sourcing file '%ls':\n"
 msgstr "%ls: Ett fel uppstod medan filen ”%ls” lästes\n"
 
-#: builtin.cpp:3344
+#: builtin.cpp:3428
 #, c-format
 msgid "%ls: '%ls' is not a file\n"
 msgstr "%ls: ”%ls” är inte en fil\n"
 
-#: builtin.cpp:3363
+#: builtin.cpp:3447
 #, c-format
 msgid "%ls: Error while reading file '%ls'\n"
 msgstr "%ls: Ett fel uppstod medan filen ”%ls” lästes\n"
 
-#: builtin.cpp:3419 builtin.cpp:3599
+#: builtin.cpp:3503 builtin.cpp:3682
 #, c-format
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls: Det finns inga lämpliga jobb\n"
 
-#: builtin.cpp:3448
+#: builtin.cpp:3531
 #, c-format
 msgid "%ls: Ambiguous job\n"
 msgstr "%ls: Mer än ett jobb matchar\n"
 
-#: builtin.cpp:3454 builtin.cpp:3622 builtin_jobs.cpp:301
+#: builtin.cpp:3537 builtin.cpp:3705 builtin_jobs.cpp:301
 #, c-format
 msgid "%ls: '%ls' is not a job\n"
 msgstr "%ls: ”%ls” är inte ett jobb\n"
 
-#: builtin.cpp:3485 builtin_jobs.cpp:316
+#: builtin.cpp:3568 builtin_jobs.cpp:316
 #, c-format
 msgid "%ls: No suitable job: %d\n"
 msgstr "%ls: Inget passande jobb: %d\n"
 
-#: builtin.cpp:3494
+#: builtin.cpp:3577
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to foreground because it is not under job "
@@ -279,12 +292,12 @@ msgstr ""
 "Kan inte skicka jobb %d, ”%ls” till förgrunden eftersom det inte anväder "
 "jobbkontroll\n"
 
-#: builtin.cpp:3547
+#: builtin.cpp:3630
 #, c-format
 msgid "%ls: Unknown job '%ls'\n"
 msgstr "%ls: Okänt jobb ”%ls”\n"
 
-#: builtin.cpp:3556
+#: builtin.cpp:3639
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to background because it is not under job "
@@ -293,239 +306,221 @@ msgstr ""
 "Kan inte skicka jobb %d, ”%ls” till bakgrunden eftersom det inte anväder "
 "jobbkontrol\n"
 
-#: builtin.cpp:3566
+#: builtin.cpp:3649
 #, c-format
 msgid "Send job %d '%ls' to background\n"
 msgstr "Skicka jobb %d ”%ls” till bakgrunden\n"
 
-#: builtin.cpp:3605
+#: builtin.cpp:3688
 msgid "(default)"
 msgstr "(standard)"
 
-#: builtin.cpp:3737
-#, c-format
-msgid "%ls: Not inside of block\n"
-msgstr "%ls: Inte i ett block\n"
-
-#: builtin.cpp:3884
-#, c-format
-msgid "%ls: Not inside of 'if' block\n"
-msgstr "%ls: Inte i ett ”if” block\n"
-
-#: builtin.cpp:3938
+#: builtin.cpp:3760
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls: Inte i en loop\n"
 
-#: builtin.cpp:4005 builtin_complete.cpp:539 builtin_set_color.cpp:140
-#: builtin.h:83
+#: builtin.cpp:3827 builtin_complete.cpp:551 builtin.h:83
 #, c-format
 msgid "%ls: Too many arguments\n"
 msgstr "%ls: För många argument\n"
 
-#: builtin.cpp:4023
+#: builtin.cpp:3845
 #, c-format
 msgid "%ls: Not inside of function\n"
 msgstr "%ls: Inte i en funktion\n"
 
-#: builtin.cpp:4059
-#, c-format
-msgid "%ls: Expected exactly one argument, got %d\n"
-msgstr "%ls: Förväntade exakt ett argument, fick %d\n"
-
-#: builtin.cpp:4090
-#, c-format
-msgid "%ls: 'case' command while not in switch block\n"
-msgstr "%ls: ”case” kommandot kan bara användas i ett ”switch”-block\n"
-
-#: builtin.cpp:4317 builtin.cpp:4360
+#: builtin.cpp:4069 builtin.cpp:4113
 #, fuzzy
 msgid "Test a condition"
 msgstr "Välj en konfigurationsinställning"
 
-#: builtin.cpp:4318
+#: builtin.cpp:4070
 msgid "Try out the new parser"
 msgstr ""
 
-#: builtin.cpp:4319
+#: builtin.cpp:4071
 msgid "Execute command if previous command suceeded"
 msgstr "Utför kommando om föregående kommando lyckades"
 
-#: builtin.cpp:4320
+#: builtin.cpp:4072
 msgid "Create a block of code"
 msgstr "Skapa ett kodblock"
 
-#: builtin.cpp:4321
+#: builtin.cpp:4073
 msgid "Send job to background"
 msgstr "Skicka jobb till bakgrunden"
 
-#: builtin.cpp:4322
+#: builtin.cpp:4074
 msgid "Handle fish key bindings"
 msgstr "Hantera tangentbordsgenvägar för fish"
 
-#: builtin.cpp:4323
+#: builtin.cpp:4075
 msgid "Temporarily block delivery of events"
 msgstr "Blockera tillfälligt leverans av händelser"
 
-#: builtin.cpp:4324
+#: builtin.cpp:4076
 msgid "Stop the innermost loop"
 msgstr "Avbryt den innersta loopen"
 
-#: builtin.cpp:4325
+#: builtin.cpp:4077
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr "Avbryt exekvering tillfälligt och starta en interaktiv debugprompt"
 
-#: builtin.cpp:4326
+#: builtin.cpp:4078
 msgid "Run a builtin command instead of a function"
 msgstr "Utför ett inbyggt kommando istället för en funktion"
 
-#: builtin.cpp:4327 builtin.cpp:4359
+#: builtin.cpp:4079 builtin.cpp:4112
 msgid "Conditionally execute a block of commands"
 msgstr "Utför ett kommando om ett villkor är uppfyllt"
 
-#: builtin.cpp:4328
+#: builtin.cpp:4080
 msgid "Change working directory"
 msgstr "Ändra arbetskatalog"
 
-#: builtin.cpp:4329
+#: builtin.cpp:4081
 msgid "Run a program instead of a function or builtin"
 msgstr "Kör ett program istället för en funktion eller ett inbuggt kommando"
 
-#: builtin.cpp:4330
+#: builtin.cpp:4082
 msgid "Set or get the commandline"
 msgstr "Ändra eller visa kommandoraden"
 
-#: builtin.cpp:4331
+#: builtin.cpp:4083
 msgid "Edit command specific completions"
 msgstr "Redigera kommando-specifika kompletteringar"
 
-#: builtin.cpp:4332
+#: builtin.cpp:4084
 msgid "Search for a specified string in a list"
 msgstr "Sök efter en angiven sträng i en lista"
 
-#: builtin.cpp:4333
+#: builtin.cpp:4085
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "Avbryt nuvarande varv i den innersta loopen"
 
-#: builtin.cpp:4334
+#: builtin.cpp:4086
 msgid "Count the number of arguments"
 msgstr "Räkna antalet argument"
 
-#: builtin.cpp:4335
+#: builtin.cpp:4087
 #, fuzzy
 msgid "Print arguments"
 msgstr "Visa antal ord"
 
-#: builtin.cpp:4336
+#: builtin.cpp:4088
 msgid "Evaluate block if condition is false"
 msgstr "Utför block om ett villkor inte är uppfyllt"
 
-#: builtin.cpp:4337
+#: builtin.cpp:4089
 msgid "Emit an event"
 msgstr "Sänd en händelse"
 
-#: builtin.cpp:4338
+#: builtin.cpp:4090
 msgid "End a block of commands"
 msgstr "Avsluta ett block av kommandon"
 
-#: builtin.cpp:4339
+#: builtin.cpp:4091
 msgid "Run command in current process"
 msgstr "Kör ett kommando i den nuvarande processen"
 
-#: builtin.cpp:4340
+#: builtin.cpp:4092
 msgid "Exit the shell"
 msgstr "Avsluta fish"
 
-#: builtin.cpp:4341
+#: builtin.cpp:4093
+msgid "Return an unsuccessful result"
+msgstr ""
+
+#: builtin.cpp:4094
 msgid "Send job to foreground"
 msgstr "Skick jobb till förgrunden"
 
-#: builtin.cpp:4342
+#: builtin.cpp:4095
 msgid "Perform a set of commands multiple times"
 msgstr "Utför ett block flera gånger"
 
-#: builtin.cpp:4343
+#: builtin.cpp:4096
 msgid "Define a new function"
 msgstr "Definera ny funktion"
 
-#: builtin.cpp:4344
+#: builtin.cpp:4097
 msgid "List or remove functions"
 msgstr "Visa eller ta bort funktioner"
 
-#: builtin.cpp:4345
+#: builtin.cpp:4098
 msgid "History of commands executed by user"
 msgstr ""
 
-#: builtin.cpp:4346
+#: builtin.cpp:4099
 msgid "Evaluate block if condition is true"
 msgstr "Utför ett block om ett villkor är uppfyllt"
 
-#: builtin.cpp:4347
+#: builtin.cpp:4100
 msgid "Print currently running jobs"
 msgstr "Visa nuvarande jobb"
 
-#: builtin.cpp:4348
+#: builtin.cpp:4101
 msgid "Negate exit status of job"
 msgstr "Negera resultatet av ett kommando"
 
-#: builtin.cpp:4349
+#: builtin.cpp:4102
 msgid "Execute command if previous command failed"
 msgstr "Utför  kommando om föregående kommando misslyckades"
 
-#: builtin.cpp:4350
+#: builtin.cpp:4103
 #, fuzzy
 msgid "Prints formatted text"
 msgstr "Visa informativa meddelanden"
 
-#: builtin.cpp:4351
+#: builtin.cpp:4104
 #, fuzzy
 msgid "Print the working directory"
 msgstr "Visa nuvarande katalog"
 
-#: builtin.cpp:4352
+#: builtin.cpp:4105
 msgid "Generate random number"
 msgstr "Generera ett slumptal"
 
-#: builtin.cpp:4353
+#: builtin.cpp:4106
 msgid "Read a line of input into variables"
 msgstr "Läs in en rad till variabler"
 
-#: builtin.cpp:4354
+#: builtin.cpp:4107
 msgid "Stop the currently evaluated function"
 msgstr "Avbryt den nuvarande funktionen"
 
-#: builtin.cpp:4355
+#: builtin.cpp:4108
 msgid "Handle environment variables"
 msgstr "Redigera miljövariabler"
 
-#: builtin.cpp:4356
+#: builtin.cpp:4109
 #, fuzzy
 msgid "Set the terminal color"
 msgstr "Sätt maximal fuzzfaktor"
 
-#: builtin.cpp:4357
+#: builtin.cpp:4110
 msgid "Evaluate contents of file"
 msgstr "Utför filinnehåll som kommandon"
 
-#: builtin.cpp:4358
+#: builtin.cpp:4111
 msgid "Return status information about fish"
 msgstr "Visa statusinformation om fish"
 
-#: builtin.cpp:4361
+#: builtin.cpp:4114
+msgid "Return a successful result"
+msgstr ""
+
+#: builtin.cpp:4115
 msgid "Set or get the shells resource usage limits"
 msgstr "Redigera eller visa skalets resursanvändningsgränser"
 
-#: builtin.cpp:4362
+#: builtin.cpp:4116
 msgid "Perform a command multiple times"
 msgstr "Utför ett kommando upprepade gånger"
 
-#: builtin.cpp:4442 parser.cpp:53
-#, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "Okänt inbyggt kommando ”%ls”"
-
-#: builtin_commandline.cpp:411
+#: builtin_commandline.cpp:466
 #, c-format
 msgid "%ls: Unknown input function '%ls'\n"
 msgstr "%ls: Okänd inläsnings-function ”%ls”\n"
@@ -542,7 +537,7 @@ msgstr "CPU\t"
 msgid "State\tCommand\n"
 msgstr "Status\tKommando\n"
 
-#: builtin_jobs.cpp:99 proc.cpp:751
+#: builtin_jobs.cpp:99 proc.cpp:843
 msgid "stopped"
 msgstr "stannat"
 
@@ -588,31 +583,31 @@ msgstr ""
 msgid "missing hexadecimal number in escape"
 msgstr ""
 
-#: builtin_printf.cpp:387
+#: builtin_printf.cpp:388
 msgid "Missing hexadecimal number in Unicode escape"
 msgstr ""
 
-#: builtin_printf.cpp:401
+#: builtin_printf.cpp:402
 #, c-format
 msgid "Unicode character out of range: \\%c%0*x"
 msgstr ""
 
-#: builtin_printf.cpp:668
+#: builtin_printf.cpp:670
 #, c-format
 msgid "invalid field width: %ls"
 msgstr ""
 
-#: builtin_printf.cpp:706
+#: builtin_printf.cpp:708
 #, fuzzy, c-format
 msgid "invalid precision: %ls"
 msgstr "%ls: Ogiltigt processid %ls\n"
 
-#: builtin_printf.cpp:737
+#: builtin_printf.cpp:739
 #, fuzzy, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%ls: Ogiltig kombination av flaggor\n"
 
-#: builtin_printf.cpp:769
+#: builtin_printf.cpp:771
 msgid "printf: not enough arguments"
 msgstr ""
 
@@ -622,57 +617,63 @@ msgid "%ls: Tried to change the read-only variable '%ls'\n"
 msgstr "%ls: Försökte ändra den skrivskyddade variablen ”%ls”\n"
 
 #: builtin_set.cpp:162
-#, c-format
-msgid "%ls: Unknown error"
-msgstr "%ls: Okänt fel"
+#, fuzzy, c-format
+msgid "%ls: Tried to set the special variable '%ls' with the wrong scope\n"
+msgstr "%ls: Försökte ändra den skrivskyddade variablen ”%ls”\n"
 
-#: builtin_set.cpp:214
+#: builtin_set.cpp:169
+#, fuzzy, c-format
+msgid "%ls: Tried to set the special variable '%ls' to an invalid value\n"
+msgstr "%ls: Försökte ändra den skrivskyddade variablen ”%ls”\n"
+
+#: builtin_set.cpp:221
 #, c-format
 msgid "%ls: Multiple variable names specified in single call (%ls and %.*ls)\n"
 msgstr "%ls: Flera variabelnamn angivna i ett anrop (%ls och %.*ls)\n"
 
-#: builtin_set.cpp:241
+#: builtin_set.cpp:248
 #, c-format
 msgid "%ls: Invalid index starting at '%ls'\n"
 msgstr "%ls: Ogiltigt index vid ”%ls”\n"
 
-#: builtin_set.cpp:640
+#: builtin_set.cpp:647
 #, fuzzy, c-format
 msgid "%ls: Erase needs a variable name\n"
 msgstr ""
 "%ls: Radering kräver ett variabelnamn\n"
 "%ls\n"
 
-#: builtin_set.cpp:684
-#, c-format
-msgid "%ls: Can not specify scope when erasing array slice\n"
-msgstr "%ls: Kan inte ange definitionsområde vid radering av arraydel\n"
-
-#: builtin_set.cpp:783
+#: builtin_set.cpp:791
 #, c-format
 msgid "%ls: Values cannot be specfied with erase\n"
 msgstr "%ls: Värden kan inte anges vid radering\n"
 
-#: builtin_set_color.cpp:149
-#, fuzzy, c-format
-msgid "%ls: Expected an argument\n"
-msgstr "%s: Förväntade argument\n"
+#: builtin_set.cpp:817
+#, c-format
+msgid ""
+"%ls: Warning: universal scope selected, but a global variable '%ls' exists.\n"
+msgstr ""
 
-#: builtin_set_color.cpp:157 builtin_set_color.cpp:164
+#: builtin_set_color.cpp:144 builtin_set_color.cpp:166
 #, fuzzy, c-format
 msgid "%ls: Unknown color '%ls'\n"
 msgstr "%s: Okänd färg ”%s”\n"
 
-#: builtin_set_color.cpp:171
+#: builtin_set_color.cpp:153
+#, fuzzy, c-format
+msgid "%ls: Expected an argument\n"
+msgstr "%s: Förväntade argument\n"
+
+#: builtin_set_color.cpp:173
 #, fuzzy, c-format
 msgid "%ls: Could not set up terminal\n"
 msgstr "Kunde inte initiera terminalen"
 
-#: common.cpp:1882
+#: common.cpp:1917
 msgid "This is a bug. Break on bugreport to debug."
 msgstr ""
 
-#: common.cpp:1901
+#: common.cpp:1936
 msgid "empty"
 msgstr "tom"
 
@@ -686,72 +687,73 @@ msgstr "Hemkatalog för %s"
 msgid "Variable: %ls"
 msgstr "Variabel: %ls"
 
-#: complete.cpp:907 complete.cpp:925
+#: complete.cpp:901 complete.cpp:919
 msgid "Unknown option: "
 msgstr "Okänd flagga: "
 
-#: complete.cpp:929
+#: complete.cpp:923
 msgid "Multiple matches for option: "
 msgstr "Mer än en flagga matchar: "
 
-#: env.cpp:251
-msgid "Could not get user information"
-msgstr "Kunde inte hitta information om användare"
-
-#: env.cpp:362
+#: env.cpp:315
 msgid "Changing language to English"
 msgstr "Byter språk till svenska"
 
-#: env.cpp:1252
+#: env.cpp:1180
 msgid "Tried to pop empty environment stack."
 msgstr "Försökte ta bort element från tom variabelstack"
 
-#: env_universal_common.cpp:529
-#, c-format
-msgid "Could not convert message '%s' to wide character string"
-msgstr "Kunde inte konvertera meddelandet ”%s” till en bred teckensträng"
+#: env_universal_common.cpp:617 path.cpp:279
+msgid ""
+"Unable to create a configuration directory for fish. Your personal settings "
+"will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
+"where the current user has write access."
+msgstr ""
+"Kunde inte skapa en konfigurationskatalog för fish. Dina personliga "
+"inställningar kommer inte sparas. Var vänlig sätt variabeln $XDH_CONFIG_HOME "
+"till en katalog där den nuvarande användaren har skrivrättigheter."
 
-#: event.cpp:168
+#: event.cpp:178
 #, c-format
 msgid "signal handler for %ls (%ls)"
 msgstr "signalhanterare för %ls (%ls)"
 
-#: event.cpp:172
+#: event.cpp:182
 #, c-format
 msgid "handler for variable '%ls'"
 msgstr "hanterare för variabel ”%ls”"
 
-#: event.cpp:178
+#: event.cpp:188
 #, c-format
 msgid "exit handler for process %d"
 msgstr "avslutshanterare för process %d"
 
-#: event.cpp:184 event.cpp:195
+#: event.cpp:194 event.cpp:205
 #, c-format
 msgid "exit handler for job %d, '%ls'"
 msgstr "avslutshanterare för jobb %d, ”%ls”"
 
-#: event.cpp:186
+#: event.cpp:196
 #, c-format
 msgid "exit handler for job with process group %d"
 msgstr "avslutshanterare för jobb med processgrupp %d"
 
-#: event.cpp:197
+#: event.cpp:207
 #, c-format
 msgid "exit handler for job with job id %d"
 msgstr "avslutshanterare för jobb med jobid %d"
 
-#: event.cpp:203
+#: event.cpp:213
 #, c-format
 msgid "handler for generic event '%ls'"
 msgstr "hanterare för generisk händelse ”%ls”"
 
-#: event.cpp:207
+#: event.cpp:217
 #, fuzzy, c-format
 msgid "Unknown event type '0x%x'"
 msgstr "Okänd händelsetyp"
 
-#: event.cpp:621
+#: event.cpp:613
 msgid "Signal list overflow. Signals have been ignored."
 msgstr "Signallistan är full. Signaler har ignorerats."
 
@@ -770,12 +772,12 @@ msgstr "Ett fel inträffade under skapandet av ett rör"
 msgid "An error occurred while redirecting file '%s'"
 msgstr "Ett fel inträffade vid IO dirigering av filen ”%ls”"
 
-#: exec.cpp:912
+#: exec.cpp:795
 #, c-format
 msgid "Unknown function '%ls'"
 msgstr "Okänd funktion ”%ls”"
 
-#: exec.cpp:1063
+#: exec.cpp:943
 #, c-format
 msgid "Unknown input redirection type %d"
 msgstr "Okänd dirigering av standard in av typ %d"
@@ -805,99 +807,60 @@ msgstr "Skalprocess"
 msgid "Last background job"
 msgstr "Senaste bakgrundsjobb"
 
-#: expand.cpp:1306
+#: expand.cpp:1419
 msgid "Mismatched brackets"
 msgstr "Klammerparanteser matchar inte varandra"
 
-#: fish.cpp:320
+#: fish.cpp:330
+msgid ""
+"Old versions of fish appear to be running. You will not be able to share "
+"variable values between old and new fish sessions. For best results, restart "
+"all running instances of fish."
+msgstr ""
+
+#: fish.cpp:420
 #, c-format
 msgid "Invalid value '%s' for debug level switch"
 msgstr "Ogiltigt värde ”%s” för debugnivåflagga"
 
-#: fish.cpp:361 mimedb.cpp:1335
+#: fish.cpp:461 mimedb.cpp:1343
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, version %s\n"
 
-#: fish.cpp:416
+#: fish.cpp:516
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "no-execute läget kan inte användas i en i interaktiv session"
 
-#: fish.cpp:517
+#: fish.cpp:619
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Ett fel uppstod medan filen ”%ls” lästes\n"
 
-#: fish_indent.cpp:345
+#: fish_indent.cpp:332
 #, c-format
 msgid "%ls, version %s\n"
 msgstr "%ls, version %s\n"
 
-#: fish_pager.cpp:113
-#, c-format
-msgid "%ls: Argument '%s' is not a valid file descriptor\n"
-msgstr "%ls: Argumentet ”%s” är inte en giltig filidentifierare\n"
-
-#: fish_pager.cpp:703
-#, c-format
-msgid " %d to %d of %d"
-msgstr " %d till %d av %d"
-
-#: fish_pager.cpp:1012
-msgid "Could not set up output file descriptors for pager"
-msgstr "Kunde inte initiera utdata-filidentifierare för visare"
-
-#: fish_pager.cpp:1018
-msgid "Could not set up input file descriptors for pager"
-msgstr "Kunde inte initiera indata-filidentifierare för visare"
-
-#: fish_pager.cpp:1024
-msgid "Could not open tty for pager"
-msgstr "Kunde inte öppna tty för visare"
-
-#: fish_pager.cpp:1031
-msgid "Could not initialize result pipe"
-msgstr "Kunde inte initiera rör för utskrift av resultat"
-
-#: fish_pager.cpp:1075 input.cpp:384 input.cpp:394
+#: input.cpp:483 input.cpp:493
 msgid "Could not set up terminal"
 msgstr "Kunde inte initiera terminalen"
 
-#: fish_pager.cpp:1110 input.cpp:436
-msgid "Error while closing terminfo"
-msgstr "Ett fel inträffade medan terminfo stängdes"
-
-#
-#: fish_pager.cpp:1306
-msgid "Unspecified file descriptors"
-msgstr "Ospecificerad filidentifierare"
-
-#
-#: fish_pager.cpp:1318
-msgid "Could not read completions"
-msgstr "Kunde inte läsa kompletteringar"
-
-#: fishd.cpp:766 path.cpp:358
-msgid ""
-"Unable to create a configuration directory for fish. Your personal settings "
-"will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
-"where the current user has write access."
-msgstr ""
-"Kunde inte skapa en konfigurationskatalog för fish. Dina personliga "
-"inställningar kommer inte sparas. Var vänlig sätt variabeln $XDH_CONFIG_HOME "
-"till en katalog där den nuvarande användaren har skrivrättigheter."
-
-#: input.cpp:387
+#: input.cpp:486
 #, c-format
 msgid "Check that your terminal type, '%ls', is supported on this system"
 msgstr ""
 
-#: input.cpp:389
+#: input.cpp:488
 #, c-format
 msgid "Attempting to use '%ls' instead"
 msgstr ""
 
-#: io.cpp:110
+#: input.cpp:535
+msgid "Error while closing terminfo"
+msgstr "Ett fel inträffade medan terminfo stängdes"
+
+#: io.cpp:112
 #, c-format
 msgid ""
 "An error occured while reading output from code block on file descriptor %d"
@@ -905,76 +868,100 @@ msgstr ""
 "Ett fel inträffade under inläsning av utdata från kodblock på "
 "filidentifierare %d"
 
-#: mimedb.cpp:173 mimedb.cpp:187 mimedb.cpp:1177
+#: mimedb.cpp:174 mimedb.cpp:188 mimedb.cpp:1179
 #, c-format
 msgid "%s: Out of memory\n"
 msgstr "%s: Slut på minne\n"
 
-#: mimedb.cpp:462
+#: mimedb.cpp:463
 #, c-format
 msgid "%s: Unknown error in munge()\n"
 msgstr "%s: Okänt fel i munge()\n"
 
-#: mimedb.cpp:480
+#: mimedb.cpp:481
 #, c-format
 msgid "%s: Locale string too long\n"
 msgstr "%s: Lokalsträng för lång\n"
 
-#: mimedb.cpp:550 mimedb.cpp:558
+#: mimedb.cpp:551 mimedb.cpp:559
 #, c-format
 msgid "%s: Could not compile regular expressions %s with error %s\n"
 msgstr "%s: Kunde inte kompilera reguljärt uttryck %s med fel %s\n"
 
-#: mimedb.cpp:674
+#: mimedb.cpp:676
 #, c-format
 msgid "%s: No description for type %s\n"
 msgstr "%s: Beskrivning saknas för typ %s\n"
 
-#: mimedb.cpp:742
+#: mimedb.cpp:744
 #, c-format
 msgid "%s: Could not parse launcher string '%s'\n"
 msgstr "%s: Kunde inte tolka körsträng ”%ls”\n"
 
-#: mimedb.cpp:778
+#: mimedb.cpp:780
 #, c-format
 msgid "%s: Default launcher '%s' does not specify how to start\n"
 msgstr "%s: Standardkörsträng ”%s” anger inte hur programmet ska startas\n"
 
-#: mimedb.cpp:1156
+#: mimedb.cpp:1158
 #, c-format
 msgid "%s: Unsupported switch '%c' in launch string '%s'\n"
 msgstr "%s: Flaggan ”%c” i körsträng ”%s” stöds inte\n"
 
-#: mimedb.cpp:1346
+#: mimedb.cpp:1354
 #, c-format
 msgid "%s: Can not launch a mimetype\n"
 msgstr "%s: Kan inte köra en mimetyp\n"
 
-#: mimedb.cpp:1374
+#: mimedb.cpp:1382
 #, c-format
 msgid "%s: Could not parse mimetype from argument '%s'\n"
 msgstr "%s: Kunde inte tolka mimetyp från argument ”%s”\n"
 
-#: mimedb.cpp:1394 signal.cpp:407 signal.cpp:422
+#: mimedb.cpp:1402 signal.cpp:407 signal.cpp:422
 msgid "Unknown"
 msgstr "Okänd"
+
+#: output.cpp:608
+#, fuzzy, c-format
+msgid ""
+"Tried to use terminfo string %s on line %ld of %s, which is undefined in "
+"terminal of type \"%ls\". Please report this error to %s"
+msgstr ""
+"Försökte använda terminfosträng %s på rad %d av %s, vilken är odefinerad i "
+"terminaler av typen ”%ls”. Vänligen rapportera detta fel till %s"
 
 #: pager.cpp:24
 #, fuzzy
 msgid "search: "
 msgstr "Välj arkitektur"
 
-#: parse_execution.cpp:526 parse_execution.cpp:961 parser.cpp:1404
+#: pager.cpp:562
 #, c-format
-msgid "Could not expand string '%ls'"
-msgstr "Kunde inte expandera strängen ”%ls”"
+msgid "%lsand 1 more row"
+msgstr ""
 
-#: parse_execution.cpp:549
+#: pager.cpp:566
+#, c-format
+msgid "%lsand %lu more rows"
+msgstr ""
+
+#: pager.cpp:571
+#, fuzzy, c-format
+msgid "rows %lu to %lu of %lu"
+msgstr " %d till %d av %d"
+
+#: pager.cpp:576
+#, fuzzy
+msgid "(no matches)"
+msgstr "Lägg till övervakning"
+
+#: parse_execution.cpp:555
 #, fuzzy, c-format
 msgid "switch: Expected exactly one argument, got %lu\n"
 msgstr "%ls: Förväntade exakt ett argument, fick %d\n"
 
-#: parse_execution.cpp:749 parser.cpp:2053
+#: parse_execution.cpp:799
 #, fuzzy, c-format
 msgid ""
 "Unknown command '%ls'. Did you mean to run %ls with a modified environment? "
@@ -985,7 +972,7 @@ msgstr ""
 "man tilldelar variabler, se hjälpsektionen om det inbyggda kommandot ”set” "
 "genom att skriva ”help set”."
 
-#: parse_execution.cpp:774 parser.cpp:2078
+#: parse_execution.cpp:824
 #, fuzzy, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function like "
@@ -997,7 +984,7 @@ msgstr ""
 "ex. ”function %ls; %ls $argv; end”. Se hjälpsektionen för function-kommandot "
 "genom att skriva ”help function”"
 
-#: parse_execution.cpp:783 parser.cpp:2087
+#: parse_execution.cpp:833
 #, fuzzy, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function or use the "
@@ -1007,7 +994,7 @@ msgstr ""
 "Variabler får inte användas som kommandon. Definera istället en funktion. Se "
 "hjälpsektionen för function-kommandot genom att skriva ”help function”"
 
-#: parse_execution.cpp:791 parser.cpp:2095
+#: parse_execution.cpp:841
 #, c-format
 msgid ""
 "Commands may not contain variables. Use the eval builtin instead, like 'eval "
@@ -1016,389 +1003,306 @@ msgstr ""
 "Okänt kommando ”%ls”. Menade du ”set VARIABEL VÄRDE”? Se hjälpsektionen om "
 "det inbyggda kommandot ”set” genom att skriva ”help set”."
 
-#: parse_execution.cpp:798 parser.cpp:2102
+#: parse_execution.cpp:848
 #, fuzzy, c-format
 msgid "The file '%ls' is not executable by this user"
 msgstr "Filen ”%ls” existerar redan"
 
-#: parse_execution.cpp:1029
+#: parse_execution.cpp:1057
 #, fuzzy, c-format
 msgid "Invalid redirection target: %ls"
 msgstr "Ogiltig IO omdirigering"
 
-#: parse_execution.cpp:1053
+#: parse_execution.cpp:1081
 #, fuzzy, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
 msgstr "IO dirigering till någonting som inte är en filidentifierare"
 
-#: parse_util.cpp:47
+#: parse_util.cpp:46
 #, fuzzy, c-format
 msgid "The '%ls' command can not be used in a pipeline"
 msgstr "Detta kommando kan ej användas i ett rör"
 
-#: parser.cpp:58
-msgid "This command can not be used in a pipeline"
+#: parse_util.cpp:49
+#, fuzzy, c-format
+msgid "The '%ls' command can not be used immediately after a backgrounded job"
 msgstr "Detta kommando kan ej användas i ett rör"
 
-#: parser.cpp:64
+#: parse_util.cpp:52
+#, fuzzy
+msgid "Backgrounded commands can not be used as conditionals"
+msgstr "Detta kommando kan ej användas i ett rör"
+
+#: parser.cpp:52
 #, c-format
 msgid "Tokenizer error: '%ls'"
 msgstr "Ett fel inträffade vid symboluppdelning: ”%ls”"
 
-#: parser.cpp:69
-msgid "An additional command is required"
-msgstr "Ett till kommand krävs"
-
-#: parser.cpp:74
-msgid ""
-"The function calls itself immediately, which would result in an infinite "
-"loop."
-msgstr ""
-
-#: parser.cpp:79
-msgid ""
-"Could not locate end of block. The 'end' command is missing, misspelled or a "
-"';' is missing."
-msgstr ""
-"Kunde inte hitta slutet på kodblock. Kommandot ”end” saknas, är felstavat "
-"eller ett ”;” saknas."
-
-#: parser.cpp:82
-#, c-format
-msgid "Expected a command name, got token of type '%ls'"
-msgstr ""
-"Förväntade att hitta ett kommandonamn, hittade en symbol av typen ”%ls”"
-
-#: parser.cpp:87 parse_constants.h:158
-#, c-format
-msgid "Illegal command name '%ls'"
-msgstr "Ogiltigt kommandonamn ”%ls”"
-
-#: parser.cpp:92 parse_constants.h:164
-#, fuzzy, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
-msgstr "Ogiltig filidentifierare ”%ls”"
-
-#: parser.cpp:97 parse_constants.h:167
-#, c-format
-msgid "No matches for wildcard '%ls'."
-msgstr ""
-
-#: parser.cpp:102
-msgid "'case' builtin not inside of switch block"
-msgstr "Det inbyggda kommandot ”case” får bara användas i ett ”switch”-block."
-
-#: parser.cpp:107
-msgid "Loop control command while not inside of loop"
-msgstr "Loopstyrningskommandon får bara användas i loopar."
-
-#: parser.cpp:112 parse_constants.h:176
-msgid "'return' builtin command outside of function definition"
-msgstr ""
-"Det inbyggda kommandot ”return” påträffades utanför en funktionsdefinition"
-
-#: parser.cpp:117
-#, fuzzy, c-format
-msgid "'%ls' builtin not inside of if block"
-msgstr "Det inbyggda kommandot ”else” får bara användas i ett if-block"
-
-#: parser.cpp:122
-#, c-format
-msgid "'%ls' used past terminating 'else'"
-msgstr ""
-
-#: parser.cpp:127
-msgid "'end' command outside of block"
-msgstr "Det inbyggda kommandot ”end” får bara användas i ett block"
-
-#: parser.cpp:132 parse_constants.h:179
-#, fuzzy, c-format
-msgid ""
-"Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
-"the set command by typing 'help set'."
-msgstr ""
-"Okänt kommando ”%ls”. Menade du ”set %ls %ls”? För mer information om hur "
-"man tilldelar variabler, se hjälpsektionen om det inbyggda kommandot ”set” "
-"genom att skriva ”help set”."
-
-#: parser.cpp:137
-#, c-format
-msgid "Expected redirection specification, got token of type '%ls'"
-msgstr "Förväntade en IO dirigering, hittade en symbol av typen ”%ls”"
-
-#: parser.cpp:142
-msgid ""
-"Encountered redirection when expecting a command name. Fish does not allow a "
-"redirection operation before a command."
-msgstr ""
-"Förväntade ett kommandonamn, hittade en IO dirigering. Fish tillåter into IO "
-"dirigeringar före kommandonamn"
-
-#: parser.cpp:147
+#: parser.cpp:57
 #, c-format
 msgid "Tried to evaluate commands using invalid block type '%ls'"
 msgstr "Försökte utföra kommandon i ogiltig blocktyp ”%ls”"
 
-#: parser.cpp:153
+#: parser.cpp:62
 #, c-format
 msgid "Unexpected token of type '%ls'"
 msgstr "Oväntad symbol av typ ”%ls”"
 
-#: parser.cpp:158 parse_constants.h:209
+#: parser.cpp:67 parse_constants.h:255
 msgid "'while' block"
 msgstr "”while” block"
 
-#: parser.cpp:163 parse_constants.h:214
+#: parser.cpp:72 parse_constants.h:260
 msgid "'for' block"
 msgstr "”for” block"
 
-#: parser.cpp:168 parse_constants.h:219
+#: parser.cpp:77 parse_constants.h:265
 msgid "Block created by breakpoint"
 msgstr "Block skapat av det inbuggde kommandot breakpoint"
 
-#: parser.cpp:175 parse_constants.h:226
+#: parser.cpp:82 parse_constants.h:272
 msgid "'if' conditional block"
 msgstr "”if” villkorligt block"
 
-#: parser.cpp:181 parse_constants.h:232
+#: parser.cpp:87 parse_constants.h:278
 msgid "function definition block"
 msgstr "funktionsdefinition-block"
 
-#: parser.cpp:187 parse_constants.h:238
+#: parser.cpp:92 parse_constants.h:284
 msgid "function invocation block"
 msgstr "funktionsanropp-block"
 
-#: parser.cpp:192 parse_constants.h:243
+#: parser.cpp:97 parse_constants.h:289
 msgid "function invocation block with no variable shadowing"
 msgstr "funktionsanroppsblock utan variabelskuggning"
 
-#: parser.cpp:198 parse_constants.h:249
+#: parser.cpp:102 parse_constants.h:295
 msgid "'switch' block"
 msgstr "”switch” block"
 
-#: parser.cpp:204 parse_constants.h:255
+#: parser.cpp:107 parse_constants.h:301
 msgid "unexecutable block"
 msgstr "oexekverbart block"
 
-#: parser.cpp:210 parse_constants.h:261
+#: parser.cpp:112 parse_constants.h:307
 msgid "global root block"
 msgstr "globalt rot-block"
 
-#: parser.cpp:216 parse_constants.h:267
+#: parser.cpp:117 parse_constants.h:313
 msgid "command substitution block"
 msgstr "kommandosubstitution-block"
 
-#: parser.cpp:222 parse_constants.h:273
+#: parser.cpp:122 parse_constants.h:319
 msgid "'begin' unconditional block"
 msgstr "”begin” ovillkorligen exekverat block"
 
-#: parser.cpp:228 parse_constants.h:279
+#: parser.cpp:127 parse_constants.h:325
 msgid "Block created by the . builtin"
 msgstr "Block skapat av det inbyggda kommandot ”.”"
 
-#: parser.cpp:233 parse_constants.h:284
+#: parser.cpp:132 parse_constants.h:330
 msgid "event handler block"
 msgstr "händelsehanterarblock"
 
-#: parser.cpp:239 parse_constants.h:290
+#: parser.cpp:137 parse_constants.h:336
 msgid "unknown/invalid block"
 msgstr "okänt/ogiltigt block"
 
-#: parser.cpp:645
+#: parser.cpp:474
 #, c-format
 msgid "Could not write profiling information to file '%s'"
 msgstr "Kunde inte skriva profileringsinformation till filen ”%s”"
 
-#: parser.cpp:651
+#: parser.cpp:480
 msgid "Time\tSum\tCommand\n"
 msgstr "Tid\tSumma\tKommando\n"
 
-#: parser.cpp:811
+#: parser.cpp:562
 #, c-format
 msgid "in event handler: %ls\n"
 msgstr "i händelsehanterare: %ls\n"
 
-#: parser.cpp:839
+#: parser.cpp:590
 #, fuzzy, c-format
 msgid "from sourcing file %ls\n"
 msgstr "Ett fel uppstod medan filen ”%ls” lästes\n"
 
-#: parser.cpp:845
+#: parser.cpp:597
 #, fuzzy, c-format
 msgid "in function '%ls'\n"
 msgstr "i funktion ”%ls”,\n"
 
-#: parser.cpp:850
+#: parser.cpp:602
 msgid "in command substitution\n"
 msgstr "i kommandosubstitution\n"
 
-#: parser.cpp:863
+#: parser.cpp:615
 #, fuzzy, c-format
 msgid "\tcalled on line %d of file %ls\n"
 msgstr "\tanropad på rad %d i fil ”%ls”,\n"
 
-#: parser.cpp:869
+#: parser.cpp:621
 #, fuzzy
 msgid "\tcalled during startup\n"
 msgstr "\tanropad från standard in,\n"
 
-#: parser.cpp:873
+#: parser.cpp:625
 #, fuzzy
 msgid "\tcalled on standard input\n"
 msgstr "\tanropad från standard in,\n"
 
-#: parser.cpp:890
+#: parser.cpp:642
 #, c-format
 msgid "\twith parameter list '%ls'\n"
 msgstr "\tmed parameterlista ”%ls”\n"
 
-#: parser.cpp:1087
+#: parser.cpp:756
 #, c-format
 msgid "%ls (line %d): "
 msgstr "%ls (rad %d): "
 
-#: parser.cpp:1091
+#: parser.cpp:760
 msgid "Startup"
 msgstr ""
 
-#: parser.cpp:1197
+#: parser.cpp:803
 msgid "Job inconsistency"
 msgstr "Jobb i ogiltigt tillstånd"
 
-#: parser.cpp:1520
-msgid "Invalid IO redirection"
-msgstr "Ogiltig IO omdirigering"
-
-#: parser.cpp:1541
-#, c-format
-msgid "Requested redirection to something that is not a file descriptor %ls"
-msgstr "IO dirigering till någonting som inte är en filidentifierare"
-
-#: parser.cpp:2667 parser.cpp:2750
+#: parser.cpp:956
 msgid "End of block mismatch. Program terminating."
 msgstr "Blockslut matchar inte. Programmet avslutas."
 
-#: parser.cpp:3034
+#: parser.cpp:1047
 #, fuzzy, c-format
 msgid "%ls (line %lu): "
 msgstr "%ls (rad %d): "
+
+#: parser.cpp:1051
+#, c-format
+msgid "%ls: "
+msgstr ""
 
 #: path.cpp:24
 #, c-format
 msgid "Error while searching for command '%ls'"
 msgstr "Ett fel uppstod under sökning efter kommandot ”%ls”"
 
-#: proc.cpp:615
+#: proc.cpp:690
+#, fuzzy, c-format
+msgid "'%ls' has %ls"
+msgstr "Jobb %d, ”%ls” har %ls"
+
+#: proc.cpp:694
 #, c-format
 msgid "Job %d, '%ls' has %ls"
 msgstr "Jobb %d, ”%ls” har %ls"
 
-#: proc.cpp:699
-#, c-format
-msgid "%ls: Job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:786
+#, fuzzy, c-format
+msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Jobb %d, ”%ls” avslutat av signal %ls (%ls)"
 
-#: proc.cpp:707
-#, c-format
-msgid ""
-"%ls: Process %d, '%ls' from job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:797
+#, fuzzy, c-format
+msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 "%ls: Process %d, ”%ls”, från jobb %d, ”%ls” avslutat av signal %ls (%ls)"
 
-#: proc.cpp:736
+#: proc.cpp:828
 msgid "ended"
 msgstr "avslutat"
 
-#: proc.cpp:969
+#: proc.cpp:1065
 msgid "An error occured while reading output from code block"
 msgstr "Ett fel inträffade under läsandet av utdata från kodblock"
 
-#: proc.cpp:998 proc.cpp:1010
+#: proc.cpp:1094 proc.cpp:1106
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Kunde inte skicka jobb %d (”%ls”) till förgrunden"
 
-#: proc.cpp:1030 proc.cpp:1040 proc.cpp:1055
+#: proc.cpp:1126 proc.cpp:1136 proc.cpp:1151
 msgid "Could not return shell to foreground"
 msgstr "Kunde inte återställa skalet till förgrunden"
 
-#: proc.cpp:1280 proc.cpp:1304
+#: proc.cpp:1354 proc.cpp:1380
 msgid "Process list pointer"
 msgstr "Processlistepekare"
 
-#: proc.cpp:1291
+#: proc.cpp:1365
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "Mer än ett jobb i förgrunden: job 1: ”%ls”, jobb 2 ”%ls”"
 
-#: proc.cpp:1302
+#: proc.cpp:1378
 msgid "Process argument list"
 msgstr "Processargumentlista"
 
-#: proc.cpp:1303
+#: proc.cpp:1379
 msgid "Process name"
 msgstr "Processnamn"
 
-#: proc.cpp:1309
+#: proc.cpp:1385
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Jobb ”%ls”, process ”%ls” har ogiltigt tillstånd ”stopped”=%d"
 
-#: proc.cpp:1319
+#: proc.cpp:1395
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr "Jobb ”%ls”, process ”%ls” har ogiltigt tillstånd ”completed”=%d"
 
-#: reader.cpp:453
+#: reader.cpp:478
 msgid "Could not set terminal mode for new job"
 msgstr "Kunde inte återställa terminalen för nytt jobb"
 
-#: reader.cpp:477
+#: reader.cpp:525
 msgid "Could not set terminal mode for shell"
 msgstr "Kunde inte återställa terminalen till skalet"
 
-#: reader.cpp:2133
+#: reader.cpp:2059
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr ""
 
-#: reader.cpp:2148
+#: reader.cpp:2074
 #, c-format
 msgid ""
 "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr ""
 
-#: reader.cpp:2179
+#: reader.cpp:2105
 msgid "Couldn't put the shell in its own process group"
 msgstr "Kunde inte skicka skalet till sin egen processgrupp"
 
-#: reader.cpp:2189
+#: reader.cpp:2115
 msgid "Couldn't grab control of terminal"
 msgstr "Kunde inte ta kontroll över terminalen"
 
-#: reader.cpp:2703
+#: reader.cpp:2616
 msgid "Pop null reader block"
 msgstr "Ta bort element från tomt läsarblock"
 
-#: reader.cpp:2956
+#: reader.cpp:2882
 msgid ""
 "There are stopped jobs. A second attempt to exit will enforce their "
 "termination.\n"
 msgstr ""
 
-#: reader.cpp:4069
+#: reader.cpp:4115
 #, c-format
 msgid "Unknown keybinding %d"
 msgstr "Okänd tangentbordsbindning %d"
 
-#: reader.cpp:4210
+#: reader.cpp:4226
 msgid "Error while reading from file descriptor"
 msgstr "Ett fel uppstod under inläsning från filidentifierare"
 
-#: reader.cpp:4227
+#: reader.cpp:4243
 msgid "Error while closing input stream"
 msgstr "Ett fel inträffade medan indataström stängdes"
 
-#: reader.cpp:4248
+#: reader.cpp:4270
 msgid "Error while opening input stream"
 msgstr "Ett fel inträffade medan indataström öppnades"
 
@@ -1631,7 +1535,7 @@ msgstr "Kör jobb i bakgrunden"
 msgid "Comment"
 msgstr "Kommentar"
 
-#: tokenizer.cpp:602
+#: tokenizer.cpp:561
 msgid "Invalid token type"
 msgstr "Ogiltig symboltyp"
 
@@ -1675,7 +1579,7 @@ msgstr "%ls: Ogiltig flagga -- ”%lc”\n"
 msgid "%ls: Invalid option -- %lc\n"
 msgstr "%ls: Ogiltigt flagga -- %lc\n"
 
-#: wgetopt.cpp:673
+#: wgetopt.cpp:676
 #, c-format
 msgid "%ls: Option requires an argument -- %lc\n"
 msgstr "%ls: Flaggan kräver ett argument -- %lc\n"
@@ -1688,7 +1592,7 @@ msgstr "Program"
 msgid "Executable link"
 msgstr "Länk till program"
 
-#: wildcard.cpp:67 share/completions/git.fish:146
+#: wildcard.cpp:67 share/completions/git.fish:178
 msgid "File"
 msgstr "Fil"
 
@@ -1819,33 +1723,24 @@ msgstr "%ls: Argumentet ”%ls” är inte ett nummer\n"
 msgid "An error occurred while setting up pipe"
 msgstr "Ett fel inträffade under skapandet av ett rör"
 
-#: expand.h:132
+#: expand.h:135
 msgid "Array index out of bounds"
 msgstr "Arrayindexet är otållåtet"
 
-#: output.h:91
-#, c-format
-msgid ""
-"Tried to use terminfo string %s on line %d of %s, which is undefined in "
-"terminal of type \"%ls\". Please report this error to %s"
-msgstr ""
-"Försökte använda terminfosträng %s på rad %d av %s, vilken är odefinerad i "
-"terminaler av typen ”%ls”. Vänligen rapportera detta fel till %s"
-
-#: parse_constants.h:145
+#: parse_constants.h:185
 #, c-format
 msgid ""
 "The function '%ls' calls itself immediately, which would result in an "
 "infinite loop."
 msgstr ""
 
-#: parse_constants.h:149
+#: parse_constants.h:189
 msgid ""
 "The function call stack limit has been exceeded. Do you have an accidental "
 "infinite loop?"
 msgstr ""
 
-#: parse_constants.h:152
+#: parse_constants.h:192
 #, fuzzy
 msgid ""
 "Expected a command, but instead found a pipe. Did you mean 'COMMAND; or "
@@ -1856,10 +1751,10 @@ msgstr ""
 "Menade du ”KOMMANDO; or KOMMANDO”? Se hjälpsektionen om ”or” genom att "
 "skriva ”help or”."
 
-#: parse_constants.h:155
+#: parse_constants.h:195
 #, fuzzy
 msgid ""
-"Expected a command, but instead found a '&'. Did you mean 'COMMAND; and "
+"Expected a command, but instead found an '&'. Did you mean 'COMMAND; and "
 "COMMAND'? See the help section for the 'and' builtin command by typing 'help "
 "and'."
 msgstr ""
@@ -1867,22 +1762,62 @@ msgstr ""
 "Menade du ”KOMMANDO; and KOMMANDO”? Se hjälpsektionen om ”and” genom att "
 "skriva ”help and”."
 
-#: parse_constants.h:161
+#: parse_constants.h:198
+#, c-format
+msgid "Illegal command name '%ls'"
+msgstr "Ogiltigt kommandonamn ”%ls”"
+
+#: parse_constants.h:201
+#, c-format
+msgid "Unknown builtin '%ls'"
+msgstr "Okänt inbyggt kommando ”%ls”"
+
+#: parse_constants.h:204
 #, fuzzy, c-format
 msgid "Unable to expand variable name '%ls'"
 msgstr "%ls: Ogiltigt variabelnamn ”%ls”\n"
 
-#: parse_constants.h:170
+#: parse_constants.h:207
+#, fuzzy, c-format
+msgid "Unable to find a process '%ls'"
+msgstr "Misslyckades med att exekvera processen ”%ls”"
+
+#: parse_constants.h:210
+#, fuzzy, c-format
+msgid "Illegal file descriptor in redirection '%ls'"
+msgstr "Ogiltig filidentifierare ”%ls”"
+
+#: parse_constants.h:213
+#, c-format
+msgid "No matches for wildcard '%ls'."
+msgstr ""
+
+#: parse_constants.h:216
 #, fuzzy
 msgid "break command while not inside of loop"
 msgstr "Loopstyrningskommandon får bara användas i loopar."
 
-#: parse_constants.h:173
+#: parse_constants.h:219
 #, fuzzy
 msgid "continue command while not inside of loop"
 msgstr "Loopstyrningskommandon får bara användas i loopar."
 
-#: parse_constants.h:184
+#: parse_constants.h:222
+msgid "'return' builtin command outside of function definition"
+msgstr ""
+"Det inbyggda kommandot ”return” påträffades utanför en funktionsdefinition"
+
+#: parse_constants.h:225
+#, fuzzy, c-format
+msgid ""
+"Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
+"the set command by typing 'help set'."
+msgstr ""
+"Okänt kommando ”%ls”. Menade du ”set %ls %ls”? För mer information om hur "
+"man tilldelar variabler, se hjälpsektionen om det inbyggda kommandot ”set” "
+"genom att skriva ”help set”."
+
+#: parse_constants.h:230
 #, c-format
 msgid ""
 "The '$' character begins a variable name. The character '%lc', which "
@@ -1895,13 +1830,13 @@ msgstr ""
 "vara noll tecken långa. För mer information om variabelexpansion i fish, "
 "skriv ”help expand-variable”."
 
-#: parse_constants.h:189
+#: parse_constants.h:235
 msgid ""
 "$? is not a valid variable in fish. If you want the exit status of the last "
 "command, try $status."
 msgstr ""
 
-#: parse_constants.h:194
+#: parse_constants.h:240
 msgid ""
 "The '$' begins a variable name. It was given at the end of an argument. "
 "Variable names may not be zero characters long. To learn more about variable "
@@ -1911,7 +1846,7 @@ msgstr ""
 "ett argument. Variabelnamn får inte vara noll tecken långa. För mer "
 "information om variabelexpansion i fish, skriv ”help expand-variable”."
 
-#: parse_constants.h:199
+#: parse_constants.h:245
 #, c-format
 msgid ""
 "Did you mean %ls{$%ls}%ls? The '$' character begins a variable name. A "
@@ -1924,7 +1859,7 @@ msgstr ""
 "variabelnamn, och variabelnamn får inte vara noll tecken långa. För mer "
 "information om variabelexpansion i fish, skriv ”help expand-variable”."
 
-#: parse_constants.h:204
+#: parse_constants.h:250
 msgid ""
 "Did you mean (COMMAND)? In fish, the '$' character is only used for "
 "accessing variables. To learn more about command substitution in fish, type "
@@ -3056,227 +2991,324 @@ msgstr "Testa om aptitude har tagit emot ett underkommando"
 msgid "Test if bundle has been given a specific subcommand"
 msgstr "Testa om aptitude har tagit emot ett underkommando"
 
-#: share/completions/bundle.fish:30
+#: share/completions/bundle.fish:31
 #, fuzzy
 msgid "Display a help page"
 msgstr "Visa manualsida"
 
-#: share/completions/bundle.fish:38 share/completions/bundle.fish:65
+#: share/completions/bundle.fish:39 share/completions/bundle.fish:83
 msgid "Install the gems specified by the Gemfile or Gemfile.lock"
 msgstr ""
 
-#: share/completions/bundle.fish:39 share/completions/bundle.fish:87
-msgid "The location of the Gemfile bundler should use."
-msgstr ""
-
-#: share/completions/bundle.fish:40
+#: share/completions/bundle.fish:40 share/completions/bundle.fish:106
 #, fuzzy
-msgid "The location to install the gems in the bundle to."
+msgid "The location of the Gemfile bundler should use"
 msgstr "Lägg till fil eller träd utan version till förrådet"
 
 #: share/completions/bundle.fish:41
-msgid "Installs the gems in the bundle to the system location."
-msgstr ""
+#, fuzzy
+msgid "The location to install the gems in the bundle to"
+msgstr "Lägg till fil eller träd utan version till förrådet"
 
 #: share/completions/bundle.fish:42
-msgid "A space-separated list of groups to skip installing."
-msgstr ""
+#, fuzzy
+msgid "Installs the gems in the bundle to the system location"
+msgstr "Lägg till fil eller träd utan version till förrådet"
 
 #: share/completions/bundle.fish:43
-msgid "Use cached gems instead of connecting to rubygems.org."
+msgid "A space-separated list of groups to skip installing"
 msgstr ""
 
 #: share/completions/bundle.fish:44
-msgid "Switches bundler's defaults into deployment mode."
+msgid "Use cached gems instead of connecting to rubygems.org"
 msgstr ""
 
 #: share/completions/bundle.fish:45
-msgid ""
-"Create a directory containing executabes that run in the context of the "
-"bundle."
+msgid "Switches bundler's defaults into deployment mode."
 msgstr ""
 
 #: share/completions/bundle.fish:46
-msgid "Specify a ruby executable to use with generated binstubs."
+msgid ""
+"Create a directory containing executabes that run in the context of the "
+"bundle"
 msgstr ""
 
 #: share/completions/bundle.fish:47
-msgid "Make a bundle that can work without RubyGems or Bundler at run-time."
+msgid "Specify a ruby executable to use with generated binstubs"
 msgstr ""
 
 #: share/completions/bundle.fish:48
-msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
+msgid "Make a bundle that can work without RubyGems or Bundler at run-time"
 msgstr ""
 
 #: share/completions/bundle.fish:49
-msgid "Do not update the cache in vendor/cache with the newly bundled gems."
+msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
 msgstr ""
 
 #: share/completions/bundle.fish:50
+msgid "Install  gems parallely by starting size number of parallel workers"
+msgstr ""
+
+#: share/completions/bundle.fish:51
+msgid "Do not update the cache in vendor/cache with the newly bundled gems"
+msgstr ""
+
+#: share/completions/bundle.fish:52
 #, fuzzy
-msgid "Do not print progress information to stdout."
+msgid "Do not print progress information to stdout"
 msgstr "Visa all information"
 
-#: share/completions/bundle.fish:53 share/completions/bundle.fish:66
+#: share/completions/bundle.fish:53
+#, fuzzy
+msgid "Run bundle clean automatically after install"
+msgstr "Upgradera paket om det är installerat"
+
+#: share/completions/bundle.fish:54 share/completions/bundle.fish:63
+msgid "Use the rubygems modern index instead of the API endpoint"
+msgstr ""
+
+#: share/completions/bundle.fish:55 share/completions/bundle.fish:164
+#, fuzzy
+msgid "Do not remove stale gems from the cache"
+msgstr "Ta bort alla gz-filer från cache"
+
+#: share/completions/bundle.fish:56
+msgid "Do not allow the Gemfile.lock to be updated after this install"
+msgstr ""
+
+#: share/completions/bundle.fish:59 share/completions/bundle.fish:84
 #, fuzzy
 msgid "Update dependencies to their latest versions"
 msgstr "Visa alla källkodspaket med version"
 
-#: share/completions/bundle.fish:54
-msgid "The name of a :git or :path source used in the Gemfile."
+#: share/completions/bundle.fish:60
+msgid "The name of a :git or :path source used in the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:58
+#: share/completions/bundle.fish:61
+msgid "Do not attempt to fetch gems remotely and use the gem cache instead"
+msgstr ""
+
+#: share/completions/bundle.fish:62
+msgid "Only output warnings and errors"
+msgstr ""
+
+#: share/completions/bundle.fish:64
+#, fuzzy
+msgid "Specify the number of jobs to run in parallel"
+msgstr "Ange antalet bytes av data att sicka"
+
+#: share/completions/bundle.fish:65
+#, fuzzy
+msgid "Update a specific group"
+msgstr "Använd angiven tagg"
+
+#: share/completions/bundle.fish:69
 msgid ""
 "Package the .gem files required by your application into the vendor/cache "
 "directory"
 msgstr ""
 
-#: share/completions/bundle.fish:61 share/completions/bundle.fish:68
+#: share/completions/bundle.fish:72
+#, fuzzy
+msgid "Install the binstubs of the listed gem"
+msgstr "Visa låtsasinstallationsutdata i tabellform"
+
+#: share/completions/bundle.fish:73
+#, fuzzy
+msgid "Binstub destination directory (default bin)"
+msgstr "Installera dokumentation (standard)"
+
+#: share/completions/bundle.fish:74
+msgid "Overwrite existing binstubs if they exist"
+msgstr ""
+
+#: share/completions/bundle.fish:78 share/completions/bundle.fish:86
 msgid "Execute a script in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:64
+#: share/completions/bundle.fish:79
+msgid "Exec runs a command, providing it access to the gems in the bundle"
+msgstr ""
+
+#: share/completions/bundle.fish:82
 msgid "Describe available tasks or one specific task"
 msgstr ""
 
-#: share/completions/bundle.fish:67
+#: share/completions/bundle.fish:85
 #, fuzzy
 msgid "Package .gem files into the vendor/cache directory"
 msgstr "Ändra arbetskatalog"
 
-#: share/completions/bundle.fish:69
+#: share/completions/bundle.fish:87
+#, fuzzy
+msgid "Specify and read configuration options for bundler"
+msgstr "Välj en konfigurationsfil"
+
+#: share/completions/bundle.fish:88
 msgid "Check bundler requirements for your application"
 msgstr ""
 
-#: share/completions/bundle.fish:70 share/completions/bundle.fish:92
+#: share/completions/bundle.fish:89
 #, fuzzy
 msgid "Show all of the gems in the current bundle"
 msgstr "Nedstig aldrig i föräldrakatalog"
 
-#: share/completions/bundle.fish:71 share/completions/bundle.fish:96
+#: share/completions/bundle.fish:90
 #, fuzzy
 msgid "Show the source location of a particular gem in the bundle"
 msgstr "Visa process-id för varje process i jobbet"
 
-#: share/completions/bundle.fish:72 share/completions/bundle.fish:100
+#: share/completions/bundle.fish:91 share/completions/bundle.fish:121
 msgid "Show all of the outdated gems in the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:73 share/completions/bundle.fish:107
+#: share/completions/bundle.fish:92 share/completions/bundle.fish:129
 msgid "Start an IRB session in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:74 share/completions/bundle.fish:110
+#: share/completions/bundle.fish:93 share/completions/bundle.fish:132
 #, sh-format
 msgid "Open an installed gem in your $EDITOR"
 msgstr ""
 
-#: share/completions/bundle.fish:75 share/completions/bundle.fish:114
+#: share/completions/bundle.fish:94 share/completions/bundle.fish:136
 msgid "Generate a visual representation of your dependencies"
 msgstr ""
 
-#: share/completions/bundle.fish:76
+#: share/completions/bundle.fish:95
 #, fuzzy
 msgid "Generate a simple Gemfile"
 msgstr "Generera huvudfil"
 
-#: share/completions/bundle.fish:77 share/completions/bundle.fish:125
+#: share/completions/bundle.fish:96 share/completions/bundle.fish:147
 msgid "Create a simple gem, suitable for development with bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:78 share/completions/bundle.fish:131
+#: share/completions/bundle.fish:97 share/completions/bundle.fish:154
 #, fuzzy
 msgid "Displays platform compatibility information"
 msgstr "Visa uppdateringsinformation"
 
-#: share/completions/bundle.fish:79 share/completions/bundle.fish:135
+#: share/completions/bundle.fish:98 share/completions/bundle.fish:158
 msgid "Cleans up unused gems in your bundler directory"
 msgstr ""
 
-#: share/completions/bundle.fish:86
+#: share/completions/bundle.fish:105
 msgid ""
 "Determine whether the requirements for your application are installed and "
 "available to bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:88
-msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)."
+#: share/completions/bundle.fish:107
+msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)"
 msgstr ""
 
-#: share/completions/bundle.fish:89
+#: share/completions/bundle.fish:108
 #, fuzzy
 msgid "Lock the Gemfile"
 msgstr "Logga till spårfil"
 
-#: share/completions/bundle.fish:93
+#: share/completions/bundle.fish:111 share/completions/bundle.fish:116
+msgid ""
+"Show lists the names and versions of all gems that are required by your "
+"Gemfile"
+msgstr ""
+
+#: share/completions/bundle.fish:112 share/completions/bundle.fish:117
 msgid "List the paths of all gems required by your Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:101
+#: share/completions/bundle.fish:122
 #, fuzzy
 msgid "Check for newer pre-release gems"
 msgstr "Kontrollera förekomst av minnesläckor"
 
-#: share/completions/bundle.fish:102
+#: share/completions/bundle.fish:123
 msgid "Check against a specific source"
 msgstr ""
 
-#: share/completions/bundle.fish:103
+#: share/completions/bundle.fish:124
 msgid "Use cached gems instead of attempting to fetch gems remotely"
 msgstr ""
 
-#: share/completions/bundle.fish:115
+#: share/completions/bundle.fish:125
+msgid "Only list newer versions allowed by your Gemfile requirements"
+msgstr ""
+
+#: share/completions/bundle.fish:137
 msgid "The name to use for the generated file (see format option)"
 msgstr ""
 
-#: share/completions/bundle.fish:116
+#: share/completions/bundle.fish:138
 #, fuzzy
 msgid "Show each gem version"
 msgstr "Källkodsträdsversion"
 
-#: share/completions/bundle.fish:117
+#: share/completions/bundle.fish:139
 msgid "Show the version of each required dependency"
 msgstr ""
 
-#: share/completions/bundle.fish:118
+#: share/completions/bundle.fish:140
 msgid "Output a specific format (png, jpg, svg, dot, ...)"
 msgstr ""
 
-#: share/completions/bundle.fish:121
+#: share/completions/bundle.fish:143
 #, fuzzy
 msgid "Generate a simple Gemfile, placed in the current directory"
 msgstr "Nedstig aldrig i föräldrakatalog"
 
-#: share/completions/bundle.fish:122
+#: share/completions/bundle.fish:144
 msgid "Use a specified .gemspec to create the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:126
+#: share/completions/bundle.fish:148
 msgid "Generate a binary for your library"
 msgstr ""
 
-#: share/completions/bundle.fish:127
+#: share/completions/bundle.fish:149
 msgid "Generate a test directory for your library (rspec or minitest)"
 msgstr ""
 
-#: share/completions/bundle.fish:128
+#: share/completions/bundle.fish:150
 #, fuzzy
 msgid "Path to your editor"
 msgstr "Välj källkatalog"
 
-#: share/completions/bundle.fish:132
+#: share/completions/bundle.fish:151
+msgid "Generate the boilerplate for C extension code"
+msgstr ""
+
+#: share/completions/bundle.fish:155
 #, fuzzy
 msgid "Only display Ruby directive information"
 msgstr "Visa uppdateringsinformation"
 
-#: share/completions/bundle.fish:136
+#: share/completions/bundle.fish:159
 msgid "Only print out changes, do not actually clean gems"
 msgstr ""
 
-#: share/completions/bundle.fish:137
+#: share/completions/bundle.fish:160
 msgid "Forces clean even if --path is not set"
 msgstr ""
+
+#: share/completions/bundle.fish:163
+msgid "Cache all the gems to vendor/cache"
+msgstr ""
+
+#: share/completions/bundle.fish:165
+msgid "Include all sources (including path and git)"
+msgstr ""
+
+#: share/completions/bundle.fish:168
+#, fuzzy
+msgid "Prints the license of all gems in the bundle"
+msgstr "Lägg till fil eller träd utan version till förrådet"
+
+#: share/completions/bundle.fish:171
+#, fuzzy
+msgid "Print information about the environment Bundler is running under"
+msgstr "Hämta ändringar från förrådet till arbetskopian"
 
 #: share/completions/configure.fish:1
 #: share/functions/__fish_complete_diff.fish:27
@@ -3290,19 +3322,15 @@ msgstr "Visa hjälp och avsluta"
 msgid "Cache test results in specified file"
 msgstr "Cache:a resultat i angiven fil"
 
-#: share/completions/cp.fish:10 share/completions/mv.fish:6
+#: share/completions/cp.fish:11 share/completions/mv.fish:6
 msgid "Backup suffix"
 msgstr "Backup-ändelse"
 
 #: share/completions/cp.fish:20
-msgid "Don't preserve the specified attributes"
-msgstr "Behåll inte de angivna attributen"
+msgid "Preserve ATTRIBUTES if possible"
+msgstr ""
 
-#: share/completions/cp.fish:24
-msgid "Control creation of sparse files"
-msgstr "Kontrollera skapandet av glesa filer"
-
-#: share/completions/cp.fish:28
+#: share/completions/cp.fish:29
 msgid "Set security context of copy to CONTEXT"
 msgstr "Ange säkerhetskontext för kopia"
 
@@ -3925,6 +3953,33 @@ msgstr "Visa filsystem av angiven typ"
 msgid "Block size"
 msgstr "Blockstorlek"
 
+#: share/completions/docker.fish:19
+#, fuzzy
+msgid "Show all containers"
+msgstr "Visa ARP-inlägg"
+
+#: share/completions/docker.fish:24
+#, fuzzy
+msgid "Show the running containers"
+msgstr "Visa dolda funktioner"
+
+#: share/completions/docker.fish:28
+#, fuzzy
+msgid "Show the exited containers"
+msgstr "Visa tid"
+
+#: share/completions/docker.fish:70 share/completions/docker.fish:92
+msgid "Docker container"
+msgstr ""
+
+#: share/completions/docker.fish:82
+msgid "Stopped container"
+msgstr ""
+
+#: share/completions/docker.fish:87
+msgid "Container running"
+msgstr ""
+
 #: share/completions/du.fish:15
 #, fuzzy
 msgid "Exclude files that match pattern in file"
@@ -3938,96 +3993,96 @@ msgstr "Exkludera filer som matchar mönster"
 msgid "Recursion limit"
 msgstr "Rekursionsgräns"
 
-#: share/completions/duply.fish:5
+#: share/completions/duply.fish:3
 #, fuzzy
 msgid "Profile"
 msgstr "Konfigurationsfil"
 
-#: share/completions/duply.fish:6
+#: share/completions/duply.fish:4
 msgid "Get usage help text"
 msgstr ""
 
-#: share/completions/duply.fish:9
+#: share/completions/duply.fish:7
 #, fuzzy
 msgid "Creates a configuration profile"
 msgstr "Välj konfigurationsfil"
 
-#: share/completions/duply.fish:10
+#: share/completions/duply.fish:8
 msgid "Backup with pre/post script execution"
 msgstr ""
 
-#: share/completions/duply.fish:11
+#: share/completions/duply.fish:9
 #, fuzzy
 msgid "Backup without executing pre/post scripts"
 msgstr "Kör inte post-skript"
 
-#: share/completions/duply.fish:12
+#: share/completions/duply.fish:10
 #, fuzzy
 msgid "Execute <profile>/pre script"
 msgstr "Kör inte pre-skript"
 
-#: share/completions/duply.fish:13
+#: share/completions/duply.fish:11
 #, fuzzy
 msgid "Execute <profile>/post script"
 msgstr "Kör inte post-skript"
 
-#: share/completions/duply.fish:14
+#: share/completions/duply.fish:12
 msgid "Force full backup"
 msgstr ""
 
-#: share/completions/duply.fish:15
+#: share/completions/duply.fish:13
 msgid "Force incremental backup"
 msgstr ""
 
-#: share/completions/duply.fish:16
+#: share/completions/duply.fish:14
 msgid "List all files in backup (as it was at <age>, default: now)"
 msgstr ""
 
-#: share/completions/duply.fish:17
+#: share/completions/duply.fish:15
 msgid "Prints backup sets and chains currently in repository"
 msgstr ""
 
-#: share/completions/duply.fish:18
+#: share/completions/duply.fish:16
 msgid "List files changed since latest backup"
 msgstr ""
 
-#: share/completions/duply.fish:19
+#: share/completions/duply.fish:17
 msgid "Shows outdated backup archives [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:20
+#: share/completions/duply.fish:18
 msgid "Shows outdated backups [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:21
+#: share/completions/duply.fish:19
 msgid "Shows broken backup archives [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:22
+#: share/completions/duply.fish:20
 msgid "Restore the backup to <target_path> [as it was at <age>]"
 msgstr ""
 
-#: share/completions/duply.fish:23
+#: share/completions/duply.fish:21
 msgid "Restore single file/folder from backup [as it was at <age>]"
 msgstr ""
 
-#: share/completions/duply.fish:26
+#: share/completions/duply.fish:24
 msgid "Really execute the commands: purge, purge-full, cleanup"
 msgstr ""
 
-#: share/completions/duply.fish:27
+#: share/completions/duply.fish:25
 msgid "Do nothing but print out generated duplicity command lines"
 msgstr ""
 
-#: share/completions/duply.fish:28
+#: share/completions/duply.fish:26
 msgid "Calculate what would be done, but dont perform any actions"
 msgstr ""
 
-#: share/completions/duply.fish:29
+#: share/completions/duply.fish:27
 msgid "Dont abort when backup different dirs to the same backend"
 msgstr ""
 
-#: share/completions/duply.fish:30
+#: share/completions/duply.fish:28
 #, fuzzy
 msgid "Output verbosity level"
 msgstr "Återställ felrapporteringsnivå till 0"
@@ -4038,14 +4093,14 @@ msgid ""
 msgstr ""
 "Visa kompletteringar för installerade packet på systemet från /var/db/pkg"
 
-#: share/completions/emerge.fish:12 share/completions/equery.fish:12
+#: share/completions/emerge.fish:13 share/completions/equery.fish:12
 msgid ""
 "Prints completions for all available packages on the system from /usr/portage"
 msgstr ""
 "Visa kompletteringar för alla tillgängliga packet på systemet från /usr/"
 "portage"
 
-#: share/completions/emerge.fish:19
+#: share/completions/emerge.fish:22
 msgid ""
 "Tests if emerge command should have an installed package as potential "
 "completion"
@@ -4053,56 +4108,13 @@ msgstr ""
 "Testa om emergekommando borde ha ett installerat paket som potentiell "
 "komplettering"
 
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-msgid "All base system packages"
-msgstr "Alla bassystempaket"
-
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-msgid "All packages in world"
-msgstr "Alla paket i världen"
-
-#: share/completions/emerge.fish:30
-msgid "Installed package"
-msgstr "Installerade paket"
-
-#: share/completions/emerge.fish:31
-#: share/functions/__fish_print_packages.fish:13
-msgid "Package"
-msgstr "Paket"
-
-#: share/completions/emerge.fish:35
-msgid "Usage overview of emerge"
-msgstr "Användningsöversikt av emerge"
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject system"
-msgstr "Hjälp för ämnet system"
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject config"
-msgstr "Hjäl för ämnet konfiguration"
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject sync"
-msgstr "Hjälp för ämnet sync"
-
-#: share/completions/emerge.fish:57
-msgid "Use colors in output"
-msgstr "Använd färger"
-
-#: share/completions/emerge.fish:57
-msgid "Don't use colors in output"
-msgstr "Använd inte färger"
-
-#: share/completions/emerge.fish:81
+#: share/completions/emerge.fish:32
 #, fuzzy
-msgid "Pull in build time dependencies"
-msgstr "Visa byggberoenden"
-
-#: share/completions/emerge.fish:81
-#, fuzzy
-msgid "Don't pull in build time dependencies"
-msgstr "Fråga efter extra beroenden"
+msgid ""
+"Print completions for all packages including the version compare if that is "
+"already typed"
+msgstr ""
+"Visa kompletteringar för installerade packet på systemet från /var/db/pkg"
 
 #: share/completions/env.fish:2
 msgid "Redefine variable"
@@ -4636,11 +4648,16 @@ msgstr ""
 msgid "Update the RubyGems system software"
 msgstr ""
 
-#: share/completions/git.fish:121 share/completions/git.fish:144
+#: share/completions/git.fish:98
+#, fuzzy
+msgid "name"
+msgstr "Användarnamn"
+
+#: share/completions/git.fish:153 share/completions/git.fish:176
 msgid "Branch"
 msgstr ""
 
-#: share/completions/git.fish:145
+#: share/completions/git.fish:177
 #, fuzzy
 msgid "Tag"
 msgstr "Mål"
@@ -4885,607 +4902,6 @@ msgstr "Hjälp om kommandosubstitution (UNDERKOMMANDO)"
 msgid "Help on process expansion %JOB"
 msgstr "Hjälp om processexpansion %JOB"
 
-#: share/completions/hg.fish:17
-#, fuzzy
-msgid "add the specified files on the next commit"
-msgstr "Lägg till angiven fil fill den nuvarande listan av nyckelringar"
-
-#: share/completions/hg.fish:18
-msgid "add all new files, delete all missing files"
-msgstr ""
-
-#: share/completions/hg.fish:19
-#, fuzzy
-msgid "show changeset information by line for each file"
-msgstr "Visa ändringsinformation för paket"
-
-#: share/completions/hg.fish:20
-#, fuzzy
-msgid "create an unversioned archive of a repository revision"
-msgstr "Lägg till fil eller träd utan version till förrådet"
-
-#: share/completions/hg.fish:21
-msgid "reverse effect of earlier changeset"
-msgstr ""
-
-#: share/completions/hg.fish:22
-msgid "subdivision search of changesets"
-msgstr ""
-
-#: share/completions/hg.fish:23
-msgid "track a line of development with movable markers"
-msgstr ""
-
-#: share/completions/hg.fish:24
-msgid "set or show the current branch name"
-msgstr ""
-
-#: share/completions/hg.fish:25
-#, fuzzy
-msgid "list repository named branches"
-msgstr "Inaktivera förråd"
-
-#: share/completions/hg.fish:26
-#, fuzzy
-msgid "create a changegroup file"
-msgstr "Skapa en kontrollpunktfil"
-
-#: share/completions/hg.fish:27
-#, fuzzy
-msgid "output the current or given revision of files"
-msgstr "Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
-
-#: share/completions/hg.fish:28
-#, fuzzy
-msgid "make a copy of an existing repository"
-msgstr "Skapa lokal kopia av förråd"
-
-#: share/completions/hg.fish:29
-#, fuzzy
-msgid "commit the specified files or all outstanding changes"
-msgstr "Dekryptera angiven fil eller standard in"
-
-#: share/completions/hg.fish:30
-msgid "mark files as copied for the next commit"
-msgstr ""
-
-#: share/completions/hg.fish:31
-#, fuzzy
-msgid "diff repository (or selected files)"
-msgstr "Radera urval"
-
-#: share/completions/hg.fish:32
-msgid "dump the header and diffs for one or more changesets"
-msgstr ""
-
-#: share/completions/hg.fish:33
-#, fuzzy
-msgid "forget the specified files on the next commit"
-msgstr "Flytta filen angiven på kommandoraden"
-
-#: share/completions/hg.fish:34
-#, fuzzy
-msgid "copy changes from other branches onto the current branch"
-msgstr "Hämta ändringar från förrådet till arbetskopian"
-
-#: share/completions/hg.fish:35
-msgid "search for a pattern in specified files and revisions"
-msgstr ""
-
-#: share/completions/hg.fish:36
-msgid "show current repository heads or show branch heads"
-msgstr ""
-
-#: share/completions/hg.fish:37
-msgid "show help for a given topic or a help overview"
-msgstr ""
-
-#: share/completions/hg.fish:38
-#, fuzzy
-msgid "identify the working copy or specified revision"
-msgstr "Uppdatera arbetskopian till en annan URL"
-
-#: share/completions/hg.fish:39
-#, fuzzy
-msgid "import an ordered set of patches"
-msgstr "Visa byteavstånd för matchningar"
-
-#: share/completions/hg.fish:40
-msgid "show new changesets found in source"
-msgstr ""
-
-#: share/completions/hg.fish:41
-#, fuzzy
-msgid "create a new repository in the given directory"
-msgstr "Skapa förråd om det inte redan existerar"
-
-#: share/completions/hg.fish:42
-#, fuzzy
-msgid "locate files matching specific patterns"
-msgstr "Visa inte filer som matchar mönster"
-
-#: share/completions/hg.fish:43
-msgid "show revision history of entire repository or files"
-msgstr ""
-
-#: share/completions/hg.fish:44
-#, fuzzy
-msgid "output the current or given revision of the project manifest"
-msgstr "Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
-
-#: share/completions/hg.fish:45
-msgid "merge working directory with another revision"
-msgstr ""
-
-#: share/completions/hg.fish:46
-#, fuzzy
-msgid "show changesets not found in the destination"
-msgstr "Fråga paket med angiven grupp"
-
-#: share/completions/hg.fish:47
-#, fuzzy
-msgid "show the parents of the working directory or revision"
-msgstr "Ändra arbetskatalog"
-
-#: share/completions/hg.fish:48
-#, fuzzy
-msgid "show aliases for remote repositories"
-msgstr "Ta bort inlägg i .cvspass för fjärrförråd"
-
-#: share/completions/hg.fish:49
-msgid "set or show the current phase name"
-msgstr ""
-
-#: share/completions/hg.fish:50
-#, fuzzy
-msgid "pull changes from the specified source"
-msgstr "Fråga paket med angiven grupp"
-
-#: share/completions/hg.fish:51
-#, fuzzy
-msgid "push changes to the specified destination"
-msgstr "Fråga paket med angiven grupp"
-
-#: share/completions/hg.fish:52
-msgid "roll back an interrupted transaction"
-msgstr ""
-
-#: share/completions/hg.fish:53
-#, fuzzy
-msgid "remove the specified files on the next commit"
-msgstr "Flytta filen angiven på kommandoraden"
-
-#: share/completions/hg.fish:54
-msgid "rename files; equivalent of copy + remove"
-msgstr ""
-
-#: share/completions/hg.fish:55
-msgid "redo merges or set/view the merge status of files"
-msgstr ""
-
-#: share/completions/hg.fish:56
-msgid "restore files to their checkout state"
-msgstr ""
-
-#: share/completions/hg.fish:57
-#, fuzzy
-msgid "roll back the last transaction (dangerous)"
-msgstr "Ordna om fixarna i förrådet"
-
-#: share/completions/hg.fish:58
-#, fuzzy
-msgid "print the root (top) of the current working directory"
-msgstr "Ändra arbetskatalog"
-
-#: share/completions/hg.fish:59
-msgid "start stand-alone webserver"
-msgstr ""
-
-#: share/completions/hg.fish:60
-msgid "show combined config settings from all hgrc files"
-msgstr ""
-
-#: share/completions/hg.fish:61
-#, fuzzy
-msgid "show changed files in the working directory"
-msgstr "Ändra arbetskatalog"
-
-#: share/completions/hg.fish:62
-#, fuzzy
-msgid "summarize working directory state"
-msgstr "Visa nuvarande katalog"
-
-#: share/completions/hg.fish:63
-msgid "add one or more tags for the current or given revision"
-msgstr ""
-
-#: share/completions/hg.fish:64
-#, fuzzy
-msgid "list repository tags"
-msgstr "Inaktivera förråd"
-
-#: share/completions/hg.fish:65
-#, fuzzy
-msgid "show the tip revision"
-msgstr "Visa tid"
-
-#: share/completions/hg.fish:66
-#, fuzzy
-msgid "apply one or more changegroup files"
-msgstr "Läs paket från fil"
-
-#: share/completions/hg.fish:67
-#, fuzzy
-msgid "update working directory (or switch revisions)"
-msgstr "Ändra arbetskatalog"
-
-#: share/completions/hg.fish:68
-#, fuzzy
-msgid "verify the integrity of the repository"
-msgstr "Ta bort ett inlägg från förråd"
-
-#: share/completions/hg.fish:69
-#, fuzzy
-msgid "output version and copyright information"
-msgstr "Ignorera versionsmagiinformation"
-
-#: share/completions/hg.fish:70
-#, fuzzy
-msgid "Configuration Files"
-msgstr "Konfigureringsfil"
-
-#: share/completions/hg.fish:71
-#, fuzzy
-msgid "Date Formats"
-msgstr "Välj format"
-
-#: share/completions/hg.fish:72
-#, fuzzy
-msgid "Diff Formats"
-msgstr "Listformat"
-
-#: share/completions/hg.fish:73
-#, fuzzy
-msgid "Environment Variables"
-msgstr "Redigera miljövariabler"
-
-#: share/completions/hg.fish:74
-msgid "Using Additional Features"
-msgstr ""
-
-#: share/completions/hg.fish:75
-#, fuzzy
-msgid "Specifying File Sets"
-msgstr "Välj konfigurationsfil"
-
-#: share/completions/hg.fish:76
-msgid "Glossary"
-msgstr ""
-
-#: share/completions/hg.fish:77
-msgid "Syntax for Mercurial Ignore Files"
-msgstr ""
-
-#: share/completions/hg.fish:78
-#, fuzzy
-msgid "Configuring hgweb"
-msgstr "Konfigureringsfil"
-
-#: share/completions/hg.fish:79
-#, fuzzy
-msgid "Merge Tools"
-msgstr "Sammanslå sorterade filer"
-
-#: share/completions/hg.fish:80
-#, fuzzy
-msgid "Specifying Multiple Revisions"
-msgstr "Ange revision"
-
-#: share/completions/hg.fish:81
-#, fuzzy
-msgid "File Name Patterns"
-msgstr "Visa inte filer som matchar mönster"
-
-#: share/completions/hg.fish:82
-msgid "Working with Phases"
-msgstr ""
-
-#: share/completions/hg.fish:83
-#, fuzzy
-msgid "Specifying Single Revisions"
-msgstr "Ange revision"
-
-#: share/completions/hg.fish:84
-#, fuzzy
-msgid "Specifying Revision Sets"
-msgstr "Ange revisionstiollstånd"
-
-#: share/completions/hg.fish:85
-#, fuzzy
-msgid "Subrepositories"
-msgstr "Aktivera förråd"
-
-#: share/completions/hg.fish:86
-msgid "Template Usage"
-msgstr ""
-
-#: share/completions/hg.fish:87
-msgid "URL Paths"
-msgstr ""
-
-#: share/completions/hg.fish:94 share/completions/hg.fish:433
-#: share/completions/hg.fish:458 share/completions/hg.fish:569
-#: share/completions/hg.fish:579 share/completions/hg.fish:594
-#: share/completions/hg.fish:606 share/completions/hg.fish:671
-#, fuzzy
-msgid "[+] include names matching the given patterns"
-msgstr "Visa inte filer som matchar mönster"
-
-#: share/completions/hg.fish:95 share/completions/hg.fish:434
-#: share/completions/hg.fish:459 share/completions/hg.fish:570
-#: share/completions/hg.fish:580 share/completions/hg.fish:595
-#: share/completions/hg.fish:607 share/completions/hg.fish:672
-#, fuzzy
-msgid "[+] exclude names matching the given patterns"
-msgstr "Lista alla moduler som matchar parameter med jokertecken"
-
-#: share/completions/hg.fish:104 share/completions/hg.fish:391
-msgid "Guess renamed files by similarity (0<=s<=100)"
-msgstr ""
-
-#: share/completions/hg.fish:105
-#, fuzzy
-msgid "[+]   include names matching the given patterns"
-msgstr "Visa inte filer som matchar mönster"
-
-#: share/completions/hg.fish:106
-#, fuzzy
-msgid "[+]   exclude names matching the given patterns"
-msgstr "Lista alla moduler som matchar parameter med jokertecken"
-
-#: share/completions/hg.fish:114
-#, fuzzy
-msgid "Annotate the specified revision"
-msgstr "Hjälp för det angivna inbyggda kommandot"
-
-#: share/completions/hg.fish:387
-#, fuzzy
-msgid "Use text as commit message"
-msgstr "Läs meddelande för tillägg från fil"
-
-#: share/completions/hg.fish:388
-msgid "Read commit message from file"
-msgstr "Läs meddelande för tillägg från fil"
-
-#: share/completions/hg.fish:389 share/completions/hg.fish:693
-#, fuzzy
-msgid "Record the specified date as commit date"
-msgstr "Hjälp för det angivna kommandot"
-
-#: share/completions/hg.fish:390 share/completions/hg.fish:694
-#, fuzzy
-msgid "Record the specified user as committer"
-msgstr "Använd angiven sträng som kommentarsträng"
-
-#: share/completions/hg.fish:400
-#, fuzzy
-msgid "File to store the bundles into"
-msgstr "Redigera fix-paketbeskrivning"
-
-#: share/completions/hg.fish:401 share/completions/hg.fish:446
-#: share/completions/hg.fish:448 share/completions/hg.fish:450
-#: share/completions/hg.fish:485 share/completions/hg.fish:534
-#: share/completions/hg.fish:536 share/completions/hg.fish:548
-#: share/completions/hg.fish:550 share/completions/hg.fish:669
-msgid "[+]"
-msgstr ""
-
-#: share/completions/hg.fish:403
-msgid "[+] a specific branch you would like to pull"
-msgstr ""
-
-#: share/completions/hg.fish:406 share/completions/hg.fish:453
-#: share/completions/hg.fish:491
-#, fuzzy
-msgid "Limit number of changes displayed"
-msgstr "Skriv bara ut angivet antal matchningar"
-
-#: share/completions/hg.fish:409 share/completions/hg.fish:456
-#: share/completions/hg.fish:494 share/completions/hg.fish:507
-#: share/completions/hg.fish:709
-msgid "Display using template map file"
-msgstr ""
-
-#: share/completions/hg.fish:410 share/completions/hg.fish:457
-#: share/completions/hg.fish:495 share/completions/hg.fish:508
-#: share/completions/hg.fish:710
-#, fuzzy
-msgid "Display with template"
-msgstr "Visa alla matchningar"
-
-#: share/completions/hg.fish:411 share/completions/hg.fish:421
-#: share/completions/hg.fish:496 share/completions/hg.fish:537
-#: share/completions/hg.fish:552
-#, fuzzy
-msgid "Specify ssh command to use"
-msgstr "Ange kommando att operera på"
-
-#: share/completions/hg.fish:412 share/completions/hg.fish:422
-#: share/completions/hg.fish:497 share/completions/hg.fish:538
-#: share/completions/hg.fish:553
-#, fuzzy
-msgid "Specify hg command to run on the remote side"
-msgstr "Välj destinationsadress"
-
-#: share/completions/hg.fish:430
-#, fuzzy
-msgid "Search the repository as it is in REV"
-msgstr "Ange förråd-URL"
-
-#: share/completions/hg.fish:441
-msgid "A filename will only show ancestors or"
-msgstr ""
-
-#: share/completions/hg.fish:443
-#, fuzzy
-msgid "Show revisions matching date spec"
-msgstr "Visa bara matchande del"
-
-#: share/completions/hg.fish:445
-msgid "[+]    do case-insensitive search for a given text"
-msgstr ""
-
-#: share/completions/hg.fish:449
-msgid "[+]   show changesets within the given named branch"
-msgstr ""
-
-#: share/completions/hg.fish:466
-#, fuzzy
-msgid "Revision to display"
-msgstr "Välj display"
-
-#: share/completions/hg.fish:475
-msgid "Revision to merge"
-msgstr ""
-
-#: share/completions/hg.fish:477 share/completions/hg.fish:593
-#, fuzzy
-msgid "Specify merge tool"
-msgstr "Ange förtroendemodell"
-
-#: share/completions/hg.fish:488
-msgid "[+] a specific branch you would like to push"
-msgstr ""
-
-#: share/completions/hg.fish:506
-#, fuzzy
-msgid "Show parents of the specified revision"
-msgstr "Fråga paket med angiven grupp"
-
-#: share/completions/hg.fish:525
-#, fuzzy
-msgid "[+] target revision"
-msgstr "Slå ihop revisioner"
-
-#: share/completions/hg.fish:535
-msgid "[+] bookmark to pull"
-msgstr ""
-
-#: share/completions/hg.fish:546
-msgid "You want to allow push to create a new named branch"
-msgstr ""
-
-#: share/completions/hg.fish:549
-msgid "[+] bookmark to push"
-msgstr ""
-
-#: share/completions/hg.fish:603 share/completions/hg.fish:726
-#, fuzzy
-msgid "Tipmost revision matching date"
-msgstr "Visa inte filer som matchar mönster"
-
-#: share/completions/hg.fish:604
-#, fuzzy
-msgid "Revert to the specified revision"
-msgstr "Flytta filen angiven på kommandoraden"
-
-#: share/completions/hg.fish:615
-msgid "Not perform actions, just print output"
-msgstr ""
-
-#: share/completions/hg.fish:629
-msgid "Name of access log file to write to"
-msgstr ""
-
-#: share/completions/hg.fish:631
-msgid "Used internally by daemon mode"
-msgstr ""
-
-#: share/completions/hg.fish:632
-msgid "Name of error log file to write to"
-msgstr ""
-
-#: share/completions/hg.fish:633
-msgid "Port to listen on (default: 8000)"
-msgstr ""
-
-#: share/completions/hg.fish:634
-msgid "Address to listen on (default: all interfaces)"
-msgstr ""
-
-#: share/completions/hg.fish:635
-msgid "Prefix path to serve from (default: server root)"
-msgstr ""
-
-#: share/completions/hg.fish:636
-msgid "Name to show in web pages (default: working"
-msgstr ""
-
-#: share/completions/hg.fish:637
-msgid "Name of the hgweb config file (see \"hg help hgweb\")"
-msgstr ""
-
-#: share/completions/hg.fish:638
-msgid "Name of file to write process ID to"
-msgstr ""
-
-#: share/completions/hg.fish:640
-#, fuzzy
-msgid "For remote clients"
-msgstr "Visa eller ta bort funktioner"
-
-#: share/completions/hg.fish:641
-msgid "Web templates to use"
-msgstr ""
-
-#: share/completions/hg.fish:642
-msgid "Template style to use"
-msgstr ""
-
-#: share/completions/hg.fish:644
-#, fuzzy
-msgid "SSL certificate file"
-msgstr "Välj certifikatpolicy"
-
-#: share/completions/hg.fish:651
-#, fuzzy
-msgid "Untrusted configuration options"
-msgstr "Välj konfigurationsinställningar"
-
-#: share/completions/hg.fish:670
-#, fuzzy
-msgid "List the changed files of a revision"
-msgstr "Visa alla engenskaper hos filer, kataloger eller revisioner"
-
-#: share/completions/hg.fish:680
-msgid "For push and pull"
-msgstr ""
-
-#: share/completions/hg.fish:689
-msgid "Revision to tag"
-msgstr ""
-
-#: share/completions/hg.fish:692
-msgid "Use <text> as commit message"
-msgstr ""
-
-#: share/completions/hg.fish:717
-msgid "To new branch head if changesets were unbundled"
-msgstr ""
-
-#: share/completions/hg.fish:727
-#, fuzzy
-msgid "Revision"
-msgstr "Slå ihop revisioner"
-
-#: share/completions/hg.fish:844
-msgid "Or select an existing template-style (--style)"
-msgstr ""
-
-#: share/completions/hg.fish:845
-msgid "Is set"
-msgstr ""
-
 #: share/completions/history.fish:1
 msgid "Match history items that start with the given prefix"
 msgstr ""
@@ -5506,6 +4922,11 @@ msgstr "Starta gränssnitt"
 #: share/completions/ifup.fish:1
 msgid "Network interface"
 msgstr "Nätverkgränssnitt"
+
+#: share/completions/kitchen.fish:3
+#, fuzzy
+msgid "Test if kitchen has yet to be given the main command"
+msgstr "Testa om apt har tagit emot ett underkommando"
 
 #: share/completions/less.fish:3
 msgid "Buffer space"
@@ -5724,6 +5145,457 @@ msgstr "Ange meddelande för tillägg"
 #: share/completions/mv.fish:4
 msgid "Answer for overwrite questions"
 msgstr "Svar till överskrivningsfrågor"
+
+#: share/completions/node.fish:9
+#, fuzzy
+msgid "Print node's version"
+msgstr "Visa kärnversion"
+
+#: share/completions/node.fish:10
+#, fuzzy
+msgid "Evaluate script"
+msgstr "Extrahera skript"
+
+#: share/completions/node.fish:11
+#, fuzzy
+msgid "Print result of --eval"
+msgstr "Visa platt profil"
+
+#: share/completions/obnam.fish:9
+#, fuzzy
+msgid "Adds an encryption key to the repository"
+msgstr "Lägg till fil/katalog till förråd"
+
+#: share/completions/obnam.fish:11
+msgid "Lists the keys associated with each client"
+msgstr ""
+
+#: share/completions/obnam.fish:12
+#, fuzzy
+msgid "Lists the clients in the repository"
+msgstr "Uppdatera förråd"
+
+#: share/completions/obnam.fish:13
+#, fuzzy
+msgid "Compares two generations"
+msgstr "Tolerera slarviga monteringsflaggor"
+
+#: share/completions/obnam.fish:14
+#, fuzzy
+msgid "Dumps the repository"
+msgstr "Uppdatera förråd"
+
+#: share/completions/obnam.fish:15
+#, fuzzy
+msgid "Removes a lock file for a client"
+msgstr "Ta bort alla gz-filer från cache"
+
+#: share/completions/obnam.fish:16
+#, fuzzy
+msgid "Removes backup generations"
+msgstr "Ta bort komplettering"
+
+#: share/completions/obnam.fish:17
+#, fuzzy
+msgid "Checks the consistency of the repository"
+msgstr "Kontrollera hela lagret"
+
+#: share/completions/obnam.fish:18
+msgid "Lists every backup generation"
+msgstr ""
+
+#: share/completions/obnam.fish:19
+msgid "Lists the identifier for every generation"
+msgstr ""
+
+#: share/completions/obnam.fish:20
+#, fuzzy
+msgid "Lists the keys"
+msgstr "Visa pålitliga nycklar"
+
+#: share/completions/obnam.fish:21
+#, fuzzy
+msgid "Lists the toplevel keys"
+msgstr "Visa pålitliga nycklar"
+
+#: share/completions/obnam.fish:22
+#, fuzzy
+msgid "Lists the contents of a given generation"
+msgstr "Visa kataloginnehåll"
+
+#: share/completions/obnam.fish:23
+#, fuzzy
+msgid "Makes the repository available via FUSE"
+msgstr "Uppdatera förråd"
+
+#: share/completions/obnam.fish:24
+msgid "Check if a backup age exceeds a threshold"
+msgstr ""
+
+#: share/completions/obnam.fish:25
+#, fuzzy
+msgid "Removes a client from the repository"
+msgstr "Ange förråd-URL"
+
+#: share/completions/obnam.fish:26
+#, fuzzy
+msgid "Removes a key from the repository"
+msgstr "Skapa lokal kopia av förråd"
+
+#: share/completions/obnam.fish:27
+#, fuzzy
+msgid "Restore files from the repository"
+msgstr "Checka in filer till förråd"
+
+#: share/completions/obnam.fish:28
+#, fuzzy
+msgid "Verifies files in the repository"
+msgstr "Checka in filer till förråd"
+
+#: share/completions/obnam.fish:30
+msgid "Restore setuid/setgid bits in restored files"
+msgstr ""
+
+#: share/completions/obnam.fish:31
+msgid "Do not restore setuid/setgid bits in restored files"
+msgstr ""
+
+#: share/completions/obnam.fish:32
+#, fuzzy
+msgid "Name of client"
+msgstr "NAmn på version at använda som kontrollpunkt"
+
+#: share/completions/obnam.fish:33
+#, fuzzy
+msgid "Compress repository with"
+msgstr "Komprimera till standard ut"
+
+#: share/completions/obnam.fish:34
+msgid "For --nagios-last-backup-age: maximum age"
+msgstr ""
+
+#: share/completions/obnam.fish:35
+msgid "Dump metadata about files"
+msgstr ""
+
+#: share/completions/obnam.fish:36
+#, fuzzy
+msgid "Do not dump metadata about files"
+msgstr "Radera inte byggda filer"
+
+#: share/completions/obnam.fish:37
+#, fuzzy
+msgid "Generate man page"
+msgstr "Generera ett nytt nyckelpar"
+
+#: share/completions/obnam.fish:38
+msgid "Which generation to restore"
+msgstr ""
+
+#: share/completions/obnam.fish:39
+#, fuzzy
+msgid "Show this help message and exit"
+msgstr "Visa version och avsluta"
+
+#: share/completions/obnam.fish:40
+msgid "Policy for what generations to keep when forgetting."
+msgstr ""
+
+#: share/completions/obnam.fish:41
+msgid "Wait TIMEOUT seconds for an existing lock"
+msgstr ""
+
+#: share/completions/obnam.fish:43
+#, fuzzy
+msgid "Do not actually change anything"
+msgstr "Skriv ingenting"
+
+#: share/completions/obnam.fish:44
+#, fuzzy
+msgid "Actually commit changes"
+msgstr "Summera ändringar"
+
+#: share/completions/obnam.fish:45
+msgid "Show only errors, no progress updates"
+msgstr ""
+
+#: share/completions/obnam.fish:46
+msgid "Show errors and progress updates"
+msgstr ""
+
+#: share/completions/obnam.fish:49
+#, fuzzy
+msgid "Simulate failures for files that match REGEXP"
+msgstr "Välj fix som matchar REGEXP"
+
+#: share/completions/obnam.fish:52
+msgid "Be more verbose"
+msgstr ""
+
+#: share/completions/obnam.fish:53
+#, fuzzy
+msgid "Do not be verbose"
+msgstr "Skriv inte över"
+
+#: share/completions/obnam.fish:54
+msgid "Verify N files randomly from the backup"
+msgstr ""
+
+#: share/completions/obnam.fish:55
+#, fuzzy
+msgid "Show version number and exit"
+msgstr "Visa version och avsluta"
+
+#: share/completions/obnam.fish:57
+msgid "Make a checkpoint after a given SIZE"
+msgstr ""
+
+#: share/completions/obnam.fish:58
+#, fuzzy
+msgid "Deduplicate mode"
+msgstr "Läs ock skrivbart läge"
+
+#: share/completions/obnam.fish:60
+#, fuzzy
+msgid "Exclude directories tagged as cache"
+msgstr "Sök i angivna kataloger efter källkod"
+
+#: share/completions/obnam.fish:61
+#, fuzzy
+msgid "Include directories tagged as cache"
+msgstr "Inkluderingskatalog"
+
+#: share/completions/obnam.fish:63
+msgid "Leave checkpoint generations at the end of backup"
+msgstr ""
+
+#: share/completions/obnam.fish:64
+msgid "Omit checkpoint generations at the end of backup"
+msgstr ""
+
+#: share/completions/obnam.fish:65
+#, fuzzy
+msgid "Do not follow mount points"
+msgstr "Radbryt inte långa rader"
+
+#: share/completions/obnam.fish:66
+#, fuzzy
+msgid "Follow mount points"
+msgstr "Monteringskatalog"
+
+#: share/completions/obnam.fish:67
+msgid "Put small files directly into the B-tree"
+msgstr ""
+
+#: share/completions/obnam.fish:68
+msgid "No not put small files into the B-tree"
+msgstr ""
+
+#: share/completions/obnam.fish:70
+#, fuzzy
+msgid "Write out the current configuration"
+msgstr "Ladda om konfiguration för tjänst"
+
+#: share/completions/obnam.fish:71
+#, fuzzy
+msgid "Write out setting names"
+msgstr "Skriv prompten"
+
+#: share/completions/obnam.fish:72
+#, fuzzy
+msgid "Show all options"
+msgstr "Visa hjälp om flaggor"
+
+#: share/completions/obnam.fish:73
+#, fuzzy
+msgid "List config files"
+msgstr "Välj konfigurationsfil"
+
+#: share/completions/obnam.fish:74
+#, fuzzy
+msgid "Clear list of configuration files to read"
+msgstr "Visa rpmkonfigurationsfiler"
+
+#: share/completions/obnam.fish:75
+msgid "PGP key with which to encrypt"
+msgstr ""
+
+#: share/completions/obnam.fish:76
+#, fuzzy
+msgid "Show additional user IDs"
+msgstr "Visa historik för alla användare"
+
+#: share/completions/obnam.fish:77
+#, fuzzy
+msgid "Do not show additional user IDs"
+msgstr "Lagra inte katalognamn"
+
+#: share/completions/obnam.fish:78
+msgid "PGP key id"
+msgstr ""
+
+#: share/completions/obnam.fish:79
+msgid "Size of symmetric key"
+msgstr ""
+
+#: share/completions/obnam.fish:80
+#, fuzzy
+msgid "Use /dev/urandom instead of /dev/random"
+msgstr "Använd rensning istället för radering"
+
+#: share/completions/obnam.fish:81
+msgid "Use default /dev/random"
+msgstr ""
+
+#: share/completions/obnam.fish:83
+msgid "fsck should try to fix problems"
+msgstr ""
+
+#: share/completions/obnam.fish:84
+msgid "fsck should not try to fix problems"
+msgstr ""
+
+#: share/completions/obnam.fish:85
+#, fuzzy
+msgid "Ignore chunks when checking integrity"
+msgstr "Ignorera skiftläge på filnamn"
+
+#: share/completions/obnam.fish:86
+msgid "Check chunks when checking integrity"
+msgstr ""
+
+#: share/completions/obnam.fish:87
+msgid "Do not check data for cient NAME."
+msgstr ""
+
+#: share/completions/obnam.fish:88
+#, fuzzy
+msgid "Check only the last generation"
+msgstr "Återupta senaste installationsoperation"
+
+#: share/completions/obnam.fish:89 share/completions/obnam.fish:95
+#, fuzzy
+msgid "Check all generations"
+msgstr "Fråga installerat paket"
+
+#: share/completions/obnam.fish:90
+#, fuzzy
+msgid "Do not check directories"
+msgstr "Lagra inte katalognamn"
+
+#: share/completions/obnam.fish:91
+#, fuzzy
+msgid "Check directories"
+msgstr "Rekursera till underkataloger"
+
+#: share/completions/obnam.fish:92
+#, fuzzy
+msgid "Do not check files"
+msgstr "Ändra inga filer"
+
+#: share/completions/obnam.fish:93
+#, fuzzy
+msgid "Check files"
+msgstr "Fråga installerat paket"
+
+#: share/completions/obnam.fish:94
+#, fuzzy
+msgid "Do not check any generations"
+msgstr "Ändra inga filer"
+
+#: share/completions/obnam.fish:96
+#, fuzzy
+msgid "Do not check per-client B-trees"
+msgstr "Skriv inte ut taggar"
+
+#: share/completions/obnam.fish:97
+msgid "Check per-client B-trees"
+msgstr ""
+
+#: share/completions/obnam.fish:98
+#, fuzzy
+msgid "Do not check shared B-trees"
+msgstr "Ändra inga filer"
+
+#: share/completions/obnam.fish:99
+#, fuzzy
+msgid "Check shared B-trees"
+msgstr "Fråga installerat paket"
+
+#: share/completions/obnam.fish:102
+msgid "Keep last N logs (10)"
+msgstr ""
+
+#: share/completions/obnam.fish:103
+msgid "Log at LEVEL"
+msgstr ""
+
+#: share/completions/obnam.fish:104
+msgid "Rotate logs larger than SIZE"
+msgstr ""
+
+#: share/completions/obnam.fish:105
+msgid "Set permissions of logfiles to MODE"
+msgstr ""
+
+#: share/completions/obnam.fish:106
+msgid "Options to pass to FUSE"
+msgstr ""
+
+#: share/completions/obnam.fish:107
+msgid "Make memory profiling dumps using METHOD"
+msgstr ""
+
+#: share/completions/obnam.fish:108
+msgid "Make memory profiling dumps at SECONDS"
+msgstr ""
+
+#: share/completions/obnam.fish:109
+msgid "Size of chunks of file data"
+msgstr ""
+
+#: share/completions/obnam.fish:110
+msgid "Encode NUM chunk ids per group"
+msgstr ""
+
+#: share/completions/obnam.fish:111
+msgid "Chunk id level size"
+msgstr ""
+
+#: share/completions/obnam.fish:112
+#, fuzzy
+msgid "Depth of chunk id mapping"
+msgstr "Djup i anroppskedjan"
+
+#: share/completions/obnam.fish:113
+msgid "Chunk id mapping lowest bits skip"
+msgstr ""
+
+#: share/completions/obnam.fish:114
+msgid "Size of LRU cache for B-tree nodes"
+msgstr ""
+
+#: share/completions/obnam.fish:115
+#, fuzzy
+msgid "Size of B-tree nodes on disk"
+msgstr "Visa ändringar i omvänd ordning"
+
+#: share/completions/obnam.fish:116
+msgid "Length of upload queue for B-tree nodes"
+msgstr ""
+
+#: share/completions/obnam.fish:117
+msgid "Use only paramiko, no openssh"
+msgstr ""
+
+#: share/completions/obnam.fish:118
+#, fuzzy
+msgid "Use openssh if available"
+msgstr "Bygg index om inte tillgängligt"
+
+#: share/completions/obnam.fish:120
+msgid "ssh host key check"
+msgstr ""
 
 #: share/completions/perl.fish:6
 msgid "Specify record separator"
@@ -6348,15 +6220,15 @@ msgstr "Byt bakgrundsfärg"
 msgid "Locale"
 msgstr "Lokal"
 
-#: share/completions/sort.fish:12
+#: share/completions/sort.fish:16
 msgid "Write to file"
 msgstr "Skriv till fil"
 
-#: share/completions/sort.fish:14
+#: share/completions/sort.fish:18
 msgid "Set memory buffer size"
 msgstr "Välj minnesbuffertstorlek"
 
-#: share/completions/sort.fish:16
+#: share/completions/sort.fish:20
 msgid "Set temporary directory"
 msgstr "Välj katalog för tillfälligt lagringsutrymme"
 
@@ -6618,7 +6490,7 @@ msgstr ""
 msgid "Test if vagrant has yet to be given the main command"
 msgstr "Testa om apt har tagit emot ett underkommando"
 
-#: share/completions/vagrant.fish:34
+#: share/completions/vagrant.fish:23
 #, fuzzy
 msgid "Lists all available Vagrant boxes"
 msgstr "Visa namnen på alla tillgängliga signaler"
@@ -7870,6 +7742,11 @@ msgstr "Visa varje file MAC-etikett"
 msgid "Include the file flags in a long (-l) output"
 msgstr "Visa filflaggor vid långt (-l) formay"
 
+#: share/functions/__fish_complete_path.fish:1
+#, fuzzy
+msgid "Complete using path"
+msgstr "Tolerera slarviga monteringsflaggor"
+
 #: share/functions/__fish_complete_ppp_peer.fish:1
 msgid "Complete isp name for pon/poff"
 msgstr ""
@@ -8469,68 +8346,52 @@ msgstr ""
 msgid "Complete md5sum sha1 etc"
 msgstr ""
 
-#: share/functions/__fish_config_interactive.fish:65
-#, sh-format
-msgid ""
-"\\nWARNING\\n\\nThe location for fish configuration files has changed to %s."
-"\\nYour old files have been moved to this location.\\nYou can change to a "
-"different location by changing the value of the variable $XDG_CONFIG_HOME.\\n"
-"\\n"
-msgstr ""
-"\\nVARNING\\n\\nLagringsplatsen för fish-konfigureringsfiler har ändrats "
-"till %s. Dina gamla filer har flyttats till denna plats.\\nDu kan ändra "
-"denna plats genom att byta värde på variabeln $XDG_CONFIG_HOME.\\n\\n"
-
 #
-#: share/functions/__fish_config_interactive.fish:82
+#: share/functions/__fish_config_interactive.fish:34
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Välkommen till fish, det vänliga interaktiva skalet"
 
 #
-#: share/functions/__fish_config_interactive.fish:83
+#: share/functions/__fish_config_interactive.fish:35
 msgid "Type %shelp%s for instructions on how to use fish"
 msgstr "Skriv %shelp%s för instruktioner om hur man använder fish"
 
-#: share/functions/__fish_config_interactive.fish:173
+#: share/functions/__fish_config_interactive.fish:130
 msgid "Event handler, repaints the prompt when fish_color_cwd changes"
 msgstr "Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
-#: share/functions/__fish_config_interactive.fish:180
+#: share/functions/__fish_config_interactive.fish:137
 #, fuzzy
 msgid "Event handler, repaints the prompt when fish_color_cwd_root changes"
 msgstr "Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
-#: share/functions/__fish_config_interactive.fish:192
+#: share/functions/__fish_config_interactive.fish:149
 msgid "Start service"
 msgstr "Starta tjänst"
 
-#: share/functions/__fish_config_interactive.fish:193
+#: share/functions/__fish_config_interactive.fish:150
 msgid "Stop service"
 msgstr "Stanna tjänst"
 
-#: share/functions/__fish_config_interactive.fish:194
+#: share/functions/__fish_config_interactive.fish:151
 msgid "Print service status"
 msgstr "Visa status för tjänst"
 
-#: share/functions/__fish_config_interactive.fish:195
+#: share/functions/__fish_config_interactive.fish:152
 msgid "Stop and then start service"
 msgstr "Stanna och starta tjänst"
 
-#: share/functions/__fish_config_interactive.fish:196
+#: share/functions/__fish_config_interactive.fish:153
 msgid "Reload service configuration"
 msgstr "Ladda om konfiguration för tjänst"
 
-#: share/functions/__fish_config_interactive.fish:228
+#: share/functions/__fish_config_interactive.fish:193
 #, sh-format
 msgid "Notify VTE of change to $PWD"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:173
 msgid "Helper function for __fish_git_prompt"
-msgstr ""
-
-#: share/functions/__fish_git_prompt.fish:244
-msgid "svn_upstream"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:348
@@ -8577,6 +8438,11 @@ msgstr "Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 msgid "Event handler, repaints prompt when any char changes"
 msgstr "Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
+#: share/functions/__fish_hg_prompt.fish:23
+#, fuzzy
+msgid "Write out the hg prompt"
+msgstr "Skriv prompten"
+
 #: share/functions/__fish_is_token_n.fish:1
 msgid "Test if current token is on Nth place"
 msgstr ""
@@ -8614,7 +8480,7 @@ msgstr "Visa en lista på alla tillåtna färgnamn"
 msgid "Prints services installed"
 msgstr "Visa status för tjänst"
 
-#: share/functions/__fish_print_help.fish:2
+#: share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr ""
 "Visa hjälpmeddelande för specificerad fish-funktion eller inbyggt kommando"
@@ -8643,6 +8509,10 @@ msgstr "Visa tillgängliga paket"
 #, fuzzy
 msgid "Print mounted devices"
 msgstr "Visa viktiga beroenden"
+
+#: share/functions/__fish_print_packages.fish:13
+msgid "Package"
+msgstr "Paket"
 
 #: share/functions/__fish_print_svn_rev.fish:1
 #, fuzzy
@@ -8698,6 +8568,44 @@ msgstr "Byt namn på standard in"
 msgid "Write out the git prompt"
 msgstr "Skriv prompten"
 
+#: share/functions/abbr.fish:1
+#, fuzzy
+msgid "Manage abbreviations"
+msgstr "Manualsektion"
+
+#: share/functions/abbr.fish:40
+#, fuzzy
+msgid "%s: invalid option -- %s\\n"
+msgstr "%ls: Ogiltigt flagga -- %lc\n"
+
+#: share/functions/abbr.fish:47
+#, fuzzy
+msgid "%s: %s cannot be specified along with %s\\n"
+msgstr "%ls: Värden kan inte anges vid radering\n"
+
+#: share/functions/abbr.fish:56
+#, fuzzy
+msgid "%s: option requires an argument -- %s\\n"
+msgstr "%ls: Flaggan kräver ett argument -- %lc\n"
+
+#: share/functions/abbr.fish:62
+#, fuzzy
+msgid "%s: Unexpected argument -- %s\\n"
+msgstr "%ls: Förväntade argument\n"
+
+#: share/functions/abbr.fish:75
+msgid "%s: abbreviation must have a non-empty key\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:79
+msgid "%s: abbreviation must have a value\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:101
+#, fuzzy
+msgid "%s: no such abbreviation '%s'\\n"
+msgstr "%s: Okänd funktion ”%s”\\n"
+
 #: share/functions/alias.fish:2
 msgid ""
 "Legacy function for creating shellscript functions using an alias-like syntax"
@@ -8705,10 +8613,19 @@ msgstr ""
 "Bakåtkompatibilitetsfunktion för att skapa skalfunktioner med en alias-"
 "liknande syntax"
 
-#: share/functions/alias.fish:34
+#: share/functions/alias.fish:36
 #, fuzzy
 msgid "%s: Expected one or two arguments, got %d\\n"
 msgstr "%ls: Förväntade ett eller två argument, fick %d"
+
+#: share/functions/alias.fish:42
+#, fuzzy
+msgid "%s: Name cannot be empty\\n"
+msgstr "%ls: Den tomma strängen är inte ett tillåtet variabelnamn\n"
+
+#: share/functions/alias.fish:45
+msgid "%s: Body cannot be empty\\n"
+msgstr ""
 
 #: share/functions/contains_seq.fish:1
 msgid "Return true if array contains a sequence"
@@ -8721,6 +8638,10 @@ msgstr "Visa arbetskatalogshistorik (bakåt och frammåt)"
 #: share/functions/dirs.fish:1
 msgid "Print directory stack"
 msgstr "Visa katalogstack"
+
+#: share/functions/export.fish:1
+msgid "Set global variable. Alias for set -g, made for bash compatibility"
+msgstr ""
 
 #: share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
@@ -8739,6 +8660,20 @@ msgstr "Skriv prompten"
 msgid "Update man-page based completions"
 msgstr "Redigera kommando-specifika kompletteringar"
 
+#: share/functions/fish_vi_key_bindings.fish:1
+#, fuzzy
+msgid "vi-like key bindings for fish"
+msgstr "Välj fil med tangentbordsgenvägar"
+
+#: share/functions/fish_vi_prompt.fish:1
+#, fuzzy
+msgid "Displays the current mode"
+msgstr "Visa säkerhetskontext"
+
+#: share/functions/fish_vi_prompt.fish:17
+msgid "Simple vi prompt"
+msgstr ""
+
 #: share/functions/funced.fish:1
 #, fuzzy
 msgid "Edit function definition"
@@ -8754,6 +8689,19 @@ msgstr "%s: Okänd flagga ”%s”\\n"
 msgid "funced: You must specify one function name\n"
 msgstr "%ls: Förväntade exakt ett funktionsnamn\n"
 
+#: share/functions/funced.fish:96
+msgid "Editing failed or was cancelled"
+msgstr ""
+
+#: share/functions/funced.fish:103
+msgid "Edit the file again\\? [Y/n]"
+msgstr ""
+
+#: share/functions/funced.fish:110
+#, fuzzy
+msgid "Cancelled function editing"
+msgstr "funktionsdefinition-block"
+
 #: share/functions/funcsave.fish:2
 msgid "Save the current definition of all specified functions to file"
 msgstr ""
@@ -8767,7 +8715,7 @@ msgstr "%ls: Förväntade ett funktionsnamn\n"
 msgid "%s: Could not create configuration directory\\n"
 msgstr "%s: Kunde inte skapa konfigurationskatalogen\\n"
 
-#: share/functions/funcsave.fish:37
+#: share/functions/funcsave.fish:36
 msgid "%s: Unknown function '%s'\\n"
 msgstr "%s: Okänd funktion ”%s”\\n"
 
@@ -8815,7 +8763,7 @@ msgstr "Visa kataloginnehåll, inklusive dolda filer i långt format"
 msgid "List contents of directory using long format"
 msgstr "Visa kataloginnehåll i långt format"
 
-#: share/functions/ls.fish:7 share/functions/ls.fish:24
+#: share/functions/ls.fish:7 share/functions/ls.fish:32
 msgid "List contents of directory"
 msgstr "Visa kataloginnehåll"
 
@@ -8862,7 +8810,6 @@ msgstr "Gå bakåt i kataloghistorik"
 msgid "The number of positions to skip must be a non-negative integer\\n"
 msgstr "Antalet positioner att hoppa över måste vara ett positivt heltal"
 
-#: share/functions/prompt_pwd.fish:3 share/functions/prompt_pwd.fish:7
 #: share/functions/prompt_pwd.fish:11
 #, fuzzy
 msgid "Print the current working directory, shortened to fit the prompt"
@@ -8906,34 +8853,34 @@ msgstr ""
 msgid "Print the type of a command"
 msgstr "Visa typ av kommando"
 
-#: share/functions/type.fish:84
+#: share/functions/type.fish:90
 msgid "%s is a function with definition\\n"
 msgstr "%s är en funktion med definitionen\\n"
 
-#: share/functions/type.fish:88
+#: share/functions/type.fish:94
 #, fuzzy
 msgid "function"
 msgstr "funktion\\n"
 
-#: share/functions/type.fish:105
+#: share/functions/type.fish:107
 msgid "%s is a builtin\\n"
 msgstr "%s är ett inbyggt kommando\\n"
 
-#: share/functions/type.fish:108
+#: share/functions/type.fish:110
 #, fuzzy
 msgid "builtin"
 msgstr "inbyggt kommando\\n"
 
-#: share/functions/type.fish:132
+#: share/functions/type.fish:130
 msgid "%s is %s\\n"
 msgstr "%s är %s\\n"
 
-#: share/functions/type.fish:135
+#: share/functions/type.fish:133
 #, fuzzy
 msgid "file"
 msgstr "fil\\n"
 
-#: share/functions/type.fish:147
+#: share/functions/type.fish:144
 msgid "%s: Could not find '%s'\\n"
 msgstr "%s: Kunde inte hitta ”%s”\\n"
 
@@ -8954,21 +8901,457 @@ msgstr "%s: För många argument\\n"
 msgid "Edit variable value"
 msgstr "Redigera variabelvärde"
 
-#: share/functions/vared.fish:41
+#: share/functions/vared.fish:40
+#, fuzzy
 msgid ""
-"%s: %s is an array variable. Use %svared%s %s[n] to edit the n:th element of "
-"%s\\n"
+"%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element "
+"of %s\\n"
 msgstr ""
 "%s: %s är en arrayvariabel. Använd %svared%s %s[n] för att redigera det n:te "
 "elementet av %s\\n"
 
-#: share/functions/vared.fish:45
+#: share/functions/vared.fish:44
 msgid ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
 "VARIABLE\\n"
 msgstr ""
 "%s: Förväntade exakt ett argument, fick %s\\n\\nSynopsis:\\n\\t%svared%s "
 "VARIABEL\\n"
+
+#, fuzzy
+#~ msgid "%ls: Expected zero or two parameters, got %d\n"
+#~ msgstr "%ls: Förväntade noll eller två argument, fick %d"
+
+#~ msgid "Current functions are: "
+#~ msgstr "Nuvarande funktioner är: "
+
+#~ msgid "%ls: Not inside of block\n"
+#~ msgstr "%ls: Inte i ett block\n"
+
+#~ msgid "%ls: Not inside of 'if' block\n"
+#~ msgstr "%ls: Inte i ett ”if” block\n"
+
+#~ msgid "%ls: Expected exactly one argument, got %d\n"
+#~ msgstr "%ls: Förväntade exakt ett argument, fick %d\n"
+
+#~ msgid "%ls: 'case' command while not in switch block\n"
+#~ msgstr "%ls: ”case” kommandot kan bara användas i ett ”switch”-block\n"
+
+#~ msgid "%ls: Unknown error"
+#~ msgstr "%ls: Okänt fel"
+
+#~ msgid "%ls: Can not specify scope when erasing array slice\n"
+#~ msgstr "%ls: Kan inte ange definitionsområde vid radering av arraydel\n"
+
+#~ msgid "Could not get user information"
+#~ msgstr "Kunde inte hitta information om användare"
+
+#~ msgid "Could not convert message '%s' to wide character string"
+#~ msgstr "Kunde inte konvertera meddelandet ”%s” till en bred teckensträng"
+
+#~ msgid "%ls: Argument '%s' is not a valid file descriptor\n"
+#~ msgstr "%ls: Argumentet ”%s” är inte en giltig filidentifierare\n"
+
+#~ msgid "Could not set up output file descriptors for pager"
+#~ msgstr "Kunde inte initiera utdata-filidentifierare för visare"
+
+#~ msgid "Could not set up input file descriptors for pager"
+#~ msgstr "Kunde inte initiera indata-filidentifierare för visare"
+
+#~ msgid "Could not open tty for pager"
+#~ msgstr "Kunde inte öppna tty för visare"
+
+#~ msgid "Could not initialize result pipe"
+#~ msgstr "Kunde inte initiera rör för utskrift av resultat"
+
+#
+#~ msgid "Unspecified file descriptors"
+#~ msgstr "Ospecificerad filidentifierare"
+
+#
+#~ msgid "Could not read completions"
+#~ msgstr "Kunde inte läsa kompletteringar"
+
+#~ msgid "Could not expand string '%ls'"
+#~ msgstr "Kunde inte expandera strängen ”%ls”"
+
+#~ msgid "An additional command is required"
+#~ msgstr "Ett till kommand krävs"
+
+#~ msgid ""
+#~ "Could not locate end of block. The 'end' command is missing, misspelled "
+#~ "or a ';' is missing."
+#~ msgstr ""
+#~ "Kunde inte hitta slutet på kodblock. Kommandot ”end” saknas, är felstavat "
+#~ "eller ett ”;” saknas."
+
+#~ msgid "Expected a command name, got token of type '%ls'"
+#~ msgstr ""
+#~ "Förväntade att hitta ett kommandonamn, hittade en symbol av typen ”%ls”"
+
+#~ msgid "'case' builtin not inside of switch block"
+#~ msgstr ""
+#~ "Det inbyggda kommandot ”case” får bara användas i ett ”switch”-block."
+
+#~ msgid "Loop control command while not inside of loop"
+#~ msgstr "Loopstyrningskommandon får bara användas i loopar."
+
+#, fuzzy
+#~ msgid "'%ls' builtin not inside of if block"
+#~ msgstr "Det inbyggda kommandot ”else” får bara användas i ett if-block"
+
+#~ msgid "'end' command outside of block"
+#~ msgstr "Det inbyggda kommandot ”end” får bara användas i ett block"
+
+#~ msgid "Expected redirection specification, got token of type '%ls'"
+#~ msgstr "Förväntade en IO dirigering, hittade en symbol av typen ”%ls”"
+
+#~ msgid ""
+#~ "Encountered redirection when expecting a command name. Fish does not "
+#~ "allow a redirection operation before a command."
+#~ msgstr ""
+#~ "Förväntade ett kommandonamn, hittade en IO dirigering. Fish tillåter into "
+#~ "IO dirigeringar före kommandonamn"
+
+#~ msgid "Invalid IO redirection"
+#~ msgstr "Ogiltig IO omdirigering"
+
+#~ msgid "Requested redirection to something that is not a file descriptor %ls"
+#~ msgstr "IO dirigering till någonting som inte är en filidentifierare"
+
+#~ msgid "Don't preserve the specified attributes"
+#~ msgstr "Behåll inte de angivna attributen"
+
+#~ msgid "Control creation of sparse files"
+#~ msgstr "Kontrollera skapandet av glesa filer"
+
+#~ msgid "All base system packages"
+#~ msgstr "Alla bassystempaket"
+
+#~ msgid "All packages in world"
+#~ msgstr "Alla paket i världen"
+
+#~ msgid "Installed package"
+#~ msgstr "Installerade paket"
+
+#~ msgid "Usage overview of emerge"
+#~ msgstr "Användningsöversikt av emerge"
+
+#~ msgid "Help on subject system"
+#~ msgstr "Hjälp för ämnet system"
+
+#~ msgid "Help on subject config"
+#~ msgstr "Hjäl för ämnet konfiguration"
+
+#~ msgid "Help on subject sync"
+#~ msgstr "Hjälp för ämnet sync"
+
+#~ msgid "Use colors in output"
+#~ msgstr "Använd färger"
+
+#~ msgid "Don't use colors in output"
+#~ msgstr "Använd inte färger"
+
+#, fuzzy
+#~ msgid "Pull in build time dependencies"
+#~ msgstr "Visa byggberoenden"
+
+#, fuzzy
+#~ msgid "Don't pull in build time dependencies"
+#~ msgstr "Fråga efter extra beroenden"
+
+#, fuzzy
+#~ msgid "add the specified files on the next commit"
+#~ msgstr "Lägg till angiven fil fill den nuvarande listan av nyckelringar"
+
+#, fuzzy
+#~ msgid "show changeset information by line for each file"
+#~ msgstr "Visa ändringsinformation för paket"
+
+#, fuzzy
+#~ msgid "create an unversioned archive of a repository revision"
+#~ msgstr "Lägg till fil eller träd utan version till förrådet"
+
+#, fuzzy
+#~ msgid "list repository named branches"
+#~ msgstr "Inaktivera förråd"
+
+#, fuzzy
+#~ msgid "create a changegroup file"
+#~ msgstr "Skapa en kontrollpunktfil"
+
+#, fuzzy
+#~ msgid "output the current or given revision of files"
+#~ msgstr "Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
+
+#, fuzzy
+#~ msgid "make a copy of an existing repository"
+#~ msgstr "Skapa lokal kopia av förråd"
+
+#, fuzzy
+#~ msgid "commit the specified files or all outstanding changes"
+#~ msgstr "Dekryptera angiven fil eller standard in"
+
+#, fuzzy
+#~ msgid "diff repository (or selected files)"
+#~ msgstr "Radera urval"
+
+#, fuzzy
+#~ msgid "forget the specified files on the next commit"
+#~ msgstr "Flytta filen angiven på kommandoraden"
+
+#, fuzzy
+#~ msgid "copy changes from other branches onto the current branch"
+#~ msgstr "Hämta ändringar från förrådet till arbetskopian"
+
+#, fuzzy
+#~ msgid "identify the working copy or specified revision"
+#~ msgstr "Uppdatera arbetskopian till en annan URL"
+
+#, fuzzy
+#~ msgid "import an ordered set of patches"
+#~ msgstr "Visa byteavstånd för matchningar"
+
+#, fuzzy
+#~ msgid "create a new repository in the given directory"
+#~ msgstr "Skapa förråd om det inte redan existerar"
+
+#, fuzzy
+#~ msgid "locate files matching specific patterns"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "output the current or given revision of the project manifest"
+#~ msgstr "Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
+
+#, fuzzy
+#~ msgid "show changesets not found in the destination"
+#~ msgstr "Fråga paket med angiven grupp"
+
+#, fuzzy
+#~ msgid "show the parents of the working directory or revision"
+#~ msgstr "Ändra arbetskatalog"
+
+#, fuzzy
+#~ msgid "show aliases for remote repositories"
+#~ msgstr "Ta bort inlägg i .cvspass för fjärrförråd"
+
+#, fuzzy
+#~ msgid "pull changes from the specified source"
+#~ msgstr "Fråga paket med angiven grupp"
+
+#, fuzzy
+#~ msgid "push changes to the specified destination"
+#~ msgstr "Fråga paket med angiven grupp"
+
+#, fuzzy
+#~ msgid "remove the specified files on the next commit"
+#~ msgstr "Flytta filen angiven på kommandoraden"
+
+#, fuzzy
+#~ msgid "roll back the last transaction (dangerous)"
+#~ msgstr "Ordna om fixarna i förrådet"
+
+#, fuzzy
+#~ msgid "print the root (top) of the current working directory"
+#~ msgstr "Ändra arbetskatalog"
+
+#, fuzzy
+#~ msgid "show changed files in the working directory"
+#~ msgstr "Ändra arbetskatalog"
+
+#, fuzzy
+#~ msgid "summarize working directory state"
+#~ msgstr "Visa nuvarande katalog"
+
+#, fuzzy
+#~ msgid "list repository tags"
+#~ msgstr "Inaktivera förråd"
+
+#, fuzzy
+#~ msgid "show the tip revision"
+#~ msgstr "Visa tid"
+
+#, fuzzy
+#~ msgid "apply one or more changegroup files"
+#~ msgstr "Läs paket från fil"
+
+#, fuzzy
+#~ msgid "update working directory (or switch revisions)"
+#~ msgstr "Ändra arbetskatalog"
+
+#, fuzzy
+#~ msgid "verify the integrity of the repository"
+#~ msgstr "Ta bort ett inlägg från förråd"
+
+#, fuzzy
+#~ msgid "output version and copyright information"
+#~ msgstr "Ignorera versionsmagiinformation"
+
+#, fuzzy
+#~ msgid "Configuration Files"
+#~ msgstr "Konfigureringsfil"
+
+#, fuzzy
+#~ msgid "Date Formats"
+#~ msgstr "Välj format"
+
+#, fuzzy
+#~ msgid "Diff Formats"
+#~ msgstr "Listformat"
+
+#, fuzzy
+#~ msgid "Environment Variables"
+#~ msgstr "Redigera miljövariabler"
+
+#, fuzzy
+#~ msgid "Specifying File Sets"
+#~ msgstr "Välj konfigurationsfil"
+
+#, fuzzy
+#~ msgid "Configuring hgweb"
+#~ msgstr "Konfigureringsfil"
+
+#, fuzzy
+#~ msgid "Merge Tools"
+#~ msgstr "Sammanslå sorterade filer"
+
+#, fuzzy
+#~ msgid "Specifying Multiple Revisions"
+#~ msgstr "Ange revision"
+
+#, fuzzy
+#~ msgid "File Name Patterns"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "Specifying Single Revisions"
+#~ msgstr "Ange revision"
+
+#, fuzzy
+#~ msgid "Specifying Revision Sets"
+#~ msgstr "Ange revisionstiollstånd"
+
+#, fuzzy
+#~ msgid "Subrepositories"
+#~ msgstr "Aktivera förråd"
+
+#, fuzzy
+#~ msgid "[+] include names matching the given patterns"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "[+] exclude names matching the given patterns"
+#~ msgstr "Lista alla moduler som matchar parameter med jokertecken"
+
+#, fuzzy
+#~ msgid "[+]   include names matching the given patterns"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "[+]   exclude names matching the given patterns"
+#~ msgstr "Lista alla moduler som matchar parameter med jokertecken"
+
+#, fuzzy
+#~ msgid "Annotate the specified revision"
+#~ msgstr "Hjälp för det angivna inbyggda kommandot"
+
+#, fuzzy
+#~ msgid "Use text as commit message"
+#~ msgstr "Läs meddelande för tillägg från fil"
+
+#~ msgid "Read commit message from file"
+#~ msgstr "Läs meddelande för tillägg från fil"
+
+#, fuzzy
+#~ msgid "Record the specified date as commit date"
+#~ msgstr "Hjälp för det angivna kommandot"
+
+#, fuzzy
+#~ msgid "Record the specified user as committer"
+#~ msgstr "Använd angiven sträng som kommentarsträng"
+
+#, fuzzy
+#~ msgid "File to store the bundles into"
+#~ msgstr "Redigera fix-paketbeskrivning"
+
+#, fuzzy
+#~ msgid "Limit number of changes displayed"
+#~ msgstr "Skriv bara ut angivet antal matchningar"
+
+#, fuzzy
+#~ msgid "Display with template"
+#~ msgstr "Visa alla matchningar"
+
+#, fuzzy
+#~ msgid "Specify ssh command to use"
+#~ msgstr "Ange kommando att operera på"
+
+#, fuzzy
+#~ msgid "Specify hg command to run on the remote side"
+#~ msgstr "Välj destinationsadress"
+
+#, fuzzy
+#~ msgid "Search the repository as it is in REV"
+#~ msgstr "Ange förråd-URL"
+
+#, fuzzy
+#~ msgid "Show revisions matching date spec"
+#~ msgstr "Visa bara matchande del"
+
+#, fuzzy
+#~ msgid "Revision to display"
+#~ msgstr "Välj display"
+
+#, fuzzy
+#~ msgid "Specify merge tool"
+#~ msgstr "Ange förtroendemodell"
+
+#, fuzzy
+#~ msgid "Show parents of the specified revision"
+#~ msgstr "Fråga paket med angiven grupp"
+
+#, fuzzy
+#~ msgid "[+] target revision"
+#~ msgstr "Slå ihop revisioner"
+
+#, fuzzy
+#~ msgid "Tipmost revision matching date"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "Revert to the specified revision"
+#~ msgstr "Flytta filen angiven på kommandoraden"
+
+#, fuzzy
+#~ msgid "For remote clients"
+#~ msgstr "Visa eller ta bort funktioner"
+
+#, fuzzy
+#~ msgid "SSL certificate file"
+#~ msgstr "Välj certifikatpolicy"
+
+#, fuzzy
+#~ msgid "Untrusted configuration options"
+#~ msgstr "Välj konfigurationsinställningar"
+
+#, fuzzy
+#~ msgid "List the changed files of a revision"
+#~ msgstr "Visa alla engenskaper hos filer, kataloger eller revisioner"
+
+#, fuzzy
+#~ msgid "Revision"
+#~ msgstr "Slå ihop revisioner"
+
+#~ msgid ""
+#~ "\\nWARNING\\n\\nThe location for fish configuration files has changed to "
+#~ "%s.\\nYour old files have been moved to this location.\\nYou can change "
+#~ "to a different location by changing the value of the variable "
+#~ "$XDG_CONFIG_HOME.\\n\\n"
+#~ msgstr ""
+#~ "\\nVARNING\\n\\nLagringsplatsen för fish-konfigureringsfiler har ändrats "
+#~ "till %s. Dina gamla filer har flyttats till denna plats.\\nDu kan ändra "
+#~ "denna plats genom att byta värde på variabeln $XDG_CONFIG_HOME.\\n\\n"
 
 #~ msgid "%ls: Missing function definition information."
 #~ msgstr "%ls: Funktionsdefinition saknas."
@@ -8987,9 +9370,6 @@ msgstr ""
 
 #~ msgid "Failed to close file descriptor %d"
 #~ msgstr "Misslyckades med att stänga filidentifierare %d"
-
-#~ msgid "Failed to execute process '%ls'"
-#~ msgstr "Misslyckades med att exekvera processen ”%ls”"
 
 #~ msgid ""
 #~ "Could not send process %d, '%ls' in job %d, '%ls' from group %d to group "
@@ -9089,10 +9469,6 @@ msgstr ""
 #~ msgstr "Skapa lokal kopia av förråd"
 
 #, fuzzy
-#~ msgid "Makes a copy of the repository"
-#~ msgstr "Skapa lokal kopia av förråd"
-
-#, fuzzy
 #~ msgid "Initialize a new source tree as a darcs repository"
 #~ msgstr "Checka in filer till förråd"
 
@@ -9104,10 +9480,6 @@ msgstr ""
 
 #~ msgid "Specify hash of creator patch (see docs)"
 #~ msgstr "Ange hash av skaparfix (se dokumentationen)"
-
-#, fuzzy
-#~ msgid "Name of version"
-#~ msgstr "NAmn på version at använda som kontrollpunkt"
 
 #~ msgid "Send to context stored in FILENAME"
 #~ msgstr "Skicka till sammanhang lagrat i FILNAMN"
@@ -9148,14 +9520,6 @@ msgstr ""
 
 #~ msgid "Use pattern from file"
 #~ msgstr "Använd mönster från fil"
-
-#, fuzzy
-#~ msgid "print information about the working copy"
-#~ msgstr "Hämta ändringar från förrådet till arbetskopian"
-
-#, fuzzy
-#~ msgid "export the repository via HTTP"
-#~ msgstr "Uppdatera förråd"
 
 #~ msgid "Debug option"
 #~ msgstr "Debugflagga"
@@ -9304,9 +9668,6 @@ msgstr ""
 
 #~ msgid "Prefix to strip on patch"
 #~ msgstr "Ta bort <prefix> på fix"
-
-#~ msgid "Use purge instead of remove"
-#~ msgstr "Använd rensning istället för radering"
 
 #~ msgid "Do not run update"
 #~ msgstr "Kör inte uppdatering"
@@ -9482,9 +9843,6 @@ msgstr ""
 #~ msgid "Overwrite"
 #~ msgstr "Skiv över"
 
-#~ msgid "Do not overwrite"
-#~ msgstr "Skriv inte över"
-
 #~ msgid "Reduce memory usage"
 #~ msgstr "Minska minnesanvändning"
 
@@ -9493,9 +9851,6 @@ msgstr ""
 
 #~ msgid "Print license"
 #~ msgstr "Skriv ut licens"
-
-#~ msgid "Compress to stdout"
-#~ msgstr "Komprimera till standard ut"
 
 #~ msgid "Compress file"
 #~ msgstr "Komprimera fil"
@@ -9880,9 +10235,6 @@ msgstr ""
 #~ msgid "Option list is not complete"
 #~ msgstr "Detta kommando accepterar andra flaggor än de här angivna"
 
-#~ msgid "Remove completion"
-#~ msgstr "Ta bort komplettering"
-
 #~ msgid ""
 #~ "The completion should only be used if the specified command has a zero "
 #~ "exit status"
@@ -10014,9 +10366,6 @@ msgstr ""
 #~ msgid "Bring work tree in sync with repository"
 #~ msgstr "Synkronisera arbetsträd med förråd"
 
-#~ msgid "Set watches"
-#~ msgstr "Lägg till övervakning"
-
 #~ msgid "See who is watching a file"
 #~ msgstr "Visa övervakningar på fil"
 
@@ -10028,9 +10377,6 @@ msgstr ""
 
 #~ msgid "Do not use the ~/.cvsrc file"
 #~ msgstr "Ignorera ~/.cvsrc"
-
-#~ msgid "Do not change any files"
-#~ msgstr "Ändra inga filer"
 
 #~ msgid "Cause CVS to be really quiet"
 #~ msgstr "Gör CVS mycket tyst läge"
@@ -10076,9 +10422,6 @@ msgstr ""
 
 #~ msgid "Process directories recursively"
 #~ msgstr "Processa underkataloger rekursivt"
-
-#~ msgid "Use a specified tag"
-#~ msgstr "Använd angiven tagg"
 
 #~ msgid "Specify filenames to be filtered"
 #~ msgstr "Ange filnamn att filtrera"
@@ -10236,9 +10579,6 @@ msgstr ""
 #~ msgid "Report on all tags"
 #~ msgstr "Rapport för alla taggar"
 
-#~ msgid "Show history for all users"
-#~ msgstr "Visa historik för alla användare"
-
 #~ msgid "Show only records for this directory"
 #~ msgstr "Visa bara poster för angiven katalog"
 
@@ -10256,9 +10596,6 @@ msgstr ""
 
 #~ msgid "Print only file info"
 #~ msgstr "Visa utförlig information"
-
-#~ msgid "Do not print tags"
-#~ msgstr "Skriv inte ut taggar"
 
 #~ msgid "Print only rcs filename"
 #~ msgstr "Skriv bara RCS-filnamn"
@@ -10364,9 +10701,6 @@ msgstr ""
 #~ "Leta inte efter filer eller kataloger att lägga till, och lägg inte till "
 #~ "dem automatiskt"
 
-#~ msgid "Summarize changes"
-#~ msgstr "Summera ändringar"
-
 #~ msgid "Suppress informational output"
 #~ msgstr "Tyst läge"
 
@@ -10405,9 +10739,6 @@ msgstr ""
 
 #~ msgid "Forward unsigned messages without extra header"
 #~ msgstr "Skicka vidare osignerade meddelanden utan extra huvud"
-
-#~ msgid "Check the entire repository"
-#~ msgstr "Kontrollera hela lagret"
 
 #~ msgid "Check patches since latest checkpoint"
 #~ msgstr "Kontrollera fixar sedan senaste kontrollpunkt"
@@ -10746,9 +11077,6 @@ msgstr ""
 #~ msgid "Erase function"
 #~ msgstr "Radera funktion"
 
-#~ msgid "Show hidden functions"
-#~ msgstr "Visa dolda funktioner"
-
 #, fuzzy
 #~ msgid "Test if function is defined"
 #~ msgstr "Testa om variabeln är definerad"
@@ -10965,9 +11293,6 @@ msgstr ""
 
 #~ msgid "List all keys with their fingerprints"
 #~ msgstr "Visa alla nycklar och deras fingeravtryck"
-
-#~ msgid "Generate a new key pair"
-#~ msgstr "Generera ett nytt nyckelpar"
 
 #~ msgid "Present a menu which enables you to do all key related tasks"
 #~ msgstr "Visa en meny som låter dig utföra alla nyckelrelaterade aktiviteter"
@@ -11490,9 +11815,6 @@ msgstr ""
 #~ msgid "Print full path of source"
 #~ msgstr "Visa full sökväg till källkod"
 
-#~ msgid "Print flat profile"
-#~ msgstr "Visa platt profil"
-
 #~ msgid "No flat profile"
 #~ msgstr "Visa inte platt profil"
 
@@ -11561,9 +11883,6 @@ msgstr ""
 
 #~ msgid "Save/restore filename"
 #~ msgstr "Spara/återställ filnamn"
-
-#~ msgid "Recurse directories"
-#~ msgstr "Rekursera till underkataloger"
 
 #~ msgid "Display compression ratios"
 #~ msgstr "Visa kompressionsgrad"
@@ -11651,9 +11970,6 @@ msgstr ""
 #~ msgid "Display status column"
 #~ msgstr "Visa statuskolumn"
 
-#~ msgid "Specify key bindings file"
-#~ msgstr "Välj fil med tangentbordsgenvägar"
-
 #~ msgid "Verbose prompt"
 #~ msgstr "Utförlig prompt"
 
@@ -11689,9 +12005,6 @@ msgstr ""
 
 #~ msgid "Multiple blank lines sqeezed"
 #~ msgstr "Slå ihop multipla tomma rader"
-
-#~ msgid "Do not fold long lines"
-#~ msgstr "Radbryt inte långa rader"
 
 #~ msgid "Edit tag"
 #~ msgstr "Redigera markering"
@@ -11840,9 +12153,6 @@ msgstr ""
 #~ msgid "Pager"
 #~ msgstr "Visare"
 
-#~ msgid "Manual sections"
-#~ msgstr "Manualsektion"
-
 #~ msgid "Always reformat"
 #~ msgstr "Formatera alltid om"
 
@@ -11959,9 +12269,6 @@ msgstr ""
 #~ msgid "Do not write mtab"
 #~ msgstr "Skriv inte till mtab"
 
-#~ msgid "Read/Write mode"
-#~ msgstr "Läs ock skrivbart läge"
-
 #~ msgid "Dynamically change postprocessing"
 #~ msgstr "Ändra efterbehyandling dynamiskt"
 
@@ -12003,9 +12310,6 @@ msgstr ""
 
 #~ msgid "Override framerate"
 #~ msgstr "Åsidosätt bildfrekvens"
-
-#~ msgid "Build index if unavailable"
-#~ msgstr "Bygg index om inte tillgängligt"
 
 #~ msgid "Load index from file"
 #~ msgstr "Ladda index från fil"
@@ -12085,9 +12389,6 @@ msgstr ""
 
 #~ msgid "Invoke CPP"
 #~ msgstr "Kör C-förprocessorn"
-
-#~ msgid "Extract script"
-#~ msgstr "Extrahera skript"
 
 #~ msgid "Open folder"
 #~ msgstr "Öppna katalog"
@@ -12182,9 +12483,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Gå förbi de vanliga rutt-tabellerna och skicka direkt till en värd på ett "
 #~ "inkopplat gränssnitt"
-
-#~ msgid "Specifies the number of data bytes to be sent"
-#~ msgstr "Ange antalet bytes av data att sicka"
 
 #~ msgid "Set socket buffer size"
 #~ msgstr "Välj uttags (socket) buffertstorlek"
@@ -12347,9 +12645,6 @@ msgstr ""
 
 #~ msgid "Explain what is done"
 #~ msgstr "Förklara vad som utförs"
-
-#~ msgid "List of rpm configuration files"
-#~ msgstr "Visa rpmkonfigurationsfiler"
 
 #~ msgid "Pipe output through specified command"
 #~ msgstr "Filtrera utdata genom angivet kommando"
@@ -12970,9 +13265,6 @@ msgstr ""
 
 #~ msgid "Print kernel release"
 #~ msgstr "Visa kärnrelese"
-
-#~ msgid "Print kernel version"
-#~ msgstr "Visa kärnversion"
 
 #~ msgid "Print machine name"
 #~ msgstr "Visa maskinnamn"
@@ -13632,9 +13924,6 @@ msgstr ""
 #~ msgid "Move into zipfile (delete files)"
 #~ msgstr "Radera de filer som läggs till arkivet"
 
-#~ msgid "Do not store directory names"
-#~ msgstr "Lagra inte katalognamn"
-
 #~ msgid "Do not compress at all"
 #~ msgstr "Komprimera inte alls"
 
@@ -13988,9 +14277,6 @@ msgstr ""
 
 #~ msgid "Reduced output from portage's displays"
 #~ msgstr "Reducerad utdata från portage"
-
-#~ msgid "Resumes the last merge operation"
-#~ msgstr "Återupta senaste installationsoperation"
 
 #~ msgid ""
 #~ "Matches the search string against the description field as well the "

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,9 +1,8 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-03-13 21:29+0800\n"
+"POT-Creation-Date: 2015-04-13 22:15+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: shankerwangmiao <shankerwangmiao@gmail.com>\n"
 "Language: zh_CN\n"
@@ -16,12 +15,12 @@ msgstr ""
 msgid "Could not autoload item '%ls', it is already being autoloaded. "
 msgstr "不能自动加载项目 “%ls”，它已经被自动加载了。"
 
-#: builtin.cpp:83
+#: builtin.cpp:84
 #, c-format
 msgid "Send job %d, '%ls' to foreground\n"
 msgstr "将任务 %d，“%ls” 发送到前台\n"
 
-#: builtin.cpp:344
+#: builtin.cpp:352
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
@@ -30,99 +29,104 @@ msgstr ""
 "%ls: 键入 “help %ls” 以获取相关的文档\n"
 "\n"
 
-#: builtin.cpp:484
+#: builtin.cpp:531
 #, c-format
 msgid "%ls: No key with name '%ls' found\n"
 msgstr "%ls：关键字 “%ls” 未找到\n"
 
-#: builtin.cpp:490
+#: builtin.cpp:537
 #, c-format
 msgid "%ls: Key with name '%ls' does not have any mapping\n"
 msgstr "%ls：名为 “%ls” 的键没有任何映射\n"
 
-#: builtin.cpp:496
+#: builtin.cpp:543
 #, c-format
 msgid "%ls: Unknown error trying to bind to key named '%ls'\n"
 msgstr "%ls：在尝试绑定名为 “%ls” 的键时发生未知错误\n"
 
-#: builtin.cpp:668
+#: builtin.cpp:794
 #, fuzzy, c-format
-msgid "%ls: Expected zero or two parameters, got %d\n"
-msgstr "%ls：应有至多一个参数，提供了 %d 个\n"
+msgid "%ls: No binding found for key '%ls'\n"
+msgstr "%s: No description for type %s\n"
 
-#: builtin.cpp:692
+#: builtin.cpp:798
+#, c-format
+msgid "%ls: No binding found for sequence '%ls'\n"
+msgstr ""
+
+#: builtin.cpp:834
 #, c-format
 msgid "%ls: Invalid state\n"
 msgstr "%ls：非法状态\n"
 
-#: builtin.cpp:796
+#: builtin.cpp:939
 #, c-format
 msgid "%ls: Can not specify scope when removing block\n"
 msgstr "%ls：当移除区块时不能指定作用域\n"
 
-#: builtin.cpp:802
+#: builtin.cpp:945
 #, c-format
 msgid "%ls: No blocks defined\n"
 msgstr "%ls：没有定义区块\n"
 
-#: builtin.cpp:1312 builtin.h:32
+#: builtin.cpp:1556 builtin.h:32
 #, c-format
 msgid "%ls: Invalid combination of options\n"
 msgstr "%ls：非法的选项组合\n"
 
-#: builtin.cpp:1334
+#: builtin.cpp:1578
 #, c-format
 msgid "%ls: Expected exactly one function name\n"
 msgstr "%ls：应恰好有一个函数名\n"
 
-#: builtin.cpp:1344 builtin.cpp:1406
+#: builtin.cpp:1588 builtin.cpp:1650
 #, c-format
 msgid "%ls: Function '%ls' does not exist\n"
 msgstr "%ls：函数 “%ls” 不存在\n"
 
-#: builtin.cpp:1394
+#: builtin.cpp:1638
 #, fuzzy, c-format
 msgid ""
 "%ls: Expected exactly two names (current function name, and new function "
 "name)\n"
 msgstr "%ls：应恰好有一个函数名\n"
 
-#: builtin.cpp:1417 builtin.cpp:1952 builtin.cpp:2259
+#: builtin.cpp:1661 builtin.cpp:2230
 #, c-format
 msgid "%ls: Illegal function name '%ls'\n"
 msgstr "%ls：函数名 “%ls” 非法\n"
 
-#: builtin.cpp:1428
+#: builtin.cpp:1672
 #, fuzzy, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy '%ls'\n"
 msgstr "%ls：函数 “%ls” 不存在\n"
 
-#: builtin.cpp:1809 builtin.cpp:2114
+#: builtin.cpp:2070
 #, c-format
 msgid "%ls: Unknown signal '%ls'\n"
 msgstr "%ls：未知的信号 “%ls”\n"
 
-#: builtin.cpp:1824 builtin.cpp:1984 builtin.cpp:2129 builtin.cpp:2291
+#: builtin.cpp:2085 builtin.cpp:2195 builtin.cpp:2263
 #, c-format
 msgid "%ls: Invalid variable name '%ls'\n"
 msgstr "%ls：变量名 “%ls” 非法\n"
 
-#: builtin.cpp:1877 builtin.cpp:2182
+#: builtin.cpp:2138
 #, c-format
 msgid "%ls: Cannot find calling job for event handler\n"
 msgstr "%ls：Cannot find calling job for event handler\n"
 
-#: builtin.cpp:1895 builtin.cpp:2200
+#: builtin.cpp:2156
 #, c-format
 msgid "%ls: Invalid process id %ls\n"
 msgstr "%ls：进程id %ls 非法\n"
 
-#: builtin.cpp:1945 builtin.cpp:2252
+#: builtin.cpp:2223
 #, c-format
 msgid "%ls: Expected function name\n"
 msgstr "%ls：应有函数名\n"
 
-#: builtin.cpp:1962 builtin.cpp:2269
+#: builtin.cpp:2240
 #, c-format
 msgid ""
 "%ls: The name '%ls' is reserved,\n"
@@ -131,395 +135,380 @@ msgstr ""
 "%ls：名字 “%ls” 已经保留，\n"
 "不能作为函数名\n"
 
-#: builtin.cpp:1970 builtin.cpp:2277 builtin.cpp:3824
+#: builtin.cpp:2248
 #, fuzzy, c-format
 msgid "%ls: No function name given\n"
 msgstr "%ls：应有函数名\n"
 
-#: builtin.cpp:1997 builtin.cpp:2304
+#: builtin.cpp:2276
 #, c-format
 msgid "%ls: Expected one argument, got %d\n"
 msgstr "%ls：应有一个参数，提供了 %d 个\n"
 
-#: builtin.cpp:2319
-msgid "Current functions are: "
-msgstr "当前的函数是： "
-
-#: builtin.cpp:2459
+#: builtin.cpp:2412
 #, c-format
 msgid "%ls: Seed value '%ls' is not a valid number\n"
 msgstr "%ls：种子值 “%ls” 不是一个有效的数字\n"
 
-#: builtin.cpp:2473
+#: builtin.cpp:2426
 #, c-format
 msgid "%ls: Expected zero or one argument, got %d\n"
 msgstr "%ls：至多应有一个参数，提供了 %d 个\n"
 
-#: builtin.cpp:2981 fish.cpp:518 parser.cpp:1095
-msgid "Standard input"
-msgstr "标准输入"
+#: builtin.cpp:2593
+#, fuzzy, c-format
+msgid "%ls: Argument '%ls' is out of range\n"
+msgstr "%ls: Argument “%ls” is not a number\n"
 
-#: builtin.cpp:3024
-msgid "This is a login shell\n"
-msgstr "这是登录shell\n"
-
-#: builtin.cpp:3026
-msgid "This is not a login shell\n"
-msgstr "这不是登录shell\n"
-
-#: builtin.cpp:3028
-#, c-format
-msgid "Job control: %ls\n"
-msgstr "任务控制：%ls\n"
-
-#: builtin.cpp:3029
-msgid "Only on interactive jobs"
-msgstr "只在不活跃的进程上"
-
-#: builtin.cpp:3030
-msgid "Never"
-msgstr "从不"
-
-#: builtin.cpp:3030
-msgid "Always"
-msgstr "总是"
-
-#: builtin.cpp:3066 builtin.cpp:3995
+#: builtin.cpp:2601 builtin.cpp:3150 builtin.cpp:3817
 #, c-format
 msgid "%ls: Argument '%ls' must be an integer\n"
 msgstr "%ls：参数 “%ls” 必须是整数\n"
 
+#: builtin.cpp:2656
+#, fuzzy, c-format
+msgid "%ls: --array option requires a single variable name.\n"
+msgstr ""
+"%ls：Erase 需要一个变量名\n"
+"%ls\n"
+
+#: builtin.cpp:3065 fish.cpp:620 parser.cpp:764
+msgid "Standard input"
+msgstr "标准输入"
+
 #: builtin.cpp:3108
+msgid "This is a login shell\n"
+msgstr "这是登录shell\n"
+
+#: builtin.cpp:3110
+msgid "This is not a login shell\n"
+msgstr "这不是登录shell\n"
+
+#: builtin.cpp:3112
+#, c-format
+msgid "Job control: %ls\n"
+msgstr "任务控制：%ls\n"
+
+#: builtin.cpp:3113
+msgid "Only on interactive jobs"
+msgstr "只在不活跃的进程上"
+
+#: builtin.cpp:3114
+msgid "Never"
+msgstr "从不"
+
+#: builtin.cpp:3114
+msgid "Always"
+msgstr "总是"
+
+#: builtin.cpp:3192
 #, c-format
 msgid "%ls: Could not find home directory\n"
 msgstr "%ls：找不到home目录\n"
 
-#: builtin.cpp:3128 builtin.cpp:3182
+#: builtin.cpp:3212 builtin.cpp:3266
 #, c-format
 msgid "%ls: '%ls' is not a directory\n"
 msgstr "%ls：“%ls” 不是一个目录\n"
 
-#: builtin.cpp:3135
+#: builtin.cpp:3219
 #, c-format
 msgid "%ls: The directory '%ls' does not exist\n"
 msgstr "%ls：目录 “%ls” 不存在\n"
 
-#: builtin.cpp:3142
+#: builtin.cpp:3226
 #, c-format
 msgid "%ls: '%ls' is a rotten symlink\n"
 msgstr "%ls：“%ls” 是一个损坏的符号链接\n"
 
-#: builtin.cpp:3150
+#: builtin.cpp:3234
 #, c-format
 msgid "%ls: Unknown error trying to locate directory '%ls'\n"
 msgstr "%ls：定位目录“%ls”时发生未知错误\n"
 
-#: builtin.cpp:3173
+#: builtin.cpp:3257
 #, c-format
 msgid "%ls: Permission denied: '%ls'\n"
 msgstr "%ls：拒绝访问：“%ls”\n"
 
-#: builtin.cpp:3197
+#: builtin.cpp:3281
 #, c-format
 msgid "%ls: Could not set PWD variable\n"
 msgstr "%ls：不能设置 PWD 变量\n"
 
-#: builtin.cpp:3284
+#: builtin.cpp:3368
 #, c-format
 msgid "%ls: Key not specified\n"
 msgstr "%ls：没有指定键\n"
 
-#: builtin.cpp:3328 builtin.cpp:3336
+#: builtin.cpp:3412 builtin.cpp:3420
 #, c-format
 msgid "%ls: Error encountered while sourcing file '%ls':\n"
 msgstr "%ls：读取源文件“%ls”时遇到错误：\n"
 
-#: builtin.cpp:3344
+#: builtin.cpp:3428
 #, c-format
 msgid "%ls: '%ls' is not a file\n"
 msgstr "%ls：“%ls” 不是一个文件\n"
 
-#: builtin.cpp:3363
+#: builtin.cpp:3447
 #, c-format
 msgid "%ls: Error while reading file '%ls'\n"
 msgstr "%ls：读取文件 “%ls” 时发生错误\n"
 
-#: builtin.cpp:3419 builtin.cpp:3599
+#: builtin.cpp:3503 builtin.cpp:3682
 #, c-format
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls：没有匹配的任务\n"
 
-#: builtin.cpp:3448
+#: builtin.cpp:3531
 #, c-format
 msgid "%ls: Ambiguous job\n"
 msgstr "%ls：不明确的任务\n"
 
-#: builtin.cpp:3454 builtin.cpp:3622 builtin_jobs.cpp:301
+#: builtin.cpp:3537 builtin.cpp:3705 builtin_jobs.cpp:301
 #, c-format
 msgid "%ls: '%ls' is not a job\n"
 msgstr "%ls：“%ls” 不是一个任务\n"
 
-#: builtin.cpp:3485 builtin_jobs.cpp:316
+#: builtin.cpp:3568 builtin_jobs.cpp:316
 #, c-format
 msgid "%ls: No suitable job: %d\n"
 msgstr "%ls：没有匹配的任务：%d\n"
 
-#: builtin.cpp:3494
+#: builtin.cpp:3577
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to foreground because it is not under job "
 "control\n"
-msgstr ""
-"%ls：不能将任务 %d, “%ls” 带到前台，因为它不受到任务"
-"控制\n"
+msgstr "%ls：不能将任务 %d, “%ls” 带到前台，因为它不受到任务控制\n"
 
-#: builtin.cpp:3547
+#: builtin.cpp:3630
 #, c-format
 msgid "%ls: Unknown job '%ls'\n"
 msgstr "%ls：未知的任务 “%ls”\n"
 
-#: builtin.cpp:3556
+#: builtin.cpp:3639
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to background because it is not under job "
 "control\n"
-msgstr ""
-"%ls：不能将任务 %d, “%ls” 置于后台，因为它不受到任务"
-"控制\n"
+msgstr "%ls：不能将任务 %d, “%ls” 置于后台，因为它不受到任务控制\n"
 
-#: builtin.cpp:3566
+#: builtin.cpp:3649
 #, c-format
 msgid "Send job %d '%ls' to background\n"
 msgstr "将任务 %d “%ls” 置于后台\n"
 
-#: builtin.cpp:3605
+#: builtin.cpp:3688
 msgid "(default)"
 msgstr "(默认)"
 
-#: builtin.cpp:3737
-#, c-format
-msgid "%ls: Not inside of block\n"
-msgstr "%ls：不在区块之内\n"
-
-#: builtin.cpp:3884
-#, c-format
-msgid "%ls: Not inside of 'if' block\n"
-msgstr "%ls：不在 “if” 区块之内\n"
-
-#: builtin.cpp:3938
+#: builtin.cpp:3760
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls：不在循环体内部\n"
 
-#: builtin.cpp:4005 builtin_complete.cpp:539 builtin_set_color.cpp:140
-#: builtin.h:83
+#: builtin.cpp:3827 builtin_complete.cpp:551 builtin.h:83
 #, c-format
 msgid "%ls: Too many arguments\n"
 msgstr "%ls：参数过多\n"
 
-#: builtin.cpp:4023
+#: builtin.cpp:3845
 #, c-format
 msgid "%ls: Not inside of function\n"
 msgstr "%ls：不在函数体之内\n"
 
-#: builtin.cpp:4059
-#, c-format
-msgid "%ls: Expected exactly one argument, got %d\n"
-msgstr "%ls：应恰好有一个参数，提供了 %d 个\n"
-
-#: builtin.cpp:4090
-#, c-format
-msgid "%ls: 'case' command while not in switch block\n"
-msgstr "%ls：“case” 命令不在 switch 块内\n"
-
-#: builtin.cpp:4317 builtin.cpp:4360
+#: builtin.cpp:4069 builtin.cpp:4113
 #, fuzzy
 msgid "Test a condition"
 msgstr "设置配置选项"
 
-#: builtin.cpp:4318
+#: builtin.cpp:4070
 msgid "Try out the new parser"
 msgstr ""
 
-#: builtin.cpp:4319
+#: builtin.cpp:4071
 msgid "Execute command if previous command suceeded"
 msgstr "如果上一个命令成功，执行命令"
 
-#: builtin.cpp:4320
+#: builtin.cpp:4072
 msgid "Create a block of code"
 msgstr "创建代码区块"
 
-#: builtin.cpp:4321
+#: builtin.cpp:4073
 msgid "Send job to background"
 msgstr "将任务置于后台"
 
-#: builtin.cpp:4322
+#: builtin.cpp:4074
 msgid "Handle fish key bindings"
 msgstr "处理 fish 键 绑定"
 
-#: builtin.cpp:4323
+#: builtin.cpp:4075
 msgid "Temporarily block delivery of events"
 msgstr "Temporarily block delivery of events"
 
-#: builtin.cpp:4324
+#: builtin.cpp:4076
 msgid "Stop the innermost loop"
 msgstr "停止最内层的循环"
 
-#: builtin.cpp:4325
+#: builtin.cpp:4077
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
-msgstr ""
-"暂时终止一个脚本的执行并运行一个交互式的 debug 提示符"
+msgstr "暂时终止一个脚本的执行并运行一个交互式的 debug 提示符"
 
-#: builtin.cpp:4326
+#: builtin.cpp:4078
 msgid "Run a builtin command instead of a function"
 msgstr "执行内部命令而不是一个函数"
 
-#: builtin.cpp:4327 builtin.cpp:4359
+#: builtin.cpp:4079 builtin.cpp:4112
 msgid "Conditionally execute a block of commands"
 msgstr "有条件地执行一个命令区块"
 
-#: builtin.cpp:4328
+#: builtin.cpp:4080
 msgid "Change working directory"
 msgstr "改变工作目录（当前目录）"
 
-#: builtin.cpp:4329
+#: builtin.cpp:4081
 msgid "Run a program instead of a function or builtin"
 msgstr "执行一个程序，而不是一个函数或内部命令"
 
-#: builtin.cpp:4330
+#: builtin.cpp:4082
 msgid "Set or get the commandline"
 msgstr "设置或取得命令行"
 
-#: builtin.cpp:4331
+#: builtin.cpp:4083
 msgid "Edit command specific completions"
 msgstr "编辑命令相关的补全"
 
-#: builtin.cpp:4332
+#: builtin.cpp:4084
 msgid "Search for a specified string in a list"
 msgstr "在指定列表中搜索一个特定的字符串"
 
-#: builtin.cpp:4333
+#: builtin.cpp:4085
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "跳过最内层循环的当前一轮的剩余部分"
 
-#: builtin.cpp:4334
+#: builtin.cpp:4086
 msgid "Count the number of arguments"
 msgstr "参数的个数的计数"
 
-#: builtin.cpp:4335
+#: builtin.cpp:4087
 #, fuzzy
 msgid "Print arguments"
 msgstr "打印单词计数"
 
-#: builtin.cpp:4336
+#: builtin.cpp:4088
 msgid "Evaluate block if condition is false"
 msgstr "条件为假时对区块求值"
 
-#: builtin.cpp:4337
+#: builtin.cpp:4089
 msgid "Emit an event"
 msgstr "触发一个事件️"
 
-#: builtin.cpp:4338
+#: builtin.cpp:4090
 msgid "End a block of commands"
 msgstr "结束一个命令块"
 
-#: builtin.cpp:4339
+#: builtin.cpp:4091
 msgid "Run command in current process"
 msgstr "在当前进程下执行命令"
 
-#: builtin.cpp:4340
+#: builtin.cpp:4092
 msgid "Exit the shell"
 msgstr "退出这个 shell"
 
-#: builtin.cpp:4341
+#: builtin.cpp:4093
+msgid "Return an unsuccessful result"
+msgstr ""
+
+#: builtin.cpp:4094
 msgid "Send job to foreground"
 msgstr "将任务带回到前台"
 
-#: builtin.cpp:4342
+#: builtin.cpp:4095
 msgid "Perform a set of commands multiple times"
 msgstr "多次执行一组指令"
 
-#: builtin.cpp:4343
+#: builtin.cpp:4096
 msgid "Define a new function"
 msgstr "定义一个新函数"
 
-#: builtin.cpp:4344
+#: builtin.cpp:4097
 msgid "List or remove functions"
 msgstr "列出或移除函数"
 
-#: builtin.cpp:4345
+#: builtin.cpp:4098
 msgid "History of commands executed by user"
 msgstr "用户执行的历史命令"
 
-#: builtin.cpp:4346
+#: builtin.cpp:4099
 msgid "Evaluate block if condition is true"
 msgstr "条件为真时对区块求值"
 
-#: builtin.cpp:4347
+#: builtin.cpp:4100
 msgid "Print currently running jobs"
 msgstr "列出当前运行的任务"
 
-#: builtin.cpp:4348
+#: builtin.cpp:4101
 msgid "Negate exit status of job"
 msgstr "负的任务退出代码（exit status）"
 
-#: builtin.cpp:4349
+#: builtin.cpp:4102
 msgid "Execute command if previous command failed"
 msgstr "如果前一条命令失败执行命令"
 
-#: builtin.cpp:4350
+#: builtin.cpp:4103
 #, fuzzy
 msgid "Prints formatted text"
 msgstr "显示命令类型"
 
-#: builtin.cpp:4351
+#: builtin.cpp:4104
 #, fuzzy
 msgid "Print the working directory"
 msgstr "显示工作目录"
 
-#: builtin.cpp:4352
+#: builtin.cpp:4105
 msgid "Generate random number"
 msgstr "生成随机数"
 
-#: builtin.cpp:4353
+#: builtin.cpp:4106
 msgid "Read a line of input into variables"
 msgstr "将输入的一行读入到变量中"
 
-#: builtin.cpp:4354
+#: builtin.cpp:4107
 msgid "Stop the currently evaluated function"
 msgstr "停止当前求值的函数"
 
-#: builtin.cpp:4355
+#: builtin.cpp:4108
 msgid "Handle environment variables"
 msgstr "处理环境变量"
 
-#: builtin.cpp:4356
+#: builtin.cpp:4109
 msgid "Set the terminal color"
 msgstr "设置终端颜色"
 
-#: builtin.cpp:4357
+#: builtin.cpp:4110
 msgid "Evaluate contents of file"
 msgstr "对文件内容求值"
 
-#: builtin.cpp:4358
+#: builtin.cpp:4111
 msgid "Return status information about fish"
 msgstr "返回 fish 的状态信息"
 
-#: builtin.cpp:4361
+#: builtin.cpp:4114
+msgid "Return a successful result"
+msgstr ""
+
+#: builtin.cpp:4115
 msgid "Set or get the shells resource usage limits"
 msgstr "显示或设置 shell 资源使用限制"
 
-#: builtin.cpp:4362
+#: builtin.cpp:4116
 msgid "Perform a command multiple times"
 msgstr "多次执行一条命令"
 
-#: builtin.cpp:4442 parser.cpp:53
-#, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "未知的内置命令 “%ls”"
-
-#: builtin_commandline.cpp:411
+#: builtin_commandline.cpp:466
 #, c-format
 msgid "%ls: Unknown input function '%ls'\n"
 msgstr "%ls：未知的输入函数 “%ls”\n"
@@ -536,7 +525,7 @@ msgstr "CPU\t"
 msgid "State\tCommand\n"
 msgstr "状态\t命令\n"
 
-#: builtin_jobs.cpp:99 proc.cpp:751
+#: builtin_jobs.cpp:99 proc.cpp:843
 msgid "stopped"
 msgstr "已终止"
 
@@ -582,31 +571,31 @@ msgstr ""
 msgid "missing hexadecimal number in escape"
 msgstr ""
 
-#: builtin_printf.cpp:387
+#: builtin_printf.cpp:388
 msgid "Missing hexadecimal number in Unicode escape"
 msgstr ""
 
-#: builtin_printf.cpp:401
+#: builtin_printf.cpp:402
 #, c-format
 msgid "Unicode character out of range: \\%c%0*x"
 msgstr ""
 
-#: builtin_printf.cpp:668
+#: builtin_printf.cpp:670
 #, c-format
 msgid "invalid field width: %ls"
 msgstr ""
 
-#: builtin_printf.cpp:706
+#: builtin_printf.cpp:708
 #, fuzzy, c-format
 msgid "invalid precision: %ls"
 msgstr "%ls：非法的进程ID %ls\n"
 
-#: builtin_printf.cpp:737
+#: builtin_printf.cpp:739
 #, fuzzy, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%ls：非法的选项组合\n"
 
-#: builtin_printf.cpp:769
+#: builtin_printf.cpp:771
 msgid "printf: not enough arguments"
 msgstr ""
 
@@ -616,58 +605,63 @@ msgid "%ls: Tried to change the read-only variable '%ls'\n"
 msgstr "%ls：试图改变只读变量 “%ls” 的值\n"
 
 #: builtin_set.cpp:162
-#, c-format
-msgid "%ls: Unknown error"
-msgstr "%ls：未知错误"
+#, fuzzy, c-format
+msgid "%ls: Tried to set the special variable '%ls' with the wrong scope\n"
+msgstr "%ls：试图改变只读变量 “%ls” 的值\n"
 
-#: builtin_set.cpp:214
+#: builtin_set.cpp:169
+#, fuzzy, c-format
+msgid "%ls: Tried to set the special variable '%ls' to an invalid value\n"
+msgstr "%ls：试图改变只读变量 “%ls” 的值\n"
+
+#: builtin_set.cpp:221
 #, c-format
 msgid "%ls: Multiple variable names specified in single call (%ls and %.*ls)\n"
-msgstr ""
-"%ls：在一个调用中指定了多个变量 (%ls and %.*ls)\n"
+msgstr "%ls：在一个调用中指定了多个变量 (%ls and %.*ls)\n"
 
-#: builtin_set.cpp:241
+#: builtin_set.cpp:248
 #, c-format
 msgid "%ls: Invalid index starting at '%ls'\n"
 msgstr "%ls：开始于 “%ls” 的索引非法\n"
 
-#: builtin_set.cpp:640
+#: builtin_set.cpp:647
 #, fuzzy, c-format
 msgid "%ls: Erase needs a variable name\n"
 msgstr ""
 "%ls：Erase 需要一个变量名\n"
 "%ls\n"
 
-#: builtin_set.cpp:684
-#, c-format
-msgid "%ls: Can not specify scope when erasing array slice\n"
-msgstr "%ls: Can not specify scope when erasing array slice\n"
-
-#: builtin_set.cpp:783
+#: builtin_set.cpp:791
 #, c-format
 msgid "%ls: Values cannot be specfied with erase\n"
 msgstr "%ls: Values cannot be specfied with erase\n"
 
-#: builtin_set_color.cpp:149
-#, fuzzy, c-format
-msgid "%ls: Expected an argument\n"
-msgstr "%s: Expected an argument\n"
+#: builtin_set.cpp:817
+#, c-format
+msgid ""
+"%ls: Warning: universal scope selected, but a global variable '%ls' exists.\n"
+msgstr ""
 
-#: builtin_set_color.cpp:157 builtin_set_color.cpp:164
+#: builtin_set_color.cpp:144 builtin_set_color.cpp:166
 #, fuzzy, c-format
 msgid "%ls: Unknown color '%ls'\n"
 msgstr "%s: Unknown color “%s”\n"
 
-#: builtin_set_color.cpp:171
+#: builtin_set_color.cpp:153
+#, fuzzy, c-format
+msgid "%ls: Expected an argument\n"
+msgstr "%s: Expected an argument\n"
+
+#: builtin_set_color.cpp:173
 #, fuzzy, c-format
 msgid "%ls: Could not set up terminal\n"
 msgstr "Could not set up terminal"
 
-#: common.cpp:1882
+#: common.cpp:1917
 msgid "This is a bug. Break on bugreport to debug."
 msgstr ""
 
-#: common.cpp:1901
+#: common.cpp:1936
 msgid "empty"
 msgstr "empty"
 
@@ -681,72 +675,70 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variable: %ls"
 
-#: complete.cpp:907 complete.cpp:925
+#: complete.cpp:901 complete.cpp:919
 msgid "Unknown option: "
 msgstr "Unknown option: "
 
-#: complete.cpp:929
+#: complete.cpp:923
 msgid "Multiple matches for option: "
 msgstr "Multiple matches for option: "
 
-#: env.cpp:251
-msgid "Could not get user information"
-msgstr "Could not get user information"
-
-#: env.cpp:362
+#: env.cpp:315
 msgid "Changing language to English"
 msgstr "Changing language to English"
 
-#: env.cpp:1252
+#: env.cpp:1180
 msgid "Tried to pop empty environment stack."
 msgstr "Tried to pop empty environment stack."
 
-#: env_universal_common.cpp:529
-#, c-format
-msgid "Could not convert message '%s' to wide character string"
-msgstr "Could not convert message “%s” to wide character string"
+#: env_universal_common.cpp:617 path.cpp:279
+msgid ""
+"Unable to create a configuration directory for fish. Your personal settings "
+"will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
+"where the current user has write access."
+msgstr ""
 
-#: event.cpp:168
+#: event.cpp:178
 #, c-format
 msgid "signal handler for %ls (%ls)"
 msgstr "signal handler for %ls (%ls)"
 
-#: event.cpp:172
+#: event.cpp:182
 #, c-format
 msgid "handler for variable '%ls'"
 msgstr "handler for variable “%ls”"
 
-#: event.cpp:178
+#: event.cpp:188
 #, c-format
 msgid "exit handler for process %d"
 msgstr "exit handler for process %d"
 
-#: event.cpp:184 event.cpp:195
+#: event.cpp:194 event.cpp:205
 #, c-format
 msgid "exit handler for job %d, '%ls'"
 msgstr "exit handler for job %d, “%ls”"
 
-#: event.cpp:186
+#: event.cpp:196
 #, c-format
 msgid "exit handler for job with process group %d"
 msgstr "exit handler for job with process group %d"
 
-#: event.cpp:197
+#: event.cpp:207
 #, c-format
 msgid "exit handler for job with job id %d"
 msgstr "exit handler for job with job id %d"
 
-#: event.cpp:203
+#: event.cpp:213
 #, c-format
 msgid "handler for generic event '%ls'"
 msgstr "handler for generic event “%ls”"
 
-#: event.cpp:207
+#: event.cpp:217
 #, fuzzy, c-format
 msgid "Unknown event type '0x%x'"
 msgstr "Unknown event type"
 
-#: event.cpp:621
+#: event.cpp:613
 msgid "Signal list overflow. Signals have been ignored."
 msgstr "Signal list overflow. Signals have been ignored."
 
@@ -765,12 +757,12 @@ msgstr "An error occurred while setting up pipe"
 msgid "An error occurred while redirecting file '%s'"
 msgstr "An error occurred while redirecting file “%ls”"
 
-#: exec.cpp:912
+#: exec.cpp:795
 #, c-format
 msgid "Unknown function '%ls'"
 msgstr "Unknown function “%ls”"
 
-#: exec.cpp:1063
+#: exec.cpp:943
 #, c-format
 msgid "Unknown input redirection type %d"
 msgstr "Unknown input redirection type %d"
@@ -800,170 +792,158 @@ msgstr "Shell process"
 msgid "Last background job"
 msgstr "Last background job"
 
-#: expand.cpp:1306
+#: expand.cpp:1419
 msgid "Mismatched brackets"
 msgstr "Mismatched brackets"
 
-#: fish.cpp:320
+#: fish.cpp:330
+msgid ""
+"Old versions of fish appear to be running. You will not be able to share "
+"variable values between old and new fish sessions. For best results, restart "
+"all running instances of fish."
+msgstr ""
+
+#: fish.cpp:420
 #, c-format
 msgid "Invalid value '%s' for debug level switch"
 msgstr "Invalid value “%s” for debug level switch"
 
-#: fish.cpp:361 mimedb.cpp:1335
+#: fish.cpp:461 mimedb.cpp:1343
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, version %s\n"
 
-#: fish.cpp:416
+#: fish.cpp:516
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "Can not use the no-execute mode when running an interactive session"
 
-#: fish.cpp:517
+#: fish.cpp:619
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Error while reading file %ls\n"
 
-#: fish_indent.cpp:345
+#: fish_indent.cpp:332
 #, c-format
 msgid "%ls, version %s\n"
 msgstr "%ls, version %s\n"
 
-#: fish_pager.cpp:113
-#, c-format
-msgid "%ls: Argument '%s' is not a valid file descriptor\n"
-msgstr "%ls: Argument “%s” is not a valid file descriptor\n"
-
-#: fish_pager.cpp:703
-#, c-format
-msgid " %d to %d of %d"
-msgstr ""
-
-#: fish_pager.cpp:1012
-msgid "Could not set up output file descriptors for pager"
-msgstr ""
-
-#: fish_pager.cpp:1018
-msgid "Could not set up input file descriptors for pager"
-msgstr "Could not set up input file descriptors for pager"
-
-#: fish_pager.cpp:1024
-msgid "Could not open tty for pager"
-msgstr "Could not open tty for pager"
-
-#: fish_pager.cpp:1031
-msgid "Could not initialize result pipe"
-msgstr ""
-
-#: fish_pager.cpp:1075 input.cpp:384 input.cpp:394
+#: input.cpp:483 input.cpp:493
 msgid "Could not set up terminal"
 msgstr "Could not set up terminal"
 
-#: fish_pager.cpp:1110 input.cpp:436
-msgid "Error while closing terminfo"
-msgstr "Error while closing terminfo"
-
-#: fish_pager.cpp:1306
-msgid "Unspecified file descriptors"
-msgstr "Unspecified file descriptors"
-
-#: fish_pager.cpp:1318
-msgid "Could not read completions"
-msgstr "Could not read completions"
-
-#: fishd.cpp:766 path.cpp:358
-msgid ""
-"Unable to create a configuration directory for fish. Your personal settings "
-"will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
-"where the current user has write access."
-msgstr ""
-
-#: input.cpp:387
+#: input.cpp:486
 #, c-format
 msgid "Check that your terminal type, '%ls', is supported on this system"
 msgstr ""
 
-#: input.cpp:389
+#: input.cpp:488
 #, c-format
 msgid "Attempting to use '%ls' instead"
 msgstr ""
 
-#: io.cpp:110
+#: input.cpp:535
+msgid "Error while closing terminfo"
+msgstr "Error while closing terminfo"
+
+#: io.cpp:112
 #, c-format
 msgid ""
 "An error occured while reading output from code block on file descriptor %d"
 msgstr ""
 "An error occured while reading output from code block on file descriptor %d"
 
-#: mimedb.cpp:173 mimedb.cpp:187 mimedb.cpp:1177
+#: mimedb.cpp:174 mimedb.cpp:188 mimedb.cpp:1179
 #, c-format
 msgid "%s: Out of memory\n"
 msgstr "%s: Out of memory\n"
 
-#: mimedb.cpp:462
+#: mimedb.cpp:463
 #, c-format
 msgid "%s: Unknown error in munge()\n"
 msgstr "%s: Unknown error in munge()\n"
 
-#: mimedb.cpp:480
+#: mimedb.cpp:481
 #, c-format
 msgid "%s: Locale string too long\n"
 msgstr "%s: Locale string too long\n"
 
-#: mimedb.cpp:550 mimedb.cpp:558
+#: mimedb.cpp:551 mimedb.cpp:559
 #, c-format
 msgid "%s: Could not compile regular expressions %s with error %s\n"
 msgstr "%s: Could not compile regular expressions %s with error %s\n"
 
-#: mimedb.cpp:674
+#: mimedb.cpp:676
 #, c-format
 msgid "%s: No description for type %s\n"
 msgstr "%s: No description for type %s\n"
 
-#: mimedb.cpp:742
+#: mimedb.cpp:744
 #, c-format
 msgid "%s: Could not parse launcher string '%s'\n"
 msgstr "%s: Could not parse launcher string “%s”\n"
 
-#: mimedb.cpp:778
+#: mimedb.cpp:780
 #, c-format
 msgid "%s: Default launcher '%s' does not specify how to start\n"
 msgstr "%s: Default launcher “%s” does not specify how to start\n"
 
-#: mimedb.cpp:1156
+#: mimedb.cpp:1158
 #, c-format
 msgid "%s: Unsupported switch '%c' in launch string '%s'\n"
 msgstr "%s: Unsupported switch “%c” in launch string “%s”\n"
 
-#: mimedb.cpp:1346
+#: mimedb.cpp:1354
 #, c-format
 msgid "%s: Can not launch a mimetype\n"
 msgstr "%s: Can not launch a mimetype\n"
 
-#: mimedb.cpp:1374
+#: mimedb.cpp:1382
 #, c-format
 msgid "%s: Could not parse mimetype from argument '%s'\n"
 msgstr "%s: Could not parse mimetype from argument “%s”\n"
 
-#: mimedb.cpp:1394 signal.cpp:407 signal.cpp:422
+#: mimedb.cpp:1402 signal.cpp:407 signal.cpp:422
 msgid "Unknown"
 msgstr "Unknown"
+
+#: output.cpp:608
+#, c-format
+msgid ""
+"Tried to use terminfo string %s on line %ld of %s, which is undefined in "
+"terminal of type \"%ls\". Please report this error to %s"
+msgstr ""
 
 #: pager.cpp:24
 #, fuzzy
 msgid "search: "
 msgstr "Set arch"
 
-#: parse_execution.cpp:526 parse_execution.cpp:961 parser.cpp:1404
+#: pager.cpp:562
 #, c-format
-msgid "Could not expand string '%ls'"
-msgstr "Could not expand string “%ls”"
+msgid "%lsand 1 more row"
+msgstr ""
 
-#: parse_execution.cpp:549
+#: pager.cpp:566
+#, c-format
+msgid "%lsand %lu more rows"
+msgstr ""
+
+#: pager.cpp:571
+#, c-format
+msgid "rows %lu to %lu of %lu"
+msgstr ""
+
+#: pager.cpp:576
+#, fuzzy
+msgid "(no matches)"
+msgstr "Set watches"
+
+#: parse_execution.cpp:555
 #, fuzzy, c-format
 msgid "switch: Expected exactly one argument, got %lu\n"
 msgstr "%ls: Expected exactly one argument, got %d\n"
 
-#: parse_execution.cpp:749 parser.cpp:2053
+#: parse_execution.cpp:799
 #, fuzzy, c-format
 msgid ""
 "Unknown command '%ls'. Did you mean to run %ls with a modified environment? "
@@ -974,7 +954,7 @@ msgstr ""
 "assigning values to variables, see the help section on the set command by "
 "typing “help set”."
 
-#: parse_execution.cpp:774 parser.cpp:2078
+#: parse_execution.cpp:824
 #, fuzzy, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function like "
@@ -986,7 +966,7 @@ msgstr ""
 "“function %ls; %ls $argv; end”. See the help section for the function "
 "command by typing “help function”."
 
-#: parse_execution.cpp:783 parser.cpp:2087
+#: parse_execution.cpp:833
 #, fuzzy, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function or use the "
@@ -996,7 +976,7 @@ msgstr ""
 "Variables may not be used as commands. Instead, define a function. See the "
 "help section for the function command by typing “help function”."
 
-#: parse_execution.cpp:791 parser.cpp:2095
+#: parse_execution.cpp:841
 #, c-format
 msgid ""
 "Commands may not contain variables. Use the eval builtin instead, like 'eval "
@@ -1005,387 +985,306 @@ msgstr ""
 "Commands may not contain variables. Use the eval builtin instead, like “eval "
 "%ls”. See the help section for the eval command by typing “help eval”."
 
-#: parse_execution.cpp:798 parser.cpp:2102
+#: parse_execution.cpp:848
 #, fuzzy, c-format
 msgid "The file '%ls' is not executable by this user"
 msgstr "The file “%ls” already exists"
 
-#: parse_execution.cpp:1029
+#: parse_execution.cpp:1057
 #, fuzzy, c-format
 msgid "Invalid redirection target: %ls"
 msgstr "Invalid IO redirection"
 
-#: parse_execution.cpp:1053
+#: parse_execution.cpp:1081
 #, fuzzy, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
 msgstr "Requested redirection to something that is not a file descriptor %ls"
 
-#: parse_util.cpp:47
+#: parse_util.cpp:46
 #, fuzzy, c-format
 msgid "The '%ls' command can not be used in a pipeline"
 msgstr "This command can not be used in a pipeline"
 
-#: parser.cpp:58
-msgid "This command can not be used in a pipeline"
+#: parse_util.cpp:49
+#, fuzzy, c-format
+msgid "The '%ls' command can not be used immediately after a backgrounded job"
 msgstr "This command can not be used in a pipeline"
 
-#: parser.cpp:64
+#: parse_util.cpp:52
+#, fuzzy
+msgid "Backgrounded commands can not be used as conditionals"
+msgstr "This command can not be used in a pipeline"
+
+#: parser.cpp:52
 #, c-format
 msgid "Tokenizer error: '%ls'"
 msgstr "Tokenizer error: “%ls”"
 
-#: parser.cpp:69
-msgid "An additional command is required"
-msgstr "An additional command is required"
-
-#: parser.cpp:74
-msgid ""
-"The function calls itself immediately, which would result in an infinite "
-"loop."
-msgstr ""
-
-#: parser.cpp:79
-msgid ""
-"Could not locate end of block. The 'end' command is missing, misspelled or a "
-"';' is missing."
-msgstr ""
-"Could not locate end of block. The “end” command is missing, misspelled or a "
-"“;” is missing."
-
-#: parser.cpp:82
-#, c-format
-msgid "Expected a command name, got token of type '%ls'"
-msgstr "Expected a command name, got token of type “%ls”"
-
-#: parser.cpp:87 parse_constants.h:158
-#, c-format
-msgid "Illegal command name '%ls'"
-msgstr "Illegal command name “%ls”"
-
-#: parser.cpp:92 parse_constants.h:164
-#, fuzzy, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
-msgstr "Illegal file descriptor “%ls”"
-
-#: parser.cpp:97 parse_constants.h:167
-#, c-format
-msgid "No matches for wildcard '%ls'."
-msgstr ""
-
-#: parser.cpp:102
-msgid "'case' builtin not inside of switch block"
-msgstr "“case” builtin not inside of switch block"
-
-#: parser.cpp:107
-msgid "Loop control command while not inside of loop"
-msgstr "Loop control command while not inside of loop"
-
-#: parser.cpp:112 parse_constants.h:176
-msgid "'return' builtin command outside of function definition"
-msgstr "“return” builtin command outside of function definition"
-
-#: parser.cpp:117
-#, fuzzy, c-format
-msgid "'%ls' builtin not inside of if block"
-msgstr "“else” builtin not inside of if block"
-
-#: parser.cpp:122
-#, c-format
-msgid "'%ls' used past terminating 'else'"
-msgstr ""
-
-#: parser.cpp:127
-msgid "'end' command outside of block"
-msgstr "“end” command outside of block"
-
-#: parser.cpp:132 parse_constants.h:179
-#, fuzzy, c-format
-msgid ""
-"Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
-"the set command by typing 'help set'."
-msgstr ""
-"Unknown command “%ls”. Did you mean “set %ls %ls”? For information on "
-"assigning values to variables, see the help section on the set command by "
-"typing “help set”."
-
-#: parser.cpp:137
-#, c-format
-msgid "Expected redirection specification, got token of type '%ls'"
-msgstr "Expected redirection specification, got token of type “%ls”"
-
-#: parser.cpp:142
-msgid ""
-"Encountered redirection when expecting a command name. Fish does not allow a "
-"redirection operation before a command."
-msgstr ""
-"Encountered redirection when expecting a command name. Fish does not allow a "
-"redirection operation before a command."
-
-#: parser.cpp:147
+#: parser.cpp:57
 #, c-format
 msgid "Tried to evaluate commands using invalid block type '%ls'"
 msgstr "Tried to evaluate commands using invalid block type “%ls”"
 
-#: parser.cpp:153
+#: parser.cpp:62
 #, c-format
 msgid "Unexpected token of type '%ls'"
 msgstr "Unexpected token of type “%ls”"
 
-#: parser.cpp:158 parse_constants.h:209
+#: parser.cpp:67 parse_constants.h:255
 msgid "'while' block"
 msgstr "“while” block"
 
-#: parser.cpp:163 parse_constants.h:214
+#: parser.cpp:72 parse_constants.h:260
 msgid "'for' block"
 msgstr "“for” block"
 
-#: parser.cpp:168 parse_constants.h:219
+#: parser.cpp:77 parse_constants.h:265
 msgid "Block created by breakpoint"
 msgstr "Block created by breakpoint"
 
-#: parser.cpp:175 parse_constants.h:226
+#: parser.cpp:82 parse_constants.h:272
 msgid "'if' conditional block"
 msgstr "“if” conditional block"
 
-#: parser.cpp:181 parse_constants.h:232
+#: parser.cpp:87 parse_constants.h:278
 msgid "function definition block"
 msgstr "function definition block"
 
-#: parser.cpp:187 parse_constants.h:238
+#: parser.cpp:92 parse_constants.h:284
 msgid "function invocation block"
 msgstr "function invocation block"
 
-#: parser.cpp:192 parse_constants.h:243
+#: parser.cpp:97 parse_constants.h:289
 msgid "function invocation block with no variable shadowing"
 msgstr "function invocation block with no variable shadowing"
 
-#: parser.cpp:198 parse_constants.h:249
+#: parser.cpp:102 parse_constants.h:295
 msgid "'switch' block"
 msgstr "“switch” block"
 
-#: parser.cpp:204 parse_constants.h:255
+#: parser.cpp:107 parse_constants.h:301
 msgid "unexecutable block"
 msgstr "unexecutable block"
 
-#: parser.cpp:210 parse_constants.h:261
+#: parser.cpp:112 parse_constants.h:307
 msgid "global root block"
 msgstr "global root block"
 
-#: parser.cpp:216 parse_constants.h:267
+#: parser.cpp:117 parse_constants.h:313
 msgid "command substitution block"
 msgstr "command substitution block"
 
-#: parser.cpp:222 parse_constants.h:273
+#: parser.cpp:122 parse_constants.h:319
 msgid "'begin' unconditional block"
 msgstr "“begin” unconditional block"
 
-#: parser.cpp:228 parse_constants.h:279
+#: parser.cpp:127 parse_constants.h:325
 msgid "Block created by the . builtin"
 msgstr "Block created by the . builtin"
 
-#: parser.cpp:233 parse_constants.h:284
+#: parser.cpp:132 parse_constants.h:330
 msgid "event handler block"
 msgstr "event handler block"
 
-#: parser.cpp:239 parse_constants.h:290
+#: parser.cpp:137 parse_constants.h:336
 msgid "unknown/invalid block"
 msgstr "unknown/invalid block"
 
-#: parser.cpp:645
+#: parser.cpp:474
 #, c-format
 msgid "Could not write profiling information to file '%s'"
 msgstr "Could not write profiling information to file “%s”"
 
-#: parser.cpp:651
+#: parser.cpp:480
 msgid "Time\tSum\tCommand\n"
 msgstr "Time\tSum\tCommand\n"
 
-#: parser.cpp:811
+#: parser.cpp:562
 #, c-format
 msgid "in event handler: %ls\n"
 msgstr "in event handler: %ls\n"
 
-#: parser.cpp:839
+#: parser.cpp:590
 #, fuzzy, c-format
 msgid "from sourcing file %ls\n"
 msgstr "Error while reading file %ls\n"
 
-#: parser.cpp:845
+#: parser.cpp:597
 #, fuzzy, c-format
 msgid "in function '%ls'\n"
 msgstr "in function “%ls”,\n"
 
-#: parser.cpp:850
+#: parser.cpp:602
 msgid "in command substitution\n"
 msgstr "in command substitution\n"
 
-#: parser.cpp:863
+#: parser.cpp:615
 #, fuzzy, c-format
 msgid "\tcalled on line %d of file %ls\n"
 msgstr "\tcalled on line %d of file “%ls”,\n"
 
-#: parser.cpp:869
+#: parser.cpp:621
 #, fuzzy
 msgid "\tcalled during startup\n"
 msgstr "\tcalled on standard input,\n"
 
-#: parser.cpp:873
+#: parser.cpp:625
 #, fuzzy
 msgid "\tcalled on standard input\n"
 msgstr "\tcalled on standard input,\n"
 
-#: parser.cpp:890
+#: parser.cpp:642
 #, c-format
 msgid "\twith parameter list '%ls'\n"
 msgstr "\twith parameter list “%ls”\n"
 
-#: parser.cpp:1087
+#: parser.cpp:756
 #, c-format
 msgid "%ls (line %d): "
 msgstr "%ls (line %d): "
 
-#: parser.cpp:1091
+#: parser.cpp:760
 msgid "Startup"
 msgstr ""
 
-#: parser.cpp:1197
+#: parser.cpp:803
 msgid "Job inconsistency"
 msgstr "Job inconsistency"
 
-#: parser.cpp:1520
-msgid "Invalid IO redirection"
-msgstr "Invalid IO redirection"
-
-#: parser.cpp:1541
-#, c-format
-msgid "Requested redirection to something that is not a file descriptor %ls"
-msgstr "Requested redirection to something that is not a file descriptor %ls"
-
-#: parser.cpp:2667 parser.cpp:2750
+#: parser.cpp:956
 msgid "End of block mismatch. Program terminating."
 msgstr "End of block mismatch. Program terminating."
 
-#: parser.cpp:3034
+#: parser.cpp:1047
 #, fuzzy, c-format
 msgid "%ls (line %lu): "
 msgstr "%ls (line %d): "
+
+#: parser.cpp:1051
+#, c-format
+msgid "%ls: "
+msgstr ""
 
 #: path.cpp:24
 #, c-format
 msgid "Error while searching for command '%ls'"
 msgstr "Error while searching for command “%ls”"
 
-#: proc.cpp:615
+#: proc.cpp:690
+#, fuzzy, c-format
+msgid "'%ls' has %ls"
+msgstr "Job %d, “%ls” has %ls"
+
+#: proc.cpp:694
 #, c-format
 msgid "Job %d, '%ls' has %ls"
 msgstr "Job %d, “%ls” has %ls"
 
-#: proc.cpp:699
-#, c-format
-msgid "%ls: Job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:786
+#, fuzzy, c-format
+msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Job %d, “%ls” terminated by signal %ls (%ls)"
 
-#: proc.cpp:707
-#, c-format
-msgid ""
-"%ls: Process %d, '%ls' from job %d, '%ls' terminated by signal %ls (%ls)"
+#: proc.cpp:797
+#, fuzzy, c-format
+msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 "%ls: Process %d, “%ls” from job %d, “%ls” terminated by signal %ls (%ls)"
 
-#: proc.cpp:736
+#: proc.cpp:828
 msgid "ended"
 msgstr "ended"
 
-#: proc.cpp:969
+#: proc.cpp:1065
 msgid "An error occured while reading output from code block"
 msgstr "An error occured while reading output from code block"
 
-#: proc.cpp:998 proc.cpp:1010
+#: proc.cpp:1094 proc.cpp:1106
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Could not send job %d (“%ls”) to foreground"
 
-#: proc.cpp:1030 proc.cpp:1040 proc.cpp:1055
+#: proc.cpp:1126 proc.cpp:1136 proc.cpp:1151
 msgid "Could not return shell to foreground"
 msgstr "Could not return shell to foreground"
 
-#: proc.cpp:1280 proc.cpp:1304
+#: proc.cpp:1354 proc.cpp:1380
 msgid "Process list pointer"
 msgstr "Process list pointer"
 
-#: proc.cpp:1291
+#: proc.cpp:1365
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "More than one job in foreground: job 1: “%ls” job 2: “%ls”"
 
-#: proc.cpp:1302
+#: proc.cpp:1378
 msgid "Process argument list"
 msgstr "Process argument list"
 
-#: proc.cpp:1303
+#: proc.cpp:1379
 msgid "Process name"
 msgstr "Process name"
 
-#: proc.cpp:1309
+#: proc.cpp:1385
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Job “%ls”, process “%ls” has inconsistent state “stopped”=%d"
 
-#: proc.cpp:1319
+#: proc.cpp:1395
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr "Job “%ls”, process “%ls” has inconsistent state “completed”=%d"
 
-#: reader.cpp:453
+#: reader.cpp:478
 msgid "Could not set terminal mode for new job"
 msgstr "Could not set terminal mode for new job"
 
-#: reader.cpp:477
+#: reader.cpp:525
 msgid "Could not set terminal mode for shell"
 msgstr "Could not set terminal mode for shell"
 
-#: reader.cpp:2133
+#: reader.cpp:2059
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr ""
 
-#: reader.cpp:2148
+#: reader.cpp:2074
 #, c-format
 msgid ""
 "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr ""
 
-#: reader.cpp:2179
+#: reader.cpp:2105
 msgid "Couldn't put the shell in its own process group"
 msgstr "Couldn't put the shell in its own process group"
 
-#: reader.cpp:2189
+#: reader.cpp:2115
 msgid "Couldn't grab control of terminal"
 msgstr "Couldn't grab control of terminal"
 
-#: reader.cpp:2703
+#: reader.cpp:2616
 msgid "Pop null reader block"
 msgstr "Pop null reader block"
 
-#: reader.cpp:2956
+#: reader.cpp:2882
 msgid ""
 "There are stopped jobs. A second attempt to exit will enforce their "
 "termination.\n"
 msgstr ""
 
-#: reader.cpp:4069
+#: reader.cpp:4115
 #, c-format
 msgid "Unknown keybinding %d"
 msgstr "Unknown keybinding %d"
 
-#: reader.cpp:4210
+#: reader.cpp:4226
 msgid "Error while reading from file descriptor"
 msgstr "Error while reading from file descriptor"
 
-#: reader.cpp:4227
+#: reader.cpp:4243
 msgid "Error while closing input stream"
 msgstr "Error while closing input stream"
 
-#: reader.cpp:4248
+#: reader.cpp:4270
 msgid "Error while opening input stream"
 msgstr "Error while opening input stream"
 
@@ -1618,7 +1517,7 @@ msgstr "Run job in background"
 msgid "Comment"
 msgstr "Comment"
 
-#: tokenizer.cpp:602
+#: tokenizer.cpp:561
 msgid "Invalid token type"
 msgstr "Invalid token type"
 
@@ -1662,7 +1561,7 @@ msgstr "%ls: Illegal option -- %lc\n"
 msgid "%ls: Invalid option -- %lc\n"
 msgstr "%ls: Invalid option -- %lc\n"
 
-#: wgetopt.cpp:673
+#: wgetopt.cpp:676
 #, c-format
 msgid "%ls: Option requires an argument -- %lc\n"
 msgstr "%ls: Option requires an argument -- %lc\n"
@@ -1675,7 +1574,7 @@ msgstr "Executable"
 msgid "Executable link"
 msgstr "Executable link"
 
-#: wildcard.cpp:67 share/completions/git.fish:146
+#: wildcard.cpp:67 share/completions/git.fish:178
 msgid "File"
 msgstr "File"
 
@@ -1803,31 +1702,24 @@ msgstr "%ls: Argument “%ls” is not a number\n"
 msgid "An error occurred while setting up pipe"
 msgstr "An error occurred while setting up pipe"
 
-#: expand.h:132
+#: expand.h:135
 msgid "Array index out of bounds"
 msgstr "Array index out of bounds"
 
-#: output.h:91
-#, c-format
-msgid ""
-"Tried to use terminfo string %s on line %d of %s, which is undefined in "
-"terminal of type \"%ls\". Please report this error to %s"
-msgstr ""
-
-#: parse_constants.h:145
+#: parse_constants.h:185
 #, c-format
 msgid ""
 "The function '%ls' calls itself immediately, which would result in an "
 "infinite loop."
 msgstr ""
 
-#: parse_constants.h:149
+#: parse_constants.h:189
 msgid ""
 "The function call stack limit has been exceeded. Do you have an accidental "
 "infinite loop?"
 msgstr ""
 
-#: parse_constants.h:152
+#: parse_constants.h:192
 #, fuzzy
 msgid ""
 "Expected a command, but instead found a pipe. Did you mean 'COMMAND; or "
@@ -1838,10 +1730,10 @@ msgstr ""
 "COMMAND”? See the help section for the “or” builtin command by typing “help "
 "or”."
 
-#: parse_constants.h:155
+#: parse_constants.h:195
 #, fuzzy
 msgid ""
-"Expected a command, but instead found a '&'. Did you mean 'COMMAND; and "
+"Expected a command, but instead found an '&'. Did you mean 'COMMAND; and "
 "COMMAND'? See the help section for the 'and' builtin command by typing 'help "
 "and'."
 msgstr ""
@@ -1849,22 +1741,61 @@ msgstr ""
 "COMMAND”? See the help section for the “and” builtin command by typing “help "
 "and”."
 
-#: parse_constants.h:161
+#: parse_constants.h:198
+#, c-format
+msgid "Illegal command name '%ls'"
+msgstr "Illegal command name “%ls”"
+
+#: parse_constants.h:201
+#, c-format
+msgid "Unknown builtin '%ls'"
+msgstr "未知的内置命令 “%ls”"
+
+#: parse_constants.h:204
 #, fuzzy, c-format
 msgid "Unable to expand variable name '%ls'"
 msgstr "%ls: Invalid variable name “%ls”\n"
 
-#: parse_constants.h:170
+#: parse_constants.h:207
+#, fuzzy, c-format
+msgid "Unable to find a process '%ls'"
+msgstr "Failed to execute process “%ls”"
+
+#: parse_constants.h:210
+#, fuzzy, c-format
+msgid "Illegal file descriptor in redirection '%ls'"
+msgstr "Illegal file descriptor “%ls”"
+
+#: parse_constants.h:213
+#, c-format
+msgid "No matches for wildcard '%ls'."
+msgstr ""
+
+#: parse_constants.h:216
 #, fuzzy
 msgid "break command while not inside of loop"
 msgstr "Loop control command while not inside of loop"
 
-#: parse_constants.h:173
+#: parse_constants.h:219
 #, fuzzy
 msgid "continue command while not inside of loop"
 msgstr "Loop control command while not inside of loop"
 
-#: parse_constants.h:184
+#: parse_constants.h:222
+msgid "'return' builtin command outside of function definition"
+msgstr "“return” builtin command outside of function definition"
+
+#: parse_constants.h:225
+#, fuzzy, c-format
+msgid ""
+"Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
+"the set command by typing 'help set'."
+msgstr ""
+"Unknown command “%ls”. Did you mean “set %ls %ls”? For information on "
+"assigning values to variables, see the help section on the set command by "
+"typing “help set”."
+
+#: parse_constants.h:230
 #, c-format
 msgid ""
 "The '$' character begins a variable name. The character '%lc', which "
@@ -1877,13 +1808,13 @@ msgstr ""
 "variable names may not be zero characters long. To learn more about variable "
 "expansion in fish, type “help expand-variable”."
 
-#: parse_constants.h:189
+#: parse_constants.h:235
 msgid ""
 "$? is not a valid variable in fish. If you want the exit status of the last "
 "command, try $status."
 msgstr ""
 
-#: parse_constants.h:194
+#: parse_constants.h:240
 msgid ""
 "The '$' begins a variable name. It was given at the end of an argument. "
 "Variable names may not be zero characters long. To learn more about variable "
@@ -1893,7 +1824,7 @@ msgstr ""
 "Variable names may not be zero characters long. To learn more about variable "
 "expansion in fish, type “help expand-variable”."
 
-#: parse_constants.h:199
+#: parse_constants.h:245
 #, c-format
 msgid ""
 "Did you mean %ls{$%ls}%ls? The '$' character begins a variable name. A "
@@ -1906,7 +1837,7 @@ msgstr ""
 "variable name, and variable names may not be zero characters long. To learn "
 "more about variable expansion in fish, type “help expand-variable”."
 
-#: parse_constants.h:204
+#: parse_constants.h:250
 msgid ""
 "Did you mean (COMMAND)? In fish, the '$' character is only used for "
 "accessing variables. To learn more about command substitution in fish, type "
@@ -3036,227 +2967,324 @@ msgstr "Test if aptitude has yet to be given the subcommand"
 msgid "Test if bundle has been given a specific subcommand"
 msgstr "Test if aptitude has yet to be given the subcommand"
 
-#: share/completions/bundle.fish:30
+#: share/completions/bundle.fish:31
 #, fuzzy
 msgid "Display a help page"
 msgstr "Display man page"
 
-#: share/completions/bundle.fish:38 share/completions/bundle.fish:65
+#: share/completions/bundle.fish:39 share/completions/bundle.fish:83
 msgid "Install the gems specified by the Gemfile or Gemfile.lock"
 msgstr ""
 
-#: share/completions/bundle.fish:39 share/completions/bundle.fish:87
-msgid "The location of the Gemfile bundler should use."
-msgstr ""
-
-#: share/completions/bundle.fish:40
+#: share/completions/bundle.fish:40 share/completions/bundle.fish:106
 #, fuzzy
-msgid "The location to install the gems in the bundle to."
+msgid "The location of the Gemfile bundler should use"
 msgstr "Commit an unversioned file or tree into the repository"
 
 #: share/completions/bundle.fish:41
-msgid "Installs the gems in the bundle to the system location."
-msgstr ""
+#, fuzzy
+msgid "The location to install the gems in the bundle to"
+msgstr "Commit an unversioned file or tree into the repository"
 
 #: share/completions/bundle.fish:42
-msgid "A space-separated list of groups to skip installing."
-msgstr ""
+#, fuzzy
+msgid "Installs the gems in the bundle to the system location"
+msgstr "Commit an unversioned file or tree into the repository"
 
 #: share/completions/bundle.fish:43
-msgid "Use cached gems instead of connecting to rubygems.org."
+msgid "A space-separated list of groups to skip installing"
 msgstr ""
 
 #: share/completions/bundle.fish:44
-msgid "Switches bundler's defaults into deployment mode."
+msgid "Use cached gems instead of connecting to rubygems.org"
 msgstr ""
 
 #: share/completions/bundle.fish:45
-msgid ""
-"Create a directory containing executabes that run in the context of the "
-"bundle."
+msgid "Switches bundler's defaults into deployment mode."
 msgstr ""
 
 #: share/completions/bundle.fish:46
-msgid "Specify a ruby executable to use with generated binstubs."
+msgid ""
+"Create a directory containing executabes that run in the context of the "
+"bundle"
 msgstr ""
 
 #: share/completions/bundle.fish:47
-msgid "Make a bundle that can work without RubyGems or Bundler at run-time."
+msgid "Specify a ruby executable to use with generated binstubs"
 msgstr ""
 
 #: share/completions/bundle.fish:48
-msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
+msgid "Make a bundle that can work without RubyGems or Bundler at run-time"
 msgstr ""
 
 #: share/completions/bundle.fish:49
-msgid "Do not update the cache in vendor/cache with the newly bundled gems."
+msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
 msgstr ""
 
 #: share/completions/bundle.fish:50
+msgid "Install  gems parallely by starting size number of parallel workers"
+msgstr ""
+
+#: share/completions/bundle.fish:51
+msgid "Do not update the cache in vendor/cache with the newly bundled gems"
+msgstr ""
+
+#: share/completions/bundle.fish:52
 #, fuzzy
-msgid "Do not print progress information to stdout."
+msgid "Do not print progress information to stdout"
 msgstr "Don't print group information"
 
-#: share/completions/bundle.fish:53 share/completions/bundle.fish:66
+#: share/completions/bundle.fish:53
+#, fuzzy
+msgid "Run bundle clean automatically after install"
+msgstr "Upgrade package if already installed"
+
+#: share/completions/bundle.fish:54 share/completions/bundle.fish:63
+msgid "Use the rubygems modern index instead of the API endpoint"
+msgstr ""
+
+#: share/completions/bundle.fish:55 share/completions/bundle.fish:164
+#, fuzzy
+msgid "Do not remove stale gems from the cache"
+msgstr "Remove all gz files from cache"
+
+#: share/completions/bundle.fish:56
+msgid "Do not allow the Gemfile.lock to be updated after this install"
+msgstr ""
+
+#: share/completions/bundle.fish:59 share/completions/bundle.fish:84
 #, fuzzy
 msgid "Update dependencies to their latest versions"
 msgstr "Updates packages to the best version available"
 
-#: share/completions/bundle.fish:54
-msgid "The name of a :git or :path source used in the Gemfile."
+#: share/completions/bundle.fish:60
+msgid "The name of a :git or :path source used in the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:58
+#: share/completions/bundle.fish:61
+msgid "Do not attempt to fetch gems remotely and use the gem cache instead"
+msgstr ""
+
+#: share/completions/bundle.fish:62
+msgid "Only output warnings and errors"
+msgstr ""
+
+#: share/completions/bundle.fish:64
+#, fuzzy
+msgid "Specify the number of jobs to run in parallel"
+msgstr "Specifies the number of data bytes to be sent"
+
+#: share/completions/bundle.fish:65
+#, fuzzy
+msgid "Update a specific group"
+msgstr "Use a specified tag"
+
+#: share/completions/bundle.fish:69
 msgid ""
 "Package the .gem files required by your application into the vendor/cache "
 "directory"
 msgstr ""
 
-#: share/completions/bundle.fish:61 share/completions/bundle.fish:68
+#: share/completions/bundle.fish:72
+#, fuzzy
+msgid "Install the binstubs of the listed gem"
+msgstr "Display the pretend output in a tabular form"
+
+#: share/completions/bundle.fish:73
+#, fuzzy
+msgid "Binstub destination directory (default bin)"
+msgstr "Install documentation files (default)"
+
+#: share/completions/bundle.fish:74
+msgid "Overwrite existing binstubs if they exist"
+msgstr ""
+
+#: share/completions/bundle.fish:78 share/completions/bundle.fish:86
 msgid "Execute a script in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:64
+#: share/completions/bundle.fish:79
+msgid "Exec runs a command, providing it access to the gems in the bundle"
+msgstr ""
+
+#: share/completions/bundle.fish:82
 msgid "Describe available tasks or one specific task"
 msgstr ""
 
-#: share/completions/bundle.fish:67
+#: share/completions/bundle.fish:85
 #, fuzzy
 msgid "Package .gem files into the vendor/cache directory"
 msgstr "Change working directory"
 
-#: share/completions/bundle.fish:69
+#: share/completions/bundle.fish:87
+#, fuzzy
+msgid "Specify and read configuration options for bundler"
+msgstr "Specify a configuration file"
+
+#: share/completions/bundle.fish:88
 msgid "Check bundler requirements for your application"
 msgstr ""
 
-#: share/completions/bundle.fish:70 share/completions/bundle.fish:92
+#: share/completions/bundle.fish:89
 #, fuzzy
 msgid "Show all of the gems in the current bundle"
 msgstr "Do not ever ascend to the parent directory"
 
-#: share/completions/bundle.fish:71 share/completions/bundle.fish:96
+#: share/completions/bundle.fish:90
 #, fuzzy
 msgid "Show the source location of a particular gem in the bundle"
 msgstr "Show the process id of each process in the job"
 
-#: share/completions/bundle.fish:72 share/completions/bundle.fish:100
+#: share/completions/bundle.fish:91 share/completions/bundle.fish:121
 msgid "Show all of the outdated gems in the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:73 share/completions/bundle.fish:107
+#: share/completions/bundle.fish:92 share/completions/bundle.fish:129
 msgid "Start an IRB session in the context of the current bundle"
 msgstr ""
 
-#: share/completions/bundle.fish:74 share/completions/bundle.fish:110
+#: share/completions/bundle.fish:93 share/completions/bundle.fish:132
 #, sh-format
 msgid "Open an installed gem in your $EDITOR"
 msgstr ""
 
-#: share/completions/bundle.fish:75 share/completions/bundle.fish:114
+#: share/completions/bundle.fish:94 share/completions/bundle.fish:136
 msgid "Generate a visual representation of your dependencies"
 msgstr ""
 
-#: share/completions/bundle.fish:76
+#: share/completions/bundle.fish:95
 #, fuzzy
 msgid "Generate a simple Gemfile"
 msgstr "Generate master file"
 
-#: share/completions/bundle.fish:77 share/completions/bundle.fish:125
+#: share/completions/bundle.fish:96 share/completions/bundle.fish:147
 msgid "Create a simple gem, suitable for development with bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:78 share/completions/bundle.fish:131
+#: share/completions/bundle.fish:97 share/completions/bundle.fish:154
 #, fuzzy
 msgid "Displays platform compatibility information"
 msgstr "Display update information"
 
-#: share/completions/bundle.fish:79 share/completions/bundle.fish:135
+#: share/completions/bundle.fish:98 share/completions/bundle.fish:158
 msgid "Cleans up unused gems in your bundler directory"
 msgstr ""
 
-#: share/completions/bundle.fish:86
+#: share/completions/bundle.fish:105
 msgid ""
 "Determine whether the requirements for your application are installed and "
 "available to bundler"
 msgstr ""
 
-#: share/completions/bundle.fish:88
-msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)."
+#: share/completions/bundle.fish:107
+msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)"
 msgstr ""
 
-#: share/completions/bundle.fish:89
+#: share/completions/bundle.fish:108
 #, fuzzy
 msgid "Lock the Gemfile"
 msgstr "Log to tracefile"
 
-#: share/completions/bundle.fish:93
+#: share/completions/bundle.fish:111 share/completions/bundle.fish:116
+msgid ""
+"Show lists the names and versions of all gems that are required by your "
+"Gemfile"
+msgstr ""
+
+#: share/completions/bundle.fish:112 share/completions/bundle.fish:117
 msgid "List the paths of all gems required by your Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:101
+#: share/completions/bundle.fish:122
 #, fuzzy
 msgid "Check for newer pre-release gems"
 msgstr "Check for memory leaks"
 
-#: share/completions/bundle.fish:102
+#: share/completions/bundle.fish:123
 msgid "Check against a specific source"
 msgstr ""
 
-#: share/completions/bundle.fish:103
+#: share/completions/bundle.fish:124
 msgid "Use cached gems instead of attempting to fetch gems remotely"
 msgstr ""
 
-#: share/completions/bundle.fish:115
+#: share/completions/bundle.fish:125
+msgid "Only list newer versions allowed by your Gemfile requirements"
+msgstr ""
+
+#: share/completions/bundle.fish:137
 msgid "The name to use for the generated file (see format option)"
 msgstr ""
 
-#: share/completions/bundle.fish:116
+#: share/completions/bundle.fish:138
 #, fuzzy
 msgid "Show each gem version"
 msgstr "Source tree version"
 
-#: share/completions/bundle.fish:117
+#: share/completions/bundle.fish:139
 msgid "Show the version of each required dependency"
 msgstr ""
 
-#: share/completions/bundle.fish:118
+#: share/completions/bundle.fish:140
 msgid "Output a specific format (png, jpg, svg, dot, ...)"
 msgstr ""
 
-#: share/completions/bundle.fish:121
+#: share/completions/bundle.fish:143
 #, fuzzy
 msgid "Generate a simple Gemfile, placed in the current directory"
 msgstr "Do not ever ascend to the parent directory"
 
-#: share/completions/bundle.fish:122
+#: share/completions/bundle.fish:144
 msgid "Use a specified .gemspec to create the Gemfile"
 msgstr ""
 
-#: share/completions/bundle.fish:126
+#: share/completions/bundle.fish:148
 msgid "Generate a binary for your library"
 msgstr ""
 
-#: share/completions/bundle.fish:127
+#: share/completions/bundle.fish:149
 msgid "Generate a test directory for your library (rspec or minitest)"
 msgstr ""
 
-#: share/completions/bundle.fish:128
+#: share/completions/bundle.fish:150
 #, fuzzy
 msgid "Path to your editor"
 msgstr "Set source directory"
 
-#: share/completions/bundle.fish:132
+#: share/completions/bundle.fish:151
+msgid "Generate the boilerplate for C extension code"
+msgstr ""
+
+#: share/completions/bundle.fish:155
 #, fuzzy
 msgid "Only display Ruby directive information"
 msgstr "Display update information"
 
-#: share/completions/bundle.fish:136
+#: share/completions/bundle.fish:159
 msgid "Only print out changes, do not actually clean gems"
 msgstr ""
 
-#: share/completions/bundle.fish:137
+#: share/completions/bundle.fish:160
 msgid "Forces clean even if --path is not set"
 msgstr ""
+
+#: share/completions/bundle.fish:163
+msgid "Cache all the gems to vendor/cache"
+msgstr ""
+
+#: share/completions/bundle.fish:165
+msgid "Include all sources (including path and git)"
+msgstr ""
+
+#: share/completions/bundle.fish:168
+#, fuzzy
+msgid "Prints the license of all gems in the bundle"
+msgstr "Commit an unversioned file or tree into the repository"
+
+#: share/completions/bundle.fish:171
+#, fuzzy
+msgid "Print information about the environment Bundler is running under"
+msgstr "Output extra information about the work being done"
 
 #: share/completions/configure.fish:1
 #: share/functions/__fish_complete_diff.fish:27
@@ -3270,19 +3298,15 @@ msgstr "Display help and exit"
 msgid "Cache test results in specified file"
 msgstr "Cache test results in specified file"
 
-#: share/completions/cp.fish:10 share/completions/mv.fish:6
+#: share/completions/cp.fish:11 share/completions/mv.fish:6
 msgid "Backup suffix"
 msgstr "Backup suffix"
 
 #: share/completions/cp.fish:20
-msgid "Don't preserve the specified attributes"
-msgstr "Don't preserve the specified attributes"
+msgid "Preserve ATTRIBUTES if possible"
+msgstr ""
 
-#: share/completions/cp.fish:24
-msgid "Control creation of sparse files"
-msgstr "Control creation of sparse files"
-
-#: share/completions/cp.fish:28
+#: share/completions/cp.fish:29
 msgid "Set security context of copy to CONTEXT"
 msgstr "Set security context of copy to CONTEXT"
 
@@ -3901,6 +3925,33 @@ msgstr "Show filesystems of specified type"
 msgid "Block size"
 msgstr "Block size"
 
+#: share/completions/docker.fish:19
+#, fuzzy
+msgid "Show all containers"
+msgstr "Show arp entries"
+
+#: share/completions/docker.fish:24
+#, fuzzy
+msgid "Show the running containers"
+msgstr "Show hidden functions"
+
+#: share/completions/docker.fish:28
+#, fuzzy
+msgid "Show the exited containers"
+msgstr "Show the time"
+
+#: share/completions/docker.fish:70 share/completions/docker.fish:92
+msgid "Docker container"
+msgstr ""
+
+#: share/completions/docker.fish:82
+msgid "Stopped container"
+msgstr ""
+
+#: share/completions/docker.fish:87
+msgid "Container running"
+msgstr ""
+
 #: share/completions/du.fish:15
 #, fuzzy
 msgid "Exclude files that match pattern in file"
@@ -3914,96 +3965,96 @@ msgstr "Exclude files that match pattern"
 msgid "Recursion limit"
 msgstr "Recursion limit"
 
-#: share/completions/duply.fish:5
+#: share/completions/duply.fish:3
 #, fuzzy
 msgid "Profile"
 msgstr "Conf file"
 
-#: share/completions/duply.fish:6
+#: share/completions/duply.fish:4
 msgid "Get usage help text"
 msgstr ""
 
-#: share/completions/duply.fish:9
+#: share/completions/duply.fish:7
 #, fuzzy
 msgid "Creates a configuration profile"
 msgstr "Set configuration file"
 
-#: share/completions/duply.fish:10
+#: share/completions/duply.fish:8
 msgid "Backup with pre/post script execution"
 msgstr ""
 
-#: share/completions/duply.fish:11
+#: share/completions/duply.fish:9
 #, fuzzy
 msgid "Backup without executing pre/post scripts"
 msgstr "Don't execute post scripts"
 
-#: share/completions/duply.fish:12
+#: share/completions/duply.fish:10
 #, fuzzy
 msgid "Execute <profile>/pre script"
 msgstr "Don't execute pre scripts"
 
-#: share/completions/duply.fish:13
+#: share/completions/duply.fish:11
 #, fuzzy
 msgid "Execute <profile>/post script"
 msgstr "Don't execute post scripts"
 
-#: share/completions/duply.fish:14
+#: share/completions/duply.fish:12
 msgid "Force full backup"
 msgstr ""
 
-#: share/completions/duply.fish:15
+#: share/completions/duply.fish:13
 msgid "Force incremental backup"
 msgstr ""
 
-#: share/completions/duply.fish:16
+#: share/completions/duply.fish:14
 msgid "List all files in backup (as it was at <age>, default: now)"
 msgstr ""
 
-#: share/completions/duply.fish:17
+#: share/completions/duply.fish:15
 msgid "Prints backup sets and chains currently in repository"
 msgstr ""
 
-#: share/completions/duply.fish:18
+#: share/completions/duply.fish:16
 msgid "List files changed since latest backup"
 msgstr ""
 
-#: share/completions/duply.fish:19
+#: share/completions/duply.fish:17
 msgid "Shows outdated backup archives [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:20
+#: share/completions/duply.fish:18
 msgid "Shows outdated backups [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:21
+#: share/completions/duply.fish:19
 msgid "Shows broken backup archives [--force, delete these files]"
 msgstr ""
 
-#: share/completions/duply.fish:22
+#: share/completions/duply.fish:20
 msgid "Restore the backup to <target_path> [as it was at <age>]"
 msgstr ""
 
-#: share/completions/duply.fish:23
+#: share/completions/duply.fish:21
 msgid "Restore single file/folder from backup [as it was at <age>]"
 msgstr ""
 
-#: share/completions/duply.fish:26
+#: share/completions/duply.fish:24
 msgid "Really execute the commands: purge, purge-full, cleanup"
 msgstr ""
 
-#: share/completions/duply.fish:27
+#: share/completions/duply.fish:25
 msgid "Do nothing but print out generated duplicity command lines"
 msgstr ""
 
-#: share/completions/duply.fish:28
+#: share/completions/duply.fish:26
 msgid "Calculate what would be done, but dont perform any actions"
 msgstr ""
 
-#: share/completions/duply.fish:29
+#: share/completions/duply.fish:27
 msgid "Dont abort when backup different dirs to the same backend"
 msgstr ""
 
-#: share/completions/duply.fish:30
+#: share/completions/duply.fish:28
 #, fuzzy
 msgid "Output verbosity level"
 msgstr "Output sources.list file"
@@ -4014,76 +4065,27 @@ msgid ""
 msgstr ""
 "Prints completions for installed packages on the system from /var/db/pkg"
 
-#: share/completions/emerge.fish:12 share/completions/equery.fish:12
+#: share/completions/emerge.fish:13 share/completions/equery.fish:12
 #, fuzzy
 msgid ""
 "Prints completions for all available packages on the system from /usr/portage"
 msgstr ""
 "Prints completions for installed packages on the system from /var/db/pkg"
 
-#: share/completions/emerge.fish:19
+#: share/completions/emerge.fish:22
 #, fuzzy
 msgid ""
 "Tests if emerge command should have an installed package as potential "
 "completion"
 msgstr "Test if emerge command should have packages as potential completion"
 
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
+#: share/completions/emerge.fish:32
 #, fuzzy
-msgid "All base system packages"
-msgstr "Erase built packages"
-
-#: share/completions/emerge.fish:30 share/completions/emerge.fish:31
-#, fuzzy
-msgid "All packages in world"
-msgstr "Sync packages installed"
-
-#: share/completions/emerge.fish:30
-#, fuzzy
-msgid "Installed package"
-msgstr "Install new package"
-
-#: share/completions/emerge.fish:31
-#: share/functions/__fish_print_packages.fish:13
-msgid "Package"
-msgstr "Package"
-
-#: share/completions/emerge.fish:35
-msgid "Usage overview of emerge"
+msgid ""
+"Print completions for all packages including the version compare if that is "
+"already typed"
 msgstr ""
-
-#: share/completions/emerge.fish:35
-msgid "Help on subject system"
-msgstr ""
-
-#: share/completions/emerge.fish:35
-#, fuzzy
-msgid "Help on subject config"
-msgstr "Help section"
-
-#: share/completions/emerge.fish:35
-#, fuzzy
-msgid "Help on subject sync"
-msgstr "Help section"
-
-#: share/completions/emerge.fish:57
-#, fuzzy
-msgid "Use colors in output"
-msgstr "Use colors"
-
-#: share/completions/emerge.fish:57
-msgid "Don't use colors in output"
-msgstr ""
-
-#: share/completions/emerge.fish:81
-#, fuzzy
-msgid "Pull in build time dependencies"
-msgstr "Show build dependencies"
-
-#: share/completions/emerge.fish:81
-#, fuzzy
-msgid "Don't pull in build time dependencies"
-msgstr "Don't automatically fulfill dependencies"
+"Prints completions for installed packages on the system from /var/db/pkg"
 
 #: share/completions/env.fish:2
 #, fuzzy
@@ -4618,11 +4620,16 @@ msgstr ""
 msgid "Update the RubyGems system software"
 msgstr ""
 
-#: share/completions/git.fish:121 share/completions/git.fish:144
+#: share/completions/git.fish:98
+#, fuzzy
+msgid "name"
+msgstr "Username"
+
+#: share/completions/git.fish:153 share/completions/git.fish:176
 msgid "Branch"
 msgstr ""
 
-#: share/completions/git.fish:145
+#: share/completions/git.fish:177
 #, fuzzy
 msgid "Tag"
 msgstr "Target"
@@ -4865,603 +4872,6 @@ msgstr "Help on command substitution (SUBCOMMAND)"
 msgid "Help on process expansion %JOB"
 msgstr "Help on process expansion %JOB"
 
-#: share/completions/hg.fish:17
-#, fuzzy
-msgid "add the specified files on the next commit"
-msgstr "Add specified file to the current list of keyrings"
-
-#: share/completions/hg.fish:18
-msgid "add all new files, delete all missing files"
-msgstr ""
-
-#: share/completions/hg.fish:19
-#, fuzzy
-msgid "show changeset information by line for each file"
-msgstr "Display change information for the package"
-
-#: share/completions/hg.fish:20
-#, fuzzy
-msgid "create an unversioned archive of a repository revision"
-msgstr "Commit an unversioned file or tree into the repository"
-
-#: share/completions/hg.fish:21
-msgid "reverse effect of earlier changeset"
-msgstr ""
-
-#: share/completions/hg.fish:22
-msgid "subdivision search of changesets"
-msgstr ""
-
-#: share/completions/hg.fish:23
-msgid "track a line of development with movable markers"
-msgstr ""
-
-#: share/completions/hg.fish:24
-msgid "set or show the current branch name"
-msgstr ""
-
-#: share/completions/hg.fish:25
-#, fuzzy
-msgid "list repository named branches"
-msgstr "Disable repository"
-
-#: share/completions/hg.fish:26
-#, fuzzy
-msgid "create a changegroup file"
-msgstr "Read package from file"
-
-#: share/completions/hg.fish:27
-#, fuzzy
-msgid "output the current or given revision of files"
-msgstr "Show the log messages for a set of revision(s) and/or file(s)"
-
-#: share/completions/hg.fish:28
-#, fuzzy
-msgid "make a copy of an existing repository"
-msgstr "Create a local copy of another repository"
-
-#: share/completions/hg.fish:29
-#, fuzzy
-msgid "commit the specified files or all outstanding changes"
-msgstr "Decrypt specified file or stdin"
-
-#: share/completions/hg.fish:30
-msgid "mark files as copied for the next commit"
-msgstr ""
-
-#: share/completions/hg.fish:31
-msgid "diff repository (or selected files)"
-msgstr ""
-
-#: share/completions/hg.fish:32
-msgid "dump the header and diffs for one or more changesets"
-msgstr ""
-
-#: share/completions/hg.fish:33
-#, fuzzy
-msgid "forget the specified files on the next commit"
-msgstr "Move file specified on commandline"
-
-#: share/completions/hg.fish:34
-#, fuzzy
-msgid "copy changes from other branches onto the current branch"
-msgstr "Bring changes from the repository into the working copy"
-
-#: share/completions/hg.fish:35
-msgid "search for a pattern in specified files and revisions"
-msgstr ""
-
-#: share/completions/hg.fish:36
-msgid "show current repository heads or show branch heads"
-msgstr ""
-
-#: share/completions/hg.fish:37
-msgid "show help for a given topic or a help overview"
-msgstr ""
-
-#: share/completions/hg.fish:38
-#, fuzzy
-msgid "identify the working copy or specified revision"
-msgstr "Update the working copy to a different URL"
-
-#: share/completions/hg.fish:39
-#, fuzzy
-msgid "import an ordered set of patches"
-msgstr "Print byte offset of matches"
-
-#: share/completions/hg.fish:40
-msgid "show new changesets found in source"
-msgstr ""
-
-#: share/completions/hg.fish:41
-#, fuzzy
-msgid "create a new repository in the given directory"
-msgstr "Create a CVS repository if it doesnt exist"
-
-#: share/completions/hg.fish:42
-#, fuzzy
-msgid "locate files matching specific patterns"
-msgstr "Exclude files that match pattern"
-
-#: share/completions/hg.fish:43
-msgid "show revision history of entire repository or files"
-msgstr ""
-
-#: share/completions/hg.fish:44
-#, fuzzy
-msgid "output the current or given revision of the project manifest"
-msgstr "Show the log messages for a set of revision(s) and/or file(s)"
-
-#: share/completions/hg.fish:45
-msgid "merge working directory with another revision"
-msgstr ""
-
-#: share/completions/hg.fish:46
-#, fuzzy
-msgid "show changesets not found in the destination"
-msgstr "Query packages with the specified group"
-
-#: share/completions/hg.fish:47
-#, fuzzy
-msgid "show the parents of the working directory or revision"
-msgstr "Change working directory"
-
-#: share/completions/hg.fish:48
-#, fuzzy
-msgid "show aliases for remote repositories"
-msgstr "Removes entry in .cvspass for remote repository"
-
-#: share/completions/hg.fish:49
-msgid "set or show the current phase name"
-msgstr ""
-
-#: share/completions/hg.fish:50
-#, fuzzy
-msgid "pull changes from the specified source"
-msgstr "Query packages with the specified group"
-
-#: share/completions/hg.fish:51
-#, fuzzy
-msgid "push changes to the specified destination"
-msgstr "Query packages with the specified group"
-
-#: share/completions/hg.fish:52
-msgid "roll back an interrupted transaction"
-msgstr ""
-
-#: share/completions/hg.fish:53
-#, fuzzy
-msgid "remove the specified files on the next commit"
-msgstr "Move file specified on commandline"
-
-#: share/completions/hg.fish:54
-msgid "rename files; equivalent of copy + remove"
-msgstr ""
-
-#: share/completions/hg.fish:55
-msgid "redo merges or set/view the merge status of files"
-msgstr ""
-
-#: share/completions/hg.fish:56
-msgid "restore files to their checkout state"
-msgstr ""
-
-#: share/completions/hg.fish:57
-msgid "roll back the last transaction (dangerous)"
-msgstr ""
-
-#: share/completions/hg.fish:58
-#, fuzzy
-msgid "print the root (top) of the current working directory"
-msgstr "Change working directory"
-
-#: share/completions/hg.fish:59
-msgid "start stand-alone webserver"
-msgstr ""
-
-#: share/completions/hg.fish:60
-msgid "show combined config settings from all hgrc files"
-msgstr ""
-
-#: share/completions/hg.fish:61
-#, fuzzy
-msgid "show changed files in the working directory"
-msgstr "Change working directory"
-
-#: share/completions/hg.fish:62
-#, fuzzy
-msgid "summarize working directory state"
-msgstr "Print working directory"
-
-#: share/completions/hg.fish:63
-msgid "add one or more tags for the current or given revision"
-msgstr ""
-
-#: share/completions/hg.fish:64
-#, fuzzy
-msgid "list repository tags"
-msgstr "Disable repository"
-
-#: share/completions/hg.fish:65
-#, fuzzy
-msgid "show the tip revision"
-msgstr "Show the time"
-
-#: share/completions/hg.fish:66
-#, fuzzy
-msgid "apply one or more changegroup files"
-msgstr "Read package from file"
-
-#: share/completions/hg.fish:67
-#, fuzzy
-msgid "update working directory (or switch revisions)"
-msgstr "Change working directory"
-
-#: share/completions/hg.fish:68
-#, fuzzy
-msgid "verify the integrity of the repository"
-msgstr "Remove an entry from the repository"
-
-#: share/completions/hg.fish:69
-#, fuzzy
-msgid "output version and copyright information"
-msgstr "Ignore version magic information"
-
-#: share/completions/hg.fish:70
-#, fuzzy
-msgid "Configuration Files"
-msgstr "Configuration file"
-
-#: share/completions/hg.fish:71
-#, fuzzy
-msgid "Date Formats"
-msgstr "Set format"
-
-#: share/completions/hg.fish:72
-#, fuzzy
-msgid "Diff Formats"
-msgstr "List format"
-
-#: share/completions/hg.fish:73
-#, fuzzy
-msgid "Environment Variables"
-msgstr "Handle environment variables"
-
-#: share/completions/hg.fish:74
-msgid "Using Additional Features"
-msgstr ""
-
-#: share/completions/hg.fish:75
-#, fuzzy
-msgid "Specifying File Sets"
-msgstr "Specify config file"
-
-#: share/completions/hg.fish:76
-msgid "Glossary"
-msgstr ""
-
-#: share/completions/hg.fish:77
-msgid "Syntax for Mercurial Ignore Files"
-msgstr ""
-
-#: share/completions/hg.fish:78
-#, fuzzy
-msgid "Configuring hgweb"
-msgstr "Configuration file"
-
-#: share/completions/hg.fish:79
-#, fuzzy
-msgid "Merge Tools"
-msgstr "Merge sorted files"
-
-#: share/completions/hg.fish:80
-#, fuzzy
-msgid "Specifying Multiple Revisions"
-msgstr "Specify revision"
-
-#: share/completions/hg.fish:81
-msgid "File Name Patterns"
-msgstr ""
-
-#: share/completions/hg.fish:82
-msgid "Working with Phases"
-msgstr ""
-
-#: share/completions/hg.fish:83
-#, fuzzy
-msgid "Specifying Single Revisions"
-msgstr "Specify revision"
-
-#: share/completions/hg.fish:84
-#, fuzzy
-msgid "Specifying Revision Sets"
-msgstr "Specify revision states"
-
-#: share/completions/hg.fish:85
-msgid "Subrepositories"
-msgstr ""
-
-#: share/completions/hg.fish:86
-msgid "Template Usage"
-msgstr ""
-
-#: share/completions/hg.fish:87
-msgid "URL Paths"
-msgstr ""
-
-#: share/completions/hg.fish:94 share/completions/hg.fish:433
-#: share/completions/hg.fish:458 share/completions/hg.fish:569
-#: share/completions/hg.fish:579 share/completions/hg.fish:594
-#: share/completions/hg.fish:606 share/completions/hg.fish:671
-#, fuzzy
-msgid "[+] include names matching the given patterns"
-msgstr "Insert modules matching the given wildcard"
-
-#: share/completions/hg.fish:95 share/completions/hg.fish:434
-#: share/completions/hg.fish:459 share/completions/hg.fish:570
-#: share/completions/hg.fish:580 share/completions/hg.fish:595
-#: share/completions/hg.fish:607 share/completions/hg.fish:672
-#, fuzzy
-msgid "[+] exclude names matching the given patterns"
-msgstr "List all modules matching the given wildcard"
-
-#: share/completions/hg.fish:104 share/completions/hg.fish:391
-msgid "Guess renamed files by similarity (0<=s<=100)"
-msgstr ""
-
-#: share/completions/hg.fish:105
-#, fuzzy
-msgid "[+]   include names matching the given patterns"
-msgstr "Insert modules matching the given wildcard"
-
-#: share/completions/hg.fish:106
-#, fuzzy
-msgid "[+]   exclude names matching the given patterns"
-msgstr "List all modules matching the given wildcard"
-
-#: share/completions/hg.fish:114
-#, fuzzy
-msgid "Annotate the specified revision"
-msgstr "Help for the specified builtin"
-
-#: share/completions/hg.fish:387
-#, fuzzy
-msgid "Use text as commit message"
-msgstr "Read commit message from file"
-
-#: share/completions/hg.fish:388
-msgid "Read commit message from file"
-msgstr "Read commit message from file"
-
-#: share/completions/hg.fish:389 share/completions/hg.fish:693
-#, fuzzy
-msgid "Record the specified date as commit date"
-msgstr "Help for the specified command"
-
-#: share/completions/hg.fish:390 share/completions/hg.fish:694
-#, fuzzy
-msgid "Record the specified user as committer"
-msgstr "Use specified string as comment string"
-
-#: share/completions/hg.fish:400
-#, fuzzy
-msgid "File to store the bundles into"
-msgstr "Edit the patch bundle description"
-
-#: share/completions/hg.fish:401 share/completions/hg.fish:446
-#: share/completions/hg.fish:448 share/completions/hg.fish:450
-#: share/completions/hg.fish:485 share/completions/hg.fish:534
-#: share/completions/hg.fish:536 share/completions/hg.fish:548
-#: share/completions/hg.fish:550 share/completions/hg.fish:669
-msgid "[+]"
-msgstr ""
-
-#: share/completions/hg.fish:403
-msgid "[+] a specific branch you would like to pull"
-msgstr ""
-
-#: share/completions/hg.fish:406 share/completions/hg.fish:453
-#: share/completions/hg.fish:491
-#, fuzzy
-msgid "Limit number of changes displayed"
-msgstr "Only print number of matches"
-
-#: share/completions/hg.fish:409 share/completions/hg.fish:456
-#: share/completions/hg.fish:494 share/completions/hg.fish:507
-#: share/completions/hg.fish:709
-msgid "Display using template map file"
-msgstr ""
-
-#: share/completions/hg.fish:410 share/completions/hg.fish:457
-#: share/completions/hg.fish:495 share/completions/hg.fish:508
-#: share/completions/hg.fish:710
-#, fuzzy
-msgid "Display with template"
-msgstr "Display all matches"
-
-#: share/completions/hg.fish:411 share/completions/hg.fish:421
-#: share/completions/hg.fish:496 share/completions/hg.fish:537
-#: share/completions/hg.fish:552
-#, fuzzy
-msgid "Specify ssh command to use"
-msgstr "Pass command to shell"
-
-#: share/completions/hg.fish:412 share/completions/hg.fish:422
-#: share/completions/hg.fish:497 share/completions/hg.fish:538
-#: share/completions/hg.fish:553
-#, fuzzy
-msgid "Specify hg command to run on the remote side"
-msgstr "Specify root directory for rpm operations"
-
-#: share/completions/hg.fish:430
-#, fuzzy
-msgid "Search the repository as it is in REV"
-msgstr "Specify the repository URL"
-
-#: share/completions/hg.fish:441
-msgid "A filename will only show ancestors or"
-msgstr ""
-
-#: share/completions/hg.fish:443
-#, fuzzy
-msgid "Show revisions matching date spec"
-msgstr "Show only matching part"
-
-#: share/completions/hg.fish:445
-msgid "[+]    do case-insensitive search for a given text"
-msgstr ""
-
-#: share/completions/hg.fish:449
-msgid "[+]   show changesets within the given named branch"
-msgstr ""
-
-#: share/completions/hg.fish:466
-#, fuzzy
-msgid "Revision to display"
-msgstr "Select display"
-
-#: share/completions/hg.fish:475
-msgid "Revision to merge"
-msgstr ""
-
-#: share/completions/hg.fish:477 share/completions/hg.fish:593
-#, fuzzy
-msgid "Specify merge tool"
-msgstr "Specify trust model"
-
-#: share/completions/hg.fish:488
-msgid "[+] a specific branch you would like to push"
-msgstr ""
-
-#: share/completions/hg.fish:506
-#, fuzzy
-msgid "Show parents of the specified revision"
-msgstr "Query packages with the specified group"
-
-#: share/completions/hg.fish:525
-#, fuzzy
-msgid "[+] target revision"
-msgstr "Merge revisions"
-
-#: share/completions/hg.fish:535
-msgid "[+] bookmark to pull"
-msgstr ""
-
-#: share/completions/hg.fish:546
-msgid "You want to allow push to create a new named branch"
-msgstr ""
-
-#: share/completions/hg.fish:549
-msgid "[+] bookmark to push"
-msgstr ""
-
-#: share/completions/hg.fish:603 share/completions/hg.fish:726
-#, fuzzy
-msgid "Tipmost revision matching date"
-msgstr "Show only matching part"
-
-#: share/completions/hg.fish:604
-#, fuzzy
-msgid "Revert to the specified revision"
-msgstr "Help for the specified builtin"
-
-#: share/completions/hg.fish:615
-msgid "Not perform actions, just print output"
-msgstr ""
-
-#: share/completions/hg.fish:629
-msgid "Name of access log file to write to"
-msgstr ""
-
-#: share/completions/hg.fish:631
-msgid "Used internally by daemon mode"
-msgstr ""
-
-#: share/completions/hg.fish:632
-msgid "Name of error log file to write to"
-msgstr ""
-
-#: share/completions/hg.fish:633
-msgid "Port to listen on (default: 8000)"
-msgstr ""
-
-#: share/completions/hg.fish:634
-msgid "Address to listen on (default: all interfaces)"
-msgstr ""
-
-#: share/completions/hg.fish:635
-msgid "Prefix path to serve from (default: server root)"
-msgstr ""
-
-#: share/completions/hg.fish:636
-msgid "Name to show in web pages (default: working"
-msgstr ""
-
-#: share/completions/hg.fish:637
-msgid "Name of the hgweb config file (see \"hg help hgweb\")"
-msgstr ""
-
-#: share/completions/hg.fish:638
-msgid "Name of file to write process ID to"
-msgstr ""
-
-#: share/completions/hg.fish:640
-#, fuzzy
-msgid "For remote clients"
-msgstr "List or remove functions"
-
-#: share/completions/hg.fish:641
-msgid "Web templates to use"
-msgstr ""
-
-#: share/completions/hg.fish:642
-msgid "Template style to use"
-msgstr ""
-
-#: share/completions/hg.fish:644
-#, fuzzy
-msgid "SSL certificate file"
-msgstr "Set certificate policy"
-
-#: share/completions/hg.fish:651
-#, fuzzy
-msgid "Untrusted configuration options"
-msgstr "Set config options"
-
-#: share/completions/hg.fish:670
-#, fuzzy
-msgid "List the changed files of a revision"
-msgstr "List all properties on files, dirs, or revisions"
-
-#: share/completions/hg.fish:680
-msgid "For push and pull"
-msgstr ""
-
-#: share/completions/hg.fish:689
-msgid "Revision to tag"
-msgstr ""
-
-#: share/completions/hg.fish:692
-msgid "Use <text> as commit message"
-msgstr ""
-
-#: share/completions/hg.fish:717
-msgid "To new branch head if changesets were unbundled"
-msgstr ""
-
-#: share/completions/hg.fish:727
-#, fuzzy
-msgid "Revision"
-msgstr "Merge revisions"
-
-#: share/completions/hg.fish:844
-msgid "Or select an existing template-style (--style)"
-msgstr ""
-
-#: share/completions/hg.fish:845
-msgid "Is set"
-msgstr ""
-
 #: share/completions/history.fish:1
 msgid "Match history items that start with the given prefix"
 msgstr ""
@@ -5482,6 +4892,11 @@ msgstr "Start interface"
 #: share/completions/ifup.fish:1
 msgid "Network interface"
 msgstr "Network interface"
+
+#: share/completions/kitchen.fish:3
+#, fuzzy
+msgid "Test if kitchen has yet to be given the main command"
+msgstr "Test if apt has yet to be given the subcommand"
 
 #: share/completions/less.fish:3
 msgid "Buffer space"
@@ -5699,6 +5114,457 @@ msgstr "Specify commit message"
 #: share/completions/mv.fish:4
 msgid "Answer for overwrite questions"
 msgstr "Answer for overwrite questions"
+
+#: share/completions/node.fish:9
+#, fuzzy
+msgid "Print node's version"
+msgstr "Print PKG versions"
+
+#: share/completions/node.fish:10
+#, fuzzy
+msgid "Evaluate script"
+msgstr "Extract script"
+
+#: share/completions/node.fish:11
+#, fuzzy
+msgid "Print result of --eval"
+msgstr "Print flat profile"
+
+#: share/completions/obnam.fish:9
+#, fuzzy
+msgid "Adds an encryption key to the repository"
+msgstr "Add a new file/directory to the repository"
+
+#: share/completions/obnam.fish:11
+msgid "Lists the keys associated with each client"
+msgstr ""
+
+#: share/completions/obnam.fish:12
+#, fuzzy
+msgid "Lists the clients in the repository"
+msgstr "Update the repository"
+
+#: share/completions/obnam.fish:13
+#, fuzzy
+msgid "Compares two generations"
+msgstr "Tolerate sloppy mount options"
+
+#: share/completions/obnam.fish:14
+#, fuzzy
+msgid "Dumps the repository"
+msgstr "Update the repository"
+
+#: share/completions/obnam.fish:15
+#, fuzzy
+msgid "Removes a lock file for a client"
+msgstr "Remove all gz files from cache"
+
+#: share/completions/obnam.fish:16
+#, fuzzy
+msgid "Removes backup generations"
+msgstr "Remove completion"
+
+#: share/completions/obnam.fish:17
+#, fuzzy
+msgid "Checks the consistency of the repository"
+msgstr "Check the entire repository"
+
+#: share/completions/obnam.fish:18
+msgid "Lists every backup generation"
+msgstr ""
+
+#: share/completions/obnam.fish:19
+msgid "Lists the identifier for every generation"
+msgstr ""
+
+#: share/completions/obnam.fish:20
+#, fuzzy
+msgid "Lists the keys"
+msgstr "List trusted keys"
+
+#: share/completions/obnam.fish:21
+#, fuzzy
+msgid "Lists the toplevel keys"
+msgstr "List trusted keys"
+
+#: share/completions/obnam.fish:22
+#, fuzzy
+msgid "Lists the contents of a given generation"
+msgstr "List contents of directory"
+
+#: share/completions/obnam.fish:23
+#, fuzzy
+msgid "Makes the repository available via FUSE"
+msgstr "Update the repository"
+
+#: share/completions/obnam.fish:24
+msgid "Check if a backup age exceeds a threshold"
+msgstr ""
+
+#: share/completions/obnam.fish:25
+#, fuzzy
+msgid "Removes a client from the repository"
+msgstr "Specify the repository URL"
+
+#: share/completions/obnam.fish:26
+#, fuzzy
+msgid "Removes a key from the repository"
+msgstr "Create a local copy of another repository"
+
+#: share/completions/obnam.fish:27
+#, fuzzy
+msgid "Restore files from the repository"
+msgstr "Check files into the repository"
+
+#: share/completions/obnam.fish:28
+#, fuzzy
+msgid "Verifies files in the repository"
+msgstr "Check files into the repository"
+
+#: share/completions/obnam.fish:30
+msgid "Restore setuid/setgid bits in restored files"
+msgstr ""
+
+#: share/completions/obnam.fish:31
+msgid "Do not restore setuid/setgid bits in restored files"
+msgstr ""
+
+#: share/completions/obnam.fish:32
+#, fuzzy
+msgid "Name of client"
+msgstr "Negate expression"
+
+#: share/completions/obnam.fish:33
+#, fuzzy
+msgid "Compress repository with"
+msgstr "Compress to stdout"
+
+#: share/completions/obnam.fish:34
+msgid "For --nagios-last-backup-age: maximum age"
+msgstr ""
+
+#: share/completions/obnam.fish:35
+msgid "Dump metadata about files"
+msgstr ""
+
+#: share/completions/obnam.fish:36
+#, fuzzy
+msgid "Do not dump metadata about files"
+msgstr "Do not del built files"
+
+#: share/completions/obnam.fish:37
+#, fuzzy
+msgid "Generate man page"
+msgstr "Generate a new key pair"
+
+#: share/completions/obnam.fish:38
+msgid "Which generation to restore"
+msgstr ""
+
+#: share/completions/obnam.fish:39
+#, fuzzy
+msgid "Show this help message and exit"
+msgstr "Load the media and exit"
+
+#: share/completions/obnam.fish:40
+msgid "Policy for what generations to keep when forgetting."
+msgstr ""
+
+#: share/completions/obnam.fish:41
+msgid "Wait TIMEOUT seconds for an existing lock"
+msgstr ""
+
+#: share/completions/obnam.fish:43
+#, fuzzy
+msgid "Do not actually change anything"
+msgstr "Do not write anything"
+
+#: share/completions/obnam.fish:44
+#, fuzzy
+msgid "Actually commit changes"
+msgstr "Summarize changes"
+
+#: share/completions/obnam.fish:45
+msgid "Show only errors, no progress updates"
+msgstr ""
+
+#: share/completions/obnam.fish:46
+msgid "Show errors and progress updates"
+msgstr ""
+
+#: share/completions/obnam.fish:49
+#, fuzzy
+msgid "Simulate failures for files that match REGEXP"
+msgstr "Select patch matching REGEXP"
+
+#: share/completions/obnam.fish:52
+msgid "Be more verbose"
+msgstr ""
+
+#: share/completions/obnam.fish:53
+#, fuzzy
+msgid "Do not be verbose"
+msgstr "Do not overwrite"
+
+#: share/completions/obnam.fish:54
+msgid "Verify N files randomly from the backup"
+msgstr ""
+
+#: share/completions/obnam.fish:55
+#, fuzzy
+msgid "Show version number and exit"
+msgstr "Display version and exit"
+
+#: share/completions/obnam.fish:57
+msgid "Make a checkpoint after a given SIZE"
+msgstr ""
+
+#: share/completions/obnam.fish:58
+#, fuzzy
+msgid "Deduplicate mode"
+msgstr "Read/Write mode"
+
+#: share/completions/obnam.fish:60
+#, fuzzy
+msgid "Exclude directories tagged as cache"
+msgstr "Search directories for source"
+
+#: share/completions/obnam.fish:61
+#, fuzzy
+msgid "Include directories tagged as cache"
+msgstr "Include directory"
+
+#: share/completions/obnam.fish:63
+msgid "Leave checkpoint generations at the end of backup"
+msgstr ""
+
+#: share/completions/obnam.fish:64
+msgid "Omit checkpoint generations at the end of backup"
+msgstr ""
+
+#: share/completions/obnam.fish:65
+#, fuzzy
+msgid "Do not follow mount points"
+msgstr "Do not fold long lines"
+
+#: share/completions/obnam.fish:66
+#, fuzzy
+msgid "Follow mount points"
+msgstr "Mount point"
+
+#: share/completions/obnam.fish:67
+msgid "Put small files directly into the B-tree"
+msgstr ""
+
+#: share/completions/obnam.fish:68
+msgid "No not put small files into the B-tree"
+msgstr ""
+
+#: share/completions/obnam.fish:70
+#, fuzzy
+msgid "Write out the current configuration"
+msgstr "Reload service configuration"
+
+#: share/completions/obnam.fish:71
+#, fuzzy
+msgid "Write out setting names"
+msgstr "Write out the prompt"
+
+#: share/completions/obnam.fish:72
+#, fuzzy
+msgid "Show all options"
+msgstr "Display help and debug options"
+
+#: share/completions/obnam.fish:73
+#, fuzzy
+msgid "List config files"
+msgstr "Use config file"
+
+#: share/completions/obnam.fish:74
+#, fuzzy
+msgid "Clear list of configuration files to read"
+msgstr "List of rpm configuration files"
+
+#: share/completions/obnam.fish:75
+msgid "PGP key with which to encrypt"
+msgstr ""
+
+#: share/completions/obnam.fish:76
+#, fuzzy
+msgid "Show additional user IDs"
+msgstr "Show history for all users"
+
+#: share/completions/obnam.fish:77
+#, fuzzy
+msgid "Do not show additional user IDs"
+msgstr "Do not store directory names"
+
+#: share/completions/obnam.fish:78
+msgid "PGP key id"
+msgstr ""
+
+#: share/completions/obnam.fish:79
+msgid "Size of symmetric key"
+msgstr ""
+
+#: share/completions/obnam.fish:80
+#, fuzzy
+msgid "Use /dev/urandom instead of /dev/random"
+msgstr "Use purge instead of remove"
+
+#: share/completions/obnam.fish:81
+msgid "Use default /dev/random"
+msgstr ""
+
+#: share/completions/obnam.fish:83
+msgid "fsck should try to fix problems"
+msgstr ""
+
+#: share/completions/obnam.fish:84
+msgid "fsck should not try to fix problems"
+msgstr ""
+
+#: share/completions/obnam.fish:85
+#, fuzzy
+msgid "Ignore chunks when checking integrity"
+msgstr "Ignore case when comparing file names"
+
+#: share/completions/obnam.fish:86
+msgid "Check chunks when checking integrity"
+msgstr ""
+
+#: share/completions/obnam.fish:87
+msgid "Do not check data for cient NAME."
+msgstr ""
+
+#: share/completions/obnam.fish:88
+#, fuzzy
+msgid "Check only the last generation"
+msgstr "Resumes the last merge operation"
+
+#: share/completions/obnam.fish:89 share/completions/obnam.fish:95
+#, fuzzy
+msgid "Check all generations"
+msgstr "Query installed packages"
+
+#: share/completions/obnam.fish:90
+#, fuzzy
+msgid "Do not check directories"
+msgstr "Do not store directory names"
+
+#: share/completions/obnam.fish:91
+#, fuzzy
+msgid "Check directories"
+msgstr "Recurse directories"
+
+#: share/completions/obnam.fish:92
+#, fuzzy
+msgid "Do not check files"
+msgstr "Do not change any files"
+
+#: share/completions/obnam.fish:93
+#, fuzzy
+msgid "Check files"
+msgstr "Query installed packages"
+
+#: share/completions/obnam.fish:94
+#, fuzzy
+msgid "Do not check any generations"
+msgstr "Do not change any files"
+
+#: share/completions/obnam.fish:96
+#, fuzzy
+msgid "Do not check per-client B-trees"
+msgstr "Do not print tags"
+
+#: share/completions/obnam.fish:97
+msgid "Check per-client B-trees"
+msgstr ""
+
+#: share/completions/obnam.fish:98
+#, fuzzy
+msgid "Do not check shared B-trees"
+msgstr "Do not change any files"
+
+#: share/completions/obnam.fish:99
+#, fuzzy
+msgid "Check shared B-trees"
+msgstr "Query installed packages"
+
+#: share/completions/obnam.fish:102
+msgid "Keep last N logs (10)"
+msgstr ""
+
+#: share/completions/obnam.fish:103
+msgid "Log at LEVEL"
+msgstr ""
+
+#: share/completions/obnam.fish:104
+msgid "Rotate logs larger than SIZE"
+msgstr ""
+
+#: share/completions/obnam.fish:105
+msgid "Set permissions of logfiles to MODE"
+msgstr ""
+
+#: share/completions/obnam.fish:106
+msgid "Options to pass to FUSE"
+msgstr ""
+
+#: share/completions/obnam.fish:107
+msgid "Make memory profiling dumps using METHOD"
+msgstr ""
+
+#: share/completions/obnam.fish:108
+msgid "Make memory profiling dumps at SECONDS"
+msgstr ""
+
+#: share/completions/obnam.fish:109
+msgid "Size of chunks of file data"
+msgstr ""
+
+#: share/completions/obnam.fish:110
+msgid "Encode NUM chunk ids per group"
+msgstr ""
+
+#: share/completions/obnam.fish:111
+msgid "Chunk id level size"
+msgstr ""
+
+#: share/completions/obnam.fish:112
+#, fuzzy
+msgid "Depth of chunk id mapping"
+msgstr "Depth of call chain"
+
+#: share/completions/obnam.fish:113
+msgid "Chunk id mapping lowest bits skip"
+msgstr ""
+
+#: share/completions/obnam.fish:114
+msgid "Size of LRU cache for B-tree nodes"
+msgstr ""
+
+#: share/completions/obnam.fish:115
+#, fuzzy
+msgid "Size of B-tree nodes on disk"
+msgstr "Show changes in reverse order"
+
+#: share/completions/obnam.fish:116
+msgid "Length of upload queue for B-tree nodes"
+msgstr ""
+
+#: share/completions/obnam.fish:117
+msgid "Use only paramiko, no openssh"
+msgstr ""
+
+#: share/completions/obnam.fish:118
+#, fuzzy
+msgid "Use openssh if available"
+msgstr "Build index if unavailable"
+
+#: share/completions/obnam.fish:120
+msgid "ssh host key check"
+msgstr ""
 
 #: share/completions/perl.fish:6
 msgid "Specify record separator"
@@ -6326,15 +6192,15 @@ msgstr "Change background color"
 msgid "Locale"
 msgstr "Locale"
 
-#: share/completions/sort.fish:12
+#: share/completions/sort.fish:16
 msgid "Write to file"
 msgstr "Write to file"
 
-#: share/completions/sort.fish:14
+#: share/completions/sort.fish:18
 msgid "Set memory buffer size"
 msgstr "Set memory buffer size"
 
-#: share/completions/sort.fish:16
+#: share/completions/sort.fish:20
 msgid "Set temporary directory"
 msgstr "Set temporary directory"
 
@@ -6596,7 +6462,7 @@ msgstr ""
 msgid "Test if vagrant has yet to be given the main command"
 msgstr "Test if apt has yet to be given the subcommand"
 
-#: share/completions/vagrant.fish:34
+#: share/completions/vagrant.fish:23
 #, fuzzy
 msgid "Lists all available Vagrant boxes"
 msgstr "List names of available signals"
@@ -7847,6 +7713,11 @@ msgstr "Display each file's MAC label"
 msgid "Include the file flags in a long (-l) output"
 msgstr "Include the file flags in a long (-l) output"
 
+#: share/functions/__fish_complete_path.fish:1
+#, fuzzy
+msgid "Complete using path"
+msgstr "Tolerate sloppy mount options"
+
 #: share/functions/__fish_complete_ppp_peer.fish:1
 msgid "Complete isp name for pon/poff"
 msgstr ""
@@ -8444,65 +8315,52 @@ msgstr ""
 msgid "Complete md5sum sha1 etc"
 msgstr ""
 
-#: share/functions/__fish_config_interactive.fish:65
-#, sh-format
-msgid ""
-"\\nWARNING\\n\\nThe location for fish configuration files has changed to %s."
-"\\nYour old files have been moved to this location.\\nYou can change to a "
-"different location by changing the value of the variable $XDG_CONFIG_HOME.\\n"
-"\\n"
-msgstr ""
-
-#: share/functions/__fish_config_interactive.fish:82
+#: share/functions/__fish_config_interactive.fish:34
 #, fuzzy
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Welcome to fish, the friendly interactive shell"
 
-#: share/functions/__fish_config_interactive.fish:83
+#: share/functions/__fish_config_interactive.fish:35
 #, fuzzy
 msgid "Type %shelp%s for instructions on how to use fish"
 msgstr "Type %shelp%s for instructions on how to use fish"
 
-#: share/functions/__fish_config_interactive.fish:173
+#: share/functions/__fish_config_interactive.fish:130
 msgid "Event handler, repaints the prompt when fish_color_cwd changes"
 msgstr "Event handler, repaints the prompt when fish_color_cwd changes"
 
-#: share/functions/__fish_config_interactive.fish:180
+#: share/functions/__fish_config_interactive.fish:137
 #, fuzzy
 msgid "Event handler, repaints the prompt when fish_color_cwd_root changes"
 msgstr "Event handler, repaints the prompt when fish_color_cwd changes"
 
-#: share/functions/__fish_config_interactive.fish:192
+#: share/functions/__fish_config_interactive.fish:149
 msgid "Start service"
 msgstr "Start service"
 
-#: share/functions/__fish_config_interactive.fish:193
+#: share/functions/__fish_config_interactive.fish:150
 msgid "Stop service"
 msgstr "Stop service"
 
-#: share/functions/__fish_config_interactive.fish:194
+#: share/functions/__fish_config_interactive.fish:151
 msgid "Print service status"
 msgstr "Print service status"
 
-#: share/functions/__fish_config_interactive.fish:195
+#: share/functions/__fish_config_interactive.fish:152
 msgid "Stop and then start service"
 msgstr "Stop and then start service"
 
-#: share/functions/__fish_config_interactive.fish:196
+#: share/functions/__fish_config_interactive.fish:153
 msgid "Reload service configuration"
 msgstr "Reload service configuration"
 
-#: share/functions/__fish_config_interactive.fish:228
+#: share/functions/__fish_config_interactive.fish:193
 #, sh-format
 msgid "Notify VTE of change to $PWD"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:173
 msgid "Helper function for __fish_git_prompt"
-msgstr ""
-
-#: share/functions/__fish_git_prompt.fish:244
-msgid "svn_upstream"
 msgstr ""
 
 #: share/functions/__fish_git_prompt.fish:348
@@ -8549,6 +8407,11 @@ msgstr "Event handler, repaints the prompt when fish_color_cwd changes"
 msgid "Event handler, repaints prompt when any char changes"
 msgstr "Event handler, repaints the prompt when fish_color_cwd changes"
 
+#: share/functions/__fish_hg_prompt.fish:23
+#, fuzzy
+msgid "Write out the hg prompt"
+msgstr "Write out the prompt"
+
 #: share/functions/__fish_is_token_n.fish:1
 msgid "Test if current token is on Nth place"
 msgstr ""
@@ -8586,7 +8449,7 @@ msgstr "Print a list of all accepted color names"
 msgid "Prints services installed"
 msgstr "Print service status"
 
-#: share/functions/__fish_print_help.fish:2
+#: share/functions/__fish_print_help.fish:1
 #, fuzzy
 msgid "Print help message for the specified fish function or builtin"
 msgstr "Print all completions for the specified commandline"
@@ -8615,6 +8478,10 @@ msgstr "Print available list"
 #, fuzzy
 msgid "Print mounted devices"
 msgstr "Print important dependencies"
+
+#: share/functions/__fish_print_packages.fish:13
+msgid "Package"
+msgstr "Package"
 
 #: share/functions/__fish_print_svn_rev.fish:1
 #, fuzzy
@@ -8669,15 +8536,62 @@ msgstr "Rename stdin"
 msgid "Write out the git prompt"
 msgstr "Write out the prompt"
 
+#: share/functions/abbr.fish:1
+#, fuzzy
+msgid "Manage abbreviations"
+msgstr "Manual sections"
+
+#: share/functions/abbr.fish:40
+#, fuzzy
+msgid "%s: invalid option -- %s\\n"
+msgstr "%ls: Invalid option -- %lc\n"
+
+#: share/functions/abbr.fish:47
+#, fuzzy
+msgid "%s: %s cannot be specified along with %s\\n"
+msgstr "%ls: Values cannot be specfied with erase\n"
+
+#: share/functions/abbr.fish:56
+#, fuzzy
+msgid "%s: option requires an argument -- %s\\n"
+msgstr "%ls: Option requires an argument -- %lc\n"
+
+#: share/functions/abbr.fish:62
+#, fuzzy
+msgid "%s: Unexpected argument -- %s\\n"
+msgstr "%ls: Expected argument\n"
+
+#: share/functions/abbr.fish:75
+msgid "%s: abbreviation must have a non-empty key\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:79
+msgid "%s: abbreviation must have a value\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:101
+#, fuzzy
+msgid "%s: no such abbreviation '%s'\\n"
+msgstr "%s: Unknown option “%s”\\n"
+
 #: share/functions/alias.fish:2
 msgid ""
 "Legacy function for creating shellscript functions using an alias-like syntax"
 msgstr ""
 
-#: share/functions/alias.fish:34
+#: share/functions/alias.fish:36
 #, fuzzy
 msgid "%s: Expected one or two arguments, got %d\\n"
 msgstr "%s: Expected 1, 2 or 3 arguments, got %d\\n"
+
+#: share/functions/alias.fish:42
+#, fuzzy
+msgid "%s: Name cannot be empty\\n"
+msgstr "%ls: Variable name can not be the empty string\n"
+
+#: share/functions/alias.fish:45
+msgid "%s: Body cannot be empty\\n"
+msgstr ""
 
 #: share/functions/contains_seq.fish:1
 msgid "Return true if array contains a sequence"
@@ -8690,6 +8604,10 @@ msgstr "Print the current directory history (the back- and fwd- lists)"
 #: share/functions/dirs.fish:1
 msgid "Print directory stack"
 msgstr "Print directory stack"
+
+#: share/functions/export.fish:1
+msgid "Set global variable. Alias for set -g, made for bash compatibility"
+msgstr ""
 
 #: share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
@@ -8708,6 +8626,20 @@ msgstr "Write out the prompt"
 msgid "Update man-page based completions"
 msgstr "Edit command specific completions"
 
+#: share/functions/fish_vi_key_bindings.fish:1
+#, fuzzy
+msgid "vi-like key bindings for fish"
+msgstr "Specify key bindings file"
+
+#: share/functions/fish_vi_prompt.fish:1
+#, fuzzy
+msgid "Displays the current mode"
+msgstr "Display version and exit"
+
+#: share/functions/fish_vi_prompt.fish:17
+msgid "Simple vi prompt"
+msgstr ""
+
 #: share/functions/funced.fish:1
 #, fuzzy
 msgid "Edit function definition"
@@ -8723,6 +8655,19 @@ msgstr "%s: Unknown option %s\\n"
 msgid "funced: You must specify one function name\n"
 msgstr "%ls: Expected exactly one function name\n"
 
+#: share/functions/funced.fish:96
+msgid "Editing failed or was cancelled"
+msgstr ""
+
+#: share/functions/funced.fish:103
+msgid "Edit the file again\\? [Y/n]"
+msgstr ""
+
+#: share/functions/funced.fish:110
+#, fuzzy
+msgid "Cancelled function editing"
+msgstr "function definition block"
+
 #: share/functions/funcsave.fish:2
 msgid "Save the current definition of all specified functions to file"
 msgstr ""
@@ -8737,7 +8682,7 @@ msgstr "%ls: Expected function name\n"
 msgid "%s: Could not create configuration directory\\n"
 msgstr "%ls: Could not find home directory\n"
 
-#: share/functions/funcsave.fish:37
+#: share/functions/funcsave.fish:36
 #, fuzzy
 msgid "%s: Unknown function '%s'\\n"
 msgstr "%s: Unknown option “%s”\\n"
@@ -8785,7 +8730,7 @@ msgstr ""
 msgid "List contents of directory using long format"
 msgstr "List contents of directory using long format"
 
-#: share/functions/ls.fish:7 share/functions/ls.fish:24
+#: share/functions/ls.fish:7 share/functions/ls.fish:32
 msgid "List contents of directory"
 msgstr "List contents of directory"
 
@@ -8832,7 +8777,6 @@ msgstr "Move back in the directory history"
 msgid "The number of positions to skip must be a non-negative integer\\n"
 msgstr "The number of positions to skip must be a non-negative integer\\n"
 
-#: share/functions/prompt_pwd.fish:3 share/functions/prompt_pwd.fish:7
 #: share/functions/prompt_pwd.fish:11
 #, fuzzy
 msgid "Print the current working directory, shortened to fit the prompt"
@@ -8875,35 +8819,35 @@ msgstr ""
 msgid "Print the type of a command"
 msgstr "Print the type of a command"
 
-#: share/functions/type.fish:84
+#: share/functions/type.fish:90
 #, fuzzy
 msgid "%s is a function with definition\\n"
 msgstr "%ls: Missing function definition information."
 
-#: share/functions/type.fish:88
+#: share/functions/type.fish:94
 #, fuzzy
 msgid "function"
 msgstr "function\\n"
 
-#: share/functions/type.fish:105
+#: share/functions/type.fish:107
 msgid "%s is a builtin\\n"
 msgstr "%s is a builtin\\n"
 
-#: share/functions/type.fish:108
+#: share/functions/type.fish:110
 #, fuzzy
 msgid "builtin"
 msgstr "builtin\\n"
 
-#: share/functions/type.fish:132
+#: share/functions/type.fish:130
 msgid "%s is %s\\n"
 msgstr "%s is %s\\n"
 
-#: share/functions/type.fish:135
+#: share/functions/type.fish:133
 #, fuzzy
 msgid "file"
 msgstr "file\\n"
 
-#: share/functions/type.fish:147
+#: share/functions/type.fish:144
 msgid "%s: Could not find '%s'\\n"
 msgstr "%s: Could not find “%s”\\n"
 
@@ -8924,21 +8868,419 @@ msgstr "%s: Too many arguments\\n"
 msgid "Edit variable value"
 msgstr "Edit variable value"
 
-#: share/functions/vared.fish:41
+#: share/functions/vared.fish:40
+#, fuzzy
 msgid ""
-"%s: %s is an array variable. Use %svared%s %s[n] to edit the n:th element of "
-"%s\\n"
+"%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element "
+"of %s\\n"
 msgstr ""
 "%s: %s is an array variable. Use %svared%s %s[n] to edit the n:th element of "
 "%s\\n"
 
-#: share/functions/vared.fish:45
+#: share/functions/vared.fish:44
 msgid ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
 "VARIABLE\\n"
 msgstr ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
 "VARIABLE\\n"
+
+#, fuzzy
+#~ msgid "%ls: Expected zero or two parameters, got %d\n"
+#~ msgstr "%ls：应有至多一个参数，提供了 %d 个\n"
+
+#~ msgid "Current functions are: "
+#~ msgstr "当前的函数是： "
+
+#~ msgid "%ls: Not inside of block\n"
+#~ msgstr "%ls：不在区块之内\n"
+
+#~ msgid "%ls: Not inside of 'if' block\n"
+#~ msgstr "%ls：不在 “if” 区块之内\n"
+
+#~ msgid "%ls: Expected exactly one argument, got %d\n"
+#~ msgstr "%ls：应恰好有一个参数，提供了 %d 个\n"
+
+#~ msgid "%ls: 'case' command while not in switch block\n"
+#~ msgstr "%ls：“case” 命令不在 switch 块内\n"
+
+#~ msgid "%ls: Unknown error"
+#~ msgstr "%ls：未知错误"
+
+#~ msgid "%ls: Can not specify scope when erasing array slice\n"
+#~ msgstr "%ls: Can not specify scope when erasing array slice\n"
+
+#~ msgid "Could not get user information"
+#~ msgstr "Could not get user information"
+
+#~ msgid "Could not convert message '%s' to wide character string"
+#~ msgstr "Could not convert message “%s” to wide character string"
+
+#~ msgid "%ls: Argument '%s' is not a valid file descriptor\n"
+#~ msgstr "%ls: Argument “%s” is not a valid file descriptor\n"
+
+#~ msgid "Could not set up input file descriptors for pager"
+#~ msgstr "Could not set up input file descriptors for pager"
+
+#~ msgid "Could not open tty for pager"
+#~ msgstr "Could not open tty for pager"
+
+#~ msgid "Unspecified file descriptors"
+#~ msgstr "Unspecified file descriptors"
+
+#~ msgid "Could not read completions"
+#~ msgstr "Could not read completions"
+
+#~ msgid "Could not expand string '%ls'"
+#~ msgstr "Could not expand string “%ls”"
+
+#~ msgid "An additional command is required"
+#~ msgstr "An additional command is required"
+
+#~ msgid ""
+#~ "Could not locate end of block. The 'end' command is missing, misspelled "
+#~ "or a ';' is missing."
+#~ msgstr ""
+#~ "Could not locate end of block. The “end” command is missing, misspelled "
+#~ "or a “;” is missing."
+
+#~ msgid "Expected a command name, got token of type '%ls'"
+#~ msgstr "Expected a command name, got token of type “%ls”"
+
+#~ msgid "'case' builtin not inside of switch block"
+#~ msgstr "“case” builtin not inside of switch block"
+
+#~ msgid "Loop control command while not inside of loop"
+#~ msgstr "Loop control command while not inside of loop"
+
+#, fuzzy
+#~ msgid "'%ls' builtin not inside of if block"
+#~ msgstr "“else” builtin not inside of if block"
+
+#~ msgid "'end' command outside of block"
+#~ msgstr "“end” command outside of block"
+
+#~ msgid "Expected redirection specification, got token of type '%ls'"
+#~ msgstr "Expected redirection specification, got token of type “%ls”"
+
+#~ msgid ""
+#~ "Encountered redirection when expecting a command name. Fish does not "
+#~ "allow a redirection operation before a command."
+#~ msgstr ""
+#~ "Encountered redirection when expecting a command name. Fish does not "
+#~ "allow a redirection operation before a command."
+
+#~ msgid "Invalid IO redirection"
+#~ msgstr "Invalid IO redirection"
+
+#~ msgid "Requested redirection to something that is not a file descriptor %ls"
+#~ msgstr ""
+#~ "Requested redirection to something that is not a file descriptor %ls"
+
+#~ msgid "Don't preserve the specified attributes"
+#~ msgstr "Don't preserve the specified attributes"
+
+#~ msgid "Control creation of sparse files"
+#~ msgstr "Control creation of sparse files"
+
+#, fuzzy
+#~ msgid "All base system packages"
+#~ msgstr "Erase built packages"
+
+#, fuzzy
+#~ msgid "All packages in world"
+#~ msgstr "Sync packages installed"
+
+#, fuzzy
+#~ msgid "Installed package"
+#~ msgstr "Install new package"
+
+#, fuzzy
+#~ msgid "Help on subject config"
+#~ msgstr "Help section"
+
+#, fuzzy
+#~ msgid "Help on subject sync"
+#~ msgstr "Help section"
+
+#, fuzzy
+#~ msgid "Use colors in output"
+#~ msgstr "Use colors"
+
+#, fuzzy
+#~ msgid "Pull in build time dependencies"
+#~ msgstr "Show build dependencies"
+
+#, fuzzy
+#~ msgid "Don't pull in build time dependencies"
+#~ msgstr "Don't automatically fulfill dependencies"
+
+#, fuzzy
+#~ msgid "add the specified files on the next commit"
+#~ msgstr "Add specified file to the current list of keyrings"
+
+#, fuzzy
+#~ msgid "show changeset information by line for each file"
+#~ msgstr "Display change information for the package"
+
+#, fuzzy
+#~ msgid "create an unversioned archive of a repository revision"
+#~ msgstr "Commit an unversioned file or tree into the repository"
+
+#, fuzzy
+#~ msgid "list repository named branches"
+#~ msgstr "Disable repository"
+
+#, fuzzy
+#~ msgid "create a changegroup file"
+#~ msgstr "Read package from file"
+
+#, fuzzy
+#~ msgid "output the current or given revision of files"
+#~ msgstr "Show the log messages for a set of revision(s) and/or file(s)"
+
+#, fuzzy
+#~ msgid "make a copy of an existing repository"
+#~ msgstr "Create a local copy of another repository"
+
+#, fuzzy
+#~ msgid "commit the specified files or all outstanding changes"
+#~ msgstr "Decrypt specified file or stdin"
+
+#, fuzzy
+#~ msgid "forget the specified files on the next commit"
+#~ msgstr "Move file specified on commandline"
+
+#, fuzzy
+#~ msgid "copy changes from other branches onto the current branch"
+#~ msgstr "Bring changes from the repository into the working copy"
+
+#, fuzzy
+#~ msgid "identify the working copy or specified revision"
+#~ msgstr "Update the working copy to a different URL"
+
+#, fuzzy
+#~ msgid "import an ordered set of patches"
+#~ msgstr "Print byte offset of matches"
+
+#, fuzzy
+#~ msgid "create a new repository in the given directory"
+#~ msgstr "Create a CVS repository if it doesnt exist"
+
+#, fuzzy
+#~ msgid "locate files matching specific patterns"
+#~ msgstr "Exclude files that match pattern"
+
+#, fuzzy
+#~ msgid "output the current or given revision of the project manifest"
+#~ msgstr "Show the log messages for a set of revision(s) and/or file(s)"
+
+#, fuzzy
+#~ msgid "show changesets not found in the destination"
+#~ msgstr "Query packages with the specified group"
+
+#, fuzzy
+#~ msgid "show the parents of the working directory or revision"
+#~ msgstr "Change working directory"
+
+#, fuzzy
+#~ msgid "show aliases for remote repositories"
+#~ msgstr "Removes entry in .cvspass for remote repository"
+
+#, fuzzy
+#~ msgid "pull changes from the specified source"
+#~ msgstr "Query packages with the specified group"
+
+#, fuzzy
+#~ msgid "push changes to the specified destination"
+#~ msgstr "Query packages with the specified group"
+
+#, fuzzy
+#~ msgid "remove the specified files on the next commit"
+#~ msgstr "Move file specified on commandline"
+
+#, fuzzy
+#~ msgid "print the root (top) of the current working directory"
+#~ msgstr "Change working directory"
+
+#, fuzzy
+#~ msgid "show changed files in the working directory"
+#~ msgstr "Change working directory"
+
+#, fuzzy
+#~ msgid "summarize working directory state"
+#~ msgstr "Print working directory"
+
+#, fuzzy
+#~ msgid "list repository tags"
+#~ msgstr "Disable repository"
+
+#, fuzzy
+#~ msgid "show the tip revision"
+#~ msgstr "Show the time"
+
+#, fuzzy
+#~ msgid "apply one or more changegroup files"
+#~ msgstr "Read package from file"
+
+#, fuzzy
+#~ msgid "update working directory (or switch revisions)"
+#~ msgstr "Change working directory"
+
+#, fuzzy
+#~ msgid "verify the integrity of the repository"
+#~ msgstr "Remove an entry from the repository"
+
+#, fuzzy
+#~ msgid "output version and copyright information"
+#~ msgstr "Ignore version magic information"
+
+#, fuzzy
+#~ msgid "Configuration Files"
+#~ msgstr "Configuration file"
+
+#, fuzzy
+#~ msgid "Date Formats"
+#~ msgstr "Set format"
+
+#, fuzzy
+#~ msgid "Diff Formats"
+#~ msgstr "List format"
+
+#, fuzzy
+#~ msgid "Environment Variables"
+#~ msgstr "Handle environment variables"
+
+#, fuzzy
+#~ msgid "Specifying File Sets"
+#~ msgstr "Specify config file"
+
+#, fuzzy
+#~ msgid "Configuring hgweb"
+#~ msgstr "Configuration file"
+
+#, fuzzy
+#~ msgid "Merge Tools"
+#~ msgstr "Merge sorted files"
+
+#, fuzzy
+#~ msgid "Specifying Multiple Revisions"
+#~ msgstr "Specify revision"
+
+#, fuzzy
+#~ msgid "Specifying Single Revisions"
+#~ msgstr "Specify revision"
+
+#, fuzzy
+#~ msgid "Specifying Revision Sets"
+#~ msgstr "Specify revision states"
+
+#, fuzzy
+#~ msgid "[+] include names matching the given patterns"
+#~ msgstr "Insert modules matching the given wildcard"
+
+#, fuzzy
+#~ msgid "[+] exclude names matching the given patterns"
+#~ msgstr "List all modules matching the given wildcard"
+
+#, fuzzy
+#~ msgid "[+]   include names matching the given patterns"
+#~ msgstr "Insert modules matching the given wildcard"
+
+#, fuzzy
+#~ msgid "[+]   exclude names matching the given patterns"
+#~ msgstr "List all modules matching the given wildcard"
+
+#, fuzzy
+#~ msgid "Annotate the specified revision"
+#~ msgstr "Help for the specified builtin"
+
+#, fuzzy
+#~ msgid "Use text as commit message"
+#~ msgstr "Read commit message from file"
+
+#~ msgid "Read commit message from file"
+#~ msgstr "Read commit message from file"
+
+#, fuzzy
+#~ msgid "Record the specified date as commit date"
+#~ msgstr "Help for the specified command"
+
+#, fuzzy
+#~ msgid "Record the specified user as committer"
+#~ msgstr "Use specified string as comment string"
+
+#, fuzzy
+#~ msgid "File to store the bundles into"
+#~ msgstr "Edit the patch bundle description"
+
+#, fuzzy
+#~ msgid "Limit number of changes displayed"
+#~ msgstr "Only print number of matches"
+
+#, fuzzy
+#~ msgid "Display with template"
+#~ msgstr "Display all matches"
+
+#, fuzzy
+#~ msgid "Specify ssh command to use"
+#~ msgstr "Pass command to shell"
+
+#, fuzzy
+#~ msgid "Specify hg command to run on the remote side"
+#~ msgstr "Specify root directory for rpm operations"
+
+#, fuzzy
+#~ msgid "Search the repository as it is in REV"
+#~ msgstr "Specify the repository URL"
+
+#, fuzzy
+#~ msgid "Show revisions matching date spec"
+#~ msgstr "Show only matching part"
+
+#, fuzzy
+#~ msgid "Revision to display"
+#~ msgstr "Select display"
+
+#, fuzzy
+#~ msgid "Specify merge tool"
+#~ msgstr "Specify trust model"
+
+#, fuzzy
+#~ msgid "Show parents of the specified revision"
+#~ msgstr "Query packages with the specified group"
+
+#, fuzzy
+#~ msgid "[+] target revision"
+#~ msgstr "Merge revisions"
+
+#, fuzzy
+#~ msgid "Tipmost revision matching date"
+#~ msgstr "Show only matching part"
+
+#, fuzzy
+#~ msgid "Revert to the specified revision"
+#~ msgstr "Help for the specified builtin"
+
+#, fuzzy
+#~ msgid "For remote clients"
+#~ msgstr "List or remove functions"
+
+#, fuzzy
+#~ msgid "SSL certificate file"
+#~ msgstr "Set certificate policy"
+
+#, fuzzy
+#~ msgid "Untrusted configuration options"
+#~ msgstr "Set config options"
+
+#, fuzzy
+#~ msgid "List the changed files of a revision"
+#~ msgstr "List all properties on files, dirs, or revisions"
+
+#, fuzzy
+#~ msgid "Revision"
+#~ msgstr "Merge revisions"
 
 #~ msgid "%ls: Missing function definition information."
 #~ msgstr "%ls: Missing function definition information."
@@ -8957,9 +9299,6 @@ msgstr ""
 
 #~ msgid "Failed to close file descriptor %d"
 #~ msgstr "Failed to close file descriptor %d"
-
-#~ msgid "Failed to execute process '%ls'"
-#~ msgstr "Failed to execute process “%ls”"
 
 #~ msgid ""
 #~ "Could not send process %d, '%ls' in job %d, '%ls' from group %d to group "
@@ -9051,10 +9390,6 @@ msgstr ""
 #~ msgid "Create a local copy of another repository"
 #~ msgstr "Create a local copy of another repository"
 
-#, fuzzy
-#~ msgid "Makes a copy of the repository"
-#~ msgstr "Create a local copy of another repository"
-
 #~ msgid "Optimize the repository"
 #~ msgstr "Optimize the repository"
 
@@ -9063,10 +9398,6 @@ msgstr ""
 
 #~ msgid "Specify hash of creator patch (see docs)"
 #~ msgstr "Specify hash of creator patch (see docs)"
-
-#, fuzzy
-#~ msgid "Name of version"
-#~ msgstr "Negate expression"
 
 #~ msgid "Send to context stored in FILENAME"
 #~ msgstr "Send to context stored in FILENAME"
@@ -9104,14 +9435,6 @@ msgstr ""
 
 #~ msgid "Use pattern from file"
 #~ msgstr "Use pattern from file"
-
-#, fuzzy
-#~ msgid "print information about the working copy"
-#~ msgstr "Output extra information about the work being done"
-
-#, fuzzy
-#~ msgid "export the repository via HTTP"
-#~ msgstr "Update the repository"
 
 #~ msgid "Debug option"
 #~ msgstr "Debug option"
@@ -9272,9 +9595,6 @@ msgstr ""
 #~ msgid "Prefix to strip on patch"
 #~ msgstr "Prefix to strip on patch"
 
-#~ msgid "Use purge instead of remove"
-#~ msgstr "Use purge instead of remove"
-
 #~ msgid "Do not run update"
 #~ msgstr "Do not run update"
 
@@ -9430,9 +9750,6 @@ msgstr ""
 #~ msgid "Overwrite"
 #~ msgstr "Overwrite"
 
-#~ msgid "Do not overwrite"
-#~ msgstr "Do not overwrite"
-
 #~ msgid "Reduce memory usage"
 #~ msgstr "Reduce memory usage"
 
@@ -9441,9 +9758,6 @@ msgstr ""
 
 #~ msgid "Print license"
 #~ msgstr "Print license"
-
-#~ msgid "Compress to stdout"
-#~ msgstr "Compress to stdout"
 
 #~ msgid "Compress file"
 #~ msgstr "Compress file"
@@ -9863,9 +10177,6 @@ msgstr ""
 #~ msgid "Option list is not complete"
 #~ msgstr "Option list is not complete"
 
-#~ msgid "Remove completion"
-#~ msgstr "Remove completion"
-
 #~ msgid ""
 #~ "The completion should only be used if the specified command has a zero "
 #~ "exit status"
@@ -9998,9 +10309,6 @@ msgstr ""
 #~ msgid "Bring work tree in sync with repository"
 #~ msgstr "Bring work tree in sync with repository"
 
-#~ msgid "Set watches"
-#~ msgstr "Set watches"
-
 #~ msgid "See who is watching a file"
 #~ msgstr "See who is watching a file"
 
@@ -10012,9 +10320,6 @@ msgstr ""
 
 #~ msgid "Do not use the ~/.cvsrc file"
 #~ msgstr "Do not use the ~/.cvsrc file"
-
-#~ msgid "Do not change any files"
-#~ msgstr "Do not change any files"
 
 #~ msgid "Cause CVS to be really quiet"
 #~ msgstr "Cause CVS to be really quiet"
@@ -10057,9 +10362,6 @@ msgstr ""
 
 #~ msgid "Process directories recursively"
 #~ msgstr "Process directories recursively"
-
-#~ msgid "Use a specified tag"
-#~ msgstr "Use a specified tag"
 
 #~ msgid "Specify filenames to be filtered"
 #~ msgstr "Specify filenames to be filtered"
@@ -10214,9 +10516,6 @@ msgstr ""
 #~ msgid "Report on all tags"
 #~ msgstr "Report on all tags"
 
-#~ msgid "Show history for all users"
-#~ msgstr "Show history for all users"
-
 #~ msgid "Show only records for this directory"
 #~ msgstr "Show only records for this directory"
 
@@ -10234,9 +10533,6 @@ msgstr ""
 
 #~ msgid "Print only file info"
 #~ msgstr "Print only file info"
-
-#~ msgid "Do not print tags"
-#~ msgstr "Do not print tags"
 
 #~ msgid "Print only rcs filename"
 #~ msgstr "Print only rcs filename"
@@ -10336,9 +10632,6 @@ msgstr ""
 #~ "Don't look for any files or directories that could be added, and don't "
 #~ "add them automatically"
 
-#~ msgid "Summarize changes"
-#~ msgstr "Summarize changes"
-
 #~ msgid "Suppress informational output"
 #~ msgstr "Suppress informational output"
 
@@ -10371,9 +10664,6 @@ msgstr ""
 
 #~ msgid "Forward unsigned messages without extra header"
 #~ msgstr "Forward unsigned messages without extra header"
-
-#~ msgid "Check the entire repository"
-#~ msgstr "Check the entire repository"
 
 #~ msgid "Check patches since latest checkpoint"
 #~ msgstr "Check patches since latest checkpoint"
@@ -10706,9 +10996,6 @@ msgstr ""
 #~ msgid "Reduced output from portage's displays"
 #~ msgstr "Reduced output from portage's displays"
 
-#~ msgid "Resumes the last merge operation"
-#~ msgstr "Resumes the last merge operation"
-
 #~ msgid ""
 #~ "Matches the search string against the description field as well the "
 #~ "package's name"
@@ -10777,9 +11064,6 @@ msgstr ""
 
 #~ msgid "Erase function"
 #~ msgstr "Erase function"
-
-#~ msgid "Show hidden functions"
-#~ msgstr "Show hidden functions"
 
 #~ msgid "Test if function is defined"
 #~ msgstr "Test if function is defined"
@@ -10994,9 +11278,6 @@ msgstr ""
 
 #~ msgid "List all keys with their fingerprints"
 #~ msgstr "List all keys with their fingerprints"
-
-#~ msgid "Generate a new key pair"
-#~ msgstr "Generate a new key pair"
 
 #~ msgid "Present a menu which enables you to do all key related tasks"
 #~ msgstr "Present a menu which enables you to do all key related tasks"
@@ -11506,9 +11787,6 @@ msgstr ""
 #~ msgid "No annotated source"
 #~ msgstr "No annotated source"
 
-#~ msgid "Print flat profile"
-#~ msgstr "Print flat profile"
-
 #~ msgid "No flat profile"
 #~ msgstr "No flat profile"
 
@@ -11574,9 +11852,6 @@ msgstr ""
 
 #~ msgid "Save/restore filename"
 #~ msgstr "Save/restore filename"
-
-#~ msgid "Recurse directories"
-#~ msgstr "Recurse directories"
 
 #~ msgid "Display compression ratios"
 #~ msgstr "Display compression ratios"
@@ -11659,9 +11934,6 @@ msgstr ""
 #~ msgid "Display status column"
 #~ msgstr "Display status column"
 
-#~ msgid "Specify key bindings file"
-#~ msgstr "Specify key bindings file"
-
 #~ msgid "Verbose prompt"
 #~ msgstr "Verbose prompt"
 
@@ -11697,9 +11969,6 @@ msgstr ""
 
 #~ msgid "Multiple blank lines sqeezed"
 #~ msgstr "Multiple blank lines sqeezed"
-
-#~ msgid "Do not fold long lines"
-#~ msgstr "Do not fold long lines"
 
 #~ msgid "Edit tag"
 #~ msgstr "Edit tag"
@@ -11824,9 +12093,6 @@ msgstr ""
 #~ msgid "Pager"
 #~ msgstr "Pager"
 
-#~ msgid "Manual sections"
-#~ msgstr "Manual sections"
-
 #~ msgid "Always reformat"
 #~ msgstr "Always reformat"
 
@@ -11932,9 +12198,6 @@ msgstr ""
 #~ msgid "Do not write mtab"
 #~ msgstr "Do not write mtab"
 
-#~ msgid "Read/Write mode"
-#~ msgstr "Read/Write mode"
-
 #~ msgid "Dynamically change postprocessing"
 #~ msgstr "Dynamically change postprocessing"
 
@@ -11973,9 +12236,6 @@ msgstr ""
 
 #~ msgid "Override framerate"
 #~ msgstr "Override framerate"
-
-#~ msgid "Build index if unavailable"
-#~ msgstr "Build index if unavailable"
 
 #~ msgid "Load index from file"
 #~ msgstr "Load index from file"
@@ -12159,9 +12419,6 @@ msgstr ""
 #~ msgid "Invoke CPP"
 #~ msgstr "Invoke CPP"
 
-#~ msgid "Extract script"
-#~ msgstr "Extract script"
-
 #~ msgid "Open folder"
 #~ msgstr "Open folder"
 
@@ -12255,9 +12512,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Bypass the normal routing tables and send directly to a host on an "
 #~ "attached interface"
-
-#~ msgid "Specifies the number of data bytes to be sent"
-#~ msgstr "Specifies the number of data bytes to be sent"
 
 #~ msgid "Set socket buffer size"
 #~ msgstr "Set socket buffer size"
@@ -12416,9 +12670,6 @@ msgstr ""
 
 #~ msgid "Explain what is done"
 #~ msgstr "Explain what is done"
-
-#~ msgid "List of rpm configuration files"
-#~ msgstr "List of rpm configuration files"
 
 #~ msgid "Pipe output through specified command"
 #~ msgstr "Pipe output through specified command"
@@ -13556,9 +13807,6 @@ msgstr ""
 
 #~ msgid "Move into zipfile (delete files)"
 #~ msgstr "Move into zipfile (delete files)"
-
-#~ msgid "Do not store directory names"
-#~ msgstr "Do not store directory names"
 
 #~ msgid "Do not compress at all"
 #~ msgstr "Do not compress at all"

--- a/share/completions/apt.fish
+++ b/share/completions/apt.fish
@@ -1,0 +1,65 @@
+# Completions for the `apt` command
+
+function __fish_apt_no_subcommand --description 'Test if apt has yet to be given the subcommand'
+	for i in (commandline -opc)
+		if contains -- $i update upgrade full-upgrade search list install show remove edit-sources
+			return 1
+		end
+	end
+	return 0
+end
+
+function __fish_apt_use_package --description 'Test if apt command should have packages as potential completion'
+	for i in (commandline -opc)
+		if contains -- $i contains install remove upgrade full-upgrade show search
+			return 0
+		end
+	end
+	return 1
+end
+
+function __fish_apt_subcommand
+    set subcommand $argv[1]; set -e argv[1]
+    complete -f -c apt -n '__fish_apt_no_subcommand' -a $subcommand $argv
+end
+
+complete -c apt -n '__fish_apt_use_package' -a '(__fish_print_packages)' --description 'Package'
+
+# Support flags
+complete -x -f -c apt -s h -l help     --description 'Display help'
+complete -x -f -c apt -s v -l version  --description 'Display version and exit'
+
+# General options
+complete -f -c apt -s o -l option       --description 'Set a configuration option'
+complete -f -c apt -s c -l config-file  --description 'Configuration file'
+complete -f -c apt -s t                 --description 'Target release'
+
+# List
+__fish_apt_subcommand list                  --description 'List packages'
+__fish_apt_subcommand list -l installed     --description 'Installed packages'
+__fish_apt_subcommand list -l upgradable    --description 'Upgradable packages'
+__fish_apt_subcommand list -l all-versions  --description 'Show all versions of any package'
+
+# Search
+__fish_apt_subcommand search -r        --description 'Search for packages'
+
+# Search
+__fish_apt_subcommand show -r          --description 'Show package information'
+
+# Install
+__fish_apt_subcommand install -r       --description 'Install packages'
+
+# Remove
+__fish_apt_subcommand remove -r        --description 'Remove packages'
+
+# Edit sources
+__fish_apt_subcommand edit-sources     --description 'Edit sources list'
+
+# Update
+__fish_apt_subcommand update -x        --description 'Update package list'
+
+# Upgrade
+__fish_apt_subcommand upgrade -r       --description 'Upgrade packages'
+
+# Full Upgrade
+__fish_apt_subcommand full-upgrade -r  --description 'Upgrade packages, removing others when needed'

--- a/share/config.fish
+++ b/share/config.fish
@@ -97,10 +97,6 @@ set -xg PATH $__fish_tmp_path
 set -e __fish_tmp_path
 functions -e __fish_load_path_helper_paths
 
-# Source any files matching /etc/profile.d/*.fish
-for file in /etc/profile.d/*.fish
-	source $file
-end
 
 # Add a handler for when fish_user_path changes, so we can apply the same changes to PATH
 # Invoke it immediately to apply the current value of fish_user_path


### PR DESCRIPTION
Similar to #1744

`LD_LIBRARY_PATH` *must* be a colon-separated string, according to `LD.SO(8)`:

```man
LD_LIBRARY_PATH
    A colon-separated list of directories in which to search for ELF libraries at execution-time.  
    Similar to the PATH environment variable.  Ignored in set-user-ID and set-group-ID programs.
```

Thus, in order for LD_LIBRARY_PATH to work with more than one entry, it must use `:` as a separator, rather than be handled as a first-class list in fish. This means I lose the benefits of treating `LD_LIBRARY_PATH` as a list in my fish configuration (to prevent cluttering). It would be convenient if fish were to implement IFS support for handling edge-cases like this.

Example of non-orthagonal behaviour:

```fish
set -x LD_LIBRARY_PATH /usr/local/lib /special_lib
ldd my_executable
    # my_library => Not found
contains /usr/local/lib $LD_LIBRARY_PATH 
    # true
```

Correct way (notice that `LD_LIBRARY_PATH` may no longer be treated as an array):

```fish
set -x LD_LIBRARY_PATH /usr/local/lib:/special_lib
ldd my_executable
    # my_library => /usr/local/lib/my_library.so.i
contains /usr/local/lib $LD_LIBRARY_PATH
    # false
```