### PR TITLE
Enable 24-bit mode for selected terminals

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -321,7 +321,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
 		end
 	end
 
-	if begin set -q KONSOLE_DBUS_SESSION # KDE's konsole
+	if begin set -q KONSOLE_PROFILE_NAME # KDE's konsole
 		or set -q ITERM_PROFILE # iTerm2
 		or string match -q -- "st-*" $TERM # suckless' st
 		or test "$VTE_VERSION" -ge 3600 # Should be all gtk3-vte-based terms after version 3.6.0.0

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -322,7 +322,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
 	end
 
 	if begin set -q KONSOLE_PROFILE_NAME # KDE's konsole
-		or set -q ITERM_PROFILE # iTerm2
+		or string match -q -- "*:*" $ITERM_SESSION_ID # Supporting versions of iTerm2 will include a colon here
 		or string match -q -- "st-*" $TERM # suckless' st
 		or test "$VTE_VERSION" -ge 3600 # Should be all gtk3-vte-based terms after version 3.6.0.0
 		or test "$COLORTERM" = truecolor -o "$COLORTERM" = 24bit # slang expects this

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -320,4 +320,13 @@ function __fish_config_interactive -d "Initializations that should be performed 
 			fish_fallback_prompt
 		end
 	end
+
+	if begin set -q KONSOLE_DBUS_SESSION # KDE's konsole
+		or set -q ITERM_PROFILE # iTerm2
+		or string match -q -- "st-*" $TERM # suckless' st
+		or test "$VTE_VERSION" -ge 3600 # Should be all gtk3-vte-based terms after version 3.6.0.0
+		or test "$COLORTERM" = truecolor -o "$COLORTERM" = 24bit # slang expects this
+	   end
+	   set -g fish_term24bit 1
+	end
 end


### PR DESCRIPTION
Unfortunately, there's no standard way to detect support (importantly,
terminfo doesn't encode it), but there's a variety of terminals that
support it that we can detect.

It's better than letting this functionality go to waste.

(Note that I'm the wrong one to see if this is working as I'm mildly color-blind)