### PR TITLE
RFC: Share some (but not all) bindings between vi- and emacs-mode

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -947,16 +947,11 @@ The `fish` editor features copy and paste, a searchable history and many editor 
 
 Similar to bash, fish has Emacs and Vi editing modes. The default editing mode is Emacs. You can switch to Vi mode with `fish_vi_key_bindings` and switch back with `fish_default_key_bindings`.
 
+\subsection shared-binds Shared bindings
 
-\subsection emacs-mode Emacs mode commands
+Some bindings are shared between emacs- and vi-mode because they aren't text editing bindings or because what Vi/Vim does for a particular key doesn't make sense for a shell.
 
 - @key{Tab} <a href="#completion">completes</a> the current token. @key{Shift, Tab} completes the current token and starts the pager's search mode.
-
-- @key{Home} or @key{Control,A} moves the cursor to the beginning of the line.
-
-- @key{End} or @key{Control,E} moves to the end of line. If the cursor is already at the end of the line, and an autosuggestion is available, @key{End} or @key{Control,E} accepts the autosuggestion.
-
-- @cursor_key{&larr;,Left} (or @key{Control,B}) and @cursor_key{&rarr;,Right} (or @key{Control,F}) move the cursor left or right by one character. If the cursor is already at the end of the line, and an autosuggestion is available, the @cursor_key{&rarr;,Right} key and the @key{Control,F} combination accept the suggestion.
 
 - @key{Alt,&larr;,Left} and @key{Alt,&rarr;,Right} move the cursor one word left or right, or moves forward/backward in the directory history if the command line is empty. If the cursor is already at the end of the line, and an autosuggestion is available, @key{Alt,&rarr;,Right} (or @key{Alt,F}) accepts the first word in the suggestion.
 
@@ -964,13 +959,9 @@ Similar to bash, fish has Emacs and Vi editing modes. The default editing mode i
 
 - @key{Alt,&uarr;,Up} and @key{Alt,&darr;,Down} search the command history for the previous/next token containing the token under the cursor before the search was started. If the commandline was not on a token when the search started, all tokens match. See the <a href='#history'>history</a> section for more information on history searching.
 
-- @key{Delete} and @key{Backspace} removes one character forwards or backwards respectively.
-
 - @key{Control,C} deletes the entire line.
 
 - @key{Control,D} delete one character to the right of the cursor. If the command line is empty, @key{Control,D} will exit fish.
-
-- @key{Control,K} moves contents from the cursor to the end of line to the <a href="#killring">killring</a>.
 
 - @key{Control,U} moves contents from the beginning of line to the cursor to the <a href="#killring">killring</a>.
 
@@ -980,17 +971,29 @@ Similar to bash, fish has Emacs and Vi editing modes. The default editing mode i
 
 - @key{Alt,D} moves the next word to the <a href="#killring">killring</a>.
 
-- @key{Alt,W} prints a short description of the command under the cursor.
+- @key{Alt,H} (or @key{F1}) shows the manual page for the current command, if one exists.
 
 - @key{Alt,L} lists the contents of the current directory, unless the cursor is over a directory argument, in which case the contents of that directory will be listed.
 
 - @key{Alt,P} adds the string '`| less;`' to the end of the job under the cursor. The result is that the output of the command will be paged.
 
+- @key{Alt,W} prints a short description of the command under the cursor.
+
+\subsection emacs-mode Emacs mode commands
+
+- @key{Home} or @key{Control,A} moves the cursor to the beginning of the line.
+
+- @key{End} or @key{Control,E} moves to the end of line. If the cursor is already at the end of the line, and an autosuggestion is available, @key{End} or @key{Control,E} accepts the autosuggestion.
+
+- @cursor_key{&larr;,Left} (or @key{Control,B}) and @cursor_key{&rarr;,Right} (or @key{Control,F}) move the cursor left or right by one character. If the cursor is already at the end of the line, and an autosuggestion is available, the @cursor_key{&rarr;,Right} key and the @key{Control,F} combination accept the suggestion.
+
+- @key{Delete} and @key{Backspace} removes one character forwards or backwards respectively.
+
+- @key{Control,K} moves contents from the cursor to the end of line to the <a href="#killring">killring</a>.
+
 - @key{Alt,C} capitalizes the current word.
 
 - @key{Alt,U} makes the current word uppercase.
