### PR TITLE
only call ioctl to export new termsize if process is in the foreground

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1592,7 +1592,10 @@ static void export_new_termsize(struct winsize *new_termsize) {
     env_set_one(L"LINES", ENV_GLOBAL | (lines.missing_or_empty() ? ENV_DEFAULT : ENV_EXPORT), buf);
 
 #ifdef HAVE_WINSIZE
-    ioctl(STDOUT_FILENO, TIOCSWINSZ, new_termsize);
+    // Only write the new terminal size if we are in the foreground (#4477)
+    if (tcgetpgrp(STDOUT_FILENO) == getpgrp()) {
+        ioctl(STDOUT_FILENO, TIOCSWINSZ, new_termsize);
+    }
 #endif
 }
 


### PR DESCRIPTION
Closes #4477.

- [ ] Tests have been added for regressions fixed

I haven't added any tests because I couldn't for the life of me create one that failed appropriately! Any assistance is appreciated.

From an interactive shell, `fish -c 'echo -n' &` fails with "Job 1, './fish -c 'echo -n' &' has stopped", but making it fail in the test harness has eluded me.