### PR TITLE
Rewrite __fish_complete_cd

### DIFF
--- a/share/functions/__fish_complete_cd.fish
+++ b/share/functions/__fish_complete_cd.fish
@@ -1,53 +1,31 @@
 function __fish_complete_cd -d "Completions for the cd command"
-	#
-	# We can't simply use __fish_complete_directories because of the CDPATH
-	#
-	set -l wd $PWD
-
-	# Check if CDPATH is set
-
-	set -l mycdpath
-
-	if test -z $CDPATH[1]
-		set mycdpath .
-	else
-		set mycdpath $CDPATH
-	end
-
-	# Note how this works: we evaluate $ctoken*/
-	# That trailing slash ensures that we only expand directories
-
-	set -l ctoken (commandline -ct)
-	if echo $ctoken | sgrep '^/\|^\./\|^\.\./\|^~/' >/dev/null
-		# This is an absolute search path
-		# Squelch descriptions per issue 254
-		eval printf '\%s\\n' $ctoken\*/
-	else
-		# This is a relative search path
-		# Iterate over every directory in CDPATH
-		# and check for possible completions
-
-		for i in $mycdpath
-			# Move to the initial directory first,
-			# in case the CDPATH directory is relative
-			builtin cd $wd ^/dev/null
-			builtin cd $i ^/dev/null
-			
-			if test $status -ne 0
-				# directory does not exists or missing permission
-				continue
-			end
-
-			# What we would really like to do is skip descriptions if all
-			# valid paths are in the same directory, but we don't know how to
-			# do that yet; so instead skip descriptions if CDPATH is just .
-			if test "$mycdpath" = .
-				eval printf '"%s\n"' $ctoken\*/
-			else
-				eval printf '"%s\tin "'$i'"\n"' $ctoken\*/
+	set -l cdpath $CDPATH
+	[ -z "$cdpath" ]; and set cdpath "."
+	# Remove the real path to "." from cdpath if we're in it
+	# so it doesn't get printed in the descriptions
+	set -l ind
+	if begin; set ind (contains -i -- (realpath .) $cdpath)
+		      and contains -- "." $cdpath
+	          end
+			  set -e cdpath[$ind]
+    end
+	for i in $cdpath
+		set -l desc
+		# Don't show description for current directory
+		# and replace $HOME with "~"
+		[ $i = "." ]; or set -l desc (echo $i | sed -e "s|$HOME|~|")
+		# Save the real path so we can go back after cd-ing in
+		# even if $i is "."
+		set -l real $PWD
+		pushd $i
+		for d in *
+			if begin [ -d $d ]
+				builtin cd $d ^/dev/null # to check permission
+				and builtin cd $real ^/dev/null # go back
+			   end
+			   printf "%s\t%s\n" $d $desc
 			end
 		end
+		popd
 	end
-
-	builtin cd $wd ^/dev/null
 end


### PR DESCRIPTION
The biggest point is that it no longer uses "eval" (which is scary).

It's also a bit shorter, which is nice.

I'd love it if this got a lot of testing before it got in, since there's bound to be a ton of edge-cases.

One thing I've found that still occurs is #562, but that seems to be caused by the escaping logic and not the completion itself.