-
-- @key{Alt,H} (or @key{F1}) shows the manual page for the current command, if one exists.
 
 - @key{Control, t} transposes the last two characters
 
@@ -1002,7 +1005,7 @@ You can change these key bindings using the <a href="commands.html#bind">bind</a
 
 \subsection vi-mode Vi mode commands
 
-Vi mode allows for the use of Vi-like commands at the prompt. Initially, <a href="#vi-mode-insert">insert mode</a> is active. @key{Escape} enters <a href="#vi-mode-command">command mode</a>. The commands available in command, insert and visual mode are described below. Vi mode builds on top of <a href="#emacs-mode">Emacs mode</a>, so all keybindings mentioned there that do not contradict the ones mentioned here also work.
+Vi mode allows for the use of Vi-like commands at the prompt. Initially, <a href="#vi-mode-insert">insert mode</a> is active. @key{Escape} enters <a href="#vi-mode-command">command mode</a>. The commands available in command, insert and visual mode are described below. Vi mode shares <a href="#shared-binds">some bindings</a> with <a href="#emacs-mode">Emacs mode</a>.
 
 \subsubsection vi-mode-command Command mode
 
@@ -1032,19 +1035,9 @@ Command mode is also known as normal mode.
 
 - @key{[} and @key{]} search the command history for the previous/next token containing the token under the cursor before the search was started. See the <a href='#history'>history</a> section for more information on history searching.
 
-- @key{Control,C} deletes the entire line.
-
 \subsubsection vi-mode-insert Insert mode
 
-- @key{Tab} <a href="#completion">completes</a> the current token.
-
 - @key{Escape} or @key{Control,C} enters <a href="#vi-mode-command">command mode</a>.
-
-- @cursor_key{&uarr;,Up} and @cursor_key{&darr;,Down} search the command history.  See the <a href='#history'>history</a> section for more information on history searching.
-
-- @key{Control,W} moves the previous word to the <a href="#killring">killring</a>.
-
-- @key{Control,U} moves contents from the beginning of line to the cursor to the <a href="#killring">killring</a>.
 
 - @key{Control,x} moves the cursor to the end of the line. If an autosuggestion is available, it will be accepted completely.
 

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -945,7 +945,17 @@ For a list of all builtins, functions and commands shipped with fish, see the <a
 
 The `fish` editor features copy and paste, a searchable history and many editor functions that can be bound to special keyboard shortcuts.
 
-Similar to bash, fish has Emacs and Vi editing modes. The default editing mode is Emacs. You can switch to Vi mode with `fish_vi_key_bindings` and switch back with `fish_default_key_bindings`.
+Similar to bash, fish has Emacs and Vi editing modes. The default editing mode is Emacs. You can switch to Vi mode with `fish_vi_key_bindings` and switch back with `fish_default_key_bindings`. You can also make your own key bindings by creating a function and setting $fish_key_bindings to its name. For example:
+
+\fish
+function hybrid_bindings --description "Vi-style bindings that inherit emacs-style bindings in all modes"
+    for mode in default insert visual
+        fish_default_key_bindings -M $mode
+    end
+    fish_vi_key_bindings
+end
+set -g fish_key_bindings hybrid_bindings
+\endfish
 
 \subsection shared-binds Shared bindings
 

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -1,13 +1,13 @@
 function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mode"
-    # These are some bindings that are supposed to be shared between vi mode and default/emacs mode
-    # They are supposed to be unrelated to text-editing
-    # This takes $argv so the vi-bindings can pass the mode they are valid in
+    # These are some bindings that are supposed to be shared between vi mode and default mode.
+    # They are supposed to be unrelated to text-editing (or movement).
+    # This takes $argv so the vi-bindings can pass the mode they are valid in.
 
     bind $argv \cy yank
 	bind $argv \ey yank-pop
 
     bind $argv \t complete
