### PR TITLE
Don't error out on ()[1]

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -1106,17 +1106,21 @@ static int expand_cmdsubst(const wcstring &input, std::vector<completion_t> *out
         tail_begin = slice_end;
         for (i = 0; i < slice_idx.size(); i++) {
             long idx = slice_idx.at(i);
-            if (idx < 1 || (size_t)idx > sub_res.size()) {
+            if (idx == 1 && sub_res.size() == 0) {
+                // Don't error out on [1], for consistency with variable expansion
+                idx = idx - 1;
+            } else if (idx < 1 || (size_t)idx > sub_res.size()) {
                 size_t pos = slice_source_positions.at(i);
                 append_syntax_error(errors, slice_begin - in + pos, ARRAY_BOUNDS_ERR);
                 return 0;
-            }
-            idx = idx - 1;
+            } else {
+                idx = idx - 1;
 
-            sub_res2.push_back(sub_res.at(idx));
-            // debug( 0, L"Pushing item '%ls' with index %d onto sliced result", al_get(
-            // sub_res, idx ), idx );
-            // sub_res[idx] = 0; // ??
+                sub_res2.push_back(sub_res.at(idx));
+                // debug( 0, L"Pushing item '%ls' with index %d onto sliced result", al_get(
+                // sub_res, idx ), idx );
+                // sub_res[idx] = 0; // ??
+            }
         }
         sub_res = sub_res2;
     }

--- a/tests/expansion.err
+++ b/tests/expansion.err
@@ -22,9 +22,6 @@ fish: echo "$foo[d]"
 Invalid index value
 fish: echo $foo[d]
                 ^
-Array index out of bounds
-fish: echo ()[1]
-              ^
 Invalid index value
 fish: echo ()[d]
               ^

--- a/tests/expansion.in
+++ b/tests/expansion.in
@@ -78,7 +78,7 @@ show $foo[2 1]
 echo "$foo[d]"
 echo $foo[d]
 
-echo ()[1]
+count ()[1]
 echo ()[d]
 
 echo "Catch your breath"

--- a/tests/expansion.out
+++ b/tests/expansion.out
@@ -40,4 +40,5 @@
 0
 1 
 0
+0
 Catch your breath


### PR DESCRIPTION
This makes command substitution consistent with variable expansion,
where $foo[1] never prints an error even if foo is empty or unset.

Fixes #3177.