### PR TITLE
implement and use `argparse`

### DIFF
--- a/.oclint
+++ b/.oclint
@@ -44,8 +44,8 @@ rule-configurations:
       value: 14
 
     # We're willing to allow slighly more execution paths through a function.
-    # Default is 300.
-    - key: HighNPathComplexity
+    # Default is 200.
+    - key: NPATH_COMPLEXITY
       value: 300
 
 disable-rules:

--- a/Makefile.in
+++ b/Makefile.in
@@ -99,21 +99,24 @@ HAVE_DOXYGEN=@HAVE_DOXYGEN@
 # All objects that the system needs to build fish, except fish.o
 #
 FISH_OBJS := obj/autoload.o obj/builtin.o obj/builtin_bg.o obj/builtin_bind.o obj/builtin_block.o \
-	obj/builtin_builtin.o obj/builtin_cd.o obj/builtin_command.o obj/builtin_commandline.o \
-	obj/builtin_complete.o obj/builtin_contains.o obj/builtin_disown.o obj/builtin_echo.o \
-	obj/builtin_emit.o obj/builtin_exit.o obj/builtin_fg.o obj/builtin_function.o \
-	obj/builtin_functions.o obj/builtin_history.o obj/builtin_jobs.o obj/builtin_printf.o \
-	obj/builtin_pwd.o obj/builtin_random.o obj/builtin_read.o obj/builtin_realpath.o \
-	obj/builtin_return.o obj/builtin_set.o obj/builtin_set_color.o obj/builtin_source.o \
-	obj/builtin_status.o obj/builtin_string.o obj/builtin_test.o obj/builtin_ulimit.o \
-	obj/color.o obj/common.o obj/complete.o obj/env.o obj/env_universal_common.o obj/event.o \
-	obj/exec.o obj/expand.o obj/fallback.o obj/fish_version.o obj/function.o obj/highlight.o \
-	obj/history.o obj/input.o obj/input_common.o obj/intern.o obj/io.o obj/iothread.o \
-	obj/kill.o obj/output.o obj/pager.o obj/parse_execution.o obj/parse_productions.o \
-	obj/parse_tree.o obj/parse_util.o obj/parser.o obj/parser_keywords.o obj/path.o \
-	obj/postfork.o obj/proc.o obj/reader.o obj/sanity.o obj/screen.o obj/signal.o \
-	obj/tokenizer.o obj/utf8.o obj/util.o obj/wcstringutil.o obj/wgetopt.o obj/wildcard.o \
-	obj/wutil.o
+	obj/builtin_builtin.o obj/builtin_cd.o obj/builtin_command.o \
+	obj/builtin_commandline.o obj/builtin_complete.o obj/builtin_contains.o \
+	obj/builtin_disown.o obj/builtin_echo.o obj/builtin_emit.o \
+	obj/builtin_exit.o obj/builtin_fg.o obj/builtin_function.o \
+	obj/builtin_functions.o obj/builtin_argparse.o obj/builtin_history.o \
+	obj/builtin_jobs.o obj/builtin_printf.o obj/builtin_pwd.o \
+	obj/builtin_random.o obj/builtin_read.o obj/builtin_realpath.o \
+	obj/builtin_return.o obj/builtin_set.o obj/builtin_set_color.o \
+	obj/builtin_source.o obj/builtin_status.o obj/builtin_string.o \
+	obj/builtin_test.o obj/builtin_ulimit.o obj/color.o obj/common.o \
+	obj/complete.o obj/env.o obj/env_universal_common.o obj/event.o obj/exec.o \
+	obj/expand.o obj/fallback.o obj/fish_version.o obj/function.o obj/highlight.o \
+	obj/history.o obj/input.o obj/input_common.o obj/intern.o obj/io.o \
+	obj/iothread.o obj/kill.o obj/output.o obj/pager.o obj/parse_execution.o \
+	obj/parse_productions.o obj/parse_tree.o obj/parse_util.o obj/parser.o \
+	obj/parser_keywords.o obj/path.o obj/postfork.o obj/proc.o obj/reader.o \
+	obj/sanity.o obj/screen.o obj/signal.o obj/tokenizer.o obj/utf8.o obj/util.o \
+	obj/wcstringutil.o obj/wgetopt.o obj/wildcard.o obj/wutil.o
 
 FISH_INDENT_OBJS := obj/fish_indent.o obj/print_help.o $(FISH_OBJS)
 
@@ -956,10 +959,10 @@ obj/builtin.o: src/builtin_command.h src/builtin_commandline.h
 obj/builtin.o: src/builtin_complete.h src/builtin_contains.h
 obj/builtin.o: src/builtin_disown.h src/builtin_echo.h src/builtin_emit.h
 obj/builtin.o: src/builtin_exit.h src/builtin_fg.h src/builtin_functions.h
-obj/builtin.o: src/builtin_history.h src/builtin_jobs.h src/builtin_printf.h
-obj/builtin.o: src/builtin_pwd.h src/builtin_random.h src/builtin_read.h
-obj/builtin.o: src/builtin_realpath.h src/builtin_return.h src/builtin_set.h
-obj/builtin.o: src/builtin_set_color.h src/builtin_source.h
+obj/builtin.o: src/builtin_argparse.h src/builtin_history.h src/builtin_jobs.h
+obj/builtin.o: src/builtin_printf.h src/builtin_pwd.h src/builtin_random.h
+obj/builtin.o: src/builtin_read.h src/builtin_realpath.h src/builtin_return.h
+obj/builtin.o: src/builtin_set.h src/builtin_set_color.h src/builtin_source.h
 obj/builtin.o: src/builtin_status.h src/builtin_string.h src/builtin_test.h
 obj/builtin.o: src/builtin_ulimit.h src/complete.h src/exec.h src/intern.h
 obj/builtin.o: src/io.h src/parse_constants.h src/parse_util.h
@@ -985,7 +988,7 @@ obj/builtin_cd.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_cd.o: src/signal.h src/builtin_cd.h src/env.h src/io.h
 obj/builtin_cd.o: src/parser.h src/event.h src/expand.h src/parse_constants.h
 obj/builtin_cd.o: src/parse_tree.h src/tokenizer.h src/proc.h src/path.h
-obj/builtin_cd.o: src/wgetopt.h src/wutil.h
+obj/builtin_cd.o: src/wutil.h
 obj/builtin_command.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_command.o: src/signal.h src/builtin_command.h src/io.h src/path.h
 obj/builtin_command.o: src/env.h src/wgetopt.h src/wutil.h
@@ -1009,13 +1012,13 @@ obj/builtin_disown.o: config.h src/signal.h src/builtin.h src/common.h
 obj/builtin_disown.o: src/fallback.h src/builtin_disown.h src/io.h
 obj/builtin_disown.o: src/parser.h src/event.h src/expand.h
 obj/builtin_disown.o: src/parse_constants.h src/parse_tree.h src/tokenizer.h
-obj/builtin_disown.o: src/proc.h src/wgetopt.h src/wutil.h
+obj/builtin_disown.o: src/proc.h src/wutil.h
 obj/builtin_echo.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_echo.o: src/signal.h src/builtin_echo.h src/io.h src/wgetopt.h
 obj/builtin_echo.o: src/wutil.h
 obj/builtin_emit.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_emit.o: src/signal.h src/builtin_emit.h src/event.h src/io.h
-obj/builtin_emit.o: src/wgetopt.h src/wutil.h
+obj/builtin_emit.o: src/wutil.h
 obj/builtin_exit.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_exit.o: src/signal.h src/builtin_exit.h src/io.h src/proc.h
 obj/builtin_exit.o: src/parse_tree.h src/parse_constants.h src/tokenizer.h
@@ -1038,6 +1041,10 @@ obj/builtin_functions.o: src/event.h src/function.h src/io.h
 obj/builtin_functions.o: src/parser_keywords.h src/proc.h src/parse_tree.h
 obj/builtin_functions.o: src/parse_constants.h src/tokenizer.h src/wgetopt.h
 obj/builtin_functions.o: src/wutil.h
+obj/builtin_argparse.o: config.h src/builtin.h src/common.h src/fallback.h
+obj/builtin_argparse.o: src/signal.h src/builtin_argparse.h src/env.h
+obj/builtin_argparse.o: src/expand.h src/parse_constants.h src/io.h
+obj/builtin_argparse.o: src/wgetopt.h src/wutil.h
 obj/builtin_history.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_history.o: src/signal.h src/builtin_history.h src/history.h
 obj/builtin_history.o: src/wutil.h src/io.h src/reader.h src/complete.h
@@ -1050,17 +1057,15 @@ obj/builtin_jobs.o: src/wutil.h
 obj/builtin_printf.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_printf.o: src/signal.h src/io.h src/wutil.h
 obj/builtin_pwd.o: config.h src/builtin.h src/common.h src/fallback.h
-obj/builtin_pwd.o: src/signal.h src/builtin_pwd.h src/event.h src/io.h
-obj/builtin_pwd.o: src/wgetopt.h src/wutil.h
+obj/builtin_pwd.o: src/signal.h src/builtin_pwd.h src/io.h src/wutil.h
 obj/builtin_random.o: config.h src/builtin.h src/common.h src/fallback.h
-obj/builtin_random.o: src/signal.h src/builtin_random.h src/io.h
-obj/builtin_random.o: src/wgetopt.h src/wutil.h
+obj/builtin_random.o: src/signal.h src/builtin_random.h src/io.h src/wutil.h
 obj/builtin_read.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_read.o: src/signal.h src/builtin_read.h src/complete.h src/env.h
 obj/builtin_read.o: src/event.h src/expand.h src/parse_constants.h
-obj/builtin_read.o: src/highlight.h src/color.h src/io.h src/proc.h
-obj/builtin_read.o: src/parse_tree.h src/tokenizer.h src/reader.h
-obj/builtin_read.o: src/wcstringutil.h src/wgetopt.h src/wutil.h
+obj/builtin_read.o: src/highlight.h src/color.h src/history.h src/wutil.h
+obj/builtin_read.o: src/io.h src/proc.h src/parse_tree.h src/tokenizer.h
+obj/builtin_read.o: src/reader.h src/wcstringutil.h src/wgetopt.h
 obj/builtin_realpath.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_realpath.o: src/signal.h src/builtin_realpath.h src/io.h
 obj/builtin_realpath.o: src/wutil.h
@@ -1081,7 +1086,7 @@ obj/builtin_source.o: src/signal.h src/builtin_source.h src/env.h
 obj/builtin_source.o: src/intern.h src/io.h src/parser.h src/event.h
 obj/builtin_source.o: src/expand.h src/parse_constants.h src/parse_tree.h
 obj/builtin_source.o: src/tokenizer.h src/proc.h src/reader.h src/complete.h
-obj/builtin_source.o: src/highlight.h src/color.h src/wgetopt.h src/wutil.h
+obj/builtin_source.o: src/highlight.h src/color.h src/wutil.h
 obj/builtin_status.o: config.h src/builtin.h src/common.h src/fallback.h
 obj/builtin_status.o: src/signal.h src/builtin_status.h src/io.h src/parser.h
 obj/builtin_status.o: src/event.h src/expand.h src/parse_constants.h
