### PR TITLE
Move fish_history to $XDG_DATA_HOME

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -87,7 +87,7 @@ FISH_OBJS := obj/function.o obj/builtin.o obj/complete.o obj/env.o obj/exec.o \
 	obj/parse_execution.o obj/pager.o obj/utf8.o obj/fish_version.o \
 	obj/wcstringutil.o
 
-FISH_INDENT_OBJS := obj/fish_indent.o obj/print_help.o $(FISH_OBJS) 
+FISH_INDENT_OBJS := obj/fish_indent.o obj/print_help.o $(FISH_OBJS)
 
 #
 # Additional files used by builtin.o
@@ -602,7 +602,7 @@ xcode-install:
 # These 'true' lines are to prevent installs from failing for (e.g.) missing man pages.
 #
 
-install-force: all install-translations
+install-force: all install-translations migrate-history
 	$(INSTALL) -m 755 -d $(DESTDIR)$(bindir)
 	for i in $(PROGRAMS); do\
 		$(INSTALL) -m 755 $$i $(DESTDIR)$(bindir) ; \
@@ -759,6 +759,31 @@ uninstall-translations:
 
 
 #
+#  Migrate fish_history file.
+#  If $(XDG_DATA_HOME)/fish_history doesn't already exist,
+#  try to move it from the old location, .config/fish/
+#
+
+#  fish-data-home = $(XDG_DATA_HOME)/fish || $(HOME)/.local/share/fish
+ifeq ($(XDG_DATA_HOME),)
+fish-data-home := $(HOME)/.local/share/fish
+else
+fish-data-home := $(XDG_DATA_HOME)/fish
+endif
+
+$(fish-data-home):
+	mkdir -p $(fish-data-home)
+
+$(fish-data-home)/fish_history: $(fish-data-home)
+	-mv $(HOME)/.config/fish/fish_history $(fish-data-home)/fish_history
+	touch $(fish-data-home)/fish_history
+
+migrate-history: $(fish-data-home)/fish_history
+.PHONY: migrate-history
+
+
+
+#
 # The build rules for all the commands
 #
 
@@ -767,7 +792,7 @@ uninstall-translations:
 #
 obj/%.o: src/%.cpp | obj
 	$(CXX) $(CXXFLAGS) -c $< -o $@
-	
+
 #
 # obj directory
 #

--- a/Makefile.in
+++ b/Makefile.in
@@ -768,7 +768,7 @@ uninstall-translations:
 ifdef XDG_DATA_HOME
 fish-data-home := $(XDG_DATA_HOME)/fish
 else
-sfish-data-home := $(HOME)/.local/share/fish
+fish-data-home := $(HOME)/.local/share/fish
 endif
 
 $(fish-data-home):

--- a/Makefile.in
+++ b/Makefile.in
@@ -759,16 +759,16 @@ uninstall-translations:
 
 
 #
-#  Migrate fish_history file.
-#  If $(XDG_DATA_HOME)/fish_history doesn't already exist,
-#  try to move it from the old location, .config/fish/
+# Migrate fish_history file.
+# If $(XDG_DATA_HOME)/fish_history doesn't already exist,
+# try to move it from the old location, .config/fish/
 #
 
-#  fish-data-home = $(XDG_DATA_HOME)/fish || $(HOME)/.local/share/fish
-ifeq ($(XDG_DATA_HOME),)
-fish-data-home := $(HOME)/.local/share/fish
-else
+# fish-data-home = $(XDG_DATA_HOME)/fish || $(HOME)/.local/share/fish
+ifdef XDG_DATA_HOME
 fish-data-home := $(XDG_DATA_HOME)/fish
+else
+sfish-data-home := $(HOME)/.local/share/fish
 endif
 
 $(fish-data-home):
@@ -778,7 +778,18 @@ $(fish-data-home)/fish_history: $(fish-data-home)
 	-mv $(HOME)/.config/fish/fish_history $(fish-data-home)/fish_history
 	touch $(fish-data-home)/fish_history
 
-migrate-history: $(fish-data-home)/fish_history
+migrate-history-as-user: $(fish-data-home)/fish_history
+.PHONY: migrate-history-as-user
+
+# "make install" would mean we're running as root, so we may need
+# to revert to the original user to get their env vars correct for
+# migrating the history file
+migrate-history:
+ifdef SUDO_USER
+	sudo -u $(SUDO_USER) make migrate-history-as-user
+else
+	make migrate-history-as-user
+endif
 .PHONY: migrate-history
 
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -87,7 +87,7 @@ FISH_OBJS := obj/function.o obj/builtin.o obj/complete.o obj/env.o obj/exec.o \
 	obj/parse_execution.o obj/pager.o obj/utf8.o obj/fish_version.o \
 	obj/wcstringutil.o
 
-FISH_INDENT_OBJS := obj/fish_indent.o obj/print_help.o $(FISH_OBJS)
+FISH_INDENT_OBJS := obj/fish_indent.o obj/print_help.o $(FISH_OBJS) 
 
 #
 # Additional files used by builtin.o
@@ -602,7 +602,7 @@ xcode-install:
 # These 'true' lines are to prevent installs from failing for (e.g.) missing man pages.
 #
 
