### PR TITLE
Improve ssh completions/__fish_print_hostnames

### DIFF
--- a/share/completions/ssh.fish
+++ b/share/completions/ssh.fish
@@ -7,11 +7,10 @@ __fish_complete_ssh ssh
 # ssh specific completions
 #
 complete -x -c ssh -d Hostname -a "
-(__fish_print_hostnames)
-
-(
-	# Prepend any username specified in the completion to the hostname
-	echo (commandline -ct)|sed -ne 's/\(.*@\).*/\1/p'
+# First print an empty line to get just the hostname
+(echo;
+# Then prepend any username specified in the completion to the hostname
+commandline -ct | string replace -rf '(.*@).*' '$1'
 )(__fish_print_hostnames)
 "
 

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -95,9 +95,16 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
         end
     end
     for file in $known_hosts
-        # Ignore hosts that are hashed, commented or have custom ports (like [localhost]:2200)
-        test -r $file
-        and string replace -ra '(\S+) .*' '$1' <$file | string match -r '^[^#|[=]+$' | string split ","
+        if test -r $file
+            # Ignore hosts that are hashed, commented or @-marked and strip the key.
+            string replace -r '[#@| ].*' '' <$file \
+            # Split on ",".
+            # Ignore negated/wildcarded hosts.
+            | string split "," | string match -rv '[!\*\?]' \
+            # Extract hosts with custom port.
+            | string replace -r '\[([^]]+)\]:.*' '$1'
+            # string replace -ra '(\S+) .*' '$1' <$file | string match -r '^[^#|[=]+$' | string split ","
+        end
     end
     return 0
 end

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -32,7 +32,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
             if contains -- '-F' $token
                 set ssh_config_path_is_next 0
             else if test $ssh_config_path_is_next -eq 0
-                set ssh_config (eval "echo $token")
+                set ssh_config (echo "echo $token" | source)
                 set ssh_config_path_is_next 1
             end
         end
@@ -66,7 +66,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
             set -l new_paths
             for path in $paths
                 set -l expanded_path
-                eval "set expanded_path (printf \"%s\n\" $path)"
+                echo "set expanded_path (printf \"%s\n\" $path)" | source
                 for path in $expanded_path
                     # Resolve "relative" paths in accordance to ssh path resolution
                     if string match -qv '/*' $path

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -53,13 +53,13 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
             set -l orig_dir $PWD
             set -l paths
             for config in $argv
-                set paths $paths (cat $config ^/dev/null \
-                # Keep only Include lines
-                | string match -r -i '^\s*Include\s+.+' \
-                # Remove Include syntax
-                | string replace -r -i '^\s*Include\s+' '' \
-                # Normalize whitespace
-                | string trim | string replace -r -a '\s+' ' ')
+                if test -r "$config"
+                    set paths $paths (
+                    # Keep only Include lines and remove Include syntax
+                    string replace -rfi '^\s*Include\s+' '' <$config \
+                    # Normalize whitespace
+                    | string trim | string replace -r -a '\s+' ' ')
+                end
             end
 
             builtin cd $relative_path
@@ -89,9 +89,9 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
     for file in $ssh_configs
         if test -r $file
             # Print hosts from system wide ssh configuration file
-            string match -r -i '^\s*Host\s+\S+' <$file | string replace -r -i '^\s*Host\s+' '' | string trim | string replace -r '\s+' ' ' | string split ' ' | string match -v '*\**'
+            string replace -rfi '^\s*Host\s+' '' <$file | string trim | string replace -r '\s+' ' ' | string split ' ' | string match -v '*\**'
             # Extract known_host paths.
-            set known_hosts $known_hosts (string match -ri '^\s*UserKnownHostsFile|^\s*GlobalKnownHostsFile' <$file | string replace -ri '.*KnownHostsFile\s*' '')
+            set known_hosts $known_hosts (string replace -rfi '.*KnownHostsFile\s*' '' <$file)
         end
     end
     for file in $known_hosts


### PR DESCRIPTION
## Description

This improves both correctness and performance of ssh completion.

Fixes issue #4377, #4374.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

@zanchey: I'd like to add this to 2.7.0 if possible.

@ThomasAH: Please test. IIRC you should be able to just download the affected files and store them in ~/.config/fish/{completions,functions}.