### PR TITLE
fix tty modes for external commands

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -105,6 +105,8 @@ demangled_backtrace(int max_frames, int skip_levels) {
     return backtrace_text;
 }
 
+static void debug_shared(const wchar_t msg_level, const wcstring &msg);
+
 void __attribute__((noinline))
 show_stackframe(const wchar_t msg_level, int frame_count, int skip_levels) {
     ASSERT_IS_NOT_FORKED_CHILD();
@@ -1716,9 +1718,10 @@ bool is_forked_child(void) {
     // Just bail if nobody's called setup_fork_guards, e.g. some of our tools.
     if (!initial_pid) return false;
 
-    bool is_child_of_fork = (getpid() != initial_pid);
+    bool is_child_of_fork = getpid() != initial_pid;
     if (is_child_of_fork) {
-        printf("Uh-oh: %d\n", getpid());
+        debug(0, "current process (pid %d) is not the top-level shell (pid %d)\n", getpid(),
+              initial_pid);
         while (1) sleep(10000);
     }
     return is_child_of_fork;

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -444,6 +444,7 @@ int main(int argc, char **argv) {
     }
 
     const struct config_paths_t paths = determine_config_directory_paths(argv[0]);
+    debug(2, L"Fish pid %d, pgid %d", getpid(), getpgrp());
 
     proc_init();
     event_init();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -128,13 +128,25 @@ void write_color(rgb_color_t color, bool is_fg) {
     }
 }
 
+void reset_color() {
+    if (!cur_term) {
+        debug(3, "reset_color called with cur_term == NULL");
+        return;
+    }
+    set_color(rgb_color_t::reset(), rgb_color_t::reset());
+}
+
 void set_color(rgb_color_t c, rgb_color_t c2) {
-#if 0
+    ASSERT_IS_MAIN_THREAD();
+
     wcstring tmp = c.description();
     wcstring tmp2 = c2.description();
-    printf("set_color %ls : %ls\n", tmp.c_str(), tmp2.c_str());
-#endif
-    ASSERT_IS_MAIN_THREAD();
+    debug(3, L"set_color called with c=%ls, c2=%ls", tmp.c_str(), tmp2.c_str());
+
+    if (!cur_term) {
+        debug(3, "set_color called with cur_term == NULL");
+        return;
+    }
 
     const rgb_color_t normal = rgb_color_t::normal();
     static rgb_color_t last_color = rgb_color_t::normal();

--- a/src/output.h
+++ b/src/output.h
@@ -50,6 +50,9 @@ enum {
 /// \param c2 Background color.
 void set_color(rgb_color_t c, rgb_color_t c2);
 
+/// Set the foreground and background colors to "normal".
+void reset_color();
+
 /// Write specified multibyte string.
 void writembs_check(char *mbs, const char *mbs_name, const char *file, long line);
 #define writembs(mbs) writembs_check((mbs), #mbs, __FILE__, __LINE__)

--- a/src/proc.h
+++ b/src/proc.h
@@ -298,6 +298,9 @@ void job_set_flag(job_t *j, unsigned int flag, int set);
 /// Returns one if the specified flag is set in the specified job, 0 otherwise.
 int job_get_flag(const job_t *j, unsigned int flag);
 
+/// Returns a string showing which job flags are set and unset.
+const char *job_flags_as_str(const job_t *j);
+
 /// Sets the status of the last process to exit.
 void proc_set_last_status(int s);
 

--- a/src/reader.h
+++ b/src/reader.h
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <termios.h>
 #include <string>
 #include <vector>
 
@@ -17,6 +18,7 @@
 class history_t;
 class env_vars_snapshot_t;
 class io_chain_t;
+class job_t;
 
 /// Helper class for storing a command line.
 class editable_line_t {
@@ -61,8 +63,17 @@ void reader_init();
 /// Destroy and free resources used by the reader.
 void reader_destroy();
 
-/// Restore the term mode at startup.
+/// Restore the tty modes to those in effect when the shell started running.
 void restore_term_mode();
+
+/// Give the tty to an external command.
+bool term_donate(job_t *j);
+
+/// Reclaim the tty from an external command.
+bool term_steal(job_t *j);
+
+/// Return the tty modes appropriate for a new external command.
+struct termios external_command_tty_modes(void);
 
 /// Returns the filename of the file currently read.
 const wchar_t *reader_current_filename();

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -266,6 +266,7 @@ int make_fd_blocking(int fd) {
     int err = 0;
     bool nonblocking = flags & O_NONBLOCK;
     if (nonblocking) {
+        debug(2, L"fd %d was non-blocking, setting to blocking", fd);
         err = fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
     }
     return err == -1 ? errno : 0;


### PR DESCRIPTION
**Editorial note:

I am not completely satisfied with this change. Nonetheless it fixes the issue, cleans up the code a bit, and improves the logging. What I'd like to see done in the future is simplifying the tests inside the `terminal_give_to_job()` and `terminal_return_from_job()` functions by changing how the job_t structure is setup.

End editorial note**

Fish doesn't set the tty modes correctly for external commands spawned from
startup scripts like config.fish.

This also corrects the use of is_forked_child() in common.cpp which I noticed
while debugging the core issue.

Fixes #2980