### PR TITLE
Fix a couple of minor issues in string examples

### DIFF
--- a/doc_src/string.txt
+++ b/doc_src/string.txt
@@ -52,7 +52,7 @@ The following subcommands are available:
 
 >_ set str foo
 >_ string length -q $str; echo $status
-1
+0
 # Equivalent to test -n $str
 \endfish
 
@@ -98,7 +98,7 @@ The following subcommands are available:
 
 \fish{cli-dark}
 >_ echo \\x07 | string escape
-<bs>c</bs>g
+<bs>cg</bs>
 \endfish
 
 \subsection string-example-match-glob Match Glob Examples


### PR DESCRIPTION
Print correct return code in 2nd example
Remove syntax colouring in \cg