### PR TITLE
Rewritten __fish_complete_proc.fish for better process completion

### DIFF
--- a/share/completions/killall.fish
+++ b/share/completions/killall.fish
@@ -22,10 +22,10 @@ if test (uname) != 'SunOS'
 		end
 	end
 
-    if test $USER = root
+    if test "$USER" = root
         complete -c killall -xa '(__fish_complete_proc)'
     else
-       complete -c killall -xa "(ps ua | awk '{print \$11}' | sed '1d;s/.*\///;/^(/d')"
+       complete -c killall -xa "(ps u | awk '{print \$11}' | sed '1d;s/.*\///;/^(/d')"
     end
 
 	if killall --version > /dev/null ^ /dev/null

--- a/share/completions/killall.fish
+++ b/share/completions/killall.fish
@@ -22,7 +22,11 @@ if test (uname) != 'SunOS'
 		end
 	end
 
-	complete -c killall -xa '(__fish_complete_proc)'
+    if test $USER = root
+        complete -c killall -xa '(__fish_complete_proc)'
+    else
+       complete -c killall -xa "(ps ua | awk '{print \$11}' | sed '1d;s/.*\///;/^(/d')"
+    end
 
 	if killall --version > /dev/null ^ /dev/null
 		complete -c killall -s e -l exact -d 'Require an exact match for very long names'

--- a/share/functions/__fish_complete_proc.fish
+++ b/share/functions/__fish_complete_proc.fish
@@ -17,16 +17,21 @@ function __fish_complete_proc --description 'Complete by list of running process
 		set sed_cmds $sed_cmds 's/ .*//'
 		
 		# Erases weird stuff Linux gives like kworker/0:0
-		set sed_cmds $sed_cmds 's|/[0-9]:[0-9]]$||g'
+		set sed_cmds $sed_cmds '/.:./d'
 		
 		# Retain the last path component only
-		set sed_cmds $sed_cmds 's|.*/||g'
+		set sed_cmds $sed_cmds 's/.*\///'
 		
-		# Strip off square brackets. Cute, huh?
-		set sed_cmds $sed_cmds 's/[][]//g'
+		# Strip off  brackets. Cute, huh?
+		set sed_cmds $sed_cmds '/^\[/d'
+        set sed_cmds $sed_cmds '/\]$/d'
+        set sed_cmds $sed_cmds '/^(/d'
 		
 		# Erase things that are just numbers
 		set sed_cmds $sed_cmds 's/^[0-9]*$//'
+
+        # Remove : from end of process
+        set sed_cmds $sed_cmds 's/:$//'
 	else
 		# OS X, BSD. Preserve leading spaces.
 		set ps_cmd 'ps axc -o comm'

--- a/share/functions/__fish_complete_proc.fish
+++ b/share/functions/__fish_complete_proc.fish
@@ -24,14 +24,14 @@ function __fish_complete_proc --description 'Complete by list of running process
 		
 		# Strip off  brackets. Cute, huh?
 		set sed_cmds $sed_cmds '/^\[/d'
-        set sed_cmds $sed_cmds '/\]$/d'
-        set sed_cmds $sed_cmds '/^(/d'
+		set sed_cmds $sed_cmds '/\]$/d'
+		set sed_cmds $sed_cmds '/^(/d'
 		
 		# Erase things that are just numbers
 		set sed_cmds $sed_cmds 's/^[0-9]*$//'
 
-        # Remove : from end of process
-        set sed_cmds $sed_cmds 's/:$//'
+		# Remove : from end of process
+		set sed_cmds $sed_cmds 's/:$//'
 	else
 		# OS X, BSD. Preserve leading spaces.
 		set ps_cmd 'ps axc -o comm'

--- a/share/functions/__fish_complete_proc.fish
+++ b/share/functions/__fish_complete_proc.fish
@@ -1,47 +1,19 @@
 function __fish_complete_proc --description 'Complete by list of running processes'
