### PR TITLE
Implement `history search --reverse`

### DIFF
--- a/doc_src/history.txt
+++ b/doc_src/history.txt
@@ -2,7 +2,7 @@
 
 \subsection history-synopsis Synopsis
 \fish{synopsis}
-history search [ --show-time ] [ --case-sensitive ] [ --exact | --prefix | --contains ] [ --max=n ] [ --null ] [ "search string"... ]
+history search [ --show-time ] [ --case-sensitive ] [ --exact | --prefix | --contains ] [ --max=n ] [ --null ] [ -R | --reverse ] [ "search string"... ]
 history delete [ --show-time ] [ --case-sensitive ] [ --exact | --prefix | --contains ] "search string"...
 history merge
 history save
@@ -16,7 +16,7 @@ history ( -h | --help )
 
 The following operations (sub-commands) are available:
 
-- `search` returns history items matching the search string. If no search string is provided it returns all history items. This is the default operation if no other operation is specified. You only have to explicitly say `history search` if you wish to search for one of the subcommands. The `--contains` search option will be used if you don't specify a different search option. Entries are ordered newest to oldest. If stdout is attached to a tty the output will be piped through your pager by the history function. The history builtin simply writes the results to stdout.
+- `search` returns history items matching the search string. If no search string is provided it returns all history items. This is the default operation if no other operation is specified. You only have to explicitly say `history search` if you wish to search for one of the subcommands. The `--contains` search option will be used if you don't specify a different search option. Entries are ordered newest to oldest unless you use the `--reverse` flag. If stdout is attached to a tty the output will be piped through your pager by the history function. The history builtin simply writes the results to stdout.
 
 - `delete` deletes history items. Without the `--prefix` or `--contains` options, the exact match of the specified text will be deleted. If you don't specify `--exact` a prompt will be displayed before any items are deleted asking you which entries are to be deleted. You can enter the word "all" to delete all matching entries. You can enter a single ID (the number in square brackets) to delete just that single entry. You can enter more than one ID separated by a space to delete multiple entries. Just press [enter] to not delete anything. Note that the interactive delete behavior is a feature of the history function. The history builtin only supports `--exact --case-sensitive` deletion.
 
@@ -32,17 +32,19 @@ These flags can appear before or immediately after one of the sub-commands liste
 
 - `-C` or `--case-sensitive` does a case-sensitive search. The default is case-insensitive. Note that prior to fish 2.4.0 the default was case-sensitive.
 
-- `-c` or `--contains` searches or deletes items in the history that contain the specified text string. This is the default for the `--search` flag. This is not currently supported by the `--delete` flag.
+- `-c` or `--contains` searches or deletes items in the history that contain the specified text string. This is the default for the `--search` flag. This is not currently supported by the `delete` subcommand.
 
-- `-e` or `--exact` searches or deletes items in the history that exactly match the specified text string. This is the default for the `--delete` flag. Note that the match is case-insensitive by default. If you really want an exact match, including letter case, you must use the `-C` or `--case-sensitive` flag.
+- `-e` or `--exact` searches or deletes items in the history that exactly match the specified text string. This is the default for the `delete` subcommand. Note that the match is case-insensitive by default. If you really want an exact match, including letter case, you must use the `-C` or `--case-sensitive` flag.
 
 - `-p` or `--prefix` searches or deletes items in the history that begin with the specified text string. This is not currently supported by the `--delete` flag.
 
-- `-t` or `--show-time` prepends each history entry with the date and time the entry was recorded . By default it uses the strftime format `# %c%n`. You can specify another format; e.g., `--show-time='%Y-%m-%d %H:%M:%S '` or `--show-time='%a%I%p'`. The short option, `-t` doesn't accept a stftime format string; it only uses the default format. Any strftime format is allowed, including `%s` to get the raw UNIX seconds since the epoch. Note that `--with-time` is also allowed but is deprecated and will be removed at a future date.
+- `-t` or `--show-time` prepends each history entry with the date and time the entry was recorded . By default it uses the strftime format `# %c%n`. You can specify another format; e.g., `--show-time="%Y-%m-%d %H:%M:%S "` or `--show-time="%a%I%p"`. The short option, `-t`, doesn't accept a stftime format string; it only uses the default format. Any strftime format is allowed, including `%s` to get the raw UNIX seconds since the epoch.
 
 - `-z` or `--null` causes history entries written by the search operations to be terminated by a NUL character rather than a newline. This allows the output to be processed by `read -z` to correctly handle multiline history entries.
 
 - `-<number>` `-n <number>` or `--max=<number>` limits the matched history items to the first "n" matching entries. This is only valid for `history search`.
