### PR TITLE
Remove extraneous reference in FAQ

### DIFF
--- a/doc_src/faq.hdr
+++ b/doc_src/faq.hdr
@@ -107,7 +107,6 @@ end
 
 See the documentation for <a href="commands.html#test">`test`</a> and <a href="commands.html#if">`if`</a> for more information.
 
-Use the <a href="commands.html#fish_update_completions">`fish_update_completions`</a> command.
 <hr>
 \section faq-single-env How do I set an environment variable for just one command?
 


### PR DESCRIPTION
"Use the fish_update_completions command.", the answer to "How do I update man page completions?", was also found at the end of the answer to "How do I get the exit status of a command?"

## Description

Removed extra sentence.

Fixes issue #4458

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
