### PR TITLE
Remove non-portable "extern int errno" declaration

### DIFF
--- a/xdgmimemagic.cpp
+++ b/xdgmimemagic.cpp
@@ -47,8 +47,6 @@
 #define  TRUE  (!FALSE)
 #endif
 
-extern int errno;
-
 typedef struct XdgMimeMagicMatch XdgMimeMagicMatch;
 typedef struct XdgMimeMagicMatchlet XdgMimeMagicMatchlet;
 


### PR DESCRIPTION
Declaring errno as an extern int breaks when errno is implemented
as a macro (as is allowed by POSIX). Specifically it breaks
building fish-shell on Android.