### PR TITLE
__fish_git_prompt: fix stateseparator color in informative_status

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -2,7 +2,7 @@
 #
 # Written by Kevin Ballard <kevin@sb.org>
 # Updated by Brian Gernhardt <brian@gernhardtsoftware.com>
-#							
+#
 # This is heavily based off of the git-prompt.bash script that ships with
 # git, which is Copyright (C) 2006,2007 Shawn O. Pearce <spearce@spearce.org>.
 # The act of porting the code, along with any new code, are Copyright (C) 2012
@@ -373,9 +373,11 @@ function __fish_git_prompt --description "Prompt function for Git"
 	__fish_git_prompt_validate_chars
 	__fish_git_prompt_validate_colors
 
+	set -l space "$___fish_git_prompt_color$___fish_git_prompt_char_stateseparator$___fish_git_prompt_color_done"
+
 	if test "true" = $inside_worktree
 		if test -n "$__fish_git_prompt_show_informative_status"
-			set informative_status "$___fish_git_prompt_char_stateseparator"(__fish_git_prompt_informative_status)
+			set informative_status "$space"(__fish_git_prompt_informative_status)
 		else
 			if test -n "$__fish_git_prompt_showdirtystate"
 				set -l config (command git config --bool bash.showDirtyState)
@@ -440,7 +442,6 @@ function __fish_git_prompt --description "Prompt function for Git"
 	end
 
 	# Formatting
-	set -l space "$___fish_git_prompt_color$___fish_git_prompt_char_stateseparator$___fish_git_prompt_color_done"
 	set -l f "$w$i$s$u"
 	if test -n "$f"
 		set f "$space$f"


### PR DESCRIPTION
In informative_status mode stateseparator did not use
fish_git_prompt_color settings.