### PR TITLE
Fix building on Android by avoiding getpwent()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -301,6 +301,7 @@ AC_CHECK_FUNCS( futimes )
 AC_CHECK_FUNCS( wcslcpy lrand48_r killpg )
 AC_CHECK_FUNCS( backtrace_symbols getifaddrs )
 AC_CHECK_FUNCS( futimens clock_gettime )
+AC_CHECK_FUNCS( getpwent )
 
 AC_CHECK_DECL( [mkostemp], [ AC_CHECK_FUNCS([mkostemp]) ] )
 

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -1188,8 +1188,11 @@ bool completer_t::try_complete_variable(const wcstring &str) {
 /// \return 0 if unable to complete, 1 otherwise
 bool completer_t::try_complete_user(const wcstring &str) {
 #ifdef __ANDROID__
-    // The getpwent() call does not exist on Android (and user names are not interesting).
-    return 0;
+    // The getpwent() function does not exist on Android. A Linux user on Android isn't
+    // really a user - each installed app gets an UID assigned. Listing all UID:s is not
+    // possible without root access, and doing a ~USER type expansion does not make sense
+    // since every app is sandboxed and can't access eachother.
+    return false;
 #else
     const wchar_t *cmd = str.c_str();
     const wchar_t *first_char = cmd;

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -1187,6 +1187,10 @@ bool completer_t::try_complete_variable(const wcstring &str) {
 ///
 /// \return 0 if unable to complete, 1 otherwise
 bool completer_t::try_complete_user(const wcstring &str) {
+#ifdef __ANDROID__
+    // The getpwent() call does not exist on Android (and user names are not interesting).
+    return 0;
+#else
     const wchar_t *cmd = str.c_str();
     const wchar_t *first_char = cmd;
     int res = 0;
@@ -1233,6 +1237,7 @@ bool completer_t::try_complete_user(const wcstring &str) {
     }
 
     return res;
+#endif
 }
 
 void complete(const wcstring &cmd_with_subcmds, std::vector<completion_t> *out_comps,

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -1187,7 +1187,7 @@ bool completer_t::try_complete_variable(const wcstring &str) {
 ///
 /// \return 0 if unable to complete, 1 otherwise
 bool completer_t::try_complete_user(const wcstring &str) {
-#ifdef HAVE_GETPWENT
+#ifndef HAVE_GETPWENT
     // The getpwent() function does not exist on Android. A Linux user on Android isn't
     // really a user - each installed app gets an UID assigned. Listing all UID:s is not
     // possible without root access, and doing a ~USER type expansion does not make sense

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -1187,7 +1187,7 @@ bool completer_t::try_complete_variable(const wcstring &str) {
 ///
 /// \return 0 if unable to complete, 1 otherwise
 bool completer_t::try_complete_user(const wcstring &str) {
-#ifdef __ANDROID__
+#ifdef HAVE_GETPWENT
     // The getpwent() function does not exist on Android. A Linux user on Android isn't
     // really a user - each installed app gets an UID assigned. Listing all UID:s is not
     // possible without root access, and doing a ~USER type expansion does not make sense


### PR DESCRIPTION
The getpwent() function does not link when building for Android, and user names on that platform are not interesting anyway.

This patch is part of an effort to upstream patches used by the fish package in [Termux](https://termux.com/).