### PR TITLE
Insert a new line with a backslash with one key bind

### DIFF
--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -102,6 +102,9 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     # remove the commenting chars so the command can be further edited then executed.
     bind $argv \e\# __fish_toggle_comment_commandline
 
+    # Insert a space, a backslash and a newline (" \\\n") by pressing Ctrl-o.
+    bind $argv \co new-line-with-backslash
+
     # The [meta-e] and [meta-v] keystrokes invoke an external editor on the command buffer.
     bind \ee edit_command_buffer
     bind \ev edit_command_buffer

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -111,6 +111,7 @@ static const wchar_t *const name_arr[] = {L"beginning-of-line",
                                           L"forward-jump",
                                           L"backward-jump",
                                           L"and",
+                                          L"new-line-with-backslash",
                                           L"cancel"};
 
 wcstring describe_char(wint_t c) {
@@ -175,6 +176,7 @@ static const wchar_t code_arr[] = {R_BEGINNING_OF_LINE,
                                    R_FORWARD_JUMP,
                                    R_BACKWARD_JUMP,
                                    R_AND,
+                                   R_NEW_LINE_WITH_BACKSLASH,
                                    R_CANCEL};
 
 /// Mappings for the current input mode.

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -71,6 +71,7 @@ enum {
     R_FORWARD_JUMP,
     R_BACKWARD_JUMP,
     R_AND,
+    R_NEW_LINE_WITH_BACKSLASH,
     R_CANCEL,
     R_TIMEOUT,  // we didn't get interactive input within wait_on_escape_ms
     R_MAX = R_CANCEL,

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -918,6 +918,7 @@ static bool command_ends_paging(wchar_t c, bool focused_on_search_field) {
         case R_VI_ARG_DIGIT:
         case R_VI_DELETE_TO:
         case R_BEGINNING_OF_BUFFER:
+        case R_NEW_LINE_WITH_BACKSLASH:
         case R_END_OF_BUFFER: {
             // These commands operate on the search field if that's where the focus is.
             return !focused_on_search_field;
@@ -3169,6 +3170,11 @@ const wchar_t *reader_readline(int nchars) {
                 }
                 input_function_set_status(status);
                 reader_repaint_needed();
+                break;
+            }
+            case R_NEW_LINE_WITH_BACKSLASH: {
+                const wchar_t *str_to_insert = L" \\\n";
+                insert_string(data->active_edit_line(), str_to_insert);
                 break;
             }
             default: {


### PR DESCRIPTION
## Description

Add an input function 'new_line_with_backslash' and bind it to 'Ctrl-o' temporarily.

For example,
```fish
$ ps aux
```
and when we press Ctrl-o, a space, a backslash and a newline will automatically entered:
```fish
$ ps aux \
  (cursor is here) 
```
Then, we can write scripts like below more smartly by using this function, I think.
```fish
$ ps aux \
  | grep fish \
  | awk '{print $2}' \
  | xargs kill -9
```

It's better if it can be done with Shift+Enter, but most terminals treat 'Enter' and 'Shift+Enter' as the same and I couldn't.
