### PR TITLE
Don't move when delete-key is pressed in emacs-mode

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -118,10 +118,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -M insert -k end end-of-line 2>/dev/null
     bind -M default -k end end-of-line 2>/dev/null
 
-    bind -M default x delete-char
+    bind -M default x delete-char or backward-char
     bind -M default X backward-delete-char
-    bind -M insert -k dc delete-char
-    bind -M default -k dc delete-char
+    bind -M insert -k dc delete-char or backward-char
+    bind -M default -k dc delete-char or backward-char
 
     # Backspace deletes a char in insert mode, but not in normal/default mode.
     bind -M insert -k backspace backward-delete-char

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -118,10 +118,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -M insert -k end end-of-line 2>/dev/null
     bind -M default -k end end-of-line 2>/dev/null
 
-    bind -M default x delete-char or backward-char
+    bind -M default x delete-char backward-char
     bind -M default X backward-delete-char
-    bind -M insert -k dc delete-char or backward-char
-    bind -M default -k dc delete-char or backward-char
+    bind -M insert -k dc delete-char backward-char
+    bind -M default -k dc delete-char backward-char
 
     # Backspace deletes a char in insert mode, but not in normal/default mode.
     bind -M insert -k backspace backward-delete-char

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -110,6 +110,7 @@ static const wchar_t *const name_arr[] = {L"beginning-of-line",
                                           L"kill-selection",
                                           L"forward-jump",
                                           L"backward-jump",
+                                          L"or",
                                           L"and",
                                           L"cancel"};
 
@@ -174,6 +175,7 @@ static const wchar_t code_arr[] = {R_BEGINNING_OF_LINE,
                                    R_KILL_SELECTION,
                                    R_FORWARD_JUMP,
                                    R_BACKWARD_JUMP,
+                                   R_OR,
                                    R_AND,
                                    R_CANCEL};
 
@@ -521,8 +523,10 @@ wint_t input_readch(bool allow_commands) {
                     // common case is that this will be empty.
                     return input_read_characters_only();
                 }
+                case R_OR:
                 case R_AND: {
-                    if (input_function_status) {
+                    if ((input_function_status && c == R_AND)
+                        || (!input_function_status && c == R_OR)) {
                         return input_readch();
                     }
                     c = input_common_readch(0);

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -70,6 +70,7 @@ enum {
     R_KILL_SELECTION,
     R_FORWARD_JUMP,
     R_BACKWARD_JUMP,
+    R_OR,
     R_AND,
     R_CANCEL,
     R_TIMEOUT,  // we didn't get interactive input within wait_on_escape_ms

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2696,13 +2696,18 @@ const wchar_t *reader_readline(int nchars) {
                 // Remove the current character in the character buffer and on the screen using
                 // syntax highlighting, etc.
                 editable_line_t *el = data->active_edit_line();
+                // Return true if there was something to delete,
+                // false if the cursor was at the end of the line.
+                bool status = false;
                 if (el->position < el->size()) {
                     update_buff_pos(el, el->position + 1);
                     remove_backward();
                     if (el->position > 0 && el->position == el->size()) {
                         update_buff_pos(el, el->position - 1);
                     }
+                    status = true;
                 }
+                input_function_set_status(status);
                 break;
             }
             // Evaluate. If the current command is unfinished, or if the charater is escaped using a

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2702,9 +2702,6 @@ const wchar_t *reader_readline(int nchars) {
                 if (el->position < el->size()) {
                     update_buff_pos(el, el->position + 1);
                     remove_backward();
-                    if (el->position > 0 && el->position == el->size()) {
-                        update_buff_pos(el, el->position - 1);
-                    }
                     status = true;
                 }
                 input_function_set_status(status);


### PR DESCRIPTION
## Description

As was discussed in #3899, it's weird that delete would move the cursor in emacs-mode, while it is what vi does.

This makes it so

- `delete-char` no longer additionally moves the cursor

- Instead, it returns a status

- This status is then used, via a newly introduced "or" bind function, to script the previous behavior in vi-mode

- emacs-mode is left with the simple behavior

Fixes issue #3899.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Has been tested by vi-users - especially the other functions that use "delete-char" - I'm not sure if they previously did the right thing
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
