### PR TITLE
Add `read --delimiter`

### DIFF
--- a/doc_src/read.txt
+++ b/doc_src/read.txt
@@ -13,6 +13,8 @@ The following options are available:
 
 - `-c CMD` or `--command=CMD` sets the initial string in the interactive mode command buffer to `CMD`.
 
+- `-d DELIMITER` or `--delimiter=DELIMITER` specifies where the string should be split. An empty delimiter means every character is its own element.
+
 - `-g` or `--global` makes the variables global.
 
 - `-i` or `--silent` makes the characters typed obfuscated. This is useful for reading things like passwords or other sensitive information. Note that in bash the short flag is `-s`. We can't use that due to the existing use as an alias for `--shell`.
@@ -41,7 +43,7 @@ The following options are available:
 
 - `-z` or `--null` reads up to NUL instead of newline. Disables interactive mode.
 
-`read` reads a single line of input from stdin, breaks it into tokens based on the `IFS` shell variable, and then assigns one token to each variable specified in `VARIABLES`. If there are more tokens than variables, the complete remainder is assigned to the last variable. As a special case, if `IFS` is set to the empty string, each character of the input is considered a separate token.
+`read` reads a single line of input from stdin, breaks it into tokens based on the delimiter set via `-d`/`--delimiter` or the `IFS` shell variable, and then assigns one token to each variable specified in `VARIABLES`. If there are more tokens than variables, the complete remainder is assigned to the last variable. As a special case, if `IFS` is set to the empty string, each character of the input is considered a separate token.
 
 If `-a` or `--array` is provided, only one variable name is allowed and the tokens are stored as an array in this variable.
 

--- a/tests/read.in
+++ b/tests/read.in
@@ -187,3 +187,35 @@ end
 if test (string length "$x") -ne $FISH_READ_BYTE_LIMIT
     echo reading the max amount of data with --nchars failed the length test
 end
+
+### Test --delimiter (and $IFS, for now)
+echo a=b | read -l foo bar
+echo $foo
+echo $bar
+echo Delimiter =
+echo a=b | read -l -d = foo bar
+echo $foo
+echo $bar
+echo Delimiter empty
+echo a=b | read -l -d '' foo bar baz
+echo $foo
+echo $bar
+echo $baz
+echo IFS empty string
+set -l IFS ''
+echo a=b | read -l foo bar baz
+echo $foo
+echo $bar
+echo $baz
+echo IFS unset
+set -e IFS
+echo a=b | read -l foo bar baz
+echo $foo
+echo $bar
+echo $baz
+echo Delimiter =
+echo a=b | read -l -d = foo bar baz
+echo $foo
+echo $bar
+echo $baz
+echo

--- a/tests/read.out
+++ b/tests/read.out
@@ -58,3 +58,25 @@ newline
 
 # chunked read tests
 Chunked reads test pass
+a=b
+
+Delimiter =
+a
+b
+Delimiter empty
+a
+=
+b
+IFS empty string
+a
+=
+b
+IFS unset
+a=b
+
+
+Delimiter =
+a
+b
+
+


### PR DESCRIPTION
## Description

This adds a `--delimiter` (or "-d") option to builtin read. It allows the same thing that setting $IFS does. It falls back to $IFS if the option wasn't given.

There's some issues left here:

- Specifying multiple characters - `echo abcdbce | read -d 'bc' foo bar baz` sets $foo to "a", $bar to "d" and $baz to "ce". That seems highly unintuitive. This behavior existed previously, but this is the chance to fix it.

- Specifying the delimiter as "-dDELIM" works as long as that DELIM isn't empty (`''`). In that case, it needs to be specified as `-d ''` or `--delimiter=''` or `--delimiter ''`.

Work towards #4156.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added
- [ ] User-visible changes noted in CHANGELOG.md

Since this is backwards-compatible (only adding a feature), we could add it to 2.7.