### PR TITLE
Tab completions shouldn't move the cursor when there are no completions

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2556,6 +2556,9 @@ const wchar_t *reader_readline(int nchars) {
                     // current token.
                     size_t end_of_token_offset = token_end - buff;
 
+                    // Store the current position so we can return to it if there are no completions
+                    size_t original_position = el->position;
+
                     // Move the cursor to the end.
                     if (el->position != end_of_token_offset) {
                         update_buff_pos(el, end_of_token_offset);
@@ -2582,6 +2585,11 @@ const wchar_t *reader_readline(int nchars) {
 
                     bool cont_after_prefix_insertion = (c == R_COMPLETE_AND_SEARCH);
                     comp_empty = handle_completions(comp, cont_after_prefix_insertion);
+
+                    if (comp.empty()) {
+                        update_buff_pos(el, original_position);
+                        reader_repaint();
+                    }
 
                     // Show the search field if requested and if we printed a list of completions.
                     if (c == R_COMPLETE_AND_SEARCH && !comp_empty && !data->pager.empty()) {

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2338,7 +2338,7 @@ const wchar_t *reader_readline(int nchars) {
     int last_char = 0;
     size_t yank_len = 0;
     const wchar_t *yank_str;
-    bool comp_empty = true;
+    bool comp_inserted_text = true;
     std::vector<completion_t> comp;
     int finished = 0;
     struct termios old_modes;
@@ -2512,7 +2512,7 @@ const wchar_t *reader_readline(int nchars) {
                 // Use the command line only; it doesn't make sense to complete in any other line.
                 editable_line_t *el = &data->command_line;
                 if (data->is_navigating_pager_contents() ||
-                    (!comp_empty && last_char == R_COMPLETE)) {
+                    (!comp_inserted_text && last_char == R_COMPLETE)) {
                     // The user typed R_COMPLETE more than once in a row. If we are not yet fully
                     // disclosed, then become so; otherwise cycle through our available completions.
                     if (data->current_page_rendering.remaining_to_disclose > 0) {
@@ -2584,7 +2584,7 @@ const wchar_t *reader_readline(int nchars) {
                     data->cycle_cursor_pos = el->position;
 
                     bool cont_after_prefix_insertion = (c == R_COMPLETE_AND_SEARCH);
-                    comp_empty = handle_completions(comp, cont_after_prefix_insertion);
+                    comp_inserted_text = handle_completions(comp, cont_after_prefix_insertion);
 
                     if (comp.empty()) {
                         update_buff_pos(el, original_position);
@@ -2592,7 +2592,7 @@ const wchar_t *reader_readline(int nchars) {
                     }
 
                     // Show the search field if requested and if we printed a list of completions.
-                    if (c == R_COMPLETE_AND_SEARCH && !comp_empty && !data->pager.empty()) {
+                    if (c == R_COMPLETE_AND_SEARCH && !comp_inserted_text && !data->pager.empty()) {
                         data->pager.set_search_field_shown(true);
                         select_completion_in_direction(direction_next);
                         reader_repaint_needed();


### PR DESCRIPTION
## Description
This fixes #4124 
This fixes the first example, `mpv --|'https://...very-very-long-url...'`. I'm not quite sure how to test it, however, because it changes the `reader.cpp` loop, which doesn't seem to have any tests in `fish_tests.cpp`.

The second example, `foo /path-typo|:/usr/lib`, is much more complicated and seems to be because the function `completer_t::complete_param_expand()` in `complete.cpp` doesn't know the cursor's position, and all surrounding code, including the main `complete()` function, assumes completions are done at the end of a token.
I looked into this a little bit and made a WIP branch [`complete_param_expand_enhancement_wip`](https://github.com/rolag/fish-shell/tree/complete_param_expand_enhancement_wip) and it's possible to have the cursor not move when there are no completions *and* even expand paths before the `:` too. But with my current implementation I don't think it's possible to do this and move the cursor to the end when there *is* a completion e.g. `fish --ver|si` -> `fish --version|`, which is probably a big breaking change.