### PR TITLE
Suppress git prompt CRLF warnings noise

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -475,7 +475,7 @@ set -g ___fish_git_prompt_status_order stagedstate invalidstate dirtystate untra
 
 function __fish_git_prompt_informative_status
 
-    set -l changedFiles (command git diff --name-status | string match -r \\w)
+    set -l changedFiles (command git diff --name-status ^/dev/null | string match -r \\w)
     set -l stagedFiles (command git diff --staged --name-status | string match -r \\w)
 
     set -l x (count $changedFiles)


### PR DESCRIPTION
Drawing prompt in repo with text=auto attribute and mixed line endings in files was spawning crlf conversion warnings to terminal from unsilenced stderr of git diff