### PR TITLE
Improvements to type.fish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - The `functions --metadata --verbose` output now includes the function description (#597).
 - Completions for `helm` added (#3829).
 - Empty CDPATH elements are now equivalent to "." (#2106).
+- `type` no longer needs the external command `which`, so it can be removed from dependencies.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Completions for `helm` added (#3829).
 - Empty CDPATH elements are now equivalent to "." (#2106).
 - `type` no longer needs the external command `which`, so it can be removed from dependencies.
+- `type`s option parser has been rewritten, improving performance for `type -q` by about 60%.
 
 ---
 

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -102,9 +102,15 @@ function type --description 'Print the type of a command'
             set paths (command -s -- $i)
         else
             # TODO: This should really be `command -sa`.
-            for file in $PATH/$i
-                test -x $file
-                and set paths $paths $file
+            for p in $PATH
+                # For compatibility with other utilities,
+                # an empty path component is equal to $PWD.
+                test -z "$p"
+                and set p "$PWD"
+                for file in $p/$i
+                    test -x $file -a ! -d $file
+                    and set paths $paths $file
+                end
             end
         end
         for path in $paths

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -123,7 +123,11 @@ function type --description "Print the type of a command"
         if test $multi != yes
             set paths (command -s -- $i)
         else
-            set paths (command which -a -- $i ^/dev/null)
+            # TODO: This should really be `command -sa`.
+            for file in $PATH/$i
+                test -x $file
+                and set paths $paths $file
+            end
         end
         for path in $paths
             set res 0

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -62,7 +62,6 @@ function type --description 'Print the type of a command'
         set -l found 0
 
         if test $selection != files
-
             if functions -q -- $i
                 set res 0
                 set found 1
@@ -83,7 +82,6 @@ function type --description 'Print the type of a command'
             end
 
             if contains -- $i (builtin -n)
-
                 set res 0
                 set found 1
                 switch $mode
@@ -97,7 +95,6 @@ function type --description 'Print the type of a command'
                     continue
                 end
             end
-
         end
 
         set -l paths
@@ -116,10 +113,8 @@ function type --description 'Print the type of a command'
             switch $mode
                 case normal
                     printf (_ '%s is %s\n') $i $path
-
                 case type
                     echo (_ 'file')
-
                 case path
                     echo $path
             end
@@ -128,13 +123,10 @@ function type --description 'Print the type of a command'
             end
         end
 
-        if begin
-                test $found = 0
-                and test $mode != quiet
-            end
+        if test $found = 0
+            and test $mode != quiet
             printf (_ "%s: Could not find '%s'\n") type $i >&2
         end
-
     end
 
     return $res


### PR DESCRIPTION
## Description

This removes the need for `which` (by doing it in fish-script) and improves performance (by removing a call to `seq`). Additionally I (as an impartial and completely unbiased observer) find the code easier to read.

There should be one functional change - invalid options are now reported, instead of interpreted as a command to check.

Otherwise, everything should be a bit faster (60% for `type -q`, as determined by `for i in (seq 1 1000); type -q type; end`) but produce the same results.

@zanchey: Should this be reported to packagers somewhere? I know at least the arch package has a `which` dependency that can now be removed.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
