### PR TITLE
Make it possible for fish_indent to read and write files.

### DIFF
--- a/doc_src/fish_indent.txt
+++ b/doc_src/fish_indent.txt
@@ -7,11 +7,15 @@ fish_indent [OPTIONS]
 
 \subsection fish_indent-description Description
 
-`fish_indent` is used to indent a piece of fish code. `fish_indent` reads commands from standard input and outputs them to standard output.
+`fish_indent` is used to indent a piece of fish code. `fish_indent` reads commands from standard input and outputs them to standard output or a specified file.
 
 The following options are available:
 
 - `-d` or `--dump` dumps information about the parsed fish commands to stderr
+
+- `-w` or `--write` indents a specified file and immediatly writes to that file
+
+- `-W` or `--write-to` does the same as `-w` or `--write`, however, it requires an argument what file to write to
 
 - `-i` or `--no-indent` do not indent commands; only reformat to one job per line
 

--- a/doc_src/fish_indent.txt
+++ b/doc_src/fish_indent.txt
@@ -13,7 +13,7 @@ The following options are available:
 
 - `-d` or `--dump` dumps information about the parsed fish commands to stderr
 
-- `-w` or `--write` indents a specified file and immediatly writes to that file
+- `-w` or `--write` indents a specified file and immediately writes to that file
 
 - `-W` or `--write-to` does the same as `-w` or `--write`, however, it requires an argument what file to write to
 

--- a/doc_src/fish_indent.txt
+++ b/doc_src/fish_indent.txt
@@ -15,8 +15,6 @@ The following options are available:
 
 - `-w` or `--write` indents a specified file and immediately writes to that file
 
-- `-W` or `--write-to` does the same as `-w` or `--write`, however, it requires an argument what file to write to
-
 - `-i` or `--no-indent` do not indent commands; only reformat to one job per line
 
 - `-v` or `--version` displays the current fish version and then exits

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -27,7 +27,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <memory>
 #include <string>
 #include <vector>
-#include <poll.h>
 
 #include "color.h"
 #include "common.h"

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <memory>
 #include <string>
 #include <vector>
+#include <poll.h>
 
 #include "color.h"
 #include "common.h"
@@ -342,11 +343,12 @@ int main(int argc, char *argv[]) {
     } output_type = output_type_plain_text;
     bool do_indent = true;
 
-    const char *short_opts = "+dhvi";
+    const char *short_opts = "+dhvwi";
     const struct option long_opts[] = {{"dump", no_argument, NULL, 'd'},
                                        {"no-indent", no_argument, NULL, 'i'},
                                        {"help", no_argument, NULL, 'h'},
                                        {"version", no_argument, NULL, 'v'},
+                                       {"write", no_argument, NULL, 'w'},
                                        {"html", no_argument, NULL, 1},
                                        {"ansi", no_argument, NULL, 2},
                                        {NULL, 0, NULL, 0}};
@@ -372,6 +374,10 @@ int main(int argc, char *argv[]) {
                 assert(0 && "Unreachable code reached");
                 break;
             }
