### PR TITLE
Solaris fixes

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -9,7 +9,7 @@ you can redistribute it and/or modify it under the terms of the GNU GPL as
 published by the Free Software Foundation.
 
 fish also includes software licensed under the GNU Lesser General Public
-License version 2, the OpenBSD license and the ISC license.
+License version 2, the OpenBSD license, the ISC license, and the NetBSD license.
 
 Full licensing information is contained in doc_src/license.hdr.
 

--- a/configure.ac
+++ b/configure.ac
@@ -310,7 +310,7 @@ AC_CHECK_FUNCS( futimes )
 AC_CHECK_FUNCS( wcslcpy lrand48_r killpg )
 AC_CHECK_FUNCS( backtrace_symbols getifaddrs )
 AC_CHECK_FUNCS( futimens clock_gettime )
-AC_CHECK_FUNCS( getpwent )
+AC_CHECK_FUNCS( getpwent flock )
 
 AC_CHECK_DECL( [mkostemp], [ AC_CHECK_FUNCS([mkostemp]) ] )
 

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,7 @@ AX_CXX_COMPILE_STDCXX_11(noext,mandatory)
 # Tell autoconf to create config.h header
 #
 AC_CONFIG_HEADERS(config.h)
-AC_CANONICAL_TARGET
+AC_CANONICAL_HOST
 
 
 #
@@ -249,6 +249,18 @@ AC_CHECK_FILES([/proc/self/stat])
 # Disable curses macros that conflict with the STL
 AC_DEFINE([NCURSES_NOMACROS], [1], [Define to 1 to disable ncurses macros that conflict with the STL])
 AC_DEFINE([NOMACROS], [1], [Define to 1 to disable curses macros that conflict with the STL])
+
+# Threading is excitingly broken on Solaris without adding -pthread to CXXFLAGS
+# Only support GCC for now
+dnl Ideally we would use the AX_PTHREAD macro here, but it's GPL3-licensed
+dnl ACX_PTHREAD is way too old and seems to break the OS X build
+dnl Both only check with AC_LANG(C) in any case
+case $host_os in
+  solaris*)
+  CXXFLAGS="$CXXFLAGS -pthread"
+  CFLAGS="$CFLAGS -pthread"
+  ;;
+esac
 
 #
 # Check presense of various libraries. This is done on a per-binary

--- a/configure.ac
+++ b/configure.ac
@@ -314,6 +314,62 @@ AC_CHECK_FUNCS( getpwent )
 
 AC_CHECK_DECL( [mkostemp], [ AC_CHECK_FUNCS([mkostemp]) ] )
 
