### PR TITLE
Add "--list-modes" option to `bind`

### DIFF
--- a/doc_src/bind.txt
+++ b/doc_src/bind.txt
@@ -7,6 +7,7 @@ bind [(-M | --mode) MODE] [(-m | --sets-mode) NEW_MODE]
 bind [(-M | --mode) MODE] [(-k | --key)] SEQUENCE
 bind (-K | --key-names) [(-a | --all)]
 bind (-f | --function-names)
+bind (-L | --list-modes)
 bind (-e | --erase) [(-M | --mode) MODE]
      (-a | --all | [(-k | --key)] SEQUENCE [SEQUENCE...])
 \endfish
@@ -42,6 +43,8 @@ The following parameters are available:
 - `-K` or `--key-names` Display a list of available key names. Specifying `-a` or `--all` includes keys that don't have a known mapping
 
 - `-f` or `--function-names` Display a list of available input functions
+
+- `-L` or `--list-modes` Display a list of defined bind modes
 
 - `-M MODE` or `--mode MODE` Specify a bind mode that the bind is used in. Defaults to "default"
 

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -126,18 +126,14 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     #
     # See http://thejh.net/misc/website-terminal-copy-paste. The second case will not be caught in KDE konsole.
     # Bind the starting sequence in every bind mode, even user-defined ones.
-    # HACK: We introspect `bind` here to list all modes.
-    # Re-running `bind` multiple times per mode is still faster than trying to make the list unique,
-    # even without calling `sort -u` or `uniq`, for the vi-bindings.
-    # TODO: This can be solved better once #3872 is implemented.
 
     # We usually just pass the text through as-is to facilitate pasting code,
     # but when the current token contains an unbalanced single-quote (`'`),
     # we escape all single-quotes and backslashes, effectively turning the paste
     # into one literal token, to facilitate pasting non-code (e.g. markdown or git commitishes)
-    set -l allmodes default
-    set allmodes $allmodes (bind -a | string match -r -- '-M \w+' | string replace -- '-M ' '')
-    for mode in $allmodes
+
+    # Exclude paste mode or there'll be an additional binding after switching between emacs and vi
+    for mode in (bind --list-modes | string match -v paste)
         bind -M $mode -m paste \e\[200~ '__fish_start_bracketed_paste'
     end
     # This sequence ends paste-mode and returns to the previous mode we have saved before.

--- a/tests/bind.expect
+++ b/tests/bind.expect
@@ -41,6 +41,14 @@ expect_prompt -re {\r\nmno pqrt\r\n} {
     puts stderr "emacs transpose words fail, default timeout: long delay"
 }
 
+# Now test that exactly the expected bind modes are defined
+send "bind --list-modes\r"
+expect_prompt -re {\r\ndefault\r\npaste} {
+    puts "emacs bind modes"
+} unmatched {
+    puts stderr "Unexpected bind modes"
+}
+
 # Test vi key bindings.
 # This should leave vi mode in the insert state.
 send "set -g fish_key_bindings fish_vi_key_bindings\r"
@@ -145,6 +153,14 @@ expect_prompt -re {\r\nTENT\r\n} {
     puts stderr "t-binding fail"
 } unmatched {
     puts stderr "Couldn't find expected output 'TENT'"
+}
+
+# Now test that exactly the expected bind modes are defined
+send "bind --list-modes\r"
+expect_prompt -re {\r\ndefault\r\ninsert\r\npaste\r\nreplace-one\r\nvisual\r\n} {
+    puts "vi bind modes"
+} unmatched {
+    puts stderr "Unexpected vi bind modes"
 }
 
 # Switch back to regular (emacs mode) key bindings.

--- a/tests/bind.expect.out
+++ b/tests/bind.expect.out
@@ -1,6 +1,7 @@
 emacs transpose words, default timeout: no delay
 emacs transpose words, default timeout: short delay
 emacs transpose words, default timeout: long delay
+emacs bind modes
 prime vi mode, default timeout
 vi-mode default timeout set correctly
 vi replace line, default timeout: long delay
@@ -9,6 +10,7 @@ vi mode delete char, default timeout: long delay
 vi replace line, 100ms timeout: long delay
 vi replace line, 100ms timeout: short delay
 t-binding success
+vi bind modes
 default-mode custom timeout set correctly
 emacs transpose words, 100ms timeout: no delay
 emacs transpose words, 100ms timeout: short delay


### PR DESCRIPTION
## Description

As discussed in #3871, sometimes it's useful to list all bind modes.

Fixes issue #3872.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

------

Obviously this is a simple implementation - it would also be possible to cache the mode when a bind is added (which would necessitate invalidation when it is removed) or to completely change the data structure here. I've opted not to do that and instead iterate over all binds since it doesn't seem performance-critical.