-install-force: all install-translations migrate-history
+install-force: all install-translations
 	$(INSTALL) -m 755 -d $(DESTDIR)$(bindir)
 	for i in $(PROGRAMS); do\
 		$(INSTALL) -m 755 $$i $(DESTDIR)$(bindir) ; \
@@ -759,42 +759,6 @@ uninstall-translations:
 
 
 #
-# Migrate fish_history file.
-# If $(XDG_DATA_HOME)/fish_history doesn't already exist,
-# try to move it from the old location, .config/fish/
-#
-
-# fish-data-home = $(XDG_DATA_HOME)/fish || $(HOME)/.local/share/fish
-ifdef XDG_DATA_HOME
-fish-data-home := $(XDG_DATA_HOME)/fish
-else
-fish-data-home := $(HOME)/.local/share/fish
-endif
-
-$(fish-data-home):
-	mkdir -p $(fish-data-home)
-
-$(fish-data-home)/fish_history: $(fish-data-home)
-	-mv $(HOME)/.config/fish/fish_history $(fish-data-home)/fish_history
-	touch $(fish-data-home)/fish_history
-
-migrate-history-as-user: $(fish-data-home)/fish_history
-.PHONY: migrate-history-as-user
-
-# "make install" would mean we're running as root, so we may need
-# to revert to the original user to get their env vars correct for
-# migrating the history file
-migrate-history:
-ifdef SUDO_USER
-	sudo -u $(SUDO_USER) make migrate-history-as-user
-else
-	make migrate-history-as-user
-endif
-.PHONY: migrate-history
-
-
-
-#
 # The build rules for all the commands
 #
 
@@ -803,7 +767,7 @@ endif
 #
 obj/%.o: src/%.cpp | obj
 	$(CXX) $(CXXFLAGS) -c $< -o $@
-
+	
 #
 # obj directory
 #

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -140,7 +140,7 @@ static void err(const wchar_t *blah, ...)
     va_list va;
     va_start(va, blah);
     err_count++;
-    
+
     // Xcode's term doesn't support color (even though TERM claims it does)
     bool colorize = ! getenv("RUNNING_IN_XCODE");
 
@@ -294,7 +294,7 @@ static void test_format(void)
         format_long_safe(buff1, j);
         sprintf(buff2, "%d", j);
         do_test(! strcmp(buff1, buff2));
-        
+
         wchar_t wbuf1[128], wbuf2[128];
         format_long_safe(wbuf1, j);
         swprintf(wbuf2, 128, L"%d", j);
@@ -467,7 +467,7 @@ static void test_tok()
             err(L"Too few tokens returned from tokenizer");
         }
     }
-    
+
     /* Test some errors */
     {
         tok_t token;
@@ -477,7 +477,7 @@ static void test_tok()
         do_test(token.error == TOK_UNTERMINATED_ESCAPE);
         do_test(token.error_offset == 3);
     }
-    
+
     {
         tok_t token;
         tokenizer_t t(L"abc defg(hij (klm)", 0);
@@ -487,7 +487,7 @@ static void test_tok()
         do_test(token.error == TOK_UNTERMINATED_SUBSHELL);
         do_test(token.error_offset == 4);
     }
