### PR TITLE
Add max_line_length to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 100
 
 [{Makefile,*.in}]
 indent_style = tab


### PR DESCRIPTION
## Description
This allows some editors to wrap comments and code to 100 characters, as in the style guide.