### PR TITLE
Fix msgid typo from commit 08d42a0507

### DIFF
--- a/po/nb.po
+++ b/po/nb.po
@@ -13,5 +13,5 @@ msgstr ""
 
 #: parse_constants.h:213
 #, c-format
-msgid "No matches for wildcard p'%ls'. See `help expand`."
+msgid "No matches for wildcard '%ls'. See `help expand`."
 msgstr "Ingen treff for jokertegnmønster «%ls» Se `help expand`."


### PR DESCRIPTION
There was a leftover **p** in there, after editing back and forth, effectively disabling the translation I added.
