### PR TITLE
Have funced check VISUAL as well as EDITOR.

### DIFF
--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -1,5 +1,8 @@
 function funced --description 'Edit function definition'
-    set -l editor $EDITOR
+    set -l editor $VISUAL
+    if test -z $editor
+        set -l editor $EDITOR
+    end
     set -l interactive
     set -l funcname
     while set -q argv[1]


### PR DESCRIPTION
Both VISUAL and EDITOR are used for setting the preferred editor. Various applications disagree about which should be used, and there are examples that use either one and not the other. Recommended practice for users is to set them both to the same thing.

However, not everyone does that, so checking them both is a bit friendlier. Since VISUAL is usually the preferred editor when they are different, it should be checked first.