### PR TITLE
Fix last status report (it's always 0)

### DIFF
--- a/share/tools/web_config/sample_prompts/informative_vcs.fish
+++ b/share/tools/web_config/sample_prompts/informative_vcs.fish
@@ -4,6 +4,8 @@
 
 
 function fish_prompt --description 'Write out the prompt'
+    set -l last_status $status
+
     if not set -q __fish_git_prompt_show_informative_status
         set -g __fish_git_prompt_show_informative_status 1
     end
@@ -58,8 +60,6 @@ function fish_prompt --description 'Write out the prompt'
     if not set -q __fish_git_prompt_color_cleanstate
         set -g __fish_git_prompt_color_cleanstate green --bold
     end
-
-    set -l last_status $status
 
     if not set -q __fish_prompt_normal
         set -g __fish_prompt_normal (set_color normal)


### PR DESCRIPTION
## Description

It seems something is overwriting the status before it is
saved to a variable. Fixed by setting the last_status variable
at the very beginning.


