### PR TITLE
Removed custom completion for source builtin

### DIFF
--- a/share/completions/source.fish
+++ b/share/completions/source.fish
@@ -1,1 +1,0 @@
-complete -c source -w .


### PR DESCRIPTION
Removed the custom source completion, but kept the `..fish` completion file (which isn't wrapped by anything else, fwiw).

Should be the correct fix per the discussion at #4292 