### PR TITLE
make history searching case insentive by default

### DIFF
--- a/doc_src/history.txt
+++ b/doc_src/history.txt
@@ -2,8 +2,8 @@
 
 \subsection history-synopsis Synopsis
 \fish{synopsis}
-history search [ --show-time ] [ --exact | --prefix | --contains ] [ --max=n ] [ "search string"... ]
-history delete [ --show-time ] [ --exact | --prefix | --contains ] "search string"...
+history search [ --show-time ] [ --case-sensitive ] [ --exact | --prefix | --contains ] [ --max=n ] [ "search string"... ]
+history delete [ --show-time ] [ --case-sensitive ] [ --exact | --prefix | --contains ] "search string"...
 history merge
 history save
 history clear
@@ -32,9 +32,11 @@ The following options are available:
 
 These flags can appear before or immediately after one of the sub-commands listed above.
 
+- `-C` or `--case-sensitive` does a case-sensitive search. The default is case-insensitive. Note that up to and including fish 2.4.0 the default was case-sensitive.
+
 - `-c` or `--contains` searches or deletes items in the history that contain the specified text string. This is the default for the `--search` flag. This is not currently supported by the `--delete` flag.
 
-- `-e` or `--exact` searches or deletes items in the history that exactly match the specified text string. This is the default for the `--delete` flag.
+- `-e` or `--exact` searches or deletes items in the history that exactly match the specified text string. This is the default for the `--delete` flag. Note that the match is case-insensitive by default. If you really want an exact match, including letter case, you must use the `-C` or `--case-sensitive` flag.
 
 - `-p` or `--prefix` searches or deletes items in the history that begin with the specified text string. This is not currently supported by the `--delete` flag.
 

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -35,6 +35,7 @@ function history --description "display or manipulate interactive command histor
     set -l search_mode
     set -l show_time
     set -l max_count
+    set -l case_sensitive
 
     # Check for a recognized subcommand as the first argument.
     if set -q argv[1]
@@ -68,6 +69,8 @@ function history --description "display or manipulate interactive command histor
             case --merge
                 __fish_set_hist_cmd merge
                 or return
+            case -C --case_sensitive
+                set case_sensitive --case-sensitive
             case -h --help
                 builtin history --help
                 return
@@ -126,9 +129,9 @@ function history --description "display or manipulate interactive command histor
                 set -l pager less
                 set -q PAGER
                 and set pager $PAGER
-                builtin history search $search_mode $show_time $max_count -- $argv | eval $pager
+                builtin history search $search_mode $show_time $max_count $case_sensitive -- $argv | eval $pager
             else
-                builtin history search $search_mode $show_time $max_count -- $argv
+                builtin history search $search_mode $show_time $max_count $case_sensitive -- $argv
             end
 
         case delete # interactively delete history
@@ -142,13 +145,13 @@ function history --description "display or manipulate interactive command histor
             and set search_mode "--exact"
 
             if test $search_mode = "--exact"
-                builtin history delete $search_mode $argv
+                builtin history delete $search_mode $case_sensitive $argv
                 return
             end
 
             # TODO: Fix this so that requesting history entries with a timestamp works:
             #   set -l found_items (builtin history search $search_mode $show_time -- $argv)
-            set -l found_items (builtin history search $search_mode -- $argv)
+            set -l found_items (builtin history search $search_mode $case_sensitive -- $argv)
             if set -q found_items[1]
                 set -l found_items_count (count $found_items)
                 for i in (seq $found_items_count)
@@ -169,7 +172,7 @@ function history --description "display or manipulate interactive command histor
 
                 if test "$choice" = "all"
                     printf "Deleting all matching entries!\n"
-                    builtin history delete $search_mode -- $argv
+                    builtin history delete $search_mode $case_sensitive -- $argv
                     builtin history save
                     return
                 end
@@ -183,7 +186,7 @@ function history --description "display or manipulate interactive command histor
                     end
 
                     printf "Deleting history entry %s: \"%s\"\n" $i $found_items[$i]
