### PR TITLE
Fix wrong max argument list size reporting

### DIFF
--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -509,7 +509,7 @@ void safe_report_exec_error(int err, const char *actual_cmd, const char * const 
 
             if (arg_max > 0)
             {
-                format_size_safe(sz2, sz);
+                format_size_safe(sz2, arg_max);
                 debug_safe(0, "The total size of the argument and environment lists %s exceeds the operating system limit of %s.", sz1, sz2);
             }
             else


### PR DESCRIPTION
Reproducing:

    $ for i in (seq 1 10000); touch "goeiemorgen dit is een hele lange bestandsnaam die ook nog eens veel spaties bevat$i.txt"; end

    $ ls *
    Failed to execute process '/bin/ls'. Reason:
    The total size of the argument and environment lists 888kB exceeds the operating system limit of 888kB.
    Try running the command again with fewer arguments.

I don't believe the operating system limit is exactly 888kB; in fact, the logger at line 512 ([postfork.cpp:512](https://github.com/fish-shell/fish-shell/blob/a6a16808e34966fa8650fdda0538ba85a8019c5e/src/postfork.cpp#L512)) uses the actual length for the operating system length. This commit should fix that.