### PR TITLE
Implement disown builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # fish 2.6.0 (released ???)
 
+## Notable fixes and improvements
+
+- Jobs running in the background can now be removed from the list of jobs with the new `disown` builtin, which behaves like the same command in other shells (#2810).
+
+## Other significant changes
+
 - The `export` and `setenv` commands now supports colon-separated `PATH`, `CDPATH` and `MANPATH`.
 - The `read` command now has a default limit of 10 MiB. If a line is longer than that it will fail with $status set to 122 and the var will be empty. You can set a different limit by setting the FISH_READ_BYTE_LIMIT variable.
 - `read` now supports the `--silent` flag to hide the characters typed (#838).

--- a/doc_src/disown.txt
+++ b/doc_src/disown.txt
@@ -1,0 +1,26 @@
+\section disown disown - remove a process from the list of jobs
+
+\subsection disown-synopsis Synopsis
+\fish{synopsis}
+disown [ PID ... ]
+\endfish
+
+\subsection disown-description Description
+
+`disown` removes the specified <a href="index.html#syntax-job-control">job</a> from the list of jobs. The job itself continues to exist, but fish does not keep track of it any longer.
+
+Jobs in the list of jobs are sent a hang-up signal when fish terminates, which usually causes the job to terminate; `disown` allows these processes to continue regardless.
+
+If no process is specified, the most recently-used job is removed (like `bg` and `fg`).  If one or more `PID`s are specified, jobs with the specified process IDs are removed from the job list. Invalid jobs are ignored and a warning is printed.
+
+If a job is stopped, it is sent a signal to continue running, and a warning is printed. It is not possible to use the `bg` builtin to continue a job once it has been disowned.
+
+The PID of the desired process is usually found by using <a href="index.html#expand-process">process expansion</a>, which can specify jobs or search by process name.
+
+`disown` returns 0 if all specified jobs were disowned successfully, and 1 if any problems were encountered.
+
+\subsection disown-example Example
+
+`firefox &; disown` will start the Firefox web browser in the background and remove it from the job list, meaning it will not be closed when the fish process is closed.
+
+`disown (jobs -p)` removes all jobs from the job list without terminating them.

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -4,7 +4,7 @@
 //
 // 1). Create a function in builtin.c with the following signature:
 //
-//     <tt>static int builtin_NAME( parser_t &parser, wchar_t ** args )</tt>
+//     <tt>static int builtin_NAME(parser_t &parser, io_streams_t &streams, wchar_t **argv)</tt>
 //
 // where NAME is the name of the builtin, and args is a zero-terminated list of arguments.
 //

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -128,6 +128,7 @@ wcstring event_get_desc(const event_t &e) {
             if (e.param1.pid > 0) {
                 result = format_string(_(L"exit handler for process %d"), e.param1.pid);
             } else {
+                // In events, PGIDs are stored as negative PIDs
                 job_t *j = job_get_from_pid(-e.param1.pid);
                 if (j)
                     result = format_string(_(L"exit handler for job %d, '%ls'"), j->job_id,
@@ -209,6 +210,7 @@ static wcstring event_desc_compact(const event_t &event) {
             } else if (event.param1.pid > 0) {
                 res = format_string(L"EVENT_EXIT(pid %d)", event.param1.pid);
             } else {
+                // In events, PGIDs are stored as negative PIDs
                 job_t *j = job_get_from_pid(-event.param1.pid);
                 if (j)
                     res = format_string(L"EVENT_EXIT(jobid %d: \"%ls\")", j->job_id,

--- a/src/event.h
+++ b/src/event.h
@@ -53,7 +53,7 @@ struct event_t {
     /// The type-specific parameter. The int types are one of the following:
     ///
     /// signal: Signal number for signal-type events.Use EVENT_ANY_SIGNAL to match any signal
-    /// pid: Process id for process-type events. Use EVENT_ANY_PID to match any pid.
+    /// pid: Process id for process-type events. Use EVENT_ANY_PID to match any pid. (Negative values are used for PGIDs).
     /// job_id: Job id for EVENT_JOB_ID type events
     union {
         int signal;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -569,8 +569,21 @@ job_t *parser_t::job_get(job_id_t id) {
 job_t *parser_t::job_get_from_pid(pid_t pid) {
     job_iterator_t jobs;
     job_t *job;
+
+    pid_t pgid = getpgid(pid);
+
+    if (pgid == -1) {
+        return 0;
+    }
+
     while ((job = jobs.next())) {
-        if (job->pgid == pid) return job;
+        if (job->pgid == pgid) {
+            for (const process_ptr_t &p : job->processes) {
+                if (p->pid == pid) {
+                    return job;
+                }
+            }
+        }
     }
     return 0;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -566,7 +566,7 @@ job_t *parser_t::job_get(job_id_t id) {
     return NULL;
 }
 
-job_t *parser_t::job_get_from_pid(int pid) {
+job_t *parser_t::job_get_from_pid(pid_t pid) {
     job_iterator_t jobs;
     job_t *job;
     while ((job = jobs.next())) {

--- a/src/parser.h
+++ b/src/parser.h
@@ -319,7 +319,7 @@ class parser_t {
     job_t *job_get(job_id_t job_id);
 
     /// Returns the job with the given pid.
-    job_t *job_get_from_pid(int pid);
+    job_t *job_get_from_pid(pid_t pid);
 
     /// Returns a new profile item if profiling is active. The caller should fill it in. The
     /// parser_t will clean it up.

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -101,7 +101,7 @@ bool set_child_group(job_t *j, process_t *p, int print_errors) {
             }
         }
     } else {
-        j->pgid = getpid();
+        j->pgid = getpgrp();
     }
 
     if (j->get_flag(JOB_TERMINAL) && j->get_flag(JOB_FOREGROUND)) {  //!OCLINT(early exit)

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -70,7 +70,8 @@ bool set_child_group(job_t *j, process_t *p, int print_errors) {
     bool retval = true;
 
     if (j->get_flag(JOB_CONTROL)) {
-        if (!j->pgid) {
+        // New jobs have the pgid set to -2
+        if (j->pgid == -2) {
             j->pgid = p->pid;
         }
 
@@ -322,10 +323,12 @@ bool fork_actions_make_spawn_properties(posix_spawnattr_t *attr,
     if (j->get_flag(JOB_CONTROL)) {
         should_set_process_group_id = true;
 
-        // PCA: I'm quite fuzzy on process groups, but I believe that the default value of 0 means
-        // that the process becomes its own group leader, which is what set_child_group did in this
-        // case. So we want this to be 0 if j->pgid is 0.
+        // set_child_group puts each job into its own process group
+        // do the same here if there is no PGID yet (i.e. PGID == -2)
         desired_process_group_id = j->pgid;
+        if (desired_process_group_id == -2 ) {
+            desired_process_group_id = 0;
+        }
     }
 
     // Set the handling for job control signals back to the default.

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -317,15 +317,15 @@ bool fork_actions_make_spawn_properties(posix_spawnattr_t *attr,
         return false;
     }
 
-    bool should_set_parent_group_id = false;
-    int desired_parent_group_id = 0;
+    bool should_set_process_group_id = false;
+    int desired_process_group_id = 0;
     if (j->get_flag(JOB_CONTROL)) {
-        should_set_parent_group_id = true;
+        should_set_process_group_id = true;
 
         // PCA: I'm quite fuzzy on process groups, but I believe that the default value of 0 means
         // that the process becomes its own group leader, which is what set_child_group did in this
         // case. So we want this to be 0 if j->pgid is 0.
-        desired_parent_group_id = j->pgid;
+        desired_process_group_id = j->pgid;
     }
 
     // Set the handling for job control signals back to the default.
@@ -338,13 +338,13 @@ bool fork_actions_make_spawn_properties(posix_spawnattr_t *attr,
     short flags = 0;
     if (reset_signal_handlers) flags |= POSIX_SPAWN_SETSIGDEF;
     if (reset_sigmask) flags |= POSIX_SPAWN_SETSIGMASK;
-    if (should_set_parent_group_id) flags |= POSIX_SPAWN_SETPGROUP;
+    if (should_set_process_group_id) flags |= POSIX_SPAWN_SETPGROUP;
 
     int err = 0;
     if (!err) err = posix_spawnattr_setflags(attr, flags);
 
-    if (!err && should_set_parent_group_id)
-        err = posix_spawnattr_setpgroup(attr, desired_parent_group_id);
+    if (!err && should_set_process_group_id)
+        err = posix_spawnattr_setpgroup(attr, desired_process_group_id);
 
     // Everybody gets default handlers.
     if (!err && reset_signal_handlers) {

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -362,8 +362,13 @@ process_t::process_t()
 {
 }
 
+/// The constructor sets the pgid to -2 as a sentinel value
+/// 0 should not be used; although it is not a valid PGID in userspace,
+///   the Linux kernel will use it for kernel processes.
+/// -1 should not be used; it is a possible return value of the getpgid()
+///   function
 job_t::job_t(job_id_t jobid, const io_chain_t &bio)
-    : block_io(bio), pgid(0), tmodes(), job_id(jobid), flags(0) {}
+    : block_io(bio), pgid(-2), tmodes(), job_id(jobid), flags(0) {}
 
 job_t::~job_t() { release_job_id(job_id); }
 

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -244,10 +244,10 @@ void job_t::set_flag(job_flag_t flag, bool set) {
 bool job_t::get_flag(job_flag_t flag) const { return !!(this->flags & flag); }
 
 int job_signal(job_t *j, int signal) {
-    pid_t my_pid = getpid();
+    pid_t my_pgid = getpgrp();
     int res = 0;
 
-    if (j->pgid != my_pid) {
+    if (j->pgid != my_pgid) {
         res = killpg(j->pgid, signal);
     } else {
         for (const process_ptr_t &p : j->processes) {

--- a/src/proc.h
+++ b/src/proc.h
@@ -217,6 +217,7 @@ class job_t {
     process_list_t processes;
 
     /// Process group ID for the process group that this job is running in.
+    /// Set to a nonexistent, non-return-value of getpgid() integer by the constructor
     pid_t pgid;
     /// The saved terminal modes of this job. This needs to be saved so that we can restore the
     /// terminal to the same state after temporarily taking control over the terminal when a job

--- a/tests/jobs.err
+++ b/tests/jobs.err
@@ -1,3 +1,4 @@
 bg: '-23' is not a valid job specifier
 fg: No suitable job: 3
 bg: Could not find job '3'
+disown: 'foo' is not a valid job specifier

--- a/tests/jobs.in
+++ b/tests/jobs.in
@@ -4,4 +4,9 @@ jobs -c
 bg -23 1
 fg 3
 bg 3
+sleep 1 &
+disown
+jobs -c
+disown foo
+disown (jobs -p)
 or exit 0

--- a/tests/jobs.out
+++ b/tests/jobs.out
@@ -1,3 +1,6 @@
 Command
 sleep
 sleep
+Command
+sleep
+sleep


### PR DESCRIPTION
This is an initial attempt at implementing a disown builtin (closing #2810 and multiple duplicates).

It is very simplistic; there is no attempt to manipulate signals and I'm not sure if this is required.

Mirroring zsh and bash, jobs that are not under job control can still be disowned.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
