### PR TITLE
Completions no sort

### DIFF
--- a/doc_src/complete.txt
+++ b/doc_src/complete.txt
@@ -8,6 +8,7 @@ complete ( -c | --command | -p | --path ) COMMAND
         [( -s | --short-option ) SHORT_OPTION]...
         [( -l | --long-option | -o | --old-option ) LONG_OPTION]...
         [( -a | --arguments ) OPTION_ARGUMENTS]
+        [( -k | --keep-order )]
         [( -f | --no-files )]
         [( -r | --require-parameter )]
         [( -x | --exclusive )]
@@ -46,6 +47,8 @@ the fish manual.
 - `-o LONG_OPTION` or `--old-option=LONG_OPTION` adds an old style long option to the completions list (See below for details).
 
 - `-a OPTION_ARGUMENTS` or `--arguments=OPTION_ARGUMENTS` adds the specified option arguments to the completions list.
+
+- `-k` or `--keep-order` preserves the order of the `OPTION_ARGUMENTS` specified via `-a` or `--arguments` instead of sorting alphabetically.
 
 - `-f` or `--no-files` specifies that the options specified by this completion may not be followed by a filename.
 

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -427,7 +427,7 @@ complete -c git -n '__fish_git_needs_command' -a commit -d 'Record changes to th
 complete -c git -n '__fish_git_using_command commit' -l amend -d 'Amend the log message of the last commit'
 complete -f -c git -n '__fish_git_using_command commit' -a '(__fish_git_modified_files)'
 complete -f -c git -n '__fish_git_using_command commit' -l fixup -d 'Fixup commit to be used with rebase --autosquash'
-complete -f -c git -n '__fish_git_using_command commit; and __fish_contains_opt fixup' -a '(__fish_git_recent_commits)'
+complete -f -c git -n '__fish_git_using_command commit; and __fish_contains_opt fixup' -k -a '(__fish_git_recent_commits)'
 # TODO options
 
 ### diff

--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -128,8 +128,9 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wcstring_list_t cmd_to_complete;
     wcstring_list_t path;
     wcstring_list_t wrap_targets;
+    bool preserve_order = false;
 
-    static const wchar_t *short_options = L":a:c:p:s:l:o:d:frxeuAn:C::w:h";
+    static const wchar_t *short_options = L":a:c:p:s:l:o:d:frxeuAn:C::w:hk";
     static const struct woption long_options[] = {{L"exclusive", no_argument, NULL, 'x'},
                                                   {L"no-files", no_argument, NULL, 'f'},
                                                   {L"require-parameter", no_argument, NULL, 'r'},
@@ -147,6 +148,7 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                                                   {L"wraps", required_argument, NULL, 'w'},
                                                   {L"do-complete", optional_argument, NULL, 'C'},
                                                   {L"help", no_argument, NULL, 'h'},
+                                                  {L"keep-order", no_argument, NULL, 'k'},
                                                   {NULL, 0, NULL, 0}};
 
     int opt;
@@ -163,6 +165,10 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
             }
             case 'r': {
                 result_mode |= NO_COMMON;
+                break;
+            }
+            case 'k': {
+                preserve_order = true;
                 break;
             }
             case 'p':
