### PR TITLE
assume getopt/getopt_long is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -752,43 +752,6 @@ else
   AC_MSG_RESULT(no)
 fi
 
-# Check if getopt_long exists and works
-AC_MSG_CHECKING([if getopt_long exists and works])
-AC_TRY_LINK(
-  [
-    #if HAVE_GETOPT_H
-    #include <getopt.h>
-    #endif
-  ],
-  [
-    static struct option
-      long_options[] =
-      {
-        0, 0, 0, 0
-      }
-    ;
-    int opt = getopt_long( 0,
-                 0,
-                 0,
-                 long_options,
-                 0 );
-
-  ],
-  have_working_getopt_long=yes,
-  have_working_getopt_long=no
-)
-if test "$have_working_getopt_long" = yes; then
-  AC_MSG_RESULT(yes)
-  AC_DEFINE(
-    [HAVE_WORKING_GETOPT_LONG],
-    [1],
-    [Define to 1 if getopt_long exists and works.]
-  )
-else
-  AC_MSG_RESULT(no)
-fi
-
-
 # Check for Solaris curses tputs having fixed length parameter list.
 AC_MSG_CHECKING([if we are using non varargs tparm.])
 AC_COMPILE_IFELSE(

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -1207,20 +1207,6 @@ int killpg(int pgr, int sig)
 }
 #endif
 
