### PR TITLE
send smkx/rmkx when entering/leaving interactive mode

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -43,6 +43,20 @@ commence.
 #include <sys/select.h>
 #endif
 
+#if HAVE_NCURSES_H
+#include <ncurses.h>
+#elif HAVE_NCURSES_CURSES_H
+#include <ncurses/curses.h>
+#else
+#include <curses.h>
+#endif
+
+#if HAVE_TERM_H
+#include <term.h>
+#elif HAVE_NCURSES_TERM_H
+#include <ncurses/term.h>
+#endif
+
 #include <signal.h>
 #include <fcntl.h>
 #include <wchar.h>
@@ -3083,6 +3097,13 @@ const wchar_t *reader_readline(int nchars)
 
     exec_prompt();
 
+    /* Send the smkx sequence if defined to enable arrow keys etc.
+     See https://github.com/fish-shell/fish-shell/issues/2139 and
+     http://invisible-island.net/xterm/xterm.faq.html#xterm_arrows
+    */
+
+    tputs(keypad_xmit, 1, &writeb);
+
     reader_super_highlight_me_plenty();
     s_reset(&data->screen, screen_reset_abandon_line);
     reader_repaint();
@@ -4194,6 +4215,13 @@ const wchar_t *reader_readline(int nchars)
         {
             wperror(L"tcsetattr");
         }
+
+        /* Send the rmkx sequence if defined to disable arrow keys etc.
+         See https://github.com/fish-shell/fish-shell/issues/2139 and
+         http://invisible-island.net/xterm/xterm.faq.html#xterm_arrows
+        */
+
+        tputs(keypad_local, 1, &writeb);
 
         set_color(rgb_color_t::reset(), rgb_color_t::reset());
     }


### PR DESCRIPTION
A possible fix for #2139. I would appreciate some testing, and also feedback on whether this is the right place to send these codes.