### PR TITLE
Breakpoint prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Notable fixes and improvements
 - The `COLUMNS` and `LINES` env vars are now correctly set the first time `fish_prompt` is run (#4141).
+- New `status is-breakpoint` command that is true when a prompt is displayed in response to a `breakpoint` command (#1310).
 
 ## Other significant changes
 

--- a/doc_src/fish_breakpoint_prompt.txt
+++ b/doc_src/fish_breakpoint_prompt.txt
@@ -1,0 +1,30 @@
+\section fish_breakpoint_prompt fish_breakpoint_prompt - define the appearance of the command line prompt when in the context of a `breakpoint` command
+
+\subsection fish_breakpoint_prompt-synopsis Synopsis
+\fish{synopsis}
+function fish_breakpoint_prompt
+    ...
+end
+\endfish
+
+\subsection fish_breakpoint_prompt-description Description
+
+By defining the `fish_breakpoint_prompt` function, the user can choose a custom prompt when asking for input in response to a `breakpoint` command. The `fish_breakpoint_prompt` function is executed when the prompt is to be shown, and the output is used as a prompt.
+
+The exit status of commands within `fish_breakpoint_prompt` will not modify the value of <a href="index.html#variables-status">$status</a> outside of the `fish_breakpoint_prompt` function.
+
+`fish` ships with a default version of this function that displays the function name and line number of the current execution context.
+
+
+\subsection fish_breakpoint_prompt-example Example
+
+A simple prompt that is a simplified version of the default debugging prompt:
+
+\fish
+function fish_breakpoint_prompt -d "Write out the debug prompt"
+    set -l function (status current-function)
+    set -l line (status current-line-number)
+    set -l prompt "$function:$line >"
+    echo -ns (set_color $fish_color_status) "BP $prompt" (set_color normal) ' '
+end
+\endfish

--- a/doc_src/status.txt
+++ b/doc_src/status.txt
@@ -6,6 +6,7 @@ status
 status is-login
 status is-interactive
 status is-block
+status is-breakpoint
 status is-command-substitution
 status is-no-job-control
 status is-full-job-control
@@ -26,6 +27,8 @@ The following operations (sub-commands) are available:
 - `is-command-sub` returns 0 if fish is currently executing a command substitution. Also `-c` or `--is-command-substitution`.
 
 - `is-block` returns 0 if fish is currently executing a block of code. Also `-b` or `--is-block`.
+
+- `is-breakpoint` returns 0 if fish is currently showing a prompt in the context of a `breakpoint` command. See also the `fish_breakpoint_prompt` function.
 
 - `is-interactive` returns 0 if fish is interactive - that is, connected to a keyboard. Also `-i` or `--is-interactive`.
 

--- a/share/completions/status.fish
+++ b/share/completions/status.fish
@@ -1,5 +1,5 @@
 # Note that when a completion file is sourced a new block scope is created so `set -l` works.
-set -l __fish_status_all_commands is-login is-interactive is-block is-command-substitution is-no-job-control is-interactive-job-control is-full-job-control current-filename current-line-number print-stack-trace job-control
+set -l __fish_status_all_commands is-login is-interactive is-block is-breakpoint is-command-substitution is-no-job-control is-interactive-job-control is-full-job-control current-filename current-line-number print-stack-trace job-control
 
 # These are the recognized flags.
 complete -c status -s h -l help --description "Display help and exit"
@@ -9,6 +9,7 @@ complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_com
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-interactive -d "Test if this is an interactive shell"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-command-substitution -d "Test if a command substitution is currently evaluated"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-block -d "Test if a code block is currently evaluated"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-breakpoing -d "Test if a breakpoint is currently in effect"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-no-job-control -d "Test if new jobs are never put under job control"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-interactive-job-control -d "Test if only interactive new jobs are put under job control"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-full-job-control -d "Test if all new jobs are put under job control"

--- a/share/functions/fish_breakpoint_prompt.fish
+++ b/share/functions/fish_breakpoint_prompt.fish
@@ -1,0 +1,18 @@
+# Define the default debugging prompt command.
+function fish_breakpoint_prompt --description "A right prompt to be used when `breakpoint` is executed"
+    set -l function (status current-function)
+    set -l line (status current-line-number)
+    # At the moment we don't include the filename because, even if we truncate it, it makes the
+    # prompt too long.
+    #set -l filename (status current-filename)
+    #set -l prompt "$filename:$function:$line >"
+    set -l prompt "$function:$line >"
+
+    # Make sure the prompt doesn't consume more than half the terminal width.
+    set -l max_len (math "$COLUMNS / 2")
+    if test (string length -- $prompt) -gt $max_len
+        set prompt ...(string sub -s -(math $max_len - 3) -- $prompt)
+    end
+
+    echo -ns (set_color $fish_color_status) "BP $prompt" (set_color normal) ' '
+end

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -69,6 +69,10 @@ enum { COMMAND_NOT_BUILTIN, BUILTIN_REGULAR, BUILTIN_FUNCTION };
 /// Error message when number expected
 #define BUILTIN_ERR_NOT_NUMBER _(L"%ls: Argument '%ls' is not a number\n")
 
+/// Command that requires a subcommand was invoked without a recognized subcommand.
+#define BUILTIN_ERR_MISSING_SUBCMD _(L"%ls: Expected a subcommand to follow the command\n")
+#define BUILTIN_ERR_INVALID_SUBCMD _(L"%ls: Subcommand '%ls' is not valid\n")
+
 /// The send stuff to foreground message.
 #define FG_MSG _(L"Send job %d, '%ls' to foreground\n")
 

--- a/src/builtin_status.cpp
+++ b/src/builtin_status.cpp
@@ -20,6 +20,7 @@ enum status_cmd_t {
     STATUS_IS_LOGIN = 1,
     STATUS_IS_INTERACTIVE,
     STATUS_IS_BLOCK,
+    STATUS_IS_BREAKPOINT,
     STATUS_IS_COMMAND_SUB,
     STATUS_IS_FULL_JOB_CTRL,
     STATUS_IS_INTERACTIVE_JOB_CTRL,
@@ -38,6 +39,7 @@ const enum_map<status_cmd_t> status_enum_map[] = {
     {STATUS_CURRENT_FUNCTION, L"current-function"},
     {STATUS_CURRENT_LINE_NUMBER, L"current-line-number"},
     {STATUS_IS_BLOCK, L"is-block"},
+    {STATUS_IS_BREAKPOINT, L"is-breakpoint"},
     {STATUS_IS_COMMAND_SUB, L"is-command-substitution"},
     {STATUS_IS_FULL_JOB_CTRL, L"is-full-job-control"},
     {STATUS_IS_INTERACTIVE, L"is-interactive"},
@@ -237,6 +239,9 @@ int builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 return STATUS_CMD_ERROR;
             }
             optind++;
+        } else {
+            streams.err.append_format(BUILTIN_ERR_INVALID_SUBCMD, cmd, argv[1]);
+            return STATUS_INVALID_ARGS;
         }
     }
 
@@ -313,6 +318,11 @@ int builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         case STATUS_IS_BLOCK: {
             CHECK_FOR_UNEXPECTED_STATUS_ARGS(opts.status_cmd)
             retval = !is_block;
+            break;
+        }
+        case STATUS_IS_BREAKPOINT: {
+            CHECK_FOR_UNEXPECTED_STATUS_ARGS(opts.status_cmd)
+            retval = !is_breakpoint;
             break;
         }
         case STATUS_IS_LOGIN: {

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1208,9 +1208,10 @@ string_subcommands[] = {
 
 /// The string builtin, for manipulating strings.
 int builtin_string(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+    wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     if (argc <= 1) {
-        streams.err.append_format(_(L"string: Expected subcommand\n"));
+        streams.err.append_format(BUILTIN_ERR_MISSING_SUBCMD, cmd);
         builtin_print_help(parser, streams, L"string", streams.err);
         return STATUS_INVALID_ARGS;
     }
@@ -1224,8 +1225,8 @@ int builtin_string(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     while (subcmd->name != 0 && wcscmp(subcmd->name, argv[1]) != 0) {
         subcmd++;
     }
-    if (subcmd->handler == 0) {
-        streams.err.append_format(_(L"string: Unknown subcommand '%ls'\n"), argv[1]);
+    if (!subcmd->handler) {
+        streams.err.append_format(BUILTIN_ERR_INVALID_SUBCMD, cmd, argv[1]);
         builtin_print_help(parser, streams, L"string", streams.err);
         return STATUS_INVALID_ARGS;
     }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -444,6 +444,7 @@ void event_fire(const event_t *event) {
             }
         }
         is_event--;
+        assert(is_event >= 0);
     }
 }
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1130,7 +1130,7 @@ void exec_job(parser_t &parser, job_t *j) {
 static int exec_subshell_internal(const wcstring &cmd, wcstring_list_t *lst,
                                   bool apply_exit_status) {
     ASSERT_IS_MAIN_THREAD();
-    int prev_subshell = is_subshell;
+    bool prev_subshell = is_subshell;
     const int prev_status = proc_get_last_status();
     bool split_output = false;
 
@@ -1139,7 +1139,7 @@ static int exec_subshell_internal(const wcstring &cmd, wcstring_list_t *lst,
         split_output = true;
     }
 
-    is_subshell = 1;
+    is_subshell = true;
     int subcommand_status = -1;  // assume the worst
 
     // IO buffer creation may fail (e.g. if we have too many open files to make a pipe), so this may

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -255,11 +255,11 @@ static int fish_parse_opt(int argc, char **argv, std::vector<std::string> *cmds)
                 break;
             }
             case 'i': {
-                is_interactive_session = 1;
+                is_interactive_session = true;
                 break;
             }
             case 'l': {
-                is_login = 1;
+                is_login = true;
                 break;
             }
             case 'n': {

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -805,7 +805,7 @@ static void test_cancellation() {
     // Test for #3780
     // Ugly hack - temporarily set is_interactive_session
     // else we will SIGINT ourselves in response to our child death
-    scoped_push<int> iis(&is_interactive_session, 1);
+    scoped_push<bool> iis(&is_interactive_session, true);
     const wchar_t *child_self_destructor = L"while true ; sh -c 'sleep .25; kill -s INT $$' ; end";
     parser_t::principal_parser().eval(child_self_destructor, io_chain_t(), TOP);
     iis.restore();

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -88,11 +88,12 @@ void print_jobs(void)
 }
 #endif
 
-int is_interactive_session = 0;
-int is_subshell = 0;
-int is_block = 0;
-int is_login = 0;
-int is_event = 0;
+bool is_interactive_session = false;
+bool is_subshell = false;
+bool is_block = false;
+bool is_breakpoint = false;
+bool is_login = false;
+int is_event = false;
 pid_t proc_last_bg_pid = 0;
 int job_control_mode = JOB_CONTROL_INTERACTIVE;
 int no_exec = 0;

--- a/src/proc.h
+++ b/src/proc.h
@@ -217,22 +217,26 @@ class job_t {
     io_chain_t all_io_redirections() const;
 };
 
-/// Whether we are running a subshell command.
-extern int is_subshell;
-
-/// Whether we are running a block of commands.
-extern int is_block;
-
 /// Whether we are reading from the keyboard right now.
 bool shell_is_interactive(void);
 
+/// Whether we are running a subshell command.
+extern bool is_subshell;
+
+/// Whether we are running a block of commands.
+extern bool is_block;
+
+/// Whether we are running due to a `breakpoint` command.
+extern bool is_breakpoint;
+
 /// Whether this shell is attached to the keyboard at all.
-extern int is_interactive_session;
+extern bool is_interactive_session;
 
 /// Whether we are a login shell.
-extern int is_login;
+extern bool is_login;
 
-/// Whether we are running an event handler.
+/// Whether we are running an event handler. This is not a bool because we keep count of the event
+/// nesting level.
 extern int is_event;
 
 // List of jobs. We sometimes mutate this while iterating - hence it must be a list, not a vector

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -92,6 +92,9 @@
 /// The name of the function that prints the fish right prompt (RPROMPT).
 #define RIGHT_PROMPT_FUNCTION_NAME L"fish_right_prompt"
 
+/// The name of the function to use in place of the left prompt if we're in the debugger context.
+#define DEBUG_PROMPT_FUNCTION_NAME L"fish_breakpoint_prompt"
+
 /// The name of the function for getting the input mode indicator.
 #define MODE_PROMPT_FUNCTION_NAME L"fish_mode_prompt"
 
@@ -2251,15 +2254,20 @@ static int read_i(void) {
 
     while ((!data->end_loop) && (!sanity_check())) {
         event_fire_generic(L"fish_prompt");
-        if (function_exists(LEFT_PROMPT_FUNCTION_NAME))
-            reader_set_left_prompt(LEFT_PROMPT_FUNCTION_NAME);
-        else
-            reader_set_left_prompt(DEFAULT_PROMPT);
 
-        if (function_exists(RIGHT_PROMPT_FUNCTION_NAME))
+        if (is_breakpoint && function_exists(DEBUG_PROMPT_FUNCTION_NAME)) {
+            reader_set_left_prompt(DEBUG_PROMPT_FUNCTION_NAME);
+        } else if (function_exists(LEFT_PROMPT_FUNCTION_NAME)) {
+            reader_set_left_prompt(LEFT_PROMPT_FUNCTION_NAME);
+        } else {
+            reader_set_left_prompt(DEFAULT_PROMPT);
+        }
+
+        if (function_exists(RIGHT_PROMPT_FUNCTION_NAME)) {
             reader_set_right_prompt(RIGHT_PROMPT_FUNCTION_NAME);
-        else
+        } else {
             reader_set_right_prompt(L"");
+        }
 
         // Put buff in temporary string and clear buff, so that we can handle a call to
         // reader_set_buffer during evaluation.
@@ -2287,6 +2295,7 @@ static int read_i(void) {
             }
         }
     }
+
     reader_pop();
     return 0;
 }

--- a/tests/string.err
+++ b/tests/string.err
@@ -4,7 +4,7 @@ string match: [
 string match: ^
 
 # string invalidarg
-string: Unknown subcommand 'invalidarg'
+string: Subcommand 'invalidarg' is not valid
 Standard input (line 183): 
 string invalidarg; and echo "unexpected exit 0" >&2
 ^


### PR DESCRIPTION
This is a partial fix for issue #1310. Partial because it doesn't actually provide the correct breakpoint context. That is because we do not currently have a way to do so. That will be addressed in my next change. This pair of changes is to solicit feedback on the basic approach of defining a `fish_breakpoint_prompt` function and using that in place of `fish_prompt` when in a breakpoint/debug context.

To test this build fish with this change and run that version. Then do

```
function x; echo yes; breakpoint; echo no; end
```

Followed by executing `x`. You should see the custom debug prompt instead or your usual left prompt. Type [ctrl-D] or `exit` to leave the debugging context. You should then see your usual left prompt.