### PR TITLE
Add completions for git checkout --ours/--theirs

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -369,9 +369,8 @@ complete -f -c git -n '__fish_git_using_command checkout' -a '(__fish_git_tags)'
 complete -f -c git -n '__fish_git_using_command checkout' -a '(__fish_git_modified_files)' --description 'File'
 complete -f -c git -n '__fish_git_using_command checkout' -s b -d 'Create a new branch'
 complete -f -c git -n '__fish_git_using_command checkout' -s t -l track -d 'Track a new branch'
-complete -f -c git -n '__fish_git_using_command checkout' -l theirs -d 'Use their version'
-complete -f -c git -n '__fish_git_using_command checkout' -l ours -d 'Use our version'
-
+complete -f -c git -n '__fish_git_using_command checkout' -l theirs -d 'Keep staged changes'
+complete -f -c git -n '__fish_git_using_command checkout' -l ours -d 'Keep unmerged changes'
 # TODO options
 
 ### apply

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -369,6 +369,9 @@ complete -f -c git -n '__fish_git_using_command checkout' -a '(__fish_git_tags)'
 complete -f -c git -n '__fish_git_using_command checkout' -a '(__fish_git_modified_files)' --description 'File'
 complete -f -c git -n '__fish_git_using_command checkout' -s b -d 'Create a new branch'
 complete -f -c git -n '__fish_git_using_command checkout' -s t -l track -d 'Track a new branch'
+complete -f -c git -n '__fish_git_using_command checkout' -l theirs -d 'Use their version'
+complete -f -c git -n '__fish_git_using_command checkout' -l ours -d 'Use our version'
+
 # TODO options
 
 ### apply


### PR DESCRIPTION
## Description

Add completions for `git checkout --ours' and `git checkout --theirs`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
