### PR TITLE
Fix error message for variable used as command

### DIFF
--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -830,7 +830,7 @@ parse_execution_result_t parse_execution_context_t::handle_command_not_found(con
     {
         this->report_error(statement_node,
                            _(L"Variables may not be used as commands. In fish, please define a function or use 'eval %ls'."),
-                           cmd+1);
+                           cmd);
     }
     else if (wcschr(cmd, L'$'))
     {


### PR DESCRIPTION
Looks like the `+1` was left over from the previous error message in the #1288 refactoring.
```
# Previously
> $foo
Variables may not be used as commands. In fish, please define a function or use 'eval foo'.
> eval foo
fish: Unknown command 'foo'

# Now
> $foo
Variables may not be used as commands. In fish, please define a function or use 'eval $foo'.
```
