### PR TITLE
Fix build on systems without shm_open()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -252,7 +252,7 @@ AC_DEFINE([NOMACROS], [1], [Define to 1 to disable curses macros that conflict w
 # Check for os dependant libraries for all binaries.
 AC_SEARCH_LIBS( connect, socket, , [AC_MSG_ERROR([Cannot find the socket library, needed to build this package.] )] )
 AC_SEARCH_LIBS( nanosleep, rt, , [AC_MSG_ERROR([Cannot find the rt library, needed to build this package.] )] )
-AC_SEARCH_LIBS( shm_open, rt, , [AC_MSG_ERROR([Cannot find the rt library, needed to build this package.] )] )
+AC_SEARCH_LIBS( shm_open, rt, [AC_DEFINE([HAVE_SHM_OPEN], [1], [Define to 1 if the shm_open() function exists])] )
 AC_SEARCH_LIBS( pthread_create, pthread, , [AC_MSG_ERROR([Cannot find the pthread library, needed to build this package.] )] )
 AC_SEARCH_LIBS( setupterm, [ncurses tinfo curses], , [AC_MSG_ERROR([Could not find a curses implementation, needed to build fish. If this is Linux, try running 'sudo apt-get install libncurses5-dev' or 'sudo yum install ncurses-devel'])] )
 AC_SEARCH_LIBS( [dladdr], [dl] )

--- a/osx/config.h
+++ b/osx/config.h
@@ -190,6 +190,9 @@
 /* Perform string translations with gettext */
 /* #undef USE_GETTEXT */
 
+/* Define to 1 if the shm_open() function exists. */
+#define HAVE_SHM_OPEN 1
+
 /* Enable extensions on AIX 3, Interix.  */
 #ifndef _ALL_SOURCE
 # define _ALL_SOURCE 1

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -984,6 +984,7 @@ wcstring get_machine_identifier() {
     return result;
 }
 
+#ifdef HAVE_SHM_OPEN
 class universal_notifier_shmem_poller_t : public universal_notifier_t {
     // This is what our shared memory looks like. Everything here is stored in network byte order
     // (big-endian).
@@ -1123,6 +1124,7 @@ class universal_notifier_shmem_poller_t : public universal_notifier_t {
         return usec_per_sec / 3;  // 3 times a second
     }
 };
+#endif
 
 /// A notifyd-based notifier. Very straightforward.
 class universal_notifier_notifyd_t : public universal_notifier_t {
@@ -1403,7 +1405,9 @@ static universal_notifier_t::notifier_strategy_t fetch_default_strategy_from_env
         const char *name;
         universal_notifier_t::notifier_strategy_t strat;
     } options[] = {{"default", universal_notifier_t::strategy_default},
+#ifdef HAVE_SHM_OPEN
                    {"shmem", universal_notifier_t::strategy_shmem_polling},
+#endif
                    {"pipe", universal_notifier_t::strategy_named_pipe},
                    {"notifyd", universal_notifier_t::strategy_notifyd}};
     const size_t opt_count = sizeof options / sizeof *options;
@@ -1458,9 +1462,11 @@ universal_notifier_t *universal_notifier_t::new_notifier_for_strategy(
         strat = resolve_default_strategy();  //!OCLINT(parameter reassignment)
     }
     switch (strat) {
+#ifdef HAVE_SHM_OPEN
         case strategy_shmem_polling: {
             return new universal_notifier_shmem_poller_t();
         }
+#endif
         case strategy_notifyd: {
             return new universal_notifier_notifyd_t();
         }

--- a/src/env_universal_common.h
+++ b/src/env_universal_common.h
@@ -115,9 +115,11 @@ class universal_notifier_t {
         // Default meta-strategy to use the 'best' notifier for the system.
         strategy_default,
 
+#ifdef HAVE_SHM_OPEN
         // Use a value in shared memory. Simple, but requires polling and therefore semi-frequent
         // wakeups.
         strategy_shmem_polling,
+#endif
 
         // Strategy that uses a named pipe. Somewhat complex, but portable and doesn't require
         // polling most of the time.

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2499,9 +2499,11 @@ static void trigger_or_wait_for_notification(universal_notifier_t *notifier,
             DIE("strategy_default should be passed");
             break;
         }
+#ifdef HAVE_SHM_OPEN
         case universal_notifier_t::strategy_shmem_polling: {
             break;  // nothing required
         }
+#endif
         case universal_notifier_t::strategy_notifyd: {
             // notifyd requires a round trip to the notifyd server, which means we have to wait a
             // little bit to receive it. In practice, this seems to be enough.
@@ -2585,7 +2587,9 @@ static void test_notifiers_with_strategy(universal_notifier_t::notifier_strategy
 static void test_universal_notifiers() {
     if (system("mkdir -p /tmp/fish_uvars_test/ && touch /tmp/fish_uvars_test/varsfile.txt"))
         err(L"mkdir failed");
+#ifdef HAVE_SHM_OPEN
     test_notifiers_with_strategy(universal_notifier_t::strategy_shmem_polling);
+#endif
     test_notifiers_with_strategy(universal_notifier_t::strategy_named_pipe);
 #if __APPLE__
     test_notifiers_with_strategy(universal_notifier_t::strategy_notifyd);


### PR DESCRIPTION
Notably, this fixes building on Android.

This patch is part of an effort to upstream patches used by the fish package in Termux.