### PR TITLE
switch to newer flag --set-upstream-to for git

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -286,7 +286,7 @@ complete -f -c git -n '__fish_git_using_command branch' -s M -d 'Force renaming 
 complete -f -c git -n '__fish_git_using_command branch' -s a -d 'Lists both local and remote branches'
 complete -f -c git -n '__fish_git_using_command branch' -s t -l track -d 'Track remote branch'
 complete -f -c git -n '__fish_git_using_command branch' -l no-track -d 'Do not track remote branch'
-complete -f -c git -n '__fish_git_using_command branch' -l set-upstream -d 'Set remote branch to track'
+complete -f -c git -n '__fish_git_using_command branch' -l set-upstream-to -d 'Set remote branch to track'
 complete -f -c git -n '__fish_git_using_command branch' -l merged -d 'List branches that have been merged'
 complete -f -c git -n '__fish_git_using_command branch' -l no-merged -d 'List branches that have not been merged'
 
@@ -410,7 +410,7 @@ complete -f -c git -n '__fish_git_using_command push' -l tags -d 'Push all refs 
 complete -f -c git -n '__fish_git_using_command push' -s n -l dry-run -d 'Do everything except actually send the updates'
 complete -f -c git -n '__fish_git_using_command push' -l porcelain -d 'Produce machine-readable output'
 complete -f -c git -n '__fish_git_using_command push' -s f -l force -d 'Force update of remote refs'
-complete -f -c git -n '__fish_git_using_command push' -s u -l set-upstream -d 'Add upstream (tracking) reference'
+complete -f -c git -n '__fish_git_using_command push' -s u -l set-upstream-to -d 'Add upstream (tracking) reference'
 complete -f -c git -n '__fish_git_using_command push' -s q -l quiet -d 'Be quiet'
 complete -f -c git -n '__fish_git_using_command push' -s v -l verbose -d 'Be verbose'
 complete -f -c git -n '__fish_git_using_command push' -l progress -d 'Force progress status'


### PR DESCRIPTION
This was a patch from awal from IRC

set-upstream was deprecated in git 1.8.0 as stated in [1] in favor
of set-upstream-to. this patch replaces the old flag in fish
completions

[1]: https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/1.8.0.txt