### PR TITLE
git prompt: faster count of untracked files

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -478,7 +478,7 @@ function __fish_git_prompt_informative_status
     set -l dirtystate (math (count $changedFiles) - (count (echo $changedFiles | grep "U")))
     set -l invalidstate (count (echo $stagedFiles | grep "U"))
     set -l stagedstate (math (count $stagedFiles) - $invalidstate)
-    set -l untrackedfiles (string trim (command git ls-files --others --exclude-standard | wc -l))
+    set -l untrackedfiles (command git ls-files --others --exclude-standard | wc -l | string trim)
 
     set -l info
 

--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -478,7 +478,7 @@ function __fish_git_prompt_informative_status
     set -l dirtystate (math (count $changedFiles) - (count (echo $changedFiles | grep "U")))
     set -l invalidstate (count (echo $stagedFiles | grep "U"))
     set -l stagedstate (math (count $stagedFiles) - $invalidstate)
-    set -l untrackedfiles (count (command git ls-files --others --exclude-standard))
+    set -l untrackedfiles (string trim (command git ls-files --others --exclude-standard | wc -l))
 
     set -l info
 


### PR DESCRIPTION
In a repository with 18k untracked files (by accident, node_modules not in .gitignore), counting them using `count (git ls-files)` was causing a considerable lag with prompt generation.

After changing it to `git ls-files | wc -l`, the count process is at least twice as fast. Not ideal, but it avoids caching the entire `git ls-files` result as a string to count the number of lines by piping the result through `wc -l` directly.