### PR TITLE
Fixed functions -D/--details completion

### DIFF
--- a/share/completions/functions.fish
+++ b/share/completions/functions.fish
@@ -6,5 +6,5 @@ complete -c functions -s d -l description --description "Set function descriptio
 complete -c functions -s q -l query --description "Test if function is defined"
 complete -c functions -s n -l names --description "List the names of the functions, but not their definition"
 complete -c functions -s c -l copy --description "Copy the specified function to the specified new name"
-complete -c functions -s m -l metadata --description "Display data about the function"
+complete -c functions -s D -l details --description "Display information about the function"
 complete -c functions -s v -l verbose --description "Print more output"


### PR DESCRIPTION
## Description

I encountered https://github.com/fish-shell/fish-shell/issues/597, but instead of mentioned there `--metadata` option, documentation mentions `--details`. At the same time `functions` doesn't recognize `--metadata`, but has a completion for it. So I guess it was renamed, but stayed in the completions.

## TODOs:

- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] User-visible changes noted in CHANGELOG.md (should I add it?)
