### PR TITLE
Rename sgrep to __fish_sgrep

### DIFF
--- a/share/completions/apt-proxy-import.fish
+++ b/share/completions/apt-proxy-import.fish
@@ -4,7 +4,7 @@ complete -f -c apt-proxy-import -s V -l version --description 'Display version a
 complete -f -c apt-proxy-import -s v -l verbose --description 'Verbose mode'
 complete -f -c apt-proxy-import -s q -l quiet --description 'No message to STDOUT'
 complete -f -c apt-proxy-import -s r -l recursive --description 'Recurse into subdir'
-complete -r -c apt-proxy-import -s i -l import-dir -a '(ls -Fp|sgrep /\$)' --description 'Dir to import'
+complete -r -c apt-proxy-import -s i -l import-dir -a '(ls -Fp| __fish_sgrep /\$)' --description 'Dir to import'
 complete -r -c apt-proxy-import -s u -l user -a '(__fish_complete_users)' --description 'Change to user'
 complete -r -c apt-proxy-import -s d -l debug --description 'Debug level[default 0]'
 

--- a/share/completions/apt-show-source.fish
+++ b/share/completions/apt-show-source.fish
@@ -2,8 +2,8 @@
 complete -c apt-show-source -s h -l help --description 'Display help and exit'
 complete -r -c apt-show-source -l status-file --description 'Read package from file' -f
 complete -r -c apt-show-source -o stf --description 'Read package from file' -f
-complete -r -c apt-show-source -l list-dir -a '(ls -Fp .|sgrep /\$) /var/lib/apt/lists' --description 'Specify APT list dir'
-complete -r -c apt-show-source -o ld -a '(ls -Fp .|sgrep /\$) /var/lib/apt/lists' --description 'Specify APT list dir'
+complete -r -c apt-show-source -l list-dir -a '(ls -Fp .| __fish_sgrep /\$) /var/lib/apt/lists' --description 'Specify APT list dir'
+complete -r -c apt-show-source -o ld -a '(ls -Fp .| __fish_sgrep /\$) /var/lib/apt/lists' --description 'Specify APT list dir'
 complete -r -c apt-show-source -s p -l package -a '(apt-cache pkgnames)' --description 'List PKG info'
 complete -f -c apt-show-source -l version-only --description 'Display version and exit'
 complete -f -c apt-show-source -s a -l all --description 'Print all source packages with version'

--- a/share/completions/apt-show-versions.fish
+++ b/share/completions/apt-show-versions.fish
@@ -9,6 +9,6 @@ complete -f -c apt-show-versions -s v -l verbose --description 'Print verbose in
 complete -f -c apt-show-versions -s i -l initialize --description 'Init or update cache only'
 complete -r -c apt-show-versions -l status-file --description 'Read package from file'
 complete -r -c apt-show-versions -o stf --description 'Read package from file'
-complete -r -c apt-show-versions -l list-dir -a '(ls -Fp .|sgrep /\$) /var/lib/apt/lists /var/state/apt/lists' --description 'Specify APT list dir'
-complete -r -c apt-show-versions -o ld -a '(ls -Fp .|sgrep /\$) /var/lib/apt/lists /var/state/apt/lists' --description 'Specify APT list dir'
+complete -r -c apt-show-versions -l list-dir -a '(ls -Fp .| __fish_sgrep /\$) /var/lib/apt/lists /var/state/apt/lists' --description 'Specify APT list dir'
+complete -r -c apt-show-versions -o ld -a '(ls -Fp .| __fish_sgrep /\$) /var/lib/apt/lists /var/state/apt/lists' --description 'Specify APT list dir'
 

--- a/share/completions/atool.fish
+++ b/share/completions/atool.fish
@@ -13,7 +13,7 @@ complete -c atool -l version -d 'output version information and exit'
 
 ##Options:
 complete -c atool -s e -l each -d 'execute command above for each file specified'
-complete -c atool -s F -l format -d 'override archive format (see below)' -xa "(man atool | sgrep -E '^\s+(\S+)\s+\(\..+\)' | sed -r 's/\s+(\S+)\s+\((.+)\)/\1\t\2/')"
+complete -c atool -s F -l format -d 'override archive format (see below)' -xa "(man atool | __fish_sgrep -E '^\s+(\S+)\s+\(\..+\)' | sed -r 's/\s+(\S+)\s+\((.+)\)/\1\t\2/')"
 complete -c atool -s O -l format-option -x -d 'give specific options to the archiver'
 complete -c atool -s D -l subdir -d 'always create subdirectory when extracting'
 complete -c atool -s f -l force -d 'allow overwriting of local files'

--- a/share/completions/brew.fish
+++ b/share/completions/brew.fish
@@ -19,7 +19,9 @@ end
 function __fish_brew_formulae
     set -l formuladir (brew --repository)/Library/Formula/
     # __fish_complete_suffix .rb
