### PR TITLE
Improve completion for python -m flag

### DIFF
--- a/share/completions/python.fish
+++ b/share/completions/python.fish
@@ -4,7 +4,7 @@ complete -c python -s d --description "Debug on"
 complete -c python -s E --description "Ignore environment variables"
 complete -c python -s h -l help --description "Display help and exit"
 complete -c python -s i --description "Interactive mode after executing commands"
-complete -c python -s m -d 'Run library module as a script (terminates option list)' -xa "( find /usr/lib/(eval python -V 2>| sed 's/ //; s/\..\$//; s/P/p/') \$PYTHONPATH -maxdepth 1 -name '*.py' -printf '%f\n' | sed 's/.py//')"
+complete -c python -s m -d 'Run library module as a script (terminates option list)' -xa '(python -c "import pkgutil; print(\'\n\'.join([p[1] for p in pkgutil.iter_modules()]))")'
 complete -c python -s O --description "Enable optimizations"
 complete -c python -o OO --description "Remove doc-strings in addition to the -O optimizations"
 complete -c python -s s --description 'Don\'t add user site directory to sys.path'

--- a/share/completions/python2.fish
+++ b/share/completions/python2.fish
@@ -1,3 +1,3 @@
 complete -c python2 -w python
 # Override this to use python2 instead of python
-complete -c python2 -s m -d 'Run library module as a script (terminates option list)' -xa "( find /usr/lib/(eval python2 -V 2>| sed 's/ //; s/\..\$//; s/P/p/') \$PYTHONPATH -maxdepth 1 -name '*.py' -printf '%f\n' | sed 's/.py//')"
+complete -c python2 -s m -d 'Run library module as a script (terminates option list)' -xa '(python2 -c "import pkgutil; print(\'\n\'.join([p[1] for p in pkgutil.iter_modules()]))")'

--- a/share/completions/python3.fish
+++ b/share/completions/python3.fish
@@ -1,4 +1,4 @@
 complete -c python3 -w python
 # Override this to use python2 instead of python
-complete -c python3 -s m -d 'Run library module as a script (terminates option list)' -xa "( find /usr/lib/(eval python3 -V 2>| sed 's/ //; s/\..\$//; s/P/p/') \$PYTHONPATH -maxdepth 1 -name '*.py' -printf '%f\n' | sed 's/.py//')"
+complete -c python3 -s m -d 'Run library module as a script (terminates option list)' -xa '(python3 -c "import pkgutil; print(\'\n\'.join([p[1] for p in pkgutil.iter_modules()]))")'
 


### PR DESCRIPTION
Completion for `python -m <module>` was breaking on my machine. It was looking for modules in `/usr/lib/(eval python -V 2>| sed 's/ //; s/\..\$//; s/P/p/')`, which would resolve to /usr/lib/python2.7.10 on my machine, but my python is installed in /usr/lib/python2.7 (Arch Linux, but I believe this is a common location).

This change should find the correct Python location on all systems. As a bonus, it will now work inside python virtualenvs, and will also find user-installed modules.