### PR TITLE
make history searching case insensitive by default

### DIFF
--- a/doc_src/history.txt
+++ b/doc_src/history.txt
@@ -2,8 +2,8 @@
 
 \subsection history-synopsis Synopsis
 \fish{synopsis}
-history search [ --show-time ] [ --exact | --prefix | --contains ] [ --max=n ] [ "search string"... ]
-history delete [ --show-time ] [ --exact | --prefix | --contains ] "search string"...
+history search [ --show-time ] [ --case-sensitive ] [ --exact | --prefix | --contains ] [ --max=n ] [ "search string"... ]
+history delete [ --show-time ] [ --case-sensitive ] [ --exact | --prefix | --contains ] "search string"...
 history merge
 history save
 history clear
@@ -20,7 +20,7 @@ The following operations (sub-commands) are available:
 
 - `search` returns history items matching the search string. If no search string is provided it returns all history items. This is the default operation if no other operation is specified. You only have to explicitly say `history search` if you wish to search for one of the subcommands. The `--contains` search option will be used if you don't specify a different search option. Entries are ordered newest to oldest. If stdout is attached to a tty the output will be piped through your pager by the history function. The history builtin simply writes the results to stdout.
 
-- `delete` deletes history items. Without the `--prefix` or `--contains` options, the exact match will be deleted. With either of these options, a prompt will be displayed before any items are deleted asking you which entries are to be deleted. You can enter the word "all" to delete all matching entries. You can enter a single ID (the number in square brackets) to delete just that single entry. You can enter more than one ID separated by a space to delete multiple entries. Just press [enter] to not delete anything. Note that the interactive delete behavior is a feature of the history function. The history builtin only supports bulk deletion.
+- `delete` deletes history items. Without the `--prefix` or `--contains` options, the exact match of the specified text will be deleted. If you don't specify `--exact` a prompt will be displayed before any items are deleted asking you which entries are to be deleted. You can enter the word "all" to delete all matching entries. You can enter a single ID (the number in square brackets) to delete just that single entry. You can enter more than one ID separated by a space to delete multiple entries. Just press [enter] to not delete anything. Note that the interactive delete behavior is a feature of the history function. The history builtin only supports `--exact --case-sensitive` deletion.
 
 - `merge` immediately incorporates history changes from other sessions. Ordinarily `fish` ignores history changes from sessions started after the current one. This command applies those changes immediately.
 
@@ -32,9 +32,11 @@ The following options are available:
 
 These flags can appear before or immediately after one of the sub-commands listed above.
 
+- `-C` or `--case-sensitive` does a case-sensitive search. The default is case-insensitive. Note that prior to fish 2.4.0 the default was case-sensitive.
+
 - `-c` or `--contains` searches or deletes items in the history that contain the specified text string. This is the default for the `--search` flag. This is not currently supported by the `--delete` flag.
 
-- `-e` or `--exact` searches or deletes items in the history that exactly match the specified text string. This is the default for the `--delete` flag.
+- `-e` or `--exact` searches or deletes items in the history that exactly match the specified text string. This is the default for the `--delete` flag. Note that the match is case-insensitive by default. If you really want an exact match, including letter case, you must use the `-C` or `--case-sensitive` flag.
 
 - `-p` or `--prefix` searches or deletes items in the history that begin with the specified text string. This is not currently supported by the `--delete` flag.
 

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -2875,10 +2875,11 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
     long max_items = LONG_MAX;
     bool history_search_type_defined = false;
     const wchar_t *show_time_format = NULL;
+    bool case_sensitive = false;
 
     // TODO: Remove the long options that correspond to subcommands (e.g., '--delete') on or after
     // 2017-10 (which will be a full year after these flags have been deprecated).
