### PR TITLE
git: Add missing remote subcommands completion

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -199,6 +199,10 @@ complete -f -c git -n '__fish_git_using_command remote' -a rm -d 'Removes a remo
 complete -f -c git -n '__fish_git_using_command remote' -a show -d 'Shows a remote'
 complete -f -c git -n '__fish_git_using_command remote' -a prune -d 'Deletes all stale tracking branches'
 complete -f -c git -n '__fish_git_using_command remote' -a update -d 'Fetches updates'
+complete -f -c git -n '__fish_git_using_command remote' -a rename -d 'Renames a remote'
+complete -f -c git -n '__fish_git_using_command remote' -a set-head -d 'Sets the default branch for a remote'
+complete -f -c git -n '__fish_git_using_command remote' -a set-url -d 'Changes URLs for a remote'
+complete -f -c git -n '__fish_git_using_command remote' -a set-branches -d 'Changes the list of branches tracked by a remote'
 # TODO options
 
 ### show


### PR DESCRIPTION
* Add completion for missing `git remote` subcommands.

* Should fix #2567

Signed-off-by: mr.Shu <mr@shu.io>

----------------------------------------------------

The descriptions for respective subcommands were taken from the [official documentation](https://www.git-scm.com/docs/git-remote). Note that completion for the whole `git remote` subcommand seems to be wrong since after getting `git remote` completed to `git remote rm` the list of possible completions will still contain all the listed subcommands.

The proper fix seems to be to make sure we deal with `git remote` in the same way `git submodule` is being dealt with, which is what I intend to do once this PR is merged.