### PR TITLE
Don't write a /usr/share/fish/tools/deroff.pyc file

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -18,6 +18,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 """
 
 import string, sys, re, os.path, bz2, gzip, traceback, getopt, errno, codecs
+sys.dont_write_bytecode = True
 from deroff import Deroffer
 
 lzma_available = True


### PR DESCRIPTION
## Description

When `create_manpage_completions.py` was run as root, it imported `deroff` and created a `deroff.pyc` file that was not managed by the package manager.

`sys.dont_write_bytecode = True` prevents the writing of this `.pyc` file.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documenation/manpages.
- [ ] Tests have been added for regressions fixed