-    const wchar_t *short_options = L":mn:epcht";
+    const wchar_t *short_options = L":Cmn:epcht";
     const struct woption long_options[] = {{L"prefix", no_argument, NULL, 'p'},
                                            {L"contains", no_argument, NULL, 'c'},
                                            {L"help", no_argument, NULL, 'h'},
@@ -2886,6 +2887,7 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
                                            {L"with-time", optional_argument, NULL, 't'},
                                            {L"exact", no_argument, NULL, 'e'},
                                            {L"max", required_argument, NULL, 'n'},
+                                           {L"case-sensitive", no_argument, 0, 'C'},
                                            {L"delete", no_argument, NULL, 1},
                                            {L"search", no_argument, NULL, 2},
                                            {L"save", no_argument, NULL, 3},
@@ -2930,6 +2932,10 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
                 if (!set_hist_cmd(cmd, &hist_cmd, HIST_MERGE, streams)) {
                     return STATUS_BUILTIN_ERROR;
                 }
+                break;
+            }
+            case 'C': {
+                case_sensitive = true;
                 break;
             }
             case 'p': {
@@ -3014,17 +3020,24 @@ static int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **ar
     int status = STATUS_BUILTIN_OK;
     switch (hist_cmd) {
         case HIST_SEARCH: {
-            if (!history->search(search_type, args, show_time_format, max_items, streams)) {
+            if (!history->search(search_type, args, show_time_format, max_items, case_sensitive,
+                                 streams)) {
                 status = STATUS_BUILTIN_ERROR;
             }
             break;
         }
         case HIST_DELETE: {
-            // TODO: Move this code to the history module and support the other search types. At
-            // this time we expect the non-exact deletions to be handled only by the history
-            // function's interactive delete feature.
+            // TODO: Move this code to the history module and support the other search types
+            // including case-insensitive matches. At this time we expect the non-exact deletions to
+            // be handled only by the history function's interactive delete feature.
             if (search_type != HISTORY_SEARCH_TYPE_EXACT) {
                 streams.err.append_format(_(L"builtin history delete only supports --exact\n"));
+                status = STATUS_BUILTIN_ERROR;
+                break;
+            }
+            if (!case_sensitive) {
+                streams.err.append_format(
+                    _(L"builtin history delete only supports --case-sensitive\n"));
                 status = STATUS_BUILTIN_ERROR;
                 break;
             }

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -161,6 +161,11 @@ static int chdir_set_pwd(const char *path) {
         if (!(e)) err(L"Test failed on line %lu: %s", __LINE__, #e); \
     } while (0)
 
+#define do_test_from(e, from_line)                                                         \
+    do {                                                                                   \
+        if (!(e)) err(L"Test failed on line %lu (from %lu): %s", __LINE__, from_line, #e); \
+    } while (0)
+
 #define do_test1(e, msg)                                                 \
     do {                                                                 \
         if (!(e)) err(L"Test failed on line %lu: %ls", __LINE__, (msg)); \
@@ -2178,7 +2183,6 @@ static void perform_one_autosuggestion_should_ignore_test(const wcstring &comman
 
 static void test_autosuggestion_ignores() {
     say(L"Testing scenarios that should produce no autosuggestions");
-    const wcstring wd = L"/tmp/autosuggest_test/";
     // Do not do file autosuggestions immediately after certain statement terminators - see #1631.
     perform_one_autosuggestion_should_ignore_test(L"echo PIPE_TEST|", __LINE__);
     perform_one_autosuggestion_should_ignore_test(L"echo PIPE_TEST&", __LINE__);
@@ -2201,18 +2205,20 @@ static void test_autosuggestion_combining() {
     do_test(combine_command_and_autosuggestion(L"alpha", L"ALPHA") == L"alpha");
 }
 
-static void test_history_matches(history_search_t &search, size_t matches) {
+static void test_history_matches(history_search_t &search, size_t matches, unsigned from_line) {
     size_t i;
     for (i = 0; i < matches; i++) {
         do_test(search.go_backwards());
         wcstring item = search.current_string();
     }
-    do_test(!search.go_backwards());
+    // do_test_from(!search.go_backwards(), from_line);
+    bool result = search.go_backwards();
+    do_test_from(!result, from_line);
 
     for (i = 1; i < matches; i++) {
-        do_test(search.go_forwards());
+        do_test_from(search.go_forwards(), from_line);
     }
-    do_test(!search.go_forwards());
+    do_test_from(!search.go_forwards(), from_line);
 }
 
 static bool history_contains(history_t *history, const wcstring &txt) {
@@ -2518,28 +2524,64 @@ static wcstring random_string(void) {
 }
 
 void history_tests_t::test_history(void) {
+    history_search_t searcher;
     say(L"Testing history");
 
     history_t &history = history_t::history_with_name(L"test_history");
     history.clear();
     history.add(L"Gamma");
+    history.add(L"beta");
+    history.add(L"BetA");
     history.add(L"Beta");
+    history.add(L"alpha");
+    history.add(L"AlphA");
     history.add(L"Alpha");
+    history.add(L"alph");
+    history.add(L"ALPH");
+    history.add(L"ZZZ");
 
-    // All three items match "a".
-    history_search_t search1(history, L"a");
-    test_history_matches(search1, 3);
-    do_test(search1.current_string() == L"Alpha");
+    // Items matching "a", case-sensitive.
+    searcher = history_search_t(history, L"a");
+    test_history_matches(searcher, 6, __LINE__);
+    do_test(searcher.current_string() == L"alph");
 
-    // One item matches "et".
-    history_search_t search2(history, L"et");
-    test_history_matches(search2, 1);
-    do_test(search2.current_string() == L"Beta");
+    // Items matching "alpha", case-insensitive. Note that HISTORY_SEARCH_TYPE_CONTAINS but we have
+    // to explicitly specify it in order to be able to pass false for the case_sensitive parameter.
+    searcher = history_search_t(history, L"AlPhA", HISTORY_SEARCH_TYPE_CONTAINS, false);
+    test_history_matches(searcher, 3, __LINE__);
+    do_test(searcher.current_string() == L"Alpha");
 
-    // Test item removal.
+    // Items matching "et", case-sensitive.
+    searcher = history_search_t(history, L"et");
+    test_history_matches(searcher, 3, __LINE__);
+    do_test(searcher.current_string() == L"Beta");
+
+    // Items starting with "be", case-sensitive.
+    searcher = history_search_t(history, L"be", HISTORY_SEARCH_TYPE_PREFIX, true);
+    test_history_matches(searcher, 1, __LINE__);
+    do_test(searcher.current_string() == L"beta");
+
+    // Items starting with "be", case-insensitive.
+    searcher = history_search_t(history, L"be", HISTORY_SEARCH_TYPE_PREFIX, false);
+    test_history_matches(searcher, 3, __LINE__);
+    do_test(searcher.current_string() == L"Beta");
+
+    // Items exactly matchine "alph", case-sensitive.
+    searcher = history_search_t(history, L"alph", HISTORY_SEARCH_TYPE_EXACT, true);
+    test_history_matches(searcher, 1, __LINE__);
+    do_test(searcher.current_string() == L"alph");
+
+    // Items exactly matchine "alph", case-insensitive.
+    searcher = history_search_t(history, L"alph", HISTORY_SEARCH_TYPE_EXACT, false);
+    test_history_matches(searcher, 2, __LINE__);
+    do_test(searcher.current_string() == L"ALPH");
+
+    // Test item removal case-sensitive.
+    searcher = history_search_t(history, L"Alpha");
+    test_history_matches(searcher, 1, __LINE__);
     history.remove(L"Alpha");
-    history_search_t search3(history, L"Alpha");
-    test_history_matches(search3, 0);
+    searcher = history_search_t(history, L"Alpha");
+    test_history_matches(searcher, 0, __LINE__);
 
     // Test history escaping and unescaping, yaml, etc.
     history_item_list_t before, after;

--- a/src/history.h
+++ b/src/history.h
@@ -59,7 +59,8 @@ class history_item_t {
     bool merge(const history_item_t &item);
 
     // The actual contents of the entry.
-    wcstring contents;
+    wcstring contents;        // value as entered by the user
+    wcstring contents_lower;  // value normalized to all lowercase for case insensitive comparisons
 
     // Original creation time for the entry.
     time_t creation_timestamp;
@@ -71,15 +72,16 @@ class history_item_t {
     path_list_t required_paths;
 
    public:
-    explicit history_item_t(const wcstring &str);
-    explicit history_item_t(const wcstring &, time_t, history_identifier_t ident = 0);
+    explicit history_item_t(const wcstring &str, time_t when = 0, history_identifier_t ident = 0);
 
     const wcstring &str() const { return contents; }
+    const wcstring &str_lower() const { return contents_lower; }
 
     bool empty() const { return contents.empty(); }
 
     // Whether our contents matches a search term.
-    bool matches_search(const wcstring &term, enum history_search_type_t type) const;
+    bool matches_search(const wcstring &term, enum history_search_type_t type,
+                        bool case_sensitive) const;
 
     time_t timestamp() const { return creation_timestamp; }
 
@@ -227,7 +229,8 @@ class history_t {
 
     // Searches history.
     bool search(history_search_type_t search_type, wcstring_list_t search_args,
-                const wchar_t *show_time_format, long max_items, io_streams_t &streams);
+                const wchar_t *show_time_format, long max_items, bool case_sensitive,
+                io_streams_t &streams);
 
     // Enable / disable automatic saving. Main thread only!
     void disable_automatic_saving();
@@ -264,6 +267,7 @@ class history_search_t {
 
     // Our type.
     enum history_search_type_t search_type;
+    bool case_sensitive;
 
     // Our list of previous matches as index, value. The end is the current match.
     typedef std::pair<size_t, history_item_t> prev_match_t;
@@ -310,11 +314,19 @@ class history_search_t {
 
     // Constructor.
     history_search_t(history_t &hist, const wcstring &str,
-                     enum history_search_type_t type = HISTORY_SEARCH_TYPE_CONTAINS)
-        : history(&hist), search_type(type), term(str) {}
+                     enum history_search_type_t type = HISTORY_SEARCH_TYPE_CONTAINS,
+                     bool case_sensitive = true)
+        : history(&hist), term(str), search_type(type), case_sensitive(case_sensitive) {
+        if (!case_sensitive) {
+            term = wcstring();
+            for (wcstring::const_iterator it = str.begin(); it != str.end(); ++it) {
+                term.push_back(towlower(*it));
+            }
+        }
+    }
 
     // Default constructor.
-    history_search_t() : history(), search_type(HISTORY_SEARCH_TYPE_CONTAINS), term() {}
+    history_search_t() : history(), term() {}
 };
 
 // Init history library. The history file won't actually be loaded until the first time a history

--- a/tests/history.expect
+++ b/tests/history.expect
@@ -112,8 +112,10 @@ expect_prompt -re {history search --exact 'echo hell'\r\n} {
 
 # ==========
 # Delete a single command we recently ran.
-send "history delete 'echo hello'\r"
-expect_prompt -re {history delete 'echo hello'\r\n} {
+send "history delete -e -C 'echo hello'\r"
+expect -re {history delete -e -C 'echo hello'\r\n}
+send "echo count hello (history search -e -C 'echo hello' | wc -l | string trim)\r"
+expect -re {\r\ncount hello 0\r\n} {
     puts "history function explicit exact delete 'echo hello' succeeded"
 } unmatched {
     puts stderr "history function explicit exact delete 'echo hello' failed"
@@ -130,24 +132,20 @@ expect -re {\[2\] echo hello again\r\n\r\n}
 expect -re {Enter nothing to cancel.*\r\nEnter "all" to delete all the matching entries\.\r\n}
 expect -re {Delete which entries\? >}
 send "1\r"
-expect_prompt -re {Deleting history entry 1: "echo hello AGAIN"\r\n} {
-    puts "history function explicit prefix delete 'echo hello' succeeded"
-} unmatched {
-    puts stderr "history function explicit prefix delete 'echo hello' failed"
-}
+expect -re {Deleting history entry 1: "echo hello AGAIN"\r\n}
 
 # Verify that the deleted history entry is gone and the other one that matched
 # the prefix search above is still there.
-send "history search --exact 'echo hello again'\r"
-expect_prompt -re {\r\necho hello again\r\n} {
+send "echo count AGAIN (history search -e -C 'echo hello AGAIN' | wc -l | string trim)\r"
+expect -re {\r\ncount AGAIN 0\r\n} {
+    puts "history function explicit prefix delete 'echo hello AGAIN' succeeded"
+} unmatched {
+    puts stderr "history function explicit prefix delete 'echo hello AGAIN' failed"
+}
+
+send "echo count again (history search -e -C 'echo hello again' | wc -l | string trim)\r"
+expect -re {\r\ncount again 1\r\n} {
     puts "history function explicit exact search 'echo hello again' succeeded"
 } unmatched {
     puts stderr "history function explicit exact search 'echo hello again' failed"
-}
-
-send "history search --exact 'echo hello AGAIN'\r"
-expect_prompt -re {\r\necho hello AGAIN\r\n} {
-    puts stderr "history function explicit exact search 'echo hello AGAIN' found the entry"
-} unmatched {
-    puts "history function explicit exact search 'echo hello AGAIN' failed to find the entry"
 }

--- a/tests/history.expect.out
+++ b/tests/history.expect.out
@@ -7,6 +7,5 @@ history function explicit exact search 'echo goodbye' succeeded
 history function explicit exact search 'echo hello' succeeded
 history function explicit exact search 'echo hell' succeeded
 history function explicit exact delete 'echo hello' succeeded
-history function explicit prefix delete 'echo hello' succeeded
+history function explicit prefix delete 'echo hello AGAIN' succeeded
 history function explicit exact search 'echo hello again' succeeded
-history function explicit exact search 'echo hello AGAIN' failed to find the entry


### PR DESCRIPTION
This fixes the issue that caused me to close my previous pull-request of this change by limiting the `builtin history delete` to case-sensitive matches. It turns out that due to how the history code is currently structured the history_t::remove() method can only remove exact (which also means case-sensitive) matches of the command string to be removed.

Fixes #3236