### PR TITLE
Fix memory leak, error message when failing to open input file

### DIFF
--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -550,34 +550,30 @@ int main(int argc, char **argv)
             }
             reader_exit(0, 0);
         }
+        else if (my_optind == argc)
+        {
+            // Interactive mode
+            check_running_fishd();
+            res = reader_read(STDIN_FILENO, empty_ios);
+        }
         else
         {
-            if (my_optind == argc)
+            char *file = *(argv+(my_optind++));
+            int fd = open(file, O_RDONLY);
+            if (fd == -1)
             {
-                // Interactive mode
-                check_running_fishd();
-                res = reader_read(STDIN_FILENO, empty_ios);
+                perror(file);
             }
             else
             {
-                char **ptr;
-                char *file = *(argv+(my_optind++));
-                int i;
-                int fd;
-
-
-                if ((fd = open(file, O_RDONLY)) == -1)
-                {
-                    wperror(L"open");
-                    return 1;
-                }
-
                 // OK to not do this atomically since we cannot have gone multithreaded yet
                 set_cloexec(fd);
 
                 if (*(argv+my_optind))
                 {
                     wcstring sb;
+                    char **ptr;
+                    int i;
                     for (i=1,ptr = argv+my_optind; *ptr; i++, ptr++)
                     {
                         if (i != 1)


### PR DESCRIPTION
The early return skipped all cleanup.
This problem is a case for the classic "goto fail" paradigm, but this
change instead makes a few adjustments to take advantage of a previously
unused level of indentation to conditionally execute the success path.

The error message now prints the filename instead of "open",
which should be more idiomatic.

Tip:
This patch makes sense if viewed with `git show --ignore-space-change`.