### PR TITLE
Fix portmaster completions when there are no matches

### DIFF
--- a/share/completions/portmaster.fish
+++ b/share/completions/portmaster.fish
@@ -48,8 +48,7 @@ complete -c portmaster -l version --description 'display the version number El E
 # Grab items from the ports directory, max depth 2
 complete -c portmaster -f --description 'Ports Directory' -a "
 (
-        ls -d /usr/ports/(commandline -ct)*/ \
-                | sed -E -e 's#/usr/ports/##' -e 's#/+#/#' -e 's#([^/]+/[^/]+).*#\1#'
+	string match -r '(?<=/usr/ports/)[^/]*(?:/[^/]*)?' (__fish_complete_directories /usr/ports/(commandline -ct))
 )"
 
 complete -c portmaster -f --description 'Installed Package' -a "(__fish_print_packages)"


### PR DESCRIPTION
Don't spew warnings when there are no matches.  Also, use the string
builtin instead of calling sed.

Fixes #3949

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.md
