### PR TITLE
Added vi mode info message

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -35,6 +35,13 @@ function __fish_config_interactive -d "Initializations that should be performed 
 			set -l line2 (printf (_ 'Type %shelp%s for instructions on how to use fish') (set_color green) (set_color normal))
 			set -U fish_greeting $line1\n$line2
 		end
+		if not set -q fish_vi_greeting
+			set -l line1 (printf (_ 'Welcome to fish, the friendly interactive shell') )
+			set -l line2 (printf (_ 'You are in vi mode. To customize your prompt, you must edit %sfish_vi_prompt%s') (set_color green) (set_color normal))
+			set -l line3 (printf (_ 'instead of %sfish_prompt%s. This message can be removed by setting') (set_color green) (set_color normal))
+			set -l line4 (printf (_ '%sfish_vi_greeting%s to %s""%s.') (set_color green) (set_color normal) (set_color green) (set_color normal))
+			set -U fish_vi_greeting $line1\n$line2\n$line3\n$line4
+		end
 		set -U __fish_init_1_50_0
 
 		#

--- a/share/functions/fish_vi_mode.fish
+++ b/share/functions/fish_vi_mode.fish
@@ -3,4 +3,11 @@ function fish_vi_mode
     fish_vi_prompt
   end
   set -g fish_key_bindings fish_vi_key_bindings
+  switch "$fish_vi_greeting"
+    case ''
+    # Do not print an empty message.
+
+    case '*'
+    echo $fish_vi_greeting
+  end
 end


### PR DESCRIPTION
Informs the user about the `fish_vi_prompt` command upon entering vi mode. Fixes #1988 (at least for 2.2.0).