### PR TITLE
Improve the fish_config/bindings page

### DIFF
--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -220,6 +220,11 @@ body {
 	word-wrap: break-word;
 }
 
+.raw_binding {
+	padding-left: 20px;
+	font-family: monospace;
+}
+
 .history_text {
 	padding-top: 5px;
 	padding-bottom: 5px;

--- a/share/tools/web_config/partials/bindings.html
+++ b/share/tools/web_config/partials/bindings.html
@@ -6,8 +6,13 @@
     <tbody>
     <tr class="data_table_row" ng-repeat="binding in bindings | filterBinding:query">
         <td ng-class="{ data_table_cell: true, no_overflow: !binding._is_selected }" style="text-align: right; padding-right: 30px;" ng-click="binding._is_selected = !binding._is_selected">{{ binding.command }}</td>
-        <!-- Some bindings are listed multiple times for e.g. function backward-char is bound to \e\[D as well as key left. Users may want to know why some bindings are listed twice, so the actual binding is shown in next line on a click -->
-        <td ng-class="{ data_table_cell: true, no_overflow: !binding._is_selected }" style="text-align: left; padding-right: 30px;" ng-click="binding._is_selected = !binding._is_selected">{{ binding.readable_binding }} <div ng-show="binding._is_selected"> {{ binding.binding }} </div> </td>
+        <!-- Raw binding commands are shown in next line on a click -->
+        <td ng-class="{ data_table_cell: true, no_overflow: !binding._is_selected }" style="text-align: left; padding-right: 30px;" ng-click="binding._is_selected = !binding._is_selected">
+            <div ng-repeat="variety in binding.bindings">
+                {{ variety.readable_binding }}
+                <div class="raw_binding" ng-repeat="raw in variety.raw_bindings" ng-show="binding._is_selected" > {{ raw }} </div>
+            </div>
+        </td>
     </tr>
     </tbody>
 </table>

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -84,6 +84,8 @@ named_colors = {
     'white'     : 'FFFFFF'
 }
 
+bindings_blacklist = set(["self-insert", "'begin;end'"])
+
 def parse_one_color(comp):
     """ A basic function to parse a single color value like 'FFA000' """
     if comp in named_colors:
@@ -586,6 +588,9 @@ class FishConfigHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 key_name = None
                 command = comps[2]
                 binding_parser.set_buffer(comps[1])
+
+            if command in bindings_blacklist:
+                continue
 
             readable_binding = binding_parser.get_readable_binding()
             if command in command_to_binding:

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -351,14 +351,22 @@ class BindingParser:
 
         # \[1\; is start of control sequence
         if c == '1':
-            self.get_char();c = self.get_char()
-            if c == ";":
+            b = self.get_char(); c = self.get_char()
+            if b == '\\' and c == '~':
+                result += "Home"
+            elif c == ";":
                 c = self.get_char()
 
         # 3 is Alt
         if c == '3':
             result += "ALT - "
             c = self.get_char()
+
+        # \[4\~ is End
+        if c == '4':
+            b = self.get_char(); c = self.get_char()
+            if b == '\\' and c == '~':
+                result += "End"
 
         # 5 is Ctrl
         if c == '5':
@@ -430,14 +438,21 @@ class BindingParser:
                     result += 'Tab'
                 elif c == 'b':
                     result += 'Backspace'
+                elif c.isalpha():
+                    result += '\\' + c
                 else:
                     result += c
+            elif c == '\x7f':
+                result += 'Backspace'
             else:
                 result += c
         if ctrl:
             readable_command += 'CTRL - '
         if alt:
             readable_command += 'ALT - '
+        
+        if result == '':
+            return 'unknown-control-sequence'
 
         return readable_command + result
 

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -398,7 +398,7 @@ class BindingParser:
         """ Gets a readable representation of binding """
 
         try:
-            result = BindingParser.readable_keys[self.buffer]
+            result = BindingParser.readable_keys[self.buffer.lower()]
         except KeyError:
             result = self.parse_binding()
 
@@ -599,7 +599,7 @@ class FishConfigHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
             if comps[1] == '-k':
                 key_name, command = comps[2].split(' ', 1)
-                binding_parser.set_buffer(key_name)
+                binding_parser.set_buffer(key_name.capitalize())
             else:
                 key_name = None
                 command = comps[2]

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -312,7 +312,8 @@ class BindingParser:
                     "sdc": "Shift Delete", "shome": "Shift Home",
                     "left": "Left Arrow", "right": "Right Arrow",
                     "up": "Up Arrow", "down": "Down Arrow",
-                    "sleft": "Shift Left", "sright": "Shift Right"
+                    "sleft": "Shift Left", "sright": "Shift Right",
+                    "btab": "Shift Tab"
                     }
 
     def set_buffer(self, buffer):


### PR DESCRIPTION
Fixes issue #3325
1. Don't show bindings like 'self-insert' or 'begin;end'.
2. Group together different keybindings to the same command. Raw bindings with the same readable name are merged. Raw binding shown on click.
3. Fix parser bugs (only for those in default bindings. incomplete.)
TODO:
Add visual prompt for the click functionality (tooltip or arrow?)