### PR TITLE
Match the whole real home directory in prompt_pwd.

### DIFF
--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -10,5 +10,5 @@ end
 
 function prompt_pwd -V args_pre -V args_post --description "Print the current working directory, shortened to fit the prompt"
 	set -l realhome ~
-	echo $PWD | sed -e "s|^$realhome|~|" $args_pre -e 's-\([^/.]\)[^/]*/-\1/-g' $args_post
+	echo $PWD | sed -e "s|^$realhome\$|~|" -e "s|^$realhome/|~/|" $args_pre -e 's-\([^/.]\)[^/]*/-\1/-g' $args_post
 end


### PR DESCRIPTION
This fixes a bug where only the prefix of the home directory is matched.

Current behavior:

```
tree@thewall ~-old> pwd
/home/tree-old
tree@thewall ~/test> pwd
/home/tree-old/test
```

And the fixed behavior:

```
tree@thewall /h/tree-old> pwd
/home/tree-old
tree@thewall /h/t/test> pwd
/home/tree-old/test
```