### PR TITLE
Better support for OpenBSD

### DIFF
--- a/share/completions/pfctl.fish
+++ b/share/completions/pfctl.fish
@@ -1,32 +1,32 @@
 complete -c pfctl -s s --description 'Show a filter parameter by modifier' -xa \
-	'queue\t"Show the currently loaded queue definitions." \
-	rules\t"Show the currently loaded filter rules." \
-	Anchors\t"Show the currently loaded anchors directly attached to the main ruleset." \
-	states\t"Show the contents of the state table."
-	Sources\t"Show the contents of the source tracking table." \
-	info\t"Show filter information (statistics and counters)." \
-	labels\t"Show per-rule statistics (label, evaluations, packets total, bytes total, packets in, bytes in, packets out, bytes out, state creations) of filter rules with labels, useful for accounting." \
-	timeouts\t"Show the current global timeouts." \
-	memory\t"Show the current pool memory hard limits." \
-	Tables\t"Show the list of tables." \
-	osfp\t"Show the list of operating system fingerprints." \
-	Interfaces\t"Show the list of interfaces and interface drivers available to PF." \
+	'queue\t"Show loaded queue definitions" \
+	rules\t"Show loaded filter rules" \
+	Anchors\t"Show anchors attached to main ruleset" \
+	states\t"Show state table"
+	Sources\t"Show source tracking table" \
+	info\t"Show filter information" \
+	labels\t"Show stats of labeled filter rules" \
+	timeouts\t"Show global timeouts" \
+	memory\t"Show pool memory hard limits" \
+	Tables\t"Show the list of tables" \
+	osfp\t"Show a list of OS fingerprints" \
+	Interfaces\t"List PF interfaces/drivers" \
 	all\t"Everything."'
-complete -c pfctl -s F --description 'Flush the filter params specified by mod' -xa \
-	'rules\t"Flush the filter rules." \
-	states\t"Flush the state table (NAT and filter)." \
-	Sources\t"Flush the source tracking table." \
-	info\t"Flush the filter information (statistics that are not bound to rules)." \
-	Tables\t"Flush the tables." \
-	ospf\t"Flush the passive operating system fingerprints." \
-	all\t"Flush everything."'
+complete -c pfctl -s F --description 'Flush filter params specified by mod' -xa \
+	'rules\t"Flush filter rules" \
+	states\t"Flush state table" \
+	Sources\t"Flush source tracking table" \
+	info\t"Flush filter information" \
+	Tables\t"Flush the tables" \
+	ospf\t"Flush the passive OS fingerprints" \
+	all\t"Flush everything"'
 complete -c pfctl -s T --description 'Table command' -xa \
 	'kill\t"Kill a table." \
-	flush\t"Flush all addresses of a table." \
-	add\t"Add one or more addresses in a table." \
-	delete\t"Delete one or more addresses from a table." \
-	expire\t"Delete addresses which had their statistics cleared more than number seconds ago." \
-	replace\t"Replace the addresses of the table." \
-	show\t"Show the content (addresses) of a table." \
-	test\t"Test if the given addresses match a table." \
-	zero\t"Clear all the statistics of a table."'
+	flush\t"Flush addresses of a table" \
+	add\t"Add one or more addresses in table" \
+	delete\t"Delete one or more addresses from a table" \
+	expire\t"Delete addresses where stats cleared > N seconds" \
+	replace\t"Replace the addresses of the table" \
+	show\t"Show the contents of a table" \
+	test\t"Test if the given addresses match a table" \
+	zero\t"Clear all the stats of a table"'

