### PR TITLE
Check for struct stat.st_ctime_nsec before using

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -284,6 +284,7 @@ AC_DEFINE_UNQUOTED([WCHAR_T_BITS], [$WCHAR_T_BITS], [The size of wchar_t in bits
 #
 # Detect nanoseconds fields in struct stat
 #
+AC_CHECK_MEMBERS([struct stat.st_ctime_nsec])
 AC_CHECK_MEMBERS([struct stat.st_mtimespec.tv_nsec])
 AC_CHECK_MEMBERS([struct stat.st_mtim.tv_nsec])
 

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -548,7 +548,7 @@ file_id_t file_id_t::file_id_from_stat(const struct stat *buf) {
     result.change_seconds = buf->st_ctime;
     result.mod_seconds = buf->st_mtime;
 
-#if STAT_HAVE_NSEC
+#ifdef HAVE_STRUCT_STAT_ST_CTIME_NSEC
     result.change_nanoseconds = buf->st_ctime_nsec;
     result.mod_nanoseconds = buf->st_mtime_nsec;
 #elif defined(__APPLE__)


### PR DESCRIPTION
Using a configure check for stat.st_ctime_nsec fixes building on Android which has that field but does not define STAT_HAVE_NSEC.

Before this change the Android build failed on the st_ctim.tv_nsec fallback #else clause.

This patch is part of an effort to upstream patches used by the fish package in [Termux](https://termux.com/).