### PR TITLE
Fixes behavior of 'x' in normal mode

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2746,6 +2746,9 @@ const wchar_t *reader_readline(int nchars) {
                 if (el->position < el->size()) {
                     update_buff_pos(el, el->position + 1);
                     remove_backward();
+                    if (el->position > 0 && el->position == el->size()) {
+                        update_buff_pos(el, el->position - 1);
+                    }
                 }
                 break;
             }

--- a/tests/bind.expect
+++ b/tests/bind.expect
@@ -92,6 +92,18 @@ expect_prompt -re {\r\nTAXT\r\n} {
     puts stderr "vi mode replace char, default timeout: long delay"
 }
 
+# Test deleting characters with 'x'.
+send "echo TEXT"
+send "\033"
+# Delay needed to allow fish to transition to vi "normal" mode.
+sleep 0.150
+send "xxxxxa\r"
+expect_prompt -re {\r\n\r\n} {
+    puts "vi mode delete char, default timeout: long delay"
+} unmatched {
+    puts stderr "vi mode delete char, default timeout: long delay"
+}
+
 # Verify that changing the escape timeout has an effect.
 send "set -g fish_escape_delay_ms 200\r"
 expect_prompt

--- a/tests/bind.expect.out
+++ b/tests/bind.expect.out
@@ -5,6 +5,7 @@ prime vi mode, default timeout
 vi-mode default timeout set correctly
 vi replace line, default timeout: long delay
 vi mode replace char, default timeout: long delay
+vi mode delete char, default timeout: long delay
 vi replace line, 100ms timeout: long delay
 vi replace line, 100ms timeout: short delay
 t-binding success


### PR DESCRIPTION
## Description

After 'x' is used to delete a character at the end of a line the cursor should be repositioned at the last character, i.e. repeatedly pressing 'x' in normal mode should delete the entire string.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [x] Tests have been added for regressions fixed