### PR TITLE
Add defaults (macOS) completion and update diskutil (macOS) completion

### DIFF
--- a/share/completions/defaults.fish
+++ b/share/completions/defaults.fish
@@ -1,0 +1,33 @@
+# completion for defaults (macOS)
+
+function __fish_defaults_domains
+    defaults domains | string split ", "
+end
+
+complete -f -c defaults -o 'currentHost' -d 'Restricts preferences operations to the host the user is currently logged in on'
+complete -f -c defaults -o 'host' -d 'Restricts preferences operations to hostname'
+
+# read
+complete -f -c defaults -n '__fish_use_subcommand' -a read -d 'Shows defaults for all or the given domain'
+complete -f -c defaults -n '__fish_seen_subcommand_from read read-type write rename delete' -a '(__fish_defaults_domains)'
+complete -f -c defaults -n '__fish_seen_subcommand_from read read-type write rename delete' -o 'app'
+
+# write
+complete -f -c defaults -n '__fish_use_subcommand' -a write -d 'Writes domain or or a key in the domain'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'string' -d 'String as the value for the given preference key'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'data' -d 'Abunch of raw data bytes as the value for the given prefer ence key'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'int' -d 'Integer as the value for the given preference key'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'float' -d 'Floating point number as the value for the given preference key'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'bool' -d 'Boolean as the value for the given preference key'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'date' -d 'Date as the value for the given preference key'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'array' -d 'Array as the value for the given preference key'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'array-add' -d 'Allows to add new elements to the end of an array'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'dict' -d 'Dictionary to the defaults database for a domain'
+complete -f -c defaults -n '__fish_seen_subcommand_from write' -o 'dict-add' -d 'Allows to add new key/value pairs to a dictionary'
+
+complete -f -c defaults -n '__fish_use_subcommand' -a read-type -d 'Shows the type for the given domain, key'
+complete -f -c defaults -n '__fish_use_subcommand' -a rename -d 'Renames old_key to new_key'
+complete -f -c defaults -n '__fish_use_subcommand' -a delete -d 'Deletes domain or a key in the domain'
+complete -f -c defaults -n '__fish_use_subcommand' -a domains -d 'Prints the names of all domains in the users defaults system'
+complete -f -c defaults -n '__fish_use_subcommand' -a find -d 'Searches for word in the domain names, keys, and values of the users defaults'
+complete -f -c defaults -n '__fish_use_subcommand' -a help -d 'Prints a list of possible command formats'

--- a/share/completions/diskutil.fish
+++ b/share/completions/diskutil.fish
@@ -1,4 +1,4 @@
-#completion for diskutil
+# completion for diskutil (macOS)
 
 function __fish_diskutil_devices
     set -l mountpoints /dev/disk*; printf '%s\n' $mountpoints
@@ -21,6 +21,10 @@ complete -f -c diskutil -n '__fish_seen_subcommand_from info' -o 'all' -d 'Proce
 
 # activity
 complete -f -c diskutil -n '__fish_use_subcommand' -a activity -d 'Continuously display system-wide disk manipulation activity'
+
+# listFilesystems
+complete -f -c diskutil -n '__fish_use_subcommand' -a listFilesystems -d 'Show the file system personalities available'
+complete -f -c diskutil -n '__fish_seen_subcommand_from listFilesystems' -o 'plist' -d 'Return a property list'
 
 # umount
 complete -f -c diskutil -n '__fish_use_subcommand' -a umount -d 'Unmount a single volume'


### PR DESCRIPTION
## Description

Add defaults (macOS) completion and update diskutil (macOS) completion.

```
$ defaults --help
Command line interface to a user's defaults.
Syntax:

'defaults' [-currentHost | -host <hostname>] followed by one of the following:

  read                                 shows all defaults
  read <domain>                        shows defaults for given domain
  read <domain> <key>                  shows defaults for given domain, key

  read-type <domain> <key>             shows the type for the given domain, key

  write <domain> <domain_rep>          writes domain (overwrites existing)
  write <domain> <key> <value>         writes key for domain

  rename <domain> <old_key> <new_key>  renames old_key to new_key

  delete <domain>                      deletes domain
  delete <domain> <key>                deletes key in domain

  import <domain> <path to plist>      writes the plist at path to domain
  import <domain> -                    writes a plist from stdin to domain
  export <domain> <path to plist>      saves domain as a binary plist to path
  export <domain> -                    writes domain as an xml plist to stdout
  domains                              lists all domains
  find <word>                          lists all entries containing word
  help                                 print this help

<domain> is ( <domain_name> | -app <application_name> | -globalDomain )
         or a path to a file omitting the '.plist' extension

<value> is one of:
  <value_rep>
  -string <string_value>
  -data <hex_digits>
  -int[eger] <integer_value>
  -float  <floating-point_value>
  -bool[ean] (true | false | yes | no)
  -date <date_rep>
  -array <value1> <value2> ...
  -array-add <value1> <value2> ...
  -dict <key1> <value1> <key2> <value2> ...
  -dict-add <key1> <value1> ...
```

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [ ] Tests have been added for regressions fixed
