### PR TITLE
Also give subshells the terminal

### DIFF
--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -1268,7 +1268,7 @@ parse_execution_result_t parse_execution_context_t::run_1_job(const parse_node_t
 
     job->set_flag(JOB_FOREGROUND, !tree.job_should_be_backgrounded(job_node));
 
-    job->set_flag(JOB_TERMINAL, job->get_flag(JOB_CONTROL) && !is_subshell && !is_event);
+    job->set_flag(JOB_TERMINAL, job->get_flag(JOB_CONTROL) && !is_event);
 
     job->set_flag(JOB_SKIP_NOTIFICATION,
                   is_subshell || is_block || is_event || !shell_is_interactive());


### PR DESCRIPTION
## Description

It turns out the reason `fzf` et al don't work in command substitutions (for some reason known as "subshells" in this part of the code) is that we don't give them the JOB_TERMINAL flag, which means we don't hand control of the terminal to their process group.

This is likely to need more testing.

Things I've tested so far:

- `echo -s x(git branch | fzf | string trim)x` (which would previously hang)

- `echo (cat)` (which would print a newline and leave a stopped cat)

Also `sudo` and `percol`.

Fixes issue #1362.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
