### PR TITLE
Fix Wildcard Bug in Function `__fish_print_filesystems`

### DIFF
--- a/share/functions/__fish_print_filesystems.fish
+++ b/share/functions/__fish_print_filesystems.fish
@@ -5,5 +5,6 @@ function __fish_print_filesystems -d "Print a list of all known filesystem types
     set fs $fs reiserfs romfs smbfs sysv tmpfs udf ufs umsdos vfat xenix xfs xiafs
     # Mount has helper binaries to mount filesystems
     # These are called mount.* and are placed somewhere in $PATH
-    printf "%s\n" $fs (string replace -ra ".*/mount." "" -- $PATH/mount.*)
+    set -l mountfs $PATH/mount.*
+    printf '%s\n' $fs (string replace -ra '.*/mount.' '' -- $mountfs)
 end


### PR DESCRIPTION
👋 Hi,

this pull request includes a minor fix for the function `__fish_print_filesystems`. If I should change anything in the included commit, then please just comment below. 

As far as I can tell, the following items of the ToDo list are not really applicable to this PR:

- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed

. I am not sure about the following item though:

- [ ] User-visible changes noted in CHANGELOG.md

. Should I add an item about this minor bugfix in `CHANGELOG.md`?

Kind regards,
  René

By the way: I think I found a minor spelling mistake in `.github/PULL_REQUEST_TEMPLATE.md`:

> …in user documen**at**ion/manpages.

should probably be 

> …in user document**at**ion/manpages.

.

---

# Description

Before this change the function `__fish_print_filesystems` would print an error message about an empty wildcard match for the pattern `$PATH/mount.*`, if the current operating system does not include any helper binaries for the command `mount`. An example for such an OS is the current version of macOS (version 10.12).