### PR TITLE
Weak linking

### DIFF
--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -535,15 +535,7 @@ bool env_universal_t::open_temporary_file(const wcstring &directory, wcstring *o
 
     for (size_t attempt = 0; attempt < 10 && !success; attempt++) {
         char *narrow_str = wcs2str(tmp_name_template.c_str());
-#if HAVE_MKOSTEMP
-        int result_fd = mkostemp(narrow_str, O_CLOEXEC);
-#else
-        int result_fd = mkstemp(narrow_str);
-        if (result_fd != -1) {
-            fcntl(result_fd, F_SETFD, FD_CLOEXEC);
-        }
-#endif
-
+        int result_fd = fish_mkstemp_cloexec(narrow_str);
         saved_errno = errno;
         success = result_fd != -1;
         *out_fd = result_fd;

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -91,6 +91,20 @@ char *tparm_solaris_kludge(char *str, ...) {
 
 #endif
 
+int fish_mkstemp_cloexec(char *name_template) {
+#if HAVE_MKOSTEMP
+    // null check because mkostemp may be a weak symbol
+    if (&mkostemp != nullptr) {
+        return mkostemp(name_template, O_CLOEXEC);
+    }
+#endif
+    int result_fd = mkstemp(name_template);
+    if (result_fd != -1) {
+        fcntl(result_fd, F_SETFD, FD_CLOEXEC);
+    }
+    return result_fd;
+}
+
 /// Fallback implementations of wcsdup and wcscasecmp. On systems where these are not needed (e.g.
 /// building on Linux) these should end up just being stripped, as they are static functions that
 /// are not referenced in this file.

--- a/src/fallback.h
+++ b/src/fallback.h
@@ -23,6 +23,11 @@
 int fish_wcwidth(wchar_t wc);
 int fish_wcswidth(const wchar_t *str, size_t n);
 
+// Replacement for mkostemp(str, O_CLOEXEC)
+// This uses mkostemp if available,
+// otherwise it uses mkstemp followed by fcntl
+int fish_mkstemp_cloexec(char *);
+
 #ifndef WCHAR_MAX
 /// This _should_ be defined by wchar.h, but e.g. OpenBSD doesn't.
 #define WCHAR_MAX INT_MAX

--- a/src/fallback.h
+++ b/src/fallback.h
@@ -63,6 +63,12 @@ char *tparm_solaris_kludge(char *str, ...);
 /// On other platforms, use what's detected at build time.
 #if __APPLE__
 #if __DARWIN_C_LEVEL >= 200809L
+// We have to explicitly redeclare these as weak,
+// since we are forced to set the MIN_REQUIRED availability macro to 10.7
+// to use libc++, which in turn exposes these as strong
+wchar_t *wcsdup(const wchar_t *) __attribute__((weak_import));
+int wcscasecmp(const wchar_t *, const wchar_t *) __attribute__((weak_import));
+int wcsncasecmp(const wchar_t *, const wchar_t *, size_t n) __attribute__((weak_import));
 wchar_t *wcsdup_use_weak(const wchar_t *);
 int wcscasecmp_use_weak(const wchar_t *, const wchar_t *);
 int wcsncasecmp_use_weak(const wchar_t *s1, const wchar_t *s2, size_t n);


### PR DESCRIPTION
This is a few changes that enable fish binaries to run on macOS 10.6 SnowLeopard, by weak-linking symbols that are not available on that system.
