### PR TITLE
Improved warning message about exiting with some jobs still active

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2229,7 +2229,6 @@ static void handle_end_loop() {
             }
             fputws(_(L"Use `disown [PID]` to let them live independently from fish.\n"), stdout);
             fputws(_(L"A further attempt to exit will terminate them.\n"), stdout);
-            fputws(_(L"See `man 1 jobs` and `man 1 disown` for more details.\n"), stdout);
             reader_exit(0, 0);
             data->prev_end_loop = 1;
             return;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2214,8 +2214,22 @@ static void handle_end_loop() {
         }
 
         if (!data->prev_end_loop && bg_jobs) {
-            fputws(_(L"There are still jobs active (use the jobs command to see them).\n"), stdout);
-            fputws(_(L"A second attempt to exit will terminate them.\n"), stdout);
+            fputws(_(L"There are still jobs active:\n"), stdout);
+            // listing active jobs
+            {
+                fputws(_(L"  PID\tCommand\n"), stdout);
+
+                jobs.reset();
+                while (job_t *j = jobs.next()) {
+                    if (!job_is_completed(j)) {
+                        fwprintf(stdout, L"  %d\t%ls\n", j->pgid, j->command_wcstr());
+                    }
+                }
+                fputws(L"\n", stdout);
+            }
+            fputws(_(L"Use `disown [PID]` to let them live independently from fish.\n"), stdout);
+            fputws(_(L"A further attempt to exit will terminate them.\n"), stdout);
+            fputws(_(L"See `man 1 jobs` and `man 1 disown` for more details.\n"), stdout);
             reader_exit(0, 0);
             data->prev_end_loop = 1;
             return;

--- a/tests/exit.expect
+++ b/tests/exit.expect
@@ -9,8 +9,12 @@ expect_prompt
 send "sleep 111 &\r"
 expect_prompt
 send "exit\r"
-expect "There are still jobs active"
-expect "A second attempt to exit will terminate them."
+expect -re "There are still jobs active:\r
+  PID\tCommand\r
+  \\d+\tsleep 111 &\r
+\r
+Use `disown \\\[PID\\\]` to let them live independently from fish.\r
+A further attempt to exit will terminate them.\r"
 expect_prompt
 
 # Running anything other than `exit` should result in the same warning with
@@ -18,8 +22,13 @@ expect_prompt
 send "sleep 113 &\r"
 expect_prompt
 send "exit\r"
-expect "There are still jobs active"
-expect "A second attempt to exit will terminate them."
+expect -re "There are still jobs active:\r
+  PID\tCommand\r
+  \\d+\tsleep 113 &\r
+  \\d+\tsleep 111 &\r
+\r
+Use `disown \\\[PID\\\]` to let them live independently from fish.\r
+A further attempt to exit will terminate them.\r"
 expect_prompt
 
 # Verify that asking to exit a second time does so.


### PR DESCRIPTION
## Description

When exiting a shell with active jobs, fish now lists the active jobs and tells the user about `disown`.

Fixes issue #4303

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