-    
+
     {
         tok_t token;
         tokenizer_t t(L"abc defg[hij (klm)", 0);
@@ -555,7 +555,7 @@ static void test_iothread(void)
     {
         say(L"Expected int to be %d, but instead it was %d", iterations, *int_ptr);
     }
-    
+
     say(L"    (%.02f msec, with max of %d threads)", (end - start) * 1000.0, max_achieved_thread_count);
 
     delete int_ptr;
@@ -707,7 +707,7 @@ static void test_parser()
     {
         err(L"Bad escape in nested command substitution not reported as error");
     }
-    
+
     if (! parse_util_detect_errors(L"false & ; and cat"))
     {
         err(L"'and' command after background not reported as error");
@@ -717,13 +717,13 @@ static void test_parser()
     {
         err(L"'or' command after background not reported as error");
     }
-    
+
     if (parse_util_detect_errors(L"true & ; not cat"))
     {
         err(L"'not' command after background falsely reported as error");
     }
 
-    
+
     if (! parse_util_detect_errors(L"if true & ; end"))
     {
         err(L"backgrounded 'if' conditional not reported as error");
@@ -1295,7 +1295,7 @@ static void test_escape_sequences(void)
     if (escape_code_length(L"\x1b[2J") != 4) err(L"test_escape_sequences failed on line %d\n", __LINE__);
     if (escape_code_length(L"\x1b[38;5;123mABC") != strlen("\x1b[38;5;123m")) err(L"test_escape_sequences failed on line %d\n", __LINE__);
     if (escape_code_length(L"\x1b@") != 2) err(L"test_escape_sequences failed on line %d\n", __LINE__);
-    
+
     // iTerm2 escape sequences
     if (escape_code_length(L"\x1b]50;CurrentDir=/tmp/foo\x07NOT_PART_OF_SEQUENCE") != 25) err(L"test_escape_sequences failed on line %d\n", __LINE__);
     if (escape_code_length(L"\x1b]50;SetMark\x07NOT_PART_OF_SEQUENCE") != 13) err(L"test_escape_sequences failed on line %d\n", __LINE__);
@@ -1391,7 +1391,7 @@ static bool expand_test(const wchar_t *in, expand_flags_t flags, ...)
         expected.push_back(wcstring(arg));
     }
     va_end(va);
-    
+
     std::set<wcstring> remaining(expected.begin(), expected.end());
     std::vector<completion_t>::const_iterator out_it = output.begin(), out_end = output.end();
     for (; out_it != out_end; ++out_it)
@@ -1406,7 +1406,7 @@ static bool expand_test(const wchar_t *in, expand_flags_t flags, ...)
     {
         res = false;
     }
-    
+
     if (!res)
     {
         if ((arg = va_arg(va, wchar_t *)) != 0)
@@ -1463,7 +1463,7 @@ static void test_expand()
 
     expand_test(L"foo\\$bar", EXPAND_SKIP_VARIABLES, L"foo$bar", 0,
                 L"Failed to handle dollar sign in variable-skipping expansion");
-    
+
 
     /*
        b
@@ -1476,7 +1476,7 @@ static void test_expand()
           xxx
        .foo
      */
-    
+
     if (system("mkdir -p /tmp/fish_expand_test/")) err(L"mkdir failed");
     if (system("mkdir -p /tmp/fish_expand_test/b/")) err(L"mkdir failed");
     if (system("mkdir -p /tmp/fish_expand_test/baz/")) err(L"mkdir failed");
@@ -1493,27 +1493,27 @@ static void test_expand()
     expand_test(L"/tmp/fish_expand_test/.*", 0,
                 L"/tmp/fish_expand_test/.foo", wnull,
                 L"Expansion not correctly handling dotfiles");
-    
+
     expand_test(L"/tmp/fish_expand_test/./.*", 0,
                 L"/tmp/fish_expand_test/./.foo", wnull,
                 L"Expansion not correctly handling literal path components in dotfiles");
-    
+
     expand_test(L"/tmp/fish_expand_test/*/xxx", 0,
                 L"/tmp/fish_expand_test/bax/xxx", L"/tmp/fish_expand_test/baz/xxx", wnull,
                 L"Glob did the wrong thing 1");
-    
+
     expand_test(L"/tmp/fish_expand_test/*z/xxx", 0,
                 L"/tmp/fish_expand_test/baz/xxx", wnull,
                 L"Glob did the wrong thing 2");
-    
+
     expand_test(L"/tmp/fish_expand_test/**z/xxx", 0,
                 L"/tmp/fish_expand_test/baz/xxx", wnull,
                 L"Glob did the wrong thing 3");
-    
+
     expand_test(L"/tmp/fish_expand_test/b**", 0,
                 L"/tmp/fish_expand_test/b", L"/tmp/fish_expand_test/b/x", L"/tmp/fish_expand_test/bar", L"/tmp/fish_expand_test/bax", L"/tmp/fish_expand_test/bax/xxx", L"/tmp/fish_expand_test/baz", L"/tmp/fish_expand_test/baz/xxx", L"/tmp/fish_expand_test/baz/yyy", wnull,
                 L"Glob did the wrong thing 4");
-    
+
     expand_test(L"/tmp/fish_expand_test/BA", EXPAND_FOR_COMPLETIONS,
                 L"/tmp/fish_expand_test/bar", L"/tmp/fish_expand_test/bax/",  L"/tmp/fish_expand_test/baz/", wnull,
                 L"Case insensitive test did the wrong thing");
@@ -1529,17 +1529,17 @@ static void test_expand()
     expand_test(L"/tmp/fish_expand_test/b/x", EXPAND_FOR_COMPLETIONS | EXPAND_FUZZY_MATCH,
                 L"", wnull, // We just expect the empty string since this is an exact match
                 L"Wrong fuzzy matching 2");
-    
+
     // some vswprintfs refuse to append ANY_STRING in a format specifiers, so don't use format_string here
     const wcstring any_str_str(1, ANY_STRING);
     expand_test(L"/tmp/fish_expand_test/b/xx*", EXPAND_FOR_COMPLETIONS | EXPAND_FUZZY_MATCH,
                 (L"/tmp/fish_expand_test/bax/xx" + any_str_str).c_str(), (L"/tmp/fish_expand_test/baz/xx" + any_str_str).c_str(), wnull,
                 L"Wrong fuzzy matching 3");
-    
+
     expand_test(L"/tmp/fish_expand_test/b/yyy", EXPAND_FOR_COMPLETIONS | EXPAND_FUZZY_MATCH,
                 L"/tmp/fish_expand_test/baz/yyy", wnull,
                 L"Wrong fuzzy matching 4");
-    
+
     if (! expand_test(L"/tmp/fish_expand_test/.*", 0, L"/tmp/fish_expand_test/.foo", 0))
     {
         err(L"Expansion not correctly handling dotfiles");
@@ -1548,7 +1548,7 @@ static void test_expand()
     {
         err(L"Expansion not correctly handling literal path components in dotfiles");
     }
-    
+
     char saved_wd[PATH_MAX] = {};
     if (NULL == getcwd(saved_wd, sizeof saved_wd))
     {
@@ -1561,17 +1561,17 @@ static void test_expand()
         err(L"chdir failed");
         return;
     }
-    
+
     expand_test(L"b/xx", EXPAND_FOR_COMPLETIONS | EXPAND_FUZZY_MATCH,
                 L"bax/xxx", L"baz/xxx", wnull,
                 L"Wrong fuzzy matching 5");
-    
+
     if (chdir(saved_wd))
     {
         err(L"chdir failed");
     }
 
-    
+
     if (system("rm -Rf /tmp/fish_expand_test")) err(L"rm failed");
 }
 
@@ -1628,7 +1628,7 @@ static void test_abbreviations(void)
     expanded = reader_expand_abbreviation_in_command(L"gc somebranch", wcslen(L"gc"), &result);
     if (! expanded) err(L"gc not expanded");
     if (result != L"git checkout somebranch") err(L"gc incorrectly expanded on line %ld to '%ls'", (long)__LINE__, result.c_str());
-    
+
     /* space separation */
     expanded = reader_expand_abbreviation_in_command(L"gx somebranch", wcslen(L"gc"), &result);
     if (! expanded) err(L"gx not expanded");
@@ -2146,7 +2146,7 @@ static void test_complete(void)
     completions.clear();
     complete(L"echo \\$Foo", completions, COMPLETION_REQUEST_DEFAULT);
     do_test(completions.empty());
-    
+
     /* File completions */
     char saved_wd[PATH_MAX + 1] = {};
     if (!getcwd(saved_wd, sizeof saved_wd))
@@ -2193,7 +2193,7 @@ static void test_complete(void)
     do_test(completions.size() == 1);
     do_test(completions.at(0).completion == L"stfile");
     completions.clear();
-    
+
     // Zero escapes can cause problems. See #1631
     complete(L"cat foo\\0", completions, COMPLETION_REQUEST_DEFAULT);
     do_test(completions.empty());
@@ -2210,9 +2210,9 @@ static void test_complete(void)
 
     if (chdir(saved_wd)) err(L"chdir failed");
     if (system("rm -Rf '/tmp/complete_test/'")) err(L"rm failed");
-    
+
     complete_set_variable_names(NULL);
-    
+
     /* Test wraps */
     do_test(comma_join(complete_get_wrap_chain(L"wrapper1")) == L"wrapper1");
     complete_add_wrapper(L"wrapper1", L"wrapper2");
@@ -2350,7 +2350,7 @@ static void test_autosuggest_suggest_special()
     perform_one_autosuggestion_special_test(L"cd '5", wd, L"cd '5foo\"bar/'", __LINE__);
 
     perform_one_autosuggestion_special_test(L"cd ~/test_autosuggest_suggest_specia", wd, L"cd ~/test_autosuggest_suggest_special/", __LINE__);
-    
+
     // A single quote should defeat tilde expansion
     perform_one_autosuggestion_special_test(L"cd '~/test_autosuggest_suggest_specia'", wd, L"", __LINE__);
 
@@ -2541,7 +2541,7 @@ static int test_universal_helper(int *x)
         }
         fputc('.', stderr);
     }
-    
+
     /* Last step is to delete the first key */
     uvars.remove(format_string(L"key_%d_%d", *x, 0));
     bool synced = uvars.sync(NULL);
@@ -2550,7 +2550,7 @@ static int test_universal_helper(int *x)
         err(L"Failed to sync universal variables");
     }
     fputc('.', stderr);
