### PR TITLE
Fix behavior of Vi mode's wWeE keybindings

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -62,10 +62,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
   bind B backward-bigword
   bind ge backward-word
   bind gE backward-bigword
-  bind w forward-word
-  bind W forward-bigword
-  bind e forward-word
-  bind E forward-bigword
+  bind w forward-word forward-char
+  bind W forward-bigword forward-char
+  bind e forward-word backward-char
+  bind E forward-bigword backward-char
 
   bind x delete-char
   bind X backward-delete-char


### PR DESCRIPTION
The w/W keys need to go to the first character of the next word.
The e/E keys need to go to the last character of the current word.

Fixes #2171 