### PR TITLE
make it easy to get the legacy hybrid key bindings

### DIFF
--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -1,12 +1,13 @@
 function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fish"
     if not set -q argv[1]
-        # Clear earlier bindings, if any
-        bind --erase --all
+        bind --erase --all  # clear earlier bindings, if any
         if test "$fish_key_bindings" != "fish_default_key_bindings"
             # Allow the user to set the variable universally
             set -q fish_key_bindings
             or set -g fish_key_bindings
-            set fish_key_bindings fish_default_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+            # This triggers the handler, which calls us again and ensures the user_key_bindings
+            # are executed.
+            set fish_key_bindings fish_default_key_bindings
             return
         end
     end

--- a/share/functions/fish_hybrid_key_bindings.fish
+++ b/share/functions/fish_hybrid_key_bindings.fish
@@ -1,0 +1,18 @@
+function fish_hybrid_key_bindings --description "Vi-style bindings that inherit emacs-style bindings in all modes"
+    bind --erase --all  # clear earlier bindings, if any
+
+    if test "$fish_key_bindings" != "fish_hybrid_key_bindings"
+        # Allow the user to set the variable universally
+        set -q fish_key_bindings
+        or set -g fish_key_bindings
+        # This triggers the handler, which calls us again and ensures the user_key_bindings
+        # are executed.
+        set fish_key_bindings fish_hybrid_key_bindings
+        return
+    end
+
+    for mode in default insert visual
+        fish_default_key_bindings -M $mode
+    end
+    fish_vi_key_bindings --no-erase
+end

--- a/share/functions/fish_mode_prompt.fish
+++ b/share/functions/fish_mode_prompt.fish
@@ -2,6 +2,7 @@
 function fish_mode_prompt --description "Displays the current mode"
   # Do nothing if not in vi mode
   if test "$fish_key_bindings" = "fish_vi_key_bindings"
+    or test "$fish_key_bindings" = "fish_hybrid_key_bindings"
     switch $fish_bind_mode
       case default
         set_color --bold --background red white

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -3,27 +3,33 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # allow for hybrid bindings.
     # This needs to be checked here because if we are called again
     # via the variable handler the argument will be gone.
-    if not contains -- $argv[1] --no-erase
-        bind --erase --all
-    else if set -q argv[1]
+    set -l rebind true
+    if test "$argv[1]" = "--no-erase"
+        set rebind false
         set -e argv[1]
+    else
+        bind --erase --all  # clear earlier bindings, if any
     end
 
     # Allow just calling this function to correctly set the bindings.
     # Because it's a rather discoverable name, users will execute it
     # and without this would then have subtly broken bindings.
     if test "$fish_key_bindings" != "fish_vi_key_bindings"
-        # Allow the user to set the variable universally
+        and test "$rebind" = "true"
+        # Allow the user to set the variable universally.
         set -q fish_key_bindings
         or set -g fish_key_bindings
-        set fish_key_bindings fish_vi_key_bindings # This triggers the handler, which calls us again and ensures the user_key_bindings are executed
+        # This triggers the handler, which calls us again and ensures the user_key_bindings
+        # are executed.
+        set fish_key_bindings fish_vi_key_bindings
         return
     end
 
     # The default escape timeout is 300ms. But for users of Vi bindings that can be slightly
     # annoying when trying to switch to Vi "normal" mode. So set a shorter timeout in this case
     # unless the user has explicitly set the delay.
-    set -q fish_escape_delay_ms; or set -g fish_escape_delay_ms 100
+    set -q fish_escape_delay_ms
+    or set -g fish_escape_delay_ms 100
 
     set -l init_mode insert
     # These are only the special vi-style keys


### PR DESCRIPTION
The changes related to issue #3068 removed most of the emacs bindings
from vi mode. However, since fish 2.4.0 was released several people have
pointed out that the directions for reinstating the legacy hybrid key
bindings don't work. This change fixes that and makes it easier to use
the legacy hybrid bindings.

Fixes #3556