### PR TITLE
Updated Readme to add further instuction for chsh (logout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,15 @@ chsh will prompt you for your password, and change your default shell. Substitut
 
 Use the following command if you didn't already add your fish path to /etc/shells.
 
-        echo /usr/local/bin/fish | sudo tee -a /etc/shells
+    echo /usr/local/bin/fish | sudo tee -a /etc/shells
 
 To switch your default shell back, you can run:
 
 	chsh -s /bin/bash
 
 Substitute /bin/bash with /bin/tcsh or /bin/zsh as appropriate.
+
+You may need to logout/login for the change (chsh) to take effect.
 
 ## Contributing Changes to the Code
 


### PR DESCRIPTION
# Description

The changing of the shell (chsh) required a logout/login (Ubuntu). This is maybe not be the case on all systems but the instruction has been added.

A Format fix in the Readme as well.

Fixes issue #
N/A
