### PR TITLE
Remove cd in __fish_print_interfaces

### DIFF
--- a/share/functions/__fish_print_interfaces.fish
+++ b/share/functions/__fish_print_interfaces.fish
@@ -1,8 +1,6 @@
 function __fish_print_interfaces --description "Print a list of known network interfaces"
     if test -d /sys/class/net
-        for i in /sys/class/net/*
-            basename $i
-        end
+        string replace /sys/class/net/ '' /sys/class/net/*
     else # OSX/BSD
         command ifconfig -l | string split ' '
     end

--- a/share/functions/__fish_print_interfaces.fish
+++ b/share/functions/__fish_print_interfaces.fish
@@ -1,6 +1,7 @@
 function __fish_print_interfaces --description "Print a list of known network interfaces"
     if test -d /sys/class/net
-        string replace /sys/class/net/ '' /sys/class/net/*
+        set -l interfaces /sys/class/net/*
+        string replace /sys/class/net/ '' $interfaces
     else # OSX/BSD
         command ifconfig -l | string split ' '
     end

--- a/share/functions/__fish_print_interfaces.fish
+++ b/share/functions/__fish_print_interfaces.fish
@@ -1,8 +1,7 @@
 function __fish_print_interfaces --description "Print a list of known network interfaces"
     if test -d /sys/class/net
-        cd /sys/class/net
-        for i in *
-            echo $i
+        for i in /sys/class/net/*
+            basename $i
         end
     else # OSX/BSD
         command ifconfig -l | string split ' '


### PR DESCRIPTION
## Description

The `cd /sys/class/net` was causing tab-completions to change directory of the shell. e.g. try: `ifup <tab>`

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documenation/manpages.
- [ ] Tests have been added for regressions fixed
