### PR TITLE
Send BEL on completion error

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1607,9 +1607,9 @@ static void select_completion_in_direction(enum selection_direction_t dir)
 }
 
 /**
-  Flash the screen. This function only changed the color of the
-  current line, since the flash_screen sequnce is rather painful to
-  look at in most terminal emulators.
+  Flash the screen. This function changes the color of the
+  current line momentarily and sends a BEL to maybe flash the
+  screen or emite a sound, depending on how it is configured.
 */
 static void reader_flash()
 {
@@ -1622,6 +1622,7 @@ static void reader_flash()
     }
 
     reader_repaint();
+    writestr(L"\a");
 
     pollint.tv_sec = 0;
     pollint.tv_nsec = 100 * 1000000;


### PR DESCRIPTION
This patch makes fish send a BEL character to trigger a visual flash or a beep (however they have their terminal setup) at the same time it tries to flash the prompt momentarily to indicate that hitting tab again won’t help when there are zero completion results. Sometimes I just don’t notice a short completion flashing like that, especially because it only does it on the first tap of the tab key. This is nicer. 