### PR TITLE
Test for Atom Package Manager now passes correctly

### DIFF
--- a/share/completions/apm.fish
+++ b/share/completions/apm.fish
@@ -69,7 +69,7 @@ function __fish_apm_list_packages
     apm list -b
 end
 
-if apm -h ^| string match -q "Atom Package Manager*"
+if apm -h ^| string match -q "*Atom Package Manager*"
     # Completions for Atom Package Manager
 
     ##################


### PR DESCRIPTION
Move to `string match` syntax from `grep` caused test to see if the Atom Package Manager is installed to always fail. This appears to fix the issue (tested on fish 2.3.0 with apm 1.6.0).