### PR TITLE
Stop always returning exit code 1 on history --merge

### DIFF
--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -35,10 +35,11 @@ function history --description "Deletes an item from history"
 			case --search
 				set cmd print
 			case --merge
+				set cmd merge
 			case --
 				set -e argv[$i]
 				break
-			case "-*" "--*"
+			case -* --*
 				printf ( _ "%s: invalid option -- %s\n" ) history $argv[1] >& 2
 				return 1
 			end
@@ -54,6 +55,10 @@ function history --description "Deletes an item from history"
 	end
 
 	switch $cmd
+
+	case merge
+		builtin history --merge
+
 	case print
 		# Print matching items
 		# Note this may end up passing --search twice to the builtin,
@@ -125,9 +130,11 @@ function history --description "Deletes an item from history"
 			#Save changes after deleting item(s)
 			builtin history --save
 		end
+
 	case save
 		#Save changes to history file
 		builtin history $argv
+
 	case clear
 		# Erase the entire history
 		echo "Are you sure you want to clear history ? (y/n)"

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -39,7 +39,7 @@ function history --description "Deletes an item from history"
 			case --
 				set -e argv[$i]
 				break
-			case -* --*
+			case "-*" "--*"
 				printf ( _ "%s: invalid option -- %s\n" ) history $argv[1] >& 2
 				return 1
 			end

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -3868,6 +3868,7 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
     if (merge_history)
     {
         history->incorporate_external_changes();
+        return STATUS_BUILTIN_OK;
     }
 
     if (search_history)


### PR DESCRIPTION
Explicitly handle the `history --merge` command, it just functioned as a side effect before. And fix `builtin_history()` function to not always have an exit code of 1.