### PR TITLE
Fix "mount -t" completions on non-Linux OSes

### DIFF
--- a/share/functions/__fish_print_filesystems.fish
+++ b/share/functions/__fish_print_filesystems.fish
@@ -5,6 +5,6 @@ function __fish_print_filesystems -d "Print a list of all known filesystem types
     set fs $fs reiserfs romfs smbfs sysv tmpfs udf ufs umsdos vfat xenix xfs xiafs
     # Mount has helper binaries to mount filesystems
     # These are called mount.* and are placed somewhere in $PATH
-    set -l mountfs $PATH/mount.*
-    printf '%s\n' $fs (string replace -ra '.*/mount.' '' -- $mountfs)
+    set -l mountfs $PATH/mount.* $PATH/mount_*
+    printf '%s\n' $fs (string replace -ra '.*/mount[._]' '' -- $mountfs)
 end


### PR DESCRIPTION

## Description

Talk about your changes here.

AFAICT Linux alone uses the "mount.XXX" convention for mount helpers.
Illumos, Irix, HPUX, OSX, and the BSDs all use "mount_XXX".  This commit
adds a configure-time check for which style of mount helper is
available.

Fixes issue #3841 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.md