+
+- `-R` or `--reverse` causes the history search results to be ordered oldest to newest. Which is the order used by most shells. The default is newest to oldest.
 
 - `-h` or `--help` display help for this command.
 

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -1,7 +1,6 @@
 #
 # Wrap the builtin history command to provide additional functionality.
 #
-
 function __fish_unexpected_hist_args --no-scope-shadowing
     if test -n "$search_mode"
         or set -q show_time[1]
@@ -20,13 +19,13 @@ function history --description "display or manipulate interactive command histor
 
     set -l options --exclusive 'c,e,p' --exclusive 'S,D,M,V,C' --exclusive 't,T'
     set -a options 'h/help' 'c/contains' 'e/exact' 'p/prefix'
-    set -a options 'C/case-sensitive' 'z/null' 't/show-time=?' 'n#max'
+    set -a options 'C/case-sensitive' 'R/reverse' 'z/null' 't/show-time=?' 'n#max'
     # This long option is deprecated and here solely for legacy compatibility. People should use
     # -t or --show-time now.
     set -a options 'T-with-time=?'
     # The following options are deprecated and will be removed in the next major release.
     # Note that they do not have usable short flags.
-    set -a options 'S-search' 'D-delete' 'M-merge' 'V-save' 'R-clear'
+    set -a options 'S-search' 'D-delete' 'M-merge' 'V-save' 'X-clear'
     argparse -n $cmd $options -- $argv
     or return
 
@@ -38,7 +37,9 @@ function history --description "display or manipulate interactive command histor
     set -l hist_cmd
     set -l show_time
 
-    set -l max_count $_flag_max
+    set -l max_count
+    set -q _flag_max
+    set max_count -n$_flag_max
 
     set -q _flag_with_time
     and set -l _flag_show_time $_flag_with_time
@@ -90,9 +91,9 @@ function history --description "display or manipulate interactive command histor
                 set -l pager less
                 set -q PAGER
                 and set pager $PAGER
-                builtin history search $search_mode $show_time $max_count $_flag_case_sensitive $_flag_null -- $argv | eval $pager
+                builtin history search $search_mode $show_time $max_count $_flag_case_sensitive $_flag_reverse $_flag_null -- $argv | eval $pager
             else
-                builtin history search $search_mode $show_time $max_count $_flag_case_sensitive $_flag_null -- $argv
+                builtin history search $search_mode $show_time $max_count $_flag_case_sensitive $_flag_reverse $_flag_null -- $argv
             end
 
         case delete # interactively delete history

--- a/src/builtin_history.cpp
+++ b/src/builtin_history.cpp
@@ -2,8 +2,8 @@
 #include "config.h"  // IWYU pragma: keep
 
 #include <errno.h>
-#include <limits.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <wchar.h>
 
 #include <string>
@@ -31,18 +31,19 @@ struct history_cmd_opts_t {
     bool print_help = false;
     hist_cmd_t hist_cmd = HIST_UNDEF;
     history_search_type_t search_type = (history_search_type_t)-1;
-    long max_items = LONG_MAX;
+    size_t max_items = SIZE_MAX;
     bool history_search_type_defined = false;
     const wchar_t *show_time_format = NULL;
     bool case_sensitive = false;
     bool null_terminate = false;
+    bool reverse = false;
 };
 
 /// Note: Do not add new flags that represent subcommands. We're encouraging people to switch to
 /// the non-flag subcommand form. While many of these flags are deprecated they must be
 /// supported at least until fish 3.0 and possibly longer to avoid breaking everyones
 /// config.fish and other scripts.
