### PR TITLE
Add __fish_needs_subcommand completion helper

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -61,36 +61,7 @@ function __fish_git_ranges
 end
 
 function __fish_git_needs_command
-  set cmd (commandline -opc)
-  if [ (count $cmd) -eq 1 ]
-	  return 0
-  else
-	  set -l skip_next 1
-	  # Skip first word because it's "git" or a wrapper
-	  for c in $cmd[2..-1]
-		  test $skip_next -eq 0; and set skip_next 1; and continue
-		  # git can only take a few options before a command, these are the ones mentioned in the "git" man page
-		  # e.g. `git --follow log` is wrong, `git --help log` is okay (and `git --help log $branch` is superfluous but works)
-		  # In case any other option is used before a command, we'll fail, but that's okay since it's invalid anyway
-		  switch $c
-			  # General options that can still take a command
-			  case "--help" "-p" "--paginate" "--no-pager" "--bare" "--no-replace-objects" --{literal,glob,noglob,icase}-pathspecs  --{exec-path,git-dir,work-tree,namespace}"=*"
-				  continue
-			  # General options with an argument we need to skip. The option=value versions have already been handled above
-			  case --{exec-path,git-dir,work-tree,namespace}
-				  set skip_next 0
-				  continue
-			  # General options that cause git to do something and exit - these behave like commands and everything after them is ignored
-			  case "--version" --{html,man,info}-path
-				  return 1
-			  # We assume that any other token that's not an argument to a general option is a command
-			  case "*"
-				  return 1
-		  end
-	  end
-	  return 0
-  end
-  return 1
+	__fish_needs_subcommand {help,paginate,no-pager,bare,no-replace-objects} {literal,glob,noglob,icase}-pathspecs --exit version {html,man,info}-path --arg {exec-path,git-dir,work-tree,namespace} --flagshort p
 end
 
 function __fish_git_using_command

--- a/share/completions/sudo.fish
+++ b/share/completions/sudo.fish
@@ -2,16 +2,23 @@
 # Completion for sudo
 #
 
-complete -c sudo -s h -n "__fish_no_arguments" --description "Display help and exit"
-complete -c sudo -s v -n "__fish_no_arguments" --description "Validate"
-complete -c sudo -s u -a "(__fish_complete_users)" -x -d "Run command as user"
-complete -c sudo -s g -a "(__fish_complete_groups)" -x -d "Run command as group"
-complete -c sudo -s E -d "Preserve environment"
-complete -c sudo -s P -d "Preserve group vector"
-complete -c sudo -s S -d "Read password from stdin"
-complete -c sudo -s H -d "Set home"
-complete -c sudo -s e -r -d "Edit"
-complete -c sudo --description "Command to run" -x -a "(__fish_complete_subcommand_root -u -g)"
+function __fish_sudo_needs_command
+	__fish_needs_subcommand --flagshort {A,b,E,e,g,H,i,K,k,l,n,P,S,s} --flag {askpass,background,preserve-env,edit,set-home,login,remove-timestamp,reset-timestamp,list,non-interactive,preserve-groups,stdin,shell} --argshort {C,g,h,p,U,u} --arg {close-from,group,host,prompt,other-user,user} --exit help version validate --exitshort h v V
+end
+
+complete -c sudo -s h -n "__fish_no_arguments" --description "Display help and exit" -f
+complete -c sudo -s v -n "__fish_no_arguments" --description "Validate" -f
+# Only offer sudo options if no command has been given
+complete -c sudo -s u -a "(__fish_complete_users)" -x -d "Run command as user" -n "__fish_sudo_needs_command" -f
+complete -c sudo -s g -a "(__fish_complete_groups)" -x -d "Run command as group" -n "__fish_sudo_needs_command" -f
+complete -c sudo -s E -d "Preserve environment" -n "__fish_sudo_needs_command" -f
+complete -c sudo -s P -d "Preserve group vector" -n "__fish_sudo_needs_command" -f
+complete -c sudo -s S -d "Read password from stdin" -n "__fish_sudo_needs_command" -f
+complete -c sudo -s H -d "Set home" -n "__fish_sudo_needs_command" -f
+complete -c sudo -s e -r -d "Edit" -n "__fish_sudo_needs_command"
+# Remove the description once we have a command
+complete -c sudo --description "Command to run" -x -a "(__fish_complete_subcommand_root -u -g)" -n "__fish_sudo_needs_command" -f
+complete -c sudo -x -a "(__fish_complete_subcommand_root -u -g)" -n "not __fish_sudo_needs_command" -f
 
 # Since sudo runs subcommands, it can accept any switches
 complete -c sudo -u

