### PR TITLE
Make abbr.fish nicer and faster

### DIFF
--- a/share/functions/abbr.fish
+++ b/share/functions/abbr.fish
@@ -157,18 +157,20 @@ function __fish_abbr_parse_entry -S -a __input __key __value
 	if test -z "$__value"
 		set __value __
 	end
-	switch $__input
-		case "*=*"
-			# No need for bounds-checking because we already matched before
-			set -l KV (string split "=" -m 1 -- $__input)
-			set $__key $KV[1]
-			set $__value $KV[2]
-		case "* *"
-			set -l KV (string split " " -m 1 -- $__input)
-			set $__key $KV[1]
-			set $__value $KV[2]
-		case "*"
-			set $__key $__input
+	# A "=" _before_ any space - we only read the first possible separator
+	# because the key can contain neither spaces nor "="
+	if string match -qr '^[^ ]+=' -- $__input
+		# No need for bounds-checking because we already matched before
+		set -l KV (string split "=" -m 1 -- $__input)
+		set $__key $KV[1]
+		set $__value $KV[2]
+	else if string match -qr '^[^ ]+ .*' -- $__input
+		set -l KV (string split " " -m 1 -- $__input)
+		set $__key $KV[1]
+		set $__value $KV[2]
+	else
+		# This is needed for `erase` et al, where we want to allow passing a value
+		set $__key $__input
 	end
 	return 0
 end

--- a/share/functions/abbr.fish
+++ b/share/functions/abbr.fish
@@ -141,8 +141,7 @@ function __fish_abbr_get_by_key
 	end
 	set -l count (count $fish_user_abbreviations)
 	if test $count -gt 0
-		set -l key
-		__fish_abbr_parse_entry $argv[1] key
+		set -l key $argv[1] # This assumes the key is valid and pre-parsed
 		set -l IFS \n # ensure newline splitting is enabled
 		for i in (seq $count)
 			set -l key_i

--- a/share/functions/abbr.fish
+++ b/share/functions/abbr.fish
@@ -116,7 +116,7 @@ function abbr --description "Manage abbreviations"
 			set -l opt_double_dash ''
 			switch $key ; case '-*'; set opt_double_dash ' --'; end
 			switch $value ; case '-*'; set opt_double_dash ' --'; end
-			echo abbr$opt_double_dash (string escape -- $key) (string escape -- $value)
+			echo abbr$opt_double_dash (string escape -- $key $value)
 		end
 		return 0
 

--- a/share/functions/abbr.fish
+++ b/share/functions/abbr.fish
@@ -109,8 +109,6 @@ function abbr --description "Manage abbreviations"
 
 	case 'show'
 		for i in $fish_user_abbreviations
-			# Disable newline splitting
-			set -lx IFS ''
 			__fish_abbr_parse_entry $i key value
 			
 			# Check to see if either key or value has a leading dash
@@ -140,7 +138,6 @@ function __fish_abbr_get_by_key
 	set -l count (count $fish_user_abbreviations)
 	if test $count -gt 0
 		set -l key $argv[1] # This assumes the key is valid and pre-parsed
-		set -l IFS \n # ensure newline splitting is enabled
 		for i in (seq $count)
 			set -l key_i
 			__fish_abbr_parse_entry $fish_user_abbreviations[$i] key_i

--- a/share/functions/abbr.fish
+++ b/share/functions/abbr.fish
@@ -120,7 +120,7 @@ function abbr --description "Manage abbreviations"
 			set -l opt_double_dash ''
 			switch $key ; case '-*'; set opt_double_dash ' --'; end
 			switch $value ; case '-*'; set opt_double_dash ' --'; end
-			echo abbr$opt_double_dash (__fish_abbr_escape "$key") (__fish_abbr_escape "$value")
+			echo abbr$opt_double_dash (string escape -- $key) (string escape -- $value)
 		end
 		return 0
 
@@ -131,20 +131,6 @@ function abbr --description "Manage abbreviations"
 			printf "%s\n" $key
 		end
 		return 0
-	end
-end
-
-function __fish_abbr_escape
-	# Prettify the common case: if everything is alphanumeric,
-	# we do not need escapes.
-	# Do this by deleting alnum characters, and check if there's anything left.
-	# Note we need to preserve spaces, so spaces are not considered alnum
-	if test -z (echo -n "$argv" | tr -d '[:alnum:]_')
-		echo $argv
-	else
-		# Escape via single quotes
-		# printf is nice for stripping the newline that sed outputs
-		printf "'%s'" (echo -n $argv | sed -e s,\\\\,\\\\\\\\,g -e s,\',\\\\\',g)
 	end
 end
 

--- a/tests/abbr.in
+++ b/tests/abbr.in
@@ -31,3 +31,7 @@ abbr -e '~__abbr2'
 abbr -- '--__abbr3' 'xyz'
 abbr | grep __abbr3
 abbr -e '--__abbr3'
+
+# Ensure we are not recognizing later "=" as separators
+abbr d2 env a=b banana
+abbr -l | string match -q d2; or echo "= test failed"

--- a/tests/abbr.out
+++ b/tests/abbr.out
@@ -5,4 +5,4 @@ abbr __abbr1 delta
 abbr __abbr1 delta
 abbr __abbr1 delta
 abbr '~__abbr2' '$xyz'
-abbr -- '--__abbr3' xyz
+abbr -- --__abbr3 xyz


### PR DESCRIPTION
As we've seen in #1976, users often have a lot of aliases from previous shells, and replacing them with abbreviations is sometimes too slow, especially on startup.

This PR attempts to improve the situation. With it, sourcing https://github.com/simnalamburt/pkg-cgitc/blob/28cb2b905d2c389464d79e58f0cdbfb2d78c74f1/init.fish (s/alias/abbr) goes from about 4 seconds to about 2 seconds with a cleared $fish_user_abbreviations. Still not quite snappy but better than before.

The case with pre-existing abbreviations isn't improved as much (750ms -> 500ms), but it still helps a bit.

In addition to that, there's a few cases in abbr where `string` comes in handy, replacing weird IFS tricks and handrolled escaping.

While this doesn't do any crazy stuff (like caching the keys separately for quicker checking, which could work but would be tricky to pull off if users are allowed to fiddle with $fish_user_abbreviations), it's still possible this changes behavior in edgecases. I've already checked one particular suspect - abbrs with newlines in the value.