### PR TITLE
use PATH to find getent in __fish_complete_groups

### DIFF
--- a/share/functions/__fish_complete_groups.fish
+++ b/share/functions/__fish_complete_groups.fish
@@ -1,6 +1,6 @@
 
 function __fish_complete_groups --description "Print a list of local groups, with group members as the description"
-	if test -x /usr/bin/getent
+	if command -s getent >/dev/null
 		getent group | cut -d ':' -f 1,4 | sed 's/:/\t/'
 	else
 		cut -d ':' -f 1,4 /etc/group | sed 's/:/\t/'


### PR DESCRIPTION
## Description

Use `command -s getent` instead of `test -x /usr/bin/getent` to find getent, per discussion in #3380.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [ ] Tests have been added for regressions fixed

