### PR TITLE
Source sys and data configs

### DIFF
--- a/etc/config.fish
+++ b/etc/config.fish
@@ -37,3 +37,10 @@ if status --is-login
 	end
 end
 
+# Source fish files
+for file in $__fish_sysconfdir/*.fish
+	if test "$file" != "$__fish_sysconfdir/config.fish"
+		source $file
+	end
+end
+

--- a/share/config.fish
+++ b/share/config.fish
@@ -152,3 +152,11 @@ function . --description 'Evaluate contents of file (deprecated, see "source")' 
 		source $argv
 	end
 end
+
+# Source fish files
+for file in $__fish_datadir/*.fish
+        if test "$file" != "$__fish_datadir/config.fish"
+                source $file
+        end
+end
+


### PR DESCRIPTION
Source config files from paths like `/etc/fish/*.fish` for sysadmins and `/usr/share/fish/*.fish` for distributions/vendors.
This basically implements #1956
