### PR TITLE
Add `read --delimiter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# fish 3.0b1
+This section is for changes merged to the `major` branch that are not also merged to 2.7.
+
+## Notable fixes and improvements
+- `read` now requires at least one var name (#4220).
+- Local exported (`set -lx`) vars are now visible to functions (#1091).
+
+## Other significant changes
+
+
 # fish 2.7b1
 
 ## Notable fixes and improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This section is for changes merged to the `major` branch that are not also merge
 ## Notable fixes and improvements
 - `read` now requires at least one var name (#4220).
 - Local exported (`set -lx`) vars are now visible to functions (#1091).
+- `set x[1] x[2] a b` is no longer valid syntax (#4236).
 
 ## Other significant changes
 

--- a/doc_src/argparse.txt
+++ b/doc_src/argparse.txt
@@ -13,7 +13,7 @@ Each OPTION_SPEC can be written in the domain specific language <a href="#argpar
 
 Each option that is seen in the ARG list will result in a var name of the form `_flag_X`, where `X` is the short flag letter and the long flag name. The OPTION_SPEC always requires a short flag even if it can't be used. So there will always be `_flag_X` var set using the short flag letter if the corresponding short or long flag is seen. The long flag name var (e.g., `_flag_help`) will only be defined, obviously, if the OPTION_SPEC includes a long flag name.
 
-For example `_flag_h` and `_flag_help` if `-h` or `--help` is seen. The var will be set with local scope (i.e., as if the script had done `set -l _flag_X`). If the flag is a boolean (that is, does not have an associated value) the value is a count of how many times the flag was seen. If the option can have zero or more values the flag var will have zero or more values corresponding to the values collected when the ARG list is processed. If the flag was not seen the flag var will not be set.
+For example `_flag_h` and `_flag_help` if `-h` or `--help` is seen. The var will be set with local scope (i.e., as if the script had done `set -l _flag_X`). If the flag is a boolean (that is, does not have an associated value) the values are the short and long flags seen. If the option is not a boolean flag the values will be zero or more values corresponding to the values collected when the ARG list is processed. If the flag was not seen the flag var will not be set.
 
 The following `argparse` options are available. They must appear before all OPTION_SPECs:
 

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -771,6 +771,9 @@ Variables can be explicitly set to be exported with the `-x` or `--export` switc
 
 -# If a variable is not explicitly set to be either exported or not exported and has never before been defined, the variable will not be exported.
 
+-# If a variable has local-scope and is exported, any function called receives a _copy_ of it, so any changes it makes to the variable disappear once the function returns.
+
+-# If a variable has global-scope, it is accessible read-write to functions whether it is exported or not.
 
 \subsection variables-arrays Arrays
 

--- a/doc_src/read.txt
+++ b/doc_src/read.txt
@@ -2,12 +2,12 @@
 
 \subsection read-synopsis Synopsis
 \fish{synopsis}
-read [OPTIONS] [VARIABLES...]
+read [OPTIONS] VARIABLES...
 \endfish
 
 \subsection read-description Description
 
-`read` reads from standard input and stores the result in one or more shell variables. By default it reads one line terminated by a newline but options are available to read up to a null character and to limit each "line" to a maximum number of characters.
+`read` reads from standard input and stores the result in one or more shell variables. By default it reads one line terminated by a newline but options are available to read up to a null character and to limit each "line" to a maximum number of characters. At least one variable name must be given. This command does not default to populating a var named `REPLY` like other shells do.
 
 The following options are available:
 

--- a/doc_src/read.txt
+++ b/doc_src/read.txt
@@ -13,6 +13,8 @@ The following options are available:
 
 - `-c CMD` or `--command=CMD` sets the initial string in the interactive mode command buffer to `CMD`.
 
+- `-d DELIMITER` or `--delimiter=DELIMITER` splits on DELIMITER.
+
 - `-g` or `--global` makes the variables global.
 
 - `-i` or `--silent` makes the characters typed obfuscated. This is useful for reading things like passwords or other sensitive information. Note that in bash the short flag is `-s`. We can't use that due to the existing use as an alias for `--shell`.
@@ -39,7 +41,7 @@ The following options are available:
 
 - `-z` or `--null` reads up to NUL instead of newline. Disables interactive mode.
 
-`read` reads a single line of input from stdin, breaks it into tokens based on the `IFS` shell variable, and then assigns one token to each variable specified in `VARIABLES`. If there are more tokens than variables, the complete remainder is assigned to the last variable. As a special case, if `IFS` is set to the empty string, each character of the input is considered a separate token.
+`read` reads a single line of input from stdin, breaks it into tokens based on the delimiter set via `-d`/`--delimiter` as a complete string or, if that has not been given the (deprecated) `IFS` shell variable as a set of characters, and then assigns one token to each variable specified in `VARIABLES`. If there are more tokens than variables, the complete remainder is assigned to the last variable. As a special case, if `IFS` is set to the empty string, each character of the input is considered a separate token.
 
 If `-a` or `--array` is provided, only one variable name is allowed and the tokens are stored as an array in this variable.
 
@@ -64,4 +66,11 @@ echo hello|read foo
 printf '%s\n' line1 line2 line3 line4 | while read -l foo
                   echo "This is another line: $foo"
               end
+
+# Delimiters given via "-d" are taken as one string
+echo a==b==c | read -d == -l a b c
+echo $a # a
+echo $b # b
+echo $c # c
+
 \endfish

--- a/doc_src/set.txt
+++ b/doc_src/set.txt
@@ -44,7 +44,7 @@ The following options are available:
 
 If a variable is set to more than one value, the variable will be an array with the specified elements. If a variable is set to zero elements, it will become an array with zero elements.
 
-If the variable name is one or more array elements, such as `PATH[1 3 7]`, only those array elements specified will be changed. When array indices are specified to `set`, multiple arguments may be used to specify additional indexes, e.g. `set PATH[1] PATH[4] /bin /sbin`. If you specify a negative index when expanding or assigning to an array variable, the index will be calculated from the end of the array. For example, the index -1 means the last index of an array.
+If the variable name is one or more array elements, such as `PATH[1 3 7]`, only those array elements specified will be changed. If you specify a negative index when expanding or assigning to an array variable, the index will be calculated from the end of the array. For example, the index -1 means the last index of an array.
 
 The scoping rules when creating or updating a variable are:
 
@@ -92,3 +92,7 @@ if set python_path (type -p python)
 end
 # Outputs the path to Python if `type -p` returns true.
 \endfish
+
+\subsection set-notes Notes
+
+Fish versions prior to 3.0 allowed you to write `set PATH[1 4] /bin /sbin` as `set PATH[1] PATH[4] /bin /sbin`. That alternative syntax is ambiguous and inconsistent. Also, no fish script in the fish project used it. Nor could we find any 3rd-party scripts in the Oh-My-Fish or Fisherman package managers that used that alternative syntax. So it was removed in the 3.0 release.

--- a/doc_src/test.txt
+++ b/doc_src/test.txt
@@ -14,6 +14,8 @@ The first form (`test`) is preferred. For compatibility with other shells, the s
 
 This test is mostly POSIX-compatible.
 
+When using a variable as an argument for a test operator you should almost always enclose it in double-quotes. There are only two situations it is safe to omit the quote marks. The first is when the argument is a literal string with no whitespace or other characters special to the shell (e.g., semicolon). For example, `test -b /my/file`. The second is using a variable that expands to exactly one element including if that element is the empty string (e.g., `set x ''`). If the variable is not set, set but with no value, or set to more than one value you must enclose it in double-quotes. For example, `test "$x" = "$y"`. Since it is always safe to enclose variables in double-quotes when used as `test` arguments that is the recommended practice.
+
 \subsection test-files Operators for files and directories
 
 - `-b FILE` returns true if `FILE` is a block device.

--- a/share/completions/dd.fish
+++ b/share/completions/dd.fish
@@ -3,17 +3,12 @@ complete -c dd -d 'display help and exit' -xa '--help'
 complete -c dd -d 'output version information and exit' -xa '--version'
 
 function __fish_complete_dd --description 'Complete dd operands'
-
     # set operand_string as a local variable containing the current command-line token.
     set -l operand_string (commandline -t)
 
     switch $operand_string
-
         case 'if=*' 'of=*'
-            # the read command uses $IFS to tokenise stdin input
-            set -l IFS =
-            # $operand now contains the left side of the operator, $value the right
-            echo $operand_string | read -l operand value
+            string replace = ' ' -- $operand_string | read -l operand value
 
             for entry in $value*
                 # if $entry is a directory, append a '/'
@@ -25,78 +20,61 @@ function __fish_complete_dd --description 'Complete dd operands'
             end
 
         case 'iflag=*' 'oflag=*'
-            set -l IFS =
-            echo $operand_string | read -l operand value
+            string replace = ' ' -- $operand_string | read -l operand complete
+            string match -q '*,' -- $complete
+            or set complete ''
 
-            set -l IFS ' '
-            echo $value | sed -e 's/\(.*\)\(,\)/\1 \2/' | read -l complete comma
-
-            # check if there is only one option
-            if test $comma = ''
-                set complete ''
-            else
-                set complete $complete,
-            end
-
-			printf "%s\t%s\n" "$operand=$complete""append" "append mode (makes sense only for output; conv=notrunc suggested)"
-			printf "%s\t%s\n" "$operand=$complete""direct" "use direct I/O for data"
-			printf "%s\t%s\n" "$operand=$complete""directory" "fail unless a directory"
-			printf "%s\t%s\n" "$operand=$complete""dsync" "use synchronized I/O for data"
-			printf "%s\t%s\n" "$operand=$complete""sync" "use synchronized I/O for data and metadata"
-			printf "%s\t%s\n" "$operand=$complete""fullblock" "accumulate full blocks of input (iflag only)"
-			printf "%s\t%s\n" "$operand=$complete""nonblock" "use non-blocking I/O"
-			printf "%s\t%s\n" "$operand=$complete""noatime" "do not update access time"
-			printf "%s\t%s\n" "$operand=$complete""nocache" "discard cached data"
-			printf "%s\t%s\n" "$operand=$complete""noctty" "do not assign controlling terminal from file"
-			printf "%s\t%s\n" "$operand=$complete""nofollow" "do not follow symbolic links"
+            printf "%s\t%s\n" "$operand=$complete""append" "append mode (makes sense only for output; conv=notrunc suggested)"
+            printf "%s\t%s\n" "$operand=$complete""direct" "use direct I/O for data"
+            printf "%s\t%s\n" "$operand=$complete""directory" "fail unless a directory"
+            printf "%s\t%s\n" "$operand=$complete""dsync" "use synchronized I/O for data"
+            printf "%s\t%s\n" "$operand=$complete""sync" "use synchronized I/O for data and metadata"
+            printf "%s\t%s\n" "$operand=$complete""fullblock" "accumulate full blocks of input (iflag only)"
+            printf "%s\t%s\n" "$operand=$complete""nonblock" "use non-blocking I/O"
+            printf "%s\t%s\n" "$operand=$complete""noatime" "do not update access time"
+            printf "%s\t%s\n" "$operand=$complete""nocache" "discard cached data"
+            printf "%s\t%s\n" "$operand=$complete""noctty" "do not assign controlling terminal from file"
+            printf "%s\t%s\n" "$operand=$complete""nofollow" "do not follow symbolic links"
 
         case 'conv=*'
-            set -l IFS =
-            echo $operand_string | read -l operand value
+            string replace = ' ' -- $operand_string | read -l operand complete
+            string match -q '*,' -- $complete
+            or set complete ''
 
-            set -l IFS ' '
-            echo $value | sed -e 's/\(.*\)\(,\)/\1 \2/' | read -l complete comma
-
-            if test $comma = ''
-                set complete ''
-            else
-                set complete $complete,
-            end
-
-			printf "%s\t%s\n" "$operand=$complete""ascii" "from EBCDIC to ASCII"
-			printf "%s\t%s\n" "$operand=$complete""ebcdic" "from ASCII to EBCDIC"
-			printf "%s\t%s\n" "$operand=$complete""ibm" "from ASCII to alternate EBCDIC"
-			printf "%s\t%s\n" "$operand=$complete""block" "pad newline-terminated records with spaces to cbs-size"
-			printf "%s\t%s\n" "$operand=$complete""unblock" "replace trailing spaces in cbs-size records with newline"
-			printf "%s\t%s\n" "$operand=$complete""lcase" "change upper case to lower case"
-			printf "%s\t%s\n" "$operand=$complete""ucase" "change lower case to upper case"
-			printf "%s\t%s\n" "$operand=$complete""swab" "swap every pair of input bytes"
-			printf "%s\t%s\n" "$operand=$complete""sync" "pad every input block with NULs to ibs-size; with block or ublock use spaces"
-			printf "%s\t%s\n" "$operand=$complete""excl" "fail if the output file already exists"
-			printf "%s\t%s\n" "$operand=$complete""nocreat" "do not create the output file"
-			printf "%s\t%s\n" "$operand=$complete""notrunc" "do not truncate the output file"
-			printf "%s\t%s\n" "$operand=$complete""noerror" "continue after read errors"
-			printf "%s\t%s\n" "$operand=$complete""fdatasync" "physically write output file data before finishing"
-			printf "%s\t%s\n" "$operand=$complete""fsync" "physically write output file data and metadata before finishing"
+            printf "%s\t%s\n" "$operand=$complete""ascii" "from EBCDIC to ASCII"
+            printf "%s\t%s\n" "$operand=$complete""ebcdic" "from ASCII to EBCDIC"
+            printf "%s\t%s\n" "$operand=$complete""ibm" "from ASCII to alternate EBCDIC"
+            printf "%s\t%s\n" "$operand=$complete""block" "pad newline-terminated records with spaces to cbs-size"
+            printf "%s\t%s\n" "$operand=$complete""unblock" "replace trailing spaces in cbs-size records with newline"
+            printf "%s\t%s\n" "$operand=$complete""lcase" "change upper case to lower case"
+            printf "%s\t%s\n" "$operand=$complete""ucase" "change lower case to upper case"
+            printf "%s\t%s\n" "$operand=$complete""swab" "swap every pair of input bytes"
+            printf "%s\t%s\n" "$operand=$complete""sync" "pad every input block with NULs to ibs-size; with block or ublock use spaces"
+            printf "%s\t%s\n" "$operand=$complete""excl" "fail if the output file already exists"
+            printf "%s\t%s\n" "$operand=$complete""nocreat" "do not create the output file"
+            printf "%s\t%s\n" "$operand=$complete""notrunc" "do not truncate the output file"
+            printf "%s\t%s\n" "$operand=$complete""noerror" "continue after read errors"
+            printf "%s\t%s\n" "$operand=$complete""fdatasync" "physically write output file data before finishing"
+            printf "%s\t%s\n" "$operand=$complete""fsync" "physically write output file data and metadata before finishing"
 
         case 'status=*'
-			printf "%s\t%s\n" status=noxfer "suppress final transfer statistics"
-			printf "%s\t%s\n" status=none "suppress everything but errors"
-			printf "%s\t%s\n" status=progress "show periodic transfer statistics"
+            printf "%s\t%s\n" status=noxfer "suppress final transfer statistics"
+            printf "%s\t%s\n" status=none "suppress everything but errors"
+            printf "%s\t%s\n" status=progress "show periodic transfer statistics"
 
         case '*'
-			printf "%s=\t%s\n" bs "read and write up to BYTES bytes at a time"
-			printf "%s=\t%s\n" cbs "convert BYTES bytes at a time"
-			printf "%s=\t%s\n" conv "convert the file as per the comma separated symbol list"
-			printf "%s=\t%s\n" count "copy only BLOCKS input blocks"
-			printf "%s=\t%s\n" ibs "read up to BYTES bytes at a time (default 512)"
-			printf "%s=\t%s\n" if "read from FILE instead of stdin"
-			printf "%s=\t%s\n" iflag "read as per the comma separated symbol list"
-			printf "%s=\t%s\n" obs "write BYTES bytes at a time (default 512)"
-			printf "%s=\t%s\n" of "write to FILE instead of stdout"
-			printf "%s=\t%s\n" oflag "write as per the comma separated symbol list"
-			printf "%s=\t%s\n" seek "skip BLOCKS obs-sized blocks at the start of output"
-			printf "%s=\t%s\n" skip "skip BLOCKS ibs-sized blocks at the start of input"
-			printf "%s=\t%s\n" status "set the level of information to print to stderr"
+            printf "%s=\t%s\n" bs "read and write up to BYTES bytes at a time"
+            printf "%s=\t%s\n" cbs "convert BYTES bytes at a time"
+            printf "%s=\t%s\n" conv "convert the file as per the comma separated symbol list"
+            printf "%s=\t%s\n" count "copy only BLOCKS input blocks"
+            printf "%s=\t%s\n" ibs "read up to BYTES bytes at a time (default 512)"
+            printf "%s=\t%s\n" if "read from FILE instead of stdin"
+            printf "%s=\t%s\n" iflag "read as per the comma separated symbol list"
+            printf "%s=\t%s\n" obs "write BYTES bytes at a time (default 512)"
+            printf "%s=\t%s\n" of "write to FILE instead of stdout"
+            printf "%s=\t%s\n" oflag "write as per the comma separated symbol list"
+            printf "%s=\t%s\n" seek "skip BLOCKS obs-sized blocks at the start of output"
+            printf "%s=\t%s\n" skip "skip BLOCKS ibs-sized blocks at the start of input"
+            printf "%s=\t%s\n" status "set the level of information to print to stderr"
     end
 end

--- a/share/completions/vagrant.fish
+++ b/share/completions/vagrant.fish
@@ -1,30 +1,32 @@
 # vagrant autocompletion
 
 function __fish_vagrant_no_command --description 'Test if vagrant has yet to be given the main command'
-  set -l cmd (commandline -opc)
-  test (count $cmd) -eq 1
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 1
 end
 
 function __fish_vagrant_using_command
-  set -l cmd (commandline -opc)
-  set -q cmd[2]; and test "$argv[1]" = $cmd[2]
+    set -l cmd (commandline -opc)
+    set -q cmd[2]
+    and test "$argv[1]" = $cmd[2]
 end
 
 function __fish_vagrant_using_command_and_no_subcommand
-  set -l cmd (commandline -opc)
-  test (count $cmd) -eq 2; and test "$argv[1]" = "$cmd[2]"
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 2
+    and test "$argv[1]" = "$cmd[2]"
 end
 
 function __fish_vagrant_using_subcommand --argument-names cmd_main cmd_sub
     set -l cmd (commandline -opc)
-    set -q cmd[3]; and test "$cmd_main" = $cmd[2] -a "$cmd_sub" = $cmd[3]
+    set -q cmd[3]
+    and test "$cmd_main" = $cmd[2] -a "$cmd_sub" = $cmd[3]
 end
 
 function __fish_vagrant_boxes --description 'Lists all available Vagrant boxes'
-  set -l IFS \n\ \t
-  command vagrant box list | while read -l name _
-    echo $name
-  end
+    command vagrant box list | while read -l name _
+        echo $name
+    end
 end
 
 # --version and --help are always active

--- a/share/functions/__fish_complete_lpr_option.fish
+++ b/share/functions/__fish_complete_lpr_option.fish
@@ -2,8 +2,7 @@ function __fish_complete_lpr_option --description 'Complete lpr option'
     set -l optstr (commandline -t)
     switch $optstr
         case '*=*'
-            set -l IFS =
-            echo $optstr | read -l opt val
+            string split -m1 = -- "$optstr" | read -l opt val
             set -l descr
             for l in (lpoptions -l ^/dev/null | string match -- "*$opt*" | string replace -r '.*/(.*):\s*(.*)$' '$1 $2' | string split " ")
                 if not set -q descr[1]

--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -265,8 +265,7 @@ function __fish_git_prompt_show_upstream --description "Helper function for __fi
                     # Use fetch config to fix upstream
                     set -l fetch_val (command git config "$cur_prefix".fetch)
                     if test -n "$fetch_val"
-                        set -l IFS :
-                        echo "$fetch_val" | read -l trunk pattern
+                        string split -m1 : -- "$fetch_val" | read -l trunk pattern
                         set upstream (string replace -r -- "/$trunk\$" '' $pattern) /$upstream
                     end
                 end

--- a/share/functions/__fish_print_help.fish
+++ b/share/functions/__fish_print_help.fish
@@ -15,8 +15,6 @@ function __fish_print_help --description "Print help message for the specified f
         return
     end
 
-    set -l IFS \n\ \t
-
     # Render help output, save output into the variable 'help'
     set -l help
     set -l cols

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -56,25 +56,21 @@ function funced --description 'Edit function definition'
     end
 
     if test "$editor" = fish
-        set -l IFS
         if functions -q -- $funcname
-            # Shadow IFS here to avoid array splitting in command substitution
-            set init (functions -- $funcname | fish_indent --no-indent)
+            functions -- $funcname | fish_indent --no-indent | read -z init
         end
 
         set -l prompt 'printf "%s%s%s> " (set_color green) '$funcname' (set_color normal)'
-        # Unshadow IFS since the fish_title breaks otherwise
-        set -e IFS
         if read -p $prompt -c "$init" -s cmd
-            # Shadow IFS _again_ to avoid array splitting in command substitution
-            set -l IFS
-            eval (echo -n $cmd | fish_indent)
+            echo -n $cmd | fish_indent | read -lz cmd
+            eval "$cmd"
         end
         return 0
     end
 
-    # OSX mktemp is rather restricted - no suffix, no way to automatically use TMPDIR
-    # Create a directory so we can use a ".fish" suffix for the file - makes editors pick up that it's a fish file
+    # OS X (macOS) `mktemp` is rather restricted - no suffix, no way to automatically use TMPDIR.
+    # Create a directory so we can use a ".fish" suffix for the file - makes editors pick up that
+    # it's a fish file.
     set -q TMPDIR
     or set -l TMPDIR /tmp
     set -l tmpdir (mktemp -d $TMPDIR/fish.XXXXXX)

--- a/share/functions/funcsave.fish
+++ b/share/functions/funcsave.fish
@@ -22,16 +22,16 @@ function funcsave --description "Save the current definition of all specified fu
         end
     end
 
-    set -l res 0
+    set -l retval 0
     for funcname in $argv
         if functions -q -- $funcname
-            functions -- $i >$configdir/fish/functions/$funcname
+            functions -- $funcname >$configdir/fish/functions/$funcname.fish
         else
             printf (_ "%s: Unknown function '%s'\n") funcsave $funcname
-            set res 1
+            set retval 1
         end
     end
 
-    return $res
+    return $retval
 end
 

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -48,12 +48,6 @@ function history --description "display or manipulate interactive command histor
         set show_time --show-time
     end
 
-    set -q _flag_null
-    and set -l null --null
-
-    set -q _flag_case_sensitive
-    and set -l case_sensitive --case-sensitive
-
     set -q _flag_prefix
     and set -l search_mode --prefix
     set -q _flag_contains
@@ -96,9 +90,9 @@ function history --description "display or manipulate interactive command histor
                 set -l pager less
                 set -q PAGER
                 and set pager $PAGER
-                builtin history search $search_mode $show_time $max_count $case_sensitive $null -- $argv | eval $pager
+                builtin history search $search_mode $show_time $max_count $_flag_case_sensitive $_flag_null -- $argv | eval $pager
             else
-                builtin history search $search_mode $show_time $max_count $case_sensitive $null -- $argv
+                builtin history search $search_mode $show_time $max_count $_flag_case_sensitive $_flag_null -- $argv
             end
 
         case delete # interactively delete history
@@ -112,14 +106,14 @@ function history --description "display or manipulate interactive command histor
             and set search_mode "--contains"
 
             if test $search_mode = "--exact"
-                builtin history delete $search_mode $case_sensitive $argv
+                builtin history delete $search_mode $_flag_case_sensitive $argv
                 return
             end
 
             # TODO: Fix this so that requesting history entries with a timestamp works:
             #   set -l found_items (builtin history search $search_mode $show_time -- $argv)
             set -l found_items
-            builtin history search $search_mode $case_sensitive --null -- $argv | while read -lz x
+            builtin history search $search_mode $_flag_case_sensitive --null -- $argv | while read -lz x
                 set found_items $found_items $x
             end
             if set -q found_items[1]

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -51,8 +51,8 @@ enum { COMMAND_NOT_BUILTIN, BUILTIN_REGULAR, BUILTIN_FUNCTION };
 #define BUILTIN_ERR_UNKNOWN _(L"%ls: Unknown option '%ls'\n")
 
 /// Error message for unexpected args.
-#define BUILTIN_ERR_ARG_COUNT1 _(L"%ls: expected %d args, got %d\n")
-#define BUILTIN_ERR_ARG_COUNT2 _(L"%ls: %ls expected %d args, got %d\n")
+#define BUILTIN_ERR_ARG_COUNT1 _(L"%ls: Expected %d args, got %d\n")
+#define BUILTIN_ERR_ARG_COUNT2 _(L"%ls %ls: Expected %d args, got %d\n")
 #define BUILTIN_ERR_MIN_ARG_COUNT1 _(L"%ls: Expected at least %d args, got only %d\n")
 #define BUILTIN_ERR_MAX_ARG_COUNT1 _(L"%ls: Expected at most %d args, got %d\n")
 

--- a/src/builtin_argparse.cpp
+++ b/src/builtin_argparse.cpp
@@ -437,6 +437,7 @@ static void populate_option_strings(
 // Add a count for how many times we saw each boolean flag but only if we saw the flag at least
 // once.
 static void update_bool_flag_counts(argparse_cmd_opts_t &opts) {
+    return;
     for (auto it : opts.options) {
         auto opt_spec = it.second;
         // The '#' short flag is special. It doesn't take any values but isn't a boolean arg.
@@ -539,6 +540,13 @@ static int argparse_parse_flags(argparse_cmd_opts_t &opts, const wchar_t *short_
         option_spec_t *opt_spec = found->second;
         opt_spec->num_seen++;
         if (opt_spec->num_allowed == 0) {
+            // It's a boolean flag. Save the flag we saw since it might be useful to know if the
+            // short or long flag was given.
+            if (long_idx == -1) {
+                opt_spec->vals.push_back(wcstring(1, L'-') + opt_spec->short_flag);
+            } else {
+                opt_spec->vals.push_back(L"--" + opt_spec->long_flag);
+            }
             assert(!w.woptarg);
             long_idx = -1;
             continue;

--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -8,7 +8,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <wchar.h>
-#include <wctype.h>
 
 #include <algorithm>
 #include <iterator>
@@ -60,14 +59,12 @@ static const struct woption long_options[] = {{L"export", no_argument, NULL, 'x'
                                               {NULL, 0, NULL, 0}};
 
 // Error message for invalid path operations.
-#define BUILTIN_SET_PATH_ERROR L"%ls: Warning: $%ls entry \"%ls\" is not valid (%s)\n"
-
+#define BUILTIN_SET_PATH_ERROR _(L"%ls: Warning: $%ls entry \"%ls\" is not valid (%s)\n")
 // Hint for invalid path operation with a colon.
-#define BUILTIN_SET_PATH_HINT L"%ls: Did you mean 'set %ls $%ls %ls'?\n"
-
-// Error for mismatch between index count and elements.
-#define BUILTIN_SET_ARG_COUNT \
-    L"%ls: The number of variable indexes does not match the number of values\n"
+#define BUILTIN_SET_PATH_HINT _(L"%ls: Did you mean 'set %ls $%ls %ls'?\n")
+#define BUILTIN_SET_MISMATCHED_ARGS _(L"%ls: You provided %d indexes but %d values\n")
+#define BUILTIN_SET_ERASE_NO_VAR _(L"%ls: Erase needs a variable name\n")
+#define BUILTIN_SET_ARRAY_BOUNDS_ERR _(L"%ls: Array index out of bounds\n")
 
 // Test if the specified variable should be subject to path validation.
 static const wcstring_list_t path_variables({L"PATH", L"CDPATH"});
@@ -143,7 +140,7 @@ static int parse_cmd_opts(set_cmd_opts_t &opts, int *optind,  //!OCLINT(high ncs
     return STATUS_CMD_OK;
 }
 
-static int validate_cmd_opts(const wchar_t *cmd, set_cmd_opts_t &opts, int optind, int argc,
+static int validate_cmd_opts(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
                              parser_t &parser, io_streams_t &streams) {
     // Can't query and erase or list.
     if (opts.query && (opts.erase || opts.list)) {
@@ -173,8 +170,8 @@ static int validate_cmd_opts(const wchar_t *cmd, set_cmd_opts_t &opts, int optin
         return STATUS_INVALID_ARGS;
     }
 
-    if (optind == argc && opts.erase) {
-        streams.err.append_format(_(L"%ls: Erase needs a variable name\n"), cmd);
+    if (argc == 0 && opts.erase) {
+        streams.err.append_format(BUILTIN_SET_ERASE_NO_VAR, cmd);
         builtin_print_help(parser, streams, cmd, streams.err);
         return STATUS_INVALID_ARGS;
     }
@@ -182,100 +179,119 @@ static int validate_cmd_opts(const wchar_t *cmd, set_cmd_opts_t &opts, int optin
     return STATUS_CMD_OK;
 }
 
+// Check if we are setting a uvar and a global of the same name exists. See
+// https://github.com/fish-shell/fish-shell/issues/806
+static int check_global_scope_exists(const wchar_t *cmd, set_cmd_opts_t &opts, const wchar_t *dest,
+                                     io_streams_t &streams) {
+    if (opts.universal) {
+        env_var_t global_dest = env_get_string(dest, ENV_GLOBAL);
+        if (!global_dest.missing()) {
+            streams.err.append_format(
+                _(L"%ls: Warning: universal scope selected, but a global variable '%ls' exists.\n"),
+                cmd, dest);
+        }
+    }
+
+    return STATUS_CMD_OK;
+}
+
+// Fix for https://github.com/fish-shell/fish-shell/issues/199 . Return success if any path setting
+// succeeds.
+static int my_env_path_setup(const wchar_t *cmd, const wchar_t *key,  //!OCLINT(npath complexity)
+                             const wcstring_list_t &list, io_streams_t &streams) {
+    bool any_success = false;
+
+    // Don't bother validating (or complaining about) values that are already present. When
+    // determining already-present values, use ENV_DEFAULT instead of the passed-in scope because
+    // in:
+    //
+    //   set -l PATH stuff $PATH
+    //
+    // where we are temporarily shadowing a variable, we want to compare against the shadowed value,
+    // not the (missing) local value. Also don't bother to complain about relative paths, which
+    // don't start with /.
+    wcstring_list_t existing_values;
+    const env_var_t existing_variable = env_get_string(key, ENV_DEFAULT);
+    if (!existing_variable.missing_or_empty())
+        tokenize_variable_array(existing_variable, existing_values);
+
+    for (size_t i = 0; i < list.size(); i++) {
+        const wcstring &dir = list.at(i);
+        if (!string_prefixes_string(L"/", dir) || contains(existing_values, dir)) {
+            any_success = true;
+            continue;
+        }
+
+        bool show_hint = false;
+        bool error = false;
+        struct stat buff;
+        if (wstat(dir, &buff) == -1) {
+            error = true;
+        } else if (!S_ISDIR(buff.st_mode)) {
+            error = true;
+            errno = ENOTDIR;
+        } else if (waccess(dir, X_OK) == -1) {
+            error = true;
+        }
+
+        if (!error) {
+            any_success = true;
+        } else {
+            streams.err.append_format(BUILTIN_SET_PATH_ERROR, cmd, key, dir.c_str(),
+                                      strerror(errno));
+            const wchar_t *colon = wcschr(dir.c_str(), L':');
+            if (colon && *(colon + 1)) show_hint = true;
+        }
+
+        if (show_hint) {
+            streams.err.append_format(BUILTIN_SET_PATH_HINT, cmd, key, key,
+                                      wcschr(dir.c_str(), L':') + 1);
+        }
+    }
+
+    // Fail at setting the path if we tried to set it to something non-empty, but it wound up
+    // empty.
+    if (!list.empty() && !any_success) return STATUS_CMD_ERROR;
+    return STATUS_CMD_OK;
+}
+
 /// Call env_set. If this is a path variable, e.g. PATH, validate the elements. On error, print a
 /// description of the problem to stderr.
-static int my_env_set(const wchar_t *key, const wcstring_list_t &list, int scope,
-                      io_streams_t &streams) {
+static int my_env_set(const wchar_t *cmd, const wchar_t *key, const wcstring_list_t &list,
+                      int scope, io_streams_t &streams) {
+    int retval;
+
     if (is_path_variable(key)) {
-        // Fix for https://github.com/fish-shell/fish-shell/issues/199 . Return success if any path
-        // setting succeeds.
-        bool any_success = false;
-
-        // Don't bother validating (or complaining about) values that are already present. When
-        // determining already-present values, use ENV_DEFAULT instead of the passed-in scope
-        // because in:
-        //
-        //   set -l PATH stuff $PATH
-        //
-        // where we are temporarily shadowing a variable, we want to compare against the shadowed
-        // value, not the (missing) local value. Also don't bother to complain about relative paths,
-        // which don't start with /.
-        wcstring_list_t existing_values;
-        const env_var_t existing_variable = env_get_string(key, ENV_DEFAULT);
-        if (!existing_variable.missing_or_empty())
-            tokenize_variable_array(existing_variable, existing_values);
-
-        for (size_t i = 0; i < list.size(); i++) {
-            const wcstring &dir = list.at(i);
-            if (!string_prefixes_string(L"/", dir) || contains(existing_values, dir)) {
-                any_success = true;
-                continue;
-            }
-
-            int show_hint = 0;
-            bool error = false;
-            struct stat buff;
-            if (wstat(dir, &buff) == -1) {
-                error = true;
-            } else if (!S_ISDIR(buff.st_mode)) {
-                error = true;
-                errno = ENOTDIR;
-            } else if (waccess(dir, X_OK) == -1) {
-                error = true;
-            }
-
-            if (!error) {
-                any_success = true;
-            } else {
-                streams.err.append_format(_(BUILTIN_SET_PATH_ERROR), L"set", key, dir.c_str(),
-                                          strerror(errno));
-                const wchar_t *colon = wcschr(dir.c_str(), L':');
-
-                if (colon && *(colon + 1)) {
-                    show_hint = 1;
-                }
-            }
-
-            if (show_hint) {
-                streams.err.append_format(_(BUILTIN_SET_PATH_HINT), L"set", key, key,
-                                          wcschr(dir.c_str(), L':') + 1);
-            }
-        }
-
-        // Fail at setting the path if we tried to set it to something non-empty, but it wound up
-        // empty.
-        if (!list.empty() && !any_success) {
-            return STATUS_CMD_ERROR;
-        }
+        retval = my_env_path_setup(cmd, key, list, streams);
+        if (retval != STATUS_CMD_OK) return retval;
     }
 
     // We don't check `val->empty()` because an array var with a single empty string will be
     // "empty". A truly empty array var is set to the special value `ENV_NULL`.
     auto val = list_to_array_val(list);
-    int retcode = env_set(key, *val == ENV_NULL ? NULL : val->c_str(), scope | ENV_USER);
-    switch (retcode) {
+    retval = env_set(key, *val == ENV_NULL ? NULL : val->c_str(), scope | ENV_USER);
+    switch (retval) {
         case ENV_OK: {
-            retcode = STATUS_CMD_OK;
+            retval = STATUS_CMD_OK;
             break;
         }
         case ENV_PERM: {
             streams.err.append_format(_(L"%ls: Tried to change the read-only variable '%ls'\n"),
-                                      L"set", key);
-            retcode = STATUS_CMD_ERROR;
+                                      cmd, key);
+            retval = STATUS_CMD_ERROR;
             break;
         }
         case ENV_SCOPE: {
             streams.err.append_format(
-                _(L"%ls: Tried to set the special variable '%ls' with the wrong scope\n"), L"set",
+                _(L"%ls: Tried to set the special variable '%ls' with the wrong scope\n"), cmd,
                 key);
-            retcode = STATUS_CMD_ERROR;
+            retval = STATUS_CMD_ERROR;
             break;
         }
         case ENV_INVALID: {
             streams.err.append_format(
-                _(L"%ls: Tried to set the special variable '%ls' to an invalid value\n"), L"set",
-                key);
-            retcode = STATUS_CMD_ERROR;
+                _(L"%ls: Tried to set the special variable '%ls' to an invalid value\n"), cmd, key);
+            retval = STATUS_CMD_ERROR;
             break;
         }
         default: {
@@ -284,70 +300,55 @@ static int my_env_set(const wchar_t *key, const wcstring_list_t &list, int scope
         }
     }
 
-    return retcode;
+    return retval;
 }
 
-/// Extract indexes from a destination argument of the form name[index1 index2...]
+/// Extract indexes from an argument of the form `var_name[index1 index2...]`.
 ///
-/// \param indexes the list to insert the new indexes into
-/// \param src the source string to parse
-/// \param name the name of the element. Return null if the name in \c src does not match this name
-/// \param var_count the number of elements in the array to parse.
+/// Inputs:
+///   indexes: the list to insert the new indexes into
+///   src: The source string to parse. This must be a var spec of the form "var[...]"
 ///
-/// \return the total number of indexes parsed, or -1 on error
-static int parse_index(std::vector<long> &indexes, const wchar_t *src, const wchar_t *name,
-                       size_t var_count, io_streams_t &streams) {
-    size_t len;
+/// Returns:
+///   The total number of indexes parsed, or -1 on error. If any indexes were found the `src` string
+///   is modified to omit the index expression leaving just the var name.
+static int parse_index(std::vector<long> &indexes, wchar_t *src, int scope, io_streams_t &streams) {
+    wchar_t *p = wcschr(src, L'[');
+    if (!p) return 0;  // no slices so nothing for us to do
+    *p = L'\0';        // split the var name from the indexes/slices
+    p++;
+
+    env_var_t var_str = env_get_string(src, scope);
+    wcstring_list_t var;
+    if (!var_str.missing()) tokenize_variable_array(var_str, var);
+
     int count = 0;
-    const wchar_t *src_orig = src;
 
-    if (src == 0) {
-        return 0;
-    }
-
-    while (*src != L'\0' && (iswalnum(*src) || *src == L'_')) src++;
-
-    if (*src != L'[') {
-        streams.err.append_format(_(BUILTIN_SET_ARG_COUNT), L"set");
-        return 0;
-    }
-
-    len = src - src_orig;
-    if ((wcsncmp(src_orig, name, len) != 0) || (wcslen(name) != (len))) {
-        streams.err.append_format(
-            _(L"%ls: Multiple variable names specified in single call (%ls and %.*ls)\n"), L"set",
-            name, len, src_orig);
-        return 0;
-    }
-
-    src++;
-    while (iswspace(*src)) src++;
-
-    while (*src != L']') {
+    while (*p != L']') {
         const wchar_t *end;
-        long l_ind = fish_wcstol(src, &end);
+        long l_ind = fish_wcstol(p, &end);
         if (errno > 0) {  // ignore errno == -1 meaning the int did not end with a '\0'
             streams.err.append_format(_(L"%ls: Invalid index starting at '%ls'\n"), L"set", src);
-            return 0;
+            return -1;
         }
+        p = (wchar_t *)end;
 
-        if (l_ind < 0) l_ind = var_count + l_ind + 1;
+        // Convert negative index to a positive index.
+        if (l_ind < 0) l_ind = var.size() + l_ind + 1;
 
-        src = end;  //!OCLINT(parameter reassignment)
-        if (*src == L'.' && *(src + 1) == L'.') {
-            src += 2;
-            long l_ind2 = fish_wcstol(src, &end);
+        if (*p == L'.' && *(p + 1) == L'.') {
+            p += 2;
+            long l_ind2 = fish_wcstol(p, &end);
             if (errno > 0) {  // ignore errno == -1 meaning the int did not end with a '\0'
-                return 1;
+                return -1;
             }
-            src = end;  //!OCLINT(parameter reassignment)
+            p = (wchar_t *)end;
 
-            if (l_ind2 < 0) {
-                l_ind2 = var_count + l_ind2 + 1;
-            }
+            // Convert negative index to a positive index.
+            if (l_ind2 < 0) l_ind2 = var.size() + l_ind2 + 1;
+
             int direction = l_ind2 < l_ind ? -1 : 1;
             for (long jjj = l_ind; jjj * direction <= l_ind2 * direction; jjj += direction) {
-                // debug(0, L"Expand range [set]: %i\n", jjj);
                 indexes.push_back(jjj);
                 count++;
             }
@@ -355,8 +356,6 @@ static int parse_index(std::vector<long> &indexes, const wchar_t *src, const wch
             indexes.push_back(l_ind);
             count++;
         }
-
-        while (iswspace(*src)) src++;
     }
 
     return count;
@@ -364,10 +363,8 @@ static int parse_index(std::vector<long> &indexes, const wchar_t *src, const wch
 
 static int update_values(wcstring_list_t &list, std::vector<long> &indexes,
                          wcstring_list_t &values) {
-    size_t i;
-
     // Replace values where needed.
-    for (i = 0; i < indexes.size(); i++) {
+    for (size_t i = 0; i < indexes.size(); i++) {
         // The '- 1' below is because the indices in fish are one-based, but the vector uses
         // zero-based indices.
         long ind = indexes[i] - 1;
@@ -379,7 +376,6 @@ static int update_values(wcstring_list_t &list, std::vector<long> &indexes,
             list.resize(ind + 1);
         }
 
-        // free((void *) al_get(list, ind));
         list[ind] = newv;
     }
 
@@ -414,10 +410,15 @@ static int compute_scope(set_cmd_opts_t &opts) {
     return scope;
 }
 
-/// Print the names of all environment variables in the scope, with or without shortening, with or
-/// without values, with or without escaping
-static int builtin_set_list(const wchar_t *cmd, set_cmd_opts_t &opts, int optind, int argc,
+/// Print the names of all environment variables in the scope. It will include the values unless the
+/// `set --list` flag was used.
+static int builtin_set_list(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
                             wchar_t **argv, parser_t &parser, io_streams_t &streams) {
+    UNUSED(cmd);
+    UNUSED(argc);
+    UNUSED(argv);
+    UNUSED(parser);
+
     bool names_only = opts.list;
     wcstring_list_t names = env_get_names(compute_scope(opts));
     sort(names.begin(), names.end());
@@ -451,42 +452,33 @@ static int builtin_set_list(const wchar_t *cmd, set_cmd_opts_t &opts, int optind
 }
 
 // Query mode. Return the number of variables that do not exist out of the specified variables.
-static int builtin_set_query(const wchar_t *cmd, set_cmd_opts_t &opts, int optind, int argc,
+static int builtin_set_query(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
                              wchar_t **argv, parser_t &parser, io_streams_t &streams) {
     int retval = 0;
+    int scope = compute_scope(opts);
 
-    for (int i = optind; i < argc; i++) {
+    for (int i = 0; i < argc; i++) {
         wchar_t *arg = argv[i];
-        bool slice = false;
-
         wchar_t *dest = wcsdup(arg);
         assert(dest);
 
-        if (wchar_t *p = wcschr(dest, L'[')) {
-            *p = L'\0';
-            slice = true;
+        std::vector<long> indexes;
+        int idx_count = parse_index(indexes, dest, scope, streams);
+        if (idx_count == -1) {
+            free(dest);
+            builtin_print_help(parser, streams, cmd, streams.err);
+            return STATUS_CMD_ERROR;
         }
 
-        if (slice) {
-            std::vector<long> indexes;
+        if (idx_count) {
             wcstring_list_t result;
-            size_t j;
-
-            env_var_t dest_str = env_get_string(dest, compute_scope(opts));
+            env_var_t dest_str = env_get_string(dest, scope);
             if (!dest_str.missing()) tokenize_variable_array(dest_str, result);
 
-            if (!parse_index(indexes, arg, dest, result.size(), streams)) {
-                builtin_print_help(parser, streams, cmd, streams.err);
-                return STATUS_CMD_ERROR;
+            for (auto idx : indexes) {
+                if (idx < 1 || (size_t)idx > result.size()) retval++;
             }
-
-            for (j = 0; j < indexes.size(); j++) {
-                long idx = indexes[j];
-                if (idx < 1 || (size_t)idx > result.size()) {
-                    retval++;
-                }
-            }
-        } else if (!env_exist(arg, compute_scope(opts))) {
+        } else if (!env_exist(arg, scope)) {
             retval++;
         }
 
@@ -494,6 +486,118 @@ static int builtin_set_query(const wchar_t *cmd, set_cmd_opts_t &opts, int optin
     }
 
     return retval;
+}
+
+/// Erase a variable.
+static int builtin_set_erase(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
+                             wchar_t **argv, parser_t &parser, io_streams_t &streams) {
+    if (argc != 1) {
+        streams.err.append_format(BUILTIN_ERR_ARG_COUNT2, cmd, L"--erase", 1, argc);
+        builtin_print_help(parser, streams, cmd, streams.err);
+        return STATUS_CMD_ERROR;
+    }
+
+    int scope = compute_scope(opts);  // calculate the variable scope based on the provided options
+    wchar_t *dest = argv[0];
+
+    std::vector<long> indexes;
+    int idx_count = parse_index(indexes, dest, scope, streams);
+    if (idx_count == -1) {
+        builtin_print_help(parser, streams, cmd, streams.err);
+        return STATUS_CMD_ERROR;
+    }
+
+    int retval;
+    if (!valid_var_name(dest)) {
+        streams.err.append_format(BUILTIN_ERR_VARNAME, cmd, dest);
+        builtin_print_help(parser, streams, cmd, streams.err);
+        return STATUS_INVALID_ARGS;
+    }
+
+    if (idx_count == 0) {  // unset the var
+        retval = env_remove(dest, scope);
+    } else {  // remove just the specified indexes of the var
+        const env_var_t dest_var = env_get_string(dest, scope);
+        if (dest_var.missing()) return STATUS_CMD_ERROR;
+        wcstring_list_t result;
+        tokenize_variable_array(dest_var, result);
+        erase_values(result, indexes);
+        retval = my_env_set(cmd, dest, result, scope, streams);
+    }
+
+    if (retval != STATUS_CMD_OK) return retval;
+    return check_global_scope_exists(cmd, opts, dest, streams);
+}
+
+/// This handles the more difficult case of setting individual slices of a var.
+static int set_slices(const wchar_t *cmd, set_cmd_opts_t &opts, const wchar_t *dest,
+                      std::vector<long> &indexes, int argc, wchar_t **argv, parser_t &parser,
+                      io_streams_t &streams) {
+    UNUSED(parser);
+
+    if (indexes.size() != static_cast<size_t>(argc)) {
+        streams.err.append_format(BUILTIN_SET_MISMATCHED_ARGS, cmd, indexes.size(), argc);
+    }
+
+    int scope = compute_scope(opts);  // calculate the variable scope based on the provided options
+    wcstring_list_t result;
+    const env_var_t dest_str = env_get_string(dest, scope);
+    if (!dest_str.missing()) tokenize_variable_array(dest_str, result);
+
+    // Slice indexes have been calculated, do the actual work.
+    wcstring_list_t new_values;
+    for (int i = 0; i < argc; i++) new_values.push_back(argv[i]);
+
+    int retval = update_values(result, indexes, new_values);
+    if (retval != STATUS_CMD_OK) {
+        streams.err.append_format(BUILTIN_SET_ARRAY_BOUNDS_ERR, cmd);
+        return retval;
+    }
+
+    retval = my_env_set(cmd, dest, result, scope, streams);
+    if (retval != STATUS_CMD_OK) return retval;
+    return check_global_scope_exists(cmd, opts, dest, streams);
+}
+
+/// Set a variable.
+static int builtin_set_set(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
+                           wchar_t **argv, parser_t &parser, io_streams_t &streams) {
+    if (argc == 0) {
+        streams.err.append_format(BUILTIN_ERR_MIN_ARG_COUNT1, cmd, 1);
+        builtin_print_help(parser, streams, cmd, streams.err);
+        return STATUS_INVALID_ARGS;
+    }
+
+    int retval;
+    int scope = compute_scope(opts);  // calculate the variable scope based on the provided options
+    wchar_t *dest = argv[0];
+    argv++;
+    argc--;
+
+    std::vector<long> indexes;
+    int idx_count = parse_index(indexes, dest, scope, streams);
+    if (idx_count == -1) {
+        builtin_print_help(parser, streams, cmd, streams.err);
+        return STATUS_INVALID_ARGS;
+    }
+
+    if (!valid_var_name(dest)) {
+        streams.err.append_format(BUILTIN_ERR_VARNAME, cmd, dest);
+        builtin_print_help(parser, streams, cmd, streams.err);
+        return STATUS_INVALID_ARGS;
+    }
+
+    if (idx_count != 0) {
+        // Handle the uncommon case of setting specific slices of a var.
+        return set_slices(cmd, opts, dest, indexes, argc, argv, parser, streams);
+    }
+
+    // This is the simple, common, case. Set the var to the specified values.
+    wcstring_list_t values;
+    for (int i = 0; i < argc; i++) values.push_back(argv[i]);
+    retval = my_env_set(cmd, dest, values, scope, streams);
+    if (retval != STATUS_CMD_OK) return retval;
+    return check_global_scope_exists(cmd, opts, dest, streams);
 }
 
 /// The set builtin creates, updates, and erases (removes, deletes) variables.
@@ -506,125 +610,28 @@ int builtin_set(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
     if (retval != STATUS_CMD_OK) return retval;
+    argv += optind;
+    argc -= optind;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd, streams.out);
         return STATUS_CMD_OK;
     }
 
-    retval = validate_cmd_opts(cmd, opts, optind, argc, parser, streams);
+    retval = validate_cmd_opts(cmd, opts, argc, parser, streams);
     if (retval != STATUS_CMD_OK) return retval;
 
-    if (opts.query) return builtin_set_query(cmd, opts, optind, argc, argv, parser, streams);
-    if (opts.list || optind == argc) {
-        return builtin_set_list(cmd, opts, optind, argc, argv, parser, streams);
-    }
-
-    // Variables used for performing the actual work.
-    int scope = compute_scope(opts);  // calculate the variable scope based on the provided options
-    wchar_t *dest = wcsdup(argv[optind]);
-    assert(dest);
-
-    bool slice = false;
-    if (wchar_t *p = wcschr(dest, L'[')) {
-        *p = L'\0';
-        slice = true;
-    }
-
-    if (!valid_var_name(dest)) {
-        streams.err.append_format(BUILTIN_ERR_VARNAME, cmd, dest);
-        builtin_print_help(parser, streams, cmd, streams.err);
-        return STATUS_INVALID_ARGS;
-    }
-
-    // Set assignment can work in two modes, either using slices or using the whole array. We detect
-    // which mode is used here.
-    if (slice) {
-        std::vector<long> indexes;
-        wcstring_list_t result;
-
-        const env_var_t dest_str = env_get_string(dest, scope);
-        if (!dest_str.missing()) {
-            tokenize_variable_array(dest_str, result);
-        } else if (opts.erase) {
-            retval = STATUS_CMD_ERROR;
-        }
-
-        if (retval == STATUS_CMD_OK) {
-            for (; optind < argc; optind++) {
-                if (!parse_index(indexes, argv[optind], dest, result.size(), streams)) {
-                    builtin_print_help(parser, streams, cmd, streams.err);
-                    retval = STATUS_CMD_ERROR;
-                    break;
-                }
-
-                size_t idx_count = indexes.size();
-                size_t val_count = argc - optind - 1;
-
-                if (!opts.erase) {
-                    if (val_count < idx_count) {
-                        streams.err.append_format(_(BUILTIN_SET_ARG_COUNT), cmd);
-                        builtin_print_help(parser, streams, cmd, streams.err);
-                        retval = STATUS_CMD_ERROR;
-                        break;
-                    }
-                    if (val_count == idx_count) {
-                        optind++;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (retval == STATUS_CMD_OK) {
-            // Slice indexes have been calculated, do the actual work.
-            if (opts.erase) {
-                erase_values(result, indexes);
-                my_env_set(dest, result, scope, streams);
-            } else {
-                wcstring_list_t value;
-
-                while (optind < argc) {
-                    value.push_back(argv[optind++]);
-                }
-
-                if (update_values(result, indexes, value)) {
-                    streams.err.append_format(L"%ls: ", cmd);
-                    streams.err.append_format(ARRAY_BOUNDS_ERR);
-                    streams.err.push_back(L'\n');
-                }
-
-                my_env_set(dest, result, scope, streams);
-            }
-        }
+    if (opts.query) {
+        retval = builtin_set_query(cmd, opts, argc, argv, parser, streams);
+    } else if (opts.erase) {
+        retval = builtin_set_erase(cmd, opts, argc, argv, parser, streams);
+    } else if (opts.list) {  // explicit list the vars we know about
+        retval = builtin_set_list(cmd, opts, argc, argv, parser, streams);
+    } else if (argc == 0) {  // implicit list the vars we know about
+        retval = builtin_set_list(cmd, opts, argc, argv, parser, streams);
     } else {
-        optind++;
-        // No slicing.
-        if (opts.erase) {
-            if (optind != argc) {
-                streams.err.append_format(_(L"%ls: Values cannot be specfied with erase\n"), cmd);
-                builtin_print_help(parser, streams, cmd, streams.err);
-                retval = STATUS_CMD_ERROR;
-            } else {
-                retval = env_remove(dest, scope);
-            }
-        } else {
-            wcstring_list_t val;
-            for (int i = optind; i < argc; i++) val.push_back(argv[i]);
-            retval = my_env_set(dest, val, scope, streams);
-        }
+        retval = builtin_set_set(cmd, opts, argc, argv, parser, streams);
     }
-
-    // Check if we are setting variables above the effective scope. See
-    // https://github.com/fish-shell/fish-shell/issues/806
-    env_var_t global_dest = env_get_string(dest, ENV_GLOBAL);
-    if (opts.universal && !global_dest.missing()) {
-        streams.err.append_format(
-            _(L"%ls: Warning: universal scope selected, but a global variable '%ls' exists.\n"),
-            L"set", dest);
-    }
-
-    free(dest);
 
     if (retval == STATUS_CMD_OK && opts.preserve_failure_exit_status) retval = incoming_exit_status;
     return retval;

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -183,6 +183,8 @@ void var_stack_t::push(bool new_scope) {
 
     // Copy local-exported variables
     auto top_node = top.get();
+    // Only if we introduce a new shadowing scope
+    // i.e. not if it's just `begin; end` or "--no-scope-shadowing".
     if (new_scope) {
         if (!(top_node == this->global_env)) {
             for (auto& var : top_node->env) {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -182,11 +182,13 @@ void var_stack_t::push(bool new_scope) {
 
     // Copy local-exported variables
     auto top_node = top.get();
-    if (!(top_node == this->global_env)) {
-        for (auto& var : top_node->env) {
-            if (var.second.exportv) {
-                // This should copy var
-                node->env.insert(var);
+    if (new_scope) {
+        if (!(top_node == this->global_env)) {
+            for (auto& var : top_node->env) {
+                if (var.second.exportv) {
+                    // This should  copy var
+                    node->env.insert(var);
+                }
             }
         }
     }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -118,7 +118,8 @@ class env_node_t {
     /// in the stack are invisible. If new_scope is set for the global variable node, the universe
     /// will explode.
     bool new_scope;
-    /// Does this node contain any variables which are exported to subshells.
+    /// Does this node contain any variables which are exported to subshells
+    /// or does it redefine any variables to not be exported?
     bool exportv = false;
     /// Pointer to next level.
     std::unique_ptr<env_node_t> next;
@@ -1109,6 +1110,9 @@ int env_set(const wcstring &key, const wchar_t *val, env_mode_flags_t var_mode) 
                 has_changed_new = true;
             } else {
                 entry.exportv = false;
+                // Set the node's exportv when it changes something about exports
+                // (also when it redefines a variable to not be exported).
+                node->exportv = has_changed_old != has_changed_new;
             }
 
             if (has_changed_old || has_changed_new) vars_stack().mark_changed_exported();

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -179,6 +179,18 @@ struct var_stack_t {
 
 void var_stack_t::push(bool new_scope) {
     std::unique_ptr<env_node_t> node(new env_node_t(new_scope));
+
+    // Copy local-exported variables
+    auto top_node = top.get();
+    if (!(top_node == this->global_env)) {
+        for (auto& var : top_node->env) {
+            if (var.second.exportv) {
+                // This should copy var
+                node->env.insert(var);
+            }
+        }
+    }
+
     node->next = std::move(this->top);
     this->top = std::move(node);
     if (new_scope && local_scope_exports(this->top.get())) {

--- a/src/expand.h
+++ b/src/expand.h
@@ -89,9 +89,6 @@ enum expand_error_t {
     EXPAND_WILDCARD_MATCH
 };
 
-/// Error issued on array out of bounds.
-#define ARRAY_BOUNDS_ERR _(L"Array index out of bounds")
-
 /// Perform various forms of expansion on in, such as tilde expansion (\~USER becomes the users home
 /// directory), variable expansion (\$VAR_NAME becomes the value of the environment variable
 /// VAR_NAME), cmdsubst expansion and wildcard expansion. The results are inserted into the list

--- a/src/wcstringutil.h
+++ b/src/wcstringutil.h
@@ -2,6 +2,7 @@
 #ifndef FISH_WCSTRINGUTIL_H
 #define FISH_WCSTRINGUTIL_H
 
+#include <algorithm>
 #include <string>
 #include <utility>
 
@@ -20,4 +21,32 @@ typedef std::pair<wcstring::size_type, wcstring::size_type> wcstring_range;
 wcstring_range wcstring_tok(wcstring& str, const wcstring& needle,
                             wcstring_range last = wcstring_range(0, 0));
 
+/// Given iterators into a string (forward or reverse), splits the haystack iterators
+/// about the needle sequence, up to max times. Inserts splits into the output array.
+/// If the iterators are forward, this does the normal thing.
+/// If the iterators are backward, this returns reversed strings, in reversed order!
+/// If the needle is empty, split on individual elements (characters).
+template <typename ITER>
+void split_about(ITER haystack_start, ITER haystack_end, ITER needle_start, ITER needle_end,
+                 wcstring_list_t *output, long max) {
+    long remaining = max;
+    ITER haystack_cursor = haystack_start;
+    while (remaining > 0 && haystack_cursor != haystack_end) {
+        ITER split_point;
+        if (needle_start == needle_end) {  // empty needle, we split on individual elements
+            split_point = haystack_cursor + 1;
+        } else {
+            split_point = std::search(haystack_cursor, haystack_end, needle_start, needle_end);
+        }
+        if (split_point == haystack_end) {  // not found
+            break;
+        }
+        output->push_back(wcstring(haystack_cursor, split_point));
+        remaining--;
+        // Need to skip over the needle for the next search note that the needle may be empty.
+        haystack_cursor = split_point + std::distance(needle_start, needle_end);
+    }
+    // Trailing component, possibly empty.
+    output->push_back(wcstring(haystack_cursor, haystack_end));
+}
 #endif

--- a/tests/argparse.err
+++ b/tests/argparse.err
@@ -29,6 +29,8 @@ argparse: Long flag 'short' already defined
 argparse: Implicit int flag '#' already defined
 # Defining an implicit int flag with modifiers
 argparse: Implicit int short flag 'v' does not allow modifiers like '='
+# Implicit int short flag only with custom validation fails
+argparse: Value '499' for flag 'x' less than min allowed of '500'
 # Implicit int flag validation fails
 argparse: Value '765x' for flag 'max' is not an integer
 argparse: Value 'a1' for flag 'm' is not an integer

--- a/tests/argparse.in
+++ b/tests/argparse.in
@@ -86,13 +86,40 @@ set -l
 for v in (set -l -n); set -e $v; end
 argparse 'v/verbose' '#-val' 't/token=' -- -123 a1 --token woohoo --234 -v a2 --verbose
 set -l
+
 echo '# Should be set to 987'
 for v in (set -l -n); set -e $v; end
 argparse 'm#max' -- argle -987 bargle
 set -l
+
 echo '# Should be set to 765'
 for v in (set -l -n); set -e $v; end
 argparse 'm#max' -- argle -987 bargle --max 765
+set -l
+
+echo '# Bool short flag only'
+for v in (set -l -n); set -e $v; end
+argparse 'C' 'v' -- -C -v arg1 -v arg2
+set -l
+
+echo '# Value taking short flag only'
+for v in (set -l -n); set -e $v; end
+argparse 'x=' 'v/verbose' -- --verbose arg1 -v -x arg2
+set -l
+
+echo '# Implicit int short flag only'
+for v in (set -l -n); set -e $v; end
+argparse 'x#' 'v/verbose' -- -v -v argle -v -x 321 bargle
+set -l
+
+echo '# Implicit int short flag only with custom validation passes'
+for v in (set -l -n); set -e $v; end
+argparse 'x#!_validate_int --max 500' 'v/verbose' -- -v -v -x 499 -v
+set -l
+
+echo '# Implicit int short flag only with custom validation fails' >&2
+for v in (set -l -n); set -e $v; end
+argparse 'x#!_validate_int --min 500' 'v/verbose' -- -v -v -x 499 -v
 set -l
 
 ##########

--- a/tests/argparse.out
+++ b/tests/argparse.out
@@ -2,8 +2,8 @@
 # One arg and no matching flags
 argv help
 # Five args with two matching a flag
-_flag_h 2
-_flag_help 2
+_flag_h '--help'  '-h'
+_flag_help '--help'  '-h'
 argv 'help'  'me'  'a lot more'
 # Required, optional, and multiple flags
 _flag_a ABC
@@ -12,23 +12,23 @@ _flag_d
 _flag_def
 _flag_g 'g1'  'g2'  'g3'
 _flag_ghk 'g1'  'g2'  'g3'
-_flag_h 1
-_flag_help 1
+_flag_h --help
+_flag_help --help
 argv 'help'  'me'
 # --stop-nonopt works
 _flag_a A2
 _flag_abc A2
-_flag_h 1
-_flag_help 1
+_flag_h -h
+_flag_help -h
 argv 'non-opt'  'second non-opt'  '--help'
 # Implicit int flags work
 _flag_val 123
 argv 'abc'  'def'
 _flag_t woohoo
 _flag_token woohoo
-_flag_v 2
+_flag_v '-v'  '--verbose'
 _flag_val -234
-_flag_verbose 2
+_flag_verbose '-v'  '--verbose'
 argv 'a1'  'a2'
 # Should be set to 987
 _flag_m 987

--- a/tests/argparse.out
+++ b/tests/argparse.out
@@ -38,6 +38,25 @@ argv 'argle'  'bargle'
 _flag_m 765
 _flag_max 765
 argv 'argle'  'bargle'
+# Bool short flag only
+_flag_C -C
+_flag_v '-v'  '-v'
+argv 'arg1'  'arg2'
+# Value taking short flag only
+_flag_v '--verbose'  '-v'
+_flag_verbose '--verbose'  '-v'
+_flag_x arg2
+argv arg1
+# Implicit int short flag only
+_flag_v '-v'  '-v'  '-v'
+_flag_verbose '-v'  '-v'  '-v'
+_flag_x 321
+argv 'argle'  'bargle'
+# Implicit int short flag only with custom validation passes
+_flag_v '-v'  '-v'  '-v'
+_flag_verbose '-v'  '-v'  '-v'
+_flag_x 499
+argv
 # Check the exit status from argparse validation
 _flag_name max
 _flag_value 83

--- a/tests/history.err
+++ b/tests/history.err
@@ -4,8 +4,8 @@ history: you cannot use any options with the merge command
 history: save expected 0 args, got 1
 history: you cannot use any options with the save command
 history: you cannot use any options with the clear command
-history: merge expected 0 args, got 1
-history: clear expected 0 args, got 2
+history merge: Expected 0 args, got 1
+history clear: Expected 0 args, got 2
 
 history: you cannot use any options with the clear command
 history: you cannot use any options with the merge command
@@ -17,7 +17,7 @@ history: Invalid combination of options,
 you cannot do both 'search' and 'merge' in the same invocation
 history: you cannot use any options with the save command
 history: you cannot use any options with the clear command
-history: merge expected 0 args, got 1
-history: clear expected 0 args, got 2
+history merge: Expected 0 args, got 1
+history clear: Expected 0 args, got 2
 history: you cannot use any options with the save command
 history: you cannot use any options with the merge command

--- a/tests/interactive.config
+++ b/tests/interactive.config
@@ -29,13 +29,13 @@ function _echo_var --no-scope-shadowing -d '_echo_var varname [guardval]'
     case 0
         echo "\$$var has no value"
     case 1
-        set -l IFS ''
-        echo "\$$var:" (_quote $$var)
+        _quote $$var | read -l x
+        echo "\$$var: $x"
     case \*
         echo "\$$var:"
         for i in (seq (count $$var))
-            set -l IFS ''
-            echo "$i:" (_quote $$var[1][$i])
+            _quote $$var[1][$i] | read -l x
+            echo "$i: $x"
         end
     end
     if set -q argv[2]; echo "@/GUARD:$argv[2]@"; end

--- a/tests/read.err
+++ b/tests/read.err
@@ -1,0 +1,5 @@
+# Read with no vars is an error
+read: Expected at least 1 args, got only 0
+# Read with -a and anything other than exactly on var name is an error
+read: Expected 1 args, got 0
+read: Expected 1 args, got 2

--- a/tests/read.in
+++ b/tests/read.in
@@ -2,6 +2,18 @@
 #
 # Test read builtin and IFS.
 #
+
+###########
+# Start by testing that invocation errors are handled correctly.
+echo '# Read with no vars is an error' >&2
+read
+echo '# Read with -a and anything other than exactly on var name is an error' >&2
+read -a
+read -a v1 v2
+read -a v1
+
+###########
+# Verify correct behavior of subcommands and splitting of input.
 count (echo one\ntwo)
 set -l IFS \t
 count (echo one\ntwo)
@@ -25,6 +37,7 @@ function print_vars --no-scope-shadowing
 end
 
 echo
+echo '# Test splitting input'
 echo 'hello there' | read -l one two
 print_vars one two
 echo 'hello there' | read -l one
@@ -41,6 +54,7 @@ echo -n 'a' | read -l one
 echo "$status $one"
 
 echo
+echo '# Test splitting input with IFS empty'
 set -l IFS
 echo 'hello' | read -l one
 print_vars one

--- a/tests/read.in
+++ b/tests/read.in
@@ -239,3 +239,15 @@ echo $foo
 echo $bar
 echo $baz
 echo
+
+echo 'Multi-char delimiters with -d'
+echo a...b...c | read -l -d "..." a b c
+echo $a
+echo $b
+echo $c
+echo 'Multi-char delimiters with IFS'
+begin
+    set IFS "..."
+    echo a...b...c | read -l a b c
+    echo $a; echo $b; echo $c
+end

--- a/tests/read.in
+++ b/tests/read.in
@@ -208,3 +208,34 @@ end
 
 echo '# Confirm reading non-interactively works (#4206 regression)'
 echo abc\ndef | ../test/root/bin/fish -i -c 'read a; read b; show a; show b'
+### Test --delimiter (and $IFS, for now)
+echo a=b | read -l foo bar
+echo $foo
+echo $bar
+echo Delimiter =
+echo a=b | read -l -d = foo bar
+echo $foo
+echo $bar
+echo Delimiter empty
+echo a=b | read -l -d '' foo bar baz
+echo $foo
+echo $bar
+echo $baz
+echo IFS empty string
+set -l IFS ''
+echo a=b | read -l foo bar baz
+echo $foo
+echo $bar
+echo $baz
+echo IFS unset
+set -e IFS
+echo a=b | read -l foo bar baz
+echo $foo
+echo $bar
+echo $baz
+echo Delimiter =
+echo a=b | read -l -d = foo bar baz
+echo $foo
+echo $bar
+echo $baz
+echo

--- a/tests/read.out
+++ b/tests/read.out
@@ -65,3 +65,25 @@ $a count=1
 $a[1]=|abc|
 $b count=1
 $b[1]=|def|
+a=b
+
+Delimiter =
+a
+b
+Delimiter empty
+a
+=
+b
+IFS empty string
+a
+=
+b
+IFS unset
+a=b
+
+
+Delimiter =
+a
+b
+
+

--- a/tests/read.out
+++ b/tests/read.out
@@ -11,6 +11,7 @@ two]
 two
 ]
 
+# Test splitting input
 1 'hello' 1 'there'
 1 'hello there'
 1 ''
@@ -19,6 +20,7 @@ two
 1 'foo' 1 'bar' 1 '  baz'
 0 a
 
+# Test splitting input with IFS empty
 1 'hello'
 1 'h' 1 'ello'
 1 'h' 1 'e' 1 'llo'

--- a/tests/read.out
+++ b/tests/read.out
@@ -87,3 +87,11 @@ a
 b
 
 
+Multi-char delimiters with -d
+a
+b
+c
+Multi-char delimiters with IFS
+a
+b
+..c

--- a/tests/test3.in
+++ b/tests/test3.in
@@ -257,6 +257,15 @@ set -lx var wuwuwu
 __fish_test_local_export
 echo $var
 
+# Test that we don't copy local-exports to blocks.
+set -lx var foo
+begin
+    echo $var
+    set var bar
+    echo $var
+end
+echo $var # should be "bar"
+
 # clear for other shells
 set -eU __fish_test_universal_variables_variable_foo
 

--- a/tests/test3.in
+++ b/tests/test3.in
@@ -247,6 +247,16 @@ __fish_test_shadow
 # Test that the variable is still exported (#2611)
 env | string match '__fish_test_env17=*'
 
+# Test that local exported variables are copied to functions (#1091)
+function __fish_test_local_export
+         echo $var
+         set var boo
+         echo $var
+end
+set -lx var wuwuwu
+__fish_test_local_export
+echo $var
+
 # clear for other shells
 set -eU __fish_test_universal_variables_variable_foo
 

--- a/tests/test3.in
+++ b/tests/test3.in
@@ -244,6 +244,8 @@ function __fish_test_shadow
   env | string match -q '__fish_test_env17=*' ; or echo SHADOWED
 end
 __fish_test_shadow
+# Test that the variable is still exported (#2611)
+env | string match '__fish_test_env17=*'
 
 # clear for other shells
 set -eU __fish_test_universal_variables_variable_foo

--- a/tests/test3.out
+++ b/tests/test3.out
@@ -19,6 +19,7 @@ count:5 content:[functionblock function global universal blocklocal]
 Test 16 pass
 __fish_test_env17=UNSHADOWED
 SHADOWED
+__fish_test_env17=UNSHADOWED
 Testing Universal Startup
 1
 1

--- a/tests/test3.out
+++ b/tests/test3.out
@@ -20,6 +20,9 @@ Test 16 pass
 __fish_test_env17=UNSHADOWED
 SHADOWED
 __fish_test_env17=UNSHADOWED
+wuwuwu
+boo
+wuwuwu
 Testing Universal Startup
 1
 1

--- a/tests/test3.out
+++ b/tests/test3.out
@@ -23,6 +23,9 @@ __fish_test_env17=UNSHADOWED
 wuwuwu
 boo
 wuwuwu
+foo
+bar
+bar
 Testing Universal Startup
 1
 1

--- a/tests/test4.in
+++ b/tests/test4.in
@@ -161,10 +161,10 @@ end;
 
 set -U -e baz
 
-echo "Verify subcommand statuses"
+echo "# Verify subcommand statuses"
 echo (false) $status (true) $status (false) $status
 
-echo "Verify that set passes through exit status, except when passed -n or -q or -e"
+echo "# Verify that set passes through exit status, except when passed -n or -q or -e"
 false ; set foo bar ; echo 1 $status # passthrough
 true ; set foo bar ; echo 2 $status # passthrough
 false ; set -q foo ; echo 3 $status # no passthrough
@@ -178,7 +178,7 @@ false ; set foo (echo A; true) ; echo 10 $status $foo
 true ; set foo (echo B; false) ; echo 11 $status $foo
 true
 
-echo "Verify set -ql behavior" # see 2502
+echo "# Verify set -ql behavior" # see 2502
 function setql_check
   set -l setql_foo val
   if set -ql setql_foo

--- a/tests/test4.out
+++ b/tests/test4.out
@@ -20,9 +20,9 @@ Test 19 pass
 Test 20 pass
 Test 21 pass
 Test 22 pass
-Verify subcommand statuses
+# Verify subcommand statuses
 1 0 1
-Verify that set passes through exit status, except when passed -n or -q or -e
+# Verify that set passes through exit status, except when passed -n or -q or -e
 1 1
 2 0
 3 0
@@ -34,5 +34,5 @@ Verify that set passes through exit status, except when passed -n or -q or -e
 9 121
 10 0 A
 11 1 B
-Verify set -ql behavior
+# Verify set -ql behavior
 Pass

--- a/tests/test_functions/mktemp.fish
+++ b/tests/test_functions/mktemp.fish
@@ -14,19 +14,19 @@ function mktemp
     set -l opts
     while set -q argv[1]
         switch $argv[1]
-        case -d
-            set opts $opts d
-        case -t
-            set opts $opts t
-        case --
-            set -e argv[1]
-            break
-        case '-*'
-            echo "mktemp: unknown flag $argv[1]" >&2
-            _mktemp_help >&2
-            exit 2
-        case '*'
-            break
+            case -d
+                set opts $opts d
+            case -t
+                set opts $opts t
+            case --
+                set -e argv[1]
+                break
+            case '-*'
+                echo "mktemp: unknown flag $argv[1]" >&2
+                _mktemp_help >&2
+                exit 2
+            case '*'
+                break
         end
         set -e argv[1]
     end
@@ -50,8 +50,7 @@ function mktemp
     # So let's outlaw them anywhere besides the end.
     # Similarly GNU sed requires at least 3 X's, BSD sed requires none. Let's require 3.
     begin
-        set -l IFS
-        printf '%s' "$template" | read -la chars
+        set -l chars (string split '' -- $template)
         set -l found_x
         for c in $chars
             if test $c = X
@@ -75,10 +74,10 @@ function mktemp
     end
     if contains t $opts
         switch $template
-        case '/*'
-            echo "mktemp: invalid template '$template' with -t, template must not be absolute" >&2
-            _mktemp_help >&2
-            exit 1
+            case '/*'
+                echo "mktemp: invalid template '$template' with -t, template must not be absolute" >&2
+                _mktemp_help >&2
+                exit 1
         end
 
         if set -q TMPDIR[1]

--- a/tests/test_util.fish
+++ b/tests/test_util.fish
@@ -35,8 +35,9 @@ if not set -q __fish_is_running_tests
     end
 
     begin
-        set -l IFS  # clear IFS so cmd substitution doesn't split
-        cd (dirname $script); or die
+        dirname $script | read -l dir
+        cd $dir
+        or die
     end
 
     set -lx XDG_DATA_HOME ../test/data


### PR DESCRIPTION
## Description

This is a continuation of #4160. The delimiter is now used as a complete string like in `string split`.

The IFS fallback remains - we should not remove it in 3.0, but we should deprecate it somehow.

Fixes issue #4156.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added
- [ ] User-visible changes noted in CHANGELOG.md
