### PR TITLE
fix several build warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Building the documentation requires Doxygen 1.8.7 or newer.
 
 ### Xcode Build and Install
 
+    autoconf
+    ./configure
+    make lexicon_filter
     xcodebuild install
     sudo ditto /tmp/fish.dst /
 

--- a/doc_src/printf.txt
+++ b/doc_src/printf.txt
@@ -60,7 +60,7 @@ This file has been imported from the printf in GNU Coreutils version 6.9. If you
 \subsection printf-example Example
 
 \fish
-printf '%s\t%s\n' flounder fish
+printf '\%s\\t\%s\n' flounder fish
 \endfish
 Will print "flounder	fish" (separated with a tab character), followed by a newline character. This is useful for writing completions, as fish expects completion scripts to output the option followed by the description, separated with a tab character.
 

--- a/doc_src/string.txt
+++ b/doc_src/string.txt
@@ -110,7 +110,7 @@ string trim --right --chars=yz xyzzy zany
 \endfish
 
 \fish
-echo \\x07 | string escape
+echo \x07 | string escape
 # Output:
 # \\cg
 \endfish
@@ -193,7 +193,7 @@ string replace -r '(\\w+)\\s+(\\w+)' '$2 $1 $$' 'left right'
 # Output:
 # right left $
 
-string replace -r '\s*newline\s*' '\n' 'put a newline here'
+string replace -r '\\s*newline\\s*' '\n' 'put a newline here'
 # Output:
 # put a
 # here

--- a/lexicon_filter.in
+++ b/lexicon_filter.in
@@ -475,7 +475,9 @@ x
 #.
 # Mark up sesitive character entities.
 #.
-:entities
+# We comment out this target because it isn't referenced and if we don't we
+# get warnings about "unused label 'entities'".
+#:entities
 s/</\&lt;/g
 s/>/\&gt;/g
 s/((d))/@/g
@@ -575,7 +577,9 @@ s/\($[$]*\)\([A-Za-z_0-9][A-Za-z_0-9]*\)/@vars{@optr{\1}\2}/g
 # Files
 s/\([^@]\)\([A-Za-z0-9_-][A-Za-z0-9_-]*\.[a-z0-9*][a-z0-9*]*\)/\1@fsfo{\2}/g
 #.
-:commands
+# We comment out this target because it isn't referenced and if we don't we
+# get warnings about "unused label 'commands'".
+#:commands
 #.
 #### This section is built in the Makefile. Just some formatting examples. #####
 #.


### PR DESCRIPTION
This fixes all but one of the warnings documented in issue #2685. The
sole remaining warning is from the

    string split '' abc

example in doc_src/string.txt. That example results in the man page
displaying

    string split {} abc

I leave it to someone else to fix that problem (I'll open an issue
specifically for it since it took some effort to track down the source
of the warning).

Resolves issue #2685.