-    ls $formuladir/*.rb | sed 's/.rb$//' | sed "s|^$formuladir||"
+	for f in $formuladir/*.rb
+		basename $f | sed 's/.rb$//'
+	end
 end
 
 function __fish_brew_installed_formulas

--- a/share/completions/chown.fish
+++ b/share/completions/chown.fish
@@ -9,4 +9,4 @@ complete -c chown -s v -l verbose --description "Output diagnostic for every fil
 complete -c chown -s h -l help --description "Display help and exit"
 complete -c chown -l version --description "Display version and exit"
 complete -c chown --description "Username" -a "(__fish_print_users):"
-complete -c chown --description "Username" -a "(echo (commandline -ct)|sgrep -o '.*:')(cat /etc/group |cut -d : -f 1)"
+complete -c chown --description "Username" -a "(echo (commandline -ct)| __fish_sgrep -o '.*:')(cat /etc/group |cut -d : -f 1)"

--- a/share/completions/chsh.fish
+++ b/share/completions/chsh.fish
@@ -3,7 +3,7 @@
 #
 
 # This grep tries to match nonempty lines that do not start with hash
-complete -c chsh -s s -l shell -x -a "(sgrep '^[^#]' /etc/shells)" -d "Specify your login shell"
+complete -c chsh -s s -l shell -x -a "( __fish_sgrep '^[^#]' /etc/shells)" -d "Specify your login shell"
 complete -c chsh -s u -l help -d "Display help and exit"
 complete -c chsh -s v -l version -d "Display version and exit"
 complete -x -c chsh -a "(__fish_complete_users)"

--- a/share/completions/emerge.fish
+++ b/share/completions/emerge.fish
@@ -31,7 +31,7 @@ end
 
 function __fish_emerge_print_all_pkgs_with_version_compare --description 'Print completions for all packages including the version compare if that is already typed'
     set -l version_comparator (commandline --current-token | \
-                               sgrep -o '^[\'"]*[<>]\?=\?' | \
+                               __fish_sgrep -o '^[\'"]*[<>]\?=\?' | \
                                sed -r 's/^[\'"]*(.*)/\1/g')
     set -l sedstring
 

--- a/share/completions/eselect.fish
+++ b/share/completions/eselect.fish
@@ -4,13 +4,13 @@ end
 
 function __fish_complete_eselect_modules
     set -l sedregexp 's/^  ([a-zA-Z0-9_-]*)[ ]*/\1\t/g'
-    __fish_eselect_cmd modules list | sgrep '^  ' | sed -r $sedregexp
+    __fish_eselect_cmd modules list | __fish_sgrep '^  ' | sed -r $sedregexp
 end
 
 function __fish_complete_eselect_actions
     set -l sedregexp 's/^  ([a-zA-Z0-9_-]*)[ ]*/\1\t/g'
     set -l cmdl (commandline -poc)
-    __fish_eselect_cmd $cmdl[2..-1] usage | sgrep '^  [^ -]' | sed -r $sedregexp
+    __fish_eselect_cmd $cmdl[2..-1] usage | __fish_sgrep '^  [^ -]' | sed -r $sedregexp
 end
 
 function __fish_complete_eselect_action_options
@@ -30,7 +30,7 @@ function __fish_complete_eselect_action_options
     set -l findregexp '/^  '$cmdl[-1]'/,/^  [^ ]/p'
 
     set cmdl[-1] usage
-    __fish_eselect_cmd $cmdl[2..-1] | sed -n -re $findregexp | sgrep '^    --' | sed -re $parseregexp
+    __fish_eselect_cmd $cmdl[2..-1] | sed -n -re $findregexp | __fish_sgrep '^    --' | sed -re $parseregexp
 end
 
 function __fish_complete_eselect_targets
@@ -50,7 +50,7 @@ function __fish_complete_eselect_targets
             set cmdl[-1] list
     end
 
-    eselect --colour=no $cmdl[2..-1] | sgrep '^  [^ -]' | sed -r $sedregexp
+    eselect --colour=no $cmdl[2..-1] | __fish_sgrep '^  [^ -]' | sed -r $sedregexp
 end
 
 complete -c eselect -n "test (__fish_number_of_cmd_args_wo_opts) = 1" \

--- a/share/completions/fusermount.fish
+++ b/share/completions/fusermount.fish
@@ -5,8 +5,8 @@
 #
 complete -c fusermount --description "Mount point" -x -a '
 (
-	cat /etc/mtab | sgrep "^sshfs" | cut -d " " -f 1-2|tr " " \n|sed -e "s/[0-9\.]*:\//\//"|sgrep "^/"
-	cat /etc/mtab | sgrep "^fuseiso" | cut -d " " -f 1-2|tr " " \n|sed -e "s/[0-9\.]*:\//\//"|sgrep "^/"
+	cat /etc/mtab | __fish_sgrep "^sshfs" | cut -d " " -f 1-2|tr " " \n|sed -e "s/[0-9\.]*:\//\//"| __fish_sgrep "^/"
+	cat /etc/mtab | __fish_sgrep "^fuseiso" | cut -d " " -f 1-2|tr " " \n|sed -e "s/[0-9\.]*:\//\//"| __fish_sgrep "^/"
 )
 '
 

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -2,7 +2,7 @@
 # Use 'command git' to avoid interactions for aliases from git to (e.g.) hub
 
 function __fish_git_branches
-  command git branch --no-color -a ^/dev/null | sgrep -v ' -> ' | sed -e 's/^..//' -e 's/^remotes\///'
+  command git branch --no-color -a ^/dev/null | __fish_sgrep -v ' -> ' | sed -e 's/^..//' -e 's/^remotes\///'
 end
 
 function __fish_git_tags
@@ -34,8 +34,8 @@ function __fish_git_ranges
   end
 
   set -l to (commandline -ot | perl -ne 'if (index($_, "..") > 0) { my @parts = split(/\.\./); print $parts[1]; }')
-  for from_ref in (__fish_git_heads | sgrep -e "$from")
-    for to_ref in (__fish_git_heads | sgrep -e "$to")
+  for from_ref in (__fish_git_heads | __fish_sgrep -e "$from")
+    for to_ref in (__fish_git_heads | __fish_sgrep -e "$to")
       printf "%s..%s\n" $from_ref $to_ref
     end
   end
@@ -385,7 +385,7 @@ complete -f -c git -n '__fish_git_using_command status' -l ignore-submodules -x 
 
 ### tag
 complete -f -c git -n '__fish_git_needs_command' -a tag -d 'Create, list, delete or verify a tag object signed with GPG'
