### PR TITLE
Fix wrong exit code for `jobs` #2505

### DIFF
--- a/src/builtin_jobs.cpp
+++ b/src/builtin_jobs.cpp
@@ -331,7 +331,7 @@ static int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv)
         /*
           Do not babble if not interactive
         */
-        if (streams.out_is_redirected)
+        if (!streams.out_is_redirected)
         {
             streams.out.append_format(
                         _(L"%ls: There are no jobs\n"),

--- a/src/builtin_jobs.cpp
+++ b/src/builtin_jobs.cpp
@@ -254,15 +254,6 @@ static int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv)
         }
     }
 
-
-    /*
-      Do not babble if not interactive
-    */
-    if (streams.out_is_redirected)
-    {
-        found=1;
-    }
-
     if (print_last)
     {
         /*
@@ -275,7 +266,7 @@ static int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv)
 
             if ((j->flags & JOB_CONSTRUCTED) && !job_is_completed(j))
             {
-                builtin_jobs_print(j, mode, !found, streams);
+                builtin_jobs_print(j, mode, !streams.out_is_redirected, streams);
                 return 0;
             }
         }
@@ -286,8 +277,6 @@ static int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv)
         if (w.woptind < argc)
         {
             int i;
-
-            found = 1;
 
             for (i=w.woptind; i<argc; i++)
             {
@@ -307,7 +296,8 @@ static int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv)
 
                 if (j && !job_is_completed(j))
                 {
-                    builtin_jobs_print(j, mode, !found, streams);
+                    builtin_jobs_print(j, mode, false, streams);
+                    found = 1;
                 }
                 else
                 {
@@ -338,9 +328,15 @@ static int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv)
 
     if (!found)
     {
-        streams.out.append_format(
-                      _(L"%ls: There are no jobs\n"),
-                      argv[0]);
+        /*
+          Do not babble if not interactive
+        */
+        if (streams.out_is_redirected)
+        {
+            streams.out.append_format(
+                        _(L"%ls: There are no jobs\n"),
+                        argv[0]);
+        }
         return 1;
     }
 


### PR DESCRIPTION
This reworks the logic around the `found` variable since it was used for duel purposes.