### PR TITLE
Make npm run-script completion faster with `jq`

### DIFF
--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -71,22 +71,22 @@ end
 complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run; and not __fish_npm_using_command run-script' -a "(__fish_complete_npm)"
 
 # list available npm scripts and their parial content
+function __fish_parse_npm_run_completions
+    while read -l name
+        set -l trim 20
+        read -l value
+        set value (string sub -l $trim -- $value)
+        printf "%s\t%s\n" $name $value
+    end
+end
+
+
 function __fish_npm_run
     # Like above, only try to call npm if there's a command by that name to facilitate aliases that call nvm.
     if command -sq jq; and test -e package.json
-        jq -r '.scripts | to_entries[] | .key,.value' <package.json | while read -l name
-            set -l trim 20
-            read -l value
-            echo "$value" | cut -c1-$trim | read -l value
-            printf "%s\t%s\n" $name $value
-        end
+        jq -r '.scripts | to_entries[] | .key,.value' <package.json | __fish_parse_npm_run_completions
     else if command -sq npm
-        command npm run | string match -r -v '^[^ ]|^$' | string trim | while read -l name
-            set -l trim 20
-            read -l value
-            echo "$value" | cut -c1-$trim | read -l value
-            printf "%s\t%s\n" $name $value
-        end
+        command npm run | string match -r -v '^[^ ]|^$' | string trim | __fish_parse_npm_run_completions
     end
 end
 

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -64,15 +64,23 @@ function __fish_complete_npm --description "Complete the commandline using npm's
 end
 
 # use npm completion for most of the things,
-# except options completion because it sucks at it.
+# except options completion (because it sucks at it)
+# and run-script completion (reading package.json is faster).
 # see: https://github.com/npm/npm/issues/9524
 # and: https://github.com/fish-shell/fish-shell/pull/2366
-complete -f -c npm -n 'not __fish_npm_needs_option' -a "(__fish_complete_npm)"
+complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run; and not __fish_npm_using_command run-script' -a "(__fish_complete_npm)"
 
 # list available npm scripts and their parial content
 function __fish_npm_run
     # Like above, only try to call npm if there's a command by that name to facilitate aliases that call nvm.
-    if command -sq npm
+    if command -sq jq; and test -e package.json
+        jq -r '.scripts | to_entries[] | .key,.value' <package.json | while read -l name
+            set -l trim 20
+            read -l value
+            echo "$value" | cut -c1-$trim | read -l value
+            printf "%s\t%s\n" $name $value
+        end
+    else if command -sq npm
         command npm run | string match -r -v '^[^ ]|^$' | string trim | while read -l name
             set -l trim 20
             read -l value

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -80,7 +80,6 @@ function __fish_parse_npm_run_completions
     end
 end
 
-
 function __fish_npm_run
     # Like above, only try to call npm if there's a command by that name to facilitate aliases that call nvm.
     if command -sq jq; and test -e package.json


### PR DESCRIPTION
## Description

When jq is available, it's actually faster to invoke jq and parse the `package.json`
invoking the `npm` command.

Also, prior to this commit, both `__fish_complete_npm` and `__fish_npm_run` were being run
whenever completions for `npm run` subcommand was being used, which was actually making
repetitive work (invoking npm command twice). This pull request is supposed to make completion
without `jq` faster as well

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
