### PR TITLE
Implement `random` redesign proposal

### DIFF
--- a/doc_src/choose.txt
+++ b/doc_src/choose.txt
@@ -1,0 +1,18 @@
+\section choose choose - Chooses a random item from a list
+
+\subsection choose-synopsis Synopsis
+\fish{synopsis}
+choose [ITEMS...]
+\endfish
+
+\subsection choose-description Description
+
+`CHOOSE` is a very simple wrapper around `RANDOM` that selects a random item
+from a given list.
+
+\subsection choose-example Example
+
+Open a random picture in any subdirectiory:
+\fish
+open (choose **.jpg) 
+\endfish

--- a/doc_src/random.txt
+++ b/doc_src/random.txt
@@ -2,31 +2,31 @@
 
 \subsection random-synopsis Synopsis
 \fish{synopsis}
-random [SEED]
+random [(-s | --seed) SEED] END
+random [(-s | --seed) SEED] START END
+random [(-s | --seed) SEED] START END STEP
 \endfish
 
 \subsection random-description Description
 
-`random` outputs a psuedo-random number from 0 to 32767, inclusive.
-Even ignoring the very narrow range of values you should not assume
-this produces truly random values within that range. Do not use the
-value for any cryptographic purposes, and take care to handle collisions:
-the same random number appearing more than once in a given fish instance.
+`RANDOM` generates a psuedo-random integer from a uniform distribution in
+the inclusive range [START; END] with a spacing of STEP. One argument
+indicates a START of 0, two arguments indicates a STEP of 1. Only integer
+arguments are supported and STEP should be strictly positive.
 
-If a `SEED` value is provided, it is used to seed the random number
-generator, and no output will be produced. This can be useful for debugging
-purposes, where it can be desirable to get the same random number sequence
-multiple times. If the random number generator is called without first
-seeding it, the current time will be used as the seed.
+If a `SEED` value is provided, the random number will be generated from that
+seed, meaning that you will get the same generated number throughout multiple
+invocations with the same parameters. Providing a seed will NOT give the same
+result across different systems.
 
+You should not consider `RANDOM` cryptographically secure.
 
 \subsection random-example Example
 
-The following code will count down from a random number to 1:
+The following code will count down from a random even number between 10 and 20 to 1:
 
 \fish
-for i in (seq (random) -1 1)
+for i in (seq (random 10 20 2) -1 1)
     echo $i
-    sleep
 end
 \endfish

--- a/share/functions/choose.fish
+++ b/share/functions/choose.fish
@@ -1,0 +1,6 @@
+function choose --description "Chooses a random item from a list"
+    if not set -q argv[1]
+        return 2
+    end
+    echo $argv[(random 1 (count $argv))]
+end

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -79,7 +79,7 @@ function psub --description "Read from stdin into a file and output the filename
 
     # Find unique function name
     while true
-        set funcname __fish_psub_(random)
+        set funcname __fish_psub_(random 10000000)
 
         if not functions $funcname >/dev/null ^/dev/null
             break
@@ -95,5 +95,6 @@ function psub --description "Read from stdin into a file and output the filename
         end
         functions -e $funcname
     end
+
 
 end

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -34,6 +34,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <random>
 
 #include "builtin.h"
 #include "builtin_commandline.h"
