### PR TITLE
Use _PATH_TMP instead of /tmp/

### DIFF
--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <paths.h>
 #include <pwd.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -136,7 +137,7 @@ static wcstring get_runtime_path() {
         }
 
         // /tmp/fish.user
-        std::string tmpdir = "/tmp/fish.";
+        std::string tmpdir = _PATH_TMP "fish.";
         tmpdir.append(uname);
         if (check_runtime_path(tmpdir.c_str()) != 0) {
             debug(0,


### PR DESCRIPTION
This fixes running on Termux, which lacks a /tmp/ directory.

I'm not totally sure how portable `_PATH_TMP` is across more exotic platforms, but it works on the platforms I've tested on (Ubuntu, OSX and FreeBSD).