-complete -f -c git -n '__fish_git_using_command tag; and __fish_not_contain_opt -s d; and __fish_not_contain_opt -s v; and test (count (commandline -opc | sgrep -v -e \'^-\')) -eq 3' -a '(__fish_git_branches)' -d 'Branch'
+complete -f -c git -n '__fish_git_using_command tag; and __fish_not_contain_opt -s d; and __fish_not_contain_opt -s v; and test (count (commandline -opc | __fish_sgrep -v -e \'^-\')) -eq 3' -a '(__fish_git_branches)' -d 'Branch'
 complete -f -c git -n '__fish_git_using_command tag' -s a -l annotate -d 'Make an unsigned, annotated tag object'
 complete -f -c git -n '__fish_git_using_command tag' -s s -l sign -d 'Make a GPG-signed tag'
 complete -f -c git -n '__fish_git_using_command tag' -s d -l delete -d 'Remove a tag'

--- a/share/completions/gpg.fish
+++ b/share/completions/gpg.fish
@@ -37,7 +37,7 @@ function __fish_print_gpg_algo -d "Complete using all algorithms of the type spe
 	# expire when the function goes out of scope, and the original locale
 	# will take effect again.
 	set -lx LC_ALL C
-	gpg --version | sgrep "$argv:"| sgrep -v "Home:"|cut -d : -f 2 |tr , \n|tr -d " "
+	gpg --version | __fish_sgrep "$argv:"| __fish_sgrep -v "Home:"|cut -d : -f 2 |tr , \n|tr -d " "
 end
 
 

--- a/share/completions/make.fish
+++ b/share/completions/make.fish
@@ -5,7 +5,7 @@
 # filename completion.  Unfortunatly, this turns out to be a bit
 # complicated to do.
 
-set -l is_assignment "commandline -ct|sgrep '..*='"
+set -l is_assignment "commandline -ct| __fish_sgrep '..*='"
 set -l complete_file_assignment '(commandline -ct|sed -e \'s/=.*/=/\')(complete --do-complete=this_command_does_not_exist\ (commandline -ct|sed -e \'s/.*=//\'))'
 complete -c make --condition $is_assignment -a $complete_file_assignment
 

--- a/share/completions/mount.fish
+++ b/share/completions/mount.fish
@@ -4,7 +4,7 @@
 # including mount and df
 
 # Completions for mount
-complete -x -c mount -a '(cat /etc/fstab|sed -e "s/^\([^ \t]*\)[ \t]*\([^ \t]*\).*/\1\n\2/"|sgrep "^/")' --description 'Mount point'
+complete -x -c mount -a '(cat /etc/fstab|sed -e "s/^\([^ \t]*\)[ \t]*\([^ \t]*\).*/\1\n\2/"| __fish_sgrep "^/")' --description 'Mount point'
 complete -c mount -s V --description 'Display version and exit'
 complete -c mount -s h --description 'Display help and exit'
 complete -c mount -s v --description 'Verbose mode'

--- a/share/completions/mplayer.fish
+++ b/share/completions/mplayer.fish
@@ -57,25 +57,25 @@ complete -c mplayer -o utf8 --description "Handle subtitlefile as utf8"
 
 complete -c mplayer -o vo -x --description "Video output" -a "
 (
-	mplayer -vo help|sgrep \t.\*\t'\|^ *[a-zA-Z0-9][a-zA-Z0-9]*  '|sed -e 's/[\t ]*\([a-zA-Z0-9]*\)[\t ]*\(.*\)/\1'\t'\2/'
+	mplayer -vo help| __fish_sgrep \t.\*\t'\|^ *[a-zA-Z0-9][a-zA-Z0-9]*  '|sed -e 's/[\t ]*\([a-zA-Z0-9]*\)[\t ]*\(.*\)/\1'\t'\2/'
 )
 "
 
 complete -c mplayer -o ao -x --description "Audio output" -a "
 (
-	mplayer -ao help|sgrep \t.\*\t'\|^ *[a-zA-Z0-9][a-zA-Z0-9]*  '|sed -e 's/[\t ]*\([a-zA-Z0-9]*\)[\t ]*\(.*\)/\1'\t'\2/'
+	mplayer -ao help| __fish_sgrep \t.\*\t'\|^ *[a-zA-Z0-9][a-zA-Z0-9]*  '|sed -e 's/[\t ]*\([a-zA-Z0-9]*\)[\t ]*\(.*\)/\1'\t'\2/'
 )
 "
 
 complete -c mplayer -o afm -x --description "Audio output" -a "
 (
-	__fish_append ',' (mplayer -afm help|sgrep \t.\*\t'\|^ *[a-zA-Z0-9][a-zA-Z0-9]*  '|sed -e 's/[\t ]*\([a-zA-Z0-9]*\)[\t ]*\(.*\)/\1'\t'\2/')
+	__fish_append ',' (mplayer -afm help| __fish_sgrep \t.\*\t'\|^ *[a-zA-Z0-9][a-zA-Z0-9]*  '|sed -e 's/[\t ]*\([a-zA-Z0-9]*\)[\t ]*\(.*\)/\1'\t'\2/')
 )
 "
 
 complete -c mplayer -o vfm -x --description "Video output" -a "
 (
-	__fish_append ',' (mplayer -vfm help|sgrep \t.\*\t'\|^ *[a-zA-Z0-9][a-zA-Z0-9]*  '|sed -e 's/[\t ]*\([a-zA-Z0-9]*\)[\t ]*\(.*\)/\1'\t'\2/')
+	__fish_append ',' (mplayer -vfm help| __fish_sgrep \t.\*\t'\|^ *[a-zA-Z0-9][a-zA-Z0-9]*  '|sed -e 's/[\t ]*\([a-zA-Z0-9]*\)[\t ]*\(.*\)/\1'\t'\2/')
 )
 "
 

--- a/share/completions/obnam.fish
+++ b/share/completions/obnam.fish
@@ -1,6 +1,6 @@
 
 function nocommand
