### PR TITLE
Fix erroneous \t in auto completions

### DIFF
--- a/share/completions/sysctl.fish
+++ b/share/completions/sysctl.fish
@@ -3,7 +3,7 @@ if type -q -f sysctl
 	if sysctl -h >/dev/null ^/dev/null
 		# Print sysctl keys and values, separated by a tab
 		function __fish_sysctl_values
-			sysctl -a ^/dev/null | string replace -a " = " "\t"
+			sysctl -a ^/dev/null | string replace -a " = " \t
 		end
 
 		complete -c sysctl -a '(__fish_sysctl_values)' -f
@@ -32,7 +32,7 @@ if type -q -f sysctl
 	else
 		# OSX sysctl
 		function __fish_sysctl_values
-			sysctl -a ^/dev/null | string replace -a ":" "\t"
+			sysctl -a ^/dev/null | string replace -a ":" \t
 		end
 
 		complete -c sysctl -a '(__fish_sysctl_values)' -f


### PR DESCRIPTION
## Description

The last commit to this auto completion changed it to use `string replace` instead of `tr`. Unfortunately they do not behave the same. `tr " = " "\t"` replaces " = " with a tabulator character, while `string replace -a " = " "\t"` replaces it with \t. Either `string` is misbehaving or this auto completion was broken.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [ ] Tests have been added for regressions fixed