### PR TITLE
Make it possible to have complete not sort

### DIFF
--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -142,6 +142,8 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
     static int recursion_level = 0;
 
+    bool dont_sort = false;
+
     argc = builtin_count_args(argv);
 
     w.woptind = 0;
@@ -157,6 +159,7 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                                                       {L"old-option", required_argument, 0, 'o'},
                                                       {L"description", required_argument, 0, 'd'},
                                                       {L"arguments", required_argument, 0, 'a'},
+                                                      {L"sorted_arguments", required_argument, 0, 'S'},
                                                       {L"erase", no_argument, 0, 'e'},
                                                       {L"unauthoritative", no_argument, 0, 'u'},
                                                       {L"authoritative", no_argument, 0, 'A'},
@@ -168,7 +171,7 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
         int opt_index = 0;
         int opt =
-            w.wgetopt_long(argc, argv, L"a:c:p:s:l:o:d:frxeuAn:C::w:h", long_options, &opt_index);
+            w.wgetopt_long(argc, argv, L"a:S:c:p:s:l:o:d:frxeuAn:C::w:h", long_options, &opt_index);
         if (opt == -1) break;
 
         switch (opt) {
@@ -248,6 +251,11 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
             }
             case 'a': {
                 comp = w.woptarg;
+                break;
+            }
+            case 'S': {
+                comp = w.woptarg;
+                dont_sort = true;
                 break;
             }
             case 'e': {
@@ -386,6 +394,8 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
             streams.out.append(complete_print());
         } else {
             int flags = COMPLETE_AUTO_SPACE;
+            if (dont_sort)
+                flags |= COMPLETE_DONT_SORT;
 
             if (remove) {
                 builtin_complete_remove(cmd, path, short_opt.c_str(), gnu_opt, old_opt);

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -225,6 +225,8 @@ completion_t &completion_t::operator=(const completion_t &him) {
 }
 
 bool completion_t::is_naturally_less_than(const completion_t &a, const completion_t &b) {
+    if (a.flags & COMPLETE_DONT_SORT || b.flags & COMPLETE_DONT_SORT)
+        return false;
     return wcsfilecmp(a.completion.c_str(), b.completion.c_str()) < 0;
 }
 
@@ -262,8 +264,9 @@ void completions_sort_and_prioritize(std::vector<completion_t> *comps) {
         }
     }
 
-    // Remove duplicates.
+    // Sort.
     sort(comps->begin(), comps->end(), completion_t::is_naturally_less_than);
+    // Remove duplicates.
     comps->erase(
         std::unique(comps->begin(), comps->end(), completion_t::is_alphabetically_equal_to),
         comps->end());

--- a/src/complete.h
+++ b/src/complete.h
@@ -40,7 +40,9 @@ enum {
     /// This completion should be inserted as-is, without escaping.
     COMPLETE_DONT_ESCAPE = 1 << 4,
     /// If you do escape, don't escape tildes.
-    COMPLETE_DONT_ESCAPE_TILDES = 1 << 5
+    COMPLETE_DONT_ESCAPE_TILDES = 1 << 5,
+    /// Do not sort this result.
+    COMPLETE_DONT_SORT = 1 << 6
 };
 typedef int complete_flags_t;
 


### PR DESCRIPTION
This is convenient when doing things like git log where most likely the
first results are more relevant than later ones.

Now it's possible to use complete ... -S '(my command)' and similar.

See #361

I assume this solution is considered rather horrible and a hack, so I'd be happy to learn how to do it nice and clean - I just thought it would be fun to spend a few minutes trying to come up with a patch.
Are there tests for this kind of command? I guess one should be added.