@@ -355,6 +361,9 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         streams.out.append(complete_print());
     } else {
         int flags = COMPLETE_AUTO_SPACE;
+        if (preserve_order) {
+            flags |= COMPLETE_DONT_SORT;
+        }
 
         if (remove) {
             builtin_complete_remove(cmd_to_complete, path, short_opt.c_str(), gnu_opt, old_opt);

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <unordered_set>
 
 #include "autoload.h"
 #include "builtin.h"
@@ -245,7 +246,7 @@ template <class Iterator, class HashFunction>
 static Iterator unique_unsorted(Iterator begin, Iterator end, HashFunction hash) {
     typedef typename std::iterator_traits<Iterator>::value_type T;
 
-    std::set<size_t> temp;
+    std::unordered_set<size_t> temp;
     return std::remove_if(begin, end, [&](const T& val) {
             return !temp.insert(hash(val)).second;
             });

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -226,7 +226,7 @@ completion_t &completion_t::operator=(const completion_t &him) {
 
 bool completion_t::is_naturally_less_than(const completion_t &a, const completion_t &b) {
     //for this to work, stable_sort must be used because results aren't interchangeable
-    if ((a.flags & COMPLETE_DONT_SORT) != 0 && (b.flags & COMPLETE_DONT_SORT) != 0) {
+    if (a.flags & b.flags & COMPLETE_DONT_SORT) {
        return false;
     }
     return wcsfilecmp(a.completion.c_str(), b.completion.c_str()) < 0;

--- a/src/complete.h
+++ b/src/complete.h
@@ -41,7 +41,9 @@ enum {
     /// This completion should be inserted as-is, without escaping.
     COMPLETE_DONT_ESCAPE = 1 << 4,
     /// If you do escape, don't escape tildes.
-    COMPLETE_DONT_ESCAPE_TILDES = 1 << 5
+    COMPLETE_DONT_ESCAPE_TILDES = 1 << 5,
+    /// Do not sort supplied completions
+    COMPLETE_DONT_SORT = 1 << 6
 };
 typedef int complete_flags_t;
 
@@ -80,7 +82,11 @@ class completion_t {
     // "Naturally less than" means in a natural ordering, where digits are treated as numbers. For
     // example, foo10 is naturally greater than foo2 (but alphabetically less than it).
     static bool is_naturally_less_than(const completion_t &a, const completion_t &b);
-    static bool is_alphabetically_equal_to(const completion_t &a, const completion_t &b);
+    static int is_alphabetically_less_than(const completion_t &a, const completion_t &b);
+
+    // Deduplicate a potentially-unsorted vector, preserving the order
+    template<class Iterator, typename BinaryPredicate>
+    static Iterator unique_unsorted(Iterator begin, Iterator end, BinaryPredicate p);
 
     // If this completion replaces the entire token, prepend a prefix. Otherwise do nothing.
     void prepend_token_prefix(const wcstring &prefix);

--- a/src/complete.h
+++ b/src/complete.h
@@ -82,11 +82,10 @@ class completion_t {
     // "Naturally less than" means in a natural ordering, where digits are treated as numbers. For
     // example, foo10 is naturally greater than foo2 (but alphabetically less than it).
     static bool is_naturally_less_than(const completion_t &a, const completion_t &b);
-    static int is_alphabetically_less_than(const completion_t &a, const completion_t &b);
 
     // Deduplicate a potentially-unsorted vector, preserving the order
-    template<class Iterator, typename BinaryPredicate>
-    static Iterator unique_unsorted(Iterator begin, Iterator end, BinaryPredicate p);
+    template <class Iterator, class HashFunction>
+    static Iterator unique_unsorted(Iterator begin, Iterator end, HashFunction hash);
 
     // If this completion replaces the entire token, prepend a prefix. Otherwise do nothing.
     void prepend_token_prefix(const wcstring &prefix);


### PR DESCRIPTION
Please be gentle, this is my first time looking at the fish source code.

This patch is intended to fix issues including #361 from 2012 and #3284 from 2016. I've done my best to take heed of the comments in those issues and believe that this patch implements an option for sources to prevent their completions from being sorted/re-ordered without sacrificing deduplication and with as minimal of a change as possible.

In reality, the previous code did deduplication and sort in the same step and they could not be functionally separated without separating the two. This patch will also make it possible to merge the two sorts in `completions_sort_and_prioritize` (first by natural order and second by match type) into a single stable sort by including both the natural comparison and the match type comparison in the  `BinaryPredicate` passed to `stable_sort`.

Previous outside attempts at implementing this behavior were functionally broken, as they continued to use `std::sort` instead of `std::stable_sort`, which isn't possible when `is_naturally_less_than` basically lies instead of universally comparing the passed arguments.

`unique_unsorted` could have been implemented by means of an `std::set`, but I believe this solution to be more performant and memory efficient, since it uses contiguous allocation and is more cache-friendly and we do not expect a massive number of duplicates to be coming in from the completion source in the first place.

I considered implementing this patch differently, introducing a new `--sort-key` parameter that would have a completion source provide an alternate sort_by value which would override the actual completion, but after implementing it almost to completion I re-evaluated my approach since it required a) changes to almost all the completion function prototypes to take an additional, optional `sort_key` value, b) changes to the `completion_t` object to introduce a new field that is only sometimes used, c) a massive hack to generate a fake sort_by key via `seq` for all results that don't actually need a custom sort but would rather just keep the completion sort's original order intact.

This patch also includes an application of `--keep-order / -k`, as shown in `share/completions/git.fish`, where the completions for `git commit --fixup ` now use this new parameter to keep the results of that completion sane/usable, given that they are SHA1 hashes and it makes no sense whatsoever to sort them (and is my initial motivation for introducing this patch).

Thanks for considering.