### PR TITLE
Split command substitution output on \0 if IFS is empty

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -464,7 +464,7 @@ end
 
 \subsection expand-command-substitution Command substitution
 
-The output of a series of commands can be used as the parameters to another command. If a parameter contains a set of parenthesis, the text enclosed by the parenthesis will be interpreted as a list of commands. On expansion, this list is executed, and substituted by the output. If the output is more than one line long, each line will be expanded to a new parameter. Setting `IFS` to the empty string will disable line splitting.
+The output of a series of commands can be used as the parameters to another command. If a parameter contains a set of parenthesis, the text enclosed by the parenthesis will be interpreted as a list of commands. On expansion, this list is executed, and substituted by the output. If `IFS` is set to a non-empty string (the contents don't matter) or unset, the output is split at each newline character into multiple parameters. If `IFS` is set to the empty string, the splitting is done at each NUL character (\0) instead of newlines.
 
 The exit status of the last run command substitution is available in the <a href='#variables-status'>status</a> variable.
 
@@ -833,7 +833,7 @@ The user can change the settings of `fish` by changing the values of certain var
 
 - `HOME`, the user's home directory. This variable can be changed by the user.
 
-- `IFS`, the internal field separator that is used for word splitting with the <a href="commands.html#read">read builtin</a>. Setting this to the empty string will also disable line splitting in <a href="#expand-command-substitution">command substitution</a>. This variable can be changed by the user.
+- `IFS`, the internal field separator that is used for word splitting with the <a href="commands.html#read">read builtin</a>. Setting this to the empty string will also change line splitting in <a href="#expand-command-substitution">command substitution</a> to split on \0 instead of newlines. This variable can be changed by the user.
 
 - `PWD`, the current working directory.
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1182,30 +1182,31 @@ static int exec_subshell_internal(const wcstring &cmd, wcstring_list_t *lst,
     if (lst != NULL && io_buffer.get() != NULL) {
         const char *begin = io_buffer->out_buffer_ptr();
         const char *end = begin + io_buffer->out_buffer_size();
-        if (split_output) {
-            const char *cursor = begin;
-            while (cursor < end) {
-                // Look for the next separator.
-                const char *stop = (const char *)memchr(cursor, '\n', end - cursor);
-                const bool hit_separator = (stop != NULL);
-                if (!hit_separator) {
-                    // If it's not found, just use the end.
-                    stop = end;
-                }
-                // Stop now points at the first character we do not want to copy.
-                const wcstring wc = str2wcstring(cursor, stop - cursor);
-                lst->push_back(wc);
+        const char sep = split_output ? '\n' : '\0';
 
-                // If we hit a separator, skip over it; otherwise we're at the end.
-                cursor = stop + (hit_separator ? 1 : 0);
-            }
-        } else {
-            // we're not splitting output, but we still want to trim off a trailing newline.
+        if (!split_output) {
+            // we're not splitting output on newlines, but we still want to trim off
+            // a trailing newline.
             if (end != begin && end[-1] == '\n') {
                 --end;
             }
-            const wcstring wc = str2wcstring(begin, end - begin);
+        }
+
+        const char *cursor = begin;
+        while (cursor < end) {
+            // Look for the next separator.
+            const char *stop = (const char *)memchr(cursor, sep, end - cursor);
+            const bool hit_separator = (stop != NULL);
+            if (!hit_separator) {
+                // If it's not found, just use the end.
+                stop = end;
+            }
+            // Stop now points at the first character we do not want to copy.
+            const wcstring wc = str2wcstring(cursor, stop - cursor);
             lst->push_back(wc);
+
+            // If we hit a separator, skip over it; otherwise we're at the end.
+            cursor = stop + (hit_separator ? 1 : 0);
         }
     }
 

--- a/tests/read.in
+++ b/tests/read.in
@@ -13,6 +13,7 @@ count (echo one\ntwo\n)
 echo [(echo -n one\ntwo\n)]
 count (echo one\ntwo\n\n)
 echo [(echo -n one\ntwo\n\n)]
+count (echo -e one'\x00'two)
 set -le IFS
 
 function print_vars --no-scope-shadowing

--- a/tests/read.out
+++ b/tests/read.out
@@ -10,6 +10,7 @@ two]
 [one
 two
 ]
+2
 
 1 'hello' 1 'there'
 1 'hello there'


### PR DESCRIPTION
Fixes #3164