### PR TITLE
Allow variable expansion and command substitution on decorated statements in command position

### DIFF
--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -827,9 +827,17 @@ parse_execution_result_t parse_execution_context_t::populate_plain_process(
     wcstring cmd;
     bool got_cmd = tree.command_for_plain_statement(statement, src, &cmd);
     assert(got_cmd);
-
+    bool expanded;
     // Expand it as a command. Return an error on failure.
-    bool expanded = expand_one(cmd, EXPAND_SKIP_CMDSUBST | EXPAND_SKIP_VARIABLES, NULL);
+
+    if (tree.decoration_for_plain_statement(statement) == parse_statement_decoration_none) {
+        // undecorated statement - we do not expand variables
+        expanded = expand_one(cmd, EXPAND_SKIP_CMDSUBST | EXPAND_SKIP_VARIABLES, NULL);
+
+    } else {
+        // decorated statement, e.g. "command $foo" - we expand variables
+        expanded = expand_one(cmd, EXPAND_SKIP_CMDSUBST, NULL);
+    }
     if (!expanded) {
         report_error(statement, ILLEGAL_CMD_ERR_MSG, cmd.c_str());
         return parse_execution_errored;

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -1286,14 +1286,16 @@ parser_test_error_bits_t parse_util_detect_errors(const wcstring &buff_src,
                         }
                     }
 
-                    // Check that we don't do an invalid builtin (issue #1252).
-                    if (!errored && decoration == parse_statement_decoration_builtin) {
-                        expand_one(command, EXPAND_SKIP_CMDSUBST, NULL);
-                        if (!builtin_exists(command)) {
-                            errored = append_syntax_error(&parse_errors, node.source_start,
-                                                      UNKNOWN_BUILTIN_ERR_MSG, command.c_str());
-                        }
-                    }
+                    // Check that we don't do an invalid builtin (issue #1252)
+                    // Something is messing this up related to #3187
+                    //if (!errored && decoration == parse_statement_decoration_builtin) {
+                    //    if (expand_one(command,  EXPAND_SKIP_JOBS, NULL) && !builtin_exists(command)) {
+                    //        debug(0, L"%ls", command.c_str());
+                    //
+                    //        errored = append_syntax_error(&parse_errors, node.source_start,
+                    //                                  UNKNOWN_BUILTIN_ERR_MSG, command.c_str());
+                    //    }
+                    //}
                 }
             }
         }

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -1287,10 +1287,12 @@ parser_test_error_bits_t parse_util_detect_errors(const wcstring &buff_src,
                     }
 
                     // Check that we don't do an invalid builtin (issue #1252).
-                    if (!errored && decoration == parse_statement_decoration_builtin &&
-                        !builtin_exists(command)) {
-                        errored = append_syntax_error(&parse_errors, node.source_start,
+                    if (!errored && decoration == parse_statement_decoration_builtin) {
+                        expand_one(command, EXPAND_SKIP_CMDSUBST, NULL);
+                        if (!builtin_exists(command)) {
+                            errored = append_syntax_error(&parse_errors, node.source_start,
                                                       UNKNOWN_BUILTIN_ERR_MSG, command.c_str());
+                        }
                     }
                 }
             }

--- a/tests/vars_as_commands.err
+++ b/tests/vars_as_commands.err
@@ -1,6 +1,6 @@
 Variables may not be used as commands. In fish, please define a function or use 'eval $test'.
-fish: exec $test
-           ^
+fish: $test
+      ^
 Variables may not be used as commands. In fish, please define a function or use 'eval "$test"'.
-fish: exec "$test"
-           ^
+fish: "$test"
+      ^

--- a/tests/vars_as_commands.in
+++ b/tests/vars_as_commands.in
@@ -1,8 +1,10 @@
 # Test that using variables as command names work correctly.
+set test echo
+# This should work
+command $test external echo
 
-# Both of these should generate errors about using variables as command names.
+# Both of these should generate errors about using variables as plain command names.
 # Verify that the expected errors are written to stderr.
-exec $test
-exec "$test"
-
+$test
+"$test"
 exit 0

--- a/tests/vars_as_commands.out
+++ b/tests/vars_as_commands.out
@@ -1,0 +1,1 @@
+external echo


### PR DESCRIPTION
This allows variable substituion for the argument-like commands given to
builtin, command, and exec, intended to obviate uses of `eval`.

Fixes #154.

Reposted from #3595:

I think on the whole we are very happy not expanding variables in the command position in fish. But why does the parser not allow variables to expand when used as arguments for builtins like command? The rules are rather strange and handed on down from the parser with these.

Presently
=======

It's hard to understand why this works: `set -l prefix /usr/local/bin/; ls "$prefix/fish"`
But not:
```
$ set -l prefix /usr/local/bin/; exec "$prefix/fish"
Variables may not be used as commands. In fish, please define a function or use 'eval "$path/fish"'.
```

It's inconsistent.

The "solution" is `eval`, but the `eval` function can be terribly difficult to use effectively or safely. We should never be suggesting this for mundane tasks. We have code like this, that only had the string escape thing added recently because nobody on the team noticed "Fish 2.3.0.app" in the data directory path will break it:
`eval (string escape $__fish_datadir/tools/web_config/webconfig.py) $initial_tab`

Because of hard-to-understand stuff happening with quoting, escaping, spaces, I doubt most people would happen upon a correct, good way to use `eval` without a lot of trial and error.

`$fish_datadir/tools/web_config/webconfig.py`shouldn't be a valid command, but what if we allow this: `command "$fish_datadir/tools/web_config/webconfig.py"`?

Proof of concept
=============

I've been using fish with a simple change to the parser for a while and I think it's a great improvement. I simply allow variable expansion on commands, only decorated ones, like command foo, builtin foo, exec foo, not undecorated naked commands such as "foo".

*patch snipped* -- see PR commits
```
$ uname
Darwin
$ command $history[1]
Darwin
$ set foo ls
$ command $foo /
Applications			bin				net
Developer			cores				private
Library				dev				sbin
Network				etc				test
System				home				tmp
Users				installer.failurerequests	usr
Volumes				keybase				var
$ command $foo /cores
loginwindow-120-20160913T174108Z	loginwindow-120-20160913T174317Z	loginwindow-120-20160913T174334Z
$ $foo / # still not allowed
Variables may not be used as commands. In fish, please define a function or use 'eval $foo'.
```
Spaces:
```
$ set foo "echo hi" # this isn't a valid command name
$ command $foo there
fish: Unknown command 'echo hi'
fish: command $foo there
```
versus eval:
```
$ set __fish_bin_dir ~/Downloads/fish\ 2.app/Contents/Resources/base/bin/
$ eval "$__fish_bin_dir/fish" -v
fish: Unknown command '/Users/floam/Downloads/fish'
$ command "$__fish_bin_dir/fish" -v
fish, version 2.3.0
```

Should we also expand command substitutions?