### PR TITLE
Fix package listing for zypper

### DIFF
--- a/share/functions/__fish_print_packages.fish
+++ b/share/functions/__fish_print_packages.fish
@@ -67,7 +67,7 @@ function __fish_print_packages
 		end
 
 		# Remove package version information from output and pipe into cache file
-		zypper --quiet --non-interactive search --type=package | tail -n +4 | sed -E 's/^. \| ((\w|[-_.])+).*/\1\t'$package'/g' > $cache_file &
+		zypper --quiet --non-interactive search --type=package | tail -n +4 | sed -r 's/^. \| ((\w|[-_.])+).*/\1\t'$package'/g' > $cache_file &
 		return
 	end
 


### PR DESCRIPTION
-E is only supported by BSD sed, switch to -r which is also supported by GNU sed

I wonder if it ever worked? As far as I can tell OpenSUSE has always shipped with GNU sed.
For sure it didn't work on my Leap install.