### PR TITLE
type: add option to dereference links

### DIFF
--- a/doc_src/type.txt
+++ b/doc_src/type.txt
@@ -21,6 +21,8 @@ The following options are available:
 
 - `-P` or `--force-path` returns the name of the disk file that would be executed, or nothing if no file with the specified name could be found in the <tt>$PATH</tt>.
 
+- `-L` or `--dereference` dereferences symbolic links in the output.
+
 - `-q` or `--quiet` suppresses all output; this is useful when testing the exit status.
 
 

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -6,6 +6,7 @@ function type --description "Print the type of a command"
 	set -l mode normal
 	set -l multi no
 	set -l selection all
+	set -l dereference no
 	set -l IFS \n\ \t
 
 	# Parse options
@@ -43,6 +44,9 @@ function type --description "Print the type of a command"
 							set mode path
 						end
 						set selection files
+
+					case -L --dereference
+						set dereference yes
 
 					case -a --all
 						set multi yes
@@ -125,6 +129,9 @@ function type --description "Print the type of a command"
 		for path in $paths
 			set res 0
 			set found 1
+			if test $dereference = yes
+				set path (realpath -- $path)
+			end
 			switch $mode
 				case normal
 					printf (_ '%s is %s\n') $i $path


### PR DESCRIPTION
This PR adds an option to `type` to dereference symbolic links in the output.

```fish
$ type gcc
gcc is /usr/bin/gcc
$ type -L gcc
gcc is /usr/bin/gcc-5
```

This is a sketchy implementation using `realpath(1)` (I am not sure we can use it on all platforms), but it's probably fine as a starting point.

Close #2181.