### PR TITLE
Fix warnings

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -492,7 +492,7 @@ static bool find_job(const wchar_t *proc, expand_flags_t flags,
     while (const job_t *j = jobs.next()) {
         if (j->command_is_empty()) continue;
 
-        size_t offset;
+        size_t offset = 0;
         if (match_pid(j->command(), proc, &offset)) {
             if (flags & EXPAND_FOR_COMPLETIONS) {
                 append_completion(completions, j->command_wcstr() + offset + wcslen(proc),
@@ -514,7 +514,7 @@ static bool find_job(const wchar_t *proc, expand_flags_t flags,
         for (const process_ptr_t &p : j->processes) {
             if (p->actual_cmd.empty()) continue;
 
-            size_t offset;
+            size_t offset = 0;
             if (match_pid(p->actual_cmd, proc, &offset)) {
                 if (flags & EXPAND_FOR_COMPLETIONS) {
                     append_completion(completions, wcstring(p->actual_cmd, offset + wcslen(proc)),
@@ -552,7 +552,7 @@ static void find_process(const wchar_t *proc, expand_flags_t flags,
     pid_t process_pid;
     process_iterator_t iterator;
     while (iterator.next_process(&process_name, &process_pid)) {
-        size_t offset;
+        size_t offset = 0;
         if (match_pid(process_name, proc, &offset)) {
             if (flags & EXPAND_FOR_COMPLETIONS) {
                 append_completion(out, process_name.c_str() + offset + wcslen(proc),

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -275,7 +275,7 @@ static void maybe_issue_path_warning(const wcstring &which_dir, const wcstring &
         debug(0, _(L"The error was '%s'."), strerror(saved_errno));
         debug(0, _(L"Please set $%ls to a directory where you have write access."), env_var);
     }
-    write(STDERR_FILENO, "\n", 1);
+    write_ignore(STDERR_FILENO, "\n", 1);
 }
 
 static void path_create(wcstring &path, const wcstring &xdg_var, const wcstring &which_dir,

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -696,14 +696,14 @@ void reader_write_title(const wcstring &cmd, bool reset_cursor_position) {
         for (size_t i = 0; i < lst.size(); i++) {
             fputws(lst.at(i).c_str(), stdout);
         }
-        write(STDOUT_FILENO, "\a", 1);
+        write_ignore(STDOUT_FILENO, "\a", 1);
     }
 
     proc_pop_interactive();
     set_color(rgb_color_t::reset(), rgb_color_t::reset());
     if (reset_cursor_position && !lst.empty()) {
         // Put the cursor back at the beginning of the line (issue #2453).
-        write(STDOUT_FILENO, "\r", 1);
+        write_ignore(STDOUT_FILENO, "\r", 1);
     }
 }
 
@@ -1291,7 +1291,7 @@ static void reader_flash() {
     }
 
     reader_repaint();
-    write(STDOUT_FILENO, "\a", 1);
+    write_ignore(STDOUT_FILENO, "\a", 1);
 
     pollint.tv_sec = 0;
     pollint.tv_nsec = 100 * 1000000;
@@ -3229,7 +3229,7 @@ const wchar_t *reader_readline(int nchars) {
         reader_repaint_if_needed();
     }
 
-    write(STDOUT_FILENO, "\n", 1);
+    write_ignore(STDOUT_FILENO, "\n", 1);
 
     // Ensure we have no pager contents when we exit.
     if (!data->pager.empty()) {


### PR DESCRIPTION
Just some minor housekeeping to silence some build warnings that were bothering me; unless the warnings for the unused result of 'write' were intended so that they could be properly addressed (how?) at some point in the future.