### PR TITLE
implement "tied" variables

### DIFF
--- a/doc_src/tie.txt
+++ b/doc_src/tie.txt
@@ -1,0 +1,52 @@
+\section tie tie - tie a scalar to an array variable
+
+\subsection tie-synopsis Synopsis
+\fish{synopsis}
+tie
+tie ( -U | --untie ) SCALAR_VAR
+tie [( -s | --sep) SEP] SCALAR_VAR [array_var]
+\endfish
+
+\subsection tie-description Description
+
+`tie` links a scalar <a href="index.html#variables">shell variable</a>, typically one that is exported, to an array variable. When one form is updated its alternate form is automatically updated. For example, you might tie `GOPATH` to `gopath`. This makes it easy to treat the `GOPATH` env var as an array of paths. Updating `gopath` will automatically result in the exported `GOPATH` env var being updated. And vice-versa.
+
+If `tie` is called with no arguments it will list all the tied variables as a sequence of `tie` commands.
+
+If only a scalar var name is given its lowercase form will be used as the array name. This means you don't need to type `tie GOPATH gopath`; you can simply type `tie GOPATH`.
+
+The following options are available:
+
+- `-U` or `--untie` does what the option implies: It removes the tie between the two variables. The variables themselves are not altered by this. However, once you untie them the vars are no longer kept in sync when either one is changed.
+
+- `-s` or `--sep` specifies a separator to use when converting between the scalar and array vars. The default is `:`. If you provide more than one character only the first char is used.
+
+If the scalar var exists at the time a tie is created it will be immediately split into the array var. If the array var exists and the scalar var does not then the scalar will be immediately created as a global exported (i.e., `set -gx`) var. If both exist the scalar var takes precedence.
+
+\subsection tie-example Example
+\fish
+tie GOPATH
+# Ties "GOPATH" to "gopath" with ":" as the separator.
+
+tie GOPATH gopath_array
+# Ties "GOPATH" to "gopath_arry" with ":" as the separator.
+
+tie -s . EVAR silly_var
+# Ties "EVAR" to "silly_var" with "." as the separator.
+
+\endfish
+
+\subsection tie-notes Notes
+
+If you use `set -l` on either tied var in a nested block you must do the same for its alternate form. Let's say you want to make a local modification to the array form. Then in that case you have to also create a local version of the scalar form:
+
+\fish
+tie GOPATH
+set gopath /path1 /path2
+block
+    set -l GOPATH
+    set -l gopath /path3 /path4
+end
+\endfish
+
+If you don't do that then `GOPATH` scalar form won't be properly restored to the original string when leaving the block.

--- a/doc_src/tie.txt
+++ b/doc_src/tie.txt
@@ -38,15 +38,17 @@ tie -s . EVAR silly_var
 
 \subsection tie-notes Notes
 
-If you use `set -l` on either tied var in a nested block you must do the same for its alternate form. Let's say you want to make a local modification to the array form. Then in that case you have to also create a local version of the scalar form:
+If you use `set -l` on a tied var in a nested block you do not need to do anything special to its mirror. The mirror var will be automatically localized. Let's say you want to make a local modification to the array form of a tied var. Just do so and a local version of the scalar form will automatically be created and restored when the block is exited:
 
 \fish
 tie GOPATH
 set gopath /path1 /path2
+set SAVED_GOPATH $GOPATH
 block
-    set -l GOPATH
     set -l gopath /path3 /path4
+    test $GOPATH = "/path3:/path4"
+    and "Yay! The localized change to gopath was reflected in GOPATH."
 end
+test $GOPATH = $SAVED_GOPATH
+and "Yay! The localized change to GOPATH did not bleed into the global scope."
 \endfish
-
-If you don't do that then `GOPATH` scalar form won't be properly restored to the original string when leaving the block.

--- a/share/config.fish
+++ b/share/config.fish
@@ -106,6 +106,16 @@ if not contains -- $__fish_datadir/completions $fish_complete_path
     set fish_complete_path $fish_complete_path $__fish_datadir/completions
 end
 
