### PR TITLE
No index out of bounds

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -796,28 +796,26 @@ static int expand_variables(const wcstring &instr, std::vector<completion_t> *ou
 
                 if (!all_vars) {
                     wcstring_list_t string_values(var_idx_list.size());
+                    int success = 0;
                     for (size_t j = 0; j < var_idx_list.size(); j++) {
                         long tmp = var_idx_list.at(j);
-                        // Check that we are within array bounds. If not, truncate the list to
-                        // exit.
-                        if (tmp < 1 || (size_t)tmp > var_item_list.size()) {
-                            size_t var_src_pos = var_pos_list.at(j);
-                            // The slice was parsed starting at stop_pos, so we have to add that
-                            // to the error position.
-                            append_syntax_error(errors, slice_start + var_src_pos,
-                                                ARRAY_BOUNDS_ERR);
-                            is_ok = false;
-                            var_idx_list.resize(j);
-                            break;
-                        } else {
-                            // Replace each index in var_idx_list inplace with the string value
-                            // at the specified index.
-                            // al_set( var_idx_list, j, wcsdup((const wchar_t *)al_get(
-                            // &var_item_list, tmp-1 ) ) );
-                            string_values.at(j) = var_item_list.at(tmp - 1);
+                        // Check that we are within array bounds. If not, skip the element.
+                        // Note: Negative indices (`echo $foo[-1]`) are already converted to
+                        // positive ones here,
+                        // so tmp < 1 means it's definitely not in.
+                        if ((size_t)tmp > var_item_list.size() || tmp < 1) {
+                            continue;
                         }
+                        // Replace each index in var_idx_list inplace with the string value
+                        // at the specified index.
+                        // al_set( var_idx_list, j, wcsdup((const wchar_t *)al_get(
+                        // &var_item_list, tmp-1 ) ) );
+                        string_values.at(success) = var_item_list.at(tmp - 1);
+                        success++;
                     }
 
+                    // Resize the list to remove invalid elements
+                    string_values.resize(success);
                     // string_values is the new var_item_list.
                     var_item_list = std::move(string_values);
                 }
@@ -892,17 +890,6 @@ static int expand_variables(const wcstring &instr, std::vector<completion_t> *ou
                 return is_ok;
             }
             stop_pos = (slice_end - in);
-
-            // Validate that the parsed indexes are valid.
-            for (size_t j = 0; j < var_idx_list.size(); j++) {
-                long tmp = var_idx_list.at(j);
-                if (tmp != 1) {
-                    size_t var_src_pos = var_pos_list.at(j);
-                    append_syntax_error(errors, slice_start + var_src_pos, ARRAY_BOUNDS_ERR);
-                    is_ok = 0;
-                    return is_ok;
-                }
-            }
         }
 
         // Expand a non-existing variable.
@@ -1090,10 +1077,8 @@ static int expand_cmdsubst(const wcstring &input, std::vector<completion_t> *out
         tail_begin = slice_end;
         for (i = 0; i < slice_idx.size(); i++) {
             long idx = slice_idx.at(i);
-            if (idx < 1 || (size_t)idx > sub_res.size()) {
-                size_t pos = slice_source_positions.at(i);
-                append_syntax_error(errors, slice_begin - in + pos, ARRAY_BOUNDS_ERR);
-                return 0;
+            if ((size_t)idx > sub_res.size() || idx < 1) {
+                continue;
             }
             idx = idx - 1;
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -650,7 +650,7 @@ static size_t parse_slice(const wchar_t *in, wchar_t **end_ptr, std::vector<long
         }
         // debug( 0, L"Push idx %d", tmp );
 
-        long i1 = tmp > -1 ? tmp : (long)array_size + tmp + 1;
+        long i1 = tmp > -1 ? tmp : size + tmp + 1;
         pos = end - in;
         while (in[pos] == INTERNAL_SEPARATOR) pos++;
         if (in[pos] == L'.' && in[pos + 1] == L'.') {
@@ -667,6 +667,13 @@ static size_t parse_slice(const wchar_t *in, wchar_t **end_ptr, std::vector<long
 
             // debug( 0, L"Push range %d %d", tmp, tmp1 );
             long i2 = tmp1 > -1 ? tmp1 : size + tmp1 + 1;
+            // Clamp to array size, but only when doing a range,
+            // and only when just one is too high.
+            if (i1 > size && i2 > size) {
+                continue;
+            }
+            i1 = i1 < size ? i1 : size;
+            i2 = i2 < size ? i2 : size;
             // debug( 0, L"Push range idx %d %d", i1, i2 );
             short direction = i2 < i1 ? -1 : 1;
             for (long jjj = i1; jjj * direction <= i2 * direction; jjj += direction) {

--- a/tests/expansion.err
+++ b/tests/expansion.err
@@ -1,30 +1,9 @@
-fish: Array index out of bounds
-show "$foo[2]"
-           ^
-fish: Array index out of bounds
-show $foo[2]
-          ^
-fish: Array index out of bounds
-show "$foo[1 2]"
-             ^
-fish: Array index out of bounds
-show $foo[1 2]
-            ^
-fish: Array index out of bounds
-show "$foo[2 1]"
-           ^
-fish: Array index out of bounds
-show $foo[2 1]
-          ^
 fish: Invalid index value
 echo "$foo[d]"
            ^
 fish: Invalid index value
 echo $foo[d]
           ^
-fish: Array index out of bounds
-echo ()[1]
-        ^
 fish: Invalid index value
 echo ()[d]
         ^

--- a/tests/expansion.in
+++ b/tests/expansion.in
@@ -83,6 +83,7 @@ show $foo[2 1]
 set -l foo a b c
 show $foo[17]
 show $foo[-17]
+show $foo[17..18]
 
 echo "$foo[d]"
 echo $foo[d]

--- a/tests/expansion.in
+++ b/tests/expansion.in
@@ -80,6 +80,9 @@ show "$foo[1 2]"
 show $foo[1 2]
 show "$foo[2 1]"
 show $foo[2 1]
+set -l foo a b c
+show $foo[17]
+show $foo[-17]
 
 echo "$foo[d]"
 echo $foo[d]

--- a/tests/expansion.in
+++ b/tests/expansion.in
@@ -62,6 +62,12 @@ show "$$foo"
 show $$foo
 show "prefix$$foo"
 show prefix$$foo
+show $foo[-5..2]
+show $foo[-2..-1]
+show $foo[-10..-5]
+show (printf '%s\n' $foo)[-5..2]
+show (printf '%s\n' $foo)[-2..-1]
+show (printf '%s\n' $foo)[-10..-5]
 
 set -l foo
 show "$foo[1]"

--- a/tests/expansion.out
+++ b/tests/expansion.out
@@ -36,8 +36,21 @@
 2 baz quux
 1 prefixbaz quux  fooest
 2 prefixbaz prefixquux
+2 bar 
+2  fooest
+0
+2 bar 
+2  fooest
+0
+1 
+0
 1 
 0
 1 
 0
+1 
+0
+1 
+0
+
 Catch your breath

--- a/tests/expansion.out
+++ b/tests/expansion.out
@@ -52,5 +52,7 @@
 0
 1 
 0
+0
+0
 
 Catch your breath

--- a/tests/expansion.out
+++ b/tests/expansion.out
@@ -54,5 +54,6 @@
 0
 0
 0
+0
 
 Catch your breath


### PR DESCRIPTION
## Description

Currently, for arrays index 1 is always valid (`echo $foo[1]` can't fail, only print nothing but a newline), while other indices may cause an ugly and annoying error. For command substitutions, even 1 isn't guaranteed, so `printf '%s\n' (somecommand)[1]` isn't a poor man's `somecommand | head -n 1`.

This fixes that by just removing every invalid index.

That means with `set foo a b c` and the "show" function from tests/expand.in:

- `show $foo[-5..-1]` prints "3 a b c" (i.e. ranges are clamped to whatever is defined)
- `show $foo[-10..1]` prints "1 a"
- `show $foo[2..5]` prints "2 b c"
- `show $foo[1 3 7 2]` prints "3 a c b" (i.e. 7 is ignored)
- `show $foo[17..18]` prints "0"
- `show $foo[12]` prints "0"

and similar for command substitutions.

Fixes issue #826 and #4127 (which would have to be done differently without the rest).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
