### PR TITLE
Changed the code to add fish to /etc/shells in the docs FAQ

### DIFF
--- a/doc_src/faq.hdr
+++ b/doc_src/faq.hdr
@@ -136,10 +136,10 @@ The `open` command uses the MIME type database and the `.desktop` files used by 
 <hr>
 \section faq-default How do I make fish my default shell?
 
-If you installed fish manually (e.g. by compiling it, not by using a package manager), you first need to add fish to the list of shells by executing the following command (assuming you installed fish in /usr/local) as root:
+If you installed fish manually (e.g. by compiling it, not by using a package manager), you first need to add fish to the list of shells by executing the following command (assuming you installed fish in /usr/local):
 
 \fish{cli-dark}
-echo /usr/local/bin/fish >>/etc/shells
+echo /usr/local/bin/fish | sudo tee -a /etc/shells
 \endfish
 
 If you installed a prepackaged version of fish, the package manager should have already done this for you.


### PR DESCRIPTION
This is a small fix in the FAQ. The reason of the change is that the original 

```
echo /usr/local/bin/fish >> /etc/shells
```

doesn't work on a "rootless" OS X El Capitan. The other variant does.
The first day I installed fish, I was reading documentation and got confused with this instruction. Later I found out the other way in the Readme or somewhere else.