### PR TITLE
Failglob woes: Recommend quoting

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -1778,8 +1778,8 @@ msgstr "Illegal file descriptor in redirection “%ls”"
 
 #: parse_constants.h:213
 #, c-format
-msgid "No matches for wildcard '%ls'."
-msgstr "No matches for wildcard “%ls”."
+msgid "No matches for wildcard pattern '%ls'. See `help expand`."
+msgstr "No matches for wildcard pattern “%ls”. See `help expand`."
 
 #: parse_constants.h:216
 msgid "break command while not inside of loop"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,0 +1,17 @@
+# fish - the friendly interactive shell
+# Copyright © 2017
+# This file is distributed under the same license as the fish package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: fish 2.5.0\n"
+"Last-Translator: Andreas Nordal <andreas.nordal_4@hotmail.com>\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: parse_constants.h:213
+#, c-format
+msgid "No matches for wildcard pattern '%ls'. See `help expand`."
+msgstr "Ingen treff for jokertegnmønster «%ls» Se `help expand`."

--- a/po/nn.po
+++ b/po/nn.po
@@ -1,0 +1,17 @@
+# fish - the friendly interactive shell
+# Copyright © 2017
+# This file is distributed under the same license as the fish package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: fish 2.5.0\n"
+"Last-Translator: Andreas Nordal <andreas.nordal_4@hotmail.com>\n"
+"Language: nn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: parse_constants.h:213
+#, c-format
+msgid "No matches for wildcard pattern '%ls'. See `help expand`."
+msgstr "Inkje treff for jokerteiknmønster «%ls» Sjå `help expand`."

--- a/po/sv.po
+++ b/po/sv.po
@@ -1793,8 +1793,8 @@ msgstr "Ogiltig filidentifierare '%ls'"
 
 #: parse_constants.h:213
 #, c-format
-msgid "No matches for wildcard '%ls'."
-msgstr ""
+msgid "No matches for wildcard pattern '%ls'. See `help expand`."
+msgstr "Ingen träff för jokerteckenmönster '%ls' Se `help expand`."
 
 #: parse_constants.h:216
 #, fuzzy

--- a/src/parse_constants.h
+++ b/src/parse_constants.h
@@ -245,9 +245,7 @@ void parse_error_offset_source_start(parse_error_list_t *errors, size_t amt);
 #define ILLEGAL_FD_ERR_MSG _(L"Illegal file descriptor in redirection '%ls'")
 
 /// Error message for wildcards with no matches.
-#define WILDCARD_ERR_MSG                                                                     \
-    _(L"No matches for wildcard '%ls'.  (Tip: empty matches are allowed in 'set', 'count', " \
-      L"'for'.)")
+#define WILDCARD_ERR_MSG _(L"No matches for wildcard pattern '%ls'. See `help expand`.")
 
 /// Error when using break outside of loop.
 #define INVALID_BREAK_ERR_MSG _(L"'break' while not inside of loop")

