### PR TITLE
Make dirs output more useful.

### DIFF
--- a/share/functions/dirs.fish
+++ b/share/functions/dirs.fish
@@ -11,8 +11,10 @@ function dirs --description 'Print directory stack'
 
         # replace $HOME with ~
         echo -n (echo (command pwd) | sed -e "s|^$HOME|~|")"  "
-        for i in $dirstack
-                echo -n (echo $i | sed -e "s|^$HOME|~|")"  "
+        if test (count $dirstack) -gt 0
+                for i in (seq (count $dirstack))
+                        echo -n +$i:(echo $dirstack[$i] | sed -e "s|^$HOME|~|")"  "
+                end
         end
         echo
 end


### PR DESCRIPTION
In the spirit of making fish friendlier than bash, the dirs output
now prefixes the directories with their position in the stack.

This helps users if they wish to use rotation based pushd
commands (pushd +n) as the relevant number is displayed.