### PR TITLE
Added another optional way to shorten the pwd

### DIFF
--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -8,18 +8,36 @@ function prompt_pwd --description "Print the current working directory, shortene
         return 0
     end
 
-    # This allows overriding fish_prompt_pwd_dir_length from the outside (global or universal) without leaking it
-    set -q fish_prompt_pwd_dir_length
-    or set -l fish_prompt_pwd_dir_length 1
+    # This allows overriding fish_prompt_pwd_dir_length and fish_prompt_pwd_depth from the outside (global or universal) without leaking it
+  set -q fish_prompt_pwd_dir_length
+  or set -l fish_prompt_pwd_dir_length 1
+  
+  set -q fish_prompt_pwd_depth
+  or set -l fish_prompt_pwd_depth 0
 
-    # Replace $HOME with "~"
-    set realhome ~
-    set -l tmp (string replace -r '^'"$realhome"'($|/)' '~$1' $PWD)
+  # Replace $HOME with "~"
+  set realhome ~
+  set -l tmp (string replace -r '^'"$realhome"'($|/)' '~$1' $PWD)
+  # Split $temp to an array(for the trim depth only) 
+  set -l tempArr (string split '/' $tmp)
 
-    if [ $fish_prompt_pwd_dir_length -eq 0 ]
-        echo $tmp
-    else
-        # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
-        string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
+  if [ $fish_prompt_pwd_dir_length -eq 0 ]
+
+    if [ $fish_prompt_pwd_depth -gt (count $tempArr) -o $fish_prompt_pwd_depth -eq 0 ] #dont trim, dont shorten
+      echo $tmp 
+    else #trim, dont shorten
+      echo (string join '/' $tempArr[(math "-1 * "$fish_prompt_pwd_depth"")..-1]) 
     end
+
+  else
+
+    if [ $fish_prompt_pwd_depth -gt (count $tempArr) -o $fish_prompt_pwd_depth -eq 0 ] #dont trim, shorten
+      # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
+      string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
+    else #trim, shorten
+      set -l trimmed_pwd (string join '/' $tempArr[(math "-1 * "$fish_prompt_pwd_depth"")..-1]) 
+      string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $trimmed_pwd
+    end
+    
+  end
 end

--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -9,35 +9,33 @@ function prompt_pwd --description "Print the current working directory, shortene
     end
 
     # This allows overriding fish_prompt_pwd_dir_length and fish_prompt_pwd_depth from the outside (global or universal) without leaking it
-  set -q fish_prompt_pwd_dir_length
-  or set -l fish_prompt_pwd_dir_length 1
+    set -q fish_prompt_pwd_dir_length
+    or set -l fish_prompt_pwd_dir_length 1
   
-  set -q fish_prompt_pwd_depth
-  or set -l fish_prompt_pwd_depth 0
+    set -q fish_prompt_pwd_depth
+    or set -l fish_prompt_pwd_depth 0
 
-  # Replace $HOME with "~"
-  set realhome ~
-  set -l tmp (string replace -r '^'"$realhome"'($|/)' '~$1' $PWD)
-  # Split $temp to an array(for the trim depth only) 
-  set -l tempArr (string split '/' $tmp)
+    # Replace $HOME with "~"
+    set realhome ~
+    set -l tmp (string replace -r '^'"$realhome"'($|/)' '~$1' $PWD)
+    # Split $temp to an array(for the trim depth only) 
+    set -l tempArr (string split '/' $tmp)
 
-  if [ $fish_prompt_pwd_dir_length -eq 0 ]
+    if [ $fish_prompt_pwd_dir_length -eq 0 ]
 
-    if [ $fish_prompt_pwd_depth -gt (count $tempArr) -o $fish_prompt_pwd_depth -eq 0 ] #dont trim, dont shorten
-      echo $tmp 
-    else #trim, dont shorten
-      echo (string join '/' $tempArr[(math "-1 * "$fish_prompt_pwd_depth"")..-1]) 
+        if [ $fish_prompt_pwd_depth -gt (count $tempArr) -o $fish_prompt_pwd_depth -eq 0 ] #dont trim, dont shorten
+            echo $tmp 
+        else #trim, dont shorten
+            echo (string join '/' $tempArr[(math "-1 * "$fish_prompt_pwd_depth"")..-1]) 
+        end
+    else
+
+        if [ $fish_prompt_pwd_depth -gt (count $tempArr) -o $fish_prompt_pwd_depth -eq 0 ] #dont trim, shorten
+            # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
+            string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
+        else #trim, shorten
+            set -l trimmed_pwd (string join '/' $tempArr[(math "-1 * "$fish_prompt_pwd_depth"")..-1]) 
+            string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $trimmed_pwd
+        end
     end
-
-  else
-
-    if [ $fish_prompt_pwd_depth -gt (count $tempArr) -o $fish_prompt_pwd_depth -eq 0 ] #dont trim, shorten
-      # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
-      string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
-    else #trim, shorten
-      set -l trimmed_pwd (string join '/' $tempArr[(math "-1 * "$fish_prompt_pwd_depth"")..-1]) 
-      string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $trimmed_pwd
-    end
-    
-  end
 end


### PR DESCRIPTION
## Description

I added another way to shorten the pwd by depth, similar to how Bash-shell and ZSH do by default. 
eg, `~/doc/projects/folder/something/foo/bar` with the **fish_prompt_pwd_depth** set to 3, it will show: `something/foo/bar`

Of course that setting  **fish_prompt_pwd_depth** to 0 will show the entire pwd depth. and **fish_prompt_pwd_depth** and **fish_prompt_pwd_dir_length** can work together

## TODOs:
<!-- Just check off what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
