### PR TITLE
Handle environment variables with = signs correctly

### DIFF
--- a/share/functions/export.fish
+++ b/share/functions/export.fish
@@ -4,7 +4,7 @@ function export --description 'Set global variable. Alias for set -g, made for b
            return 0
         end
         for arg in $argv
-            set -l v (echo $arg|tr '=' \n)
+            set -l v (echo $arg|sed 's/=/\n/')
             set -l c (count $v)
             switch $c
                     case 1


### PR DESCRIPTION
## Scenario:

I need to run this line:

    export THEANO_FLAGS='floatX=float32,device=gpu,nvcc.fastmath=True'

but the current implementation of the export function doesn't export anything, since the `tr` command would split the string at all the occurrences of the equal sign and end up having no case in the switch statement.

## Solution

By using `sed` we ensure that the string gets split at only the first occurrence of the equal sign, emulating more carefully bash's behavior.