### PR TITLE
Add functions and "snippets" hierarchy

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -623,9 +623,12 @@ install-force: all install-translations
 		true ;\
 	done;
 	$(INSTALL) -m 755 -d $(DESTDIR)$(sysconfdir)/fish
+	$(INSTALL) -m 755 -d $(DESTDIR)$(sysconfdir)/fish/snippets
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/completions
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/vendor_completions.d
+	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/vendor_functions.d
+	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/vendor_snippets.d
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/functions
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/man/man1
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/tools

--- a/Makefile.in
+++ b/Makefile.in
@@ -623,12 +623,12 @@ install-force: all install-translations
 		true ;\
 	done;
 	$(INSTALL) -m 755 -d $(DESTDIR)$(sysconfdir)/fish
-	$(INSTALL) -m 755 -d $(DESTDIR)$(sysconfdir)/fish/snippets
+	$(INSTALL) -m 755 -d $(DESTDIR)$(sysconfdir)/fish/conf.d
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/completions
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/vendor_completions.d
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/vendor_functions.d
-	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/vendor_snippets.d
+	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/vendor_conf.d
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/functions
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/man/man1
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/tools

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -1044,6 +1044,7 @@ function on_exit --on-process %self
 end
 \endfish
 
+Right after reading /usr/share/fish/config.fish and before reading /etc/fish/config.fish, fish will also read files in ~/.config/fish/conf.d/, /etc/fish/conf.d and /usr/share/fish/vendor_conf.d (the exact values depend on $XDG_CONFIG_HOME, $__fish_sysconfdir and $__fish_datadir). If there are files with the same name in two or all of these, fish will only attempt to read the first (skipping all files with that name if it is unreadable). ~/.config takes precedence over /etc/ which takes precedence over /usr. The path to the latter can also be gotten via `pkg-config` as "confdir", and is meant for third-party applications to integrate with fish.
 
 \section other Other features
 

--- a/fish.pc.in
+++ b/fish.pc.in
@@ -1,6 +1,8 @@
 prefix=@prefix@
 datadir=@datadir@
 completionsdir=${datadir}/fish/vendor_completions.d
+functionsdir=${datadir}/fish/vendor_functions.d
+snippetsdir=${datadir}/fish/vendor_snippets.d
 
 Name: fish
 Description: fish, the friendly interactive shell

--- a/fish.pc.in
+++ b/fish.pc.in
@@ -2,7 +2,7 @@ prefix=@prefix@
 datadir=@datadir@
 completionsdir=${datadir}/fish/vendor_completions.d
 functionsdir=${datadir}/fish/vendor_functions.d
-snippetsdir=${datadir}/fish/vendor_snippets.d
+confdir=${datadir}/fish/vendor_conf.d
 
 Name: fish
 Description: fish, the friendly interactive shell

--- a/share/config.fish
+++ b/share/config.fish
@@ -153,10 +153,10 @@ function . --description 'Evaluate contents of file (deprecated, see "source")' 
 	end
 end
 
-# As last part of initialization, source the snippets directories
+# As last part of initialization, source the conf directories
 # Implement precedence (User > Admin > Vendors > Fish) by basically doing "basename"
 set -l sourcelist
-for file in $configdir/fish/snippets/* $__fish_sysconfdir/snippets/* $__fish_datadir/vendor_snippets.d/*
+for file in $configdir/fish/conf.d/* $__fish_sysconfdir/conf.d/* $__fish_datadir/vendor_conf.d/*
 	set -l basename (string replace -r '^.*/' '' -- $file)
 	contains -- $basename $sourcelist; and continue
 	set sourcelist $sourcelist $basename

--- a/share/config.fish
+++ b/share/config.fish
@@ -50,7 +50,7 @@ end
 # default functions/completions are included in the respective path.
 
 if not set -q fish_function_path
-	set fish_function_path $configdir/fish/functions    $__fish_sysconfdir/functions    $__fish_datadir/functions
+	set fish_function_path $configdir/fish/functions    $__fish_sysconfdir/functions $__fish_datadir/vendor_functions.d   $__fish_datadir/functions
 end
 
 if not contains $__fish_datadir/functions $fish_function_path
@@ -151,4 +151,16 @@ function . --description 'Evaluate contents of file (deprecated, see "source")' 
 	else
 		source $argv
 	end
+end
+
+# As last part of initialization, source the snippets directories
+# Implement precedence (User > Admin > Vendors > Fish) by basically doing "basename"
+set -l sourcelist
+for file in $XDG_CONFIG_HOME/fish/snippets/* $__fish_sysconfdir/snippets/* $__fish_datadir/vendor_snippets.d/*
+	set -l basename (string replace -r '^.*/' '' -- $file)
+	contains -- $basename $sourcelist; and continue
+	set sourcelist $sourcelist $basename
+	# Also skip non-files or unreadable files
+	# This allows one to use e.g. symlinks to /dev/null to "mask" something (like in systemd)
+	[ -f $file -a -r $file ]; and source $file
 end

--- a/share/config.fish
+++ b/share/config.fish
@@ -156,6 +156,7 @@ end
 # As last part of initialization, source the snippets directories
 # Implement precedence (User > Admin > Vendors > Fish) by basically doing "basename"
 set -l sourcelist
+set -q XDG_CONFIG_HOME; or set -l XDG_CONFIG_HOME ~/.config
 for file in $XDG_CONFIG_HOME/fish/snippets/* $__fish_sysconfdir/snippets/* $__fish_datadir/vendor_snippets.d/*
 	set -l basename (string replace -r '^.*/' '' -- $file)
 	contains -- $basename $sourcelist; and continue

--- a/share/config.fish
+++ b/share/config.fish
@@ -156,8 +156,7 @@ end
 # As last part of initialization, source the snippets directories
 # Implement precedence (User > Admin > Vendors > Fish) by basically doing "basename"
 set -l sourcelist
-set -q XDG_CONFIG_HOME; or set -l XDG_CONFIG_HOME ~/.config
-for file in $XDG_CONFIG_HOME/fish/snippets/* $__fish_sysconfdir/snippets/* $__fish_datadir/vendor_snippets.d/*
+for file in $configdir/fish/snippets/* $__fish_sysconfdir/snippets/* $__fish_datadir/vendor_snippets.d/*
 	set -l basename (string replace -r '^.*/' '' -- $file)
 	contains -- $basename $sourcelist; and continue
 	set sourcelist $sourcelist $basename


### PR DESCRIPTION
This allows "vendors" (i.e. third-party upstreams interested in
supporting fish) to add auto-loaded functions and eager-loaded
"snippets", while still allowing both the user and the administrator to
fully override all of that.

This has been inspired by systemd's configuration hierarchy.

Fixes #1956

This is a slightly-less-quick alternative to #2496. It's probably not ready (the terms aren't final either), it's just meant to get the conversation going again.