### PR TITLE
Output current default priority in dpkg-reconfigure completion

### DIFF
--- a/share/completions/dpkg-reconfigure.fish
+++ b/share/completions/dpkg-reconfigure.fish
@@ -1,0 +1,14 @@
+# Completions for the `dpkg-reconfigure` command
+
+complete -f -c dpkg-reconfigure -a '(__fish_print_packages)' --description 'Package'
+
+# Support flags
+complete -x -f -c dpkg-reconfigure -s h -l help     --description 'Display help'
+
+# General options
+complete -f -c dpkg-reconfigure -s f -l frontend -r -a "dialog readline noninteractive gnome kde editor web" --description 'Set configuration frontend'
+complete -f -c dpkg-reconfigure -s p -l priority -r -a "low medium high critical" --description 'Set priority threshold'
+complete -f -c dpkg-reconfigure -l default-priority --description 'Use default priority threshold'
+complete -f -c dpkg-reconfigure -s u -l unseen-only --description 'Show only unseen question'
+complete -f -c dpkg-reconfigure -l force --description 'Reconfigure also inconsistent packages'
+complete -f -c dpkg-reconfigure -l no-reload --description 'Prevent reloading templates'

--- a/share/completions/dpkg-reconfigure.fish
+++ b/share/completions/dpkg-reconfigure.fish
@@ -8,7 +8,7 @@ complete -x -f -c dpkg-reconfigure -s h -l help     --description 'Display help'
 # General options
 complete -f -c dpkg-reconfigure -s f -l frontend -r -a "dialog readline noninteractive gnome kde editor web" --description 'Set configuration frontend'
 complete -f -c dpkg-reconfigure -s p -l priority -r -a "low medium high critical" --description 'Set priority threshold'
-complete -f -c dpkg-reconfigure -l default-priority --description "Use current default ("(echo get debconf/priority | debconf-communicate | string match -r '\w*$')") priority threshold"
+complete -f -c dpkg-reconfigure -l default-priority --description "Use current default ("(echo get debconf/priority | debconf-communicate | string match -r '\w+$')") priority threshold"
 complete -f -c dpkg-reconfigure -s u -l unseen-only --description 'Show only unseen question'
 complete -f -c dpkg-reconfigure -l force --description 'Reconfigure also inconsistent packages'
 complete -f -c dpkg-reconfigure -l no-reload --description 'Prevent reloading templates'

--- a/share/completions/dpkg-reconfigure.fish
+++ b/share/completions/dpkg-reconfigure.fish
@@ -8,7 +8,7 @@ complete -x -f -c dpkg-reconfigure -s h -l help     --description 'Display help'
 # General options
 complete -f -c dpkg-reconfigure -s f -l frontend -r -a "dialog readline noninteractive gnome kde editor web" --description 'Set configuration frontend'
 complete -f -c dpkg-reconfigure -s p -l priority -r -a "low medium high critical" --description 'Set priority threshold'
-complete -f -c dpkg-reconfigure -l default-priority --description 'Use default priority threshold'
+complete -f -c dpkg-reconfigure -l default-priority --description "Use current default ("(echo get debconf/priority | debconf-communicate | string match -r '\w*$')") priority threshold"
 complete -f -c dpkg-reconfigure -s u -l unseen-only --description 'Show only unseen question'
 complete -f -c dpkg-reconfigure -l force --description 'Reconfigure also inconsistent packages'
 complete -f -c dpkg-reconfigure -l no-reload --description 'Prevent reloading templates'


### PR DESCRIPTION
I wanted to separate this commit into another pull request, as I am not sure if dynamically changing descriptions are okay (but I included the former change, which is already merged, as it logically builds upon it).

This might be a bit over the top, but getting the information that a default priority threshold is used without knowing what that value is or how to find out might not be so useful after all. Thus, change the completion to include this information dynamically.