### PR TITLE
Add missing color definitions to __fish_init_1_50_0 reset.

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -900,6 +900,10 @@ The following variables are available to change the highlighting colors in fish:
 
 - `fish_color_autosuggestion`, the color used for autosuggestions
 
+- `fish_color_user`, the color used to print the current username in some of fish default prompts
+
+- `fish_color_host`, the color used to print the current host system in some of fish default prompts
+
 Additionally, the following variables are available to change the highlighting in the completion pager:
 
 - `fish_pager_color_prefix`, the color of the prefix string, i.e. the string that is to be completed

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -46,8 +46,12 @@ function __fish_config_interactive -d "Initializations that should be performed 
 		set -q fish_color_error; or set -U fish_color_error red --bold
 		set -q fish_color_escape; or set -U fish_color_escape cyan
 		set -q fish_color_operator; or set -U fish_color_operator cyan
+		set -q fish_color_end; or set -U fish_color_end green
 		set -q fish_color_quote; or set -U fish_color_quote brown
 		set -q fish_color_autosuggestion; or set -U fish_color_autosuggestion 555 yellow
+		set -q fish_color_user; or set -U fish_color_user green
+
+		set -q fish_color_host; or set -U fish_color_host normal
 		set -q fish_color_valid_path; or set -U fish_color_valid_path --underline
 
 		set -q fish_color_cwd; or set -U fish_color_cwd green


### PR DESCRIPTION
The values where determined by inspecting the values of:

* `fish_color_end`
* `fish_color_user`
* `fish_color_host`

after resetting the color theme via fish_config.