### PR TITLE
Don't set loop control var local to for block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This section is for changes merged to the `major` branch that are not also merge
 - `.` command no longer exists -- use `source` (#4294).
 - `read` now requires at least one var name (#4220).
 - `set x[1] x[2] a b` is no longer valid syntax (#4236).
+- For loop control variables are no longer local to the for block (#1935).
 
 ## Notable fixes and improvements
 - `read` has a new `--delimiter` option as a better alternative to the `IFS` variable (#4256).

--- a/doc_src/for.txt
+++ b/doc_src/for.txt
@@ -7,7 +7,7 @@ for VARNAME in [VALUES...]; COMMANDS...; end
 
 \subsection for-description Description
 
-`for` is a loop construct. It will perform the commands specified by `COMMANDS` multiple times. On each iteration, the local variable specified by `VARNAME` is assigned a new value from `VALUES`. If `VALUES` is empty, `COMMANDS` will not be executed at all.
+`for` is a loop construct. It will perform the commands specified by `COMMANDS` multiple times. On each iteration, the local variable specified by `VARNAME` is assigned a new value from `VALUES`. If `VALUES` is empty, `COMMANDS` will not be executed at all. The `VARNAME` is visible when the loop terminates and will contain the last value assigned to it. If `VARNAME` does not already exist it will be set in the local scope.
 
 \subsection for-example Example
 
@@ -19,3 +19,18 @@ foo
 bar
 baz
 \endfish
+
+\subsection for-notes Notes
+
+The `VARNAME` was local to the for block in releases prior to 3.0.0. This means that if you did something like this:
+
+\fish
+for var in a b c
+    if break_from_loop
+        break
+    end
+end
+echo $var
+\endfish
+
+The last value assigned to `var` when the loop terminated would not be available outside the loop. What `echo $var` would write depended on what it was set to before the loop was run. Likely nothing.

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -332,6 +332,10 @@ static bool is_read_only(const wcstring &key) {
     return env_read_only.find(key) != env_read_only.end();
 }
 
+bool env_var_t::read_only() const {
+    return is_read_only(name);
+}
+
 /// Table of variables whose value is dynamically calculated, such as umask, status, etc.
 static const_string_set_t env_electric;
 

--- a/src/env.h
+++ b/src/env.h
@@ -102,6 +102,7 @@ class env_var_t {
     bool empty(void) const { return vals.empty() || (vals.size() == 1 && vals[0].empty()); };
     bool missing(void) const { return is_missing; }
     bool missing_or_empty(void) const { return missing() || empty(); }
+    bool read_only(void) const;
 
     bool matches_string(const wcstring &str) {
         if (is_missing) return false;

--- a/tests/argparse.err
+++ b/tests/argparse.err
@@ -32,9 +32,9 @@ argparse: Implicit int short flag '#' does not allow modifiers like '='
 ####################
 # Invalid arg in the face of a "#-val" spec
 argparse: Unknown option '-x'
-Standard input (line 38): 
-argparse '#-val' -- abc -x def
-^
+Standard input (line 41): 
+    argparse '#-val' -- abc -x def
+    ^
 
 ####################
 # Defining a short flag more than once

--- a/tests/argparse.in
+++ b/tests/argparse.in
@@ -32,28 +32,42 @@ begin
 end
 
 logmsg Invalid \"#-val\" spec
-argparse '#-val=' -- abc -x def
+begin
+    argparse '#-val=' -- abc -x def
+end
 
 logmsg Invalid arg in the face of a \"#-val\" spec
-argparse '#-val' -- abc -x def
+begin
+    argparse '#-val' -- abc -x def
+end
 
 logmsg Defining a short flag more than once
-argparse 's/short' 'x/xray' 's/long' -- -s -x --long
+begin
+    argparse 's/short' 'x/xray' 's/long' -- -s -x --long
+end
 
 logmsg Defining a long flag more than once
-argparse 's/short' 'x/xray' 'l/short' -- -s -x --long
+begin
+    argparse 's/short' 'x/xray' 'l/short' -- -s -x --long
+end
 
 logmsg Defining an implicit int flag more than once
-argparse '#-val' 'x/xray' 'v#val' -- -s -x --long
+begin
+    argparse '#-val' 'x/xray' 'v#val' -- -s -x --long
+end
 
 logmsg Defining an implicit int flag with modifiers
-argparse 'v#val=' --
+begin
+    argparse 'v#val=' --
+end
 
 ##########
 # Now verify that validly formed invocations work as expected.
 
 logmsg No args
-argparse h/help --
+begin
+    argparse h/help --
+end
 
 logmsg One arg and no matching flags
 begin
@@ -80,47 +94,56 @@ begin
 end
 
 logmsg Implicit int flags work
-for v in (set -l -n); set -e $v; end
-argparse '#-val' -- abc -123 def
-set -l
-for v in (set -l -n); set -e $v; end
-argparse 'v/verbose' '#-val' 't/token=' -- -123 a1 --token woohoo --234 -v a2 --verbose
-set -l
+begin
+    argparse '#-val' -- abc -123 def
+    set -l
+end
+begin
+    argparse 'v/verbose' '#-val' 't/token=' -- -123 a1 --token woohoo --234 -v a2 --verbose
+    set -l
+end
 
 logmsg Should be set to 987
-for v in (set -l -n); set -e $v; end
-argparse 'm#max' -- argle -987 bargle
-set -l
+begin
+    argparse 'm#max' -- argle -987 bargle
+    set -l
+end
 
 logmsg Should be set to 765
-for v in (set -l -n); set -e $v; end
-argparse 'm#max' -- argle -987 bargle --max 765
-set -l
+begin
+    argparse 'm#max' -- argle -987 bargle --max 765
+    set -l
+end
 
 logmsg Bool short flag only
-for v in (set -l -n); set -e $v; end
-argparse 'C' 'v' -- -C -v arg1 -v arg2
-set -l
+begin
+    argparse 'C' 'v' -- -C -v arg1 -v arg2
+    set -l
+end
 
 logmsg Value taking short flag only
-for v in (set -l -n); set -e $v; end
-argparse 'x=' 'v/verbose' -- --verbose arg1 -v -x arg2
-set -l
+begin
+    argparse 'x=' 'v/verbose' -- --verbose arg1 -v -x arg2
+    set -l
+end
 
 logmsg Implicit int short flag only
-for v in (set -l -n); set -e $v; end
-argparse 'x#' 'v/verbose' -- -v -v argle -v -x 321 bargle
-set -l
+begin
+    argparse 'x#' 'v/verbose' -- -v -v argle -v -x 321 bargle
+    set -l
+end
 
 logmsg Implicit int short flag only with custom validation passes
-for v in (set -l -n); set -e $v; end
-argparse 'x#!_validate_int --max 500' 'v/verbose' -- -v -v -x 499 -v
-set -l
+begin
+    argparse 'x#!_validate_int --max 500' 'v/verbose' -- -v -v -x 499 -v
+    set -l
+end
 
 logmsg Implicit int short flag only with custom validation fails
-for v in (set -l -n); set -e $v; end
-argparse 'x#!_validate_int --min 500' 'v/verbose' -- -v -v -x 499 -v
-set -l
+begin
+    argparse 'x#!_validate_int --min 500' 'v/verbose' -- -v -v -x 499 -v
+    set -l
+end
 
 ##########
 # Verify that flag value validation works.

--- a/tests/test1.err
+++ b/tests/test1.err
@@ -39,6 +39,9 @@ for status in a b c
     ^
 
 ####################
+# For loop control vars available outside the for block
+
+####################
 # Comments allowed in between lines (#1987)
 
 ####################

--- a/tests/test1.in
+++ b/tests/test1.in
@@ -155,6 +155,31 @@ for status in a b c
   echo $status
 end
 
+logmsg For loop control vars available outside the for block
+begin
+  set -l loop_var initial-value
+  for loop_var in a b c
+    # do nothing
+  end
+  set --show loop_var
+end
+
+set -g loop_var global_val
+for loop_var in a b c
+  if test $loop_var = b
+    break
+  end
+end
+set --show loop_var
+
+begin
+  set -l loop_var
+  for loop_var in aa bb cc
+  end
+  set --show loop_var
+end
+set --show loop_var
+
 logmsg 'Comments allowed in between lines (#1987)'
 echo before comment \
   # comment

--- a/tests/test1.out
+++ b/tests/test1.out
@@ -91,6 +91,30 @@ Checking for infinite loops in no-execute
 # For loops with read-only vars is an error (#4342)
 
 ####################
+# For loop control vars available outside the for block
+$loop_var: set in local scope, unexported, with 1 elements
+$loop_var[1]: length=1 value=|c|
+$loop_var: not set in global scope
+$loop_var: not set in universal scope
+
+$loop_var: not set in local scope
+$loop_var: set in global scope, unexported, with 1 elements
+$loop_var[1]: length=1 value=|b|
+$loop_var: not set in universal scope
+
+$loop_var: set in local scope, unexported, with 1 elements
+$loop_var[1]: length=2 value=|cc|
+$loop_var: set in global scope, unexported, with 1 elements
+$loop_var[1]: length=1 value=|b|
+$loop_var: not set in universal scope
+
+$loop_var: not set in local scope
+$loop_var: set in global scope, unexported, with 1 elements
+$loop_var[1]: length=1 value=|b|
+$loop_var: not set in universal scope
+
+
+####################
 # Comments allowed in between lines (#1987)
 before comment after comment
 


### PR DESCRIPTION
This change makes fish `for` loops behave like most other shells.
Specifically, the loop control variable is now visible when the loop
terminates with the last value assigned to it.

Fixes #1935