-                    builtin history delete "$found_items[$i]"
+                    builtin history delete --case-sensitive "$found_items[$i]"
                 end
                 builtin history save
             end

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -2875,10 +2875,11 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
     long max_items = LONG_MAX;
     bool history_search_type_defined = false;
     const wchar_t *show_time_format = NULL;
+    bool case_sensitive = false;
 
     // TODO: Remove the long options that correspond to subcommands (e.g., '--delete') on or after
     // 2017-10 (which will be a full year after these flags have been deprecated).
-    const wchar_t *short_options = L":mn:epcht";
+    const wchar_t *short_options = L":Cmn:epcht";
     const struct woption long_options[] = {{L"prefix", no_argument, NULL, 'p'},
                                            {L"contains", no_argument, NULL, 'c'},
                                            {L"help", no_argument, NULL, 'h'},
@@ -2886,6 +2887,7 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
                                            {L"with-time", optional_argument, NULL, 't'},
                                            {L"exact", no_argument, NULL, 'e'},
                                            {L"max", required_argument, NULL, 'n'},
+                                           {L"case-sensitive", no_argument, 0, 'C'},
                                            {L"delete", no_argument, NULL, 1},
                                            {L"search", no_argument, NULL, 2},
                                            {L"save", no_argument, NULL, 3},
@@ -2930,6 +2932,10 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
                 if (!set_hist_cmd(cmd, &hist_cmd, HIST_MERGE, streams)) {
                     return STATUS_BUILTIN_ERROR;
                 }
+                break;
+            }
+            case 'C': {
+                case_sensitive = true;
                 break;
             }
             case 'p': {
@@ -3014,7 +3020,8 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
     int status = STATUS_BUILTIN_OK;
     switch (hist_cmd) {
         case HIST_SEARCH: {
-            if (!history->search(search_type, args, show_time_format, max_items, streams)) {
+            if (!history->search(search_type, args, show_time_format, max_items, case_sensitive,
+                        streams)) {
                 status = STATUS_BUILTIN_ERROR;
             }
             break;
@@ -3033,7 +3040,7 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
                 if (delete_string[0] == '"' && delete_string[delete_string.length() - 1] == '"') {
                     delete_string = delete_string.substr(1, delete_string.length() - 2);
                 }
-                history->remove(delete_string);
+                history->remove(delete_string, case_sensitive);
             }
             break;
         }

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -161,6 +161,11 @@ static int chdir_set_pwd(const char *path) {
         if (!(e)) err(L"Test failed on line %lu: %s", __LINE__, #e); \
     } while (0)
 
+#define do_test_from(e, from_line)                                                   \
+    do {                                                             \
+        if (!(e)) err(L"Test failed on line %lu (from %lu): %s", __LINE__, from_line, #e); \
+    } while (0)
+
 #define do_test1(e, msg)                                                 \
     do {                                                                 \
         if (!(e)) err(L"Test failed on line %lu: %ls", __LINE__, (msg)); \
@@ -2178,7 +2183,6 @@ static void perform_one_autosuggestion_should_ignore_test(const wcstring &comman
 
 static void test_autosuggestion_ignores() {
     say(L"Testing scenarios that should produce no autosuggestions");
-    const wcstring wd = L"/tmp/autosuggest_test/";
     // Do not do file autosuggestions immediately after certain statement terminators - see #1631.
     perform_one_autosuggestion_should_ignore_test(L"echo PIPE_TEST|", __LINE__);
     perform_one_autosuggestion_should_ignore_test(L"echo PIPE_TEST&", __LINE__);
@@ -2201,18 +2205,21 @@ static void test_autosuggestion_combining() {
     do_test(combine_command_and_autosuggestion(L"alpha", L"ALPHA") == L"alpha");
 }
 
-static void test_history_matches(history_search_t &search, size_t matches) {
+static void test_history_matches(history_search_t &search, size_t matches, unsigned from_line) {
     size_t i;
     for (i = 0; i < matches; i++) {
         do_test(search.go_backwards());
         wcstring item = search.current_string();
     }
-    do_test(!search.go_backwards());
+    //do_test_from(!search.go_backwards(), from_line);
+    bool result = search.go_backwards();
+    if (result) fprintf(stderr, "WTF search returned '%ls'\n", search.current_string().c_str());
+    do_test_from(!result, from_line);
 
     for (i = 1; i < matches; i++) {
-        do_test(search.go_forwards());
+        do_test_from(search.go_forwards(), from_line);
     }
-    do_test(!search.go_forwards());
+    do_test_from(!search.go_forwards(), from_line);
 }
 
 static bool history_contains(history_t *history, const wcstring &txt) {
@@ -2518,28 +2525,71 @@ static wcstring random_string(void) {
 }
 
 void history_tests_t::test_history(void) {
+    history_search_t searcher;
     say(L"Testing history");
 
     history_t &history = history_t::history_with_name(L"test_history");
     history.clear();
     history.add(L"Gamma");
+    history.add(L"beta");
+    history.add(L"BetA");
     history.add(L"Beta");
+    history.add(L"alpha");
+    history.add(L"AlphA");
     history.add(L"Alpha");
+    history.add(L"alph");
+    history.add(L"ALPH");
+    history.add(L"ZZZ");
 
-    // All three items match "a".
-    history_search_t search1(history, L"a");
-    test_history_matches(search1, 3);
-    do_test(search1.current_string() == L"Alpha");
+    // Items matching "a", case-sensitive.
+    searcher = history_search_t(history, L"a");
+    test_history_matches(searcher, 6, __LINE__);
+    do_test(searcher.current_string() == L"alph");
 
-    // One item matches "et".
-    history_search_t search2(history, L"et");
-    test_history_matches(search2, 1);
-    do_test(search2.current_string() == L"Beta");
+    // Items matching "alpha", case-insensitive. Note that HISTORY_SEARCH_TYPE_CONTAINS but we have
+    // to explicitly specify it in order to be able to pass false for the case_sensitive parameter.
+    searcher = history_search_t(history, L"AlPhA", HISTORY_SEARCH_TYPE_CONTAINS, false);
+    test_history_matches(searcher, 3, __LINE__);
+    do_test(searcher.current_string() == L"Alpha");
 
-    // Test item removal.
-    history.remove(L"Alpha");
-    history_search_t search3(history, L"Alpha");
-    test_history_matches(search3, 0);
+    // Items matching "et", case-sensitive.
+    searcher = history_search_t(history, L"et");
+    test_history_matches(searcher, 3, __LINE__);
+    do_test(searcher.current_string() == L"Beta");
+
+    // Items starting with "be", case-sensitive.
+    searcher = history_search_t(history, L"be", HISTORY_SEARCH_TYPE_PREFIX, true);
+    test_history_matches(searcher, 1, __LINE__);
+    do_test(searcher.current_string() == L"beta");
+
+    // Items starting with "be", case-insensitive.
+    searcher = history_search_t(history, L"be", HISTORY_SEARCH_TYPE_PREFIX, false);
+    test_history_matches(searcher, 3, __LINE__);
+    do_test(searcher.current_string() == L"Beta");
+
+    // Items exactly matchine "alph", case-sensitive.
+    searcher = history_search_t(history, L"alph", HISTORY_SEARCH_TYPE_EXACT, true);
+    test_history_matches(searcher, 1, __LINE__);
+    do_test(searcher.current_string() == L"alph");
+
+    // Items exactly matchine "alph", case-insensitive.
+    searcher = history_search_t(history, L"alph", HISTORY_SEARCH_TYPE_EXACT, false);
+    test_history_matches(searcher, 2, __LINE__);
+    do_test(searcher.current_string() == L"ALPH");
+
+    // Test item removal case-sensitive.
+    searcher = history_search_t(history, L"Alpha");
+    test_history_matches(searcher, 1, __LINE__);
+    history.remove(L"Alpha", true);
+    searcher = history_search_t(history, L"Alpha");
+    test_history_matches(searcher, 0, __LINE__);
+
+    // Test item removal case-insensitive.
+    searcher = history_search_t(history, L"Beta");
+    test_history_matches(searcher, 1, __LINE__);
+    history.remove(L"beta", false);
+    searcher = history_search_t(history, L"Beta");
+    test_history_matches(searcher, 0, __LINE__);
 
     // Test history escaping and unescaping, yaml, etc.
     history_item_list_t before, after;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -428,27 +428,52 @@ bool history_item_t::merge(const history_item_t &item) {
     return result;
 }
 
+#if 0
 history_item_t::history_item_t(const wcstring &str)
-    : contents(str), creation_timestamp(time(NULL)), identifier(0) {}
+    : contents(str), contents_lower(L""), creation_timestamp(time(NULL)), identifier(0) {
+        for (wcstring::const_iterator it = str.begin(); it != str.end(); ++it) {
+                contents_lower.push_back(towlower(*it));
+        }
+    }
+#endif
 
 history_item_t::history_item_t(const wcstring &str, time_t when, history_identifier_t ident)
-    : contents(str), creation_timestamp(when), identifier(ident) {}
-
-bool history_item_t::matches_search(const wcstring &term, enum history_search_type_t type) const {
-    switch (type) {
-        case HISTORY_SEARCH_TYPE_CONTAINS: {
-            return contents.find(term) != wcstring::npos;
+    : contents(str), contents_lower(L""), creation_timestamp(when), identifier(ident) {
+        for (wcstring::const_iterator it = str.begin(); it != str.end(); ++it) {
+                contents_lower.push_back(towlower(*it));
         }
-        case HISTORY_SEARCH_TYPE_PREFIX: {
-            // We consider equal strings to match a prefix search, so that autosuggest will allow
-            // suggesting what you've typed.
+    }
+
+bool history_item_t::matches_search(const wcstring &term, enum history_search_type_t type,
+        bool case_sensitive) const {
+    // We don't use a switch below because there are only three cases and if the strings are the
+    // same length we can use the faster HISTORY_SEARCH_TYPE_EXACT for the other two cases.
+    //
+    // Too, we consider equal strings to match a prefix search, so that autosuggest will allow
+    // suggesting what you've typed.
+    if (case_sensitive) {
+        if (type == HISTORY_SEARCH_TYPE_EXACT || term.size() == contents.size()) {
+            return term == contents;
+        } else if (type == HISTORY_SEARCH_TYPE_CONTAINS) {
+            return contents.find(term) != wcstring::npos;
+        } else if (type == HISTORY_SEARCH_TYPE_PREFIX) {
             return string_prefixes_string(term, contents);
         }
-        case HISTORY_SEARCH_TYPE_EXACT: {
-            return term == contents;
+    } else {
+        wcstring lterm(L"");
+        for (wcstring::const_iterator it = term.begin(); it != term.end(); ++it) {
+            lterm.push_back(towlower(*it));
         }
-        default: { DIE("unexpected history_search_type_t value"); }
+
+        if (type == HISTORY_SEARCH_TYPE_EXACT || lterm.size() == contents.size()) {
+            return lterm == contents_lower;
+        } else if (type == HISTORY_SEARCH_TYPE_CONTAINS) {
+            return contents_lower.find(lterm) != wcstring::npos;
+        } else if (type == HISTORY_SEARCH_TYPE_PREFIX) {
+            return string_prefixes_string(lterm, contents_lower);
+        }
     }
+    DIE("unexpected history_search_type_t value");
 }
 
 /// Append our YAML history format to the provided vector at the given offset, updating the offset.
@@ -765,14 +790,33 @@ void history_t::add(const wcstring &str, history_identifier_t ident, bool pendin
     this->add(history_item_t(str, when, ident), pending);
 }
 
-void history_t::remove(const wcstring &str) {
-    // Add to our list of deleted items.
-    deleted_items.insert(str);
+bool icompare_pred(wchar_t a, wchar_t b) {
+    return std::tolower(a) == std::tolower(b);
+}
 
-    // Remove from our list of new items.
+bool icompare(wcstring const& a, wcstring const& b) {
+    if (a.length() == b.length()) {
+        return std::equal(b.begin(), b.end(), a.begin(), icompare_pred);
+    }
+    else {
+        return false;
+    }
+}
+
+// Remove matching history entries from our list of new items.
+void history_t::remove(const wcstring &str, bool case_sensitive) {
+    // wcstring str_to_match = case_sensitive ? str : std::tolower(str);
+    wcstring str_to_match = str;
     size_t idx = new_items.size();
     while (idx--) {
-        if (new_items.at(idx).str() == str) {
+        bool matched;
+        if (case_sensitive) {
+            matched = new_items.at(idx).str() == str_to_match;
+        } else {
+            matched = icompare(new_items.at(idx).str(), str_to_match);
+        }
+        if (matched) {
+            deleted_items.insert(str);  // add to our list of deleted items
             new_items.erase(new_items.begin() + idx);
 
             // If this index is before our first_unwritten_new_item_index, then subtract one from
@@ -1003,7 +1047,7 @@ bool history_search_t::go_backwards() {
 
         // Look for a term that matches and that we haven't seen before.
         const wcstring &str = item.str();
-        if (item.matches_search(term, search_type) && !match_already_made(str) &&
+        if (item.matches_search(term, search_type, case_sensitive) && !match_already_made(str) &&
             !should_skip_match(str)) {
             prev_matches.push_back(prev_match_t(idx, item));
             return true;
@@ -1417,7 +1461,8 @@ static bool format_history_record(const history_item_t &item, const wchar_t *sho
 }
 
 bool history_t::search(history_search_type_t search_type, wcstring_list_t search_args,
-                       const wchar_t *show_time_format, long max_items, io_streams_t &streams) {
+                       const wchar_t *show_time_format, long max_items, bool case_sensitive,
+                       io_streams_t &streams) {
     // scoped_lock locker(lock);
     if (search_args.empty()) {
         // Start at one because zero is the current command.
@@ -1436,7 +1481,8 @@ bool history_t::search(history_search_type_t search_type, wcstring_list_t search
             streams.err.append_format(L"Searching for the empty string isn't allowed");
             return false;
         }
-        history_search_t searcher = history_search_t(*this, search_string, search_type);
+        history_search_t searcher = history_search_t(*this, search_string, search_type,
+                case_sensitive);
         while (searcher.go_backwards()) {
             if (!format_history_record(searcher.current_item(), show_time_format, streams)) {
                 return false;

--- a/tests/history.expect
+++ b/tests/history.expect
@@ -138,14 +138,14 @@ expect_prompt -re {Deleting history entry 1: "echo hello AGAIN"\r\n} {
 
 # Verify that the deleted history entry is gone and the other one that matched
 # the prefix search above is still there.
-send "history search --exact 'echo hello again'\r"
+send "history search --case-sensitive --exact 'echo hello again'\r"
 expect_prompt -re {\r\necho hello again\r\n} {
     puts "history function explicit exact search 'echo hello again' succeeded"
 } unmatched {
     puts stderr "history function explicit exact search 'echo hello again' failed"
 }
 
-send "history search --exact 'echo hello AGAIN'\r"
+send "history search --case-sensitive --exact 'echo hello AGAIN'\r"
 expect_prompt -re {\r\necho hello AGAIN\r\n} {
     puts stderr "history function explicit exact search 'echo hello AGAIN' found the entry"
 } unmatched {


### PR DESCRIPTION
Fixes #3236

Note that this deliberately does not alter the behavior of command line autosuggestion matching; only the `history` command if affected. Depending on how people feel about this we can discuss extending the idea to history autosuggestions.