### PR TITLE
Make overriding cnf-handler work

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -23,10 +23,6 @@ end
 # This will be erased in __fish_command_not_found_setup once we're interactive
 #
 function __fish_startup_command_not_found_handler --on-event fish_command_not_found
-	# If we're already interactive, do nothing since we'll be deleted
-	if type -q __fish_command_not_found_setup
-		return 0
-	end
     __fish_default_command_not_found_handler $argv
 end
 

--- a/share/config.fish
+++ b/share/config.fish
@@ -19,9 +19,14 @@ end
 
 #
 # Hook up the default as the principal command_not_found handler
-# This is likely to be overwritten in __fish_config_interactive
+# for starting up since finding and executing a real one is not cheap
+# This will be erased in __fish_command_not_found_setup once we're interactive
 #
-function __fish_command_not_found_handler --on-event fish_command_not_found
+function __fish_startup_command_not_found_handler --on-event fish_command_not_found
+	# If we're already interactive, do nothing since we'll be deleted
+	if type -q __fish_command_not_found_setup
+		return 0
+	end
     __fish_default_command_not_found_handler $argv
 end
 

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -196,12 +196,13 @@ function __fish_config_interactive -d "Initializations that should be performed 
 		end
 	end
 
+	# Remove the startup command_not_found handler since we're done with it
+	functions -e __fish_startup_command_not_found_handler
+
 	# Now install our fancy variant
 	function __fish_command_not_found_setup --on-event fish_command_not_found
 		# Remove fish_command_not_found_setup so we only execute this once
 		functions --erase __fish_command_not_found_setup
-		# Remove the startup handler since we're done with it
-		functions --erase __fish_startup_command_not_found_handler
 
 		# If the user defined a handler, it takes precedence
 		# It does not need to be executed because it's been defined before the event

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -196,17 +196,18 @@ function __fish_config_interactive -d "Initializations that should be performed 
 		end
 	end
 
-	# The first time a command is not found, look for command-not-found
-	# This is not cheap so we try to avoid doing it during startup
-	# config.fish already installed a handler for noninteractive command-not-found,
-	# so delete it here since we are now interactive
-	functions -e __fish_command_not_found_handler
-
 	# Now install our fancy variant
 	function __fish_command_not_found_setup --on-event fish_command_not_found
 		# Remove fish_command_not_found_setup so we only execute this once
 		functions --erase __fish_command_not_found_setup
+		# Remove the startup handler since we're done with it
+		functions --erase __fish_startup_command_not_found_handler
 
+		# If the user defined a handler, it takes precedence
+		# It does not need to be executed because it's been defined before the event
+		if type -q __fish_command_not_found_handler
+			return 0
+		end
 		# First check if we are on OpenSUSE since SUSE's handler has no options
 		# and expects first argument to be a command and second database
 		# also check if there is command-not-found command.


### PR DESCRIPTION
Do this by renaming the __fish_command_not_found_handler used during
startup to __fish_startup_command_not_found_handler. That allows us to
check if __fish_command_not_found_handler has been defined and skip the
setup of the normal one.

Now disabling cnf-handling can be done via defining an empty
__fish_command_not_found_handler in config.fish.

It's quite possible that I haven't understood the full complexity of the situation so I've decided to open a PR instead of just pushing. Of course solving #845 could make all of this moot.