### PR TITLE
an invalid flag to `function` is handled wrong

### DIFF
--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -498,10 +498,15 @@ const wchar_t *wcsvarname(const wchar_t *str) {
 /// \return null if this is a valid name, and a pointer to the first invalid character otherwise.
 const wchar_t *wcsvarname(const wcstring &str) { return wcsvarname(str.c_str()); }
 
-/// Test if the given string is a valid function name.
+/// Test if the string is a valid function name.
 ///
-/// \return null if this is a valid name, and a pointer to the first invalid character otherwise.
-const wchar_t *wcsfuncname(const wcstring &str) { return wcschr(str.c_str(), L'/'); }
+/// \return true if it is valid else false.
+bool wcsfuncname(const wcstring &str) {
+    if (str.size() == 0) return false;
+    if (str.at(0) == L'-') return false;
+    if (str.find_first_of(L'/') != wcstring::npos) return false;
+    return true;
+}
 
 /// Test if the given string is valid in a variable name.
 ///

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -112,7 +112,7 @@ int fish_iswgraph(wint_t wc);
 
 const wchar_t *wcsvarname(const wchar_t *str);
 const wchar_t *wcsvarname(const wcstring &str);
-const wchar_t *wcsfuncname(const wcstring &str);
+bool wcsfuncname(const wcstring &str);
 bool wcsvarchr(wchar_t chr);
 int fish_wcswidth(const wchar_t *str);
 int fish_wcswidth(const wcstring &str);

--- a/tests/function.err
+++ b/tests/function.err
@@ -1,0 +1,9 @@
+function: Illegal function name '-a'
+fish: function -a arg1 arg2 name2 ; end
+      ^
+function: Illegal function name '--argument-names'
+fish: function --argument-names arg1 arg2 name4 ; end
+      ^
+function: Unexpected positional argument 'abc'
+fish: function name5 abc --argument-names def ; end
+      ^

--- a/tests/function.in
+++ b/tests/function.in
@@ -31,16 +31,16 @@ set bar 'bad bar'
 set baz 'bad baz'
 frob
 
-# Test that -a does not mix up the function name with arguments
-# See #2068
+# This sequence of tests originally verified that functions `name2` and
+# `name4` were created. See issue #2068. That behavior is not what we want.
+# The function name must always be the first argument of the `function`
+# command. See issue #2827.
 function name1 -a arg1 arg2 ; end
 function -a arg1 arg2 name2 ; end
 function name3 --argument-names arg1 arg2 ; end
 function --argument-names arg1 arg2 name4 ; end
-for i in (seq 4)
-    if functions -q name$i
-        echo "Function name$i found"
-    else
-        echo "Function name$i not found, but should have been"
-    end
-end
+function name5 abc --argument-names def ; end
+functions -q name1; and echo "Function name1 found"
+functions -q name2; or echo "Function name2 not found as expected"
+functions -q name3; and echo "Function name3 found"
+functions -q name4; or echo "Function name4 not found as expected"

--- a/tests/function.out
+++ b/tests/function.out
@@ -19,6 +19,6 @@ $bar: (5)
 5: '3'
 $baz: (0)
 Function name1 found
-Function name2 found
+Function name2 not found as expected
 Function name3 found
-Function name4 found
+Function name4 not found as expected


### PR DESCRIPTION
Specifically, an invalid flag keeps the function from being defined but
does not emit an error message.

Fixes #2827