### PR TITLE
Limit the number of commits in completions

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -10,6 +10,14 @@ function __fish_git_commits
     | string replace -r '(.{73}).+' '$1…'
 end
 
+function __fish_git_recent_commits
+    # Like __fish_git_commits, but not on all branches and limited to
+    # the last 50 commits. Used for fixup, where only the current branch
+    # and the latest commits make sense.
+    command git log --pretty=tformat:"%h"\t"%s" --max-count=50 ^/dev/null \
+    | string replace -r '(.{73}).+' '$1…'
+end
+
 function __fish_git_branches
     # In some cases, git can end up on no branch - e.g. with a detached head
     # This will result in output like `* (no branch)` or a localized `* (HEAD detached at SHA)`
@@ -396,7 +404,7 @@ complete -c git -n '__fish_git_needs_command' -a commit -d 'Record changes to th
 complete -c git -n '__fish_git_using_command commit' -l amend -d 'Amend the log message of the last commit'
 complete -f -c git -n '__fish_git_using_command commit' -a '(__fish_git_modified_files)'
 complete -f -c git -n '__fish_git_using_command commit' -l fixup -d 'Fixup commit to be used with rebase --autosquash'
-complete -f -c git -n '__fish_git_using_command commit; and __fish_contains_opt fixup' -a '(__fish_git_commits)'
+complete -f -c git -n '__fish_git_using_command commit; and __fish_contains_opt fixup' -a '(__fish_git_recent_commits)'
 # TODO options
 
 ### diff


### PR DESCRIPTION
Offering auto completion for existing commits is great, but on big
repositories, it suddenly becomes really slow, even with fast hard
disks, since each commit is read and then a line processed for it.

Instead limit to the last 500 commits (arbitrary number) which still
feels fast. Going back further in history can easily and more reasonably
done with git log etc.