### PR TITLE
feature: Capture read command contents without displaying it with the silent flag

### DIFF
--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -1976,9 +1976,9 @@ static int builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **arg
 
 /// Read from the tty. This is only valid when the stream is stdin and it is attached to a tty and
 /// we weren't asked to split on null characters.
-static int read_interactive(wcstring &buff, int nchars, bool shell, const wchar_t *mode_name,
-                            const wchar_t *prompt, const wchar_t *right_prompt,
-                            const wchar_t *commandline) {
+static int read_interactive(wcstring &buff, int nchars, bool shell, bool silent,
+                            const wchar_t *mode_name, const wchar_t *prompt,
+                            const wchar_t *right_prompt, const wchar_t *commandline) {
     int exit_res = STATUS_BUILTIN_OK;
     const wchar_t *line;
 
@@ -1994,6 +1994,7 @@ static int read_interactive(wcstring &buff, int nchars, bool shell, const wchar_
     reader_set_allow_autosuggesting(false);
     reader_set_expand_abbreviations(false);
     reader_set_exit_on_interrupt(true);
+    reader_set_silent_status(silent);
 
     reader_set_buffer(commandline, wcslen(commandline));
     proc_push_interactive(1);
@@ -2137,9 +2138,10 @@ static int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv)
     int nchars = 0;
     bool shell = false;
     bool array = false;
+    bool silent = false;
     bool split_null = false;
 
-    const wchar_t *short_options = L"ac:ghlm:n:p:suxzP:UR:";
+    const wchar_t *short_options = L"ac:ghlm:n:p:siuxzP:UR:";
     const struct woption long_options[] = {{L"export", no_argument, NULL, 'x'},
                                            {L"global", no_argument, NULL, 'g'},
                                            {L"local", no_argument, NULL, 'l'},
@@ -2150,6 +2152,7 @@ static int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv)
                                            {L"right-prompt", required_argument, NULL, 'R'},
                                            {L"command", required_argument, NULL, 'c'},
                                            {L"mode-name", required_argument, NULL, 'm'},
+                                           {L"silent", no_argument, NULL, 'i'},
                                            {L"nchars", required_argument, NULL, 'n'},
                                            {L"shell", no_argument, NULL, 's'},
                                            {L"array", no_argument, NULL, 'a'},
@@ -2224,6 +2227,10 @@ static int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv)
             }
             case 'a': {
                 array = true;
+                break;
+            }
+            case L'i': {
+                silent = true;
                 break;
             }
             case L'z': {
@@ -2302,8 +2309,8 @@ static int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv)
         // We should read interactively using reader_readline(). This does not support splitting on
         // null. The call to reader_readline may change woptind, so we save and restore it.
         int saved_woptind = w.woptind;
-        exit_res =
-            read_interactive(buff, nchars, shell, mode_name, prompt, right_prompt, commandline);
+        exit_res = read_interactive(buff, nchars, shell, silent, mode_name, prompt, right_prompt,
+                                    commandline);
         w.woptind = saved_woptind;
     } else if (!nchars && !stream_stdin_is_a_tty && lseek(streams.stdin_fd, 0, SEEK_CUR) != -1) {
         exit_res = read_in_chunks(streams.stdin_fd, buff, split_null);

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -2141,7 +2141,7 @@ static int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv)
     bool silent = false;
     bool split_null = false;
 
