### PR TITLE
Pass the full argv to the NixOS command-not-found handler

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -230,7 +230,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
 		# Check for NixOS handler
 		else if test -f /run/current-system/sw/bin/command-not-found
 			function __fish_command_not_found_handler --on-event fish_command_not_found
-				/run/current-system/sw/bin/command-not-found $argv[1]
+				/run/current-system/sw/bin/command-not-found $argv
 			end
 		# Ubuntu Feisty places this command in the regular path instead
 		else if type -q -p command-not-found


### PR DESCRIPTION
This patch is currently floated from the NixOS side as part of
https://github.com/NixOS/nixpkgs/pull/12000, but prior versions of the
hook ignore anything but the first argument anyway, so this is
backwards-compatible.