### PR TITLE
Improvements to __fish_print_hostnames

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -20,23 +20,13 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 		string match -r '^\s*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3]:|^[a-zA-Z\.]*:' </etc/fstab | string replace -r ':.*' ''
 	end
 
-	# Print hosts with known ssh keys
-	# Does not match hostnames with @directives specified
-
-	# Print hosts from system wide ssh configuration file
-	if [ -e /etc/ssh/ssh_config ]
-		awk -v FS="[ =]+" -v OFS='\n' 'tolower($0) ~ /^ *host[^*?!]*$/{ $1=""; print }' /etc/ssh/ssh_config
-	end
-
-	# Print hosts from ssh configuration file
-	if [ -e ~/.ssh/config ]
-		awk -v FS="[ =]+" -v OFS='\n' 'tolower($0) ~ /^ *host[^*?!]*$/{ $1=""; print }' ~/.ssh/config
-	end
-
-	# Check external ssh KnownHostsFiles
+	# Check hosts known to ssh
 	set -l known_hosts ~/.ssh/known_hosts{,2} /etc/ssh/known_hosts{,2} # Yes, seriously - the default specifies both with and without "2"
 	for file in /etc/ssh/ssh_config ~/.ssh/config
 		if test -r $file
+			# Print hosts from system wide ssh configuration file
+			# Note the non-capturing group to avoid printing "name"
+			string match -r '\s*Host(?:name)? \w.*' < $file | string replace -r '^\s*Host(?:name)?\s*(\S+)' '$1'
 			set known_hosts $known_hosts (string match -r '^\s*UserKnownHostsFile|^\s*GlobalKnownHostsFile' <$file \
 			| string replace -r '.*KnownHostsFile\s*' '')
 		end

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -12,9 +12,10 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 		grep -v '^\s*0.0.0.0\|^\s*#\|^\s*$' /etc/hosts \
 		| string replace -r '[0-9.]*\s*' '' | string trim | string replace -ra '\s' '\n'
 	end
+
 	# Print nfs servers from /etc/fstab
 	if test -r /etc/fstab
-		string match -r '^\s*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3]:|[a-zA-Z\.]*:' </etc/fstab | string replace -r ':.*' ''
+		string match -r '^\s*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3]:|^[a-zA-Z\.]*:' </etc/fstab | string replace -r ':.*' ''
 	end
 
 	# Print hosts with known ssh keys

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -42,6 +42,8 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 		end
 	end
 	for file in $known_hosts
-		test -r $file; and string replace -ra '(\S+) .*' '$1' <$file | string replace -ra '^\[([0-9.]+)\]:[0-9]+$' '$1' | string split ","
+		# Ignore hosts that are hashed, commented or have custom ports (like [localhost]:2200)
+		test -r $file; and string replace -ra '(\S+) .*' '$1' < $file | string match -r '^[^#|[=]+$' | string split ","
 	end
+	return 0
 end

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -1,11 +1,19 @@
 
 function __fish_print_hostnames -d "Print a list of known hostnames"
+	# HACK: This only deals with ipv4
 
+	# Ignore zero ips
+	# An option like grep's "-v" would make this massively simpler
+	# It can't be grouped because that would lead to one line for the entire thing and one per-group
+	set -l renonzero '^[^0].+|^0.[^0].+|^0.0.[^0].+|^0.0.0.[^0].+'
 	# Print all hosts from /etc/hosts
 	if type -q getent
-		getent hosts 2>/dev/null | tr -s ' ' ' ' | cut -d ' ' -f 2- | tr ' ' '\n'
+		getent hosts | string match -r $renonzero \
+		| string replace -r '[0-9.]*\s*' '' | string split " "
 	else if test -r /etc/hosts
-		tr -s ' \t' '  ' < /etc/hosts | sed 's/ *#.*//' | cut -s -d ' ' -f 2- | __fish_sgrep -o '[^ ]*'
+		# Ignore commented lines
+		string match -r '^[^#\s]+ .*$' </etc/hosts | string match -r $renonzero \
+		| string replace -r '[0-9.]*\s*' '' | string split " "
 	end
 	# Print nfs servers from /etc/fstab
 		if test -r /etc/fstab

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -2,18 +2,15 @@
 function __fish_print_hostnames -d "Print a list of known hostnames"
 	# HACK: This only deals with ipv4
 
