### PR TITLE
Allow null character input (\x00) to be bound to action

### DIFF
--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -13,7 +13,7 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
     end
 
     # This is the default binding, i.e. the one used if no other binding matches
-    bind $argv "" self-insert
+    bind $argv \uE000 self-insert
 
     bind $argv \n execute
     bind $argv \r execute

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -24,7 +24,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     fish_default_key_bindings -M default
 
     # Remove the default self-insert bindings in default mode
-    bind -e "" -M default
+    bind -e \uE000 -M default
     # Add way to kill current command line while in insert mode.
     bind -M insert \cc __fish_cancel_commandline
     # Add a way to switch from insert to normal (command) mode.
@@ -180,7 +180,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # Lowercase r, enters replace-one mode
     #
     bind -m replace-one r force-repaint
-    bind -M replace-one -m default '' delete-char self-insert backward-char force-repaint
+    bind -M replace-one -m default \uE000 delete-char self-insert backward-char force-repaint
     bind -M replace-one -m default \e cancel force-repaint
 
     #

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1071,7 +1071,7 @@ size_t read_unquoted_escape(const wchar_t *input, wcstring *result, bool allow_i
             const wchar_t sequence_char = input[in_pos++];
             if (sequence_char >= L'a' && sequence_char <= (L'a' + 32)) {
                 result_char_or_none = sequence_char - L'a' + 1;
-            } else if (sequence_char >= L'A' && sequence_char <= (L'A' + 32)) {
+            } else if (sequence_char >= L'@' && sequence_char <= (L'A' + 32)) {
                 result_char_or_none = sequence_char - L'A' + 1;
             } else {
                 errored = true;


### PR DESCRIPTION
# Description

Fix #3189 by changing existing self-insert binding of null character to a unicode reserved codepoint. Input mapping matcher is also accordingly modified to properly handle null-character maps and the token parser no longer complains \c@ is an invalid token.