### PR TITLE
Add a template to parse integers easily/correctly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -215,7 +215,7 @@ CXXFLAGS="$CXXFLAGS -fno-exceptions"
 # But signed comparison warnings are way too aggressive
 #
 
-CXXFLAGS="$CXXFLAGS -Wextra -Wshorten-64-to-32"
+CXXFLAGS="$CXXFLAGS -Wextra"
 
 #
 # This is needed in order to get the really cool backtraces on Linux

--- a/configure.ac
+++ b/configure.ac
@@ -215,7 +215,7 @@ CXXFLAGS="$CXXFLAGS -fno-exceptions"
 # But signed comparison warnings are way too aggressive
 #
 
-CXXFLAGS="$CXXFLAGS -Wextra"
+CXXFLAGS="$CXXFLAGS -Wextra -Wshorten-64-to-32"
 
 #
 # This is needed in order to get the really cool backtraces on Linux

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -1594,8 +1594,8 @@ int builtin_function(parser_t &parser, io_streams_t &streams, const wcstring_lis
                         e.param1.job_id = job_id;
                     }
                 } else {
-                    pid_t pid = wcstoimax(w.woptarg, &end, 10);
-                    if (pid < 1 || !(*w.woptarg != L'\0' && *end == L'\0')) {
+                    pid_t pid;
+                    if (!(parse_integer(w.woptarg, &pid)) || pid < 1) {
                         append_format(*out_err, _(L"%ls: Invalid process id '%ls'"), argv[0],
                                       w.woptarg);
                         res = STATUS_BUILTIN_ERROR;

--- a/src/common.h
+++ b/src/common.h
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <termios.h>
 #include <stddef.h>
+#include <limits>
 #include <inttypes.h>
 #include <wchar.h>
 #include <memory>

--- a/src/common.h
+++ b/src/common.h
@@ -11,6 +11,8 @@
 #include <string.h>
 #include <sys/types.h>
 #include <termios.h>
+#include <stddef.h>
+#include <inttypes.h>
 #include <wchar.h>
 #include <memory>
 #include <sstream>
@@ -691,6 +693,21 @@ ssize_t read_loop(int fd, void *buff, size_t count);
 /// program_name is 'fish'.
 void __attribute__((noinline)) debug(int level, const char *msg, ...);
 void __attribute__((noinline)) debug(int level, const wchar_t *msg, ...);
+
+/// Parse an integer and check limits for type
+/// The only way to be safe from overflows is intmax_t.
+/// Do that, and make sure the result isn't bigger than the maximum supported for whatever type.
+template <typename T>
+bool parse_integer(const wchar_t *in, T* out) {
+  wchar_t *end;
+  intmax_t res = wcstoimax(in, &end, 0);
+
+  if (!(*in != L'\0' && *end == L'\0')) return false;
+  if (std::numeric_limits<T>::max() < res || res < std::numeric_limits<T>::min()) return false;
+
+  *out = static_cast<T>(res);
+  return true;
+}
 
 /// Replace special characters with backslash escape sequences. Newline is replaced with \n, etc.
 ///


### PR DESCRIPTION
It's not enough to use `intmax_t` and check for empty strings/converted strings:


```fish
$ function --on-process-exit= 999999999999 foo; end;
$ functions foo
function foo --on-process-exit 1874919423
end
```

... there are limits. This starts getting really tedious.

* Adds a template to make it easy to parse an integer of any type.
* Adds a compiler flag to flag potential existing problems.

(this PR: `function: Invalid process id '999999999999'`)