### PR TITLE
Select fonts actually used on terminals for the web config.

### DIFF
--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -1,6 +1,6 @@
 body {
     background-color: #292929;
-    font-family: "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-family: "Source Code Pro", Menlo, "DejaVu Sans Mono", "Ubuntu Mono", Consolas, Monaco, "Lucida Console", monospace, fixed;
     color: white;
 }
 

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -1,6 +1,6 @@
 body {
     background-color: #292929;
-    font-family: "Source Code Pro", Menlo, "DejaVu Sans Mono", "Ubuntu Mono", Consolas, Monaco, "Lucida Console", monospace, fixed;
+    font-family: "Source Code Pro", "DejaVu Sans Mono", Menlo, "Ubuntu Mono", Consolas, Monaco, "Lucida Console", monospace, fixed;
     color: white;
 }
 

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -1,6 +1,6 @@
 body {
     background-color: #292929;
-    font-family: Courier, "Courier New", monospace;
+    font-family: "Source Code Pro", Menlo, Consolas, "Bitstream Vera Sans Mono", monospace;
     color: white;
 }
 

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -1,6 +1,6 @@
 body {
     background-color: #292929;
-    font-family: "Source Code Pro", Menlo, Consolas, "Bitstream Vera Sans Mono", monospace;
+    font-family: "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace;
     color: white;
 }
 


### PR DESCRIPTION
Fixes #2924

Instead of just using Courier New across the board<sup>1</sup>, give the browser several good options for a fixed width font to use.

This is the new list of fonts to have it use. Browser will use the first one in the list they have. `monospace` is a special reserved name for a fallback, which has the browser use whatever it has hardcoded in or configured to be used for fixed width text if all else fails. This is Courier or Courier New on the majority of browsers.

1. `"Source Code Pro"` (can has Powerline)
2. `Menlo`      (OS X default)
3. `Consolas` (Windows default)
4. `"Bitstream Vera Sans Mono"`(On many Linux machines)
5. `monospace`

The ordering was made under the consideration that Source Code Pro is a nice font which is "out there" and has official Powerline support in case someone ever tries to render a powerline glyph here. We also can legally embed this font if we ever wish. Otherwise I hope to get something reasonable that is more likely than not going to be what someone's terminal would be configured with out of the box. Someone with Menlo (belongs to Apple, is the default Terminal.app font) is likely to be on OS X and want to use that before Consolas (belongs to Microsoft which is the default Win10 cmd.exe font, but also comes with Office for Mac) even if they have both. Bitstream Vera Sans Mono is going to be on a lot of Linux machines but also many OS X and Windows machines because it's been around a long while and is open source, so it goes to the end before the browser is left to its own devices. 

[1]: it's actually Courier New with a fallback of `monospace`. `monospace` is often Courier New but not everywhere.