### PR TITLE
Death of clipboard

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -1062,9 +1062,6 @@ Command mode is also known as normal mode.
 
 `fish` uses an Emacs style kill ring for copy and paste functionality. Use @key{Control,K} to cut from the current cursor position to the end of the line. The string that is cut (a.k.a. killed) is inserted into a linked list of kills, called the kill ring. To paste the latest value from the kill ring use @key{Control,Y}. After pasting, use @key{Alt,Y} to rotate to the previous kill.
 
-If the environment variable `DISPLAY` is set and the `xsel` program is installed, `fish` will try to connect to the X Windows server specified by this variable, and use the clipboard on the X server for copying and pasting.
-
-
 \subsection history-search Searchable history
 
 After a command has been entered, it is inserted at the end of a history list. Any duplicate history items are automatically removed. By pressing the up and down keys, the user can search forwards and backwards in the history. If the current command line is not empty when starting a history search, only the commands containing the string entered into the command line are shown.

--- a/share/functions/fish_clipboard_copy.fish
+++ b/share/functions/fish_clipboard_copy.fish
@@ -1,0 +1,7 @@
+function fish_clipboard_copy
+	if type -q pbcopy
+        commandline | pbcopy
+    else if type -q xsel
+        commandline | xsel --clipboard
+    end
+end

--- a/share/functions/fish_clipboard_paste.fish
+++ b/share/functions/fish_clipboard_paste.fish
@@ -1,0 +1,7 @@
+function fish_clipboard_paste
+	if type -q pbpaste
+        commandline -i (pbpaste)
+    else if type -q xsel
+        commandline -i (xsel --clipboard)
+    end
+end

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -18,7 +18,8 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 	bind $argv \r execute
 
 	bind $argv \ck kill-line
-	bind $argv \cy yank
+    bind $argv \cy fish_clipboard_copy
+    bind $argv \cv fish_clipboard_paste
 	bind $argv \t complete
 
 	bind $argv \e\n "commandline -i \n"

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -1,158 +1,159 @@
 
 function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fish"
-	if not set -q argv[1]
-		if test "$fish_key_bindings" != "fish_default_key_bindings"
-			# Allow the user to set the variable universally
-			set -q fish_key_bindings; or set -g fish_key_bindings
-			set fish_key_bindings fish_default_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
-			return
-		end
-		# Clear earlier bindings, if any
-		bind --erase --all
-	end
+    if not set -q argv[1]
+        if test "$fish_key_bindings" != "fish_default_key_bindings"
+            # Allow the user to set the variable universally
+            set -q fish_key_bindings
+            or set -g fish_key_bindings
+            set fish_key_bindings fish_default_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+            return
+        end
+        # Clear earlier bindings, if any
+        bind --erase --all
+    end
 
-	# This is the default binding, i.e. the one used if no other binding matches
-	bind $argv "" self-insert
+    # This is the default binding, i.e. the one used if no other binding matches
+    bind $argv "" self-insert
 
-	bind $argv \n execute
-	bind $argv \r execute
+    bind $argv \n execute
+    bind $argv \r execute
 
-	bind $argv \ck kill-line
+    bind $argv \ck kill-line
     bind $argv \cy fish_clipboard_copy
     bind $argv \cv fish_clipboard_paste
-	bind $argv \t complete
+    bind $argv \t complete
 
-	bind $argv \e\n "commandline -i \n"
-	bind $argv \e\r "commandline -i \n"
+    bind $argv \e\n "commandline -i \n"
+    bind $argv \e\r "commandline -i \n"
 
