### PR TITLE
Support reading to stdout via builtin `read -`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This section is for changes merged to the `major` branch that are not also merge
 - `math` is now a builtin rather than a wrapper around `bc` (#3157).
 - `history search` supports globs for wildcard searching (#3136).
 - `bind` has a new `--silent` option to ignore bind requests for named keys not available under the current `$TERMINAL` (#4188, #4431)
+- `read` can write directly to stdout if `-` is supplied as a variable name (#4407)
 
 ## Other significant changes
 - Command substitution output is now limited to 10 MB by default (#3822).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This section is for changes merged to the `major` branch that are not also merge
 - `math` is now a builtin rather than a wrapper around `bc` (#3157).
 - `history search` supports globs for wildcard searching (#3136).
 - `bind` has a new `--silent` option to ignore bind requests for named keys not available under the current `$TERMINAL` (#4188, #4431)
-- `read` can write directly to stdout if `-` is supplied as a variable name (#4407)
+- `read` writes directly to stdout if called without arguments (#4407)
 
 ## Other significant changes
 - Command substitution output is now limited to 10 MB by default (#3822).

--- a/doc_src/read.txt
+++ b/doc_src/read.txt
@@ -7,10 +7,7 @@ read [OPTIONS] VARIABLES...
 
 \subsection read-description Description
 
-`read` reads from standard input and stores the result in one or more shell variables. By default,
-one line (terminated by a newline) is read into each variable. Alternatively, a null character or a
-maximum number of characters can be used to terminate the input. Unlike other shells, there is no
-default variable (such as `REPLY`) for storing the result.
+`read` reads from standard input and either writes the result back to the terminal for use in command substitution or stores the result in one or more shell variables. By default, one line (terminated by a newline) is read into each variable. Alternatively, a null character or a maximum number of characters can be used to terminate the input. Unlike other shells, there is no default variable (such as `REPLY`) for storing the result.
 
 The following options are available:
 
@@ -47,6 +44,12 @@ The following options are available:
   disables interactive mode.
 
 `read` reads a single line of input from stdin, breaks it into tokens based on the delimiter set via `-d`/`--delimiter` as a complete string (like `string split` or, if that has not been given the (deprecated) `IFS` shell variable as a set of characters, and then assigns one token to each variable specified in `VARIABLES`. If there are more tokens than variables, the complete remainder is assigned to the last variable. As a special case, if `IFS` is set to the empty string, each character of the input is considered a separate token.
+
+If no parameters are provided, `read` enters a special case that simply provides redirection from `stdin` to `stdout`, useful for command substitution. For instance, the fish shell command below can be used to read data that should be provided via a command line argument from the console instead of hardcoding it in the command itself, allowing the command to both be reused as-is in various contexts with different input values and preventing possibly sensitive text from being included in the shell history:
+
+`mysql -uuser -p(read)`
+
+When running in stdout redirect mode, `read` does not split the input in any way and text is redirected to standard output without any further processing or manipulation.
 
 If `-a` or `--array` is provided, only one variable name is allowed and the tokens are stored as an array in this variable.
 

--- a/src/builtin_read.cpp
+++ b/src/builtin_read.cpp
@@ -2,7 +2,6 @@
 #include "config.h"  // IWYU pragma: keep
 
 #include <errno.h>
-#include <iostream>
 #include <limits.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/tests/read.err
+++ b/tests/read.err
@@ -1,7 +1,6 @@
 
 ####################
-# Read with no vars is an error
-read: Expected at least 1 args, got only 0
+# Read with no vars is not an error
 
 ####################
 # Read with -a and anything other than exactly on var name is an error

--- a/tests/read.expect
+++ b/tests/read.expect
@@ -16,6 +16,11 @@ expect_prompt
 
 # read
 
+send_line "read"
+expect_read_prompt
+send_line "text"
+expect_prompt
+
 send_line "read foo"
 expect_read_prompt
 send_line "text"

--- a/tests/read.in
+++ b/tests/read.in
@@ -3,7 +3,7 @@
 # Test read builtin and IFS.
 #
 
-logmsg Read with no vars is an error
+logmsg Read with no vars is not an error
 read
 
 logmsg Read with -a and anything other than exactly on var name is an error

--- a/tests/read.out
+++ b/tests/read.out
@@ -1,6 +1,6 @@
 
 ####################
-# Read with no vars is an error
+# Read with no vars is not an error
 
 ####################
 # Read with -a and anything other than exactly on var name is an error


### PR DESCRIPTION
Added an option to read to stdout via `read -`. While it may seem
useless at first blush, it lets you do things like include

    mysql -p(read --silent) ...

Without needing to save to a local variable and then echo it back.
Kicks in when `-` is provided as the variable name to read to. This is
in keeping with the de facto syntax for reading/writing from/to
stdin/stdout instead of a file in, e.g., tar, cat, and other standard
unix utilities.

It doesn't make anything possible that wasn't previously doable with `(read temp_var; echo $temp_var)` but it doesn't interfere with anything either and makes fish that much easier to use. Willing to reconsider if there is friction against including this in 3.0.