### PR TITLE
Handle return values from fchown

### DIFF
--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -866,9 +866,10 @@ bool env_universal_t::sync(callback_data_list_t *callbacks)
         struct stat sbuf;
         if (wstat(vars_path, &sbuf) >= 0)
         {
-            if (0 > fchown(private_fd, sbuf.st_uid, sbuf.st_gid))
+            if (fchown(private_fd, sbuf.st_uid, sbuf.st_gid) == -1)
                 UNIVERSAL_LOG("fchown() failed");
-            fchmod(private_fd, sbuf.st_mode);
+            if (fchmod(private_fd, sbuf.st_mode) == -1)
+                UNIVERSAL_LOG("fchmod() failed");
         }
 
         /* Linux by default stores the mtime with low precision, low enough that updates that occur in quick succession may

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1453,16 +1453,19 @@ bool history_t::save_internal_via_rewrite()
                 if (wstat(new_name, &sbuf) >= 0)
                 {
                    /* Success */
-                    if (0 > fchown(out_fd, sbuf.st_uid, sbuf.st_gid))
+                    if (fchown(out_fd, sbuf.st_uid, sbuf.st_gid) == -1)
                     {
-                        debug(2, L"Error when changing ownership of history file");
+                        debug(2, L"Error %d when changing ownership of history file", errno);
                     }
-                    fchmod(out_fd, sbuf.st_mode);
+                    if (fchmod(out_fd, sbuf.st_mode) == -1)
+                    {
+                        debug(2, L"Error %d when changing mode of history file", errno);
+                    }
                 }
 
-                if (0 > wrename(tmp_name, new_name))
+                if (wrename(tmp_name, new_name) == -1)
                 {
-                    debug(2, L"Error when renaming history file");
+                    debug(2, L"Error %d when renaming history file", errno);
                 }
             }
             close(out_fd);

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1453,7 +1453,10 @@ bool history_t::save_internal_via_rewrite()
                 if (wstat(new_name, &sbuf) >= 0)
                 {
                    /* Success */
-                    fchown(out_fd, sbuf.st_uid, sbuf.st_gid);
+                    if (0 > fchown(out_fd, sbuf.st_uid, sbuf.st_gid))
+                    {
+                        debug(2, L"Error when changing ownership of history file");
+                    }
                     fchmod(out_fd, sbuf.st_mode);
                 }
 


### PR DESCRIPTION
1) The function fchown is annotated with warn_unused_result.
As formerly used in the code, it would emit a compiler warning
```warning: ignoring return value of ‘fchown’, declared with attribute
warn_unused_result [-Wunused-result]```

This commit notes the return value and emits appropriate error/logging
messages if the call fails, creating more traceable results and
satisfying the compiler.

2) Cosmetic change:  remove extraneous whitespace at end-of-line in source files