### PR TITLE
Fix key bindings

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -863,6 +863,8 @@ Similar to bash, fish has Emacs and Vi editing modes. The default editing mode i
 
 - @key{Tab} <a href="#completion">completes</a> the current token.
 
+- @key{Shift,Tab} <a href="#completion">completes</a> the current token, followed by a search. This means you will cycle the list in reverse order.
+
 - @key{Home} or @key{Control,A} moves the cursor to the beginning of the line.
 
 - @key{End} or @key{Control,E} moves to the end of line. If the cursor is already at the end of the line, and an autosuggestion is available, @key{End} or @key{Control,E} accepts the autosuggestion.
@@ -943,6 +945,8 @@ Command mode is also known as normal mode.
 \subsubsection vi-mode-insert Insert mode
 
 - @key{Tab} <a href="#completion">completes</a> the current token.
+
+- @key{Shift,Tab} <a href="#completion">completes</a> the current token, followed by a search. This means you will cycle the list in reverse order.
 
 - @key{Escape} or @key{Control,C} enters <a href="#vi-mode-command">command mode</a>.
 

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -108,8 +108,8 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 	bind $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
 	bind $argv \cd delete-or-exit
 
-	bind \ed forward-kill-word
-	bind \ed kill-word
+	bind $argv \ed forward-kill-word
+	bind $argv \ed kill-word
 
 	# Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh)
 	bind $argv -k f1 __fish_man_page
@@ -119,15 +119,15 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 	bind $argv \ep '__fish_paginate'
 	
 	# shift-tab does a tab complete followed by a search
-	bind --key btab complete-and-search
+	bind $argv --key btab complete-and-search
 
 	# escape cancels stuff	
-	bind \e cancel
+	bind $argv \e cancel
 
 	# Ignore some known-bad control sequences
 	# https://github.com/fish-shell/fish-shell/issues/1917
-	bind \e\[I 'begin;end'
-	bind \e\[O 'begin;end'
+	bind $argv \e\[I 'begin;end'
+	bind $argv \e\[O 'begin;end'
 
 	# term-specific special bindings
 	switch "$TERM"

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -164,6 +164,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
   bind -M insert \e\[3\;2~ backward-delete-char 
 
   bind -M insert \t complete
+  # shift-tab does a tab complete followed by a search
+  bind -M insert --key btab complete-and-search
 
 	# OS X SnowLeopard doesn't have these keys. Don't show an annoying error message.
 	bind -M insert -k home beginning-of-line 2> /dev/null


### PR DESCRIPTION
This fixes some bindings in the default key bindings that didn't respect the passed options.

There are a few ones bellow there, but I suspect those might be intentional, or should they also respect argv?

Adds missing key binding for <kbd>Shift</kbd><kbd>Tab</kbd> in vi mode. This got me confused for a while until I realized it wasn't configured.