### PR TITLE
Remove const from _wgetopt_internal's argv argument

### DIFF
--- a/src/wgetopt.cpp
+++ b/src/wgetopt.cpp
@@ -585,7 +585,7 @@ int wgetopter_t::_wgetopt_internal(int argc, wchar_t **argv, const wchar_t *opts
     }
 }
 
-int wgetopter_t::wgetopt(int argc, wchar_t *const *argv, const wchar_t *optstring)
+int wgetopter_t::wgetopt(int argc, wchar_t **argv, const wchar_t *optstring)
 {
     return _wgetopt_internal(argc, argv, optstring,
                              (const struct woption *) 0,
@@ -593,12 +593,12 @@ int wgetopter_t::wgetopt(int argc, wchar_t *const *argv, const wchar_t *optstrin
                              0);
 }
 
-int wgetopter_t::wgetopt_long(int argc, wchar_t *const *argv, const wchar_t *options, const struct woption *long_options, int *opt_index)
+int wgetopter_t::wgetopt_long(int argc, wchar_t **argv, const wchar_t *options, const struct woption *long_options, int *opt_index)
 {
     return _wgetopt_internal(argc, argv, options, long_options, opt_index, 0);
 }
 
-int wgetopter_t::wgetopt_long_only(int argc, wchar_t *const *argv, const wchar_t *options, const struct woption *long_options, int *opt_index)
+int wgetopter_t::wgetopt_long_only(int argc, wchar_t **argv, const wchar_t *options, const struct woption *long_options, int *opt_index)
 {
     return _wgetopt_internal(argc, argv, options, long_options, opt_index, 1);
 }

--- a/src/wgetopt.cpp
+++ b/src/wgetopt.cpp
@@ -294,7 +294,7 @@ const wchar_t * wgetopter_t::_wgetopt_initialize(const wchar_t *optstring)
    If LONG_ONLY is nonzero, '-' as well as '--' can introduce
    long-named options.  */
 
-int wgetopter_t::_wgetopt_internal(int argc, wchar_t *const *argv, const wchar_t *optstring, const struct woption *longopts, int *longind, int long_only)
+int wgetopter_t::_wgetopt_internal(int argc, wchar_t **argv, const wchar_t *optstring, const struct woption *longopts, int *longind, int long_only)
 {
     woptarg = NULL;
 

--- a/src/wgetopt.h
+++ b/src/wgetopt.h
@@ -54,7 +54,7 @@ class wgetopter_t
 private:
     void exchange(wchar_t **argv);
     const wchar_t * _wgetopt_initialize(const wchar_t *optstring);
-    int _wgetopt_internal(int argc, wchar_t *const *argv, const wchar_t *optstring, const struct woption *longopts, int *longind, int long_only);
+    int _wgetopt_internal(int argc, wchar_t **argv, const wchar_t *optstring, const struct woption *longopts, int *longind, int long_only);
     
 public:
     /* For communication from `getopt' to the caller.
@@ -147,9 +147,9 @@ public:
     {
     }
     
-    int wgetopt(int argc, wchar_t *const *argv, const wchar_t *optstring);
-    int wgetopt_long(int argc, wchar_t *const *argv, const wchar_t *options, const struct woption *long_options, int *opt_index);
-    int wgetopt_long_only(int argc, wchar_t *const *argv, const wchar_t *options, const struct woption *long_options, int *opt_index);
+    int wgetopt(int argc, wchar_t **argv, const wchar_t *optstring);
+    int wgetopt_long(int argc, wchar_t **argv, const wchar_t *options, const struct woption *long_options, int *opt_index);
+    int wgetopt_long_only(int argc, wchar_t **argv, const wchar_t *options, const struct woption *long_options, int *opt_index);
 };
 
 /** Describe the long-named options requested by the application.


### PR DESCRIPTION
The argv argument may be modified on calls to exchange within the function and should not be const qualified (it's not true from the caller's point of view).