### PR TITLE
consistent cursor in web config

### DIFF
--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -111,6 +111,7 @@ body {
 }
 
 .master_element {
+    cursor: pointer;
     padding-top: 6px;
     padding-bottom: 11px;
     padding-left: 5px;


### PR DESCRIPTION
Minor css tweak,
Currently, hovering over some of the clickable elements in the web config (such as the listed items in the colors tab) would present a text-selection cursor. This is a little non-intuitive, so it has been changed to a `pointer`.

Tested in Firefox 36, 37, and Chromium 42.