### PR TITLE
2.2.0 without sys wcwidth

### DIFF
--- a/doc_src/user_doc.css
+++ b/doc_src/user_doc.css
@@ -271,5 +271,3 @@ tt, code, pre, .fish {
     position: absolute;
     left: -2rem;
 }
-
-

--- a/fallback.cpp
+++ b/fallback.cpp
@@ -1260,11 +1260,7 @@ double nan(char *tagp)
 
 /* Big hack to use our versions of wcswidth where we know them to be broken, like on OS X */
 #ifndef HAVE_BROKEN_WCWIDTH
-#if __APPLE__
 #define HAVE_BROKEN_WCWIDTH 1
-#else
-#define HAVE_BROKEN_WCWIDTH 0
-#endif
 #endif
 
 #if ! HAVE_BROKEN_WCWIDTH

--- a/release_notes.html
+++ b/release_notes.html
@@ -134,7 +134,7 @@ Because set does not modify $status on success, the if branch effectively tests 
 <h3>New Features</h3>
 <ul>
 <li>A <b>history builtin</b>, and associated interactive function that enables deleting history items. Example usage:
-	
+
 <ul>
 <li>Print all history items beginning with echo: <span class="mono">history --prefix echo</span></li>
 <li>Print all history items containing foo: <span class="mono">history --contains foo</span></li>
@@ -201,7 +201,7 @@ The autosuggestion feature is incredible. I miss it dearly every time I use anyt
 <p>Here are some system call counts for launching and then exiting fish with the default configuration, on OS X. The first column is fish trunk, the next column is with our changes, and the last column is bash for comparison. This data was collected via dtrace.
 
 <pre>
