### PR TITLE
Drop "which" dependency completely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Completions for `helm` added (#3829).
 - Empty CDPATH elements are now equivalent to "." (#2106).
 - The `read` command now accepts simple strings for the prompt rather than fish script via the new `-P` and `--prompt-str` flags (#802).
-- `type` now no longer requires `which`, which means fish no longer uses it anywhere. Packagers should remove the dependency (#3912).
+- `type` now no longer requires `which`, which means it is no longer a runtime dependency (#3912).
 - Using symbolic permissions with the `umask` command now works (#738).
 - Command substitutions now have access to the terminal, allowing tools like `fzf` to work in them (#1362, #3922).
 - `bg`s argument parsing has been reworked. It now fails for invalid arguments but allows non-existent jobs (#3909).

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_SUBST(EXTRA_PCRE2)
 AC_MSG_CHECKING([if autoreconf needs to be run])
 if test configure -ot configure.ac; then
   AC_MSG_RESULT([yes])
-  if which autoreconf >/dev/null; then
+  if command -v autoreconf >/dev/null; then
     # No need to provide any error messages if autoreconf fails, the
     # shell and autconf should take care of that themselves
     AC_MSG_NOTICE([running autoreconf --no-recursive])
@@ -68,7 +68,7 @@ fi
 AC_MSG_CHECKING([if autoheader needs to be run])
 if test ! -f ./config.h.in -o config.h.in -ot configure.ac; then
   AC_MSG_RESULT([yes])
-  if which autoheader >/dev/null; then
+  if command -v autoheader >/dev/null; then
     AC_MSG_NOTICE([running autoheader])
     autoheader || exit 1
   else

--- a/share/completions/mutt.fish
+++ b/share/completions/mutt.fish
@@ -1,4 +1,4 @@
-if which abook >/dev/null ^/dev/null
+if command -sq abook
     complete -c mutt -f -a '(__fish_print_abook_emails)'
     complete -c mutt -s c -x -d 'Specify a carbon-copy (CC) recipient' -a '(__fish_print_abook_emails)'
     complete -c mutt -s b -x -d 'Specify a blind-carbon-copy (BCC) recipient' -a '(__fish_print_abook_emails)'


### PR DESCRIPTION
## Description

I've already dropped some uses of which in #3912, but erroneously assumed that'd be all of them.

@zanchey: This is using `command -v` in configure.ac, which [according to POSIX](http://pubs.opengroup.org/onlinepubs/009696899/utilities/command.html) also prints functions and builtins. I'm assuming we don't care about systems that have an "autoreconf" or "autoheader" function but not command.

Also, is there anything more we need to do to inform packagers?

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md - I'll adjust this later to include a reference to this PR.
