### PR TITLE
Add .fish suffix to funced's tempfile name

### DIFF
--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -81,7 +81,7 @@ function funced --description 'Edit function definition'
         return 0
     end
 
-    set tmpname (mktemp -t fish_funced.XXXXXXXXXX)
+    set tmpname (mktemp -t fish_funced.XXXXXXXXXX.fish)
 
     if functions -q -- $funcname
         functions -- $funcname > $tmpname


### PR DESCRIPTION
This allows editors (like emacs) to pick up on the fact that it's a fish script.

Without it, I'd have to do `M-x fish-mode` to get my syntax highlighting and indenting.