### PR TITLE
Reinstate failglob behaviour for most commands

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -413,8 +413,19 @@ Examples:
 
 - `**` matches any files and directories in the current directory and all of its subdirectories.
 
-Note that if no matches are found for a specific wildcard, it will expand into zero arguments, i.e. to nothing. If none of the wildcarded arguments sent to a command result in any matches, the command will not be executed. If this happens when using the shell interactively, a warning will also be printed.
+Note that for most commands, if any wildcard fails to expand, the command is not executed, <a href='#variables-status'>`$status`</a> is set to nonzero, and a warning is printed. This behavior is consistent with setting `shopt -s failglob` in bash. There are exactly 3 exceptions, namely <a href="commands.html#set">`set`</a>, <a href="commands.html#count">`count`</a> and <a href="commands.html#for">`for`</a>. Their globs are permitted to expand to zero arguments, as with `shopt -s nullglob` in bash.
 
+Examples:
+\fish
+ls *.foo
+# Lists the .foo files, or warns if there aren't any.
+
+set foos *.foo
+if test (count $foos) -ge 1
+    ls $foos
+end
+# Lists the .foo files, if any.
+\endfish
 
 \subsection expand-command-substitution Command substitution
 

--- a/src/parse_execution.h
+++ b/src/parse_execution.h
@@ -102,7 +102,12 @@ private:
     parse_execution_result_t run_function_statement(const parse_node_t &header, const parse_node_t &block_end_command);
     parse_execution_result_t run_begin_statement(const parse_node_t &header, const parse_node_t &contents);
 
-    parse_execution_result_t determine_arguments(const parse_node_t &parent, wcstring_list_t *out_arguments);
+    enum globspec_t
+    {
+        failglob,
+        nullglob
+    };
+    parse_execution_result_t determine_arguments(const parse_node_t &parent, wcstring_list_t *out_arguments, globspec_t glob_behavior);
 
     /* Determines the IO chain. Returns true on success, false on error */
     bool determine_io_chain(const parse_node_t &statement, io_chain_t *out_chain);

--- a/tests/test5.err
+++ b/tests/test5.err
@@ -1,0 +1,3 @@
+No matches for wildcard '*ee*'.
+fish: 	case *ee*
+      	     ^


### PR DESCRIPTION
Expand globs to zero arguments (nullglob) only for set, for and count.

The warning about failing globs, and setting the accompanying $status,
now happens regardless of mode, interactive or not.

It is assumed that the above commands are the common cases where
nullglob behaviour is desirable.
More importantly, doing this with `set` is a real feature enabler,
since the resulting empty array can be passed on to any command.

The previous behaviour was actually all nullglob (since commit
cab115c8b9933ae7db9412c66d452c0ccb2d7152), but this was undocumented;
the failglob warning was still printed in interactive mode,
and the documentation was bragging about failglob behaviour.