### PR TITLE
fix 'printf "%o"' handling on powerpc64

### DIFF
--- a/src/builtin_printf.cpp
+++ b/src/builtin_printf.cpp
@@ -444,6 +444,7 @@ void builtin_printf_state_t::print_direc(const wchar_t *start, size_t length, wc
         case L'X':
         case L'd':
         case L'i':
+        case L'o':
         case L'u': {
             fmt.append(L"ll");
             break;


### PR DESCRIPTION
On powerpc64 (big-endian platform) one test failed as:

  Testing file printf.in ... fail
  Output differs for file printf.in. Diff follows:
  --- printf.tmp.out      2017-10-02 18:14:17.740000000 -0700
  +++ printf.out  2017-10-02 18:11:59.370000000 -0700
  @@ -1,5 +1,5 @@
   Hello 1 2 3.000000 4.000000 5 6
  -a B 0 18446744073709551615
  +a B 10 18446744073709551615

It happens due to roughly the following code:
    swprintf(..., L"%o", (long long)8);
Here mismatch happens between "%o" (requires 32-bit value)
and 'long long' (requires 64-bit value).

The fix turns it effectively to:
    swprintf(..., L"%llo", (long long)8);
as it was previously done for 'x', 'd' and other int-like types.

Makes tests pass on powerpc64.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>