### PR TITLE
Accept return as a valid answer to 'Edit the file again?'

### DIFF
--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -105,9 +105,7 @@ function funced --description 'Edit function definition'
                 echo # add a line between the parse error and the prompt
                 set -l repeat
                 set -l prompt (_ 'Edit the file again\? [Y/n]')
-                while test -z "$repeat"
-                    read -p "echo $prompt\  " repeat
-                end
+                read -p "echo $prompt\  " repeat
                 if not contains $repeat n N no NO No nO
                     continue
                 end

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -106,7 +106,7 @@ function funced --description 'Edit function definition'
                 set -l repeat
                 set -l prompt (_ 'Edit the file again\? [Y/n]')
                 read -p "echo $prompt\  " repeat
-                if not contains $repeat n N no NO No nO
+                if test -z $repeat; or contains $repeat {Y,y}{E,e,}{S,s,}
                     continue
                 end
                 echo (_ "Cancelled function editing")


### PR DESCRIPTION
## Description

when you used `funced` and there was an error when you finished editing the function, it asks the question
> Edit the file again? [Y/n]  

the uppercase `Y` of course being the default answer.
in pretty much every piece of software I've used that does this `Y/n` / `y/N` stuff - return means the default option, the capital letter

this PR does that

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
