### PR TITLE
Missing several __fish_print_hostnames name matching rules

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -26,9 +26,10 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 		if test -r $file
 			# Print hosts from system wide ssh configuration file
 			# Note the non-capturing group to avoid printing "name"
-			string match -ri '\s*Host(?:name)? \w.*' < $file | string replace -ri '^\s*Host(?:name)?\s*(\S+)' '$1'
-			set known_hosts $known_hosts (string match -ri '^\s*UserKnownHostsFile|^\s*GlobalKnownHostsFile' <$file \
-			| string replace -ri '.*KnownHostsFile\s*' '')
+			string match -ri '\s*Host(?:name)?(?:\s+|\s*=\s*)\w.*' < $file | string replace -ri '^\s*Host(?:name)?\s*(\S+)' '$1' \
+				| string replace -r '\s+' ' ' | string split ' '
+			set known_hosts $known_hosts (string match -ri '^\s*UserKnownHostsFile|^\s*GlobalKnownHostsFile' < $file \
+				| string replace -ri '.*KnownHostsFile\s*' '')
 		end
 	end
 	for file in $known_hosts


### PR DESCRIPTION
### Several ssh_config rules aren't being matched

1. It should be possible to add multiple whitespace characters between the keyword (i.e. Host) and the argument(s), for example: `Host     myhost` or `Hostname \t\t myhost`
2. It is allowed to have a single = and whitespace between the keyword and the argument(s), for example: `Host=myhost` or `Host = myhost`
3. It is possible to add multiple host names under a single Host directive by spacing the names apart, for example: `Host myhold defaulthost`

Reference: https://www.freebsd.org/cgi/man.cgi?query=ssh_config&sektion=5

### Use case
Items 1 and 3 are actual conventions that we use in our dev team, and I couldn't get auto-complete working for fish without this modification.

### Modification explained
* The _space_ between `Host(?:name)?` and the `\w.*` was replaced by `(?:\s+|\s*=\s*)` to match any sequence of whitespace characters, or optional whitespaces with a single =, per spec.
* Result of first replacement is piped through another string replace to replace duplicate whitespace characters by a single space, and then piped again to be split by a space. This allows specifying several aliases or host names in a single Host/Hostname definition, also per spec.