### PR TITLE
Don't move cursor in delete-char

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -118,10 +118,13 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -M insert -k end end-of-line 2>/dev/null
     bind -M default -k end end-of-line 2>/dev/null
 
-    bind -M default x delete-char
+    # Vi moves the cursor back if, after deleting, it is at EOL.
+    # To emulate that, move forward, then backward, which will be a NOP
+    # if there is something to move forward to.
+    bind -M default x delete-char forward-char backward-char
     bind -M default X backward-delete-char
-    bind -M insert -k dc delete-char
-    bind -M default -k dc delete-char
+    bind -M insert -k dc delete-char forward-char backward-char
+    bind -M default -k dc delete-char forward-char backward-char
 
     # Backspace deletes a char in insert mode, but not in normal/default mode.
     bind -M insert -k backspace backward-delete-char

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2709,9 +2709,6 @@ const wchar_t *reader_readline(int nchars) {
                 if (el->position < el->size()) {
                     update_buff_pos(el, el->position + 1);
                     remove_backward();
-                    if (el->position > 0 && el->position == el->size()) {
-                        update_buff_pos(el, el->position - 1);
-                    }
                 }
                 break;
             }


### PR DESCRIPTION
Instead, move forward and backward in vi-mode.

Fixes #3899.

It turns out this was much simpler than I thought.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

I intend to merge this in a week unless someone objects.