### PR TITLE
Fix multi-line prompt resize

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -55,6 +55,10 @@ static void invalidate_soft_wrap(screen_t *scr);
 typedef std::vector<char> data_buffer_t;
 static data_buffer_t *s_writeb_buffer = 0;
 
+/// Clears num_lines of lines from the current cursor position upwards. At the end the cursor is
+/// left at the top left hand side of the resulting cleard rectangle
+static void clear_lines(screen_t *const s, const size_t num_lines);
+
 static int s_writeb(char character);
 
 /// Class to temporarily set s_writeb_buffer and the writer function in a scoped way.
@@ -260,23 +264,26 @@ size_t escape_code_length(const wchar_t *code) {
 // Information about a prompt layout.
 struct prompt_layout_t {
     // How many lines the prompt consumes.
-    size_t line_count;
+    size_t line_count = 0;
     // Width of the longest line.
-    size_t max_line_width;
+    size_t max_line_width = 0;
     // Width of the last line.
-    size_t last_line_width;
+    size_t last_line_width = 0;
 };
 
 /// Calculate layout information for the given prompt. Does some clever magic to detect common
 /// escape sequences that may be embeded in a prompt, such as color codes.
 static prompt_layout_t calc_prompt_layout(const wchar_t *prompt) {
-    size_t current_line_width = 0;
-    size_t j;
-
     prompt_layout_t prompt_layout = {};
+
+    if (prompt == nullptr || !prompt[0]) {
+        return prompt_layout;
+    }
+
+    size_t current_line_width = 0;
     prompt_layout.line_count = 1;
 
-    for (j = 0; prompt[j]; j++) {
+    for (size_t j = 0; prompt[j]; j++) {
         if (prompt[j] == L'\x1b') {
             // This is the start of an escape code. Skip over it if it's at least one character
             // long.
@@ -305,14 +312,7 @@ static prompt_layout_t calc_prompt_layout(const wchar_t *prompt) {
 }
 
 static size_t calc_prompt_lines(const wcstring &prompt) {
-    // Hack for the common case where there's no newline at all. I don't know if a newline can
-    // appear in an escape sequence, so if we detect a newline we have to defer to
-    // calc_prompt_width_and_lines.
-    size_t result = 1;
-    if (prompt.find(L'\n') != wcstring::npos || prompt.find(L'\f') != wcstring::npos) {
-        result = calc_prompt_layout(prompt.c_str()).line_count;
-    }
-    return result;
+    return calc_prompt_layout(prompt.c_str()).line_count;
 }
 
 /// Stat stdout and stderr and save result. This should be done before calling a function that may
@@ -598,6 +598,21 @@ static bool perform_any_impending_soft_wrap(screen_t *scr, int x, int y) {
         }
     }
     return false;
+}
+
+static void clear_lines(screen_t *const s, const size_t numlines) {
+    s->actual.cursor.y = 0;
+    s->actual.cursor.x = 0;
+
+    if (numlines < 1) {
+        return;  // We're done
+    }
+
+    // Fill the space after new line so there are no artefacts
+    printf("%s", "\r\x1b[2K");  // go to the front and delete the first line
+    for (size_t i = 1; i < numlines; ++i) {
+        printf("%s", "\x1b[1A\x1b[2K");  // go up one and kill the line
+    }
 }
 
 /// Make sure we don't soft wrap.
@@ -1168,9 +1183,26 @@ void s_reset(screen_t *s, screen_reset_mode_t mode) {
         // by lying to ourselves and claiming that we're really below what we consider "line 0"
         // (which is the last line of the prompt). This will cause us to move up to try to get back
         // to line 0, but really we're getting back to the initial line of the prompt.
-        const size_t prompt_line_count = calc_prompt_lines(s->actual_left_prompt);
-        assert(prompt_line_count >= 1);
-        s->actual.cursor.y += (prompt_line_count - 1);
+        const auto prompt_layout = calc_prompt_layout(s->actual_left_prompt.c_str());
+        const auto current_width = static_cast<unsigned int>(common_get_width());
+        assert(prompt_layout.line_count >= 1);
+
+        if (prompt_layout.line_count > 1) {
+            if (static_cast<unsigned int>(s->actual_width) > current_width) {
+                // Multi-line wrapped
+                clear_lines(s, static_cast<unsigned int>(s->actual_width) / current_width +
+                                   prompt_layout.line_count);
+            } else {
+                // Multi-line
+                clear_lines(s, prompt_layout.line_count);
+            }
+        } else if (prompt_layout.max_line_width > current_width) {
+            // Single-line wrapped
+            clear_lines(s, prompt_layout.max_line_width / current_width + prompt_layout.line_count);
+        } else {
+            // Single-line
+            clear_lines(s, prompt_layout.line_count);
+        }
     } else if (abandon_line) {
         s->actual.cursor.y = 0;
     }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -264,11 +264,11 @@ size_t escape_code_length(const wchar_t *code) {
 // Information about a prompt layout.
 struct prompt_layout_t {
     // How many lines the prompt consumes.
-    size_t line_count = 0;
+    size_t line_count;
     // Width of the longest line.
-    size_t max_line_width = 0;
+    size_t max_line_width;
     // Width of the last line.
-    size_t last_line_width = 0;
+    size_t last_line_width;
 };
 
 /// Calculate layout information for the given prompt. Does some clever magic to detect common
@@ -276,7 +276,7 @@ struct prompt_layout_t {
 static prompt_layout_t calc_prompt_layout(const wchar_t *prompt) {
     prompt_layout_t prompt_layout = {};
 
-    if (prompt == nullptr || !prompt[0]) {
+    if (prompt == 0 || !prompt[0]) {
         return prompt_layout;
     }
 
@@ -309,10 +309,6 @@ static prompt_layout_t calc_prompt_layout(const wchar_t *prompt) {
     }
     prompt_layout.last_line_width = current_line_width;
     return prompt_layout;
-}
-
-static size_t calc_prompt_lines(const wcstring &prompt) {
-    return calc_prompt_layout(prompt.c_str()).line_count;
 }
 
 /// Stat stdout and stderr and save result. This should be done before calling a function that may
@@ -1183,8 +1179,8 @@ void s_reset(screen_t *s, screen_reset_mode_t mode) {
         // by lying to ourselves and claiming that we're really below what we consider "line 0"
         // (which is the last line of the prompt). This will cause us to move up to try to get back
         // to line 0, but really we're getting back to the initial line of the prompt.
-        const auto prompt_layout = calc_prompt_layout(s->actual_left_prompt.c_str());
-        const auto current_width = static_cast<unsigned int>(common_get_width());
+        const prompt_layout_t prompt_layout = calc_prompt_layout(s->actual_left_prompt.c_str());
+        const unsigned int current_width = static_cast<unsigned int>(common_get_width());
         assert(prompt_layout.line_count >= 1);
 
         if (prompt_layout.line_count > 1) {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -274,14 +274,8 @@ struct prompt_layout_t {
 /// Calculate layout information for the given prompt. Does some clever magic to detect common
 /// escape sequences that may be embeded in a prompt, such as color codes.
 static prompt_layout_t calc_prompt_layout(const wchar_t *prompt) {
-    prompt_layout_t prompt_layout = {};
-
-    if (prompt == 0 || !prompt[0]) {
-        return prompt_layout;
-    }
-
+    prompt_layout_t prompt_layout = {1, 0, 0};
     size_t current_line_width = 0;
-    prompt_layout.line_count = 1;
 
     for (size_t j = 0; prompt[j]; j++) {
         if (prompt[j] == L'\x1b') {


### PR DESCRIPTION
There is one 'issue' with this fix:
While resizing a multi-line prompt the cursor, prompt and content of the
terminal is moving upwards to the top of the terminal. I guess the reason
for that is that the terminal is seeing that something is written to it
and decides that it needs to scroll to keep everything visible.

Please review it for compatibility - I tried it with termite on archlinux. I tested multi and single line prompts with resizes that didn't interfere with the prompt and interfered with it. 

There **should** be a problem with terminals that do not soft wrap. I do not know how to check for that so a fix for these kinds of terminals has to come from someone else. But it should be stright forward to do see line 1190 1200 of the s_reset function. 

Edit: Fixes #2320 