### PR TITLE
Update job completions

### DIFF
--- a/share/completions/bg.fish
+++ b/share/completions/bg.fish
@@ -1,2 +1,2 @@
-
+complete -c bg -x -a "(__fish_complete_job_pids)"
 complete -c bg -s h -l help --description 'Display help and exit'

--- a/share/completions/fg.fish
+++ b/share/completions/fg.fish
@@ -1,2 +1,2 @@
-
+complete -c fg -x -a "(__fish_complete_job_pids)"
 complete -c fg -s h -l help --description 'Display help and exit'

--- a/share/functions/__fish_complete_job_pids.fish
+++ b/share/functions/__fish_complete_job_pids.fish
@@ -1,0 +1,13 @@
+function __fish_complete_job_pids --description "Print a list of job PIDs and their commands"
+    if set -l jobpids (jobs -p)
+        # when run at the commandline, the first line of output is a header, but
+        # that doesn't seem to be printed when you run jobs in a subshell
+
+        # then we can use the jobs command again to get the corresponding
+        # command to provide as a description for each job PID
+        for jobpid in $jobpids
+            set -l cmd (jobs -c $jobpid)
+            printf "%s\tJob: %s\n" $jobpid $cmd
+        end
+    end
+end

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -590,8 +590,12 @@ static int find_job(const struct find_job_data_t *info)
 
     const job_t *j;
     int found = 0;
-    // do the empty param check first, because an empty string passes our 'numeric' check
-    if (wcslen(proc)==0)
+    // If we are not doing tab completion, we first check for the single '%'
+    // character, because an empty string will pass the numeric check below.
+    // But if we are doing tab completion, we want all of the job IDs as
+    // completion options, not just the last job backgrounded, so we pass this
+    // first block in favor of the second.
+    if (wcslen(proc)==0 && !(flags & EXPAND_FOR_COMPLETIONS))
     {
         /*
           This is an empty job expansion: '%'


### PR DESCRIPTION
This addresses the issues discussed in #2555.

Tab completion after a `%` now properly shows the job IDs of all jobs.

A new function was added to complete the PIDs of jobs.  Both `bg` and `fg` were configured to use this new function for tab completion.