### PR TITLE
Migrate abbrs

### DIFF
--- a/doc_src/abbr.txt
+++ b/doc_src/abbr.txt
@@ -2,7 +2,7 @@
 
 \subsection abbr-synopsis Synopsis
 \fish{synopsis}
-abbr -a word="phrase"
+abbr -a word phrase...
 abbr -s
 abbr -l
 abbr -e word
@@ -25,6 +25,8 @@ The following parameters are available:
 - `-l` or `--list` Lists all abbreviated words.
 
 - `-e WORD` or `--erase WORD` Erase the abbreviation WORD.
+
+Note: fish version 2.1 supported `-a WORD=PHRASE`. This syntax is now deprecated but will still be converted.
 
 \subsection abbr-example Examples
 

--- a/share/config.fish
+++ b/share/config.fish
@@ -171,7 +171,7 @@ end
 if not set -q __fish_init_2_3_0
 	set -l fab
 	for abb in $fish_user_abbreviations
-		set fab $fab (string replace -ra '^([^ ]+)=(.*)' '$1 $2' -- $abb)
+		set fab $fab (string replace -r '^([^ =]+)=(.*)$' '$1 $2' -- $abb)
 	end
 	set fish_user_abbreviations $fab
 	set -U __fish_init_2_3_0

--- a/share/config.fish
+++ b/share/config.fish
@@ -165,3 +165,14 @@ for file in $configdir/fish/conf.d/* $__fish_sysconfdir/conf.d/* $__fish_datadir
 	# This allows one to use e.g. symlinks to /dev/null to "mask" something (like in systemd)
 	[ -f $file -a -r $file ]; and source $file
 end
+
+# Upgrade pre-existing abbreviations from the old "key=value" to the new "key value" syntax
+# This needs to be in share/config.fish because __fish_config_interactive is called after sourcing config.fish, which might contain abbr calls
+if not set -q __fish_init_2_3_0
+	set -l fab
+	for abb in $fish_user_abbreviations
+		set fab $fab (string replace -ra '^([^ ]+)=(.*)' '$1 $2' -- $abb)
+	end
+	set fish_user_abbreviations $fab
+	set -U __fish_init_2_3_0
+end


### PR DESCRIPTION
This silently migrates old abbreviations from "key=value" to "key value".

We might want to push a bit harder by e.g. printing a warning if an abbr with the old syntax is about to be added.

This closes #2051.