-        if commandline | sgrep -qe "add-key\|backup\|client-keys\|clients\|diff\|dump-repo\|force-lock\|forget\|fsck\|generations\|genids\|list-keys\|list-toplevels\|ls\|mount\|nagios-last-backup-age\|remove-client\|remove-key\|restore\|verify"
+        if commandline | __fish_sgrep -qe "add-key\|backup\|client-keys\|clients\|diff\|dump-repo\|force-lock\|forget\|fsck\|generations\|genids\|list-keys\|list-toplevels\|ls\|mount\|nagios-last-backup-age\|remove-client\|remove-key\|restore\|verify"
                 return 1
         end
         return 0

--- a/share/completions/perl.fish
+++ b/share/completions/perl.fish
@@ -1,6 +1,6 @@
 begin
-    set -l unicode 'commandline | sgrep -qe "-[a-zA-Z]*C[a-zA-Z]*\$"'
-    set -l noopt 'commandline | not sgrep -qe "-[a-zA-Z]*C[a-zA-Z]*\$"'
+    set -l unicode 'commandline | __fish_sgrep -qe "-[a-zA-Z]*C[a-zA-Z]*\$"'
+    set -l noopt 'commandline | not __fish_sgrep -qe "-[a-zA-Z]*C[a-zA-Z]*\$"'
     set -l modules "(find (perl -lE'print for @INC') -name '*.pm' -printf '%P\n' ^/dev/null \
                         | awk '{ gsub(\"/\", \"::\") } /[^-.]/' RS='\\\\\\\\.pm'\n | sort | uniq)"
     complete -c perl -s 0 -n $noopt --description 'Specify record separator'
@@ -18,7 +18,7 @@ begin
     complete -c perl -s CO -n $unicode --description 'STDOUT is UTF-8'
     complete -c perl -s CS -n $unicode --description 'STDOUT, STDIN, and STDERR are UTF-8'
     complete -c perl -s d -n $noopt --description 'Debugger'
-    complete -c perl -s dt -n 'commandline | sgrep -qe "d\$"' --description 'Debugger, with threads'
+    complete -c perl -s dt -n 'commandline | __fish_sgrep -qe "d\$"' --description 'Debugger, with threads'
     complete -c perl -s D -n $noopt -x --description 'Debug option'
     complete -c perl -s e -n $noopt -x --description 'Execute command'
     complete -c perl -s E -n $noopt -x --description 'Execute command, enable optional features'

--- a/share/completions/portmaster.fish
+++ b/share/completions/portmaster.fish
@@ -48,8 +48,7 @@ complete -c portmaster -l version --description 'display the version number El E
 # Grab items from the ports directory, max depth 2
 complete -c portmaster -f --description 'Ports Directory' -a "
 (
-        ls -d /usr/ports/(commandline -ct)*/ \
-                | sed -E -e 's#/usr/ports/##' -e 's#/+#/#' -e 's#([^/]+/[^/]+).*#\1#'
+    find /usr/ports -name (commandline -ct)'*' -maxdepth 2 -type d | sed -e 's#/usr/ports##'
 )"
 
 complete -c portmaster -f --description 'Installed Package' -a "(__fish_print_packages)"

--- a/share/completions/rsync.fish
+++ b/share/completions/rsync.fish
@@ -123,12 +123,12 @@ complete -c rsync -d Hostname -a "
 #
 # Remote path
 #
-complete -c rsync -d "Remote path" -n "commandline -ct|sgrep -q :" -a "
+complete -c rsync -d "Remote path" -n "commandline -ct| __fish_sgrep -q :" -a "
 (
 	#Prepend any user@host:/path information supplied before the remote completion
-	commandline -ct|sgrep -Eo '.*:+(.*/)?'
+	commandline -ct| __fish_sgrep -Eo '.*:+(.*/)?'
 )(
 	#Get the list of remote files from the specified rsync server
-	rsync --list-only (commandline -ct|sgrep -Eo '.*:+(.*/)?') ^/dev/null | sed '/^d/ s,\$,/, ' | tr -s ' '| cut -d' ' -f 5-
+	rsync --list-only (commandline -ct| __fish_sgrep -Eo '.*:+(.*/)?') ^/dev/null | sed '/^d/ s,\$,/, ' | tr -s ' '| cut -d' ' -f 5-
 )
 "

--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -24,14 +24,14 @@ complete -c scp -d Hostname -a "
 #
 # Remote path
 #
-complete -c scp -d "Remote Path" -n "commandline -ct|sgrep -o '.*:'" -a "
+complete -c scp -d "Remote Path" -n "commandline -ct| __fish_sgrep -o '.*:'" -a "
 
 (
 	#Prepend any user@host information supplied before the remote completion
-	commandline -ct|sgrep -o '.*:'
+	commandline -ct| __fish_sgrep -o '.*:'
 )(
 	#Get the list of remote files from the specified ssh server
-        ssh (commandline -c|sgrep -o '\-P [0-9]*'|tr P p) -o \"BatchMode yes\" (commandline -ct|sed -ne 's/\(.*\):.*/\1/p') ls\ -dp\ (commandline -ct|sed -ne 's/.*://p')\* 2> /dev/null
+        ssh (commandline -c| __fish_sgrep -o '\-P [0-9]*'|tr P p) -o \"BatchMode yes\" (commandline -ct|sed -ne 's/\(.*\):.*/\1/p') ls\ -dp\ (commandline -ct|sed -ne 's/.*://p')\* 2> /dev/null
 )
 
 "

--- a/share/completions/screen.fish
+++ b/share/completions/screen.fish
@@ -1,5 +1,5 @@
 function __fish_complete_screen --description "Print a list of running screen sessions"
-	screen -list |sgrep \^\t.\*\(.\*\)|sed -e 's/\t\(.*\)\t(\(.*\))/\1'\t'Screen: \2/'
+	screen -list | __fish_sgrep \^\t.\*\(.\*\)|sed -e 's/\t\(.*\)\t(\(.*\))/\1'\t'Screen: \2/'
 end
 
 complete -c screen -x

