### PR TITLE
Ignore comments when creating man page completion

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -528,7 +528,6 @@ class TypeDarwinManParser(ManParser):
         line = line.replace('.Nm', CMDNAME)
         line = line.replace('\\ ', ' ')
         line = line.replace('\& ', '')
-        line = line.replace(r'.\"', '')
         return line
 
     def is_option(self, line):
@@ -567,6 +566,9 @@ class TypeDarwinManParser(ManParser):
             desc_lines = []
             while lines and not self.is_option(lines[0]):
                 line = lossy_unicode(lines.pop(0).strip())
+                # Ignore comments
+                if line.startswith(r'.\"'):
+                    continue
                 if line.startswith('.'):
                     line = self.groff_replace_escapes(line)
                     line = self.trim_groff(line).strip()


### PR DESCRIPTION
Comments aren't shown in man pages and shouldn't be parsed.