### PR TITLE
Fix error when using tmux with vi mode

### DIFF
--- a/share/functions/fish_vi_cursor.fish
+++ b/share/functions/fish_vi_cursor.fish
@@ -35,7 +35,10 @@ function fish_vi_cursor -d 'Set cursor shape for different vi modes'
             and begin set -q KONSOLE_PROFILE_NAME
                 or set -q ITERM_PROFILE
                 or set -q VTE_VERSION # which version is already checked above
-                or test (string replace -r "XTerm\((\d+)\)" '$1' -- $XTERM_VERSION) -ge 280
+                or begin
+                    set -q XTERM_VERSION
+                    and test (string replace -r "XTerm\((\d+)\)" '$1' -- $XTERM_VERSION) -ge 280
+                end
             end
             # .. unless an unsupporting terminal has been started in tmux inside a supporting one
             and begin string match -q "screen*" -- $TERM


### PR DESCRIPTION
## Description
I'm not sure when XTERM_VERSION is guarenteed to be defined, but it isn't when I use tmux in macOS so I added a check to ensure it is.

Fixes issue #3876

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md