### PR TITLE
`mount` & `udisksctl` completions: split `-o` options

### DIFF
--- a/share/completions/mount.fish
+++ b/share/completions/mount.fish
@@ -24,9 +24,4 @@ complete -c mount -s O -x --description 'Exclude file systems'
 complete -c mount -l bind -f --description 'Remount a subtree to a second position'
 complete -c mount -l move -f --description 'Move a subtree to a new position'
 complete -c mount -x -s t --description 'File system' -a "(__fish_print_filesystems)"
-
-complete -c mount -x -s o --description 'Mount option' -a '(__fish_append , $__fish_mount_opts)'
-
-set -g __fish_mount_opts async\tUse\ asynchronous\ I/O atime\tUpdate\ time\ on\ each\ access auto\tMounted\ with\ -a defaults\tUse\ default\ options dev\tInterpret\ character/block\ special\ devices exec\tPermit\ executables _netdev\tFilesystem\ uses\ network noatime\tDo\ not\ update\ time\ on\ each\ access noauto\tNot\ mounted\ by\ -a nodev\tDo\ not\ interpret\ character/block\ special\ devices noexec\tDo\ not\ permit\ executables nosuid\tIgnore\ suid\ bits nouser\tOnly\ root\ may\ mount remount\tRemount\ read-only\ filesystem ro\tMount\ read-only rw\tMount\ read-write suid\tAllow\ suid\ bits sync\tUse\ synchronous\ I/O dirsync\tUse\ synchronous\ directory\ operations user\tAny\ user\ may\ mount users\tAny\ user\ may\ mount\ and\ unmount
-
-
+complete -c mount -x -s o --description 'Mount option' -a '(__fish_append , (__fish_print_mount_opts))'

--- a/share/completions/udisksctl.fish
+++ b/share/completions/udisksctl.fish
@@ -1,8 +1,5 @@
 set -l cmds help info dump status monitor mount unmount unlock lock loop-setup loop-delete power-off smart-simulate
 
-set __fish_mount_opts async\tUse\ asynchronous\ I/O atime\tUpdate\ time\ on\ each\ access auto\tMounted\ with\ -a defaults\tUse\ default\ options dev\tInterpret\ character/block\ special\ devices exec\tPermit\ executables _netdev\tFilesystem\ uses\ network noatime\tDo\ not\ update\ time\ on\ each\ access noauto\tNot\ mounted\ by\ -a nodev\tDo\ not\ interpret\ character/block\ special\ devices noexec\tDo\ not\ permit\ executables nosuid\tIgnore\ suid\ bits nouser\tOnly\ root\ may\ mount remount\tRemount\ read-only\ filesystem ro\tMount\ read-only rw\tMount\ read-write suid\tAllow\ suid\ bits sync\tUse\ synchronous\ I/O dirsync\tUse\ synchronous\ directory\ operations user\tAny\ user\ may\ mount users\tAny\ user\ may\ mount\ and\ unmount
-
-
 function __fish_print_mounted_blockdevice
     if test -r /proc/mounts
         string match -r "^/[^ ]*" < /proc/mounts
@@ -29,7 +26,7 @@ complete -c udisksctl -n "__fish_seen_subcommand_from info" -s b -l block-device
 complete -f -c udisksctl -n "__fish_seen_subcommand_from info" -s d -l drive -d "Drive to get information about"
 
 complete -x -c udisksctl -n "__fish_seen_subcommand_from mount" -s t -l filesystem-type -d "Filesystem type to use" -a "(__fish_print_filesystems)"
-complete -x -c udisksctl -n "__fish_seen_subcommand_from mount" -s o -l options -d "Mount options" -a '(__fish_append , $__fish_mount_opts)'
+complete -x -c udisksctl -n "__fish_seen_subcommand_from mount" -s o -l options -d "Mount options" -a '(__fish_append , (__fish_print_mount_opts))'
 
 complete -c udisksctl -n "__fish_seen_subcommand_from unmount" -s f -l force -d "Force/layzy unmount"
 complete -c udisksctl -n "__fish_seen_subcommand_from unmount" -a "(__fish_print_mounted)" -f -d "Mount point"

--- a/share/functions/__fish_print_mount_opts.fish
+++ b/share/functions/__fish_print_mount_opts.fish
@@ -1,0 +1,20 @@
+function __fish_print_mount_opts
+    echo async\tUse\ asynchronous\ I/O
+    echo atime\tUpdate\ time\ on\ each\ access
+    echo auto\tMounted\ with\ -a
+    echo defaults\tUse\ default\ options
+    echo dev\tInterpret\ character/block\ special\ devices
+    echo exec\tPermit\ executables _netdev\tFilesystem\ uses\ network
+    echo noatime\tDo\ not\ update\ time\ on\ each\ access
+    echo noauto\tNot\ mounted\ by\ -a
+    echo nodev\tDo\ not\ interpret\ character/block\ special\ devices
+    echo noexec\tDo\ not\ permit\ executables
+    echo nosuid\tIgnore\ suid\ bits nouser\tOnly\ root\ may\ mount
+    echo remount\tRemount\ read-only\ filesystem
+    echo ro\tMount\ read-only rw\tMount\ read-write
+    echo suid\tAllow\ suid\ bits
+    echo sync\tUse\ synchronous\ I/O
+    echo dirsync\tUse\ synchronous\ directory\ operations
+    echo user\tAny\ user\ may\ mount
+    echo users\tAny\ user\ may\ mount\ and\ unmount
+end


### PR DESCRIPTION
`mount` and `udisksctl` share the same `-o` option, so I figured it would be better if they were put in a same place. I'm not sure this is the best way to do it though but that's the only thing I could come up with.