### PR TITLE
[Informative VCS Prompt] Pretty print failing exit codes

### DIFF
--- a/share/tools/web_config/sample_prompts/informative_vcs.fish
+++ b/share/tools/web_config/sample_prompts/informative_vcs.fish
@@ -3,8 +3,12 @@
 # human readable exit codes: Johan Walles <johan.walles at gmail.com>
 function _print_exitcode --description 'Print a human-readable exit code'
     set -l exitcode $argv[1]
+    if math $exitcode == 126 > /dev/null
+        echo -n "Not executable"
+        return
+    end
     if math $exitcode == 127 > /dev/null
-        echo -n "Command not found"
+        echo -n "Not found"
         return
     end
 


### PR DESCRIPTION
## Description

Before this change, if a command failed, this was indicated by the `$` at the end of the prompt turning red.

With this change in place, if a command fails, the exit code of the failing command is displayed in `[`square brackets`]`.

Also, some exit codes are parsed and printed in a more human friendly
form:
127: `Not found`
129 and up: Name of terminating signal
SIGINT: `CTRL-C`
SIGKILL: `kill -9`
SIGTERM: `kill`

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] **N/A**: Changes to fish usage are reflected in user documentation/manpages.
- [ ] **N/A**Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

Regarding the CHANGELOG.md, even though this is user visible I'm not convinced this is a big enough change for an entry there. If you disagree let me know and I'll add one.