### PR TITLE
Implement /etc/locale.conf support

### DIFF
--- a/etc/config.fish
+++ b/etc/config.fish
@@ -8,15 +8,6 @@
 
 if status --is-login
 
-	#
-	# Set some value for LANG if nothing was set before, and this is a
-	# login shell.
-	#
-
-	if not set -q LANG >/dev/null
-		set -gx LANG en_US.UTF-8
-	end
-
 	# Check for i18n information in
 	# /etc/sysconfig/i18n
 

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -494,6 +494,37 @@ int main(int argc, char **argv)
     set_main_thread();
     setup_fork_guards();
 
+    const char *lang = getenv("LANG");
+    if (lang == NULL)
+    {
+        FILE *f = wfopen(L"/etc/locale.conf", "r");
+        if (f)
+        {
+            bool success = false, has_newline = false;
+            do
+            {
+                char buff[128];
+                const char *name = buff, *value;
+                success = !! fgets(buff, sizeof buff, f);
+                if (success)
+                {
+                    char *newline = strchr(buff, '\n');
+                    if (newline) *newline = '\0';
+                    has_newline = (newline != NULL);
+                    char *sep = strchr(buff, '=');
+                    if (sep)
+                    {
+                        *sep = '\0';
+                        value = sep+1;
+                        setenv(name, value, 0);
+                    }
+                }
+            }
+            while (success && ! has_newline);
+            fclose(f);
+        }
+    }
+
     wsetlocale(LC_ALL, L"");
     is_interactive_session=1;
     program_name=L"fish";


### PR DESCRIPTION
When `wsetlocale(LC_ALL, L"")` is used then libc will use `$LANG` to get locale and if it's not set then it defaults to `C` locale which will make some C functions to fail when they encounter non-ASCII strings.

It can't be set later or in `etc/config.fish` because by then fish will already have used C functions which expect `$LANG`.

This fixes several locale/encoding related issues like #277, #1749 

`/etc/locale.conf` is correct file for system-wide locale settings, when systemd is used then `localectl set-locale` will simply write to that file. See more [man locale.conf](http://www.freedesktop.org/software/systemd/man/locale.conf.html)
`bash` also gets locale from there.

`su -l` keeps only `HOME, SHELL, USER, LOGNAME, PATH` and doesn't keep `LANG` so it won't be set for fish and that's why need to set it ourselves.