+# Tie these vars to array equivalents so that we can begin the transition to
+# using the tied array vars. That way in the next major release we can stop special-casing these env
+# vars in the fish C++ code and they can go back to always being the single element string form.
+# Note that we don't use the lowercase variant of the env var name because that is too likely to
+# cause conflicts. Especially `path` since that is already used in several functions such as the
+# `type` command.
+tie PATH fish_path
+tie MANPATH fish_manpath
+tie CDPATH fish_cdpath
+
 #
 # This is a Solaris-specific test to modify the PATH so that
 # Posix-conformant tools are used by default. It is separate from the

--- a/share/functions/man.fish
+++ b/share/functions/man.fish
@@ -10,9 +10,9 @@ function man --description "Format and display the on-line manual pages"
         type -q manpath
         and set MANPATH (command manpath)
     end
-    set -l fish_manpath (dirname $__fish_datadir)/fish/man
-    if test -d "$fish_manpath" -a -n "$MANPATH"
-        set MANPATH "$fish_manpath":$MANPATH
+    set -l fish_man_path (dirname $__fish_datadir)/fish/man
+    if test -d "$fish_man_path" -a -n "$MANPATH"
+        set MANPATH "$fish_man_path":$MANPATH
 
         # Invoke man with this manpath, and we're done
         command man $argv

