### PR TITLE
Fix xcode include paths for pcre2.h

### DIFF
--- a/fish.xcodeproj/project.pbxproj
+++ b/fish.xcodeproj/project.pbxproj
@@ -1847,6 +1847,7 @@
 				);
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/osx/pcre2";
 			};
 			name = Debug;
 		};
@@ -1859,6 +1860,7 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/osx/pcre2";
 			};
 			name = Release;
 		};
@@ -1871,6 +1873,7 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				PRODUCT_NAME = fish;
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/osx/pcre2";
 			};
 			name = Debug;
 		};
@@ -1883,6 +1886,7 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				PRODUCT_NAME = fish;
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/osx/pcre2";
 			};
 			name = Release;
 		};

--- a/fish.xcodeproj/project.pbxproj
+++ b/fish.xcodeproj/project.pbxproj
@@ -1556,6 +1556,7 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				PRODUCT_NAME = fish;
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/osx/pcre2";
 			};
 			name = "Release_C++11";
 		};
@@ -1568,6 +1569,7 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/osx/pcre2";
 			};
 			name = "Release_C++11";
 		};


### PR DESCRIPTION
The Xcode project needs additional USER_HEADER_SEARCH_PATHS in order to find pcre2.h.

Based on previous changes, this file seems to be expected to be in osx/pcre2.

Note: pcre2 seems to require ./configure step and copy of pcre2/src/pcre2.h file to osx/pcre2) before xcodebuild can be successfully run.
