### PR TITLE
Clean up completions for Fossil

### DIFF
--- a/share/completions/fossil.fish
+++ b/share/completions/fossil.fish
@@ -1,6 +1,10 @@
 # fish completion for fossil
 # http://www.fossil-scm.org/
 
+function __fish_fossil
+    command fossil $argv ^/dev/null
+end
+
 function __fish_fossil_needs_command
     test (count (commandline -poc)) -eq 1
 end
@@ -46,7 +50,7 @@ complete -c fossil -n '__fish_fossil_command add' -l case-sensitive -x -a 'yes n
 complete -c fossil -n '__fish_fossil_command add' -l dotfiles -d 'Include dotfiles'
 complete -c fossil -n '__fish_fossil_command add' -l ignore -r -d 'Files to ignore'
 complete -c fossil -n '__fish_fossil_command add' -l clean -r -d 'Files to ignore'
-complete -c fossil -n '__fish_fossil_command add' -a '(fossil extra --rel-paths ^/dev/null)' -x -d 'File'
+complete -c fossil -n '__fish_fossil_command add' -a '(__fish_fossil extra --rel-paths)' -x -d 'File'
 
 # addremove
 complete -c fossil -n __fish_fossil_needs_command -a addremove -f -d 'Remove and add files to checkout'
@@ -60,7 +64,7 @@ complete -c fossil -n '__fish_fossil_command addremove' -s n -l dry-run -d 'Disp
 complete -c fossil -n __fish_fossil_needs_command -a all -f -d 'Check all repositories'
 complete -c fossil -n '__fish_fossil_subcommand all' -a changes -f -d 'List changes'
 complete -c fossil -n '__fish_fossil_subcommand all' -a ignore -d 'Ignore repository'
-complete -c fossil -n '__fish_fossil_subsubcommand all ignore' -x -a '(fossil all ls)' -d 'Ignore repository'
+complete -c fossil -n '__fish_fossil_subsubcommand all ignore' -x -a '(__fish_fossil all ls)' -d 'Ignore repository'
 complete -c fossil -n '__fish_fossil_subcommand all' -a 'list ls' -d 'Display locations'
 complete -c fossil -n '__fish_fossil_subcommand all' -a pull -d 'Pull repositories'
 complete -c fossil -n '__fish_fossil_subcommand all' -a push -d 'Push repositories'
@@ -115,7 +119,7 @@ complete -c fossil -n '__fish_fossil_command branch' -s R -l repository -r -d 'R
 # cat
 complete -c fossil -n __fish_fossil_needs_command -a cat -d 'Print a file'
 complete -c fossil -n '__fish_fossil_command cat' -s R -l repository -r -d 'Run command on repository'
-complete -c fossil -n '__fish_fossil_command cat' -s r -x -a '(fossil tag list ^/dev/null)' -d 'Print specific revision'
+complete -c fossil -n '__fish_fossil_command cat' -s r -x -a '(__fish_fossil tag list)' -d 'Print specific revision'
 
 # changes
 complete -c fossil -n __fish_fossil_needs_command -f -a changes -d 'List local changes'
@@ -127,7 +131,7 @@ complete -c fossil -n '__fish_fossil_command changes' -s v -l verbose -d 'Say (n
 
 # checkout
 complete -c fossil -n __fish_fossil_needs_command -f -a 'co checkout' -d 'Checkout version'
-complete -c fossil -n '__fish_fossil_command co checkout' -x -a '(fossil tag list ^/dev/null)' -d 'Version to check out'
+complete -c fossil -n '__fish_fossil_command co checkout' -x -a '(__fish_fossil tag list)' -d 'Version to check out'
 complete -c fossil -n '__fish_fossil_command co checkout' -l force -d 'Ignore edited files'
 complete -c fossil -n '__fish_fossil_command co checkout' -l force-missing -d 'Ignore missing content'
 complete -c fossil -n '__fish_fossil_command co checkout' -l keep -d 'Only update the manifest'
@@ -153,7 +157,7 @@ complete -c fossil -n '__fish_fossil_command clone' -l ssl-identity -r -d 'Use S
 
 # commit
 complete -c fossil -n __fish_fossil_needs_command -a 'ci commit' -d 'Create new revision'
