### PR TITLE
On Cygwin default to using the shmem notifier strategy.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -822,6 +822,24 @@ else
   AC_MSG_RESULT(no)
 fi
 
+# Check for usable FIFO (Cygwin allows only a single reader which causes problems)
+AC_MSG_CHECKING([if we have usable FIFOs.])
+AC_CANONICAL_HOST
+case $host_os in
+  *cygwin* ) usable_fifos=no;;
+         * ) usable_fifos=yes;;
+esac
+if test "x$usable_fifos" = "xyes"; then
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(
+    [HAVE_USABLE_FIFOS],
+    [1],
+    [Define to 1 if we have usable FIFOs.]
+  )
+else
+  AC_MSG_RESULT(no)
+fi
+
 # Tell the world what we know
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -1626,8 +1626,10 @@ universal_notifier_t::notifier_strategy_t universal_notifier_t::resolve_default_
     }
 #if FISH_NOTIFYD_AVAILABLE
     return strategy_notifyd;
-#else
+#elif HAVE_USABLE_FIFOS
     return strategy_named_pipe;
+#else
+    return strategy_shmem_polling;
 #endif
 }
 


### PR DESCRIPTION
I gave putting together a portable solution for #2152 a shot. It just tests for Cygwin. I think the autoconf philosophy is to test for the actual feature you would like to use, but testing for usable FIFOs is not within my current capabilities. Note this is my first exposure to autoconf and I don't have any code sense for C or the norms of this project, if there's a better way to go I welcome criticism.

I tested it on FreeBSD and Cygwin x86_64, which are the only hosts I have handy at the moment.

I should point out that I'm not 100% sure I have the order of conditions right in env_universal_common.cpp. I think so but it warrants review.

This is my first time using git (I use Bazaar at work) and in figuring out how to do this I accidentally made a phantom commit that's linked to the issue.  Sorry about that.