### PR TITLE
Enable 24bit/truecolor mode earlier

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -27,7 +27,8 @@ if status --is-interactive
 			or test "$VTE_VERSION" -ge 3600 # Should be all gtk3-vte-based terms after version 3.6.0.0
 			or test "$COLORTERM" = truecolor -o "$COLORTERM" = 24bit # slang expects this
 		end
-		set -g fish_term24bit 1
+		# Only set it if it isn't to allow override by setting to 0
+		set -q fish_term24bit; or set -g fish_term24bit 1
 	end
 else
 	# Hook up the default as the principal command_not_found handler

--- a/share/config.fish
+++ b/share/config.fish
@@ -17,12 +17,24 @@ function __fish_default_command_not_found_handler
 	echo "fish: Unknown command '$argv'" >&2
 end
 
-#
-# Hook up the default as the principal command_not_found handler
-# in case we are not interactive
-#
-status -i; or function __fish_command_not_found_handler --on-event fish_command_not_found
-	__fish_default_command_not_found_handler $argv
+if status --is-interactive
+	# Enable truecolor/24-bit support for select terminals
+	if not set -q NVIM_LISTEN_ADDRESS # Neovim will swallow the 24bit sequences, rendering text white
+		and begin
+			set -q KONSOLE_PROFILE_NAME # KDE's konsole
+			or string match -q -- "*:*" $ITERM_SESSION_ID # Supporting versions of iTerm2 will include a colon here
+			or string match -q -- "st-*" $TERM # suckless' st
+			or test "$VTE_VERSION" -ge 3600 # Should be all gtk3-vte-based terms after version 3.6.0.0
+			or test "$COLORTERM" = truecolor -o "$COLORTERM" = 24bit # slang expects this
+		end
+		set -g fish_term24bit 1
+	end
+else
+	# Hook up the default as the principal command_not_found handler
+	# in case we are not interactive
+	function __fish_command_not_found_handler --on-event fish_command_not_found
+		__fish_default_command_not_found_handler $argv
+	end
 end
 
 #

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -287,15 +287,4 @@ function __fish_config_interactive -d "Initializations that should be performed 
 			fish_fallback_prompt
 		end
 	end
-
-	if not set -q NVIM_LISTEN_ADDRESS # Neovim will swallow the 24bit sequences, rendering text white
-		and begin
-			set -q KONSOLE_PROFILE_NAME # KDE's konsole
-			or string match -q -- "*:*" $ITERM_SESSION_ID # Supporting versions of iTerm2 will include a colon here
-			or string match -q -- "st-*" $TERM # suckless' st
-			or test "$VTE_VERSION" -ge 3600 # Should be all gtk3-vte-based terms after version 3.6.0.0
-			or test "$COLORTERM" = truecolor -o "$COLORTERM" = 24bit # slang expects this
-		end
-		set -g fish_term24bit 1
-	end
 end


### PR DESCRIPTION
This should fix #2941, in which the prompt is redisplayed because fish_term24bit is reset.

The second commit is nice-to-have, as it enables users disabling truecolor e.g. via their terms configuration. This would have been more important without the first (as we'd overwrite any fish_term24bit = 0 setting from config.fish, which we now don't anymore).