### PR TITLE
Implement backwards-compatible 'random' redesign

### DIFF
--- a/doc_src/random.txt
+++ b/doc_src/random.txt
@@ -6,6 +6,7 @@ random
 random SEED
 random START END
 random START STEP END
+random choice [ITEMS...]
 \endfish
 
 \subsection random-description Description
@@ -18,11 +19,13 @@ argument for future invocations of `RANDOM` and no output will be produced.
 Two arguments indicate a range of [START; END].
 Three arguments indicate a range of [START; END] with a spacing of STEP
 between possible outputs.
+`RANDOM choice` will select one random item from the succeeding arguments.
 
 Note that seeding the engine will NOT give the same result across different
 systems.
 
-You should not consider `RANDOM` cryptographically secure.
+You should not consider `RANDOM` cryptographically secure, or even
+statistically accurate.
 
 \subsection random-example Example
 
@@ -31,4 +34,8 @@ The following code will count down from a random even number between 10 and 20 t
 for i in (seq (random 10 2 20) -1 1)
     echo $i
 end
+\endfish
+And this will open a random picture from any of the subdirectories:
+\fish 
+open (random choice **jpg)
 \endfish

--- a/doc_src/random.txt
+++ b/doc_src/random.txt
@@ -2,31 +2,33 @@
 
 \subsection random-synopsis Synopsis
 \fish{synopsis}
-random [SEED]
+random
+random SEED
+random START END
+random START STEP END
 \endfish
 
 \subsection random-description Description
 
-`random` outputs a psuedo-random number from 0 to 32767, inclusive.
-Even ignoring the very narrow range of values you should not assume
-this produces truly random values within that range. Do not use the
-value for any cryptographic purposes, and take care to handle collisions:
-the same random number appearing more than once in a given fish instance.
+`RANDOM` generates a pseudo-random integer from a uniform distribution. The
+range (inclusive) is dependent on the arguments passed.
+No arguments indicate a range of [0; 32767].
+If one argument is specified, the internal engine will be seeded with the
+argument for future invocations of `RANDOM` and no output will be produced.
+Two arguments indicate a range of [START; END].
+Three arguments indicate a range of [START; END] with a spacing of STEP
+between possible outputs.
 
-If a `SEED` value is provided, it is used to seed the random number
-generator, and no output will be produced. This can be useful for debugging
-purposes, where it can be desirable to get the same random number sequence
-multiple times. If the random number generator is called without first
-seeding it, the current time will be used as the seed.
+Note that seeding the engine will NOT give the same result across different
+systems.
 
+You should not consider `RANDOM` cryptographically secure.
 
 \subsection random-example Example
 
-The following code will count down from a random number to 1:
-
+The following code will count down from a random even number between 10 and 20 to 1:
 \fish
-for i in (seq (random) -1 1)
+for i in (seq (random 10 2 20) -1 1)
     echo $i
