### PR TITLE
Only include <spawn.h> if HAVE_SPAWN_H

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -18,7 +18,9 @@
 #include <assert.h>
 #include <vector>
 #include <algorithm>
+#ifdef HAVE_SPAWN_H
 #include <spawn.h>
+#endif
 #include <wctype.h>
 #include <map>
 #include <string>


### PR DESCRIPTION
This fixes building on platforms such as Android which lacks `<spawn.h>`.