-    
+
     return 0;
 }
 
@@ -2558,14 +2558,14 @@ static void test_universal()
 {
     say(L"Testing universal variables");
     if (system("mkdir -p /tmp/fish_uvars_test/")) err(L"mkdir failed");
-    
+
     const int threads = 16;
     for (int i=0; i < threads; i++)
     {
         iothread_perform(test_universal_helper, new int(i));
     }
     iothread_drain_all();
-    
+
     env_universal_t uvars(UVARS_TEST_PATH);
     bool loaded = uvars.load();
     if (! loaded)
@@ -2598,7 +2598,7 @@ static void test_universal()
             }
         }
     }
-    
+
     if (system("rm -Rf /tmp/fish_uvars_test")) err(L"rm failed");
     putc('\n', stderr);
 }
@@ -2613,7 +2613,7 @@ static void test_universal_callbacks()
     if (system("mkdir -p /tmp/fish_uvars_test/")) err(L"mkdir failed");
     env_universal_t uvars1(UVARS_TEST_PATH);
     env_universal_t uvars2(UVARS_TEST_PATH);
-    
+
     /* Put some variables into both */
     uvars1.set(L"alpha", L"1", false);
     uvars1.set(L"beta", L"1", false);
@@ -2622,17 +2622,17 @@ static void test_universal_callbacks()
     uvars1.set(L"lambda", L"1", false);
     uvars1.set(L"kappa", L"1", false);
     uvars1.set(L"omicron", L"1", false);
