### PR TITLE
Allow customization of ^C with a new color variable

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -918,6 +918,8 @@ The following variables are available to change the highlighting colors in fish:
 
 - `fish_color_host`, the color used to print the current host system in some of fish default prompts
 
+- `fish_color_cancel`, the color for the '^C' indicator on a canceled command
+
 Additionally, the following variables are available to change the highlighting in the completion pager:
 
 - `fish_pager_color_prefix`, the color of the prefix string, i.e. the string that is to be completed

--- a/share/functions/__fish_cancel_commandline.fish
+++ b/share/functions/__fish_cancel_commandline.fish
@@ -3,16 +3,10 @@ function __fish_cancel_commandline
     set -l cmd (commandline)
     if test -n "$cmd"
         commandline -C 1000000
-        # TODO: Switch from using tput and standout mode to `set_color` when themes have been
-        # augmented to include support for background colors or has support for standout/reverse
-        # mode.
-        #
-        # Set reverse fg/bg color mode, output ^C, restore normal mode, clear to EOL (to erase any
-        # autosuggestion).
+        echo -ns (set_color $fish_color_cancel) "^C" (set_color normal)
         if command -sq tput
-            echo -ns (set_color -r) "^C" (set_color normal) (tput el; or tput ce)
-        else
-            echo -n "^C"
+            # Clear to EOL (to erase any autosuggestion).
+            echo -n (tput el; or tput ce)
         end
         for i in (seq (commandline -L))
             echo ""

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -86,6 +86,9 @@ function __fish_config_interactive -d "Initializations that should be performed 
         set -q fish_color_selection
         or set -U fish_color_selection white --bold --background=brblack
 
+        set -q fish_color_cancel
+        or set -U fish_color_cancel -r
+
         # Pager colors
         set -q fish_pager_color_prefix
         or set -U fish_pager_color_prefix white --bold --underline


### PR DESCRIPTION
## Description

I've modified the `__fish_cancel_commandline` function to print `^C` using a color defined in a new `fish_color_cancel` variable.

I've set the default value of this variable to `-r` to match the current behaviour.

Please let me know if there's anywhere I should add documentation. I looked but didn't find the other color variables documented anywhere.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
