### PR TITLE
Remove OSX/Cygwin special cases from prompt_pwd

### DIFF
--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -1,15 +1,4 @@
-set -l s1
-set -l r1
-switch (uname)
-case Darwin
-	set s1 '^/private/'
-	set r1 /
-case 'CYGWIN_*'
-	set s1 '^/cygdrive/(.)'
-	set r1 '$1:'
-end
-
-function prompt_pwd -V s1 -V r1 --description "Print the current working directory, shortened to fit the prompt"
+function prompt_pwd --description "Print the current working directory, shortened to fit the prompt"
 	set realhome ~
-	string replace -r '^'"$realhome"'($|/)' '~$1' $PWD | string replace -r "$s1" "$r1" | string replace -ar '([^/.])[^/]*/' '$1/'
+	string replace -r '^'"$realhome"'($|/)' '~$1' $PWD | string replace -ar '([^/.])[^/]*/' '$1/'
 end


### PR DESCRIPTION
For cygwin, you can't `cd C:`, so a prompt of "C:/Something" is
misleading.

For OSX, we dereference symlinks elsewhere

This also simplifies prompt_pwd quite a bit.

Like @zanchey said on gitter:

>I think we should drop the cygdrive transformation; you can't do e.g. cd c:/

and

>I'm conflicted about the /private stuff. on the one hand at least you can cd to the printed directory. on the other hand we give a strong case for dereferencing symlinks in other places.