### PR TITLE
Fix user browser for help in Cygwin

### DIFF
--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -79,8 +79,12 @@ function help --description 'Show help for the fish shell'
 	end
 
 	# In Cygwin, start the user-specified browser using cygstart
-	if begin; type -q cygstart; and test $fish_browser != "cygstart"; end
-		set fish_browser cygstart \"$fish_browser\"
+	if type -q cygstart
+		if test $fish_browser != "cygstart"
+			# Escaped quotes are necessary to work with spaces in the path
+			# when the command is finally eval'd.
+			set fish_browser cygstart \"$fish_browser\"
+		end
 	end
 
 	set -l fish_help_item $argv[1]

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -78,6 +78,11 @@ function help --description 'Show help for the fish shell'
 		return 1
 	end
 
+        # In Cygwin, start the user-specified browser using cygstart
+        if begin; type -q cygstart; and test $fish_browser != "cygstart"; end
+                set fish_browser cygstart \"$fish_browser\"
+        end
+
 	set -l fish_help_item $argv[1]
 
 	switch "$fish_help_item"
@@ -109,6 +114,11 @@ function help --description 'Show help for the fish shell'
 	if test -f $__fish_help_dir/index.html
 		# Help is installed, use it
 		set page_url file://$__fish_help_dir/$fish_help_page
+
+                # In Cygwin, we need to convert the base help dir to a Windows path before converting it to a file URL
+                if type -q cygpath
+                        set page_url file://(cygpath -m $__fish_help_dir)/$fish_help_page
+                end
 	else
 		# Go to the web. Only include one dot in the version string
 		set -l version_string (echo $FISH_VERSION| cut -d . -f 1,2)

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -78,10 +78,10 @@ function help --description 'Show help for the fish shell'
 		return 1
 	end
 
-        # In Cygwin, start the user-specified browser using cygstart
-        if begin; type -q cygstart; and test $fish_browser != "cygstart"; end
-                set fish_browser cygstart \"$fish_browser\"
-        end
+	# In Cygwin, start the user-specified browser using cygstart
+	if begin; type -q cygstart; and test $fish_browser != "cygstart"; end
+		set fish_browser cygstart \"$fish_browser\"
+	end
 
 	set -l fish_help_item $argv[1]
 
@@ -115,10 +115,10 @@ function help --description 'Show help for the fish shell'
 		# Help is installed, use it
 		set page_url file://$__fish_help_dir/$fish_help_page
 
-                # In Cygwin, we need to convert the base help dir to a Windows path before converting it to a file URL
-                if type -q cygpath
-                        set page_url file://(cygpath -m $__fish_help_dir)/$fish_help_page
-                end
+		# In Cygwin, we need to convert the base help dir to a Windows path before converting it to a file URL
+		if type -q cygpath
+			set page_url file://(cygpath -m $__fish_help_dir)/$fish_help_page
+		end
 	else
 		# Go to the web. Only include one dot in the version string
 		set -l version_string (echo $FISH_VERSION| cut -d . -f 1,2)


### PR DESCRIPTION
Fixes the invocation of a user-specified browser by the `help` command on Cygwin.

- Use `cygstart` to launch the browser with escaped quotes to avoid problems with spaces in the path to the browser, (e.g. Program Files).
- Use `cygpath` to convert the base help dir to a Windows path before constructing the file URL to pass to the browser.

This doesn't fix the case described in #1314 where there is no user-specified browser, since the problem lies in `cygstart` itself and how it handles direct invocation of file URLs.
