### PR TITLE
Make psub use `command cat` instead of `cat`

### DIFF
--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -64,14 +64,14 @@ function psub --description "Read from stdin into a file and output the filename
         or return
         set filename $dirname/psub.fifo"$suffix"
         mkfifo $filename
-        cat >$filename &
+        command cat >$filename &
     else if test -z $suffix
         set filename (mktemp "$TMPDIR[1]"/.psub.XXXXXXXXXX)
-        cat >$filename
+        command cat >$filename
     else
         set dirname (mktemp -d "$TMPDIR[1]"/.psub.XXXXXXXXXX)
         set filename $dirname/psub"$suffix"
-        cat >$filename
+        command cat >$filename
     end
 
     # Write filename to stdout


### PR DESCRIPTION
## Description

psub should use `command cat` instead of `cat`, see #3868.

Fixes issue #3868

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
