### PR TITLE
Split off __fish_complete_blockdevice from mount.fish.

### DIFF
--- a/share/completions/mount.fish
+++ b/share/completions/mount.fish
@@ -1,12 +1,4 @@
 # Completions for mount
-function __fish_complete_blockdevice
-	set -l cmd (commandline -ct)
-	[ "" = "$cmd" ]; and return
-	for f in $cmd*
-		[ -b $f ]; and printf "%s\t%s\n" $f "Block device"
-		[ -d $f ]; and printf "%s\n" $f/
-	end
-end
 
 complete -x -c mount -a '(__fish_complete_blockdevice)'
 # In case `mount UUID=` and similar also works

--- a/share/functions/__fish_complete_blockdevice.fish
+++ b/share/functions/__fish_complete_blockdevice.fish
@@ -1,0 +1,8 @@
+function __fish_complete_blockdevice
+	set -l cmd (commandline -ct)
+	[ "" = "$cmd" ]; and return
+	for f in $cmd*
+		[ -b $f ]; and printf "%s\t%s\n" $f "Block device"
+		[ -d $f ]; and printf "%s\n" $f/
+	end
+end


### PR DESCRIPTION
The __fish_complete_blockdevice function can be useful to other completions than mount.fish, so it should live on its own so its available to those.

I wrote a `complete` file for a local shell script I'm using, which takes a block device as one of its arguments. Rather than have a copy of `__fish_complete_blockdevice.fish` in .config/fish, I figured I'd move to have mount.fish split upstream.