### PR TITLE
Vi-mode fixes

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -79,10 +79,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
   bind B backward-bigword
   bind ge backward-word
   bind gE backward-bigword
-  bind w forward-word
-  bind W forward-bigword
-  bind e forward-word
-  bind E forward-bigword
+  bind w forward-word forward-char
+  bind W forward-bigword forward-char
+  bind e forward-char forward-word backward-char
+  bind E forward-bigword backward-char
 
   bind x delete-char
   bind X backward-delete-char


### PR DESCRIPTION
Seems to fix `w` and `e` (with a trick to cope with big-words) to behave like in vi(m).
I may miss something obvious as this seems trivial, in case please advice on how to do better.

Other things which IMHO are missing, any feedback is welcome (shall I open an issue?):
   - undo/redo (at least minimal) features -> no idea on how to add it and if it complies with the fish philosophy, as a priori it seems to require an editing buffer
   - possibility to invoke vim or EDITOR to edit the shell command (damn useful) -> looking into it, should be doable via functions
   - in visual mode unbound keys should rather have no effect than appear as typed in the command line ->  can look into it
   - second order detail: the cursor in vim mode goes too far in the line by 1 char, which is confusing at first - not a big deal to get used to it