### PR TITLE
Fix clearing abandoned line with VTE

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -1287,7 +1287,7 @@ void s_reset(screen_t *s, screen_reset_mode_t mode) {
         // line above your prompt. This doesn't make a difference in normal usage, but copying and
         // pasting your terminal log becomes a pain. This commit clears that line, making it an
         // actual empty line.
-        abandon_line_string.append(L"\e[2K");
+        abandon_line_string.append(L"\e[K");
 
         const std::string narrow_abandon_line_string = wcs2string(abandon_line_string);
         write_loop(STDOUT_FILENO, narrow_abandon_line_string.c_str(),

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -1287,7 +1287,7 @@ void s_reset(screen_t *s, screen_reset_mode_t mode) {
         // line above your prompt. This doesn't make a difference in normal usage, but copying and
         // pasting your terminal log becomes a pain. This commit clears that line, making it an
         // actual empty line.
-        abandon_line_string.append(L"\e[K");
+        abandon_line_string.append(str2wcstring(clr_eol));
 
         const std::string narrow_abandon_line_string = wcs2string(abandon_line_string);
         write_loop(STDOUT_FILENO, narrow_abandon_line_string.c_str(),


### PR DESCRIPTION
With VTE-based terminals, resizing currently causes multi-line prompts
to go weird.

This changes the sequence we use to clear the line to one suggested by
a VTE
developer (https://bugzilla.gnome.org/show_bug.cgi?id=763390#c4).

It changes nothing in konsole 17.04.3 and urxvt 9.22, but they already
work.

Note that this does not fix the case where output did not end in a
newline, but that doesn't seem to be up to us. Also, it only affects
those lines.

Fixes #2320.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.md
