### PR TITLE
Renamed "replace-one" vi bind mode to "replaceone"

### DIFF
--- a/share/functions/fish_default_mode_prompt.fish
+++ b/share/functions/fish_default_mode_prompt.fish
@@ -9,7 +9,7 @@ function fish_default_mode_prompt --description "Display the default mode for th
             case insert
                 set_color --bold --background green white
                 echo '[I]'
-            case replace-one
+            case replaceone
                 set_color --bold --background green white
                 echo '[R]'
             case visual

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -207,11 +207,11 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind '"*P' backward-char "commandline -i ( xsel -p; echo )[1]"
 
     #
-    # Lowercase r, enters replace-one mode
+    # Lowercase r, enters replaceone mode
     #
-    bind -m replace-one r force-repaint
-    bind -M replace-one -m default '' delete-char self-insert backward-char force-repaint
-    bind -M replace-one -m default \e cancel force-repaint
+    bind -m replaceone r force-repaint
+    bind -M replaceone -m default '' delete-char self-insert backward-char force-repaint
+    bind -M replaceone -m default \e cancel force-repaint
 
     #
     # visual mode

--- a/tests/bind.expect
+++ b/tests/bind.expect
@@ -157,7 +157,7 @@ expect_prompt -re {\r\nTENT\r\n} {
 
 # Now test that exactly the expected bind modes are defined
 send "bind --list-modes\r"
-expect_prompt -re {\r\ndefault\r\ninsert\r\npaste\r\nreplace-one\r\nvisual\r\n} {
+expect_prompt -re {\r\ndefault\r\ninsert\r\npaste\r\nreplaceone\r\nvisual\r\n} {
     puts "vi bind modes"
 } unmatched {
     puts stderr "Unexpected vi bind modes"


### PR DESCRIPTION
Fixes invalid character in variable name `fish_cursor_replace-one` (expanded from `fish_cursor_$fish_bind_mode`) in [`fish_vi_cursor_handle`](https://github.com/fish-shell/fish-shell/blob/f17ddb6770626892217d2a3a7cf494e5bcbbd720/share/functions/fish_vi_cursor.fish#L106-L109) by renaming `replace-one` bind mode to `replaceone`.

