### PR TITLE
Brew completion: strip tap prefix

### DIFF
--- a/share/completions/brew.fish
+++ b/share/completions/brew.fish
@@ -26,7 +26,8 @@ function __fish_brew_formulae
     # 'vim' for core VIM
     # 'custUser/custRepo/vim' for more prior VIM
     # more info: https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/brew-tap.md#formula-duplicate-names
-    brew search
+    set -l formula_regex '[a-zA-Z0-9\-_+]'
+    brew search | sed "s|$formula_regex*/$formula_regex*/||"
 end
 
 function __fish_brew_installed_formulas


### PR DESCRIPTION
## Description

If the user has extra repositories (taps) configured, their formulae will be listed in the format `username/reponame/formula`, which may limit tab-completion. For example, if the user tries to do `brew install net` and hits tab, `homebrew/games/nethack` won't be in the results because of more immediate results like `netcat` from the core repository.

This strips the tap prefix, listing all formulae with their basenames instead.

Before:

```
$ brew install net
net-snmp  netcat6  netpbm   nettle
netcat    nethogs  netperf
```

After:

```
$ brew install net
net-snmp  netcat6   nethacked  netperf  nettoe
net6      nethack   nethogs    netris
netcat    nethack4  netpbm     nettle
```

Tested using fish 2.3.1 installed via brew.