### PR TITLE
Disable 24bit in screen and terms with < 8 colors

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -35,6 +35,12 @@ if status --is-interactive
 	else
 		# Enable truecolor/24-bit support for select terminals
 		if not set -q NVIM_LISTEN_ADDRESS # (Neovim will swallow the 24bit sequences, rendering text white)
+            # Still check $TERM because these other variables are exported, and will also be set in e.g. emacs ansi-term.
+            # We could blacklist just "eterm*" here, but it might be changed to support it in the future,
+            # and there might be other terminal-in-a-terminal programs with issues.
+            # We could also call `tput colors`, but that requires an additional fork.
+            and string match -q "*-256color" $TERM # If 256 colors aren't supported, 24bit isn't going to be either
+            and not set -q STY # This is set in GNU screen, which doesn't support 24bit
 			and begin
 				set -q KONSOLE_PROFILE_NAME # KDE's konsole
 				or string match -q -- "*:*" $ITERM_SESSION_ID # Supporting versions of iTerm2 will include a colon here


### PR DESCRIPTION
## Description

There are some cases where we enable 24bit/truecolor-mode when it's not supported, because we base our decision on exported variables. In particular this applies to terminal-within-a-terminal programs such as GNU screen and emacs' "ansi-term" mode (tmux supports 24bit).

We should instead not enable it in these cases, otherwise the text will display white, which can be a bit disorienting with suggestions.

PR because there's bound to be a bunch of cases I haven't come up with yet.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages. (24bit is undocumented currently)
- [x] Tests have been added for regressions fixed (N/A - I don't think we can test this currently)