### PR TITLE
add function to autoload functions and completions

### DIFF
--- a/share/functions/auto.fish
+++ b/share/functions/auto.fish
@@ -1,0 +1,21 @@
+#
+# auto -- autoload functions and completions
+#
+# Synopsis
+#   auto <path> [<path>...]
+#
+# Description
+#   Add the specified list of directories to $fish_function_path
+#   or $fish_complete_path.
+#
+function auto -d "autoload functions and completions"
+	for path in $argv
+		test -d "$path"; and set -l dest fish_function_path; or continue
+		switch $path
+			case \*/completions; set dest fish_complete_path
+		end
+		set -l i (contains -i -- "$path" $$dest); and set -e $dest[1][$i]
+		set $dest "$path" $$dest
+	end
+end
+


### PR DESCRIPTION
#### `auto <path> [<path>...]`

```
  auto -- autoload functions and completions

  Synopsis
    auto <path> [<path>...]

  Description
    Add the specified list of directories to $fish_function_path
    or $fish_complete_path.
```

I always find myself appending to `$fish_function_path` and `$fish_complete_path` and I think it would be useful, specially to folks writing fish “frameworks” to have a standard function we can all benefit from.


```fish
auto {$my_home,$my_custom}/stuff
```


In the original Oh My Fish! we had a somewhat similar set of `_append` and `_prepend` bulky ones which we later improved in Wahoo. The current OMF uses a similar version to this one based in Wahoo and the new project I am working on uses this exact one, but it would be much nicer if fish just gave it to us :smile: 

This function could also be a “plumbing” function `__fish_auto`. Other name suggestions:

+ funcauto
+ autoload
+ __fish_add_path
+ Add as an extra option to `functions --add` or `funcsave --path`?

This PR contains a function I decided to name `auto` for lack of a cooler name. Feel free to suggest better alternatives.