### PR TITLE
fix error when completing vi if it didnt exist

### DIFF
--- a/share/completions/vi.fish
+++ b/share/completions/vi.fish
@@ -4,7 +4,7 @@
 # +command : same as -c command
 
 # Check if vi exists at all ( needed for vi --version )
-if type vi > /dev/null ^ /dev/null
+if type -q vi
     # Check if vi is really vim
     if vi --version > /dev/null ^ /dev/null
         complete -c vi -w vim

--- a/share/completions/vi.fish
+++ b/share/completions/vi.fish
@@ -3,22 +3,23 @@
 # -wn : Set the default window size to n
 # +command : same as -c command
 
-
-# Check if vi is really vim
-if vi --version > /dev/null ^ /dev/null
-    complete -c vi -w vim
-else
-    complete -c vi -s s --description 'Suppress all interactive user feedback'
-    complete -c vi -s C --description 'Encrypt/decrypt text'
-    complete -c vi -s l --description 'Set up for editing LISP programs'
-    complete -c vi -s L --description 'List saved file names after crash'
-    complete -c vi -s R --description 'Read-only mode'
-    complete -c vi -s S --description 'Use linear search for tags if tag file not sorted'
-    complete -c vi -s v --description 'Start in display editing state'
-    complete -c vi -s V --description 'Verbose mode'
-    complete -c vi -s x --description 'Encrypt/decrypt text'
-    complete -c vi -r -s r --description 'Recover file after crash'
-    complete -c vi -r -s t --description 'Edit the file containing a tag'
-    complete -c vi -r -c t --description 'Begin editing by executing the specified  editor command'
+# Check if vi exists at all ( needed for vi --version )
+if type vi > /dev/null ^ /dev/null
+    # Check if vi is really vim
+    if vi --version > /dev/null ^ /dev/null
+        complete -c vi -w vim
+    else
+        complete -c vi -s s --description 'Suppress all interactive user feedback'
+        complete -c vi -s C --description 'Encrypt/decrypt text'
+        complete -c vi -s l --description 'Set up for editing LISP programs'
+        complete -c vi -s L --description 'List saved file names after crash'
+        complete -c vi -s R --description 'Read-only mode'
+        complete -c vi -s S --description 'Use linear search for tags if tag file not sorted'
+        complete -c vi -s v --description 'Start in display editing state'
+        complete -c vi -s V --description 'Verbose mode'
+        complete -c vi -s x --description 'Encrypt/decrypt text'
+        complete -c vi -r -s r --description 'Recover file after crash'
+        complete -c vi -r -s t --description 'Edit the file containing a tag'
+        complete -c vi -r -c t --description 'Begin editing by executing the specified  editor command'
+    end
 end
-


### PR DESCRIPTION
## Description

If vi wasn't in the OS by default, invoking completion with vi instantiated an error : 

```
fish: Unknown command 'vi'
/usr/share/fish/completions/vi.fish (line 8): if vi --version > /dev/null ^ /dev/null
...
```

This commit fixed that by checking if 'vi' exists with the 'type' command beforehand


