### PR TITLE
feature: status returns the function name when called with -u parameter

### DIFF
--- a/doc_src/status.txt
+++ b/doc_src/status.txt
@@ -11,6 +11,7 @@ status is-no-job-control
 status is-full-job-control
 status is-interactive-job-control
 status current-filename
+status current-function
 status current-line-number
 status print-stack-trace
 status job-control CONTROL-TYPE
@@ -37,6 +38,8 @@ The following operations (sub-commands) are available:
 - `is-no-job-control` returns 0 if no job control is enabled. Also `--is-no-job-control` (no short flag).
 
 - `current-filename` prints the filename of the currently running script. Also `-f` or `--current-filename`.
+
+- `current-function` prints the name of the currently called function if able, when missing displays "Not a function". Also `-u` or `--current-function`.
 
 - `current-line-number` prints the line number of the currently running script. Also `-n` or `--current-line-number`.
 

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -2453,7 +2453,7 @@ static int builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **arg
     /// the non-flag subcommand form. While these flags are deprecated they must be supported at
     /// least until fish 3.0 and possibly longer to avoid breaking everyones config.fish and other
     /// scripts.
-    const wchar_t *short_options = L":bcfhij:lnut";
+    const wchar_t *short_options = L":cbilfnhj:t";
     const struct woption long_options[] = {{L"help", no_argument, 0, 'h'},
                                            {L"is-command-substitution", no_argument, 0, 'c'},
                                            {L"is-block", no_argument, 0, 'b'},
@@ -2463,7 +2463,6 @@ static int builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **arg
                                            {L"is-interactive-job-control", no_argument, 0, 2},
                                            {L"is-no-job-control", no_argument, 0, 3},
                                            {L"current-filename", no_argument, 0, 'f'},
-                                           {L"current-function", no_argument, 0, 'u'},
                                            {L"current-line-number", no_argument, 0, 'n'},
                                            {L"job-control", required_argument, 0, 'j'},
                                            {L"print-stack-trace", no_argument, 0, 't'},
@@ -2533,12 +2532,6 @@ static int builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **arg
                 }
                 new_job_control_mode = job_control_str_to_mode(w.woptarg, cmd, streams);
                 if (new_job_control_mode == -1) {
-                    return STATUS_BUILTIN_ERROR;
-                }
-                break;
-            }
-            case 'u': {
-                if (!set_status_cmd(cmd, &status_cmd, STATUS_CURRENT_FUNCTION, streams)) {
                     return STATUS_BUILTIN_ERROR;
                 }
                 break;
@@ -2630,7 +2623,7 @@ static int builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **arg
         }
         case STATUS_CURRENT_FUNCTION: {
             CHECK_FOR_UNEXPECTED_STATUS_ARGS(status_cmd)
-            const wchar_t *fn = parser.get_function();
+            const wchar_t *fn = parser.get_function_name();
 
             if (!fn) fn = _(L"Not a function");
             streams.out.append_format(L"%ls\n", fn);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -440,7 +440,7 @@ const wchar_t *parser_t::is_function() const {
     return result;
 }
 
-const wchar_t *parser_t::get_function() {
+const wchar_t *parser_t::get_function_name() {
     return this->is_function();
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -440,6 +440,10 @@ const wchar_t *parser_t::is_function() const {
     return result;
 }
 
+const wchar_t *parser_t::get_function() {
+    return this->is_function();
+}
+
 int parser_t::get_lineno() const {
     int lineno = -1;
     if (!execution_contexts.empty()) {

--- a/src/parser.h
+++ b/src/parser.h
@@ -350,7 +350,7 @@ class parser_t {
 
     ~parser_t();
 
-    const wchar_t *get_function();
+    const wchar_t *get_function_name();
 };
 
 #endif

--- a/src/parser.h
+++ b/src/parser.h
@@ -349,6 +349,8 @@ class parser_t {
     wcstring stack_trace() const;
 
     ~parser_t();
+
+    const wchar_t *get_function();
 };
 
 #endif

--- a/tests/status.in
+++ b/tests/status.in
@@ -39,3 +39,13 @@ status --job-control=1none
 
 # Now set it to a valid mode.
 status job-control none
+
+# Check status -u outside functions
+status -u
+
+function test_function
+    status -u
+end
+
+test_function
+eval test_function

--- a/tests/status.in
+++ b/tests/status.in
@@ -41,10 +41,10 @@ status --job-control=1none
 status job-control none
 
 # Check status -u outside functions
-status -u
+status current-function
 
 function test_function
-    status -u
+    status current-function
 end
 
 test_function

--- a/tests/status.out
+++ b/tests/status.out
@@ -1,0 +1,3 @@
+Not a function
+test_function
+test_function


### PR DESCRIPTION
## Description

Added a `--current-function`, `-u` parameter for the `status` function, if the function  exists on the parser the function name is sent to the out stream, when missing a "Not a function" message is sended instead.

It's unclear what to do when the function is not found.
Maybe the terminal should: 
  - display message and exit code 0
  - no message and exit code 1
  - display message and exit code 1
  
Fixes issue #1743

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
