### PR TITLE
Make h1 distinguishable from h2

### DIFF
--- a/doc_src/user_doc.css
+++ b/doc_src/user_doc.css
@@ -105,7 +105,7 @@ h1, h2, h3, h4, h5, h6 {
 h1 {
     margin: 1.6rem 0 1rem 0;
     font-weight: 700;
-    font-size: 1.7rem;
+    font-size: 2.5rem;
 }
 h2 {
     margin: 1.6rem 0 1rem 0;


### PR DESCRIPTION
## Description

In the documentation, section headlines `<h1>` and `<h2>` share the same style. This makes navigating the documentation harder than it should be.

Fixes issue: none.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
