### PR TITLE
Bg arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `type` now no longer requires `which`, which means fish no longer uses it anywhere. Packagers should remove the dependency (#3912).
 - Using symbolic permissions with the `umask` command now works (#738).
 - Command substitutions now have access to the terminal, allowing tools like `fzf` to work in them (#1362, #3922).
+- `bg`s argument parsing has been reworked. It now fails for invalid arguments but allows non-existent jobs (#3909).
 
 ---
 

--- a/doc_src/bg.txt
+++ b/doc_src/bg.txt
@@ -11,7 +11,17 @@ bg [PID...]
 
 The PID of the desired process is usually found by using <a href="index.html#expand-process">process expansion</a>.
 
+When at least one of the arguments isn't a valid job specifier (i.e. PID),
+`bg` will print an error without backgrounding anything.
+
+When all arguments are valid job specifiers, bg will background all matching jobs that exist.
 
 \subsection bg-example Example
 
 `bg %1` will put the job with job ID 1 in the background.
+
+`bg 123 456 789` will background 123, 456 and 789.
+
+If only 123 and 456 exist, it will still background them and not print an error about 789.
+
+`bg 123 banana` or `bg banana 123` will complain that "banana" is not a valid job specifier.

--- a/doc_src/bg.txt
+++ b/doc_src/bg.txt
@@ -22,6 +22,6 @@ When all arguments are valid job specifiers, bg will background all matching job
 
 `bg 123 456 789` will background 123, 456 and 789.
 
-If only 123 and 456 exist, it will still background them and not print an error about 789.
+If only 123 and 789 exist, it will still background them and print an error about 456.
 
 `bg 123 banana` or `bg banana 123` will complain that "banana" is not a valid job specifier.

--- a/tests/jobs.err
+++ b/tests/jobs.err
@@ -1,2 +1,3 @@
 bg: '-23' is not a valid job specifier
 fg: No suitable job: 3
+bg: Could not find job '3'

--- a/tests/jobs.err
+++ b/tests/jobs.err
@@ -1,2 +1,2 @@
-bg: '3' is not a job
+bg: '-23' is not a valid job specifier
 fg: No suitable job: 3

--- a/tests/jobs.in
+++ b/tests/jobs.in
@@ -1,6 +1,7 @@
-sleep 1 &
-sleep 1 &
+sleep 5 &
+sleep 5 &
 jobs -c
-bg 3
+bg -23 1
 fg 3
+bg 3
 or exit 0


### PR DESCRIPTION
## Description

As discussed in #3909, `bg` currently backgrounds all jobs up to the first failing one, which makes it weirdly ordering-dependent.

This changes it so it fails when any invalid (i.e. couldn't possibly be a PID) arguments are given, but allows non-existent jobs without failing.

This means after bg has finished, it either errored without doing anything, or all jobs are backgrounded or finished.

Fixes issue #3909.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
