### PR TITLE
Add support for subcommands in __fish_man_page

### DIFF
--- a/share/functions/__fish_man_page.fish
+++ b/share/functions/__fish_man_page.fish
@@ -1,4 +1,24 @@
 function __fish_man_page
-    man (basename (commandline -po; echo)[1]) ^/dev/null
-    or printf \a
+    # Get all commandline tokens not starting with "-"
+    set -l args (commandline -po | string match -rv '^-')
+
+    # If commandline is empty, exit.
+    if not set -q args[1]
+        printf \a
+        return
+    end
+
+    # If there are at least two tokens not starting with "-", the second one might be a subcommand.
+    # Try "man first-second" and fall back to "man first" if that doesn't work out.
+    set -l maincmd (basename $args[1])
+    if set -q args[2]
+        man "$maincmd-$args[2]" ^/dev/null
+        or man "$maincmd" ^/dev/null
+        or printf \a
+    else
+        man "$maincmd" ^/dev/null
+        or printf \a
+    end
+
+    commandline -f repaint
 end


### PR DESCRIPTION
This PR adds a feature that after typing `git add` and pressing
`alt+h`, the manpage for `git-add` instead of `git` would be displayed.

The new logic takes the first argument which doesn't start with a dash
and tries to display manpage for `command-argument`; it falls back to
`man command` it the first try doesn't succeed.

Fixes #3618.