### PR TITLE
Fix Unknown Signal 'winch'

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -183,7 +183,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
 	__fish_reload_key_bindings ^ /dev/null
 
 	# Repaint screen when window changes size
-	function __fish_winch_handler --on-signal winch
+	function __fish_winch_handler --on-signal WINCH
 		commandline -f repaint
 	end
 


### PR DESCRIPTION
Fixes an annoying error that affects machines with Turkish locales.

Below is the output after running fish on an Ubuntu 14.04 without the fix:
```
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
function: Unknown signal 'winch'
/usr/share/fish/functions/__fish_config_interactive.fish (line 212): 	function __fish_winch_handler --on-signal winch
                                                                             ^
in function '__fish_config_interactive',
	called on line 108 of file '/usr/share/fish/config.fish',

in function '__fish_on_interactive',
	called on standard input,

in event handler: handler for generic event 'fish_prompt


       function - create a function

   Synopsis
       function [OPTIONS] NAME; BODY; end

function: Type 'help function' for related documentation

Current functions are: N_  Plugin  Theme  alias  cd  contains_seq  delete-or-exit  dirh  dirs  down-or-search  eval  fish_config  fish_default_key_bindings  fish_indent  fish_prompt  fish_sigtrap_handler  fish_update_completions  funced  funcsave  grep  help  history  import  isatty  la  ll  ls  man  math  mimedb  nextd  nextd-or-forward-word  omf  omf.git  omf.helper  omf.log  omf.packages  omf.packages.install  omf.packages.update  open  popd  prevd  prevd-or-backward-word  prompt_pwd  psub  pushd  restore_original_fish_colors  seq  setenv  sgrep  source_script  theme  theme.util.get.themes  theme.util.remove.current  trap  type  umask  up-or-search  vared  
 ~ locale
LANG=tr_TR.UTF-8
LANGUAGE=tr
LC_CTYPE="tr_TR.UTF-8"
LC_NUMERIC="tr_TR.UTF-8"
LC_TIME="tr_TR.UTF-8"
LC_COLLATE="tr_TR.UTF-8"
LC_MONETARY="tr_TR.UTF-8"
LC_MESSAGES="tr_TR.UTF-8"
LC_PAPER="tr_TR.UTF-8"
LC_NAME="tr_TR.UTF-8"
LC_ADDRESS="tr_TR.UTF-8"
LC_TELEPHONE="tr_TR.UTF-8"
LC_MEASUREMENT="tr_TR.UTF-8"
LC_IDENTIFICATION="tr_TR.UTF-8"
LC_ALL=
```