### PR TITLE
Fix usage of osascript in help

### DIFF
--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -131,7 +131,8 @@ function help --description 'Show help for the fish shell'
     # OS X /usr/bin/open swallows fragments (anchors), so use osascript
     # Eval is just a cheesy way of removing the hash escaping
     if test "$fish_browser" = osascript
-        osascript -e 'open location "'(eval echo $page_url)'"'
+        set -l opencmd 'open location "'(eval echo $page_url)'"'
+        osascript -e 'try' -e $opencmd -e 'on error' -e $opencmd -e 'end try'
         return
     end
 

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -62,14 +62,9 @@ function help --description 'Show help for the fish shell'
                 set fish_browser xdg-open
             end
 
-            # On OS X, we use osascript < 10.12.5, and open after (see #4035)
+            # On OS X, we go through osascript by default
             if test (uname) = Darwin
-                set -l version (sw_vers -productVersion | string split .) 0 0 0
-                if [ $version[1] -gt 10 ]
-                    or [ $version[1] -eq 10 -a $version[2] -gt 12 ]
-                    or [ $version[1] -eq 10 -a $version[2] -eq 12 -a $version[3] -ge 5 ]
-                    set fish_browser open
-                else
+                if type -q osascript
                     set fish_browser osascript
                 end
             end


### PR DESCRIPTION
This reverts f234637e53deea68303f35c342faa8518e058bec and implements a better workaround for the `osascript` bug.