--- a/share/completions/setfacl.fish
+++ b/share/completions/setfacl.fish
@@ -7,15 +7,15 @@ function __fish_facl_list_spec_keyword
 end
 
 function __fish_facl_starts_with_spec_user
-  echo (commandline -ct) | sgrep -q -E 'u(ser)?:'
+  echo (commandline -ct) | __fish_sgrep -q -E 'u(ser)?:'
 end
 
 function __fish_facl_starts_with_spec_group
-  echo (commandline -ct) | sgrep -q -E 'g(roup)?:'
+  echo (commandline -ct) | __fish_sgrep -q -E 'g(roup)?:'
 end
 
 function __fish_facl_extract_acl
-  echo (commandline -ct) | sgrep -o -E '\w*:'
+  echo (commandline -ct) | __fish_sgrep -o -E '\w*:'
 end
 
 complete -c setfacl    -s m -s x -l modify -l remove -l set -n '__fish_facl_starts_with_spec_user'  -a '(__fish_facl_extract_acl)(__fish_complete_users  | sed "s/\t/:\t/g")'

--- a/share/completions/ssh.fish
+++ b/share/completions/ssh.fish
@@ -15,7 +15,7 @@ complete -x -c ssh -d Hostname -a "
 "
 
 complete -x -c ssh -d User -a "
-(__fish_print_users | sgrep -v '^_')@
+(__fish_print_users | __fish_sgrep -v '^_')@
 "
 complete -c ssh --description "Command to run" -x -a '(__fish_complete_subcommand --fcs-skip=2)'
 
@@ -23,7 +23,7 @@ complete -c ssh -s a --description "Disables forwarding of the authentication ag
 complete -c ssh -s A --description "Enables forwarding of the authentication agent"
 complete -x -c ssh -s b --description "Interface to transmit from" -a "
 (
-	cat /proc/net/arp ^/dev/null| sgrep -v '^IP'|cut -d ' ' -f 1 ^/dev/null
+	cat /proc/net/arp ^/dev/null| __fish_sgrep -v '^IP'|cut -d ' ' -f 1 ^/dev/null
 )
 "
 

--- a/share/completions/useradd.fish
+++ b/share/completions/useradd.fish
@@ -18,5 +18,5 @@ complete -c useradd -s u -l uid --description 'The numerical value of the user\'
 complete -c useradd -s b -l base-dir --description 'The initial path prefix for a new user\'s home directory' -r -a '(__fish_complete_directories)'
 complete -c useradd -s e -l expiredate --description 'The date on which the user account is disabled' -r
 complete -c useradd -s f -l inactive --description 'The number of days after a password has expired before the account will be disabled' -r
-complete -c useradd -s g -l gid --description 'The group name or ID for a new user\'s initial group' -x -a '(sgrep "^[^#]" /etc/group|cut -d : -f 1,3|sed -e "s/:/\n/")'
-complete -c useradd -s s -l shell --description 'Name of the new user\'s login shell' -x -a '(sgrep "^[^#]" /etc/shells)'
+complete -c useradd -s g -l gid --description 'The group name or ID for a new user\'s initial group' -x -a '( __fish_sgrep "^[^#]" /etc/group|cut -d : -f 1,3|sed -e "s/:/\n/")'
+complete -c useradd -s s -l shell --description 'Name of the new user\'s login shell' -x -a '( __fish_sgrep "^[^#]" /etc/shells)'

--- a/share/completions/valgrind.fish
+++ b/share/completions/valgrind.fish
@@ -1,7 +1,7 @@
 # Don't go invoking valgrind unless it is installed
 
 set -l skin tool
-if begin ; type valgrind >/dev/null ; and valgrind --version ^/dev/null | sgrep -- '-2\.[012]\.' >/dev/null ^/dev/null ; end
+if begin ; type valgrind >/dev/null ; and valgrind --version ^/dev/null | __fish_sgrep -- '-2\.[012]\.' >/dev/null ^/dev/null ; end
 	# In older versions of Valgrind, the skin selection option was
     # '--skin'
 	# But someone decided that it would be fun to change this to

--- a/share/functions/__fish_complete_aura.fish
+++ b/share/functions/__fish_complete_aura.fish
@@ -10,19 +10,19 @@ function __fish_complete_aura -d 'Complete Aura (ARCH/AUR package manager)' --ar
     set -l listrepos     "(cat /etc/pacman.conf | grep '^\[.\+\]' | sed 's/[]\[]//g')"
     set -l listgroups    "(pacman -Sg | sed 's/\(.*\)/\1\tPackage group/g')"
 
