### PR TITLE
do not execute external command in pkill completions

### DIFF
--- a/share/completions/pkill.fish
+++ b/share/completions/pkill.fish
@@ -2,8 +2,7 @@
 __fish_complete_pgrep pkill
 __fish_make_completion_signals
 for i in $__kill_signals
-    set number (echo $i | cut -d " " -f 1)
-    set name (echo $i | cut -d " " -f 2)
+    echo $i | read number name
     complete -c pkill -o $number -d $name
     complete -c pkill -o $name -d $name
 end


### PR DESCRIPTION
## Description

Running "cut" multiple times in a loop has an adverse performance
impact on first use, especially on slow systems. Using builtin "read"
for the same purpose is faster and cleaner.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