--- a/share/completions/pfctl.fish
+++ b/share/completions/pfctl.fish
@@ -1,0 +1,32 @@
+complete -c pfctl -s s --description 'Show a filter parameter by modifier' -xa \
+	'queue\t"Show the currently loaded queue definitions." \
+	rules\t"Show the currently loaded filter rules." \
+	Anchors\t"Show the currently loaded anchors directly attached to the main ruleset." \
+	states\t"Show the contents of the state table."
+	Sources\t"Show the contents of the source tracking table." \
+	info\t"Show filter information (statistics and counters)." \
+	labels\t"Show per-rule statistics (label, evaluations, packets total, bytes total, packets in, bytes in, packets out, bytes out, state creations) of filter rules with labels, useful for accounting." \
+	timeouts\t"Show the current global timeouts." \
+	memory\t"Show the current pool memory hard limits." \
+	Tables\t"Show the list of tables." \
+	osfp\t"Show the list of operating system fingerprints." \
+	Interfaces\t"Show the list of interfaces and interface drivers available to PF." \
+	all\t"Everything."'
+complete -c pfctl -s F --description 'Flush the filter params specified by mod' -xa \
+	'rules\t"Flush the filter rules." \
+	states\t"Flush the state table (NAT and filter)." \
+	Sources\t"Flush the source tracking table." \
+	info\t"Flush the filter information (statistics that are not bound to rules)." \
+	Tables\t"Flush the tables." \
+	ospf\t"Flush the passive operating system fingerprints." \
+	all\t"Flush everything."'
+complete -c pfctl -s T --description 'Table command' -xa \
+	'kill\t"Kill a table." \
+	flush\t"Flush all addresses of a table." \
+	add\t"Add one or more addresses in a table." \
+	delete\t"Delete one or more addresses from a table." \
+	expire\t"Delete addresses which had their statistics cleared more than number seconds ago." \
+	replace\t"Replace the addresses of the table." \
+	show\t"Show the content (addresses) of a table." \
+	test\t"Test if the given addresses match a table." \
+	zero\t"Clear all the statistics of a table."'

--- a/share/completions/pkg_add.fish
+++ b/share/completions/pkg_add.fish
@@ -1,0 +1,9 @@
+#completion for pkg_add
+
+complete -c pkg_add -o D -d 'failsafe to overwrite' -xa 'allversions arch checksum dontmerge donttie downgrade installed libdepends nonroot paranoid repair scripts SIGNER snap unsigned updatedepends'
+complete -c pkg_add -o V -d 'Turn on stats'
+complete -c pkg_add -o a -d 'Automated package installation'
+complete -c pkg_add -o h -d 'Print help'
+complete -c pkg_add -o u -d 'Update packages'
+complete -c pkg_add -o z -d 'Fuzzy match'
+

--- a/share/completions/pkg_delete.fish
+++ b/share/completions/pkg_delete.fish
@@ -1,0 +1,8 @@
+#completion for pkg_delete
+
+
+complete -c pkg_delete -a '(__fish_print_packages)' --description 'Package'
+
+complete -c pkg_delete -o a -d 'Delete unsed deps'
+complete -c pkg_delete -o V -d 'Turn on stats'
+

--- a/share/completions/pkg_info.fish
+++ b/share/completions/pkg_info.fish
@@ -1,0 +1,5 @@
+#completion for pkg_info
+
+
+complete -c pkg_info -a '(__fish_print_packages)' --description 'Package'
+

--- a/share/completions/rcctl.fish
+++ b/share/completions/rcctl.fish
@@ -1,0 +1,3 @@
+
+complete -c rcctl -xa 'check ls reload restart stop start disable enable' -n 'not __fish_seen_subcommand_from list check ls reload restart stop start enable disable'
+complete -c rcctl -n '__fish_seen_subcommand_from check reload restart stop start enable disable' -xa '(set -l files /etc/rc.d/*; string replace '/etc/rc.d/' '' -- $files)'

--- a/share/completions/rcctl.fish
+++ b/share/completions/rcctl.fish
@@ -1,3 +1,3 @@
 
 complete -c rcctl -xa 'check ls reload restart stop start disable enable' -n 'not __fish_seen_subcommand_from list check ls reload restart stop start enable disable'
-complete -c rcctl -n '__fish_seen_subcommand_from check reload restart stop start enable disable' -xa '(set -l files /etc/rc.d/*; string replace '/etc/rc.d/' '' -- $files)'
+complete -c rcctl -n '__fish_seen_subcommand_from check reload restart stop start enable disable' -xa '(set -l files /etc/rc.d/*; string replace "/etc/rc.d/" "" -- $files)'

