### PR TITLE
For config paths use SYSCONFDIR

### DIFF
--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -188,7 +188,11 @@ static struct config_paths_t determine_config_directory_paths(const char *argv0)
                 base_path.resize(base_path.size() - strlen(suffix));
 
                 paths.data = base_path + L"/share/fish";
+#if defined(SYSCONFDIR)
+                paths.sysconf = L"" SYSCONFDIR L"/fish";
+#else
                 paths.sysconf = base_path + L"/etc/fish";
+#endif
                 paths.doc = base_path + L"/share/doc/fish";
                 paths.bin = base_path + L"/bin";
 


### PR DESCRIPTION
On ArchLinux applications are installed in `/usr/{bin,lib,share}` but config is still in `/etc`
So in configure it's specified like
```
./configure --prefix=/usr --sysconfdir=/etc --docdir=/usr/share/doc/fish
```

But currently if there's a folder `/usr/etc/fish` then fish's `$__fish_sysconfdir` will use that instead of `/etc/fish`.

This PR fixes it so that it always use specified `sysconfdir` `/etc`
