### PR TITLE
parse_execution.cpp: Remove line continuations

### DIFF
--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -1367,13 +1367,11 @@ parse_execution_result_t parse_execution_context_t::run_1_job(const parse_node_t
 
     job_set_flag(j, JOB_FOREGROUND, ! tree.job_should_be_backgrounded(job_node));
 
-    job_set_flag(j, JOB_TERMINAL, job_get_flag(j, JOB_CONTROL) \
-                 && (!is_subshell && !is_event));
+    job_set_flag(j, JOB_TERMINAL,
+                 job_get_flag(j, JOB_CONTROL) && !is_subshell && !is_event);
 
-    job_set_flag(j, JOB_SKIP_NOTIFICATION, is_subshell \
-                 || is_block \
-                 || is_event \
-                 || (!get_is_interactive()));
+    job_set_flag(j, JOB_SKIP_NOTIFICATION,
+                 is_subshell || is_block || is_event || !get_is_interactive());
 
     /* Tell the current block what its job is. This has to happen before we populate it (#1394) */
     parser->current_block()->job = j;


### PR DESCRIPTION
My IDE (Kdevelop 4.7.3) didn't tackle them.