-    sleep
 end
 \endfish

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -1821,12 +1821,9 @@ static int builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **arg
             step = 1;
         } else if (arg_count == 1) {
             long long seed = parse_ll(argv[w.woptind]);
-            if (!parse_error) {
-                engine.seed(seed);
-                return STATUS_BUILTIN_OK;
-            } else {
-                return STATUS_BUILTIN_ERROR;
-            }
+            if (parse_error) return STATUS_BUILTIN_ERROR;
+            engine.seed(static_cast<uint32_t>(seed));
+            return STATUS_BUILTIN_OK;
         } else if (arg_count == 2) {
             start = parse_ll(argv[w.woptind]);
             step = 1;

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -1742,11 +1742,12 @@ int builtin_function(parser_t &parser, io_streams_t &streams, const wcstring_lis
 /// The random builtin generates random numbers.
 static int builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     static bool seeded = false;
-    static std::mt19937_64 engine;
+    static std::minstd_rand engine;
     if (!seeded) {
-        // seed engine with 8*32 bits of random data
+        // seed engine with 2*32 bits of random data
+        // for the 64 bits of internal state of minstd_rand
         std::random_device rd;
-        std::seed_seq seed{rd(), rd(), rd(), rd(), rd(), rd(), rd(), rd()};
+        std::seed_seq seed{rd(), rd()};
         engine.seed(seed);
         seeded = true;
     }

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -631,11 +631,13 @@ long long fish_wcstoll(const wchar_t *str, const wchar_t **endptr, int base) {
 /// annoying to use them in a portable fashion.
 ///
 /// The caller doesn't have to zero errno. Sets errno to -1 if the int ends with something other
-/// than a digit. Leading whitespace is ignored (per the base wcstoll implementation). Trailing
-/// whitespace is also ignored.
+/// than a digit. Leading minus is considered invalid. Leading whitespace is ignored (per the base
+/// wcstoull implementation). Trailing whitespace is also ignored.
 unsigned long long fish_wcstoull(const wchar_t *str, const wchar_t **endptr, int base) {
     while (iswspace(*str)) ++str;  // skip leading whitespace
-    if (!*str) {  // this is because some implementations don't handle this sensibly
+    if (!*str ||      // this is because some implementations don't handle this sensibly
+        *str == '-')  // disallow minus as the first character to avoid questionable wrap-around
+    {
         errno = EINVAL;
         if (endptr) *endptr = str;
         return 0;

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -625,6 +625,37 @@ long long fish_wcstoll(const wchar_t *str, const wchar_t **endptr, int base) {
     return result;
 }
 
+/// An enhanced version of wcstoull().
+///
+/// This is needed because BSD and GNU implementations differ in several ways that make it really
+/// annoying to use them in a portable fashion.
+///
+/// The caller doesn't have to zero errno. Sets errno to -1 if the int ends with something other
+/// than a digit. Leading whitespace is ignored (per the base wcstoll implementation). Trailing
+/// whitespace is also ignored.
+unsigned long long fish_wcstoull(const wchar_t *str, const wchar_t **endptr, int base) {
+    while (iswspace(*str)) ++str;  // skip leading whitespace
+    if (!*str) {  // this is because some implementations don't handle this sensibly
+        errno = EINVAL;
+        if (endptr) *endptr = str;
+        return 0;
+    }
+
+    errno = 0;
+    wchar_t *_endptr;
+    unsigned long long result = wcstoull(str, &_endptr, base);
+    while (iswspace(*_endptr)) ++_endptr;  // skip trailing whitespace
+    if (!errno && *_endptr) {
+        if (_endptr == str) {
+            errno = EINVAL;
+        } else {
+            errno = -1;
+        }
+    }
+    if (endptr) *endptr = _endptr;
+    return result;
+}
+
 file_id_t file_id_t::file_id_from_stat(const struct stat *buf) {
     assert(buf != NULL);
 

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -120,6 +120,7 @@ int fish_wcswidth(const wcstring &str);
 int fish_wcstoi(const wchar_t *str, const wchar_t **endptr = NULL, int base = 10);
 long fish_wcstol(const wchar_t *str, const wchar_t **endptr = NULL, int base = 10);
 long long fish_wcstoll(const wchar_t *str, const wchar_t **endptr = NULL, int base = 10);
+unsigned long long fish_wcstoull(const wchar_t *str, const wchar_t **endptr = NULL, int base = 10);
 
 /// Class for representing a file's inode. We use this to detect and avoid symlink loops, among
 /// other things. While an inode / dev pair is sufficient to distinguish co-existing files, Linux

--- a/tests/random.err
+++ b/tests/random.err
@@ -1,0 +1,14 @@
+random: a is not a valid integer
+random: 18446744073709551614 is not a valid integer
+random: Too many arguments
+random: END must be greater than START
+random: 18446744073709551614 is not a valid integer
+random: 1d is not a valid integer
+random: 1c is not a valid integer
+random: END must be greater than START
+random: range contains only one possible value
+random: STEP must be a positive integer
+random: range contains only one possible value
+random: range contains only one possible value
+random: nothing to choose from
+random: Too many arguments

--- a/tests/random.err
+++ b/tests/random.err
@@ -6,7 +6,9 @@ random: 18446744073709551614 is not a valid integer
 random: 1d is not a valid integer
 random: 1c is not a valid integer
 random: END must be greater than START
-random: range contains only one possible value
+random: - is not a valid integer
+random: -1 is not a valid integer
+random: -9223372036854775807 is not a valid integer
 random: STEP must be a positive integer
 random: range contains only one possible value
 random: range contains only one possible value

--- a/tests/random.in
+++ b/tests/random.in
@@ -13,7 +13,9 @@ random -- 10 $diff_max
 random -- 1 1d
 random -- 1 1c 10
 random -- 10 10
+random -- 1 - 10
 random -- 1 -1 10
+random -- 1 $min 10
 random -- 1 0 10
 random -- 1 11 10
 random -- 0 $diff_max $max

--- a/tests/random.in
+++ b/tests/random.in
@@ -1,0 +1,96 @@
+set -l max 9223372036854775807
+set -l close_max 9223372036854775806
+set -l min -9223372036854775807
+set -l close_min -9223372036854775806
+set -l diff_max 18446744073709551614
+
+# check failure cases
+random a
+random $diff_max
+random -- 1 2 3 4
+random -- 10 -10
+random -- 10 $diff_max
+random -- 1 1d
+random -- 1 1c 10
+random -- 10 10
+random -- 1 -1 10
+random -- 1 0 10
+random -- 1 11 10
+random -- 0 $diff_max $max
+random choice
+random choic a b c
+
+function check_boundaries
+    if not test $argv[1] -ge $argv[2] -a $argv[1] -le $argv[3] 
+        printf "Unexpected: %s <= %s <= %s not verified\n" $argv[2] $argv[1] $argv[3] >&2
+        return 1
+    end
+end
+
+function test_range
+    return (check_boundaries (random -- $argv) $argv)
+end
+
+function check_contains
+    if not contains -- $argv[1] $argv[2..-1]
+        printf "Unexpected: %s not among possibilities" $argv[1] >&2
+        printf " %s" $argv[2..-1] >&2
+        printf "\n" >&2
+        return 1
+    end
+end
+
+function test_step
+    return (check_contains (random -- $argv) (seq -- $argv))
+end
+
+function test_choice
+    return (check_contains (random choice $argv) $argv)
+end
+
+for i in (seq 10)
+    check_boundaries (random) 0 32767
+
+    test_range 0 10
+    test_range -10 -1
+    test_range -10 10
+
+    test_range 0 $max
+    test_range $min -1
+    test_range $min $max
+
+    test_range $close_max $max
+    test_range $min $close_min
+    test_range $close_min $close_max
+
+    #OSX's `seq` uses scientific notation for large numbers, hence not usable here
+    check_contains (random -- 0 $max $max) 0 $max
+    check_contains (random -- 0 $close_max $max) 0 $close_max
+    check_contains (random -- $min $max 0) $min 0
+    check_contains (random -- $min $close_max 0) $min -1
+    check_contains (random -- $min $max $max) $min 0 $max
+    check_contains (random -- $min $diff_max $max) $min $max
+
+    test_step 0 $i 10
+    test_step -5 $i 5
+    test_step -10 $i 0
+    
+    test_choice a
+    test_choice foo bar
+    test_choice bass trout salmon zander perch carp
+end
+
+
+#check seeding
+set -l seed (random)
+random $seed
+set -l run1 (random) (random) (random) (random) (random)
+random $seed
+set -l run2 (random) (random) (random) (random) (random)
+if not test "$run1" = "$run2"
+    printf "Unexpected different sequences after seeding with %s\n" $seed
+    printf "%s " $run1
+    printf "\n"
+    printf "%s " $run2
+    printf "\n"
+end


### PR DESCRIPTION
#2642

This should preserve the behavior for 0 or 1 argument. 

The seeding is a bit arbitrary (8\*32 bits of random data for the ~19937~ 624\*32 bits of internal state in the engine) but the initialization step of the algorithm is here to make the most of the initial data. It's definitely better than 32 bits seeding to produce 64 bits output.

Regarding performance, I'm not sure if there is any concern to be had. The first invocation should be slower due to initialization, but insignificantly so ($CMD_DURATION reports 0ms on my end). 