--- a/share/functions/tie.fish
+++ b/share/functions/tie.fish
@@ -1,0 +1,257 @@
+#
+# Implement support for tying scalar and array variables together. So that updating one
+# automatically updates the other. This is useful for environment variables like LD_LIBRARY_PATH.
+#
+# TODO: At the next major release stop special-casing PATH, MANPATH, CDPATH.
+
+# Display the list of tied variables in a form that can be run as commands to re-tie them.
+function __fish_tie_list
+    # Iterate over the private vars that define tied variables. Note that we don't pipe the var
+    # names through `sort` because we're relying on `set --names` output to already be sorted.
+    for tied in (string match '__fish_tied_*' (set --names))
+        set -l scalar_var (string replace '__fish_tied_' '' $tied)
+        set -l tied_data $$tied
+        set -l type $tied_data[1]
+
+        # We pay attention to the tied vars that refer to their mirror array var and ignore the
+        # inverse. This is because we only want to emit one `tie` command per pair of variables.
+        if test $type != "array"
+            continue
+        end
+
+        set -l array_var $tied_data[2]
+        set -l sep $tied_data[3]
+        printf "tie --sep %s %s %s\n" (string escape $sep) $scalar_var $array_var
+    end
+end
+
+# Remove the relationship between two tied variables. This does not unset either the scalar or array
+# variable. It simply stops fish from keeping them in sync. It accepts either the scalar or array
+# var name.
+function __fish_untie_var
+    set -l var_to_untie $argv[1]
+    set -l mirror_var_to_untie __fish_tied_$var_to_untie
+    if not set -q $mirror_var_to_untie
+        printf (_ "tie: '%s' is not a tied variable\n") $var_to_untie
+        return 1
+    end
+    set -l mirror_var_type $$mirror_var_to_untie[1][1]
+    set -l mirror_var_to_untie $$mirror_var_to_untie[1][2]
+
+    set -e __fish_tied_$var_to_untie
+    set -e __fish_tied_$mirror_var_to_untie
+    if test $mirror_var_type = array
+        functions -e __fish_tied_update_$mirror_var_to_untie
+    else
+        functions -e __fish_tied_update_$var_to_untie
+    end
+end
+
+# This is a helper function that syncs two tied vars when the tie is created. It favors the scalar
+# var since that is the common case. That is, tying a scalar env var like PATH to a global array
+# var. If the scalar var does not exist but the array var does then the scalar var is instantiated
+# as a global var.
+function __fish_tie_sync_vars --no-scope-shadowing
+    set -l scalar_var $argv[1]
+    set -l array_var $argv[2]
+    set -l sep $argv[3]
+
+    if set -q $scalar_var
+        # The scalar var in a tie has precedence. This means that if the array var is already
+        # defined it is overwritten.
+        __fish_tie_sync_to_array $scalar_var $array_var $sep
+    else if set -q $array_var
+        # If the scalar var is not defined but the array var is then set the scalar based on the
+        # array var.
+        __fish_tie_sync_to_scalar $scalar_var $array_var $sep
+    end
+end
+
+# Sync the scalar to the array var.
+function __fish_tie_sync_to_array --no-scope-shadowing
+    set -l scalar_var $argv[1]
+    set -l array_var $argv[2]
+    set -l sep $argv[3]
+
+    switch $scalar_var
+        # TODO: In the next major update stop special casing these vars.
+        case PATH MANPATH CDPATH
+            if set -q $array_var
+                set $array_var $$scalar_var
+            else
+                set -g $array_var $$scalar_var
+            end
+        case '*'
+            if set -q $array_var
+                set $array_var (string split -- $sep $$scalar_var)
+            else
+                set -g $array_var (string split -- $sep $$scalar_var)
+            end
+    end
+end
+
+# Sync the array to the scalar var.
+function __fish_tie_sync_to_scalar --no-scope-shadowing
+    set -l scalar_var $argv[1]
+    set -l array_var $argv[2]
+    set -l sep $argv[3]
+
+    switch $scalar_var
+        # TODO: In the next major update stop special casing these vars.
+        case PATH MANPATH CDPATH
+            if set -q $array_var
+                set $scalar_var $$array_var
+            else
+                set -g $scalar_var $$array_var
+            end
+        case '*'
+            if set -q $scalar_var
+                set $scalar_var (string join -- $sep $$array_var)
+            else
+                set -gx $scalar_var (string join -- $sep $$array_var)
+            end
+    end
+end
+
+# Tie a scalar and array variable to each other so that changes to one are reflected in the other.
+# Either of the two vars may be exported but this code does not require or assume that is the case.
+# However, the common use case is to map an exported environment var to a fish array.
+function __fish_tie_var --no-scope-shadowing
+    set -l scalar_var $argv[1]
+    set -l array_var
+    if set -q argv[2]
+        set array_var $argv[2]
+    else
+        set array_var (echo $scalar_var | tr '[:upper:]' '[:lower:]')
+        if test $scalar_var = $array_var
+            printf (_ "%s: You must supply two variable names when the scalar var is all lowercase\n") $cmd >&2
+            return 1
+        end
+    end
+
+    if test $scalar_var = $array_var
+        printf (_ "%s: The scalar and array vars cannot be the same\n") $cmd >&2
+        return 1
+    end
+
+    if not string match -qr '^[\w_]+$' -- $scalar_var
+        printf (_ "%s: Invalid var name: %s\n") $cmd $scalar_var
+        return 1
+    end
+    set -g __fish_tied_$array_var scalar $scalar_var $sep
+    set -g __fish_tied_$scalar_var array $array_var $sep
+
+    # Ensure the scalar and array vars are in sync at this point in time.
+    __fish_tie_sync_vars $scalar_var $array_var $sep
+
+    function __fish_tied_update_$array_var -V sep -V scalar_var -V array_var -v $scalar_var -v $array_var --no-scope-shadowing
+        if set -q __fish_tied__recurse__
+            return 0 # we were invoked recursively
+        end
+
+        set -l what $argv[1]
+        set -l op $argv[2]
+        set -l var_changed $argv[3]
+
+        if test $what != 'VARIABLE'
+            return 1 # this should be impossible
+        end
+
+        set -g __fish_tied__recurse__ 1 # make sure we don't run recursively
+
+        if test $var_changed = $scalar_var
+            # The scalar var was modified so update the tied array var.
+            # Test for the unusual case of a tied var being erased.
+            if test $op = ERASE
+                set -e $array_var
+                set -e __fish_tied__recurse__
+                return 0
+            end
+
+            if test $op != SET
+                set -e __fish_tied__recurse__
+                return 1 # this should be impossible
+            end
+
+            # Now handle the usual case where the scalar var is being modified so we need to update
+            # its mirror array var.
+            __fish_tie_sync_to_array $scalar_var $array_var $sep
+        else
+            # The array var was modified so update the tied scalar var.
+            # Test for the unusual case of a tied var being erased.
+            if test $op = ERASE
+                set -e $scalar_var
+                set -e __fish_tied__recurse__
+                return 0
+            end
+
+            if test $op != SET
+                set -e __fish_tied__recurse__
+                return 1 # this should be impossible
+            end
+
+            # Now handle the usual case where the array var is being modified so we need to update
+            # its mirror scalar var.
+            __fish_tie_sync_to_scalar $scalar_var $array_var $sep
+        end
+
+        set -e __fish_tied__recurse__
+    end
+end
+
+# The `tie` command. This may list tied variables, remove a tie, or create a tie between two
+# variables.
+function tie
+    set -l cmd $_
+
+    if not set -q argv[1]
+        __fish_tie_list
+        return 0
+    end
+
+    set -l untie no
+    set -l sep :
+    while set -q argv[1]
+        switch $argv[1]
+            case -s --sep
+                if not set -q argv[2]
+                    printf (_ "%s: The -s / --sep option requires one argument\n") $cmd >&2
+                    return 1
+                end
+                set sep (string sub -s 1 -l 1 -- $argv[2])
+                set -e argv[2]
+            case -U --untie
+                set untie yes
+            case -h --help
+                printf (_ "usage: %s [-U] [-s SEP] SCALAR_VAR [array_var]\n") $cmd
+                return 0
+            case --
+                set -e argv[1]
+                break
+            case '-*'
+                printf (_ "%s: Unrecognized option %s\n") $cmd $argv[1] >&2
+                return 1
+            case '*'
+                break
+        end
+        set -e argv[1]
+    end
+
+    if not set -q argv[1]
+        printf (_ "%s: You must supply at least one non-option argument\n") $cmd >&2
+        return 1
+    else if set -q argv[2]
+        and test $untie = "yes"
+        printf (_ "%s: The untie option accepts only one non-option argument\n") $cmd >&2
+        return 1
+    else if set -q argv[3]
+        printf (_ "%s: Too many non-option arguments\n") $cmd >&2
+        return 1
+    end
+
+    if test $untie = "yes"
+        __fish_untie_var $argv
+    else
+        __fish_tie_var $argv
+    end
+end

