### PR TITLE
Fixes issue #4544

### DIFF
--- a/doc_src/fish_color_selection.txt
+++ b/doc_src/fish_color_selection.txt
@@ -1,11 +1,11 @@
-\section fish_color_selection - color selection
+\section fish_color_selection - set color for selected text in vi mode
 
 \subsection fish_color_selection-synopsis Synopsis
 \fish{synopsis}
 fish_color_selection [OPTIONS] VALUE
 \endfish
 
-\subsection set_color-description Description
+\subsection fish_color_selection-description Description
 
 `fish_color_selection` is used to set which color to display for highlighting the selected text in vi mode. `VALUE` corresponds to a reserved color name such as *red* or a RGB color value given as 3 or 6 hexadecimal digits.
 

--- a/doc_src/fish_color_selection.txt
+++ b/doc_src/fish_color_selection.txt
@@ -1,0 +1,14 @@
+\section fish_color_selection - color selection
+
+\subsection fish_color_selection-synopsis Synopsis
+\fish{synopsis}
+fish_color_selection [OPTIONS] VALUE
+\endfish
+
+\subsection set_color-description Description
+
+`fish_color_selection` is used to set which color to display for highlighting the selected text in vi mode. `VALUE` corresponds to a reserved color name such as *red* or a RGB color value given as 3 or 6 hexadecimal digits.
+
+Valid colors include:
+
+see set_color section


### PR DESCRIPTION
## Description

The documentation for $fish_color_selection variable were missing. And this PR is meant to fix that.
From my understand $fish_color_selection is used to set which color to display for highlighting the selected text in vi mode please correct me if I am wrong.

For writing the doc
I created a file named 'fish_color_selection' under doc_src folder and added the documentation of $fish_color_selection on it.