### PR TITLE
prefix status command with builtin

### DIFF
--- a/etc/config.fish
+++ b/etc/config.fish
@@ -6,7 +6,7 @@
 # Some things should only be done for login terminals
 #
 
-if status --is-login
+if builtin status --is-login
 
 	#
 	# Set some value for LANG if nothing was set before, and this is a

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -101,7 +101,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
         eval "$__fish_bin_dir/fish -c 'fish_update_completions > /dev/null ^/dev/null' &"
     end
 
-	if status -i
+	if builtin status -i
 		#
 		# Print a greeting
 		#
@@ -128,14 +128,14 @@ function __fish_config_interactive -d "Initializations that should be performed 
 	#
 
 	function __fish_repaint --on-variable fish_color_cwd --description "Event handler, repaints the prompt when fish_color_cwd changes"
-		if status --is-interactive
+		if builtin status --is-interactive
 			set -e __fish_prompt_cwd
 			commandline -f repaint ^/dev/null
 		end
 	end
 
 	function __fish_repaint_root --on-variable fish_color_cwd_root --description "Event handler, repaints the prompt when fish_color_cwd_root changes"
-		if status --is-interactive
+		if builtin  status --is-interactive
 			set -e __fish_prompt_cwd
 			commandline -f repaint ^/dev/null
 		end
@@ -191,7 +191,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
 	# Notify vte-based terminals when $PWD changes (issue #906)
 	if test "$VTE_VERSION" -ge 3405 -o "$TERM_PROGRAM" = "Apple_Terminal"
 		function __update_vte_cwd --on-variable PWD --description 'Notify VTE of change to $PWD'
-			status --is-command-substitution; and return
+			builtin status --is-command-substitution; and return
 			printf '\033]7;file://%s%s\a' (hostname) (pwd | __fish_urlencode)
 		end
 		__update_vte_cwd # Run once because we might have already inherited a PWD from an old tab

--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -734,7 +734,7 @@ for var in repaint describe_style show_informative_status showdirtystate showsta
 	set varargs $varargs --on-variable __fish_git_prompt_$var
 end
 function __fish_git_prompt_repaint $varargs --description "Event handler, repaints prompt when functionality changes"
-	if status --is-interactive
+	if builtin status --is-interactive
 		if test $argv[3] = __fish_git_prompt_show_informative_status
 			# Clear characters that have different defaults with/without informative status
 			for name in cleanstate dirtystate invalidstate stagedstate stateseparator untrackedfiles upstream_ahead upstream_behind
@@ -752,7 +752,7 @@ for var in '' _prefix _suffix _bare _merging _cleanstate _invalidstate _upstream
 end
 set varargs $varargs --on-variable __fish_git_prompt_showcolorhints
 function __fish_git_prompt_repaint_color $varargs --description "Event handler, repaints prompt when any color changes"
-	if status --is-interactive
+	if builtin status --is-interactive
 		set -l var $argv[3]
 		set -e _$var
 		set -e _{$var}_done
@@ -772,7 +772,7 @@ for var in cleanstate dirtystate invalidstate stagedstate stashstate statesepara
 	set varargs $varargs --on-variable __fish_git_prompt_char_$var
 end
 function __fish_git_prompt_repaint_char $varargs --description "Event handler, repaints prompt when any char changes"
-	if status --is-interactive
+	if builtin status --is-interactive
 		set -e _$argv[3]
 		commandline -f repaint ^/dev/null
 	end

--- a/share/functions/cd.fish
+++ b/share/functions/cd.fish
@@ -5,7 +5,7 @@
 function cd --description "Change directory"
 
 	# Skip history in subshells
-	if status --is-command-substitution
+	if builtin status --is-command-substitution
 		builtin cd $argv
 		return $status
 	end
@@ -33,4 +33,3 @@ function cd --description "Change directory"
 
 	return $cd_status
 end
-

--- a/share/functions/eval.fish
+++ b/share/functions/eval.fish
@@ -23,17 +23,17 @@ function eval -S -d "Evaluate parameters as a command"
 	# used interactively, like less, wont work using eval.
 
 	set -l mode
-	if status --is-interactive-job-control
+	if builtin status --is-interactive-job-control
 		set mode interactive
 	else
-		if status --is-full-job-control
+		if builtin status --is-full-job-control
 			set mode full
 		else
 			set mode none
 		end
 	end
-	if status --is-interactive
-		status --job-control full
+	if builtin status --is-interactive
+		builtin status --job-control full
 	end
 	__fish_restore_status $status_copy
 
@@ -60,6 +60,6 @@ function eval -S -d "Evaluate parameters as a command"
 	echo "begin; $argv "\n" ;end <&3 3<&-" | source 3<&0
 	set -l res $status
 
-	status --job-control $mode
+	builtin status --job-control $mode
 	return $res
 end

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -44,7 +44,7 @@ function history --description "Deletes an item from history"
 		end
 	else
 		#Execute history builtin without any argument
-		if status --is-interactive
+		if builtin status --is-interactive
 			builtin history  | eval $pager
 		else
 			builtin history

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -46,7 +46,7 @@ function psub --description "Read from stdin into a file and output the filename
 		end
 	end
 
-	if not status --is-command-substitution
+	if not builtin status --is-command-substitution
 		echo psub: Not inside of command substitution >&2
 		return 1
 	end

--- a/share/functions/suspend.fish
+++ b/share/functions/suspend.fish
@@ -6,9 +6,9 @@ end
 
 function suspend -d "Suspend the current shell."
     if begin contains -- $argv --force
-             or not status --is-interactive
+             or not builtin status --is-interactive
              or begin test $SHLVL -ge $suspend_minimum_SHLVL
-                      and not status --is-login
+                      and not builtin status --is-login
                 end
        end
        kill -STOP %self

--- a/share/tools/web_config/sample_prompts/classic_vcs.fish
+++ b/share/tools/web_config/sample_prompts/classic_vcs.fish
@@ -17,25 +17,25 @@ function fish_prompt --description 'Write out the prompt'
 		set -g __fish_classic_git_functions_defined
 
 		function __fish_repaint_user --on-variable fish_color_user --description "Event handler, repaint when fish_color_user changes"
-			if status --is-interactive
+			if builtin status --is-interactive
 				commandline -f repaint ^/dev/null
 			end
 		end
-		
+
 		function __fish_repaint_host --on-variable fish_color_host --description "Event handler, repaint when fish_color_host changes"
-			if status --is-interactive
+			if builtin status --is-interactive
 				commandline -f repaint ^/dev/null
 			end
 		end
-		
+
 		function __fish_repaint_status --on-variable fish_color_status --description "Event handler; repaint when fish_color_status changes"
-			if status --is-interactive
+			if builtin status --is-interactive
 				commandline -f repaint ^/dev/null
 			end
 		end
 
 		function __fish_repaint_bind_mode --on-variable fish_key_bindings --description "Event handler; repaint when fish_key_bindings changes"
-			if status --is-interactive
+			if builtin status --is-interactive
 				commandline -f repaint ^/dev/null
 			end
 		end

--- a/tests/test_util.fish
+++ b/tests/test_util.fish
@@ -4,7 +4,7 @@
 if test "$argv[1]" = (status -f)
     echo 'test_util.fish requires sourcing script as argument to `source`' >&2
     echo 'use `source test_util.fish (status -f); or exit`' >&2
-    status --print-stack-trace >&2
+    builtin status --print-stack-trace >&2
     exit 1
 end
 


### PR DESCRIPTION
This is needed on NixOS, where we predefine `status` as an alias for `systemctl status`. Since it's such a general word, I think prefixing it with builtin is better anyways.