### PR TITLE
Verify grep --color=auto works

### DIFF
--- a/share/functions/grep.fish
+++ b/share/functions/grep.fish
@@ -2,9 +2,8 @@
 # Match colors for grep, if supported
 #
 
-if command grep --color=auto --help 1>/dev/null 2>/dev/null
+if echo | command grep --color=auto "" >/dev/null 2>&1
 	function grep
 		command grep --color=auto $argv
 	end
 end
-


### PR DESCRIPTION
This wasn't working for OS X. Just try to grep nothing with the option and see if that was OK or not instead of checking --help. Fixes #2746