### PR TITLE
don't use getent to list hosts if its not supported

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -3,6 +3,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	# HACK: This only deals with ipv4
 
 	# Print all hosts from /etc/hosts
+	# use 'getent hosts' on OSes that support it (OpenBSD and Cygwin do not)
 	if type -q getent; and getent hosts > /dev/null 2>&1 # test if 'getent hosts' works and redirect output so errors don't print
 		# Ignore zero ips
 		getent hosts | string match -r -v '^0.0.0.0' \

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -3,7 +3,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	# HACK: This only deals with ipv4
 
 	# Print all hosts from /etc/hosts
-	if begin; type -q getent; and getent hosts > /dev/null 2>&1; end
+	if type -q getent; and getent hosts > /dev/null 2>&1 # test if 'getent hosts' works and redirect output so errors don't print
 		# Ignore zero ips
 		getent hosts | string match -r -v '^0.0.0.0' \
 		| string replace -r '[0-9.]*\s*' '' | string split " "

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -3,7 +3,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 	# HACK: This only deals with ipv4
 
 	# Print all hosts from /etc/hosts
-	if type -q getent
+	if begin; type -q getent; and getent hosts > /dev/null 2>&1; end
 		# Ignore zero ips
 		getent hosts | string match -r -v '^0.0.0.0' \
 		| string replace -r '[0-9.]*\s*' '' | string split " "


### PR DESCRIPTION
# Description

Don't use ````getent hosts```` if its not supported.

Fixes issue #2137 

# TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [ ] Tests have been added for regressions fixed
