### PR TITLE
fix how fish behaves when FISH_HISTORY is set

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -613,8 +613,7 @@ static void react_to_variable_change(const wcstring &key) {
     } else if (key == L"FISH_READ_BYTE_LIMIT") {
         env_set_read_limit();
     } else if (key == L"FISH_HISTORY") {
-        history_destroy();
-        reader_push(history_session_id().c_str());
+        reader_change_history(history_session_id().c_str());
     }
 }
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1995,6 +1995,11 @@ static parser_test_error_bits_t default_test(const wchar_t *b) {
     return 0;
 }
 
+void reader_change_history(const wchar_t *name) {
+    data->history->save();
+    data->history = &history_t::history_with_name(name);
+}
+
 void reader_push(const wchar_t *name) {
     reader_data_t *n = new reader_data_t();
 

--- a/src/reader.h
+++ b/src/reader.h
@@ -72,6 +72,9 @@ const wchar_t *reader_current_filename();
 /// \param fn The fileanme to push
 void reader_push_current_filename(const wchar_t *fn);
 
+/// Change the history file for the current command reading context.
+void reader_change_history(const wchar_t *fn);
+
 /// Pop the current filename from the stack of read files.
 void reader_pop_current_filename();
 


### PR DESCRIPTION
Without this change setting `FISH_HISTORY` causes interactive input to
no longer provide autosuggestions, completions, etc.

Fixes #4234