### PR TITLE
Check if vi exists

### DIFF
--- a/share/completions/vi.fish
+++ b/share/completions/vi.fish
@@ -4,21 +4,24 @@
 # +command : same as -c command
 
 
-# Check if vi is really vim
-if vi --version > /dev/null ^ /dev/null
-    complete -c vi -w vim
-else
-    complete -c vi -s s --description 'Suppress all interactive user feedback'
-    complete -c vi -s C --description 'Encrypt/decrypt text'
-    complete -c vi -s l --description 'Set up for editing LISP programs'
-    complete -c vi -s L --description 'List saved file names after crash'
-    complete -c vi -s R --description 'Read-only mode'
-    complete -c vi -s S --description 'Use linear search for tags if tag file not sorted'
-    complete -c vi -s v --description 'Start in display editing state'
-    complete -c vi -s V --description 'Verbose mode'
-    complete -c vi -s x --description 'Encrypt/decrypt text'
-    complete -c vi -r -s r --description 'Recover file after crash'
-    complete -c vi -r -s t --description 'Edit the file containing a tag'
-    complete -c vi -r -c t --description 'Begin editing by executing the specified  editor command'
+# Check if vi exists
+if type vi > /dev/null ^ /dev/null
+    # Check if vi is really vim
+    if vi --version > /dev/null ^ /dev/null
+        complete -c vi -w vim
+    else
+        complete -c vi -s s --description 'Suppress all interactive user feedback'
+        complete -c vi -s C --description 'Encrypt/decrypt text'
+        complete -c vi -s l --description 'Set up for editing LISP programs'
+        complete -c vi -s L --description 'List saved file names after crash'
+        complete -c vi -s R --description 'Read-only mode'
+        complete -c vi -s S --description 'Use linear search for tags if tag file not sorted'
+        complete -c vi -s v --description 'Start in display editing state'
+        complete -c vi -s V --description 'Verbose mode'
+        complete -c vi -s x --description 'Encrypt/decrypt text'
+        complete -c vi -r -s r --description 'Recover file after crash'
+        complete -c vi -r -s t --description 'Edit the file containing a tag'
+        complete -c vi -r -c t --description 'Begin editing by executing the specified  editor command'
+    end
 end
 


### PR DESCRIPTION
If `vi` isn't installed then typing `vi` I get

```
> vi vi may be found in the following packages:
  core/vi 1:070224-1    /usr/bin/vi
/usr/share/fish/completions/vi.fish (line 8): if vi --version > /dev/null ^ /dev/null
                                                 ^
from sourcing file /usr/share/fish/completions/vi.fish
        called on standard input
in command substitution
        called on standard input
vi may be found in the following packages:
  core/vi 1:070224-1    /usr/bin/vi
```

this PR fixes that by first checking if it's installed.
