### PR TITLE
make it harder for people to break non-interactive uses

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -315,11 +315,11 @@ test_high_level: test_fishscript test_interactive
 .PHONY: test_high_level
 
 test_fishscript: $(call filter_up_to,test_fishscript,$(active_test_goals))
-	cd tests; ../test/root/bin/fish test.fish
+	cd tests; XDG_CONFIG_HOME=../test/home XDG_DATA_HOME=../test/data ../test/root/bin/fish test.fish
 .PHONY: test_fishscript
 
 test_interactive: $(call filter_up_to,test_interactive,$(active_test_goals))
-	cd tests; ../test/root/bin/fish interactive.fish
+	cd tests; XDG_CONFIG_HOME=../test/home XDG_DATA_HOME=../test/data ../test/root/bin/fish interactive.fish
 .PHONY: test_interactive
 
 #

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -380,6 +380,11 @@ static int get_terminfo_sequence(const wchar_t *seq, wcstring *out_seq, io_strea
 static int builtin_bind_add(const wchar_t *seq, const wchar_t *const *cmds, size_t cmds_len,
                             const wchar_t *mode, const wchar_t *sets_mode, int terminfo,
                             io_streams_t &streams) {
+    if (!is_interactive_session) {
+        debug(2, L"ignoring bind --add command since not interactive");
+        return 0;
+    }
+
     if (terminfo) {
         wcstring seq2;
         if (get_terminfo_sequence(seq, &seq2, streams)) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -199,7 +199,7 @@ static std::vector<terminfo_mapping_t> terminfo_mappings;
 static std::vector<terminfo_mapping_t> mappings;
 
 /// Set to one when the input subsytem has been initialized.
-static bool is_init = false;
+static bool input_subsystem_initialized = false;
 
 /// Initialize terminfo.
 static void input_terminfo_init();
@@ -337,10 +337,10 @@ void update_fish_color_support(void) {
     output_set_color_support(support);
 }
 
-int input_init() {
-    if (is_init) return 1;
-
-    is_init = true;
+void input_init() {
+    if (!is_interactive_session) return;
+    if (input_subsystem_initialized) return;
+    input_subsystem_initialized = true;
 
     input_common_init(&interrupt_handler);
 
@@ -381,12 +381,13 @@ int input_init() {
         input_mapping_add(L"\x5", L"bind");
     }
 
-    return 1;
+    return;
 }
 
 void input_destroy() {
-    if (!is_init) return;
-    is_init = false;
+    if (!is_interactive_session) return;
+    if (!input_subsystem_initialized) return;
+    input_subsystem_initialized = false;
     input_common_destroy();
 
     if (del_curterm(cur_term) == ERR) {

--- a/src/input.h
+++ b/src/input.h
@@ -19,7 +19,7 @@ wcstring describe_char(wint_t c);
 /// sequences for special keys.
 ///
 /// Before calling input_init, terminfo is not initialized and MUST not be used.
-int input_init();
+void input_init();
 
 /// free up memory used by terminal functions.
 void input_destroy();


### PR DESCRIPTION
Issue #3100 is yet another report of a misconfigured fish shell breaking
tools like sftp and scp. The cause in that case was changing the fish
key bindings without regard to whether the shell was interactive. That's
a very common cause of such issues. This change makes such mistakes
innocuous by not initializing the interactive input subsystem if the
shell is not interactive.

While testing those changes I noticed the two driver scripts for the high
level tests were affected by my personal `config.fish` script. Which is
generally harmless but we might as well fix that while we're fixing the
core issue.

Fixes #3107