### PR TITLE
[Informative VCS Prompt] Print failing exit codes

### DIFF
--- a/share/tools/web_config/sample_prompts/informative_vcs.fish
+++ b/share/tools/web_config/sample_prompts/informative_vcs.fish
@@ -90,9 +90,9 @@ function fish_prompt --description 'Write out the prompt'
 
     if not test $last_status -eq 0
         set_color $fish_color_error
+        echo -n "[$last_status] "
+        set_color normal
     end
 
     echo -n "$suffix "
-
-    set_color normal
 end


### PR DESCRIPTION
## Description

Before this change, if a command failed, this was indicated by the `$` at the end of the prompt turning red.

With this change in place, if a command fails, the exit code of the failing command is displayed in [square brackets].

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] **N/A**: Changes to fish usage are reflected in user documentation/manpages.
- [ ] **N/A**Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

Regarding the CHANGELOG.md, even though this is user visible I'm not convinced this is a big enough change for an entry there. If you disagree let me know and I'll add one.

This is like #4567 but without the exit code parsing.