### PR TITLE
__fish_print_{addresses,interfaces}: Add alternative to net-tools

### DIFF
--- a/share/functions/__fish_print_addresses.fish
+++ b/share/functions/__fish_print_addresses.fish
@@ -1,4 +1,8 @@
 function __fish_print_addresses --description "Print a list of known network addresses"
-	/sbin/ifconfig | __fish_sgrep 'inet addr'|cut -d : -f 2|cut -d ' ' -f 1
+	if command -s ip >/dev/null
+		command ip --oneline address | cut -d" " -f7 | sed "s:\(.*\)/.*:\1:"
+	else if command -s ifconfig >/dev/null
+		command ifconfig |sgrep 'inet addr'|cut -d : -f 2|cut -d ' ' -f 1
+	end
 end
 

--- a/share/functions/__fish_print_addresses.fish
+++ b/share/functions/__fish_print_addresses.fish
@@ -2,7 +2,10 @@ function __fish_print_addresses --description "Print a list of known network add
 	if command -s ip >/dev/null
 		command ip --oneline address | cut -d" " -f7 | sed "s:\(.*\)/.*:\1:"
 	else if command -s ifconfig >/dev/null
-		command ifconfig |sgrep 'inet addr'|cut -d : -f 2|cut -d ' ' -f 1
+		# This is for OSX/BSD
+		# There's also linux ifconfig but that has at least two different output formats
+		# is basically dead, and ip is installed on everything now
+		ifconfig | awk '/^\tinet/ { print $2 } '
 	end
 end
 

--- a/share/functions/__fish_print_interfaces.fish
+++ b/share/functions/__fish_print_interfaces.fish
@@ -1,3 +1,10 @@
 function __fish_print_interfaces --description "Print a list of known network interfaces"
-	netstat -i -n -a | awk 'NR>2'|awk '{print $1}'
+	if test -d /sys/class/net
+		cd /sys/class/net
+		for i in *
+			echo $i
+		end
+	else
+		netstat -i -n -a | awk 'NR>2'|awk '{print $1}'
+	end
 end

--- a/share/functions/__fish_print_interfaces.fish
+++ b/share/functions/__fish_print_interfaces.fish
@@ -4,7 +4,7 @@ function __fish_print_interfaces --description "Print a list of known network in
 		for i in *
 			echo $i
 		end
-	else
-		netstat -i -n -a | awk 'NR>2'|awk '{print $1}'
+	else # OSX/BSD
+		command ifconfig -l | tr ' ' '\n'
 	end
 end


### PR DESCRIPTION
net-tools, which provides `ifconfig` and `netstat`, among other things,
has last been updated in 2013. This means `ifconfig` on linux is
basically dead.

Instead of ifconfig, use `ip` (from iproute2), which is much more powerful and
provides a much more annoying commandline syntax.

Instead of netstat, just look at /sys/class/net.

In particular, archlinux doesn't ship net-tools by default anymore.

If anyone could confirm this doesn't break anything on OSX I'd be thankful.