### PR TITLE
Use the $TERM value from fish's computed environment for ncurses setup

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -466,7 +466,7 @@ int input_init()
 
     const env_var_t term = env_get_string(L"TERM");
     int errret;
-    if (setupterm(0, STDOUT_FILENO, &errret) == ERR)
+    if (setupterm(const_cast<char *>(wcs2string(term).c_str()), STDOUT_FILENO, &errret) == ERR)
     {
         debug(0, _(L"Could not set up terminal"));
         if (errret == 0)


### PR DESCRIPTION
Previously, the process's inherited $TERM value would be used.
This prevented users from being able to set $TERM in their config.fish files.

To make matters worse, the error message would print the computed $TERM value,
giving the mistaken impression that it was being used.