### PR TITLE
Add example code for handling && or ||

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -171,6 +171,11 @@ COMPLETIONS_DIR_FILES := $(wildcard share/completions/*.fish) share/completions/
 FUNCTIONS_DIR_FILES := $(wildcard share/functions/*.fish)
 
 #
+# Files in ./share/examples/
+#
+EXAMPLES_DIR_FILES := $(wildcard share/examples/*.fish)
+
+#
 # Programs to install
 #
 PROGRAMS := fish fish_indent fish_key_reader
@@ -592,6 +597,7 @@ install-force: all install-translations
 	$(INSTALL) -m 755 -d $(DESTDIR)$(extra_functionsdir); true
 	$(INSTALL) -m 755 -d $(DESTDIR)$(extra_confdir); true
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/functions
+	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/examples
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/man/man1
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/tools
 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/tools/web_config
@@ -609,6 +615,10 @@ install-force: all install-translations
 	done;
 	for i in $(FUNCTIONS_DIR_FILES:%='%'); do \
 		$(INSTALL) -m 644 $$i $(DESTDIR)$(datadir)/fish/functions/; \
+		true; \
+	done;
+	for i in $(EXAMPLES_DIR_FILES:%='%'); do \
+		$(INSTALL) -m 644 $$i $(DESTDIR)$(datadir)/fish/examples/; \
 		true; \
 	done;
 	for i in share/man/man1/*.1; do \

--- a/doc_src/tutorial.hdr
+++ b/doc_src/tutorial.hdr
@@ -399,6 +399,8 @@ Unlike other shells, `fish` does not have special syntax like &amp;&amp; or || t
 \outp{Backup failed}
 \endfish
 
+If you need to handle &amp;&amp; or || (for example in pasted snippets), add the contents of /usr/share/fish/examples/fish_user_key_bindings_handle_combiners.fish to ~/.config/fish/functions/fish_user_key_bindings.fish.
+
 
 \section tut_conditionals Conditionals (If, Else, Switch)
 

--- a/share/examples/fish_user_key_bindings_handle_combiners.fish
+++ b/share/examples/fish_user_key_bindings_handle_combiners.fish
@@ -1,0 +1,56 @@
+# Example script to handle && and || in fish
+# The contents of this file can be added to
+# ~/.config/fish/functions/fish_user_key_bindings.fish
+# to automatically replace the combiners.
+
+function handle_input_bash_conditional --description 'Function used for binding to replace && and ||'
+    # This function is expected to be called with a single argument of either & or |
+    # The argument indicates which key was pressed to invoke this function
+    if begin; commandline --search-mode; or commandline --paging-mode; end
+        # search or paging mode; use normal behavior
+        commandline -i $argv[1]
+        return
+    end
+    # is our cursor positioned after a '&'/'|'?
+    switch (commandline -c)[-1]
+    case \*$argv[1]
+        # experimentally, `commandline -t` only prints string-type tokens,
+        # so it prints nothing for the background operator. We need -c as well
+        # so if the cursor is after & in `&wat` it doesn't print "wat".
+        if test -z (commandline -c -t)[-1]
+            # Ideally we'd just emit a backspace and then insert the text
+            # but injected readline functions run after any commandline modifications.
+            # So instead we have to build the new commandline
+            #
+            # NB: We could really use some string manipulation operators and some basic math support.
+            # The `math` function is actually a wrawpper around `bc` which is kind of terrible.
+            # Instead we're going to use `expr`, which is a bit lighter-weight.
+
+            # get the cursor position
+            set -l count (commandline -C)
+            # calculate count-1 and count+1 to give to `cut`
+            set -l prefix (expr $count - 1)
+            set -l suffix (expr $count + 1)
+            # cut doesn't like 1-0 so we need to special-case that
+            set -l cutlist 1-$prefix,$suffix-
+            if test "$prefix" = 0
+                set cutlist $suffix-
+            end
+            commandline (commandline | cut -c $cutlist)
+            commandline -C $prefix
+            if test $argv[1] = '&'
+                commandline -i '; and '
+            else
+                commandline -i '; or '
+            end
+            return
+        end
+    end
+    # no special behavior, insert the character
+    commandline -i $argv[1]
+end
+
+function fish_user_key_bindings
+    bind \& 'handle_input_bash_conditional \&'
+    bind \| 'handle_input_bash_conditional \|'
+end


### PR DESCRIPTION
Add an example how to handle the combiners. I understand that fish doesn't want to add them to it's syntax, but mentioning this work-around will help many users.

Code taken from
https://github.com/fish-shell/fish-shell/issues/150#issuecomment-53133716

See issue #150