### PR TITLE
Do not redirect to / in status.in/err test.

### DIFF
--- a/tests/status.err
+++ b/tests/status.err
@@ -1,4 +1,4 @@
-<W> fish: An error occurred while redirecting file '/'
+<W> fish: An error occurred while redirecting file '.'
 open: Is a directory
 status: Invalid combination of options,
 you cannot do both 'is-interactive' and 'is-login' in the same invocation

--- a/tests/status.in
+++ b/tests/status.in
@@ -10,7 +10,7 @@ end
 
 # Issue #1728
 # Bad file redirection on a block causes `status --is-block` to return 0 forever.
-begin; end >/ # / is a directory, it can't be opened for writing
+begin; end >. # . is a directory, it can't be opened for writing
 status -b
 and echo '"status -b" unexpectedly returned true after bad redirect on a begin block'
 


### PR DESCRIPTION
## Description

I was running fish test and this is the only test failing under sandboxed environment Gentoo linux uses during build/test process.
It does not allow to write outside of sandbox so >/ redirect is failing.
Trying to redirect something to / looks a bit scary, 
redirect to current directory looks safer and does not try to escape sandbox.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
