### PR TITLE
allow \cJ (\n) to be bound separate from \cM (\r)

### DIFF
--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -9,6 +9,7 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 	bind $argv "" self-insert
 
 	bind $argv \n execute
+	bind $argv \r execute
 
 	bind $argv \ck kill-line
 	bind $argv \cy yank

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -38,6 +38,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
   bind -k right forward-char
   bind -k left backward-char
   bind -m insert \n execute
+  bind -m insert \r execute
   bind -m insert i force-repaint
   bind -m insert I beginning-of-line force-repaint
   bind -m insert a forward-char force-repaint

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -499,6 +499,7 @@ int input_init()
     {
         input_mapping_add(L"", L"self-insert");
         input_mapping_add(L"\n", L"execute");
+        input_mapping_add(L"\r", L"execute");
         input_mapping_add(L"\t", L"complete");
         input_mapping_add(L"\x3", L"commandline \"\"");
         input_mapping_add(L"\x4", L"exit");

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1028,6 +1028,8 @@ void reader_init()
 
     /* Set the mode used for the terminal, initialized to the current mode */
     memcpy(&shell_modes, &terminal_mode_on_startup, sizeof shell_modes);
+    shell_modes.c_iflag &= ~ICRNL;    /* turn off mapping CR (\cM) to NL (\cJ) */
+    shell_modes.c_iflag &= ~INLCR;    /* turn off mapping NL (\cJ) to CR (\cM) */
     shell_modes.c_lflag &= ~ICANON;   /* turn off canonical mode */
     shell_modes.c_lflag &= ~ECHO;     /* turn off echo mode */
     shell_modes.c_iflag &= ~IXON;     /* disable flow control */

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1045,6 +1045,15 @@ void reader_init()
     shell_modes.c_cc[VDSUSP] = _POSIX_VDISABLE;
 #endif
 #endif
+
+    // We don't use term_steal because this can fail if fd 0 isn't associated
+    // with a tty and this function is run regardless of whether stdin is tied
+    // to a tty. This is harmless in that case. We do it unconditionally
+    // because disabling ICRNL mode (see above) needs to be done at the
+    // earliest possible moment. Doing it here means it will be done within
+    // approximately 1 ms of the start of the shell rather than 250 ms (or
+    // more) when reader_interactive_init is eventually called.
+    tcsetattr(STDIN_FILENO, TCSANOW,&shell_modes);
 }
 
 


### PR DESCRIPTION
This makes it possible (on UNIX systems, don't know about MS Windows)
to bind \cJ (\n) independently of \cM (\r, aka [enter]).

Resolves #217