### PR TITLE
history.fish: Fix input handling

### DIFF
--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -98,7 +98,7 @@ function history --description "Deletes an item from history"
 				end
 
 				#Following two validations could be embedded with "and" but I find the syntax kind of weird.
-				if not string match -qr '^[0-9]+$'
+				if not string match -qr '^[0-9]+$' $i
 					printf "Invalid input: %s\n" $i
 					continue
 				end


### PR DESCRIPTION
Pass the input to 'string', it was accidentally removed in fcdc6a48c0bbdc796975db8d0b7f32434d86d249.