### PR TITLE
Making spacing of .fish files uniform.

### DIFF
--- a/share/functions/ll.fish
+++ b/share/functions/ll.fish
@@ -4,4 +4,3 @@
 function ll --description "List contents of directory using long format"
 	ls -lh $argv
 end
-

--- a/share/functions/math.fish
+++ b/share/functions/math.fish
@@ -19,4 +19,3 @@ function math --description "Perform math calculations in bc"
 	return 2
 
 end
-

--- a/share/functions/open.fish
+++ b/share/functions/open.fish
@@ -1,4 +1,3 @@
-
 #
 # This allows us to use 'open FILENAME' to open a given file in the default
 # application for the file.
@@ -27,4 +26,3 @@ if not test (uname) = Darwin
 		end
 	end
 end
-

--- a/share/functions/popd.fish
+++ b/share/functions/popd.fish
@@ -18,4 +18,3 @@ function popd --description "Pop dir from stack"
 	set -e dirstack[1]
 
 end
-

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -1,5 +1,4 @@
 
-
 function psub --description "Read from stdin into a file and output the filename. Remove the file when the command that called psub exits."
 
 	set -l filename

--- a/share/functions/pushd.fish
+++ b/share/functions/pushd.fish
@@ -1,5 +1,4 @@
 
-
 function pushd --description 'Push directory to stack'
 	if count $argv >/dev/null
 		# check for --help

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -148,4 +148,3 @@ function type --description "Print the type of a command"
 
 	return $res
 end
-

--- a/share/functions/vared.fish
+++ b/share/functions/vared.fish
@@ -44,4 +44,3 @@ function vared --description "Edit variable value"
 		printf (_ '%s: Expected exactly one argument, got %s.\n\nSynopsis:\n\t%svared%s VARIABLE\n') vared (count $argv) (set_color $fish_color_command; echo) (set_color $fish_color_normal; echo)
 	end
 end
-


### PR DESCRIPTION
I noticed some extra leading newlines at the end of some fish functions. 
In an attempt to unify the formatting of fish functions in shared I got rid of some trailing new lines.