### PR TITLE
Fix utf-8 decoding error in file_is_overwritable

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -664,7 +664,7 @@ class TypeDeroffManParser(ManParser):
 # Raises IOError if it cannot be opened
 def file_is_overwritable(path):
     result = False
-    file = open(path, 'r')
+    file = codecs.open(path, "r", encoding="utf-8")
     for line in file:
         # Skip leading empty lines
         line = line.strip()


### PR DESCRIPTION
Got this error when I attempted to use `fish_update_completions`

    Traceback (most recent call last):
      File "/usr/share/fish/tools/create_manpage_completions.py", line 973, in <module>
        cleanup_autogenerated_completions_in_directory(output_directory)
      File "/usr/share/fish/tools/create_manpage_completions.py", line 693, in cleanup_autogenerated_completions_in_directory
        cleanup_autogenerated_file(path)
      File "/usr/share/fish/tools/create_manpage_completions.py", line 701, in cleanup_autogenerated_file
        if file_is_overwritable(path):
      File "/usr/share/fish/tools/create_manpage_completions.py", line 668, in file_is_overwritable
        for line in file:
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 350: ordinal not in range(128)

My change fixes the above error.