--- a/src/env.h
+++ b/src/env.h
@@ -18,25 +18,22 @@ extern bool curses_initialized;
 enum {
     /// Default mode.
     ENV_DEFAULT = 0,
-
-    /// Flag for local (to the current block) variable.
-    ENV_LOCAL = 1,
-
-    /// Flag for exported (to commands) variable.
-    ENV_EXPORT = 2,
-
-    /// Flag for unexported variable.
-    ENV_UNEXPORT = 16,
-
+    /// Flag for setting a local (i.e., private to the current block) variable.
+    ENV_LOCAL = (1 << 0),
+    /// Flag to export the variable.
+    ENV_EXPORT = (1 << 1),
+    /// Flag to unexport the variable.
+    ENV_UNEXPORT = (1 << 2),
     /// Flag for global variable.
-    ENV_GLOBAL = 4,
-
+    ENV_GLOBAL = (1 << 3),
     /// Flag for variable update request from the user. All variable changes that are made directly
     /// by the user, such as those from the 'set' builtin must have this flag set.
-    ENV_USER = 8,
-
-    /// Flag for universal variable.
-    ENV_UNIVERSAL = 32
+    ENV_USER = (1 << 4),
+    /// Flag for setting a universal variable.
+    ENV_UNIVERSAL = (1 << 5),
+    /// Flag for inhibiting sending an event on variable change. This should only be used when
+    /// ENV_LOCAL is also specified when updating the mirror of a tied variable.
+    ENV_NO_EVENT = (1 << 6),
 };
 typedef uint32_t env_mode_flags_t;
 
@@ -59,7 +56,7 @@ void env_init(const struct config_paths_t *paths = NULL);
 /// routines.
 void misc_init();
 