--- a/share/functions/__fish_needs_subcommand.fish
+++ b/share/functions/__fish_needs_subcommand.fish
@@ -1,0 +1,55 @@
+function __fish_needs_subcommand --description "Completion helper to see if a command needs a subcommand or already has one, while skipping specified options"
+	set -l flag_opts # Options that just cause some behavior to be switched - we just skip'em
+	set -l exit_opts # Options that cause the command to exit regardless of subcommand
+	set -l arg_opts # Options that take an argument - we assume that these have an option=value version that we skip
+	# And the short versions of those
+	set -l flag_shortopts
+	set -l exit_shortopts
+	set -l arg_shortopts # We also assume that the last short option in a group can have a =value
+	set -l dest flag_opts
+	for a in $argv
+		switch $a
+			case "--exit"
+				set dest exit_opts
+			case "--arg"
+				set dest arg_opts
+			case "--flag"
+				set dest flag_opts
+			case "--shortexit"
+				set dest exit_shortopts
+			case "--shortarg"
+				set dest arg_shortopts
+			case "--shortflag"
+				set dest flag_shortopts
+			case "*"
+				set $dest $$dest $a
+		end
+	end
+	set cmd (commandline -opc)
+	if [ (count $cmd) -eq 1 ]
+		return 0
+	else
+		set -l skip_next 1
+		# Skip first word because it's the main command
+		for c in $cmd[2..-1]
+			test $skip_next -eq 0; and set skip_next 1; and continue
+			switch $c
+				# General options that can still take a command
+				case --$flag_opts --$arg_opts"=*" -$flag_shortopts "-*"$arg_shortopts"="
+					continue
+					# General options with an argument we need to skip. The option=value versions have already been handled above
+				case --$arg_opts "-*"$arg_shortopts"="
+					set skip_next 0
+					continue
+					# General options that cause git to do something and exit - these behave like commands and everything after them is ignored
+				case --$exit_opts -$exit_shortopts
+					return 1
+					# We assume that any other token that's not an argument to a general option is a command
+				case "*"
+					return 1
+			end
+		end
+		return 0
+	end
+	return 1
+end


### PR DESCRIPTION
This isn't beautiful and would be obsoleted by #478 (which is something I've said a few times already), but while that's not ready, this could be used to improve our completions in both accuracy and line-count.

I've not written documentation because the interface is a bit odd (but still the best I could come up with other than doing --inherit-variable, which feels unfishy). Essentially we take a few options that switch how we view the next arguments.

The way it works is you specify all options (though wildcards should work, I've not tested it) a command can take before a subcommand, in six different types:

- "Flag options" - options that just switch certain behavior on or off (think `--paginate` or `--no-color`)

- "Exit options" - options that cause a command to ignore all future arguments (think `--version`)

- "Argument options" - options that take an argument

and their respective short versions. We assume short options can be grouped (like `ls -lah`) and that argument options can _also_ be specified in a `--option=value` form, including the short version as `-*option=value`.

There is no specific support for "old-style" one-dash options because I couldn't think of an old-style tool that still takes a subcommand.

For the git completion, this is basically cleanup. For the sudo completion, this improves accuracy (since it no longer offers sudo options after a command has been given, and removes the "Command to be run" description from arguments to that command).