### PR TITLE
Prevent error in acidhub prompt by quoting the regex

### DIFF
--- a/share/tools/web_config/sample_prompts/acidhub.fish
+++ b/share/tools/web_config/sample_prompts/acidhub.fish
@@ -12,7 +12,7 @@ function fish_prompt -d "Write out the prompt"
     if [ (_git_branch_name) ]
         set -l git_branch (set_color -o blue)(_git_branch_name)
         if [ (_is_git_dirty) ]
-            for i in (git branch -qv --no-color | string match -r \* | cut -d' ' -f4- | cut -d] -f1 | tr , \n)\
+            for i in (git branch -qv --no-color | string match -r '\*' | cut -d' ' -f4- | cut -d] -f1 | tr , \n)\
  (git status --porcelain | cut -c 1-2 | uniq)
                 switch $i
                     case "*[ahead *"


### PR DESCRIPTION
## Description

string errors if this regex isn't quoted. This results in this error:
http://stackoverflow.com/questions/40942185/fish-shell-init-git-repo-yields-constant-terminal-output-after-every-command

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [ ] Tests have been added for regressions fixed