### PR TITLE
Aucompletion guards for /etc/passwd #3980

### DIFF
--- a/share/functions/__fish_complete_users.fish
+++ b/share/functions/__fish_complete_users.fish
@@ -4,7 +4,7 @@ function __fish_complete_users --description "Print a list of local users, with 
         getent passwd | cut -d : -f 1,5 | string replace -r ':' \t
     else if test -x /usr/bin/dscl
         dscl . -list /Users RealName | string match -r -v '^_' | string replace -r ' {2,}' \t
-    else
+    else if test -e /etc/passwd
         string match -v -r '^\s*#' </etc/passwd | cut -d : -f 1,5 | string replace ':' \t
     end
 end

--- a/share/functions/__fish_print_users.fish
+++ b/share/functions/__fish_print_users.fish
@@ -4,7 +4,7 @@ function __fish_print_users --description "Print a list of local users"
         getent passwd | cut -d : -f 1
     else if test -x /usr/bin/dscl # OS X support
         dscl . -list /Users | string match -r -v '^_'
-    else
+    else if test -e /etc/passwd
         string match -v -r '^\w*#' </etc/passwd | cut -d : -f 1
     end
 end


### PR DESCRIPTION
## Description

Prevents fish from crashing when `/etc/passwd` is not available.

Fixes issue #3980

## Before pulling:

* Does this warrant an entry in CHANGELOG?
* Are there any tests covering autocompletions?