### PR TITLE
Fix string regex replace hang up

### DIFF
--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -668,7 +668,11 @@ class regex_replacer_t : public string_replacer_t {
 
         while (*orig != L'\0') {
             if (*orig == L'\\') {
-                orig += read_unquoted_escape(orig, &result, true, false);
+                size_t pos = read_unquoted_escape(orig, &result, true, false);
+                if (pos == 0) {
+                    break;
+                }
+                orig += pos;
             } else {
                 result += *orig;
                 orig++;

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3963,6 +3963,9 @@ static void test_string(void) {
         {{L"string", L"replace", L"-r", L"(a)", L"$2", L"a", 0}, 2, L""},
         {{L"string", L"replace", L"-r", L"*", L".", L"a", 0}, 2, L""},
         {{L"string", L"replace", L"-r", L"^(.)", L"\t$1", L"abc", L"x", 0}, 0, L"\tabc\n\tx\n"},
+        {{L"string", L"replace", L"-r", L"x", L"\\xff", 0}, 1, L""},
+        {{L"string", L"replace", L"-r", L"x", L"\\xff", L"x", 0}, 0, L"\n"},
+        {{L"string", L"replace", L"-r", L"x", L"\\\\c", 0}, 1, L""},
 
         {{L"string", L"split", 0}, 2, L""},
         {{L"string", L"split", L":", 0}, 1, L""},


### PR DESCRIPTION
## Description
If a parse error occurred in read_unquoted_escape(), it returns 0 to
the caller. But the result would be used as an increment in function
interpret_escapes() without any check, leading to an infinite loop.
The fix here checks the return value and jumps out of the loop if we
get 0.

Fixes issue #3381

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [x] Tests have been added for regressions fixed