-	bind $argv \e\[A up-or-search
-	bind $argv \e\[B down-or-search
-	bind $argv -k down down-or-search
-	bind $argv -k up up-or-search
+    bind $argv \e\[A up-or-search
+    bind $argv \e\[B down-or-search
+    bind $argv -k down down-or-search
+    bind $argv -k up up-or-search
 
-	# Some linux VTs output these (why?)
-	bind $argv \eOA up-or-search
-	bind $argv \eOB down-or-search
-	bind $argv \eOC forward-char
-	bind $argv \eOD backward-char
+    # Some linux VTs output these (why?)
+    bind $argv \eOA up-or-search
+    bind $argv \eOB down-or-search
+    bind $argv \eOC forward-char
+    bind $argv \eOD backward-char
 
-	bind $argv \e\[C forward-char
-	bind $argv \e\[D backward-char
-	bind $argv -k right forward-char
-	bind $argv -k left backward-char
+    bind $argv \e\[C forward-char
+    bind $argv \e\[D backward-char
+    bind $argv -k right forward-char
+    bind $argv -k left backward-char
 
-	bind $argv -k dc delete-char
-	bind $argv -k backspace backward-delete-char
-	bind $argv \x7f backward-delete-char
+    bind $argv -k dc delete-char
+    bind $argv -k backspace backward-delete-char
+    bind $argv \x7f backward-delete-char
 
-	bind $argv \e\[H beginning-of-line
-	bind $argv \e\[F end-of-line
+    bind $argv \e\[H beginning-of-line
+    bind $argv \e\[F end-of-line
 
-	# for PuTTY
-	# https://github.com/fish-shell/fish-shell/issues/180
-	bind $argv \e\[1~ beginning-of-line
-	bind $argv \e\[3~ delete-char
-	bind $argv \e\[4~ end-of-line
+    # for PuTTY
+    # https://github.com/fish-shell/fish-shell/issues/180
+    bind $argv \e\[1~ beginning-of-line
+    bind $argv \e\[3~ delete-char
+    bind $argv \e\[4~ end-of-line
 
-	# OS X SnowLeopard doesn't have these keys. Don't show an annoying error message.
-	bind $argv -k home beginning-of-line 2> /dev/null
-	bind $argv -k end end-of-line 2> /dev/null
-	bind $argv \e\[3\;2~ backward-delete-char # Mavericks Terminal.app shift-delete
+    # OS X SnowLeopard doesn't have these keys. Don't show an annoying error message.
+    bind $argv -k home beginning-of-line 2>/dev/null
+    bind $argv -k end end-of-line 2>/dev/null
+    bind $argv \e\[3\;2~ backward-delete-char # Mavericks Terminal.app shift-delete
 
-	bind $argv \e\eOC nextd-or-forward-word
-	bind $argv \e\eOD prevd-or-backward-word
-	bind $argv \e\e\[C nextd-or-forward-word
-	bind $argv \e\e\[D prevd-or-backward-word
-	bind $argv \eO3C nextd-or-forward-word
-	bind $argv \eO3D prevd-or-backward-word
-	bind $argv \e\[3C nextd-or-forward-word
-	bind $argv \e\[3D prevd-or-backward-word
-	bind $argv \e\[1\;3C nextd-or-forward-word
-	bind $argv \e\[1\;3D prevd-or-backward-word
+    bind $argv \e\eOC nextd-or-forward-word
+    bind $argv \e\eOD prevd-or-backward-word
+    bind $argv \e\e\[C nextd-or-forward-word
+    bind $argv \e\e\[D prevd-or-backward-word
+    bind $argv \eO3C nextd-or-forward-word
+    bind $argv \eO3D prevd-or-backward-word
+    bind $argv \e\[3C nextd-or-forward-word
+    bind $argv \e\[3D prevd-or-backward-word
+    bind $argv \e\[1\;3C nextd-or-forward-word
+    bind $argv \e\[1\;3D prevd-or-backward-word
 
-	bind $argv \e\eOA history-token-search-backward
-	bind $argv \e\eOB history-token-search-forward
-	bind $argv \e\e\[A history-token-search-backward
-	bind $argv \e\e\[B history-token-search-forward
-	bind $argv \eO3A history-token-search-backward
-	bind $argv \eO3B history-token-search-forward
-	bind $argv \e\[3A history-token-search-backward
-	bind $argv \e\[3B history-token-search-forward
-	bind $argv \e\[1\;3A history-token-search-backward
-	bind $argv \e\[1\;3B history-token-search-forward
+    bind $argv \e\eOA history-token-search-backward
+    bind $argv \e\eOB history-token-search-forward
+    bind $argv \e\e\[A history-token-search-backward
+    bind $argv \e\e\[B history-token-search-forward
+    bind $argv \eO3A history-token-search-backward
+    bind $argv \eO3B history-token-search-forward
+    bind $argv \e\[3A history-token-search-backward
+    bind $argv \e\[3B history-token-search-forward
+    bind $argv \e\[1\;3A history-token-search-backward
+    bind $argv \e\[1\;3B history-token-search-forward
 
-	bind $argv \ca beginning-of-line
-	bind $argv \ce end-of-line
-	bind $argv \ey yank-pop
-	bind $argv \ch backward-delete-char
-	bind $argv \cp up-or-search
-	bind $argv \cn down-or-search
-	bind $argv \cf forward-char
-	bind $argv \cb backward-char
-	bind $argv \ct transpose-chars
-	bind $argv \et transpose-words
-	bind $argv \eu upcase-word
+    bind $argv \ca beginning-of-line
+    bind $argv \ce end-of-line
+    bind $argv \ey yank-pop
+    bind $argv \ch backward-delete-char
+    bind $argv \cp up-or-search
+    bind $argv \cn down-or-search
+    bind $argv \cf forward-char
+    bind $argv \cb backward-char
+    bind $argv \ct transpose-chars
+    bind $argv \et transpose-words
+    bind $argv \eu upcase-word
 
-	# This clashes with __fish_list_current_token
-	# bind $argv \el downcase-word
-	bind $argv \ec capitalize-word
-	bind $argv \e\x7f backward-kill-word
-	bind $argv \eb backward-word
-	bind $argv \ef forward-word
-	bind $argv \e\[1\;5C forward-word
-	bind $argv \e\[1\;5D backward-word
-	bind $argv \e\[1\;9A history-token-search-backward # iTerm2
-	bind $argv \e\[1\;9B history-token-search-forward # iTerm2
-	bind $argv \e\[1\;9C nextd-or-forward-word #iTerm2
-	bind $argv \e\[1\;9D prevd-or-backward-word #iTerm2
-	# Bash compatibility
-	# https://github.com/fish-shell/fish-shell/issues/89
-	bind $argv \e. history-token-search-backward
-	bind $argv -k ppage beginning-of-history
-	bind $argv -k npage end-of-history
-	bind $argv \e\< beginning-of-buffer
-	bind $argv \e\> end-of-buffer
+    # This clashes with __fish_list_current_token
+    # bind $argv \el downcase-word
+    bind $argv \ec capitalize-word
+    bind $argv \e\x7f backward-kill-word
+    bind $argv \eb backward-word
+    bind $argv \ef forward-word
+    bind $argv \e\[1\;5C forward-word
+    bind $argv \e\[1\;5D backward-word
+    bind $argv \e\[1\;9A history-token-search-backward # iTerm2
+    bind $argv \e\[1\;9B history-token-search-forward # iTerm2
+    bind $argv \e\[1\;9C nextd-or-forward-word #iTerm2
+    bind $argv \e\[1\;9D prevd-or-backward-word #iTerm2
+    # Bash compatibility
+    # https://github.com/fish-shell/fish-shell/issues/89
+    bind $argv \e. history-token-search-backward
+    bind $argv -k ppage beginning-of-history
+    bind $argv -k npage end-of-history
+    bind $argv \e\< beginning-of-buffer
+    bind $argv \e\> end-of-buffer
 
-	bind $argv \el __fish_list_current_token
-	bind $argv \ew 'set tok (commandline -pt); if test $tok[1]; echo; whatis $tok[1]; commandline -f repaint; end'
-	bind $argv \cl 'clear; commandline -f repaint'
-	bind $argv \cc __fish_cancel_commandline
-	bind $argv \cu backward-kill-line
-	bind $argv \cw backward-kill-path-component
-	bind $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
-	bind $argv \cd delete-or-exit
+    bind $argv \el __fish_list_current_token
+    bind $argv \ew 'set tok (commandline -pt); if test $tok[1]; echo; whatis $tok[1]; commandline -f repaint; end'
+    bind $argv \cl 'clear; commandline -f repaint'
+    bind $argv \cc __fish_cancel_commandline
+    bind $argv \cu backward-kill-line
+    bind $argv \cw backward-kill-path-component
+    bind $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
+    bind $argv \cd delete-or-exit
 
-	bind \ed forward-kill-word
-	bind \ed kill-word
+    bind \ed forward-kill-word
+    bind \ed kill-word
 
-	# Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh)
-	bind $argv -k f1 __fish_man_page
-	bind $argv \eh __fish_man_page
+    # Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh)
+    bind $argv -k f1 __fish_man_page
+    bind $argv \eh __fish_man_page
 
-	# This will make sure the output of the current command is paged using the default pager when you press Meta-p
-	# If none is set, less will be used
-	bind $argv \ep '__fish_paginate'
-	
-	# shift-tab does a tab complete followed by a search
-	bind $argv --key btab complete-and-search
+    # This will make sure the output of the current command is paged using the default pager when you press Meta-p
+    # If none is set, less will be used
+    bind $argv \ep '__fish_paginate'
 
-	# escape cancels stuff	
-	bind \e cancel
+    # shift-tab does a tab complete followed by a search
+    bind $argv --key btab complete-and-search
 
-	# Ignore some known-bad control sequences
-	# https://github.com/fish-shell/fish-shell/issues/1917
-	bind \e\[I 'begin;end'
-	bind \e\[O 'begin;end'
+    # escape cancels stuff	
+    bind \e cancel
 
-	# term-specific special bindings
-	switch "$TERM"
-		case 'rxvt*'
-			bind $argv \e\[8~ end-of-line
-			bind $argv \eOc forward-word
-			bind $argv \eOd backward-word
-	end
+    # Ignore some known-bad control sequences
+    # https://github.com/fish-shell/fish-shell/issues/1917
+    bind \e\[I 'begin;end'
+    bind \e\[O 'begin;end'
 
-	# Make it easy to turn an unexecuted command into a comment in the shell history. Also,
-	# remove the commenting chars so the command can be further edited then executed.
-	bind \e\# __fish_toggle_comment_commandline
+    # term-specific special bindings
+    switch "$TERM"
+        case 'rxvt*'
+            bind $argv \e\[8~ end-of-line
+            bind $argv \eOc forward-word
+            bind $argv \eOd backward-word
+    end
+
+    # Make it easy to turn an unexecuted command into a comment in the shell history. Also,
+    # remove the commenting chars so the command can be further edited then executed.
+    bind \e\# __fish_toggle_comment_commandline
 end

--- a/src/kill.cpp
+++ b/src/kill.cpp
@@ -1,7 +1,7 @@
 // The killring.
 //
 // Works like the killring in emacs and readline. The killring is cut and paste with a memory of
-// previous cuts. It supports integration with the X clipboard.
+// previous cuts.
 #include "config.h"  // IWYU pragma: keep
 
 #include <stdbool.h>
@@ -12,8 +12,6 @@
 #include <string>
 
 #include "common.h"
-#include "env.h"
-#include "exec.h"
 #include "fallback.h"  // IWYU pragma: keep
 #include "kill.h"
 #include "path.h"
@@ -22,59 +20,10 @@
 typedef std::list<wcstring> kill_list_t;
 static kill_list_t kill_list;
 
-/// Contents of the X clipboard, at last time we checked it.
-static wcstring cut_buffer;
-
-/// Test if the xsel command is installed.  Since this is called often, cache the result.
-static int has_xsel() {
-    static signed char res = -1;
-    if (res < 0) {
-        res = !!path_get_path(L"xsel", NULL);
-    }
-
-    return res;
-}
-
 void kill_add(const wcstring &str) {
     ASSERT_IS_MAIN_THREAD();
     if (str.empty()) return;
-
-    wcstring cmd;
-    wcstring escaped_str;
     kill_list.push_front(str);
-
-    // Check to see if user has set the FISH_CLIPBOARD_CMD variable, and, if so, use it instead of
-    // checking the display, etc.
-    //
-    // I couldn't think of a safe way to allow overide of the echo command too, so, the command used
-    // must accept the input via stdin.
-    const env_var_t clipboard_wstr = env_get_string(L"FISH_CLIPBOARD_CMD");
-    if (!clipboard_wstr.missing()) {
-        escaped_str = escape(str.c_str(), ESCAPE_ALL);
-        cmd.assign(L"echo -n ");
-        cmd.append(escaped_str);
-        cmd.append(clipboard_wstr);
-    } else {
-        // This is for sending the kill to the X copy-and-paste buffer.
-        if (!has_xsel()) {
-            return;
-        }
-
-        const env_var_t disp_wstr = env_get_string(L"DISPLAY");
-        if (!disp_wstr.missing()) {
-            escaped_str = escape(str.c_str(), ESCAPE_ALL);
-            cmd.assign(L"echo -n ");
-            cmd.append(escaped_str);
-            cmd.append(L" | xsel -i -b");
-        }
-    }
-
-    if (!cmd.empty()) {
-        if (exec_subshell(cmd, false /* do not apply exit status */) == -1) {
-            // Do nothing on failure.
-        }
-        cut_buffer = escaped_str;
-    }
 }
 
 /// Remove first match for specified string from circular list.
@@ -99,38 +48,7 @@ const wchar_t *kill_yank_rotate() {
     return kill_list.front().c_str();
 }
 
-/// Check the X clipboard. If it has been changed, add the new clipboard contents to the fish
-/// killring.
-static void kill_check_x_buffer() {
-    if (!has_xsel()) return;
-
-    const env_var_t disp = env_get_string(L"DISPLAY");
-    if (!disp.missing()) {
-        size_t i;
-        wcstring cmd = L"xsel -t 500 -b";
-        wcstring new_cut_buffer = L"";
-        wcstring_list_t list;
-        if (exec_subshell(cmd, list, false /* do not apply exit status */) != -1) {
-            for (i = 0; i < list.size(); i++) {
-                wcstring next_line = escape_string(list.at(i), 0);
-                if (i > 0) new_cut_buffer += L"\\n";
-                new_cut_buffer += next_line;
-            }
-
-            if (new_cut_buffer.size() > 0) {
-                // The buffer is inserted with backslash escapes, since we don't really like tabs,
-                // newlines, etc. anyway.
-                if (cut_buffer != new_cut_buffer) {
-                    cut_buffer = new_cut_buffer;
-                    kill_list.push_front(new_cut_buffer);
-                }
-            }
-        }
-    }
-}
-
 const wchar_t *kill_yank() {
-    kill_check_x_buffer();
     if (kill_list.empty()) {
         return L"";
     }
@@ -141,4 +59,4 @@ void kill_sanity_check() {}
 
 void kill_init() {}
 
-void kill_destroy() { cut_buffer.clear(); }
+void kill_destroy() {}


### PR DESCRIPTION
This removes our clipboard integration and replaces it with a set of explicit binding functions.

It _should_ work on OSX via pbcopy/pbpaste (please test!) and on X11 via `xsel`.

I've explicitly not silenced the errors xsel throws when $DISPLAY is invalid so the user knows that it's not going to work.

This should fix #2894 and #2556 and provide a workaround for #2188.