### PR TITLE
include exit status indicator in robbyrussell sample prompt

### DIFF
--- a/share/tools/web_config/sample_prompts/robbyrussell.fish
+++ b/share/tools/web_config/sample_prompts/robbyrussell.fish
@@ -2,6 +2,7 @@
 # author: Bruno Ferreira Pinto, Pawel Zubrycki
 
 function fish_prompt
+    set -l __last_command_exit_status $status
 
     if not set -q -g __fish_robbyrussell_functions_defined
         set -g __fish_robbyrussell_functions_defined
@@ -58,12 +59,18 @@ function fish_prompt
     set -l cyan (set_color -o cyan)
     set -l yellow (set_color -o yellow)
     set -l red (set_color -o red)
+    set -l green (set_color -o green)
     set -l blue (set_color -o blue)
     set -l normal (set_color normal)
 
-    set -l arrow "$red➜ "
+    set -l arrow_color "$green"
+    if test $__last_command_exit_status != 0
+        set arrow_color "$red"
+    end
+
+    set -l arrow "$arrow_color➜ "
     if [ $USER = 'root' ]
-        set arrow "$red# "
+        set arrow "$arrow_color# "
     end
 
     set -l cwd $cyan(basename (prompt_pwd))


### PR DESCRIPTION
## Description
one piece of behaviour from the zsh version of this prompt that i sorely missed upon switching to fish is that the color of the arrow changes between green and red based on whether the exit status of the previous command was zero or non-zero, respectively. i'm still new to fish scripting, so there might be a better way to do it than how i've implemented it here, but it worked for me, and i wanted to make sure other people switching from zsh and the robbyrussell prompt would have an easier time of it, so here it is. i haven't added any changes to the shell itself, only to the sample prompt i use.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
