### PR TITLE
Fixes a race condition in output chaining in job control

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1066,8 +1066,9 @@ void exec_job(parser_t &parser, job_t *j) {
                 {
                     pid = execute_fork(false);
                     if (pid == 0) {
-                        // a hack that fixes any tcsetpgrp errors caused by race conditions
+                        // usleep is a hack that fixes any tcsetpgrp errors caused by race conditions
                         // usleep(20 * 1000);
+                        // it should no longer be needed with the chained_wait_next code below.
                         if (chained_wait_next != nullptr) {
                             debug(3, L"Waiting for next command in chain to start.\n");
                             sem_wait(chained_wait_next);
@@ -1121,6 +1122,7 @@ void exec_job(parser_t &parser, job_t *j) {
             debug(3, L"Unblocking previous command in chain.\n");
             sem_post(chained_wait_prev);
             munmap(chained_wait_prev, sizeof(sem_t));
+            chained_wait_prev = nullptr;
         }
         if (chained_wait_next != nullptr) {
             chained_wait_prev = chained_wait_next;

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -590,16 +590,6 @@ void exec_job(parser_t &parser, job_t *j) {
             }
             env_export_arr();
         }
-        else {
-            // Since the main loop itself is going to be (potentially) reading from the previous
-            // process, we need to unblock it here instead of after "executing" the next process
-            // in the chain.
-            if (blocked_pid != -1) {
-                //now that next command in the chain has been started, unblock the previous command
-                unblock_pid(blocked_pid);
-                blocked_pid = -1;
-            }
-        }
 
         // Set up fds that will be used in the pipe.
         if (pipes_to_next_command) {
@@ -640,12 +630,23 @@ void exec_job(parser_t &parser, job_t *j) {
         // This is the IO buffer we use for storing the output of a block or function when it is in
         // a pipeline.
         shared_ptr<io_buffer_t> block_output_io_buffer;
+        auto unblock_previous = [&] () {
+            if (blocked_pid != -1) {
+                //now that next command in the chain has been started, unblock the previous command
+                unblock_pid(blocked_pid);
+                blocked_pid = -1;
+            }
+        };
 
         // This is the io_streams we pass to internal builtins.
         std::unique_ptr<io_streams_t> builtin_io_streams;
 
         switch (p->type) {
             case INTERNAL_FUNCTION: {
+                //internal function never forks
+                //unblock previous (if any) to prevent hang
+                unblock_previous();
+
                 // Calls to function_get_definition might need to source a file as a part of
                 // autoloading, hence there must be no blocks.
                 signal_unblock();
@@ -824,6 +825,9 @@ void exec_job(parser_t &parser, job_t *j) {
 
                     signal_unblock();
 
+                    //main loop is performing a blocking read from previous command's output
+                    //make sure read source is not blocked
+                    unblock_previous();
                     p->status = builtin_run(parser, p->get_argv(), *builtin_io_streams);
 
                     signal_block();
@@ -944,6 +948,10 @@ void exec_job(parser_t &parser, job_t *j) {
                 // output, so that we can truncate the file. Does not apply to /dev/null.
                 bool must_fork = redirection_is_to_real_file(stdout_io.get()) ||
                                  redirection_is_to_real_file(stderr_io.get());
+                if (!must_fork) {
+                    //we are handling reads directly in the main loop. Make sure source is unblocked.
+                    unblock_previous();
+                }
                 if (!must_fork && p->is_last_in_job) {
                     const bool stdout_is_to_buffer = stdout_io && stdout_io->io_mode == IO_BUFFER;
                     const bool no_stdout_output = stdout_buffer.empty();
@@ -1157,12 +1165,9 @@ void exec_job(parser_t &parser, job_t *j) {
             }
         }
 
-        if (blocked_pid != -1) {
-            //now that next command in the chain has been started, unblock the previous command
-            unblock_pid(blocked_pid);
-            blocked_pid = -1;
-        }
 
+        //if the command we ran before this one was SIGSTOP'd to let this one catch up, unblock it now.
+        unblock_previous();
         if (command_blocked) {
             //store the newly-blocked command's PID so that it can be SIGCONT'd once the next process
             //in the chain is started. That may be in this job or in another job.

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <sys/mman.h>
+#include <semaphore.h>
 
 #include "builtin.h"
 #include "common.h"
@@ -491,6 +493,7 @@ void exec_job(parser_t &parser, job_t *j) {
     //
     // We are careful to set these to -1 when closed, so if we exit the loop abruptly, we can still
     // close them.
+    sem_t *chained_wait_prev = nullptr;
     int pipe_current_read = -1, pipe_current_write = -1, pipe_next_read = -1;
     for (std::unique_ptr<process_t> &unique_p : j->processes) {
         if (exec_error) {
@@ -508,6 +511,14 @@ void exec_job(parser_t &parser, job_t *j) {
 
         // See if we need a pipe.
         const bool pipes_to_next_command = !p->is_last_in_job;
+
+        //these semaphores will be used to make sure the first process lives long enough for the
+        //next process in the chain to open its handles, process group, etc.
+        //this child will block on this one, the next child will have to call sem_post against it.
+        sem_t *chained_wait_next = !pipes_to_next_command ? nullptr : (sem_t*)mmap(NULL, sizeof(sem_t*), PROT_READ|PROT_WRITE,MAP_SHARED|MAP_ANONYMOUS,-1, 0);
+        if (chained_wait_next != nullptr) {
+            sem_init(chained_wait_next, 1, 0);
+        }
 
         // The pipes the current process write to and read from. Unfortunately these can't be just
         // allocated on the stack, since j->io wants shared_ptr.
@@ -1055,6 +1066,14 @@ void exec_job(parser_t &parser, job_t *j) {
                 {
                     pid = execute_fork(false);
                     if (pid == 0) {
+                        // a hack that fixes any tcsetpgrp errors caused by race conditions
+                        // usleep(20 * 1000);
+                        if (chained_wait_next != nullptr) {
+                            debug(3, L"Waiting for next command in chain to start.\n");
+                            sem_wait(chained_wait_next);
+                            sem_destroy(chained_wait_next);
+                            munmap(chained_wait_next, sizeof(sem_t));
+                        }
                         // This is the child process.
                         p->pid = getpid();
                         setup_child_process(j, p, process_net_io_chain);
@@ -1095,6 +1114,16 @@ void exec_job(parser_t &parser, job_t *j) {
         if (pipe_current_write >= 0) {
             exec_close(pipe_current_write);
             pipe_current_write = -1;
+        }
+
+        //now that next command in the chain has been started, unblock the previous command
+        if (chained_wait_prev != nullptr) {
+            debug(3, L"Unblocking previous command in chain.\n");
+            sem_post(chained_wait_prev);
+            munmap(chained_wait_prev, sizeof(sem_t));
+        }
+        if (chained_wait_next != nullptr) {
+            chained_wait_prev = chained_wait_next;
         }
     }
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -511,10 +511,6 @@ void exec_job(parser_t &parser, job_t *j) {
         const bool pipes_to_next_command = !p->is_last_in_job;
         bool command_blocked = false;
 
-        //these semaphores will be used to make sure the first process lives long enough for the
-        //next process in the chain to open its handles, process group, etc.
-        //this child will block on this one, the next child will have to call sem_post against it.
-
         // The pipes the current process write to and read from. Unfortunately these can't be just
         // allocated on the stack, since j->io wants shared_ptr.
         //

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -23,8 +23,6 @@
 #include <string>
 #include <type_traits>
 #include <vector>
-#include <sys/mman.h>
-#include <semaphore.h>
 
 #include "builtin.h"
 #include "common.h"
@@ -493,7 +491,7 @@ void exec_job(parser_t &parser, job_t *j) {
     //
     // We are careful to set these to -1 when closed, so if we exit the loop abruptly, we can still
     // close them.
-    sem_t *chained_wait_prev = nullptr;
+    int last_pid = -1;
     int pipe_current_read = -1, pipe_current_write = -1, pipe_next_read = -1;
     for (std::unique_ptr<process_t> &unique_p : j->processes) {
         if (exec_error) {
@@ -515,10 +513,6 @@ void exec_job(parser_t &parser, job_t *j) {
         //these semaphores will be used to make sure the first process lives long enough for the
         //next process in the chain to open its handles, process group, etc.
         //this child will block on this one, the next child will have to call sem_post against it.
-        sem_t *chained_wait_next = !pipes_to_next_command ? nullptr : (sem_t*)mmap(NULL, sizeof(sem_t*), PROT_READ|PROT_WRITE,MAP_SHARED|MAP_ANONYMOUS,-1, 0);
-        if (chained_wait_next != nullptr) {
-            sem_init(chained_wait_next, 1, 0);
-        }
 
         // The pipes the current process write to and read from. Unfortunately these can't be just
         // allocated on the stack, since j->io wants shared_ptr.
@@ -1066,17 +1060,17 @@ void exec_job(parser_t &parser, job_t *j) {
                 {
                     pid = execute_fork(false);
                     if (pid == 0) {
-                        // usleep is a hack that fixes any tcsetpgrp errors caused by race conditions
-                        // usleep(20 * 1000);
-                        // it should no longer be needed with the chained_wait_next code below.
-                        if (chained_wait_next != nullptr) {
-                            debug(3, L"Waiting for next command in chain to start.\n");
-                            sem_wait(chained_wait_next);
-                            sem_destroy(chained_wait_next);
-                            munmap(chained_wait_next, sizeof(sem_t));
-                        }
                         // This is the child process.
                         p->pid = getpid();
+                        // start child processes that are part of a job in a stopped state
+                        // to ensure that they are still running when the next command in the
+                        // chain is started.
+                        if (pipes_to_next_command) {
+                            debug(3, L"Blocking process %d waiting for next command in chain.\n", p->pid);
+                            kill(p->pid, SIGSTOP);
+                        }
+                        // the process will be resumed by the shell when the next command in the
+                        // chain is started
                         setup_child_process(j, p, process_net_io_chain);
                         safe_launch_process(p, actual_cmd, argv, envv);
                         // safe_launch_process _never_ returns...
@@ -1118,14 +1112,12 @@ void exec_job(parser_t &parser, job_t *j) {
         }
 
         //now that next command in the chain has been started, unblock the previous command
-        if (chained_wait_prev != nullptr) {
-            debug(3, L"Unblocking previous command in chain.\n");
-            sem_post(chained_wait_prev);
-            munmap(chained_wait_prev, sizeof(sem_t));
-            chained_wait_prev = nullptr;
+        if (last_pid != -1) {
+            debug(3, L"Unblocking process %d.\n", last_pid);
+            kill(last_pid, SIGCONT);
         }
-        if (chained_wait_next != nullptr) {
-            chained_wait_prev = chained_wait_next;
+        if (pid != 0) {
+            last_pid = pid;
         }
     }
 

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -789,6 +789,23 @@ static bool terminal_give_to_job(job_t *j, int cont) {
         return true;
     }
 
+    //it may not be safe to call tcsetpgrp if we've already done so, as at that point we are no longer
+    //the controlling process group for the terminal and no longer have permission to set the process
+    //group that is in control, causing tcsetpgrp to return EPERM, even though that's not the documented
+    //behavior in tcsetpgrp(3), which instead says other bad things will happen (it says SIGTTOU will be
+    //sent to all members of the background *calling* process group, but it's more complicated than that,
+    //SIGTTOU may or may not be sent depending on the TTY configuration and whether or not signal handlers
+    //for SIGTTOU are installed. Read: http://curiousthing.org/sigttin-sigttou-deep-dive-linux
+    //In all cases, our goal here was just to hand over control of the terminal to this process group,
+    //which is a no-op if it's already been done.
+    if (tcgetpgrp(STDIN_FILENO) == j->pgid) {
+        debug(2, L"Process group %d already has control of terminal\n", j->pgid);
+        return true;
+    }
+
+    debug(4, L"Attempting bring process group to foreground via tcsetpgrp for job->pgid %d\n", j->pgid);
+    debug(4, L"caller session id: %d, pgid %d has session id: %d\n", getsid(0), j->pgid, getsid(j->pgid));
+
     signal_block(true);
     int result = -1;
     errno = EINTR;
@@ -797,7 +814,7 @@ static bool terminal_give_to_job(job_t *j, int cont) {
     }
     if (result == -1) {
         if (errno == ENOTTY) redirect_tty_output();
-        debug(1, _(L"Could not send job %d ('%ls') to foreground"), j->job_id, j->command_wcstr());
+        debug(1, _(L"terminal_give_to_job(): Could not send job %d ('%ls') with pgid %d to foreground"), j->job_id, j->command_wcstr(), j->pgid);
         wperror(L"tcsetpgrp");
         signal_unblock(true);
         return false;


### PR DESCRIPTION
I'm not sure if this happens on all platforms, but under WSL with the
existing codebase, processes in the job chain that pipe their
stdout/stderr to the next process in the job could terminate before the
next job started (on fast enough machines for quick enough jobs).

This caused issues like #4235 and possibly #3952, at least for external
commands. What was happening is that the first process was finishing
before the second process was fully set up. fish would then try to
assign (in both the child and the parent) the process group id belonging
to the process group leader to the new process; and if the first process
had already terminated, it would have ended its process group with it as
well before that happened.

I'm not sure if there was already a mechanism in place for ensuring that
a process remains running at least as long as it takes for the next
process in the chain to join its group, etc., but if that code was
there, it wasn't working in my test setup (WSL).

(Actually, I'm sure there is because this would have been a much bigger 
deal for everyone if there was no such mechanism.)

I'm not sure how I should
handle non-external commands (and external commands executed via
posix_spawn). I don't know if they are affected by the race condition in
the first place, but when I tried to add the same "wait for next command
in chain to run before unblocking" that would cause black screens
requiring ctrl+c to bypass.