-complete -c fossil -n '__fish_fossil_command ci commit' -a '(fossil changes --rel-paths ^/dev/null | cut -c12-)' -x -d 'File'
+complete -c fossil -n '__fish_fossil_command ci commit' -a '(__fish_fossil changes --rel-paths | cut -c12-)' -x -d 'File'
 complete -c fossil -n '__fish_fossil_command ci commit' -l allow-conflict -d 'Allow unresolved merge conflicts'
 complete -c fossil -n '__fish_fossil_command ci commit' -l allow-empty -d 'Allow empty check-ins'
 complete -c fossil -n '__fish_fossil_command ci commit' -l allow-fork -d 'Allow forking'
@@ -176,15 +180,15 @@ complete -c fossil -n '__fish_fossil_command ci commit' -l tag -x -d 'Assign a t
 # diff
 complete -c fossil -n __fish_fossil_needs_command -a 'diff gdiff' -d 'Show differences'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -l binary -r -d 'Binary files glob pattern'
-complete -c fossil -n '__fish_fossil_command diff gdiff' -l branch -x -a '(fossil tag list ^/dev/null)' -d 'Show diff of branch'
+complete -c fossil -n '__fish_fossil_command diff gdiff' -l branch -x -a '(__fish_fossil tag list)' -d 'Show diff of branch'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -l brief -d 'Show file names only'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -s c -l context -x -d 'Context lines'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -l diff-binary -a 'yes no' -x -d 'Include binary files'
-complete -c fossil -n '__fish_fossil_command diff gdiff' -s r -l from -x -a '(fossil tag list ^/dev/null)' -d 'Select revision to compare with'
+complete -c fossil -n '__fish_fossil_command diff gdiff' -s r -l from -x -a '(__fish_fossil tag list)' -d 'Select revision to compare with'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -s i -l internal -d 'Use internal diff logic'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -s y -l side-by-side -d 'Side-by-side diff'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -l tk -d 'Launch GUI'
-complete -c fossil -n '__fish_fossil_command diff gdiff' -l to -x -a '(fossil tag list ^/dev/null)' -d 'Select revision to compare to'
+complete -c fossil -n '__fish_fossil_command diff gdiff' -l to -x -a '(__fish_fossil tag list)' -d 'Select revision to compare to'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -l unified -d 'Unified diff'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -s v -l verbose -d 'Output complete text'
 complete -c fossil -n '__fish_fossil_command diff gdiff' -s W -l width -x -d 'Line width in side-by-side diff'
@@ -211,7 +215,7 @@ complete -c fossil -n '__fish_fossil_command finfo' -s l -l log -d 'Select log m
 complete -c fossil -n '__fish_fossil_command finfo' -s n -l limit -x -d 'Limit analyzed versions'
 complete -c fossil -n '__fish_fossil_command finfo' -l offset -x -d 'Skip changes'
 complete -c fossil -n '__fish_fossil_command finfo' -s p -l print -d 'Select print mode'
-complete -c fossil -n '__fish_fossil_command finfo' -s r -l revision -x -a '(fossil tag list ^/dev/null)' -d 'Print specific revision'
+complete -c fossil -n '__fish_fossil_command finfo' -s r -l revision -x -a '(__fish_fossil tag list)' -d 'Print specific revision'
 complete -c fossil -n '__fish_fossil_command finfo' -s s -l status -d 'Select status mode'
 
 # help
@@ -243,14 +247,14 @@ complete -c fossil -n '__fish_fossil_command json' -s R -l repository -r -d 'Run
 
 # ls
 complete -c fossil -n __fish_fossil_needs_command -a ls -d 'List files'
-complete -c fossil -n '__fish_fossil_command ls' -s r -x -a '(fossil tag list ^/dev/null)' -d 'Tag'
+complete -c fossil -n '__fish_fossil_command ls' -s r -x -a '(__fish_fossil tag list)' -d 'Tag'
 complete -c fossil -n '__fish_fossil_command ls' -l age -d 'Show commit time'
 complete -c fossil -n '__fish_fossil_command ls' -s v -l verbose -d 'Provide extra information'
 
 # merge
 complete -c fossil -n __fish_fossil_needs_command -a merge -d 'Merge commits'
