### PR TITLE
fix broken completion of screen on osx, test on ubuntu and mac

### DIFF
--- a/share/completions/screen.fish
+++ b/share/completions/screen.fish
@@ -1,5 +1,9 @@
 function __fish_complete_screen --description "Print a list of running screen sessions"
-    screen -list | __fish_sgrep \^\t.\*\(.\*\)| string replace -r '\t(.*)\s+\((.*)\)' '$1\tScreen:$2'
+    screen -list | string match -r '^\t.*\(.*\)\s*$'| string replace -r '\t(.*)\s+\((.*)\)' '$1\tScreen:$2'
+end
+
+function __fish_complete_screen_attached --description "Print a list of attached screen sessions"
+    screen -list | string match -r '^\t.*\(Attached\)\s*$'| string replace -r '\t(.*)\s+\((.*)\)' '$1\tScreen:$2'
 end
 
 complete -c screen -x
@@ -32,6 +36,6 @@ complete -c screen -s t -x -d 'Session title'
 complete -c screen -s U -d 'UTF-8 mode'
 complete -c screen -s v -d 'Display version and exit'
 complete -c screen -o wipe -d 'Wipe dead sessions'
-complete -c screen -s x -d 'Multi attach'
+complete -c screen -s x -d 'Multi attach' -a '(__fish_complete_screen_attached)'
 complete -c screen -s X -r -d 'Send command'
 

--- a/share/completions/screen.fish
+++ b/share/completions/screen.fish
@@ -6,12 +6,18 @@ function __fish_detect_screen_socket_dir --description "Detect which folder scre
 end
 
 function __fish_complete_screen_general_list_mac --description "Get the socket list on mac"
-    switch $argv
-        case "Detached"
-            stat -f "%Lp %Sm %N" -t "%D %T" $__fish_screen_socket_dir/* | string match -r '^6\d{2} .*$' | string replace -r '^6\d{2} (\S* \S*) \S*/(\S+)' '$2\t$1 Detached'
-        case "Attached"
-            stat -f "%Lp %Sm %N" -t "%D %T" $__fish_screen_socket_dir/* | string match -r '^7\d{2} .*$' | string replace -r '^7\d{2} (\S* \S*) \S*/(\S+)' '$2\t$1 Attached'
+    pushd $__fish_screen_socket_dir > /dev/null
+    ls
+    set sockets (ls)
+    if test (count $socket) -ne 0
+        switch $argv
+            case "Detached"
+                stat -f "%Lp %Sm %N" -t "%D %T" $sockets | string match -r '^6\d{2} .*$' | string replace -r '^6\d{2} (\S* \S*) \S*/(\S+)' '$2\t$1 Detached'
+            case "Attached"
+                stat -f "%Lp %Sm %N" -t "%D %T" $sockets | string match -r '^7\d{2} .*$' | string replace -r '^7\d{2} (\S* \S*) \S*/(\S+)' '$2\t$1 Attached'
+        end
     end
+    popd > /dev/null
 end
 
 function __fish_complete_screen_detached --description "Print a list of detached screen sessions"

--- a/share/completions/screen.fish
+++ b/share/completions/screen.fish
@@ -7,17 +7,20 @@ end
 
 function __fish_complete_screen_general_list_mac --description "Get the socket list on mac"
     pushd $__fish_screen_socket_dir > /dev/null
-    ls
-    set sockets (ls)
-    if test (count $socket) -ne 0
+    set -l sockets (ls)
+    if test (count $sockets) -ne 0
         switch $argv
             case "Detached"
-                stat -f "%Lp %Sm %N" -t "%D %T" $sockets | string match -r '^6\d{2} .*$' | string replace -r '^6\d{2} (\S* \S*) \S*/(\S+)' '$2\t$1 Detached'
+                stat -f "%Lp %SB %N" -t "%D %T" $sockets | string match -r '^6\d{2} .*$' | string replace -r '^6\d{2} (\S+ \S+) (\S+)' '$2\t$1 Detached'
             case "Attached"
