### PR TITLE
deal with broken ttys on MS Windows

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -71,6 +71,8 @@ static rwlock_t termsize_rwlock;
 static char *wcs2str_internal(const wchar_t *in, char *out);
 static void debug_shared(const wchar_t msg_level, const wcstring &msg);
 
+bool has_working_tty_timestamps = true;
+
 #ifdef HAVE_BACKTRACE_SYMBOLS
 // This function produces a stack backtrace with demangled function & method names. It is based on
 // https://gist.github.com/fmela/591333 but adapted to the style of the fish project.

--- a/src/common.h
+++ b/src/common.h
@@ -21,6 +21,13 @@
 #include "fallback.h"  // IWYU pragma: keep
 #include "signal.h"    // IWYU pragma: keep
 
+// Define a symbol we can use elsewhere in our code to determine if we're being built on MS Windows
+// under Cygwin.
+#if defined(_WIN32) || defined(_WIN64) || defined(WIN32) || defined(__CYGWIN__) || \
+    defined(__WIN32__)
+#define OS_IS_CYGWIN
+#endif
+
 /// Avoid writing the type name twice in a common "static_cast-initialization". Caveat: This doesn't
 /// work with type names containing commas!
 #define CAST_INIT(type, dst, src) type dst = static_cast<type>(src)
@@ -187,6 +194,10 @@ extern const wchar_t *program_name;
 // Variants of read() and write() that ignores return values, defeating a warning.
 void read_ignore(int fd, void *buff, size_t count);
 void write_ignore(int fd, const void *buff, size_t count);
+
+/// Set to false at run-time if it's been determined we can't trust the last modified timestamp on
+/// the tty.
+extern bool has_working_tty_timestamps;
 
 /// This macro is used to check that an input argument is not null. It is a bit lika a non-fatal
 /// form of assert. Instead of exit-ing on failure, the current function is ended at once. The

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -407,6 +407,36 @@ static int fish_parse_opt(int argc, char **argv, std::vector<std::string> *cmds)
     return optind;
 }
 
+/// Various things we need to initialize at run-time that don't really fit any of the other init
+/// routines.
+static void misc_init() {
+#ifdef OS_IS_CYGWIN
+    // MS Windows tty devices do not have either a read or write timestamp. Those respective fields
+    // of `struct stat` are always the current time. Which means we can't use them. So we assume no
+    // external program has written to the terminal behind our back. This makes multiline prompts
+    // usable. See issue #2859.
+    has_working_tty_timestamps = false;
+#else
+    // This covers Windows Subsystem for Linux (WSL).
+    int fd = open("/proc/sys/kernel/osrelease", O_RDONLY);
+    if (fd != -1) {
+        const char *magic_suffix = "Microsoft";
+        int len_magic_suffix = strlen(magic_suffix);
+        char osrelease[128] = {0};
+        int len_osrelease = read(fd, osrelease, sizeof(osrelease) - 1);
+        if (osrelease[len_osrelease - 1] == '\n') {
+            osrelease[len_osrelease - 1] = '\0';
+            len_osrelease--;
+        }
+        if (len_osrelease >= len_magic_suffix &&
+            strcmp(magic_suffix, osrelease + len_osrelease - len_magic_suffix) == 0) {
+            has_working_tty_timestamps = false;
+        }
+        close(fd);
+    }
+#endif  // OS_IS_MS_WINDOWS
+}
+
 int main(int argc, char **argv) {
     int res = 1;
     int my_optind = 0;
@@ -452,6 +482,7 @@ int main(int argc, char **argv) {
     history_init();
     // For set_color to support term256 in config.fish (issue #1022).
     update_fish_color_support();
+    misc_init();
 
     parser_t &parser = parser_t::principal_parser();
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -347,12 +347,18 @@ static void s_save_status(screen_t *s) {
 static void s_check_status(screen_t *s) {
     fflush(stdout);
     fflush(stderr);
+    if (!has_working_tty_timestamps) {
+        // We can't reliably determine if the terminal has been written to behind our back so we
+        // just assume that hasn't happened and hope for the best. This is important for multi-line
+        // prompts to work correctly.
+        return;
+    }
 
     fstat(1, &s->post_buff_1);
     fstat(2, &s->post_buff_2);
 
-    int changed = (s->prev_buff_1.st_mtime != s->post_buff_1.st_mtime) ||
-                  (s->prev_buff_2.st_mtime != s->post_buff_2.st_mtime);
+    bool changed = (s->prev_buff_1.st_mtime != s->post_buff_1.st_mtime) ||
+                   (s->prev_buff_2.st_mtime != s->post_buff_2.st_mtime);
 
 #if defined HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC
     changed = changed ||


### PR DESCRIPTION
The tty device timestamps on MS Windows aren't usable because they're always
the current time. So fish can't use them to decide if the entire prompt needs
to be repainted.

Fixes #2859