### PR TITLE
Adding subcommand completions for apt

### DIFF
--- a/share/completions/apt.fish
+++ b/share/completions/apt.fish
@@ -2,7 +2,7 @@
 
 function __fish_apt_no_subcommand --description 'Test if apt has yet to be given the subcommand'
 	for i in (commandline -opc)
-		if contains -- $i update upgrade full-upgrade search list install show remove edit-sources purge
+		if contains -- $i update upgrade full-upgrade search list install show remove edit-sources purge changelog
 			return 1
 		end
 	end
@@ -11,7 +11,7 @@ end
 
 function __fish_apt_use_package --description 'Test if apt command should have packages as potential completion'
 	for i in (commandline -opc)
-		if contains -- $i install remove upgrade full-upgrade show search purge
+		if contains -- $i install remove upgrade full-upgrade show search purge changelog
 			return 0
 		end
 	end
@@ -66,3 +66,6 @@ __fish_apt_subcommand full-upgrade -r  --description 'Upgrade packages, removing
 
 # Purge
 __fish_apt_subcommand purge -x         --description 'Remove packages and delete their config files'
+
+# Changelog
+__fish_apt_subcommand changelog -r     --description 'Download and display package changelog'


### PR DESCRIPTION
Add completion for the changelog subcommand of apt.
Note this command is not documented in the apt man page.