### PR TITLE
Treat `LD_LIBRARY_PATH` as colon-delimited array.

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -398,7 +398,7 @@ wcstring env_get_pwd_slash(void)
 /* Here is the whitelist of variables that we colon-delimit, both incoming from the environment and outgoing back to it. This is deliberately very short - we don't want to add language-specific values like CLASSPATH. */
 static bool variable_is_colon_delimited_array(const wcstring &str)
 {
-    return contains(str, L"PATH", L"MANPATH", L"CDPATH");
+    return contains(str, L"PATH", L"MANPATH", L"CDPATH", L"LD_LIBRARY_PATH");
 }
 
 void env_init(const struct config_paths_t *paths /* or NULL */)


### PR DESCRIPTION
I have seen and read c0b8e81b and read the issues linked therein ( #1374 and #1656), and I see no reason for omitting `LD_LIBRARY_PATH` from this list. Actually, whenever I modify `PATH`, I also need to modify `LD_LIBRARY_PATH`.

See also #2456.

Should this PR get accepted, I can amend this commit to also change [the documentation](https://github.com/fish-shell/fish-shell/blob/master/doc_src/index.hdr.in#L724).