-    # shift-tab does a tab complete followed by a search
+    # shift-tab does a tab complete followed by a search.
     bind $argv --key btab complete-and-search
 
 
@@ -61,12 +61,12 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
     bind $argv \cd delete-or-exit
 
-    # Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh)
+    # Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh).
     bind $argv -k f1 __fish_man_page
     bind $argv \eh __fish_man_page
 
-    # This will make sure the output of the current command is paged using the default pager when you press Meta-p
-    # If none is set, less will be used
+    # This will make sure the output of the current command is paged using the default pager when you press Meta-p.
+    # If none is set, less will be used.
     bind $argv \ep '__fish_paginate'
     
     # Make it easy to turn an unexecuted command into a comment in the shell history. Also,

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -5,6 +5,15 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
 
     bind $argv \e cancel
 
+    # Left/Right arrow
+    bind $argv -k right forward-char
+    bind $argv -k left backward-char
+    bind $argv \e\[C forward-char
+    bind $argv \e\[D backward-char
+    # Some terminals output these when they're in in keypad mode.
+    bind $argv \eOC forward-char
+    bind $argv \eOD backward-char
+
     # Interaction with the system clipboard.
     bind $argv \cy fish_clipboard_copy
     bind $argv \cv fish_clipboard_paste

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -1,0 +1,75 @@
+function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mode"
+    # These are some bindings that are supposed to be shared between vi mode and default/emacs mode
+    # They are supposed to be unrelated to text-editing
+    # This takes $argv so the vi-bindings can pass the mode they are valid in
+
+    bind $argv \cy yank
+	bind $argv \ey yank-pop
+
+    bind $argv \t complete
+    # shift-tab does a tab complete followed by a search
+    bind $argv --key btab complete-and-search
+
+
+    bind $argv \e\n "commandline -i \n"
+    bind $argv \e\r "commandline -i \n"
+
+    bind $argv -k down down-or-search
+    bind $argv -k up up-or-search
+    bind $argv \e\[A up-or-search
+    bind $argv \e\[B down-or-search
+    bind $argv \eOA up-or-search
+    bind $argv \eOB down-or-search
+
+    # Alt-left/Alt-right
+    bind $argv \e\eOC nextd-or-forward-word
+    bind $argv \e\eOD prevd-or-backward-word
+    bind $argv \e\e\[C nextd-or-forward-word
+    bind $argv \e\e\[D prevd-or-backward-word
+    bind $argv \eO3C nextd-or-forward-word
+    bind $argv \eO3D prevd-or-backward-word
+    bind $argv \e\[3C nextd-or-forward-word
+    bind $argv \e\[3D prevd-or-backward-word
+    bind $argv \e\[1\;3C nextd-or-forward-word
+    bind $argv \e\[1\;3D prevd-or-backward-word
+    bind $argv \e\[1\;9C nextd-or-forward-word #iTerm2
+    bind $argv \e\[1\;9D prevd-or-backward-word #iTerm2
+
+    # Alt-up/Alt-down
+    bind $argv \e\eOA history-token-search-backward
+    bind $argv \e\eOB history-token-search-forward
+    bind $argv \e\e\[A history-token-search-backward
+    bind $argv \e\e\[B history-token-search-forward
+    bind $argv \eO3A history-token-search-backward
+    bind $argv \eO3B history-token-search-forward
+    bind $argv \e\[3A history-token-search-backward
+    bind $argv \e\[3B history-token-search-forward
+    bind $argv \e\[1\;3A history-token-search-backward
+    bind $argv \e\[1\;3B history-token-search-forward
+    bind $argv \e\[1\;9A history-token-search-backward # iTerm2
+    bind $argv \e\[1\;9B history-token-search-forward # iTerm2
+    # Bash compatibility
+    # https://github.com/fish-shell/fish-shell/issues/89
+    bind $argv \e. history-token-search-backward
+
+    bind $argv \el __fish_list_current_token
+    bind $argv \ew 'set tok (commandline -pt); if test $tok[1]; echo; whatis $tok[1]; commandline -f repaint; end'
+    bind $argv \cl 'clear; commandline -f repaint'
+    bind $argv \cc __fish_cancel_commandline
+    bind $argv \cu backward-kill-line
+    bind $argv \cw backward-kill-path-component
+    bind $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
+    bind $argv \cd delete-or-exit
+
+    # Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh)
+    bind $argv -k f1 __fish_man_page
+    bind $argv \eh __fish_man_page
+
+    # This will make sure the output of the current command is paged using the default pager when you press Meta-p
+    # If none is set, less will be used
+    bind $argv \ep '__fish_paginate'
+    
+    # Make it easy to turn an unexecuted command into a comment in the shell history. Also,
+    # remove the commenting chars so the command can be further edited then executed.
+    bind $argv \e\# __fish_toggle_comment_commandline
+end

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -3,8 +3,13 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     # They are supposed to be unrelated to text-editing (or movement).
     # This takes $argv so the vi-bindings can pass the mode they are valid in.
 
-    bind $argv \cy yank
-	bind $argv \ey yank-pop
+    bind $argv \e cancel
+
+    # Interaction with the system clipboard.
+    bind $argv \cy fish_clipboard_copy
+    bind $argv \cv fish_clipboard_paste
+
+    bind $argv \ey yank-pop
 
     bind $argv \t complete
     # shift-tab does a tab complete followed by a search.

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -11,7 +11,7 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 		bind --erase --all
 	end
 
-    # These are shelly bindings that we share with vi mode
+    # These are shell-specific bindings that we share with vi mode.
     __fish_shared_key_bindings
 
 	# This is the default binding, i.e. the one used if no other binding matches

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -11,6 +11,9 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 		bind --erase --all
 	end
 
+    # These are shelly bindings that we share with vi mode
+    __fish_shared_key_bindings
+
 	# This is the default binding, i.e. the one used if no other binding matches
 	bind $argv "" self-insert
 
@@ -18,23 +21,9 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 	bind $argv \r execute
 
 	bind $argv \ck kill-line
-	bind $argv \cy yank
-	bind $argv \t complete
 
-	bind $argv \e\n "commandline -i \n"
-	bind $argv \e\r "commandline -i \n"
-
-	bind $argv \e\[A up-or-search
-	bind $argv \e\[B down-or-search
-	bind $argv -k down down-or-search
-	bind $argv -k up up-or-search
-
-	# Some linux VTs output these (why?)
-	bind $argv \eOA up-or-search
-	bind $argv \eOB down-or-search
 	bind $argv \eOC forward-char
 	bind $argv \eOD backward-char
-
 	bind $argv \e\[C forward-char
 	bind $argv \e\[D backward-char
 	bind $argv -k right forward-char
@@ -58,31 +47,8 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 	bind $argv -k end end-of-line 2> /dev/null
 	bind $argv \e\[3\;2~ backward-delete-char # Mavericks Terminal.app shift-delete
 
-	bind $argv \e\eOC nextd-or-forward-word
-	bind $argv \e\eOD prevd-or-backward-word
-	bind $argv \e\e\[C nextd-or-forward-word
-	bind $argv \e\e\[D prevd-or-backward-word
-	bind $argv \eO3C nextd-or-forward-word
-	bind $argv \eO3D prevd-or-backward-word
-	bind $argv \e\[3C nextd-or-forward-word
-	bind $argv \e\[3D prevd-or-backward-word
-	bind $argv \e\[1\;3C nextd-or-forward-word
-	bind $argv \e\[1\;3D prevd-or-backward-word
-
-	bind $argv \e\eOA history-token-search-backward
-	bind $argv \e\eOB history-token-search-forward
-	bind $argv \e\e\[A history-token-search-backward
-	bind $argv \e\e\[B history-token-search-forward
-	bind $argv \eO3A history-token-search-backward
-	bind $argv \eO3B history-token-search-forward
-	bind $argv \e\[3A history-token-search-backward
-	bind $argv \e\[3B history-token-search-forward
-	bind $argv \e\[1\;3A history-token-search-backward
-	bind $argv \e\[1\;3B history-token-search-forward
-
 	bind $argv \ca beginning-of-line
 	bind $argv \ce end-of-line
-	bind $argv \ey yank-pop
 	bind $argv \ch backward-delete-char
 	bind $argv \cp up-or-search
 	bind $argv \cn down-or-search
@@ -100,40 +66,13 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 	bind $argv \ef forward-word
 	bind $argv \e\[1\;5C forward-word
 	bind $argv \e\[1\;5D backward-word
-	bind $argv \e\[1\;9A history-token-search-backward # iTerm2
-	bind $argv \e\[1\;9B history-token-search-forward # iTerm2
-	bind $argv \e\[1\;9C nextd-or-forward-word #iTerm2
-	bind $argv \e\[1\;9D prevd-or-backward-word #iTerm2
-	# Bash compatibility
-	# https://github.com/fish-shell/fish-shell/issues/89
-	bind $argv \e. history-token-search-backward
 	bind $argv -k ppage beginning-of-history
 	bind $argv -k npage end-of-history
 	bind $argv \e\< beginning-of-buffer
 	bind $argv \e\> end-of-buffer
 
-	bind $argv \el __fish_list_current_token
-	bind $argv \ew 'set tok (commandline -pt); if test $tok[1]; echo; whatis $tok[1]; commandline -f repaint; end'
-	bind $argv \cl 'clear; commandline -f repaint'
-	bind $argv \cc __fish_cancel_commandline
-	bind $argv \cu backward-kill-line
-	bind $argv \cw backward-kill-path-component
-	bind $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
-	bind $argv \cd delete-or-exit
-
 	bind \ed forward-kill-word
 	bind \ed kill-word
-
-	# Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh)
-	bind $argv -k f1 __fish_man_page
-	bind $argv \eh __fish_man_page
-
-	# This will make sure the output of the current command is paged using the default pager when you press Meta-p
-	# If none is set, less will be used
-	bind $argv \ep '__fish_paginate'
-	
-	# shift-tab does a tab complete followed by a search
-	bind $argv --key btab complete-and-search
 
 	# escape cancels stuff	
 	bind \e cancel
@@ -150,8 +89,4 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 			bind $argv \eOc forward-word
 			bind $argv \eOd backward-word
 	end
-
-	# Make it easy to turn an unexecuted command into a comment in the shell history. Also,
-	# remove the commenting chars so the command can be further edited then executed.
-	bind \e\# __fish_toggle_comment_commandline
 end

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -31,7 +31,6 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
         __fish_shared_key_bindings -M $mode
     end
 
-    bind \e cancel
     bind -M insert \r execute
     bind -M insert \n execute
     
@@ -46,17 +45,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind :q exit
     bind \cd exit
     bind -m insert \cc __fish_cancel_commandline
-    bind h backward-char
-    bind l forward-char
-    bind \e\[C forward-char
-    bind \e\[D backward-char
-
-    # Some terminals output these when they're in in keypad mode.
-    bind \eOC forward-char
-    bind \eOD backward-char
-
-    bind -k right forward-char
-    bind -k left backward-char
+    bind -M default h backward-char
+    bind -M default l forward-char
     bind -m insert \n execute
     bind -m insert \r execute
     bind -m insert i force-repaint
@@ -198,12 +188,6 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     #
     # visual mode
     #
-    bind -M visual \e\[C forward-char
-    bind -M visual \e\[D backward-char
-    bind -M visual -k right forward-char
-    bind -M visual -k left backward-char
-    bind -M insert \eOC forward-char
-    bind -M insert \eOD backward-char
     bind -M visual h backward-char
     bind -M visual l forward-char
 

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -31,6 +31,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
         __fish_shared_key_bindings -M $mode
     end
 
+    bind -M insert "" self-insert
+
     # Add way to kill current command line while in insert mode.
     bind -M insert \cc __fish_cancel_commandline
     # Add a way to switch from insert to normal (command) mode.

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -31,6 +31,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
         __fish_shared_key_bindings -M $mode
     end
 
+    bind \e cancel
+    
     bind -M insert "" self-insert
 
     # Add way to kill current command line while in insert mode.

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -17,14 +17,13 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
         set init_mode $argv[1]
     end
 
-    # Inherit default key bindings.
+    # Inherit shared key bindings.
     # Do this first so vi-bindings win over default.
     bind --erase --all
-    fish_default_key_bindings -M insert
-    fish_default_key_bindings -M default
+    for mode in insert default visual
+        __fish_shared_key_bindings -M $mode
+    end
 
-    # Remove the default self-insert bindings in default mode
-    bind -e "" -M default
     # Add way to kill current command line while in insert mode.
     bind -M insert \cc __fish_cancel_commandline
     # Add a way to switch from insert to normal (command) mode.
@@ -231,7 +230,4 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # the commenting chars so the command can be further edited then executed.
     bind -M default \# __fish_toggle_comment_commandline
     bind -M visual \# __fish_toggle_comment_commandline
-    bind -M default \e\# __fish_toggle_comment_commandline
-    bind -M insert \e\# __fish_toggle_comment_commandline
-    bind -M visual \e\# __fish_toggle_comment_commandline
 end

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -1,10 +1,17 @@
 function fish_vi_key_bindings --description 'vi-like key bindings for fish'
-	if test "$fish_key_bindings" != "fish_vi_key_bindings"
-		# Allow the user to set the variable universally
-		set -q fish_key_bindings; or set -g fish_key_bindings
-		set fish_key_bindings fish_vi_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
-		return
-	end
+    # Allow any argument to skip setting the variable.
+    if not set -q argv[1]
+        # Allow just calling this function to correctly set the bindings.
+        # Because it's a rather discoverable name, users will execute it
+        # and without this would then have subtly broken bindings.
+        if test "$fish_key_bindings" != "fish_vi_key_bindings"
+            # Allow the user to set the variable universally
+            set -q fish_key_bindings
+            or set -g fish_key_bindings
+            set fish_key_bindings fish_vi_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+            return
+        end
+    end
     # The default escape timeout is 300ms. But for users of Vi bindings that can be slightly
     # annoying when trying to switch to Vi "normal" mode. So set a shorter timeout in this case
     # unless the user has explicitly set the delay.

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -32,6 +32,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     end
 
     bind \e cancel
+    bind -M insert \r execute
+    bind -M insert \n execute
     
     bind -M insert "" self-insert
 

--- a/tests/bind.expect
+++ b/tests/bind.expect
@@ -80,18 +80,6 @@ expect_prompt -re {\r\nsuccess: default escape timeout\r\n} {
     puts stderr "vi replace line, default timeout: long delay"
 }
 
-# Verify that a human can transpose words using \et (which is an emacs default
-# binding but should be valid while in vi insert or normal mode).
-send "echo abc def"
-send "\033"
-sleep 0.010
-send "t\r"
-expect_prompt -re {\r\ndef abc\r\n} {
-    puts "vi transpose words, default timeout: short delay"
-} unmatched {
-    puts stderr "vi transpose words, default timeout: short delay"
-}
-
 # Test replacing a single character.
 send "echo TEXT"
 send "\033"

--- a/tests/bind.expect.out
+++ b/tests/bind.expect.out
@@ -4,7 +4,6 @@ emacs transpose words, default timeout: long delay
 prime vi mode, default timeout
 vi-mode default timeout set correctly
 vi replace line, default timeout: long delay
-vi transpose words, default timeout: short delay
 vi mode replace char, default timeout: long delay
 vi replace line, 100ms timeout: long delay
 vi replace line, 100ms timeout: short delay


### PR DESCRIPTION
This undoes the inheritance since it shared too much.

Of course we need some discussion about which bindings precisely should be shared - I've tried to only pick ones which aren't related to text editing as such. Bindings without modifiers (alt/escape or control) are also likely to be superseded by improvements to vi-mode so probably aren't good candidates.

@krader1961: I'm particularly interested in your thoughts as you were vehemently against inheritance and use vi-mode.

(Note: This currently does not include #3061)

<!-- Tasks. Mark compete with '[x]'.
Changes in your PR should be documented. See CONTRIBUTING.md.
Fish developers will take care of the release notes task
Feel free to add further TODOs after the first two: -->
- [ ] Documentation updated 
- [ ] Release notes updated
- [x] Fix the test failures