### PR TITLE
Set runtime dir to /tmp/user.$USER if user cannot access $XDG_RUNTIME_DIR

### DIFF
--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -147,7 +147,9 @@ static wcstring get_runtime_path()
 {
     wcstring result;
     const char *dir = getenv("XDG_RUNTIME_DIR");
-    if (dir != NULL)
+
+    int mode = R_OK | W_OK | X_OK;
+    if (dir != NULL && access(dir, mode) == 0)
     {
         result = str2wcstring(dir);
     }


### PR DESCRIPTION
Add simple access checking to see if user has RWX access to XDG_RUNTIME_DIR