### PR TITLE
Allow copy/pasting commands with prompts.

### DIFF
--- a/share/functions/$.fish
+++ b/share/functions/$.fish
@@ -1,0 +1,3 @@
+function \$
+	eval $argv
+end


### PR DESCRIPTION
This aliases `$` to `eval`, allowing copy/pasting from something like this:

```
$ git clone git@github.com:fish-shell/fish-shell
$ cd fish-shell
```