### PR TITLE
Enhance git repo for Robbyrussell prompt

### DIFF
--- a/share/tools/web_config/sample_prompts/robbyrussell.fish
+++ b/share/tools/web_config/sample_prompts/robbyrussell.fish
@@ -6,7 +6,12 @@ function fish_prompt
     if not set -q -g __fish_robbyrussell_functions_defined
         set -g __fish_robbyrussell_functions_defined
         function _git_branch_name
-            echo (git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+            set -l branch (git symbolic-ref --quiet HEAD ^/dev/null)
+            if test $branch
+                echo $branch | sed -e 's|^refs/heads/||'
+            else
+                echo (git rev-parse --short HEAD ^/dev/null)
+            end
         end
 
         function _is_git_dirty

--- a/share/tools/web_config/sample_prompts/robbyrussell.fish
+++ b/share/tools/web_config/sample_prompts/robbyrussell.fish
@@ -7,8 +7,8 @@ function fish_prompt
         set -g __fish_robbyrussell_functions_defined
         function _git_branch_name
             set -l branch (git symbolic-ref --quiet HEAD ^/dev/null)
-            if test $branch
-                echo $branch | sed -e 's|^refs/heads/||'
+            if set -q branch[1]
+                echo (string sub -s 12 $branch)
             else
                 echo (git rev-parse --short HEAD ^/dev/null)
             end

--- a/share/tools/web_config/sample_prompts/robbyrussell.fish
+++ b/share/tools/web_config/sample_prompts/robbyrussell.fish
@@ -8,7 +8,7 @@ function fish_prompt
         function _git_branch_name
             set -l branch (git symbolic-ref --quiet HEAD ^/dev/null)
             if set -q branch[1]
-                echo (string sub -s 12 $branch)
+                echo (string replace -r '^refs/heads/' '' $branch)
             else
                 echo (git rev-parse --short HEAD ^/dev/null)
             end


### PR DESCRIPTION
## Description

When I'm using Robbyrussell prompt and working on a git repo, it works well on branches, but if switch to certain commit, the shell outputs:
```
➜  some_dir git:()
``` 

It's blank. This PR solves the problem, for exmaple:
```
➜  some_dir git:(311468d)
``` 

## TODOs:
- [ ] Don't know much about how `hg` works if it's necessary to add the feature.
- [ ] Other prompts.
