### PR TITLE
Fix global known host file name for ubuntu in __fish_print_hostnames.fish

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -18,7 +18,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
     end
 
     # Check hosts known to ssh
-    set -l known_hosts ~/.ssh/known_hosts{,2} /etc/ssh/known_hosts{,2} # Yes, seriously - the default specifies both with and without "2"
+    set -l known_hosts ~/.ssh/known_hosts{,2} /etc/ssh/{,ssh_}known_hosts{,2} # Yes, seriously - the default specifies both with and without "2"
     # Check default ssh configs
     set -l ssh_config
     # Get alias and commandline options


### PR DESCRIPTION
For Ubuntu the default global known host files are :
/etc/ssh/ssh_known_hosts  
/etc/ssh/ssh_known_hosts2

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
