### PR TITLE
Mention nullglob exceptions in failglob error message

### DIFF
--- a/src/parse_constants.h
+++ b/src/parse_constants.h
@@ -209,7 +209,7 @@ void parse_error_offset_source_start(parse_error_list_t *errors, size_t amt);
 #define ILLEGAL_FD_ERR_MSG _(L"Illegal file descriptor in redirection '%ls'")
 
 /// Error message for wildcards with no matches.
-#define WILDCARD_ERR_MSG _(L"No matches for wildcard '%ls'.")
+#define WILDCARD_ERR_MSG _(L"No matches for wildcard '%ls'.  (Tip: empty matches are allowed in 'set', 'count', 'for'.)")
 
 /// Error when using break outside of loop.
 #define INVALID_BREAK_ERR_MSG _(L"'break' while not inside of loop")


### PR DESCRIPTION
I was trying `rm -i **.orig **\# **/*\~` which errored with
`No matches for wildcard “**.orig”.`, while I wanted it to proceed
with whatever did match - and had no idea how to achieve that.

- Googling "fish zero matches" and similar leads to multiple github
  discussions, not all related.  Eventually I found the long #2394
  and learnt the terms "failglob" / "nullglob" and the `set`, `count`
  and `for` exceptions.

- The 2.3 documentation and release notes do mention these exceptions,
  but it hadn't occurred to me to look there, or what portion to read
  (well duh the section on globbing, but I didn't expect the rule has
  exceptions).

This PR mentions the 3 exceptions briefly in the error message itself:

    "No matches for wildcard '**.orig'.  (Tip: empty matches are allowed in 'set', 'count', 'for'.)

I'm afraid my wording is unclear but at least it gives _some_ lead?
I'm strongly tempted to instead give a concrete example:

    "No matches for wildcard '**.orig'.  (Tip: 'set matches **.orig' would succeed.)`

since if you know that, you can achieve nullglob anywhere.
But I'm concerned that mentioning only one way would lead to people
assuming that's all there is and never learning about `count`, `for`.