### PR TITLE
Use `string split` in `alias`.

### DIFF
--- a/share/functions/alias.fish
+++ b/share/functions/alias.fish
@@ -21,7 +21,7 @@ function alias --description 'Creates a function wrapping a command'
             end
             return 0
         case 1
-            set -l tmp (string replace -r "=" '\n' -- $argv) ""
+            set -l tmp (string split -m 1 "=" -- $argv) ""
             set name $tmp[1]
             set body $tmp[2]
 


### PR DESCRIPTION
## Description

Using `string split` rather than `string replace` makes more sense here.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md