-int env_set(const wcstring &key, const wchar_t *val, env_mode_flags_t mode);
+int env_set(const wcstring &key, const wchar_t *val, env_mode_flags_t var_mode);
 
 class env_var_t : public wcstring {
    private:

--- a/tests/tie.in
+++ b/tests/tie.in
@@ -84,19 +84,32 @@ end
 echo $xyz
 echo $XYZ
 
+begin
+    set XYZ x1:y3:z5
+end
+echo $xyz
+echo $XYZ
+
 echo '# Changing a tied var in a nested block via `set -l` should not affect the global scope.'
 set -g not_tied xx yy
+tie -s - GHI
 begin
     set -l not_tied abc def
-    set -l XYZ $XYZ
     set -l xyz 2 4 6
+    set -l GHI g-h-i
     echo $not_tied
     echo $xyz
     echo $XYZ
+    echo $ghi
+    echo $GHI
 end
 echo $not_tied
 echo $xyz
 echo $XYZ
+set -q ghi
+or echo ghi not set in outer scope as expected
+set -q GHI
+or echo GHI not set in outer scope as expected
 
 echo '# Erasing a tied var should erase it\'s mirror but should leave the tie in place.'
 set -e XYZ

--- a/tests/tie.in
+++ b/tests/tie.in
@@ -1,0 +1,112 @@
+# Test tied variables.
+
+echo '# At this point we should have just the default tied vars.'
+tie
+
+echo '# Add a tied var.'
+tie XYZ
+tie
+
+echo '# Add a custom tied var using period as the separator.'
+tie -s . ABC abc_array
+tie
+
+echo '# Add a custom tied var using space as the separator.'
+tie -s ' ' SPACE
+tie
+
+echo '# Test modifying the array var by setting it to zero elements.'
+set xyz
+echo $xyz
+echo $XYZ
+
+echo '# Test modifying the array var by setting it to one element.'
+set xyz one-string
+echo $xyz
+echo $XYZ
+
+echo '# Test modifying the array var by setting it to more than one element.'
+set xyz abc def ghi
+echo $xyz
+echo $XYZ
+
+echo '# Test modifying the scalar var by setting it to zero elements.'
+set XYZ
+echo $xyz
+echo $XYZ
+
+echo '# Test modifying the scalar var by setting it to one element.'
+set XYZ ONE-STRING
+echo $xyz
+echo $XYZ
+
+
+echo '# Test modifying the scalar var by setting it to more than one element.'
+set XYZ a:b:c:d
+echo $xyz
+echo $XYZ
+
+echo '# Test modifying the scalar var with a non-standard separator.'
+set ABC a:b.c:d.e.f
+echo $abc_array
+echo $ABC
+
+echo '# Test modifying the array var with a non-standard separator.'
+set abc_array aa:bb $abc_array yy:zz
+echo $abc_array
+echo $ABC
+
+echo '# Removing a tie should leave the tied vars unchanged and no longer kept in sync.'
+tie -U ABC
+echo $abc_array
+echo $ABC
+set abc_array 1 2
+set ABC 1:2:3
+echo $abc_array
+echo $ABC
+
+echo '# Test modifying the tied var with a space separator.'
+set space s p a c e
+printf "space |%s|\n" $space
+printf "SPACE |%s|\n" $SPACE
+echo count space (count $space)
+echo count SPACE (count $SPACE)
+set SPACE 's:p a c:e'
+printf "space |%s|\n" $space
+printf "SPACE |%s|\n" $SPACE
+echo count space (count $space)
+echo count SPACE (count $SPACE)
+
+echo '# Changing a tied var in a nested block should affect the global scope.'
+begin
+    set xyz 1 3 5
+end
+echo $xyz
+echo $XYZ
+
+echo '# Changing a tied var in a nested block via `set -l` should not affect the global scope.'
+set -g not_tied xx yy
+begin
+    set -l not_tied abc def
+    set -l XYZ $XYZ
+    set -l xyz 2 4 6
+    echo $not_tied
+    echo $xyz
+    echo $XYZ
+end
+echo $not_tied
+echo $xyz
+echo $XYZ
+
+echo '# Erasing a tied var should erase it\'s mirror but should leave the tie in place.'
+set -e XYZ
+set -q XYZ
+and echo XYZ unexpectedly defined
+set -q xyz
+and echo xyz unexpectedly defined
+set XYZ salmon:tuna:cod
+echo $xyz
+echo $XYZ
+set xyz clam mollusk oyster
+echo $xyz
+echo $XYZ

--- a/tests/tie.out
+++ b/tests/tie.out
@@ -67,13 +67,19 @@ count SPACE 1
 # Changing a tied var in a nested block should affect the global scope.
 1 3 5
 1:3:5
+x1 y3 z5
+x1:y3:z5
 # Changing a tied var in a nested block via `set -l` should not affect the global scope.
 abc def
 2 4 6
 2:4:6
+g h i
+g-h-i
 xx yy
-1 3 5
-1:3:5
+x1 y3 z5
+x1:y3:z5
+ghi not set in outer scope as expected
+GHI not set in outer scope as expected
 # Erasing a tied var should erase it's mirror but should leave the tie in place.
 salmon tuna cod
 salmon:tuna:cod

--- a/tests/tie.out
+++ b/tests/tie.out
@@ -1,0 +1,81 @@
+# At this point we should have just the default tied vars.
+tie --sep : CDPATH fish_cdpath
+tie --sep : MANPATH fish_manpath
+tie --sep : PATH fish_path
+# Add a tied var.
+tie --sep : CDPATH fish_cdpath
+tie --sep : MANPATH fish_manpath
+tie --sep : PATH fish_path
+tie --sep : XYZ xyz
+# Add a custom tied var using period as the separator.
+tie --sep . ABC abc_array
+tie --sep : CDPATH fish_cdpath
+tie --sep : MANPATH fish_manpath
+tie --sep : PATH fish_path
+tie --sep : XYZ xyz
+# Add a custom tied var using space as the separator.
+tie --sep . ABC abc_array
+tie --sep : CDPATH fish_cdpath
+tie --sep : MANPATH fish_manpath
+tie --sep : PATH fish_path
+tie --sep ' ' SPACE space
+tie --sep : XYZ xyz
+# Test modifying the array var by setting it to zero elements.
+
+
+# Test modifying the array var by setting it to one element.
+one-string
+one-string
+# Test modifying the array var by setting it to more than one element.
+abc def ghi
+abc:def:ghi
+# Test modifying the scalar var by setting it to zero elements.
+
+
+# Test modifying the scalar var by setting it to one element.
+ONE-STRING
+ONE-STRING
+# Test modifying the scalar var by setting it to more than one element.
+a b c d
+a:b:c:d
+# Test modifying the scalar var with a non-standard separator.
+a:b c:d e f
+a:b.c:d.e.f
+# Test modifying the array var with a non-standard separator.
+aa:bb a:b c:d e f yy:zz
+aa:bb.a:b.c:d.e.f.yy:zz
+# Removing a tie should leave the tied vars unchanged and no longer kept in sync.
+aa:bb a:b c:d e f yy:zz
+aa:bb.a:b.c:d.e.f.yy:zz
+1 2
+1:2:3
+# Test modifying the tied var with a space separator.
+space |s|
+space |p|
+space |a|
+space |c|
+space |e|
+SPACE |s p a c e|
+count space 5
+count SPACE 1
+space |s:p|
+space |a|
+space |c:e|
+SPACE |s:p a c:e|
+count space 3
+count SPACE 1
+# Changing a tied var in a nested block should affect the global scope.
+1 3 5
+1:3:5
+# Changing a tied var in a nested block via `set -l` should not affect the global scope.
+abc def
+2 4 6
+2:4:6
+xx yy
+1 3 5
+1:3:5
+# Erasing a tied var should erase it's mirror but should leave the tie in place.
+salmon tuna cod
+salmon:tuna:cod
+clam mollusk oyster
+clam:mollusk:oyster


### PR DESCRIPTION
People have wanted a way to more transparently handle other env vars
that are implicitly lists much like fish already does for PATH, MANPATH,
and CDPATH. I was originally leaning towards augmenting the set builtin
to allow the user to mark other vars for the same magic treatment. But
after much thought I decided the zsh "tied" variable feature is more
flexible and easier to use. This change implements that for fish.

Fixes #436

## TODOs:

The documentation needs more work. I also need to add more unit tests to verify corner cases. But the core implementation seems solid so I wanted to get this out for discussion.

I am ambivalent about whether to introduce a new `tie` command or augment `set` with `-T` / `--tie` and `-U` / `--untie` flags. Thoughts?