### PR TITLE
Remove completer_t::complete_special_cd

### DIFF
--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -317,8 +317,6 @@ class completer_t {
     void complete_param_expand(const wcstring &str, bool do_file,
                                bool handle_as_special_cd = false);
 
-    void complete_special_cd(const wcstring &str);
-
     void complete_cmd(const wcstring &str, bool use_function, bool use_builtin, bool use_command,
                       bool use_implicit_cd);
 


### PR DESCRIPTION
The class `completer_t` declares `complete_special_cd`, an unused method. I searched the entire source tree and this declaration seems to be the only instance of `complete_special_cd`. There is no definition or uses which likely means this is dead code.
