### PR TITLE
Add repeat subcommand to builtin string

### DIFF
--- a/doc_src/string.txt
+++ b/doc_src/string.txt
@@ -15,6 +15,7 @@ string match [(-a | --all)] [(-i | --ignore-case)] [(-r | --regex)]
              [(-n | --index)] [(-q | --quiet)] [(-v | --invert)] PATTERN [STRING...]
 string replace [(-a | --all)] [(-i | --ignore-case)] [(-r | --regex)]
                [(-q | --quiet)] PATTERN REPLACEMENT [STRING...]
+string repeat [(-t | --times)] [(-n | --no-newline)] [(-q | --quiet)] [STRING...]
 \endfish
 
 
@@ -47,6 +48,8 @@ The following subcommands are available:
 - `match` tests each STRING against PATTERN and prints matching substrings. Only the first match for each STRING is reported unless `-a` or `--all` is given, in which case all matches are reported. Matching can be made case-insensitive with `-i` or `--ignore-case`. If `-n` or `--index` is given, each match is reported as a 1-based start position and a length. By default, PATTERN is interpreted as a glob pattern matched against each entire STRING argument. A glob pattern is only considered a valid match if it matches the entire STRING. If `-r` or `--regex` is given, PATTERN is interpreted as a Perl-compatible regular expression, which does not have to match the entire STRING. For a regular expression containing capturing groups, multiple items will be reported for each match, one for the entire match and one for each capturing group. If --invert or -v is used the selected lines will be only those which do not match the given glob pattern or regular expression.  Exit status: 0 if at least one match was found, or 1 otherwise.
 
 - `replace` is similar to `match` but replaces non-overlapping matching substrings with a replacement string and prints the result. By default, PATTERN is treated as a literal substring to be matched. If `-r` or `--regex` is given, PATTERN is interpreted as a Perl-compatible regular expression, and REPLACEMENT can contain C-style escape sequences like `\t` as well as references to capturing groups by number or name as `$n` or `${n}`. Exit status: 0 if at least one replacement was performed, or 1 otherwise.
+
+- `repeat` repeats the STRING `-t` or `--times` times. If `-n` or `--no-newline` is given, the output won't contain a newline character at the end. Exit status: 0 if yielded string is not empty, 1 otherwise.
 
 \subsection regular-expressions Regular Expressions
 
@@ -189,4 +192,14 @@ In general, special characters are special by default, so `a+` matches one or mo
 >_ string replace -r '\\s*newline\\s*' '\\n' 'put a newline here'
 <outp>put a</outp>
 <outp>here</outp>
+\endfish
+
+\subsection string-example-repeat Repeat Examples
+
+\fish{cli-dark}
+>_ string repeat -t 2 'string '
+<outp>string string</outp>
+
+>_ echo string | string repeat -t 2
+<outp>stringstring</outp>
 \endfish

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -950,12 +950,14 @@ static int string_split(parser_t &parser, io_streams_t &streams, int argc, wchar
 }
 
 static int string_repeat(parser_t &parser, io_streams_t &streams, int argc, wchar_t **argv) {
-	const wchar_t *short_options = L":t:q";
+	const wchar_t *short_options = L":t:nq";
 	const struct woption long_options[] = {{L"times", required_argument, 0, 't'},
+										   {L"no-newline", no_argument, 0, 'n'},
 										   {L"quiet", no_argument, 0, 'q'},
 										   {0, 0, 0, 0}};
 
 	bool quiet = false;
+	bool newline = true;
 	long times = 0;
 	wgetopter_t w;
 
@@ -979,6 +981,10 @@ static int string_repeat(parser_t &parser, io_streams_t &streams, int argc, wcha
 				string_error(streams, BUILTIN_ERR_NOT_NUMBER, argv[0], w.woptarg);
 				return BUILTIN_STRING_ERROR;
 			}
+			break;
+		}
+		case 'n': {
+			newline = false;
 			break;
 		}
 		case 'q': {
@@ -1023,9 +1029,12 @@ static int string_repeat(parser_t &parser, io_streams_t &streams, int argc, wcha
 
 		is_not_empty = !final_string.empty();
 
+		if (newline) {
+			final_string += L"\n";
+		}
+
 		if (!quiet && is_not_empty) {
 			streams.out.append(final_string);
-			streams.out.append(L"\n");
 		}
 	}
 	return is_not_empty ? BUILTIN_STRING_OK : BUILTIN_STRING_NONE;

--- a/tests/string.err
+++ b/tests/string.err
@@ -1,0 +1,5 @@
+string repeat: Invalid times value '-1'
+string repeat: Argument 'notanumber' is not a number
+string repeat: Too many arguments
+string repeat: Expected argument
+string repeat: Unknown option '-l'

--- a/tests/string.in
+++ b/tests/string.in
@@ -90,3 +90,32 @@ string match -r -v "[dcantg].*" dog can cat diz; or echo "no regexp invert match
 string match -v "???" dog can cat diz; or echo "no glob invert match"
 
 string match -rvn a bbb
+
+# test repeat subcommand
+string repeat -t 2 'string'
+
+string repeat --times 2 'string'
+
+echo string | string repeat -t 2
+
+string repeat -t2 -q 'string'; and echo "exit 0"
+
+string repeat -t2 --quiet 'string'; and echo "exit 0"
+
+string repeat -t0 'string'; or echo "exit 1"
+
+string repeat -t0; or echo "exit 1"
+
+string repeat -t1 -n 'there is '; echo "no newline"
+
+string repeat -t1 --no-newline 'there is '; echo "no newline"
+
+string repeat -t-1 'string'; or echo "exit 2"
+
+string repeat -t notanumber 'string'; or echo "exit 2"
+
+echo 'stdin' | string repeat -t1 'and arg'; or echo "exit 2"
+
+string repeat -t; or echo "exit 2"
+
+string repeat -l fakearg 2>&1 | head -n1 1>&2

--- a/tests/string.out
+++ b/tests/string.out
@@ -63,3 +63,16 @@ missing argument returns 0
 no regexp invert match
 no glob invert match
 1 3
+stringstring
+stringstring
+stringstring
+exit 0
+exit 0
+exit 1
+exit 1
+there is no newline
+there is no newline
+exit 2
+exit 2
+exit 2
+exit 2


### PR DESCRIPTION
I often use this well-known snippet to repeat a string and pipe it as input to other programs.
```fish
python -c 'print "A"*10'
AAAAAAAAAA
```
Not finding this very clean and idiomatic, i came up with a simple addition to the fish shell to replicate this functionnality out of the box.
```fish
string repeat -t10 A
AAAAAAAAAA
```

the subcommand can take two arguments:
-t, --times: number of times to repeat the string
-n, --no-newlines: choose whether we want to append a newline or not

Docs and integration tests are already included.
Let me know what you think.