### PR TITLE
Add the possibility to rename abbreviations

### DIFF
--- a/doc_src/abbr.txt
+++ b/doc_src/abbr.txt
@@ -3,6 +3,7 @@
 \subsection abbr-synopsis Synopsis
 \fish{synopsis}
 abbr --add word phrase...
+abbr --rename word new_word
 abbr --show
 abbr --list
 abbr --erase word
@@ -33,6 +34,8 @@ The following parameters are available:
 
 - `-a WORD PHRASE` or `--add WORD PHRASE` Adds a new abbreviation, causing WORD to be expanded to PHRASE.
 
+- `-r WORD NEW_WORD` or `--rename WORD NEW_WORD` Renames an abbreviation, from WORD to NEW_WORD.
+
 - `-s` or `--show` Show all abbreviated words and their expanded phrases in a manner suitable for export and import.
 
 - `-l` or `--list` Lists all abbreviated words.
@@ -47,6 +50,11 @@ Note: fish version 2.1 supported `-a WORD=PHRASE`. This syntax is now deprecated
 abbr -a gco git checkout
 \endfish
 Add a new abbreviation where `gco` will be replaced with `git checkout`.
+
+\fish
+abbr -r gco gch
+\endfish
+Renames an existing abbreviation from `gco` to `gch`.
 
 \fish
 abbr -e gco

--- a/share/functions/abbr.fish
+++ b/share/functions/abbr.fish
@@ -13,6 +13,9 @@ function abbr --description "Manage abbreviations"
             case '-a' '--add'
                 set new_mode add
                 set needs_arg multi
+            case '-r' '--rename'
+                set new_mode rename
+                set needs_arg double
             case '-e' '--erase'
                 set new_mode erase
                 set needs_arg single
@@ -54,6 +57,19 @@ function abbr --description "Manage abbreviations"
         set mode_arg $argv[1]
         set needs_arg no
         set -e argv[1]
+    else if test $needs_arg = double
+        # Pull the two parameters from argv.
+        # * leave argv non-empty, if there are more than two arguments
+        # * leave needs_arg set to double if there is not enough arguments
+        if set -q argv[1]
+            set param1 $argv[1]
+            set -e argv[1]
+            if set -q argv[1]
+                set param2 $argv[1]
+                set needs_arg no
+                set -e argv[1]
+            end
+        end
     else if test $needs_arg = multi
         set mode_arg $argv
         set needs_arg no
@@ -105,6 +121,33 @@ function abbr --description "Manage abbreviations"
             end
             set fish_user_abbreviations $fish_user_abbreviations "$key $value"
             return 0
+
+        case 'rename'
+            set -l old_name $param1
+            set -l new_name $param2
+
+            # if the target name already exists, throw an error
+            if set -l idx (__fish_abbr_get_by_key $new_name)
+                printf ( _ "%s: abbreviation '%s' already exists, cannot rename\n" ) abbr $new_name >&2
+                return 2
+            end
+
+            # Because we later store "$key $value", there can't be any spaces in the key
+            if string match -q "* *" -- $new_name
+                printf ( _ "%s: abbreviation cannot have spaces in the key\n" ) abbr >&2
+                return 1
+            end
+
+            if set -l idx (__fish_abbr_get_by_key $old_name)
+                set -l kv (string split " " -m 1 -- $fish_user_abbreviations[$idx])
+                set -l value $kv[2]
+
+                set fish_user_abbreviations[$idx] "$new_name $value"
+                return 0
+            else
+                printf ( _ "%s: no such abbreviation '%s'\n" ) abbr $old_name >&2
+                return 2
+            end
 
         case 'erase'
             if set -l idx (__fish_abbr_get_by_key $mode_arg)

--- a/tests/abbr.err
+++ b/tests/abbr.err
@@ -1,2 +1,7 @@
 abbr: no such abbreviation 'NOT_AN_ABBR'
 abbr: abbreviation cannot have spaces in the key
+abbr: no such abbreviation '__abbr6'
+abbr: abbreviation cannot have spaces in the key
+abbr: option requires an argument -- -r
+abbr: Unexpected argument -- __abbr10
+abbr: abbreviation '__abbr12' already exists, cannot rename

--- a/tests/abbr.in
+++ b/tests/abbr.in
@@ -37,3 +37,35 @@ abbr d2 env a=b banana
 abbr -l | string match -q d2; or echo "= test failed"
 
 abbr "a b c" "d e f"; or true
+
+# Test renaming
+abbr __abbr4 omega
+abbr | grep __abbr5
+abbr -r __abbr4 __abbr5
+abbr | grep __abbr5
+abbr -e __abbr5
+abbr | grep __abbr4
+
+# Test renaming a nonexistent abbreviation
+abbr -r __abbr6 __abbr; or true
+
+# Test renaming to a abbreviation with spaces
+abbr __abbr4 omega
+abbr -r __abbr4 "g h i"; or true
+abbr -e __abbr4
+
+# Test renaming without arguments
+abbr __abbr7 omega
+abbr -r __abbr7; or true
+
+# Test renaming with too many arguments
+abbr __abbr8 omega
+abbr -r __abbr8 __abbr9 __abbr10; or true
+abbr | grep __abbr8
+abbr | grep __abbr9; or true
+abbr | grep __abbr10; or true
+
+# Test renaming to existing abbreviation
+abbr __abbr11 omega11
+abbr __abbr12 omega12
+abbr -r __abbr11 __abbr12; or true

--- a/tests/abbr.out
+++ b/tests/abbr.out
@@ -6,3 +6,5 @@ abbr __abbr1 delta
 abbr __abbr1 delta
 abbr '~__abbr2' '$xyz'
 abbr -- --__abbr3 xyz
+abbr __abbr5 omega
+abbr __abbr8 omega


### PR DESCRIPTION
## Description

The abbr function doesn't have the possiblity to rename abbreviations.
You have to delete the old one and create a new one. This commit adds
this functionality and uses the syntax:
```
abbr -r OLD_KEY NEW_KEY
```
Fixes issue #2155 .

## TODOs:
<!-- Just check off what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documenation/manpages.
- [x] Tests have been added