### PR TITLE
make alt-L output respect multi-line prompts

### DIFF
--- a/share/functions/__fish_list_current_token.fish
+++ b/share/functions/__fish_list_current_token.fish
@@ -15,6 +15,9 @@ function __fish_list_current_token -d "List contents of token under the cursor i
 			ls $dir
 		else
 			ls
+			for line in (seq 1 (math (count (fish_prompt))" -1") )
+				printf "\n"
+			end
 		end
 	end
 	commandline -f repaint


### PR DESCRIPTION
I was playing around with multi-line prompts, and noticed that this happened when I hit alt-L:
```
________________________________________________________________________________0
o1@o1-grey-kubuntu
'/home/o1'
$ 

________________________________________________________________________________0ors/   stef-config/   traineo/      packages
o1@o1-grey-kubuntu/    Dropbox/     bin/               hugos/            plgen_v1.8.2/  steno-theory/  0c@           pdfscissors-offline.jnlp
'/home/o1'             TESTSCRAP/   emacs-24.5/        ncp-1.2.4/        saneo/         testdir/       0sg@          xprop.txt
$ sktop/               Wallpapers/  ergodox-firmware/  one/              schmozzle/     torrents/      SHADDOWN.txt  xprop2.txt
```

which should be:

```
________________________________________________________________________________0
o1@o1-grey-kubuntu
'/home/o1'
$

0db1-wr+cs-sentences/  Downloads/   annex/             git-annex-utils/  pdfscissors/   stef-config/   traineo/      packages
0db2-cs-predicates/    Dropbox/     bin/               hugos/            plgen_v1.8.2/  steno-theory/  0c@           pdfscissors-offline.jnlp
Anki/                  TESTSCRAP/   emacs-24.5/        ncp-1.2.4/        saneo/         testdir/       0sg@          xprop.txt
Desktop/               Wallpapers/  ergodox-firmware/  one/              schmozzle/     torrents/      SHADDOWN.txt  xprop2.txt
________________________________________________________________________________0
o1@o1-grey-kubuntu
'/home/o1'
$
```
