### PR TITLE
Add git commit --fixup completions

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -335,6 +335,8 @@ complete -f -c git -n '__fish_git_using_command clone' -l recursive -d 'Initiali
 complete -c git -n '__fish_git_needs_command'    -a commit -d 'Record changes to the repository'
 complete -c git -n '__fish_git_using_command commit' -l amend -d 'Amend the log message of the last commit'
 complete -f -c git -n '__fish_git_using_command commit' -a '(__fish_git_modified_files)'
+complete -f -c git -n '__fish_git_using_command commit' -l fixup -d 'Fixup commit to be used with rebase --autosquash'
+complete -f -c git -n '__fish_git_using_command commit; and __fish_contains_opt fixup' -a '(__fish_git_commits)'
 # TODO options
 
 ### diff


### PR DESCRIPTION
This adds completions to be used with the fixup option for git commit.

![2016-05-11-080450_998x598_scrot](https://cloud.githubusercontent.com/assets/280235/15171469/15ba85d4-174f-11e6-8cef-eee723c2fa33.png)

![2016-05-11-080354_998x598_scrot](https://cloud.githubusercontent.com/assets/280235/15171447/efdffdf8-174e-11e6-9b93-656d0f06de9c.png)