-    set -l noopt     'commandline | not sgrep -qe "-[a-z]*[ABCDLMOQRSTU]\|--aursync\|--save\|--downgrade\|--viewlog\|--abssync\|--orphans\|--database\|--query\|--sync\|--remove\|--upgrade\|--deptest"'
-    set -l database  'commandline | sgrep -qe "-[a-z]*D\|--database"'
-    set -l query     'commandline | sgrep -qe "-[a-z]*Q\|--query"'
-    set -l remove    'commandline | sgrep -qe "-[a-z]*R\|--remove"'
-    set -l sync      'commandline | sgrep -qe "-[a-z]*S\|--sync"'
-    set -l upgrade   'commandline | sgrep -qe "-[a-z]*U\|--upgrade"'
-    set -l aur       'commandline | sgrep -qe "-[a-z]*A\|--aursync"'
-    set -l abs       'commandline | sgrep -qe "-[a-z]*M\|--abssync"'
-    set -l save      'commandline | sgrep -qe "-[a-z]*B\|--save"'
-    set -l downgrade 'commandline | sgrep -qe "-[a-z]*C\|--downgrade"'
-    set -l orphans   'commandline | sgrep -qe "-[a-z]*O\|--orphans"'
-    set -l logfile   'commandline | sgrep -qe "-[a-z]*L\|--viewlog"'
-    set -l search    'commandline | sgrep -qe "-[a-zA]*s\|--search"'
+    set -l noopt     'commandline | not __fish_sgrep -qe "-[a-z]*[ABCDLMOQRSTU]\|--aursync\|--save\|--downgrade\|--viewlog\|--abssync\|--orphans\|--database\|--query\|--sync\|--remove\|--upgrade\|--deptest"'
+    set -l database  'commandline | __fish_sgrep -qe "-[a-z]*D\|--database"'
+    set -l query     'commandline | __fish_sgrep -qe "-[a-z]*Q\|--query"'
+    set -l remove    'commandline | __fish_sgrep -qe "-[a-z]*R\|--remove"'
+    set -l sync      'commandline | __fish_sgrep -qe "-[a-z]*S\|--sync"'
+    set -l upgrade   'commandline | __fish_sgrep -qe "-[a-z]*U\|--upgrade"'
+    set -l aur       'commandline | __fish_sgrep -qe "-[a-z]*A\|--aursync"'
+    set -l abs       'commandline | __fish_sgrep -qe "-[a-z]*M\|--abssync"'
+    set -l save      'commandline | __fish_sgrep -qe "-[a-z]*B\|--save"'
+    set -l downgrade 'commandline | __fish_sgrep -qe "-[a-z]*C\|--downgrade"'
+    set -l orphans   'commandline | __fish_sgrep -qe "-[a-z]*O\|--orphans"'
+    set -l logfile   'commandline | __fish_sgrep -qe "-[a-z]*L\|--viewlog"'
+    set -l search    'commandline | __fish_sgrep -qe "-[a-zA]*s\|--search"'
 
     # By default fish expands the arguments with the option which is not desired
     # due to performance reasons.

--- a/share/functions/__fish_complete_cd.fish
+++ b/share/functions/__fish_complete_cd.fish
@@ -18,7 +18,7 @@ function __fish_complete_cd -d "Completions for the cd command"
 	# That trailing slash ensures that we only expand directories
 
 	set -l ctoken (commandline -ct)
-	if echo $ctoken | sgrep '^/\|^\./\|^\.\./\|^~/' >/dev/null
+	if echo $ctoken | __fish_sgrep '^/\|^\./\|^\.\./\|^~/' >/dev/null
 		# This is an absolute search path
 		# Squelch descriptions per issue 254
 		eval printf '\%s\\n' $ctoken\*/

--- a/share/functions/__fish_complete_users.fish
+++ b/share/functions/__fish_complete_users.fish
@@ -3,6 +3,6 @@ function __fish_complete_users --description "Print a list of local users, with 
 	if test -x /usr/bin/getent
 		getent passwd | cut -d : -f 1,5 | sed 's/:/\t/'
 	else
-		sgrep -ve '^#' /etc/passwd | cut -d : -f 1,5 | sed 's/:/\t/'
+		__fish_sgrep -ve '^#' /etc/passwd | cut -d : -f 1,5 | sed 's/:/\t/'
 	end
 end

--- a/share/functions/__fish_contains_opt.fish
+++ b/share/functions/__fish_contains_opt.fish
@@ -29,11 +29,11 @@ function __fish_contains_opt -d "Checks if a specific option has been given in t
 			continue
 		end
 
-		if commandline -cpo | sgrep -- "^-"$i"\|^-[^-]*"$i >/dev/null
+		if commandline -cpo | __fish_sgrep -- "^-"$i"\|^-[^-]*"$i >/dev/null
 			return 0
 		end
 
-		if commandline -ct | sgrep -- "^-"$i"\|^-[^-]*"$i >/dev/null
+		if commandline -ct | __fish_sgrep -- "^-"$i"\|^-[^-]*"$i >/dev/null
 			return 0
 		end
 	end

--- a/share/functions/__fish_list_current_token.fish
+++ b/share/functions/__fish_list_current_token.fish
@@ -8,13 +8,19 @@ function __fish_list_current_token -d "List contents of token under the cursor i
 	set val (eval echo (commandline -t))
 	printf "\n"
 	if test -d $val
