### PR TITLE
Fix vi mode 't' and 'T' bindings

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -42,6 +42,7 @@
 #include "output.h"
 #include <vector>
 #include <algorithm>
+#include <deque>
 
 #define DEFAULT_TERM L"ansi"
 #define MAX_INPUT_FUNCTION_ARGS 20
@@ -537,10 +538,23 @@ wchar_t input_function_pop_arg()
 void input_function_push_args(int code)
 {
     int arity = input_function_arity(code);
+    std::deque<wchar_t> skipped;
+
     for (int i = 0; i < arity; i++)
     {
-        input_function_push_arg(input_common_readch(0));
+        wchar_t arg;
+
+        // skip and queue up any function codes
+        while(((arg = input_common_readch(0)) >= R_MIN) && (arg <= R_MAX))
+        {
+            skipped.push_front(arg);
+        }
+
+        input_function_push_arg(arg);
     }
+
+    // push the function codes back into the input stream
+    std::for_each(skipped.begin(), skipped.end(), input_common_next_ch);
 }
 
 /**

--- a/tests/bind.expect
+++ b/tests/bind.expect
@@ -37,6 +37,17 @@ expect_prompt -re {\r\nTAXT\r\n} {
     puts stderr "Couldn't find expected output 'TAXT'"
 }
 
+# Test 't' binding that contains non-zero arity function (forward-jump) followed
+# by another function (and) https://github.com/fish-shell/fish-shell/issues/2357
+send_line "\033ddiecho TEXT\033hhtTrN"
+expect_prompt -re {\r\nTENT\r\n} {
+    puts "t-binding success"
+} -nounmatched -re {\r\nfail} {
+    puts stderr "t-binding fail"
+} unmatched {
+    puts stderr "Couldn't find expected output 'TENT'"
+}
+
 # still in insert mode, switch back to regular key bindings
 send_line "set -g fish_key_bindings fish_default_key_bindings"
 expect_prompt

--- a/tests/bind.expect.out
+++ b/tests/bind.expect.out
@@ -1,4 +1,5 @@
 success
 success
 replace success
+t-binding success
 success


### PR DESCRIPTION
Fix non-zero arity functions followed by other functions by temporarily skipping any queued function code characters when reading the current function's arguments.

Also include an expect test to avoid future regressions.

Fixes #2357.
