### PR TITLE
Add a shell suspend function

### DIFF
--- a/share/functions/suspend.fish
+++ b/share/functions/suspend.fish
@@ -1,7 +1,18 @@
-function suspend -d "Suspend the current shell so long as it is not a login shell."
-    if status --is-login
-        echo cannot suspend login shell >&2
+# If the user hasn't set it, make sure our test level has a value
+if not set -q suspend_minimum_SHLVL
+    set -g suspend_minimum_SHLVL 3
+end
+
+
+function suspend -d "Suspend the current shell."
+    if begin contains -- $argv --force
+             or not status --is-interactive
+             or begin test $SHLVL -ge $suspend_minimum_SHLVL
+                      and not status --is-login
+                end
+       end
+       kill -STOP %self
     else
-        kill -STOP %self
+       echo 2>&1 Cannot suspend login shell or SHLVL to low, use --force to force.
     end
 end

--- a/share/functions/suspend.fish
+++ b/share/functions/suspend.fish
@@ -1,4 +1,4 @@
-function suspend
+function suspend -d "Suspend the current shell so long as it is not a login shell."
     if status --is-login
         echo cannot suspend login shell >&2
     else

--- a/share/functions/suspend.fish
+++ b/share/functions/suspend.fish
@@ -1,0 +1,7 @@
+function suspend
+    if status --is-login
+        echo cannot suspend login shell >&2
+    else
+        kill -STOP %self
+    end
+end


### PR DESCRIPTION
The "suspend" function to suspend the current shell - which is common in most shells - isn't in fish. This adds it as a function. Not clear if it should be doing any tty cleanup before stopping, but things seem to work ok.