### PR TITLE
proof of concept implementation for treating undefined vars as an error

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -37,6 +37,16 @@ if status --is-interactive
     else
         # Enable truecolor/24-bit support for select terminals
         # Ignore Neovim (in 0.1.4 at least), Screen and emacs' ansi-term as they swallow the sequences, rendering the text white.
+
+        # Make sure these env vars are defined. This sucks but so does the subsequent complicated
+        # `if` conditional.
+        set -q ITERM_SESSION_ID
+        or set -l ITERM_SESSION_ID
+        set -q VTE_VERSION
+        or set -l VTE_VERSION
+        set -q COLORTERM
+        or set -l COLORTERM
+
         if not set -q NVIM_LISTEN_ADDRESS
             and not set -q STY
             and not string match -q -- 'eterm*' $TERM

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -1163,7 +1163,6 @@ env_var_t env_get_string(const wcstring &key, env_mode_flags_t mode) {
     const bool search_local = !has_scope || (mode & ENV_LOCAL);
     const bool search_global = !has_scope || (mode & ENV_GLOBAL);
     const bool search_universal = !has_scope || (mode & ENV_UNIVERSAL);
-
     const bool search_exported = (mode & ENV_EXPORT) || !(mode & ENV_UNEXPORT);
     const bool search_unexported = (mode & ENV_UNEXPORT) || !(mode & ENV_EXPORT);
 
@@ -1218,7 +1217,9 @@ env_var_t env_get_string(const wcstring &key, env_mode_flags_t mode) {
         }
     }
 
-    if (!search_universal) return env_var_t::missing_var();
+    if (!search_universal) {
+        return env_var_t::undef_var();
+    }
 
     // Another hack. Only do a universal barrier on the main thread (since it can change variable
     // values). Make sure we do this outside the env_lock because it may itself call env_get_string.
@@ -1235,7 +1236,8 @@ env_var_t env_get_string(const wcstring &key, env_mode_flags_t mode) {
         }
         return env_var;
     }
-    return env_var_t::missing_var();
+
+    return env_var_t::undef_var();
 }
 
 bool env_exist(const wchar_t *key, env_mode_flags_t mode) {
@@ -1517,7 +1519,7 @@ env_var_t env_vars_snapshot_t::get(const wcstring &key) const {
         return env_get_string(key);
     }
     std::map<wcstring, wcstring>::const_iterator iter = vars.find(key);
-    return iter == vars.end() ? env_var_t::missing_var() : env_var_t(iter->second);
+    return iter == vars.end() ? env_var_t::undef_var() : env_var_t(iter->second);
 }
 
 const wchar_t *const env_vars_snapshot_t::highlighting_keys[] = {L"PATH", L"CDPATH",

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -617,6 +617,8 @@ static void react_to_variable_change(const wcstring &key) {
     } else if (key == L"FISH_HISTORY") {
         history_destroy();
         reader_push(history_session_id().c_str());
+    } else if (key == L"fish_undef_var") {
+        update_fish_undef_var_behavior();
     }
 }
 
@@ -754,6 +756,8 @@ void misc_init() {
         fclose(procsyskosrel);
     }
 #endif  // OS_IS_MS_WINDOWS
