### PR TITLE
Adds a `--quiet`/`-q` option for `command -s`

### DIFF
--- a/doc_src/command.txt
+++ b/doc_src/command.txt
@@ -13,7 +13,7 @@ The following options are available:
 
 - `-s` or `--search` returns the name of the disk file that would be executed, or nothing if no file with the specified name could be found in the `$PATH`.
 
-With the `-s` option, `command` treats every argument as a separate command to look up and sets the exit status to 0 if any of the specified commands were found, or 1 if no commands could be found.
+With the `-s` option, `command` treats every argument as a separate command to look up and sets the exit status to 0 if any of the specified commands were found, or 1 if no commands could be found. Additionally passing a `-q` or `--quiet` option prevents any paths from being printed, like the `type -q`, for testing only the exit status.
 
 For basic compatibility with POSIX `command`, the `-v` flag is recognized as an alias for `-s`.
 

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -821,17 +821,18 @@ static int builtin_emit(parser_t &parser, io_streams_t &streams, wchar_t **argv)
 static int builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wgetopter_t w;
     int argc = builtin_count_args(argv);
-    int print_path = 0;
+    bool find_path = false;
+    bool quiet = false;
 
     w.woptind = 0;
 
     static const struct woption long_options[] = {
-        {L"search", no_argument, 0, 's'}, {L"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
+         {L"quiet", no_argument, 0, 'q'}, {L"search", no_argument, 0, 's'}, {L"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
 
     while (1) {
         int opt_index = 0;
 
-        int opt = w.wgetopt_long(argc, argv, L"svh", long_options, &opt_index);
+        int opt = w.wgetopt_long(argc, argv, L"qsvh", long_options, &opt_index);
         if (opt == -1) break;
 
         switch (opt) {
@@ -848,7 +849,11 @@ static int builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **ar
             }
             case 's':
             case 'v': {
-                print_path = 1;
+                find_path = true;
+                break;
+            }
+            case 'q': {
+                quiet = true;
                 break;
             }
             case '?': {
@@ -862,7 +867,7 @@ static int builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **ar
         }
     }
 
-    if (!print_path) {
+    if (!find_path) {
         builtin_print_help(parser, streams, argv[0], streams.out);
         return STATUS_BUILTIN_ERROR;
     }
@@ -873,7 +878,7 @@ static int builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **ar
         const wchar_t *command_name = argv[idx];
         wcstring path;
         if (path_get_path(command_name, &path)) {
-            streams.out.append_format(L"%ls\n", path.c_str());
+            if (!quiet) streams.out.append_format(L"%ls\n", path.c_str());
             ++found;
         }
     }


### PR DESCRIPTION
## Description

I think devnull'ing `command -v program_name` to check presence is a common
enough chore that a `--quiet` option which works like it does on `type` would be handy for writers of shell scripts. Simply mutes the output for checking the exit status.

`command -qs foo` should behave identically to `command -s foo >/dev/null`, `command -v foo >/dev/null`

Includes updated documentation.