### PR TITLE
Remove $history and implement `history count` and `history item`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This section is for changes merged to the `major` branch that are not also merge
 - `read` now requires at least one var name (#4220).
 - `set x[1] x[2] a b` is no longer valid syntax (#4236).
 - For loop control variables are no longer local to the for block (#1935).
+- The `history` variable has been replaced by the `history item` command (#4366).
 
 ## Notable fixes and improvements
 - `read` has a new `--delimiter` option as a better alternative to the `IFS` variable (#4256).

--- a/doc_src/history.txt
+++ b/doc_src/history.txt
@@ -4,6 +4,7 @@
 \fish{synopsis}
 history search [ --show-time ] [ --case-sensitive ] [ --exact | --prefix | --contains ] [ --max=n ] [ --null ] [ -R | --reverse ] [ "search string"... ]
 history delete [ --show-time ] [ --case-sensitive ] [ --exact | --prefix | --contains ] "search string"...
+history item "idx"
 history merge
 history save
 history clear
@@ -25,6 +26,10 @@ The following operations (sub-commands) are available:
 - `save` immediately writes all changes to the history file. The shell automatically saves the history file; this option is provided for internal use and should not normally need to be used by the user.
 
 - `clear` clears the history file. A prompt is displayed before the history is erased asking you to confirm you really want to clear all history unless `builtin history` is used.
+
+- `count` returns the number of entries in the command history not including the currently running interactive command.
+
+- `item` returns the history item at the specified index. The index must be greater than zero. If the index is greater than the number of entries in the command history then nothing is output. If the index matches a history entry then three lines are written: the command line, the seconds since the UNIX epoch when the command was run, the paths associated with the command. Note that the paths are encoded in an unusual fashion. You have to run the line through `string unescape --style=script` once to convert it to individual paths. You then need to pass each path through the same unescape command to obtain the original, literal, path. For example, to retrieve the most recently run command (not the current command being run) you would do `set hist_entry (history item 1)`. Note that you should not assume the number of lines (values) output will remain three. In the future additional data may be stored in the history and output by this subcommand. However, the currently documented lines will remain in their current order.
 
 The following options are available:
 

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -850,7 +850,9 @@ The user can change the settings of `fish` by changing the values of certain var
 
 - `argv`, an array of arguments to the shell or function. `argv` is only defined when inside a function call, or if fish was invoked with a list of arguments, like `fish myscript.fish foo bar`. This variable can be changed by the user.
 
-- `history`, an array containing the last commands that were entered.
+- `history` was an array available in fish 2.x containing the interactive commands
+  that were run. In fish 3.0 and later versions it no longer exists and
+  has been replaced by the more flexible, and faster, `history item` command.
 
 - `fish_history`: Name of the history session. It defaults to `fish` (which typically means the history will be saved in `~/.local/share/fish/fish_history`). This variable can be changed by the user. It does not have to be an environment variable. You can change it at will within an interactive fish session to change where subsequent commands are logged.
 

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -68,7 +68,7 @@ function history --description "display or manipulate interactive command histor
     # command. This allows the flags to appear before or after the subcommand.
     if not set -q hist_cmd[1]
         and set -q argv[1]
-        if contains $argv[1] search delete merge save clear
+        if contains $argv[1] search delete merge save clear item count
             set hist_cmd $argv[1]
             set -e argv[1]
         end
@@ -178,6 +178,15 @@ function history --description "display or manipulate interactive command histor
             else
                 printf (_ "You did not say 'yes' so I will not clear your command history\n")
             end
+
+        case count # retrieve an item from the history by index
+            __fish_unexpected_hist_args $argv
+            and return 1
+
+            builtin history count
+
+        case item # retrieve an item from the history by index
+            builtin history item $argv
 
         case '*'
             printf "%ls: unexpected subcommand '%ls'\n" $cmd $hist_cmd

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -857,7 +857,6 @@ void env_init(const struct config_paths_t *paths /* or NULL */) {
     // These variables can not be altered directly by the user.
     for (auto &k : {
              wcstring(L"status"),
-             wcstring(L"history"),
              wcstring(L"_"),
              wcstring(L"PWD"),
              wcstring(L"FISH_VERSION") }) {
@@ -866,7 +865,6 @@ void env_init(const struct config_paths_t *paths /* or NULL */) {
     };
 
     // Names of all dynamically calculated variables.
-    env_electric.emplace(L"history");
     env_electric.emplace(L"status");
     env_electric.emplace(L"umask");
 
@@ -1336,7 +1334,7 @@ maybe_t<env_var_t> env_get(const wcstring &key, env_mode_flags_t mode) {
             return env_var_t(L"umask", format_string(L"0%0.3o", get_umask()));
         }
         // We should never get here unless the electric var list is out of sync with the above code.
-        DIE("unerecognized electric var name");
+        DIE("unrecognized electric var name");
     }
 
     if (search_local || search_global) {

--- a/src/history.h
+++ b/src/history.h
@@ -244,6 +244,9 @@ class history_t {
     // Saves history.
     void save();
 
+    // Dumps a history item to stdout.
+    void dump_item(size_t idx, io_streams_t &iostreams);
+
     // Searches history.
     bool search(history_search_type_t search_type, wcstring_list_t search_args,
                 const wchar_t *show_time_format, size_t max_items, bool case_sensitive,

--- a/tests/generic.expect
+++ b/tests/generic.expect
@@ -6,32 +6,10 @@ spawn $fish
 
 expect_prompt
 
-# ensure the Apple key () is typeable
+# Ensure the Apple key () is typeable.
 send_line "echo "
 expect_prompt "" {} unmatched {
     puts stderr "Couldn't type apple key ()"
-}
-
-# check that history is returned in the right order (#2028)
-# this hist_command nonsense is the cleanest way to send the $ char
-set hist_command "echo \$history\[1\]"
-
-# first send 'echo stuff'
-send_line "echo stuff"
-expect_prompt "stuff" {} unmatched {
-    puts stderr "Couldn't find expected output 'stuff'"
-}
-
-# last history item should be 'echo stuff'
-send_line $hist_command
-expect_prompt "echo stuff" {} unmatched {
-    puts stderr "Couldn't find expected output 'echo stuff'"
-}
-
-# last history command should be the one that printed the history
-send_line $hist_command
-expect_prompt -re {echo .history.*} {} unmatched {
-    puts stderr "Couldn't find expected output $hist_command"
 }
 
 # Backslashes at end of comments (#1255)

--- a/tests/history.err
+++ b/tests/history.err
@@ -21,3 +21,4 @@ history merge: Expected 0 args, got 1
 history clear: Expected 0 args, got 2
 history: you cannot use any options with the save command
 history: you cannot use any options with the merge command
+history: item subcommand requires a single integer >= 1

--- a/tests/history.expect
+++ b/tests/history.expect
@@ -158,10 +158,19 @@ expect -re {\r\ncount again 1\r\n} {
     puts stderr "history function explicit exact search 'echo hello again' failed"
 }
 
-# Verify that the $history var has the expected content.
-send "echo history2=\$history\[2\]\r"
+# Verify that the `history item` command has the expected output.
+send "echo history2=(history item 2)\r"
 expect -re {\r\nhistory2=echo count AGAIN .*\r\n} {
-    puts "history\[2\] had the correct data"
+    puts "history item 2 had the correct data"
 } timeout {
-    puts stderr "history\[2\] had the wrong data"
+    puts stderr "history item 2 had the wrong data"
+}
+
+# Running `history item` with an index beyond the end of the history should
+# output nothing.
+send "echo history99 (history item 99)\r"
+expect -re {\r\nhistory99\r\n} {
+    puts "history item 99 had the correct data"
+} timeout {
+    puts stderr "history item 99 had the wrong data"
 }

--- a/tests/history.expect.out
+++ b/tests/history.expect.out
@@ -10,4 +10,5 @@ history function explicit glob search 'echo start*echo end' succeeded
 history function explicit exact delete 'echo hello' succeeded
 history function explicit prefix delete 'echo hello AGAIN' succeeded
 history function explicit exact search 'echo hello again' succeeded
-history[2] had the correct data
+history item 2 had the correct data
+history item 99 had the correct data

--- a/tests/history.in
+++ b/tests/history.in
@@ -39,6 +39,9 @@ builtin history clear abc def
 builtin history --contains save
 builtin history -t merge
 
+# `history item` with an invalid index should result in an error.
+history item 0
+
 # Now do a history command that should succeed so we exit with a zero,
 # success, status.
 builtin history save


### PR DESCRIPTION
Since @krader1961 has left the fish project, I've taken the liberty of cherry-picking this commit verbatim from his fork (with his permission, of course!). I've also granted maintainers of the fish project write permission to my fork, so feel free to tweak it as you see fit.

> The `history` variable is incredibly inefficient. Just doing `set -g`
> might take an extra 200 ms if you have 30,000 entries in your history.
> It's also very limited since it only provides the command line but not
> when it was run or the paths that fish extracted from the command.
> 
> So replace the `history` var with a `history item` command.
> 
> Fixes #4366 
> 