### PR TITLE
don't run fish_update_completions in unit tests

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -110,9 +110,14 @@ function __fish_config_interactive -d "Initializations that should be performed 
     # Generate man page completions if not present.
     #
     if not test -d $userdatadir/fish/generated_completions
-        command -s python >/dev/null # feature needs python, don't try this on launch without it (#3588)
-        # fish_update_completions is a function, so it can not be directly run in background.
-        and eval (string escape "$__fish_bin_dir/fish") "-c 'fish_update_completions >/dev/null ^/dev/null' &"
+        # Generating completions from man pages needs python (see issue #3588).
+        # Don't do this if we're being invoked as part of running unit tests.
+        if command -qs python
+        and not set -q FISH_UNIT_TESTS_RUNNING
+            # We cannot simply do `fish_update_completions &` because it is a function. Hence the
+            # need for the convoluted `eval` to run it in a subshell.
+            eval (string escape "$__fish_bin_dir/fish") "-c 'fish_update_completions >/dev/null ^/dev/null' &"
+        end
     end
 
     #

--- a/tests/interactive.fish
+++ b/tests/interactive.fish
@@ -7,6 +7,10 @@
 # This is a list of flakey tests that often succeed when rerun.
 set TESTS_TO_RETRY bind.expect
 
+# Set this var to modify behavior of the code being tests. Such as avoiding running
+# `fish_update_completions` when running tests.
+set -x FISH_UNIT_TESTS_RUNNING 1
+
 # Change to directory containing this script
 cd (dirname (status -f))
 

--- a/tests/test.fish
+++ b/tests/test.fish
@@ -4,6 +4,10 @@
 # should be running it via `make test` to ensure the environment is properly
 # setup.
 
+# Set this var to modify behavior of the code being tests. Such as avoiding running
+# `fish_update_completions` when running tests.
+set -x FISH_UNIT_TESTS_RUNNING 1
+
 # Change to directory containing this script
 cd (dirname (status -f))
 


### PR DESCRIPTION
Running `fish_update_completions` in unit tests is not needed and
hideously expensive. To the point it can cause flakey test behavior.
