### PR TITLE
restore the terminal modes before an "exec"

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -45,6 +45,7 @@
 #include "parse_util.h"
 #include "io.h"
 #include "parse_tree.h"
+#include "reader.h"
 
 /**
    file descriptor redirection error message
@@ -253,7 +254,8 @@ static void safe_launch_process(process_t *p, const char *actual_cmd, const char
 }
 
 /**
-   This function is similar to launch_process, except it is not called after a fork (i.e. it only calls exec) and therefore it can allocate memory.
+   This function is similar to launch_process, except it is not called after a
+   fork (i.e. it only calls exec) and therefore it can allocate memory.
 */
 static void launch_process_nofork(process_t *p)
 {
@@ -266,6 +268,8 @@ static void launch_process_nofork(process_t *p)
     const char *const *envv = env_export_arr(false);
     char *actual_cmd = wcs2str(p->actual_cmd.c_str());
 
+    /* Ensure the terminal modes are what they were before we changed them. */
+    restore_term_mode();
     /* Bounce to launch_process. This never returns. */
     safe_launch_process(p, actual_cmd, argv_array.get(), envv);
 }


### PR DESCRIPTION
When replacing the existing fish process with a new process it is
important to restore the temrinal modes to what they were when fish
started running. We don't want any tweaks done for the benefit of fish
(e.g., disabling ICRNL mode) to bleed thru to an "exec"ed command.

Resolves #2609