### PR TITLE
Fix documentation links for `or` and `and` commands

### DIFF
--- a/doc_src/and.txt
+++ b/doc_src/and.txt
@@ -9,7 +9,7 @@ COMMAND1; and COMMAND2
 
 `and` is used to execute a command if the current exit status (as set by the previous command) is 0.
 
-`and` statements may be used as part of the condition in an <a href="#if">`and`</a> or <a href="#while">`while`</a> block. See the documentation
+`and` statements may be used as part of the condition in an <a href="#and">`and`</a> or <a href="#while">`while`</a> block. See the documentation
 for <a href="#if">`if`</a> and <a href="#while">`while`</a> for examples.
 
 `and` does not change the current exit status. The exit status of the last foreground command to exit can always be accessed using the <a href="index.html#variables-status">$status</a> variable.

--- a/doc_src/if.txt
+++ b/doc_src/if.txt
@@ -12,7 +12,7 @@ end
 
 `if` will execute the command `CONDITION`. If the condition's exit status is 0, the commands `COMMANDS_TRUE` will execute.  If the exit status is not 0 and `else` is given, `COMMANDS_FALSE` will be executed.
 
-You can use <a href="#and">`and`</a> or <a href="#and">`or`</a> in the condition. See the second example below.
+You can use <a href="#and">`and`</a> or <a href="#or">`or`</a> in the condition. See the second example below.
 
 The exit status of the last foreground command to exit can always be accessed using the <a href="index.html#variables-status">$status</a> variable.
 

--- a/doc_src/while.txt
+++ b/doc_src/while.txt
@@ -11,7 +11,7 @@ while CONDITION; COMMANDS...; end
 
 If the exit status of `CONDITION` is non-zero on the first iteration, `COMMANDS` will not be executed at all.
 
-You can use <a href="#and">`and`</a> or <a href="#and">`or`</a> for complex conditions. Even more complex control can be achieved with `while true` containing a <a href="#break">break</a>.
+You can use <a href="#and">`and`</a> or <a href="#or">`or`</a> for complex conditions. Even more complex control can be achieved with `while true` containing a <a href="#break">break</a>.
 
 \subsection while-example Example
 


### PR DESCRIPTION
The incorrect links were introduced in ade6ebf5226e67aa5d5fa64ad56921d69f03f4e9.