### PR TITLE
Only reassume control of term if all foreground jobs finished

### DIFF
--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -835,13 +835,12 @@ static bool terminal_return_from_job(job_t *j) {
         return true;
     }
 
-    // HACK: Only return if this was the last foreground jobid
-    // See issue #4238.
-    job_iterator_t jobs;
-    for (auto job = jobs.next(); job; jobs.next()) {
-        if (job != j && job->get_flag(JOB_TERMINAL) && job->get_flag(JOB_FOREGROUND)) {
-            return false;
-        }
+    // HACK: If the job did not have control over the terminal, someone else should have.
+    // This fixes `cat | while read` (#4238).
+    // The real solution is to not have two jobs there in the first place.
+    if (tcgetpgrp(STDIN_FILENO) != j->pgid) {
+        debug(2, L"Job %d didn't have control", j->job_id);
+        return true;
     }
 
     signal_block(true);

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -838,7 +838,7 @@ static bool terminal_return_from_job(job_t *j) {
     // HACK: Only return if this was the last foreground jobid
     // See issue #4238.
     job_iterator_t jobs;
-    for (auto &job = jobs.next(); job; jobs.next()) {
+    for (auto job = jobs.next(); job; jobs.next()) {
         if (job != j && job->get_flag(JOB_TERMINAL) && job->get_flag(JOB_FOREGROUND)) {
             return false;
         }

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -835,6 +835,15 @@ static bool terminal_return_from_job(job_t *j) {
         return true;
     }
 
+    // HACK: Only return if this was the last foreground jobid
+    // See issue #4238.
+    job_iterator_t jobs;
+    for (auto &job = jobs.next(); job; jobs.next()) {
+        if (job != j && job->get_flag(JOB_TERMINAL) && job->get_flag(JOB_FOREGROUND)) {
+            return false;
+        }
+    }
+
     signal_block(true);
     if (tcsetpgrp(STDIN_FILENO, getpgrp()) == -1) {
         if (errno == ENOTTY) redirect_tty_output();


### PR DESCRIPTION
## Description

In some cases one process of a job quits early, and fish then reassumes control of the terminal. This is especially prevalent with `while read` loops (since every read only lasts for a single line).

We "fix" this by checking if all interactive jobs have finished before reassuming control. It's not a real fix (presumably that involves not considering the job finished in this case), but should be a good workaround.

Since this has some potential for breaking stuff, I'd appreciate some testing.

Fixes issue #4238.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed - this is kinda hard to test.
- [N/A] User-visible changes noted in CHANGELOG.md

Since this is a bug-fix, I'd like to have it in 2.7.0.