### PR TITLE
Fix kInvalidFileID not matching file_id_t

### DIFF
--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -28,7 +28,7 @@
 
 typedef std::string cstring;
 
-const file_id_t kInvalidFileID = {(dev_t)-1LL, (ino_t)-1LL, (uint64_t)-1LL, -1, -1, -1, -1, (uint32_t)-1};
+const file_id_t kInvalidFileID = {(dev_t)-1LL, (ino_t)-1LL, (uint64_t)-1LL, -1, -1, -1, -1};
 
 #ifndef PATH_MAX
 #ifdef MAXPATHLEN
@@ -560,12 +560,7 @@ file_id_t file_id_t::file_id_from_stat(const struct stat *buf)
     result.change_nanoseconds = 0;
     result.mod_nanoseconds = 0;
 #endif
-
-#if defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__) ||  defined(__OpenBSD__) || defined(__NetBSD__)
-    result.generation = buf->st_gen;
-#else
-    result.generation = 0;
-#endif
+    
     return result;
 }
 
@@ -624,7 +619,6 @@ int file_id_t::compare_file_id(const file_id_t &rhs) const
     if (! ret) ret = compare(device, rhs.device);
     if (! ret) ret = compare(inode, rhs.inode);
     if (! ret) ret = compare(size, rhs.size);
-    if (! ret) ret = compare(generation, rhs.generation);
     if (! ret) ret = compare(change_seconds, rhs.change_seconds);
     if (! ret) ret = compare(change_nanoseconds, rhs.change_nanoseconds);
     if (! ret) ret = compare(mod_seconds, rhs.mod_seconds);

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -28,7 +28,7 @@
 
 typedef std::string cstring;
 
-const file_id_t kInvalidFileID = {(dev_t)-1LL, (ino_t)-1LL, (uint64_t)-1LL, -1, -1, (uint32_t)-1};
+const file_id_t kInvalidFileID = {(dev_t)-1LL, (ino_t)-1LL, (uint64_t)-1LL, -1, -1, -1, -1, (uint32_t)-1};
 
 #ifndef PATH_MAX
 #ifdef MAXPATHLEN

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -145,8 +145,7 @@ struct file_id_t
     long change_nanoseconds;
     time_t mod_seconds;
     long mod_nanoseconds;
-    uint32_t generation;
-    
+        
     bool operator==(const file_id_t &rhs) const;
     bool operator!=(const file_id_t &rhs) const;
     


### PR DESCRIPTION
In testing I noticed at runtime what appeared to be `time_t` timestamps being converted  to `uint32_t` for `kInvalidFileId`.

45dfa2d8640ab94c86ba97d5dc15db87badc67fb added `mod_seconds` and `mod_nanosecondas` to file_id_t:

```c++
 struct file_id_t
 {
      dev_t device;
      ino_t inode;
      uint64_t size;
      time_t change_seconds;
      long change_nanoseconds;
 +    time_t mod_seconds;
 +    long mod_nanoseconds;
      uint32_t generation;
]
```

But this wasn't updated:

```c++
const file_id_t kInvalidFileID = {(dev_t)-1LL, (ino_t)-1LL, (uint64_t)-1LL, -1, -1, (uint32_t)-1};
```

Where it has `(uint32_t)-1` it still assumes that is the `generation` field but that is `mod_seconds` now!

It's basically used to initialize file_id_t prior to being overwritten by `stat()` values (if all goes well).