### PR TITLE
Improve situation for linux in-kernel VTs (TERM = "linux")

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -254,4 +254,62 @@ function __fish_config_interactive -d "Initializations that should be performed 
 		end
 		__fish_command_not_found_handler $argv
 	end
+	if test $TERM = "linux" # A linux in-kernel VT with 8 colors and 256/512 glyphs
+		# In a VT we have
+		# black (invisible)
+		# red
+		# green
+		# yellow
+		# blue
+		# magenta
+		# cyan
+		# white
+
+		# Pretty much just set at random
+		set -g fish_color_normal normal
+		set -g fish_color_command yellow
+		set -g fish_color_param cyan
+		set -g fish_color_redirection normal
+		set -g fish_color_comment red
+		set -g fish_color_error red
+		set -g fish_color_escape cyan
+		set -g fish_color_operator cyan
+		set -g fish_color_quote blue
+		set -g fish_color_autosuggestion yellow
+		set -g fish_color_valid_path
+		set -g fish_color_cwd green
+		set -g fish_color_cwd_root red
+		set -g fish_color_match cyan
+		set -g fish_color_history_current cyan
+		set -g fish_color_search_match cyan
+		set -g fish_color_selection blue
+		set -g fish_color_end yellow
+		set -g fish_color_host normal
+		set -g fish_color_status red
+		set -g fish_color_user green
+		set -g fish_pager_color_prefix cyan
+		set -g fish_pager_color_completion normal
+		set -g fish_pager_color_description yellow
+		set -g fish_pager_color_progress cyan
+
+		# Don't allow setting color other than what linux offers (see #2001)
+		functions -e set_color
+		function set_color
+			set -l term_colors black red green yellow blue magenta cyan white normal
+			for a in $argv
+				if not contains -- $a $term_colors
+					echo "Color not valid in TERM = linux: $a"
+					return 1
+				end
+			end
+			builtin set_color $argv
+			return $status
+		end
+
+		# Set fish_prompt to a VT-friendly version
+		# without color or unicode
+		function fish_prompt
+			fish_fallback_prompt
+		end
+	end
 end

--- a/share/functions/fish_fallback_prompt.fish
+++ b/share/functions/fish_fallback_prompt.fish
@@ -1,0 +1,27 @@
+# vim: set noet:
+#
+# Set the default prompt command.
+
+function fish_fallback_prompt --description "A simple fallback prompt without too much color or special characters for linux VTs"
+	# Just calculate this once, to save a few cycles when displaying the prompt
+	if not set -q __fish_prompt_hostname
+		set -g __fish_prompt_hostname (hostname|cut -d . -f 1)
+	end
+
+	set -l color_cwd
+	set -l suffix
+	switch $USER
+	case root toor
+		if set -q fish_color_cwd_root
+			set color_cwd $fish_color_cwd_root
+		else
+			set color_cwd $fish_color_cwd
+		end
+		set suffix '#'
+	case '*'
+		set color_cwd $fish_color_cwd
+		set suffix '>'
+	end
+
+	echo -n -s "$USER" @ "$__fish_prompt_hostname" ' ' (set_color $color_cwd) (prompt_pwd) (set_color normal) "$suffix "
+end


### PR DESCRIPTION
This adds a special colorscheme and prompt function (a clone of the "classic" prompt) guaranteed to work
on a VT and activates them automatically if $TERM = "linux".

set_color is overridden to only allow the 8 colors VTs have (under the
assumption those are always the same) and the color variables are
shadowed with global ones so they don't pollute our nice capable terms.

Fixes #2070.

Everyone okay with the approach or should we bend over backwards even harder?