### PR TITLE
Notify vte-based terminals when a command completes

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -196,6 +196,16 @@ function __fish_config_interactive -d "Initializations that should be performed 
 		end
 	end
 
+	# Notify vte-based terminals when a command completes
+	if test "$VTE_VERSION" -ge 3405
+		switch "$TERM"
+			case 'vte*' 'xterm*'
+				function __notify_vte_command_completed --on-event fish_postexec --description 'Notify VTE of command completion'
+					printf '\e]777;notify;Command completed;%s\a' (echo "$argv" | cat --show-nonprinting | tr --delete \;)
+				end
+		end
+	end
+
 	# The first time a command is not found, look for command-not-found
 	# This is not cheap so we try to avoid doing it during startup
 	# config.fish already installed a handler for noninteractive command-not-found,


### PR DESCRIPTION
Notification is sent using an [OSC 777 escape sequence](http://known.phyks.me/2014/local-notifications-for-weechat-and-urxvt). The specific notification is crafted to match that emitted by `bash` when running under Fedora 22 with the `vte-profile` RPM installed. See [the code for `__vte_prompt_command`](http://pkgs.fedoraproject.org/cgit/vte291.git/tree/vte291-command-notify.patch#n307) to see exactly what `bash` produces.  My approach is, however, a bit more paranoid about control characters embedded in commands.

Gnome-terminal 3.16 responds to this escape sequence by posting a desktop notification if the containing terminal window does not have focus. This lets the user know that a long-running background command has completed. Job notification is [promoted as a Fedora 22 feature](http://fedoramagazine.org/terminal-job-notifications-in-fedora-22-workstation/), so it would be good for `fish` users to be benefit from it.

Conversely, anyone who does not want this feature can use `functions --erase __notify_vte_command_completed` to turn it off.