### PR TITLE
doc: faq: avoid overwriting config.fish.

### DIFF
--- a/doc_src/faq.hdr
+++ b/doc_src/faq.hdr
@@ -162,7 +162,7 @@ Quick answer:
 Run the following command in fish:
 
 \fish{cli-dark}
-echo 'function fish_title;end' > ~/.config/fish/config.fish
+echo 'function fish_title;end' >> ~/.config/fish/config.fish
 \endfish
 
 Problem solved!


### PR DESCRIPTION
In FAQ:

> I'm seeing weird output before each prompt when using screen. What's wrong?

The command provided is

    echo 'function fish_title;end' > ~/.config/fish/config.fish

Using `>` will overwrite current config.fish.

We should use `>>` instead.