### PR TITLE
Fix the build on FreeBSD with Clang

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -47,8 +47,8 @@ static int wcsfilecmp_leading_digits(const wchar_t **a, const wchar_t **b) {
 ///
 /// Returns: -1 if a < b, 0 if a == b, 1 if a > b.
 int wcsfilecmp(const wchar_t *a, const wchar_t *b) {
-    CHECK(a, NULL);
-    CHECK(b, NULL);
+    CHECK(a, 0);
+    CHECK(b, 0);
     const wchar_t *orig_a = a;
     const wchar_t *orig_b = b;
     int retval = 0;  // assume the strings will be equal


### PR DESCRIPTION
NULL expands to nullptr which cannot be cast to an int.  Replace it with
0 in wcsfilecmp.

Fixes issue #4136

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.md
