### PR TITLE
Fix `No command 'dscl' found` error of killall command

### DIFF
--- a/share/completions/killall.fish
+++ b/share/completions/killall.fish
@@ -13,7 +13,7 @@ if test (uname) != 'SunOS'
 
 	# Finds and completes all users, and their respective UID.
 	function __make_users_completions
-		set -l users (dscl . list /Users | grep -v '^_.*')
+		set -l users (__fish_print_users)
 		for user in $users
 			set -l uid (id -u $user)
 			# GNU doesn't support UID

--- a/share/functions/__fish_print_users.fish
+++ b/share/functions/__fish_print_users.fish
@@ -3,7 +3,7 @@ function __fish_print_users --description "Print a list of local users"
 	if test -x /usr/bin/getent
 		getent passwd | cut -d : -f 1
 	else if test -x /usr/bin/dscl # OS X support
-		dscl . -list /Users
+		dscl . -list /Users | __fish_sgrep -v '^_'
 	else
 		__fish_sgrep -ve '^#' /etc/passwd | cut -d : -f 1
 	end


### PR DESCRIPTION
`dscl` command only support `OS X` system, replace to `__fish_print_users`