### PR TITLE
Be compatible with older versions of bc

### DIFF
--- a/share/functions/math.fish
+++ b/share/functions/math.fish
@@ -8,6 +8,9 @@ function math --description "Perform math calculations in bc"
 		end
 
 		set -lx BC_LINE_LENGTH 0
+		if test (echo 'scale = 70; 1/2' | bc | wc -l) -gt 1
+			set BC_LINE_LENGTH 2147483647  # bc version <= 1.06
+		end
 		set -l out (echo $argv | bc)
                 test -z "$out"; and return 1
 		echo $out


### PR DESCRIPTION
bc on Mac OS 10.11 from http://ftp.gnu.org/gnu/bc/

```
/usr/bin/bc --version
bc 1.06
Copyright 1991-1994, 1997, 1998, 2000 Free Software Foundation, Inc.
```

Latest bc 1.06.95 from http://alpha.gnu.org/gnu/bc/

```
bc 1.06.95
Copyright 1991-1994, 1997, 1998, 2000, 2004, 2006 Free Software Foundation, Inc.
```

`INT_MAX` 2147483647 is the largest number we can manually set for `BC_LINE_LENGTH`.