### PR TITLE
trap: update function parameter for EXIT signal

### DIFF
--- a/share/functions/trap.fish
+++ b/share/functions/trap.fish
@@ -12,7 +12,7 @@ function __trap_switch
 
 	switch $argv[1]
 		case EXIT
-			echo --on-exit %self
+			echo --on-process-exit %self
 
 		case '*'
 			echo --on-signal $argv[1]


### PR DESCRIPTION
changed `function __trap_handler_EXIT --on-exit %self` to `function __trap_handler_EXIT --on-process-exit %self`

I'm guessing the on-exit syntax was from an older version? Trapping EXIT with that syntax caused errors.