### PR TITLE
Fix file URL for Terminal.app using a UTF-8 locale

### DIFF
--- a/share/functions/__fish_urlencode.fish
+++ b/share/functions/__fish_urlencode.fish
@@ -3,8 +3,8 @@ function __fish_urlencode --description "URL-encode stdin"
 	set -l chars
 	# Set locale to C and IFS to "" in order to split a line into bytes.
 	while begin; set -lx LC_ALL C; set -lx IFS ''; read --array chars; end
-		for char in $chars
-			set output $output (printf '%%%02x' "'$char")
+		if count $chars > /dev/null
+			set output $output (printf '%%%02x' "'"$chars)
 		end
 	end
 	echo -s $output | sed -e 's/%2[fF]/\//g'

--- a/share/functions/__fish_urlencode.fish
+++ b/share/functions/__fish_urlencode.fish
@@ -1,10 +1,11 @@
 function __fish_urlencode --description "URL-encode stdin"
-	set -l IFS ''
 	set -l output
-	while read --array --local lines
-		if [ (count $lines) -gt 0 ]
-			set output $output (printf '%%%02x' "'"$lines"'" | sed -e 's/%2[fF]/\//g')
+	set -l chars
+	# Set locale to C and IFS to "" in order to split a line into bytes.
+	while begin; set -lx LC_ALL C; set -lx IFS ''; read --array chars; end
+		for char in $chars
+			set output $output (printf '%%%02x' "'$char")
 		end
 	end
-	echo -s $output
+	echo -s $output | sed -e 's/%2[fF]/\//g'
 end


### PR DESCRIPTION
Steps to reproduce the problem (locale is `en_US.UTF-8`):

1. `mkdir Äpfel`
2. `cd Äpfel`
3. switch to a new tab with the same setting and $PWD by pressing cmd-T
4. now $PWD is /Users/myname

Solution: Set locale to C in order to read one byte at a time, so the expected output `%XX` does not become `%XXX` or `%XXXX`.
