### PR TITLE
Fix deprecated flags in `history` example in docs

### DIFF
--- a/doc_src/history.txt
+++ b/doc_src/history.txt
@@ -49,13 +49,13 @@ These flags can appear before or immediately after one of the sub-commands liste
 \subsection history-examples Example
 
 \fish
-history --clear
+history clear
 # Deletes all history items
 
-history --search --contains "foo"
+history search --contains "foo"
 # Outputs a list of all previous commands containing the string "foo".
 
-history --delete --prefix "foo"
+history delete --prefix "foo"
 # Interactively deletes commands which start with "foo" from the history.
 # You can select more than one entry by entering their IDs seperated by a space.
 \endfish


### PR DESCRIPTION
## Description

Update the Example section in the documentation for the `history` command so that it uses the subcommands instead of the deprecated long options.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] (N/A) Changes to fish usage are reflected in user documentation/manpages.
- [X] (N/A) Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

Is this small change worth noting in CHANGELOG.md? I see only one similar previous entry in the change log, “Multiple documentation updates” with fish 2.3.0.