### PR TITLE
Improve make target completion

### DIFF
--- a/share/completions/make.fish
+++ b/share/completions/make.fish
@@ -15,7 +15,7 @@ complete -c make -n 'commandline -ct | string match "*=*"'
 
 complete -x -c make -a "(__fish_complete_make_targets (commandline -c))" --description "Target"
 complete -r -c make -s f --description "Use file as makefile" -r
-complete -x -c make -s C -x -a "(__fish_complete_directories (commandline -ct))" --description "Change directory"
+complete -x -c make -s C -l directory -x -a "(__fish_complete_directories (commandline -ct))" --description "Change directory"
 complete -c make -s d --description "Debug mode"
 complete -c make -s e --description "Environment before makefile"
 complete -c make -s i --description "Ignore errors"

--- a/share/completions/make.fish
+++ b/share/completions/make.fish
@@ -1,6 +1,6 @@
 # Completions for make
 function __fish_complete_make_targets
-    set directory (echo $argv | string replace -r '^make .*(-C|--directory) ?([^ ]*) .*$' '$2')
+    set directory (string replace -r '^make .*(-C ?|--directory[= ]?)([^ ]*) .*$' '$2' -- $argv)
     if test $status -eq 0 -a -d $directory
         __fish_print_make_targets $directory
     else

--- a/share/completions/make.fish
+++ b/share/completions/make.fish
@@ -1,11 +1,19 @@
 # Completions for make
+function __fish_complete_make_targets
+    set directory (echo $argv | string replace -r '^make .*(-C|--directory) ?([^ ]*) .*$' '$2')
+    if test $status -eq 0 -a -d $directory
+        __fish_print_make_targets $directory
+    else
+        __fish_print_make_targets
+    end
+end
 
 # This completion reenables file completion on
 # assignments, so e.g. 'make foo FILES=<tab>' will receive standard
 # filename completion.
 complete -c make -n 'commandline -ct | string match "*=*"'
 
-complete -x -c make -a "(__fish_print_make_targets)" --description "Target"
+complete -x -c make -a "(__fish_complete_make_targets (commandline -c))" --description "Target"
 complete -r -c make -s f --description "Use file as makefile" -r
 complete -x -c make -s C -x -a "(__fish_complete_directories (commandline -ct))" --description "Change directory"
 complete -c make -s d --description "Debug mode"

--- a/share/functions/__fish_print_make_targets.fish
+++ b/share/functions/__fish_print_make_targets.fish
@@ -8,7 +8,7 @@ function __fish_print_make_targets --argument directory
     end
 
     set -l bsd_make
-    if make -p -f/dev/null ^/dev/null
+    if make -C $directory -p >/dev/null ^/dev/null
         set bsd_make 0
     else
         set bsd_make 1

--- a/share/functions/__fish_print_make_targets.fish
+++ b/share/functions/__fish_print_make_targets.fish
@@ -1,13 +1,11 @@
-function __fish_print_make_targets
-    # Some seds (e.g. on Mac OS X), don't support \n in the RHS
-    # Use a literal newline instead
-    # http://sed.sourceforge.net/sedfaq4.html#s4.1
-    # The 'rev | cut | rev' trick removes everything after the last colon
-    for file in GNUmakefile Makefile makefile
+function __fish_print_make_targets --argument directory
+    if test -z "$directory"
+        set directory '.'
+    end
+
+    for file in $directory/{GNUmakefile,Makefile,makefile}
         if test -f $file
-            __fish_sgrep -h -o -E '^[^#%=$[:space:]][^#%=$]*:([^=]|$)' $file ^/dev/null | rev | cut -d ":" -f 2- | rev | sed -e 's/^ *//;s/ *$//;s/  */\\
-/g' ^/dev/null
-            # On case insensitive filesystems, Makefile and makefile are the same; stop now so we don't double-print 
+            make -C $directory -prRn | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($1 !~ "^[#.]") {print $1}}' ^/dev/null
             break
         end
     end

--- a/share/functions/__fish_print_make_targets.fish
+++ b/share/functions/__fish_print_make_targets.fish
@@ -7,9 +7,20 @@ function __fish_print_make_targets --argument directory
         set directory '.'
     end
 
+    set -l bsd_make
+    if make -p -f/dev/null ^/dev/null
+        set bsd_make 0
+    else
+        set bsd_make 1
+    end
+
     for file in $directory/{GNUmakefile,Makefile,makefile}
         if test -f $file
-            make -C $directory -prRn | awk -v RS= -F: '/^# Files/,/^# Finished Make data base/ {if ($1 !~ "^[#.]") {print $1}}' ^/dev/null
+            if test "$bsd_make" = 0
+                make -C $directory -prRn | awk -v RS= -F: '/^# Files/,/^# Finished Make data base/ {if ($1 !~ "^[#.]") {print $1}}' ^/dev/null
+            else
+                make -C $directory -d g1 -rn >/dev/null ^| awk -F, '/^#\*\*\* Input graph:/,/^$/ {if ($1 !~ "^#... ") {gsub(/# /,"",$1); print $1}}' ^/dev/null
+            end
             break
         end
     end

--- a/share/functions/__fish_print_make_targets.fish
+++ b/share/functions/__fish_print_make_targets.fish
@@ -1,11 +1,15 @@
 function __fish_print_make_targets --argument directory
+    # Since we filter based on localized text, we need to ensure the
+    # text will be using the correct locale.
+    set -lx LC_ALL C
+
     if test -z "$directory"
         set directory '.'
     end
 
     for file in $directory/{GNUmakefile,Makefile,makefile}
         if test -f $file
-            make -C $directory -prRn | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($1 !~ "^[#.]") {print $1}}' ^/dev/null
+            make -C $directory -prRn | awk -v RS= -F: '/^# Files/,/^# Finished Make data base/ {if ($1 !~ "^[#.]") {print $1}}' ^/dev/null
             break
         end
     end

--- a/share/functions/__fish_print_make_targets.fish
+++ b/share/functions/__fish_print_make_targets.fish
@@ -8,7 +8,7 @@ function __fish_print_make_targets --argument directory
     end
 
     set -l bsd_make
-    if make -C $directory -p >/dev/null ^/dev/null
+    if make -C $directory -pn >/dev/null ^/dev/null
         set bsd_make 0
     else
         set bsd_make 1


### PR DESCRIPTION
I am not sure if the code is as good as it can be, please let me know if
there are any potential bugs that you spot straight away.

I have been using Makefile's quite extensively recently and missed the
completion of dynamic targets and also when I run tasks for subfolders
via `make -C`.

This pull-request solves these two issues, first by getting the make
targets by querying the make database. This solution is based on
the ideas presented [here](http://stackoverflow.com/questions/4219255/how-do-you-get-the-list-of-targets-in-a-makefile).

This also wraps the call to `__fish_print_make_targets` and figures out
if the commandline contains any `-C` or `--directory`, if that is the
case the directory is assigned to a variable and then passed along to
the function.

I have introduced a new argument to the function
`__fish_print_make_targets` which is the directory to look for the
Makefile, it will default to `.` if none provided.

Potential issues (or likely) issues, are that we now explicitly use
the `make` command and don't parse these files and thus if the command
would be something else it would not work. Personally I have only had
the use-case with `make` though.

## TLDR;
- Support completing dynamic make targets.
- Support completing make targets when using `-C`/`--directory`.