+
+    update_fish_undef_var_behavior();
 }
 
 void env_init(const struct config_paths_t *paths /* or NULL */) {

--- a/src/env.h
+++ b/src/env.h
@@ -64,27 +64,37 @@ int env_set(const wcstring &key, const wchar_t *val, env_mode_flags_t mode);
 class env_var_t : public wcstring {
    private:
     bool is_missing;
+    bool is_undef;
 
    public:
     static env_var_t missing_var() {
         env_var_t result((wcstring()));
         result.is_missing = true;
+        result.is_undef = false;
         return result;
     }
 
-    env_var_t(const env_var_t &x) : wcstring(x), is_missing(x.is_missing) {}
-    env_var_t(const wcstring &x) : wcstring(x), is_missing(false) {}
-    env_var_t(const wchar_t *x) : wcstring(x), is_missing(false) {}
-    env_var_t() : wcstring(L""), is_missing(false) {}
+    static env_var_t undef_var() {
+        env_var_t result((wcstring()));
+        result.is_missing = true;
+        result.is_undef = true;
+        return result;
+    }
 
+    env_var_t(const env_var_t &x) : wcstring(x), is_missing(x.is_missing), is_undef(x.is_undef) {}
+    env_var_t(const wcstring &x) : wcstring(x), is_missing(false), is_undef(false) {}
+    env_var_t(const wchar_t *x) : wcstring(x), is_missing(false), is_undef(false)  {}
+    env_var_t() : wcstring(L""), is_missing(false), is_undef(false)  {}
+
+    bool undef(void) const { return is_undef; }
     bool missing(void) const { return is_missing; }
-
     bool missing_or_empty(void) const { return missing() || empty(); }
 
     const wchar_t *c_str(void) const;
 
     env_var_t &operator=(const env_var_t &s) {
         is_missing = s.is_missing;
+        is_undef = s.is_undef;
         wcstring::operator=(s);
         return *this;
     }
@@ -109,8 +119,8 @@ class env_var_t : public wcstring {
     bool operator!=(const wchar_t *s) const { return !(*this == s); }
 };
 
-/// Gets the variable with the specified name, or env_var_t::missing_var if it does not exist or is
-/// an empty array.
+/// Gets the variable with the specified name, or env_var_t::undef_var if it does not exist or
+/// env_var_t::missing_var if it is an empty array.
 ///
 /// \param key The name of the variable to get
 /// \param mode An optional scope to search in. All scopes are searched if unset

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -273,7 +273,7 @@ env_universal_t::env_universal_t(const wcstring &path)
 env_universal_t::~env_universal_t() { pthread_mutex_destroy(&lock); }
 
 env_var_t env_universal_t::get(const wcstring &name) const {
-    env_var_t result = env_var_t::missing_var();
+    env_var_t result = env_var_t::undef_var();
     var_table_t::const_iterator where = vars.find(name);
     if (where != vars.end()) {
         result = env_var_t(where->second.val);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -778,6 +778,12 @@ static int expand_variables(const wcstring &instr, std::vector<completion_t> *ou
             var_val = expand_var(var_tmp.c_str());
         }
 
+        if (var_val.undef()) {
+            append_syntax_error(errors, start_pos, _(L"Undefined variable"));
+            is_ok = false;
+            break;
+        }
+
         if (!var_val.missing()) {
             int all_vars = 1;
             wcstring_list_t var_item_list;
@@ -794,7 +800,7 @@ static int expand_variables(const wcstring &instr, std::vector<completion_t> *ou
                     bad_pos = parse_slice(in + slice_start, &slice_end, var_idx_list, var_pos_list,
                                           var_item_list.size());
                     if (bad_pos != 0) {
-                        append_syntax_error(errors, stop_pos + bad_pos, L"Invalid index value");
+                        append_syntax_error(errors, stop_pos + bad_pos, _(L"Invalid index value"));
                         is_ok = false;
                         break;
                     }

--- a/src/expand.h
+++ b/src/expand.h
@@ -154,4 +154,5 @@ bool expand_abbreviation(const wcstring &src, wcstring *output);
 bool fish_xdm_login_hack_hack_hack_hack(std::vector<std::string> *cmds, int argc,
                                         const char *const *argv);
 
+void update_fish_undef_var_behavior();
 #endif

--- a/src/expand.h
+++ b/src/expand.h
@@ -46,7 +46,9 @@ enum {
     EXPAND_SPECIAL_FOR_CD = 1 << 11,
     /// Do expansions specifically to support external command completions. This means using PATH as
     /// a list of potential working directories.
-    EXPAND_SPECIAL_FOR_COMMAND = 1 << 12
+    EXPAND_SPECIAL_FOR_COMMAND = 1 << 12,
+    /// Dereferencing an undefined variable is not an error.
+    EXPAND_UNDEF_VAR_OK = 1 << 13
 };
 typedef int expand_flags_t;
 

--- a/src/parse_execution.h
+++ b/src/parse_execution.h
@@ -107,9 +107,11 @@ class parse_execution_context_t {
                                                  const parse_node_t &contents);
 
     enum globspec_t { failglob, nullglob };
+    enum undef_var_t { undef_var_valid, undef_var_invalid };
     parse_execution_result_t determine_arguments(const parse_node_t &parent,
                                                  wcstring_list_t *out_arguments,
-                                                 globspec_t glob_behavior);
+                                                 globspec_t glob_behavior,
+                                                 undef_var_t undef_var_behavior);
 
     // Determines the IO chain. Returns true on success, false on error.
     bool determine_io_chain(const parse_node_t &statement, io_chain_t *out_chain);


### PR DESCRIPTION
This is a proof of concept implementation for treating dereferencing undefined vars as an error. It will not be merged in the fish 2.x branch. I want people to build a custom fish with this PR and report on whether it identifies any actual bugs or is just a PITA with zero redeeming value.

Note that this defaults to only warning about dereferencing undefined vars. Do `set -gx fish_undef_var 1` then launch a new fish to see what the fish 3.0 behavior might be like.

I have already fixed all of the core fish script to correctly handle undefined vars in light of this change. So any errors you see are going to be due to personal customizations. What I'm interested in is whether this identifies fish script that has actual bugs, or at least should be made more "fishy", or simply produces lots of failures for otherwise reasonable statements involving undefined vars.