### PR TITLE
Use open instead of osacsript in help and fish_config on latest macOS

### DIFF
--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -62,9 +62,14 @@ function help --description 'Show help for the fish shell'
                 set fish_browser xdg-open
             end
 
-            # On OS X, we go through osascript by default
+            # On OS X, we use osascript < 10.12.5, and open after (see #4035)
             if test (uname) = Darwin
-                if type -q osascript
+                set -l version (sw_vers -productVersion | string split .) 0 0 0
+                if [ $version[1] -gt 10 ]
+                    or [ $version[1] -eq 10 -a $version[2] -gt 12 ]
+                    or [ $version[1] -eq 10 -a $version[2] -eq 12 -a $version[3] -ge 5 ]
+                    set fish_browser open
+                else
                     set fish_browser osascript
                 end
             end

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -4,10 +4,12 @@ from __future__ import unicode_literals
 from __future__ import print_function
 import binascii
 import cgi
+from distutils.version import LooseVersion
 import glob
 import multiprocessing.pool
 import operator
 import os
+import platform
 import random
 import re
 import select
@@ -28,6 +30,12 @@ else:
     import http.server as SimpleHTTPServer
     import socketserver as SocketServer
     from urllib.parse import parse_qs
+
+def isMacOS10_12_5_OrLater():
+    """ Return whether this system is macOS 10.12.5 or a later version. """
+    version = platform.mac_ver()[0]
+    return version and LooseVersion(version) >= LooseVersion('10.12.5')
+
 
 # Disable CLI web browsers
 term = os.environ.pop('TERM', None)
@@ -1124,9 +1132,13 @@ f.write(redirect_template_html % (url, url))
 f.close()
 
 # Open temporary file as URL
+# Use open on macOS >= 10.12.5 to work around #4035.
 fileurl = 'file://' + filename
 print("Web config started at '%s'. Hit enter to stop." % fileurl)
-webbrowser.open(fileurl)
+if isMacOS10_12_5_OrLater():
+    subprocess.check_call(['open', fileurl])
+else:
+    webbrowser.open(fileurl)
 
 # Select on stdin and httpd
 stdin_no = sys.stdin.fileno()


### PR DESCRIPTION
This switches to using `open` instead of `osascript` for both `help` and `fish_config` on Mac OS 10.12.5, working around #4035. We can't switch for prior versions because `open` drops fragments, but it seems that has been fixed.

Fixes issue #4035
