### PR TITLE
Warning when function is not modified by the editor after calling `funced`

### DIFF
--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -105,7 +105,8 @@ function funced --description 'Edit function definition'
     # If the editor command itself fails, we assume the user cancelled or the file
     # could not be edited, and we do not try again
     while true
-        if which md5sum > /dev/null
+        set -l checksum
+        if type -q md5sum
             set checksum (md5sum $tmpname)
         end
 
@@ -114,7 +115,7 @@ function funced --description 'Edit function definition'
         else
             # Verify the checksum (if present) to detect potential problems
             # with the editor command
-            if set -q checksum
+            if set -q checksum[1]
                 if echo "$checksum" | md5sum --check --status
                     echo (_ "Editor exited but the function was not modified")
                 end

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -3,8 +3,7 @@ function __funced_md5
         # GNU systems
         md5sum $argv[1] | cut -d' ' -f1
         return 0
-    end
-    if type -q md5
+    else if type -q md5
         # BSD systems
         md5 -q $argv[1]
         return 0

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -39,8 +39,7 @@ function funced --description 'Edit function definition'
 
     if test (count $funcname) -ne 1
         set_color red
-        _ "funced: You must specify one function name
-"
+        echo (_ "funced: You must specify one function name")
         set_color normal
         return 1
     end
@@ -58,8 +57,7 @@ function funced --description 'Edit function definition'
         set -l editor_cmd
         eval set editor_cmd $editor
         if not type -q -f "$editor_cmd[1]"
-            _ "funced: The value for \$EDITOR '$editor' could not be used because the command '$editor_cmd[1]' could not be found
-    "
+            echo (_ "funced: The value for \$EDITOR '$editor' could not be used because the command '$editor_cmd[1]' could not be found")
             set editor fish
         end
     end
@@ -112,15 +110,13 @@ function funced --description 'Edit function definition'
         end
 
         if not eval $editor $tmpname
-            _ "Editing failed or was cancelled"
-            echo
+            echo (_ "Editing failed or was cancelled")
         else
             # Verify the checksum (if present) to detect potential problems
             # with the editor command
             if set -q checksum
                 if echo "$checksum" | md5sum --check --status
-                    _ "Editor exited but the function was not modified"
-                    echo
+                    echo (_ "Editor exited but the function was not modified")
                 end
             end
 
@@ -135,12 +131,12 @@ function funced --description 'Edit function definition'
                 if not contains $repeat n N no NO No nO
                     continue
                 end
-                _ "Cancelled function editing"
-                echo
+                echo (_ "Cancelled function editing")
             end
         end
         break
     end
+
     set -l stat $status
     rm $tmpname >/dev/null
     and rmdir $tmpdir >/dev/null

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -1,7 +1,7 @@
 function __funced_md5
     if type -q md5sum
         # GNU systems
-        md5sum $argv[1] | cut -d' ' -f1
+        echo (md5sum $argv[1] | string split ' ')[1]
         return 0
     else if type -q md5
         # BSD systems


### PR DESCRIPTION
## Description

`funced` runs the editor command with a temporary file and quits silently once the process completes. However, in some cases the editor command might return immediately (see #1081). This change shows a warning if the file wasn't modified (according to the MD5 checksum) to make it easier to spot problems like that.

Fixes issue #1081 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
