### PR TITLE
Fix git alias completion

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -161,7 +161,7 @@ function __fish_git_using_command
 
     # Check aliases.
     set -l varname __fish_git_alias_(string escape --style=var -- $cmd)
-    set -q $$varname
+    set -q $varname
     and contains -- $$varname $argv
     and return 0
     return 1


### PR DESCRIPTION
## Description

The check for git aliases has one too many `$` in the check for existing variables. Because of this, no arguments are completed for aliases.

This removes that surplus `$`.
