### PR TITLE
Fix a typo in the French translation file

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -8154,7 +8154,7 @@ msgstr "Bienvenue dans fish, le shell amical et interactif"
 
 #: share/functions/__fish_config_interactive.fish:35
 msgid "Type %shelp%s for instructions on how to use fish"
-msgstr "Tappez %shelp%s pour des instructions sur l'utilisation de fish"
+msgstr "Tapez %shelp%s pour des instructions sur l'utilisation de fish"
 
 #: share/functions/__fish_config_interactive.fish:130
 msgid "Event handler, repaints the prompt when fish_color_cwd changes"


### PR DESCRIPTION
This is a non-exciting change at all -- just a quick and simple typo fix in the fish welcome message. However small the typo is though, it is in the possibly most seen fish message ever, so fixing this is quite *important*.