-	# Our function runs ps, followed by a massive list of commands passed to sed
-	set -l ps_cmd
-	set -l sed_cmds
-	if test (uname) = Linux
-		# comm and ucomm return a truncated name, so parse it from the command line field,
-		# which means we have to trim off the arguments.
-		# Unfortunately, it doesn't seem to escape spaces - so we can't distinguish
-		# between the command name, and the first argument. Still, processes with spaces
-		# in the name seem more common on OS X than on Linux, so prefer to parse out the
-		# command line rather than using the stat data.
-		# If the command line is unavailable, you get the stat data in brackets - so
-		# parse out brackets too.
-		set ps_cmd 'ps -A -o command'
-		
-		# Erase everything after the first space
-		set sed_cmds $sed_cmds 's/ .*//'
-		
-		# Erases weird stuff Linux gives like kworker/0:0
-		set sed_cmds $sed_cmds 's|/[0-9]:[0-9]]$||g'
-		
-		# Retain the last path component only
-		set sed_cmds $sed_cmds 's|.*/||g'
-		
-		# Strip off square brackets. Cute, huh?
-		set sed_cmds $sed_cmds 's/[][]//g'
-		
-		# Erase things that are just numbers
-		set sed_cmds $sed_cmds 's/^[0-9]*$//'
-	else
-		# OS X, BSD. Preserve leading spaces.
-		set ps_cmd 'ps axc -o comm'
-		
-		# Delete parenthesized (zombie) processes
-		set sed_cmds $sed_cmds '/(.*)/d'	
-	end
-	
-	# Append sed command to delete first line (the header)
-	set sed_cmds $sed_cmds '1d'
-	
-	# Append sed commands to delete leading dashes and trailing spaces
-	# In principle, commands may have trailing spaces, but ps emits space padding on OS X
-	set sed_cmds $sed_cmds 's/^-//' 's/ *$//'
-	
-	# Run ps, pipe it through our massive set of sed commands, then sort and unique
-	eval $ps_cmd | sed '-e '$sed_cmds | sort -u
+    set -l ps_cmd
+    set -l sed_cmds
+    if test (uname) = Linux    
+        # Displays processes
+        set ps_cmd 'ps eu'
+        # Prints the program name
+        set awk_cmds $awk_cmds '{print $11}'
+        # Removes everything up to the last / and deletes first line
+        set sed_cmds $sed_cmds 's/.*\///;1d'
+        eval $ps_cmd | awk $awk_cmds | sed $sed_cmds | sort -u
+    else
+        # OS X, BSD. Preserve leading spaces.
+        set ps_cmd 'ps axc -o comm'
+        # Delete parenthesized (zombie) processes
+        set sed_cmds $sed_cmds '/(.*)/d'    
+        eval $ps_cmd | sed $sed_cmds | sort -u
+    end
 end

--- a/share/functions/__fish_complete_proc.fish
+++ b/share/functions/__fish_complete_proc.fish
@@ -1,19 +1,47 @@
 function __fish_complete_proc --description 'Complete by list of running processes'
-    set -l ps_cmd
-    set -l sed_cmds
-    if test (uname) = Linux    
-        # Displays processes
-        set ps_cmd 'ps eu'
-        # Prints the program name
-        set awk_cmds $awk_cmds '{print $11}'
-        # Removes everything up to the last / and deletes first line
-        set sed_cmds $sed_cmds 's/.*\///;1d'
-        eval $ps_cmd | awk $awk_cmds | sed $sed_cmds | sort -u
-    else
-        # OS X, BSD. Preserve leading spaces.
-        set ps_cmd 'ps axc -o comm'
-        # Delete parenthesized (zombie) processes
-        set sed_cmds $sed_cmds '/(.*)/d'    
-        eval $ps_cmd | sed $sed_cmds | sort -u
-    end
+	# Our function runs ps, followed by a massive list of commands passed to sed
+	set -l ps_cmd
+	set -l sed_cmds
+	if test (uname) = Linux
+		# comm and ucomm return a truncated name, so parse it from the command line field,
+		# which means we have to trim off the arguments.
+		# Unfortunately, it doesn't seem to escape spaces - so we can't distinguish
+		# between the command name, and the first argument. Still, processes with spaces
+		# in the name seem more common on OS X than on Linux, so prefer to parse out the
+		# command line rather than using the stat data.
+		# If the command line is unavailable, you get the stat data in brackets - so
+		# parse out brackets too.
+		set ps_cmd 'ps -A -o command'
+		
+		# Erase everything after the first space
+		set sed_cmds $sed_cmds 's/ .*//'
+		
+		# Erases weird stuff Linux gives like kworker/0:0
+		set sed_cmds $sed_cmds 's|/[0-9]:[0-9]]$||g'
+		
+		# Retain the last path component only
+		set sed_cmds $sed_cmds 's|.*/||g'
+		
+		# Strip off square brackets. Cute, huh?
+		set sed_cmds $sed_cmds 's/[][]//g'
+		
+		# Erase things that are just numbers
+		set sed_cmds $sed_cmds 's/^[0-9]*$//'
+	else
+		# OS X, BSD. Preserve leading spaces.
+		set ps_cmd 'ps axc -o comm'
+		
+		# Delete parenthesized (zombie) processes
+		set sed_cmds $sed_cmds '/(.*)/d'	
+	end
+	
+	# Append sed command to delete first line (the header)
+	set sed_cmds $sed_cmds '1d'
+	
+	# Append sed commands to delete leading dashes and trailing spaces
+	# In principle, commands may have trailing spaces, but ps emits space padding on OS X
+	set sed_cmds $sed_cmds 's/^-//' 's/ *$//'
+	
+	# Run ps, pipe it through our massive set of sed commands, then sort and unique
+	eval $ps_cmd | sed '-e '$sed_cmds | sort -u
 end


### PR DESCRIPTION
When I used completions on killall, I noticed that it was displaying kernel Kworker processes and processes that didn't exist, so I decided to fix that.

Before:
![screenshot from 2016-05-11 08-57-09](https://cloud.githubusercontent.com/assets/8982584/15172455/71442e62-1756-11e6-8dfa-fe12786e268d.png)
After:
![screenshot from 2016-05-11 08-56-14](https://cloud.githubusercontent.com/assets/8982584/15172460/79f26cf4-1756-11e6-8cc8-292059aa45b7.png)



