### PR TITLE
Update index.hdr.in list keybindings for history

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -977,7 +977,7 @@ Some bindings are shared between emacs- and vi-mode because they aren't text edi
 
 - @key{Alt,&larr;,Left} and @key{Alt,&rarr;,Right} move the cursor one word left or right, or moves forward/backward in the directory history if the command line is empty. If the cursor is already at the end of the line, and an autosuggestion is available, @key{Alt,&rarr;,Right} (or @key{Alt,F}) accepts the first word in the suggestion.
 
-- @cursor_key{&uarr;,Up} and @cursor_key{&darr;,Down} search the command history for the previous/next command containing the string that was specified on the commandline before the search was started. If the commandline was empty when the search started, all commands match. See the <a href='#history'>history</a> section for more information on history searching.
+- @key{Control,P} and @key{Control,N}, or @cursor_key{&uarr;,Up} and @cursor_key{&darr;,Down} search the command history for the previous/next command containing the string that was specified on the commandline before the search was started. If the commandline was empty when the search started, all commands match. See the <a href='#history'>history</a> section for more information on history searching.
 
 - @key{Alt,&uarr;,Up} and @key{Alt,&darr;,Down} search the command history for the previous/next token containing the token under the cursor before the search was started. If the commandline was not on a token when the search started, all tokens match. See the <a href='#history'>history</a> section for more information on history searching.
 


### PR DESCRIPTION
## Additional keybinding mentioned 

There is still a discussion going on with  the Issue #288 and the keybindings I and others use are not mentioned in the documentation.

Adds to issue #288 

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [?] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md (does not apply?)