-                stat -f "%Lp %Sm %N" -t "%D %T" $sockets | string match -r '^7\d{2} .*$' | string replace -r '^7\d{2} (\S* \S*) \S*/(\S+)' '$2\t$1 Attached'
+                stat -f "%Lp %SB %N" -t "%D %T" $sockets | string match -r '^7\d{2} .*$' | string replace -r '^7\d{2} (\S+ \S+) (\S+)' '$2\t$1 Attached'
         end
     end
     popd > /dev/null
+end
+
+function __fish_complete_screen_general_list --description "Get the socket list"
+    screen -list | string match -r '^\t.*\(.*\)\s*\('$argv'\)\s*$'| string replace -r '\t(.*)\s+\((.*)\)\s*\((.*)\)' '$1\t$2 $3'
 end
 
 function __fish_complete_screen_detached --description "Print a list of detached screen sessions"
@@ -25,7 +28,7 @@ function __fish_complete_screen_detached --description "Print a list of detached
         case Darwin
             __fish_complete_screen_general_list_mac Detached
         case '*'
-            screen -list | string match -r '^\t.*\(.*\)\s*\(Detached\)\s*$'| string replace -r '\t(.*)\s+\((.*)\)\s*\((.*)\)' '$1\t$2 $3'
+            __fish_complete_screen_general_list Detached
     end
 end
 
@@ -34,7 +37,7 @@ function __fish_complete_screen_attached --description "Print a list of attached
         case Darwin
             __fish_complete_screen_general_list_mac Attached
         case '*'
-            screen -list | string match -r '^\t.*\(.*\)\s*\(Attached\)\s*$'| string replace -r '\t(.*)\s+\((.*)\)\s*\((.*)\)' '$1\t$2 $3'
+            __fish_complete_screen_general_list Attached
     end
 end
 

--- a/share/completions/screen.fish
+++ b/share/completions/screen.fish
@@ -1,5 +1,5 @@
 function __fish_complete_screen --description "Print a list of running screen sessions"
-	screen -list | __fish_sgrep \^\t.\*\(.\*\)|sed -e 's/'\t'\(.*\)(\(.*\))/\1 Screen: \2/'
+    screen -list | __fish_sgrep \^\t.\*\(.\*\)| string replace -r '\t(.*)\s+\((.*)\)' '$1\tScreen:$2'
 end
 
 complete -c screen -x

--- a/share/completions/screen.fish
+++ b/share/completions/screen.fish
@@ -1,5 +1,5 @@
 function __fish_complete_screen --description "Print a list of running screen sessions"
-	screen -list | __fish_sgrep \^\t.\*\(.\*\)|sed -e 's/\t\(.*\)\t(\(.*\))/\1'\t'Screen: \2/'
+	screen -list | __fish_sgrep \^\t.\*\(.\*\)|sed -e 's/'\t'\(.*\)(\(.*\))/\1 Screen: \2/'
 end
 
 complete -c screen -x


### PR DESCRIPTION
## Description

Change sed expression of function '__fish_complete_screen' in share/completion/screen.fish to support completion on both mac and linux.
I have tested on my mac and ubuntu server.

Fixes issue #

fish does not complete `screen -r` when tapping Tab on mac (both GNU and FAU version)

## Output example
on mac:
```bash
~/W/G/f/s/completions (master)$ screen -r 819
81930.test1  (Screen: Detached)  81951.test3  (Screen: Detached)
81940.test2  (Screen: Detached)  81961.test4  (Screen: Detached)
```

on linux (ubuntu):
```bash
xxx@localhost ~> screen -r 4
4171.test1  ((07/28/16 08:09:41) Screen:Detached)  4272.test3  ((07/28/16 08:10:19) Screen:Detached)
4255.test2  ((07/28/16 08:10:17) Screen:Detached)  4289.test4  ((07/28/16 08:10:21) Screen:Detached)
```

You will find that they are a little different because `screen -list` on mac doesn't show time.