### PR TITLE
implement `set --show`

### DIFF
--- a/doc_src/set.txt
+++ b/doc_src/set.txt
@@ -8,6 +8,7 @@ set [OPTIONS] VARIABLE_NAME[INDICES]... VALUES...
 set ( -q | --query ) [SCOPE_OPTIONS] VARIABLE_NAMES...
 set ( -e | --erase ) [SCOPE_OPTIONS] VARIABLE_NAME
 set ( -e | --erase ) [SCOPE_OPTIONS] VARIABLE_NAME[INDICES]...
+set ( -S | --show ) [SCOPE_OPTIONS] [VARIABLE_NAME]...
 \endfish
 
 \subsection set-description Description
@@ -38,6 +39,8 @@ The following options are available:
 - `-q` or `--query` test if the specified variable names are defined. Does not output anything, but the builtins exit status is the number of variables specified that were not defined.
 
 - `-n` or `--names` List only the names of all defined variables, not their value. The names are guaranteed to be sorted.
+
+- `-S` or `--show` Shows information about the given variables. If no variable names are given then all variables are shown in sorted order. No other flags can be used with this option. The information shown includes whether or not it is set in each of the local, global, and universal scopes. If it is set in one of those scopes whether or not it is exported is reported. The individual elements are also shown along with the length of each element.
 
 - `-L` or `--long` do not abbreviate long values when printing set variables
 

--- a/tests/set.err
+++ b/tests/set.err
@@ -1,0 +1,2 @@
+# Verify behavior of `set --show` given an invalid var name
+$argle bargle: invalid var name

--- a/tests/set.in
+++ b/tests/set.in
@@ -1,0 +1,15 @@
+# Test various behaviors of the `set` command.
+
+echo '# Verify behavior of `set --show` given an invalid var name' >&2
+set --show 'argle bargle'
+
+echo '# Verify behavior of `set --show`'
+set -U var1 hello
+set --show var1
+
+set -l var1
+set -g var1 goodbye "and don't come back"
+set --show var1
+
+set -g var2
+set --show _unset_var var2

--- a/tests/set.out
+++ b/tests/set.out
@@ -1,0 +1,21 @@
+# Verify behavior of `set --show`
+$var1: not set in local scope
+$var1: not set in global scope
+$var1: set in universal scope, unexported, with 1 elements
+$var1[0]: length=5 value=|hello|
+
+$var1: set in local scope, unexported, with 0 elements
+$var1: set in global scope, unexported, with 2 elements
+$var1[0]: length=7 value=|goodbye|
+$var1[1]: length=19 value=|and don\'t come back|
+$var1: set in universal scope, unexported, with 1 elements
+$var1[0]: length=5 value=|hello|
+
+$_unset_var: not set in local scope
+$_unset_var: not set in global scope
+$_unset_var: not set in universal scope
+
+$var2: not set in local scope
+$var2: set in global scope, unexported, with 0 elements
+$var2: not set in universal scope
+


### PR DESCRIPTION
This adds a new capability to the `set` command. It is similar to
running `set` with no other arguments but provides far more detail about
each variable. Such as whether it is set in each of the local, global,
and universal scopes. And the values in each scope. You can also ask for
specific variables to be shown.

Fixes #4265