--- a/src/parse_tree.cpp
+++ b/src/parse_tree.cpp
@@ -29,7 +29,8 @@ static bool production_is_empty(const production_element_t *production) {
 /// Returns a string description of this parse error.
 wcstring parse_error_t::describe_with_prefix(const wcstring &src, const wcstring &prefix,
                                              bool is_interactive, bool skip_caret) const {
-    wcstring result = text;
+    wcstring result = prefix;
+    result.append(this->text);
 
     if (skip_caret || source_start >= src.size() || source_start + source_length > src.size()) {
         return result;
@@ -72,16 +73,14 @@ wcstring parse_error_t::describe_with_prefix(const wcstring &src, const wcstring
     if (!result.empty()) {
         result.push_back(L'\n');
     }
-    result.append(prefix);
     result.append(src, line_start, line_end - line_start);
 
     // Append the caret line. The input source may include tabs; for that reason we
     // construct a "caret line" that has tabs in corresponding positions.
-    const wcstring line_to_measure = prefix + wcstring(src, line_start, source_start - line_start);
     wcstring caret_space_line;
     caret_space_line.reserve(source_start - line_start);
-    for (size_t i = 0; i < line_to_measure.size(); i++) {
-        wchar_t wc = line_to_measure.at(i);
+    for (size_t i = line_start; i < source_start; i++) {
+        wchar_t wc = src.at(i);
         if (wc == L'\t') {
             caret_space_line.push_back(L'\t');
         } else if (wc == L'\n') {

--- a/tests/expansion.err
+++ b/tests/expansion.err
@@ -1,33 +1,33 @@
-Array index out of bounds
-fish: show "$foo[2]"
-                 ^
-Array index out of bounds
-fish: show $foo[2]
-                ^
-Array index out of bounds
-fish: show "$foo[1 2]"
-                   ^
-Array index out of bounds
-fish: show $foo[1 2]
-                  ^
-Array index out of bounds
-fish: show "$foo[2 1]"
-                 ^
-Array index out of bounds
-fish: show $foo[2 1]
-                ^
-Invalid index value
-fish: echo "$foo[d]"
-                 ^
-Invalid index value
-fish: echo $foo[d]
-                ^
-Array index out of bounds
-fish: echo ()[1]
-              ^
-Invalid index value
-fish: echo ()[d]
-              ^
-$) is not a valid variable in fish.
-fish: echo $$paren
+fish: Array index out of bounds
+show "$foo[2]"
+           ^
+fish: Array index out of bounds
+show $foo[2]
+          ^
+fish: Array index out of bounds
+show "$foo[1 2]"
+             ^
+fish: Array index out of bounds
+show $foo[1 2]
             ^
+fish: Array index out of bounds
+show "$foo[2 1]"
+           ^
+fish: Array index out of bounds
+show $foo[2 1]
+          ^
+fish: Invalid index value
+echo "$foo[d]"
+           ^
+fish: Invalid index value
+echo $foo[d]
+          ^
+fish: Array index out of bounds
+echo ()[1]
+        ^
+fish: Invalid index value
+echo ()[d]
+        ^
+fish: $) is not a valid variable in fish.
+echo $$paren
+      ^

--- a/tests/function.err
+++ b/tests/function.err
@@ -1,9 +1,9 @@
-function: Illegal function name '-a'
-fish: function -a arg1 arg2 name2 ; end
-      ^
-function: Illegal function name '--argument-names'
-fish: function --argument-names arg1 arg2 name4 ; end
-      ^
-function: Unexpected positional argument 'abc'
-fish: function name5 abc --argument-names def ; end
-      ^
+fish: function: Illegal function name '-a'
+function -a arg1 arg2 name2 ; end
+^
+fish: function: Illegal function name '--argument-names'
+function --argument-names arg1 arg2 name4 ; end
+^
+fish: function: Unexpected positional argument 'abc'
+function name5 abc --argument-names def ; end
+^

--- a/tests/test5.err
+++ b/tests/test5.err
@@ -1,3 +1,3 @@
-fish: No matches for wildcard '*ee*'.  (Tip: empty matches are allowed in 'set', 'count', 'for'.)
+fish: No matches for wildcard pattern '*ee*'. See `help expand`.
 	case *ee*
 	     ^

--- a/tests/test5.err
+++ b/tests/test5.err
@@ -1,3 +1,3 @@
-No matches for wildcard '*ee*'.  (Tip: empty matches are allowed in 'set', 'count', 'for'.)
-fish: 	case *ee*
-      	     ^
+fish: No matches for wildcard '*ee*'.  (Tip: empty matches are allowed in 'set', 'count', 'for'.)
+	case *ee*
+	     ^

--- a/tests/test9.err
+++ b/tests/test9.err
@@ -1,7 +1,7 @@
 emit: expected event name
-Missing end to balance this begin
-Missing end to balance this while loop
-Missing end to balance this for loop
-Missing end to balance this switch statement
-Missing end to balance this function definition
-Missing end to balance this if statement
+- (line 1): Missing end to balance this begin
+- (line 1): Missing end to balance this while loop
+- (line 1): Missing end to balance this for loop
+- (line 1): Missing end to balance this switch statement
+- (line 1): Missing end to balance this function definition
+- (line 1): Missing end to balance this if statement

--- a/tests/vars_as_commands.err
+++ b/tests/vars_as_commands.err
@@ -1,6 +1,6 @@
-Variables may not be used as commands. In fish, please define a function or use 'eval $test'.
-fish: exec $test
-           ^
-Variables may not be used as commands. In fish, please define a function or use 'eval "$test"'.
-fish: exec "$test"
-           ^
+fish: Variables may not be used as commands. In fish, please define a function or use 'eval $test'.
+exec $test
+     ^
+fish: Variables may not be used as commands. In fish, please define a function or use 'eval "$test"'.
+exec "$test"
+     ^


### PR DESCRIPTION
## Description

The first commit moves the prefix part of all error messages. This is to resolve doubt about where the first part of the message comes from; the second part is the context, so that says itself.

The second commit changes the wildcard error message. Apologies for breaking all the translations, I have contributed the ones I can.

Fixes issue #3649 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
