### PR TITLE
Work around OS X issue with dropped #fragment in launched URLs

### DIFF
--- a/doc_src/user_doc.footer.html
+++ b/doc_src/user_doc.footer.html
@@ -1,2 +1,12 @@
 </body>
+<script type='text/javascript'>
+// Some platforms don't handle launching a browser to navigate a page with
+// a #fragment specified, so we use this workaround combined with a query string.
+// See https://github.com/fish-shell/fish-shell/issues/4480
+var params = new URLSearchParams(window.location.search); //?section=foo
+var section = params.get("section");
+if (section != null && location.hash == "") {
+	location.hash = "#" + section;
+}
+</script>
 </html>

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -86,16 +86,18 @@ function help --description 'Show help for the fish shell'
     end
 
     switch "$fish_help_item"
+        # Issue #4480: OS X strips the #fragment when opening URLs, so we also pass it in as
+        # a query string and jump to the appropriate section with some very basic javascript
         case "."
-            set fish_help_page "commands.html\#source"
+            set fish_help_page "commands.html\?section=source\#source"
         case globbing
-            set fish_help_page "index.html\#expand"
+            set fish_help_page "index.html\?section=expand\#expand"
         case (__fish_print_commands)
-            set fish_help_page "commands.html\#$fish_help_item"
+            set fish_help_page "commands.html\?section=$fish_help_item\#$fish_help_item"
         case $help_topics
-            set fish_help_page "index.html\#$fish_help_item"
+            set fish_help_page "index.html\?section=$fish_help_item\#$fish_help_item"
         case 'tut_*'
-            set fish_help_page "tutorial.html\#$fish_help_item"
+            set fish_help_page "tutorial.html\?section=$fish_help_item\#$fish_help_item"
         case tutorial
             set fish_help_page "tutorial.html"
         case "*"
@@ -128,15 +130,6 @@ function help --description 'Show help for the fish shell'
         set -l version_string (echo $version| cut -d . -f 1,2)
         set page_url https://fishshell.com/docs/$version_string/$fish_help_page
     end
-
-    # OS X /usr/bin/open swallows fragments (anchors), so use osascript
-    # Eval is just a cheesy way of removing the hash escaping
-    if test "$fish_browser" = osascript
-        set -l opencmd 'open location "'(eval echo $page_url)'"'
-        osascript -e 'try' -e $opencmd -e 'on error' -e $opencmd -e 'end try'
-        return
-    end
-
 
     # If browser is known to be graphical, put into background
     if contains -- $fish_browser[1] $graphical_browsers


### PR DESCRIPTION
The previous hack used to work around an OS X issue/bug where launching
a URL with a #fragment appended would drop the fragment by using
`osascript` does not seem to work any more. Append the section name as a
query string (in addition to, not instead of #section) and then use some
basic javascript appended to the user doc HTML template to parse that
and jump to the correct section (if the section was dropped).

Closes #4480