-	# Ignore zero ips
-	# An option like grep's "-v" would make this massively simpler
-	# It can't be grouped because that would lead to one line for the entire thing and one per-group
-	set -l renonzero '^[^0].+|^0.[^0].+|^0.0.[^0].+|^0.0.0.[^0].+'
 	# Print all hosts from /etc/hosts
 	if type -q getent
-		getent hosts | string match -r $renonzero \
+		# Ignore zero ips
+		getent hosts | grep -v '^0.0.0.0' \
 		| string replace -r '[0-9.]*\s*' '' | string split " "
 	else if test -r /etc/hosts
-		# Ignore commented lines
-		string match -r '^[^#\s]+ .*$' </etc/hosts | string match -r $renonzero \
-		| string replace -r '[0-9.]*\s*' '' | string split " "
+		# Ignore commented lines and functionally empty lines
+		grep -v '^\s*0.0.0.0\|^\s*#\|^\s*$' /etc/hosts \
+		| string replace -r '[0-9.]*\s*' '' | string trim | string replace -ra '\s' '\n'
 	end
 	# Print nfs servers from /etc/fstab
 	if test -r /etc/fstab

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -10,7 +10,9 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	else if test -r /etc/hosts
 		# Ignore commented lines and functionally empty lines
 		grep -v '^\s*0.0.0.0\|^\s*#\|^\s*$' /etc/hosts \
-		| string replace -r '[0-9.]*\s*' '' | string trim | string replace -ra '\s' '\n'
+		# Strip comments
+		| string replace -ra '#.*$' '' \
+		| string replace -r '[0-9.]*\s*' '' | string trim | string replace -ra '\s+' '\n'
 	end
 
 	# Print nfs servers from /etc/fstab

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -16,8 +16,8 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 		| string replace -r '[0-9.]*\s*' '' | string split " "
 	end
 	# Print nfs servers from /etc/fstab
-		if test -r /etc/fstab
-		__fish_sgrep </etc/fstab "^\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\|[a-zA-Z.]*\):"|cut -d : -f 1
+	if test -r /etc/fstab
+		string match -r '^\s*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3]:|[a-zA-Z\.]*:' </etc/fstab | string replace -r ':.*' ''
 	end
 
 	# Print hosts with known ssh keys

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -22,7 +22,6 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 
 	# Print hosts with known ssh keys
 	# Does not match hostnames with @directives specified
-	__fish_sgrep -Eoh '^[^#@|, ]*' ~/.ssh/known_hosts{,2} ^/dev/null | string replace -r '^\[([^]]+)\]:[0-9]+$' '$1'
 
 	# Print hosts from system wide ssh configuration file
 	if [ -e /etc/ssh/ssh_config ]
@@ -32,5 +31,17 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	# Print hosts from ssh configuration file
 	if [ -e ~/.ssh/config ]
 		awk -v FS="[ =]+" -v OFS='\n' 'tolower($0) ~ /^ *host[^*?!]*$/{ $1=""; print }' ~/.ssh/config
+	end
+
+	# Check external ssh KnownHostsFiles
+	set -l known_hosts ~/.ssh/known_hosts{,2} /etc/ssh/known_hosts{,2} # Yes, seriously - the default specifies both with and without "2"
+	for file in /etc/ssh/ssh_config ~/.ssh/config
+		if test -r $file
+			set known_hosts $known_hosts (string match -r '^\s*UserKnownHostsFile|^\s*GlobalKnownHostsFile' <$file \
+			| string replace -r '.*KnownHostsFile\s*' '')
+		end
+	end
+	for file in $known_hosts
+		test -r $file; and string replace -ra '(\S+) .*' '$1' <$file | string replace -ra '^\[([0-9.]+)\]:[0-9]+$' '$1' | string split ","
 	end
 end


### PR DESCRIPTION
This is basically #2313 and #2764 rolled into one.

One improvement is reading ssh's KnownHostsFiles - configured in the ssh_config files, these contain additional hosts and are hence a nice source of info.

Another is ignoring hosts set to 0.0.0.0 from /etc/hosts (or `getent hosts`), which might be a lot of useless entries if you use hosts-based blocking.

Because this reads configuration I don't really have I'd appreciate some testing (@zanchey?).

@sysbot, @floam: Thanks for the ideas! Mind taking a look at my attempt?