@@ -1143,11 +1148,11 @@ obj/fish_indent.o: src/signal.h src/env.h src/fish_version.h src/highlight.h
 obj/fish_indent.o: src/output.h src/parse_constants.h src/parse_tree.h
 obj/fish_indent.o: src/tokenizer.h src/print_help.h src/wutil.h
 obj/fish_key_reader.o: config.h src/signal.h src/common.h src/fallback.h
-obj/fish_key_reader.o: src/env.h src/input.h src/builtin_bind.h
-obj/fish_key_reader.o: src/input_common.h src/print_help.h src/proc.h
-obj/fish_key_reader.o: src/io.h src/parse_tree.h src/parse_constants.h
-obj/fish_key_reader.o: src/tokenizer.h src/reader.h src/complete.h
-obj/fish_key_reader.o: src/highlight.h src/color.h src/wutil.h
+obj/fish_key_reader.o: src/env.h src/fish_version.h src/input.h
+obj/fish_key_reader.o: src/builtin_bind.h src/input_common.h src/print_help.h
+obj/fish_key_reader.o: src/proc.h src/io.h src/parse_tree.h
+obj/fish_key_reader.o: src/parse_constants.h src/tokenizer.h src/reader.h
+obj/fish_key_reader.o: src/complete.h src/highlight.h src/color.h src/wutil.h
 obj/fish_tests.o: config.h src/signal.h src/builtin.h src/common.h
 obj/fish_tests.o: src/fallback.h src/color.h src/complete.h src/env.h
 obj/fish_tests.o: src/env_universal_common.h src/wutil.h src/event.h
@@ -1195,13 +1200,13 @@ obj/pager.o: config.h src/common.h src/fallback.h src/signal.h src/complete.h
 obj/pager.o: src/highlight.h src/color.h src/env.h src/pager.h src/reader.h
 obj/pager.o: src/parse_constants.h src/screen.h src/util.h src/wutil.h
 obj/parse_execution.o: config.h src/builtin.h src/common.h src/fallback.h
-obj/parse_execution.o: src/signal.h src/complete.h src/env.h src/event.h
-obj/parse_execution.o: src/exec.h src/expand.h src/parse_constants.h
-obj/parse_execution.o: src/function.h src/io.h src/parse_execution.h
-obj/parse_execution.o: src/parse_tree.h src/tokenizer.h src/proc.h
-obj/parse_execution.o: src/parse_util.h src/parser.h src/path.h src/reader.h
-obj/parse_execution.o: src/highlight.h src/color.h src/util.h src/wildcard.h
-obj/parse_execution.o: src/wutil.h
+obj/parse_execution.o: src/signal.h src/builtin_function.h src/complete.h
+obj/parse_execution.o: src/env.h src/event.h src/exec.h src/expand.h
+obj/parse_execution.o: src/parse_constants.h src/function.h src/io.h
+obj/parse_execution.o: src/parse_execution.h src/parse_tree.h src/tokenizer.h
+obj/parse_execution.o: src/proc.h src/parse_util.h src/parser.h src/path.h
+obj/parse_execution.o: src/reader.h src/highlight.h src/color.h src/util.h
+obj/parse_execution.o: src/wildcard.h src/wutil.h
 obj/parse_productions.o: config.h src/common.h src/fallback.h src/signal.h
 obj/parse_productions.o: src/parse_constants.h src/parse_productions.h
 obj/parse_productions.o: src/parse_tree.h src/tokenizer.h

--- a/doc_src/argparse.txt
+++ b/doc_src/argparse.txt
@@ -1,0 +1,107 @@
+\section argparse argparse - parse options passed to a fish script or function
+
+\subsection argparse-synopsis Synopsis
+\fish{synopsis}
+argparse [OPTIONS] OPTION_SPEC... -- [ARG...]
+\endfish
+
+\subsection argparse-description Description
+
+This command makes it easy for fish scripts and functions to handle arguments in a manner 100% identical to how fish builtin commands handle their arguments. You pass a sequence of arguments that define the options recognized, followed by a literal `--`, then the arguments to be parsed (which might also include a literal `--`). More on this in the <a href="#argparse-usage">usage</a> section below.
+
+Each OPTION_SPEC can be written in the domain specific language <a href="#argparse-option-specs">described below</a> or created using the companion <a href="#fish-opt">`fish_opt`</a> command.
+
+Each option that is seen in the ARG list will result in a var name of the form `_flag_X`, where `X` is the short flag letter and the long flag name. The OPTION_SPEC always requires a short flag even if it can't be used. So there will always be `_flag_X` var set using the short flag letter if the corresponding short or long flag is seen. The long flag name var (e.g., `_flag_help`) will only be defined, obviously, if the OPTION_SPEC includes a long flag name.
+
+For example `_flag_h` and `_flag_help` if `-h` or `--help` is seen. The var will be set with local scope (i.e., as if the script had done `set -l _flag_X`). If the flag is a boolean (that is, does not have an associated value) the value is a count of how many times the flag was seen. If the option can have zero or more values the flag var will have zero or more values corresponding to the values collected when the ARG list is processed. If the flag was not seen the flag var will not be set.
+
+The following `argparse` options are available:
+
+- `-n` or `--name` is the command name to insert into any error messages. If you don't provide this value `argparse` will be used.
+
+- `-x` or `--exclusive` should be followed by a comma separated list of short of long options that are mutually exclusive. You can use this option more than once to define multiple sets of mutually exclusive options.
+
+- `-N` or `--min-args` is followed by an integer that defines the minimum number of acceptable non-option arguments. The default is zero.
+
+- `-X` or `--max-args` is followed by an integer that defines the maximum number of acceptable non-option arguments. The default is infinity.
+
+- `-s` or `--stop-nonopt` causes scanning the arguments to stop as soon as the first non-option argument is seen. Using this arg is equivalent to calling the C function `getopt_long()` with the short options starting with a `+` symbol. This is sometimes known as "POSIXLY CORRECT". If this flag is not used then arguments are reordered (i.e., permuted) so that all non-option arguments are moved after option arguments. This mode has several uses but the main one is to implement a command that has subcommands.
+
+- `-h` or `--help` displays help about using this command.
+
+\subsection argparse-usage Usage
+
+Using this command involves passing two sets of arguments separated by `--`. The first set consists of one or more option specifications (`OPTION_SPEC` above) and options that modify the behavior of `argparse`. These must be listed before the `--` argument. The second set are the arguments to be parsed in accordance with the option specifications. They occur after the `--` argument and can be empty. More about this below but here is a simple example that might be used in a function named `my_function`:
+
+\fish
+argparse --name=my_function 'h/help' 'n/name:' -- $argv
+or return
+\endfish
+
+If `$argv` is empty then there is nothing to parse and `argparse` returns zero to indicate success. If `$argv` is not empty then it is checked for flags `-h`, `--help`, `-n` and `--name`. If they are found they are removed from the arguments and local variables (more on this <a href="argparse-local-variables">below</a>) are set so the script can determine which options were seen. Assuming `$argv` doesn't have any errors, such as a missing mandatory value for an option, then `argparse` exits with status zero. Otherwise it writes appropriate error messages to stderr and exits with a status of one.
+
+Not including a `--` argument is an error condition. You do not have to include any arguments after the `--` but you must include the `--`. For example, this is acceptable:
+
+\fish
+set -l argv
+argparse 'h/help' 'n/name' -- $argv
+\endfish
+
+But this is not:
+
+\fish
+set -l argv
+argparse 'h/help' 'n/name' $argv
+\endfish
+
+The first `--` seen is what allows the `argparse` command to reliably seperate the option specifications from the command arguments.
+
+\subsection argparse-option-specs Option Specifications
+
+Each option specification is a string composed of
+
+- A short flag letter (which is mandatory).
+
+- A `/` if the short flag can be used by someone invoking your command else `-` if it should not be exposed as a valid short flag. If there is no long flag name these characters should be omitted.
+
+- A long flag name which is optional. If not present then only the short flag letter can be used.
+
+- Nothing if the flag is a boolean that takes no argument, else
+
+- `=` if it requires a value and only the last instance of the flag is saved, else
+
+- `=?` it takes an optional value and only the last instance of the flag is saved, else
+
+- `=+` if it requires a value each instance of the flag is saved.
+
+See the <a href="#fish-opt">`fish_opt`</a> command for a friendlier but more verbose way to create option specifications.
+
+In the following examples if a flag is not seen when parsing the arguments then the corresponding _flag_X var(s) will not be set.
+
+\subsection argparse-optspec-examples Example OPTION_SPECs
+
+Some OPTION_SPEC examples:
+
+- `h/help` means that both `-h` and `--help` are valid. The flag is a boolean and can be used more than once. If either flag is used then `_flag_h` and `_flag_help` will be set to the count of how many times either flag was seen.
+
+- `h-help` means that only `--help` is valid. The flag is a boolean and can be used more than once. If the long flag is used then `_flag_h` and `_flag_help` will be set to the count of how many times the long flag was seen.
+
+- `n/name=` means that both `-n` and `--name` are valid. It requires a value and can be used at most once. If the flag is seen then `_flag_n` and `_flag_name` will be set with the single mandatory value associated with the flag.
+
+- `n/name=?` means that both `-n` and `--name` are valid. It accepts an optional value and can be used at most once. If the flag is seen then `_flag_n` and `_flag_name` will be set with the value associated with the flag if one was provided else it will be set with no values.
+
+- `n-name=+` means that only `--name` is valid. It requires a value and can be used more than once. If the flag is seen then `_flag_n` and `_flag_name` will be set with the values associated with each occurrence of the flag.
+
+- `x` means that only `-x` is valid. It is a boolean can can be used more than once. If it is seen then `_flag_x` will be set to the count of how many times the flag was seen.
+
+- `x=`, `x=?`, and `x=+` are similar to the n/name examples above but there is no long flag alternative to the short flag `-x`.
+
+- `x-` is not valid since there is no long flag name and therefore the short flag, `-x`, has to be usable. This is obviously true whether or not the specification also includes one of `:`, `::`, `+`.
+
+After parsing the arguments the argv var is set (with local scope) to any values not already consumed during flag processing.
+
+If an error occurs during argparse processing it will exit with a non-zero status and appropriate error messages are written to stderr.
+
+\subsection argparse-notes Notes
+
+Prior to the addition of this builtin command in the 2.7.0 release there were two main ways to parse the arguments passed to a fish script or function. One way was to use the OS provided `getopt` command. The problem with that is that the GNU and BSD implementations are not compatible. Which makes using that external command difficult other than trivial situations. The other way is to iterate over `$argv` and use the fish `switch` statement to decide how to handle the argument. That, however, involves a huge amount of boilerplate code. It is also borderline impossible to implement the same behavior as the builtin commands using either approach.

