### PR TITLE
Fix status code when bad command name is entered

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -865,6 +865,8 @@ If `fish` encounters a problem while executing a command, the status variable ma
 
 - 1 is the generally the exit status from fish builtin commands if they were supplied with invalid arguments
 
+- 123 means that the command was not executed because the command name contained invalid characters
+
 - 124 means that the command was not executed because none of the wildcards in the command produced any matches
 
 - 125 means that while an executable with the specified name was located, the operating system could not actually execute the command

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -832,6 +832,7 @@ parse_execution_result_t parse_execution_context_t::populate_plain_process(
     bool expanded = expand_one(cmd, EXPAND_SKIP_CMDSUBST | EXPAND_SKIP_VARIABLES, NULL);
     if (!expanded) {
         report_error(statement, ILLEGAL_CMD_ERR_MSG, cmd.c_str());
+        proc_set_last_status(STATUS_ILLEGAL_CMD);
         return parse_execution_errored;
     }
 

--- a/src/proc.h
+++ b/src/proc.h
@@ -29,6 +29,9 @@
 /// The status code use when a wildcard had no matches.
 #define STATUS_UNMATCHED_WILDCARD 124
 
+/// The status code use when illegal command name is encountered.
+#define STATUS_ILLEGAL_CMD 123
+
 /// The status code used for normal exit in a  builtin.
 #define STATUS_BUILTIN_OK 0
 


### PR DESCRIPTION
## Description

This commit fixes a bug which causes that

```fish
fish -c ')'; echo $status
```

("Illegal command name" error) returns 0. This is inconsistent with
e.g. when trying to run non-existent command:

```fish
fish -c 'invalid-command'; echo $status
```
("Unknown command" error) which correctly returns 127.

A new status code,

    STATUS_ILLEGAL_CMD = 123

is introduced - which is returned whenever the 'Illegal command name *'
message is printed.

This commit also adds a test which checks if valid commands return 0,
while commands with illegal name return status code 123.

Fixes #3606.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documenation/manpages.
- [x] Tests have been added
- [ ] Decide if new status code `STATUS_ILLEGAL_CMD=123` should really be added, or `STATUS_UNKNOWN_COMMAND=127` should be reused (as the issue reporter suggested)

What do you think? Should `STATUS_UNKNOWN_COMMAND` be used instead? I don't have problems rewriting the commit to use it instead of new status code.

And please check the test. I'm not very experienced with C++ .