### PR TITLE
Use $suffix in classic_vcs prompt instead of hardcoding to '>'

### DIFF
--- a/share/tools/web_config/sample_prompts/classic_vcs.fish
+++ b/share/tools/web_config/sample_prompts/classic_vcs.fish
@@ -66,5 +66,5 @@ function fish_prompt --description 'Write out the prompt'
         set prompt_status ' ' (set_color $fish_color_status) "[$last_status]" "$normal"
     end
 
-    echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $fish_color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (__fish_vcs_prompt) $normal $prompt_status "> "
+    echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $fish_color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (__fish_vcs_prompt) $normal $prompt_status $suffix " "
 end

--- a/share/tools/web_config/sample_prompts/classic_vcs.fish
+++ b/share/tools/web_config/sample_prompts/classic_vcs.fish
@@ -48,6 +48,7 @@ function fish_prompt --description 'Write out the prompt'
 
     set -l color_cwd
     set -l prefix
+    set -l suffix
     switch $USER
         case root toor
             if set -q fish_color_cwd_root

--- a/share/tools/web_config/sample_prompts/informative_vcs.fish
+++ b/share/tools/web_config/sample_prompts/informative_vcs.fish
@@ -67,6 +67,7 @@ function fish_prompt --description 'Write out the prompt'
 
     set -l color_cwd
     set -l prefix
+    set -l suffix
     switch $USER
         case root toor
             if set -q fish_color_cwd_root


### PR DESCRIPTION
Fixes #3991

## Description

Instead of hardcoding '>', use the previously defined $suffix variable.
Fixes issue #3991 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
