### PR TITLE
.editorconfig: specifying indentation per file-type for the project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+indent_size = 4
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{Makefile,*.in}]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{sh,ac}]
+indent_size = 2
+
+[Dockerfile]
+indent_size = 2


### PR DESCRIPTION
Helps specifying specific indent styles per project, supported by various IDEs.
This is a clean-up PR for #3313