-static const wchar_t *short_options = L":Cmn:epcht::z";
+static const wchar_t *short_options = L":CRcehmn:pt::z";
 static const struct woption long_options[] = {{L"prefix", no_argument, NULL, 'p'},
                                               {L"contains", no_argument, NULL, 'c'},
                                               {L"help", no_argument, NULL, 'h'},
@@ -57,6 +58,7 @@ static const struct woption long_options[] = {{L"prefix", no_argument, NULL, 'p'
                                               {L"save", no_argument, NULL, 3},
                                               {L"clear", no_argument, NULL, 4},
                                               {L"merge", no_argument, NULL, 5},
+                                              {L"reverse", no_argument, NULL, 'R'},
                                               {NULL, 0, NULL, 0}};
 
 /// Remember the history subcommand and disallow selecting more than one history subcommand.
@@ -133,6 +135,10 @@ static int parse_cmd_opts(history_cmd_opts_t &opts, int *optind,  //!OCLINT(high
                 opts.case_sensitive = true;
                 break;
             }
+            case 'R': {
+                opts.reverse = true;
+                break;
+            }
             case 'p': {
                 opts.search_type = HISTORY_SEARCH_TYPE_PREFIX;
                 opts.history_search_type_defined = true;
@@ -153,12 +159,13 @@ static int parse_cmd_opts(history_cmd_opts_t &opts, int *optind,  //!OCLINT(high
                 break;
             }
             case 'n': {
-                opts.max_items = fish_wcstol(w.woptarg);
+                long x = fish_wcstol(w.woptarg);
                 if (errno) {
                     streams.err.append_format(_(L"%ls: max value '%ls' is not a valid number\n"),
                                               cmd, w.woptarg);
                     return STATUS_INVALID_ARGS;
                 }
+                opts.max_items = static_cast<size_t>(x);
                 break;
             }
             case 'z': {
@@ -242,7 +249,7 @@ int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     switch (opts.hist_cmd) {
         case HIST_SEARCH: {
             if (!history->search(opts.search_type, args, opts.show_time_format, opts.max_items,
-                                 opts.case_sensitive, opts.null_terminate, streams)) {
+                                 opts.case_sensitive, opts.null_terminate, opts.reverse, streams)) {
                 status = STATUS_CMD_ERROR;
             }
             break;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1527,8 +1527,10 @@ void history_t::save(void) {
     this->save_internal(false);
 }
 
-// Formats a single history record, including a trailing newline.  Returns true
-// if bytes were written to the output stream and false otherwise.
+// Formats a single history record, including a trailing newline.
+//
+// Returns nothing. The only possible failure involves formatting the timestamp. If that happens we
+// simply omit the timestamp from the output.
 static void format_history_record(const history_item_t &item, const wchar_t *show_time_format,
                                   bool null_terminate, wcstring &result) {
     if (show_time_format) {
@@ -1550,7 +1552,6 @@ static void format_history_record(const history_item_t &item, const wchar_t *sho
     } else {
         result.push_back(L'\n');
     }
-    return;
 }
 
 /// This handles the slightly unusual case of someone searching history for

--- a/src/history.h
+++ b/src/history.h
@@ -238,8 +238,11 @@ class history_t {
 
     // Searches history.
     bool search(history_search_type_t search_type, wcstring_list_t search_args,
-                const wchar_t *show_time_format, long max_items, bool case_sensitive,
-                bool null_terminate, io_streams_t &streams);
+                const wchar_t *show_time_format, size_t max_items, bool case_sensitive,
+                bool null_terminate, bool reverse, io_streams_t &streams);
+    bool search_with_args(history_search_type_t search_type, wcstring_list_t search_args,
+                          const wchar_t *show_time_format, size_t max_items, bool case_sensitive,
+                          bool null_terminate, bool reverse, io_streams_t &streams);
 
     // Enable / disable automatic saving. Main thread only!
     void disable_automatic_saving();
@@ -267,6 +270,9 @@ class history_t {
     // Return the specified history at the specified index. 0 is the index of the current
     // commandline. (So the most recent item is at index 1.)
     history_item_t item_at_index(size_t idx);
+
+    // Return the number of history entries.
+    size_t size();
 };
 
 class history_search_t {

--- a/tests/history.expect
+++ b/tests/history.expect
@@ -50,8 +50,8 @@ expect_prompt -re {start2\r\necho start1; builtin history; echo end1\r\nend2\r\n
 # ==========
 # Verify explicit searching for the first two commands in the previous tests
 # returns the expected results.
-send "history search echo start\r"
-expect_prompt -re {\r\necho start1.*\r\necho start2} {
+send "history search --reverse 'echo start'\r"
+expect_prompt -re {\r\necho start1;.*\r\necho start2;} {
     puts "history function explicit search succeeded"
 } timeout {
     puts stderr "history function explicit search failed"


### PR DESCRIPTION
It should be possible to have `history search` output ordered oldest to
newest like nearly every other shell including bash, ksh, zsh, and csh.
We can't make this the default because too many people expect the
current behavior. This simply makes it possible for people to define
their own abbreviations or functions that provide behavior they are
likely used to if they are transitioning to fish from another shell.

This also fixes a bug in the `history` function with respect to how it
handles the `-n` / `--max` flag.

Fixes #4354