### PR TITLE
empty CDPATH elements are equivalent to "."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Completions for `helm` added (#3829).
 - Support for bracketed paste (#3871). This is unconditionally enabled since support seems to be ubiquitous.
 - When the current token has an open single-quote (`'`), fish will now escape any `'` and `\` in pasted text so that it can be used as a single token. Note that this requires either bracketed paste or use of the special `fish_clipboard_paste` function (bound to \cv by default).
+- Empty CDPATH elements are now equivalent to "." (#2106).
 
 ---
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1919,22 +1919,6 @@ scoped_rwlock::~scoped_rwlock() {
     }
 }
 
-wcstokenizer::wcstokenizer(const wcstring &s, const wcstring &separator)
-    : buffer(), str(), state(), sep(separator) {
-    buffer = wcsdup(s.c_str());
-    str = buffer;
-    state = NULL;
-}
-
-bool wcstokenizer::next(wcstring &result) {
-    wchar_t *tmp = wcstok(str, sep.c_str(), &state);
-    str = NULL;
-    if (tmp) result = tmp;
-    return tmp != NULL;
-}
-
-wcstokenizer::~wcstokenizer() { free(buffer); }
-
 template <typename CharType_t>
 static CharType_t **make_null_terminated_array_helper(
     const std::vector<std::basic_string<CharType_t> > &argv) {

--- a/src/common.h
+++ b/src/common.h
@@ -640,21 +640,6 @@ class scoped_push {
     }
 };
 
-/// Wrapper around wcstok.
-class wcstokenizer {
-    wchar_t *buffer, *str, *state;
-    const wcstring sep;
-
-    // No copying.
-    wcstokenizer &operator=(const wcstokenizer &);
-    wcstokenizer(const wcstokenizer &);
-
-   public:
-    wcstokenizer(const wcstring &s, const wcstring &separator);
-    bool next(wcstring &result);
-    ~wcstokenizer();
-};
-
 /// Appends a path component, with a / if necessary.
 void append_path_component(wcstring &path, const wcstring &component);
 

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -216,9 +216,10 @@ static bool is_potential_cd_path(const wcstring &path, const wcstring &working_d
         if (cdpath.missing_or_empty()) cdpath = L".";
 
         // Tokenize it into directories.
-        wcstokenizer tokenizer(cdpath, ARRAY_SEP_STR);
-        wcstring next_path;
-        while (tokenizer.next(next_path)) {
+        std::vector<wcstring> pathsv;
+        tokenize_variable_array(cdpath, pathsv);
+        for (auto next_path : pathsv) {
+            if (next_path.empty()) next_path = L".";
             // Ensure that we use the working directory for relative cdpaths like ".".
             directories.push_back(path_apply_working_directory(next_path, working_directory));
         }


### PR DESCRIPTION
In the process of fixing the issue I decided it didn't make sense to
have two, incompatible, ways of converting variable strings to arrays.
Especially since the one I'm removing does not return empty array elements.

Fixes #2106