### PR TITLE
Fix reading of /etc/paths on OS X

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -231,7 +231,7 @@ if status --is-login
     # OS X-ism: Load the path files out of /etc/paths and /etc/paths.d/*
     set -g __fish_tmp_path
     function __fish_append_to_tmp_path -a new_path_comp
-        if not contains $new_path_comp $__fish_tmp_path
+        if not contains -- $new_path_comp $__fish_tmp_path
             set __fish_tmp_path $__fish_tmp_path $new_path_comp
         end
     end

--- a/share/config.fish
+++ b/share/config.fish
@@ -200,6 +200,7 @@ end
 # Some things should only be done for login terminals
 # This used to be in etc/config.fish - keep it here to keep the semantics
 #
+
 if status --is-login
     # OS X-ism: Call path_helper and set its output to $PATH and $MANPATH.
     if command -sq /usr/libexec/path_helper

--- a/share/config.fish
+++ b/share/config.fish
@@ -122,30 +122,6 @@ if test -d /usr/xpg4/bin
     end
 end
 
-# OS X-ism: Load the path files out of /etc/paths and /etc/paths.d/*
-set -g __fish_tmp_path $PATH
-function __fish_load_path_helper_paths
-    # We want to rearrange the path to reflect this order. Delete that path component if it exists and then prepend it.
-    # Since we are prepending but want to preserve the order of the input file, we reverse the array, append, and then reverse it again
-    set __fish_tmp_path $__fish_tmp_path[-1..1]
-    while read -l new_path_comp
-        if test -d $new_path_comp
-            set -l where (contains -i -- $new_path_comp $__fish_tmp_path)
-            and set -e __fish_tmp_path[$where]
-            set __fish_tmp_path $new_path_comp $__fish_tmp_path
-        end
-    end
-    set __fish_tmp_path $__fish_tmp_path[-1..1]
-end
-test -r /etc/paths
-and __fish_load_path_helper_paths </etc/paths
-for pathfile in /etc/paths.d/*
-    __fish_load_path_helper_paths <$pathfile
-end
-set -xg PATH $__fish_tmp_path
-set -e __fish_tmp_path
-functions -e __fish_load_path_helper_paths
-
 # OS X-ism: Load the manpath files out of /etc/manpaths and /etc/manpaths.d/*
 if set -q MANPATH
     set -g __fish_tmp_manpath $MANPATH
@@ -174,7 +150,6 @@ end
 
 
 # Add a handler for when fish_user_path changes, so we can apply the same changes to PATH
-# Invoke it immediately to apply the current value of fish_user_path
 function __fish_reconstruct_path -d "Update PATH when fish_user_paths changes" --on-variable fish_user_paths
     set -l local_path $PATH
 
@@ -197,8 +172,6 @@ function __fish_reconstruct_path -d "Update PATH when fish_user_paths changes" -
 
     set -xg PATH $local_path
 end
-
-__fish_reconstruct_path
 
 #
 # Launch debugger on SIGTRAP
@@ -254,8 +227,24 @@ end
 # Some things should only be done for login terminals
 # This used to be in etc/config.fish - keep it here to keep the semantics
 #
-
 if status --is-login
+    set -g __fish_tmp_path
+    # OS X-ism: Load the path files out of /etc/paths and /etc/paths.d/*
+    function __fish_load_path_helper_paths
+        while read -l new_path_comp
+            set __fish_tmp_path $__fish_tmp_path $new_path_comp
+        end
+    end
+
+    test -r /etc/paths
+    and __fish_load_path_helper_paths </etc/paths
+    for pathfile in /etc/paths.d/*
+        __fish_load_path_helper_paths <$pathfile
+    end
+    set -xg PATH $__fish_tmp_path
+    set -e __fish_tmp_path
+    functions -e __fish_load_path_helper_paths
+
     #
     # Put linux consoles in unicode mode.
     #
@@ -267,3 +256,7 @@ if status --is-login
         end
     end
 end
+
+# Invoke this here to apply the current value of fish_user_path after
+# PATH is possibly set above.
+__fish_reconstruct_path

--- a/share/config.fish
+++ b/share/config.fish
@@ -202,7 +202,7 @@ end
 #
 if status --is-login
     # OS X-ism: Call path_helper and set its output to $PATH and $MANPATH.
-    if test -x /usr/libexec/path_helper
+    if command -sq /usr/libexec/path_helper
         set -l lines (/usr/libexec/path_helper -c)
         if test (count $lines) -ge 1
             and set -l match (string match -r '^setenv PATH "(.*)";$' $lines[1])

--- a/share/config.fish
+++ b/share/config.fish
@@ -122,33 +122,6 @@ if test -d /usr/xpg4/bin
     end
 end
 
-# OS X-ism: Load the manpath files out of /etc/manpaths and /etc/manpaths.d/*
-if set -q MANPATH
-    set -g __fish_tmp_manpath $MANPATH
-    function __fish_load_manpath_helper_manpaths
-        # We want to rearrange the manpath to reflect this order. Delete that manpath component if it exists and then prepend it.
-        # Since we are prepending but want to preserve the order of the input file, we reverse the array, append, and then reverse it again
-        set __fish_tmp_manpath $__fish_tmp_manpath[-1..1]
-        while read -l new_manpath_comp
-            if test -d $new_manpath_comp
-                set -l where (contains -i -- $new_manpath_comp $__fish_tmp_manpath)
-                and set -e __fish_tmp_manpath[$where]
-                set __fish_tmp_manpath $new_manpath_comp $__fish_tmp_manpath
-            end
-        end
-        set __fish_tmp_manpath $__fish_tmp_manpath[-1..1]
-    end
-    test -r /etc/manpaths
-    and __fish_load_manpath_helper_manpaths </etc/manpaths
-    for manpathfile in /etc/manpaths.d/*
-        __fish_load_manpath_helper_manpaths <$manpathfile
-    end
-    set -xg MANPATH $__fish_tmp_manpath
-    set -e __fish_tmp_manpath
-    functions -e __fish_load_manpath_helper_manpaths
-end
-
-
 # Add a handler for when fish_user_path changes, so we can apply the same changes to PATH
 function __fish_reconstruct_path -d "Update PATH when fish_user_paths changes" --on-variable fish_user_paths
     set -l local_path $PATH
@@ -228,36 +201,20 @@ end
 # This used to be in etc/config.fish - keep it here to keep the semantics
 #
 if status --is-login
-    # OS X-ism: Load the path files out of /etc/paths and /etc/paths.d/*
-    set -g __fish_tmp_path
-    function __fish_append_to_tmp_path -a new_path_comp
-        if not contains -- $new_path_comp $__fish_tmp_path
-            set __fish_tmp_path $__fish_tmp_path $new_path_comp
+    # OS X-ism: Call path_helper and set its output to $PATH and $MANPATH.
+    if test -x /usr/libexec/path_helper
+        set -l lines (/usr/libexec/path_helper -c)
+        if test (count $lines) -ge 1
+            and set -l match (string match -r '^setenv PATH "(.*)";$' $lines[1])
+            and count $match >= 2
+            set -xg PATH (string split ':' $match[2])
+        end
+        if test (count $lines) -ge 2
+            and set -l match (string match -r '^setenv MANPATH "(.*)";$' $lines[2])
+            and count $match >= 2
+            set -xg MANPATH (string split ':' $match[2])
         end
     end
-
-    function __fish_append_stdin_to_tmp_path
-        while read -l new_path_comp
-            __fish_append_to_tmp_path $new_path_comp
-        end
-    end
-
-    # Read from /etc/paths, then /etc/paths.d/*, then $PATH, and
-    # remove subsequent duplicates to match the behavior of
-    # path_helper.
-    test -r /etc/paths
-    and __fish_append_stdin_to_tmp_path </etc/paths
-    for pathfile in /etc/paths.d/*
-        __fish_append_stdin_to_tmp_path <$pathfile
-    end
-
-    for new_path_comp in $PATH
-        __fish_append_to_tmp_path $new_path_comp
-    end
-
-    set -xg PATH $__fish_tmp_path
-    set -e __fish_tmp_path
-    functions -e __fish_append_to_tmp_path __fish_append_stdin_to_tmp_path
 
     #
     # Put linux consoles in unicode mode.

--- a/share/config.fish
+++ b/share/config.fish
@@ -241,7 +241,8 @@ if status --is-login
     for pathfile in /etc/paths.d/*
         __fish_load_path_helper_paths <$pathfile
     end
-    set -xg PATH $__fish_tmp_path
+    test -n "$__fish_tmp_path"
+    and set -xg PATH $__fish_tmp_path
     set -e __fish_tmp_path
     functions -e __fish_load_path_helper_paths
 

--- a/share/config.fish
+++ b/share/config.fish
@@ -212,6 +212,21 @@ if status --is-login
             #
             # ignoring whitespace before and after value, and an
             # optional trailing semicolon.
+            #
+            # Some examples of lines that successfully match to "FOO" and "bar baz":
+            #
+            #   "setenv FOO bar baz"
+            #   "setenv FOO bar baz;"
+            #   "setenv FOO bar baz; "
+            #   "  setenv   FOO   bar baz;"
+            #
+            # and some examples that fail to match:
+            #
+            #   "SetEnv FOO bar"
+            #   "setenv foo bar"
+            #   "setenv FOO1 bar"
+            #   "setenv FOO_BAR bar"
+            #   "setenv FOO-BAR bar"
             if set -l match (string match -r '^\s*setenv\s+([A-Z]+)\s+(.*?)\s*;?\s*$' -- $line)
                 set -l key $match[2]
                 # Only set PATH and MANPATH, the two environment


### PR DESCRIPTION
(and /etc/paths.d/*)

Do so by calling /usr/libexec/path_helper for login shells, matching
the behavior in /etc/profile.

This also handles setting MANPATH if necessary.

Fixes issue #4336

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md