### PR TITLE
Don't extract 0.0.0.0 hostnames from /etc/hosts for completions.

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -5,10 +5,11 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	if type -q getent
 		getent hosts 2>/dev/null | tr -s ' ' ' ' | cut -d ' ' -f 2- | tr ' ' '\n'
 	else if test -r /etc/hosts
-		tr -s ' \t' '  ' < /etc/hosts | sed 's/ *#.*//' | cut -s -d ' ' -f 2- | __fish_sgrep -o '[^ ]*'
+		tr -s ' \t' '  ' < /etc/hosts | sed 's/ *#.*//' | sed 's/^[0.]* .*$//' | cut -s -d ' ' -f 2- | __fish_sgrep -o '[^ ]*'
 	end
+	
 	# Print nfs servers from /etc/fstab
-		if test -r /etc/fstab
+	if test -r /etc/fstab
 		__fish_sgrep </etc/fstab "^\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\|[a-zA-Z.]*\):"|cut -d : -f 1
 	end
 


### PR DESCRIPTION
My /etc/hosts is 12432 lines long. I use [this hosts file](http://someonewhocares.org/hosts/zero/) (which uses 0.0.0.0 instead of the more traditional 127.0.0.1) to block stuff.

So, typing ssh and hitting tab gives me suggestions for thousands of hostnames I want nothing to do with. It’s very slow.

This change sped things up significantly and made my completions useful. Don’t think it should affect things negatively as 0.0.0.0 isn’t routable - it’s hard to imagine someone expecting such hosts in their completions.