### PR TITLE
Travis CI: Move non-test tasks to `before_script`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,13 @@ matrix:
         - CXXFLAGS="-g -lstdc++"
   fast_finish: true
 
-script:
+before_script:
   - autoreconf
   - ./configure --prefix=$HOME/prefix || cat config.log
   - make -j2
   - make install
+  
+script:
   - make test DESTDIR=$HOME/prefix/ SHOW_INTERACTIVE_LOG=1
 
 notifications:


### PR DESCRIPTION
## Description

This change ensures "non test" tasks are not included in the `script` Travis CI job section, with this change if any of the tasks in the `before_script` section fail Travis CI will report the job as `errored` rather than `failed`

Hopefully this will help your Travis CI Mac jobs 😄 


Fixes issue # (I didn't create an issue, apologies if you'd prefer one)



