### PR TITLE
Prevent line-full-of-spaces in s_reset

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -1448,6 +1448,7 @@ void s_reset(screen_t *s, screen_reset_mode_t mode)
         // now we are certainly on a new line. But we may have dropped the omitted newline char on it. So append enough spaces to overwrite the omitted newline char, and then
         abandon_line_string.append(non_space_width, L' ');
         abandon_line_string.push_back(L'\r');
+        abandon_line_string.append(L"\x1b[2K"); //clear all the spaces from the new line
 
         const std::string narrow_abandon_line_string = wcs2string(abandon_line_string);
         write_loop(STDOUT_FILENO, narrow_abandon_line_string.c_str(), narrow_abandon_line_string.size());


### PR DESCRIPTION
If you have a prompt preceded by a new line, you'll get a line full of spaces instead of an empty line above your prompt. This doesn't make a difference in normal usage, but copying and pasting your terminal log becomes a pain. This commit clears that line, making it an actual empty line.