-           before   after    bash    
+           before   after    bash
   open          9       4       5
   fork         28      14       0
   stat        131      85      11

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -117,7 +117,7 @@ body {
     padding-top: 6px;
     padding-bottom: 11px;
     padding-left: 5px;
-    padding-right: 22px;    
+    padding-right: 22px;
     font-size: 12pt;
 	/* Make our border overlap the detail, even if we're unselected (so it doesn't jump when selected) */
 	position: relative;
@@ -130,10 +130,10 @@ body {
 	border: 1px solid #555;
 	border-right: none;
 	background-color: #181818;
-	
+
 	border-top-left-radius: 5;
 	border-bottom-left-radius: 5;
-	
+
 	/* Pad one less than .master_element, to accomodate our border. */
     padding-top: 5px;
     padding-bottom: 10px;
@@ -226,7 +226,7 @@ body {
 	vertical-align: top;
 	overflow:hidden;
 	border-bottom: #444 dotted 1px;
-	word-wrap: break-word;	
+	word-wrap: break-word;
 }
 
 .history_delete {

--- a/share/tools/web_config/js/angular.js
+++ b/share/tools/web_config/js/angular.js
@@ -203,7 +203,7 @@ function nextUid() {
 
 /**
  * Set or clear the hashkey for an object.
- * @param obj object 
+ * @param obj object
  * @param h the hashkey (!truthy to delete the hashkey)
  */
 function setHashKey(obj, h) {
@@ -2154,21 +2154,21 @@ forEach({
                 }
               }
               return false;
-            };	
+            };
 
           events[type] = [];
-		
+
 		  // Refer to jQuery's implementation of mouseenter & mouseleave
           // Read about mouseenter and mouseleave:
           // http://www.quirksmode.org/js/events_mouse.html#link8
-          var eventmap = { mouseleave : "mouseout", mouseenter : "mouseover"}          
+          var eventmap = { mouseleave : "mouseout", mouseenter : "mouseover"}
           bindFn(element, eventmap[type], function(event) {
             var ret, target = this, related = event.relatedTarget;
             // For mousenter/leave call the handler if related is outside the target.
             // NB: No relatedTarget if the mouse left/entered the browser window
             if ( !related || (related !== target && !contains(target, related)) ){
               handle(event, type);
-            }	
+            }
 
           });
 
@@ -3472,18 +3472,18 @@ function $BrowserProvider(){
  *
  * @description
  * Factory that constructs cache objects and gives access to them.
- * 
+ *
  * <pre>
- * 
+ *
  *  var cache = $cacheFactory('cacheId');
  *  expect($cacheFactory.get('cacheId')).toBe(cache);
  *  expect($cacheFactory.get('noSuchCacheId')).not.toBeDefined();
  *
  *  cache.put("key", "value");
  *  cache.put("another key", "another value");
- * 
+ *
  *  expect(cache.info()).toEqual({id: 'cacheId', size: 2}); // Since we've specified no options on creation
- * 
+ *
  * </pre>
  *
  *
@@ -3660,10 +3660,10 @@ function $CacheFactoryProvider() {
  * @name ng.$templateCache
  *
  * @description
- * The first time a template is used, it is loaded in the template cache for quick retrieval.  You can 
- * load templates directly into the cache in a `script` tag, or by consuming the `$templateCache` 
+ * The first time a template is used, it is loaded in the template cache for quick retrieval.  You can
+ * load templates directly into the cache in a `script` tag, or by consuming the `$templateCache`
  * service directly.
- * 
+ *
  * Adding via the `script` tag:
  * <pre>
  * <html ng-app>
@@ -3675,29 +3675,29 @@ function $CacheFactoryProvider() {
  *   ...
  * </html>
  * </pre>
- * 
- * **Note:** the `script` tag containing the template does not need to be included in the `head` of the document, but 
+ *
+ * **Note:** the `script` tag containing the template does not need to be included in the `head` of the document, but
  * it must be below the `ng-app` definition.
- * 
+ *
  * Adding via the $templateCache service:
- * 
+ *
  * <pre>
  * var myApp = angular.module('myApp', []);
  * myApp.run(function($templateCache) {
  *   $templateCache.put('templateId.html', 'This is the content of the template');
  * });
  * </pre>
- * 
+ *
  * To retrieve the template later, simply use it in your HTML:
  * <pre>
  * <div ng-include=" 'templateId.html' "></div>
  * </pre>
- * 
+ *
  * or get it via Javascript:
  * <pre>
  * $templateCache.get('templateId.html')
  * </pre>
- * 
+ *
  * See {@link ng.$cacheFactory $cacheFactory}.
  *
  */
@@ -6902,25 +6902,25 @@ function $ParseProvider() {
  *   you can treat promises attached to a scope as if they were the resulting values.
  * - Q has many more features than $q, but that comes at a cost of bytes. $q is tiny, but contains
  *   all the important functionality needed for common async tasks.
- * 
+ *
  *  # Testing
- * 
+ *
  *  <pre>
  *    it('should simulate promise', inject(function($q, $rootScope) {
  *      var deferred = $q.defer();
  *      var promise = deferred.promise;
  *      var resolvedValue;
- * 
+ *
  *      promise.then(function(value) { resolvedValue = value; });
  *      expect(resolvedValue).toBeUndefined();
- * 
+ *
  *      // Simulate resolving of promise
  *      deferred.resolve(123);
  *      // Note that the 'then' function does not get called synchronously.
  *      // This is because we want the promise API to always be async, whether or not
  *      // it got called synchronously or asynchronously.
  *      expect(resolvedValue).toBeUndefined();
- * 
+ *
  *      // Propagate promise resolution to 'then' functions using $apply().
  *      $rootScope.$apply();
  *      expect(resolvedValue).toEqual(123);
@@ -8140,7 +8140,7 @@ function $RootScopeProvider(){
        *
        * @description
        * Broadcasted when a scope and its children are being destroyed.
-       * 
+       *
        * Note that, in AngularJS, there is also a `$destroy` jQuery event, which can be used to
        * clean up DOM bindings before an element is removed from the DOM.
        */
@@ -8164,7 +8164,7 @@ function $RootScopeProvider(){
        * Just before a scope is destroyed a `$destroy` event is broadcasted on this scope.
        * Application code can register a `$destroy` event handler that will give it chance to
        * perform any necessary cleanup.
-       * 
+       *
        * Note that, in AngularJS, there is also a `$destroy` jQuery event, which can be used to
        * clean up DOM bindings before an element is removed from the DOM.
        */
@@ -12677,8 +12677,8 @@ var ngValueDirective = function() {
  * Typically, you don't use `ngBind` directly, but instead you use the double curly markup like
  * `{{ expression }}` which is similar but less verbose.
  *
- * It is preferrable to use `ngBind` instead of `{{ expression }}` when a template is momentarily 
- * displayed by the browser in its raw state before Angular compiles it. Since `ngBind` is an 
+ * It is preferrable to use `ngBind` instead of `{{ expression }}` when a template is momentarily
+ * displayed by the browser in its raw state before Angular compiles it. Since `ngBind` is an
  * element attribute, it makes the bindings invisible to the user while the page is loading.
  *
  * An alternative solution to this problem would be using the
@@ -13174,20 +13174,20 @@ var ngControllerDirective = [function() {
  * @element html
  * @description
  * Enables [CSP (Content Security Policy)](https://developer.mozilla.org/en/Security/CSP) support.
- * 
+ *
  * This is necessary when developing things like Google Chrome Extensions.
- * 
+ *
  * CSP forbids apps to use `eval` or `Function(string)` generated functions (among other things).
  * For us to be compatible, we just need to implement the "getterFn" in $parse without violating
  * any of these restrictions.
- * 
+ *
  * AngularJS uses `Function(string)` generated functions as a speed optimization. By applying `ngCsp`
  * it is be possible to opt into the CSP compatible mode. When this mode is on AngularJS will
  * evaluate all expressions up to 30% slower than in non-CSP mode, but no security violations will
  * be raised.
- * 
+ *
  * In order to use this feature put `ngCsp` directive on the root element of the application.
- * 
+ *
  * @example
  * This example shows how to apply the `ngCsp` directive to the `html` tag.
    <pre>

--- a/share/tools/web_config/js/app.js
+++ b/share/tools/web_config/js/app.js
@@ -41,9 +41,9 @@ fishconfig.config(function($httpProvider, $compileProvider) {
     var global_error_element = null;
 
     var showMessage = function(content) {
-        global_error_element.text(content); 
+        global_error_element.text(content);
     };
-    
+
     $httpProvider.responseInterceptors.push(function($q) {
         return function(promise) {
             return promise.then(function(successResponse) {

--- a/share/tools/web_config/js/colorutils.js
+++ b/share/tools/web_config/js/colorutils.js
@@ -280,7 +280,7 @@ function adjust_lightness(color_str, func) {
 	if (color_str[0] == '#') {
 		color_str = color_str.substring(1);
 	}
-	
+
     /* Hack to handle for example F00 */
     if (color_str.length == 3) {
         color_str = color_str[0] + color_str[0] + color_str[1] + color_str[1] + color_str[2] + color_str[2]
@@ -332,9 +332,9 @@ function text_color_for_color(color_str) {
         return new_lightness
     }
     return adjust_lightness(color_str, compute_constrast);
-}		
+}
 
-function rgb_to_hsl(r, g, b){	
+function rgb_to_hsl(r, g, b){
     r /= 255, g /= 255, b /= 255;
     var max = Math.max(r, g, b), min = Math.min(r, g, b);
     var h, s, l = (max + min) / 2;
@@ -412,7 +412,7 @@ var color_scheme_fish_default = {
     "name": "fish default",
     "colors": [],
     'preferred_background': 'black',
-    
+
     'autosuggestion': '555',
     'command': '005fd7',
     'param': '00afff',
@@ -429,12 +429,12 @@ var color_scheme_fish_default = {
 var TomorrowTheme = {
     tomorrow_night: {'Background': '1d1f21', 'Current Line': '282a2e', 'Selection': '373b41', 'Foreground': 'c5c8c6', 'Comment': '969896', 'Red': 'cc6666', 'Orange': 'de935f',  'Yellow': 'f0c674', 'Green': 'b5bd68', 'Aqua': '8abeb7', 'Blue': '81a2be', 'Purple': 'b294bb'
     },
-    
+
     tomorrow: {'Background': 'ffffff', 'Current Line': 'efefef', 'Selection': 'd6d6d6', 'Foreground': '4d4d4c', 'Comment': '8e908c', 'Red': 'c82829', 'Orange': 'f5871f', 'Yellow': 'eab700', 'Green': '718c00', 'Aqua': '3e999f', 'Blue': '4271ae', 'Purple': '8959a8'
     },
-    
+
     tomorrow_night_bright: {'Background': '000000', 'Current Line': '2a2a2a', 'Selection': '424242', 'Foreground': 'eaeaea', 'Comment': '969896', 'Red': 'd54e53', 'Orange': 'e78c45', 'Yellow': 'e7c547', 'Green': 'b9ca4a', 'Aqua': '70c0b1', 'Blue': '7aa6da', 'Purple': 'c397d8'},
-    
+
     apply: function(theme, receiver){
         receiver['autosuggestion'] = theme['Comment']
         receiver['command'] = theme['Purple']
@@ -444,7 +444,7 @@ var TomorrowTheme = {
         receiver['param'] = theme['Blue']
         receiver['quote'] = theme['Green']
         receiver['redirection'] = theme['Aqua']
-        
+
         receiver['colors'] = []
         for (var key in theme) receiver['colors'].push(theme[key])
     }
@@ -459,9 +459,9 @@ var solarized = {
 var color_scheme_solarized_light = {
     name: "Solarized Light",
     colors: dict_values(solarized),
-    
+
     preferred_background: '#' + solarized.base3,
-    
+
     autosuggestion: solarized.base1,
     command: solarized.base01,
     comment: solarized.base1,
@@ -470,7 +470,7 @@ var color_scheme_solarized_light = {
     param: solarized.base00,
     quote: solarized.base0,
     redirection: solarized.violet,
-    
+
     url: 'http://ethanschoonover.com/solarized'
 };
 
@@ -478,7 +478,7 @@ var color_scheme_solarized_dark = {
     name: "Solarized Dark",
     colors: dict_values(solarized),
     preferred_background: '#' + solarized.base03,
-    
+
     autosuggestion: solarized.base01,
     command: solarized.base1,
     comment: solarized.base01,
@@ -487,7 +487,7 @@ var color_scheme_solarized_dark = {
     param: solarized.base0,
     quote: solarized.base00,
     redirection: solarized.violet,
-    
+
     url: 'http://ethanschoonover.com/solarized'
 };
 
@@ -518,15 +518,15 @@ function construct_scheme_analogous(label, background, color_list) {
         name: label,
         preferred_background: background,
         colors: color_list,
-        
+
         command: color_list[0],
         quote: color_list[6],
         param: color_list[5],
         autosuggestion: color_list[4],
-        
+
         error: color_list[9],
         comment: color_list[12],
-        
+
         end: color_list[10],
         redirection: color_list[11]
     };
@@ -537,16 +537,16 @@ function construct_scheme_triad(label, background, color_list) {
         name: label,
         preferred_background: background,
         colors: color_list,
-        
+
         command: color_list[0],
         quote: color_list[2],
         param: color_list[1],
         autosuggestion: color_list[3],
         redirection: color_list[4],
-        
+
         error: color_list[8],
         comment: color_list[10],
-        
+
         end: color_list[7],
     };
 }
@@ -556,30 +556,30 @@ function construct_scheme_complementary(label, background, color_list) {
         name: label,
         preferred_background: background,
         colors: color_list,
-        
+
         command: color_list[0],
         quote: color_list[4],
         param: color_list[3],
         autosuggestion: color_list[2],
         redirection: color_list[6],
-        
+
         error: color_list[5],
         comment: color_list[8],
-        
+
         end: color_list[9],
     };
 }
 
 function construct_color_scheme_mono(label, background, from_end) {
     var mono_colors = ['000000', '121212', '1c1c1c', '262626', '303030', '3a3a3a', '444444', '4e4e4e', '585858', '5f5f5f', '626262', '6c6c6c', '767676', '808080', '878787', '8a8a8a', '949494', '9e9e9e', 'a8a8a8', 'afafaf', 'b2b2b2', 'bcbcbc', 'c6c6c6', 'd0d0d0', 'd7d7d7', 'dadada', 'e4e4e4', 'eeeeee', 'ffffff'];
-    
+
     if (from_end) mono_colors.reverse();
-    
+
     return {
         name: label,
         preferred_background: background,
         colors: mono_colors,
-        
+
         autosuggestion: '777777',
         command: mono_colors[0],
         comment: mono_colors[7],
@@ -593,21 +593,21 @@ function construct_color_scheme_mono(label, background, from_end) {
 
 var additional_color_schemes = [
     construct_scheme_analogous('Snow Day', 'white', ['164CC9', '325197', '072D83', '4C7AE4', '7596E4', '4319CC', '4C3499', '260885', '724EE5', '9177E5', '02BDBD', '248E8E', '007B7B', '39DEDE', '65DEDE']),
-    
+
     construct_scheme_analogous('Lava', '#232323', ['FF9400', 'BF8330', 'A66000', 'FFAE40', 'FFC473', 'FFC000', 'BF9C30', 'A67D00', 'FFD040', 'FFDD73', 'FF4C00', 'BF5B30', 'A63100', 'FF7940', 'FF9D73']),
-    
+
     construct_scheme_analogous('Seaweed', '#232323', ['00BF32', '248F40', '007C21', '38DF64', '64DF85', '04819E', '206676', '015367', '38B2CE', '60B9CE', '8EEB00', '7CB02C', '5C9900', 'ACF53D', 'C0F56E']),
-    
+
     construct_scheme_triad('Fairground', '#003', ['0772A1', '225E79', '024A68', '3BA3D0', '63AFD0', 'D9005B', 'A3295C', '8D003B', 'EC3B86', 'EC6AA1', 'FFE100', 'BFAE30', 'A69200', 'FFE840', 'FFEE73']),
-    
+
     construct_scheme_complementary('Bay Cruise', 'black', ['009999', '1D7373', '006363', '33CCCC', '5CCCCC', 'FF7400', 'BF7130', 'A64B00', 'FF9640', 'FFB273']),
 
 {
     'name': 'Old School',
     'preferred_background': 'black',
-    
+
     colors: ['00FF00', '30BE30', '00A400', '44FF44', '7BFF7B', 'FF0000', 'BE3030', 'A40000', 'FF7B7B', '777777', 'CCCCCC'],
-    
+
     autosuggestion: '777777',
     command: '00FF00',
     comment: '30BE30',
@@ -621,9 +621,9 @@ var additional_color_schemes = [
 {
     'name': 'Just a Touch',
     'preferred_background': 'black',
-    
+
     colors: ['B0B0B0', '969696', '789276', 'F4F4F4', 'A0A0F0', '666A80', 'F0F0F0', 'D7D7D7', 'B7B7B7', 'FFA779', 'FAFAFA'],
-    
+
     autosuggestion: '9C9C9C',
     command: 'F4F4F4',
     comment: 'B0B0B0',
@@ -637,4 +637,3 @@ var additional_color_schemes = [
 construct_color_scheme_mono('Mono Lace', 'white', false),
 construct_color_scheme_mono('Mono Smoke', 'black', true)
 ];
-

--- a/share/tools/web_config/js/controllers.js
+++ b/share/tools/web_config/js/controllers.js
@@ -22,7 +22,7 @@ controllers.controller("colorsController", function($scope, $http) {
         $scope.colorArraysArray = $scope.getColorArraysArray();
         //TODO: Save button should be shown only when colors are changed
         $scope.showSaveButton = true;
-        
+
         $scope.noteThemeChanged();
     }
 
@@ -31,7 +31,7 @@ controllers.controller("colorsController", function($scope, $http) {
     }
 
     $scope.text_color_for_color = text_color_for_color;
-    
+
     $scope.border_color_for_color = border_color_for_color;
 
     $scope.getColorArraysArray = function() {
@@ -42,7 +42,7 @@ controllers.controller("colorsController", function($scope, $http) {
             result =  get_colors_as_nested_array(term_256_colors, 32);
         return result;
     }
-    
+
     $scope.beginCustomizationWithSetting = function(setting) {
     	if (! $scope.customizationActive) {
 	    	$scope.customizationActive = true;
@@ -51,14 +51,14 @@ controllers.controller("colorsController", function($scope, $http) {
 			$scope.csUserVisibleTitle = user_visible_title_for_setting_name(setting);
     	}
     }
-        
+
     $scope.selectColorSetting = function(name) {
     	$scope.selectedColorSetting = name;
     	$scope.csEditingType = $scope.customizationActive ? name : '';
     	$scope.csUserVisibleTitle = user_visible_title_for_setting_name(name);
     	$scope.beginCustomizationWithSetting(name);
     }
-    
+
     $scope.toggleCustomizationActive = function() {
 	    if (! $scope.customizationActive) {
 	    	$scope.beginCustomizationWithSetting($scope.selectedColorSetting || 'command');
@@ -93,7 +93,7 @@ controllers.controller("colorsController", function($scope, $http) {
      })};
 
 	$scope.saveThemeButtonTitle = "Set Theme";
-	
+
 	$scope.noteThemeChanged = function() {
 		$scope.saveThemeButtonTitle = "Set Theme";
 	}
@@ -135,7 +135,7 @@ controllers.controller("promptController", function($scope, $http) {
 
     $scope.selectPrompt = function(prompt) {
         $scope.selectedPrompt= prompt;
-        
+
         $scope.savePromptButtonTitle = "Set Prompt";
     }
 
@@ -163,7 +163,7 @@ controllers.controller("promptController", function($scope, $http) {
 
 controllers.controller("functionsController", function($scope, $http) {
     $scope.selectedFunction = null;
-    $scope.functionDefinition = ""; 
+    $scope.functionDefinition = "";
 
     $scope.selectFunction = function(fun) {
         $scope.selectedFunction = fun;

--- a/share/tools/web_config/partials/colors.html
+++ b/share/tools/web_config/partials/colors.html
@@ -5,7 +5,7 @@
         <div class="color_picker_background_cells">
 	        <span data-ng-style="{'color': text_color_for_color(terminalBackgroundColor || 'white')}">Background: </span>
             <div ng-style="{'background-color': color}" ng-repeat="color in sampleTerminalBackgroundColors" ng-click="changeTerminalBackgroundColor(color)"  title="Preview with this background color.
-            
+
 fish cannot change the background color of your terminal. Refer to your terminal documentation to set its background color."></div>
         </div>
         <!-- This is the sample text -->
@@ -14,7 +14,7 @@ fish cannot change the background color of your terminal. Refer to your terminal
         	  ng-mouseleave="csHoveredType = false"
               data-ng-style="{ 'color': selectedColorScheme.command}"
               ng-click="selectColorSetting('command')">/bright/vixens</span>
-        
+
         <span ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'param'}"
         	  ng-mouseenter="csHoveredType = 'param'"
         	  ng-mouseleave="csHoveredType = false"
@@ -26,60 +26,60 @@ fish cannot change the background color of your terminal. Refer to your terminal
         	  ng-mouseleave="csHoveredType = false"
               data-ng-style="{ 'color': selectedColorScheme.end}"
               ng-click="selectColorSetting('end')">|</span>
-              
+
         <span ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'command'}"
         	  ng-mouseenter="csHoveredType = 'command'"
         	  ng-mouseleave="csHoveredType = false"
               data-ng-style="{ 'color': selectedColorScheme.command}"
               ng-click="selectColorSetting('command')">dozy</span>
-    	
+
         <span ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'quote'}"
         	  ng-mouseenter="csHoveredType = 'quote'"
         	  ng-mouseleave="csHoveredType = false"
               data-ng-style="{ 'color': selectedColorScheme.quote}"
               ng-click="selectColorSetting('quote')"> "fowl"</span>
-        
+
         <span ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'redirection'}"
         	  ng-mouseenter="csHoveredType = 'redirection'"
         	  ng-mouseleave="csHoveredType = false"
               data-ng-style="{ 'color': selectedColorScheme.redirection}"
               ng-click="selectColorSetting('redirection')">&gt; quack</span>
-        
+
         <span ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'end'}"
         	  ng-mouseenter="csHoveredType = 'end'"
         	  ng-mouseleave="csHoveredType = false"
               data-ng-style="{ 'color': selectedColorScheme.end}"
               ng-click="selectColorSetting('end')">&</span>
-              
+
         <br>
-        
+
         <span ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'command'}"
         	  ng-mouseenter="csHoveredType = 'command'"
         	  ng-mouseleave="csHoveredType = false"
               data-ng-style="{ 'color': selectedColorScheme.command}"
               ng-click="selectColorSetting('command')">echo</span>
-        
+
         <span ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'error'}"
         	  ng-mouseenter="csHoveredType = 'error'"
         	  ng-mouseleave="csHoveredType = false"
               data-ng-style="{ 'color': selectedColorScheme.error}"
               ng-click="selectColorSetting('error')">'Errors are the portals to discovery</span>
-    	
+
         <br>
-        
+
         <span ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'comment'}"
         	  ng-mouseenter="csHoveredType = 'comment'"
         	  ng-mouseleave="csHoveredType = false"
         	  data-ng-style="{ 'color': selectedColorScheme.comment}"
         	  ng-click="selectColorSetting('comment')"># This is a comment</span>
-        
+
         <br>
-        
+
         <span ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'command'}"
         	  ng-mouseenter="csHoveredType = 'command'"
         	  ng-mouseleave="csHoveredType = false"
               data-ng-style="{ 'color': selectedColorScheme.command}"
-              ng-click="selectColorSetting('command')">Th</span><span 
+              ng-click="selectColorSetting('command')">Th</span><span
               class="fake_cursor"><span style="visibility: hidden">i</span></span><span
               ng-class="{cs_clickable: customizationActive, cs_editing: csEditingType == 'autosuggestion'}"
         	  ng-mouseenter="csHoveredType = 'autosuggestion'"
@@ -89,12 +89,12 @@ fish cannot change the background color of your terminal. Refer to your terminal
 
 
 		<div style="position: absolute; right: 5px; bottom: 5px;">
-		
+
 			<span class="customize_theme_button"
 				  ng-class="{button_highlight: customizationActive}"
 				  data-ng-style="{'color': text_color_for_color(terminalBackgroundColor || 'white')}"
 				  ng-click="toggleCustomizationActive();">Customize</span>
-			  
+
 			<span class="save_button"
 				  data-ng-style="{'color': text_color_for_color(terminalBackgroundColor || 'white')}"
 				  ng-show="showSaveButton"
@@ -102,12 +102,12 @@ fish cannot change the background color of your terminal. Refer to your terminal
 		</div>
 
     </div>
-            
+
     <div ng-show="customizationActive">
 		<div style="margin: 10px 0 7px 35px;">Choose a color for {{csUserVisibleTitle}}:</div>
 		<table class="colorpicker_term256" style="margin: 0px 20px;">
 			<tbody>
-				<tr class="colorpicker_term256_row" data-ng-repeat="color_array in colorArraysArray"> 
+				<tr class="colorpicker_term256_row" data-ng-repeat="color_array in colorArraysArray">
 					<td class="colorpicker_term256_cell" data-ng-style="{'background-color': color, 'color': color}" ng-click="changeSelectedTextColor(color)" ng-repeat="color in color_array">
 						<div class="colorpicker_term256_selection_indicator" ng-show="selectedColorScheme[selectedColorSetting] == color" ng-style="{'border-color': border_color_for_color(color)}"</div>
 					</td>
@@ -116,9 +116,9 @@ fish cannot change the background color of your terminal. Refer to your terminal
 			<!-- /ko -->
 		</table>
 	</div>
-    
+
     <div style="margin: 10px 0 7px 35px;">Preview a theme below:</div>
-    
+
     <div class="color_scheme_choices_scrollview">
 		<div class="color_scheme_choices_list">
 			<div class="color_scheme_choice_container" data-ng-repeat="colorScheme in colorSchemes" ng-click="changeSelectedColorScheme(colorScheme)">


### PR DESCRIPTION
Mostly a simple patch, which may not be worthy as is: treat all wcwidth implementations as broken, not just OS X's. This fixes #2199 for me.

(Note that my git config is really aggressive about cleaning up WS - all other file changes are trailing WS being stripped.)

It seems to me that the correct approach here is to just change fish_wcwidth to be mk_wcwidth and be done ... unless there are cases where *that* would be wrong, in which case the configure tests need to check for broken-ness rather than assume __APPLE__ is broken and everything else is okay.

I'm willing to continue to work on this if it seems worthwhile. In the meantime, fish completions work for me!