### PR TITLE
Remove optimizeLegibility and display:inline-block

### DIFF
--- a/doc_src/user_doc.css
+++ b/doc_src/user_doc.css
@@ -9,7 +9,6 @@ html, body {
     color: #111;
 }
 body {
-    text-rendering: optimizeLegibility;
     overflow: hidden;
 }
 .logo {
@@ -95,9 +94,6 @@ a { color: #3d5cb3; }
 }
 .fish_right_bar ul li {
     margin-bottom: 0.6rem;
-}
-.fish_right_bar p > code {
-    display: inline-block;
 }
 /* Typography */
 p { margin: 1rem 0; }
@@ -271,5 +267,3 @@ tt, code, pre, .fish {
     position: absolute;
     left: -2rem;
 }
-
-


### PR DESCRIPTION
## Description

These make the inline commands illegible on Android Chrome:
respectively, overlapped with other text, and smaller than the body
text.

They don't seem necessary for correct display on Chrome or Safari.

You can preview this from a mobile device at https://storage.googleapis.com/fish-test-123/8/tutorial.html

Fixes fish-shell/fish-site/issues/34