### PR TITLE
Workaround su

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -831,9 +831,11 @@ void env_init(const struct config_paths_t *paths /* or NULL */) {
     env_read_only.insert(L"SHLVL");
 
     // Set up the HOME variable.
-    // As with $USER, some su implementations pass this along
-    // if the target user is root. Work around that.
-    if (env_get_string(L"HOME").missing_or_empty() || uid == 0) {
+    // Unlike $USER, it doesn't seem that `su`s pass this along
+    // if the target user is root, unless "--preserve-environment" is used.
+    // Since that is an explicit choice, we should allow it to enable e.g.
+    //     env HOME=(mktemp -d) su --preserve-environment fish
+    if (env_get_string(L"HOME").missing_or_empty()) {
         struct passwd *pw = getpwuid(uid);
         // If pw is NULL, there's not much we can do here.
         assert(pw != NULL);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -803,7 +803,14 @@ void env_init(const struct config_paths_t *paths /* or NULL */) {
 
     // Set up the USER and PATH variables
     setup_path();
-    setup_user(false);
+
+    // Some `su`s keep $USER (and $HOME)
+    // when changing to root.
+    // This leads to issues later on (and e.g. in prompts),
+    // so we work around it by resetting $USER.
+    // TODO: Figure out if that su actually checks if username == "root"(as the man page says) or UID == 0.
+    uid_t uid = getuid();
+    setup_user(uid == 0);
 
     // Set up the version variable.
     wcstring version = str2wcstring(get_fish_version());
@@ -824,7 +831,9 @@ void env_init(const struct config_paths_t *paths /* or NULL */) {
     env_read_only.insert(L"SHLVL");
 
     // Set up the HOME variable.
-    if (env_get_string(L"HOME").missing_or_empty()) {
+    // As with $USER, some su implementations pass this along
+    // if the target user is root. Work around that.
+    if (env_get_string(L"HOME").missing_or_empty() || uid == 0) {
         const env_var_t unam = env_get_string(L"USER");
         char *unam_narrow = wcs2str(unam.c_str());
         struct passwd *pw = getpwnam(unam_narrow);


### PR DESCRIPTION
## Description

As we've seen, some `su`s keep $USER and $HOME if the target user is root (I'm assuming that means uid == 0, so `su toor` would also be affected).

Since this seems to be the only case where $USER points to an existing but wrong user, we work around this explicit case by force-initializing $USER and $HOME.

Fixes issue #3916.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

I'd like to see this tested on a system with multiple uid 0 users (e.g. the above-mentioned "toor").