### PR TITLE
Fix slow pasting

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -582,7 +582,7 @@ static void input_mapping_execute(const input_mapping_t &m, bool allow_commands)
     if (count >= 1)
     {
         size_t index = count - 1;
-        
+
         while (index--)
         {
             wcstring command = m.commands.at(index);
@@ -598,7 +598,7 @@ static void input_mapping_execute(const input_mapping_t &m, bool allow_commands)
             }
         }
         
-        if (count == 1)
+        if (!has_commands)
         {
             input_set_bind_mode(m.sets_mode);
             return;


### PR DESCRIPTION
This restores the behaviour of input_mapping_execute to its behaviour prior to 722fedc8fd590cb436109a553fb68f02790117f3. If the commands list contained only a function it would perform one iteration of the loop on line 569, entering the first if statement, calling input_function_push_args and then leaving the loop. The commit that slowed pasting did not behave this way. Instead when allow_commands was false it'd instead iterate through m.seq and push an R_NULL to the queue of unread characters.

That behaviour caused significantly more iterations of the loop on line 3107 in src/reader.cpp. It would break out of the loop on line 3122 via 3161 by failing the condition on 3155. c was equal to 57344. It was performing around a thousand iterations of the loop rather than a single iteration when pasting a string of around 200 characters.

Note, I don't know if my explanation makes sense as I don't really understand what's going on. I just noticed that the behaviour of input_mapping_execute had changed slightly after that commit. Since I'm unsure about what's going on I'm hesitant to refactor this to remove some of the duplication as I may end up breaking some other behaviour.

This resolves fish-shell/fish-shell#2215