### PR TITLE
limit size of cd history to 25 directories

### DIFF
--- a/doc_src/cd.txt
+++ b/doc_src/cd.txt
@@ -14,7 +14,7 @@ If `DIRECTORY` is a relative path, the paths found in the `CDPATH` environment v
 
 Note that the shell will attempt to change directory without requiring `cd` if the name of a directory is provided (starting with `.`, `/` or `~`, or ending with `/`).
 
-Fish also ships a wrapper function around `cd` that understands `cd -` as changing to the previous directory. See <a href="commands.html#prevd">`prevd`</a>.
+Fish also ships a wrapper function around the builtin `cd` that understands `cd -` as changing to the previous directory. See also <a href="commands.html#prevd">`prevd`</a>. This wrapper function maintains a history of the 20 most recently visited directories in the `$dirprev` and `$dirnext` global variables.
 
 \subsection cd-example Examples
 

--- a/doc_src/dirh.txt
+++ b/doc_src/dirh.txt
@@ -10,3 +10,5 @@ dirh
 `dirh` prints the current directory history. The current position in the history is highlighted using the color defined in the `fish_color_history_current` environment variable.
 
 `dirh` does not accept any parameters.
+
+Note that the `cd` command limits directory history to the 20 most recently visited directories. The history is stored in the `$dirprev` and `$dirnext` variables.

--- a/doc_src/nextd.txt
+++ b/doc_src/nextd.txt
@@ -11,6 +11,7 @@ nextd [ -l | --list ] [POS]
 
 If the `-l` or `--list` flag is specified, the current directory history is also displayed.
 
+Note that the `cd` command limits directory history to the 20 most recently visited directories. The history is stored in the `$dirprev` and `$dirnext` variables which this command manipulates.
 
 \subsection nextd-example Example
 

--- a/doc_src/prevd.txt
+++ b/doc_src/prevd.txt
@@ -11,6 +11,7 @@ prevd [ -l | --list ] [POS]
 
 If the `-l` or `--list` flag is specified, the current history is also displayed.
 
+Note that the `cd` command limits directory history to the 20 most recently visited directories. The history is stored in the `$dirprev` and `$dirnext` variables which this command manipulates.
 
 \subsection prevd-example Example
 

--- a/share/functions/cd.fish
+++ b/share/functions/cd.fish
@@ -1,36 +1,41 @@
 #
-# The following functions add support for a directory history
+# Wrap the builtin cd command to maintain directory history.
 #
-
 function cd --description "Change directory"
+    set -l MAX_DIR_HIST 25
 
-	# Skip history in subshells
-	if status --is-command-substitution
-		builtin cd $argv
-		return $status
-	end
+    if test (count $argv) -gt 1
+        printf "%s\n" (_ "Too many args for cd command")
+        return 1
+    end
 
-	# Avoid set completions
-	set -l previous $PWD
+    # Skip history in subshells.
+    if status --is-command-substitution
+        builtin cd $argv
+        return $status
+    end
 
-	if test $argv[1] = - ^/dev/null
-		if test "$__fish_cd_direction" = next ^/dev/null
-			nextd
-		else
-			prevd
-		end
-		return $status
-	end
+    # Avoid set completions
+    set -l previous $PWD
 
-	builtin cd $argv[1]
-	set -l cd_status $status
+    if test "$argv" = "-"
+        if test "$__fish_cd_direction" = "next"
+            nextd
+        else
+            prevd
+        end
+        return $status
+    end
 
-	if test $cd_status = 0 -a "$PWD" != "$previous"
-		set -g dirprev $dirprev $previous
-		set -e dirnext
-		set -g __fish_cd_direction prev
-	end
+    builtin cd $argv
+    set -l cd_status $status
 
-	return $cd_status
+    if test $cd_status -eq 0 -a "$PWD" != "$previous"
+        set -q dirprev[$MAX_DIR_HIST]; and set -e dirprev[1]
+        set -g dirprev $dirprev $previous
+        set -e dirnext
+        set -g __fish_cd_direction prev
+    end
+
+    return $cd_status
 end
-

--- a/share/functions/cd.fish
+++ b/share/functions/cd.fish
@@ -2,7 +2,7 @@
 # Wrap the builtin cd command to maintain directory history.
 #
 function cd --description "Change directory"
-    set -l MAX_DIR_HIST 25
+    set -l MAX_DIR_HIST 20
 
     if test (count $argv) -gt 1
         printf "%s\n" (_ "Too many args for cd command")


### PR DESCRIPTION
The existing implementation grows the $dirprev array without bounds. Besides
causing what would appear to be a memory leak it also makes the nextd and
prevd commands more expensive than they need to be. It also makes it harder to
create a useful "menu" cd command.

In addition to implementing a reasonable limit on the size of the $dirprev
array I've reformatted the code using fish_indent.

Fixes 2836