### PR TITLE
[WIP] Overhaul of job control process synchronization

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1200,6 +1200,11 @@ void exec_job(parser_t &parser, job_t *j) {
             exec_close(pipe_current_write);
             pipe_current_write = -1;
         }
+
+        //unblock the last process because there's no need for it to stay SIGSTOP'd for anything
+        if (p->is_last_in_job) {
+            unblock_previous();
+        }
     }
 
     // Clean up any file descriptors we left open.

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1168,6 +1168,7 @@ void exec_job(parser_t &parser, job_t *j) {
             if (!pgrp_set) {
                 set_child_group(j, p->pid);
                 //only once per job, and only once we've executed an external command for real
+                //we can't rely on p->is_first_in_job because a builtin may have been the first
                 pgrp_set = true;
             }
         }

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -517,8 +517,6 @@ void exec_job(parser_t &parser, job_t *j) {
         //set to true if we end up forking for this process
         bool child_forked = false;
         bool child_spawned = false;
-        // bool block_child = !needs_keepalive;
-        // bool block_child = pipes_to_next_command;
         bool block_child = true;
 
         // The pipes the current process write to and read from. Unfortunately these can't be just

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1194,13 +1194,6 @@ void exec_job(parser_t &parser, job_t *j) {
         }
     }
 
