### PR TITLE
Stop outputting duplicate titles in man pages

### DIFF
--- a/build_tools/build_documentation.sh
+++ b/build_tools/build_documentation.sh
@@ -134,8 +134,8 @@ if test "$RESULT" = 0 ; then
 			-e "s/^\\.SH \"\(.*\)\"/\\.SH \1\\n/"
 		sed < ${CMD_NAME}.1.tmp-delete-quote > ${CMD_NAME}.1.tmp-bold \
 			-e "s/^\\.SH \("$CMD_NAME"\) \\-/\\.SH \\\fB\1\\\fP \\-/"
-		sed < ${CMD_NAME}.1.tmp-bold > ${CMD_NAME}.1.tmp-shape \
-			-z "s/\\.SH NAME\\n$CMD_NAME \\\- \\n\\.SH /\\.SH NAME\\n/"
+		cat ${CMD_NAME}.1.tmp-bold | perl -0pe \
+			"s/.SH NAME\n$CMD_NAME \\\- \n.SH /.SH NAME\n/m" > ${CMD_NAME}.1.tmp-shape
 		cp "${CMD_NAME}.1.tmp-shape" "${CMD_NAME}.1"
 		rm "${CMD_NAME}.1.tmp-delete-quote" "${CMD_NAME}.1.tmp-bold" "${CMD_NAME}.1.tmp-shape"
 	done


### PR DESCRIPTION
## Description

Command name continues twice in man page.

#### Current version's example

```
NAME
       andand - conditionally execute a command
```

![screenshot from 2017-11-13 01-32-11](https://user-images.githubusercontent.com/795197/32701060-98da4010-c812-11e7-9f52-4b0d2b30d087.png)


#### Fixed version:

```
NAME
       and - conditionally execute a command
```

![screenshot from 2017-11-13 01-32-34](https://user-images.githubusercontent.com/795197/32701059-98a9172e-c812-11e7-8e5c-89f761d5ef1e.png)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
