### PR TITLE
Makefile.in to honor LINGUAS variable.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -195,11 +195,16 @@ ifeq ($(shell uname), Darwin)
 endif
 
 #
-# All translation message catalogs
+# All translation message catalogs, filter files based on LINGUAS.
 #
 TRANSLATIONS_SRC := $(wildcard po/*.po)
-ifdef HAVE_GETTEXT
+ifeq ($(HAVE_GETTEXT), 1)
 	TRANSLATIONS := $(TRANSLATIONS_SRC:.po=.gmo)
+ifdef LINGUAS
+	TRANSLATIONS_ALL := $(TRANSLATIONS)
+	TRANSLATIONS_WANTED = $(patsubst %,po/%.gmo,$(LINGUAS))
+	TRANSLATIONS = $(filter $(TRANSLATIONS_WANTED),$(TRANSLATIONS_ALL))
+endif
 else
 	TRANSLATIONS :=
 endif


### PR DESCRIPTION
## Description

An attempt to make fish Makefile honor LINGUAS variable.
I've considered adding a full blown Makefile to the po directory and using gettext po.m4 macro, but what's just insane amount of code and effort, so I found a much simpler solution.

Have not properly tested yet. I have access to couple of linux boxes, and latest osx sierra.
```make test``` runs fine, but I don't know if it covers this case.

Fixes issue #3863 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
