### PR TITLE
only swith to shell tty mode if interactive

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1053,7 +1053,12 @@ void reader_init()
     // earliest possible moment. Doing it here means it will be done within
     // approximately 1 ms of the start of the shell rather than 250 ms (or
     // more) when reader_interactive_init is eventually called.
-    tcsetattr(STDIN_FILENO, TCSANOW,&shell_modes);
+    //
+    // TODO: Remove this condition when issue #2315 and #1041 are addressed.
+    if (is_interactive_session)
+    {
+        tcsetattr(STDIN_FILENO, TCSANOW,&shell_modes);
+    }
 }
 
 


### PR DESCRIPTION
My PR #2578 had the unexpected side-effect of altering the tty modes of
commands run via "fish -c command" or "fish scriptname". This change fixes
that; albeit incompletely. The correct solution is to unconditionally set
shell tty modes if stdin is attached to a tty and restore the appropriate
modes whenever an external command is run -- regardless of the path used to
run the external command. The proper fix should be done as part of addressing
issues #2315 and #1041.

Resolves issue #2619