### PR TITLE
Fix apt subcommand option completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This section is for changes merged to the `major` branch that are not also merge
 - `read` failures due to too much data should define the var (#4180).
 - multiple `read` commands in non-interactive scripts were broken in fish 2.6.0 (#4206).
 - Fix regression involving universal variables with side-effects at startup such as `set -U fish_escape_delay_ms 10` (#4196).
+- Option completion for `apt list` now works properly.
 - Added completions for:
  - `as` (#4130).
  - `jest` (#4142).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ This section is for changes merged to the `major` branch that are not also merge
 - `read` failures due to too much data should define the var (#4180).
 - multiple `read` commands in non-interactive scripts were broken in fish 2.6.0 (#4206).
 - Fix regression involving universal variables with side-effects at startup such as `set -U fish_escape_delay_ms 10` (#4196).
-- Option completion for `apt list` now works properly.
+- Option completion for `apt list` now works properly (#4350).
 - Added completions for:
  - `as` (#4130).
  - `jest` (#4142).

--- a/share/completions/apt.fish
+++ b/share/completions/apt.fish
@@ -26,7 +26,7 @@ end
 
 function __fish_apt_using_subcommand --description 'Test if given subcommand is used'
     for i in (commandline -opc)
-        if contains -- $i $argv[1]
+        if contains -- $i $argv
             return 0
         end
     end

--- a/share/completions/apt.fish
+++ b/share/completions/apt.fish
@@ -23,6 +23,20 @@ function __fish_apt_subcommand
     complete -f -c apt -n '__fish_apt_no_subcommand' -a $subcommand $argv
 end
 
+function __fish_apt_using_subcommand --description 'Test if given subcommand is used'
+    for i in (commandline -opc)
+        if contains -- $i $argv[1]
+            return 0
+        end
+    end
+    return 1
+end
+
+function __fish_apt_option
+    set subcommand $argv[1]; set -e argv[1]
+    complete -f -c apt -n "__fish_apt_using_subcommand $subcommand" $argv
+end
+
 complete -c apt -n '__fish_apt_use_package' -a '(__fish_print_packages)' --description 'Package'
 
 # Support flags
@@ -36,9 +50,9 @@ complete -f -c apt -s t                 --description 'Target release'
 
 # List
 __fish_apt_subcommand list                  --description 'List packages'
-__fish_apt_subcommand list -l installed     --description 'Installed packages'
-__fish_apt_subcommand list -l upgradable    --description 'Upgradable packages'
-__fish_apt_subcommand list -l all-versions  --description 'Show all versions of any package'
+__fish_apt_option     list -l installed     --description 'Installed packages'
+__fish_apt_option     list -l upgradable    --description 'Upgradable packages'
+__fish_apt_option     list -l all-versions  --description 'Show all versions of any package'
 
 # Search
 __fish_apt_subcommand search -r        --description 'Search for packages'

--- a/share/completions/apt.fish
+++ b/share/completions/apt.fish
@@ -19,7 +19,8 @@ function __fish_apt_use_package --description 'Test if apt command should have p
 end
 
 function __fish_apt_subcommand
-    set subcommand $argv[1]; set -e argv[1]
+    set subcommand $argv[1]
+    set -e argv[1]
     complete -f -c apt -n '__fish_apt_no_subcommand' -a $subcommand $argv
 end
 
@@ -33,7 +34,8 @@ function __fish_apt_using_subcommand --description 'Test if given subcommand is 
 end
 
 function __fish_apt_option
-    set subcommand $argv[1]; set -e argv[1]
+    set subcommand $argv[1]
+    set -e argv[1]
     complete -f -c apt -n "__fish_apt_using_subcommand $subcommand" $argv
 end
 


### PR DESCRIPTION
## Description
Repost of #4330.
 
As title says, option completion for apt list was offering only general flags, not the subcommand specific ones. This fixes it.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
