### PR TITLE
Drop deprecated `history search --with-time` flag

### DIFF
--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -16,13 +16,9 @@ end
 
 function history --description "display or manipulate interactive command history"
     set -l cmd history
-
-    set -l options --exclusive 'c,e,p' --exclusive 'S,D,M,V,C' --exclusive 't,T'
+    set -l options --exclusive 'c,e,p' --exclusive 'S,D,M,V,C'
     set -a options 'h/help' 'c/contains' 'e/exact' 'p/prefix'
     set -a options 'C/case-sensitive' 'R/reverse' 'z/null' 't/show-time=?' 'n#max'
-    # This long option is deprecated and here solely for legacy compatibility. People should use
-    # -t or --show-time now.
-    set -a options 'T-with-time=?'
     # The following options are deprecated and will be removed in the next major release.
     # Note that they do not have usable short flags.
     set -a options 'S-search' 'D-delete' 'M-merge' 'V-save' 'X-clear'

--- a/src/builtin_history.cpp
+++ b/src/builtin_history.cpp
@@ -48,7 +48,6 @@ static const struct woption long_options[] = {{L"prefix", no_argument, NULL, 'p'
                                               {L"contains", no_argument, NULL, 'c'},
                                               {L"help", no_argument, NULL, 'h'},
                                               {L"show-time", optional_argument, NULL, 't'},
-                                              {L"with-time", optional_argument, NULL, 't'},
                                               {L"exact", no_argument, NULL, 'e'},
                                               {L"max", required_argument, NULL, 'n'},
                                               {L"null", no_argument, NULL, 'z'},


### PR DESCRIPTION
This flag was only documented for a few weeks before being renamed
`--show-time` and has been deprecated for a long time. Fish 3.0 is a good
opportunity to remove it.