### PR TITLE
update PROMPT_SP heuristic

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -14,6 +14,13 @@
 #include <time.h>
 #include <unistd.h>
 #include <wchar.h>
+
+#if HAVE_TERM_H
+#include <term.h>
+#elif HAVE_NCURSES_TERM_H
+#include <ncurses/term.h>
+#endif
+
 #include <algorithm>
 #include <map>
 #include <set>
@@ -49,6 +56,9 @@
 extern char **environ;
 
 bool g_use_posix_spawn = false;  // will usually be set to true
+
+/// Does the terminal have the "eat_newline_glitch".
+int term_has_xn = 0;
 
 /// Struct representing one level in the function variable stack.
 struct env_node_t {
@@ -245,6 +255,7 @@ static void handle_curses(const wchar_t *env_var_name) {
     // changed. At the present time it can be called just once. Also, we should really only do this
     // if the TERM var is set.
     // input_init();
+    term_has_xn = tgetflag((char *)"xn");  // does terminal have the eat_newline_glitch
 }
 
 /// React to modifying the given variable.

--- a/src/env.h
+++ b/src/env.h
@@ -184,4 +184,6 @@ struct var_entry_t {
 };
 
 typedef std::map<wcstring, var_entry_t> var_table_t;
+
+extern int term_has_xn;  // does the terminal have the "eat_newline_glitch"
 #endif


### PR DESCRIPTION
## ToDo

I've verified this works on a real xterm, macOS Terminal, iTerm2, Mintty on Windows, ConEmu on Windows, and WSL on Windows 10. I'd like to see a few other terminals like st, Konsole, and Gnome-terminal tested before merging to help ensure this doesn't break fish's behavior where it currently works okay.

## Description

Update our implementation of the PROMPT_SP heuristic to match current
zsh behavior. This makes it behave better on terminals like ConEmu and
the native MS Windows console which automatically insert a newline when
writing to the last column of the line.

Fixes #789