+            case 'w': {
+                // write to argv or specified file here
+                break;
+            }
             case 'i': {
                 do_indent = false;
                 break;
@@ -391,7 +397,17 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    const wcstring src = read_file(stdin);
+    wcstring src;
+    struct pollfd fds;
+    int ret;
+    fds.fd = 0;
+    fds.events = POLLIN;
+    ret = poll(&fds, 1, 0);
+    if (ret == 0)
+        src = read_file(argv);
+    else
+        src = read_file(stdin);
+
     const wcstring output_wtext = prettify(src, do_indent);
 
     // Maybe colorize.

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -344,12 +344,13 @@ int main(int argc, char *argv[]) {
     const char* output_location;
     bool do_indent = true;
 
-    const char *short_opts = "+dhvw:i";
+    const char *short_opts = "+dhvwW:i";
     const struct option long_opts[] = {{"dump", no_argument, NULL, 'd'},
                                        {"no-indent", no_argument, NULL, 'i'},
                                        {"help", no_argument, NULL, 'h'},
                                        {"version", no_argument, NULL, 'v'},
-                                       {"write", required_argument, NULL, 'w'},
+                                       {"write", no_argument, NULL, 'w'},
+                                       {"write-to", required_argument, NULL, 'W'},
                                        {"html", no_argument, NULL, 1},
                                        {"ansi", no_argument, NULL, 2},
                                        {NULL, 0, NULL, 0}};
@@ -376,6 +377,10 @@ int main(int argc, char *argv[]) {
                 break;
             }
             case 'w': {
+                output_type = output_type_file;
+                break;
+            }
+            case 'W': {
                 output_type = output_type_file;
                 output_location = optarg;
                 break;
@@ -410,6 +415,9 @@ int main(int argc, char *argv[]) {
         if (fh) {
             src = read_file(fh);
             fclose(fh);
+            if (output_location) {
+                output_location = *argv;
+            }
         } else {
             fwprintf(stderr, _(L"File could not be opened\n"), *argv);
             exit(1);
@@ -437,7 +445,7 @@ int main(int argc, char *argv[]) {
         case output_type_file: {
             FILE *fh = fopen(output_location, "w");
             if (fh) {
-                fputs(output_wtext, fh);
+                fputs(wcs2str(output_wtext), fh);
                 fclose(fh);
                 exit(0);
             } else {

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -344,13 +344,12 @@ int main(int argc, char *argv[]) {
     const char* output_location;
     bool do_indent = true;
 
-    const char *short_opts = "+dhvwW:i";
+    const char *short_opts = "+dhvwi";
     const struct option long_opts[] = {{"dump", no_argument, NULL, 'd'},
                                        {"no-indent", no_argument, NULL, 'i'},
                                        {"help", no_argument, NULL, 'h'},
                                        {"version", no_argument, NULL, 'v'},
                                        {"write", no_argument, NULL, 'w'},
-                                       {"write-to", required_argument, NULL, 'W'},
                                        {"html", no_argument, NULL, 1},
                                        {"ansi", no_argument, NULL, 2},
                                        {NULL, 0, NULL, 0}};
@@ -378,11 +377,6 @@ int main(int argc, char *argv[]) {
             }
             case 'w': {
                 output_type = output_type_file;
-                break;
-            }
-            case 'W': {
-                output_type = output_type_file;
-                output_location = optarg;
                 break;
             }
             case 'i': {
@@ -415,9 +409,7 @@ int main(int argc, char *argv[]) {
         if (fh) {
             src = read_file(fh);
             fclose(fh);
-            if (output_location) {
-                output_location = *argv;
-            }
+            output_location = *argv;
         } else {
             fwprintf(stderr, _(L"%s\n"), strerror(errno));
             exit(1);

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -419,7 +419,7 @@ int main(int argc, char *argv[]) {
                 output_location = *argv;
             }
         } else {
-            fwprintf(stderr, _(L"File could not be opened\n"), *argv);
+            fwprintf(stderr, _(L"%s\n"), strerror(errno));
             exit(1);
         }
     } else {
@@ -449,7 +449,7 @@ int main(int argc, char *argv[]) {
                 fclose(fh);
                 exit(0);
             } else {
-                fwprintf(stderr, _(L"Could not write output\n"));
+                fwprintf(stderr, _(L"%s\n"), strerror(errno));
                 exit(1);
             }
             break;


### PR DESCRIPTION
See https://github.com/fish-shell/fish-shell/issues/3037

@krader1961 suggested to also create a ".bak" or ".orig", however I pretty much created this to as similar as possible to gofmt, which is often used in edit scripts that for example make it execute on save, having fish_indent create a backup-file in cases like that would be kinda cumbersome, also commands like `>`, `sed -i`, etc., also do not create a backup file. However let me know if there is a strong need for a backup file, and I'll try to make it write a backup by default and some flag that disables it.