### PR TITLE
Fix syntax error in gphoto2 completions

### DIFF
--- a/share/completions/gphoto2.fish
+++ b/share/completions/gphoto2.fish
@@ -1,6 +1,6 @@
 
 #Common options
-complete -c gphoto2    -s '?'-l 'help'                             -d 'Print complete help message on program usage'
+complete -c gphoto2   -s '?' -l 'help'                             -d 'Print complete help message on program usage'
 complete -c gphoto2          -l 'usage'                            -d 'Print short message on program usage'
 complete -c gphoto2          -l 'debug'                            -d 'Turn on debugging'
 complete -c gphoto2          -l 'debug-logfile' -r                 -d 'Name of file to write debug info to'


### PR DESCRIPTION
## Description

Fix syntax error in gphoto2 completion file

Fixes issue #4031 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.md
