### PR TITLE
Drop fishd check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `command` now accepts "-q"/"--quiet" for `command -sq $command` (#3591).
 - Selection mode (used with "begin-selection") no longer selects a character the cursor does not move over (#3684).
 - The `help` command now reads the $fish_help_browser variable (#3131).
+- fish no longer prints a warning when it identifies a running instance of an old version (2.1.0 and earlier). Changes to universal variables may not propagate between these old versions and 2.5b1.
 
 ## Notable fixes and improvements
 - `complete` no longer prints errors when given an empty string as a description (#3557).

--- a/configure.ac
+++ b/configure.ac
@@ -270,7 +270,6 @@ esac
 #
 
 # Check for os dependant libraries for all binaries.
-AC_SEARCH_LIBS( connect, [socket network], , [AC_MSG_ERROR([Cannot find the socket library, needed to build this package.] )] )
 AC_SEARCH_LIBS( nanosleep, rt, , [AC_MSG_ERROR([Cannot find the rt library, needed to build this package.] )] )
 AC_SEARCH_LIBS( shm_open, rt, [AC_DEFINE([HAVE_SHM_OPEN], [1], [Define to 1 if the shm_open() function exists])] )
 AC_SEARCH_LIBS( pthread_create, pthread, , [AC_MSG_ERROR([Cannot find the pthread library, needed to build this package.] )] )

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -16,10 +16,8 @@
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>  // IWYU pragma: keep
 #endif
-#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>  // IWYU pragma: keep
-#include <sys/types.h>
 // We need the sys/file.h for the flock() declaration on Linux but not OS X.
 #include <sys/file.h>  // IWYU pragma: keep
 // We need the ioctl.h header so we can check if SIOCGIFHWADDR is defined by it so we know if we're
@@ -866,6 +864,7 @@ void env_universal_t::parse_message_internal(const wcstring &msgstr, var_table_t
 #ifdef SIOCGIFHWADDR
 
 // Linux
+#include <sys/socket.h>
 #include <net/if.h>
 static bool get_mac_address(unsigned char macaddr[MAC_ADDRESS_MAX_LEN],
                             const char *interface = "eth0") {

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -22,14 +22,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <getopt.h>
 #include <limits.h>
 #include <locale.h>
-#include <pwd.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>  // IWYU pragma: keep
 #include <sys/stat.h>
-#include <sys/un.h>
 #include <unistd.h>
 #include <wchar.h>
 #include <memory>
@@ -197,82 +194,6 @@ static void source_config_in_directory(const wcstring &dir) {
     parser.set_is_within_fish_initialization(true);
     parser.eval(cmd, io_chain_t(), TOP);
     parser.set_is_within_fish_initialization(false);
-}
-
-static int try_connect_socket(std::string &name) {
-    int s, r, ret = -1;
-
-    /// Connect to a DGRAM socket rather than the expected STREAM. This avoids any notification to a
-    /// remote socket that we have connected, preventing any surprising behaviour. If the connection
-    /// fails with EPROTOTYPE, the connection is probably a STREAM; if it succeeds or fails any
-    /// other way, there is no cause for alarm. With thanks to Andrew Lutomirski <github.com/amluto>
-    if ((s = socket(AF_UNIX, SOCK_DGRAM, 0)) == -1) {
-        wperror(L"socket");
-        return -1;
-    }
-
-    debug(3, L"Connect to socket %s at fd %d", name.c_str(), s);
-
-    struct sockaddr_un local = {};
-    local.sun_family = AF_UNIX;
-    strncpy(local.sun_path, name.c_str(), (sizeof local.sun_path) - 1);
-
-    r = connect(s, (struct sockaddr *)&local, sizeof local);
-
-    if (r == -1 && errno == EPROTOTYPE) {
-        ret = 0;
-    }
-
-    close(s);
-    return ret;
-}
-
-/// Check for a running fishd from old versions and warn about not being able to share variables.
-/// https://github.com/fish-shell/fish-shell/issues/1730
-static void check_running_fishd() {
-    // There are two paths to check:
-    // $FISHD_SOCKET_DIR/fishd.socket.$USER or /tmp/fishd.socket.$USER
-    //   - referred to as the "old socket"
-    // $XDG_RUNTIME_DIR/fishd.socket or /tmp/fish.$USER/fishd.socket
-    //   - referred to as the "new socket"
-    // All existing versions of fish attempt to create the old socket, but
-    // failure in newer versions is not treated as critical, so both need
-    // to be checked.
-    const char *uname = getenv("USER");
-    if (uname == NULL) {
-        const struct passwd *pw = getpwuid(getuid());
-        uname = pw->pw_name;
-    }
-
-    const char *dir_old_socket = getenv("FISHD_SOCKET_DIR");
-    std::string path_old_socket;
-
-    if (dir_old_socket == NULL) {
-        path_old_socket = "/tmp/";
-    } else {
-        path_old_socket.append(dir_old_socket);
-    }
-
-    path_old_socket.append("fishd.socket.");
-    path_old_socket.append(uname);
-
-    const char *dir_new_socket = getenv("XDG_RUNTIME_DIR");
-    std::string path_new_socket;
-    if (dir_new_socket == NULL) {
-        path_new_socket = "/tmp/fish.";
-        path_new_socket.append(uname);
-        path_new_socket.push_back('/');
-    } else {
-        path_new_socket.append(dir_new_socket);
-    }
-
-    path_new_socket.append("fishd.socket");
-
-    if (try_connect_socket(path_old_socket) == 0 || try_connect_socket(path_new_socket) == 0) {
-        debug(1, _(L"Old versions of fish appear to be running. You will not be able to share "
-                   L"variable values between old and new fish sessions. For best results, restart "
-                   L"all running instances of fish."));
-    }
 }
 
 /// Parse init files. exec_path is the path of fish executable as determined by argv[0].
@@ -487,7 +408,6 @@ int main(int argc, char **argv) {
             reader_exit(0, 0);
         } else if (my_optind == argc) {
             // Interactive mode
-            check_running_fishd();
             res = reader_read(STDIN_FILENO, empty_ios);
         } else {
             char *file = *(argv + (my_optind++));


### PR DESCRIPTION
These changes drop the old running fishd check (discussed in #3669 and #2360).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documenation/manpages.
- [N/A] Tests have been added for regressions fixed
