### PR TITLE
Python's pip and pipenv completions

### DIFF
--- a/share/completions/pip.fish
+++ b/share/completions/pip.fish
@@ -1,3 +1,13 @@
 if command -sq pip
     eval (pip completion --fish)
 end
+
+# Some distributions prefer to have separate pip commands
+# depending on the version of Python running
+if command -sq pip2
+    eval (pip2 completion --fish)
+end
+
+if command -sq pip3
+    eval (pip3 completion --fish)
+end

--- a/share/completions/pip.fish
+++ b/share/completions/pip.fish
@@ -1,0 +1,3 @@
+if test (command -v pip)
+    eval (pip completion --fish)
+end

--- a/share/completions/pip.fish
+++ b/share/completions/pip.fish
@@ -1,3 +1,3 @@
-if test (command -v pip)
+if command -sq pip
     eval (pip completion --fish)
 end

--- a/share/completions/pip.fish
+++ b/share/completions/pip.fish
@@ -2,12 +2,3 @@ if command -sq pip
     eval (pip completion --fish)
 end
 
-# Some distributions prefer to have separate pip commands
-# depending on the version of Python running
-if command -sq pip2
-    eval (pip2 completion --fish)
-end
-
-if command -sq pip3
-    eval (pip3 completion --fish)
-end

--- a/share/completions/pip2.fish
+++ b/share/completions/pip2.fish
@@ -1,0 +1,3 @@
+if command -sq pip2
+    eval (pip2 completion --fish)
+end

--- a/share/completions/pip3.fish
+++ b/share/completions/pip3.fish
@@ -1,0 +1,3 @@
+if command -sq pip3
+    eval (pip3 completion --fish)
+end

--- a/share/completions/pipenv.fish
+++ b/share/completions/pipenv.fish
@@ -1,3 +1,3 @@
-if test (command -v pipenv)
+if command -sq pipenv
     eval (pipenv --completion)
 end

--- a/share/completions/pipenv.fish
+++ b/share/completions/pipenv.fish
@@ -1,0 +1,3 @@
+if test (command -v pipenv)
+    eval (pipenv --completion)
+end


### PR DESCRIPTION
## pip and pipenv completions

Both pip and pipenv has its own completion support for fish, so we only call their native completion support if the command is installed in the path, nothing fancy but this avoids having to manually install the completion.