-		ls $val
+		for f in $val/*
+			echo $f
+		end
 	else
 		set dir (dirname $val)
 		if test $dir != . -a -d $dir
-			ls $dir
+			for f in $dir/*
+				echo $f
+			end
 		else
-			ls
+			for f in *
+				echo $f
+			end
 		end
 	end
 	commandline -f repaint

--- a/share/functions/__fish_make_completion_signals.fish
+++ b/share/functions/__fish_make_completion_signals.fish
@@ -5,7 +5,7 @@ function __fish_make_completion_signals --description 'Make list of kill signals
         # Debian and some related systems use 'kill -L' to write out a numbered list
         # of signals. Use this to complete on both number _and_ on signal name.
         complete -c kill -s L --description "List codes and names of available signals"
-        set -g __kill_signals (kill -L | sed -e 's/\([0-9][0-9]*\)  *\([A-Z,0-9][A-Z,0-9]*\)/\1 \2\n/g;s/ +/ /g' | sed -e 's/^ \+//' | sgrep -E '^[^ ]+')
+        set -g __kill_signals (kill -L | sed -e 's/\([0-9][0-9]*\)  *\([A-Z,0-9][A-Z,0-9]*\)/\1 \2\n/g;s/ +/ /g' | sed -e 's/^ \+//' | __fish_sgrep -E '^[^ ]+')
     else
         # Posix systems print out the name of a signal using 'kill -l
         # SIGNUM', so we use this instead.

--- a/share/functions/__fish_not_contain_opt.fish
+++ b/share/functions/__fish_not_contain_opt.fish
@@ -28,11 +28,11 @@ function __fish_not_contain_opt -d "Checks that a specific option is not in the 
 			continue
 		end
 
-		if commandline -cpo | sgrep -- "^-"$i"\|^-[^-]*"$i >/dev/null
+		if commandline -cpo | __fish_sgrep -- "^-"$i"\|^-[^-]*"$i >/dev/null
 			return 1
 		end
 
-		if commandline -ct | sgrep -- "^-"$i"\|^-[^-]*"$i >/dev/null
+		if commandline -ct | __fish_sgrep -- "^-"$i"\|^-[^-]*"$i >/dev/null
 			return 1
 		end
 	end

--- a/share/functions/__fish_ports_dirs.fish
+++ b/share/functions/__fish_ports_dirs.fish
@@ -1,5 +1,7 @@
 # a function to print a list of ports local collections
 
 function __fish_ports_dirs -d 'Obtain a list of ports local collections'
-	ls /usr/ports
+	for f in /usr/ports/*
+		echo $f
+	end
 end

--- a/share/functions/__fish_print_addresses.fish
+++ b/share/functions/__fish_print_addresses.fish
@@ -1,4 +1,4 @@
 function __fish_print_addresses --description "Print a list of known network addresses"
-	/sbin/ifconfig |sgrep 'inet addr'|cut -d : -f 2|cut -d ' ' -f 1
+	/sbin/ifconfig | __fish_sgrep 'inet addr'|cut -d : -f 2|cut -d ' ' -f 1
 end
 

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -5,16 +5,16 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	if type -q getent
 		getent hosts 2>/dev/null | tr -s ' ' ' ' | cut -d ' ' -f 2- | tr ' ' '\n'
 	else if test -r /etc/hosts
-		tr -s ' \t' '  ' < /etc/hosts | sed 's/ *#.*//' | cut -s -d ' ' -f 2- | sgrep -o '[^ ]*'
+		tr -s ' \t' '  ' < /etc/hosts | sed 's/ *#.*//' | cut -s -d ' ' -f 2- | __fish_sgrep -o '[^ ]*'
 	end
 	# Print nfs servers from /etc/fstab
 		if test -r /etc/fstab
-		sgrep </etc/fstab "^\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\|[a-zA-Z.]*\):"|cut -d : -f 1
+		__fish_sgrep </etc/fstab "^\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\|[a-zA-Z.]*\):"|cut -d : -f 1
 	end
 
 	# Print hosts with known ssh keys
 	# Does not match hostnames with @directives specified
-	sgrep -Eoh '^[^#@|, ]*' ~/.ssh/known_hosts{,2} ^/dev/null | sed -E 's/^\[([^]]+)\]:([0-9]+)$/\1/'
+	__fish_sgrep -Eoh '^[^#@|, ]*' ~/.ssh/known_hosts{,2} ^/dev/null | sed -E 's/^\[([^]]+)\]:([0-9]+)$/\1/'
 
 	# Print hosts from system wide ssh configuration file
 	if [ -e /etc/ssh/ssh_config ]

--- a/share/functions/__fish_print_make_targets.fish
+++ b/share/functions/__fish_print_make_targets.fish
@@ -5,7 +5,7 @@ function __fish_print_make_targets
 	# The 'rev | cut | rev' trick removes everything after the last colon
 	for file in GNUmakefile Makefile makefile
 		if test -f $file
-			sgrep -h -o -E '^[^#%=$[:space:]][^#%=$]*:([^=]|$)' $file ^/dev/null | rev | cut -d ":" -f 2- | rev | sed -e 's/^ *//;s/ *$//;s/  */\\
+			__fish_sgrep -h -o -E '^[^#%=$[:space:]][^#%=$]*:([^=]|$)' $file ^/dev/null | rev | cut -d ":" -f 2- | rev | sed -e 's/^ *//;s/ *$//;s/  */\\
 /g' ^/dev/null
 			# On case insensitive filesystems, Makefile and makefile are the same; stop now so we don't double-print 
 			break

--- a/share/functions/__fish_print_mounted.fish
+++ b/share/functions/__fish_print_mounted.fish
@@ -4,6 +4,6 @@ function __fish_print_mounted --description 'Print mounted devices'
 		# So it's safe to get the second "field" and then replace it
 		sed -e "s/[^ ]\+ \([^ ]\+\) .*/\\1/" -e "s/\\040/ /g" /etc/mtab
 	else
-		mount | cut -d " " -f 1-3|tr " " \n|sed -e "s/[0-9\.]*:\//\//"|sgrep "^/"
+		mount | cut -d " " -f 1-3|tr " " \n|sed -e "s/[0-9\.]*:\//\//"| __fish_sgrep "^/"
 	end
 end

--- a/share/functions/__fish_print_packages.fish
+++ b/share/functions/__fish_print_packages.fish
@@ -124,7 +124,7 @@ function __fish_print_packages
 	else
 		# FIXME?  Seems to be broken
 		if type -q -f emerge
-			emerge -s \^(commandline -tc) |sgrep "^*" |cut -d\  -f3 |cut -d/ -f2
+			emerge -s \^(commandline -tc) | __fish_sgrep "^*" |cut -d\  -f3 |cut -d/ -f2
 			return
 		end
 	end

--- a/share/functions/__fish_print_users.fish
+++ b/share/functions/__fish_print_users.fish
@@ -5,7 +5,7 @@ function __fish_print_users --description "Print a list of local users"
 	else if test -x /usr/bin/dscl # OS X support
 		dscl . -list /Users
 	else
-		sgrep -ve '^#' /etc/passwd | cut -d : -f 1
+		__fish_sgrep -ve '^#' /etc/passwd | cut -d : -f 1
 	end
 end
 

--- a/share/functions/__fish_sgrep.fish
+++ b/share/functions/__fish_sgrep.fish
@@ -1,0 +1,5 @@
+
+function __fish_sgrep -d "Call grep without honoring GREP_OPTIONS settings"
+	set -l GREP_OPTIONS
+	command grep $argv
+end