--- a/doc_src/fish_opt.txt
+++ b/doc_src/fish_opt.txt
@@ -1,0 +1,54 @@
+\section fish_opt fish_opt - create an option spec for the argparse command
+
+\subsection fish_opt-synopsis Synopsis
+\fish{synopsis}
+fish_opt [ -h | --help ]
+fish_opt ( -s X | --short=X ) [ -l LONG | --long=LONG ] [ --long-only ] \
+    [ -o | --optional-val ] [ -r | --required-val ] [ --multiple-vals ]
+\endfish
+
+\subsection fish_opt-description Description
+
+This command provides a way to produce option specifications suitable for use with the <a href="#argparse">`argparse`</a> command. You can, of course, write the option specs by hand without using this command. But you might prefer to use this for the clarity it provides.
+
+The following `argparse` options are available:
+
+- `-s` or `--short` takes a single letter that is used as the short flag in the option being defined. This option is mandatory.
+
+- `-l` or `--long` takes a string that is used as the long flag in the option being defined. This option is optional and has no default. If no long flag is defined then only the short flag will be allowed when parsing arguments using the option spec.
+
+- `--long-only` means the option spec being defined will only allow the long flag name to be used. The short flag name must still be defined (i.e., `--short` must be specified) but it cannot be used when parsing args using this option spec.
+
+- `-o` or `--optional` means the option being defined can take a value but it is optional rather than required. If the option is seen more than once when parsing arguments only the last value seen is saved. This means the resulting flag variable created by `argparse` will zero elements if no value was given with the option else it will have exactly one element.
+
+- `-r` or `--required` means the option being defined requires a value. If the option is seen more than once when parsing arguments only the last value seen is saved. This means the resulting flag variable created by `argparse` will have exactly one element.
+
+- `--multiple-vals` means the option being defined requires a value each time it is seen. Each instance is stored. This means the resulting flag variable created by `argparse` will have one element for each instance of this option in the args.
+
+- `-h` or `--help` displays help about using this command.
+
+\subsection fish_opt-examples Examples
+
+Define a single option spec for the boolean help flag:
+
+\fish
+set -l options (fish_opt -s h -l help)
+argparse $options -- $argv
+\endfish
+
+Same as above but with a second flag that requires a value:
+
+\fish
+set -l options (fish_opt -s h -l help)
+set options $options (fish_opt -s m -l max --required-val)
+argparse $options -- $argv
+\endfish
+
+Same as above but with a third flag that can be given multiple times saving the value of each instance seen and only the long flag name (`--token`) can be used:
+
+\fish
+set -l options (fish_opt --short=h --long=help)
+set options $options (fish_opt --short=m --long=max --required-val)
+set options $options (fish_opt --short=t --long=token --multiple-vals --long-only)
+argparse $options -- $argv
+\endfish

--- a/fish.xcodeproj/project.pbxproj
+++ b/fish.xcodeproj/project.pbxproj
@@ -117,6 +117,9 @@
 		9C7A557D1DCD71890049C25D /* fish_key_reader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C7A557C1DCD717C0049C25D /* fish_key_reader.cpp */; };
 		9C7A557E1DCD71CD0049C25D /* print_help.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D0A0855613B3ACEE0099B651 /* print_help.cpp */; };
 		9C7A55811DCD739C0049C25D /* fish_key_reader in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C7A55721DCD71330049C25D /* fish_key_reader */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		CB0F034C1F156FE3001827D3 /* builtin_argparse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB0F034A1F156FE3001827D3 /* builtin_argparse.cpp */; };
+		CB0F034D1F156FE3001827D3 /* builtin_argparse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB0F034A1F156FE3001827D3 /* builtin_argparse.cpp */; };
+		CB0F034E1F156FE3001827D3 /* builtin_argparse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB0F034A1F156FE3001827D3 /* builtin_argparse.cpp */; };
 		D001B5EE1F041CBD000838CC /* builtin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D05F592F1F041AE4003EE978 /* builtin.cpp */; };
 		D001B5F01F041CBD000838CC /* builtin_ulimit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D05F59311F041AE4003EE978 /* builtin_ulimit.cpp */; };
 		D001B5F21F041CBD000838CC /* builtin_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D05F59331F041AE4003EE978 /* builtin_test.cpp */; };
