### PR TITLE
make sure p->ifa_addr is not NULL before using it

### DIFF
--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -931,7 +931,7 @@ static bool get_mac_address(unsigned char macaddr[MAC_ADDRESS_MAX_LEN],
 
     if (getifaddrs(&ifap) == 0) {
         for (const ifaddrs *p = ifap; p; p = p->ifa_next) {
-            if (p->ifa_addr->sa_family == AF_LINK) {
+            if (p->ifa_addr && p->ifa_addr->sa_family == AF_LINK) {
                 if (p->ifa_name && p->ifa_name[0] &&
                     !strcmp((const char *)p->ifa_name, interface)) {
                     const sockaddr_dl &sdl = *reinterpret_cast<sockaddr_dl *>(p->ifa_addr);


### PR DESCRIPTION
## Description

p->ifa_addr might be a NULL pointer and thus crash the program

From
http://man7.org/linux/man-pages/man3/getifaddrs.3.html

 The ifa_addr field points to a structure containing the interface
       address.  (The sa_family subfield should be consulted to determine
       the format of the address structure.)  ***This field may contain a null
       pointer.***