-#ifndef HAVE_WORKING_GETOPT_LONG
-
-int getopt_long(int argc,
-                char * const argv[],
-                const char *optstring,
-                const struct option *longopts,
-                int *longindex)
-{
-    return getopt(argc, argv, optstring);
-}
-
-
-#endif
-
 #ifndef HAVE_BACKTRACE
 int backtrace(void **buffer, int size)
 {

--- a/src/fallback.h
+++ b/src/fallback.h
@@ -413,53 +413,6 @@ extern int _nl_msg_cat_cntr;
 int killpg(int pgr, int sig);
 #endif
 
-
-#ifndef HAVE_WORKING_GETOPT_LONG
-
-/**
-   Struct describing a long getopt option
- */
-struct option
-{
-    /**
-       Name of option
-     */
-    const char *name;
-    /**
-       Flag
-     */
-    int has_arg;
-    /**
-       Flag
-     */
-    int *flag;
-    /**
-       Return value
-     */
-    int val;
-}
-;
-
-#ifndef no_argument
-#define  no_argument 0
-#endif
-
-#ifndef required_argument
-#define  required_argument 1
-#endif
-
-#ifndef optional_argument
-#define  optional_argument 2
-#endif
-
-int getopt_long(int argc,
-                char * const argv[],
-                const char *optstring,
-                const struct option *longopts,
-                int *longindex);
-
-#endif
-
 #ifndef HAVE_SYSCONF
 
 #define _SC_ARG_MAX 1

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "config.h"
 
 #include <assert.h>
+#include <getopt.h>
 #include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -39,15 +40,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <sys/socket.h> // IWYU pragma: keep - suggests internal header
 #include <sys/un.h>
 #include <pwd.h>
-
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#endif
-
 #include <locale.h>
 
 #include "fallback.h" // IWYU pragma: keep
-
 #include "common.h"
 #include "reader.h"
 #include "builtin.h"
@@ -71,11 +66,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #ifndef PATH_MAX
 #define PATH_MAX 1024
 #endif
-
-/**
-   The string describing the single-character options accepted by the main fish binary
-*/
-#define GETOPT_STRING "+hilnvc:p:d:"
 
 /* If we are doing profiling, the filename to output to */
 static const char *s_profiling_output_filename = NULL;
@@ -370,7 +360,8 @@ static int read_init(const struct config_paths_t &paths)
  */
 static int fish_parse_opt(int argc, char **argv, std::vector<std::string> *cmds)
 {
-    const struct option long_options[] =
+    const char *short_opts = "+hilnvc:p:d:";
+    const struct option long_opts[] =
     {
         { "command", required_argument, NULL, 'c' },
         { "debug-level", required_argument, NULL, 'd' },
@@ -383,17 +374,15 @@ static int fish_parse_opt(int argc, char **argv, std::vector<std::string> *cmds)
         { NULL, 0, NULL, 0 }
     };
 
-    while (1)
+    int opt;
+    while ((opt = getopt_long(argc, argv, short_opts, long_opts, NULL)) != -1)
     {
-        int opt = getopt_long(argc, argv, GETOPT_STRING, long_options, NULL);
-        if (opt == -1)
-            break;
-
         switch (opt)
         {
             case 0:
             {
-                break;
+                fwprintf(stderr, _(L"getopt_long() unexpectedly returned zero\n"));
+                exit_without_destructors(127);
             }
 
             case 'c':
@@ -462,6 +451,7 @@ static int fish_parse_opt(int argc, char **argv, std::vector<std::string> *cmds)
 
             default:
             {
+                // We assume getopt_long() has already emitted a diagnostic msg.
                 exit_without_destructors(1);
             }
 

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -21,13 +21,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #include "config.h"
 
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <wchar.h>
 #include <vector>
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#endif
 #include <assert.h>
 #include <locale.h>
 #include <stddef.h>
@@ -297,40 +295,34 @@ int main(int argc, char *argv[])
         output_type_ansi,
         output_type_html
     } output_type = output_type_plain_text;
-
-    /* Whether to indent (true) or just reformat to one job per line (false) */
     bool do_indent = true;
 
-    while (1)
+    const char *short_opts = "+hvi";
+    const struct option long_opts[] =
     {
-        const struct option long_options[] =
-        {
-            { "no-indent", no_argument, 0, 'i' },
-            { "help", no_argument, 0, 'h' },
-            { "version", no_argument, 0, 'v' },
-            { "html", no_argument, 0, 1 },
-            { "ansi", no_argument, 0, 2 },
-            { 0, 0, 0, 0 }
-        };
+        { "no-indent", no_argument, NULL, 'i' },
+        { "help", no_argument, NULL, 'h' },
+        { "version", no_argument, NULL, 'v' },
+        { "html", no_argument, NULL, 1 },
+        { "ansi", no_argument, NULL, 2 },
+        { NULL, 0, NULL, 0 }
+    };
 
-        int opt_index = 0;
-        int opt = getopt_long(argc, argv, "hvi", long_options, &opt_index);
-        if (opt == -1)
-            break;
-
+    int opt;
+    while ((opt = getopt_long(argc, argv, short_opts, long_opts, NULL)) != -1)
+    {
         switch (opt)
         {
             case 0:
             {
-                break;
+                fwprintf(stderr, _(L"getopt_long() unexpectedly returned zero\n"));
+                exit_without_destructors(127);
             }
 
             case 'h':
             {
                 print_help("fish_indent", 1);
-                exit(0);
-                assert(0 && "Unreachable code reached");
-                break;
+                exit_without_destructors(0);
             }
 
             case 'v':
@@ -359,9 +351,10 @@ int main(int argc, char *argv[])
                 break;
             }
 
-            case '?':
+            default:
             {
-                exit(1);
+                // We assume getopt_long() has already emitted a diagnostic msg.
+                exit_without_destructors(1);
             }
         }
     }

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -4,7 +4,6 @@
 
 #include "config.h"
 
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <wchar.h>
@@ -24,20 +23,13 @@
 #include <sstream>
 #include <algorithm>
 #include <iterator>
-
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#endif
-
 #include <signal.h>
-
 #include <locale.h>
 #include <dirent.h>
 #include <time.h>
 
 #include "fallback.h"
 #include "util.h"
-
 #include "common.h"
 #include "proc.h"
 #include "reader.h"


### PR DESCRIPTION
There is no longer a good reason to detect whether or not getopt_long()
is available. All UNIX implementations we're likely to run on have it. And
if we ever find one that doesn't the right thing to do is not fallback to
getopt() but to include the getopt_long() source in our package like we
do with the pcre2 library. Since it's licensed under LGPL we can legally
do so if it becomes necessary.

This partially addresses issue #2790.