### PR TITLE
Makefile: skip the open manpage on OS X

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -181,6 +181,17 @@ PROGRAMS := fish fish_indent fish_key_reader
 # Manual pages to install
 #
 MANUALS := $(addsuffix .1, $(addprefix share/man/man1/, $(PROGRAMS)))
+HELP_MANPAGES := $(wildcard share/man/man1/*.1)
+
+# Determine which man pages we don't want to install
+# On OS X, don't install a man page for open, since we defeat fish's open
+# function on OS X.
+# This is also done in build_tools/build_documentation.sh, but because the
+# tarball includes this page, we need to skip it in the Makefile too (see
+# https://github.com/fish-shell/fish-shell/issues/2561).
+ifeq ($(shell uname), Darwin)
+	HELP_MANPAGES := $(filter-out share/man/man1/open.1, $(HELP_MANPAGES))
+endif
 
 #
 # All translation message catalogs
@@ -675,7 +686,7 @@ install-force: all install-translations | show-datadir show-sysconfdir show-extr
 	done;
 	@echo "Installing $(bo)man pages$(sgr0)";
 	$v $(INSTALL) -m 644 share/groff/* $(DESTDIR)$(datadir)/fish/groff/
-	$v for i in $(wildcard share/man/man1/*.1); do \
+	$v for i in $(HELP_MANPAGES); do \
 		$(INSTALL) -m 644 $$i $(DESTDIR)$(datadir)/fish/man/man1/; \
 	done;
 	@echo "Installing helper tools";

--- a/build_tools/build_documentation.sh
+++ b/build_tools/build_documentation.sh
@@ -21,6 +21,7 @@ fi
 
 # Determine which man pages we don't want to generate.
 # on OS X, don't make a man page for open, since we defeat fish's open function on OS X.
+# This is also done in the Makefile, but the Xcode build doesn't use that
 CONDEMNED_PAGES=
 if test `uname` = 'Darwin'; then
 	CONDEMNED_PAGES="$CONDEMNED_PAGES open.1"


### PR DESCRIPTION
This is normally handled by the build_documentation.sh script, but if the tarball includes the documentation then that script is never run.

We should do it in both places as the Xcode build uses only the build_documentation.sh script!

Fixes #2561.