### PR TITLE
Speedup git prompt

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -383,7 +383,7 @@ function __fish_git_prompt --description "Prompt function for Git"
             if set -q __fish_git_prompt_showuntrackedfiles
                 set -l config (command git config --bool bash.showUntrackedFiles)
                 if test "$config" != false
-                    if command git ls-files --others --exclude-standard --error-unmatch -- '*' >/dev/null ^/dev/null
+                    if command git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- '*' >/dev/null ^/dev/null
                         set u $___fish_git_prompt_char_untrackedfiles
                     end
                 end


### PR DESCRIPTION
Fix `__fish_git_prompt` too slow under repo with lots of untracked
files when `__fish_git_prompt_showuntrackedfiles` enabled.