+dnl AC_CHECK_FUNCS uses C linkage, but sometimes (Solaris!) the behaviour is
+dnl different with C++.
+AC_MSG_CHECKING([for wcsdup])
+AC_TRY_LINK( [ #include <wchar.h> ],
+             [ wchar_t* foo = wcsdup(L""); ],
+             [ AC_MSG_RESULT(yes)
+               AC_DEFINE(HAVE_WCSDUP, 1, Define to 1 if you have the `wcsdup' function.)
+             ],
+             [AC_MSG_RESULT(no)],
+             )
+
+AC_MSG_CHECKING([for std::wcsdup])
+AC_TRY_LINK( [ #include <wchar.h> ],
+             [ wchar_t* foo = std::wcsdup(L""); ],
+             [ AC_MSG_RESULT(yes)
+               AC_DEFINE(HAVE_STD__WCSDUP, 1, Define to 1 if you have the `std::wcsdup' function.)
+             ],
+             [AC_MSG_RESULT(no)],
+             )
+
+AC_MSG_CHECKING([for wcscasecmp])
+AC_TRY_LINK( [ #include <wchar.h> ],
+             [ int foo = wcscasecmp(L"", L""); ],
+             [ AC_MSG_RESULT(yes)
+               AC_DEFINE(HAVE_WCSCASECMP, 1, Define to 1 if you have the `wcscasecmp' function.)
+             ],
+             [AC_MSG_RESULT(no)],
+             )
+
+AC_MSG_CHECKING([for std::wcscasecmp])
+AC_TRY_LINK( [ #include <wchar.h> ],
+             [ int foo = std::wcscasecmp(L"", L""); ],
+             [ AC_MSG_RESULT(yes)
+               AC_DEFINE(HAVE_STD__WCSCASECMP, 1, Define to 1 if you have the `std::wcscasecmp' function.)
+             ],
+             [AC_MSG_RESULT(no)],
+             )
+
+AC_MSG_CHECKING([for wcsncasecmp])
+AC_TRY_LINK( [ #include <wchar.h> ],
+             [ int foo = wcsncasecmp(L"", L"", 0); ],
+             [ AC_MSG_RESULT(yes)
+               AC_DEFINE(HAVE_WCSNCASECMP, 1, Define to 1 if you have the `wcsncasecmp' function.)
+             ],
+             [AC_MSG_RESULT(no)],
+             )
+
+AC_MSG_CHECKING([for std::wcsncasecmp])
+AC_TRY_LINK( [ #include <wchar.h> ],
+             [ int foo = std::wcsncasecmp(L"", L"", 0); ],
+             [ AC_MSG_RESULT(yes)
+               AC_DEFINE(HAVE_STD__WCSNCASECMP, 1, Define to 1 if you have the `std::wcsncasecmp' function.)
+             ],
+             [AC_MSG_RESULT(no)],
+             )
+
 if test x$local_gettext != xno; then
   AC_CHECK_FUNCS( gettext )
 

--- a/configure.ac
+++ b/configure.ac
@@ -536,6 +536,33 @@ else
   AC_MSG_RESULT(no)
 fi
 
+# Check that threads actually work on Solaris
+AC_MSG_CHECKING([for threadsafe errno])
+AC_RUN_IFELSE(
+  [AC_LANG_PROGRAM([
+    #include <errno.h>
+    #include <pthread.h>
+    #include <signal.h>
+
+    void *thread1_func(void *p_arg)
+    {
+            errno = 1;
+    }
+    ],[
+    errno = 0;
+    pthread_t t1;
+    pthread_create(&t1, NULL, thread1_func, NULL);
+    pthread_join(t1, NULL);
+    return errno;
+  ])],
+  [AC_MSG_RESULT(yes)],
+  [
+    AC_MSG_RESULT(no)
+    AC_MSG_FAILURE([errno is not threadsafe - check your compiler settings])
+  ],
+  [AC_MSG_RESULT(crosscompiling, skipped)]
+)
+
 pcre2_min_version=10.21
 EXTRA_PCRE2=
 AC_ARG_WITH(

--- a/doc_src/license.hdr
+++ b/doc_src/license.hdr
@@ -320,6 +320,38 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
+
+----
+
+
+## License for flock
+
+`fish` also contains small amounts of code from NetBSD, namely the `flock` fallback function. This code is copyright 2001 The NetBSD Foundation, Inc., and derived from software contributed to The NetBSD Foundation by Todd Vierling.
+
+The NetBSD license follows.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
 \htmlonly[block]
 </div>
 </div>

--- a/src/common.h
+++ b/src/common.h
@@ -825,4 +825,16 @@ static const wchar_t *enum_to_str(T enum_val, const enum_map<T> map[]) {
     return NULL;
 };
 
+#if !defined(HAVE_WCSDUP) && defined(HAVE_STD__WCSDUP)
+using std::wcsdup;
+#endif
+
+#if !defined(HAVE_WCSCASECMP) && defined(HAVE_STD__WCSCASECMP)
+using std::wcscasecmp;
+#endif
+
+#if !defined(HAVE_WCSNCASECMP) && defined(HAVE_STD__WCSNCASECMP)
+using std::wcsncasecmp;
+#endif
+
 #endif

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -464,3 +464,76 @@ static int mk_wcswidth(const wchar_t *pwcs, size_t n) {
     return width;
 }
 #endif  // HAVE_BROKEN_WCWIDTH
+
+#ifndef HAVE_FLOCK
+/*	$NetBSD: flock.c,v 1.6 2008/04/28 20:24:12 martin Exp $	*/
+
+/*-
+ * Copyright (c) 2001 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Todd Vierling.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Emulate flock() with fcntl(), where available.
+ * Otherwise, don't do locking; just pretend success.
+ */
+
+int flock(int fd, int op) {
+    int rc = 0;
+
+#if defined(F_SETLK) && defined(F_SETLKW)
+    struct flock fl = {0};
+
+    switch (op & (LOCK_EX|LOCK_SH|LOCK_UN)) {
+        case LOCK_EX:
+            fl.l_type = F_WRLCK;
+            break;
+
+        case LOCK_SH:
+            fl.l_type = F_RDLCK;
+            break;
+
+        case LOCK_UN:
+            fl.l_type = F_UNLCK;
+            break;
+
+        default:
+            errno = EINVAL;
+            return -1;
+    }
+
+    fl.l_whence = SEEK_SET;
+    rc = fcntl(fd, op & LOCK_NB ? F_SETLK : F_SETLKW, &fl);
+
+    if (rc && (errno == EAGAIN))
+        errno = EWOULDBLOCK;
+#endif
+
+    return rc;
+}
+
+#endif // HAVE_FLOCK

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -498,14 +498,12 @@ static int mk_wcswidth(const wchar_t *pwcs, size_t n) {
  */
 
 /*
- * Emulate flock() with fcntl(), where available.
- * Otherwise, don't do locking; just pretend success.
+ * Emulate flock() with fcntl().
  */
 
 int flock(int fd, int op) {
     int rc = 0;
 
-#if defined(F_SETLK) && defined(F_SETLKW)
     struct flock fl = {0};
 
     switch (op & (LOCK_EX|LOCK_SH|LOCK_UN)) {
@@ -531,7 +529,6 @@ int flock(int fd, int op) {
 
     if (rc && (errno == EAGAIN))
         errno = EWOULDBLOCK;
-#endif
 
     return rc;
 }

--- a/src/fallback.h
+++ b/src/fallback.h
@@ -125,4 +125,17 @@ char *fish_textdomain(const char *domainname);
 int killpg(int pgr, int sig);
 #endif
 
+#ifndef HAVE_FLOCK
+/// Fallback implementation of flock in terms of fcntl
+/// Danger! The semantics of flock and fcntl locking are very different.
+/// Use with caution.
+int flock(int fd, int op);
+
+#define LOCK_SH 1       /* Shared lock.  */
+#define LOCK_EX 2       /* Exclusive lock.  */
+#define LOCK_UN 8       /* Unlock.  */
+#define LOCK_NB 4       /* Don't block when locking.  */
+
+#endif
+
 #endif


### PR DESCRIPTION
This branch adds some commits which improve the build on Solaris, and produce a working binary.

One thing I'd like to add is a lint check which bans `flock` by default, unless acknowledged in the source, as the fallback is not implemented with the same semantics as `flock`. Arguably all locking is broken in one way or another on UNIX anyway.