### PR TITLE
use __fish_complete_groups to complete group names for chown

### DIFF
--- a/share/completions/chown.fish
+++ b/share/completions/chown.fish
@@ -9,4 +9,4 @@ complete -c chown -s v -l verbose --description "Output diagnostic for every fil
 complete -c chown -s h -l help --description "Display help and exit"
 complete -c chown -l version --description "Display version and exit"
 complete -c chown --description "Username" -a "(__fish_print_users):"
-complete -c chown --description "Username" -a "(echo (commandline -ct)| __fish_sgrep -o '.*:')(if test -x /usr/bin/getent; getent group; else; cat /etc/group; end |cut -d : -f 1)"
+complete -c chown --description "Username" -a "(echo (commandline -ct)| __fish_sgrep -o '.*:')(__fish_complete_groups)"

--- a/share/completions/chown.fish
+++ b/share/completions/chown.fish
@@ -9,4 +9,4 @@ complete -c chown -s v -l verbose --description "Output diagnostic for every fil
 complete -c chown -s h -l help --description "Display help and exit"
 complete -c chown -l version --description "Display version and exit"
 complete -c chown --description "Username" -a "(__fish_print_users):"
-complete -c chown --description "Username" -a "(echo (commandline -ct)| __fish_sgrep -o '.*:')(cat /etc/group |cut -d : -f 1)"
+complete -c chown --description "Username" -a "(echo (commandline -ct)| __fish_sgrep -o '.*:')(if test -x /usr/bin/getent; getent group; else; cat /etc/group; end |cut -d : -f 1)"


### PR DESCRIPTION
## Description

chown completion chown currently uses `cat /etc/group` to fetch the list of group names. In Cygwin there's no /etc/group file any more (user and group names are fetched directly from the OS), so when a user tries to tab-complete the group name they get an error message:

`ASchulma@LZ77E1AASCHULMA ~/d/fish> chown ASchulma:cat: /etc/group: No such file or directory`

This change fixes that by using `getent group` by preference to get the group names, and falling back to /etc/group. This is more portable, and it also agrees with the logic used for chgrp completion in __fish_complete_groups.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [ ] Tests have been added for regressions fixed

