### PR TITLE
Trivial: Remove redundant/non-existent bind forward-kill-word

### DIFF
--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -75,7 +75,6 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
     bind $argv \e\< beginning-of-buffer
     bind $argv \e\> end-of-buffer
 
-    bind \ed forward-kill-word
     bind \ed kill-word
 
     # Ignore some known-bad control sequences


### PR DESCRIPTION
## Description

`\ed` gets `bind`ed to a non-existing function, then re-`bind`ed. See: [here](https://github.com/fish-shell/fish-shell/blob/d37e7bcc259877d2098ea09deccd0926bde81e80/share/functions/fish_default_key_bindings.fish#L79). I went through the history to the [original commit](https://github.com/fish-shell/fish-shell/commit/cf8e746d0c04aec16df8e69d2987c785cb510d46#diff-067ffb921f9aa8e90eda1008e0d2fbecR71) and don't see any cause for this addition (such as some legacy function for example)

Fixes issue #N/A 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

As far as I can tell this change is trivial and the above checks do not apply. I've tested through a local change that Alt-d continues to work (and it does).