### PR TITLE
Copy local-exported variables

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -771,6 +771,9 @@ Variables can be explicitly set to be exported with the `-x` or `--export` switc
 
 -# If a variable is not explicitly set to be either exported or not exported and has never before been defined, the variable will not be exported.
 
+-# If a variable has local-scope and is exported, any function called receives a _copy_ of it, so any changes it makes to the variable disappear once the function returns.
+
+-# If a variable has global-scope, it is accessible read-write to functions whether it is exported or not.
 
 \subsection variables-arrays Arrays
 

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -182,6 +182,18 @@ struct var_stack_t {
 
 void var_stack_t::push(bool new_scope) {
     std::unique_ptr<env_node_t> node(new env_node_t(new_scope));
+
+    // Copy local-exported variables
+    auto top_node = top.get();
+    if (!(top_node == this->global_env)) {
+        for (auto& var : top_node->env) {
+            if (var.second.exportv) {
+                // This should copy var
+                node->env.insert(var);
+            }
+        }
+    }
+
     node->next = std::move(this->top);
     this->top = std::move(node);
     if (new_scope && local_scope_exports(this->top.get())) {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -185,11 +185,13 @@ void var_stack_t::push(bool new_scope) {
 
     // Copy local-exported variables
     auto top_node = top.get();
-    if (!(top_node == this->global_env)) {
-        for (auto& var : top_node->env) {
-            if (var.second.exportv) {
-                // This should copy var
-                node->env.insert(var);
+    if (new_scope) {
+        if (!(top_node == this->global_env)) {
+            for (auto& var : top_node->env) {
+                if (var.second.exportv) {
+                    // This should  copy var
+                    node->env.insert(var);
+                }
             }
         }
     }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -186,6 +186,8 @@ void var_stack_t::push(bool new_scope) {
 
     // Copy local-exported variables
     auto top_node = top.get();
+    // Only if we introduce a new shadowing scope
+    // i.e. not if it's just `begin; end` or "--no-scope-shadowing".
     if (new_scope) {
         if (!(top_node == this->global_env)) {
             for (auto& var : top_node->env) {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -121,7 +121,8 @@ class env_node_t {
     /// in the stack are invisible. If new_scope is set for the global variable node, the universe
     /// will explode.
     bool new_scope;
-    /// Does this node contain any variables which are exported to subshells.
+    /// Does this node contain any variables which are exported to subshells
+    /// or does it redefine any variables to not be exported?
     bool exportv = false;
     /// Pointer to next level.
     std::unique_ptr<env_node_t> next;
@@ -1067,6 +1068,9 @@ int env_set(const wcstring &key, const wchar_t *val, env_mode_flags_t var_mode) 
                 has_changed_new = true;
             } else {
                 entry.exportv = false;
+                // Set the node's exportv when it changes something about exports
+                // (also when it redefines a variable to not be exported).
+                node->exportv = has_changed_old != has_changed_new;
             }
 
             if (has_changed_old || has_changed_new) vars_stack().mark_changed_exported();

--- a/tests/test3.in
+++ b/tests/test3.in
@@ -238,6 +238,16 @@ __fish_test_shadow
 # Test that the variable is still exported (#2611)
 env | string match '__fish_test_env17=*'
 
+# Test that local exported variables are copied to functions (#1091)
+function __fish_test_local_export
+         echo $var
+         set var boo
+         echo $var
+end
+set -lx var wuwuwu
+__fish_test_local_export
+echo $var
+
 # clear for other shells
 set -eU __fish_test_universal_variables_variable_foo
 

--- a/tests/test3.in
+++ b/tests/test3.in
@@ -248,6 +248,15 @@ set -lx var wuwuwu
 __fish_test_local_export
 echo $var
 
+# Test that we don't copy local-exports to blocks.
+set -lx var foo
+begin
+    echo $var
+    set var bar
+    echo $var
+end
+echo $var # should be "bar"
+
 # clear for other shells
 set -eU __fish_test_universal_variables_variable_foo
 

--- a/tests/test3.in
+++ b/tests/test3.in
@@ -235,6 +235,8 @@ function __fish_test_shadow
   env | string match -q '__fish_test_env17=*' ; or echo SHADOWED
 end
 __fish_test_shadow
+# Test that the variable is still exported (#2611)
+env | string match '__fish_test_env17=*'
 
 # clear for other shells
 set -eU __fish_test_universal_variables_variable_foo

--- a/tests/test3.out
+++ b/tests/test3.out
@@ -18,6 +18,7 @@ Foo change detected
 Test 16 pass
 __fish_test_env17=UNSHADOWED
 SHADOWED
+__fish_test_env17=UNSHADOWED
 Testing Universal Startup
 1
 1

--- a/tests/test3.out
+++ b/tests/test3.out
@@ -19,6 +19,9 @@ Test 16 pass
 __fish_test_env17=UNSHADOWED
 SHADOWED
 __fish_test_env17=UNSHADOWED
+wuwuwu
+boo
+wuwuwu
 Testing Universal Startup
 1
 1

--- a/tests/test3.out
+++ b/tests/test3.out
@@ -22,6 +22,9 @@ __fish_test_env17=UNSHADOWED
 wuwuwu
 boo
 wuwuwu
+foo
+bar
+bar
 Testing Universal Startup
 1
 1


### PR DESCRIPTION
This is a quick implementation of #1091 to get the discussion going.

------

When executing a function, local-exported (`set -lx`) variables
previously were not accessible at all. This is weird e.g. in case of
aliases, since

```fish
set -lx PAGER cat
git something # which will call $PAGER
```

would not work if `git` were a function, even if that ends up calling
`command git`.

Now, we copy these variables, so functions get a local-exported copy.

```fish
function x
    echo $var
    set var wurst
    echo $var
end
set -lx var banana
x # prints "banana" and "wurst"
echo $var # prints "banana"
```

One weirdness here is that, if a variable is both local and global,
the local-copy takes precedence:

```fish
set -gx var banana
set -lx var pineapple
echo $var # prints "pineapple"
x # from above, prints "pineapple" and "wurst"
echo $var # still prints "pineapple"
set -el var # deletes local version
echo $var # "banana" again
```

I don't think there is any more consistent way to handle this - the
local version is the one that is accessed first, so it should also be
written to first.

This is **backwards-incompatible**, since a function that expects to change the global environment without a previously-defined variable (a bare `set var`) will now no longer function if there is a local-exported variable. I'm unsure how to work around this. Also, it's sloppy to just `set` a variable, since this would break if no global variable was defined previously. So it should always be `set -g`.

Anyway, I expect this to be the main point of contention. One possibility is to push this to fish 3.0 and formally declare a backwards-compatibility break.

Global-exported variables are _not_ copied, instead they still offer
full read-write access.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

i.e. nothing yet.