-    const wchar_t *short_options = L"ac:ghlm:n:p:siuxzP:UR:";
+    const wchar_t *short_options = L"ac:ghilm:n:p:suxzP:UR:";
     const struct woption long_options[] = {{L"export", no_argument, NULL, 'x'},
                                            {L"global", no_argument, NULL, 'g'},
                                            {L"local", no_argument, NULL, 'l'},

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -50,6 +50,7 @@ static bool thread_asserts_cfg_for_testing = false;
 
 wchar_t ellipsis_char;
 wchar_t omitted_newline_char;
+wchar_t obfuscation_read_char;
 bool g_profiling_active = false;
 const wchar_t *program_name;
 int debug_level = 1;         // default maximum debug output level (errors and warnings)
@@ -457,6 +458,9 @@ void fish_setlocale() {
 
     // Use the Unicode "return" symbol if it can be encoded using the current locale.
     omitted_newline_char = can_be_encoded(L'\x23CE') ? L'\x23CE' : L'~';
+
+    // solid circle unicode character if it is able, fallback to the hash character
+    obfuscation_read_char = can_be_encoded(L'\u25cf') ? L'\u25cf' : L'#';
 }
 
 long read_blocked(int fd, void *buf, size_t count) {

--- a/src/common.h
+++ b/src/common.h
@@ -159,6 +159,9 @@ extern wchar_t ellipsis_char;
 /// Character representing an omitted newline at the end of text.
 extern wchar_t omitted_newline_char;
 
+/// Character used for the silent mode of the read command
+extern wchar_t obfuscation_read_char;
+
 /// The verbosity level of fish. If a call to debug has a severity level higher than \c debug_level,
 /// it will not be printed.
 extern int debug_level;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -376,9 +376,7 @@ wcstring combine_command_and_autosuggestion(const wcstring &cmdline,
     // last token of the command line contains any uppercase characters, we use its case. Otherwise
     // we use the case of the autosuggestion. This is an idea from issue #335.
     wcstring full_line;
-    if (data->silent) {
-        full_line = std::wstring(cmdline.length(), L'●');
-    } else if (autosuggestion.size() <= cmdline.size() || cmdline.empty()) {
+    if (autosuggestion.size() <= cmdline.size() || cmdline.empty()) {
         // No or useless autosuggestion, or no command line.
         full_line = cmdline;
     } else if (string_prefixes_string(cmdline, autosuggestion)) {
@@ -416,8 +414,13 @@ static void reader_repaint() {
     // Update the indentation.
     data->indents = parse_util_compute_indents(cmd_line->text);
 
-    // Combine the command and autosuggestion into one string.
-    wcstring full_line = combine_command_and_autosuggestion(cmd_line->text, data->autosuggestion);
+    wcstring full_line;
+    if (data->silent) {
+        full_line = wcstring(cmd_line->text.length(), L'●');
+    } else {
+        // Combine the command and autosuggestion into one string.
+        full_line = combine_command_and_autosuggestion(cmd_line->text, data->autosuggestion);
+    }
 
     size_t len = full_line.size();
     if (len < 1) len = 1;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2052,7 +2052,7 @@ void reader_set_test_function(parser_test_error_bits_t (*f)(const wchar_t *)) {
 
 void reader_set_exit_on_interrupt(bool i) { data->exit_on_interrupt = i; }
 
-void reader_set_silent_status(bool f) { data->silent = f; }
+void reader_set_silent_status(bool flag) { data->silent = flag; }
 
 void reader_import_history_if_necessary(void) {
     // Import history from older location (config path) if our current history is empty.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -261,6 +261,7 @@ class reader_data_t {
         : allow_autosuggestion(false),
           suppress_autosuggestion(false),
           expand_abbreviations(false),
+          silent(false),
           history(0),
           token_history_pos(0),
           search_pos(0),
@@ -416,7 +417,7 @@ static void reader_repaint() {
 
     wcstring full_line;
     if (data->silent) {
-        full_line = wcstring(cmd_line->text.length(), L'●');
+        full_line = wcstring(cmd_line->text.length(), obfuscation_read_char);
     } else {
         // Combine the command and autosuggestion into one string.
         full_line = combine_command_and_autosuggestion(cmd_line->text, data->autosuggestion);

--- a/src/reader.h
+++ b/src/reader.h
@@ -189,6 +189,8 @@ void reader_set_expand_abbreviations(bool flag);
 /// Sets whether the reader should exit on ^C.
 void reader_set_exit_on_interrupt(bool flag);
 
+void reader_set_silent_status(bool f);
+
 /// Returns true if the shell is exiting, 0 otherwise.
 bool shell_is_exiting();
 

--- a/tests/read.expect
+++ b/tests/read.expect
@@ -36,6 +36,15 @@ expect_prompt
 expect_marker 2
 print_var_contents foo
 
+# read -i
+
+send_line "read -i foo"
+expect_read_prompt
+send_line -h "read_i\r_marker 3"
+expect_prompt
+expect_marker 3
+print_var_contents foo
+
 # read -n
 
 send_line "read -n 3 foo"

--- a/tests/read.expect.out
+++ b/tests/read.expect.out
@@ -1,6 +1,7 @@
 $foo: 'text'
 $foo: 'again'
 $foo: 'bar'
+$foo: 'read_i'
 $foo: '123'
 $foo: '456'
 $foo: 'hello'


### PR DESCRIPTION
## Description

This PR updates the reader object adding a `silent` parameter.

If this parameter is set to true, it doesn't displays the commandline contents when the readline command is called. Allowing silent prompts for password or discrete command entries, the command can be modified to use a offuscation char like '*', but at the moment instead of masking the contents it doesn't displays them.

Fixes issue #838

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
