### PR TITLE
Update xdg-mime helper

### DIFF
--- a/share/completions/xdg-mime.fish
+++ b/share/completions/xdg-mime.fish
@@ -12,7 +12,7 @@ complete -c xdg-mime -d 'Query default application for type' -n 'contains_seq qu
 complete -c xdg-mime -d 'Query file\'s filetype' -n 'contains_seq query filetype -- (commandline -cop)' -r
 
 # complete xdg-mime default
-complete -c xdg-mime -d 'Choose application' -n '__fish_seen_subcommand_from default; and __fish_is_token_n 3' -xa '(__fish_print_xdg_mimeapps)'
+complete -c xdg-mime -d 'Choose application' -n '__fish_seen_subcommand_from default; and __fish_is_token_n 3' -xa '(__fish_print_xdg_desktop_file_ids)'
 complete -c xdg-mime -d 'Mimetype'           -n '__fish_seen_subcommand_from default; and __fish_is_token_n 4' -xa '(__fish_print_xdg_mimetypes)'
 
 # complete xdg-mime install
@@ -29,4 +29,3 @@ complete -c xdg-mime -d 'Set mode'                    -n 'contains_seq xdg-mime 
 complete -c xdg-mime -l help -d 'Display help'
 complete -c xdg-mime -l manual -d 'Diplay long help'
 complete -c xdg-mime -l version -d 'Print version'
-

--- a/share/functions/__fish_print_xdg_applications_directories.fish
+++ b/share/functions/__fish_print_xdg_applications_directories.fish
@@ -1,10 +1,20 @@
 function __fish_print_xdg_applications_directories --description 'Print directories where desktop files are stored'
-    set -l search_path ~/.local/share/applications /usr/share/applications
-    if test -d /usr/local/share/applications
-        set search_path $search_path /usr/local/share/applications
+    set -l data_home $XDG_DATA_HOME
+    if test -z "$data_home"
+        set data_home $HOME/.local/share/
     end
 
-    for p in $search_path
-        echo $p
+    set -l data_dirs $XDG_DATA_DIRS
+    if test -z "$data_dirs"
+        set data_dirs /usr/local/share/:/usr/share/
+    end
+
+    set data_dirs $data_home:$data_dirs
+
+    for path in (string split : $data_dirs)
+        set path $path"applications"
+        if test -d $path
+            echo $path
+        end
     end
 end

--- a/share/functions/__fish_print_xdg_applications_directories.fish
+++ b/share/functions/__fish_print_xdg_applications_directories.fish
@@ -1,0 +1,10 @@
+function __fish_print_xdg_applications_directories --description 'Print directories where desktop files are stored'
+    set -l search_path ~/.local/share/applications /usr/share/applications
+    if test -d /usr/local/share/applications
+        set search_path $search_path /usr/local/share/applications
+    end
+
+    for p in $search_path
+        echo $p
+    end
+end

--- a/share/functions/__fish_print_xdg_desktop_file_ids.fish
+++ b/share/functions/__fish_print_xdg_desktop_file_ids.fish
@@ -1,0 +1,3 @@
+function __fish_print_xdg_desktop_file_ids --description 'Print all available xdg desktop file IDs'
+    find (__fish_print_xdg_applications_directories) -name \*.desktop \( -type f -or -type l \) -printf '%P\n' | tr / - | sort -u
+end

--- a/share/functions/__fish_print_xdg_mimeapps.fish
+++ b/share/functions/__fish_print_xdg_mimeapps.fish
@@ -1,4 +1,0 @@
-function __fish_print_xdg_mimeapps --description 'Print xdg mime applications'
-    find (__fish_print_xdg_applications_directories) -name \*.desktop \( -type f -or -type l \) -printf '%P\n' | sort -u
-
-end

--- a/share/functions/__fish_print_xdg_mimeapps.fish
+++ b/share/functions/__fish_print_xdg_mimeapps.fish
@@ -1,4 +1,4 @@
 function __fish_print_xdg_mimeapps --description 'Print xdg mime applications'
-    find ~/.local/share/applications/ /usr/share/applications/ -name \*.desktop \( -type f -or -type l \) -printf '%P\n' | sort -u
+    find (__fish_print_xdg_applications_directories) -name \*.desktop \( -type f -or -type l \) -printf '%P\n' | sort -u
 
 end

--- a/share/functions/__fish_print_xdg_mimetypes.fish
+++ b/share/functions/__fish_print_xdg_mimetypes.fish
@@ -1,3 +1,3 @@
 function __fish_print_xdg_mimetypes --description 'Print XDG mime types'
-    cat {(__fish_print_xdg_applications_directories)}/mimeinfo.cache ^/dev/null | string match -v '[MIME Cache]' | string replace = \t
+    cat {__fish_print_xdg_applications_directories}/mimeinfo.cache ^/dev/null | string match -v '[MIME Cache]' | string replace = \t
 end

--- a/share/functions/__fish_print_xdg_mimetypes.fish
+++ b/share/functions/__fish_print_xdg_mimetypes.fish
@@ -1,3 +1,3 @@
 function __fish_print_xdg_mimetypes --description 'Print XDG mime types'
-    cat ~/.local/share/applications/mimeinfo.cache /usr/share/applications/mimeinfo.cache ^/dev/null | string match -v '[MIME Cache]' | string replace = \t
+    cat {(__fish_print_xdg_applications_directories)}/mimeinfo.cache ^/dev/null | string match -v '[MIME Cache]' | string replace = \t
 end


### PR DESCRIPTION
## Description

This will respect the directory `/usr/local/share/applications/` when fetching mime infos.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