-    
+
     uvars1.sync(NULL);
     uvars2.sync(NULL);
-    
+
     /* Change uvars1 */
     uvars1.set(L"alpha", L"2", false); //changes value
     uvars1.set(L"beta", L"1", true); //changes export
     uvars1.remove(L"delta"); //erases value
     uvars1.set(L"epsilon", L"1", false); //changes nothing
     uvars1.sync(NULL);
-    
+
     /* Change uvars2. It should treat its value as correct and ignore changes from uvars1. */
     uvars2.set(L"lambda", L"1", false); //same value
     uvars2.set(L"kappa", L"2", false); //different value
@@ -2640,10 +2640,10 @@ static void test_universal_callbacks()
     /* Now see what uvars2 sees */
     callback_data_list_t callbacks;
     uvars2.sync(&callbacks);
-    
+
     /* Sort them to get them in a predictable order */
     std::sort(callbacks.begin(), callbacks.end(), callback_data_less_than);
-    
+
     /* Should see exactly two changes */
     do_test(callbacks.size() == 3);
     do_test(callbacks.at(0).type == SET);
@@ -2656,7 +2656,7 @@ static void test_universal_callbacks()
     do_test(callbacks.at(2).key == L"delta");
     do_test(callbacks.at(2).val == L"");
 
-    
+
     if (system("rm -Rf /tmp/fish_uvars_test")) err(L"rm failed");
 }
 
@@ -2667,7 +2667,7 @@ bool poll_notifier(universal_notifier_t *note)
     {
         result = note->poll();
     }
