### PR TITLE
Add special function fish_end_prompt to enable marking end-of-prompt.

### DIFF
--- a/reader.cpp
+++ b/reader.cpp
@@ -131,6 +131,8 @@ commence.
 /* The name of the function for getting the input mode indicator */
 #define MODE_PROMPT_FUNCTION_NAME L"fish_mode_prompt"
 
+/* The name of the function to be executed immediately following prompt */
+#define END_PROMPT_FUNCTION_NAME L"fish_end_prompt"
 
 /**
    The default title for the reader. This is used by reader_readline.
@@ -1022,6 +1024,18 @@ static void exec_prompt()
             {
                 if (i > 0) data->left_prompt_buff += L'\n';
                 data->left_prompt_buff += prompt_list.at(i);
+            }
+        }
+
+        // Append any end-of-prompt command to the left prompt
+        if (function_exists(END_PROMPT_FUNCTION_NAME))
+        {
+            wcstring_list_t end_prompt_list;
+            exec_subshell(END_PROMPT_FUNCTION_NAME, end_prompt_list, apply_exit_status);
+            // We do not support multiple lines in the end-of-prompt command, so just concatenate all of them
+            for (size_t i = 0; i < end_prompt_list.size(); i++)
+            {
+                data->left_prompt_buff += end_prompt_list.at(i);
             }
         }
 


### PR DESCRIPTION
I've [been working](https://gitlab.com/gnachman/iterm2/issues/3634) to get the shell integration [for the upcoming 3.0 release of iTerm 2](https://gitlab.com/gnachman/iterm2/milestones/1) (shell integration being the major new feature there) for fish up to par with the support in other shells. It's [presently in a very sorry state](https://github.com/gnachman/iterm2-website/blob/master/source/misc/fish_startup.in); it "works" by copying `fish_prompt` to `iterm2_fish_prompt`, then writing a new `fish_prompt` wrapping  `iterm2_fish_prompt` with the necessary escapes. It breaks the prompt feature of `fish_config` pretty badly, and, of course, doesn't work if `fish_prompt` is changed in any way.

I've reimplemented it using the fish_prompt, fish_preexec, and fish_postexec hooks for 2.2, which go most of the way needed to be able to leave `fish_prompt` alone. But there's one crucial feature missing in fish: the way iTerm's integration has been implemented, there must be a hook that marks the **end** of the prompt. This is [easy in shells like zsh](https://github.com/gnachman/iterm2-website/blob/master/source/misc/zsh_startup.in) where PS1 is a variable (just append the variable with command substition), but not so much in fish.

So the short version is I've copied the `fish_mode_prompt` code in reader.cpp, but for the _end_ of the prompt, rather that the start; and this would be _really really_ nice to have, for the reasons below. _With_ this PR, `case 2.2` in the code below is all the implementation necessary.

I **tried** — [really I did](https://github.com/gnachman/iterm2-website/pull/11) — to find a way to implement this without making any changes to the source. But there was no reliable way to do it. You can see my closest attempt at `case 0` in the code below. The weak spot there is `funced -e cat iterm2_fish_prompt | sed 's|iterm2_fish_prompt|fish_prompt|' | source -`. (It fails in a lot of edge cases.) This oddity is needed because one cannot `functions -e fish_prompt; functions -c other_function fish_prompt` — `fish_prompt` gets immediately redefined with the default prompt after `functions -e fish_prompt`. A bug, I'd say, because there are plenty of places in e.g. `reader.cpp` where the code checks to see _if_ there's any prompt function defined, and happily goes on without one; `function fish_prompt; end` is pefectly fine as well.

---

```fish
switch (echo $FISH_VERSION | sed 's|\(.\..\).*|\1|')
  case 2.2
    [ "$TERM" = "screen" ]; and exit # tmux can't our escape sequences so bail
    set -q iterm2_hostname; or set iterm2_hostname (hostname -f)

    # Usage: iterm2_set_user_var key value
    function iterm2_set_user_var
      set -l var $argv[1]
      set -l val (printf '%s' $argv[2] | base64)
      printf '\033]1337;SetUserVar=%s=%s\007' $var $val
    end

    # To be overridden; use iterm2_set_user_var calls and produce no output.
    function iterm2_print_user_vars -e fish_postexec; end
    
    function iterm2_fish_prompt -e fish_prompt
      printf '\033]133;D;%s\007' $status # Inform iTerm2 of last status.
      printf '\033]1337;RemoteHost=%s@%s\007' $USER $iterm2_hostname 
      printf '\033]1337;CurrentDir=%s\007' $PWD
      printf '\033]133;A\007' # Start of prompt for iTerm.
    end

    function fish_end_prompt # Would probably be better as an event hook, but same for fish_mode_prompt, so...
      printf '\033]133;B\007' # End of prompt for iTerm.
    end

    function iterm2_preexec -e fish_preexec
      printf '\033]133;C\007' # Tell iTerm2 to create a mark.
    end
    
    printf '\033]1337;ShellIntegrationVersion=1\007'
  
 ############################################
  case 0 # My first try for 2.2, without this PR.
    function iterm2_prompt -e fish_prompt
      functions -e iterm2_fish_prompt
      functions -c fish_prompt iterm2_fish_prompt
      function fish_prompt
        set -l last_status $status
        printf '\033]133;D;%s\007' $last_status # Tell iTerm2 last status.
        printf '\033]1337;RemoteHost=%s@%s\007' $USER $iterm2_hostname 
        printf '\033]1337;CurrentDir=%s\007' $PWD
        printf '\033]133;A\007' # Start of prompt for iTerm.

        iterm2_fish_prompt
        printf '\033]133;B\007' # End of prompt for iTerm.
      end
    end

    function iterm2_restore_prompt -e fish_preexec
      funced -e cat iterm2_fish_prompt | sed 's|iterm2_fish_prompt|fish_prompt|' | source -
      functions -e iterm2_fish_prompt
    end

    function iterm2_status -e fish_postexec
      printf '\033]133;D;%s\007' $status
    end

    function iterm2_preexec -e fish_preexec
      printf "\033]133;C\007" # Tell iTerm2 to create a mark.
    end

    printf "\033]1337;ShellIntegrationVersion=1\007"

  ############################################
  case '*' # The current, pre 2.2 implementation.
    if [ x"$TERM" != "xscreen" ] 
      function iterm2_status
        printf "\033]133;D;%s\007" $argv
      end

      # Mark start of prompt
      function iterm2_prompt_start
        printf "\033]133;A\007"
      end

      # Mark end of prompt
      function iterm2_prompt_end
        printf "\033]133;B\007"
      end

      # Tell terminal to create a mark at this location
      function iterm2_preexec
        # For other shells we would output status here but we can't do that in fish.
        printf "\033]133;C\007"
      end

      # Usage: iterm2_set_user_var key value
      # These variables show up in badges (and later in other places). For example
      # iterm2_set_user_var currentDirectory "$PWD"
      # Gives a variable accessible in a badge by \(user.currentDirectory)
      # Calls to this go in iterm2_print_user_vars.
      function iterm2_set_user_var
        printf "\033]1337;SetUserVar=%s=%s\007" "$argv[1]" (printf "%s" "$argv[2]" | base64)
      end

      # Users can override this.
      # It should call iterm2_set_user_var and produce no other output.
      function iterm2_print_user_vars
      end

      # iTerm2 inform terminal that command starts here
      function iterm2_precmd
        printf "\033]1337;RemoteHost=%s@%s\007\033]1337;CurrentDir=$PWD\007" $USER $iterm2_hostname
        iterm2_print_user_vars
      end

      functions -c fish_prompt iterm2_fish_prompt

      function fish_prompt --description 'Write out the prompt; do not replace this. Instead, change fish_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_prompt instead.'
        # Save our status
        set -l last_status $status

        iterm2_status $last_status
        iterm2_prompt_start
        # Restore the status
        sh -c "exit $last_status"
        iterm2_fish_prompt
        iterm2_prompt_end
      end

      function -v _ underscore_change
        if [ x$_ = xfish ]
          iterm2_precmd
        else
          iterm2_preexec
        end
      end

      # If hostname -f is slow for you, set iterm2_hostname before sourcing this script
      if not set -q iterm2_hostname
        set iterm2_hostname (hostname -f)
      end

      iterm2_precmd
      printf "\033]1337;ShellIntegrationVersion=1\007"
    end
end
```