### PR TITLE
Fixed 'cannot parse LS_COLORS' errors due to redirection being part of this global varible

### DIFF
--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -21,7 +21,7 @@ if command ls --version 1>/dev/null 2>/dev/null
 					break
 				end
 			end
-			set -gx LS_COLORS (dircolors -c $colorfile | string replace -r 'setenv LS_COLORS \'(.*)\'' '$1')
+			set -gx LS_COLORS (dircolors -c $colorfile | string replace -r 'setenv LS_COLORS \'(.*)\'' '$1' | string replace ' >&/dev/null'  '' )
 		end
 	end
 


### PR DESCRIPTION
## Description

On Cygwin there was an error when doing `ls`: 'unparsable value for LS_COLORS environment variable.'
This was caused by the fact that `dircolors` was adding ' &>/dev/null' at the end of the string it was generating. This redirection part was exported to as a part of LS_COLORS global variable. Simply added replacing this superflous part with empty string.