-    
+
     int fd = note->notification_fd();
     if (! result && fd >= 0)
     {
@@ -2690,17 +2690,17 @@ static void trigger_or_wait_for_notification(universal_notifier_t *notifier, uni
         case universal_notifier_t::strategy_default:
             assert(0 && "strategy_default should be passed");
             break;
-            
+
         case universal_notifier_t::strategy_shmem_polling:
             // nothing required
             break;
-            
+
         case universal_notifier_t::strategy_notifyd:
             // notifyd requires a round trip to the notifyd server, which means we have to wait a little bit to receive it
             // In practice, this seems to be enough
             usleep(1000000 / 25);
             break;
-            
+
         case universal_notifier_t::strategy_named_pipe:
         case universal_notifier_t::strategy_null:
             break;
@@ -2713,13 +2713,13 @@ static void test_notifiers_with_strategy(universal_notifier_t::notifier_strategy
     say(L"Testing universal notifiers with strategy %d", (int)strategy);
     universal_notifier_t *notifiers[16];
     size_t notifier_count = sizeof notifiers / sizeof *notifiers;
-    
+
     // Populate array of notifiers
     for (size_t i=0; i < notifier_count; i++)
     {
         notifiers[i] = universal_notifier_t::new_notifier_for_strategy(strategy, UVARS_TEST_PATH);
     }
-    
+
     // Nobody should poll yet
     for (size_t i=0; i < notifier_count; i++)
     {
@@ -2733,10 +2733,10 @@ static void test_notifiers_with_strategy(universal_notifier_t::notifier_strategy
     for (size_t post_idx=0; post_idx < notifier_count; post_idx++)
     {
         notifiers[post_idx]->post_notification();
-        
+
         // Do special stuff to "trigger" a notification for testing
         trigger_or_wait_for_notification(notifiers[post_idx], strategy);
-        
+
         for (size_t i=0; i < notifier_count; i++)
         {
             // We aren't concerned with the one who posted
@@ -2746,13 +2746,13 @@ static void test_notifiers_with_strategy(universal_notifier_t::notifier_strategy
                 poll_notifier(notifiers[i]);
                 continue;
             }
-            
+
             if (! poll_notifier(notifiers[i]))
             {
                 err(L"Universal variable notifier (%lu) %p polled failed to notice changes, with strategy %d", i, notifiers[i], (int)strategy);
             }
         }
-        
+
         // Named pipes have special cleanup requirements
         if (strategy == universal_notifier_t::strategy_named_pipe)
         {
@@ -2765,7 +2765,7 @@ static void test_notifiers_with_strategy(universal_notifier_t::notifier_strategy
             }
         }
     }
-    
+
     // Nobody should poll now
     for (size_t i=0; i < notifier_count; i++)
     {
@@ -2774,7 +2774,7 @@ static void test_notifiers_with_strategy(universal_notifier_t::notifier_strategy
             err(L"Universal variable notifier polled true after all changes, with strategy %d", (int)strategy);
         }
     }
-    
+
     // Clean up
     for (size_t i=0; i < notifier_count; i++)
     {
@@ -2790,7 +2790,7 @@ static void test_universal_notifiers()
 #if __APPLE__
     test_notifiers_with_strategy(universal_notifier_t::strategy_notifyd);
 #endif
-    
+
     if (system("rm -Rf /tmp/fish_uvars_test/")) err(L"rm failed");
 }
 
@@ -3112,8 +3112,13 @@ void history_tests_t::test_history_merge(void)
 
 static bool install_sample_history(const wchar_t *name)
 {
+    wcstring path;
+    if (! path_get_data(path)) {
+        err(L"Failed to get data directory");
+        return false;
+    }
     char command[512];
-    snprintf(command, sizeof command, "cp tests/%ls ~/.config/fish/%ls_history", name, name);
+    snprintf(command, sizeof command, "cp tests/%ls %ls/%ls_history", name, path.c_str(), name);
     if (system(command))
     {
         err(L"Failed to copy sample history");
@@ -3164,7 +3169,7 @@ static bool history_equals(history_t &hist, const wchar_t * const *strings)
 void history_tests_t::test_history_formats(void)
 {
     const wchar_t *name;
-    
+
     // Test inferring and reading legacy and bash history formats
     name = L"history_sample_fish_1_x";
     say(L"Testing %ls", name);
@@ -3257,7 +3262,7 @@ void history_tests_t::test_history_formats(void)
         test_history.clear();
         fclose(f);
     }
-    
+
     name = L"history_sample_corrupt1";
     say(L"Testing %ls", name);
     if (! install_sample_history(name))
@@ -3271,11 +3276,11 @@ void history_tests_t::test_history_formats(void)
         const wchar_t *expected[] =
         {
             L"no_newline_at_end_of_file",
-            
+
             L"corrupt_prefix",
-            
+
             L"this_command_is_ok",
-            
+
             NULL
         };
         if (! history_equals(test_history, expected))
@@ -3638,13 +3643,13 @@ static wcstring_list_t separate_by_format_specifiers(const wchar_t *format)
             next_specifier = end;
         }
         assert(next_specifier != NULL);
-        
+
         /* Don't return empty strings */
         if (next_specifier > cursor)
         {
             result.push_back(wcstring(cursor, next_specifier - cursor));
         }
-        
+
         /* Walk over the format specifier (if any) */
         cursor = next_specifier;
         if (*cursor == '%')
@@ -3732,7 +3737,7 @@ static void test_error_messages()
         {L"echo foo || echo bar", ERROR_BAD_OR},
         {L"echo foo && echo bar", ERROR_BAD_AND}
     };
-    
+
     parse_error_list_t errors;
     for (size_t i=0; i < sizeof error_tests / sizeof *error_tests; i++)
     {
@@ -4042,7 +4047,7 @@ int main(int argc, char **argv)
             perror("chdir");
         }
     }
-    
+
     setlocale(LC_ALL, "");
     //srand(time(0));
     configure_thread_assertions_for_testing();

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -388,8 +388,8 @@ static size_t offset_of_next_item_fish_2_0(const char *begin, size_t mmap_length
                 ! memcmp(line_start, "---", 3) ||
                 ! memcmp(line_start, "...", 3))
             continue;
-        
-        
+
+
         /* Hackish: fish 1.x rewriting a fish 2.0 history file can produce lines with lots of leading "- cmd: - cmd: - cmd:". Trim all but one leading "- cmd:". */
         const char *double_cmd = "- cmd: - cmd: ";
         const size_t double_cmd_len = strlen(double_cmd);
@@ -398,13 +398,13 @@ static size_t offset_of_next_item_fish_2_0(const char *begin, size_t mmap_length
             /* Skip over just one of the - cmd. In the end there will be just one left. */
             line_start += strlen("- cmd: ");
         }
-        
+
         /* Hackish: fish 1.x rewriting a fish 2.0 history file can produce commands like "when: 123456". Ignore those. */
         const char *cmd_when = "- cmd:    when:";
         const size_t cmd_when_len = strlen(cmd_when);
         if (newline - line_start >= cmd_when_len && ! memcmp(line_start, cmd_when, cmd_when_len))
             continue;
-        
+
 
         /* At this point, we know line_start is at the beginning of an item. But maybe we want to skip this item because of timestamps. A 0 cutoff means we don't care; if we do care, then try parsing out a timestamp. */
         if (cutoff_timestamp != 0)
@@ -733,7 +733,7 @@ history_item_t history_t::item_at_index(size_t idx)
     {
         resolved_new_item_count -= 1;
     }
-    
+
     /* idx=0 corresponds to the last resolved item */
     if (idx < resolved_new_item_count)
     {
@@ -816,7 +816,7 @@ history_item_t history_t::decode_item_fish_2_0(const char *base, size_t len)
 
     size_t indent = 0, cursor = 0;
     std::string key, value, line;
-    
+
     /* Read the "- cmd:" line */
     size_t advance = read_line(base, cursor, len, line);
     trim_leading_spaces(line);
@@ -824,7 +824,7 @@ history_item_t history_t::decode_item_fish_2_0(const char *base, size_t len)
     {
         goto done;
     }
-    
+
     cursor += advance;
     cmd = str2wcstring(value);
 
@@ -1275,7 +1275,7 @@ static void unescape_yaml(std::string *str)
 static wcstring history_filename(const wcstring &name, const wcstring &suffix)
 {
     wcstring path;
-    if (! path_get_config(path))
+    if (! path_get_data(path))
         return L"";
 
     wcstring result = path;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1650,6 +1650,53 @@ bool history_t::is_empty(void)
     return empty;
 }
 
+
+/* Populates from older location (in config path, rather than data path)
+   This is accomplished by clearing ourselves, and copying the contents of
+   the old history file to the new history file.  The new contents will
+   automatically be re-mapped later.
+*/
+void history_t::populate_from_config_path()
+{
+    wcstring old_file;
+    if (path_get_config(old_file)) {
+        old_file.append(L"/");
+        old_file.append(name);
+        old_file.append(L"_history");
+        int src_fd = wopen_cloexec(old_file, O_RDONLY, 0);
+        if (src_fd != -1)
+        {
+            wcstring new_file;
+            history_filename(new_file, L"");
+
+            /* clear must come after we've retrieved the new_file name,
+               and before we open destination file descriptor,
+               since it destroys the name and the file */
+            this->clear();
+
+            int dst_fd = wopen_cloexec(new_file, O_WRONLY | O_CREAT, 0644);
+
+            char buf[BUFSIZ];
+            size_t size;
+            while ((size = read(src_fd, buf, BUFSIZ)) > 0) {
+                ssize_t written = write(dst_fd, buf, size);
+                if (written == -1) {
+                    /*
+                      This message does not have high enough priority to
+                      be shown by default.
+                    */
+                    debug(2, L"Error when writing history file");
+                    break;
+                }
+            }
+
+            close(src_fd);
+            close(dst_fd);
+        }
+    }
+}
+
+
 /* Indicate whether we ought to import the bash history file into fish */
 static bool should_import_bash_history_line(const std::string &line)
 {

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1666,8 +1666,7 @@ void history_t::populate_from_config_path()
         int src_fd = wopen_cloexec(old_file, O_RDONLY, 0);
         if (src_fd != -1)
         {
-            wcstring new_file;
-            history_filename(new_file, L"");
+            wcstring new_file = history_filename(name, wcstring());
 
             /* clear must come after we've retrieved the new_file name,
                and before we open destination file descriptor,

--- a/src/history.h
+++ b/src/history.h
@@ -64,7 +64,7 @@ private:
 
     /** Paths that we require to be valid for this item to be autosuggested */
     path_list_t required_paths;
-    
+
 public:
     const wcstring &str() const
     {
@@ -141,7 +141,7 @@ private:
 
     /** Whether we have a pending item. If so, the most recently added item is ignored by item_at_index. */
     bool has_pending_item;
-    
+
     /** Whether we should disable saving to the file for a time */
     uint32_t disable_automatic_save_counter;
 
@@ -222,7 +222,7 @@ public:
 
     /** Add a new pending history item to the end, and then begin file detection on the items to determine which arguments are paths */
     void add_pending_with_file_detection(const wcstring &str);
-    
+
     /** Resolves any pending history items, so that they may be returned in history searches. */
     void resolve_pending();
 
@@ -235,6 +235,9 @@ public:
 
     /** Irreversibly clears history */
     void clear();
+
+    /** Populates from older location ()in config path, rather than data path) */
+    void populate_from_config_path();
 
     /** Populates from a bash history file */
     void populate_from_bash(FILE *f);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -276,10 +276,54 @@ static wcstring path_create_config()
     return res;
 }
 
+static wcstring path_create_data()
+{
+    bool done = false;
+    wcstring res;
+
+    const env_var_t xdg_dir  = env_get_string(L"XDG_DATA_HOME");
+    if (! xdg_dir.missing())
+    {
+        res = xdg_dir + L"/fish";
+        if (!create_directory(res))
+        {
+            done = true;
+        }
+    }
+    else
+    {
+        const env_var_t home = env_get_string(L"HOME");
+        if (! home.missing())
+        {
+            res = home + L"/.local/share/fish";
+            if (!create_directory(res))
+            {
+                done = true;
+            }
+        }
+    }
+
+    if (! done)
+    {
+        res.clear();
+
+        debug(0, _(L"Unable to create a data directory for fish. Your history will not be saved. Please set the $XDG_DATA_HOME variable to a directory where the current user has write access."));
+    }
+    return res;
+}
+
 /* Cache the config path */
 bool path_get_config(wcstring &path)
 {
     static const wcstring result = path_create_config();
+    path = result;
+    return ! result.empty();
+}
+
+/* Cache the data path */
+bool path_get_data(wcstring &path)
+{
+    static const wcstring result = path_create_data();
     path = result;
     return ! result.empty();
 }

--- a/src/path.h
+++ b/src/path.h
@@ -20,12 +20,25 @@
 
 /**
    Returns the user configuration directory for fish. If the directory
-   or one of it's parents doesn't exist, they are first created.
+   or one of its parents doesn't exist, they are first created.
 
    \param path The directory as an out param
    \return whether the directory was returned successfully
 */
 bool path_get_config(wcstring &path);
+
+/**
+   Returns the user data directory for fish. If the directory
+   or one of its parents doesn't exist, they are first created.
+
+   Volatile files presumed to be local to the machine,
+   such as the fish_history and all the generated_completions,
+   will be stored in this directory.
+
+   \param path The directory as an out param
+   \return whether the directory was returned successfully
+*/
+bool path_get_data(wcstring &path);
 
 /**
    Finds the full path of an executable. Returns YES if successful.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1240,7 +1240,7 @@ static bool insert_string(editable_line_t *el, const wcstring &str, bool allow_e
     size_t len = str.size();
     if (len == 0)
         return false;
-    
+
     /* Start inserting. If we are expanding abbreviations, we have to do this after every space (see #1434), so look for spaces. We try to do this efficiently (rather than the simpler character at a time) to avoid expensive work in command_line_changed() */
     size_t cursor = 0;
     while (cursor < len)
@@ -1250,14 +1250,14 @@ static bool insert_string(editable_line_t *el, const wcstring &str, bool allow_e
         size_t char_triggering_expansion_pos = allow_expand_abbreviations ? str.find_first_of(expansion_triggering_chars, cursor) : wcstring::npos;
         bool has_expansion_triggering_char = (char_triggering_expansion_pos != wcstring::npos);
         size_t range_end = (has_expansion_triggering_char ? char_triggering_expansion_pos + 1 : len);
-        
+
         /* Insert from the cursor up to but not including the range end */
         assert(range_end > cursor);
         el->insert_string(str, cursor, range_end - cursor);
-        
+
         update_buff_pos(el, el->position);
         data->command_line_changed(el);
-        
+
         /* If we got an expansion trigger, then the last character we inserted was it (i.e. was a space). Expand abbreviations. */
         if (has_expansion_triggering_char && allow_expand_abbreviations)
         {
@@ -1267,16 +1267,16 @@ static bool insert_string(editable_line_t *el, const wcstring &str, bool allow_e
         }
         cursor = range_end;
     }
-    
+
     if (el == &data->command_line)
     {
         data->suppress_autosuggestion = false;
-        
+
         /* Syntax highlight. Note we must have that buff_pos > 0 because we just added something nonzero to its length  */
         assert(el->position > 0);
         reader_super_highlight_me_plenty(-1);
     }
-    
+
     reader_repaint();
 
     return true;
@@ -1576,7 +1576,7 @@ static void accept_autosuggestion(bool full)
     {
         /* Accepting an autosuggestion clears the pager */
         clear_pager();
-        
+
         /* Accept the autosuggestion */
         if (full)
         {
@@ -1891,7 +1891,7 @@ static bool handle_completions(const std::vector<completion_t> &comp, bool conti
                     break;
             }
         }
-        
+
         /* Determine if we use the prefix. We use it if it's non-empty and it will actually make the command line longer. It may make the command line longer by virtue of not using REPLACE_TOKEN (so it always appends to the command line), or by virtue of replacing the token but being longer than it. */
         bool use_prefix = common_prefix.size() > (will_replace_token ? tok.size() : 0);
         assert(! use_prefix || ! common_prefix.empty());
@@ -2674,7 +2674,13 @@ void reader_set_exit_on_interrupt(bool i)
 
 void reader_import_history_if_necessary(void)
 {
-    /* Import history from bash, etc. if our current history is empty */
+    /* Import history from older location (config path) if our current history is empty */
+    if (data->history && data->history->is_empty())
+    {
+        data->history->populate_from_config_path();
+    }
+
+    /* Import history from bash, etc. if our current history is still empty */
     if (data->history && data->history->is_empty())
     {
         /* Try opening a bash file. We make an effort to respect $HISTFILE; this isn't very complete (AFAIK it doesn't have to be exported), and to really get this right we ought to ask bash itself. But this is better than nothing.
@@ -3178,7 +3184,7 @@ const wchar_t *reader_readline(int nchars)
 
                     editable_line_t *el = data->active_edit_line();
                     insert_string(el, arr, true);
-                    
+
                     /* End paging upon inserting into the normal command line */
                     if (el == &data->command_line)
                     {
@@ -3461,7 +3467,7 @@ const wchar_t *reader_readline(int nchars)
                 {
                     begin--;
                 }
-                
+
                 /* Push end forwards to just past the next newline, or just past the last char. */
                 size_t end = el->position;
                 while (buff[end] != L'\0')


### PR DESCRIPTION
Add new functions path_get_data and path_create_data which parallel existing
functions path_get_config and path_create_data.  The new functions refer to
XDG_DATA_HOME, if it is defined, or ./local/share if not.

Modify history_filename to use the new function path_get_data.

As a consequence, fish_history will now be located in XDG_DATA_HOME,
not XDG_CONFIG_HOME.

Note that these changes mirror what is already used in
fish-shell/share/tools/create_manpage_completions.py, which stores the
completions in XDG_DATA_HOME

This change matches recommendations in the xdg basedir spec at
http://standards.freedesktop.org/basedir-spec/basedir-spec-0.7.html
($XDG_DATA_HOME defines the base directory relative to which user specific data
files should be stored. If $XDG_DATA_HOME is either not set or empty, a default
equal to $HOME/.local/share should be used.)

It addresses suggestions from the following issues:

1. Don't put history in $XDG_CONFIG_HOME #744
   fish-shell#744

2. Fish is placing non-config files in $XDG_CONFIG_HOME #1257
   fish-shell#1257

3. Move non-config data out of $XDG_CONFIG_HOME #1669
   fish-shell#1669
