### PR TITLE
mount & udisksctl: improve `-o` completions`

### DIFF
--- a/share/completions/mount.fish
+++ b/share/completions/mount.fish
@@ -24,9 +24,4 @@ complete -c mount -s O -x --description 'Exclude file systems'
 complete -c mount -l bind -f --description 'Remount a subtree to a second position'
 complete -c mount -l move -f --description 'Move a subtree to a new position'
 complete -c mount -x -s t --description 'File system' -a "(__fish_print_filesystems)"
-
-complete -c mount -x -s o --description 'Mount option' -a '(__fish_append , $__fish_mount_opts)'
-
-set -g __fish_mount_opts async\tUse\ asynchronous\ I/O atime\tUpdate\ time\ on\ each\ access auto\tMounted\ with\ -a defaults\tUse\ default\ options dev\tInterpret\ character/block\ special\ devices exec\tPermit\ executables _netdev\tFilesystem\ uses\ network noatime\tDo\ not\ update\ time\ on\ each\ access noauto\tNot\ mounted\ by\ -a nodev\tDo\ not\ interpret\ character/block\ special\ devices noexec\tDo\ not\ permit\ executables nosuid\tIgnore\ suid\ bits nouser\tOnly\ root\ may\ mount remount\tRemount\ read-only\ filesystem ro\tMount\ read-only rw\tMount\ read-write suid\tAllow\ suid\ bits sync\tUse\ synchronous\ I/O dirsync\tUse\ synchronous\ directory\ operations user\tAny\ user\ may\ mount users\tAny\ user\ may\ mount\ and\ unmount
-
-
+complete -c mount -x -s o --description 'Mount option' -a '(__fish_complete_mount_opts)'

--- a/share/completions/udisksctl.fish
+++ b/share/completions/udisksctl.fish
@@ -1,11 +1,8 @@
 set -l cmds help info dump status monitor mount unmount unlock lock loop-setup loop-delete power-off smart-simulate
 
-set __fish_mount_opts async\tUse\ asynchronous\ I/O atime\tUpdate\ time\ on\ each\ access auto\tMounted\ with\ -a defaults\tUse\ default\ options dev\tInterpret\ character/block\ special\ devices exec\tPermit\ executables _netdev\tFilesystem\ uses\ network noatime\tDo\ not\ update\ time\ on\ each\ access noauto\tNot\ mounted\ by\ -a nodev\tDo\ not\ interpret\ character/block\ special\ devices noexec\tDo\ not\ permit\ executables nosuid\tIgnore\ suid\ bits nouser\tOnly\ root\ may\ mount remount\tRemount\ read-only\ filesystem ro\tMount\ read-only rw\tMount\ read-write suid\tAllow\ suid\ bits sync\tUse\ synchronous\ I/O dirsync\tUse\ synchronous\ directory\ operations user\tAny\ user\ may\ mount users\tAny\ user\ may\ mount\ and\ unmount
-
-
 function __fish_print_mounted_blockdevice
     if test -r /proc/mounts
-        string match -r "^/[^ ]*" < /proc/mounts
+        string match -r "^/[^ ]*" </proc/mounts
     end
 end
 
@@ -29,7 +26,7 @@ complete -c udisksctl -n "__fish_seen_subcommand_from info" -s b -l block-device
 complete -f -c udisksctl -n "__fish_seen_subcommand_from info" -s d -l drive -d "Drive to get information about"
 
 complete -x -c udisksctl -n "__fish_seen_subcommand_from mount" -s t -l filesystem-type -d "Filesystem type to use" -a "(__fish_print_filesystems)"
-complete -x -c udisksctl -n "__fish_seen_subcommand_from mount" -s o -l options -d "Mount options" -a '(__fish_append , $__fish_mount_opts)'
+complete -x -c udisksctl -n "__fish_seen_subcommand_from mount" -s o -l options -d "Mount options" -a '(__fish_complete_mount_opts)'
 
 complete -c udisksctl -n "__fish_seen_subcommand_from unmount" -s f -l force -d "Force/layzy unmount"
 complete -c udisksctl -n "__fish_seen_subcommand_from unmount" -a "(__fish_print_mounted)" -f -d "Mount point"

--- a/share/functions/__fish_complete_mount_opts.fish
+++ b/share/functions/__fish_complete_mount_opts.fish
@@ -1,16 +1,16 @@
 function __fish_print_user_ids
-    if test -x /usr/bin/getent
+    if command -sq getent
         for line in (getent passwd)
-            set v (string split : $line)
+            set v (string split : -- $line)
             printf "%s\t%s\n" $v[3] $v[1]
         end
     end
 end
 
 function __fish_print_group_ids
-    if test -x /usr/bin/getent
+    if command -sq getent
         for line in (getent group)
-            set v (string split : $line)
+            set v (string split : -- $line)
             printf "%s\t%s\n" $v[3] $v[1]
         end
     end
@@ -137,13 +137,13 @@ function __fish_complete_mount_opts
  acl\
 
 
-    set -l token (commandline -tc | string replace -r '^-o' '')
-    set -l args (string split , $token ^/dev/null)
+    set -l token (commandline -tc | string replace -r '^-o' -- '')
+    set -l args (string split , -- $token)
 
     set -l last_arg $args[-1]
     set -e args[-1]
 
-    switch $last_arg
+    switch (string replace -r '=.*' '=' -- $last_arg)
         case uid=
             set fish_mount_opts $fish_mount_opts uid=(__fish_print_user_ids)
         case gid=
@@ -157,18 +157,8 @@ function __fish_complete_mount_opts
 
     set -l prefix ''
     if set -q args[1]
-        set prefix (string join , $args),
+        set prefix (string join , -- $args),
     end
 
-    for opt in $fish_mount_opts
-        printf '%s\n' $prefix$opt
-
-        if not string match '*=*' $opt ^/dev/null >/dev/null
-            if string match -r '\t' $opt ^/dev/null >/dev/null
-                printf '%s\n' $prefix(string replace \t ,\t $opt)
-            else
-                printf '%s\n' $prefix$opt,
-            end
-        end
-    end
+    printf '%s\n' $prefix$fish_mount_opts
 end

--- a/share/functions/__fish_complete_mount_opts.fish
+++ b/share/functions/__fish_complete_mount_opts.fish
@@ -1,0 +1,174 @@
+function __fish_print_user_ids
+    if test -x /usr/bin/getent
+        for line in (getent passwd)
+            set v (string split : $line)
+            printf "%s\t%s\n" $v[3] $v[1]
+        end
+    end
+end
+
+function __fish_print_group_ids
+    if test -x /usr/bin/getent
+        for line in (getent group)
+            set v (string split : $line)
+            printf "%s\t%s\n" $v[3] $v[1]
+        end
+    end
+end
+
+function __fish_complete_mount_opts
+    set -l fish_mount_opts\
+ async\t'Use asynchronous I/O'\
+ atime\t'Update time on each access'\
+ noatime\t'Do not update time on each access'\
+ auto\t'Mounted with'\
+ noauto\t'Not mounted by -a'\
+ defaults\t'Use default options'\
+ dev\t'Interpret character/block special devices'\
+ nodev\t'Do not interpret character/block special devices'\
+ diratime\t'Update directory inode access time'\
+ nodiratime\t'Don\'t update directory inode access time'\
+ dirsync\t'Use synchronous directory operations'\
+ exec\t'Permit executables'\
+ noexec\t'Do not permit executables'\
+ group\t'Any user within device group may mount'\
+ iversion\t'Increment i_version field on inode modification'\
+ noiversion\t'Don\'t increment i_version field on inode modification'\
+ mand\t'Allow mandatory locks'\
+ nomand\t'Don\'t allow mandatory locks'\
+ _netdev\t'Filesystem uses network'\
+ nofail\t'Don\'t report errors'\
+ relatime\t'Update inode access times'\
+ norelatime\t'Don\'t update inode access times'\
+ strictatime\
+ nostrictatime\
+ lazytime\
+ nolazytime\
+ suid\t'Allow suid bits'\
+ nosuid\t'Ignore suid bits'\
+ silent\
+ loud\
+ owner\
+ remount\t'Remount read-only filesystem'\
+ ro\t'Mount read-only'\
+ rw\t'Mount read-write'\
+ sync\t'Use synchronous I/O'\
+ user\t'Any user may mount'\
+ nouser\t'Only root may mount'\
+ users\t'Any user may mount and unmount'\
+ protect\
+ usemp\
+ verbose\
+ {grp,no,usr,}quota\
+ autodefrag\
+ compress\
+ compress-force\
+ degraded\
+ discard\
+ enospc_debug\
+ flushoncommit\
+ inode_cache\
+ context=\t'Set SELinux context'\
+ uid=\
+ gid=\
+ ownmask=\
+ othmask=\
+ setuid=\
+ setgid=\
+ mode=\
+ prefix=\
+ volume=\
+ reserved=\
+ root=\
+ bs=\
+ alloc_start=\
+ check_int{,_data,_print,_mask}=\
+ commit=\
+ compress=\
+ compress-force=\
+ device=\
+ fatal_errors=\
+ max_inline=\
+ metadata_ratio=\
+ noacl\
+ nobarrier\
+ nodatacow\
+ nodatasum\
+ notreelog\
+ recovery\
+ rescan_uuid_tree\
+ skip_balance\
+ nospace_cache\
+ clear_cache\
+ ssd\
+ nossd\
+ ssd_spread\
+ subvol=\
+ subvolrootid=\
+ thread_pool=\
+ user_subvol_rm_allowed\
+ acl\
+ noacl\
+ bsddf\
+ minixdf\
+ check=none\
+ nocheck\
+ debug\
+ errors={continue,remount-ro,panic}\
+ grpid\
+ bsdgroups\
+ bsdgroups\
+ bsdgroups\
+ nouid32\
+ grpquota\
+ grpquota\
+ resgid=\
+ resuid=\
+ sb=\
+ {user,nouser}_xattr\
+ journal={update,unum}\
+ journal{_dev,_path}=\
+ norecovery\
+ noload\
+ data={journal,ordered,writeback}\
+ data_err={ignore,abort}\
+ barrier={0,1}\
+ user_xattr\
+ acl\
+
+
+    set -l token (commandline -tc | string replace -r '^-o' '')
+    set -l args (string split , $token ^/dev/null)
+
+    set -l last_arg $args[-1]
+    set -e args[-1]
+
+    switch $last_arg
+        case uid=
+            set fish_mount_opts $fish_mount_opts uid=(__fish_print_user_ids)
+        case gid=
+            set fish_mount_opts $fish_mount_opts gid=(__fish_print_group_ids)
+        case setuid=
+            set fish_mount_opts $fish_mount_opts setuid=(__fish_print_user_ids)
+        case setgid=
+            set fish_mount_opts $fish_mount_opts setgid=(__fish_print_group_ids)
+    end
+
+
+    set -l prefix ''
+    if set -q args[1]
+        set prefix (string join , $args),
+    end
+
+    for opt in $fish_mount_opts
+        printf '%s\n' $prefix$opt
+
+        if not string match '*=*' $opt ^/dev/null >/dev/null
+            if string match -r '\t' $opt ^/dev/null >/dev/null
+                printf '%s\n' $prefix(string replace \t ,\t $opt)
+            else
+                printf '%s\n' $prefix$opt,
+            end
+        end
+    end
+end


### PR DESCRIPTION
Aside from completing new options, it also completes `uid` and `gid` options with users and groups ids.

Exemple:
```
> mount -o ro,uid=<tab>
```

Will complete with user ids.