### PR TITLE
psub: add -s, --suffix

### DIFF
--- a/doc_src/psub.txt
+++ b/doc_src/psub.txt
@@ -2,7 +2,7 @@
 
 \subsection psub-synopsis Synopsis
 \fish{synopsis}
-COMMAND1 ( COMMAND2 | psub [-f] )
+COMMAND1 ( COMMAND2 | psub [-f] [-s SUFFIX])
 \endfish
 
 \subsection psub-description Description
@@ -11,10 +11,15 @@ Posix shells feature a syntax that is a mix between command substitution and pip
 
 If the `-f` or `--file` switch is given to `psub`, `psub` will use a regular file instead of a named pipe to communicate with the calling process. This will cause `psub` to be significantly slower when large amounts of data are involved, but has the advantage that the reading process can seek in the stream.
 
+If the `-s` or `---suffix` switch is given, `psub` will append SUFFIX to the filename.
+
 
 \subsection psub-example Example
 
 \fish
 diff (sort a.txt | psub) (sort b.txt | psub)
 # shows the difference between the sorted versions of files `a.txt` and `b.txt`.
+
+source-highlight -f esc (cpp main.c | psub -s .c)
+# highlights `main.c` after preprocessing as a C source.
 \endfish

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -36,9 +36,9 @@ function psub --description "Read from stdin into a file and output the filename
 				set -e argv[1]
 				set argv $opts $argv
 
-                        case "*"
-                                printf "psub: extra operand: '%s'\n" $argv[1]
-                                return 1
+			case "*"
+				printf "psub: extra operand: '%s'\n" $argv[1]
+				return 1
 		end
 	end
 

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -33,6 +33,10 @@ function psub --description "Read from stdin into a file and output the filename
 				set opts (printf "-%s\n" (printf $argv[1] |grep -o "\w"))
 				set -e argv[1]
 				set argv $opts $argv
+
+                        case "*"
+                                printf "psub: extra operand: '%s'\n" $argv[1]
+                                return 1
 		end
 	end
 

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -30,7 +30,8 @@ function psub --description "Read from stdin into a file and output the filename
 				return 1
 
 			case "-*"
-				set opts (printf "-%s\n" (printf $argv[1] |grep -o "\w"))
+				# Ungroup short options: -hfs => -h -f -s
+				set opts (string sub -s 2 -- $argv[1] | string split "" | string replace -r "^" -)
 				set -e argv[1]
 				set argv $opts $argv
 

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -1,6 +1,7 @@
 
 function psub --description "Read from stdin into a file and output the filename. Remove the file when the command that called psub exits."
 
+	set -l dir
 	set -l filename
 	set -l funcname
 	set -l suffix
@@ -80,8 +81,11 @@ function psub --description "Read from stdin into a file and output the filename
 	end
 
 	# Make sure we erase file when caller exits
-	function $funcname --on-job-exit caller --inherit-variable filename --inherit-variable funcname
+	function $funcname --on-job-exit caller --inherit-variable filename --inherit-variable dir --inherit-variable funcname
 		command rm $filename
+		if count $dir >/dev/null
+			command rmdir $dir
+		end
 		functions -e $funcname
 	end
 

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -25,13 +25,14 @@ function psub --description "Read from stdin into a file and output the filename
 				set -e argv[1]
 				break
 
-			case "-?"
+			case "-?" "--*"
 				printf "psub: invalid option: '%s'\n" $argv[1]
 				return 1
 
 			case "-*"
 				set opts (printf "-%s\n" (printf $argv[1] |grep -o "\w"))
-				set argv $opts $argv[2..-1]
+				set -e argv[1]
+				set argv $opts $argv
 		end
 	end
 

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -1,7 +1,7 @@
 
 function psub --description "Read from stdin into a file and output the filename. Remove the file when the command that called psub exits."
 
-	set -l dir
+	set -l dirname
 	set -l filename
 	set -l funcname
 	set -l suffix
@@ -60,16 +60,16 @@ function psub --description "Read from stdin into a file and output the filename
 		# Write output to pipe. This needs to be done in the background so
 		# that the command substitution exits without needing to wait for
 		# all the commands to exit
-		set dir (mktemp -d "$TMPDIR[1]"/.psub.XXXXXXXXXX); or return
-		set filename $dir/psub.fifo"$suffix"
+		set dirname (mktemp -d "$TMPDIR[1]"/.psub.XXXXXXXXXX); or return
+		set filename $dirname/psub.fifo"$suffix"
 		mkfifo $filename
 		cat >$filename &
 	else if test -z $suffix
 		set filename (mktemp "$TMPDIR[1]"/.psub.XXXXXXXXXX)
 		cat >$filename
 	else
