### PR TITLE
Improve ssh/scp completion

### DIFF
--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -8,7 +8,14 @@ __fish_complete_ssh scp
 # scp specific completions
 #
 
-complete -c scp -d Hostname -a "
+#
+# Hostname
+#
+complete \
+	--command     scp \
+	--description Hostname \
+	--condition   "commandline --cut-at-cursor --current-token | string match --invert '*:*'" \
+	--arguments   "
 
 (__fish_print_hostnames):
 
@@ -22,9 +29,22 @@ complete -c scp -d Hostname -a "
 "
 
 #
+# Local path
+#
+complete \
+	--command     scp \
+	--description "Local Path" \
+	--condition   "commandline -ct | string match ':'"
+
+#
 # Remote path
 #
-complete -c scp -d "Remote Path" -n "commandline -ct| __fish_sgrep -o '.*:'" -a "
+complete \
+	--command     scp \
+	--description "Remote Path" \
+	--no-files \
+	--condition   "commandline --cut-at-cursor --current-token | string match --regex '.+:'" \
+	--arguments   "
 
 (
 	#Prepend any user@host information supplied before the remote completion
@@ -43,4 +63,3 @@ complete -c scp -s p --description "Preserves modification times, access times, 
 complete -c scp -s q --description "Do not display progress bar"
 complete -c scp -s r --description "Recursively copy"
 complete -c scp -s S --description "Encryption program"
-

--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -24,7 +24,8 @@ complete \
 	commandline -ct |sed -ne 's/\(.*@\).*/\1/p'
 )(__fish_print_hostnames):
 
-(__fish_print_users)@\tUsername
+# Disable as username completion is not very useful
+# (__fish_print_users)@\tUsername
 
 "
 

--- a/share/completions/ssh.fish
+++ b/share/completions/ssh.fish
@@ -14,9 +14,10 @@ complete -x -c ssh -d Hostname -a "
 )(__fish_print_hostnames)
 "
 
-complete -x -c ssh -d User -a "
-(__fish_print_users | string match -r -v '^_')@
-"
+# Disable as username completion is not very useful
+# complete -x -c ssh -d User -a "
+# (__fish_print_users | string match -r -v '^_')@
+# "
 complete -c ssh --description "Command to run" -x -a '(__fish_complete_subcommand --fcs-skip=2)'
 
 complete -c ssh -s a --description "Disables forwarding of the authentication agent"


### PR DESCRIPTION
The commits (especially long form) explain everything. The benefits of some of the changes may be disputable. This should modernise ssh to the latest release, and provide support for customisation options which can make ssh adhere to XDG (you are probably sick of hearing that acronym by now) standards; furthermore, it fixes and removes completions that only get in the way.

I haven't touched other ssh related commands since I don't use them and do not know what is ideal.

Also, I hope you don't mind me using the long options as I think it makes the source easier to understand. It does take up a lot more lines, but the tradeoff is worth it. I also tend to be heavy with the documentation when regex is involved since one cannot describe intent -- but only implementation -- with regex.