-    //unblock the last process in the group
-    if (blocked_pid != -1)
-    {
-        kill(blocked_pid, SIGCONT);
-        blocked_pid = -1;
-    }
-
     // Clean up any file descriptors we left open.
     if (pipe_current_read >= 0) exec_close(pipe_current_read);
     if (pipe_current_write >= 0) exec_close(pipe_current_write);

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1108,7 +1108,7 @@ void exec_job(parser_t &parser, job_t *j) {
                 } else
 #endif
                 {
-                    if (!do_fork(false, "internal builtin", [&] {
+                    if (!do_fork(false, "external command", [&] {
                             safe_launch_process(p, actual_cmd, argv, envv);
                         })) {
                         break;

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -494,6 +494,8 @@ void exec_job(parser_t &parser, job_t *j) {
     // We are careful to set these to -1 when closed, so if we exit the loop abruptly, we can still
     // close them.
     bool pgrp_set = false;
+    //this is static since processes can block on input/output across jobs
+    //the main exec_job loop is only ever run in a single thread, so this is OK
     static pid_t blocked_pid = -1;
     int pipe_current_read = -1, pipe_current_write = -1, pipe_next_read = -1;
     for (std::unique_ptr<process_t> &unique_p : j->processes) {

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1158,7 +1158,14 @@ void exec_job(parser_t &parser, job_t *j) {
             //but we only need to call set_child_group for the first process in the group.
             //If needs_keepalive is set, this has already been called for the keepalive process
             pid_t pid_status{};
-            if (waitpid(p->pid, &pid_status, WUNTRACED) == -1) {
+            int result;
+            while ((result = waitpid(p->pid, &pid_status, WUNTRACED)) == -1 && errno == EINTR) {
+                //This could be a superfluous interrupt or Ctrl+C at the terminal
+                //In all cases, it is OK to retry since the forking code above is specifically designed
+                //to never, ever hang/block in a child process before the SIGSTOP call is reached.
+                continue;
+            }
+            if (result == -1) {
                 exec_error = true;
                 debug(1, L"waitpid(%d) call in unblock_pid failed:!\n", p->pid);
                 wperror(L"waitpid");

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -630,8 +630,8 @@ void exec_job(parser_t &parser, job_t *j) {
             if (blocked_pid != -1) {
                 debug(2, L"Unblocking process %d.\n", blocked_pid);
                 kill(blocked_pid, SIGCONT);
+                blocked_pid = -1;
             }
-            blocked_pid = -1;
         };
 
         // This is the io_streams we pass to internal builtins.
@@ -1169,15 +1169,13 @@ void exec_job(parser_t &parser, job_t *j) {
             //no one awaits it.
         }
         //regardless of whether the child blocked or not:
-        if (child_spawned || child_forked) {
+        //only once per job, and only once we've actually executed an external command
+        if ((child_spawned || child_forked) && !pgrp_set) {
             //this should be called after waitpid if child_forked && pipes_to_next_command
             //it can be called at any time if child_spawned
-            if (!pgrp_set) {
-                set_child_group(j, p->pid);
-                //only once per job, and only once we've executed an external command for real
-                //we can't rely on p->is_first_in_job because a builtin may have been the first
-                pgrp_set = true;
-            }
+            set_child_group(j, p->pid);
+            //we can't rely on p->is_first_in_job because a builtin may have been the first
+            pgrp_set = true;
         }
         //if the command we ran _before_ this one was SIGSTOP'd to let this one catch up, unblock it now.
         //this must be after the wait_pid on the process we just started, if any.

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -683,6 +683,28 @@ void exec_job(parser_t &parser, job_t *j) {
             return true;
         };
 
+
+        //helper routine executed by INTERNAL_FUNCTION and INTERNAL_BLOCK_NODE to make sure
+        //an output buffer exists in case there is another command in the job chain that will
+        //be reading from this command's output.
+        auto verify_buffer_output = [&] () {
+            if (!p->is_last_in_job) {
+                // Be careful to handle failure, e.g. too many open fds.
+                block_output_io_buffer = io_buffer_t::create(STDOUT_FILENO, all_ios);
+                if (block_output_io_buffer.get() == NULL) {
+                    exec_error = true;
+                    job_mark_process_as_failed(j, p);
+                } else {
+                    // This looks sketchy, because we're adding this io buffer locally - they
+                    // aren't in the process or job redirection list. Therefore select_try won't
+                    // be able to read them. However we call block_output_io_buffer->read()
+                    // below, which reads until EOF. So there's no need to select on this.
+                    process_net_io_chain.push_back(block_output_io_buffer);
+                }
+            }
+        };
+
+
         switch (p->type) {
             case INTERNAL_FUNCTION: {
                 // Calls to function_get_definition might need to source a file as a part of
@@ -713,20 +735,7 @@ void exec_job(parser_t &parser, job_t *j) {
 
                 parser.forbid_function(func_name);
 
-                if (!p->is_last_in_job) {
-                    // Be careful to handle failure, e.g. too many open fds.
-                    block_output_io_buffer = io_buffer_t::create(STDOUT_FILENO, all_ios);
-                    if (block_output_io_buffer.get() == NULL) {
-                        exec_error = true;
-                        job_mark_process_as_failed(j, p);
-                    } else {
-                        // This looks sketchy, because we're adding this io buffer locally - they
-                        // aren't in the process or job redirection list. Therefore select_try won't
-                        // be able to read them. However we call block_output_io_buffer->read()
-                        // below, which reads until EOF. So there's no need to select on this.
-                        process_net_io_chain.push_back(block_output_io_buffer);
-                    }
-                }
+                verify_buffer_output();
 
                 if (!exec_error) {
                     internal_exec_helper(parser, def, NODE_OFFSET_INVALID, TOP,
@@ -740,18 +749,7 @@ void exec_job(parser_t &parser, job_t *j) {
             }
 
             case INTERNAL_BLOCK_NODE: {
-                if (!p->is_last_in_job) {
-                    block_output_io_buffer = io_buffer_t::create(STDOUT_FILENO, all_ios);
-                    if (block_output_io_buffer.get() == NULL) {
-                        // We failed (e.g. no more fds could be created).
-                        exec_error = true;
-                        job_mark_process_as_failed(j, p);
-                    } else {
-                        // See the comment above about it's OK to add an IO redirection to this
-                        // local buffer, even though it won't be handled in select_try.
-                        process_net_io_chain.push_back(block_output_io_buffer);
-                    }
-                }
+                verify_buffer_output();
 
                 if (!exec_error) {
                     internal_exec_helper(parser, wcstring(), p->internal_block_node, TOP,
@@ -861,7 +859,7 @@ void exec_job(parser_t &parser, job_t *j) {
                     const int fg = j->get_flag(JOB_FOREGROUND);
                     j->set_flag(JOB_FOREGROUND, false);
 
-                    //main loop is performing a blocking read from previous command's output
+                    //main loop may need to perform a blocking read from previous command's output.
                     //make sure read source is not blocked
                     unblock_previous();
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1066,8 +1066,9 @@ void exec_job(parser_t &parser, job_t *j) {
                 {
                     pid = execute_fork(false);
                     if (pid == 0) {
-                        // a hack that fixes any tcsetpgrp errors caused by race conditions
+                        // usleep is a hack that fixes any tcsetpgrp errors caused by race conditions
                         // usleep(20 * 1000);
+                        // it should no longer be needed with the chained_wait_next code below.
                         if (chained_wait_next != nullptr) {
                             debug(3, L"Waiting for next command in chain to start.\n");
                             sem_wait(chained_wait_next);
@@ -1121,6 +1122,7 @@ void exec_job(parser_t &parser, job_t *j) {
             debug(3, L"Unblocking previous command in chain.\n");
             sem_post(chained_wait_prev);
             munmap(chained_wait_prev, sizeof(sem_t));
+            chained_wait_prev = nullptr;
         }
         if (chained_wait_next != nullptr) {
             chained_wait_prev = chained_wait_next;

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1133,7 +1133,7 @@ void exec_job(parser_t &parser, job_t *j) {
         }
 
         if (child_spawned) {
-            child_set_group(j, p);
+            //posix_spawn'd processes won't SIGSTOP
             set_child_group(j, p->pid);
         }
         else if (child_forked) {
@@ -1142,17 +1142,17 @@ void exec_job(parser_t &parser, job_t *j) {
             pid_t pid_status{};
             if (waitpid(p->pid, &pid_status, WUNTRACED) != -1) {
                 //the child is SIGSTOP'd and is guaranteed to have called child_set_group() at this point.
-                set_child_group(j, p->pid); //update our own process group info to match
+                //but we only need to call set_child_group for the first process in the group.
+                //If needs_keepalive is set, this has already been called for the keepalive process
+                if (p->is_first_in_job) {
+                    set_child_group(j, p->pid);
+                }
                 //we are not unblocking the child via SIGCONT just yet to give the next process a chance to open
                 //the pipes and join the process group. We only unblock the last process in the job chain because
                 //no one awaits it.
-                if (!pipes_to_next_command)
-                {
-                    kill(p->pid, SIGCONT);
-                }
             }
             else {
-                debug(2, L"waitpid(%d) call in unblock_pid failed:!\n", p->pid);
+                debug(1, L"waitpid(%d) call in unblock_pid failed:!\n", p->pid);
                 wperror(L"waitpid");
             }
         }
@@ -1177,6 +1177,13 @@ void exec_job(parser_t &parser, job_t *j) {
             exec_close(pipe_current_write);
             pipe_current_write = -1;
         }
+    }
+
+    //unblock the last process in the group
+    if (blocked_pid != -1)
+    {
+        kill(blocked_pid, SIGCONT);
+        blocked_pid = -1;
     }
 
     // Clean up any file descriptors we left open.

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -366,6 +366,39 @@ static bool can_use_posix_spawn_for_job(const job_t *job, const process_t *proce
     return result;
 }
 
+void internal_exec(job_t *j, const io_chain_t &&all_ios) {
+    // Do a regular launch -  but without forking first...
+    signal_block();
+
+    // setup_child_process makes sure signals are properly set up. It will also call
+    // signal_unblock.
+
+    // PCA This is for handling exec. Passing all_ios here matches what fish 2.0.0 and 1.x did.
+    // It's known to be wrong - for example, it means that redirections bound for subsequent
+    // commands in the pipeline will apply to exec. However, using exec in a pipeline doesn't
+    // really make sense, so I'm not trying to fix it here.
+    if (!setup_child_process(0, all_ios)) {
+        // Decrement SHLVL as we're removing ourselves from the shell "stack".
+        const env_var_t shlvl_str = env_get_string(L"SHLVL", ENV_GLOBAL | ENV_EXPORT);
+        wcstring nshlvl_str = L"0";
+        if (!shlvl_str.missing()) {
+            long shlvl_i = fish_wcstol(shlvl_str.c_str());
+            if (!errno && shlvl_i > 0) {
+                nshlvl_str = to_string<long>(shlvl_i - 1);
+            }
+        }
+        env_set(L"SHLVL", nshlvl_str.c_str(), ENV_GLOBAL | ENV_EXPORT);
+
+        // launch_process _never_ returns.
+        launch_process_nofork(j->processes.front().get());
+    } else {
+        j->set_flag(JOB_CONSTRUCTED, true);
+        j->processes.front()->completed = 1;
+        return;
+    }
+}
+
+
 void exec_job(parser_t &parser, job_t *j) {
     pid_t pid = 0;
 
@@ -399,35 +432,7 @@ void exec_job(parser_t &parser, job_t *j) {
     }
 
     if (j->processes.front()->type == INTERNAL_EXEC) {
-        // Do a regular launch -  but without forking first...
-        signal_block();
-
-        // setup_child_process makes sure signals are properly set up. It will also call
-        // signal_unblock.
-
-        // PCA This is for handling exec. Passing all_ios here matches what fish 2.0.0 and 1.x did.
-        // It's known to be wrong - for example, it means that redirections bound for subsequent
-        // commands in the pipeline will apply to exec. However, using exec in a pipeline doesn't
-        // really make sense, so I'm not trying to fix it here.
-        if (!setup_child_process(0, all_ios)) {
-            // Decrement SHLVL as we're removing ourselves from the shell "stack".
-            const env_var_t shlvl_str = env_get_string(L"SHLVL", ENV_GLOBAL | ENV_EXPORT);
-            wcstring nshlvl_str = L"0";
-            if (!shlvl_str.missing()) {
-                long shlvl_i = fish_wcstol(shlvl_str.c_str());
-                if (!errno && shlvl_i > 0) {
-                    nshlvl_str = to_string<long>(shlvl_i - 1);
-                }
-            }
-            env_set(L"SHLVL", nshlvl_str.c_str(), ENV_GLOBAL | ENV_EXPORT);
-
-            // launch_process _never_ returns.
-            launch_process_nofork(j->processes.front().get());
-        } else {
-            j->set_flag(JOB_CONSTRUCTED, true);
-            j->processes.front()->completed = 1;
-            return;
-        }
+        internal_exec(j, std::move(all_ios));
         DIE("this should be unreachable");
     }
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -516,6 +516,7 @@ void exec_job(parser_t &parser, job_t *j) {
         bool child_forked = false;
         bool child_spawned = false;
         // bool block_child = !needs_keepalive;
+        // bool block_child = pipes_to_next_command;
         bool block_child = true;
 
         // The pipes the current process write to and read from. Unfortunately these can't be just

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -627,6 +627,8 @@ void exec_job(parser_t &parser, job_t *j) {
         // a pipeline.
         shared_ptr<io_buffer_t> block_output_io_buffer;
 
+        //used to SIGCONT the previously SIGSTOP'd process so the main loop or next command in job can read
+        //from its output.
         auto unblock_previous = [&j] () {
             //we've already called waitpid after forking the child, so we've guaranteed that they're
             //already SIGSTOP'd. Otherwise we'd be risking a deadlock because we can call SIGCONT before
@@ -640,6 +642,46 @@ void exec_job(parser_t &parser, job_t *j) {
 
         // This is the io_streams we pass to internal builtins.
         std::unique_ptr<io_streams_t> builtin_io_streams;
+
+        auto do_fork = [&j, &p, &pid, &exec_error, &process_net_io_chain, &block_child, &child_forked]
+            (bool drain_threads, const char *fork_type, std::function<void()> child_action) -> bool {
+            pid = execute_fork(drain_threads);
+            if (pid == 0) {
+                // This is the child process. Setup redirections, print correct output to
+                // stdout and stderr, and then exit.
+                p->pid = getpid();
+                blocked_pid = -1;
+                child_set_group(j, p);
+                // Make child processes pause after executing setup_child_process() to give down-chain
+                // commands in the job a chance to join their process group and read their pipes.
+                // The process will be resumed when the next command in the chain is started.
+                if (block_child) {
+                    kill(p->pid, SIGSTOP);
+                }
+                //the parent will wake us up when we're ready to execute
+                setup_child_process(p, process_net_io_chain);
+                child_action();
+                DIE("Child process returned control to do_fork lambda!");
+            }
+            else {
+                if (pid < 0) {
+                    debug(1, L"Failed to fork %s!\n", fork_type);
+                    job_mark_process_as_failed(j, p);
+                    exec_error = true;
+                    return false;
+                }
+                // This is the parent process. Store away information on the child, and
+                // possibly give it control over the terminal.
+                debug(2, L"Fork #%d, pid %d: %s for '%ls'", g_fork_count, pid, fork_type, p->argv0());
+                child_forked = true;
+                if (block_child) {
+                    debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
+                }
+                p->pid = pid;
+            }
+
+            return true;
+        };
 
         switch (p->type) {
             case INTERNAL_FUNCTION: {
@@ -884,33 +926,11 @@ void exec_job(parser_t &parser, job_t *j) {
 
                 if (block_output_io_buffer->out_buffer_size() > 0) {
                     // We don't have to drain threads here because our child process is simple.
-                    pid = execute_fork(false);
-                    if (pid == 0) {
-                        // This is the child process. Write out the contents of the pipeline.
-                        p->pid = getpid();
-                        blocked_pid = -1;
-                        child_set_group(j, p);
-                        // Make child processes pause after executing setup_child_process() to give down-chain
-                        // commands in the job a chance to join their process group and read their pipes.
-                        // The process will be resumed when the next command in the chain is started.
-                        if (block_child) {
-                            kill(p->pid, SIGSTOP);
-                        }
-                        setup_child_process(p, process_net_io_chain);
-
-                        exec_write_and_exit(block_output_io_buffer->fd, buffer, count, status);
-                    } else {
-                        // This is the parent process. Store away information on the child, and
-                        // possibly give it control over the terminal.
-                        debug(2, L"Fork #%d, pid %d: internal block or function for '%ls'",
-                              g_fork_count, pid, p->argv0());
-                        child_forked = true;
-                        if (block_child) {
-                            debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
-                        }
-                        p->pid = pid;
+                    if (!do_fork(false, "internal block or function", [&] {
+                            exec_write_and_exit(block_output_io_buffer->fd, buffer, count, status);
+                        })) {
+                        break;
                     }
-
                 } else {
                     if (p->is_last_in_job) {
                         proc_set_last_status(j->get_flag(JOB_NEGATE) ? (!status) : status);
@@ -1012,33 +1032,11 @@ void exec_job(parser_t &parser, job_t *j) {
 
                     fflush(stdout);
                     fflush(stderr);
-                    pid = execute_fork(false);
-                    if (pid == 0) {
-                        // This is the child process. Setup redirections, print correct output to
-                        // stdout and stderr, and then exit.
-                        p->pid = getpid();
-                        blocked_pid = -1;
-                        child_set_group(j, p);
-                        // Make child processes pause after executing setup_child_process() to give down-chain
-                        // commands in the job a chance to join their process group and read their pipes.
-                        // The process will be resumed when the next command in the chain is started.
-                        if (block_child) {
-                            kill(p->pid, SIGSTOP);
-                        }
-                        setup_child_process(p, process_net_io_chain);
-
-                        do_builtin_io(outbuff, outbuff_len, errbuff, errbuff_len);
-                        exit_without_destructors(p->status);
-                    } else {
-                        // This is the parent process. Store away information on the child, and
-                        // possibly give it control over the terminal.
-                        debug(2, L"Fork #%d, pid %d: internal builtin for '%ls'", g_fork_count, pid,
-                              p->argv0());
-                        child_forked = true;
-                        if (block_child) {
-                            debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
-                        }
-                        p->pid = pid;
+                    if (!do_fork(false, "internal builtin", [&] {
+                            do_builtin_io(outbuff, outbuff_len, errbuff, errbuff_len);
+                            exit_without_destructors(p->status);
+                        })) {
+                        break;
                     }
                 }
 
@@ -1110,34 +1108,10 @@ void exec_job(parser_t &parser, job_t *j) {
                 } else
 #endif
                 {
-                    pid = execute_fork(false);
-                    if (pid == 0) {
-                        // This is the child process.
-                        p->pid = getpid();
-                        blocked_pid = -1;
-                        child_set_group(j, p);
-                        // Make child processes pause after executing setup_child_process() to give down-chain
-                        // commands in the job a chance to join their process group and read their pipes.
-                        // The process will be resumed when the next command in the chain is started.
-                        if (block_child) {
-                            kill(p->pid, SIGSTOP);
-                        }
-                        setup_child_process(p, process_net_io_chain);
-
-                        safe_launch_process(p, actual_cmd, argv, envv);
-                        // safe_launch_process _never_ returns...
-                        DIE("safe_launch_process should not have returned");
-                    } else {
-                        debug(2, L"Fork #%d, pid %d: external command '%s' from '%ls'",
-                              g_fork_count, pid, p->argv0(), file ? file : L"<no file>");
-                        if (pid < 0) {
-                            job_mark_process_as_failed(j, p);
-                            exec_error = true;
-                        }
-                        child_forked = true;
-                        if (block_child) {
-                            debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
-                        }
+                    if (!do_fork(false, "internal builtin", [&] {
+                            safe_launch_process(p, actual_cmd, argv, envv);
+                        })) {
+                        break;
                     }
                 }
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -513,6 +513,7 @@ void exec_job(parser_t &parser, job_t *j) {
         const bool pipes_to_next_command = !p->is_last_in_job;
         //set to true if we end up forking for this process
         bool child_forked = false;
+        bool child_spawned = false;
 
         // The pipes the current process write to and read from. Unfortunately these can't be just
         // allocated on the stack, since j->io wants shared_ptr.
@@ -1087,6 +1088,9 @@ void exec_job(parser_t &parser, job_t *j) {
                         job_mark_process_as_failed(j, p);
                         exec_error = true;
                     }
+                    else {
+                        child_spawned = true;
+                    }
                 } else
 #endif
                 {
@@ -1128,7 +1132,11 @@ void exec_job(parser_t &parser, job_t *j) {
             }
         }
 
-        if (child_forked) {
+        if (child_spawned) {
+            child_set_group(j, p);
+            set_child_group(j, p->pid);
+        }
+        else if (child_forked) {
             //we have to wait to ensure the child has set their progress group and is in SIGSTOP state
             //otherwise, we can later call SIGCONT before they call SIGSTOP and they'll be blocked indefinitely.
             pid_t pid_status{};

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -410,7 +410,7 @@ void exec_job(parser_t &parser, job_t *j) {
         // It's known to be wrong - for example, it means that redirections bound for subsequent
         // commands in the pipeline will apply to exec. However, using exec in a pipeline doesn't
         // really make sense, so I'm not trying to fix it here.
-        if (!setup_child_process(j, 0, all_ios)) {
+        if (!setup_child_process(0, all_ios)) {
             // Decrement SHLVL as we're removing ourselves from the shell "stack".
             const env_var_t shlvl_str = env_get_string(L"SHLVL", ENV_GLOBAL | ENV_EXPORT);
             wcstring nshlvl_str = L"0";
@@ -892,7 +892,7 @@ void exec_job(parser_t &parser, job_t *j) {
                         if (block_child) {
                             kill(p->pid, SIGSTOP);
                         }
-                        setup_child_process(j, p, process_net_io_chain);
+                        setup_child_process(p, process_net_io_chain);
 
                         exec_write_and_exit(block_output_io_buffer->fd, buffer, count, status);
                     } else {
@@ -1021,7 +1021,7 @@ void exec_job(parser_t &parser, job_t *j) {
                         if (block_child) {
                             kill(p->pid, SIGSTOP);
                         }
-                        setup_child_process(j, p, process_net_io_chain);
+                        setup_child_process(p, process_net_io_chain);
 
                         do_builtin_io(outbuff, outbuff_len, errbuff, errbuff_len);
                         exit_without_destructors(p->status);
@@ -1118,7 +1118,7 @@ void exec_job(parser_t &parser, job_t *j) {
                         if (block_child) {
                             kill(p->pid, SIGSTOP);
                         }
-                        setup_child_process(j, p, process_net_io_chain);
+                        setup_child_process(p, process_net_io_chain);
 
                         safe_launch_process(p, actual_cmd, argv, envv);
                         // safe_launch_process _never_ returns...

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -934,11 +934,10 @@ void exec_job(parser_t &parser, job_t *j) {
                 // output, so that we can truncate the file. Does not apply to /dev/null.
                 bool must_fork = redirection_is_to_real_file(stdout_io.get()) ||
                                  redirection_is_to_real_file(stderr_io.get());
-                if (!must_fork) {
-                    //we are handling reads directly in the main loop. Make sure source is unblocked.
-                    unblock_previous();
-                }
                 if (!must_fork && p->is_last_in_job) {
+                    //we are handling reads directly in the main loop. Make sure source is unblocked.
+                    //Note that we may still end up forking.
+                    unblock_previous();
                     const bool stdout_is_to_buffer = stdout_io && stdout_io->io_mode == IO_BUFFER;
                     const bool no_stdout_output = stdout_buffer.empty();
                     const bool no_stderr_output = stderr_buffer.empty();

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -590,16 +590,6 @@ void exec_job(parser_t &parser, job_t *j) {
             }
             env_export_arr();
         }
-        else {
-            // Since the main loop itself is going to be (potentially) reading from the previous
-            // process, we need to unblock it here instead of after "executing" the next process
-            // in the chain.
-            if (blocked_pid != -1) {
-                //now that next command in the chain has been started, unblock the previous command
-                unblock_pid(blocked_pid);
-                blocked_pid = -1;
-            }
-        }
 
         // Set up fds that will be used in the pipe.
         if (pipes_to_next_command) {
@@ -640,12 +630,23 @@ void exec_job(parser_t &parser, job_t *j) {
         // This is the IO buffer we use for storing the output of a block or function when it is in
         // a pipeline.
         shared_ptr<io_buffer_t> block_output_io_buffer;
+        auto unblock_previous = [&] () {
+            if (blocked_pid != -1) {
+                //now that next command in the chain has been started, unblock the previous command
+                unblock_pid(blocked_pid);
+                blocked_pid = -1;
+            }
+        };
 
         // This is the io_streams we pass to internal builtins.
         std::unique_ptr<io_streams_t> builtin_io_streams;
 
         switch (p->type) {
             case INTERNAL_FUNCTION: {
+                //internal function never forks
+                //unblock previous (if any) to prevent hang
+                unblock_previous();
+
                 // Calls to function_get_definition might need to source a file as a part of
                 // autoloading, hence there must be no blocks.
                 signal_unblock();
@@ -824,6 +825,9 @@ void exec_job(parser_t &parser, job_t *j) {
 
                     signal_unblock();
 
+                    //main loop is performing a blocking read from previous command's output
+                    //make sure read source is not blocked
+                    unblock_previous();
                     p->status = builtin_run(parser, p->get_argv(), *builtin_io_streams);
 
                     signal_block();
@@ -944,6 +948,10 @@ void exec_job(parser_t &parser, job_t *j) {
                 // output, so that we can truncate the file. Does not apply to /dev/null.
                 bool must_fork = redirection_is_to_real_file(stdout_io.get()) ||
                                  redirection_is_to_real_file(stderr_io.get());
+                if (!must_fork) {
+                    //we are handling reads directly in the main loop. Make sure source is unblocked.
+                    unblock_previous();
+                }
                 if (!must_fork && p->is_last_in_job) {
                     const bool stdout_is_to_buffer = stdout_io && stdout_io->io_mode == IO_BUFFER;
                     const bool no_stdout_output = stdout_buffer.empty();
@@ -1157,12 +1165,9 @@ void exec_job(parser_t &parser, job_t *j) {
             }
         }
 
-        if (blocked_pid != -1) {
-            //now that next command in the chain has been started, unblock the previous command
-            unblock_pid(blocked_pid);
-            blocked_pid = -1;
-        }
 
+        //if the command we ran before this one was SIGSTOP'd to let this one catch up, unblock it now.
+        unblock_previous();
         if (command_blocked) {
             //store the newly-blocked command's PID so that it can be SIGCONT'd once the next process
             //in the chain is started. That may be in this job or in another job.

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -383,21 +384,6 @@ void exec_job(parser_t &parser, job_t *j) {
         return;
     }
 
-    auto unblock_pid = [] (pid_t blocked_pid) {
-        //this is correct, except there's a race condition if the child hasn't yet SIGSTOP'd
-        //in that case, they never receive the SIGCONT
-        pid_t pid_status{};
-        if (waitpid(blocked_pid, &pid_status, WUNTRACED) != -1) {
-            // if (WIFSTOPPED(pid_status)) {
-                debug(2, L"Unblocking process %d.\n", blocked_pid);
-                kill(blocked_pid, SIGCONT);
-                return true;
-            // }
-        }
-        debug(2, L"waitpid call in unblock_pid failed!\n");
-        return false;
-    };
-
     debug(4, L"Exec job '%ls' with id %d", j->command_wcstr(), j->job_id);
 
     // Verify that all IO_BUFFERs are output. We used to support a (single, hacked-in) magical input
@@ -483,14 +469,14 @@ void exec_job(parser_t &parser, job_t *j) {
         if (keepalive.pid == 0) {
             // Child
             keepalive.pid = getpid();
-            set_child_group(j, &keepalive, 1);
+            child_set_group(j, &keepalive);
             pause();
             exit_without_destructors(0);
         } else {
             // Parent
             debug(2, L"Fork #%d, pid %d: keepalive fork for '%ls'", g_fork_count, keepalive.pid,
                   j->command_wcstr());
-            set_child_group(j, &keepalive, 0);
+            set_child_group(j, keepalive.pid);
         }
     }
 
@@ -525,7 +511,8 @@ void exec_job(parser_t &parser, job_t *j) {
 
         // See if we need a pipe.
         const bool pipes_to_next_command = !p->is_last_in_job;
-        bool command_blocked = false;
+        //set to true if we end up forking for this process
+        bool child_forked = false;
 
         // The pipes the current process write to and read from. Unfortunately these can't be just
         // allocated on the stack, since j->io wants shared_ptr.
@@ -630,12 +617,16 @@ void exec_job(parser_t &parser, job_t *j) {
         // This is the IO buffer we use for storing the output of a block or function when it is in
         // a pipeline.
         shared_ptr<io_buffer_t> block_output_io_buffer;
-        auto unblock_previous = [&] () {
+
+        auto unblock_previous = [&j] () {
+            //we've already called waitpid after forking the child, so we've guaranteed that they're
+            //already SIGSTOP'd. Otherwise we'd be risking a deadlock because we can call SIGCONT before
+            //they've actually stopped, and they'll remain suspended indefinitely.
             if (blocked_pid != -1) {
-                //now that next command in the chain has been started, unblock the previous command
-                unblock_pid(blocked_pid);
-                blocked_pid = -1;
+                debug(2, L"Unblocking process %d.\n", blocked_pid);
+                kill(blocked_pid, SIGCONT);
             }
+            blocked_pid = -1;
         };
 
         // This is the io_streams we pass to internal builtins.
@@ -892,14 +883,10 @@ void exec_job(parser_t &parser, job_t *j) {
                         // This is the child process. Write out the contents of the pipeline.
                         p->pid = getpid();
                         setup_child_process(j, p, process_net_io_chain);
-                        // Start child processes that are part of a chain in a stopped state
-                        // to ensure that they are still running when the next command in the
-                        // chain is started.
+                        // Make child processes pause after executing setup_child_process() to give down-chain
+                        // commands in the job a chance to join their process group and read their pipes.
                         // The process will be resumed when the next command in the chain is started.
-                        // Note that this may span multiple jobs, as jobs can read from each other.
-                        if (pipes_to_next_command) {
-                            kill(p->pid, SIGSTOP);
-                        }
+                        kill(p->pid, SIGSTOP);
 
                         exec_write_and_exit(block_output_io_buffer->fd, buffer, count, status);
                     } else {
@@ -907,14 +894,9 @@ void exec_job(parser_t &parser, job_t *j) {
                         // possibly give it control over the terminal.
                         debug(2, L"Fork #%d, pid %d: internal block or function for '%ls'",
                               g_fork_count, pid, p->argv0());
-                        if (pipes_to_next_command) {
-                            //it actually blocked itself after forking above, but print in here for output
-                            //synchronization & so we can assign command_blocked in the correct address space
-                            debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
-                            command_blocked = true;
-                        }
+                        child_forked = true;
+                        debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
                         p->pid = pid;
-                        set_child_group(j, p, 0);
                     }
 
                 } else {
@@ -1025,14 +1007,11 @@ void exec_job(parser_t &parser, job_t *j) {
                         // stdout and stderr, and then exit.
                         p->pid = getpid();
                         setup_child_process(j, p, process_net_io_chain);
-                        // Start child processes that are part of a chain in a stopped state
-                        // to ensure that they are still running when the next command in the
-                        // chain is started.
+                        // Make child processes pause after executing setup_child_process() to give down-chain
+                        // commands in the job a chance to join their process group and read their pipes.
                         // The process will be resumed when the next command in the chain is started.
-                        // Note that this may span multiple jobs, as jobs can read from each other.
-                        if (pipes_to_next_command) {
-                            kill(p->pid, SIGSTOP);
-                        }
+                        kill(p->pid, SIGSTOP);
+
                         do_builtin_io(outbuff, outbuff_len, errbuff, errbuff_len);
                         exit_without_destructors(p->status);
                     } else {
@@ -1040,15 +1019,9 @@ void exec_job(parser_t &parser, job_t *j) {
                         // possibly give it control over the terminal.
                         debug(2, L"Fork #%d, pid %d: internal builtin for '%ls'", g_fork_count, pid,
                               p->argv0());
-                        if (pipes_to_next_command) {
-                            //it actually blocked itself after forking above, but print in here for output
-                            //synchronization & so we can assign command_blocked in the correct address space
-                            debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
-                            command_blocked = true;
-                        }
+                        child_forked = true;
+                        debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
                         p->pid = pid;
-
-                        set_child_group(j, p, 0);
                     }
                 }
 
@@ -1122,15 +1095,10 @@ void exec_job(parser_t &parser, job_t *j) {
                         // This is the child process.
                         p->pid = getpid();
                         setup_child_process(j, p, process_net_io_chain);
-
-                        // Start child processes that are part of a chain in a stopped state
-                        // to ensure that they are still running when the next command in the
-                        // chain is started.
+                        // Make child processes pause after executing setup_child_process() to give down-chain
+                        // commands in the job a chance to join their process group and read their pipes.
                         // The process will be resumed when the next command in the chain is started.
-                        // Note that this may span multiple jobs, as jobs can read from each other.
-                        if (pipes_to_next_command) {
-                            kill(p->pid, SIGSTOP);
-                        }
+                        kill(p->pid, SIGSTOP);
 
                         safe_launch_process(p, actual_cmd, argv, envv);
                         // safe_launch_process _never_ returns...
@@ -1142,19 +1110,14 @@ void exec_job(parser_t &parser, job_t *j) {
                             job_mark_process_as_failed(j, p);
                             exec_error = true;
                         }
-                        if (pipes_to_next_command) {
-                            //it actually blocked itself after forking above, but print in here for output
-                            //synchronization & so we can assign command_blocked in the correct address space
-                            debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
-                            command_blocked = true;
-                        }
+                        child_forked = true;
+                        debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
                     }
                 }
 
                 // This is the parent process. Store away information on the child, and possibly
                 // fice it control over the terminal.
                 p->pid = pid;
-                set_child_group(j, p, 0);
                 break;
             }
 
@@ -1165,10 +1128,31 @@ void exec_job(parser_t &parser, job_t *j) {
             }
         }
 
-
-        //if the command we ran before this one was SIGSTOP'd to let this one catch up, unblock it now.
+        if (child_forked) {
+            //we have to wait to ensure the child has set their progress group and is in SIGSTOP state
+            //otherwise, we can later call SIGCONT before they call SIGSTOP and they'll be blocked indefinitely.
+            pid_t pid_status{};
+            if (waitpid(p->pid, &pid_status, WUNTRACED) != -1) {
+                //the child is SIGSTOP'd and is guaranteed to have called child_set_group() at this point.
+                set_child_group(j, p->pid); //update our own process group info to match
+                //we are not unblocking the child via SIGCONT just yet to give the next process a chance to open
+                //the pipes and join the process group. We only unblock the last process in the job chain because
+                //no one awaits it.
+                if (!pipes_to_next_command)
+                {
+                    kill(p->pid, SIGCONT);
+                }
+            }
+            else {
+                debug(2, L"waitpid(%d) call in unblock_pid failed:!\n", p->pid);
+                wperror(L"waitpid");
+            }
+        }
+        //if the command we ran _before_ this one was SIGSTOP'd to let this one catch up, unblock it now.
+        //this must be after the wait_pid on the process we just started, if any.
         unblock_previous();
-        if (command_blocked) {
+
+        if (child_forked) {
             //store the newly-blocked command's PID so that it can be SIGCONT'd once the next process
             //in the chain is started. That may be in this job or in another job.
             blocked_pid = p->pid;

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <sys/mman.h>
+#include <semaphore.h>
 
 #include "builtin.h"
 #include "common.h"
@@ -491,6 +493,7 @@ void exec_job(parser_t &parser, job_t *j) {
     //
     // We are careful to set these to -1 when closed, so if we exit the loop abruptly, we can still
     // close them.
+    sem_t *chained_wait_prev = nullptr;
     int pipe_current_read = -1, pipe_current_write = -1, pipe_next_read = -1;
     for (std::unique_ptr<process_t> &unique_p : j->processes) {
         if (exec_error) {
@@ -508,6 +511,14 @@ void exec_job(parser_t &parser, job_t *j) {
 
         // See if we need a pipe.
         const bool pipes_to_next_command = !p->is_last_in_job;
+
+        //these semaphores will be used to make sure the first process lives long enough for the
+        //next process in the chain to open its handles, process group, etc.
+        //this child will block on this one, the next child will have to call sem_post against it.
+        sem_t *chained_wait_next = !pipes_to_next_command ? nullptr : (sem_t*)mmap(NULL, sizeof(sem_t*), PROT_READ|PROT_WRITE,MAP_SHARED|MAP_ANONYMOUS,-1, 0);
+        if (chained_wait_next != nullptr) {
+            sem_init(chained_wait_next, 1, 0);
+        }
 
         // The pipes the current process write to and read from. Unfortunately these can't be just
         // allocated on the stack, since j->io wants shared_ptr.
@@ -1055,6 +1066,14 @@ void exec_job(parser_t &parser, job_t *j) {
                 {
                     pid = execute_fork(false);
                     if (pid == 0) {
+                        // a hack that fixes any tcsetpgrp errors caused by race conditions
+                        // usleep(20 * 1000);
+                        if (chained_wait_next != nullptr) {
+                            debug(3, L"Waiting for next command in chain to start.\n");
+                            sem_wait(chained_wait_next);
+                            sem_destroy(chained_wait_next);
+                            munmap(chained_wait_next, sizeof(sem_t));
+                        }
                         // This is the child process.
                         p->pid = getpid();
                         setup_child_process(j, p, process_net_io_chain);
@@ -1095,6 +1114,16 @@ void exec_job(parser_t &parser, job_t *j) {
         if (pipe_current_write >= 0) {
             exec_close(pipe_current_write);
             pipe_current_write = -1;
+        }
+
+        //now that next command in the chain has been started, unblock the previous command
+        if (chained_wait_prev != nullptr) {
+            debug(3, L"Unblocking previous command in chain.\n");
+            sem_post(chained_wait_prev);
+            munmap(chained_wait_prev, sizeof(sem_t));
+        }
+        if (chained_wait_next != nullptr) {
+            chained_wait_prev = chained_wait_next;
         }
     }
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -511,10 +511,6 @@ void exec_job(parser_t &parser, job_t *j) {
         const bool pipes_to_next_command = !p->is_last_in_job;
         bool command_blocked = false;
 
-        //these semaphores will be used to make sure the first process lives long enough for the
-        //next process in the chain to open its handles, process group, etc.
-        //this child will block on this one, the next child will have to call sem_post against it.
-
         // The pipes the current process write to and read from. Unfortunately these can't be just
         // allocated on the stack, since j->io wants shared_ptr.
         //

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -23,8 +23,6 @@
 #include <string>
 #include <type_traits>
 #include <vector>
-#include <sys/mman.h>
-#include <semaphore.h>
 
 #include "builtin.h"
 #include "common.h"
@@ -493,7 +491,7 @@ void exec_job(parser_t &parser, job_t *j) {
     //
     // We are careful to set these to -1 when closed, so if we exit the loop abruptly, we can still
     // close them.
-    sem_t *chained_wait_prev = nullptr;
+    int last_pid = -1;
     int pipe_current_read = -1, pipe_current_write = -1, pipe_next_read = -1;
     for (std::unique_ptr<process_t> &unique_p : j->processes) {
         if (exec_error) {
@@ -515,10 +513,6 @@ void exec_job(parser_t &parser, job_t *j) {
         //these semaphores will be used to make sure the first process lives long enough for the
         //next process in the chain to open its handles, process group, etc.
         //this child will block on this one, the next child will have to call sem_post against it.
-        sem_t *chained_wait_next = !pipes_to_next_command ? nullptr : (sem_t*)mmap(NULL, sizeof(sem_t*), PROT_READ|PROT_WRITE,MAP_SHARED|MAP_ANONYMOUS,-1, 0);
-        if (chained_wait_next != nullptr) {
-            sem_init(chained_wait_next, 1, 0);
-        }
 
         // The pipes the current process write to and read from. Unfortunately these can't be just
         // allocated on the stack, since j->io wants shared_ptr.
@@ -1066,17 +1060,17 @@ void exec_job(parser_t &parser, job_t *j) {
                 {
                     pid = execute_fork(false);
                     if (pid == 0) {
-                        // usleep is a hack that fixes any tcsetpgrp errors caused by race conditions
-                        // usleep(20 * 1000);
-                        // it should no longer be needed with the chained_wait_next code below.
-                        if (chained_wait_next != nullptr) {
-                            debug(3, L"Waiting for next command in chain to start.\n");
-                            sem_wait(chained_wait_next);
-                            sem_destroy(chained_wait_next);
-                            munmap(chained_wait_next, sizeof(sem_t));
-                        }
                         // This is the child process.
                         p->pid = getpid();
+                        // start child processes that are part of a job in a stopped state
+                        // to ensure that they are still running when the next command in the
+                        // chain is started.
+                        if (pipes_to_next_command) {
+                            debug(3, L"Blocking process %d waiting for next command in chain.\n", p->pid);
+                            kill(p->pid, SIGSTOP);
+                        }
+                        // the process will be resumed by the shell when the next command in the
+                        // chain is started
                         setup_child_process(j, p, process_net_io_chain);
                         safe_launch_process(p, actual_cmd, argv, envv);
                         // safe_launch_process _never_ returns...
@@ -1118,14 +1112,12 @@ void exec_job(parser_t &parser, job_t *j) {
         }
 
         //now that next command in the chain has been started, unblock the previous command
-        if (chained_wait_prev != nullptr) {
-            debug(3, L"Unblocking previous command in chain.\n");
-            sem_post(chained_wait_prev);
-            munmap(chained_wait_prev, sizeof(sem_t));
-            chained_wait_prev = nullptr;
+        if (last_pid != -1) {
+            debug(3, L"Unblocking process %d.\n", last_pid);
+            kill(last_pid, SIGCONT);
         }
-        if (chained_wait_next != nullptr) {
-            chained_wait_prev = chained_wait_next;
+        if (pid != 0) {
+            last_pid = pid;
         }
     }
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -493,6 +493,7 @@ void exec_job(parser_t &parser, job_t *j) {
     //
     // We are careful to set these to -1 when closed, so if we exit the loop abruptly, we can still
     // close them.
+    bool pgrp_set = false;
     static pid_t blocked_pid = -1;
     int pipe_current_read = -1, pipe_current_write = -1, pipe_next_read = -1;
     for (std::unique_ptr<process_t> &unique_p : j->processes) {
@@ -514,6 +515,7 @@ void exec_job(parser_t &parser, job_t *j) {
         //set to true if we end up forking for this process
         bool child_forked = false;
         bool child_spawned = false;
+        // bool child_blocked = false;
 
         // The pipes the current process write to and read from. Unfortunately these can't be just
         // allocated on the stack, since j->io wants shared_ptr.
@@ -635,10 +637,6 @@ void exec_job(parser_t &parser, job_t *j) {
 
         switch (p->type) {
             case INTERNAL_FUNCTION: {
-                //internal function never forks
-                //unblock previous (if any) to prevent hang
-                unblock_previous();
-
                 // Calls to function_get_definition might need to source a file as a part of
                 // autoloading, hence there must be no blocks.
                 signal_unblock();
@@ -815,11 +813,12 @@ void exec_job(parser_t &parser, job_t *j) {
                     const int fg = j->get_flag(JOB_FOREGROUND);
                     j->set_flag(JOB_FOREGROUND, false);
 
-                    signal_unblock();
-
                     //main loop is performing a blocking read from previous command's output
                     //make sure read source is not blocked
                     unblock_previous();
+
+                    signal_unblock();
+
                     p->status = builtin_run(parser, p->get_argv(), *builtin_io_streams);
 
                     signal_block();
@@ -887,7 +886,9 @@ void exec_job(parser_t &parser, job_t *j) {
                         // Make child processes pause after executing setup_child_process() to give down-chain
                         // commands in the job a chance to join their process group and read their pipes.
                         // The process will be resumed when the next command in the chain is started.
-                        kill(p->pid, SIGSTOP);
+                        if (pipes_to_next_command) {
+                            kill(p->pid, SIGSTOP);
+                        }
 
                         exec_write_and_exit(block_output_io_buffer->fd, buffer, count, status);
                     } else {
@@ -896,7 +897,9 @@ void exec_job(parser_t &parser, job_t *j) {
                         debug(2, L"Fork #%d, pid %d: internal block or function for '%ls'",
                               g_fork_count, pid, p->argv0());
                         child_forked = true;
-                        debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
+                        if (pipes_to_next_command) {
+                            debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
+                        }
                         p->pid = pid;
                     }
 
@@ -1011,7 +1014,9 @@ void exec_job(parser_t &parser, job_t *j) {
                         // Make child processes pause after executing setup_child_process() to give down-chain
                         // commands in the job a chance to join their process group and read their pipes.
                         // The process will be resumed when the next command in the chain is started.
-                        kill(p->pid, SIGSTOP);
+                        if (pipes_to_next_command) {
+                            kill(p->pid, SIGSTOP);
+                        }
 
                         do_builtin_io(outbuff, outbuff_len, errbuff, errbuff_len);
                         exit_without_destructors(p->status);
@@ -1021,7 +1026,9 @@ void exec_job(parser_t &parser, job_t *j) {
                         debug(2, L"Fork #%d, pid %d: internal builtin for '%ls'", g_fork_count, pid,
                               p->argv0());
                         child_forked = true;
-                        debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
+                        if (pipes_to_next_command) {
+                            debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
+                        }
                         p->pid = pid;
                     }
                 }
@@ -1102,7 +1109,9 @@ void exec_job(parser_t &parser, job_t *j) {
                         // Make child processes pause after executing setup_child_process() to give down-chain
                         // commands in the job a chance to join their process group and read their pipes.
                         // The process will be resumed when the next command in the chain is started.
-                        kill(p->pid, SIGSTOP);
+                        if (pipes_to_next_command) {
+                            kill(p->pid, SIGSTOP);
+                        }
 
                         safe_launch_process(p, actual_cmd, argv, envv);
                         // safe_launch_process _never_ returns...
@@ -1115,7 +1124,9 @@ void exec_job(parser_t &parser, job_t *j) {
                             exec_error = true;
                         }
                         child_forked = true;
-                        debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
+                        if (pipes_to_next_command) {
+                            debug(2, L"Blocking process %d waiting for next command in chain.\n", pid);
+                        }
                     }
                 }
 
@@ -1132,35 +1143,39 @@ void exec_job(parser_t &parser, job_t *j) {
             }
         }
 
-        if (child_spawned) {
-            //posix_spawn'd processes won't SIGSTOP
-            set_child_group(j, p->pid);
-        }
-        else if (child_forked) {
+        bool child_blocked = child_forked && pipes_to_next_command; //to make things clearer below
+        if (child_blocked) {
             //we have to wait to ensure the child has set their progress group and is in SIGSTOP state
             //otherwise, we can later call SIGCONT before they call SIGSTOP and they'll be blocked indefinitely.
+            //The child is SIGSTOP'd and is guaranteed to have called child_set_group() at this point.
+            //but we only need to call set_child_group for the first process in the group.
+            //If needs_keepalive is set, this has already been called for the keepalive process
             pid_t pid_status{};
-            if (waitpid(p->pid, &pid_status, WUNTRACED) != -1) {
-                //the child is SIGSTOP'd and is guaranteed to have called child_set_group() at this point.
-                //but we only need to call set_child_group for the first process in the group.
-                //If needs_keepalive is set, this has already been called for the keepalive process
-                if (p->is_first_in_job) {
-                    set_child_group(j, p->pid);
-                }
-                //we are not unblocking the child via SIGCONT just yet to give the next process a chance to open
-                //the pipes and join the process group. We only unblock the last process in the job chain because
-                //no one awaits it.
-            }
-            else {
+            if (waitpid(p->pid, &pid_status, WUNTRACED) == -1) {
+                exec_error = true;
                 debug(1, L"waitpid(%d) call in unblock_pid failed:!\n", p->pid);
                 wperror(L"waitpid");
+                break;
+            }
+            //we are not unblocking the child via SIGCONT just yet to give the next process a chance to open
+            //the pipes and join the process group. We only unblock the last process in the job chain because
+            //no one awaits it.
+        }
+        //regardless of whether the child blocked or not:
+        if (child_spawned || child_forked) {
+            //this should be called after waitpid if child_forked && pipes_to_next_command
+            //it can be called at any time if child_spawned
+            if (!pgrp_set) {
+                set_child_group(j, p->pid);
+                //only once per job, and only once we've executed an external command for real
+                pgrp_set = true;
             }
         }
         //if the command we ran _before_ this one was SIGSTOP'd to let this one catch up, unblock it now.
         //this must be after the wait_pid on the process we just started, if any.
         unblock_previous();
 
-        if (child_forked) {
+        if (child_blocked) {
             //store the newly-blocked command's PID so that it can be SIGCONT'd once the next process
             //in the chain is started. That may be in this job or in another job.
             blocked_pid = p->pid;

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -83,7 +83,7 @@ bool child_set_group(job_t *j, process_t *p) {
         //times to get the kernel to see the new group. (Linux 4.4.0)
         int failure = setpgid(p->pid, j->pgid);
         while (failure == -1 && (errno == EPERM || errno == EINTR)) {
-            debug_safe(2, "Retrying setpgid in child process");
+            debug_safe(1, "Retrying setpgid in child process");
             failure = setpgid(p->pid, j->pgid);
         }
         // TODO: Figure out why we're testing whether the pgid is correct after attempting to
@@ -149,7 +149,8 @@ bool set_child_group(job_t *j, pid_t child_pid) {
             //handle it)..
             debug(4, L"Process group %d already has control of terminal\n", j->pgid);
         }
-        else {
+        else
+        {
             //no need to duplicate the code here, a function already exists that does just this
             retval = terminal_give_to_job(j, false /*new job, so not continuing*/);
         }
@@ -266,7 +267,7 @@ int setup_child_process(job_t *j, process_t *p, const io_chain_t &io_chain) {
         //In the case of IO_FILE, this can hang until data is available to read/write!
         ok = (0 == handle_child_io(io_chain));
         if (p != 0 && !ok) {
-            debug_safe(0, "p!=0 && !ok");
+            debug_safe(4, "handle_child_io failed in setup_child_process");
             exit_without_destructors(1);
         }
     }
@@ -293,6 +294,7 @@ pid_t execute_fork(bool wait_for_threads_to_die) {
         // Make sure we have no outstanding threads before we fork. This is a pretty sketchy thing
         // to do here, both because exec.cpp shouldn't have to know about iothreads, and because the
         // completion handlers may do unexpected things.
+        debug_safe(4, "waiting for threads to drain.");
         iothread_drain_all();
     }
 

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -82,8 +82,9 @@ bool child_set_group(job_t *j, process_t *p) {
         //because we are SIGSTOPing the previous job in the chain. Sometimes we have to try a few
         //times to get the kernel to see the new group. (Linux 4.4.0)
         int failure = setpgid(p->pid, j->pgid);
-        while (failure == -1 && errno == EPERM) {
+        while (failure == -1 && (errno == EPERM || errno == EINTR)) {
             debug_safe(2, "Retrying setpgid in child process");
+            failure = setpgid(p->pid, j->pgid);
         }
         // TODO: Figure out why we're testing whether the pgid is correct after attempting to
         // set it failed. This was added in commit 4e912ef8 from 2012-02-27.

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -260,7 +260,7 @@ static int handle_child_io(const io_chain_t &io_chain) {
     return 0;
 }
 
-int setup_child_process(job_t *j, process_t *p, const io_chain_t &io_chain) {
+int setup_child_process(process_t *p, const io_chain_t &io_chain) {
     bool ok = true;
 
     if (ok) {

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -83,7 +83,7 @@ bool child_set_group(job_t *j, process_t *p) {
         //times to get the kernel to see the new group. (Linux 4.4.0)
         int failure = setpgid(p->pid, j->pgid);
         while (failure == -1 && (errno == EPERM || errno == EINTR)) {
-            debug_safe(1, "Retrying setpgid in child process");
+            debug_safe(4, "Retrying setpgid in child process");
             failure = setpgid(p->pid, j->pgid);
         }
         // TODO: Figure out why we're testing whether the pgid is correct after attempting to

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -59,14 +59,18 @@ static void debug_safe_int(int level, const char *format, int val) {
     debug_safe(level, format, buff);
 }
 
-/// This function should be called by both the parent process and the child right after fork() has
-/// been called. If job control is enabled, the child is put in the jobs group, and if the child is
-/// also in the foreground, it is also given control of the terminal. When called in the parent
-/// process, this function may fail, since the child might have already finished and called exit.
-/// The parent process may safely ignore the exit status of this call.
+/// Called only by the child to set its own process group (possibly creating a new group in the
+/// process if it is the first in a JOB_CONTROL job. The parent will wait for this to finish.
+/// A process that isn't already in control of the terminal can't give itself control of the
+/// terminal without hanging, but it's not right for the child to try and give itself control
+/// from the very beginning because the parent may not have gotten around to doing so yet. Let
+/// the parent figure it out; if the child doesn't have terminal control and it later tries to
+/// read from the terminal, the kernel will send it SIGTTIN and it'll hang anyway.
+/// The key here is that the parent should transfer control of the terminal (if appropriate)
+/// prior to sending the child SIGCONT to wake it up to exec.
 ///
 /// Returns true on sucess, false on failiure.
-bool set_child_group(job_t *j, process_t *p, int print_errors) {
+bool child_set_group(job_t *j, process_t *p) {
     bool retval = true;
 
     if (j->get_flag(JOB_CONTROL)) {
@@ -74,32 +78,53 @@ bool set_child_group(job_t *j, process_t *p, int print_errors) {
         if (j->pgid == -2) {
             j->pgid = p->pid;
         }
+        int failure = setpgid(p->pid, j->pgid);
+        // TODO: Figure out why we're testing whether the pgid is correct after attempting to
+        // set it failed. This was added in commit 4e912ef8 from 2012-02-27.
+        failure = failure && getpgid(p->pid) != j->pgid;
+        if (failure) {  //!OCLINT(collapsible if statements)
+            char pid_buff[128];
+            char job_id_buff[128];
+            char getpgid_buff[128];
+            char job_pgid_buff[128];
+            char argv0[64];
+            char command[64];
 
-        if (setpgid(p->pid, j->pgid)) {  //!OCLINT(collapsible if statements)
-            // TODO: Figure out why we're testing whether the pgid is correct after attempting to
-            // set it failed. This was added in commit 4e912ef8 from 2012-02-27.
-            if (getpgid(p->pid) != j->pgid && print_errors) {
-                char pid_buff[128];
-                char job_id_buff[128];
-                char getpgid_buff[128];
-                char job_pgid_buff[128];
-                char argv0[64];
-                char command[64];
+            format_long_safe(pid_buff, p->pid);
+            format_long_safe(job_id_buff, j->job_id);
+            format_long_safe(getpgid_buff, getpgid(p->pid));
+            format_long_safe(job_pgid_buff, j->pgid);
+            narrow_string_safe(argv0, p->argv0());
+            narrow_string_safe(command, j->command_wcstr());
 
-                format_long_safe(pid_buff, p->pid);
-                format_long_safe(job_id_buff, j->job_id);
-                format_long_safe(getpgid_buff, getpgid(p->pid));
-                format_long_safe(job_pgid_buff, j->pgid);
-                narrow_string_safe(argv0, p->argv0());
-                narrow_string_safe(command, j->command_wcstr());
+            debug_safe(
+                1, "Could not send own process %s, '%s' in job %s, '%s' from group %s to group %s",
+                pid_buff, argv0, job_id_buff, command, getpgid_buff, job_pgid_buff);
 
-                debug_safe(
-                    1, "Could not send process %s, '%s' in job %s, '%s' from group %s to group %s",
-                    pid_buff, argv0, job_id_buff, command, getpgid_buff, job_pgid_buff);
+            safe_perror("setpgid");
+            retval = false;
+        }
+    } else {
+        //this is probably stays unused in the child
+        j->pgid = getpgrp();
+    }
 
-                safe_perror("setpgid");
-                retval = false;
-            }
+    return retval;
+}
+
+/// Called only by the parent only after a child forks and successfully calls child_set_group, guaranteeing
+/// the job control process group has been created and that the child belongs to the correct process group.
+/// Here we can update our job_t structure to reflect the correct process group in the case of JOB_CONTROL,
+/// and we can give the new process group control of the terminal if it's to run in the foreground. Note that
+/// we can guarantee the child won't try to read from the terminal before we've had a chance to run this code,
+/// because we haven't woken them up with a SIGCONT yet.
+bool set_child_group(job_t *j, pid_t child_pid) {
+    bool retval = true;
+
+    if (j->get_flag(JOB_CONTROL)) {
+        // New jobs have the pgid set to -2
+        if (j->pgid == -2) {
+            j->pgid = child_pid;
         }
     } else {
         j->pgid = getpgrp();
@@ -107,33 +132,16 @@ bool set_child_group(job_t *j, process_t *p, int print_errors) {
 
     if (j->get_flag(JOB_TERMINAL) && j->get_flag(JOB_FOREGROUND)) {  //!OCLINT(early exit)
         if (tcgetpgrp(STDIN_FILENO) == j->pgid) {
+            //we've already assigned the process group control of the terminal when the first process in the job
+            //was started. There's no need to do so again, and on some platforms this can cause an EPERM error.
+            //In addition, if we've given control of the terminal to a process group, attempting to call tcsetpgrp
+            //from the background will cause SIGTTOU to be sent to everything in our process group (unless we
+            //handle it)..
             debug(4, L"Process group %d already has control of terminal\n", j->pgid);
         }
         else {
-            debug(4, L"Attempting bring process group to foreground via tcsetpgrp for job->pgid %d\n", j->pgid);
-            debug(4, L"caller session id: %d, pgid %d has session id: %d\n", getsid(0), j->pgid, getsid(j->pgid));
-            int result = -1;
-            errno = EINTR;
-            while (result == -1 && errno == EINTR) {
-                signal_block(true);
-                result = tcsetpgrp(STDIN_FILENO, j->pgid);
-                signal_unblock(true);
-            }
-            if (result == -1) {
-                if (errno == ENOTTY) redirect_tty_output();
-                if (print_errors) {
-                    char job_id_buff[64];
-                    char command_buff[64];
-                    char job_pgid_buff[128];
-                    format_long_safe(job_id_buff, j->job_id);
-                    narrow_string_safe(command_buff, j->command_wcstr());
-                    format_long_safe(job_pgid_buff, j->pgid);
-                    debug_safe(1, "Could not send job %s ('%s') with pgid %s to foreground", job_id_buff,
-                               command_buff, job_pgid_buff);
-                    safe_perror("tcsetpgrp");
-                    retval = false;
-                }
-            }
+            //no need to duplicate the code here, a function already exists that does just this
+            retval = terminal_give_to_job(j, false /*new job, so not continuing*/);
         }
     }
 
@@ -242,10 +250,10 @@ static int handle_child_io(const io_chain_t &io_chain) {
 }
 
 int setup_child_process(job_t *j, process_t *p, const io_chain_t &io_chain) {
-    bool ok = true;
+    bool ok = false;
 
     if (p) {
-        ok = set_child_group(j, p, 1);
+        ok = child_set_group(j, p);
     }
 
     if (ok) {

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -78,7 +78,13 @@ bool child_set_group(job_t *j, process_t *p) {
         if (j->pgid == -2) {
             j->pgid = p->pid;
         }
+        //retry on EPERM because there's no way that a child cannot join an existing progress group
+        //because we are SIGSTOPing the previous job in the chain. Sometimes we have to try a few
+        //times to get the kernel to see the new group. (Linux 4.4.0)
         int failure = setpgid(p->pid, j->pgid);
+        while (failure == -1 && errno == EPERM) {
+            debug_safe(2, "Retrying setpgid in child process");
+        }
         // TODO: Figure out why we're testing whether the pgid is correct after attempting to
         // set it failed. This was added in commit 4e912ef8 from 2012-02-27.
         failure = failure && getpgid(p->pid) != j->pgid;

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -125,6 +125,9 @@ bool child_set_group(job_t *j, process_t *p) {
 /// and we can give the new process group control of the terminal if it's to run in the foreground. Note that
 /// we can guarantee the child won't try to read from the terminal before we've had a chance to run this code,
 /// because we haven't woken them up with a SIGCONT yet.
+/// This musn't be called as a part of setup_child_process because that can hang indefinitely until data is
+/// available to read/write in the case of IO_FILE, which means we'll never reach our SIGSTOP and everything
+/// hangs.
 bool set_child_group(job_t *j, pid_t child_pid) {
     bool retval = true;
 
@@ -259,14 +262,11 @@ static int handle_child_io(const io_chain_t &io_chain) {
 int setup_child_process(job_t *j, process_t *p, const io_chain_t &io_chain) {
     bool ok = true;
 
-    //p is zero when EXEC_INTERNAL
-    if (p) {
-        ok = child_set_group(j, p);
-    }
-
     if (ok) {
+        //In the case of IO_FILE, this can hang until data is available to read/write!
         ok = (0 == handle_child_io(io_chain));
         if (p != 0 && !ok) {
+            debug_safe(0, "p!=0 && !ok");
             exit_without_destructors(1);
         }
     }

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -250,8 +250,9 @@ static int handle_child_io(const io_chain_t &io_chain) {
 }
 
 int setup_child_process(job_t *j, process_t *p, const io_chain_t &io_chain) {
-    bool ok = false;
+    bool ok = true;
 
+    //p is zero when EXEC_INTERNAL
     if (p) {
         ok = child_set_group(j, p);
     }

--- a/src/postfork.h
+++ b/src/postfork.h
@@ -33,7 +33,7 @@ bool child_set_group(job_t *j, process_t *p); //called by child
 ///
 /// \return 0 on sucess, -1 on failiure. When this function returns, signals are always unblocked.
 /// On failiure, signal handlers, io redirections and process group of the process is undefined.
-int setup_child_process(job_t *j, process_t *p, const io_chain_t &io_chain);
+int setup_child_process(process_t *p, const io_chain_t &io_chain);
 
 /// Call fork(), optionally waiting until we are no longer multithreaded. If the forked child
 /// doesn't do anything that could allocate memory, take a lock, etc. (like call exec), then it's

--- a/src/postfork.h
+++ b/src/postfork.h
@@ -18,7 +18,8 @@ class io_chain_t;
 class job_t;
 class process_t;
 
-bool set_child_group(job_t *j, process_t *p, int print_errors);
+bool set_child_group(job_t *j, pid_t child_pid); //called by parent
+bool child_set_group(job_t *j, process_t *p); //called by child
 
 /// Initialize a new child process. This should be called right away after forking in the child
 /// process. If job control is enabled for this job, the process is put in the process group of the

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -782,7 +782,7 @@ static void read_try(job_t *j) {
 /// \param j The job to give the terminal to.
 /// \param cont If this variable is set, we are giving back control to a job that has previously
 /// been stopped. In that case, we need to set the terminal attributes to those saved in the job.
-static bool terminal_give_to_job(job_t *j, int cont) {
+bool terminal_give_to_job(job_t *j, int cont) {
     errno = 0;
     if (j->pgid == 0) {
         debug(2, "terminal_give_to_job() returning early due to no process group");

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -906,7 +906,9 @@ void job_continue(job_t *j, bool cont) {
     j->set_flag(JOB_NOTIFIED, false);
 
     CHECK_BLOCK();
-    debug(4, L"Continue job %d, gid %d (%ls), %ls, %ls", j->job_id, j->pgid, j->command_wcstr(),
+    debug(4, L"%ls job %d, gid %d (%ls), %ls, %ls",
+          cont ? L"Continue" : L"Start",
+          j->job_id, j->pgid, j->command_wcstr(),
           job_is_completed(j) ? L"COMPLETED" : L"UNCOMPLETED",
           is_interactive ? L"INTERACTIVE" : L"NON-INTERACTIVE");
 

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -791,10 +791,7 @@ bool terminal_give_to_job(job_t *j, int cont) {
 
     signal_block(true);
 
-    //Previously, terminal_give_to_job was being called for each process in a job, hence all the comments
-    //and warnings below. It is now only called for the first process in a job.t d
-
-    //it may not be safe to call tcsetpgrp if we've already done so, as at that point we are no longer
+    //It may not be safe to call tcsetpgrp if we've already done so, as at that point we are no longer
     //the controlling process group for the terminal and no longer have permission to set the process
     //group that is in control, causing tcsetpgrp to return EPERM, even though that's not the documented
     //behavior in tcsetpgrp(3), which instead says other bad things will happen (it says SIGTTOU will be
@@ -807,8 +804,7 @@ bool terminal_give_to_job(job_t *j, int cont) {
         debug(2, L"Process group %d already has control of terminal\n", j->pgid);
     }
     else {
-        debug(4, L"Attempting bring process group to foreground via tcsetpgrp for job->pgid %d\n", j->pgid);
-        debug(4, L"caller session id: %d, pgid %d has session id: %d\n", getsid(0), j->pgid, getsid(j->pgid));
+        debug(4, L"Attempting to bring process group to foreground via tcsetpgrp for job->pgid %d\n", j->pgid);
 
         //the tcsetpgrp(2) man page says that EPERM is thrown if "pgrp has a supported value, but is not the
         //process group ID of a process in the same session as the calling process."
@@ -819,22 +815,15 @@ bool terminal_give_to_job(job_t *j, int cont) {
         //thing is that we can guarantee the process isn't going to exit while we wait (which would cause us to
         //possibly block indefinitely).
 
-        auto pgroupTerminated = [&j]() {
-            //everyone in the process group has exited
-            //The only way that can happen is if the very last process in the group terminated, and didn't need
-            //to access the terminal, otherwise it would have hung waiting for terminal IO. We can ignore this.
-            debug(3, L"terminal_give_to_job(): tcsetpgrp called but process group %d has terminated.\n", j->pgid);
-        };
-
         while (tcsetpgrp(STDIN_FILENO, j->pgid) != 0) {
+            bool pgroup_terminated = false;
             if (errno == EINTR) {
-                //always retry on EINTR
+                //always retry on EINTR, see comments in tcsetattr EINTR code below.
             }
             else if (errno == EINVAL) {
                 //OS X returns EINVAL if the process group no longer lives. Probably other OSes, too.
-                //See comments in pgroupTerminated() above.
-                pgroupTerminated();
-                break;
+                //Unlike EPERM below, EINVAL can only happen if the process group has terminated
+                pgroup_terminated = true;
             }
             else if (errno == EPERM) {
                 //retry so long as this isn't because the process group is dead
@@ -844,18 +833,28 @@ bool terminal_give_to_job(job_t *j, int cont) {
                     //because no such process group exists any longer. This is the observed behavior on Linux 4.4.0.
                     //a "success" result would mean processes from the group still exist but is still running in some state
                     //or the other.
-                    //See comments in pgroupTerminated() above.
-                    pgroupTerminated();
-                    break;
+                    pgroup_terminated = true;
                 }
-                debug(2, L"terminal_give_to_job(): EPERM.\n", j->pgid);
+                else {
+                    //debug the original tcsetpgrp error (not the waitpid errno) to the log, and then retry until not EPERM
+                    //or the process group has exited.
+                    debug(2, L"terminal_give_to_job(): EPERM.\n", j->pgid);
+                }
             }
             else {
                 if (errno == ENOTTY) redirect_tty_output();
-                debug(1, _(L"terminal_give_to_job(): Could not send job %d ('%ls') with pgid %d to foreground"), j->job_id, j->command_wcstr(), j->pgid);
+                debug(1, _(L"Could not send job %d ('%ls') with pgid %d to foreground"), j->job_id, j->command_wcstr(), j->pgid);
                 wperror(L"tcsetpgrp");
                 signal_unblock(true);
                 return false;
+            }
+
+            if (pgroup_terminated) {
+                //all processes in the process group has exited. Since we force all child procs to SIGSTOP on startup,
+                //the only way that can happen is if the very last process in the group terminated, and didn't need
+                //to access the terminal, otherwise it would have hung waiting for terminal IO (SIGTTIN). We can ignore this.
+                debug(3, L"tcsetpgrp called but process group %d has terminated.\n", j->pgid);
+                break;
             }
         }
     }
@@ -871,8 +870,7 @@ bool terminal_give_to_job(job_t *j, int cont) {
         }
         if (result == -1) {
             if (errno == ENOTTY) redirect_tty_output();
-            debug(1, _(L"terminal_give_to_job(): Could not send job %d ('%ls') to foreground"),
-                  j->job_id, j->command_wcstr());
+            debug(1, _(L"Could not send job %d ('%ls') to foreground"), j->job_id, j->command_wcstr());
             wperror(L"tcsetattr");
             signal_unblock(true);
             return false;

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -819,22 +819,33 @@ bool terminal_give_to_job(job_t *j, int cont) {
         //thing is that we can guarantee the process isn't going to exit while we wait (which would cause us to
         //possibly block indefinitely).
 
+        auto pgroupTerminated = [&j]() {
+            //everyone in the process group has exited
+            //The only way that can happen is if the very last process in the group terminated, and didn't need
+            //to access the terminal, otherwise it would have hung waiting for terminal IO. We can ignore this.
+            debug(3, L"terminal_give_to_job(): tcsetpgrp called but process group %d has terminated.\n", j->pgid);
+        };
+
         while (tcsetpgrp(STDIN_FILENO, j->pgid) != 0) {
             if (errno == EINTR) {
                 //always retry on EINTR
             }
+            else if (errno == EINVAL) {
+                //OS X returns EINVAL if the process group no longer lives. Probably other OSes, too.
+                //See comments in pgroupTerminated() above.
+                pgroupTerminated();
+                break;
+            }
             else if (errno == EPERM) {
-                //so long as this isn't because the process group is dead
+                //retry so long as this isn't because the process group is dead
                 int wait_result = waitpid(-1 * j->pgid, &wait_result, WNOHANG);
                 if (wait_result == -1) {
-                    //everyone in the process group has exited
-                    //The only way that can happen is if the very last process in the group terminated, and didn't need
-                    //to access the terminal, otherwise it would have hung waiting for terminal IO. We can ignore this.
                     //Note that -1 is technically an "error" for waitpid in the sense that an invalid argument was specified
-                    //because no such process group exists any longer.
+                    //because no such process group exists any longer. This is the observed behavior on Linux 4.4.0.
                     //a "success" result would mean processes from the group still exist but is still running in some state
                     //or the other.
-                    debug(3, L"terminal_give_to_job(): tcsetpgrp called but process group %d has terminated.\n", j->pgid);
+                    //See comments in pgroupTerminated() above.
+                    pgroupTerminated();
                     break;
                 }
                 debug(2, L"terminal_give_to_job(): EPERM.\n", j->pgid);

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -789,6 +789,23 @@ static bool terminal_give_to_job(job_t *j, int cont) {
         return true;
     }
 
+    //it may not be safe to call tcsetpgrp if we've already done so, as at that point we are no longer
+    //the controlling process group for the terminal and no longer have permission to set the process
+    //group that is in control, causing tcsetpgrp to return EPERM, even though that's not the documented
+    //behavior in tcsetpgrp(3), which instead says other bad things will happen (it says SIGTTOU will be
+    //sent to all members of the background *calling* process group, but it's more complicated than that,
+    //SIGTTOU may or may not be sent depending on the TTY configuration and whether or not signal handlers
+    //for SIGTTOU are installed. Read: http://curiousthing.org/sigttin-sigttou-deep-dive-linux
+    //In all cases, our goal here was just to hand over control of the terminal to this process group,
+    //which is a no-op if it's already been done.
+    if (tcgetpgrp(STDIN_FILENO) == j->pgid) {
+        debug(2, L"Process group %d already has control of terminal\n", j->pgid);
+        return true;
+    }
+
+    debug(4, L"Attempting bring process group to foreground via tcsetpgrp for job->pgid %d\n", j->pgid);
+    debug(4, L"caller session id: %d, pgid %d has session id: %d\n", getsid(0), j->pgid, getsid(j->pgid));
+
     signal_block(true);
     int result = -1;
     errno = EINTR;
@@ -797,7 +814,7 @@ static bool terminal_give_to_job(job_t *j, int cont) {
     }
     if (result == -1) {
         if (errno == ENOTTY) redirect_tty_output();
-        debug(1, _(L"Could not send job %d ('%ls') to foreground"), j->job_id, j->command_wcstr());
+        debug(1, _(L"terminal_give_to_job(): Could not send job %d ('%ls') with pgid %d to foreground"), j->job_id, j->command_wcstr(), j->pgid);
         wperror(L"tcsetpgrp");
         signal_unblock(true);
         return false;

--- a/src/proc.h
+++ b/src/proc.h
@@ -365,3 +365,5 @@ void proc_pop_interactive();
 int proc_format_status(int status);
 
 #endif
+
+bool terminal_give_to_job(job_t *j, int cont);


### PR DESCRIPTION
While PR #4246 fixes the initial issue I had with #4235, I ran into a number of issues with the code while working on this and I don't feel that the PR would be anything more than a bandaid. I have been working on a new branch that fixes the overall parent-child and child-child synchronization in `exec_job`; it's pushed here: https://github.com/mqudsi/fish-shell/tree/fork_exec_changes

I'm still working on it but I finally have it passing all the tests. I'm using it as my daily shell on OS X, WSL, and FreeBSD; so I'm patching things as I uncover them but I'm confident enough to at least share the current branch here for feedback.

Unfortunately I ran into a lot of problems trying to switch the code over to something more elegant because there are a number of (unclear) cases where the main `exec_job` loop can block as it tries to read from a preceding pipe or file (as an optimization, using the builtins instead of forking a new process). The previous code seems to duplicate a lot of functionality between child and parent in hopes that one or the other executes first (pretty much like all other job control code out there), but the problem is that it's not able to tell when something is an error and when it's OK to fail, leading to problems like the WSL issue and a few others I've seen in my searches.

The new code defines an explicit order for the system calls used to set up a new child process, and strictly enforces it. No kernel code for setting up process groups is duplicated between child and parent, each has a specific responsibility to set up something to arrive at the final state. I've also eliminated all the race conditions I could find in the code; there were a lot of cases where a preceding process could have terminated before the next process in the job chain started up and tried to join the existing process group and read from the previous process' pipes. It was all scenarios that almost never happened, but there was nothing as far as I could tell to actually make sure it didn't/handle it if it did.

I think I've finally tracked down all that blocking code and have the flow working ok now, but I'm going to keep stress-testing it to see if anything comes up.

Changing the `exec_job` code involved _a lot_ of research (both reading and testing) on different operating systems to get the actual behavior of `tcsetpgrp` and `waitpid` ironed out in all the different cases; I've done my best to clarify everything with copious amounts of comments so that it's all clear for future maintenance or if anything along the lines of "why is this being done here" comes up. I tried to make my changes both as localized and as clear as possible in hopes of making potentially merging this in at some point easier.

I still want to break up `exec_job` further, I don't like the two giant switch cases and there's a ton of overlapping behavior between them; some of it differs only slightly in ways that make it unclear whether or not the deviations are on purpose or simply a matter of omission (for example, `exec_error` is only set if fork fails for external processes, but isn't for builtins - from what I can tell, it should be for both). 

Since we're requiring C++11, I've implemented a few things as lambdas and call them where needed to eliminated code duplication without convoluting the code further; hopefully that is OK. I want to do that for most of the code in `exec_job` so that the different cases can all be handled in one spot where possible; but I refrained from doing it until the overhaul of the actual synchronization was complete and working so that I have a good control to compare behavior against.

I've also commented any occurrences of blocking code in the main `exec_job` loop to hopefully save anyone from pulling their hair out in the future while trying to pin down a hang in job control. It's not at all clear from the code itself which operations and function calls might block the main loop while they attempt IO from a file or another process.

Anyway, like I said, this is still a work in progress but I wanted to get feedback and work on this in public rather than come in with a massive patch a month from now.

Thanks.