### PR TITLE
Terraform command completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 - Command substitutions now have access to the terminal, allowing tools like `fzf` to work in them (#1362, #3922).
 - `bg`s argument parsing has been reworked. It now fails for invalid arguments but allows non-existent jobs (#3909).
 - `read` now supports the `--silent` flag to hide the characters typed (#838).
-- Added completions for `terraform`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Command substitutions now have access to the terminal, allowing tools like `fzf` to work in them (#1362, #3922).
 - `bg`s argument parsing has been reworked. It now fails for invalid arguments but allows non-existent jobs (#3909).
 - `read` now supports the `--silent` flag to hide the characters typed (#838).
+- Added completions for `terraform`.
 
 ---
 

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -1,207 +1,171 @@
-function __fish_terraform_needs_command
-    set cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
-        return 0
-    end
-
-    for arg in $cmd[-1..2]
-        switch $arg
-            case '--*'
-                # ignore global flags
-            case '*'
-                return 1
-        end
-    end
-    return 0
-end
-
-function __fish_terraform_using_command
-    set cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
-        return 0
-    end
-
-    for arg in $cmd[-1..2]
-        switch $arg
-            case '--*'
-                # ignore global flags
-            case $argv[1]
-                return 0
-            case '*'
-                return 1
-        end
-    end
-    return 1
-end
-
 # general options
 complete -f -c terraform -l version -d 'Print version information'
 complete -f -c terraform -l help -d 'Show help'
 
 ### apply
-complete -f -c terraform -n '__fish_terraform_needs_command' -a apply -d 'Builds or changes infrastructure'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o input -d 'Ask for input for variables if not directly set'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o parallelism -d 'Limit the number of concurrent operations'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o refresh -d 'Update state prior to checking for differences'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o state-out -d 'Path to write state'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o target -d 'Resource to target'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_terraform_using_command apply' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n '__fish_use_subcommand' -a apply -d 'Builds or changes infrastructure'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o input -d 'Ask for input for variables if not directly set'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o parallelism -d 'Limit the number of concurrent operations'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o refresh -d 'Update state prior to checking for differences'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o target -d 'Resource to target'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o var-file -d 'Set variables from a file'
 
 ### console
-complete -f -c terraform -n '__fish_terraform_needs_command' -a console -d 'Interactive console for Terraform interpolations'
-complete -f -c terraform -n '__fish_terraform_using_command console' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_terraform_using_command console' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_terraform_using_command console' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n '__fish_use_subcommand' -a console -d 'Interactive console for Terraform interpolations'
+complete -f -c terraform -n '__fish_seen_subcommand_from console' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from console' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from console' -o var-file -d 'Set variables from a file'
 
 ### destroy
-complete -f -c terraform -n '__fish_terraform_needs_command' -a destroy -d 'Destroy Terraform-managed infrastructure'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o force -d 'Don\'t ask for input for destroy confirmation'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o parallelism -d 'Limit the number of concurrent operations'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o refresh -d 'Update state prior to checking for differences'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o state-out -d 'Path to write state'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o target -d 'Resource to target'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_terraform_using_command destroy' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n '__fish_use_subcommand' -a destroy -d 'Destroy Terraform-managed infrastructure'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o force -d 'Don\'t ask for input for destroy confirmation'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o parallelism -d 'Limit the number of concurrent operations'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o refresh -d 'Update state prior to checking for differences'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o target -d 'Resource to target'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o var-file -d 'Set variables from a file'
 
 ### env
-complete -f -c terraform -n '__fish_terraform_needs_command' -a env -d 'Environment management'
-complete -f -c terraform -n '__fish_terraform_using_command env' -a list -d 'List environments'
-complete -f -c terraform -n '__fish_terraform_using_command env' -a select -d 'Select an environment'
-complete -f -c terraform -n '__fish_terraform_using_command env' -a new -d 'Create a new environment'
-complete -f -c terraform -n '__fish_terraform_using_command env' -a delete -d 'Delete an existing environment'
+complete -f -c terraform -n '__fish_use_subcommand' -a env -d 'Environment management'
+complete -f -c terraform -n '__fish_seen_subcommand_from env' -a list -d 'List environments'
+complete -f -c terraform -n '__fish_seen_subcommand_from env' -a select -d 'Select an environment'
+complete -f -c terraform -n '__fish_seen_subcommand_from env' -a new -d 'Create a new environment'
+complete -f -c terraform -n '__fish_seen_subcommand_from env' -a delete -d 'Delete an existing environment'
 
 ### fmt
-complete -f -c terraform -n '__fish_terraform_needs_command' -a fmt -d 'Rewrites config files to canonical format'
-complete -f -c terraform -n '__fish_terraform_using_command fmt' -o list -d 'List files whose formatting differs'
-complete -f -c terraform -n '__fish_terraform_using_command fmt' -o write -d 'Write result to source file'
-complete -f -c terraform -n '__fish_terraform_using_command fmt' -o diff -d 'Display diffs of formatting changes'
+complete -f -c terraform -n '__fish_use_subcommand' -a fmt -d 'Rewrites config files to canonical format'
+complete -f -c terraform -n '__fish_seen_subcommand_from fmt' -o list -d 'List files whose formatting differs'
+complete -f -c terraform -n '__fish_seen_subcommand_from fmt' -o write -d 'Write result to source file'
+complete -f -c terraform -n '__fish_seen_subcommand_from fmt' -o diff -d 'Display diffs of formatting changes'
 
 ### get
-complete -f -c terraform -n '__fish_terraform_needs_command' -a get -d 'Download and install modules for the configuration'
-complete -f -c terraform -n '__fish_terraform_using_command get' -o update -d 'Check modules for updates'
-complete -f -c terraform -n '__fish_terraform_using_command get' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_use_subcommand' -a get -d 'Download and install modules for the configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from get' -o update -d 'Check modules for updates'
+complete -f -c terraform -n '__fish_seen_subcommand_from get' -o no-color -d 'If specified, output won\'t contain any color'
 
 ### graph
-complete -f -c terraform -n '__fish_terraform_needs_command' -a graph -d 'Create a visual graph of Terraform resources'
-complete -f -c terraform -n '__fish_terraform_using_command graph' -o draw-cycles -d 'Highlight any cycles in the graph'
-complete -f -c terraform -n '__fish_terraform_using_command graph' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command graph' -o type -d 'Type of graph to output'
+complete -f -c terraform -n '__fish_use_subcommand' -a graph -d 'Create a visual graph of Terraform resources'
+complete -f -c terraform -n '__fish_seen_subcommand_from graph' -o draw-cycles -d 'Highlight any cycles in the graph'
+complete -f -c terraform -n '__fish_seen_subcommand_from graph' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from graph' -o type -d 'Type of graph to output'
 
 ### import
-complete -f -c terraform -n '__fish_terraform_needs_command' -a import -d 'Import existing infrastructure into Terraform'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o config -d 'Path to a directory of configuration files'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o input -d 'Ask for input for variables if not directly set'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o provider -d 'Specific provider to use for import'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o state-out -d 'Path to write state'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_terraform_using_command import' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n '__fish_use_subcommand' -a import -d 'Import existing infrastructure into Terraform'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o config -d 'Path to a directory of configuration files'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o input -d 'Ask for input for variables if not directly set'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o provider -d 'Specific provider to use for import'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from import' -o var-file -d 'Set variables from a file'
 
 ### init
-complete -f -c terraform -n '__fish_terraform_needs_command' -a init -d 'Initialize a new or existing Terraform configuration'
-complete -f -c terraform -n '__fish_terraform_using_command init' -o backend -d 'Configure the backend for this environment'
-complete -f -c terraform -n '__fish_terraform_using_command init' -o backend-config -d 'Backend configuration'
-complete -f -c terraform -n '__fish_terraform_using_command init' -o get -d 'Download modules for this configuration'
-complete -f -c terraform -n '__fish_terraform_using_command init' -o input -d 'Ask for input if necessary'
-complete -f -c terraform -n '__fish_terraform_using_command init' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_terraform_using_command init' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_terraform_using_command init' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command init' -o force-copy -d 'Suppress prompts about copying state data'
+complete -f -c terraform -n '__fish_use_subcommand' -a init -d 'Initialize a new or existing Terraform configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from init' -o backend -d 'Configure the backend for this environment'
+complete -f -c terraform -n '__fish_seen_subcommand_from init' -o backend-config -d 'Backend configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from init' -o get -d 'Download modules for this configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from init' -o input -d 'Ask for input if necessary'
+complete -f -c terraform -n '__fish_seen_subcommand_from init' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_seen_subcommand_from init' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_seen_subcommand_from init' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from init' -o force-copy -d 'Suppress prompts about copying state data'
 
 ### output
-complete -f -c terraform -n '__fish_terraform_needs_command' -a output -d 'Read an output from a state file'
-complete -f -c terraform -n '__fish_terraform_using_command output' -o state -d 'Path to the state file to read'
-complete -f -c terraform -n '__fish_terraform_using_command output' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command output' -o module -d 'Return the outputs for a specific module'
-complete -f -c terraform -n '__fish_terraform_using_command output' -o json -d 'Print output in JSON format'
+complete -f -c terraform -n '__fish_use_subcommand' -a output -d 'Read an output from a state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from output' -o state -d 'Path to the state file to read'
+complete -f -c terraform -n '__fish_seen_subcommand_from output' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from output' -o module -d 'Return the outputs for a specific module'
+complete -f -c terraform -n '__fish_seen_subcommand_from output' -o json -d 'Print output in JSON format'
 
 ### plan
-complete -f -c terraform -n '__fish_terraform_needs_command' -a plan -d 'Generate and show an execution plan'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o destroy -d 'Generate a plan to destroy all resources'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o detailed-exitcode -d 'Return detailed exit codes'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o input -d 'Ask for input for variables if not directly set'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o module-depth -d 'Depth of modules to show in the output'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o out -d 'Write a plan file to the given path'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o parallelism -d 'Limit the number of concurrent operations'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o refresh -d 'Update state prior to checking for differences'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o target -d 'Resource to target'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_terraform_using_command plan' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n '__fish_use_subcommand' -a plan -d 'Generate and show an execution plan'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o destroy -d 'Generate a plan to destroy all resources'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o detailed-exitcode -d 'Return detailed exit codes'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o input -d 'Ask for input for variables if not directly set'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o module-depth -d 'Depth of modules to show in the output'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o out -d 'Write a plan file to the given path'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o parallelism -d 'Limit the number of concurrent operations'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o refresh -d 'Update state prior to checking for differences'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o target -d 'Resource to target'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o var-file -d 'Set variables from a file'
 
 ### push
-complete -f -c terraform -n '__fish_terraform_needs_command' -a push -d 'Upload this Terraform module to Atlas to run'
-complete -f -c terraform -n '__fish_terraform_using_command push' -o atlas-address -d 'An alternate address to an Atlas instance'
-complete -f -c terraform -n '__fish_terraform_using_command push' -o upload-modules -d 'Lock modules and upload completely'
-complete -f -c terraform -n '__fish_terraform_using_command push' -o name -d 'Name of the configuration in Atlas'
-complete -f -c terraform -n '__fish_terraform_using_command push' -o token -d 'Access token to use to upload'
-complete -f -c terraform -n '__fish_terraform_using_command push' -o overwrite -d 'Variable keys that should overwrite values in Atlas'
-complete -f -c terraform -n '__fish_terraform_using_command push' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_terraform_using_command push' -o var-file -d 'Set variables from a file'
-complete -f -c terraform -n '__fish_terraform_using_command push' -o vcs -d 'Upload only files committed to your VCS'
-complete -f -c terraform -n '__fish_terraform_using_command push' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_use_subcommand' -a push -d 'Upload this Terraform module to Atlas to run'
+complete -f -c terraform -n '__fish_seen_subcommand_from push' -o atlas-address -d 'An alternate address to an Atlas instance'
+complete -f -c terraform -n '__fish_seen_subcommand_from push' -o upload-modules -d 'Lock modules and upload completely'
+complete -f -c terraform -n '__fish_seen_subcommand_from push' -o name -d 'Name of the configuration in Atlas'
+complete -f -c terraform -n '__fish_seen_subcommand_from push' -o token -d 'Access token to use to upload'
+complete -f -c terraform -n '__fish_seen_subcommand_from push' -o overwrite -d 'Variable keys that should overwrite values in Atlas'
+complete -f -c terraform -n '__fish_seen_subcommand_from push' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from push' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n '__fish_seen_subcommand_from push' -o vcs -d 'Upload only files committed to your VCS'
+complete -f -c terraform -n '__fish_seen_subcommand_from push' -o no-color -d 'If specified, output won\'t contain any color'
 
 ### refresh
-complete -f -c terraform -n '__fish_terraform_needs_command' -a refresh -d 'Update local state file against real resources'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o input -d 'Ask for input for variables if not directly set'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o state-out -d 'Path to write state'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o target -d 'Resource to target'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_terraform_using_command refresh' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n '__fish_use_subcommand' -a refresh -d 'Update local state file against real resources'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o input -d 'Ask for input for variables if not directly set'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o target -d 'Resource to target'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o var-file -d 'Set variables from a file'
 
 ### show
-complete -f -c terraform -n '__fish_terraform_needs_command' -a show -d 'Inspect Terraform state or plan'
-complete -f -c terraform -n '__fish_terraform_using_command show' -o module-depth -d 'Depth of modules to show in the output'
-complete -f -c terraform -n '__fish_terraform_using_command show' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_use_subcommand' -a show -d 'Inspect Terraform state or plan'
+complete -f -c terraform -n '__fish_seen_subcommand_from show' -o module-depth -d 'Depth of modules to show in the output'
+complete -f -c terraform -n '__fish_seen_subcommand_from show' -o no-color -d 'If specified, output won\'t contain any color'
 
 ### taint
-complete -f -c terraform -n '__fish_terraform_needs_command' -a taint -d 'Manually mark a resource for recreation'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o allow-missing -d 'Succeed even if resource is missing'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o module -d 'The module path where the resource lives'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_use_subcommand' -a taint -d 'Manually mark a resource for recreation'
+complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o allow-missing -d 'Succeed even if resource is missing'
+complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o module -d 'The module path where the resource lives'
+complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o state-out -d 'Path to write state'
 
 ### untaint
-complete -f -c terraform -n '__fish_terraform_needs_command' -a untaint -d 'Manually unmark a resource as tainted'
-complete -f -c terraform -n '__fish_terraform_using_command untaint' -o allow-missing -d 'Succeed even if resource is missing'
-complete -f -c terraform -n '__fish_terraform_using_command untaint' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_terraform_using_command untaint' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_terraform_using_command untaint' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_terraform_using_command untaint' -o module -d 'The module path where the resource lives'
-complete -f -c terraform -n '__fish_terraform_using_command untaint' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command untaint' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_terraform_using_command untaint' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_use_subcommand' -a untaint -d 'Manually unmark a resource as tainted'
+complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o allow-missing -d 'Succeed even if resource is missing'
+complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o module -d 'The module path where the resource lives'
+complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o state-out -d 'Path to write state'
 
 ### validate
-complete -f -c terraform -n '__fish_terraform_needs_command' -a validate -d 'Validates the Terraform files'
-complete -f -c terraform -n '__fish_terraform_using_command validate' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_use_subcommand' -a validate -d 'Validates the Terraform files'
+complete -f -c terraform -n '__fish_seen_subcommand_from validate' -o no-color -d 'If specified, output won\'t contain any color'
 
 ### version
-complete -f -c terraform -n '__fish_terraform_needs_command' -a version -d 'Prints the Terraform version'
+complete -f -c terraform -n '__fish_use_subcommand' -a version -d 'Prints the Terraform version'

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -1,0 +1,74 @@
+function __fish_terraform_needs_command
+    set cmd (commandline -opc)
+    if [ (count $cmd) -eq 1 ]
+        return 0
+    end
+
+    for arg in $cmd[2..-1]
+        switch $arg
+            case '--*'
+                # ignore global flags
+            case '*'
+                return 1
+        end
+    end
+    return 0
+end
+
+# general options
+complete -f -c terraform -n '__fish_terraform_needs_command' -l version -d 'Print version information'
+complete -f -c terraform -n '__fish_terraform_needs_command' -l help -d 'Show help'
+
+### apply
+complete -f -c terraform -n '__fish_terraform_needs_command' -a apply -d 'Builds or changes infrastructure'
+
+### console
+complete -f -c terraform -n '__fish_terraform_needs_command' -a console -d 'Interactive console for Terraform interpolations'
+
+### destroy
+complete -f -c terraform -n '__fish_terraform_needs_command' -a destroy -d 'Destroy Terraform-managed infrastructure'
+
+### env
+complete -f -c terraform -n '__fish_terraform_needs_command' -a env -d 'Environment management'
+
+### fmt
+complete -f -c terraform -n '__fish_terraform_needs_command' -a fmt -d 'Rewrites config files to canonical format'
+
+### get
+complete -f -c terraform -n '__fish_terraform_needs_command' -a get -d 'Download and install modules for the configuration'
+
+### graph
+complete -f -c terraform -n '__fish_terraform_needs_command' -a graph -d 'Create a visual graph of Terraform resources'
+
+### import
+complete -f -c terraform -n '__fish_terraform_needs_command' -a import -d 'Import existing infrastructure into Terraform'
+
+### init
+complete -f -c terraform -n '__fish_terraform_needs_command' -a init -d 'Initialize a new or existing Terraform configuration'
+
+### output
+complete -f -c terraform -n '__fish_terraform_needs_command' -a output -d 'Read an output from a state file'
+
+### plan
+complete -f -c terraform -n '__fish_terraform_needs_command' -a plan -d 'Generate and show an execution plan'
+
+### push
+complete -f -c terraform -n '__fish_terraform_needs_command' -a push -d 'Upload this Terraform module to Atlas to run'
+
+### refresh
+complete -f -c terraform -n '__fish_terraform_needs_command' -a refresh -d 'Update local state file against real resources'
+
+### show
+complete -f -c terraform -n '__fish_terraform_needs_command' -a show -d 'Inspect Terraform state or plan'
+
+### taint
+complete -f -c terraform -n '__fish_terraform_needs_command' -a taint -d 'Manually mark a resource for recreation'
+
+### untaint
+complete -f -c terraform -n '__fish_terraform_needs_command' -a untaint -d 'Manually unmark a resource as tainted'
+
+### validate
+complete -f -c terraform -n '__fish_terraform_needs_command' -a validate -d 'Validates the Terraform files'
+
+### version
+complete -f -c terraform -n '__fish_terraform_needs_command' -a version -d 'Prints the Terraform version'

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -3,7 +3,7 @@ complete -f -c terraform -l version -d 'Print version information'
 complete -f -c terraform -l help -d 'Show help'
 
 ### apply
-complete -f -c terraform -n '__fish_use_subcommand' -a apply -d 'Builds or changes infrastructure'
+complete -f -c terraform -n '__fish_use_subcommand' -a apply -d 'Build or change infrastructure'
 complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o backup -d 'Path to backup the existing state file'
 complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o lock -d 'Lock the state file when locking is supported'
 complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o lock-timeout -d 'Duration to retry a state lock'
@@ -46,7 +46,7 @@ complete -f -c terraform -n '__fish_seen_subcommand_from env' -a new -d 'Create 
 complete -f -c terraform -n '__fish_seen_subcommand_from env' -a delete -d 'Delete an existing environment'
 
 ### fmt
-complete -f -c terraform -n '__fish_use_subcommand' -a fmt -d 'Rewrites config files to canonical format'
+complete -f -c terraform -n '__fish_use_subcommand' -a fmt -d 'Rewrite config files to canonical format'
 complete -f -c terraform -n '__fish_seen_subcommand_from fmt' -o list -d 'List files whose formatting differs'
 complete -f -c terraform -n '__fish_seen_subcommand_from fmt' -o write -d 'Write result to source file'
 complete -f -c terraform -n '__fish_seen_subcommand_from fmt' -o diff -d 'Display diffs of formatting changes'
@@ -164,8 +164,8 @@ complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o state -d 'P
 complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o state-out -d 'Path to write state'
 
 ### validate
-complete -f -c terraform -n '__fish_use_subcommand' -a validate -d 'Validates the Terraform files'
+complete -f -c terraform -n '__fish_use_subcommand' -a validate -d 'Validate the Terraform files'
 complete -f -c terraform -n '__fish_seen_subcommand_from validate' -o no-color -d 'If specified, output won\'t contain any color'
 
 ### version
-complete -f -c terraform -n '__fish_use_subcommand' -a version -d 'Prints the Terraform version'
+complete -f -c terraform -n '__fish_use_subcommand' -a version -d 'Print the Terraform version'

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -190,14 +190,14 @@ complete -f -c terraform -n '__fish_terraform_using_command taint' -o state-out 
 
 ### untaint
 complete -f -c terraform -n '__fish_terraform_needs_command' -a untaint -d 'Manually unmark a resource as tainted'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o allow-missing -d 'Succeed even if resource is missing'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o module -d 'The module path where the resource lives'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_terraform_using_command taint' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_terraform_using_command untaint' -o allow-missing -d 'Succeed even if resource is missing'
+complete -f -c terraform -n '__fish_terraform_using_command untaint' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_terraform_using_command untaint' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_terraform_using_command untaint' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_terraform_using_command untaint' -o module -d 'The module path where the resource lives'
+complete -f -c terraform -n '__fish_terraform_using_command untaint' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command untaint' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_terraform_using_command untaint' -o state-out -d 'Path to write state'
 
 ### validate
 complete -f -c terraform -n '__fish_terraform_needs_command' -a validate -d 'Validates the Terraform files'

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -4,7 +4,7 @@ function __fish_terraform_needs_command
         return 0
     end
 
-    for arg in $cmd[2..-1]
+    for arg in $cmd[-1..2]
         switch $arg
             case '--*'
                 # ignore global flags
@@ -21,7 +21,7 @@ function __fish_terraform_using_command
         return 0
     end
 
-    for arg in $cmd[2..-1]
+    for arg in $cmd[-1..2]
         switch $arg
             case '--*'
                 # ignore global flags

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -15,60 +15,193 @@ function __fish_terraform_needs_command
     return 0
 end
 
+function __fish_terraform_using_command
+    set cmd (commandline -opc)
+    if [ (count $cmd) -eq 1 ]
+        return 0
+    end
+
+    for arg in $cmd[2..-1]
+        switch $arg
+            case '--*'
+                # ignore global flags
+            case $argv[1]
+                return 0
+            case '*'
+                return 1
+        end
+    end
+    return 1
+end
+
 # general options
-complete -f -c terraform -n '__fish_terraform_needs_command' -l version -d 'Print version information'
-complete -f -c terraform -n '__fish_terraform_needs_command' -l help -d 'Show help'
+complete -f -c terraform -l version -d 'Print version information'
+complete -f -c terraform -l help -d 'Show help'
 
 ### apply
 complete -f -c terraform -n '__fish_terraform_needs_command' -a apply -d 'Builds or changes infrastructure'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o input -d 'Ask for input for variables if not directly set'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o parallelism -d 'Limit the number of concurrent operations'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o refresh -d 'Update state prior to checking for differences'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o target -d 'Resource to target'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_terraform_using_command apply' -o var-file -d 'Set variables from a file'
 
 ### console
 complete -f -c terraform -n '__fish_terraform_needs_command' -a console -d 'Interactive console for Terraform interpolations'
+complete -f -c terraform -n '__fish_terraform_using_command console' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_terraform_using_command console' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_terraform_using_command console' -o var-file -d 'Set variables from a file'
 
 ### destroy
 complete -f -c terraform -n '__fish_terraform_needs_command' -a destroy -d 'Destroy Terraform-managed infrastructure'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o force -d 'Don\'t ask for input for destroy confirmation'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o parallelism -d 'Limit the number of concurrent operations'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o refresh -d 'Update state prior to checking for differences'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o target -d 'Resource to target'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_terraform_using_command destroy' -o var-file -d 'Set variables from a file'
 
 ### env
 complete -f -c terraform -n '__fish_terraform_needs_command' -a env -d 'Environment management'
+complete -f -c terraform -n '__fish_terraform_using_command env' -a list -d 'List environments'
+complete -f -c terraform -n '__fish_terraform_using_command env' -a select -d 'Select an environment'
+complete -f -c terraform -n '__fish_terraform_using_command env' -a new -d 'Create a new environment'
+complete -f -c terraform -n '__fish_terraform_using_command env' -a delete -d 'Delete an existing environment'
 
 ### fmt
 complete -f -c terraform -n '__fish_terraform_needs_command' -a fmt -d 'Rewrites config files to canonical format'
+complete -f -c terraform -n '__fish_terraform_using_command fmt' -o list -d 'List files whose formatting differs'
+complete -f -c terraform -n '__fish_terraform_using_command fmt' -o write -d 'Write result to source file'
+complete -f -c terraform -n '__fish_terraform_using_command fmt' -o diff -d 'Display diffs of formatting changes'
 
 ### get
 complete -f -c terraform -n '__fish_terraform_needs_command' -a get -d 'Download and install modules for the configuration'
+complete -f -c terraform -n '__fish_terraform_using_command get' -o update -d 'Check modules for updates'
+complete -f -c terraform -n '__fish_terraform_using_command get' -o no-color -d 'If specified, output won\'t contain any color'
 
 ### graph
 complete -f -c terraform -n '__fish_terraform_needs_command' -a graph -d 'Create a visual graph of Terraform resources'
+complete -f -c terraform -n '__fish_terraform_using_command graph' -o draw-cycles -d 'Highlight any cycles in the graph'
+complete -f -c terraform -n '__fish_terraform_using_command graph' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command graph' -o type -d 'Type of graph to output'
 
 ### import
 complete -f -c terraform -n '__fish_terraform_needs_command' -a import -d 'Import existing infrastructure into Terraform'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o config -d 'Path to a directory of configuration files'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o input -d 'Ask for input for variables if not directly set'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o provider -d 'Specific provider to use for import'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_terraform_using_command import' -o var-file -d 'Set variables from a file'
 
 ### init
 complete -f -c terraform -n '__fish_terraform_needs_command' -a init -d 'Initialize a new or existing Terraform configuration'
+complete -f -c terraform -n '__fish_terraform_using_command init' -o backend -d 'Configure the backend for this environment'
+complete -f -c terraform -n '__fish_terraform_using_command init' -o backend-config -d 'Backend configuration'
+complete -f -c terraform -n '__fish_terraform_using_command init' -o get -d 'Download modules for this configuration'
+complete -f -c terraform -n '__fish_terraform_using_command init' -o input -d 'Ask for input if necessary'
+complete -f -c terraform -n '__fish_terraform_using_command init' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_terraform_using_command init' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_terraform_using_command init' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command init' -o force-copy -d 'Suppress prompts about copying state data'
 
 ### output
 complete -f -c terraform -n '__fish_terraform_needs_command' -a output -d 'Read an output from a state file'
+complete -f -c terraform -n '__fish_terraform_using_command output' -o state -d 'Path to the state file to read'
+complete -f -c terraform -n '__fish_terraform_using_command output' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command output' -o module -d 'Return the outputs for a specific module'
+complete -f -c terraform -n '__fish_terraform_using_command output' -o json -d 'Print output in JSON format'
 
 ### plan
 complete -f -c terraform -n '__fish_terraform_needs_command' -a plan -d 'Generate and show an execution plan'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o destroy -d 'Generate a plan to destroy all resources'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o detailed-exitcode -d 'Return detailed exit codes'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o input -d 'Ask for input for variables if not directly set'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o module-depth -d 'Depth of modules to show in the output'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o out -d 'Write a plan file to the given path'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o parallelism -d 'Limit the number of concurrent operations'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o refresh -d 'Update state prior to checking for differences'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o target -d 'Resource to target'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_terraform_using_command plan' -o var-file -d 'Set variables from a file'
 
 ### push
 complete -f -c terraform -n '__fish_terraform_needs_command' -a push -d 'Upload this Terraform module to Atlas to run'
+complete -f -c terraform -n '__fish_terraform_using_command push' -o atlas-address -d 'An alternate address to an Atlas instance'
+complete -f -c terraform -n '__fish_terraform_using_command push' -o upload-modules -d 'Lock modules and upload completely'
+complete -f -c terraform -n '__fish_terraform_using_command push' -o name -d 'Name of the configuration in Atlas'
+complete -f -c terraform -n '__fish_terraform_using_command push' -o token -d 'Access token to use to upload'
+complete -f -c terraform -n '__fish_terraform_using_command push' -o overwrite -d 'Variable keys that should overwrite values in Atlas'
+complete -f -c terraform -n '__fish_terraform_using_command push' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_terraform_using_command push' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n '__fish_terraform_using_command push' -o vcs -d 'Upload only files committed to your VCS'
+complete -f -c terraform -n '__fish_terraform_using_command push' -o no-color -d 'If specified, output won\'t contain any color'
 
 ### refresh
 complete -f -c terraform -n '__fish_terraform_needs_command' -a refresh -d 'Update local state file against real resources'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o input -d 'Ask for input for variables if not directly set'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o state-out -d 'Path to write state'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o target -d 'Resource to target'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o var -d 'Set a variable in the Terraform configuration'
+complete -f -c terraform -n '__fish_terraform_using_command refresh' -o var-file -d 'Set variables from a file'
 
 ### show
 complete -f -c terraform -n '__fish_terraform_needs_command' -a show -d 'Inspect Terraform state or plan'
+complete -f -c terraform -n '__fish_terraform_using_command show' -o module-depth -d 'Depth of modules to show in the output'
+complete -f -c terraform -n '__fish_terraform_using_command show' -o no-color -d 'If specified, output won\'t contain any color'
 
 ### taint
 complete -f -c terraform -n '__fish_terraform_needs_command' -a taint -d 'Manually mark a resource for recreation'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o allow-missing -d 'Succeed even if resource is missing'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o module -d 'The module path where the resource lives'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o state-out -d 'Path to write state'
 
 ### untaint
 complete -f -c terraform -n '__fish_terraform_needs_command' -a untaint -d 'Manually unmark a resource as tainted'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o allow-missing -d 'Succeed even if resource is missing'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o backup -d 'Path to backup the existing state file'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o lock -d 'Lock the state file when locking is supported'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o lock-timeout -d 'Duration to retry a state lock'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o module -d 'The module path where the resource lives'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o state -d 'Path to a Terraform state file'
+complete -f -c terraform -n '__fish_terraform_using_command taint' -o state-out -d 'Path to write state'
 
 ### validate
 complete -f -c terraform -n '__fish_terraform_needs_command' -a validate -d 'Validates the Terraform files'
+complete -f -c terraform -n '__fish_terraform_using_command validate' -o no-color -d 'If specified, output won\'t contain any color'
 
 ### version
 complete -f -c terraform -n '__fish_terraform_needs_command' -a version -d 'Prints the Terraform version'


### PR DESCRIPTION
## Description

Terraform is an open source declarative infrastructure management tool:
https://www.terraform.io
https://github.com/hashicorp/terraform

This PR adds completions for all basic commands and their flags:

```
$ terraform help
Usage: terraform [--version] [--help] <command> [args]

The available commands for execution are listed below.
The most common, useful commands are shown first, followed by
less common or more advanced commands. If you're just getting
started with Terraform, stick with the common commands. For the
other commands, please read the help and docs before usage.

Common commands:
    apply              Builds or changes infrastructure
    console            Interactive console for Terraform interpolations
    destroy            Destroy Terraform-managed infrastructure
    env                Environment management
    fmt                Rewrites config files to canonical format
    get                Download and install modules for the configuration
    graph              Create a visual graph of Terraform resources
    import             Import existing infrastructure into Terraform
    init               Initialize a new or existing Terraform configuration
    output             Read an output from a state file
    plan               Generate and show an execution plan
    push               Upload this Terraform module to Atlas to run
    refresh            Update local state file against real resources
    show               Inspect Terraform state or plan
    taint              Manually mark a resource for recreation
    untaint            Manually unmark a resource as tainted
    validate           Validates the Terraform files
    version            Prints the Terraform version
```

The code was based on Git completions in order to keep things consistent.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages (N/A)
- [ ] Tests have been added for regressions fixed (N/A)
- [x] User-visible changes noted in CHANGELOG.md
