### PR TITLE
Fix history --merge error

### DIFF
--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -34,12 +34,13 @@ function history --description "Deletes an item from history"
 				set cmd clear
 			case --search
 				set cmd print
+			case --merge
 			case --
 				set -e argv[$i]
 				break
-			case -* --*
+			case "-*" "--*"
 				printf ( _ "%s: invalid option -- %s\n" ) history $argv[1] >& 2
-				return 1
+				return 
 			end
 		end
 	else

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -40,7 +40,7 @@ function history --description "Deletes an item from history"
 				break
 			case "-*" "--*"
 				printf ( _ "%s: invalid option -- %s\n" ) history $argv[1] >& 2
-				return 
+				return 1
 			end
 		end
 	else


### PR DESCRIPTION
Think the globbing behavior change caused the error I saw in #2658:

```
~ $ history --merge

No matches for wildcard '-*'.
/usr/local/Cellar/fish/HEAD/share/fish/functions/history.fish (line 34):    case -* --*
                                                                                         ^
in function 'history'
    called on standard input
    with parameter list '--merge'
```

This fixes it for me. 