### PR TITLE
provide a realpath implementation

### DIFF
--- a/doc_src/realpath.txt
+++ b/doc_src/realpath.txt
@@ -1,0 +1,18 @@
+\section realpath realpath - print the resolved path
+
+\subsection command-synopsis Synopsis
+\fish{synopsis}
+realpath [OPTIONS] PATH
+\endfish
+
+\subsection command-description Description
+
+`realpath` converts relative paths to absolute paths, resolves any symlinks, and prints the result. If the path is already a absolute path without symlinks then it is printed as is.
+
+This is a fish function that simply passes the arguments through to the external command if it is available. Otherwise it ignores any options and falls back to alternative implementations such as using the `readlink` command.
+
+\subsection command-example Examples
+
+`realpath ../user2/file` will write `/home/user2/file` assuming the PWD is `/home/some-dir` and neither component of that relative path are symlinks.
+
+`realpath bin/prog` will write `/usr/local/bin/prog` assuming `bin/prog` is a symlink to `/usr/local/bin/prog`.

--- a/share/functions/realpath.fish
+++ b/share/functions/realpath.fish
@@ -1,0 +1,18 @@
+# Provide a minimalist realpath implementation to help deal with platforms that may not provide it
+# as a command. If a realpath command is available simply pass all arguments thru to it. If not
+# fallback to alternative solutions.
+function realpath --description 'realpath implementation with fallbacks if command not present'
+    if type -q -P realpath
+        command realpath $argv
+    else if type -q -P readlink
+        readlink -f $argv[-1]
+    else if type -q -P python2
+        python2 -c 'import os, sys; print os.path.realpath(sys.argv[1])' $argv[-1]
+    else if type -q -P python3
+        python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' $argv[-1]
+    else
+        echo 'error: cannot find a way to implement realpath' >&2
+        echo $argv[-1]
+        exit 1
+    end
+end


### PR DESCRIPTION
Not all distros have a `realpath` command. Provide a function that uses the
real command if available else try fallback solutions.

Fixes #2932