-complete -c fossil -n '__fish_fossil_command merge' -a '(fossil tag list ^/dev/null)' -d 'Tag'
-complete -c fossil -n '__fish_fossil_command merge' -l baseline -a '(fossil tag list ^/dev/null)' -x -d 'Use baseline'
+complete -c fossil -n '__fish_fossil_command merge' -a '(__fish_fossil tag list)' -d 'Tag'
+complete -c fossil -n '__fish_fossil_command merge' -l baseline -a '(__fish_fossil tag list)' -x -d 'Use baseline'
 complete -c fossil -n '__fish_fossil_command merge' -l binary -r -d 'Binary files glob pattern'
 complete -c fossil -n '__fish_fossil_command merge' -l case-sensitive -x -a 'yes no' -d 'Case insensitive file matching'
 complete -c fossil -n '__fish_fossil_command merge' -s f -l force -d 'Allow empty merge'
@@ -296,8 +300,8 @@ complete -c fossil -n __fish_fossil_needs_command -a remote-url -d 'Default serv
 
 # revert
 complete -c fossil -n __fish_fossil_needs_command -f -a revert -d 'Revert a commit'
-complete -c fossil -n '__fish_fossil_command revert' -a '(fossil tag list ^/dev/null)' -d 'Tag'
-complete -c fossil -n '__fish_fossil_command revert' -s r -x -a '(fossil tag list ^/dev/null)' -d 'Revert back to given revision'
+complete -c fossil -n '__fish_fossil_command revert' -a '(__fish_fossil tag list)' -d 'Tag'
+complete -c fossil -n '__fish_fossil_command revert' -s r -x -a '(__fish_fossil tag list)' -d 'Revert back to given revision'
 
 # rm
 complete -c fossil -n __fish_fossil_needs_command -a 'rm delete' -d 'Remove a file from repository'
@@ -388,13 +392,13 @@ complete -c fossil -n '__fish_fossil_subcommand tag' -x -a add -d 'Add tag to ch
 complete -c fossil -n '__fish_fossil_subsubcommand tag add' -l raw -d 'Add raw tag'
 complete -c fossil -n '__fish_fossil_subsubcommand tag add' -l propagate -d 'Propagate tag'
 complete -c fossil -n '__fish_fossil_subcommand tag' -x -a remove -d 'Remove tag from check-in'
-complete -c fossil -n '__fish_fossil_subsubcommand tag remove' -a '(fossil tag list ^/dev/null)' -d 'Tag'
+complete -c fossil -n '__fish_fossil_subsubcommand tag remove' -a '(__fish_fossil tag list)' -d 'Tag'
 complete -c fossil -n '__fish_fossil_subsubcommand tag remove' -l raw -d 'Remove raw tag'
 complete -c fossil -n '__fish_fossil_subcommand tag' -x -a find -d 'Find tag'
 complete -c fossil -n '__fish_fossil_subsubcommand tag find' -l raw -d 'Find raw tag'
 complete -c fossil -n '__fish_fossil_subsubcommand tag find' -s t -l type -x -a 'ci e' -d 'Find tag type'
 complete -c fossil -n '__fish_fossil_subsubcommand tag find' -s n -l limit -x -d 'Limit number of tags'
-complete -c fossil -n '__fish_fossil_subsubcommand tag find' -a '(fossil tag list ^/dev/null)' -d 'Tag'
+complete -c fossil -n '__fish_fossil_subsubcommand tag find' -a '(__fish_fossil tag list)' -d 'Tag'
 complete -c fossil -n '__fish_fossil_subcommand tag' -x -a list -d 'List tags'
 complete -c fossil -n '__fish_fossil_subsubcommand tag list' -l raw -d 'List raw tags'
 


### PR DESCRIPTION
There are two main problems in the existing Fossil autocompletion that this
patch solves:

  * Because Fossil lacks an alias system similar to those in Hg and Git,
    wrapper scripts are common, and aliasing them to `fossil` is also fairly
    common. The lack of the `command fossil` pattern in the completions script
    meant that the actual fossil command might not be called, but rather the
    alias. This problem has been fixed by introducing a `__fish_fossil` command,
    similar to the `__fish_hg` and `__fish_git` commands in those completion shells,
    that does this, and converting all explicit fossil calls in the completion
    script to use `__fish_fossil` instead
  * Because there's now a centralized location for calling Fossil, I also moved
    all of the repetitive stderr redirects that function.

This results in more robust and cleaner code.