--- a/share/completions/signify.fish
+++ b/share/completions/signify.fish
@@ -1,0 +1,4 @@
+complete -c signify -n '__fish_seen_subcommand_from' -s C --description 'Verify a signed checksum list'
+complete -c signify -n '__fish_seen_subcommand_from' -s G --description 'Generate a new key pair'
+complete -c signify -n '__fish_seen_subcommand_from' -s S --description 'Sign specified message'
+complete -c signify -n '__fish_seen_subcommand_from' -s V --description 'Verify a signed message and sig'

--- a/share/completions/vmctl.fish
+++ b/share/completions/vmctl.fish
@@ -1,4 +1,4 @@
 
 complete -c vmctl -xa 'console create load log reload reset start status stop pause unpause send receive' -n 'not __fish_seen_subcommand_from list console create load log reload reset start status stop pause unpause send receive'
-complete -c vmctl -n '__fish_seen_subcommand_from console reload reset start status stop pause unpause send receive' -xa '(vmctl status | string match -e -v 'MAXMEM' | string replace -r '^(\s+\S+\s+){7}' '')'
+complete -c vmctl -n '__fish_seen_subcommand_from console reload reset start status stop pause unpause send receive' -xa '(vmctl status | string match -e -v "MAXMEM" | string replace -r "^(\s+\S+\s+){7}" "")'
 

--- a/share/completions/vmctl.fish
+++ b/share/completions/vmctl.fish
@@ -1,0 +1,4 @@
+
+complete -c vmctl -xa 'console create load log reload reset start status stop pause unpause send receive' -n 'not __fish_seen_subcommand_from list console create load log reload reset start status stop pause unpause send receive'
+complete -c vmctl -n '__fish_seen_subcommand_from console reload reset start status stop pause unpause send receive' -xa '(vmctl status | string match -e -v 'MAXMEM' | string replace -r '^(\s+\S+\s+){7}' '')'
+

--- a/share/functions/__fish_print_filesystems.fish
+++ b/share/functions/__fish_print_filesystems.fish
@@ -1,5 +1,5 @@
 function __fish_print_filesystems -d "Print a list of all known filesystem types"
-    set -l fs adfs affs autofs coda coherent cramfs devpts efs ext ext2 ext3
+    set -l fs adfs affs autofs coda coherent cramfs devpts efs ext ext2 ext3 ffs
     set -a fs hfs hpfs iso9660 jfs minix msdos ncpfs nfs ntfs proc qnx4 ramfs
     set -a fs reiserfs romfs smbfs sysv tmpfs udf ufs umsdos vfat xenix xfs xiafs
     # Mount has helper binaries to mount filesystems

