### PR TITLE
fish_update_completions: error when python not found

### DIFF
--- a/share/functions/fish_update_completions.fish
+++ b/share/functions/fish_update_completions.fish
@@ -1,4 +1,13 @@
 function fish_update_completions --description "Update man-page based completions"
+    set -l options 'h/help'
+    argparse -n open --min-args=0 $options -- $argv
+    or return
+
+    if set -q _flag_help
+        __fish_print_help fish_update_completions
+        return 0
+    end
+
     # Clean up old paths
     set -l update_args -B $__fish_datadir/tools/create_manpage_completions.py --manpath --cleanup-in '~/.config/fish/completions' --cleanup-in '~/.config/fish/generated_completions' --progress
     if command -qs python3
@@ -7,5 +16,8 @@ function fish_update_completions --description "Update man-page based completion
         python2 $update_args
     else if command -qs python
         python $update_args
+    else
+        printf "%s\n" (_ "python executable not found")
+        return 1
     end
 end


### PR DESCRIPTION
## Description
I had a system without python and wondered why fish_update_completions was not working correctly, it exited quickly and printed nothing.
So I added a message for the user.

Added an option (-q/--quiet) which skips the message and returns 0.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed (not needed)
- [ ] User-visible changes noted in CHANGELOG.md (where exactly?)
