### PR TITLE
Fix mountpoints with spaces on linux

### DIFF
--- a/share/functions/__fish_print_mounted.fish
+++ b/share/functions/__fish_print_mounted.fish
@@ -2,6 +2,8 @@ function __fish_print_mounted --description 'Print mounted devices'
 	if test (uname) = Darwin
 		mount | cut -d " " -f 1-2|tr " " \n|sed -e "s/[0-9\.]*:\//\//"|sgrep "^/"
 	else
-		cat /etc/mtab | cut -d " " -f 1-2|tr " " \n|sed -e "s/[0-9\.]*:\//\//"|sgrep "^/"
+		# In mtab, spaces are replaced by a literal '\040'
+		# So it's safe to get the second "field" and then replace it
+		sed -e "s/[^ ]\+ \([^ ]\+\) .*/\\1/" -e "s/\\040/ /g" /etc/mtab
 	end
 end


### PR DESCRIPTION
Previously this would fail on

    mkdir /tmp/"mustard sauce"
    mount --bind /var /tmp/"mustard sauce"
    umount <TAB>

because mountpoints can have spaces.

I don't know if devices can also have them, so I decided to take the safe approach and use mtab for everything.

Since sed can do everything cut and tr can and cat is completely unnecessary here, sed now does everything.

I have no idea if this also needs fixing for OSX.