### PR TITLE
Disable HAVE_BROKEN_WCWIDTH

### DIFF
--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -266,7 +266,7 @@ int killpg(int pgr, int sig) {
 // Big hack to use our versions of wcswidth where we know them to be broken, which is
 // EVERYWHERE (https://github.com/fish-shell/fish-shell/issues/2199)
 #ifndef HAVE_BROKEN_WCWIDTH
-#define HAVE_BROKEN_WCWIDTH 1
+#define HAVE_BROKEN_WCWIDTH 0
 #endif
 
 #if !HAVE_BROKEN_WCWIDTH


### PR DESCRIPTION
## Description

As talked about in #4539, this disables HAVE_BROKEN_WCWIDTH.

It does not remove fish_wcwidth because I'm assuming that we need to reenable it in a bunch of cases, but I'm assuming the default should be to rely on the OSs implementation

Fixes issue #4539 (and possibly a bunch of others, e.g. #4306).

This is probably not something to merge, it's just to allow testing on common ground.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
