### PR TITLE
Preserve the tty modes between commands.

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -496,6 +496,7 @@ static void update_buff_pos(editable_line_t *el, size_t buff_pos)
 static void term_steal()
 {
 
+    tcgetattr(0, &terminal_mode_for_executing_programs);
     while (1)
     {
         if (tcsetattr(0,TCSANOW,&shell_modes))
@@ -1029,8 +1030,6 @@ void reader_init()
 
     /* Set the mode used for program execution, initialized to the current mode */
     memcpy(&terminal_mode_for_executing_programs, &terminal_mode_on_startup, sizeof terminal_mode_for_executing_programs);
-    terminal_mode_for_executing_programs.c_iflag &= ~IXON;     /* disable flow control */
-    terminal_mode_for_executing_programs.c_iflag &= ~IXOFF;    /* disable flow control */
 
     /* Set the mode used for the terminal, initialized to the current mode */
     memcpy(&shell_modes, &terminal_mode_on_startup, sizeof shell_modes);


### PR DESCRIPTION
This removes the default disabling of flow control, and then copies the tty modes to the terminal_mode_for_exucuting_programs after a command exits. This copies the behavior of other shells, and thus behaves as most people expect terminal modes to.

This is a fix for issue #2315. I could not reproduce issue #814 locally no matter what I set ixon to.