### PR TITLE
Add doxygen to Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: shells
 Priority: extra
 Maintainer: ridiculous_fish <corydoras@ridiculousfish.com>
 Uploaders: David Adam <zanchey@ucc.gu.uwa.edu.au>
-Build-Depends: debhelper (>= 8.0.0), libncurses5-dev, autoconf, autotools-dev, dh-autoreconf, gettext
+Build-Depends: debhelper (>= 8.0.0), libncurses5-dev, autoconf, autotools-dev, dh-autoreconf, gettext, doxygen
 # When libpcre2-dev is available on all supported Debian versions, add a dependency on that.
 Standards-Version: 3.9.4
 Homepage: http://fishshell.com/


### PR DESCRIPTION
Without doxygen listed in `Build-Depends`, sbuild/dpkg-buildpackage builds a fish-common package without the man pages or HTML documentation.

I tested with sbuild on Ubuntu 16.04.1, both before and after the change.

Before:

```
Installing man pages
Installing helper tools
Installing online user documentation
Installing more man pages
/usr/bin/install: cannot stat 'share/man/man1/fish.1': No such file or directory
/usr/bin/install: cannot stat 'share/man/man1/fish_indent.1': No such file or directory
/usr/bin/install: cannot stat 'share/man/man1/fish_key_reader.1': No such file or directory
```

```
# dpkg -i fish_2.4-master_amd64.deb fish-common_2.4-master_all.deb 
(Reading database ... 234022 files and directories currently installed.)
Preparing to unpack fish_2.4-master_amd64.deb ...
Unpacking fish (2.4-master) over (2-master) ...
Selecting previously unselected package fish-common.
Preparing to unpack fish-common_2.4-master_all.deb ...
Unpacking fish-common (2.4-master) ...
Setting up fish-common (2.4-master) ...
Setting up fish (2.4-master) ...
Processing triggers for man-db (2.7.5-1) ...
Processing triggers for doc-base (0.10.7) ...
Processing 1 added doc-base file...
Error in `/usr/share/doc-base/fish', line 11: all `Format' sections are invalid.
Note: `install-docs --verbose --check file_name' may give more details about the above error.
```

After: no install errors or dpkg errors