### PR TITLE
Show history timestamps on separate line to better group multi-line entries

### DIFF
--- a/doc_src/history.txt
+++ b/doc_src/history.txt
@@ -34,7 +34,7 @@ The following options are available:
 
 - `-p` or `--prefix` searches or deletes items in the history that begin with the specified text string. This is not currently supported by the `--delete` flag.
 
-- `-t` or `--with-time` outputs the date and time history items were recorded at before each history entry, formatted for the configured locale. See environ(7) for more information.
+- `-t` or `--with-time` outputs the date and time ("%Y-%m-%d %H:%M:%S") history items were recorded at on a line starting with "#" before each history entry. 
 
 \subsection history-examples Example
 

--- a/doc_src/history.txt
+++ b/doc_src/history.txt
@@ -34,7 +34,7 @@ The following options are available:
 
 - `-p` or `--prefix` searches or deletes items in the history that begin with the specified text string. This is not currently supported by the `--delete` flag.
 
-- `-t` or `--with-time` prefixes the output of each displayed history entry with the time it was recorded in the format "%Y-%m-%d %H:%M:%S" in your local timezone.
+- `-t` or `--with-time` outputs the date and time history items were recorded at before each history entry, formatted for the configured locale. See environ(7) for more information.
 
 \subsection history-examples Example
 

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1402,9 +1402,9 @@ static bool format_history_record(const history_item_t &item, const bool with_ti
         const time_t seconds = item.timestamp();
         struct tm timestamp;
         if (!localtime_r(&seconds, &timestamp)) return false;
-        char timestamp_string[22];
-        if (strftime(timestamp_string, 22, "%Y-%m-%d %H:%M:%S  ", &timestamp) != 21) return false;
-        streams.out.append(str2wcstring(timestamp_string));
+        wchar_t timestamp_string[64];
+        if (std::wcsftime(timestamp_string, 63, L"# %c:\n", &timestamp) == 0) return false;
+        streams.out.append(timestamp_string);
     }
     streams.out.append(item.str());
     streams.out.append(L"\n");

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1402,8 +1402,8 @@ static bool format_history_record(const history_item_t &item, const bool with_ti
         const time_t seconds = item.timestamp();
         struct tm timestamp;
         if (!localtime_r(&seconds, &timestamp)) return false;
-        wchar_t timestamp_string[64];
-        if (std::wcsftime(timestamp_string, 63, L"# %c:\n", &timestamp) == 0) return false;
+        wchar_t timestamp_string[24];
+        if (std::wcsftime(timestamp_string, 23, L"# %Y-%m-%d %H:%M:%S\n", &timestamp) == 0) return false;
         streams.out.append(timestamp_string);
     }
     streams.out.append(item.str());

--- a/tests/history.expect
+++ b/tests/history.expect
@@ -78,7 +78,7 @@ expect_prompt -re {\r\necho start1.*\r\necho start2} {
 # ==========
 # Verify implicit searching with a request for timestamps includes the timestamps.
 send "history -t echo start\r"
-expect_prompt -re {\r\n\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d  echo start1; builtin history;.*\r\n\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d  echo start2; builtin history} {
+expect_prompt -re {\r\n# \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\r\necho start1; builtin history;.*\r\n# \d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\r\necho start2; builtin history} {
     puts "history function implicit search with timestamps succeeded"
 } unmatched {
     puts stderr "history function implicit search with timestamps failed"


### PR DESCRIPTION
## Description

~~I had commited to master at one point a change which had switched
the date format to %c. It looks like that was changed to a fixed format in a later
commit so pushing to this PR first in case that is not preferred.~~

This ~~restores the behavior, and further~~ improves the output by separating timestamps and history entires onto separate lines. This helps with what could sometimes be confusing output for multi-line history items. By prefixing the timestamps with `#`, effectively commenting them out, this trick is made possible: `history -t | fish-indent --ansi`.

<img width="440" alt="screenshot 2016-08-24 at 9 32 39 pm" src="https://cloud.githubusercontent.com/assets/291142/17956915/52385b76-6a42-11e6-82b2-bc497684b5ec.png">

For performance reasons if we ever decided to make `history` so pretty we'd want to implement the styling differently.