### PR TITLE
Just pick a python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Command substitutions now have access to the terminal, allowing tools like `fzf` to work in them (#1362, #3922).
 - `bg`s argument parsing has been reworked. It now fails for invalid arguments but allows non-existent jobs (#3909).
 - fish will now reset $USER if the uid is 0. This is to workaround some su implementations that pass along $USER when switching to root (#3944).
+- Our python-using functions now pick any python version (preferring python3), making dependencies on a specific python version unnecessary (#3970).
 
 ---
 

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -123,12 +123,12 @@ function __fish_config_interactive -d "Initializations that should be performed 
             # Hence we'll call python directly.
             # c_m_p.py should work with any python version.
             set -l update_args -B $__fish_datadir/tools/create_manpage_completions.py --manpath --cleanup-in '~/.config/fish/completions' --cleanup-in '~/.config/fish/generated_completions'
-            if command -qs python
-                python $update_args >/dev/null ^/dev/null &
+            if command -qs python3
+                python3 $update_args >/dev/null ^/dev/null &
             else if command -qs python2
                 python2 $update_args >/dev/null ^/dev/null &
-            else if command -qs python3
-                python3 $update_args >/dev/null ^/dev/null &
+            else if command -qs python
+                python $update_args >/dev/null ^/dev/null &
             end
         end
     end

--- a/share/functions/fish_config.fish
+++ b/share/functions/fish_config.fish
@@ -1,9 +1,10 @@
 function fish_config --description "Launch fish's web based configuration"
-    # Support passing an initial tab like "colors" or "functions"
-    set -l initial_tab
-    if count $argv >/dev/null
-        set initial_tab $argv[1]
+    set -lx __fish_bin_dir $__fish_bin_dir
+    if command -sq python3
+        python3 "$__fish_datadir/tools/web_config/webconfig.py" $argv
+    else if command -sq python2
+        python2 "$__fish_datadir/tools/web_config/webconfig.py" $argv
+    else if command -sq python
+        python "$__fish_datadir/tools/web_config/webconfig.py" $argv
     end
-    set -x __fish_bin_dir $__fish_bin_dir
-    eval (string escape $__fish_datadir/tools/web_config/webconfig.py) $initial_tab
 end

--- a/share/functions/fish_update_completions.fish
+++ b/share/functions/fish_update_completions.fish
@@ -1,4 +1,11 @@
 function fish_update_completions --description "Update man-page based completions"
     # Clean up old paths
-    python -B $__fish_datadir/tools/create_manpage_completions.py --manpath --progress --cleanup-in '~/.config/fish/completions' --cleanup-in '~/.config/fish/generated_completions'
+    set -l update_args -B $__fish_datadir/tools/create_manpage_completions.py --manpath --cleanup-in '~/.config/fish/completions' --cleanup-in '~/.config/fish/generated_completions' --progress
+    if command -qs python3
+        python3 $update_args
+    else if command -qs python2
+        python2 $update_args
+    else if command -qs python
+        python $update_args
+    end
 end


### PR DESCRIPTION
## Description

As we've heard about previously (e.g. #2655), using `python` in shebangs causes issues with OSs that don't install a `python` symlink by default (because they are following https://www.python.org/dev/peps/pep-0394/ and don't use python2 by default).

This fixes it by just always doing the

```fish
if command -sq python3
    python3
else if command -sq python2
   python2
else if command -sq python
   python
end
```

dance.

This also makes it so we consistently pick python3, then python2, then python.

Fixes issue #3970.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.md

Note: I could have created another helper function (`fish_python`), but decided against it since it'd be six lines that mask what is going on. Also it could not be used in f_c_i since we can't use a function there (backgrounding).