### PR TITLE
[hg completions] remove a grep and use hg's native query syntax

### DIFF
--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -318,7 +318,7 @@ function __fish_hg_sources
 end
 
 function __fish_hg_mq_enabled
-    if set -l line (__fish_hg config | grep extensions.hgext.mq)
+    if set -l line (__fish_hg config extensions.hgext.mq)
         set -l parts (string split "=" -m 1 $line)
         not string match -r -q -- "^!" $parts[2]
         return


### PR DESCRIPTION
## Description

Small simplification of the hg completions code, likely a teeny tiny performance win from not spawning two processes.

This has the side benefit of working around a wild bug with readline+fish that I've reported to the upstream readline developers. (The result of that bug is that the hg processes are constantly being leaked as `bg` jobs in the shell, which is how I came to notice this in the first place)
