### PR TITLE
Rework bind mode switching

### DIFF
--- a/doc_src/fish_vi_mode.txt
+++ b/doc_src/fish_vi_mode.txt
@@ -7,4 +7,6 @@ fish_vi_mode
 
 \subsection fish_vi_mode-description Description
 
+This function is deprecated. Please call `fish_vi_key_bindings directly`
+
 `fish_vi_mode` enters a vi-like command editing mode. To always start in vi mode, add `fish_vi_mode` to your `config.fish` file.

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -1,6 +1,6 @@
 
-function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fish" -a mode
-	if not set -q mode[1]
+function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fish"
+	if not set -q argv[1]
 		if test "$fish_key_bindings" != "fish_default_key_bindings"
 			set -g fish_key_bindings fish_default_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
 			return

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -2,7 +2,7 @@
 function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fish" -a mode
 	if not set -q mode[1]
 		if test "$fish_key_bindings" != "fish_default_key_bindings"
-			set fish_key_bindings fish_default_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+			set -g fish_key_bindings fish_default_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
 			return
 		end
 		# Clear earlier bindings, if any

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -1,6 +1,10 @@
 
 function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fish" -a mode
 	if not set -q mode[1]
+		if test "$fish_key_bindings" != "fish_default_key_bindings"
+			set fish_key_bindings fish_default_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+			return
+		end
 		# Clear earlier bindings, if any
 		bind --erase --all
 	end

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -2,7 +2,9 @@
 function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fish"
 	if not set -q argv[1]
 		if test "$fish_key_bindings" != "fish_default_key_bindings"
-			set -g fish_key_bindings fish_default_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+			# Allow the user to set the variable universally
+			set -q fish_key_bindings; or set -g fish_key_bindings
+			set fish_key_bindings fish_default_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
 			return
 		end
 		# Clear earlier bindings, if any

--- a/share/functions/fish_mode_prompt.fish
+++ b/share/functions/fish_mode_prompt.fish
@@ -1,7 +1,7 @@
 # The fish_mode_prompt function is prepended to the prompt
 function fish_mode_prompt --description "Displays the current mode"
   # Do nothing if not in vi mode
-  if set -q __fish_vi_mode
+  if test "$fish_key_bindings" = "fish_vi_key_bindings"
     switch $fish_bind_mode
       case default
         set_color --bold --background red white

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -1,4 +1,8 @@
 function fish_vi_key_bindings --description 'vi-like key bindings for fish'
+	if test "$fish_key_bindings" != "fish_vi_key_bindings"
+		set fish_key_bindings fish_vi_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+		return
+	end
     # The default escape timeout is 300ms. But for users of Vi bindings that can
     # be slightly annoying when trying to switch to Vi "normal" mode. Too,
     # vi-mode users are unlikely to use escape-as-meta. So set a much shorter

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -1,6 +1,8 @@
 function fish_vi_key_bindings --description 'vi-like key bindings for fish'
 	if test "$fish_key_bindings" != "fish_vi_key_bindings"
-		set -g fish_key_bindings fish_vi_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+		# Allow the user to set the variable universally
+		set -q fish_key_bindings; or set -g fish_key_bindings
+		set fish_key_bindings fish_vi_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
 		return
 	end
     # The default escape timeout is 300ms. But for users of Vi bindings that can

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -1,6 +1,6 @@
 function fish_vi_key_bindings --description 'vi-like key bindings for fish'
 	if test "$fish_key_bindings" != "fish_vi_key_bindings"
-		set fish_key_bindings fish_vi_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+		set -g fish_key_bindings fish_vi_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
 		return
 	end
     # The default escape timeout is 300ms. But for users of Vi bindings that can

--- a/share/functions/fish_vi_mode.fish
+++ b/share/functions/fish_vi_mode.fish
@@ -1,8 +1,4 @@
 function fish_vi_mode
-  # Set the __fish_vi_mode variable
-  # This triggers fish_mode_prompt to output the mode indicator
-  set -g __fish_vi_mode 1
-  
   # Turn on vi keybindings
   set -g fish_key_bindings fish_vi_key_bindings
 end

--- a/share/functions/fish_vi_mode.fish
+++ b/share/functions/fish_vi_mode.fish
@@ -1,4 +1,5 @@
 function fish_vi_mode
-  # Turn on vi keybindings
-  set -g fish_key_bindings fish_vi_key_bindings
+	echo "This function is deprecated. Please call fish_vi_key_bindings directly" >&2
+	# Turn on vi keybindings
+	set -g fish_key_bindings fish_vi_key_bindings
 end

--- a/tests/interactive.expect.rc
+++ b/tests/interactive.expect.rc
@@ -51,7 +51,7 @@ set prompt_counter 1
 proc expect_prompt {args} {
     global prompt_counter
     upvar expect_out expect_out
-    set prompt_pat [list -re "(?:\\r\\n?|^)prompt $prompt_counter>(?:$|\\r)"]
+    set prompt_pat [list -re "(?:\\r\\n?|^)(?:\\\[.\\\] )?prompt $prompt_counter>(?:$|\\r)"]
     if {[llength $args] == 1 && [string match "\n*" $args]} {
         set args [join $args]
     }


### PR DESCRIPTION
Fixes #2918.

The main idea here is to simplify switching by making one variable - `$fish_key_bindings` - the one to check.

This means that now `set -g fish_key_bindings fish_vi_key_bindings` and `fish_vi_key_bindings` are equivalent (in fact the latter just executes the former) and `fish_vi_mode` is deprecated, which means just setting the bindings to default will also deactivate the mode indicator.

This removes $__fish_vi_mode, which was previously used by `fish_mode_prompt` to decide when to print a mode. This results in the mode indicator being printed where it previously wasn't, though I feel for vi-mode a mode indicator is a really useful thing that most users would welcome. We might want to alter the documentation to mention altering this function to e.g. disable it.

@krader1961: Does this look okay to you?