### PR TITLE
docs: set should have -x for PATH in config.fish

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -1170,7 +1170,7 @@ If you want to add the directory `~/linux/bin` to your PATH variable when using 
 
 \fish
 if status --is-login
-    set PATH $PATH ~/linux/bin
+    set -x PATH $PATH ~/linux/bin
 end
 \endfish
 


### PR DESCRIPTION
Fixes what was discussed in #3452 