### PR TITLE
Allow suggestions more often

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -530,9 +530,6 @@ void reader_data_t::pager_selection_changed() {
     }
     reader_set_buffer_maintaining_pager(new_cmd_line, cursor_pos);
 
-    // Since we just inserted a completion, don't immediately do a new autosuggestion.
-    this->suppress_autosuggestion = true;
-
     // Trigger repaint (see issue #765).
     reader_repaint_needed();
 }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1132,9 +1132,6 @@ static void completion_insert(const wchar_t *val, complete_flags_t flags) {
     wcstring new_command_line = completion_apply_to_command_line(val, flags, el->text, &cursor,
                                                                  false /* not append only */);
     reader_set_buffer_maintaining_pager(new_command_line, cursor);
-
-    // Since we just inserted a completion, don't immediately do a new autosuggestion.
-    data->suppress_autosuggestion = true;
 }
 
 struct autosuggestion_context_t {
@@ -2780,14 +2777,14 @@ const wchar_t *reader_readline(int nchars) {
             // Evaluate. If the current command is unfinished, or if the charater is escaped using a
             // backslash, insert a newline.
             case R_EXECUTE: {
-                // Delete any autosuggestion.
-                data->autosuggestion.clear();
-
                 // If the user hits return while navigating the pager, it only clears the pager.
                 if (data->is_navigating_pager_contents()) {
                     clear_pager();
                     break;
                 }
+
+                // Delete any autosuggestion.
+                data->autosuggestion.clear();
 
                 // The user may have hit return with pager contents, but while not navigating them.
                 // Clear the pager in that event.


### PR DESCRIPTION
I have to say I don't get why we suppressed autosuggestions in these circumstances. It feels better to allow it, and it doesn't _seem_ to crash or overwhelm my poor little laptop or anything.

It also suppresses after killing, which might be a little more sensible - otherwise it often suggests just what you deleted (which _would_ be a poor man's undo).

Also I quite like that this doesn't include a single new _character_. All made from free-range recycled bytes.

See #3016.