### PR TITLE
Allow `export` to set colon-separated `PATH`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # fish 2.6.0 (released ???)
 
+- The `export` command now supports colon-separated `PATH`, `CDPATH` and `MANPATH`.
 - The `read` command now has a default limit of 10 MiB. If a line is longer than that it will fail with $status set to 122 and the var will be empty. You can set a different limit by setting the FISH_READ_BYTE_LIMIT variable.
 
 ---

--- a/share/functions/export.fish
+++ b/share/functions/export.fish
@@ -9,7 +9,12 @@ function export --description 'Set global variable. Alias for set -gx, made for 
             case 1
                 set -gx $v $$v
             case 2
-                set -gx $v[1] $v[2]
+                if contains -- $v[1] PATH CDPATH MANPATH
+                    set -l colonized_path (string replace -- "$$v[1]" (string join ":" -- $$v[1]) $v[2])
+                    set -gx $v[1] (string split ":" -- $colonized_path)
+                else
+                    set -gx $v[1] $v[2]
+                end
         end
     end
 end


### PR DESCRIPTION
## Description

The `export` function is purely for compatibility with Bash, so I think it makes sense to also allow exporting `PATH` with colons, in order to being able to have a global configuration across shells.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
