### PR TITLE
Add Expert Options to zypper dup command completion

### DIFF
--- a/share/completions/zypper.fish
+++ b/share/completions/zypper.fish
@@ -342,6 +342,14 @@ complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l no-recommends        
 complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l recommends                    --description 'Install also recommended packages in addition to the required'
 complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l from                          --description 'Restrict upgrade to specified repository'
 complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l download                      --description 'Set the download-install mode. Available modes: only, in-advance, in-heaps, as-needed'
+complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l no-allow-downgrade            --description 'Do not allow installed resolvables to be downgraded'
+complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l allow-downgrade               --description 'Allow installed resolvables to be downgraded'
+complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l no-allow-name-change          --description 'Do not allow installed resolvables to change name'
+complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l allow-name-change             --description 'Allow installed resolvables to change name'
+complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l no-allow-arch-change          --description 'Do not allow installed resolvables to change architectures'
+complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l allow-arch-change             --description 'Allow installed resolvables to change architectures'
+complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l no-allow-vendor-change        --description 'Do not allow installed resolvables to switch vendors'
+complete -c zypper -n '__fish_zypper_is_subcommand_dup' -l allow-vendor-change           --description 'Allow installed resolvables to switch vendors'
 
 function __fish_zypper_is_subcommand_pchk
         __fish_zypper_cmd_in_array patch-check pchk


### PR DESCRIPTION
## Description

I added 8 options (4 affirmative and their negative counterparts) to the zypper.fish completion file. These are listed as "expert options" in the man page. I believe they should be included as they can be important for any openSUSE user and especially for openSUSE Tumbleweed users. The recommended update command for Tumbleweed is:

`zypper dup --no-allow-vendor-change`

which currently cannot be completed with fish.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
- [ ] Confirm wording for description of each item