-		set dir (mktemp -d "$TMPDIR[1]"/.psub.XXXXXXXXXX)
-		set filename $dir/psub"$suffix"
+		set dirname (mktemp -d "$TMPDIR[1]"/.psub.XXXXXXXXXX)
+		set filename $dirname/psub"$suffix"
 		cat >$filename
 	end
 
@@ -85,10 +85,10 @@ function psub --description "Read from stdin into a file and output the filename
 	end
 
 	# Make sure we erase file when caller exits
-	function $funcname --on-job-exit caller --inherit-variable filename --inherit-variable dir --inherit-variable funcname
+	function $funcname --on-job-exit caller --inherit-variable filename --inherit-variable dirname --inherit-variable funcname
 		command rm $filename
-		if count $dir >/dev/null
-			command rmdir $dir
+		if count $dirname >/dev/null
+			command rmdir $dirname
 		end
 		functions -e $funcname
 	end

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -31,7 +31,7 @@ function psub --description "Read from stdin into a file and output the filename
 
 			case "-*"
 				# Ungroup short options: -hfs => -h -f -s
-				set opts (string sub -s 2 -- $argv[1] | string split "" | string replace -r "^" -)
+				set opts "-"(string sub -s 2 -- $argv[1] | string split "")
 				set -e argv[1]
 				set argv $opts $argv
 

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -56,7 +56,7 @@ function psub --description "Read from stdin into a file and output the filename
 		# that the command substitution exits without needing to wait for
 		# all the commands to exit
 		set dir (mktemp -d "$TMPDIR[1]"/.psub.XXXXXXXXXX); or return
-		set filename $dir/psub.fifo$suffix
+		set filename $dir/psub.fifo"$suffix"
 		mkfifo $filename
 		cat >$filename &
 	else if test -z $suffix
@@ -64,7 +64,7 @@ function psub --description "Read from stdin into a file and output the filename
 		cat >$filename
 	else
 		set dir (mktemp -d "$TMPDIR[1]"/.psub.XXXXXXXXXX)
-		set filename $dir/psub$suffix
+		set filename $dir/psub"$suffix"
 		cat >$filename
 	end
 

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -19,6 +19,10 @@ function psub --description "Read from stdin into a file and output the filename
 				set -e argv[1]
 
 			case -s --suffix
+				if not set -q argv[2]
+					printf "psub: missing operand\n"
+					return 1
+				end
 				set suffix $argv[2]
 				set -e argv[1..2]
 

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -5,43 +5,34 @@ function psub --description "Read from stdin into a file and output the filename
 	set -l funcname
 	set -l suffix
 	set -l use_fifo 1
-	set -l shortopt -o hfs:
-	set -l longopt -l help,file,suffix:
 
-	if getopt -T >/dev/null
-		set longopt
-	end
+	while count $argv >/dev/null
 
-	if not getopt -n psub -Q $shortopt $longopt -- $argv >/dev/null
-		return 1
-	end
-
-	set -l tmp (getopt $shortopt $longopt -- $argv)
-
-	eval set opt $tmp
-
-	while count $opt >/dev/null
-
-		switch $opt[1]
+		switch $argv[1]
 			case -h --help
 				__fish_print_help psub
 				return 0
 
 			case -f --file
 				set use_fifo 0
+				set -e argv[1]
 
 			case -s --suffix
-				set suffix $opt[2]
-				set -e opt[1..2]
+				set suffix $argv[2]
+				set -e argv[1..2]
 
 			case --
-				set -e opt[1]
+				set -e argv[1]
 				break
 
+			case "-?"
+				printf "psub: invalid option: '%s'\n" $argv[1]
+				return 1
+
+			case "-*"
+				set opts (printf "-%s\n" (printf $argv[1] |grep -o "\w"))
+				set argv $opts $argv[2..-1]
 		end
-
-		set -e opt[1]
-
 	end
 
 	if not status --is-command-substitution

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -3,9 +3,10 @@ function psub --description "Read from stdin into a file and output the filename
 
 	set -l filename
 	set -l funcname
+	set -l suffix
 	set -l use_fifo 1
-	set -l shortopt -o hf
-	set -l longopt -l help,file
+	set -l shortopt -o hfs:
+	set -l longopt -l help,file,suffix:
 
 	if getopt -T >/dev/null
 		set longopt