@@ -1740,19 +1741,19 @@ int builtin_function(parser_t &parser, io_streams_t &streams, const wcstring_lis
 
 /// The random builtin generates random numbers.
 static int builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
-    static int seeded = 0;
-    static struct drand48_data seed_buffer;
-
     int argc = builtin_count_args(argv);
 
     wgetopter_t w;
 
-    static const struct woption long_options[] = {{L"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
-
+    static const struct woption long_options[] = {{L"help", no_argument, 0, 'h'},
+                                                 {L"seed", required_argument, 0, 's'},
+                                                 {0,0,0,0}};
+    bool seeded = false;
+    long seed = 0;
     while (1) {
         int opt_index = 0;
 
-        int opt = w.wgetopt_long(argc, argv, L"h", long_options, &opt_index);
+        int opt = w.wgetopt_long(argc, argv, L"hs:", long_options, &opt_index);
         if (opt == -1) break;
 
         switch (opt) {
@@ -1763,9 +1764,18 @@ static int builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **arg
                 builtin_print_help(parser, streams, argv[0], streams.err);
                 return STATUS_BUILTIN_ERROR;
             }
+            case 's': {
+                seed = fish_wcstol(w.woptarg);
+                if (errno) {
+                    streams.err.append_format(BUILTIN_ERR_NOT_NUMBER, argv[0], w.woptarg);
+                    return STATUS_BUILTIN_ERROR;
+                }
+                seeded = true;
+                break;
+            }
             case 'h': {
                 builtin_print_help(parser, streams, argv[0], streams.out);
-                break;
+                return STATUS_BUILTIN_OK;
             }
             case '?': {
                 builtin_unknown_option(parser, streams, argv[0], argv[w.woptind - 1]);
@@ -1777,31 +1787,60 @@ static int builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **arg
             }
         }
     }
-
-    int arg_count = argc - w.woptind;
-    if (arg_count == 0) {
-        long res;
-        if (!seeded) {
-            seeded = 1;
-            srand48_r(time(0), &seed_buffer);
-        }
-        lrand48_r(&seed_buffer, &res);
-        streams.out.append_format(L"%ld\n", res % 32768);
-    } else if (arg_count == 1) {
-        long foo = fish_wcstol(argv[w.woptind]);
+    // argument parsing
+    bool parse_error = false;
+    auto parse_ll = [&](const wchar_t* str) {
+        long long ll = fish_wcstoll(str);
         if (errno) {
-            streams.err.append_format(_(L"%ls: Seed value '%ls' is not a valid number\n"), argv[0],
-                                      argv[w.woptind]);
-            return STATUS_BUILTIN_ERROR;
+            streams.err.append_format(L"%ls: %ls is not a valid integer\n", argv[0], str);
+            parse_error = true;
         }
-        seeded = 1;
-        srand48_r(foo, &seed_buffer);
+        return ll;
+    };
+    int arg_count = argc - w.woptind;
+    long long start, end, step;
+    if (arg_count == 0) {
+        streams.err.append_format(L"%ls: Need at least one argument\n", argv[0]);
+        return STATUS_BUILTIN_ERROR;
+    } else if (arg_count == 1) {
+        start = 0;
+        end = parse_ll(argv[w.woptind]);
+        step = 1;
+    } else if (arg_count == 2) {
+        start = parse_ll(argv[w.woptind]);
+        end = parse_ll(argv[w.woptind+1]);
+        step = 1;
+    } else if (arg_count == 3) {
+        start = parse_ll(argv[w.woptind]);
+        end = parse_ll(argv[w.woptind+1]);
+        step = parse_ll(argv[w.woptind+2]);
     } else {
-        streams.err.append_format(_(L"%ls: Expected zero or one argument, got %d\n"), argv[0],
-                                  argc - w.woptind);
-        builtin_print_help(parser, streams, argv[0], streams.err);
+        streams.err.append_format(BUILTIN_ERR_TOO_MANY_ARGUMENTS, argv[0]);
         return STATUS_BUILTIN_ERROR;
     }
+
+    // error handling
+    if (parse_error) {
+        return STATUS_BUILTIN_ERROR;
+    } else if (start > end) {
+        streams.err.append_format(L"%ls: END must be greater than or equal to START\n", argv[0]);
+        return STATUS_BUILTIN_ERROR;
+    } else if (step <= 0) {
+        streams.err.append_format(L"%ls: STEP must be a positive integer\n", argv[0]);
+        return STATUS_BUILTIN_ERROR;
+    }
+
+    // rng-ing
+    long long result;
+    if (end - start < step) {
+        // nine nine nine nine nine nine
+        result = start;
+    } else {
+        std::mt19937_64 engine(seeded ? seed : std::random_device()());
+        std::uniform_int_distribution<long long> dist(start, start+(end-start)/step);
+        result = start+step*(dist(engine)-start);
+    }
+    streams.out.append_format(L"%ld\n", result);
     return STATUS_BUILTIN_OK;
 }
 


### PR DESCRIPTION
Following the C++11 changes, this implements #2642. I should have waited a couple more days to get `fish_wcstoll` from 2f33c24a07ab5df55ea7992ef0bf11941b068019 to spare myself from making the same changes, but now I know the madness that are the `wcsto*` functions.

I added a way to specify a seed from the initial proposal. 

I'm not entirely sure how to test how random the implementation truly is, but it seems random. I could do some more testing if you'd like.

It goes without saying that these are breaking changes, so I'm not sure how they fit in the release cycle.