--- a/share/functions/__fish_print_interfaces.fish
+++ b/share/functions/__fish_print_interfaces.fish
@@ -3,6 +3,11 @@ function __fish_print_interfaces --description "Print a list of known network in
         set -l interfaces /sys/class/net/*
         string replace /sys/class/net/ '' $interfaces
     else # OSX/BSD
-        command ifconfig -l | string split ' '
+        set -l os (uname)
+        if string match -e -q "BSD" -- $os
+            command ifconfig | string match -e -r '^[a-z]' | string replace -r ':.*' '' | string split ' '
+        else
+            command ifconfig -l | string split ' '
+        end
     end
 end

--- a/share/functions/__fish_print_packages.fish
+++ b/share/functions/__fish_print_packages.fish
@@ -27,10 +27,7 @@ function __fish_print_packages
 
     # Pkg is fast on FreeBSD and provides versioning info which we want for
     # installed packages
-    if begin
-            type -q -f pkg
-            and test (uname) = "FreeBSD"
-        end
+    if type -q -f pkg
         pkg query "%n-%v"
         return
     end
@@ -39,10 +36,7 @@ function __fish_print_packages
     # installed packages but, calling it directly can cause delays in
     # returning information if another pkg_* tool have a lock.
     # Listing /var/db/pkg is a clean alternative.
-    if begin
-            type -q -f pkg_add
-            and test (uname) = "OpenBSD"
-        end
+    if type -q -f pkg_add
         set -l files /var/db/pkg/*; string replace '/var/db/pkg/' '' -- $files
         return
     end

--- a/share/functions/__fish_print_packages.fish
+++ b/share/functions/__fish_print_packages.fish
@@ -35,6 +35,18 @@ function __fish_print_packages
         return
     end
 
+    # pkg_info on OpenBSD provides versioning info which we want for
+    # installed packages but, calling it directly can cause delays in
+    # returning information if another pkg_* tool have a lock.
+    # Listing /var/db/pkg is a clean alternative.
+    if begin
+            type -q -f pkg_add
+            and test (uname) = "OpenBSD"
+        end
+        set -l files /var/db/pkg/*; string replace '/var/db/pkg/' '' -- $files
+        return
+    end
+
     # Caches for 5 minutes
     if type -q -f pacman
         set cache_file $XDG_CACHE_HOME/.pac-cache.$USER

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -876,7 +876,7 @@ def get_paths_from_man_locations():
         parent_paths = manpath.decode().strip().split(':')
     if (not parent_paths) or (proc and proc.returncode > 0):
         # HACK: Use some fallbacks in case we can't get anything else.
-        # `mandoc` does not provide `manpath` or `man --path` and $MANPATH might not be set, so just use the default for mandoc (minus /usr/X11R6/man, because that's not relevant).
+        # `mandoc` does not provide `manpath` or `man --path` and $MANPATH might not be set.
         # The alternative is reading its config file (/etc/man.conf)
         if os.path.isfile('/etc/man.conf'):
             data = open('/etc/man.conf', 'r')

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -857,7 +857,7 @@ def parse_and_output_man_pages(paths, output_directory, show_progress):
     add_diagnostic("Successfully parsed %d / %d pages" % (successful_count, total_count), BRIEF_VERBOSE)
     flush_diagnostics(sys.stderr)
 
-def get_paths_from_manpath():
+def get_paths_from_man_locations():
     # Return all the paths to man(1) and man(8) files in the manpath
     import subprocess, os
     proc = None
@@ -866,7 +866,6 @@ def get_paths_from_manpath():
         parent_paths = os.getenv("MANPATH").strip().split(':')
     else:
         # Some systems have manpath, others have `man --path` (like Haiku).
-        # TODO: Deal with systems that have neither (OpenBSD)
         for prog in [['manpath'], ['man', '--path']]:
             try:
                 proc = subprocess.Popen(prog, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -876,10 +875,18 @@ def get_paths_from_manpath():
         manpath, err_data = proc.communicate()
         parent_paths = manpath.decode().strip().split(':')
     if (not parent_paths) or (proc and proc.returncode > 0):
-        # HACK: Use some fallback in case we can't get anything else.
+        # HACK: Use some fallbacks in case we can't get anything else.
         # `mandoc` does not provide `manpath` or `man --path` and $MANPATH might not be set, so just use the default for mandoc (minus /usr/X11R6/man, because that's not relevant).
         # The alternative is reading its config file (/etc/man.conf)
-        sys.stderr.write("Unable to get the manpath, falling back to /usr/share/man:/usr/local/share/man. Please set $MANPATH if that is not correct.\n")
+        if os.path.isfile('/etc/man.conf'):
+            data = open('/etc/man.conf', 'r')
+            for line in data:
+                if ('manpath' in line or 'MANPATH' in line):
+                    p = line.split(' ')[1]
+                    p = p.split()[0]
+                    parent_paths.append(p)
+        if (not parent_paths):
+            sys.stderr.write("Unable to get the manpath, falling back to /usr/share/man:/usr/local/share/man. Please set $MANPATH if that is not correct.\n")
         parent_paths = ["/usr/share/man", "/usr/local/share/man"]
     result = []
     for parent_path in parent_paths:
@@ -943,8 +950,8 @@ if __name__ == "__main__":
             assert False, "unhandled option"
 
     if use_manpath:
-        # Fetch all man1 and man8 files from the manpath
-        file_paths.extend(get_paths_from_manpath())
+        # Fetch all man1 and man8 files from the manpath or man.conf
+        file_paths.extend(get_paths_from_man_locations())
 
     if cleanup_directories:
         for cleanup_dir in cleanup_directories:


### PR DESCRIPTION
## Description

This PR adds support for parsing `man.conf`, interfaces and packages on OpenBSD. It also brings in a set of completions for OpenBSD tools.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