@@ -28,6 +29,10 @@ function psub --description "Read from stdin into a file and output the filename
 
 			case -f --file
 				set use_fifo 0
+
+			case -s --suffix
+				set suffix $opt[2]
+				set -e opt[1..2]
 
 			case --
 				set -e opt[1]
@@ -54,11 +59,15 @@ function psub --description "Read from stdin into a file and output the filename
 		# that the command substitution exits without needing to wait for
 		# all the commands to exit
 		set dir (mktemp -d "$TMPDIR[1]"/.psub.XXXXXXXXXX); or return
-		set filename $dir/psub.fifo
+		set filename $dir/psub.fifo$suffix
 		mkfifo $filename
 		cat >$filename &
-	else
+	else if test -z $suffix
 		set filename (mktemp "$TMPDIR[1]"/.psub.XXXXXXXXXX)
+		cat >$filename
+	else
+		set dir (mktemp -d "$TMPDIR[1]"/.psub.XXXXXXXXXX)
+		set filename $dir/psub$suffix
 		cat >$filename
 	end
 

--- a/tests/test9.in
+++ b/tests/test9.in
@@ -97,6 +97,18 @@ else
     echo 'psub file was deleted'
 end
 
+if count (echo foo | psub -s .cc | grep -o '\.cc$') >/dev/null
+    echo 'psub filename ends with .cc'
+else
+    echo 'psub filename does not end with .cc'
+end
+
+if count (echo foo | psub -f -s .cc | grep -o '\.cc$') >/dev/null
+    echo 'psub filename ends with .cc'
+else
+    echo 'psub filename does not end with .cc'
+end
+
 # Test support for unbalanced blocks
 function try_unbalanced_block
     ../fish -c "echo $argv | source " 2>&1 | grep "Missing end" 1>&2

--- a/tests/test9.in
+++ b/tests/test9.in
@@ -109,6 +109,8 @@ else
     echo 'psub filename does not end with .cc'
 end
 
+diff -q (__fish_print_help psub | psub) (psub -hs banana | psub)
+
 # Test support for unbalanced blocks
 function try_unbalanced_block
     ../fish -c "echo $argv | source " 2>&1 | grep "Missing end" 1>&2

--- a/tests/test9.in
+++ b/tests/test9.in
@@ -109,6 +109,13 @@ else
     echo 'psub filename does not end with .cc'
 end
 
+set -l filename (echo foo | psub -s .fish)
+if test -e (dirname $filename)
+    echo 'psub directory was not deleted'
+else
+    echo 'psub directory was deleted'
+end
+
 diff -q (__fish_print_help psub | psub) (psub -hs banana | psub)
 
 # Test support for unbalanced blocks

--- a/tests/test9.out
+++ b/tests/test9.out
@@ -19,6 +19,7 @@ baz
 psub file was deleted
 psub filename ends with .cc
 psub filename ends with .cc
+psub directory was deleted
 bom_test
 not#a#comment
 is

--- a/tests/test9.out
+++ b/tests/test9.out
@@ -17,6 +17,8 @@ foo
 bar
 baz
 psub file was deleted
+psub filename ends with .cc
+psub filename ends with .cc
 bom_test
 not#a#comment
 is


### PR DESCRIPTION
This patch adds `-s, --suffix <suffix>` option for psub. `psub -s <suffix>` is equivalent to `psub` except that the temporary file/fifo name is guaranteed to end with `<suffix>`.

For example:

```
$ echo (some-command | psub)
/tmp/.psub.7kdPWozaPi
$ echo (some-command | psub -s .cc)
/tmp/.psub.7kdPWozaPi.cc
```

This is useful because some programs (`source-highlight`, `gcc`, `open` among others) analyze file extensions and change the behavior accordingly.

One of use cases is viewing generated files with syntax highlighting in `less` with `$LESSOPEN`:

```
$ less (printf "foo && bar" |psub)
# No syntax highlighting.

$ printf "foo && bar" >script.sh
$ less script.sh
# Syntax highlighting!
```

Hopefully this makes `psub` more useful in some situations than it is at the moment.

Implementation wise, in `use_fifo = 0` case a new directory needs to be created to get around [the limitation][mktemp-error] of `mktemp`. A new directory is also created if `use_fifo = 1`, as before. I am not sure why, but if the reason is that on some platforms fifos must end with `.fifo`, then `-s` should also enforce `-f`.

[mktemp-error]: https://github.com/fish-shell/fish-shell/blob/0918ad6cee61e398bcdd2572100ef1faa578013e/tests/test_functions/mktemp.fish#L60

Close #1829.