@@ -647,8 +650,10 @@
 		63A2C0E81CC5F9FB00973404 /* pcre2_find_bracket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pcre2_find_bracket.c; sourceTree = "<group>"; };
 		9C7A55721DCD71330049C25D /* fish_key_reader */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fish_key_reader; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C7A557C1DCD717C0049C25D /* fish_key_reader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fish_key_reader.cpp; sourceTree = "<group>"; };
-		CBB772591F11F93F00780A21 /* builtin_argparse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = builtin_argparse.cpp; sourceTree = "<group>"; };
-		CBB7725A1F11F93F00780A21 /* builtin_argparse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = builtin_argparse.h; sourceTree = "<group>"; };
+		CB0F034A1F156FE3001827D3 /* builtin_argparse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = builtin_argparse.cpp; sourceTree = "<group>"; };
+		CB0F034B1F156FE3001827D3 /* builtin_argparse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = builtin_argparse.h; sourceTree = "<group>"; };
+		CBB7725B1F14964100780A21 /* fish-shell */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "fish-shell"; sourceTree = "<group>"; };
+		CBB7725C1F1496AF00780A21 /* fish-shell */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "fish-shell"; sourceTree = "<group>"; };
 		D00769421990137800CA4627 /* fish_tests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fish_tests; sourceTree = BUILT_PRODUCTS_DIR; };
 		D00F63F019137E9D00FCCDEC /* fish_version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fish_version.cpp; sourceTree = "<group>"; };
 		D01A2D23169B730A00767098 /* man1 */ = {isa = PBXFileReference; lastKnownFileType = text; name = man1; path = pages_for_manpath/man1; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -964,6 +969,8 @@
 		D0A084F013B3AC130099B651 = {
 			isa = PBXGroup;
 			children = (
+				CBB7725C1F1496AF00780A21 /* fish-shell */,
+				CBB7725B1F14964100780A21 /* fish-shell */,
 				D0D02A91159845EF008E62BD /* Sources */,
 				D0D02AFC159871BF008E62BD /* Launcher */,
 				D0D02A8E15983D5F008E62BD /* Libraries */,
@@ -986,8 +993,8 @@
 		D0D02A91159845EF008E62BD /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				CBB772591F11F93F00780A21 /* builtin_argparse.cpp */,
-				CBB7725A1F11F93F00780A21 /* builtin_argparse.h */,
+				CB0F034A1F156FE3001827D3 /* builtin_argparse.cpp */,
+				CB0F034B1F156FE3001827D3 /* builtin_argparse.h */,
 				9C7A557C1DCD717C0049C25D /* fish_key_reader.cpp */,
 				4E142D731B56B5D7008783C8 /* config.h */,
 				D0C6FCCB14CFA4B7004CE8AD /* autoload.h */,
@@ -1684,6 +1691,7 @@
 				D007692D1990137800CA4627 /* proc.cpp in Sources */,
 				D007692E1990137800CA4627 /* reader.cpp in Sources */,
 				D007692F1990137800CA4627 /* sanity.cpp in Sources */,
+				CB0F034E1F156FE3001827D3 /* builtin_argparse.cpp in Sources */,
 				D05F597F1F041AE4003EE978 /* builtin_source.cpp in Sources */,
 				D05F59B51F041AE4003EE978 /* builtin_contains.cpp in Sources */,
 				D05F59911F041AE4003EE978 /* builtin_random.cpp in Sources */,
@@ -1771,6 +1779,7 @@
 				D05F59AB1F041AE4003EE978 /* builtin_emit.cpp in Sources */,
 				D05F59961F041AE4003EE978 /* builtin_printf.cpp in Sources */,
 				D030FC001A4A38F300F7ADA0 /* function.cpp in Sources */,
+				CB0F034D1F156FE3001827D3 /* builtin_argparse.cpp in Sources */,
 				D05F59C61F041AE4003EE978 /* builtin_block.cpp in Sources */,
 				D05F59C91F041AE4003EE978 /* builtin_bind.cpp in Sources */,
 				D05F599C1F041AE4003EE978 /* builtin_history.cpp in Sources */,
@@ -1880,6 +1889,7 @@
 				D0D02A7015983842008E62BD /* proc.cpp in Sources */,
 				D0D02A7115983848008E62BD /* reader.cpp in Sources */,
 				D0D02A721598384C008E62BD /* sanity.cpp in Sources */,
+				CB0F034C1F156FE3001827D3 /* builtin_argparse.cpp in Sources */,
 				D05F597D1F041AE4003EE978 /* builtin_source.cpp in Sources */,
 				D05F59B31F041AE4003EE978 /* builtin_contains.cpp in Sources */,
 				D05F598F1F041AE4003EE978 /* builtin_random.cpp in Sources */,

--- a/fish.xcodeproj/project.pbxproj
+++ b/fish.xcodeproj/project.pbxproj
@@ -647,6 +647,8 @@
 		63A2C0E81CC5F9FB00973404 /* pcre2_find_bracket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pcre2_find_bracket.c; sourceTree = "<group>"; };
 		9C7A55721DCD71330049C25D /* fish_key_reader */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fish_key_reader; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C7A557C1DCD717C0049C25D /* fish_key_reader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fish_key_reader.cpp; sourceTree = "<group>"; };
+		CBB772591F11F93F00780A21 /* builtin_argparse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = builtin_argparse.cpp; sourceTree = "<group>"; };
+		CBB7725A1F11F93F00780A21 /* builtin_argparse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = builtin_argparse.h; sourceTree = "<group>"; };
 		D00769421990137800CA4627 /* fish_tests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fish_tests; sourceTree = BUILT_PRODUCTS_DIR; };
 		D00F63F019137E9D00FCCDEC /* fish_version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fish_version.cpp; sourceTree = "<group>"; };
 		D01A2D23169B730A00767098 /* man1 */ = {isa = PBXFileReference; lastKnownFileType = text; name = man1; path = pages_for_manpath/man1; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -984,6 +986,8 @@
 		D0D02A91159845EF008E62BD /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				CBB772591F11F93F00780A21 /* builtin_argparse.cpp */,
+				CBB7725A1F11F93F00780A21 /* builtin_argparse.h */,
 				9C7A557C1DCD717C0049C25D /* fish_key_reader.cpp */,
 				4E142D731B56B5D7008783C8 /* config.h */,
 				D0C6FCCB14CFA4B7004CE8AD /* autoload.h */,

--- a/share/functions/fish_opt.fish
+++ b/share/functions/fish_opt.fish
@@ -1,0 +1,47 @@
+# This is a helper function for `fish_opt`. It does some basic validation of the arguments.
+function __fish_opt_validate_args --no-scope-shadowing
+    if not set -q _flag_short
+        or test 1 -ne (string length -- $_flag_short)
+        printf (_ "%s: The --short flag is required and must be a single character\n") fish_opt >&2
+        return 1
+    end
+
+    return 0
+end
+
+# The `fish_opt` command.
+function fish_opt -d 'Produce an option specification suitable for use with `argparse`.'
+    set -l options 'h/help' 's/short=' 'l/long=' 'o/optional-val' 'r/required-val'
+    set options $options 'L-long-only' 'M-multiple-vals'
+    argparse -n fish_opt --max-args=0 --exclusive=r,o --exclusive=M,o $options -- $argv
+    or return
+
+    if set -q _flag_help
+        __fish_print_help nextd
+        return 0
+    end
+
+    __fish_opt_validate_args
+    or return
+
+    set -l opt_spec $_flag_short
+
+    if set -q _flag_long
+        if set -q _flag_long_only
+            set opt_spec "$opt_spec-"
+        else
+            set opt_spec "$opt_spec/"
+        end
+        set opt_spec "$opt_spec$_flag_long"
+    end
+
+    if set -q _flag_multiple_vals
+        set opt_spec "$opt_spec=+"
+    else if set -q _flag_required_val
+        set opt_spec "$opt_spec="
+    else if set -q _flag_optional_val
+        and set opt_spec "$opt_spec=?"
+    end
+
+    echo $opt_spec
+end

--- a/share/functions/isatty.fish
+++ b/share/functions/isatty.fish
@@ -1,6 +1,6 @@
 function isatty -d "Tests if a file descriptor is a tty"
     set -l options 'h/help'
-    argparse $options -- $argv
+    argparse -n isatty $options -- $argv
     or return
 
     if set -q _flag_help

--- a/share/functions/isatty.fish
+++ b/share/functions/isatty.fish
@@ -1,30 +1,31 @@
-
 function isatty -d "Tests if a file descriptor is a tty"
-    set -l fd 0
-    if count $argv >/dev/null
-        switch $argv[1]
+    set -l options 'h/help'
+    argparse $options -- $argv
+    or return
 
-            case -h --h --he --hel --help
-                __fish_print_help isatty
-                return 0
+    if set -q _flag_help
+        __fish_print_help isatty
+        return 0
+    end
 
-            case stdin ''
-                set fd 0
+    if set -q argv[2]
+        printf (_ "%s: Too many arguments") isatty >&2
+        return 1
+    end
 
-            case stdout
-                set fd 1
-
-            case stderr
-                set fd 2
-
-            case '*'
-                set fd $argv[1]
-
-        end
+    set -l fd
+    switch "$argv"
+        case stdin ''
+            set fd 0
+        case stdout
+            set fd 1
+        case stderr
+            set fd 2
+        case '*'
+            set fd $argv[1]
     end
 
     # Use `command test` because `builtin test` doesn't open the regular fd's.
     # See https://github.com/fish-shell/fish-shell/issues/1228
     command test -t "$fd"
-
 end

--- a/share/functions/nextd.fish
+++ b/share/functions/nextd.fish
@@ -1,6 +1,6 @@
 function nextd --description "Move forward in the directory history"
     set -l options 'h/help' 'l/list'
-    argparse $options -- $argv
+    argparse -n nextd $options -- $argv
     or return
 
     if set -q _flag_help

--- a/share/functions/nextd.fish
+++ b/share/functions/nextd.fish
@@ -1,64 +1,49 @@
-
 function nextd --description "Move forward in the directory history"
+    set -l options 'h/help' 'l/list'
+    argparse $options -- $argv
+    or return
 
-    if count $argv >/dev/null
-        switch $argv[1]
-            case -h --h --he --hel --help
-                __fish_print_help nextd
-                return 0
-        end
+    if set -q _flag_help
+        __fish_print_help nextd
+        return 0
     end
 
-    # Parse arguments
-    set -l show_hist 0
+    if set -q argv[2]
+        printf (_ "%s: Too many arguments") nextd >&2
+        return 1
+    end
+
     set -l times 1
-    if count $argv >/dev/null
-        for i in (seq (count $argv))
-            switch $argv[$i]
-                case '-l' --l --li --lis --list
-                    set show_hist 1
-                    continue
-                case '-*'
-                    printf (_ "%s: Unknown option %s\n" ) nextd $argv[$i]
-                    return 1
-                case '*'
-                    if test $argv[$i] -ge 0 ^/dev/null
-                        set times $argv[$i]
-                    else
-                        printf (_ "%s: The number of positions to skip must be a non-negative integer\n" ) nextd
-                        return 1
-                    end
-                    continue
-            end
+    if set -q $argv[1]
+        if test $argv[1] -ge 0 ^/dev/null
+            set times $argv[1]
+        else
+            printf (_ "%s: The number of positions to skip must be a non-negative integer\n") nextd
+            return 1
         end
     end
 
     # Traverse history
     set -l code 1
-    if count $times >/dev/null
-        for i in (seq $times)
-            # Try one step backward
-            if __fish_move_last dirnext dirprev
-
-                # We consider it a success if we were able to do at least 1 step
-                # (low expectations are the key to happiness ;)
-                set code 0
-            else
-                break
-            end
+    for i in (seq $times)
+        # Try one step backward
+        if __fish_move_last dirnext dirprev
+            # We consider it a success if we were able to do at least 1 step
+            # (low expectations are the key to happiness ;)
+            set code 0
+        else
+            break
         end
     end
 
     # Show history if needed
-    if test $show_hist = 1
+    if set -q _flag_list
         dirh
     end
 
     # Set direction for 'cd -'
-    if test $code = 0 ^/dev/null
-        set -g __fish_cd_direction prev
-    end
+    test $code = 0
+    and set -g __fish_cd_direction prev
 
-    # All done
     return $code
 end

--- a/share/functions/trap.fish
+++ b/share/functions/trap.fish
@@ -16,71 +16,33 @@ function __trap_switch
 end
 
 function trap -d 'Perform an action when the shell receives a signal'
+    set -l options 'h/help' 'l/list-signals' 'p/print'
+    argparse $options -- $argv
+    or return
+
+    if set -q _flag_help
+        __fish_print_help trap
+        return 0
+    end
 
     set -l mode
     set -l cmd
     set -l sig
 
-    set -l options
-    set -l longopt
-    set -l shortopt lph
-    if not getopt -T >/dev/null
-        # GNU getopt
-        set longopt print,help,list-signals
-        set options -o $shortopt -l $longopt --
-        # Verify options
-        if not getopt -n type $options $argv >/dev/null
-            return 1
-        end
+    # Determine the mode based on either an explicit flag or the non-flag args.
+    if set -q _flag_print
+        set mode print
+    else if set -q _flag_list_signals
+        set mode list
     else
-        # Old getopt, used on OS X
-        set options $shortopt
-        # Verify options
-        if not getopt $options $argv >/dev/null
-            return 1
-        end
-    end
-
-    # Do the real getopt invocation
-    set -l tmp (getopt $options $argv)
-
-    # Break tmp up into an array
-    set -l opt
-    eval set opt $tmp
-
-    while count $opt >/dev/null
-        switch $opt[1]
-            case -h --help
-                __fish_print_help trap
-                return 0
-
-            case -p --print
-                set mode print
-
-            case -l --list-signals
-                set mode list
-
-            case --
-                set -e opt[1]
-                break
-
-        end
-        set -e opt[1]
-    end
-
-    if not count $mode >/dev/null
-
-        switch (count $opt)
-
+        switch (count $argv)
             case 0
                 set mode print
-
             case 1
                 set mode clear
-
             case '*'
-                if test opt[1] = -
-                    set -e opt[1]
+                if test $argv[1] = -
+                    set -e argv[1]
                     set mode clear
                 else
                     set mode set
@@ -90,7 +52,7 @@ function trap -d 'Perform an action when the shell receives a signal'
 
     switch $mode
         case clear
-            for i in $opt
+            for i in $argv
                 set sig (__trap_translate_signal $i)
                 if test $sig
                     functions -e __trap_handler_$sig
@@ -98,10 +60,10 @@ function trap -d 'Perform an action when the shell receives a signal'
             end
 
         case set
-            set -l cmd $opt[1]
-            set -e opt[1]
+            set -l cmd $argv[1]
+            set -e argv[1]
 
-            for i in $opt
+            for i in $argv
                 set -l sig (__trap_translate_signal $i)
                 set sw (__trap_switch $sig)
 
@@ -114,15 +76,13 @@ function trap -d 'Perform an action when the shell receives a signal'
 
         case print
             set -l names
-
-            if count $opt >/dev/null
-                set names $opt
+            if set -q argv[1]
+                set names $argv
             else
-                set names (functions -na| string match "__trap_handler_*" | string replace '__trap_handler_' '')
+                set names (functions -na | string match "__trap_handler_*" | string replace '__trap_handler_' '')
             end
 
             for i in $names
-
                 set sig (__trap_translate_signal $i)
 
                 if test sig
@@ -130,12 +90,9 @@ function trap -d 'Perform an action when the shell receives a signal'
                 else
                     return 1
                 end
-
             end
 
         case list
             kill -l
-
     end
-
 end

--- a/share/functions/trap.fish
+++ b/share/functions/trap.fish
@@ -17,7 +17,7 @@ end
 
 function trap -d 'Perform an action when the shell receives a signal'
     set -l options 'h/help' 'l/list-signals' 'p/print'
-    argparse $options -- $argv
+    argparse -n trap $options -- $argv
     or return
 
     if set -q _flag_help

--- a/share/functions/umask.fish
+++ b/share/functions/umask.fish
@@ -149,67 +149,30 @@ function __fish_umask_print_symbolic
 end
 
 function umask --description "Set default file permission mask"
-    set -l as_command 0
-    set -l symbolic 0
-    set -l options
-    set -l shortopt pSh
-    if not getopt -T >/dev/null
-        # GNU getopt
-        set longopt -l as-command,symbolic,help
-        set options -o $shortopt $longopt --
-        # Verify options
-        if not getopt -n umask $options $argv >/dev/null
-            return 1
-        end
-    else
-        # Old getopt, used on OS X
-        set options $shortopt
-        # Verify options
-        if not getopt $options $argv >/dev/null
-            return 1
-        end
+    set -l options 'h/help' 'p/as-command' 'S/symbolic'
+    argparse $options -- $argv
+    or return
+
+    if set -q _flag_help
+        __fish_print_help umask
+        return 0
     end
 
-    set -l tmp (getopt $options $argv)
-    eval set opt $tmp
-
-    while count $opt >/dev/null
-        switch $opt[1]
-            case -h --help
-                __fish_print_help umask
-                return 0
-
-            case -p --as-command
-                set as_command 1
-
-            case -S --symbolic
-                set symbolic 1
-
-            case --
-                set -e opt[1]
-                break
-        end
-
-        set -e opt[1]
-    end
-
-    switch (count $opt)
+    switch (count $argv)
         case 0
-            if not set -q umask
-                set -g umask 113
-            end
-            if test $as_command -eq 1
+            set -q umask
+            or set -g umask 113
+
+            if set -q _flag_as_command
                 echo umask $umask
+            else if set -q _flag_symbolic
+                __fish_umask_print_symbolic $umask
             else
-                if test $symbolic -eq 1
-                    __fish_umask_print_symbolic $umask
-                else
-                    echo $umask
-                end
+                echo $umask
             end
 
         case 1
-            if set -l parsed (__fish_umask_parse $opt)
+            if set -l parsed (__fish_umask_parse $argv)
                 set -g umask $parsed
                 return 0
             end

--- a/share/functions/umask.fish
+++ b/share/functions/umask.fish
@@ -150,7 +150,7 @@ end
 
 function umask --description "Set default file permission mask"
     set -l options 'h/help' 'p/as-command' 'S/symbolic'
-    argparse $options -- $argv
+    argparse -n umask $options -- $argv
     or return
 
     if set -q _flag_help

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "builtin.h"
+#include "builtin_argparse.h"
 #include "builtin_bg.h"
 #include "builtin_bind.h"
 #include "builtin_block.h"
@@ -406,6 +407,7 @@ int builtin_false(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 static const builtin_data_t builtin_datas[] = {
     {L"[", &builtin_test, N_(L"Test a condition")},
     {L"and", &builtin_generic, N_(L"Execute command if previous command suceeded")},
+    {L"argparse", &builtin_argparse, N_(L"Parse options in fish script")},
     {L"begin", &builtin_generic, N_(L"Create a block of code")},
     {L"bg", &builtin_bg, N_(L"Send job to background")},
     {L"bind", &builtin_bind, N_(L"Handle fish key bindings")},

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -53,6 +53,8 @@ enum { COMMAND_NOT_BUILTIN, BUILTIN_REGULAR, BUILTIN_FUNCTION };
 /// Error message for unexpected args.
 #define BUILTIN_ERR_ARG_COUNT1 _(L"%ls: expected %d args, got %d\n")
 #define BUILTIN_ERR_ARG_COUNT2 _(L"%ls: %ls expected %d args, got %d\n")
+#define BUILTIN_ERR_MIN_ARG_COUNT1 _(L"%ls: Expected at least %d args, got only %d\n")
+#define BUILTIN_ERR_MAX_ARG_COUNT1 _(L"%ls: Expected at most %d args, got %d\n")
 
 /// Error message for invalid variable name.
 #define BUILTIN_ERR_VARNAME _(L"%ls: Variable name '%ls' is not valid. See `help identifiers`.\n")

--- a/src/builtin_argparse.cpp
+++ b/src/builtin_argparse.cpp
@@ -51,7 +51,7 @@ class argparse_cmd_opts_t {
     bool print_help = false;
     bool stop_nonopt = false;
     size_t min_args = 0;
-    size_t max_args = SIZE_T_MAX;
+    size_t max_args = SIZE_MAX;
     wcstring name = L"argparse";
     wcstring_list_t raw_exclusive_flags;
     wcstring_list_t argv;
@@ -437,7 +437,7 @@ static int argparse_parse_args(argparse_cmd_opts_t &opts, const wcstring_list_t 
         streams.err.append_format(BUILTIN_ERR_MIN_ARG_COUNT1, cmd, opts.min_args, opts.argv.size());
         return STATUS_CMD_ERROR;
     }
-    if (opts.max_args != SIZE_T_MAX && opts.argv.size() > opts.max_args) {
+    if (opts.max_args != SIZE_MAX && opts.argv.size() > opts.max_args) {
         streams.err.append_format(BUILTIN_ERR_MAX_ARG_COUNT1, cmd, opts.max_args, opts.argv.size());
         return STATUS_CMD_ERROR;
     }

--- a/src/builtin_argparse.cpp
+++ b/src/builtin_argparse.cpp
@@ -1,0 +1,354 @@
+// Implementation of the argparse builtin.
+//
+// See issue #4190 for the rationale behind the original behavior of this builtin.
+#include "config.h"  // IWYU pragma: keep
+
+#if 0
+#include <malloc/malloc.h>
+#endif
+
+#include <stddef.h>
+#include <wchar.h>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "builtin.h"
+#include "builtin_argparse.h"
+#include "common.h"
+#include "env.h"
+#include "fallback.h"  // IWYU pragma: keep
+#include "io.h"
+#include "wgetopt.h"  // IWYU pragma: keep
+#include "wutil.h"    // IWYU pragma: keep
+
+class parser_t;
+
+#define BUILTIN_ERR_INVALID_OPT_SPEC _(L"%ls: Invalid option spec '%ls' at char '%lc'\n")
+
+class option_spec_t {
+   public:
+    wchar_t short_flag;
+    wcstring long_flag;
+    wcstring_list_t vals;
+    bool short_flag_valid;
+    int num_allowed;
+    int num_seen;
+
+    option_spec_t(wchar_t s)
+        : short_flag(s), long_flag(), vals(), short_flag_valid(true), num_allowed(0), num_seen(0) {}
+};
+
+class argparse_cmd_opts_t {
+   public:
+    bool print_help = false;
+    bool require_order = false;
+    wcstring name = L"argparse";
+    wcstring_list_t argv;
+    struct std::map<wchar_t, option_spec_t *> options;
+
+    ~argparse_cmd_opts_t() {
+        for (auto it : options) {
+            delete it.second;
+        }
+    }
+};
+
+static const wchar_t *short_options = L"+:hn:r";
+static const struct woption long_options[] = {{L"require-order", no_argument, NULL, 'r'},
+                                              {L"name", required_argument, NULL, 'n'},
+                                              {L"help", no_argument, NULL, 'h'},
+                                              {NULL, 0, NULL, 0}};
+
+static bool parse_flag_modifiers(argparse_cmd_opts_t &opts, option_spec_t *opt_spec,
+                                 const wcstring &option_spec, const wchar_t *s,
+                                 io_streams_t &streams) {
+    if (*s == '+') {
+        opt_spec->num_allowed = 2;  // mandatory arg and can appear more than once
+        s++;
+    } else if (*s == ':') {
+        s++;
+        if (*s == ':') {
+            opt_spec->num_allowed = -1;  // optional arg
+            s++;
+        } else {
+            opt_spec->num_allowed = 1;  // mandatory arg and can appear only once
+        }
+    }
+
+    if (*s) {
+        streams.err.append_format(BUILTIN_ERR_INVALID_OPT_SPEC, opts.name.c_str(),
+                                  option_spec.c_str(), *s);
+        return false;
+    }
+
+    opts.options.emplace(opt_spec->short_flag, opt_spec);
+    return true;
+}
+
+// This parses an option spec string into a struct option_spec.
+static bool parse_option_spec(argparse_cmd_opts_t &opts, wcstring option_spec,
+                              io_streams_t &streams) {
+    if (option_spec.empty()) {
+        streams.err.append_format(_(L"%s: An option spec must have a short flag letter\n"),
+                                  opts.name.c_str());
+        return false;
+    }
+
+    const wchar_t *s = option_spec.c_str();
+    option_spec_t *opt_spec = new option_spec_t(*s++);
+
+    if (*s == '/') {
+        s++;  // the struct is initialized assuming short_flag_valid should be true
+    } else if (*s == '-') {
+        opt_spec->short_flag_valid = false;
+        s++;
+    } else {
+        // Long flag name not allowed if second char isn't '/' or '-' so just check for
+        // behavior modifier chars.
+        return parse_flag_modifiers(opts, opt_spec, option_spec, s, streams);
+    }
+
+    const wchar_t *e = s;
+    while (*e && *e != '+' && *e != ':') e++;
+    if (e == s) {
+        streams.err.append_format(BUILTIN_ERR_INVALID_OPT_SPEC, opts.name.c_str(),
+                                  option_spec.c_str(), *(s - 1));
+        return false;
+    }
+
+    opt_spec->long_flag = wcstring(s, e - s);
+    return parse_flag_modifiers(opts, opt_spec, option_spec, e, streams);
+}
+
+static int parse_cmd_opts(argparse_cmd_opts_t &opts, int *optind,  //!OCLINT(high ncss method)
+                          int argc, wchar_t **argv, parser_t &parser, io_streams_t &streams) {
+    wchar_t *cmd = argv[0];
+    int opt;
+    wgetopter_t w;
+    while ((opt = w.wgetopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+        switch (opt) {
+            case 'n': {
+                opts.name = w.woptarg;
+                break;
+            }
+            case 'r': {
+                opts.require_order = true;
+                break;
+            }
+            case 'h': {
+                opts.print_help = true;
+                break;
+            }
+            case ':': {
+                builtin_missing_argument(parser, streams, cmd, argv[w.woptind - 1]);
+                return STATUS_INVALID_ARGS;
+            }
+            case '?': {
+                builtin_unknown_option(parser, streams, cmd, argv[w.woptind - 1]);
+                return STATUS_INVALID_ARGS;
+            }
+            default: {
+                DIE("unexpected retval from wgetopt_long");
+                break;
+            }
+        }
+    }
+
+    *optind = w.woptind;
+    return STATUS_CMD_OK;
+}
+
+static void populate_option_strings(
+    argparse_cmd_opts_t &opts, wcstring &short_options,
+    std::unique_ptr<woption, std::function<void(woption *)>> &long_options) {
+    int i = 0;
+    for (auto it : opts.options) {
+        option_spec_t *opt_spec = it.second;
+        if (opt_spec->short_flag_valid) short_options.push_back(opt_spec->short_flag);
+
+        int arg_type = no_argument;
+        if (opt_spec->num_allowed == -1) {
+            arg_type = optional_argument;
+            if (opt_spec->short_flag_valid) short_options.append(L"::");
+        } else if (opt_spec->num_allowed > 0) {
+            arg_type = required_argument;
+            if (opt_spec->short_flag_valid) short_options.append(L":");
+        }
+
+        if (!opt_spec->long_flag.empty()) {
+            long_options.get()[i++] = {opt_spec->long_flag.c_str(), arg_type, NULL,
+                                       opt_spec->short_flag};
+        }
+    }
+    long_options.get()[i] = {NULL, 0, NULL, 0};
+}
+
+// This function mimics the `wgetopt_long()` usage found elsewhere in our other builtin commands.
+// It's different in that the short and long option structures are constructed dynamically based on
+// arguments provided to the `argparse` command.
+static int argparse_parse_args(argparse_cmd_opts_t &opts, const wcstring_list_t &args,
+                                  parser_t &parser, io_streams_t &streams) {
+    if (args.empty()) return STATUS_CMD_OK;
+
+    wcstring short_options = opts.require_order ? L"+:" : L":";
+    int nflags = opts.options.size();
+    // This assumes every option has a long flag. Which is the worst case and isn't worth optimizing
+    // since the number of options is always quite small. Thus the size of the array will never be
+    // much larger than the minimum size required for all the long options.
+    auto long_options = std::unique_ptr<woption, std::function<void(woption *)>>(
+        new woption[nflags + 1], [](woption *p) { delete[] p; });
+    populate_option_strings(opts, short_options, long_options);
+
+    const wchar_t *cmd = opts.name.c_str();
+    int argc = args.size();
+
+    // This is awful but we need to convert our wcstring_list_t to a <wchar_t **> that can be passed
+    // to w.wgetopt_long(). Furthermore, because we're dynamically allocating the array of pointers
+    // we need to ensure the memory for the data structure is freed when we leave this scope.
+    null_terminated_array_t<wchar_t> argv_container(args);
+    auto argv = (wchar_t **)argv_container.get();
+
+    int opt;
+    wgetopter_t w;
+    auto long_opts = long_options.get();
+    while ((opt = w.wgetopt_long(argc, argv, short_options.c_str(), long_opts, NULL)) != -1) {
+        switch (opt) {
+            case ':': {
+                builtin_missing_argument(parser, streams, cmd, argv[w.woptind - 1]);
+                return STATUS_INVALID_ARGS;
+            }
+            case '?': {
+                builtin_unknown_option(parser, streams, cmd, argv[w.woptind - 1]);
+                return STATUS_INVALID_ARGS;
+            }
+            default: {
+                auto found = opts.options.find(opt);
+                assert(found != opts.options.end());
+
+                option_spec_t *opt_spec = found->second;
+                opt_spec->num_seen++;
+                if (opt_spec->num_allowed == 0) {
+                    assert(!w.woptarg);
+                } else if (opt_spec->num_allowed == -1 || opt_spec->num_allowed == 1) {
+                    // This is subtle. We're depending on `wgetopt_long()` to report that a
+                    // mandatory value is missing if `opt_spec->num_allowed == 1` and thus return
+                    // ':' so that we don't take this branch if the mandatory arg is missing.
+                    // Otherwise we can treat the optional and mandatory arg cases the same. That
+                    // is, store the arg as the only value for the flag. Even if we've seen earlier
+                    // instances of the flag.
+                    opt_spec->vals.clear();
+                    if (w.woptarg) {
+                        opt_spec->vals.push_back(w.woptarg);
+                    }
+                } else {
+                    assert(w.woptarg);
+                    opt_spec->vals.push_back(w.woptarg);
+                }
+                break;
+            }
+        }
+    }
+
+    // Add a count for how many times we saw each boolean flag but only if we saw the flag at least
+    // once.
+    for (auto it : opts.options) {
+        auto opt_spec = it.second;
+        if (opt_spec->num_allowed != 0 || opt_spec->num_seen == 0) continue;
+        wchar_t count[20];
+        swprintf(count, sizeof count / sizeof count[0], L"%d", opt_spec->num_seen);
+        opt_spec->vals.push_back(wcstring(count));
+    }
+
+    for (int i = w.woptind; argv[i]; i++) opts.argv.push_back(argv[i]);
+    return STATUS_CMD_OK;
+}
+
+/// The argparse builtin. This is explicitly not compatible with the BSD or GNU version of this
+/// command. That's because fish doesn't have the weird quoting problems of POSIX shells. So we
+/// don't need to support flags like `--unquoted`. Similarly we don't want to support introducing
+/// long options with a single dash so we don't support the `--alternative` flag. That `getopt` is
+/// an external command also means its output has to be in a form that can be eval'd. Because our
+/// version is a builtin it can directly set variables local to the current scope (e.g., a
+/// function). It doesn't need to write anything to stdout that then needs to be eval'd.
+int builtin_argparse(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+    const wchar_t *cmd = argv[0];
+    int argc = builtin_count_args(argv);
+    argparse_cmd_opts_t opts;
+
+    int optind;
+    int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
+    if (retval != STATUS_CMD_OK) return retval;
+
+    if (opts.print_help) {
+        builtin_print_help(parser, streams, cmd, streams.out);
+        return STATUS_CMD_OK;
+    }
+
+    if (optind == argc) {
+        streams.err.append_format(BUILTIN_ERR_ARG_COUNT1, cmd, 2, 0);
+        return STATUS_INVALID_ARGS;
+    }
+
+    while (true) {
+        if (wcscmp(L"--", argv[optind]) == 0) {
+            optind++;
+            break;
+        }
+
+        if (!parse_option_spec(opts, argv[optind], streams)) {
+            return STATUS_CMD_ERROR;
+        }
+
+        if (++optind == argc) {
+            streams.err.append_format(BUILTIN_ERR_ARG_COUNT1, cmd, 2, 0);
+            return STATUS_INVALID_ARGS;
+        }
+    }
+
+#if 0
+    auto stats = mstats();
+    fwprintf(stderr, L"WTF %d  bytes_total %lu  chunks_used %lu  bytes_used %lu  chunks_free %lu  bytes_free %lu\n", __LINE__, stats.bytes_total, stats.chunks_used, stats.bytes_used, stats.chunks_free);
+#endif
+
+    wcstring_list_t args;
+    args.push_back(opts.name);
+    while (optind < argc) args.push_back(argv[optind++]);
+
+    retval = argparse_parse_args(opts, args, parser, streams);
+    if (retval != STATUS_CMD_OK) return retval;
+
+    for (auto it : opts.options) {
+        option_spec_t *opt_spec = it.second;
+        if (!opt_spec->num_seen) continue;
+
+        wcstring var_name_prefix = L"_flag_";
+        auto val = list_to_array_val(opt_spec->vals);
+        env_set(var_name_prefix + opt_spec->short_flag, *val == ENV_NULL ? NULL : val->c_str(),
+                ENV_LOCAL);
+        if (!opt_spec->long_flag.empty()) {
+            // We do a simple replacement of all non alphanum chars rather than calling
+            // escape_string(long_flag, 0, STRING_STYLE_VAR).
+            wcstring long_flag = opt_spec->long_flag;
+            for (size_t pos = 0; pos < long_flag.size(); pos++) {
+                if (!iswalnum(long_flag[pos])) long_flag[pos] = L'_';
+            }
+            env_set(var_name_prefix + long_flag, *val == ENV_NULL ? NULL : val->c_str(),
+                    ENV_LOCAL);
+        }
+    }
+
+    auto val = list_to_array_val(opts.argv);
+    env_set(L"argv", *val == ENV_NULL ? NULL : val->c_str(), ENV_LOCAL);
+
+#if 0
+    stats = mstats();
+    fwprintf(stderr, L"WTF %d  bytes_total %lu  chunks_used %lu  bytes_used %lu  chunks_free %lu  bytes_free %lu\n", __LINE__, stats.bytes_total, stats.chunks_used, stats.bytes_used, stats.chunks_free);
+#endif
+
+    return retval;
+}

--- a/src/builtin_argparse.cpp
+++ b/src/builtin_argparse.cpp
@@ -3,19 +3,22 @@
 // See issue #4190 for the rationale behind the original behavior of this builtin.
 #include "config.h"  // IWYU pragma: keep
 
-#if 0
-#include <malloc/malloc.h>
-#endif
-
+#include <errno.h>
+#include <limits.h>
 #include <stddef.h>
 #include <wchar.h>
 
+#include <algorithm>
 #include <functional>
+#include <iostream>
+#include <iterator>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "builtin.h"
 #include "builtin_argparse.h"
@@ -48,8 +51,11 @@ class argparse_cmd_opts_t {
     bool print_help = false;
     bool require_order = false;
     wcstring name = L"argparse";
+    wcstring_list_t raw_exclusive_flags;
     wcstring_list_t argv;
-    struct std::map<wchar_t, option_spec_t *> options;
+    std::map<wchar_t, option_spec_t *> options;
+    std::map<wcstring, wchar_t> long_to_short_flag;
+    std::vector<std::vector<wchar_t>> exclusive_flag_sets;
 
     ~argparse_cmd_opts_t() {
         for (auto it : options) {
@@ -58,11 +64,107 @@ class argparse_cmd_opts_t {
     }
 };
 
-static const wchar_t *short_options = L"+:hn:r";
+static const wchar_t *short_options = L"+:hn:rx:";
 static const struct woption long_options[] = {{L"require-order", no_argument, NULL, 'r'},
                                               {L"name", required_argument, NULL, 'n'},
+                                              {L"exclusive", required_argument, NULL, 'x'},
                                               {L"help", no_argument, NULL, 'h'},
                                               {NULL, 0, NULL, 0}};
+
+// Check if any pair of mutually exclusive options was seen. Note that since every option must have
+// a short name we only need to check those.
+static int check_for_mutually_exclusive_flags(argparse_cmd_opts_t &opts, io_streams_t &streams) {
+    for (auto it : opts.options) {
+        auto opt_spec = it.second;
+        if (opt_spec->num_seen == 0) continue;
+
+        // We saw this option at least once. Check all the sets of mutually exclusive options to see
+        // if this option appears in any of them.
+        for (auto xarg_set : opts.exclusive_flag_sets) {
+            auto found = std::find(xarg_set.begin(), xarg_set.end(), opt_spec->short_flag);
+            if (found != xarg_set.end()) {
+                // Okay, this option is in a mutually exclusive set of options. Check if any of the
+                // other mutually exclusive options have been seen.
+                for (auto xflag : xarg_set) {
+                    auto xopt_spec = opts.options[xflag];
+                    // Ignore this flag in the list of mutually exclusive flags.
+                    if (xopt_spec->short_flag == opt_spec->short_flag) continue;
+
+                    // If it is a different flag check if it has been seen.
+                    if (xopt_spec->num_seen) {
+                        wcstring flag1;
+                        if (opt_spec->short_flag_valid) flag1 = wcstring(1, opt_spec->short_flag);
+                        if (!opt_spec->long_flag.empty()) {
+                            if (opt_spec->short_flag_valid) flag1 += L"/";
+                            flag1 += opt_spec->long_flag;
+                        }
+                        wcstring flag2;
+                        if (xopt_spec->short_flag_valid) flag2 = wcstring(1, xopt_spec->short_flag);
+                        if (!xopt_spec->long_flag.empty()) {
+                            if (xopt_spec->short_flag_valid) flag2 += L"/";
+                            flag2 += xopt_spec->long_flag;
+                        }
+                        streams.err.append_format(
+                            _(L"%ls: Mutually exclusive flags '%ls' and `%ls` seen\n"),
+                            opts.name.c_str(), flag1.c_str(), flag2.c_str());
+                        return STATUS_CMD_ERROR;
+                    }
+                }
+            }
+        }
+    }
+
+    return STATUS_CMD_OK;
+}
+
+// This is used as a specialization to allow us to force operator>> to split the input on something
+// other than spaces.
+class WordDelimitedByComma : public wcstring {};
+
+// Cppcheck incorrectly complains this is unused. It is indirectly used by std:istream_iterator.
+std::wistream &operator>>(std::wistream &is, WordDelimitedByComma &output) {  // cppcheck-suppress
+    std::getline(is, output, L',');
+    return is;
+}
+
+// This should be called after all the option specs have been parsed. At that point we have enough
+// information to parse the values associated with any `--exclusive` flags.
+static int parse_exclusive_args(argparse_cmd_opts_t &opts, io_streams_t &streams) {
+    for (auto raw_xflags : opts.raw_exclusive_flags) {
+        // This is an advanced technique that leverages the C++ STL to split the string on commas.
+        std::wistringstream iss(raw_xflags);
+        wcstring_list_t xflags((std::istream_iterator<WordDelimitedByComma, wchar_t>(iss)),
+                std::istream_iterator<WordDelimitedByComma, wchar_t>());
+        if (xflags.size() < 2) {
+            streams.err.append_format(_(L"%ls: exclusive flag string '%ls' is not valid\n"),
+                    opts.name.c_str(), raw_xflags.c_str());
+            return STATUS_CMD_ERROR;
+        }
+
+        std::vector<wchar_t> exclusive_set;
+        for (auto flag : xflags) {
+            if (flag.size() == 1 && opts.options.find(flag[0]) != opts.options.end()) {
+                // It's a short flag.
+                exclusive_set.push_back(flag[0]);
+            } else {
+                auto x = opts.long_to_short_flag.find(flag);
+                if (x != opts.long_to_short_flag.end()) {
+                    // It's a long flag we store as its short flag equivalent.
+                    exclusive_set.push_back(x->second);
+                } else {
+                    streams.err.append_format(_(L"%ls: exclusive flag '%ls' is not valid\n"),
+                            opts.name.c_str(), flag.c_str());
+                    return STATUS_CMD_ERROR;
+                }
+            }
+        }
+
+        // Store the set of exclusive flags for use when parsing the supplied set of arguments.
+        opts.exclusive_flag_sets.push_back(exclusive_set);
+    }
+
+    return STATUS_CMD_OK;
+}
 
 static bool parse_flag_modifiers(argparse_cmd_opts_t &opts, option_spec_t *opt_spec,
                                  const wcstring &option_spec, const wchar_t *s,
@@ -122,7 +224,28 @@ static bool parse_option_spec(argparse_cmd_opts_t &opts, wcstring option_spec,
     }
 
     opt_spec->long_flag = wcstring(s, e - s);
+    opts.long_to_short_flag.emplace(opt_spec->long_flag, opt_spec->short_flag);
     return parse_flag_modifiers(opts, opt_spec, option_spec, e, streams);
+}
+
+static int collect_option_specs(argparse_cmd_opts_t &opts, int *optind, int argc, wchar_t **argv,
+                                io_streams_t &streams) {
+    wchar_t *cmd = argv[0];
+    while (true) {
+        if (wcscmp(L"--", argv[*optind]) == 0) {
+            ++*optind;
+            return STATUS_CMD_OK;
+        }
+
+        if (!parse_option_spec(opts, argv[*optind], streams)) {
+            return STATUS_CMD_ERROR;
+        }
+
+        if (++*optind == argc) {
+            streams.err.append_format(BUILTIN_ERR_ARG_COUNT1, cmd, 2, 0);
+            return STATUS_INVALID_ARGS;
+        }
+    }
 }
 
 static int parse_cmd_opts(argparse_cmd_opts_t &opts, int *optind,  //!OCLINT(high ncss method)
@@ -138,6 +261,12 @@ static int parse_cmd_opts(argparse_cmd_opts_t &opts, int *optind,  //!OCLINT(hig
             }
             case 'r': {
                 opts.require_order = true;
+                break;
+            }
+            case 'x': {
+                // Just save the raw string here. Later, when we have all the short and long flag
+                // definitions we'll parse these strings into a more useful data structure.
+                opts.raw_exclusive_flags.push_back(w.woptarg);
                 break;
             }
             case 'h': {
@@ -160,7 +289,7 @@ static int parse_cmd_opts(argparse_cmd_opts_t &opts, int *optind,  //!OCLINT(hig
     }
 
     *optind = w.woptind;
-    return STATUS_CMD_OK;
+    return collect_option_specs(opts, optind, argc, argv, streams);
 }
 
 static void populate_option_strings(
@@ -188,74 +317,9 @@ static void populate_option_strings(
     long_options.get()[i] = {NULL, 0, NULL, 0};
 }
 
-// This function mimics the `wgetopt_long()` usage found elsewhere in our other builtin commands.
-// It's different in that the short and long option structures are constructed dynamically based on
-// arguments provided to the `argparse` command.
-static int argparse_parse_args(argparse_cmd_opts_t &opts, const wcstring_list_t &args,
-                                  parser_t &parser, io_streams_t &streams) {
-    if (args.empty()) return STATUS_CMD_OK;
-
-    wcstring short_options = opts.require_order ? L"+:" : L":";
-    int nflags = opts.options.size();
-    // This assumes every option has a long flag. Which is the worst case and isn't worth optimizing
-    // since the number of options is always quite small. Thus the size of the array will never be
-    // much larger than the minimum size required for all the long options.
-    auto long_options = std::unique_ptr<woption, std::function<void(woption *)>>(
-        new woption[nflags + 1], [](woption *p) { delete[] p; });
-    populate_option_strings(opts, short_options, long_options);
-
-    const wchar_t *cmd = opts.name.c_str();
-    int argc = args.size();
-
-    // This is awful but we need to convert our wcstring_list_t to a <wchar_t **> that can be passed
-    // to w.wgetopt_long(). Furthermore, because we're dynamically allocating the array of pointers
-    // we need to ensure the memory for the data structure is freed when we leave this scope.
-    null_terminated_array_t<wchar_t> argv_container(args);
-    auto argv = (wchar_t **)argv_container.get();
-
-    int opt;
-    wgetopter_t w;
-    auto long_opts = long_options.get();
-    while ((opt = w.wgetopt_long(argc, argv, short_options.c_str(), long_opts, NULL)) != -1) {
-        switch (opt) {
-            case ':': {
-                builtin_missing_argument(parser, streams, cmd, argv[w.woptind - 1]);
-                return STATUS_INVALID_ARGS;
-            }
-            case '?': {
-                builtin_unknown_option(parser, streams, cmd, argv[w.woptind - 1]);
-                return STATUS_INVALID_ARGS;
-            }
-            default: {
-                auto found = opts.options.find(opt);
-                assert(found != opts.options.end());
-
-                option_spec_t *opt_spec = found->second;
-                opt_spec->num_seen++;
-                if (opt_spec->num_allowed == 0) {
-                    assert(!w.woptarg);
-                } else if (opt_spec->num_allowed == -1 || opt_spec->num_allowed == 1) {
-                    // This is subtle. We're depending on `wgetopt_long()` to report that a
-                    // mandatory value is missing if `opt_spec->num_allowed == 1` and thus return
-                    // ':' so that we don't take this branch if the mandatory arg is missing.
-                    // Otherwise we can treat the optional and mandatory arg cases the same. That
-                    // is, store the arg as the only value for the flag. Even if we've seen earlier
-                    // instances of the flag.
-                    opt_spec->vals.clear();
-                    if (w.woptarg) {
-                        opt_spec->vals.push_back(w.woptarg);
-                    }
-                } else {
-                    assert(w.woptarg);
-                    opt_spec->vals.push_back(w.woptarg);
-                }
-                break;
-            }
-        }
-    }
-
-    // Add a count for how many times we saw each boolean flag but only if we saw the flag at least
-    // once.
+// Add a count for how many times we saw each boolean flag but only if we saw the flag at least
+// once.
+static void update_bool_flag_counts(argparse_cmd_opts_t &opts) {
     for (auto it : opts.options) {
         auto opt_spec = it.second;
         if (opt_spec->num_allowed != 0 || opt_spec->num_seen == 0) continue;
@@ -263,8 +327,83 @@ static int argparse_parse_args(argparse_cmd_opts_t &opts, const wcstring_list_t 
         swprintf(count, sizeof count / sizeof count[0], L"%d", opt_spec->num_seen);
         opt_spec->vals.push_back(wcstring(count));
     }
+}
 
-    for (int i = w.woptind; argv[i]; i++) opts.argv.push_back(argv[i]);
+static int argparse_parse_flags(argparse_cmd_opts_t &opts, const wchar_t *short_options,
+                                const woption *long_options, const wchar_t *cmd, int argc,
+                                wchar_t **argv, int *optind, parser_t &parser,
+                                io_streams_t &streams) {
+    int opt;
+    wgetopter_t w;
+    while ((opt = w.wgetopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+        if (opt == ':') {
+            builtin_missing_argument(parser, streams, cmd, argv[w.woptind - 1]);
+            return STATUS_INVALID_ARGS;
+        }
+        if (opt == '?') {
+            builtin_unknown_option(parser, streams, cmd, argv[w.woptind - 1]);
+            return STATUS_INVALID_ARGS;
+        }
+
+        auto found = opts.options.find(opt);
+        assert(found != opts.options.end());
+
+        option_spec_t *opt_spec = found->second;
+        opt_spec->num_seen++;
+        if (opt_spec->num_allowed == 0) {
+            assert(!w.woptarg);
+        } else if (opt_spec->num_allowed == -1 || opt_spec->num_allowed == 1) {
+            // We're depending on `wgetopt_long()` to report that a mandatory value is missing if
+            // `opt_spec->num_allowed == 1` and thus return ':' so that we don't take this branch if
+            // the mandatory arg is missing.
+            opt_spec->vals.clear();
+            if (w.woptarg) {
+                opt_spec->vals.push_back(w.woptarg);
+            }
+        } else {
+            assert(w.woptarg);
+            opt_spec->vals.push_back(w.woptarg);
+        }
+    }
+
+    *optind = w.woptind;
+    return STATUS_CMD_OK;
+}
+
+// This function mimics the `wgetopt_long()` usage found elsewhere in our other builtin commands.
+// It's different in that the short and long option structures are constructed dynamically based on
+// arguments provided to the `argparse` command.
+static int argparse_parse_args(argparse_cmd_opts_t &opts, const wcstring_list_t &args,
+                               parser_t &parser, io_streams_t &streams) {
+    if (args.empty()) return STATUS_CMD_OK;
+
+    wcstring short_options = opts.require_order ? L"+:" : L":";
+    size_t nflags = opts.options.size();
+    // This assumes every option has a long flag. Which is the worst case and isn't worth optimizing
+    // since the number of options is always quite small.
+    auto long_options = std::unique_ptr<woption, std::function<void(woption *)>>(
+        new woption[nflags + 1], [](woption *p) { delete[] p; });
+    populate_option_strings(opts, short_options, long_options);
+
+    const wchar_t *cmd = opts.name.c_str();
+    int argc = static_cast<int>(args.size());
+
+    // This is awful but we need to convert our wcstring_list_t to a <wchar_t **> that can be passed
+    // to w.wgetopt_long(). Furthermore, because we're dynamically allocating the array of pointers
+    // we need to ensure the memory for the data structure is freed when we leave this scope.
+    null_terminated_array_t<wchar_t> argv_container(args);
+    auto argv = (wchar_t **)argv_container.get();
+
+    int optind;
+    int retval = argparse_parse_flags(opts, short_options.c_str(), long_options.get(), cmd, argc,
+                                      argv, &optind, parser, streams);
+    if (retval != STATUS_CMD_OK) return retval;
+
+    retval = check_for_mutually_exclusive_flags(opts, streams);
+    if (retval != STATUS_CMD_OK) return retval;
+    update_bool_flag_counts(opts);
+
+    for (int i = optind; argv[i]; i++) opts.argv.push_back(argv[i]);
     return STATUS_CMD_OK;
 }
 
@@ -290,34 +429,17 @@ int builtin_argparse(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     }
 
     if (optind == argc) {
-        streams.err.append_format(BUILTIN_ERR_ARG_COUNT1, cmd, 2, 0);
-        return STATUS_INVALID_ARGS;
+        // Apparently we weren't handed any arguments to be parsed according to the option specs we
+        // just collected. So there isn't anything for us to do.
+        return STATUS_CMD_OK;
     }
-
-    while (true) {
-        if (wcscmp(L"--", argv[optind]) == 0) {
-            optind++;
-            break;
-        }
-
-        if (!parse_option_spec(opts, argv[optind], streams)) {
-            return STATUS_CMD_ERROR;
-        }
-
-        if (++optind == argc) {
-            streams.err.append_format(BUILTIN_ERR_ARG_COUNT1, cmd, 2, 0);
-            return STATUS_INVALID_ARGS;
-        }
-    }
-
-#if 0
-    auto stats = mstats();
-    fwprintf(stderr, L"WTF %d  bytes_total %lu  chunks_used %lu  bytes_used %lu  chunks_free %lu  bytes_free %lu\n", __LINE__, stats.bytes_total, stats.chunks_used, stats.bytes_used, stats.chunks_free);
-#endif
 
     wcstring_list_t args;
     args.push_back(opts.name);
     while (optind < argc) args.push_back(argv[optind++]);
+
+    retval = parse_exclusive_args(opts, streams);
+    if (retval != STATUS_CMD_OK) return retval;
 
     retval = argparse_parse_args(opts, args, parser, streams);
     if (retval != STATUS_CMD_OK) return retval;
@@ -344,11 +466,6 @@ int builtin_argparse(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
     auto val = list_to_array_val(opts.argv);
     env_set(L"argv", *val == ENV_NULL ? NULL : val->c_str(), ENV_LOCAL);
-
-#if 0
-    stats = mstats();
-    fwprintf(stderr, L"WTF %d  bytes_total %lu  chunks_used %lu  bytes_used %lu  chunks_free %lu  bytes_free %lu\n", __LINE__, stats.bytes_total, stats.chunks_used, stats.bytes_used, stats.chunks_free);
-#endif
 
     return retval;
 }

--- a/src/builtin_argparse.cpp
+++ b/src/builtin_argparse.cpp
@@ -441,6 +441,7 @@ static int argparse_parse_args(argparse_cmd_opts_t &opts, const wcstring_list_t 
         streams.err.append_format(BUILTIN_ERR_MAX_ARG_COUNT1, cmd, opts.max_args, opts.argv.size());
         return STATUS_CMD_ERROR;
     }
+
     return STATUS_CMD_OK;
 }
 

--- a/src/builtin_argparse.h
+++ b/src/builtin_argparse.h
@@ -1,0 +1,9 @@
+// Prototypes for executing builtin_getopt function.
+#ifndef FISH_BUILTIN_ARGPARSE_H
+#define FISH_BUILTIN_ARGPARSE_H
+
+class parser_t;
+struct io_streams_t;
+
+int builtin_argparse(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+#endif

--- a/tests/argparse.err
+++ b/tests/argparse.err
@@ -1,0 +1,16 @@
+# No args is an error
+argparse: No option specs were provided
+# Missing -- is an error
+argparse: Missing -- separator
+# Flags but no option specs is an error
+argparse: No option specs were provided
+# Invalid option specs
+argparse: Invalid option spec 'h-' at char '-'
+argparse: Invalid option spec '+help' at char 'h'
+argparse: Invalid option spec 'h/help:' at char ':'
+argparse: Invalid option spec 'h-help::' at char ':'
+argparse: Invalid option spec 'h-help=x' at char 'x'
+# --max-args and --min-args work
+min-max: Expected at least 1 args, got only 0
+min-max: Expected at most 3 args, got 4
+min-max: Expected at most 1 args, got 2

--- a/tests/argparse.in
+++ b/tests/argparse.in
@@ -1,0 +1,66 @@
+# Test the `argparse` builtin.
+
+##########
+# Start by verifying a bunch of error conditions.
+
+echo '# No args is an error' >&2
+argparse
+
+echo '# Missing -- is an error' >&2
+argparse h/help
+
+echo '# Flags but no option specs is an error' >&2
+argparse -s -- hello
+
+echo '# Invalid option specs' >&2
+argparse h-
+argparse +help
+argparse h/help:
+argparse h-help::
+argparse h-help=x
+
+echo '# --max-args and --min-args work' >&2
+begin
+    argparse --name min-max --min-args 1 h/help --
+    argparse --name min-max --min-args 1 --max-args 3 h/help -- arg1
+    argparse --name min-max --min-args 1 --max-args 3 h/help -- arg1 arg2
+    argparse --name min-max --min-args 1 --max-args 3 h/help -- --help arg1 arg2 arg3
+    argparse --name min-max --min-args 1 --max-args 3 h/help -- arg1 arg2 -h arg3 arg4
+    argparse --name min-max --max-args 1 h/help --
+    argparse --name min-max --max-args 1 h/help -- arg1
+    argparse --name min-max --max-args 1 h/help -- arg1 arg2
+end
+
+##########
+# Now verify that validly formed invocations work as expected.
+
+echo '# No args'
+argparse h/help --
+
+echo '# One arg and no matching flags'
+begin
+    argparse h/help -- help
+    set -l
+    show $argv
+end
+
+echo '# Five args with two matching a flag'
+begin
+    argparse h/help -- help --help me -h 'a lot more'
+    set -l
+    show $argv
+end
+
+echo '# Required, optional, and multiple flags'
+begin
+    argparse 'h/help' 'a/abc=' 'd/def=?' 'g/ghk=+' -- help --help me --ghk=g1 --abc=ABC --ghk g2 --d -g g3
+    set -l
+    show $argv
+end
+
+echo '# --stop-nonopt works'
+begin
+    argparse --stop-nonopt 'h/help' 'a/abc=' -- -a A1 -h --abc A2 non-opt 'second non-opt' --help
+    set -l
+    show $argv
+end

--- a/tests/argparse.out
+++ b/tests/argparse.out
@@ -1,0 +1,36 @@
+# No args
+# One arg and no matching flags
+argv help
+count=1
+|help|
+# Five args with two matching a flag
+_flag_h 2
+_flag_help 2
+argv 'help'  'me'  'a lot more'
+count=3
+|help|
+|me|
+|a lot more|
+# Required, optional, and multiple flags
+_flag_a ABC
+_flag_abc ABC
+_flag_d
+_flag_def
+_flag_g 'g1'  'g2'  'g3'
+_flag_ghk 'g1'  'g2'  'g3'
+_flag_h 1
+_flag_help 1
+argv 'help'  'me'
+count=2
+|help|
+|me|
+# --stop-nonopt works
+_flag_a A2
+_flag_abc A2
+_flag_h 1
+_flag_help 1
+argv 'non-opt'  'second non-opt'  '--help'
+count=3
+|non-opt|
+|second non-opt|
+|--help|

--- a/tests/fish_opt.err
+++ b/tests/fish_opt.err
@@ -1,0 +1,11 @@
+# no args is an error
+fish_opt: The --short flag is required and must be a single character
+# no short flag or an invalid short flag is an error
+fish_opt: The --short flag is required and must be a single character
+fish_opt: The --short flag is required and must be a single character
+# a required and optional arg makes no sense
+fish_opt: Mutually exclusive flags 'o/optional-val' and `r/required-val` seen
+# a repeated and optional arg makes no sense
+fish_opt: Mutually exclusive flags 'multiple-vals' and `o/optional-val` seen
+# an unexpected arg not associated with a flag is an error
+fish_opt: Expected at most 0 args, got 1

--- a/tests/fish_opt.in
+++ b/tests/fish_opt.in
@@ -1,0 +1,62 @@
+# Start by testing a bunch of error conditions.
+
+echo '# no args is an error' >&2
+fish_opt
+and echo unexpected status $status
+
+echo '# no short flag or an invalid short flag is an error' >&2
+fish_opt -l help
+and echo unexpected status $status
+fish_opt -s help
+and echo unexpected status $status
+
+echo '# a required and optional arg makes no sense' >&2
+fish_opt -s h -l help -r --optional-val
+and echo unexpected status $status
+
+echo '# a repeated and optional arg makes no sense' >&2
+fish_opt -s h -l help --multiple-vals --optional-val
+and echo unexpected status $status
+
+echo '# an unexpected arg not associated with a flag is an error' >&2
+fish_opt -s h -l help hello
+and echo unexpected status $status
+
+# Now verify that valid combinations of options produces the correct output.
+
+echo '# bool, short only'
+fish_opt -s h
+or echo unexpected status $status
+
+echo '# bool, short and long'
+fish_opt --short h --long help
+or echo unexpected status $status
+
+echo '# bool, short and long but the short var cannot be used'
+fish_opt --short h --long help --long-only
+
+echo '# required val, short and long but the short var cannot be used'
+fish_opt --short h --long help -r --long-only
+or echo unexpected status $status
+
+echo '# optional val, short and long valid'
+fish_opt --short h -l help --optional-val
+or echo unexpected status $status
+
+echo '# optional val, short and long but the short var cannot be used'
+fish_opt --short h -l help --optional-val --long-only
+or echo unexpected status $status
+
+echo '# repeated val, short and long valid'
+fish_opt --short h -l help --multiple-vals
+or echo unexpected status $status
+
+echo '# repeated val, short and long but short not valid'
+fish_opt --short h -l help --multiple-vals --long-only
+or echo unexpected status $status
+
+echo '# repeated val, short only'
+fish_opt -s h --multiple-vals
+or echo unexpected status $status
+fish_opt -s h --multiple-vals --long-only
+or echo unexpected status $status

--- a/tests/fish_opt.out
+++ b/tests/fish_opt.out
@@ -1,0 +1,19 @@
+# bool, short only
+h
+# bool, short and long
+h/help
+# bool, short and long but the short var cannot be used
+h-help
+# required val, short and long but the short var cannot be used
+h-help=
+# optional val, short and long valid
+h/help=?
+# optional val, short and long but the short var cannot be used
+h-help=?
+# repeated val, short and long valid
+h/help=+
+# repeated val, short and long but short not valid
+h-help=+
+# repeated val, short only
+h=+
+h=+

--- a/tests/test_functions/show.fish
+++ b/tests/test_functions/show.fish
@@ -1,0 +1,4 @@
+function show
+    echo count=(count $argv)
+    printf '|%s|\n' $argv
+end


### PR DESCRIPTION
Note that I decided to change the command name from `fish_getopt` to `argparse` as I didn't really like the `fish_` prefix but don't want any confusion regarding compatibility with the legacy `getopt` external command. 

I've done extensive testing to verify this doesn't leak memory. The calls to `mstat()` that are ifdef'd out of the code are there because an earlier version of the code was leaking memory.

This includes a couple of functions converted to use `argparse` so people can see actual examples of how this works in practice.

Fixes #4190 