### PR TITLE
Make test errors redirectable

### DIFF
--- a/src/builtin_test.cpp
+++ b/src/builtin_test.cpp
@@ -810,11 +810,11 @@ int builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     expression *expr = test_parser::parse_args(args, err, program_name);
     if (!expr) {
 #if 0
-        fwprintf(stderr, L"Oops! test was given args:\n");
+        streams.err.append(L"Oops! test was given args:\n");
         for (size_t i=0; i < argc; i++) {
-            fwprintf(stderr, L"\t%ls\n", args.at(i).c_str());
+            streams.err.append_format(L"\t%ls\n", args.at(i).c_str());
         }
-        fwprintf(stderr, L"and returned parse error: %ls\n", err.c_str());
+        streams.err.append_format(L"and returned parse error: %ls\n", err.c_str());
 #endif
         streams.err.append(err);
         return BUILTIN_TEST_FAIL;
@@ -823,9 +823,9 @@ int builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wcstring_list_t eval_errors;
     bool result = expr->evaluate(eval_errors);
     if (!eval_errors.empty() && !should_suppress_stderr_for_tests()) {
-        fwprintf(stderr, L"test returned eval errors:\n");
+        streams.err.append(L"test returned eval errors:\n");
         for (size_t i = 0; i < eval_errors.size(); i++) {
-            fwprintf(stderr, L"\t%ls\n", eval_errors.at(i).c_str());
+            streams.err.append_format(L"\t%ls\n", eval_errors.at(i).c_str());
         }
     }
     delete expr;


### PR DESCRIPTION
This can't use `fwprintf`, since that goes directly to actual stderr.

It needs to use the passed stream.

Fixes #3753.

This is possibly something that needs to be more widely checked.