### PR TITLE
Propagate curse vars before initializing input

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -583,6 +583,21 @@ int env_set(const wcstring &key, const wchar_t *val, env_mode_flags_t var_mode) 
     return 0;
 }
 
+int env_sync_env(const wcstring &key)
+{
+    const env_var_t var = env_get_string(key, ENV_GLOBAL | ENV_EXPORT);
+    const std::string &name = wcs2string(key);
+    if (var.missing())
+    {
+        return unsetenv(name.c_str());
+    }
+    else
+    {
+        const std::string &value = wcs2string(var);
+        return setenv(name.c_str(), value.c_str(), 1);
+    }
+}
+
 /// Attempt to remove/free the specified key/value pair from the specified map.
 ///
 /// \return zero if the variable was not found, non-zero otherwise

--- a/src/env.h
+++ b/src/env.h
@@ -74,6 +74,16 @@ void env_init(const struct config_paths_t *paths = NULL);
 /// * ENV_INVALID, the variable value was invalid. This applies only to special variables.
 int env_set(const wcstring &key, const wchar_t *val, env_mode_flags_t mode);
 
+///  Reflect the state of the variable whose name matches key in this process environment.
+///
+///  The return values reflect the ones returned by (un)setenv.
+///  See setenv man pages for details.
+///
+///  \param key The name of the variable to sync
+///
+///  \returns 0 on success, -1 on failure; sets errno to indicate error cause.
+int env_sync_env(const wcstring &key);
+
 class env_var_t : public wcstring {
    private:
     bool is_missing;


### PR DESCRIPTION
This allows users to override TERMINFO-related variables before input is initialized.
It is the smallest fix for #3060. See that issue for more info.