### PR TITLE
Replace printf with wprintf

### DIFF
--- a/src/autoload.cpp
+++ b/src/autoload.cpp
@@ -25,7 +25,7 @@
 static const int kAutoloadStalenessInterval = 15;
 
 file_access_attempt_t access_file(const wcstring &path, int mode) {
-    // printf("Touch %ls\n", path.c_str());
+    // wprintf(L"Touch %ls\n", path.c_str());
     file_access_attempt_t result = {};
     struct stat statbuf;
     if (wstat(path, &statbuf)) {

--- a/src/builtin_test.cpp
+++ b/src/builtin_test.cpp
@@ -810,11 +810,11 @@ int builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     expression *expr = test_parser::parse_args(args, err, program_name);
     if (!expr) {
 #if 0
-        printf("Oops! test was given args:\n");
+        fwprintf(stderr, L"Oops! test was given args:\n");
         for (size_t i=0; i < argc; i++) {
-            printf("\t%ls\n", args.at(i).c_str());
+            fwprintf(stderr, L"\t%ls\n", args.at(i).c_str());
         }
-        printf("and returned parse error: %ls\n", err.c_str());
+        fwprintf(stderr, L"and returned parse error: %ls\n", err.c_str());
 #endif
         streams.err.append(err);
         return BUILTIN_TEST_FAIL;
@@ -823,9 +823,9 @@ int builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wcstring_list_t eval_errors;
     bool result = expr->evaluate(eval_errors);
     if (!eval_errors.empty() && !should_suppress_stderr_for_tests()) {
-        printf("test returned eval errors:\n");
+        fwprintf(stderr, L"test returned eval errors:\n");
         for (size_t i = 0; i < eval_errors.size(); i++) {
-            printf("\t%ls\n", eval_errors.at(i).c_str());
+            fwprintf(stderr, L"\t%ls\n", eval_errors.at(i).c_str());
         }
     }
     delete expr;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -606,7 +606,7 @@ void debug_safe(int level, const char *msg, const char *param1, const char *para
                                   param7, param8, param9, param10, param11, param12};
     if (!msg) return;
 
-    // Can't call printf, that may allocate memory Just call write() over and over.
+    // Can't call wprintf, that may allocate memory Just call write() over and over.
     if (level > debug_level) return;
     int errno_old = errno;
 
@@ -1689,7 +1689,7 @@ bool is_forked_child(void) {
 
     bool is_child_of_fork = (getpid() != initial_pid);
     if (is_child_of_fork) {
-        printf("Uh-oh: %d\n", getpid());
+        wprintf(L"Uh-oh: %d\n", getpid());
         while (1) sleep(10000);
     }
     return is_child_of_fork;

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -166,7 +166,7 @@ static void show_all_handlers(void) {
     for (event_list_t::const_iterator iter = events.begin(); iter != events.end(); ++iter) {
         const event_t *foo = *iter;
         wcstring tmp = event_get_desc(foo);
-        printf("    handler now %ls\n", tmp.c_str());
+        wprintf(L"    handler now %ls\n", tmp.c_str());
     }
 }
 #endif

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -162,7 +162,7 @@ wcstring event_get_desc(const event_t &e) {
 
 #if 0
 static void show_all_handlers(void) {
-    puts("event handlers:");
+    wprintf(L"event handlers:\n");
     for (event_list_t::const_iterator iter = events.begin(); iter != events.end(); ++iter) {
         const event_t *foo = *iter;
         wcstring tmp = event_get_desc(foo);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -763,7 +763,7 @@ static int expand_variables(const wcstring &instr, std::vector<completion_t> *ou
             stop_pos++;
         }
 
-        // printf( "Stop for '%c'\n", in[stop_pos]);
+        // wprintf(L"Stop for '%c'\n", in[stop_pos]);
         var_len = stop_pos - start_pos;
 
         if (var_len == 0) {

--- a/src/fish_key_reader.cpp
+++ b/src/fish_key_reader.cpp
@@ -183,7 +183,7 @@ static void output_info_about_char(wchar_t wc) {
 static bool output_matching_key_name(wchar_t wc) {
     char *name = sequence_name(wc);
     if (name) {
-        printf("bind -k %s 'do something'\n", name);
+        wprintf(L"bind -k %s 'do something'\n", name);
         free(name);
         return true;
     }

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -1726,7 +1726,7 @@ static void test_1_word_motion(word_motion_t motion, move_word_style_t style,
         size_t char_idx = (motion == word_motion_left ? idx - 1 : idx);
         wchar_t wc = command.at(char_idx);
         bool will_stop = !sm.consume_char(wc);
-        // printf("idx %lu, looking at %lu (%c): %d\n", idx, char_idx, (char)wc, will_stop);
+        // wprintf(L"idx %lu, looking at %lu (%c): %d\n", idx, char_idx, (char)wc, will_stop);
         bool expected_stop = (stops.count(idx) > 0);
         if (will_stop != expected_stop) {
             wcstring tmp = command;

--- a/src/iothread.cpp
+++ b/src/iothread.cpp
@@ -275,7 +275,7 @@ void iothread_drain_all(void) {
     }
 #if TIME_DRAIN
     double after = timef();
-    printf("(Waited %.02f msec for %d thread(s) to drain)\n", 1000 * (after - now), thread_count);
+    wprintf(L"(Waited %.02f msec for %d thread(s) to drain)\n", 1000 * (after - now), thread_count);
 #endif
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -537,7 +537,7 @@ rgb_color_t parse_color(const wcstring &val, bool is_background) {
 
 #if 0
     wcstring desc = result.description();
-    printf("Parsed %ls from %ls (%s)\n", desc.c_str(), val.c_str(),
+    wprintf(L"Parsed %ls from %ls (%s)\n", desc.c_str(), val.c_str(),
            is_background ? "background" : "foreground");
 #endif
 

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -80,7 +80,7 @@ void print_jobs(void)
     job_iterator_t jobs;
     job_t *j;
     while (j = jobs.next()) {
-        printf("%p -> %ls -> (foreground %d, complete %d, stopped %d, constructed %d)\n",
+        wprintf("%p -> %ls -> (foreground %d, complete %d, stopped %d, constructed %d)\n",
                 j, j->command_wcstr(), job_get_flag(j, JOB_FOREGROUND), job_is_completed(j),
                 job_is_stopped(j), job_get_flag(j, JOB_CONSTRUCTED));
     }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -661,7 +661,7 @@ static bool test_stuff(screen_t *scr)
         int c = getchar();
         if (c != EOF) break;
     }
-    puts("Bye");
+    wprintf(L"Bye\n");
     exit(0);
     while (1) sleep(10000);
     return true;

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -666,7 +666,7 @@ bool move_word_state_machine_t::consume_char_path_components(wchar_t c) {
         s_end
     };
 
-    // printf("state %d, consume '%lc'\n", state, c);
+    // wprintf(L"state %d, consume '%lc'\n", state, c);
     bool consumed = false;
     while (state != s_end && !consumed) {
         switch (state) {


### PR DESCRIPTION
## Description

As noted in b118ed69d3be39aec1971aebc5ca6a613bb8741e:

>On some platforms, notably GNU libc, you cannot mix narrow and wide
    stdio functions on a stream like stdout or stderr. Doing so will drop
    the output of one or the other.

What was missed there was `printf`, which this changes to `wprintf`.

In the specific case of `builtin_test`, it converts to `fwprintf(stderr,...` instead, since error output should go to stderr.

Fixes issue #3704.

## TODOs:
- [X] Changes to fish usage are reflected in user documenation/manpages. (N/A)
- [ ] Tests have been added for regressions fixed

The test tests haven't been updated since 754b78a7485ea58453e2d02c56f629f1b5e6aab2 specifically prevents this output from being generated in tests, which I'm unsure about.

The other calls aren't known to cause any issues.