### PR TITLE
Disable killall completions if it doesn't exist

### DIFF
--- a/share/completions/killall.fish
+++ b/share/completions/killall.fish
@@ -1,5 +1,5 @@
 # For Solaris OS, we don't need to generate completions. Since it can hang the PC.
-if test (uname) != 'SunOS'
+if test (uname) != 'SunOS' -a -x /usr/bin/killall
 	__fish_make_completion_signals
 
 	for i in $__kill_signals

--- a/share/completions/killall.fish
+++ b/share/completions/killall.fish
@@ -1,6 +1,9 @@
 # For Solaris OS, we don't need to generate completions. Since it can hang the PC.
-if test (uname) != 'SunOS' -a -x /usr/bin/killall
-	__fish_make_completion_signals
+# Similarly if killall doesn't exist (e.g. Cygwin)
+if test (uname) != 'SunOS'
+    and command -s killall > /dev/null
+
+    __fish_make_completion_signals
 
 	for i in $__kill_signals
 		set number (echo $i | cut -d " " -f 1)


### PR DESCRIPTION
## Description

If the killall binary doesn't exist, as it doesn't on Cygwin for example, typing killall at the command prompt generates a few screenfuls of error messages as various attempts are made to execute killall to build the completions.

This patch simply aborts the completion script if the killall binary doesn't exist on the path.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [ ] Tests have been added for regressions fixed
