### PR TITLE
Try harder to get manpath in completions generator

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -875,7 +875,7 @@ def get_paths_from_manpath():
         # HACK: Use some fallback in case we can't get anything else.
         # `mandoc` does not provide `manpath` or `man --path` and $MANPATH might not be set, so just use the default for mandoc (minus /usr/X11R6/man, because that's not relevant).
         # The alternative is reading its config file (/etc/man.conf)
-        sys.stderr.write("Unable to get the manpath, falling back to /usr/share/man:/usr/local/share/man. Please set $MANPATH if that is not correct.")
+        sys.stderr.write("Unable to get the manpath, falling back to /usr/share/man:/usr/local/share/man. Please set $MANPATH if that is not correct.\n")
         parent_paths = ["/usr/share/man", "/usr/local/share/man"]
     result = []
     for parent_path in parent_paths:

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -873,8 +873,11 @@ def get_paths_from_manpath():
         manpath, err_data = proc.communicate()
     parent_paths = manpath.decode().strip().split(':')
     if not parent_paths:
-        sys.stderr.write("Unable to get the manpath (tried `%s`)\n" % " ".join(program))
-        sys.exit(-1)
+        # HACK: Use some fallback in case we can't get anything else.
+        # `mandoc` does not provide `manpath` or `man --path` and $MANPATH might not be set, so just use he default for mandoc (minus /usr/X11R6/man, because that's not relevant).
+        # The alternative is reading its config file (/etc/man.conf)
+        sys.stderr.write("Unable to get the manpath, falling back to /usr/share/man:/usr/local/share/man. Please set $MANPATH if that is not correct.")
+        manpath = "/usr/share/man:/usr/local/share/man"
     result = []
     for parent_path in parent_paths:
         for section in ['man1', 'man6', 'man8']:

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -857,16 +857,20 @@ def parse_and_output_man_pages(paths, output_directory, show_progress):
 def get_paths_from_manpath():
     # Return all the paths to man(1) and man(8) files in the manpath
     import subprocess, os
-    # Some systems have manpath, others have `man --path` (like Haiku).
-    # TODO: Deal with systems that have neither (OpenBSD)
-    for prog in [['manpath'], ['man', '--path']]:
-        try:
-            program = prog
-            proc = subprocess.Popen(program, stdout=subprocess.PIPE)
-        except OSError: # Command does not exist, keep trying
-            continue
-        break # Command exists, use it.
-    manpath, err_data = proc.communicate()
+    # $MANPATH takes precedence, just like with `man` on the CLI.
+    if os.getenv("MANPATH"):
+        manpath = os.getenv("MANPATH")
+    else:
+        # Some systems have manpath, others have `man --path` (like Haiku).
+        # TODO: Deal with systems that have neither (OpenBSD)
+        for prog in [['manpath'], ['man', '--path']]:
+            try:
+                program = prog
+                proc = subprocess.Popen(program, stdout=subprocess.PIPE)
+            except OSError: # Command does not exist, keep trying
+                continue
+            break # Command exists, use it.
+        manpath, err_data = proc.communicate()
     parent_paths = manpath.decode().strip().split(':')
     if not parent_paths:
         sys.stderr.write("Unable to get the manpath (tried `%s`)\n" % " ".join(program))

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -857,11 +857,19 @@ def parse_and_output_man_pages(paths, output_directory, show_progress):
 def get_paths_from_manpath():
     # Return all the paths to man(1) and man(8) files in the manpath
     import subprocess, os
-    proc = subprocess.Popen(['manpath'], stdout=subprocess.PIPE)
+    # Some systems have manpath, others have `man --path` (like Haiku).
+    # TODO: Deal with systems that have neither (OpenBSD)
+    for prog in [['manpath'], ['man', '--path']]:
+        try:
+            program = prog
+            proc = subprocess.Popen(program, stdout=subprocess.PIPE)
+        except OSError: # Command does not exist, keep trying
+            continue
+        break # Command exists, use it.
     manpath, err_data = proc.communicate()
     parent_paths = manpath.decode().strip().split(':')
     if not parent_paths:
-        sys.stderr.write("Unable to get the manpath (tried manpath)\n")
+        sys.stderr.write("Unable to get the manpath (tried `%s`)\n" % " ".join(program))
         sys.exit(-1)
     result = []
     for parent_path in parent_paths:

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -865,8 +865,7 @@ def get_paths_from_manpath():
         # TODO: Deal with systems that have neither (OpenBSD)
         for prog in [['manpath'], ['man', '--path']]:
             try:
-                program = prog
-                proc = subprocess.Popen(program, stdout=subprocess.PIPE)
+                proc = subprocess.Popen(prog, stdout=subprocess.PIPE)
             except OSError: # Command does not exist, keep trying
                 continue
             break # Command exists, use it.
@@ -874,7 +873,7 @@ def get_paths_from_manpath():
     parent_paths = manpath.decode().strip().split(':')
     if not parent_paths:
         # HACK: Use some fallback in case we can't get anything else.
-        # `mandoc` does not provide `manpath` or `man --path` and $MANPATH might not be set, so just use he default for mandoc (minus /usr/X11R6/man, because that's not relevant).
+        # `mandoc` does not provide `manpath` or `man --path` and $MANPATH might not be set, so just use the default for mandoc (minus /usr/X11R6/man, because that's not relevant).
         # The alternative is reading its config file (/etc/man.conf)
         sys.stderr.write("Unable to get the manpath, falling back to /usr/share/man:/usr/local/share/man. Please set $MANPATH if that is not correct.")
         manpath = "/usr/share/man:/usr/local/share/man"

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -865,18 +865,18 @@ def get_paths_from_manpath():
         # TODO: Deal with systems that have neither (OpenBSD)
         for prog in [['manpath'], ['man', '--path']]:
             try:
-                proc = subprocess.Popen(prog, stdout=subprocess.PIPE)
+                proc = subprocess.Popen(prog, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             except OSError: # Command does not exist, keep trying
                 continue
             break # Command exists, use it.
         manpath, err_data = proc.communicate()
     parent_paths = manpath.decode().strip().split(':')
-    if not parent_paths:
+    if not parent_paths or proc.returncode > 0:
         # HACK: Use some fallback in case we can't get anything else.
         # `mandoc` does not provide `manpath` or `man --path` and $MANPATH might not be set, so just use the default for mandoc (minus /usr/X11R6/man, because that's not relevant).
         # The alternative is reading its config file (/etc/man.conf)
         sys.stderr.write("Unable to get the manpath, falling back to /usr/share/man:/usr/local/share/man. Please set $MANPATH if that is not correct.")
-        manpath = "/usr/share/man:/usr/local/share/man"
+        parent_paths = ["/usr/share/man", "/usr/local/share/man"]
     result = []
     for parent_path in parent_paths:
         for section in ['man1', 'man6', 'man8']:


### PR DESCRIPTION
## Description

In the completions generator (and our `man` function, which I'll change later), we currently only use `manpath` to figure out $MANPATH.

This changes it so it (in order)

- Uses $MANPATH

- Tries both `manpath` and `man --path`

- Uses a hardcoded fallback of "/usr/share/man:/usr/local/share/man" if neither is available

Note that the last point hasn't been heavily tested. In particular I do not know what happens if those directories don't exist (though the other paths theoretically also need to deal with that).

Fixes issue #3671, #2194 (in a hacky way - this would use the fallback).

## TODOs:
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [X] Tests have been added for regressions fixed (N/A)

This isn't _huge_ priority and can be dropped from 2.5.0 if necessary.