### PR TITLE
Add --force-with-lease completion for git push

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -746,6 +746,7 @@ complete -f -c git -n '__fish_git_using_command push' -l tags -d 'Push all refs 
 complete -f -c git -n '__fish_git_using_command push' -s n -l dry-run -d 'Do everything except actually send the updates'
 complete -f -c git -n '__fish_git_using_command push' -l porcelain -d 'Produce machine-readable output'
 complete -f -c git -n '__fish_git_using_command push' -s f -l force -d 'Force update of remote refs'
+complete -f -c git -n '__fish_git_using_command push' -s f -l force-with-lease -d 'Force update of remote refs, stopping if other\'s changes would be overwritten'
 complete -f -c git -n '__fish_git_using_command push' -s u -l set-upstream -d 'Add upstream (tracking) reference'
 complete -f -c git -n '__fish_git_using_command push' -s q -l quiet -d 'Be quiet'
 complete -f -c git -n '__fish_git_using_command push' -s v -l verbose -d 'Be verbose'


### PR DESCRIPTION
## Description

Besides the well known `--force` switch to `git push` there's the very useful `--force-with-lease` which prevents accidently overwriting refs that others have pushed to a branch since one last pulled.

With this PR I want to add completions for this switch.

As this is my first ever PR to the fish code base and I'm a fish user for less than a week, I very likely missed something. Plus it's hard for me to verify the correctness of the change besides changing that file locally, as I haven't set up the project for development (which also would kind of seem overkill for such a minor change).

In any case I'm happy to do additional changes to this PR, though I'm unsure about how relevant the template TODO items below are for such a change, especially when looking at comparable PRs (such as #4367)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