--- a/share/functions/la.fish
+++ b/share/functions/la.fish
@@ -1,7 +1,7 @@
 #
 # These are very common and useful
 #
-function la --description "List contents of directory, including hidden files in directory using long format"
-	ls -lah $argv
+function la --description "List contents of directory, including hidden files in directory using long format" --wraps ls
+	command ls -lah $argv
 end
 

--- a/share/functions/ll.fish
+++ b/share/functions/ll.fish
@@ -1,7 +1,7 @@
 #
 # These are very common and useful
 #
-function ll --description "List contents of directory using long format"
-	ls -lh $argv
+function ll --description "List contents of directory using long format" --wraps ls
+	command ls -lh $argv
 end
 

--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -4,7 +4,7 @@
 
 if command ls --version 1>/dev/null 2>/dev/null
 	# This is GNU ls
-	function ls --description "List contents of directory"
+	function ls --description "List contents of directory" --wraps ls
 		set -l param --color=auto
 		if isatty 1
 			set param $param --indicator-style=classify

--- a/share/functions/sgrep.fish
+++ b/share/functions/sgrep.fish
@@ -1,5 +1,0 @@
-
-function sgrep -d "Call grep without honoring GREP_OPTIONS settings"
-	set -l GREP_OPTIONS
-	command grep $argv
-end

--- a/share/functions/trap.fish
+++ b/share/functions/trap.fish
@@ -124,7 +124,7 @@ function trap -d 'Perform an action when the shell receives a signal'
 			if count $opt >/dev/null
 				set names $opt
 			else
-				set names (functions -na|sgrep "^__trap_handler_"|sed -e 's/__trap_handler_//' )
+				set names (functions -na| __fish_sgrep "^__trap_handler_"|sed -e 's/__trap_handler_//' )
 			end
 
 			for i in $names

--- a/share/functions/umask.fish
+++ b/share/functions/umask.fish
@@ -1,13 +1,13 @@
 
 function __fish_umask_parse -d "Internal umask function"
 	# Test if already a valid octal mask, and pad it with zeros
-	if echo $argv | sgrep -E '^0?[0-7]{1,3}$' >/dev/null
+	if echo $argv | __fish_sgrep -E '^0?[0-7]{1,3}$' >/dev/null
 		set -l char_count (echo $argv| wc -c)
 		for i in (seq (math 5 - $char_count)); set argv 0$argv; end
 		echo $argv
 	else
 		# Test if argument really is a valid symbolic mask
-		if not echo $argv | sgrep -E '^(((u|g|o|a|)(=|\+|-)|)(r|w|x)*)(,(((u|g|o|a|)(=|\+|-)|)(r|w|x)*))*$' >/dev/null
+		if not echo $argv | __fish_sgrep -E '^(((u|g|o|a|)(=|\+|-)|)(r|w|x)*)(,(((u|g|o|a|)(=|\+|-)|)(r|w|x)*))*$' >/dev/null
 			printf (_ "%s: Invalid mask '%s'\n") umask $argv >&2
 			return 1
 		end
@@ -72,19 +72,19 @@ function __fish_umask_parse -d "Internal umask function"
 					set mode set
 			end
 
-			if not echo $perm|sgrep -E '^(r|w|x)*$' >/dev/null
+			if not echo $perm| __fish_sgrep -E '^(r|w|x)*$' >/dev/null
 				printf (_ "%s: Invalid mask '%s'\n") umask $argv >&2
 				return
 			end
 
 			set val 0
-			if echo $i |sgrep 'r' >/dev/null
+			if echo $i | __fish_sgrep 'r' >/dev/null
 				set val 4
 			end
-			if echo $i |sgrep 'w' >/dev/null
+			if echo $i | __fish_sgrep 'w' >/dev/null
 				set val (math $val + 2)
 			end
-			if echo $i |sgrep 'x' >/dev/null
+			if echo $i | __fish_sgrep 'x' >/dev/null
 				set val (math $val + 1)
 			end
 

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -2192,7 +2192,7 @@ static wrapper_map_t &wrap_map()
     return *wrapper_map;
 }
 
-/* Add a new target that is wrapped by command. Example: sgrep (command) wraps grep (target). */
+/* Add a new target that is wrapped by command. Example: __fish_sgrep (command) wraps grep (target). */
 bool complete_add_wrapper(const wcstring &command, const wcstring &new_target)
 {
     if (command.empty() || new_target.empty())

--- a/tests/test3.in
+++ b/tests/test3.in
@@ -151,7 +151,7 @@ end
 set -Ue __fish_test_universal_variables_variable_foo
 
 # Should no longer be in environment (#2046)
-env | sgrep __fish_test_universal_variables_variable_foo
+env | __fish_sgrep __fish_test_universal_variables_variable_foo
 
 set -Ux __fish_test_universal_variables_variable_foo bar
 set -U __fish_test_universal_variables_variable_foo baz
@@ -229,10 +229,10 @@ end
 
 # Test that shadowing with a non-exported variable works
 set -gx __fish_test_env17 UNSHADOWED
-env | sgrep __fish_test_env17
+env | __fish_sgrep __fish_test_env17
 function __fish_test_shadow
   set -l __fish_test_env17
-  env | sgrep __fish_test_env17 ; or echo SHADOWED
+  env | __fish_sgrep __fish_test_env17 ; or echo SHADOWED
 end
 __fish_test_shadow
 

--- a/tests/test9.in
+++ b/tests/test9.in
@@ -115,7 +115,7 @@ try_unbalanced_block 'if false'
 
 # BOM checking (see #1518)
 # But only in UTF8
-if locale | sgrep -q -i utf-8
+if locale | __fish_sgrep -q -i utf-8
     echo \uFEFF"echo bom_test" | source
 else
     echo "echo bom_test" | source


### PR DESCRIPTION
Makes it harder to cause issues with aliases, see fish-shell#2245

This is sed-patched and lightly tested. Additional testing appreciated.