### PR TITLE
Improve __fish_print_xdg_mimetypes function

### DIFF
--- a/share/functions/__fish_print_xdg_mimetypes.fish
+++ b/share/functions/__fish_print_xdg_mimetypes.fish
@@ -1,5 +1,7 @@
 function __fish_print_xdg_mimetypes --description 'Print XDG mime types'
-    cat ~/.local/share/applications/mimeinfo.cache | grep -v "\[MIME Cache\]" | tr = \t
-    cat /usr/share/applications/mimeinfo.cache | grep -v "\[MIME Cache\]" | tr = \t
-
+    for file in {~/.local,/usr}/share/applications/mimeinfo.cache
+        if test -r $file
+            string match -v "[MIME Cache]" <$file | string replace = \t
+        end
+    end
 end


### PR DESCRIPTION
`__fish_print_xdg_mimetypes` function has been giving me an error (because it tries to read a file that doesn't exist on my system) which is not what we want when completing a command, so I rewrote it. See commit for details.