### PR TITLE
Add tags to completion list for git show.

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -245,6 +245,7 @@ complete -f -c git -n "__fish_git_using_command remote; and __fish_seen_subcomma
 complete -f -c git -n '__fish_git_needs_command' -a show -d 'Shows the last commit of a branch'
 complete -f -c git -n '__fish_git_using_command show' -a '(__fish_git_branches)' -d 'Branch'
 complete -f -c git -n '__fish_git_using_command show' -a '(__fish_git_unique_remote_branches)' -d 'Remote branch'
+complete -f -c git -n '__fish_git_using_command show' -a '(__fish_git_tags)' --description 'Tag'
 complete -f -c git -n '__fish_git_using_command show' -a '(__fish_git_commits)'
 # TODO options
 


### PR DESCRIPTION
Pretty much what the title says, adds git tags completions to the `git show` command.

Here's a preview of what it looks like:
![screen shot 2016-05-06 at 2 55 05 pm](https://cloud.githubusercontent.com/assets/1955273/15087083/9224a4aa-139a-11e6-8a40-82a5a1f860e8.png)
