### PR TITLE
Updated `*.po` files, improved `mdadm` completions l10n

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-08 16:50+0100\n"
 "PO-Revision-Date: 2013-11-01 18:36+0100\n"
 "Last-Translator: Fabian Homborg\n"
 "Language-Team: deutsch <de@li.org>\n"
@@ -113,12 +113,12 @@ msgstr "Sende Job %d '%ls' in den Hintergrund\n"
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls: Es gibt keine passenden Jobs\n"
 
-#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82
+#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, fuzzy, c-format
 msgid "%ls: '%ls' is not a valid job specifier\n"
 msgstr "%ls: '%ls' ist kein Job\n"
 
-#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89
+#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89 src/builtin_wait.cpp:163
 #, fuzzy, c-format
 msgid "%ls: Could not find job '%d'\n"
 msgstr "%ls: Konnte '%d' nicht finden\n"
@@ -228,7 +228,7 @@ msgstr "%ls: -o benötigt einen nicht-leeren String\n"
 msgid "%ls: Key not specified\n"
 msgstr "%ls: Schlüssel nicht angegeben\n"
 
-#: src/builtin.cpp:261
+#: src/builtin.cpp:262
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
@@ -237,224 +237,228 @@ msgstr ""
 "%ls: Benutzen sie 'help %ls' für mehr Information\n"
 "\n"
 
-#: src/builtin.cpp:337
+#: src/builtin.cpp:338
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls: Nicht innerhalb einer Schleife\n"
 
-#: src/builtin.cpp:371
+#: src/builtin.cpp:372
 #, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr ""
 
-#: src/builtin.cpp:409 src/builtin.cpp:459
+#: src/builtin.cpp:410 src/builtin.cpp:460
 #, fuzzy
 msgid "Test a condition"
 msgstr "Eine Bedingung testen"
 
-#: src/builtin.cpp:410
+#: src/builtin.cpp:411
 msgid "Execute command if previous command suceeded"
 msgstr "Befehl ausführen, wenn vorheriger Befehl erfolgreich war"
 
-#: src/builtin.cpp:411
+#: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:412
+#: src/builtin.cpp:413
 msgid "Create a block of code"
 msgstr "Codeblock erstellen"
 
-#: src/builtin.cpp:413
+#: src/builtin.cpp:414
 msgid "Send job to background"
 msgstr "Job in Hintergrund schicken"
 
-#: src/builtin.cpp:414
+#: src/builtin.cpp:415
 msgid "Handle fish key bindings"
 msgstr "Fish-Tastenbelegungen bearbeiten"
 
-#: src/builtin.cpp:415
+#: src/builtin.cpp:416
 msgid "Temporarily block delivery of events"
 msgstr "Ereignisweitergabe vorübergehend blockieren"
 
-#: src/builtin.cpp:416
+#: src/builtin.cpp:417
 msgid "Stop the innermost loop"
 msgstr "Innerste Schleife beenden"
 
-#: src/builtin.cpp:418
+#: src/builtin.cpp:419
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 "Temporär Ausführung eines Skripts anhalten und einen interaktiven "
 "Debugprompt starten"
 
-#: src/builtin.cpp:419
+#: src/builtin.cpp:420
 msgid "Run a builtin command instead of a function"
 msgstr "Internen Befehl anstatt einer Funktion ausführen"
 
-#: src/builtin.cpp:420 src/builtin.cpp:458
+#: src/builtin.cpp:421 src/builtin.cpp:459
 msgid "Conditionally execute a block of commands"
 msgstr "Befehlsblock bedingt ausführen"
 
-#: src/builtin.cpp:421
+#: src/builtin.cpp:422
 msgid "Change working directory"
 msgstr "Arbeitsverzeichnis wechseln"
 
-#: src/builtin.cpp:422
+#: src/builtin.cpp:423
 msgid "Run a program instead of a function or builtin"
 msgstr "Programm statt Funktion oder internem Befehl ausführen"
 
-#: src/builtin.cpp:423
+#: src/builtin.cpp:424
 msgid "Set or get the commandline"
 msgstr "Festlegen oder Abrufen der Befehlszeile"
 
-#: src/builtin.cpp:424
+#: src/builtin.cpp:425
 msgid "Edit command specific completions"
 msgstr "Befehlsspezifische Erweiterungen bearbeiten"
 
-#: src/builtin.cpp:425
+#: src/builtin.cpp:426
 msgid "Search for a specified string in a list"
 msgstr "Nach einem String in einer Liste suchen"
 
-#: src/builtin.cpp:427
+#: src/builtin.cpp:428
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "Rest des aktuellen Durchlaufs der innersten Schleife überspringen"
 
-#: src/builtin.cpp:428
+#: src/builtin.cpp:429
 #, fuzzy
 msgid "Count the number of arguments"
 msgstr "Anzahl der Argumente zählen"
 
-#: src/builtin.cpp:429
+#: src/builtin.cpp:430
 #, fuzzy
 msgid "Remove job from job list"
 msgstr "Job aus Datei lesen"
 
-#: src/builtin.cpp:430
+#: src/builtin.cpp:431
 #, fuzzy
 msgid "Print arguments"
 msgstr "Argumente ausgeben"
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:432
 msgid "Evaluate block if condition is false"
 msgstr "Werte Block aus, wenn die Bedingung falsch ist"
 
-#: src/builtin.cpp:432
+#: src/builtin.cpp:433
 #, fuzzy
 msgid "Emit an event"
 msgstr "Ein Ereignis auslösen"
 
-#: src/builtin.cpp:433
+#: src/builtin.cpp:434
 msgid "End a block of commands"
 msgstr "Befehlsblock beenden"
 
-#: src/builtin.cpp:434
+#: src/builtin.cpp:435
 msgid "Run command in current process"
 msgstr "Befehl im aktuellen Prozess ausführen"
 
-#: src/builtin.cpp:435
+#: src/builtin.cpp:436
 msgid "Exit the shell"
 msgstr "Shell verlassen"
 
-#: src/builtin.cpp:436
+#: src/builtin.cpp:437
 msgid "Return an unsuccessful result"
 msgstr "Ein erfolgloses Resultat zurückgeben"
 
-#: src/builtin.cpp:437
+#: src/builtin.cpp:438
 msgid "Send job to foreground"
 msgstr "Job in Vordergrund schicken"
 
-#: src/builtin.cpp:438
+#: src/builtin.cpp:439
 msgid "Perform a set of commands multiple times"
 msgstr "Eine Befehlsfolge mehrmals ausführen"
 
-#: src/builtin.cpp:439
+#: src/builtin.cpp:440
 msgid "Define a new function"
 msgstr "Neue Funktion definieren"
 
-#: src/builtin.cpp:440
+#: src/builtin.cpp:441
 msgid "List or remove functions"
 msgstr "Funktionen auflisten oder entfernen"
 
-#: src/builtin.cpp:441
+#: src/builtin.cpp:442
 msgid "History of commands executed by user"
 msgstr "Befehlsgeschichte"
 
-#: src/builtin.cpp:442
+#: src/builtin.cpp:443
 msgid "Evaluate block if condition is true"
 msgstr "Block auswerten, wenn Bedingung wahr ist"
 
-#: src/builtin.cpp:443
+#: src/builtin.cpp:444
 msgid "Print currently running jobs"
 msgstr "Derzeit laufende Jobs ausgeben"
 
-#: src/builtin.cpp:444
+#: src/builtin.cpp:445
 #, fuzzy
 msgid "Evaluate math expressions"
 msgstr "Ausdruck auswerten"
 
-#: src/builtin.cpp:445
+#: src/builtin.cpp:446
 msgid "Negate exit status of job"
 msgstr "Exit-Status des Jobs verneinen"
 
-#: src/builtin.cpp:446
+#: src/builtin.cpp:447
 msgid "Execute command if previous command failed"
 msgstr "Befehl ausführen, wenn vorheriger Befehl fehlerhaft war"
 
-#: src/builtin.cpp:447
+#: src/builtin.cpp:448
 #, fuzzy
 msgid "Prints formatted text"
 msgstr "Befehlstyp ausgeben"
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:449
 #, fuzzy
 msgid "Print the working directory"
 msgstr "Arbeitsverzeichnis ausgeben"
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:450
 msgid "Generate random number"
 msgstr "Zufallszahl generieren"
 
-#: src/builtin.cpp:450
+#: src/builtin.cpp:451
 msgid "Read a line of input into variables"
 msgstr "Eine Eingabezeile in Variablen einlesen"
 
-#: src/builtin.cpp:451
+#: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr "Pfad zu absolutem Pfad ohne Symlinks konvertieren"
 
-#: src/builtin.cpp:452
+#: src/builtin.cpp:453
 msgid "Stop the currently evaluated function"
 msgstr "Derzeit ausgewertete Funktion stoppen"
 
-#: src/builtin.cpp:453
+#: src/builtin.cpp:454
 msgid "Handle environment variables"
 msgstr "Behandlung von Umgebungsvariablen"
 
-#: src/builtin.cpp:454
+#: src/builtin.cpp:455
 msgid "Set the terminal color"
 msgstr "Setzen der Terminalfarbe"
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:456
 msgid "Evaluate contents of file"
 msgstr "Inhalt einer Datei auswerten"
 
-#: src/builtin.cpp:456
+#: src/builtin.cpp:457
 msgid "Return status information about fish"
 msgstr "Statusinformation über Fish zurückgeben"
 
-#: src/builtin.cpp:457
+#: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr "Strings manipulieren"
 
-#: src/builtin.cpp:460
+#: src/builtin.cpp:461
 msgid "Return a successful result"
 msgstr "Ein erfolgreiches Resultat zurückgeben"
 
-#: src/builtin.cpp:461
+#: src/builtin.cpp:462
 msgid "Set or get the shells resource usage limits"
 msgstr "Die Ressourcengrenzen der Shell festlegen/abrufen"
 
-#: src/builtin.cpp:462
+#: src/builtin.cpp:463
+msgid "Wait for background processes completed"
+msgstr ""
+
+#: src/builtin.cpp:464
 msgid "Perform a command multiple times"
 msgstr "Einen Befehl mehrmals ausführen"
 
@@ -1525,58 +1529,58 @@ msgstr "Ihre persönlichen Einstellungen werden NICHT gespeichert."
 msgid "Your history will not be saved."
 msgstr "Ihre Geschichte wird nicht gespeichert."
 
-#: src/proc.cpp:590
+#: src/proc.cpp:586
 #, c-format
 msgid "Job %d, "
 msgstr ""
 
-#: src/proc.cpp:591
+#: src/proc.cpp:587
 #, fuzzy, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: %ls'%ls' durch Signal %ls (%ls) beendet"
 
-#: src/proc.cpp:599
+#: src/proc.cpp:595
 #, fuzzy, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Prozess %d, '%ls' %ls'%ls' durch Signal %ls (%ls) beendet"
 
-#: src/proc.cpp:769
+#: src/proc.cpp:779
 msgid "An error occured while reading output from code block"
 msgstr "Fehler während des Lesens der Ausgabe aus Codeblock"
 
-#: src/proc.cpp:846
+#: src/proc.cpp:856
 #, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr ""
 
-#: src/proc.cpp:875
+#: src/proc.cpp:885
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Konnte Job %d ('%ls') nicht in den Vordergrund schicken"
 
-#: src/proc.cpp:899 src/proc.cpp:908 src/proc.cpp:922
+#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
 msgid "Could not return shell to foreground"
 msgstr "Konnte Shell nicht wieder in Vordergrund zurückholen"
 
-#: src/proc.cpp:1055
+#: src/proc.cpp:1065
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "Mehr als ein Job im Vordergrund: Job 1: '%ls' Job 2: '%ls'"
 
-#: src/proc.cpp:1065
+#: src/proc.cpp:1075
 msgid "Process argument list"
 msgstr "Prozessargumentliste"
 
-#: src/proc.cpp:1066
+#: src/proc.cpp:1076
 msgid "Process name"
 msgstr "Prozessname"
 
-#: src/proc.cpp:1069
+#: src/proc.cpp:1079
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Job '%ls', Prozess '%ls' hat inkonsistenten Status 'stopped'=%d"
 
-#: src/proc.cpp:1075
+#: src/proc.cpp:1085
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr "Job '%ls', Prozess '%ls' hat inkonsistenten Status 'completed'=%d"
@@ -1957,8 +1961,7 @@ msgstr ""
 #: src/builtin.h:45
 #, fuzzy, c-format
 msgid "%ls: Variable scope can only be one of universal, global and local\n"
-msgstr ""
-"%ls: Variablenbereich kann nur universell, global oder lokal sein\n"
+msgstr "%ls: Variablenbereich kann nur universell, global oder lokal sein\n"
 
 #: src/builtin.h:48
 #, fuzzy, c-format
@@ -2572,6 +2575,229 @@ msgstr "Kernel-Version ausgeben"
 msgid "Prints the usage for a given subcommand"
 msgstr "Pfad zu Befehl ausgeben"
 
+#: /tmp/fish/explicit/share/completions/mdadm.fish:1
+#: /tmp/fish/explicit/share/completions/mdadm.fish:2
+msgid "Use original 0.90 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:3
+#: /tmp/fish/explicit/share/completions/mdadm.fish:4
+#, fuzzy
+msgid "Use last 1.x format superblock"
+msgstr "Normale Ausgabe unterdrücken"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:5
+msgid "Use 1.0 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:6
+msgid "Use 1.1 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:7
+msgid "Use 1.2 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:8
+msgid "Use DDF (Disk Data Format) format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:9
+msgid "Use Intel(R) Matrix Storage Manager format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:10
+msgid "JBOD"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:11
+#: /tmp/fish/explicit/share/completions/mdadm.fish:12
+#: /tmp/fish/explicit/share/completions/mdadm.fish:13
+#, fuzzy
+msgid "Stripped volume (RAID 0)"
+msgstr "Konfigurationsdatei angeben"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:14
+#: /tmp/fish/explicit/share/completions/mdadm.fish:15
+#: /tmp/fish/explicit/share/completions/mdadm.fish:16
+msgid "Mirrored volume (RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:17
+#: /tmp/fish/explicit/share/completions/mdadm.fish:18
+msgid "Stripped volume with parity disk (RAID 4)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:19
+#: /tmp/fish/explicit/share/completions/mdadm.fish:20
+msgid "Stripped volume with distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:21
+#: /tmp/fish/explicit/share/completions/mdadm.fish:22
+msgid "Stripped volume with double distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:23
+#: /tmp/fish/explicit/share/completions/mdadm.fish:24
+msgid "Mirrored stripped volume (RAID 10)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:25
+#: /tmp/fish/explicit/share/completions/mdadm.fish:26
+msgid "Multiple access device, AKA multipath (deprecated)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:27
+msgid "Pseudo RAID layer for single device (akin faulty RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:28
+#, fuzzy
+msgid "Container"
+msgstr "Kein Neue-Zeile-Zeichen"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:29
+msgid "Alias of left-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:30
+msgid "Alias of right-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:31
+msgid "Alias of left-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:32
+msgid "Alias of right-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:33
+msgid "Alias of write-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:34
+#, fuzzy
+msgid "Alias of read-transient"
+msgstr "Alias für atrm"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:35
+msgid "Alias of write-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:36
+msgid "Alias of read-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:37
+#, fuzzy
+msgid "Alias of read-fixable"
+msgstr "Datei ist lesbar"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:38
+#, fuzzy
+msgid "Use standard format (default)"
+msgstr "Normale Ausgabe unterdrücken"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:39
+#, fuzzy
+msgid "Use a non-partitionable array"
+msgstr "Paketdepot aktualisieren"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:40
+#: /tmp/fish/explicit/share/completions/mdadm.fish:41
+#: /tmp/fish/explicit/share/completions/mdadm.fish:42
+#, fuzzy
+msgid "Use a partitionable array"
+msgstr "Paketdepot aktualisieren"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:43
+msgid "Remove superblock misalignement from SPARC kernel 2.2"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:44
+#, fuzzy
+msgid "Correct superblock summaries"
+msgstr "Quellen aktualisieren"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:45
+#, fuzzy
+msgid "Update array UUID"
+msgstr "Quellen aktualisieren"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:46
+#, fuzzy
+msgid "Update array name"
+msgstr "Dienstname"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:47
+#, fuzzy
+msgid "Update array nodes"
+msgstr "Quellen aktualisieren"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:48
+#, fuzzy
+msgid "Update array homehost"
+msgstr "Quellen aktualisieren"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:49
+#, fuzzy
+msgid "Update array cluster name"
+msgstr "Dienstname"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:50
+msgid "Mark the array as dirty, thus forcing resync"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:51
+msgid "Reverse superblock endianness"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:52
+#, fuzzy
+msgid "Refresh device size"
+msgstr "Depot deaktivieren"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:53
+msgid "Assume bitmap absence"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:54
+#, fuzzy
+msgid "Reserve space for bad block list"
+msgstr "Komprimierte Patche erstellen"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:55
+msgid "Free reserved space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:56
+msgid "Convert 0.90 metadata to 1.0"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:57
+msgid "Reset preferred minor to current one"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:58
+#, fuzzy
+msgid "Abort currently running actions"
+msgstr "Derzeit laufende Jobs ausgeben"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:59
+msgid "Abort currently running actions, prevent their restart"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:60
+msgid "Scrub the array (i.e. check constistency)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:61
+#, fuzzy
+msgid "Check, then resync"
+msgstr "Installierte Pakete abfragen"
+
 #: /tmp/fish/explicit/share/completions/set.fish:1
 msgid "Locale"
 msgstr "Locale"
@@ -2999,8 +3225,8 @@ msgid ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
 "VARIABLE\\n"
 msgstr ""
-"%s: Erwartete genau ein Argument, erhielt %s.\\n\\nSynopsis:\\n\\t%svared"
-"%s VARIABLE\\n"
+"%s: Erwartete genau ein Argument, erhielt %s.\\n\\nSynopsis:\\n\\t%svared%s "
+"VARIABLE\\n"
 
 #: /tmp/fish/implicit/share/config.fish:1
 msgid "Update PATH when fish_user_paths changes"
@@ -3545,6 +3771,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
 #: /tmp/fish/implicit/share/completions/asp.fish:6
 #: /tmp/fish/implicit/share/completions/bc.fish:7
+#: /tmp/fish/implicit/share/completions/bd.fish:4
 #: /tmp/fish/implicit/share/completions/bg.fish:1
 #: /tmp/fish/implicit/share/completions/bind.fish:4
 #: /tmp/fish/implicit/share/completions/block.fish:1
@@ -4186,7 +4413,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bzr.fish:1
 #: /tmp/fish/implicit/share/completions/climate.fish:1
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:17
-#: /tmp/fish/implicit/share/completions/cygport.fish:23
+#: /tmp/fish/implicit/share/completions/cygport.fish:25
 #: /tmp/fish/implicit/share/completions/godoc.fish:25
 #: /tmp/fish/implicit/share/completions/gofmt.fish:8
 #: /tmp/fish/implicit/share/completions/goimports.fish:6
@@ -5622,6 +5849,7 @@ msgstr "Datei zum Speichern des Quellenzwischenspeichers auswählen"
 #: /tmp/fish/implicit/share/completions/apt-get.fish:24
 #: /tmp/fish/implicit/share/completions/configure.fish:3
 #: /tmp/fish/implicit/share/completions/gpg.fish:62
+#: /tmp/fish/implicit/share/completions/hugo.fish:5
 #: /tmp/fish/implicit/share/completions/make.fish:16
 #: /tmp/fish/implicit/share/completions/ping.fish:16
 #: /tmp/fish/implicit/share/completions/rpm.fish:3
@@ -5792,6 +6020,7 @@ msgid "Set a configuration option"
 msgstr "Konfigurationsoption festlegen"
 
 #: /tmp/fish/implicit/share/completions/apt.fish:8
+#: /tmp/fish/implicit/share/completions/hugo.fish:1
 #: /tmp/fish/implicit/share/completions/man.fish:14
 #: /tmp/fish/implicit/share/completions/modprobe.fish:2
 #: /tmp/fish/implicit/share/completions/yum.fish:13
@@ -9031,6 +9260,19 @@ msgstr "POSIX bc genau verarbeiten"
 msgid "Do not print the GNU welcome"
 msgstr "GNU welcome-Meldung nicht ausgeben"
 
+#: /tmp/fish/implicit/share/completions/bd.fish:1
+msgid "Classic mode: goes back to the first directory named as the string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:2
+msgid "Seems mode: goes back to the first directory containing string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:3
+#, fuzzy
+msgid "Case insensitive move (implies seems mode)"
+msgstr "Groß-/Klein-Schreibung nicht unterscheiden"
+
 #: /tmp/fish/implicit/share/completions/bind.fish:1
 msgid "Show unavailable key bindings/erase all bindings"
 msgstr ""
@@ -10587,7 +10829,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/caddy.fish:24
 #: /tmp/fish/implicit/share/completions/canto.fish:2
-#: /tmp/fish/implicit/share/completions/cygport.fish:24
+#: /tmp/fish/implicit/share/completions/cygport.fish:26
 #: /tmp/fish/implicit/share/completions/grub-install.fish:33
 #: /tmp/fish/implicit/share/completions/lua.fish:4
 #: /tmp/fish/implicit/share/completions/magento.fish:23
@@ -13907,29 +14149,39 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:17
 #, fuzzy
+msgid "Create packages, marked as test"
+msgstr "Paketdepot aktualisieren"
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:18
+#, fuzzy
 msgid "Create packages"
 msgstr "Paket löschen"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:18
+#: /tmp/fish/implicit/share/completions/cygport.fish:19
 #, fuzzy
 msgid "Create source patches"
 msgstr "Quellpakete bereinigen"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:19
+#: /tmp/fish/implicit/share/completions/cygport.fish:20
 #, fuzzy
 msgid "Upload finished packages"
 msgstr "Pakete aktualisieren"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:20
+#: /tmp/fish/implicit/share/completions/cygport.fish:21
+#, fuzzy
+msgid "Upload packages without marking !ready"
+msgstr "Ein Paket neu erstellen"
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:22
 msgid "Send announcement email"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:21
+#: /tmp/fish/implicit/share/completions/cygport.fish:23
 #, fuzzy
 msgid "Delete working directory"
 msgstr "Arbeitsverzeichnis wechseln"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:22
+#: /tmp/fish/implicit/share/completions/cygport.fish:24
 msgid "Same as prep build inst pkg"
 msgstr ""
 
@@ -33389,6 +33641,7 @@ msgid "Name of the output file"
 msgstr "Keine Ausgabedateien erstellen"
 
 #: /tmp/fish/implicit/share/completions/highlight.fish:5
+#: /tmp/fish/implicit/share/completions/hugo.fish:57
 #: /tmp/fish/implicit/share/completions/tex.fish:10
 #, fuzzy
 msgid "Output directory"
@@ -33438,6 +33691,558 @@ msgstr "Benutzer beobachten"
 #, fuzzy
 msgid "Sort column"
 msgstr "Nach Spalten auflisten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:2
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
+#, fuzzy
+msgid "Debug output"
+msgstr "Debug-Ausgabe aktivieren"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:3
+#, fuzzy
+msgid "Enable logging"
+msgstr "Entfernung der Zusatzinformationen abschalten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:4
+#, fuzzy
+msgid "Log file"
+msgstr "Log in Datei schreiben"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:6
+#: /tmp/fish/implicit/share/completions/iptables.fish:25
+#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
+#, fuzzy
+msgid "Verbose output"
+msgstr "Ausführlicher Prompt"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:7
+#, fuzzy
+msgid "Verbose logging"
+msgstr "Angemeldete Benutzer auflisten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:8
+#, fuzzy
+msgid "Hostname and path to the root"
+msgstr "Paketdepot aktualisieren"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:9
+#, fuzzy
+msgid "Include content marked as draft"
+msgstr "include-Verzeichnis"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:10
+#, fuzzy
+msgid "Include expired content"
+msgstr "include-Verzeichnis"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:11
+#, fuzzy
+msgid "Include content with publishdate in the future"
+msgstr "Umgekehrte Abhängigkeiten für das Paket auflisten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:12
+#, fuzzy
+msgid "Cache directory"
+msgstr "Verzeichnis wechseln"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:13
+msgid "Canonicalize all relative URLs using baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:14
+#, fuzzy
+msgid "Remove files from destination not found in static directories"
+msgstr "Dateien nach Archivierung entfernen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:15
+#, fuzzy
+msgid "Content directory"
+msgstr "Verzeichnis wechseln"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:16
+#, fuzzy
+msgid "Destination directory"
+msgstr "CVS-Paketdepot erstellen, wenn es nicht existiert"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:17
+#, fuzzy
+msgid "Do not build 404 page"
+msgstr "Erstellte Dateien nicht löschen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:18
+#, fuzzy
+msgid "Disable different kinds of pages"
+msgstr "Sparse-Dateien bearbeiten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:19
+#, fuzzy
+msgid "Do not build RSS files"
+msgstr "Erstellte Dateien nicht löschen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:20
+#, fuzzy
+msgid "Do not build sitemap files"
+msgstr "Erstellte Dateien nicht löschen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:21
+msgid "Add Git revision, date and author info to the pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:22
+msgid "Copy all files when static is changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:23
+msgid "Help for hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:24
+#, fuzzy
+msgid "Print missing translations"
+msgstr "Kompressionsraten ausgeben"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:25
+#, fuzzy
+msgid "Ignore the cache directory"
+msgstr "include-Verzeichnis"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:26
+#, fuzzy
+msgid "Layout directory"
+msgstr "mime-Typ ausgeben"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:27
+#, fuzzy
+msgid "Do not sync permission mode of files"
+msgstr "Quelldateien nicht löschen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:28
+#, fuzzy
+msgid "Do not sync modification time of files"
+msgstr "Nach Veränderungsdatum sortieren"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:29
+msgid "Pluralize titles in lists using inflect"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:30
+msgid "Preserve taxonomy names as written"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:31
+#: /tmp/fish/implicit/share/completions/hugo.fish:45
+#, fuzzy
+msgid "Render to memory"
+msgstr "Speicherbedarf reduzieren"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:32
+#: /tmp/fish/implicit/share/completions/hugo.fish:58
+#: /tmp/fish/implicit/share/completions/hugo.fish:92
+#: /tmp/fish/implicit/share/completions/hugo.fish:103
+#, fuzzy
+msgid "Source directory"
+msgstr "Quellverzeichnis eintragen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:33
+#: /tmp/fish/implicit/share/completions/hugo.fish:46
+#, fuzzy
+msgid "Display memory and timing of different steps of the program"
+msgstr "Namen aller Signale anzeigen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:34
+#: /tmp/fish/implicit/share/completions/hugo.fish:47
+#, fuzzy
+msgid "Display metrics about template executions"
+msgstr "$ am Zeilenende anzeigen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:35
+#: /tmp/fish/implicit/share/completions/hugo.fish:48
+msgid "Calculate some improvement hints when combined with --templateMetrics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:36
+#, fuzzy
+msgid "Theme to use"
+msgstr "Mail an Benutzer senden"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:37
+#, fuzzy
+msgid "Themes directory"
+msgstr "Das test-Verzeichnis entfernen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:38
+#, fuzzy
+msgid "Use /filename.html instead of /filename/"
+msgstr "purge anstelle von remove verwenden"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:39
+#, fuzzy
+msgid "Watch filesystem for changes and recreate as needed"
+msgstr "Lokale Änderungen patchen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:40
+msgid "Benchmark Hugo by building the site a number of times"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:41
+msgid "Number of times to build the site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:42
+#, fuzzy
+msgid "CPU profile file"
+msgstr "Konfigurationsdatei benutzen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:43
+msgid "Help for benchmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:44
+#, fuzzy
+msgid "Memory profile file"
+msgstr "Datei nicht erstellen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:49
+#, fuzzy
+msgid "Perform some verification checks"
+msgstr "Inhaltsgenerierung durchführen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:50
+msgid "Help for check"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:51
+msgid "Check system ulimit settings"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:52
+#, fuzzy
+msgid "Help for ulimit"
+msgstr "Rekursionsgrenze"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:53
+#, fuzzy
+msgid "Print the site configuration"
+msgstr "Dienstkonfiguration neu laden"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:54
+#, fuzzy
+msgid "Help for config"
+msgstr "Hilfeabschnitt zu"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:55
+#, fuzzy
+msgid "Convert the content to different formats"
+msgstr "Keine Verzeichnis-Hierarchie erstellen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:56
+#, fuzzy
+msgid "Help for convert"
+msgstr "Alias für atq"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:59
+#, fuzzy
+msgid "Enable less safe operations"
+msgstr "Zeichensatzeigenschaften anzeigen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:60
+msgid "Convert front matter to JSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:61
+msgid "Help for toJSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:62
+msgid "Convert front matter to TOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:63
+msgid "Help for toTOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:64
+msgid "Convert front matter to YAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:65
+msgid "Help for toYAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:66
+#, fuzzy
+msgid "Print Hugo version and environment info"
+msgstr "Sämtliche Versions-Informationen ignorieren"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:67
+#, fuzzy
+msgid "Help for env"
+msgstr "Alias für atq"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:68
+msgid "Collection of several useful generators"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:69
+msgid "Help for gen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:70
+msgid "Generate shell autocompletion script for Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:71
+#, fuzzy
+msgid "Autocompletion file"
+msgstr "Saloppe Einhäng-Optionen tolerieren"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:72
+msgid "Help for autocomplete"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:73
+#, fuzzy
+msgid "Autocompletion type"
+msgstr "Pfad, bei dem Vervollständigung berücksichtigt werden soll"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:74
+msgid "Generate CSS stylesheet for the Chroma code highlighter"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:75
+msgid "Help for chromastyles"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:76
+#, fuzzy
+msgid "Style used for highlighting lines"
+msgstr "Keine Hervorhebung bei Suche"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:77
+#, fuzzy
+msgid "Style used for line numbers"
+msgstr "Version anzeigen und beenden"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:78
+msgid "Highlighter style"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:79
+#, fuzzy
+msgid "Generate Markdown documentation for the Hugo CLI"
+msgstr "Ein installiertes Paket neu erstellen und installieren"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:80
+#, fuzzy
+msgid "Doc directory"
+msgstr "Verzeichnis"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:81
+msgid "Help for doc"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:82
+#, fuzzy
+msgid "Generate man pages for the Hugo CLI"
+msgstr "Inhaltsdatei erstellen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:83
+#, fuzzy
+msgid "Man pages directory"
+msgstr "Verzeichnis wechseln"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:84
+#, fuzzy
+msgid "Help for man"
+msgstr "Kurzes Format"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:85
+#, fuzzy
+msgid "Import your site from others"
+msgstr "Auf Standardausgabe komprimieren"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:86
+#, fuzzy
+msgid "Help for import"
+msgstr "Zu importierendes Verzeichnis"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:87
+msgid "Import from Jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:88
+#, fuzzy
+msgid "Allow import into non-empty target directory"
+msgstr "Eine lokale Kopie eines weiteren Paketdepots erstellen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:89
+msgid "Help for jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:90
+#, fuzzy
+msgid "List various types of content"
+msgstr "Archiv auflisten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:91
+#, fuzzy
+msgid "Help for list"
+msgstr "Heimordner für %ls"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:93
+#, fuzzy
+msgid "List all drafts"
+msgstr "Namen der verfügbaren Signale auflisten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:94
+msgid "Help for drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:95
+#, fuzzy
+msgid "List all expired posts"
+msgstr "Namen der verfügbaren Signale auflisten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:96
+#, fuzzy
+msgid "Help for expired"
+msgstr "Zeitgeber abgelaufen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:97
+#, fuzzy
+msgid "List all posts dated in the future"
+msgstr "Paketdepot aktualisieren"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:98
+#, fuzzy
+msgid "Help for future"
+msgstr "Alias für atrm"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:99
+#, fuzzy
+msgid "Create new content"
+msgstr "Umgebung erhalten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:100
+#, fuzzy
+msgid "Editor to use"
+msgstr "Mail an Benutzer senden"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:101
+msgid "Help for new"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:102
+#, fuzzy
+msgid "Content type to create"
+msgstr "Ausgabe an Datei anfügen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:104
+#, fuzzy
+msgid "Create a new site"
+msgstr "Neues Projekt erstellen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:105
+#, fuzzy
+msgid "Create site inside non-empty directory"
+msgstr "CVS-Paketdepot erstellen, wenn es nicht existiert"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:106
+msgid "Config and front matter format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:107
+#, fuzzy
+msgid "Help for site"
+msgstr "Heimordner für %ls"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:108
+#, fuzzy
+msgid "Create a new theme"
+msgstr "Umgebung erhalten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:109
+#, fuzzy
+msgid "Help for theme"
+msgstr "Nach anderem System suchen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:110
+#, fuzzy
+msgid "Start high performance web server"
+msgstr "Dienst starten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:111
+#, fuzzy
+msgid "Append port to baseurl"
+msgstr "Eingabe an Auswahl anfügen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:112
+msgid "Interface to which the server will bind"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:113
+#, fuzzy
+msgid "Enable full re-renders on changes"
+msgstr "Fehler aus Paketen auflisten"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:114
+msgid "Watch without enabling live browser reload on rebuild"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:115
+#, fuzzy
+msgid "Help for server"
+msgstr "Proxy-Server verwenden"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:116
+#, fuzzy
+msgid "Port for live reloading"
+msgstr "Dynamische Port-Weiterleitung"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:117
+msgid "Interval to poll memory usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:118
+#, fuzzy
+msgid "Memory usage log file"
+msgstr "Veraltete Dateien löschen"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:119
+msgid "Navigate to changed content file on live browser reload"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:120
+msgid "Prevent HTTP caching"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:121
+msgid "Port on which the server will listen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:122
+#, fuzzy
+msgid "Render to destination directory"
+msgstr "CVS-Paketdepot erstellen, wenn es nicht existiert"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:123
+msgid "Reset the content draft status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:124
+msgid "Help for undraft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:125
+#, fuzzy
+msgid "Print the version number of Hugo"
+msgstr "Zeilennummer ausgeben"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:126
+#, fuzzy
+msgid "Help for version"
+msgstr "Name des Patch"
 
 #: /tmp/fish/implicit/share/completions/i3-msg.fish:1
 msgid "Only send ipc message and suppress output"
@@ -34021,13 +34826,6 @@ msgstr ""
 msgid "Initialize packet and byte counters of a rule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/iptables.fish:25
-#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
-#, fuzzy
-msgid "Verbose output"
-msgstr "Ausführlicher Prompt"
-
 #: /tmp/fish/implicit/share/completions/iptables.fish:26
 msgid "Wait for the xtables lock"
 msgstr ""
@@ -34398,6 +35196,114 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/jest.fish:77
 msgid "Disable using watchman for file crawling"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:1
+#, fuzzy
+msgid "Enable debugger"
+msgstr "Entfernung der Zusatzinformationen abschalten"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:2
+#, fuzzy
+msgid "Output usage information"
+msgstr "Kann Benutzerinformation nicht abrufen"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:3
+#, fuzzy
+msgid "Output version number"
+msgstr "Versionsnummer"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:4
+#, fuzzy
+msgid "Create a new JHipster application"
+msgstr "Neues Projekt erstellen"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:5
+#, fuzzy
+msgid "Deploy the current application to AWS"
+msgstr "Veraltete Paketdateien löschen"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:6
+msgid "Create pipeline scripts for popular CI tools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:7
+msgid "Create a new JHipster client-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:8
+msgid "Prepare Cloud Foundry deployment"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:9
+msgid ""
+"Create all required Docker deployment configuration for the selected "
+"applications"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:10
+msgid ""
+"Create a new JHipster entity: JPA entity, Spring server-side components and "
+"Angular client-side components"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:11
+#, fuzzy
+msgid "Create a JDL file from the existing entities"
+msgstr "Alle gz-Dateien aus dem Zwischenspeicher entfernen"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:12
+#, fuzzy
+msgid "Deploy the current application to Heroku"
+msgstr "Veraltete Paketdateien löschen"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:13
+msgid "Create entities from the JDL file passed in argument"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:14
+#, fuzzy
+msgid "Display information about your current project and system"
+msgstr "Statusinformationen zu ausgecheckten Dateien anzeigen"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:15
+#, fuzzy
+msgid "Deploy the current application to Kubernetes"
+msgstr "Überprüfungsstatus von Schlüsselsignaturen nicht zwischenspeichern"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:16
+msgid ""
+"Select languages from a list of available languages. The i18n files will be "
+"copied to the /webapp/i18n folder"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:17
+#, fuzzy
+msgid "Deploy the current application to OpenShift"
+msgstr "Version und unterstützte Algorithmen anzeigen und beenden"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:18
+#, fuzzy
+msgid "Deploy the current application to Rancher"
+msgstr "Veraltete Paketdateien löschen"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:19
+#, fuzzy
+msgid "Create a new JHipster server-side application"
+msgstr "Ein oder mehrere Dateien/Verzeichnisse aus dem Paketdepot entfernen"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:20
+#, fuzzy
+msgid "Create a new Spring service bean"
+msgstr "Umgebung erhalten"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:21
+msgid "Upgrade the JHipster version and the generated application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:22
+#, fuzzy
+msgid "Print command completion script"
+msgstr "Befehle auf Standardfehlerausgabe ausgeben"
 
 #: /tmp/fish/implicit/share/completions/jobs.fish:2
 #, fuzzy
@@ -52199,11 +53105,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:125
 msgid "Set default root object"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
-#, fuzzy
-msgid "Debug output"
-msgstr "Debug-Ausgabe aktivieren"
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:130
 msgid "Cache FILE containing MD5 values"

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:00+0100\n"
+"POT-Creation-Date: 2017-12-08 16:50+0100\n"
 "PO-Revision-Date: 2014-11-15 09:00+0800\n"
 "Last-Translator: David Adam <zanchey@ucc.gu.uwa.edu.au>\n"
 "Language-Team: English <fish-users@lists.sourceforge.net>\n"
@@ -109,12 +109,12 @@ msgstr "Send job %d “%ls” to background\n"
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls: There are no suitable jobs\n"
 
-#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82
+#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, fuzzy, c-format
 msgid "%ls: '%ls' is not a valid job specifier\n"
 msgstr "%ls: '%ls' is not a valid variable name\n"
 
-#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89
+#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89 src/builtin_wait.cpp:163
 #, fuzzy, c-format
 msgid "%ls: Could not find job '%d'\n"
 msgstr "%s: Could not find “%s”\n"
@@ -224,7 +224,7 @@ msgstr "%ls: Variable name can not be the empty string\n"
 msgid "%ls: Key not specified\n"
 msgstr "%ls: Key not specified\n"
 
-#: src/builtin.cpp:261
+#: src/builtin.cpp:262
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
@@ -233,217 +233,221 @@ msgstr ""
 "%ls: Type “help %ls” for related documentation\n"
 "\n"
 
-#: src/builtin.cpp:337
+#: src/builtin.cpp:338
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls: Not inside of loop\n"
 
-#: src/builtin.cpp:371
+#: src/builtin.cpp:372
 #, fuzzy, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr "%ls: Command only available in interactive sessions\n"
 
-#: src/builtin.cpp:409 src/builtin.cpp:459
+#: src/builtin.cpp:410 src/builtin.cpp:460
 msgid "Test a condition"
 msgstr "Test a condition"
 
-#: src/builtin.cpp:410
+#: src/builtin.cpp:411
 msgid "Execute command if previous command suceeded"
 msgstr "Execute command if previous command suceeded"
 
-#: src/builtin.cpp:411
+#: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:412
+#: src/builtin.cpp:413
 msgid "Create a block of code"
 msgstr "Create a block of code"
 
-#: src/builtin.cpp:413
+#: src/builtin.cpp:414
 msgid "Send job to background"
 msgstr "Send job to background"
 
-#: src/builtin.cpp:414
+#: src/builtin.cpp:415
 msgid "Handle fish key bindings"
 msgstr "Handle fish key bindings"
 
-#: src/builtin.cpp:415
+#: src/builtin.cpp:416
 msgid "Temporarily block delivery of events"
 msgstr "Temporarily block delivery of events"
 
-#: src/builtin.cpp:416
+#: src/builtin.cpp:417
 msgid "Stop the innermost loop"
 msgstr "Stop the innermost loop"
 
-#: src/builtin.cpp:418
+#: src/builtin.cpp:419
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 
-#: src/builtin.cpp:419
+#: src/builtin.cpp:420
 msgid "Run a builtin command instead of a function"
 msgstr "Run a builtin command instead of a function"
 
-#: src/builtin.cpp:420 src/builtin.cpp:458
+#: src/builtin.cpp:421 src/builtin.cpp:459
 msgid "Conditionally execute a block of commands"
 msgstr "Conditionally execute a block of commands"
 
-#: src/builtin.cpp:421
+#: src/builtin.cpp:422
 msgid "Change working directory"
 msgstr "Change working directory"
 
-#: src/builtin.cpp:422
+#: src/builtin.cpp:423
 msgid "Run a program instead of a function or builtin"
 msgstr "Run a program instead of a function or builtin"
 
-#: src/builtin.cpp:423
+#: src/builtin.cpp:424
 msgid "Set or get the commandline"
 msgstr "Set or get the commandline"
 
-#: src/builtin.cpp:424
+#: src/builtin.cpp:425
 msgid "Edit command specific completions"
 msgstr "Edit command specific completions"
 
-#: src/builtin.cpp:425
+#: src/builtin.cpp:426
 msgid "Search for a specified string in a list"
 msgstr "Search for a specified string in a list"
 
-#: src/builtin.cpp:427
+#: src/builtin.cpp:428
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "Skip the rest of the current lap of the innermost loop"
 
-#: src/builtin.cpp:428
+#: src/builtin.cpp:429
 msgid "Count the number of arguments"
 msgstr "Count the number of arguments"
 
-#: src/builtin.cpp:429
+#: src/builtin.cpp:430
 #, fuzzy
 msgid "Remove job from job list"
 msgstr "Read job from file"
 
-#: src/builtin.cpp:430
+#: src/builtin.cpp:431
 msgid "Print arguments"
 msgstr "Print arguments"
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:432
 msgid "Evaluate block if condition is false"
 msgstr "Evaluate block if condition is false"
 
-#: src/builtin.cpp:432
+#: src/builtin.cpp:433
 msgid "Emit an event"
 msgstr "Emit an event"
 
-#: src/builtin.cpp:433
+#: src/builtin.cpp:434
 msgid "End a block of commands"
 msgstr "End a block of commands"
 
-#: src/builtin.cpp:434
+#: src/builtin.cpp:435
 msgid "Run command in current process"
 msgstr "Run command in current process"
 
-#: src/builtin.cpp:435
+#: src/builtin.cpp:436
 msgid "Exit the shell"
 msgstr "Exit the shell"
 
-#: src/builtin.cpp:436
+#: src/builtin.cpp:437
 msgid "Return an unsuccessful result"
 msgstr "Return an unsuccessful result"
 
-#: src/builtin.cpp:437
+#: src/builtin.cpp:438
 msgid "Send job to foreground"
 msgstr "Send job to foreground"
 
-#: src/builtin.cpp:438
+#: src/builtin.cpp:439
 msgid "Perform a set of commands multiple times"
 msgstr "Perform a set of commands multiple times"
 
-#: src/builtin.cpp:439
+#: src/builtin.cpp:440
 msgid "Define a new function"
 msgstr "Define a new function"
 
-#: src/builtin.cpp:440
+#: src/builtin.cpp:441
 msgid "List or remove functions"
 msgstr "List or remove functions"
 
-#: src/builtin.cpp:441
+#: src/builtin.cpp:442
 msgid "History of commands executed by user"
 msgstr "History of commands executed by user"
 
-#: src/builtin.cpp:442
+#: src/builtin.cpp:443
 msgid "Evaluate block if condition is true"
 msgstr "Evaluate block if condition is true"
 
-#: src/builtin.cpp:443
+#: src/builtin.cpp:444
 msgid "Print currently running jobs"
 msgstr "Print currently running jobs"
 
-#: src/builtin.cpp:444
+#: src/builtin.cpp:445
 #, fuzzy
 msgid "Evaluate math expressions"
 msgstr "Evaluate expression"
 
-#: src/builtin.cpp:445
+#: src/builtin.cpp:446
 msgid "Negate exit status of job"
 msgstr "Negate exit status of job"
 
-#: src/builtin.cpp:446
+#: src/builtin.cpp:447
 msgid "Execute command if previous command failed"
 msgstr "Execute command if previous command failed"
 
-#: src/builtin.cpp:447
+#: src/builtin.cpp:448
 msgid "Prints formatted text"
 msgstr "Prints formatted text"
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:449
 msgid "Print the working directory"
 msgstr "Print the working directory"
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:450
 msgid "Generate random number"
 msgstr "Generate random number"
 
-#: src/builtin.cpp:450
+#: src/builtin.cpp:451
 msgid "Read a line of input into variables"
 msgstr "Read a line of input into variables"
 
-#: src/builtin.cpp:451
+#: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr ""
 
-#: src/builtin.cpp:452
+#: src/builtin.cpp:453
 msgid "Stop the currently evaluated function"
 msgstr "Stop the currently evaluated function"
 
-#: src/builtin.cpp:453
+#: src/builtin.cpp:454
 msgid "Handle environment variables"
 msgstr "Handle environment variables"
 
-#: src/builtin.cpp:454
+#: src/builtin.cpp:455
 msgid "Set the terminal color"
 msgstr "Set the terminal color"
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:456
 msgid "Evaluate contents of file"
 msgstr "Evaluate contents of file"
 
-#: src/builtin.cpp:456
+#: src/builtin.cpp:457
 msgid "Return status information about fish"
 msgstr "Return status information about fish"
 
-#: src/builtin.cpp:457
+#: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr ""
 
-#: src/builtin.cpp:460
+#: src/builtin.cpp:461
 msgid "Return a successful result"
 msgstr "Return a successful result"
 
-#: src/builtin.cpp:461
+#: src/builtin.cpp:462
 msgid "Set or get the shells resource usage limits"
 msgstr "Set or get the shells resource usage limits"
 
-#: src/builtin.cpp:462
+#: src/builtin.cpp:463
+msgid "Wait for background processes completed"
+msgstr ""
+
+#: src/builtin.cpp:464
 msgid "Perform a command multiple times"
 msgstr "Perform a command multiple times"
 
@@ -1481,58 +1485,58 @@ msgstr ""
 msgid "Your history will not be saved."
 msgstr ""
 
-#: src/proc.cpp:590
+#: src/proc.cpp:586
 #, c-format
 msgid "Job %d, "
 msgstr ""
 
-#: src/proc.cpp:591
+#: src/proc.cpp:587
 #, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: %ls“%ls” terminated by signal %ls (%ls)"
 
-#: src/proc.cpp:599
+#: src/proc.cpp:595
 #, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Process %d, “%ls” %ls“%ls” terminated by signal %ls (%ls)"
 
-#: src/proc.cpp:769
+#: src/proc.cpp:779
 msgid "An error occured while reading output from code block"
 msgstr "An error occured while reading output from code block"
 
-#: src/proc.cpp:846
+#: src/proc.cpp:856
 #, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr "Could not send job %d ('%ls') with pgid %d to foreground"
 
-#: src/proc.cpp:875
+#: src/proc.cpp:885
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Could not send job %d (“%ls”) to foreground"
 
-#: src/proc.cpp:899 src/proc.cpp:908 src/proc.cpp:922
+#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
 msgid "Could not return shell to foreground"
 msgstr "Could not return shell to foreground"
 
-#: src/proc.cpp:1055
+#: src/proc.cpp:1065
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "More than one job in foreground: job 1: “%ls” job 2: “%ls”"
 
-#: src/proc.cpp:1065
+#: src/proc.cpp:1075
 msgid "Process argument list"
 msgstr "Process argument list"
 
-#: src/proc.cpp:1066
+#: src/proc.cpp:1076
 msgid "Process name"
 msgstr "Process name"
 
-#: src/proc.cpp:1069
+#: src/proc.cpp:1079
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Job “%ls”, process “%ls” has inconsistent state “stopped”=%d"
 
-#: src/proc.cpp:1075
+#: src/proc.cpp:1085
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr "Job “%ls”, process “%ls” has inconsistent state “completed”=%d"
@@ -2488,6 +2492,211 @@ msgstr "Print node's version"
 msgid "Prints the usage for a given subcommand"
 msgstr "Print the type of a command"
 
+#: /tmp/fish/explicit/share/completions/mdadm.fish:1
+#: /tmp/fish/explicit/share/completions/mdadm.fish:2
+msgid "Use original 0.90 format superblock"
+msgstr "Use original 0.90 format superblock"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:3
+#: /tmp/fish/explicit/share/completions/mdadm.fish:4
+msgid "Use last 1.x format superblock"
+msgstr "Use last 1.x format superblock"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:5
+msgid "Use 1.0 format superblock"
+msgstr "Use 1.0 format superblock"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:6
+msgid "Use 1.1 format superblock"
+msgstr "Use 1.1 format superblock"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:7
+msgid "Use 1.2 format superblock"
+msgstr "Use 1.2 format superblock"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:8
+msgid "Use DDF (Disk Data Format) format"
+msgstr "Use DDF (Disk Data Format) format"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:9
+msgid "Use Intel(R) Matrix Storage Manager format"
+msgstr "Use Intel(R) Matrix Storage Manager format"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:10
+msgid "JBOD"
+msgstr "JBOD"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:11
+#: /tmp/fish/explicit/share/completions/mdadm.fish:12
+#: /tmp/fish/explicit/share/completions/mdadm.fish:13
+msgid "Stripped volume (RAID 0)"
+msgstr "Stripped volume (RAID 0)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:14
+#: /tmp/fish/explicit/share/completions/mdadm.fish:15
+#: /tmp/fish/explicit/share/completions/mdadm.fish:16
+msgid "Mirrored volume (RAID 1)"
+msgstr "Mirrored volume (RAID 1)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:17
+#: /tmp/fish/explicit/share/completions/mdadm.fish:18
+msgid "Stripped volume with parity disk (RAID 4)"
+msgstr "Stripped volume with parity disk (RAID 4)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:19
+#: /tmp/fish/explicit/share/completions/mdadm.fish:20
+msgid "Stripped volume with distributed parity (RAID 5)"
+msgstr "Stripped volume with distributed parity (RAID 5)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:21
+#: /tmp/fish/explicit/share/completions/mdadm.fish:22
+msgid "Stripped volume with double distributed parity (RAID 5)"
+msgstr "Stripped volume with double distributed parity (RAID 5)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:23
+#: /tmp/fish/explicit/share/completions/mdadm.fish:24
+msgid "Mirrored stripped volume (RAID 10)"
+msgstr "Mirrored stripped volume (RAID 10)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:25
+#: /tmp/fish/explicit/share/completions/mdadm.fish:26
+msgid "Multiple access device, AKA multipath (deprecated)"
+msgstr "Multiple access device, AKA multipath (deprecated)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:27
+msgid "Pseudo RAID layer for single device (akin faulty RAID 1)"
+msgstr "Pseudo RAID layer for single device (akin faulty RAID 1)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:28
+msgid "Container"
+msgstr "Container"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:29
+msgid "Alias of left-asymmetric"
+msgstr "Alias of left-asymmetric"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:30
+msgid "Alias of right-asymmetric"
+msgstr "Alias of right-asymmetric"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:31
+msgid "Alias of left-symmetric"
+msgstr "Alias of left-symmetric"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:32
+msgid "Alias of right-symmetric"
+msgstr "Alias of right-symmetric"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:33
+msgid "Alias of write-transient"
+msgstr "Alias of write-transient"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:34
+msgid "Alias of read-transient"
+msgstr "Alias of read-transient"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:35
+msgid "Alias of write-persistent"
+msgstr "Alias of write-persistent"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:36
+msgid "Alias of read-persistent"
+msgstr "Alias of read-persistent"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:37
+msgid "Alias of read-fixable"
+msgstr "Alias of read-fixable"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:38
+msgid "Use standard format (default)"
+msgstr "Use standard format (default)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:39
+msgid "Use a non-partitionable array"
+msgstr "Use a non-partitionable array"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:40
+#: /tmp/fish/explicit/share/completions/mdadm.fish:41
+#: /tmp/fish/explicit/share/completions/mdadm.fish:42
+msgid "Use a partitionable array"
+msgstr "Use a partitionable array"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:43
+msgid "Remove superblock misalignement from SPARC kernel 2.2"
+msgstr "Remove superblock misalignement from SPARC kernel 2.2"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:44
+msgid "Correct superblock summaries"
+msgstr "Correct superblock summaries"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:45
+msgid "Update array UUID"
+msgstr "Update array UUID"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:46
+msgid "Update array name"
+msgstr "Update array name"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:47
+msgid "Update array nodes"
+msgstr "Update array nodes"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:48
+msgid "Update array homehost"
+msgstr "Update array homehost"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:49
+msgid "Update array cluster name"
+msgstr "Update array cluster name"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:50
+msgid "Mark the array as dirty, thus forcing resync"
+msgstr "Mark the array as dirty, thus forcing resync"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:51
+msgid "Reverse superblock endianness"
+msgstr "Reverse superblock endianness"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:52
+msgid "Refresh device size"
+msgstr "Refresh device size"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:53
+msgid "Assume bitmap absence"
+msgstr "Assume bitmap absence"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:54
+msgid "Reserve space for bad block list"
+msgstr "Reserve space for bad block list"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:55
+msgid "Free reserved space for bad block list"
+msgstr "Free reserved space for bad block list"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:56
+msgid "Convert 0.90 metadata to 1.0"
+msgstr "Convert 0.90 metadata to 1.0"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:57
+msgid "Reset preferred minor to current one"
+msgstr "Reset preferred minor to current one"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:58
+msgid "Abort currently running actions"
+msgstr "Abort currently running actions"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:59
+msgid "Abort currently running actions, prevent their restart"
+msgstr "Abort currently running actions, prevent their restart"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:60
+msgid "Scrub the array (i.e. check constistency)"
+msgstr "Scrub the array (i.e. check constistency)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:61
+msgid "Check, then resync"
+msgstr "Check, then resync"
+
 #: /tmp/fish/explicit/share/completions/set.fish:1
 msgid "Locale"
 msgstr "Locale"
@@ -3442,6 +3651,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
 #: /tmp/fish/implicit/share/completions/asp.fish:6
 #: /tmp/fish/implicit/share/completions/bc.fish:7
+#: /tmp/fish/implicit/share/completions/bd.fish:4
 #: /tmp/fish/implicit/share/completions/bg.fish:1
 #: /tmp/fish/implicit/share/completions/bind.fish:4
 #: /tmp/fish/implicit/share/completions/block.fish:1
@@ -4084,7 +4294,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bzr.fish:1
 #: /tmp/fish/implicit/share/completions/climate.fish:1
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:17
-#: /tmp/fish/implicit/share/completions/cygport.fish:23
+#: /tmp/fish/implicit/share/completions/cygport.fish:25
 #: /tmp/fish/implicit/share/completions/godoc.fish:25
 #: /tmp/fish/implicit/share/completions/gofmt.fish:8
 #: /tmp/fish/implicit/share/completions/goimports.fish:6
@@ -5520,6 +5730,7 @@ msgstr "Select file to store source cache"
 #: /tmp/fish/implicit/share/completions/apt-get.fish:24
 #: /tmp/fish/implicit/share/completions/configure.fish:3
 #: /tmp/fish/implicit/share/completions/gpg.fish:62
+#: /tmp/fish/implicit/share/completions/hugo.fish:5
 #: /tmp/fish/implicit/share/completions/make.fish:16
 #: /tmp/fish/implicit/share/completions/ping.fish:16
 #: /tmp/fish/implicit/share/completions/rpm.fish:3
@@ -5689,6 +5900,7 @@ msgid "Set a configuration option"
 msgstr "Set a config option"
 
 #: /tmp/fish/implicit/share/completions/apt.fish:8
+#: /tmp/fish/implicit/share/completions/hugo.fish:1
 #: /tmp/fish/implicit/share/completions/man.fish:14
 #: /tmp/fish/implicit/share/completions/modprobe.fish:2
 #: /tmp/fish/implicit/share/completions/yum.fish:13
@@ -8887,6 +9099,19 @@ msgstr "Process exactly POSIX bc"
 msgid "Do not print the GNU welcome"
 msgstr "Do not print the GNU welcome"
 
+#: /tmp/fish/implicit/share/completions/bd.fish:1
+msgid "Classic mode: goes back to the first directory named as the string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:2
+msgid "Seems mode: goes back to the first directory containing string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:3
+#, fuzzy
+msgid "Case insensitive move (implies seems mode)"
+msgstr "Case insensitive"
+
 #: /tmp/fish/implicit/share/completions/bind.fish:1
 msgid "Show unavailable key bindings/erase all bindings"
 msgstr ""
@@ -10431,7 +10656,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/caddy.fish:24
 #: /tmp/fish/implicit/share/completions/canto.fish:2
-#: /tmp/fish/implicit/share/completions/cygport.fish:24
+#: /tmp/fish/implicit/share/completions/cygport.fish:26
 #: /tmp/fish/implicit/share/completions/grub-install.fish:33
 #: /tmp/fish/implicit/share/completions/lua.fish:4
 #: /tmp/fish/implicit/share/completions/magento.fish:23
@@ -13803,29 +14028,39 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:17
 #, fuzzy
+msgid "Create packages, marked as test"
+msgstr "Update the repository"
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:18
+#, fuzzy
 msgid "Create packages"
 msgstr "Erase package"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:18
+#: /tmp/fish/implicit/share/completions/cygport.fish:19
 #, fuzzy
 msgid "Create source patches"
 msgstr "Clean source packages"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:19
+#: /tmp/fish/implicit/share/completions/cygport.fish:20
 #, fuzzy
 msgid "Upload finished packages"
 msgstr "Upgrade packages"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:20
+#: /tmp/fish/implicit/share/completions/cygport.fish:21
+#, fuzzy
+msgid "Upload packages without marking !ready"
+msgstr "Add a package lock"
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:22
 msgid "Send announcement email"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:21
+#: /tmp/fish/implicit/share/completions/cygport.fish:23
 #, fuzzy
 msgid "Delete working directory"
 msgstr "Change working directory"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:22
+#: /tmp/fish/implicit/share/completions/cygport.fish:24
 msgid "Same as prep build inst pkg"
 msgstr ""
 
@@ -33184,6 +33419,7 @@ msgid "Name of the output file"
 msgstr "Do not create output files"
 
 #: /tmp/fish/implicit/share/completions/highlight.fish:5
+#: /tmp/fish/implicit/share/completions/hugo.fish:57
 #: /tmp/fish/implicit/share/completions/tex.fish:10
 #, fuzzy
 msgid "Output directory"
@@ -33232,6 +33468,558 @@ msgstr "Monitor user"
 #, fuzzy
 msgid "Sort column"
 msgstr "List by columns"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:2
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
+#, fuzzy
+msgid "Debug output"
+msgstr "Debug option"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:3
+#, fuzzy
+msgid "Enable logging"
+msgstr "Enable debug"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:4
+#, fuzzy
+msgid "Log file"
+msgstr "Log to tracefile"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:6
+#: /tmp/fish/implicit/share/completions/iptables.fish:25
+#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
+#, fuzzy
+msgid "Verbose output"
+msgstr "Verbose prompt"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:7
+#, fuzzy
+msgid "Verbose logging"
+msgstr "List users logged in"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:8
+#, fuzzy
+msgid "Hostname and path to the root"
+msgstr "List patches in the repository"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:9
+#, fuzzy
+msgid "Include content marked as draft"
+msgstr "Include directories tagged as cache"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:10
+#, fuzzy
+msgid "Include expired content"
+msgstr "Include directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:11
+#, fuzzy
+msgid "Include content with publishdate in the future"
+msgstr "Include reverse dependencies in the output"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:12
+#, fuzzy
+msgid "Cache directory"
+msgstr "Change directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:13
+msgid "Canonicalize all relative URLs using baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:14
+#, fuzzy
+msgid "Remove files from destination not found in static directories"
+msgstr "Remove files from version control"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:15
+#, fuzzy
+msgid "Content directory"
+msgstr "Change directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:16
+#, fuzzy
+msgid "Destination directory"
+msgstr "Create any missing directories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:17
+#, fuzzy
+msgid "Do not build 404 page"
+msgstr "Do not del built files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:18
+#, fuzzy
+msgid "Disable different kinds of pages"
+msgstr "Control creation of sparse files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:19
+#, fuzzy
+msgid "Do not build RSS files"
+msgstr "Do not del built files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:20
+#, fuzzy
+msgid "Do not build sitemap files"
+msgstr "Do not del built files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:21
+msgid "Add Git revision, date and author info to the pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:22
+msgid "Copy all files when static is changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:23
+msgid "Help for hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:24
+#, fuzzy
+msgid "Print missing translations"
+msgstr "Print compression ratios"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:25
+#, fuzzy
+msgid "Ignore the cache directory"
+msgstr "Include directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:26
+#, fuzzy
+msgid "Layout directory"
+msgstr "Output mimetype"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:27
+#, fuzzy
+msgid "Do not sync permission mode of files"
+msgstr "Do not check files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:28
+#, fuzzy
+msgid "Do not sync modification time of files"
+msgstr "Sort by modification time"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:29
+msgid "Pluralize titles in lists using inflect"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:30
+msgid "Preserve taxonomy names as written"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:31
+#: /tmp/fish/implicit/share/completions/hugo.fish:45
+#, fuzzy
+msgid "Render to memory"
+msgstr "Reduce memory usage"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:32
+#: /tmp/fish/implicit/share/completions/hugo.fish:58
+#: /tmp/fish/implicit/share/completions/hugo.fish:92
+#: /tmp/fish/implicit/share/completions/hugo.fish:103
+#, fuzzy
+msgid "Source directory"
+msgstr "Clean source directories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:33
+#: /tmp/fish/implicit/share/completions/hugo.fish:46
+#, fuzzy
+msgid "Display memory and timing of different steps of the program"
+msgstr "Display the contents of the installed gems"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:34
+#: /tmp/fish/implicit/share/completions/hugo.fish:47
+#, fuzzy
+msgid "Display metrics about template executions"
+msgstr "Display detailed information about the packages"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:35
+#: /tmp/fish/implicit/share/completions/hugo.fish:48
+msgid "Calculate some improvement hints when combined with --templateMetrics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:36
+#, fuzzy
+msgid "Theme to use"
+msgstr "Send mail to user"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:37
+#, fuzzy
+msgid "Themes directory"
+msgstr "Remove the test directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:38
+#, fuzzy
+msgid "Use /filename.html instead of /filename/"
+msgstr "Use /dev/urandom instead of /dev/random"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:39
+msgid "Watch filesystem for changes and recreate as needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:40
+msgid "Benchmark Hugo by building the site a number of times"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:41
+#, fuzzy
+msgid "Number of times to build the site"
+msgstr "Name of the darcs executable on the remote server"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:42
+#, fuzzy
+msgid "CPU profile file"
+msgstr "Use config file"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:43
+msgid "Help for benchmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:44
+#, fuzzy
+msgid "Memory profile file"
+msgstr "Move or rename files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:49
+#, fuzzy
+msgid "Perform some verification checks"
+msgstr "Perform contents generation"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:50
+msgid "Help for check"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:51
+msgid "Check system ulimit settings"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:52
+#, fuzzy
+msgid "Help for ulimit"
+msgstr "Recursion limit"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:53
+#, fuzzy
+msgid "Print the site configuration"
+msgstr "Write out the current configuration"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:54
+#, fuzzy
+msgid "Help for config"
+msgstr "Help on subject config"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:55
+#, fuzzy
+msgid "Convert the content to different formats"
+msgstr "Don't add contents of subdirectories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:56
+#, fuzzy
+msgid "Help for convert"
+msgstr "Alias for “get”"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:59
+#, fuzzy
+msgid "Enable less safe operations"
+msgstr "Disable multi-threaded operation"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:60
+msgid "Convert front matter to JSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:61
+msgid "Help for toJSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:62
+msgid "Convert front matter to TOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:63
+msgid "Help for toTOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:64
+msgid "Convert front matter to YAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:65
+msgid "Help for toYAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:66
+#, fuzzy
+msgid "Print Hugo version and environment info"
+msgstr "Print version information and exit"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:67
+#, fuzzy
+msgid "Help for env"
+msgstr "Alias for “get”"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:68
+msgid "Collection of several useful generators"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:69
+msgid "Help for gen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:70
+msgid "Generate shell autocompletion script for Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:71
+#, fuzzy
+msgid "Autocompletion file"
+msgstr "Complete using path"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:72
+msgid "Help for autocomplete"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:73
+#, fuzzy
+msgid "Autocompletion type"
+msgstr "Path to add completion to"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:74
+msgid "Generate CSS stylesheet for the Chroma code highlighter"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:75
+msgid "Help for chromastyles"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:76
+#, fuzzy
+msgid "Style used for highlighting lines"
+msgstr "No search highlighting"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:77
+#, fuzzy
+msgid "Style used for line numbers"
+msgstr "Show version number and exit"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:78
+msgid "Highlighter style"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:79
+#, fuzzy
+msgid "Generate Markdown documentation for the Hugo CLI"
+msgstr "Generate RDoc documentation for the gem on install"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:80
+#, fuzzy
+msgid "Doc directory"
+msgstr "Directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:81
+msgid "Help for doc"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:82
+#, fuzzy
+msgid "Generate man pages for the Hugo CLI"
+msgstr "Generate contents file"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:83
+#, fuzzy
+msgid "Man pages directory"
+msgstr "Change directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:84
+#, fuzzy
+msgid "Help for man"
+msgstr "Short format"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:85
+#, fuzzy
+msgid "Import your site from others"
+msgstr "Compress repository with"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:86
+#, fuzzy
+msgid "Help for import"
+msgstr "Dir to import"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:87
+msgid "Import from Jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:88
+#, fuzzy
+msgid "Allow import into non-empty target directory"
+msgstr "Create a local copy of another repository"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:89
+msgid "Help for jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:90
+#, fuzzy
+msgid "List various types of content"
+msgstr "List archive contents"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:91
+#, fuzzy
+msgid "Help for list"
+msgstr "Home for %ls"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:93
+#, fuzzy
+msgid "List all drafts"
+msgstr "List all available patches"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:94
+msgid "Help for drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:95
+#, fuzzy
+msgid "List all expired posts"
+msgstr "List all available products"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:96
+#, fuzzy
+msgid "Help for expired"
+msgstr "Timer expired"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:97
+#, fuzzy
+msgid "List all posts dated in the future"
+msgstr "List patches in the repository"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:98
+#, fuzzy
+msgid "Help for future"
+msgstr "Alias for atrm"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:99
+#, fuzzy
+msgid "Create new content"
+msgstr "Preserve environment"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:100
+#, fuzzy
+msgid "Editor to use"
+msgstr "Send mail to user"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:101
+msgid "Help for new"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:102
+#, fuzzy
+msgid "Content type to create"
+msgstr "Concatenate output to file"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:104
+#, fuzzy
+msgid "Create a new site"
+msgstr "Create new project"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:105
+#, fuzzy
+msgid "Create site inside non-empty directory"
+msgstr "Create any missing directories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:106
+msgid "Config and front matter format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:107
+#, fuzzy
+msgid "Help for site"
+msgstr "Home for %ls"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:108
+#, fuzzy
+msgid "Create a new theme"
+msgstr "Preserve environment"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:109
+#, fuzzy
+msgid "Help for theme"
+msgstr "Search for other system"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:110
+#, fuzzy
+msgid "Start high performance web server"
+msgstr "Start service"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:111
+#, fuzzy
+msgid "Append port to baseurl"
+msgstr "Append input to selection"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:112
+msgid "Interface to which the server will bind"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:113
+#, fuzzy
+msgid "Enable full re-renders on changes"
+msgstr "Make no changes"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:114
+msgid "Watch without enabling live browser reload on rebuild"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:115
+#, fuzzy
+msgid "Help for server"
+msgstr "Use proxy server"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:116
+#, fuzzy
+msgid "Port for live reloading"
+msgstr "Dynamic port forwarding"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:117
+msgid "Interval to poll memory usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:118
+#, fuzzy
+msgid "Memory usage log file"
+msgstr "Erase obsolete files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:119
+msgid "Navigate to changed content file on live browser reload"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:120
+msgid "Prevent HTTP caching"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:121
+msgid "Port on which the server will listen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:122
+#, fuzzy
+msgid "Render to destination directory"
+msgstr "Create any missing directories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:123
+msgid "Reset the content draft status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:124
+msgid "Help for undraft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:125
+#, fuzzy
+msgid "Print the version number of Hugo"
+msgstr "Print line number"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:126
+#, fuzzy
+msgid "Help for version"
+msgstr "Name of client"
 
 #: /tmp/fish/implicit/share/completions/i3-msg.fish:1
 #, fuzzy
@@ -33818,13 +34606,6 @@ msgstr ""
 msgid "Initialize packet and byte counters of a rule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/iptables.fish:25
-#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
-#, fuzzy
-msgid "Verbose output"
-msgstr "Verbose prompt"
-
 #: /tmp/fish/implicit/share/completions/iptables.fish:26
 msgid "Wait for the xtables lock"
 msgstr ""
@@ -34183,6 +34964,114 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/jest.fish:77
 msgid "Disable using watchman for file crawling"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:1
+#, fuzzy
+msgid "Enable debugger"
+msgstr "Enable debug"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:2
+#, fuzzy
+msgid "Output usage information"
+msgstr "Could not get user information"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:3
+#, fuzzy
+msgid "Output version number"
+msgstr "Version number"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:4
+#, fuzzy
+msgid "Create a new JHipster application"
+msgstr "Create new project"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:5
+#, fuzzy
+msgid "Deploy the current application to AWS"
+msgstr "Delete cached package files"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:6
+msgid "Create pipeline scripts for popular CI tools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:7
+msgid "Create a new JHipster client-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:8
+msgid "Prepare Cloud Foundry deployment"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:9
+msgid ""
+"Create all required Docker deployment configuration for the selected "
+"applications"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:10
+msgid ""
+"Create a new JHipster entity: JPA entity, Spring server-side components and "
+"Angular client-side components"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:11
+#, fuzzy
+msgid "Create a JDL file from the existing entities"
+msgstr "Remove files after adding to archive"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:12
+#, fuzzy
+msgid "Deploy the current application to Heroku"
+msgstr "Delete cached package files"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:13
+msgid "Create entities from the JDL file passed in argument"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:14
+#, fuzzy
+msgid "Display information about your current project and system"
+msgstr "Display information about a local or remote item."
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:15
+#, fuzzy
+msgid "Deploy the current application to Kubernetes"
+msgstr "Do not cache authentication tokens"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:16
+msgid ""
+"Select languages from a list of available languages. The i18n files will be "
+"copied to the /webapp/i18n folder"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:17
+#, fuzzy
+msgid "Deploy the current application to OpenShift"
+msgstr "Display version and supported algorithms, and exit"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:18
+#, fuzzy
+msgid "Deploy the current application to Rancher"
+msgstr "Delete cached package files"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:19
+#, fuzzy
+msgid "Create a new JHipster server-side application"
+msgstr "Create a new directory under version control."
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:20
+#, fuzzy
+msgid "Create a new Spring service bean"
+msgstr "Preserve environment"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:21
+msgid "Upgrade the JHipster version and the generated application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:22
+#, fuzzy
+msgid "Print command completion script"
+msgstr "Print commands to stderr"
 
 #: /tmp/fish/implicit/share/completions/jobs.fish:2
 #, fuzzy
@@ -51918,11 +52807,6 @@ msgstr ""
 msgid "Set default root object"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
-#, fuzzy
-msgid "Debug output"
-msgstr "Debug option"
-
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:130
 msgid "Cache FILE containing MD5 values"
 msgstr ""
@@ -64642,9 +65526,6 @@ msgstr "Edit variable value"
 
 #~ msgid "Stopped container"
 #~ msgstr "Stopped container"
-
-#~ msgid "Container running"
-#~ msgstr "Container running"
 
 #~ msgid "Dont abort when backup different dirs to the same backend"
 #~ msgstr "Dont abort when backup different dirs to the same backend"

--- a/po/fr.po
+++ b/po/fr.po
@@ -74,12 +74,14 @@
 # to query (hors BDD)                                     obtenir
 # sparse file                                             fichier creux
 # to search                                               rechercher
+# array (RAID)                                            ensemble
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.2.8POT-Creation-Date: 2006-07-10 13:44-0400\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
-"PO-Revision-Date: 2017-10-09 16:43+0200\n"
+"POT-Creation-Date: 2017-12-08 16:50+0100\n"
+"PO-Revision-Date: 2017-12-08 17:27+0100\n"
 "Last-Translator: David Guyot <david.guyot@europecamions-interactive.com>\n"
 "Language-Team: français <david.guyot@europecamions-interactive.com>\n"
 "Language: fr\n"
@@ -184,12 +186,12 @@ msgstr "Envoyer la tâche %d '%ls' en arrière-plan\n"
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls: Aucune tâche appropriée\n"
 
-#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82
+#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, fuzzy, c-format
 msgid "%ls: '%ls' is not a valid job specifier\n"
 msgstr "%ls: '%ls' est un nom de variable invalide\n"
 
-#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89
+#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89 src/builtin_wait.cpp:163
 #, c-format
 msgid "%ls: Could not find job '%d'\n"
 msgstr "%ls: Impossible de trouver la tâche '%d'\n"
@@ -299,7 +301,7 @@ msgstr "%ls: Le nom de variable ne peut pas être une chaîne vide\n"
 msgid "%ls: Key not specified\n"
 msgstr "%ls: Clé non spécifiée\n"
 
-#: src/builtin.cpp:261
+#: src/builtin.cpp:262
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
@@ -308,218 +310,223 @@ msgstr ""
 "%ls: Tapez 'help %ls' pour sa documentation\n"
 "\n"
 
-#: src/builtin.cpp:337
+#: src/builtin.cpp:338
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls: À l'extérieur de la boucle\n"
 
-#: src/builtin.cpp:371
+#: src/builtin.cpp:372
 #, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr ""
 
-#: src/builtin.cpp:409 src/builtin.cpp:459
+#: src/builtin.cpp:410 src/builtin.cpp:460
 msgid "Test a condition"
 msgstr "Vérifier une condition"
 
-#: src/builtin.cpp:410
+#: src/builtin.cpp:411
 msgid "Execute command if previous command suceeded"
 msgstr "Exécuter la commande si la précédente a réussi"
 
-#: src/builtin.cpp:411
+#: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:412
+#: src/builtin.cpp:413
 msgid "Create a block of code"
 msgstr "Créer un bloc de code"
 
-#: src/builtin.cpp:413
+#: src/builtin.cpp:414
 msgid "Send job to background"
 msgstr "Mettre la tâche en arrière-plan"
 
-#: src/builtin.cpp:414
+#: src/builtin.cpp:415
 msgid "Handle fish key bindings"
 msgstr "Gérer les raccourcis clavier de fish"
 
-#: src/builtin.cpp:415
+#: src/builtin.cpp:416
 msgid "Temporarily block delivery of events"
 msgstr "Bloquer temporairement la distribution des événements"
 
-#: src/builtin.cpp:416
+#: src/builtin.cpp:417
 msgid "Stop the innermost loop"
 msgstr "Arrêter la boucle interne"
 
-#: src/builtin.cpp:418
+#: src/builtin.cpp:419
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 "Arrête temporairement l'exécution du script and lance une invite de débogage "
 "interactif"
 
-#: src/builtin.cpp:419
+#: src/builtin.cpp:420
 msgid "Run a builtin command instead of a function"
 msgstr "Exécuter une commande interne au lieu d'une fonction"
 
-#: src/builtin.cpp:420 src/builtin.cpp:458
+#: src/builtin.cpp:421 src/builtin.cpp:459
 msgid "Conditionally execute a block of commands"
 msgstr "Exécuter conditionnellement un bloc de commandes"
 
-#: src/builtin.cpp:421
+#: src/builtin.cpp:422
 msgid "Change working directory"
 msgstr "Modifier le dossier de travail"
 
-#: src/builtin.cpp:422
+#: src/builtin.cpp:423
 msgid "Run a program instead of a function or builtin"
 msgstr "Exécuter un programme au lieu d'une fonction ou d'une commande interne"
 
-#: src/builtin.cpp:423
+#: src/builtin.cpp:424
 msgid "Set or get the commandline"
 msgstr "Paramétrer ou obtenir la ligne de commande"
 
-#: src/builtin.cpp:424
+#: src/builtin.cpp:425
 msgid "Edit command specific completions"
 msgstr "Éditer les complétions spécifiques aux commandes"
 
-#: src/builtin.cpp:425
+#: src/builtin.cpp:426
 msgid "Search for a specified string in a list"
 msgstr "Rechercher une chaîne de caractères donnée dans une liste"
 
-#: src/builtin.cpp:427
+#: src/builtin.cpp:428
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "Sauter le reste du passage actuel dans la boucle interne"
 
-#: src/builtin.cpp:428
+#: src/builtin.cpp:429
 msgid "Count the number of arguments"
 msgstr "Compter le nombre d’arguments"
 
-#: src/builtin.cpp:429
+#: src/builtin.cpp:430
 msgid "Remove job from job list"
 msgstr "Supprimer la tâche de la liste des tâches"
 
-#: src/builtin.cpp:430
+#: src/builtin.cpp:431
 msgid "Print arguments"
 msgstr "Afficher les arguments"
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:432
 msgid "Evaluate block if condition is false"
 msgstr "Évalue le bloc si la condition est fausse"
 
-#: src/builtin.cpp:432
+#: src/builtin.cpp:433
 msgid "Emit an event"
 msgstr "Émettre un événement"
 
-#: src/builtin.cpp:433
+#: src/builtin.cpp:434
 msgid "End a block of commands"
 msgstr "Termine un bloc de commandes"
 
-#: src/builtin.cpp:434
+#: src/builtin.cpp:435
 msgid "Run command in current process"
 msgstr "Exécuter la commande dans le processus actuel"
 
-#: src/builtin.cpp:435
+#: src/builtin.cpp:436
 msgid "Exit the shell"
 msgstr "Quitter le shell"
 
-#: src/builtin.cpp:436
+#: src/builtin.cpp:437
 msgid "Return an unsuccessful result"
 msgstr "Retourne un résulat d'échec"
 
-#: src/builtin.cpp:437
+#: src/builtin.cpp:438
 msgid "Send job to foreground"
 msgstr "Mettre la tâche en premier plan"
 
-#: src/builtin.cpp:438
+#: src/builtin.cpp:439
 msgid "Perform a set of commands multiple times"
 msgstr "Exécuter un jeu de commandes plusieurs fois"
 
-#: src/builtin.cpp:439
+#: src/builtin.cpp:440
 msgid "Define a new function"
 msgstr "Définir une nouvelle fonction"
 
-#: src/builtin.cpp:440
+#: src/builtin.cpp:441
 msgid "List or remove functions"
 msgstr "Lister ou supprimer des fonctions"
 
-#: src/builtin.cpp:441
+#: src/builtin.cpp:442
 msgid "History of commands executed by user"
 msgstr "Historique des commandes exécutées par l'utilisateur"
 
-#: src/builtin.cpp:442
+#: src/builtin.cpp:443
 msgid "Evaluate block if condition is true"
 msgstr "Évaluer le bloc si la condition est vraie"
 
-#: src/builtin.cpp:443
+#: src/builtin.cpp:444
 msgid "Print currently running jobs"
 msgstr "Afficher les tâches en cours d’exécution"
 
-#: src/builtin.cpp:444
+#: src/builtin.cpp:445
 #, fuzzy
 msgid "Evaluate math expressions"
 msgstr "Nier logique l’expression"
 
-#: src/builtin.cpp:445
+#: src/builtin.cpp:446
 msgid "Negate exit status of job"
 msgstr "Inverser le code de retour de la tâche"
 
-#: src/builtin.cpp:446
+#: src/builtin.cpp:447
 msgid "Execute command if previous command failed"
 msgstr "Exécuter la commande si la précédente a échoué"
 
-#: src/builtin.cpp:447
+#: src/builtin.cpp:448
 msgid "Prints formatted text"
 msgstr "Affiche le texte formaté"
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:449
 msgid "Print the working directory"
 msgstr "Afficher le dossier de travail"
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:450
 msgid "Generate random number"
 msgstr "Génère un nombre aléatoire"
 
-#: src/builtin.cpp:450
+#: src/builtin.cpp:451
 msgid "Read a line of input into variables"
 msgstr "Lire une ligne d'entrée dans des variables"
 
-#: src/builtin.cpp:451
+#: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr "Convertir le chemin en chemin absolu sans lien symbolique"
 
-#: src/builtin.cpp:452
+#: src/builtin.cpp:453
 msgid "Stop the currently evaluated function"
 msgstr "Arrêter la fonction actuellement en évaluation"
 
-#: src/builtin.cpp:453
+#: src/builtin.cpp:454
 msgid "Handle environment variables"
 msgstr "Gérer les variables d'environnement"
 
-#: src/builtin.cpp:454
+#: src/builtin.cpp:455
 msgid "Set the terminal color"
 msgstr "Paramétrer la couleur du terminal"
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:456
 msgid "Evaluate contents of file"
 msgstr "Évaluer le contenu d'un fichier"
 
-#: src/builtin.cpp:456
+#: src/builtin.cpp:457
 msgid "Return status information about fish"
 msgstr "Retourner l’information sur l’état de fish"
 
-#: src/builtin.cpp:457
+#: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr "Manipuler les chaînes"
 
-#: src/builtin.cpp:460
+#: src/builtin.cpp:461
 msgid "Return a successful result"
 msgstr "Retourne un résultat d'échec"
 
-#: src/builtin.cpp:461
+#: src/builtin.cpp:462
 msgid "Set or get the shells resource usage limits"
 msgstr ""
 "Paramétrer ou obtenir les limites d'utilisation des ressources du shell"
 
-#: src/builtin.cpp:462
+#: src/builtin.cpp:463
+#, fuzzy
+msgid "Wait for background processes completed"
+msgstr "Attendre la mort de tous les processus concernés"
+
+#: src/builtin.cpp:464
 msgid "Perform a command multiple times"
 msgstr "Exécuter une commande plusieurs fois"
 
@@ -638,7 +645,8 @@ msgstr "%ls: Nom de fonction illégal '%ls'\n"
 #: src/builtin_functions.cpp:368
 #, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy '%ls'\n"
-msgstr "%ls: La fonction '%ls' existe déjà. Impossible de créer la copie '%ls'\n"
+msgstr ""
+"%ls: La fonction '%ls' existe déjà. Impossible de créer la copie '%ls'\n"
 
 #: src/builtin_history.cpp:71 src/builtin_status.cpp:117
 #, c-format
@@ -1144,12 +1152,16 @@ msgstr ""
 #: src/env_universal_common.cpp:1396
 #, c-format
 msgid "Unable to make a pipe for universal variables using '%ls': %s"
-msgstr "Impossible de créer un tube pour les variables universelles à l’aide de '%ls' : %s"
+msgstr ""
+"Impossible de créer un tube pour les variables universelles à l’aide de "
+"'%ls' : %s"
 
 #: src/env_universal_common.cpp:1405
 #, c-format
 msgid "Unable to open a pipe for universal variables using '%ls': %s"
-msgstr "Impossible d’ouvrir un tube pour les variables universelles à l’aide de '%ls' : %s"
+msgstr ""
+"Impossible d’ouvrir un tube pour les variables universelles à l’aide de "
+"'%ls' : %s"
 
 #: src/event.cpp:119
 #, c-format
@@ -1591,63 +1603,63 @@ msgstr "Vos paramètres personnels ne seront pas sauvegardés."
 msgid "Your history will not be saved."
 msgstr "Votre historique ne sera pas sauvegardé."
 
-#: src/proc.cpp:590
+#: src/proc.cpp:586
 #, c-format
 msgid "Job %d, "
 msgstr "Tâche %d,"
 
-#: src/proc.cpp:591
+#: src/proc.cpp:587
 #, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Tâche %ls, '%ls' terminée par le signal %ls (%ls)"
 
-#: src/proc.cpp:599
+#: src/proc.cpp:595
 #, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 "%ls: Processus %d, '%ls' de la tâche %ls, '%ls' terminé par le signal %ls "
 "(%ls)"
 
-#: src/proc.cpp:769
+#: src/proc.cpp:779
 msgid "An error occured while reading output from code block"
 msgstr ""
 "Une erreur est survenue lors de la lecture de la sortie du bloc de code"
 
-#: src/proc.cpp:846
+#: src/proc.cpp:856
 #, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr ""
 "Mise en premier plan impossible pour la tâche %d ('%ls') à l’identifiant de "
 "groupe de processus %d"
 
-#: src/proc.cpp:875
+#: src/proc.cpp:885
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Mise en premier plan impossible pour la tâche %d ('%ls')"
 
-#: src/proc.cpp:899 src/proc.cpp:908 src/proc.cpp:922
+#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
 msgid "Could not return shell to foreground"
 msgstr "Impossible de remettre le shell en premier plan"
 
-#: src/proc.cpp:1055
+#: src/proc.cpp:1065
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "Plus d'une tâche en premier plan: tâche 1: '%ls' tâche 2: '%ls'"
 
-#: src/proc.cpp:1065
+#: src/proc.cpp:1075
 msgid "Process argument list"
 msgstr "Liste des arguments du processus"
 
-#: src/proc.cpp:1066
+#: src/proc.cpp:1076
 msgid "Process name"
 msgstr "Nom du processus"
 
-#: src/proc.cpp:1069
+#: src/proc.cpp:1079
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Tâche '%ls', le processus '%ls' a un état inconsistant 'arrêté'=%d"
 
-#: src/proc.cpp:1075
+#: src/proc.cpp:1085
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr "Tâche '%ls', le processus '%ls' a un état inconsistant 'complété'=%d"
@@ -2602,6 +2614,213 @@ msgstr "Affiche la version de launchd"
 msgid "Prints the usage for a given subcommand"
 msgstr "Affiche l’utilisation d’une sous-commande spécifiée"
 
+#: /tmp/fish/explicit/share/completions/mdadm.fish:1
+#: /tmp/fish/explicit/share/completions/mdadm.fish:2
+msgid "Use original 0.90 format superblock"
+msgstr "Utiliser le format de superbloc 0.90 original"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:3
+#: /tmp/fish/explicit/share/completions/mdadm.fish:4
+msgid "Use last 1.x format superblock"
+msgstr "Utiliser le format de superbloc 1.xx le plus récent"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:5
+msgid "Use 1.0 format superblock"
+msgstr "Utiliser le format de superbloc 1.0"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:6
+msgid "Use 1.1 format superblock"
+msgstr "Utiliser le format de superbloc 1.1"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:7
+msgid "Use 1.2 format superblock"
+msgstr "Utiliser le format de superbloc 1.2"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:8
+msgid "Use DDF (Disk Data Format) format"
+msgstr "Utiliser le format DDF (Disk Data Format)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:9
+msgid "Use Intel(R) Matrix Storage Manager format"
+msgstr "Utiliser le format Intel(R) Matrix Storage Manager"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:10
+msgid "JBOD"
+msgstr "JBOD"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:11
+#: /tmp/fish/explicit/share/completions/mdadm.fish:12
+#: /tmp/fish/explicit/share/completions/mdadm.fish:13
+msgid "Stripped volume (RAID 0)"
+msgstr "Volume agrégé par bandes (RAID 0)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:14
+#: /tmp/fish/explicit/share/completions/mdadm.fish:15
+#: /tmp/fish/explicit/share/completions/mdadm.fish:16
+msgid "Mirrored volume (RAID 1)"
+msgstr "Volume en miroir (RAID 1)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:17
+#: /tmp/fish/explicit/share/completions/mdadm.fish:18
+msgid "Stripped volume with parity disk (RAID 4)"
+msgstr "Volume agrégé par bandes avec disque de parité (RAID 4)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:19
+#: /tmp/fish/explicit/share/completions/mdadm.fish:20
+msgid "Stripped volume with distributed parity (RAID 5)"
+msgstr "Volume agrégé par bandes à parité répartie (RAID 5)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:21
+#: /tmp/fish/explicit/share/completions/mdadm.fish:22
+msgid "Stripped volume with double distributed parity (RAID 5)"
+msgstr "Volume agrégé par bandes à parité double répartie (RAID 5)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:23
+#: /tmp/fish/explicit/share/completions/mdadm.fish:24
+msgid "Mirrored stripped volume (RAID 10)"
+msgstr "Volume en miroir, agrégé par bandes (RAID 10)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:25
+#: /tmp/fish/explicit/share/completions/mdadm.fish:26
+msgid "Multiple access device, AKA multipath (deprecated)"
+msgstr "Périphérique à accès multiples, soit "
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:27
+msgid "Pseudo RAID layer for single device (akin faulty RAID 1)"
+msgstr "Pseudo-couche RAID pour périphérique isolé (c-à-d RAID 1 défectueux)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:28
+msgid "Container"
+msgstr "Conteneur"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:29
+msgid "Alias of left-asymmetric"
+msgstr "Alias de left-asymmetric"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:30
+msgid "Alias of right-asymmetric"
+msgstr "Alias de right-asymmetric"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:31
+msgid "Alias of left-symmetric"
+msgstr "Alias de left-symmetric"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:32
+msgid "Alias of right-symmetric"
+msgstr "Alias de right-symmetric"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:33
+msgid "Alias of write-transient"
+msgstr "Alias de write-transient"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:34
+msgid "Alias of read-transient"
+msgstr "Alias de read-transient"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:35
+msgid "Alias of write-persistent"
+msgstr "Alias de write-persistent"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:36
+msgid "Alias of read-persistent"
+msgstr "Alias de read-persistent"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:37
+msgid "Alias of read-fixable"
+msgstr "Alias de read-fixable"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:38
+msgid "Use standard format (default)"
+msgstr "Utiliser le format standard (défaut)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:39
+msgid "Use a non-partitionable array"
+msgstr "Utiliser un ensemble non partitionable"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:40
+#: /tmp/fish/explicit/share/completions/mdadm.fish:41
+#: /tmp/fish/explicit/share/completions/mdadm.fish:42
+msgid "Use a partitionable array"
+msgstr "Utiliser un ensemble partitionable"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:43
+msgid "Remove superblock misalignement from SPARC kernel 2.2"
+msgstr "Supprimer le mauvais alignement du superbloc pour les noyaux 2.2 SPARC"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:44
+msgid "Correct superblock summaries"
+msgstr "Corriger les résumés de superbloc"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:45
+msgid "Update array UUID"
+msgstr "Mettre à jour l’UUID"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:46
+msgid "Update array name"
+msgstr "Mettre à jour le nom de l’ensemble"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:47
+msgid "Update array nodes"
+msgstr "Mettre à jour les nœuds de l’ensemble"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:48
+msgid "Update array homehost"
+msgstr "Mettre à jour l’hôte de l’ensemble"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:49
+msgid "Update array cluster name"
+msgstr "Mettre à jour le nom de grappe de l’ensemble"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:50
+msgid "Mark the array as dirty, thus forcing resync"
+msgstr "Marquer l’ensemble comme modifié, afin de forcer une resynchronisation"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:51
+msgid "Reverse superblock endianness"
+msgstr "Inverser le boutisme du superbloc"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:52
+msgid "Refresh device size"
+msgstr "Rafraîchir la taille des périphériques"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:53
+msgid "Assume bitmap absence"
+msgstr "Présumer de l’absence de la table des intentions d’écriture"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:54
+msgid "Reserve space for bad block list"
+msgstr "Réserver de l’espace pour la liste des blocs défectueux"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:55
+msgid "Free reserved space for bad block list"
+msgstr "Libérer l’espace réservé à la liste des blocs défectueux"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:56
+msgid "Convert 0.90 metadata to 1.0"
+msgstr "Convertir les métadonnées 0.90 au format 1.0"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:57
+#, fuzzy
+msgid "Reset preferred minor to current one"
+msgstr "Réinitialiser le mineur favori pour utiliser l’actuel"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:58
+msgid "Abort currently running actions"
+msgstr "Annuler les opérations en cours d’exécution"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:59
+msgid "Abort currently running actions, prevent their restart"
+msgstr ""
+"Annuler les opérations en cours d’exécution, en les empêchant de redémarrer"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:60
+msgid "Scrub the array (i.e. check constistency)"
+msgstr "Vérifier l’ensemble (c-à-d vérifier sa cohérence)"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:61
+msgid "Check, then resync"
+msgstr "Vérifier, puis resynchroniser"
+
 #: /tmp/fish/explicit/share/completions/set.fish:1
 msgid "Locale"
 msgstr "Locale"
@@ -3498,6 +3717,7 @@ msgstr "<dir> chemin vers les informations ACPI (/proc/acpi)"
 #: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
 #: /tmp/fish/implicit/share/completions/asp.fish:6
 #: /tmp/fish/implicit/share/completions/bc.fish:7
+#: /tmp/fish/implicit/share/completions/bd.fish:4
 #: /tmp/fish/implicit/share/completions/bg.fish:1
 #: /tmp/fish/implicit/share/completions/bind.fish:4
 #: /tmp/fish/implicit/share/completions/block.fish:1
@@ -4119,7 +4339,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bzr.fish:1
 #: /tmp/fish/implicit/share/completions/climate.fish:1
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:17
-#: /tmp/fish/implicit/share/completions/cygport.fish:23
+#: /tmp/fish/implicit/share/completions/cygport.fish:25
 #: /tmp/fish/implicit/share/completions/godoc.fish:25
 #: /tmp/fish/implicit/share/completions/gofmt.fish:8
 #: /tmp/fish/implicit/share/completions/goimports.fish:6
@@ -5521,6 +5741,7 @@ msgstr "Choisir le fichier de cache des sources"
 #: /tmp/fish/implicit/share/completions/apt-get.fish:24
 #: /tmp/fish/implicit/share/completions/configure.fish:3
 #: /tmp/fish/implicit/share/completions/gpg.fish:62
+#: /tmp/fish/implicit/share/completions/hugo.fish:5
 #: /tmp/fish/implicit/share/completions/make.fish:16
 #: /tmp/fish/implicit/share/completions/ping.fish:16
 #: /tmp/fish/implicit/share/completions/rpm.fish:3
@@ -5691,6 +5912,7 @@ msgid "Set a configuration option"
 msgstr "Paramétrer une option de configuration"
 
 #: /tmp/fish/implicit/share/completions/apt.fish:8
+#: /tmp/fish/implicit/share/completions/hugo.fish:1
 #: /tmp/fish/implicit/share/completions/man.fish:14
 #: /tmp/fish/implicit/share/completions/modprobe.fish:2
 #: /tmp/fish/implicit/share/completions/yum.fish:13
@@ -8778,6 +9000,18 @@ msgstr "Traiter exactement comme bc POSIX"
 msgid "Do not print the GNU welcome"
 msgstr "Ne pas afficher le message de bienvenue GNU"
 
+#: /tmp/fish/implicit/share/completions/bd.fish:1
+msgid "Classic mode: goes back to the first directory named as the string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:2
+msgid "Seems mode: goes back to the first directory containing string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:3
+msgid "Case insensitive move (implies seems mode)"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/bind.fish:1
 msgid "Show unavailable key bindings/erase all bindings"
 msgstr "Afficher ou effacer toutes les combinaisons existantes"
@@ -10246,7 +10480,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/caddy.fish:24
 #: /tmp/fish/implicit/share/completions/canto.fish:2
-#: /tmp/fish/implicit/share/completions/cygport.fish:24
+#: /tmp/fish/implicit/share/completions/cygport.fish:26
 #: /tmp/fish/implicit/share/completions/grub-install.fish:33
 #: /tmp/fish/implicit/share/completions/lua.fish:4
 #: /tmp/fish/implicit/share/completions/magento.fish:23
@@ -13392,27 +13626,37 @@ msgid "Show project homepage URL"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:17
+#, fuzzy
+msgid "Create packages, marked as test"
+msgstr "Créer un dépôt de paquets"
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:18
 msgid "Create packages"
 msgstr "Créer les paquets"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:18
+#: /tmp/fish/implicit/share/completions/cygport.fish:19
 #, fuzzy
 msgid "Create source patches"
 msgstr "Créer les patchs de source"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:19
+#: /tmp/fish/implicit/share/completions/cygport.fish:20
 msgid "Upload finished packages"
 msgstr "Téléverser les paquets achevés"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:20
+#: /tmp/fish/implicit/share/completions/cygport.fish:21
+#, fuzzy
+msgid "Upload packages without marking !ready"
+msgstr "Téléverser un paquet vers Hackage"
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:22
 msgid "Send announcement email"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:21
+#: /tmp/fish/implicit/share/completions/cygport.fish:23
 msgid "Delete working directory"
 msgstr "Supprimer le dossier de travail"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:22
+#: /tmp/fish/implicit/share/completions/cygport.fish:24
 msgid "Same as prep build inst pkg"
 msgstr ""
 
@@ -32050,6 +32294,7 @@ msgid "Name of the output file"
 msgstr "Nom du fichier de sortie"
 
 #: /tmp/fish/implicit/share/completions/highlight.fish:5
+#: /tmp/fish/implicit/share/completions/hugo.fish:57
 #: /tmp/fish/implicit/share/completions/tex.fish:10
 msgid "Output directory"
 msgstr "Dossier de sortie"
@@ -32092,6 +32337,556 @@ msgstr "Surveiller l’utilisateur spécifié"
 #: /tmp/fish/implicit/share/completions/htop.fish:7
 msgid "Sort column"
 msgstr "Colonne de tri"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:2
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
+#, fuzzy
+msgid "Debug output"
+msgstr "Option de débogage"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:3
+#, fuzzy
+msgid "Enable logging"
+msgstr "Activer le débogage"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:4
+#, fuzzy
+msgid "Log file"
+msgstr "Ficher de configuration"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:6
+#: /tmp/fish/implicit/share/completions/iptables.fish:25
+#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
+msgid "Verbose output"
+msgstr "Mode verbeux"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:7
+#, fuzzy
+msgid "Verbose logging"
+msgstr "Demander une journalisation verbeuse"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:8
+#, fuzzy
+msgid "Hostname and path to the root"
+msgstr "Paramétrer le chemin vers le dépôt"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:9
+msgid "Include content marked as draft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:10
+#, fuzzy
+msgid "Include expired content"
+msgstr "Inclure les documents RI générés"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:11
+#, fuzzy
+msgid "Include content with publishdate in the future"
+msgstr "Inclure les symboles spéciaux dans la sortie"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:12
+#, fuzzy
+msgid "Cache directory"
+msgstr "Créer un dossier"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:13
+msgid "Canonicalize all relative URLs using baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:14
+#, fuzzy
+msgid "Remove files from destination not found in static directories"
+msgstr "Supprimer des fichiers du dépôt"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:15
+#, fuzzy
+msgid "Content directory"
+msgstr "Modifier le dossier des polices"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:16
+#, fuzzy
+msgid "Destination directory"
+msgstr "Créer un dossier de destination"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:17
+#, fuzzy
+msgid "Do not build 404 page"
+msgstr "Ne pas éditer les fichiers de construction"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:18
+#, fuzzy
+msgid "Disable different kinds of pages"
+msgstr "Désactiver la création de fichiers creux"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:19
+#, fuzzy
+msgid "Do not build RSS files"
+msgstr "Ne pas éditer les fichiers de construction"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:20
+#, fuzzy
+msgid "Do not build sitemap files"
+msgstr "Ne pas suppr. les fichiers construits"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:21
+msgid "Add Git revision, date and author info to the pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:22
+msgid "Copy all files when static is changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:23
+msgid "Help for hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:24
+#, fuzzy
+msgid "Print missing translations"
+msgstr "Afficher les ratios de compression"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:25
+#, fuzzy
+msgid "Ignore the cache directory"
+msgstr "Ignorer les dossiers"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:26
+#, fuzzy
+msgid "Layout directory"
+msgstr "Dossier de sortie"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:27
+#, fuzzy
+msgid "Do not sync permission mode of files"
+msgstr "Ne pas vérifier les sommes de contrôle des fichiers"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:28
+#, fuzzy
+msgid "Do not sync modification time of files"
+msgstr "Trier selon l’horodatage de modification"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:29
+msgid "Pluralize titles in lists using inflect"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:30
+msgid "Preserve taxonomy names as written"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:31
+#: /tmp/fish/implicit/share/completions/hugo.fish:45
+#, fuzzy
+msgid "Render to memory"
+msgstr "Réduire l'utilisation de la mémoire"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:32
+#: /tmp/fish/implicit/share/completions/hugo.fish:58
+#: /tmp/fish/implicit/share/completions/hugo.fish:92
+#: /tmp/fish/implicit/share/completions/hugo.fish:103
+#, fuzzy
+msgid "Source directory"
+msgstr "Paramétrer le dossier source"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:33
+#: /tmp/fish/implicit/share/completions/hugo.fish:46
+#, fuzzy
+msgid "Display memory and timing of different steps of the program"
+msgstr "Afficher la version du programme"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:34
+#: /tmp/fish/implicit/share/completions/hugo.fish:47
+#, fuzzy
+msgid "Display metrics about template executions"
+msgstr "Afficher les informations sur la fonction"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:35
+#: /tmp/fish/implicit/share/completions/hugo.fish:48
+msgid "Calculate some improvement hints when combined with --templateMetrics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:36
+#, fuzzy
+msgid "Theme to use"
+msgstr "Le fichier de PID à utiliser"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:37
+#, fuzzy
+msgid "Themes directory"
+msgstr "Supprimer un dossier"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:38
+#, fuzzy
+msgid "Use /filename.html instead of /filename/"
+msgstr "Utiliser /dev/urandom au lieu de /dev/random"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:39
+#, fuzzy
+msgid "Watch filesystem for changes and recreate as needed"
+msgstr "Surveiller les modifications des fichiers"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:40
+msgid "Benchmark Hugo by building the site a number of times"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:41
+msgid "Number of times to build the site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:42
+#, fuzzy
+msgid "CPU profile file"
+msgstr "Utiliser le fichier de config"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:43
+msgid "Help for benchmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:44
+#, fuzzy
+msgid "Memory profile file"
+msgstr "Déplacer ou renommer des fichiers"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:49
+#, fuzzy
+msgid "Perform some verification checks"
+msgstr "Générer le contenu"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:50
+msgid "Help for check"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:51
+msgid "Check system ulimit settings"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:52
+#, fuzzy
+msgid "Help for ulimit"
+msgstr "Nouvelle limite sur les ressources"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:53
+#, fuzzy
+msgid "Print the site configuration"
+msgstr "Afficher la configuration actuelle de l’écran"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:54
+#, fuzzy
+msgid "Help for config"
+msgstr "Utiliser une autre configuration"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:55
+msgid "Convert the content to different formats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:56
+#, fuzzy
+msgid "Help for convert"
+msgstr "Alias pour -a"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:59
+#, fuzzy
+msgid "Enable less safe operations"
+msgstr "Activer touts les options de configuration utilisateur"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:60
+msgid "Convert front matter to JSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:61
+msgid "Help for toJSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:62
+msgid "Convert front matter to TOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:63
+msgid "Help for toTOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:64
+msgid "Convert front matter to YAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:65
+msgid "Help for toYAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:66
+#, fuzzy
+msgid "Print Hugo version and environment info"
+msgstr "Afficher la version et quitter"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:67
+#, fuzzy
+msgid "Help for env"
+msgstr "Alias pour -a"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:68
+msgid "Collection of several useful generators"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:69
+msgid "Help for gen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:70
+msgid "Generate shell autocompletion script for Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:71
+#, fuzzy
+msgid "Autocompletion file"
+msgstr "Compléter en utilisant les fichiers"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:72
+msgid "Help for autocomplete"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:73
+#, fuzzy
+msgid "Autocompletion type"
+msgstr "Chemin auquel ajouter une complétion"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:74
+msgid "Generate CSS stylesheet for the Chroma code highlighter"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:75
+msgid "Help for chromastyles"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:76
+#, fuzzy
+msgid "Style used for highlighting lines"
+msgstr "Ne pas surligner lors de la recherche"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:77
+#, fuzzy
+msgid "Style used for line numbers"
+msgstr "Afficher le numéro de version"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:78
+#, fuzzy
+msgid "Highlighter style"
+msgstr "Style de surlignement"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:79
+#, fuzzy
+msgid "Generate Markdown documentation for the Hugo CLI"
+msgstr "Générer la documentation RDoc de la gemme en installation"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:80
+#, fuzzy
+msgid "Doc directory"
+msgstr "Dossier"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:81
+msgid "Help for doc"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:82
+#, fuzzy
+msgid "Generate man pages for the Hugo CLI"
+msgstr "Générer le code pour le SH1"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:83
+#, fuzzy
+msgid "Man pages directory"
+msgstr "Nettoyer le dossier de cache"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:84
+#, fuzzy
+msgid "Help for man"
+msgstr "Paramétrer le format"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:85
+#, fuzzy
+msgid "Import your site from others"
+msgstr "Importer le dépôt git"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:86
+#, fuzzy
+msgid "Help for import"
+msgstr "Dossier à importer"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:87
+msgid "Import from Jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:88
+#, fuzzy
+msgid "Allow import into non-empty target directory"
+msgstr "Importer le fichier dans le dossiers des patchs"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:89
+msgid "Help for jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:90
+#, fuzzy
+msgid "List various types of content"
+msgstr "Lister les seuls noms des jeux"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:91
+msgid "Help for list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:93
+#, fuzzy
+msgid "List all drafts"
+msgstr "Lister les branches"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:94
+msgid "Help for drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:95
+#, fuzzy
+msgid "List all expired posts"
+msgstr "Lister tous les ports"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:96
+#, fuzzy
+msgid "Help for expired"
+msgstr "Expiration du délai"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:97
+#, fuzzy
+msgid "List all posts dated in the future"
+msgstr "Lister tous les patchs de cette catégorie"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:98
+#, fuzzy
+msgid "Help for future"
+msgstr "Alias pour atrm"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:99
+#, fuzzy
+msgid "Create new content"
+msgstr "Créer une nouvelle révision"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:100
+#, fuzzy
+msgid "Editor to use"
+msgstr "Affichage à utiliser"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:101
+msgid "Help for new"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:102
+#, fuzzy
+msgid "Content type to create"
+msgstr "Concaténer la sortie au fichier spécifié"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:104
+#, fuzzy
+msgid "Create a new site"
+msgstr "Créer un dossier"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:105
+#, fuzzy
+msgid "Create site inside non-empty directory"
+msgstr "Créer un dossier de destination"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:106
+msgid "Config and front matter format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:107
+msgid "Help for site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:108
+#, fuzzy
+msgid "Create a new theme"
+msgstr "Créer un dossier"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:109
+#, fuzzy
+msgid "Help for theme"
+msgstr "Rechercher un autre système"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:110
+#, fuzzy
+msgid "Start high performance web server"
+msgstr "Démarrer le serveur web"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:111
+#, fuzzy
+msgid "Append port to baseurl"
+msgstr "Ajouter les entrées à la sélection"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:112
+#, fuzzy
+msgid "Interface to which the server will bind"
+msgstr "Date à laquelle l’utilisateur sera désactivé"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:113
+#, fuzzy
+msgid "Enable full re-renders on changes"
+msgstr "Sauvegarder les modifications actuelles"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:114
+msgid "Watch without enabling live browser reload on rebuild"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:115
+#, fuzzy
+msgid "Help for server"
+msgstr "Utiliser un proxy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:116
+#, fuzzy
+msgid "Port for live reloading"
+msgstr "Port d’écoute"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:117
+msgid "Interval to poll memory usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:118
+#, fuzzy
+msgid "Memory usage log file"
+msgstr "Fusionner des fichiers déjà triés ; ne pas trier"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:119
+msgid "Navigate to changed content file on live browser reload"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:120
+msgid "Prevent HTTP caching"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:121
+#, fuzzy
+msgid "Port on which the server will listen"
+msgstr "Date à laquelle l’utilisateur sera désactivé"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:122
+#, fuzzy
+msgid "Render to destination directory"
+msgstr "Créer un dossier de destination"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:123
+msgid "Reset the content draft status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:124
+msgid "Help for undraft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:125
+#, fuzzy
+msgid "Print the version number of Hugo"
+msgstr "Afficher le numéro de version"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:126
+#, fuzzy
+msgid "Help for version"
+msgstr "Nom de la version"
 
 #: /tmp/fish/implicit/share/completions/i3-msg.fish:1
 msgid "Only send ipc message and suppress output"
@@ -32617,12 +33412,6 @@ msgstr ""
 "Initialiser les compteurs de paquets et d’octets d’une règle à des valeurs "
 "arbitraires"
 
-#: /tmp/fish/implicit/share/completions/iptables.fish:25
-#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
-msgid "Verbose output"
-msgstr "Mode verbeux"
-
 #: /tmp/fish/implicit/share/completions/iptables.fish:26
 msgid "Wait for the xtables lock"
 msgstr "Attendre le verrou xtables"
@@ -32989,6 +33778,113 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/jest.fish:77
 msgid "Disable using watchman for file crawling"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:1
+#, fuzzy
+msgid "Enable debugger"
+msgstr "Activer le débogage"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:2
+#, fuzzy
+msgid "Output usage information"
+msgstr "Afficher les informations d’utilisation"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:3
+#, fuzzy
+msgid "Output version number"
+msgstr "Afficher le numéro de version"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:4
+#, fuzzy
+msgid "Create a new JHipster application"
+msgstr "Créer un nouveau projet Elixir"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:5
+#, fuzzy
+msgid "Deploy the current application to AWS"
+msgstr "Supprimer les fichiers applicatifs générés"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:6
+msgid "Create pipeline scripts for popular CI tools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:7
+msgid "Create a new JHipster client-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:8
+msgid "Prepare Cloud Foundry deployment"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:9
+msgid ""
+"Create all required Docker deployment configuration for the selected "
+"applications"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:10
+msgid ""
+"Create a new JHipster entity: JPA entity, Spring server-side components and "
+"Angular client-side components"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:11
+#, fuzzy
+msgid "Create a JDL file from the existing entities"
+msgstr "Supprimer un jeu de fichiers d’une archive existante"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:12
+#, fuzzy
+msgid "Deploy the current application to Heroku"
+msgstr "Supprimer les fichiers applicatifs générés"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:13
+msgid "Create entities from the JDL file passed in argument"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:14
+#, fuzzy
+msgid "Display information about your current project and system"
+msgstr "Afficher les informations sur un élément local ou distant"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:15
+#, fuzzy
+msgid "Deploy the current application to Kubernetes"
+msgstr "Supprimer les fichiers applicatifs générés"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:16
+msgid ""
+"Select languages from a list of available languages. The i18n files will be "
+"copied to the /webapp/i18n folder"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:17
+#, fuzzy
+msgid "Deploy the current application to OpenShift"
+msgstr "Afficher la version de l’application p4 et quitter"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:18
+#, fuzzy
+msgid "Deploy the current application to Rancher"
+msgstr "Supprimer les fichiers applicatifs générés"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:19
+msgid "Create a new JHipster server-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:20
+#, fuzzy
+msgid "Create a new Spring service bean"
+msgstr "Créer un dossier"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:21
+msgid "Upgrade the JHipster version and the generated application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:22
+#, fuzzy
+msgid "Print command completion script"
+msgstr "Afficher la description des options de la ligne de commande"
 
 #: /tmp/fish/implicit/share/completions/jobs.fish:2
 msgid "Show the process id of each process in the job"
@@ -49865,11 +50761,6 @@ msgstr ""
 msgid "Set default root object"
 msgstr "Paramétrer la cible par défaut pour le démarrage"
 
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
-#, fuzzy
-msgid "Debug output"
-msgstr "Option de débogage"
-
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:130
 #, fuzzy
 msgid "Cache FILE containing MD5 values"
@@ -61599,8 +62490,8 @@ msgstr ""
 #~ msgid ""
 #~ "%ls: Multiple variable names specified in single call (%ls and %.*ls)\n"
 #~ msgstr ""
-#~ "%ls: Plusieurs noms de variable spécifiés dans un seul appel (%ls and "
-#~ "%.*ls)\n"
+#~ "%ls: Plusieurs noms de variable spécifiés dans un seul appel (%ls and %."
+#~ "*ls)\n"
 
 #, fuzzy
 #~ msgid "%ls: Values cannot be specfied with erase\n"

--- a/po/nb.po
+++ b/po/nb.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 2.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-08 16:50+0100\n"
 "Last-Translator: Andreas Nordal <andreas.nordal_4@hotmail.com>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
@@ -103,12 +103,12 @@ msgstr ""
 msgid "%ls: There are no suitable jobs\n"
 msgstr ""
 
-#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82
+#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, c-format
 msgid "%ls: '%ls' is not a valid job specifier\n"
 msgstr ""
 
-#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89
+#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89 src/builtin_wait.cpp:163
 #, c-format
 msgid "%ls: Could not find job '%d'\n"
 msgstr ""
@@ -218,221 +218,225 @@ msgstr ""
 msgid "%ls: Key not specified\n"
 msgstr ""
 
-#: src/builtin.cpp:261
+#: src/builtin.cpp:262
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
 "\n"
 msgstr ""
 
-#: src/builtin.cpp:337
+#: src/builtin.cpp:338
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr ""
 
-#: src/builtin.cpp:371
+#: src/builtin.cpp:372
 #, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr ""
 
-#: src/builtin.cpp:409 src/builtin.cpp:459
+#: src/builtin.cpp:410 src/builtin.cpp:460
 msgid "Test a condition"
 msgstr ""
 
-#: src/builtin.cpp:410
+#: src/builtin.cpp:411
 msgid "Execute command if previous command suceeded"
 msgstr ""
 
-#: src/builtin.cpp:411
+#: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:412
+#: src/builtin.cpp:413
 msgid "Create a block of code"
 msgstr ""
 
-#: src/builtin.cpp:413
+#: src/builtin.cpp:414
 msgid "Send job to background"
 msgstr ""
 
-#: src/builtin.cpp:414
+#: src/builtin.cpp:415
 msgid "Handle fish key bindings"
 msgstr ""
 
-#: src/builtin.cpp:415
+#: src/builtin.cpp:416
 msgid "Temporarily block delivery of events"
 msgstr ""
 
-#: src/builtin.cpp:416
+#: src/builtin.cpp:417
 msgid "Stop the innermost loop"
 msgstr ""
 
-#: src/builtin.cpp:418
+#: src/builtin.cpp:419
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 
-#: src/builtin.cpp:419
+#: src/builtin.cpp:420
 msgid "Run a builtin command instead of a function"
 msgstr ""
 
-#: src/builtin.cpp:420 src/builtin.cpp:458
+#: src/builtin.cpp:421 src/builtin.cpp:459
 msgid "Conditionally execute a block of commands"
 msgstr ""
 
-#: src/builtin.cpp:421
+#: src/builtin.cpp:422
 msgid "Change working directory"
 msgstr ""
 
-#: src/builtin.cpp:422
+#: src/builtin.cpp:423
 msgid "Run a program instead of a function or builtin"
 msgstr ""
 
-#: src/builtin.cpp:423
+#: src/builtin.cpp:424
 msgid "Set or get the commandline"
 msgstr ""
 
-#: src/builtin.cpp:424
+#: src/builtin.cpp:425
 msgid "Edit command specific completions"
 msgstr ""
 
-#: src/builtin.cpp:425
+#: src/builtin.cpp:426
 msgid "Search for a specified string in a list"
 msgstr ""
 
-#: src/builtin.cpp:427
+#: src/builtin.cpp:428
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr ""
 
-#: src/builtin.cpp:428
+#: src/builtin.cpp:429
 msgid "Count the number of arguments"
 msgstr ""
 
-#: src/builtin.cpp:429
+#: src/builtin.cpp:430
 msgid "Remove job from job list"
 msgstr ""
 
-#: src/builtin.cpp:430
+#: src/builtin.cpp:431
 msgid "Print arguments"
 msgstr ""
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:432
 msgid "Evaluate block if condition is false"
 msgstr ""
 
-#: src/builtin.cpp:432
+#: src/builtin.cpp:433
 msgid "Emit an event"
 msgstr ""
 
-#: src/builtin.cpp:433
+#: src/builtin.cpp:434
 msgid "End a block of commands"
 msgstr ""
 
-#: src/builtin.cpp:434
+#: src/builtin.cpp:435
 msgid "Run command in current process"
 msgstr ""
 
-#: src/builtin.cpp:435
+#: src/builtin.cpp:436
 msgid "Exit the shell"
 msgstr ""
 
-#: src/builtin.cpp:436
+#: src/builtin.cpp:437
 msgid "Return an unsuccessful result"
 msgstr ""
 
-#: src/builtin.cpp:437
+#: src/builtin.cpp:438
 msgid "Send job to foreground"
 msgstr ""
 
-#: src/builtin.cpp:438
+#: src/builtin.cpp:439
 msgid "Perform a set of commands multiple times"
 msgstr ""
 
-#: src/builtin.cpp:439
+#: src/builtin.cpp:440
 msgid "Define a new function"
 msgstr ""
 
-#: src/builtin.cpp:440
+#: src/builtin.cpp:441
 msgid "List or remove functions"
 msgstr ""
 
-#: src/builtin.cpp:441
+#: src/builtin.cpp:442
 msgid "History of commands executed by user"
 msgstr ""
 
-#: src/builtin.cpp:442
+#: src/builtin.cpp:443
 msgid "Evaluate block if condition is true"
 msgstr ""
 
-#: src/builtin.cpp:443
+#: src/builtin.cpp:444
 msgid "Print currently running jobs"
 msgstr ""
 
-#: src/builtin.cpp:444
+#: src/builtin.cpp:445
 msgid "Evaluate math expressions"
 msgstr ""
 
-#: src/builtin.cpp:445
+#: src/builtin.cpp:446
 msgid "Negate exit status of job"
 msgstr ""
 
-#: src/builtin.cpp:446
+#: src/builtin.cpp:447
 msgid "Execute command if previous command failed"
 msgstr ""
 
-#: src/builtin.cpp:447
+#: src/builtin.cpp:448
 msgid "Prints formatted text"
 msgstr ""
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:449
 msgid "Print the working directory"
 msgstr ""
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:450
 msgid "Generate random number"
 msgstr ""
 
-#: src/builtin.cpp:450
+#: src/builtin.cpp:451
 msgid "Read a line of input into variables"
 msgstr ""
 
-#: src/builtin.cpp:451
+#: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr ""
 
-#: src/builtin.cpp:452
+#: src/builtin.cpp:453
 msgid "Stop the currently evaluated function"
 msgstr ""
 
-#: src/builtin.cpp:453
+#: src/builtin.cpp:454
 msgid "Handle environment variables"
 msgstr ""
 
-#: src/builtin.cpp:454
+#: src/builtin.cpp:455
 msgid "Set the terminal color"
 msgstr ""
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:456
 msgid "Evaluate contents of file"
 msgstr ""
 
-#: src/builtin.cpp:456
+#: src/builtin.cpp:457
 msgid "Return status information about fish"
 msgstr ""
 
-#: src/builtin.cpp:457
+#: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr ""
 
-#: src/builtin.cpp:460
+#: src/builtin.cpp:461
 msgid "Return a successful result"
 msgstr ""
 
-#: src/builtin.cpp:461
+#: src/builtin.cpp:462
 msgid "Set or get the shells resource usage limits"
 msgstr ""
 
-#: src/builtin.cpp:462
+#: src/builtin.cpp:463
+msgid "Wait for background processes completed"
+msgstr ""
+
+#: src/builtin.cpp:464
 msgid "Perform a command multiple times"
 msgstr ""
 
@@ -1456,58 +1460,58 @@ msgstr ""
 msgid "Your history will not be saved."
 msgstr ""
 
-#: src/proc.cpp:590
+#: src/proc.cpp:586
 #, c-format
 msgid "Job %d, "
 msgstr ""
 
-#: src/proc.cpp:591
+#: src/proc.cpp:587
 #, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 
-#: src/proc.cpp:599
+#: src/proc.cpp:595
 #, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 
-#: src/proc.cpp:769
+#: src/proc.cpp:779
 msgid "An error occured while reading output from code block"
 msgstr ""
 
-#: src/proc.cpp:846
+#: src/proc.cpp:856
 #, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr ""
 
-#: src/proc.cpp:875
+#: src/proc.cpp:885
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr ""
 
-#: src/proc.cpp:899 src/proc.cpp:908 src/proc.cpp:922
+#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
 msgid "Could not return shell to foreground"
 msgstr ""
 
-#: src/proc.cpp:1055
+#: src/proc.cpp:1065
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr ""
 
-#: src/proc.cpp:1065
+#: src/proc.cpp:1075
 msgid "Process argument list"
 msgstr ""
 
-#: src/proc.cpp:1066
+#: src/proc.cpp:1076
 msgid "Process name"
 msgstr ""
 
-#: src/proc.cpp:1069
+#: src/proc.cpp:1079
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr ""
 
-#: src/proc.cpp:1075
+#: src/proc.cpp:1085
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr ""
@@ -2429,6 +2433,211 @@ msgstr ""
 msgid "Prints the usage for a given subcommand"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/mdadm.fish:1
+#: /tmp/fish/explicit/share/completions/mdadm.fish:2
+msgid "Use original 0.90 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:3
+#: /tmp/fish/explicit/share/completions/mdadm.fish:4
+msgid "Use last 1.x format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:5
+msgid "Use 1.0 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:6
+msgid "Use 1.1 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:7
+msgid "Use 1.2 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:8
+msgid "Use DDF (Disk Data Format) format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:9
+msgid "Use Intel(R) Matrix Storage Manager format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:10
+msgid "JBOD"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:11
+#: /tmp/fish/explicit/share/completions/mdadm.fish:12
+#: /tmp/fish/explicit/share/completions/mdadm.fish:13
+msgid "Stripped volume (RAID 0)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:14
+#: /tmp/fish/explicit/share/completions/mdadm.fish:15
+#: /tmp/fish/explicit/share/completions/mdadm.fish:16
+msgid "Mirrored volume (RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:17
+#: /tmp/fish/explicit/share/completions/mdadm.fish:18
+msgid "Stripped volume with parity disk (RAID 4)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:19
+#: /tmp/fish/explicit/share/completions/mdadm.fish:20
+msgid "Stripped volume with distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:21
+#: /tmp/fish/explicit/share/completions/mdadm.fish:22
+msgid "Stripped volume with double distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:23
+#: /tmp/fish/explicit/share/completions/mdadm.fish:24
+msgid "Mirrored stripped volume (RAID 10)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:25
+#: /tmp/fish/explicit/share/completions/mdadm.fish:26
+msgid "Multiple access device, AKA multipath (deprecated)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:27
+msgid "Pseudo RAID layer for single device (akin faulty RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:28
+msgid "Container"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:29
+msgid "Alias of left-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:30
+msgid "Alias of right-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:31
+msgid "Alias of left-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:32
+msgid "Alias of right-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:33
+msgid "Alias of write-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:34
+msgid "Alias of read-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:35
+msgid "Alias of write-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:36
+msgid "Alias of read-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:37
+msgid "Alias of read-fixable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:38
+msgid "Use standard format (default)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:39
+msgid "Use a non-partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:40
+#: /tmp/fish/explicit/share/completions/mdadm.fish:41
+#: /tmp/fish/explicit/share/completions/mdadm.fish:42
+msgid "Use a partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:43
+msgid "Remove superblock misalignement from SPARC kernel 2.2"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:44
+msgid "Correct superblock summaries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:45
+msgid "Update array UUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:46
+msgid "Update array name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:47
+msgid "Update array nodes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:48
+msgid "Update array homehost"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:49
+msgid "Update array cluster name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:50
+msgid "Mark the array as dirty, thus forcing resync"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:51
+msgid "Reverse superblock endianness"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:52
+msgid "Refresh device size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:53
+msgid "Assume bitmap absence"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:54
+msgid "Reserve space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:55
+msgid "Free reserved space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:56
+msgid "Convert 0.90 metadata to 1.0"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:57
+msgid "Reset preferred minor to current one"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:58
+msgid "Abort currently running actions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:59
+msgid "Abort currently running actions, prevent their restart"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:60
+msgid "Scrub the array (i.e. check constistency)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:61
+msgid "Check, then resync"
+msgstr ""
+
 #: /tmp/fish/explicit/share/completions/set.fish:1
 msgid "Locale"
 msgstr ""
@@ -3304,6 +3513,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
 #: /tmp/fish/implicit/share/completions/asp.fish:6
 #: /tmp/fish/implicit/share/completions/bc.fish:7
+#: /tmp/fish/implicit/share/completions/bd.fish:4
 #: /tmp/fish/implicit/share/completions/bg.fish:1
 #: /tmp/fish/implicit/share/completions/bind.fish:4
 #: /tmp/fish/implicit/share/completions/block.fish:1
@@ -3897,7 +4107,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bzr.fish:1
 #: /tmp/fish/implicit/share/completions/climate.fish:1
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:17
-#: /tmp/fish/implicit/share/completions/cygport.fish:23
+#: /tmp/fish/implicit/share/completions/cygport.fish:25
 #: /tmp/fish/implicit/share/completions/godoc.fish:25
 #: /tmp/fish/implicit/share/completions/gofmt.fish:8
 #: /tmp/fish/implicit/share/completions/goimports.fish:6
@@ -5268,6 +5478,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-get.fish:24
 #: /tmp/fish/implicit/share/completions/configure.fish:3
 #: /tmp/fish/implicit/share/completions/gpg.fish:62
+#: /tmp/fish/implicit/share/completions/hugo.fish:5
 #: /tmp/fish/implicit/share/completions/make.fish:16
 #: /tmp/fish/implicit/share/completions/ping.fish:16
 #: /tmp/fish/implicit/share/completions/rpm.fish:3
@@ -5435,6 +5646,7 @@ msgid "Set a configuration option"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt.fish:8
+#: /tmp/fish/implicit/share/completions/hugo.fish:1
 #: /tmp/fish/implicit/share/completions/man.fish:14
 #: /tmp/fish/implicit/share/completions/modprobe.fish:2
 #: /tmp/fish/implicit/share/completions/yum.fish:13
@@ -8389,6 +8601,18 @@ msgstr ""
 msgid "Do not print the GNU welcome"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/bd.fish:1
+msgid "Classic mode: goes back to the first directory named as the string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:2
+msgid "Seems mode: goes back to the first directory containing string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:3
+msgid "Case insensitive move (implies seems mode)"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/bind.fish:1
 msgid "Show unavailable key bindings/erase all bindings"
 msgstr ""
@@ -9811,7 +10035,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/caddy.fish:24
 #: /tmp/fish/implicit/share/completions/canto.fish:2
-#: /tmp/fish/implicit/share/completions/cygport.fish:24
+#: /tmp/fish/implicit/share/completions/cygport.fish:26
 #: /tmp/fish/implicit/share/completions/grub-install.fish:33
 #: /tmp/fish/implicit/share/completions/lua.fish:4
 #: /tmp/fish/implicit/share/completions/magento.fish:23
@@ -12884,26 +13108,34 @@ msgid "Show project homepage URL"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:17
-msgid "Create packages"
+msgid "Create packages, marked as test"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:18
-msgid "Create source patches"
+msgid "Create packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:19
-msgid "Upload finished packages"
+msgid "Create source patches"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:20
-msgid "Send announcement email"
+msgid "Upload finished packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:21
-msgid "Delete working directory"
+msgid "Upload packages without marking !ready"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:22
+msgid "Send announcement email"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:23
+msgid "Delete working directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:24
 msgid "Same as prep build inst pkg"
 msgstr ""
 
@@ -30969,6 +31201,7 @@ msgid "Name of the output file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/highlight.fish:5
+#: /tmp/fish/implicit/share/completions/hugo.fish:57
 #: /tmp/fish/implicit/share/completions/tex.fish:10
 msgid "Output directory"
 msgstr ""
@@ -31010,6 +31243,481 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/htop.fish:7
 msgid "Sort column"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:2
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
+msgid "Debug output"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:3
+msgid "Enable logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:4
+msgid "Log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:6
+#: /tmp/fish/implicit/share/completions/iptables.fish:25
+#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
+msgid "Verbose output"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:7
+msgid "Verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:8
+msgid "Hostname and path to the root"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:9
+msgid "Include content marked as draft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:10
+msgid "Include expired content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:11
+msgid "Include content with publishdate in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:12
+msgid "Cache directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:13
+msgid "Canonicalize all relative URLs using baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:14
+msgid "Remove files from destination not found in static directories"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:15
+msgid "Content directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:16
+msgid "Destination directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:17
+msgid "Do not build 404 page"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:18
+msgid "Disable different kinds of pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:19
+msgid "Do not build RSS files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:20
+msgid "Do not build sitemap files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:21
+msgid "Add Git revision, date and author info to the pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:22
+msgid "Copy all files when static is changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:23
+msgid "Help for hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:24
+msgid "Print missing translations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:25
+msgid "Ignore the cache directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:26
+msgid "Layout directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:27
+msgid "Do not sync permission mode of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:28
+msgid "Do not sync modification time of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:29
+msgid "Pluralize titles in lists using inflect"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:30
+msgid "Preserve taxonomy names as written"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:31
+#: /tmp/fish/implicit/share/completions/hugo.fish:45
+msgid "Render to memory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:32
+#: /tmp/fish/implicit/share/completions/hugo.fish:58
+#: /tmp/fish/implicit/share/completions/hugo.fish:92
+#: /tmp/fish/implicit/share/completions/hugo.fish:103
+msgid "Source directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:33
+#: /tmp/fish/implicit/share/completions/hugo.fish:46
+msgid "Display memory and timing of different steps of the program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:34
+#: /tmp/fish/implicit/share/completions/hugo.fish:47
+msgid "Display metrics about template executions"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:35
+#: /tmp/fish/implicit/share/completions/hugo.fish:48
+msgid "Calculate some improvement hints when combined with --templateMetrics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:36
+msgid "Theme to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:37
+msgid "Themes directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:38
+msgid "Use /filename.html instead of /filename/"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:39
+msgid "Watch filesystem for changes and recreate as needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:40
+msgid "Benchmark Hugo by building the site a number of times"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:41
+msgid "Number of times to build the site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:42
+msgid "CPU profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:43
+msgid "Help for benchmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:44
+msgid "Memory profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:49
+msgid "Perform some verification checks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:50
+msgid "Help for check"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:51
+msgid "Check system ulimit settings"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:52
+msgid "Help for ulimit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:53
+msgid "Print the site configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:54
+msgid "Help for config"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:55
+msgid "Convert the content to different formats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:56
+msgid "Help for convert"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:59
+msgid "Enable less safe operations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:60
+msgid "Convert front matter to JSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:61
+msgid "Help for toJSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:62
+msgid "Convert front matter to TOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:63
+msgid "Help for toTOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:64
+msgid "Convert front matter to YAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:65
+msgid "Help for toYAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:66
+msgid "Print Hugo version and environment info"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:67
+msgid "Help for env"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:68
+msgid "Collection of several useful generators"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:69
+msgid "Help for gen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:70
+msgid "Generate shell autocompletion script for Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:71
+msgid "Autocompletion file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:72
+msgid "Help for autocomplete"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:73
+msgid "Autocompletion type"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:74
+msgid "Generate CSS stylesheet for the Chroma code highlighter"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:75
+msgid "Help for chromastyles"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:76
+msgid "Style used for highlighting lines"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:77
+msgid "Style used for line numbers"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:78
+msgid "Highlighter style"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:79
+msgid "Generate Markdown documentation for the Hugo CLI"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:80
+msgid "Doc directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:81
+msgid "Help for doc"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:82
+msgid "Generate man pages for the Hugo CLI"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:83
+msgid "Man pages directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:84
+msgid "Help for man"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:85
+msgid "Import your site from others"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:86
+msgid "Help for import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:87
+msgid "Import from Jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:88
+msgid "Allow import into non-empty target directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:89
+msgid "Help for jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:90
+msgid "List various types of content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:91
+msgid "Help for list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:93
+msgid "List all drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:94
+msgid "Help for drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:95
+msgid "List all expired posts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:96
+msgid "Help for expired"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:97
+msgid "List all posts dated in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:98
+msgid "Help for future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:99
+msgid "Create new content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:100
+msgid "Editor to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:101
+msgid "Help for new"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:102
+msgid "Content type to create"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:104
+msgid "Create a new site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:105
+msgid "Create site inside non-empty directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:106
+msgid "Config and front matter format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:107
+msgid "Help for site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:108
+msgid "Create a new theme"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:109
+msgid "Help for theme"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:110
+msgid "Start high performance web server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:111
+msgid "Append port to baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:112
+msgid "Interface to which the server will bind"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:113
+msgid "Enable full re-renders on changes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:114
+msgid "Watch without enabling live browser reload on rebuild"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:115
+msgid "Help for server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:116
+msgid "Port for live reloading"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:117
+msgid "Interval to poll memory usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:118
+msgid "Memory usage log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:119
+msgid "Navigate to changed content file on live browser reload"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:120
+msgid "Prevent HTTP caching"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:121
+msgid "Port on which the server will listen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:122
+msgid "Render to destination directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:123
+msgid "Reset the content draft status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:124
+msgid "Help for undraft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:125
+msgid "Print the version number of Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:126
+msgid "Help for version"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/i3-msg.fish:1
@@ -31526,12 +32234,6 @@ msgstr ""
 msgid "Initialize packet and byte counters of a rule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/iptables.fish:25
-#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
-msgid "Verbose output"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/iptables.fish:26
 msgid "Wait for the xtables lock"
 msgstr ""
@@ -31871,6 +32573,100 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/jest.fish:77
 msgid "Disable using watchman for file crawling"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:1
+msgid "Enable debugger"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:2
+msgid "Output usage information"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:3
+msgid "Output version number"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:4
+msgid "Create a new JHipster application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:5
+msgid "Deploy the current application to AWS"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:6
+msgid "Create pipeline scripts for popular CI tools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:7
+msgid "Create a new JHipster client-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:8
+msgid "Prepare Cloud Foundry deployment"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:9
+msgid ""
+"Create all required Docker deployment configuration for the selected "
+"applications"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:10
+msgid ""
+"Create a new JHipster entity: JPA entity, Spring server-side components and "
+"Angular client-side components"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:11
+msgid "Create a JDL file from the existing entities"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:12
+msgid "Deploy the current application to Heroku"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:13
+msgid "Create entities from the JDL file passed in argument"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:14
+msgid "Display information about your current project and system"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:15
+msgid "Deploy the current application to Kubernetes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:16
+msgid ""
+"Select languages from a list of available languages. The i18n files will be "
+"copied to the /webapp/i18n folder"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:17
+msgid "Deploy the current application to OpenShift"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:18
+msgid "Deploy the current application to Rancher"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:19
+msgid "Create a new JHipster server-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:20
+msgid "Create a new Spring service bean"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:21
+msgid "Upgrade the JHipster version and the generated application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:22
+msgid "Print command completion script"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/jobs.fish:2
@@ -48407,10 +49203,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:125
 msgid "Set default root object"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
-msgid "Debug output"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:130

--- a/po/nn.po
+++ b/po/nn.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 2.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-08 16:50+0100\n"
 "Last-Translator: Andreas Nordal <andreas.nordal_4@hotmail.com>\n"
 "Language: nn\n"
 "MIME-Version: 1.0\n"
@@ -103,12 +103,12 @@ msgstr ""
 msgid "%ls: There are no suitable jobs\n"
 msgstr ""
 
-#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82
+#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, c-format
 msgid "%ls: '%ls' is not a valid job specifier\n"
 msgstr ""
 
-#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89
+#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89 src/builtin_wait.cpp:163
 #, c-format
 msgid "%ls: Could not find job '%d'\n"
 msgstr ""
@@ -218,221 +218,225 @@ msgstr ""
 msgid "%ls: Key not specified\n"
 msgstr ""
 
-#: src/builtin.cpp:261
+#: src/builtin.cpp:262
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
 "\n"
 msgstr ""
 
-#: src/builtin.cpp:337
+#: src/builtin.cpp:338
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr ""
 
-#: src/builtin.cpp:371
+#: src/builtin.cpp:372
 #, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr ""
 
-#: src/builtin.cpp:409 src/builtin.cpp:459
+#: src/builtin.cpp:410 src/builtin.cpp:460
 msgid "Test a condition"
 msgstr ""
 
-#: src/builtin.cpp:410
+#: src/builtin.cpp:411
 msgid "Execute command if previous command suceeded"
 msgstr ""
 
-#: src/builtin.cpp:411
+#: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:412
+#: src/builtin.cpp:413
 msgid "Create a block of code"
 msgstr ""
 
-#: src/builtin.cpp:413
+#: src/builtin.cpp:414
 msgid "Send job to background"
 msgstr ""
 
-#: src/builtin.cpp:414
+#: src/builtin.cpp:415
 msgid "Handle fish key bindings"
 msgstr ""
 
-#: src/builtin.cpp:415
+#: src/builtin.cpp:416
 msgid "Temporarily block delivery of events"
 msgstr ""
 
-#: src/builtin.cpp:416
+#: src/builtin.cpp:417
 msgid "Stop the innermost loop"
 msgstr ""
 
-#: src/builtin.cpp:418
+#: src/builtin.cpp:419
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 
-#: src/builtin.cpp:419
+#: src/builtin.cpp:420
 msgid "Run a builtin command instead of a function"
 msgstr ""
 
-#: src/builtin.cpp:420 src/builtin.cpp:458
+#: src/builtin.cpp:421 src/builtin.cpp:459
 msgid "Conditionally execute a block of commands"
 msgstr ""
 
-#: src/builtin.cpp:421
+#: src/builtin.cpp:422
 msgid "Change working directory"
 msgstr ""
 
-#: src/builtin.cpp:422
+#: src/builtin.cpp:423
 msgid "Run a program instead of a function or builtin"
 msgstr ""
 
-#: src/builtin.cpp:423
+#: src/builtin.cpp:424
 msgid "Set or get the commandline"
 msgstr ""
 
-#: src/builtin.cpp:424
+#: src/builtin.cpp:425
 msgid "Edit command specific completions"
 msgstr ""
 
-#: src/builtin.cpp:425
+#: src/builtin.cpp:426
 msgid "Search for a specified string in a list"
 msgstr ""
 
-#: src/builtin.cpp:427
+#: src/builtin.cpp:428
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr ""
 
-#: src/builtin.cpp:428
+#: src/builtin.cpp:429
 msgid "Count the number of arguments"
 msgstr ""
 
-#: src/builtin.cpp:429
+#: src/builtin.cpp:430
 msgid "Remove job from job list"
 msgstr ""
 
-#: src/builtin.cpp:430
+#: src/builtin.cpp:431
 msgid "Print arguments"
 msgstr ""
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:432
 msgid "Evaluate block if condition is false"
 msgstr ""
 
-#: src/builtin.cpp:432
+#: src/builtin.cpp:433
 msgid "Emit an event"
 msgstr ""
 
-#: src/builtin.cpp:433
+#: src/builtin.cpp:434
 msgid "End a block of commands"
 msgstr ""
 
-#: src/builtin.cpp:434
+#: src/builtin.cpp:435
 msgid "Run command in current process"
 msgstr ""
 
-#: src/builtin.cpp:435
+#: src/builtin.cpp:436
 msgid "Exit the shell"
 msgstr ""
 
-#: src/builtin.cpp:436
+#: src/builtin.cpp:437
 msgid "Return an unsuccessful result"
 msgstr ""
 
-#: src/builtin.cpp:437
+#: src/builtin.cpp:438
 msgid "Send job to foreground"
 msgstr ""
 
-#: src/builtin.cpp:438
+#: src/builtin.cpp:439
 msgid "Perform a set of commands multiple times"
 msgstr ""
 
-#: src/builtin.cpp:439
+#: src/builtin.cpp:440
 msgid "Define a new function"
 msgstr ""
 
-#: src/builtin.cpp:440
+#: src/builtin.cpp:441
 msgid "List or remove functions"
 msgstr ""
 
-#: src/builtin.cpp:441
+#: src/builtin.cpp:442
 msgid "History of commands executed by user"
 msgstr ""
 
-#: src/builtin.cpp:442
+#: src/builtin.cpp:443
 msgid "Evaluate block if condition is true"
 msgstr ""
 
-#: src/builtin.cpp:443
+#: src/builtin.cpp:444
 msgid "Print currently running jobs"
 msgstr ""
 
-#: src/builtin.cpp:444
+#: src/builtin.cpp:445
 msgid "Evaluate math expressions"
 msgstr ""
 
-#: src/builtin.cpp:445
+#: src/builtin.cpp:446
 msgid "Negate exit status of job"
 msgstr ""
 
-#: src/builtin.cpp:446
+#: src/builtin.cpp:447
 msgid "Execute command if previous command failed"
 msgstr ""
 
-#: src/builtin.cpp:447
+#: src/builtin.cpp:448
 msgid "Prints formatted text"
 msgstr ""
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:449
 msgid "Print the working directory"
 msgstr ""
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:450
 msgid "Generate random number"
 msgstr ""
 
-#: src/builtin.cpp:450
+#: src/builtin.cpp:451
 msgid "Read a line of input into variables"
 msgstr ""
 
-#: src/builtin.cpp:451
+#: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr ""
 
-#: src/builtin.cpp:452
+#: src/builtin.cpp:453
 msgid "Stop the currently evaluated function"
 msgstr ""
 
-#: src/builtin.cpp:453
+#: src/builtin.cpp:454
 msgid "Handle environment variables"
 msgstr ""
 
-#: src/builtin.cpp:454
+#: src/builtin.cpp:455
 msgid "Set the terminal color"
 msgstr ""
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:456
 msgid "Evaluate contents of file"
 msgstr ""
 
-#: src/builtin.cpp:456
+#: src/builtin.cpp:457
 msgid "Return status information about fish"
 msgstr ""
 
-#: src/builtin.cpp:457
+#: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr ""
 
-#: src/builtin.cpp:460
+#: src/builtin.cpp:461
 msgid "Return a successful result"
 msgstr ""
 
-#: src/builtin.cpp:461
+#: src/builtin.cpp:462
 msgid "Set or get the shells resource usage limits"
 msgstr ""
 
-#: src/builtin.cpp:462
+#: src/builtin.cpp:463
+msgid "Wait for background processes completed"
+msgstr ""
+
+#: src/builtin.cpp:464
 msgid "Perform a command multiple times"
 msgstr ""
 
@@ -1456,58 +1460,58 @@ msgstr ""
 msgid "Your history will not be saved."
 msgstr ""
 
-#: src/proc.cpp:590
+#: src/proc.cpp:586
 #, c-format
 msgid "Job %d, "
 msgstr ""
 
-#: src/proc.cpp:591
+#: src/proc.cpp:587
 #, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 
-#: src/proc.cpp:599
+#: src/proc.cpp:595
 #, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 
-#: src/proc.cpp:769
+#: src/proc.cpp:779
 msgid "An error occured while reading output from code block"
 msgstr ""
 
-#: src/proc.cpp:846
+#: src/proc.cpp:856
 #, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr ""
 
-#: src/proc.cpp:875
+#: src/proc.cpp:885
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr ""
 
-#: src/proc.cpp:899 src/proc.cpp:908 src/proc.cpp:922
+#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
 msgid "Could not return shell to foreground"
 msgstr ""
 
-#: src/proc.cpp:1055
+#: src/proc.cpp:1065
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr ""
 
-#: src/proc.cpp:1065
+#: src/proc.cpp:1075
 msgid "Process argument list"
 msgstr ""
 
-#: src/proc.cpp:1066
+#: src/proc.cpp:1076
 msgid "Process name"
 msgstr ""
 
-#: src/proc.cpp:1069
+#: src/proc.cpp:1079
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr ""
 
-#: src/proc.cpp:1075
+#: src/proc.cpp:1085
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr ""
@@ -2429,6 +2433,211 @@ msgstr ""
 msgid "Prints the usage for a given subcommand"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/mdadm.fish:1
+#: /tmp/fish/explicit/share/completions/mdadm.fish:2
+msgid "Use original 0.90 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:3
+#: /tmp/fish/explicit/share/completions/mdadm.fish:4
+msgid "Use last 1.x format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:5
+msgid "Use 1.0 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:6
+msgid "Use 1.1 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:7
+msgid "Use 1.2 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:8
+msgid "Use DDF (Disk Data Format) format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:9
+msgid "Use Intel(R) Matrix Storage Manager format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:10
+msgid "JBOD"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:11
+#: /tmp/fish/explicit/share/completions/mdadm.fish:12
+#: /tmp/fish/explicit/share/completions/mdadm.fish:13
+msgid "Stripped volume (RAID 0)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:14
+#: /tmp/fish/explicit/share/completions/mdadm.fish:15
+#: /tmp/fish/explicit/share/completions/mdadm.fish:16
+msgid "Mirrored volume (RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:17
+#: /tmp/fish/explicit/share/completions/mdadm.fish:18
+msgid "Stripped volume with parity disk (RAID 4)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:19
+#: /tmp/fish/explicit/share/completions/mdadm.fish:20
+msgid "Stripped volume with distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:21
+#: /tmp/fish/explicit/share/completions/mdadm.fish:22
+msgid "Stripped volume with double distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:23
+#: /tmp/fish/explicit/share/completions/mdadm.fish:24
+msgid "Mirrored stripped volume (RAID 10)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:25
+#: /tmp/fish/explicit/share/completions/mdadm.fish:26
+msgid "Multiple access device, AKA multipath (deprecated)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:27
+msgid "Pseudo RAID layer for single device (akin faulty RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:28
+msgid "Container"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:29
+msgid "Alias of left-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:30
+msgid "Alias of right-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:31
+msgid "Alias of left-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:32
+msgid "Alias of right-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:33
+msgid "Alias of write-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:34
+msgid "Alias of read-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:35
+msgid "Alias of write-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:36
+msgid "Alias of read-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:37
+msgid "Alias of read-fixable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:38
+msgid "Use standard format (default)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:39
+msgid "Use a non-partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:40
+#: /tmp/fish/explicit/share/completions/mdadm.fish:41
+#: /tmp/fish/explicit/share/completions/mdadm.fish:42
+msgid "Use a partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:43
+msgid "Remove superblock misalignement from SPARC kernel 2.2"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:44
+msgid "Correct superblock summaries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:45
+msgid "Update array UUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:46
+msgid "Update array name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:47
+msgid "Update array nodes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:48
+msgid "Update array homehost"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:49
+msgid "Update array cluster name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:50
+msgid "Mark the array as dirty, thus forcing resync"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:51
+msgid "Reverse superblock endianness"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:52
+msgid "Refresh device size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:53
+msgid "Assume bitmap absence"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:54
+msgid "Reserve space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:55
+msgid "Free reserved space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:56
+msgid "Convert 0.90 metadata to 1.0"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:57
+msgid "Reset preferred minor to current one"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:58
+msgid "Abort currently running actions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:59
+msgid "Abort currently running actions, prevent their restart"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:60
+msgid "Scrub the array (i.e. check constistency)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:61
+msgid "Check, then resync"
+msgstr ""
+
 #: /tmp/fish/explicit/share/completions/set.fish:1
 msgid "Locale"
 msgstr ""
@@ -3304,6 +3513,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
 #: /tmp/fish/implicit/share/completions/asp.fish:6
 #: /tmp/fish/implicit/share/completions/bc.fish:7
+#: /tmp/fish/implicit/share/completions/bd.fish:4
 #: /tmp/fish/implicit/share/completions/bg.fish:1
 #: /tmp/fish/implicit/share/completions/bind.fish:4
 #: /tmp/fish/implicit/share/completions/block.fish:1
@@ -3897,7 +4107,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bzr.fish:1
 #: /tmp/fish/implicit/share/completions/climate.fish:1
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:17
-#: /tmp/fish/implicit/share/completions/cygport.fish:23
+#: /tmp/fish/implicit/share/completions/cygport.fish:25
 #: /tmp/fish/implicit/share/completions/godoc.fish:25
 #: /tmp/fish/implicit/share/completions/gofmt.fish:8
 #: /tmp/fish/implicit/share/completions/goimports.fish:6
@@ -5268,6 +5478,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-get.fish:24
 #: /tmp/fish/implicit/share/completions/configure.fish:3
 #: /tmp/fish/implicit/share/completions/gpg.fish:62
+#: /tmp/fish/implicit/share/completions/hugo.fish:5
 #: /tmp/fish/implicit/share/completions/make.fish:16
 #: /tmp/fish/implicit/share/completions/ping.fish:16
 #: /tmp/fish/implicit/share/completions/rpm.fish:3
@@ -5435,6 +5646,7 @@ msgid "Set a configuration option"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt.fish:8
+#: /tmp/fish/implicit/share/completions/hugo.fish:1
 #: /tmp/fish/implicit/share/completions/man.fish:14
 #: /tmp/fish/implicit/share/completions/modprobe.fish:2
 #: /tmp/fish/implicit/share/completions/yum.fish:13
@@ -8389,6 +8601,18 @@ msgstr ""
 msgid "Do not print the GNU welcome"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/bd.fish:1
+msgid "Classic mode: goes back to the first directory named as the string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:2
+msgid "Seems mode: goes back to the first directory containing string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:3
+msgid "Case insensitive move (implies seems mode)"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/bind.fish:1
 msgid "Show unavailable key bindings/erase all bindings"
 msgstr ""
@@ -9811,7 +10035,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/caddy.fish:24
 #: /tmp/fish/implicit/share/completions/canto.fish:2
-#: /tmp/fish/implicit/share/completions/cygport.fish:24
+#: /tmp/fish/implicit/share/completions/cygport.fish:26
 #: /tmp/fish/implicit/share/completions/grub-install.fish:33
 #: /tmp/fish/implicit/share/completions/lua.fish:4
 #: /tmp/fish/implicit/share/completions/magento.fish:23
@@ -12884,26 +13108,34 @@ msgid "Show project homepage URL"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:17
-msgid "Create packages"
+msgid "Create packages, marked as test"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:18
-msgid "Create source patches"
+msgid "Create packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:19
-msgid "Upload finished packages"
+msgid "Create source patches"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:20
-msgid "Send announcement email"
+msgid "Upload finished packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:21
-msgid "Delete working directory"
+msgid "Upload packages without marking !ready"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:22
+msgid "Send announcement email"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:23
+msgid "Delete working directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:24
 msgid "Same as prep build inst pkg"
 msgstr ""
 
@@ -30969,6 +31201,7 @@ msgid "Name of the output file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/highlight.fish:5
+#: /tmp/fish/implicit/share/completions/hugo.fish:57
 #: /tmp/fish/implicit/share/completions/tex.fish:10
 msgid "Output directory"
 msgstr ""
@@ -31010,6 +31243,481 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/htop.fish:7
 msgid "Sort column"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:2
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
+msgid "Debug output"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:3
+msgid "Enable logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:4
+msgid "Log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:6
+#: /tmp/fish/implicit/share/completions/iptables.fish:25
+#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
+msgid "Verbose output"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:7
+msgid "Verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:8
+msgid "Hostname and path to the root"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:9
+msgid "Include content marked as draft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:10
+msgid "Include expired content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:11
+msgid "Include content with publishdate in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:12
+msgid "Cache directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:13
+msgid "Canonicalize all relative URLs using baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:14
+msgid "Remove files from destination not found in static directories"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:15
+msgid "Content directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:16
+msgid "Destination directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:17
+msgid "Do not build 404 page"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:18
+msgid "Disable different kinds of pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:19
+msgid "Do not build RSS files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:20
+msgid "Do not build sitemap files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:21
+msgid "Add Git revision, date and author info to the pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:22
+msgid "Copy all files when static is changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:23
+msgid "Help for hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:24
+msgid "Print missing translations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:25
+msgid "Ignore the cache directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:26
+msgid "Layout directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:27
+msgid "Do not sync permission mode of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:28
+msgid "Do not sync modification time of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:29
+msgid "Pluralize titles in lists using inflect"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:30
+msgid "Preserve taxonomy names as written"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:31
+#: /tmp/fish/implicit/share/completions/hugo.fish:45
+msgid "Render to memory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:32
+#: /tmp/fish/implicit/share/completions/hugo.fish:58
+#: /tmp/fish/implicit/share/completions/hugo.fish:92
+#: /tmp/fish/implicit/share/completions/hugo.fish:103
+msgid "Source directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:33
+#: /tmp/fish/implicit/share/completions/hugo.fish:46
+msgid "Display memory and timing of different steps of the program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:34
+#: /tmp/fish/implicit/share/completions/hugo.fish:47
+msgid "Display metrics about template executions"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:35
+#: /tmp/fish/implicit/share/completions/hugo.fish:48
+msgid "Calculate some improvement hints when combined with --templateMetrics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:36
+msgid "Theme to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:37
+msgid "Themes directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:38
+msgid "Use /filename.html instead of /filename/"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:39
+msgid "Watch filesystem for changes and recreate as needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:40
+msgid "Benchmark Hugo by building the site a number of times"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:41
+msgid "Number of times to build the site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:42
+msgid "CPU profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:43
+msgid "Help for benchmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:44
+msgid "Memory profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:49
+msgid "Perform some verification checks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:50
+msgid "Help for check"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:51
+msgid "Check system ulimit settings"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:52
+msgid "Help for ulimit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:53
+msgid "Print the site configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:54
+msgid "Help for config"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:55
+msgid "Convert the content to different formats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:56
+msgid "Help for convert"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:59
+msgid "Enable less safe operations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:60
+msgid "Convert front matter to JSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:61
+msgid "Help for toJSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:62
+msgid "Convert front matter to TOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:63
+msgid "Help for toTOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:64
+msgid "Convert front matter to YAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:65
+msgid "Help for toYAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:66
+msgid "Print Hugo version and environment info"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:67
+msgid "Help for env"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:68
+msgid "Collection of several useful generators"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:69
+msgid "Help for gen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:70
+msgid "Generate shell autocompletion script for Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:71
+msgid "Autocompletion file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:72
+msgid "Help for autocomplete"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:73
+msgid "Autocompletion type"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:74
+msgid "Generate CSS stylesheet for the Chroma code highlighter"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:75
+msgid "Help for chromastyles"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:76
+msgid "Style used for highlighting lines"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:77
+msgid "Style used for line numbers"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:78
+msgid "Highlighter style"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:79
+msgid "Generate Markdown documentation for the Hugo CLI"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:80
+msgid "Doc directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:81
+msgid "Help for doc"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:82
+msgid "Generate man pages for the Hugo CLI"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:83
+msgid "Man pages directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:84
+msgid "Help for man"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:85
+msgid "Import your site from others"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:86
+msgid "Help for import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:87
+msgid "Import from Jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:88
+msgid "Allow import into non-empty target directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:89
+msgid "Help for jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:90
+msgid "List various types of content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:91
+msgid "Help for list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:93
+msgid "List all drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:94
+msgid "Help for drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:95
+msgid "List all expired posts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:96
+msgid "Help for expired"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:97
+msgid "List all posts dated in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:98
+msgid "Help for future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:99
+msgid "Create new content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:100
+msgid "Editor to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:101
+msgid "Help for new"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:102
+msgid "Content type to create"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:104
+msgid "Create a new site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:105
+msgid "Create site inside non-empty directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:106
+msgid "Config and front matter format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:107
+msgid "Help for site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:108
+msgid "Create a new theme"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:109
+msgid "Help for theme"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:110
+msgid "Start high performance web server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:111
+msgid "Append port to baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:112
+msgid "Interface to which the server will bind"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:113
+msgid "Enable full re-renders on changes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:114
+msgid "Watch without enabling live browser reload on rebuild"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:115
+msgid "Help for server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:116
+msgid "Port for live reloading"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:117
+msgid "Interval to poll memory usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:118
+msgid "Memory usage log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:119
+msgid "Navigate to changed content file on live browser reload"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:120
+msgid "Prevent HTTP caching"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:121
+msgid "Port on which the server will listen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:122
+msgid "Render to destination directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:123
+msgid "Reset the content draft status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:124
+msgid "Help for undraft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:125
+msgid "Print the version number of Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:126
+msgid "Help for version"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/i3-msg.fish:1
@@ -31526,12 +32234,6 @@ msgstr ""
 msgid "Initialize packet and byte counters of a rule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/iptables.fish:25
-#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
-msgid "Verbose output"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/iptables.fish:26
 msgid "Wait for the xtables lock"
 msgstr ""
@@ -31871,6 +32573,100 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/jest.fish:77
 msgid "Disable using watchman for file crawling"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:1
+msgid "Enable debugger"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:2
+msgid "Output usage information"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:3
+msgid "Output version number"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:4
+msgid "Create a new JHipster application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:5
+msgid "Deploy the current application to AWS"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:6
+msgid "Create pipeline scripts for popular CI tools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:7
+msgid "Create a new JHipster client-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:8
+msgid "Prepare Cloud Foundry deployment"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:9
+msgid ""
+"Create all required Docker deployment configuration for the selected "
+"applications"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:10
+msgid ""
+"Create a new JHipster entity: JPA entity, Spring server-side components and "
+"Angular client-side components"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:11
+msgid "Create a JDL file from the existing entities"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:12
+msgid "Deploy the current application to Heroku"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:13
+msgid "Create entities from the JDL file passed in argument"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:14
+msgid "Display information about your current project and system"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:15
+msgid "Deploy the current application to Kubernetes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:16
+msgid ""
+"Select languages from a list of available languages. The i18n files will be "
+"copied to the /webapp/i18n folder"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:17
+msgid "Deploy the current application to OpenShift"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:18
+msgid "Deploy the current application to Rancher"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:19
+msgid "Create a new JHipster server-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:20
+msgid "Create a new Spring service bean"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:21
+msgid "Upgrade the JHipster version and the generated application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:22
+msgid "Print command completion script"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/jobs.fish:2
@@ -48407,10 +49203,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:125
 msgid "Set default root object"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
-msgid "Debug output"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:130

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-08 16:50+0100\n"
 "PO-Revision-Date: 2017-01-07 10:24:59+0000\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
@@ -105,12 +105,12 @@ msgstr "Wyślij zadanie %d '%ls' w tło\n"
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls: Brak pasujących zadań\n"
 
-#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82
+#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, fuzzy, c-format
 msgid "%ls: '%ls' is not a valid job specifier\n"
 msgstr "%ls: '%ls' nie jest zadaniem\n"
 
-#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89
+#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89 src/builtin_wait.cpp:163
 #, c-format
 msgid "%ls: Could not find job '%d'\n"
 msgstr ""
@@ -220,7 +220,7 @@ msgstr "%ls: Nazwa zmiennej nie może być pustym ciągiem znaków \n"
 msgid "%ls: Key not specified\n"
 msgstr "%ls: Nie określono klawisza\n"
 
-#: src/builtin.cpp:261
+#: src/builtin.cpp:262
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
@@ -229,214 +229,218 @@ msgstr ""
 "%ls: Wpisz 'help %ls' aby uzyskać informacje z tym związane\n"
 "\n"
 
-#: src/builtin.cpp:337
+#: src/builtin.cpp:338
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr ""
 
-#: src/builtin.cpp:371
+#: src/builtin.cpp:372
 #, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr ""
 
-#: src/builtin.cpp:409 src/builtin.cpp:459
+#: src/builtin.cpp:410 src/builtin.cpp:460
 msgid "Test a condition"
 msgstr ""
 
-#: src/builtin.cpp:410
+#: src/builtin.cpp:411
 msgid "Execute command if previous command suceeded"
 msgstr "Wykonaj komendę jeżeli poprzednia komenda zakończy się powodzeniem"
 
-#: src/builtin.cpp:411
+#: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:412
+#: src/builtin.cpp:413
 msgid "Create a block of code"
 msgstr "Stwórz blok kodu"
 
-#: src/builtin.cpp:413
+#: src/builtin.cpp:414
 msgid "Send job to background"
 msgstr "Przenieś zadanie w tło"
 
-#: src/builtin.cpp:414
+#: src/builtin.cpp:415
 msgid "Handle fish key bindings"
 msgstr "Steruj przypisaniami klawiszy fish'a"
 
-#: src/builtin.cpp:415
+#: src/builtin.cpp:416
 msgid "Temporarily block delivery of events"
 msgstr ""
 
-#: src/builtin.cpp:416
+#: src/builtin.cpp:417
 msgid "Stop the innermost loop"
 msgstr ""
 
-#: src/builtin.cpp:418
+#: src/builtin.cpp:419
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 
-#: src/builtin.cpp:419
+#: src/builtin.cpp:420
 msgid "Run a builtin command instead of a function"
 msgstr ""
 
-#: src/builtin.cpp:420 src/builtin.cpp:458
+#: src/builtin.cpp:421 src/builtin.cpp:459
 msgid "Conditionally execute a block of commands"
 msgstr ""
 
-#: src/builtin.cpp:421
+#: src/builtin.cpp:422
 msgid "Change working directory"
 msgstr "Zmień katalog roboczy"
 
-#: src/builtin.cpp:422
+#: src/builtin.cpp:423
 msgid "Run a program instead of a function or builtin"
 msgstr ""
 
-#: src/builtin.cpp:423
+#: src/builtin.cpp:424
 msgid "Set or get the commandline"
 msgstr ""
 
-#: src/builtin.cpp:424
+#: src/builtin.cpp:425
 msgid "Edit command specific completions"
 msgstr "Edytuj sugestie do określonej komendy"
 
-#: src/builtin.cpp:425
+#: src/builtin.cpp:426
 msgid "Search for a specified string in a list"
 msgstr "Szukaj określonego ciągu znaków w liście"
 
-#: src/builtin.cpp:427
+#: src/builtin.cpp:428
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr ""
 
-#: src/builtin.cpp:428
+#: src/builtin.cpp:429
 msgid "Count the number of arguments"
 msgstr "Wylicz liczbę argumentów"
 
-#: src/builtin.cpp:429
+#: src/builtin.cpp:430
 msgid "Remove job from job list"
 msgstr ""
 
-#: src/builtin.cpp:430
+#: src/builtin.cpp:431
 msgid "Print arguments"
 msgstr "Wypisz argumenty"
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:432
 msgid "Evaluate block if condition is false"
 msgstr ""
 
-#: src/builtin.cpp:432
+#: src/builtin.cpp:433
 msgid "Emit an event"
 msgstr ""
 
-#: src/builtin.cpp:433
+#: src/builtin.cpp:434
 msgid "End a block of commands"
 msgstr "Zakończ zestaw komend"
 
-#: src/builtin.cpp:434
+#: src/builtin.cpp:435
 msgid "Run command in current process"
 msgstr "Uruchom komendę w obecnym procesie"
 
-#: src/builtin.cpp:435
+#: src/builtin.cpp:436
 msgid "Exit the shell"
 msgstr "Opuść powłokę"
 
-#: src/builtin.cpp:436
+#: src/builtin.cpp:437
 msgid "Return an unsuccessful result"
 msgstr "Zwróć niepomyślny wynik"
 
-#: src/builtin.cpp:437
+#: src/builtin.cpp:438
 msgid "Send job to foreground"
 msgstr ""
 
-#: src/builtin.cpp:438
+#: src/builtin.cpp:439
 msgid "Perform a set of commands multiple times"
 msgstr "Wykonaj zestaw komend wielokrotnie"
 
-#: src/builtin.cpp:439
+#: src/builtin.cpp:440
 msgid "Define a new function"
 msgstr "Zdefiniuj nową funkcję"
 
-#: src/builtin.cpp:440
+#: src/builtin.cpp:441
 msgid "List or remove functions"
 msgstr "Wypisz lub usuń funkcje"
 
-#: src/builtin.cpp:441
+#: src/builtin.cpp:442
 msgid "History of commands executed by user"
 msgstr "Historia komend wykonanych przez użytkownika"
 
-#: src/builtin.cpp:442
+#: src/builtin.cpp:443
 msgid "Evaluate block if condition is true"
 msgstr ""
 
-#: src/builtin.cpp:443
+#: src/builtin.cpp:444
 msgid "Print currently running jobs"
 msgstr "Wypisz obecnie uruchomione zadania"
 
-#: src/builtin.cpp:444
+#: src/builtin.cpp:445
 msgid "Evaluate math expressions"
 msgstr ""
 
-#: src/builtin.cpp:445
+#: src/builtin.cpp:446
 msgid "Negate exit status of job"
 msgstr ""
 
-#: src/builtin.cpp:446
+#: src/builtin.cpp:447
 msgid "Execute command if previous command failed"
 msgstr "Wykonaj komendę jeżeli poprzednia komenda zakończy się niepowodzeniem"
 
-#: src/builtin.cpp:447
+#: src/builtin.cpp:448
 msgid "Prints formatted text"
 msgstr "Zwraca sformatowany tekst"
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:449
 msgid "Print the working directory"
 msgstr "Zwróć katalog roboczy"
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:450
 msgid "Generate random number"
 msgstr "Zwróć losową liczbę"
 
-#: src/builtin.cpp:450
+#: src/builtin.cpp:451
 msgid "Read a line of input into variables"
 msgstr ""
 
-#: src/builtin.cpp:451
+#: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr "Zamień ścieżkę na ścieżkę bezwzględną bez nawiązań symbolicznych"
 
-#: src/builtin.cpp:452
+#: src/builtin.cpp:453
 msgid "Stop the currently evaluated function"
 msgstr "Zatrzymaj obecnie używaną funkcję"
 
-#: src/builtin.cpp:453
+#: src/builtin.cpp:454
 msgid "Handle environment variables"
 msgstr "Operuj zmiennymi środowiskowymi"
 
-#: src/builtin.cpp:454
+#: src/builtin.cpp:455
 msgid "Set the terminal color"
 msgstr "Ustaw kolor terminala"
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:456
 msgid "Evaluate contents of file"
 msgstr ""
 
-#: src/builtin.cpp:456
+#: src/builtin.cpp:457
 msgid "Return status information about fish"
 msgstr "Zwróć informacje o fish"
 
-#: src/builtin.cpp:457
+#: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr "Zmień wartości ciągów znaków"
 
-#: src/builtin.cpp:460
+#: src/builtin.cpp:461
 msgid "Return a successful result"
 msgstr "Zwróć pomyślny wynik"
 
-#: src/builtin.cpp:461
+#: src/builtin.cpp:462
 msgid "Set or get the shells resource usage limits"
 msgstr ""
 
-#: src/builtin.cpp:462
+#: src/builtin.cpp:463
+msgid "Wait for background processes completed"
+msgstr ""
+
+#: src/builtin.cpp:464
 msgid "Perform a command multiple times"
 msgstr "Wykonaj komendę wielokrotnie"
 
@@ -1472,60 +1476,60 @@ msgstr ""
 msgid "Your history will not be saved."
 msgstr ""
 
-#: src/proc.cpp:590
+#: src/proc.cpp:586
 #, c-format
 msgid "Job %d, "
 msgstr ""
 
-#: src/proc.cpp:591
+#: src/proc.cpp:587
 #, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: %ls'%ls' zakończony sygnałem %ls (%ls)"
 
-#: src/proc.cpp:599
+#: src/proc.cpp:595
 #, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Proces %d, '%ls' %ls'%ls' zakończony sygnałem %ls (%ls)"
 
-#: src/proc.cpp:769
+#: src/proc.cpp:779
 msgid "An error occured while reading output from code block"
 msgstr "Wystąpił błąd podczas odczytywania wyjścia z bloku kodu"
 
-#: src/proc.cpp:846
+#: src/proc.cpp:856
 #, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr ""
 
-#: src/proc.cpp:875
+#: src/proc.cpp:885
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Nie można przenieść zadania %d ('%ls') na pierwszy plan"
 
-#: src/proc.cpp:899 src/proc.cpp:908 src/proc.cpp:922
+#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
 msgid "Could not return shell to foreground"
 msgstr "Nie można przywrócić powłoki na pierwszy plan"
 
-#: src/proc.cpp:1055
+#: src/proc.cpp:1065
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr ""
 "Więcej niż jedno zadanie na pierwszym planie: zadanie 1: '%ls' zadanie 2: "
 "'%ls'"
 
-#: src/proc.cpp:1065
+#: src/proc.cpp:1075
 msgid "Process argument list"
 msgstr "Lista argumentów procesu"
 
-#: src/proc.cpp:1066
+#: src/proc.cpp:1076
 msgid "Process name"
 msgstr "Nazwa procesu"
 
-#: src/proc.cpp:1069
+#: src/proc.cpp:1079
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr ""
 
-#: src/proc.cpp:1075
+#: src/proc.cpp:1085
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr ""
@@ -2461,6 +2465,215 @@ msgstr ""
 msgid "Prints the usage for a given subcommand"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/mdadm.fish:1
+#: /tmp/fish/explicit/share/completions/mdadm.fish:2
+msgid "Use original 0.90 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:3
+#: /tmp/fish/explicit/share/completions/mdadm.fish:4
+msgid "Use last 1.x format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:5
+msgid "Use 1.0 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:6
+msgid "Use 1.1 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:7
+msgid "Use 1.2 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:8
+msgid "Use DDF (Disk Data Format) format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:9
+msgid "Use Intel(R) Matrix Storage Manager format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:10
+msgid "JBOD"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:11
+#: /tmp/fish/explicit/share/completions/mdadm.fish:12
+#: /tmp/fish/explicit/share/completions/mdadm.fish:13
+msgid "Stripped volume (RAID 0)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:14
+#: /tmp/fish/explicit/share/completions/mdadm.fish:15
+#: /tmp/fish/explicit/share/completions/mdadm.fish:16
+msgid "Mirrored volume (RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:17
+#: /tmp/fish/explicit/share/completions/mdadm.fish:18
+msgid "Stripped volume with parity disk (RAID 4)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:19
+#: /tmp/fish/explicit/share/completions/mdadm.fish:20
+msgid "Stripped volume with distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:21
+#: /tmp/fish/explicit/share/completions/mdadm.fish:22
+msgid "Stripped volume with double distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:23
+#: /tmp/fish/explicit/share/completions/mdadm.fish:24
+msgid "Mirrored stripped volume (RAID 10)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:25
+#: /tmp/fish/explicit/share/completions/mdadm.fish:26
+msgid "Multiple access device, AKA multipath (deprecated)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:27
+msgid "Pseudo RAID layer for single device (akin faulty RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:28
+msgid "Container"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:29
+msgid "Alias of left-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:30
+msgid "Alias of right-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:31
+msgid "Alias of left-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:32
+msgid "Alias of right-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:33
+msgid "Alias of write-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:34
+msgid "Alias of read-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:35
+msgid "Alias of write-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:36
+msgid "Alias of read-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:37
+msgid "Alias of read-fixable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:38
+msgid "Use standard format (default)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:39
+msgid "Use a non-partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:40
+#: /tmp/fish/explicit/share/completions/mdadm.fish:41
+#: /tmp/fish/explicit/share/completions/mdadm.fish:42
+msgid "Use a partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:43
+msgid "Remove superblock misalignement from SPARC kernel 2.2"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:44
+msgid "Correct superblock summaries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:45
+msgid "Update array UUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:46
+#, fuzzy
+msgid "Update array name"
+msgstr "Nazwa procesu"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:47
+#, fuzzy
+msgid "Update array nodes"
+msgstr "Nazwa procesu"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:48
+msgid "Update array homehost"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:49
+#, fuzzy
+msgid "Update array cluster name"
+msgstr "Nazwa procesu"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:50
+msgid "Mark the array as dirty, thus forcing resync"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:51
+msgid "Reverse superblock endianness"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:52
+msgid "Refresh device size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:53
+msgid "Assume bitmap absence"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:54
+msgid "Reserve space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:55
+msgid "Free reserved space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:56
+msgid "Convert 0.90 metadata to 1.0"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:57
+msgid "Reset preferred minor to current one"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:58
+#, fuzzy
+msgid "Abort currently running actions"
+msgstr "Wypisz obecnie uruchomione zadania"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:59
+msgid "Abort currently running actions, prevent their restart"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:60
+msgid "Scrub the array (i.e. check constistency)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:61
+msgid "Check, then resync"
+msgstr ""
+
 #: /tmp/fish/explicit/share/completions/set.fish:1
 msgid "Locale"
 msgstr ""
@@ -3360,6 +3573,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
 #: /tmp/fish/implicit/share/completions/asp.fish:6
 #: /tmp/fish/implicit/share/completions/bc.fish:7
+#: /tmp/fish/implicit/share/completions/bd.fish:4
 #: /tmp/fish/implicit/share/completions/bg.fish:1
 #: /tmp/fish/implicit/share/completions/bind.fish:4
 #: /tmp/fish/implicit/share/completions/block.fish:1
@@ -3958,7 +4172,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bzr.fish:1
 #: /tmp/fish/implicit/share/completions/climate.fish:1
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:17
-#: /tmp/fish/implicit/share/completions/cygport.fish:23
+#: /tmp/fish/implicit/share/completions/cygport.fish:25
 #: /tmp/fish/implicit/share/completions/godoc.fish:25
 #: /tmp/fish/implicit/share/completions/gofmt.fish:8
 #: /tmp/fish/implicit/share/completions/goimports.fish:6
@@ -5334,6 +5548,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-get.fish:24
 #: /tmp/fish/implicit/share/completions/configure.fish:3
 #: /tmp/fish/implicit/share/completions/gpg.fish:62
+#: /tmp/fish/implicit/share/completions/hugo.fish:5
 #: /tmp/fish/implicit/share/completions/make.fish:16
 #: /tmp/fish/implicit/share/completions/ping.fish:16
 #: /tmp/fish/implicit/share/completions/rpm.fish:3
@@ -5503,6 +5718,7 @@ msgid "Set a configuration option"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt.fish:8
+#: /tmp/fish/implicit/share/completions/hugo.fish:1
 #: /tmp/fish/implicit/share/completions/man.fish:14
 #: /tmp/fish/implicit/share/completions/modprobe.fish:2
 #: /tmp/fish/implicit/share/completions/yum.fish:13
@@ -8501,6 +8717,18 @@ msgstr ""
 msgid "Do not print the GNU welcome"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/bd.fish:1
+msgid "Classic mode: goes back to the first directory named as the string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:2
+msgid "Seems mode: goes back to the first directory containing string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:3
+msgid "Case insensitive move (implies seems mode)"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/bind.fish:1
 msgid "Show unavailable key bindings/erase all bindings"
 msgstr ""
@@ -9929,7 +10157,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/caddy.fish:24
 #: /tmp/fish/implicit/share/completions/canto.fish:2
-#: /tmp/fish/implicit/share/completions/cygport.fish:24
+#: /tmp/fish/implicit/share/completions/cygport.fish:26
 #: /tmp/fish/implicit/share/completions/grub-install.fish:33
 #: /tmp/fish/implicit/share/completions/lua.fish:4
 #: /tmp/fish/implicit/share/completions/magento.fish:23
@@ -13027,27 +13255,35 @@ msgid "Show project homepage URL"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:17
-msgid "Create packages"
+msgid "Create packages, marked as test"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:18
-msgid "Create source patches"
+msgid "Create packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:19
-msgid "Upload finished packages"
+msgid "Create source patches"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:20
-msgid "Send announcement email"
+msgid "Upload finished packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:21
+msgid "Upload packages without marking !ready"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:22
+msgid "Send announcement email"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:23
 #, fuzzy
 msgid "Delete working directory"
 msgstr "Zmień katalog roboczy"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:22
+#: /tmp/fish/implicit/share/completions/cygport.fish:24
 msgid "Same as prep build inst pkg"
 msgstr ""
 
@@ -31241,6 +31477,7 @@ msgid "Name of the output file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/highlight.fish:5
+#: /tmp/fish/implicit/share/completions/hugo.fish:57
 #: /tmp/fish/implicit/share/completions/tex.fish:10
 #, fuzzy
 msgid "Output directory"
@@ -31284,6 +31521,509 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/htop.fish:7
 msgid "Sort column"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:2
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
+#, fuzzy
+msgid "Debug output"
+msgstr "Wymuszono zatrzymanie"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:3
+#, fuzzy
+msgid "Enable logging"
+msgstr "Link wykonywalny"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:4
+msgid "Log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:6
+#: /tmp/fish/implicit/share/completions/iptables.fish:25
+#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
+msgid "Verbose output"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:7
+msgid "Verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:8
+msgid "Hostname and path to the root"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:9
+msgid "Include content marked as draft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:10
+#, fuzzy
+msgid "Include expired content"
+msgstr "Katalog"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:11
+msgid "Include content with publishdate in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:12
+#, fuzzy
+msgid "Cache directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:13
+msgid "Canonicalize all relative URLs using baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:14
+msgid "Remove files from destination not found in static directories"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:15
+#, fuzzy
+msgid "Content directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:16
+#, fuzzy
+msgid "Destination directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:17
+msgid "Do not build 404 page"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:18
+msgid "Disable different kinds of pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:19
+msgid "Do not build RSS files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:20
+msgid "Do not build sitemap files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:21
+msgid "Add Git revision, date and author info to the pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:22
+msgid "Copy all files when static is changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:23
+msgid "Help for hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:24
+msgid "Print missing translations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:25
+#, fuzzy
+msgid "Ignore the cache directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:26
+#, fuzzy
+msgid "Layout directory"
+msgstr "Katalog"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:27
+msgid "Do not sync permission mode of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:28
+msgid "Do not sync modification time of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:29
+msgid "Pluralize titles in lists using inflect"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:30
+msgid "Preserve taxonomy names as written"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:31
+#: /tmp/fish/implicit/share/completions/hugo.fish:45
+msgid "Render to memory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:32
+#: /tmp/fish/implicit/share/completions/hugo.fish:58
+#: /tmp/fish/implicit/share/completions/hugo.fish:92
+#: /tmp/fish/implicit/share/completions/hugo.fish:103
+#, fuzzy
+msgid "Source directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:33
+#: /tmp/fish/implicit/share/completions/hugo.fish:46
+msgid "Display memory and timing of different steps of the program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:34
+#: /tmp/fish/implicit/share/completions/hugo.fish:47
+#, fuzzy
+msgid "Display metrics about template executions"
+msgstr "Zwróć informacje o fish"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:35
+#: /tmp/fish/implicit/share/completions/hugo.fish:48
+msgid "Calculate some improvement hints when combined with --templateMetrics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:36
+msgid "Theme to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:37
+#, fuzzy
+msgid "Themes directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:38
+msgid "Use /filename.html instead of /filename/"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:39
+msgid "Watch filesystem for changes and recreate as needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:40
+msgid "Benchmark Hugo by building the site a number of times"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:41
+msgid "Number of times to build the site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:42
+msgid "CPU profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:43
+msgid "Help for benchmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:44
+msgid "Memory profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:49
+msgid "Perform some verification checks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:50
+msgid "Help for check"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:51
+msgid "Check system ulimit settings"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:52
+msgid "Help for ulimit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:53
+#, fuzzy
+msgid "Print the site configuration"
+msgstr "Wypisz obecnie uruchomione zadania"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:54
+msgid "Help for config"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:55
+msgid "Convert the content to different formats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:56
+msgid "Help for convert"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:59
+msgid "Enable less safe operations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:60
+msgid "Convert front matter to JSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:61
+msgid "Help for toJSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:62
+msgid "Convert front matter to TOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:63
+msgid "Help for toTOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:64
+msgid "Convert front matter to YAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:65
+msgid "Help for toYAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:66
+#, fuzzy
+msgid "Print Hugo version and environment info"
+msgstr "Zwraca sformatowany tekst"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:67
+msgid "Help for env"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:68
+msgid "Collection of several useful generators"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:69
+msgid "Help for gen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:70
+msgid "Generate shell autocompletion script for Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:71
+msgid "Autocompletion file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:72
+msgid "Help for autocomplete"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:73
+msgid "Autocompletion type"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:74
+msgid "Generate CSS stylesheet for the Chroma code highlighter"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:75
+msgid "Help for chromastyles"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:76
+msgid "Style used for highlighting lines"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:77
+msgid "Style used for line numbers"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:78
+msgid "Highlighter style"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:79
+msgid "Generate Markdown documentation for the Hugo CLI"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:80
+#, fuzzy
+msgid "Doc directory"
+msgstr "Katalog"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:81
+msgid "Help for doc"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:82
+#, fuzzy
+msgid "Generate man pages for the Hugo CLI"
+msgstr "Zwróć losową liczbę"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:83
+#, fuzzy
+msgid "Man pages directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:84
+msgid "Help for man"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:85
+msgid "Import your site from others"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:86
+msgid "Help for import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:87
+msgid "Import from Jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:88
+#, fuzzy
+msgid "Allow import into non-empty target directory"
+msgstr "Nawiązanie symboliczne do katalogu"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:89
+msgid "Help for jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:90
+msgid "List various types of content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:91
+#, fuzzy
+msgid "Help for list"
+msgstr "Katalog domowy dla %ls"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:93
+#, fuzzy
+msgid "List all drafts"
+msgstr "Zakończ zestaw komend"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:94
+msgid "Help for drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:95
+#, fuzzy
+msgid "List all expired posts"
+msgstr "Zakończ zestaw komend"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:96
+msgid "Help for expired"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:97
+msgid "List all posts dated in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:98
+msgid "Help for future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:99
+#, fuzzy
+msgid "Create new content"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:100
+msgid "Editor to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:101
+msgid "Help for new"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:102
+msgid "Content type to create"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:104
+#, fuzzy
+msgid "Create a new site"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:105
+#, fuzzy
+msgid "Create site inside non-empty directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:106
+msgid "Config and front matter format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:107
+#, fuzzy
+msgid "Help for site"
+msgstr "Katalog domowy dla %ls"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:108
+#, fuzzy
+msgid "Create a new theme"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:109
+msgid "Help for theme"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:110
+msgid "Start high performance web server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:111
+msgid "Append port to baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:112
+msgid "Interface to which the server will bind"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:113
+msgid "Enable full re-renders on changes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:114
+msgid "Watch without enabling live browser reload on rebuild"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:115
+msgid "Help for server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:116
+msgid "Port for live reloading"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:117
+msgid "Interval to poll memory usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:118
+msgid "Memory usage log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:119
+msgid "Navigate to changed content file on live browser reload"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:120
+msgid "Prevent HTTP caching"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:121
+msgid "Port on which the server will listen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:122
+#, fuzzy
+msgid "Render to destination directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:123
+msgid "Reset the content draft status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:124
+msgid "Help for undraft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:125
+#, fuzzy
+msgid "Print the version number of Hugo"
+msgstr "Zwróć katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:126
+#, fuzzy
+msgid "Help for version"
+msgstr "Wymuszono zatrzymanie"
 
 #: /tmp/fish/implicit/share/completions/i3-msg.fish:1
 msgid "Only send ipc message and suppress output"
@@ -31807,12 +32547,6 @@ msgstr ""
 msgid "Initialize packet and byte counters of a rule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/iptables.fish:25
-#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
-msgid "Verbose output"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/iptables.fish:26
 msgid "Wait for the xtables lock"
 msgstr ""
@@ -32158,6 +32892,105 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/jest.fish:77
 msgid "Disable using watchman for file crawling"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:1
+msgid "Enable debugger"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:2
+#, fuzzy
+msgid "Output usage information"
+msgstr "Zwróć informacje o fish"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:3
+#, fuzzy
+msgid "Output version number"
+msgstr "Zwróć katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:4
+msgid "Create a new JHipster application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:5
+msgid "Deploy the current application to AWS"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:6
+msgid "Create pipeline scripts for popular CI tools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:7
+msgid "Create a new JHipster client-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:8
+msgid "Prepare Cloud Foundry deployment"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:9
+msgid ""
+"Create all required Docker deployment configuration for the selected "
+"applications"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:10
+msgid ""
+"Create a new JHipster entity: JPA entity, Spring server-side components and "
+"Angular client-side components"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:11
+msgid "Create a JDL file from the existing entities"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:12
+msgid "Deploy the current application to Heroku"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:13
+msgid "Create entities from the JDL file passed in argument"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:14
+#, fuzzy
+msgid "Display information about your current project and system"
+msgstr "Zwróć informacje o fish"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:15
+msgid "Deploy the current application to Kubernetes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:16
+msgid ""
+"Select languages from a list of available languages. The i18n files will be "
+"copied to the /webapp/i18n folder"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:17
+msgid "Deploy the current application to OpenShift"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:18
+msgid "Deploy the current application to Rancher"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:19
+msgid "Create a new JHipster server-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:20
+#, fuzzy
+msgid "Create a new Spring service bean"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:21
+msgid "Upgrade the JHipster version and the generated application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:22
+#, fuzzy
+msgid "Print command completion script"
+msgstr "Edytuj sugestie do określonej komendy"
 
 #: /tmp/fish/implicit/share/completions/jobs.fish:2
 msgid "Show the process id of each process in the job"
@@ -48806,11 +49639,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:125
 msgid "Set default root object"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
-#, fuzzy
-msgid "Debug output"
-msgstr "Wymuszono zatrzymanie"
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:130
 msgid "Cache FILE containing MD5 values"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-08 16:50+0100\n"
 "PO-Revision-Date: 2015-10-11 20:35-0300\n"
 "Last-Translator: Fábio Nogueira <deb-user-ba@ubuntu.com>\n"
 "Language-Team: Português Brasileiro <>\n"
@@ -113,12 +113,12 @@ msgstr "Enviando tarefa %d “%ls” para segundo plano\n"
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls: Não há tarefas adequadas\n"
 
-#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82
+#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, fuzzy, c-format
 msgid "%ls: '%ls' is not a valid job specifier\n"
 msgstr "%ls: “%ls” não é um nome válido para variável\n"
 
-#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89
+#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89 src/builtin_wait.cpp:163
 #, c-format
 msgid "%ls: Could not find job '%d'\n"
 msgstr ""
@@ -228,7 +228,7 @@ msgstr "%ls: Nome da variável não pode ser a string vazia\n"
 msgid "%ls: Key not specified\n"
 msgstr "%ls: Chave não especificada\n"
 
-#: src/builtin.cpp:261
+#: src/builtin.cpp:262
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
@@ -237,218 +237,222 @@ msgstr ""
 "%ls: Digite “help %ls” para documentação relacionada\n"
 "\n"
 
-#: src/builtin.cpp:337
+#: src/builtin.cpp:338
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls: Não está dentro de laço\n"
 
-#: src/builtin.cpp:371
+#: src/builtin.cpp:372
 #, fuzzy, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr "%ls: Do no interactive prompting\n"
 
-#: src/builtin.cpp:409 src/builtin.cpp:459
+#: src/builtin.cpp:410 src/builtin.cpp:460
 msgid "Test a condition"
 msgstr "Testa uma condição"
 
-#: src/builtin.cpp:410
+#: src/builtin.cpp:411
 msgid "Execute command if previous command suceeded"
 msgstr "Executa comando se o comando anterior obteve sucesso"
 
-#: src/builtin.cpp:411
+#: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:412
+#: src/builtin.cpp:413
 msgid "Create a block of code"
 msgstr "Cria um bloco de código"
 
-#: src/builtin.cpp:413
+#: src/builtin.cpp:414
 msgid "Send job to background"
 msgstr "Envia tarefa para segundo plano"
 
-#: src/builtin.cpp:414
+#: src/builtin.cpp:415
 msgid "Handle fish key bindings"
 msgstr "Gerencia atalhos de teclado"
 
-#: src/builtin.cpp:415
+#: src/builtin.cpp:416
 msgid "Temporarily block delivery of events"
 msgstr "Bloqueia temporariamente a entrega de eventos"
 
-#: src/builtin.cpp:416
+#: src/builtin.cpp:417
 msgid "Stop the innermost loop"
 msgstr "Pára o laço mais interno"
 
-#: src/builtin.cpp:418
+#: src/builtin.cpp:419
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 "Interrompe temporariamente a execução de um script e abre um prompt de debug "
 "interativo"
 
-#: src/builtin.cpp:419
+#: src/builtin.cpp:420
 msgid "Run a builtin command instead of a function"
 msgstr "Executa um comando builtin em vez de uma função"
 
-#: src/builtin.cpp:420 src/builtin.cpp:458
+#: src/builtin.cpp:421 src/builtin.cpp:459
 msgid "Conditionally execute a block of commands"
 msgstr "Executa condicionalmente um bloco de comandos"
 
-#: src/builtin.cpp:421
+#: src/builtin.cpp:422
 msgid "Change working directory"
 msgstr "Muda diretório de trabalho"
 
-#: src/builtin.cpp:422
+#: src/builtin.cpp:423
 msgid "Run a program instead of a function or builtin"
 msgstr "Executa um programa em vez de uma função ou builtin"
 
-#: src/builtin.cpp:423
+#: src/builtin.cpp:424
 msgid "Set or get the commandline"
 msgstr "Obtém ou altera o buffer da linha de comando"
 
-#: src/builtin.cpp:424
+#: src/builtin.cpp:425
 msgid "Edit command specific completions"
 msgstr "Edita compleções específicas para um comando"
 
-#: src/builtin.cpp:425
+#: src/builtin.cpp:426
 msgid "Search for a specified string in a list"
 msgstr "Procura uma string especificada em uma lista"
 
-#: src/builtin.cpp:427
+#: src/builtin.cpp:428
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "Pula o restante da iteração atual do laço mais interno"
 
-#: src/builtin.cpp:428
+#: src/builtin.cpp:429
 msgid "Count the number of arguments"
 msgstr "Conta o número de argumentos"
 
-#: src/builtin.cpp:429
+#: src/builtin.cpp:430
 #, fuzzy
 msgid "Remove job from job list"
 msgstr "Read job from file"
 
-#: src/builtin.cpp:430
+#: src/builtin.cpp:431
 msgid "Print arguments"
 msgstr "Imprime os argumentos"
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:432
 msgid "Evaluate block if condition is false"
 msgstr "Executa bloco se a condição é falsa"
 
-#: src/builtin.cpp:432
+#: src/builtin.cpp:433
 msgid "Emit an event"
 msgstr "Emite um evento"
 
-#: src/builtin.cpp:433
+#: src/builtin.cpp:434
 msgid "End a block of commands"
 msgstr "Finaliza um bloco de comandos"
 
-#: src/builtin.cpp:434
+#: src/builtin.cpp:435
 msgid "Run command in current process"
 msgstr "Executa um comando como o processo atual"
 
-#: src/builtin.cpp:435
+#: src/builtin.cpp:436
 msgid "Exit the shell"
 msgstr "Sai do shell"
 
-#: src/builtin.cpp:436
+#: src/builtin.cpp:437
 msgid "Return an unsuccessful result"
 msgstr ""
 
-#: src/builtin.cpp:437
+#: src/builtin.cpp:438
 msgid "Send job to foreground"
 msgstr "Envia tarefa para primeiro plano"
 
-#: src/builtin.cpp:438
+#: src/builtin.cpp:439
 msgid "Perform a set of commands multiple times"
 msgstr "Executa um conjunto de comandos várias vezes"
 
-#: src/builtin.cpp:439
+#: src/builtin.cpp:440
 msgid "Define a new function"
 msgstr "Define uma nova função"
 
-#: src/builtin.cpp:440
+#: src/builtin.cpp:441
 msgid "List or remove functions"
 msgstr "Lista ou remove funções"
 
-#: src/builtin.cpp:441
+#: src/builtin.cpp:442
 msgid "History of commands executed by user"
 msgstr "Histórico de funções executadas pelo usuário"
 
-#: src/builtin.cpp:442
+#: src/builtin.cpp:443
 msgid "Evaluate block if condition is true"
 msgstr "Executa bloco se a condição é verdadeira"
 
-#: src/builtin.cpp:443
+#: src/builtin.cpp:444
 msgid "Print currently running jobs"
 msgstr "Imprime as tarefas em execução"
 
-#: src/builtin.cpp:444
+#: src/builtin.cpp:445
 #, fuzzy
 msgid "Evaluate math expressions"
 msgstr "Evaluate expression"
 
-#: src/builtin.cpp:445
+#: src/builtin.cpp:446
 msgid "Negate exit status of job"
 msgstr "Nega estado de saída da tarefa"
 
-#: src/builtin.cpp:446
+#: src/builtin.cpp:447
 msgid "Execute command if previous command failed"
 msgstr "Executa comando se o comando anterior falhou"
 
-#: src/builtin.cpp:447
+#: src/builtin.cpp:448
 msgid "Prints formatted text"
 msgstr "Imprime texto formatado"
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:449
 msgid "Print the working directory"
 msgstr "Imprime o diretório de trabalho"
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:450
 msgid "Generate random number"
 msgstr "Gera um número aleatório"
 
-#: src/builtin.cpp:450
+#: src/builtin.cpp:451
 msgid "Read a line of input into variables"
 msgstr "Lê uma linha de entrada e a coloca em variáveis"
 
-#: src/builtin.cpp:451
+#: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr ""
 
-#: src/builtin.cpp:452
+#: src/builtin.cpp:453
 msgid "Stop the currently evaluated function"
 msgstr "Pára a função em execução"
 
-#: src/builtin.cpp:453
+#: src/builtin.cpp:454
 msgid "Handle environment variables"
 msgstr "Modifica variáveis de ambiente"
 
-#: src/builtin.cpp:454
+#: src/builtin.cpp:455
 msgid "Set the terminal color"
 msgstr "Muda a cor do terminal"
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:456
 msgid "Evaluate contents of file"
 msgstr "Executa conteúdo do arquivo"
 
-#: src/builtin.cpp:456
+#: src/builtin.cpp:457
 msgid "Return status information about fish"
 msgstr "Retorna informação de estado do fish"
 
-#: src/builtin.cpp:457
+#: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr ""
 
-#: src/builtin.cpp:460
+#: src/builtin.cpp:461
 msgid "Return a successful result"
 msgstr ""
 
-#: src/builtin.cpp:461
+#: src/builtin.cpp:462
 msgid "Set or get the shells resource usage limits"
 msgstr "Modifica ou obtém limites de uso de recursos pelo shell"
 
-#: src/builtin.cpp:462
+#: src/builtin.cpp:463
+msgid "Wait for background processes completed"
+msgstr ""
+
+#: src/builtin.cpp:464
 msgid "Perform a command multiple times"
 msgstr "Executa um comando várias vezes"
 
@@ -747,8 +751,7 @@ msgstr ""
 #: src/builtin_set.cpp:66
 #, fuzzy, c-format
 msgid "%ls: Erase needs a variable name\n"
-msgstr ""
-"%ls: Erase needs a variable name\n"
+msgstr "%ls: Erase needs a variable name\n"
 
 #: src/builtin_set.cpp:67
 #, fuzzy, c-format
@@ -1495,58 +1498,58 @@ msgstr ""
 msgid "Your history will not be saved."
 msgstr ""
 
-#: src/proc.cpp:590
+#: src/proc.cpp:586
 #, c-format
 msgid "Job %d, "
 msgstr ""
 
-#: src/proc.cpp:591
+#: src/proc.cpp:587
 #, fuzzy, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Tarefa %d, “%ls” terminado pelo sinal %ls (%ls)"
 
-#: src/proc.cpp:599
+#: src/proc.cpp:595
 #, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr "%ls: Processo %d, '%ls' %ls'%ls' terminado pelo sinal %ls (%ls)"
 
-#: src/proc.cpp:769
+#: src/proc.cpp:779
 msgid "An error occured while reading output from code block"
 msgstr "Ocorreu um erro ao ler saída de bloco de código"
 
-#: src/proc.cpp:846
+#: src/proc.cpp:856
 #, fuzzy, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr "Não foi possível enviar tarefa %d (“%ls”) para primeiro plano pgid %d"
 
-#: src/proc.cpp:875
+#: src/proc.cpp:885
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "Não foi possível enviar tarefa %d (“%ls”) para primeiro plano"
 
-#: src/proc.cpp:899 src/proc.cpp:908 src/proc.cpp:922
+#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
 msgid "Could not return shell to foreground"
 msgstr "Não foi possível retornar shell ao primeiro plano"
 
-#: src/proc.cpp:1055
+#: src/proc.cpp:1065
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr "Mais de uma tarefa em primeiro plano: tarefa 1: “%ls” tarefa 2: “%ls”"
 
-#: src/proc.cpp:1065
+#: src/proc.cpp:1075
 msgid "Process argument list"
 msgstr "Lista de argumentos de processo"
 
-#: src/proc.cpp:1066
+#: src/proc.cpp:1076
 msgid "Process name"
 msgstr "Nome de processo"
 
-#: src/proc.cpp:1069
+#: src/proc.cpp:1079
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr "Tarefa “%ls”, processo “%ls” está em estado inconsistente “parado”=%d"
 
-#: src/proc.cpp:1075
+#: src/proc.cpp:1085
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr ""
@@ -2535,6 +2538,229 @@ msgstr "Print PKG versions"
 #, fuzzy
 msgid "Prints the usage for a given subcommand"
 msgstr "Print the type of a command"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:1
+#: /tmp/fish/explicit/share/completions/mdadm.fish:2
+msgid "Use original 0.90 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:3
+#: /tmp/fish/explicit/share/completions/mdadm.fish:4
+#, fuzzy
+msgid "Use last 1.x format superblock"
+msgstr "Suppresses normal output"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:5
+msgid "Use 1.0 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:6
+msgid "Use 1.1 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:7
+msgid "Use 1.2 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:8
+msgid "Use DDF (Disk Data Format) format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:9
+msgid "Use Intel(R) Matrix Storage Manager format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:10
+msgid "JBOD"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:11
+#: /tmp/fish/explicit/share/completions/mdadm.fish:12
+#: /tmp/fish/explicit/share/completions/mdadm.fish:13
+#, fuzzy
+msgid "Stripped volume (RAID 0)"
+msgstr "Specify conffile"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:14
+#: /tmp/fish/explicit/share/completions/mdadm.fish:15
+#: /tmp/fish/explicit/share/completions/mdadm.fish:16
+msgid "Mirrored volume (RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:17
+#: /tmp/fish/explicit/share/completions/mdadm.fish:18
+msgid "Stripped volume with parity disk (RAID 4)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:19
+#: /tmp/fish/explicit/share/completions/mdadm.fish:20
+msgid "Stripped volume with distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:21
+#: /tmp/fish/explicit/share/completions/mdadm.fish:22
+msgid "Stripped volume with double distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:23
+#: /tmp/fish/explicit/share/completions/mdadm.fish:24
+msgid "Mirrored stripped volume (RAID 10)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:25
+#: /tmp/fish/explicit/share/completions/mdadm.fish:26
+msgid "Multiple access device, AKA multipath (deprecated)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:27
+msgid "Pseudo RAID layer for single device (akin faulty RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:28
+#, fuzzy
+msgid "Container"
+msgstr "Set context size"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:29
+msgid "Alias of left-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:30
+msgid "Alias of right-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:31
+msgid "Alias of left-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:32
+msgid "Alias of right-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:33
+msgid "Alias of write-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:34
+#, fuzzy
+msgid "Alias of read-transient"
+msgstr "Nome alternativo para atrm"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:35
+msgid "Alias of write-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:36
+msgid "Alias of read-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:37
+#, fuzzy
+msgid "Alias of read-fixable"
+msgstr "File is readable"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:38
+#, fuzzy
+msgid "Use standard format (default)"
+msgstr "Suppresses normal output"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:39
+#, fuzzy
+msgid "Use a non-partitionable array"
+msgstr "Adicionar um novo repositório"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:40
+#: /tmp/fish/explicit/share/completions/mdadm.fish:41
+#: /tmp/fish/explicit/share/completions/mdadm.fish:42
+#, fuzzy
+msgid "Use a partitionable array"
+msgstr "Adicionar um novo repositório"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:43
+msgid "Remove superblock misalignement from SPARC kernel 2.2"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:44
+#, fuzzy
+msgid "Correct superblock summaries"
+msgstr "Update sources"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:45
+#, fuzzy
+msgid "Update array UUID"
+msgstr "Update sources"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:46
+#, fuzzy
+msgid "Update array name"
+msgstr "Service name"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:47
+#, fuzzy
+msgid "Update array nodes"
+msgstr "Update sources"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:48
+#, fuzzy
+msgid "Update array homehost"
+msgstr "Update sources"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:49
+#, fuzzy
+msgid "Update array cluster name"
+msgstr "Service name"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:50
+msgid "Mark the array as dirty, thus forcing resync"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:51
+msgid "Reverse superblock endianness"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:52
+#, fuzzy
+msgid "Refresh device size"
+msgstr "Specify the repository URL"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:53
+msgid "Assume bitmap absence"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:54
+#, fuzzy
+msgid "Reserve space for bad block list"
+msgstr "Create compressed patches"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:55
+msgid "Free reserved space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:56
+msgid "Convert 0.90 metadata to 1.0"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:57
+msgid "Reset preferred minor to current one"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:58
+#, fuzzy
+msgid "Abort currently running actions"
+msgstr "Imprime as tarefas em execução"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:59
+msgid "Abort currently running actions, prevent their restart"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:60
+msgid "Scrub the array (i.e. check constistency)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:61
+#, fuzzy
+msgid "Check, then resync"
+msgstr "Query installed packages"
 
 #: /tmp/fish/explicit/share/completions/set.fish:1
 #, fuzzy
@@ -3535,6 +3761,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
 #: /tmp/fish/implicit/share/completions/asp.fish:6
 #: /tmp/fish/implicit/share/completions/bc.fish:7
+#: /tmp/fish/implicit/share/completions/bd.fish:4
 #: /tmp/fish/implicit/share/completions/bg.fish:1
 #: /tmp/fish/implicit/share/completions/bind.fish:4
 #: /tmp/fish/implicit/share/completions/block.fish:1
@@ -4181,7 +4408,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bzr.fish:1
 #: /tmp/fish/implicit/share/completions/climate.fish:1
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:17
-#: /tmp/fish/implicit/share/completions/cygport.fish:23
+#: /tmp/fish/implicit/share/completions/cygport.fish:25
 #: /tmp/fish/implicit/share/completions/godoc.fish:25
 #: /tmp/fish/implicit/share/completions/gofmt.fish:8
 #: /tmp/fish/implicit/share/completions/goimports.fish:6
@@ -5667,6 +5894,7 @@ msgstr "Select file to store source cache"
 #: /tmp/fish/implicit/share/completions/apt-get.fish:24
 #: /tmp/fish/implicit/share/completions/configure.fish:3
 #: /tmp/fish/implicit/share/completions/gpg.fish:62
+#: /tmp/fish/implicit/share/completions/hugo.fish:5
 #: /tmp/fish/implicit/share/completions/make.fish:16
 #: /tmp/fish/implicit/share/completions/ping.fish:16
 #: /tmp/fish/implicit/share/completions/rpm.fish:3
@@ -5863,6 +6091,7 @@ msgid "Set a configuration option"
 msgstr "Set a config option"
 
 #: /tmp/fish/implicit/share/completions/apt.fish:8
+#: /tmp/fish/implicit/share/completions/hugo.fish:1
 #: /tmp/fish/implicit/share/completions/man.fish:14
 #: /tmp/fish/implicit/share/completions/modprobe.fish:2
 #: /tmp/fish/implicit/share/completions/yum.fish:13
@@ -9222,6 +9451,19 @@ msgstr "Process exactly POSIX bc"
 msgid "Do not print the GNU welcome"
 msgstr "Do not print the GNU welcome"
 
+#: /tmp/fish/implicit/share/completions/bd.fish:1
+msgid "Classic mode: goes back to the first directory named as the string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:2
+msgid "Seems mode: goes back to the first directory containing string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:3
+#, fuzzy
+msgid "Case insensitive move (implies seems mode)"
+msgstr "Case insensitive"
+
 #: /tmp/fish/implicit/share/completions/bind.fish:1
 msgid "Show unavailable key bindings/erase all bindings"
 msgstr ""
@@ -10789,7 +11031,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/caddy.fish:24
 #: /tmp/fish/implicit/share/completions/canto.fish:2
-#: /tmp/fish/implicit/share/completions/cygport.fish:24
+#: /tmp/fish/implicit/share/completions/cygport.fish:26
 #: /tmp/fish/implicit/share/completions/grub-install.fish:33
 #: /tmp/fish/implicit/share/completions/lua.fish:4
 #: /tmp/fish/implicit/share/completions/magento.fish:23
@@ -14175,29 +14417,39 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:17
 #, fuzzy
+msgid "Create packages, marked as test"
+msgstr "Atualizar o repositório"
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:18
+#, fuzzy
 msgid "Create packages"
 msgstr "Erase package"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:18
+#: /tmp/fish/implicit/share/completions/cygport.fish:19
 #, fuzzy
 msgid "Create source patches"
 msgstr "Clean source packages"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:19
+#: /tmp/fish/implicit/share/completions/cygport.fish:20
 #, fuzzy
 msgid "Upload finished packages"
 msgstr "Upgrade packages"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:20
+#: /tmp/fish/implicit/share/completions/cygport.fish:21
+#, fuzzy
+msgid "Upload packages without marking !ready"
+msgstr "Rebuild a package"
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:22
 msgid "Send announcement email"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:21
+#: /tmp/fish/implicit/share/completions/cygport.fish:23
 #, fuzzy
 msgid "Delete working directory"
 msgstr "Muda diretório de trabalho"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:22
+#: /tmp/fish/implicit/share/completions/cygport.fish:24
 msgid "Same as prep build inst pkg"
 msgstr ""
 
@@ -33719,6 +33971,7 @@ msgid "Name of the output file"
 msgstr "Do not create output files"
 
 #: /tmp/fish/implicit/share/completions/highlight.fish:5
+#: /tmp/fish/implicit/share/completions/hugo.fish:57
 #: /tmp/fish/implicit/share/completions/tex.fish:10
 #, fuzzy
 msgid "Output directory"
@@ -33768,6 +34021,558 @@ msgstr "Monitor user"
 #, fuzzy
 msgid "Sort column"
 msgstr "Lista por colunas"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:2
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
+#, fuzzy
+msgid "Debug output"
+msgstr "Turn on debug output"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:3
+#, fuzzy
+msgid "Enable logging"
+msgstr "Enable debug"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:4
+#, fuzzy
+msgid "Log file"
+msgstr "Log to tracefile"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:6
+#: /tmp/fish/implicit/share/completions/iptables.fish:25
+#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
+#, fuzzy
+msgid "Verbose output"
+msgstr "Verbose prompt"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:7
+#, fuzzy
+msgid "Verbose logging"
+msgstr "List users logged in"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:8
+#, fuzzy
+msgid "Hostname and path to the root"
+msgstr "Update the repository"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:9
+#, fuzzy
+msgid "Include content marked as draft"
+msgstr "Include directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:10
+#, fuzzy
+msgid "Include expired content"
+msgstr "Include directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:11
+#, fuzzy
+msgid "Include content with publishdate in the future"
+msgstr "List reverse dependencies for the package"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:12
+#, fuzzy
+msgid "Cache directory"
+msgstr "Muda diretório"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:13
+msgid "Canonicalize all relative URLs using baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:14
+#, fuzzy
+msgid "Remove files from destination not found in static directories"
+msgstr "Place files or directories under version control"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:15
+#, fuzzy
+msgid "Content directory"
+msgstr "Muda diretório"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:16
+#, fuzzy
+msgid "Destination directory"
+msgstr "Create any missing directories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:17
+#, fuzzy
+msgid "Do not build 404 page"
+msgstr "Do not del built files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:18
+#, fuzzy
+msgid "Disable different kinds of pages"
+msgstr "Control creation of sparse files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:19
+#, fuzzy
+msgid "Do not build RSS files"
+msgstr "Do not del built files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:20
+#, fuzzy
+msgid "Do not build sitemap files"
+msgstr "Do not del built files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:21
+msgid "Add Git revision, date and author info to the pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:22
+msgid "Copy all files when static is changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:23
+msgid "Help for hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:24
+#, fuzzy
+msgid "Print missing translations"
+msgstr "Print compression ratios"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:25
+#, fuzzy
+msgid "Ignore the cache directory"
+msgstr "Include directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:26
+#, fuzzy
+msgid "Layout directory"
+msgstr "Output mimetype"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:27
+#, fuzzy
+msgid "Do not sync permission mode of files"
+msgstr "Do not change any files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:28
+#, fuzzy
+msgid "Do not sync modification time of files"
+msgstr "Ordena por hora de modificação"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:29
+msgid "Pluralize titles in lists using inflect"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:30
+msgid "Preserve taxonomy names as written"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:31
+#: /tmp/fish/implicit/share/completions/hugo.fish:45
+#, fuzzy
+msgid "Render to memory"
+msgstr "Reduce memory usage"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:32
+#: /tmp/fish/implicit/share/completions/hugo.fish:58
+#: /tmp/fish/implicit/share/completions/hugo.fish:92
+#: /tmp/fish/implicit/share/completions/hugo.fish:103
+#, fuzzy
+msgid "Source directory"
+msgstr "Clean source directories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:33
+#: /tmp/fish/implicit/share/completions/hugo.fish:46
+#, fuzzy
+msgid "Display memory and timing of different steps of the program"
+msgstr "Display the pretend output in a tabular form"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:34
+#: /tmp/fish/implicit/share/completions/hugo.fish:47
+#, fuzzy
+msgid "Display metrics about template executions"
+msgstr "Display $ at end of line"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:35
+#: /tmp/fish/implicit/share/completions/hugo.fish:48
+msgid "Calculate some improvement hints when combined with --templateMetrics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:36
+#, fuzzy
+msgid "Theme to use"
+msgstr "Send mail to user"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:37
+#, fuzzy
+msgid "Themes directory"
+msgstr "Remove the test directory"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:38
+#, fuzzy
+msgid "Use /filename.html instead of /filename/"
+msgstr "Use purge instead of remove"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:39
+#, fuzzy
+msgid "Watch filesystem for changes and recreate as needed"
+msgstr "Patch local changes"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:40
+msgid "Benchmark Hugo by building the site a number of times"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:41
+msgid "Number of times to build the site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:42
+#, fuzzy
+msgid "CPU profile file"
+msgstr "Use config file"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:43
+msgid "Help for benchmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:44
+#, fuzzy
+msgid "Memory profile file"
+msgstr "Do not create file"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:49
+#, fuzzy
+msgid "Perform some verification checks"
+msgstr "Perform contents generation"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:50
+msgid "Help for check"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:51
+msgid "Check system ulimit settings"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:52
+#, fuzzy
+msgid "Help for ulimit"
+msgstr "Recursion limit"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:53
+#, fuzzy
+msgid "Print the site configuration"
+msgstr "Reload service configuration"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:54
+#, fuzzy
+msgid "Help for config"
+msgstr "Help section"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:55
+#, fuzzy
+msgid "Convert the content to different formats"
+msgstr "Don't add contents of subdirectories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:56
+#, fuzzy
+msgid "Help for convert"
+msgstr "Nome alternativo para atq"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:59
+#, fuzzy
+msgid "Enable less safe operations"
+msgstr "Disable multi-threaded operation"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:60
+msgid "Convert front matter to JSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:61
+msgid "Help for toJSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:62
+msgid "Convert front matter to TOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:63
+msgid "Help for toTOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:64
+msgid "Convert front matter to YAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:65
+msgid "Help for toYAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:66
+#, fuzzy
+msgid "Print Hugo version and environment info"
+msgstr "Ignore all version information"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:67
+#, fuzzy
+msgid "Help for env"
+msgstr "Nome alternativo para atq"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:68
+msgid "Collection of several useful generators"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:69
+msgid "Help for gen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:70
+msgid "Generate shell autocompletion script for Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:71
+#, fuzzy
+msgid "Autocompletion file"
+msgstr "Tolerate sloppy mount options"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:72
+msgid "Help for autocomplete"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:73
+#, fuzzy
+msgid "Autocompletion type"
+msgstr "Path to add completion to"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:74
+msgid "Generate CSS stylesheet for the Chroma code highlighter"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:75
+msgid "Help for chromastyles"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:76
+#, fuzzy
+msgid "Style used for highlighting lines"
+msgstr "No search highlighting"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:77
+#, fuzzy
+msgid "Style used for line numbers"
+msgstr "Mostra a versão e sai"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:78
+msgid "Highlighter style"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:79
+#, fuzzy
+msgid "Generate Markdown documentation for the Hugo CLI"
+msgstr "Generate contents file"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:80
+#, fuzzy
+msgid "Doc directory"
+msgstr "Diretório"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:81
+msgid "Help for doc"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:82
+#, fuzzy
+msgid "Generate man pages for the Hugo CLI"
+msgstr "Generate contents file"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:83
+#, fuzzy
+msgid "Man pages directory"
+msgstr "Muda diretório"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:84
+#, fuzzy
+msgid "Help for man"
+msgstr "Short format"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:85
+#, fuzzy
+msgid "Import your site from others"
+msgstr "Compress to stdout"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:86
+#, fuzzy
+msgid "Help for import"
+msgstr "Dir to import"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:87
+msgid "Import from Jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:88
+#, fuzzy
+msgid "Allow import into non-empty target directory"
+msgstr "Create a local copy of another repository"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:89
+msgid "Help for jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:90
+#, fuzzy
+msgid "List various types of content"
+msgstr "List archive"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:91
+#, fuzzy
+msgid "Help for list"
+msgstr "Diretório de usuário para %ls"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:93
+#, fuzzy
+msgid "List all drafts"
+msgstr "List names of available signals"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:94
+msgid "Help for drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:95
+#, fuzzy
+msgid "List all expired posts"
+msgstr "List names of available signals"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:96
+#, fuzzy
+msgid "Help for expired"
+msgstr "Temporizador expirado"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:97
+#, fuzzy
+msgid "List all posts dated in the future"
+msgstr "Update the repository"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:98
+#, fuzzy
+msgid "Help for future"
+msgstr "Nome alternativo para atrm"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:99
+#, fuzzy
+msgid "Create new content"
+msgstr "Preserve environment"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:100
+#, fuzzy
+msgid "Editor to use"
+msgstr "Send mail to user"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:101
+msgid "Help for new"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:102
+#, fuzzy
+msgid "Content type to create"
+msgstr "Concatenate output to file"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:104
+#, fuzzy
+msgid "Create a new site"
+msgstr "Create new project"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:105
+#, fuzzy
+msgid "Create site inside non-empty directory"
+msgstr "Create any missing directories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:106
+msgid "Config and front matter format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:107
+#, fuzzy
+msgid "Help for site"
+msgstr "Diretório de usuário para %ls"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:108
+#, fuzzy
+msgid "Create a new theme"
+msgstr "Preserve environment"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:109
+#, fuzzy
+msgid "Help for theme"
+msgstr "Search for other system"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:110
+#, fuzzy
+msgid "Start high performance web server"
+msgstr "Start service"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:111
+#, fuzzy
+msgid "Append port to baseurl"
+msgstr "Append input to selection"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:112
+msgid "Interface to which the server will bind"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:113
+#, fuzzy
+msgid "Enable full re-renders on changes"
+msgstr "Make no changes"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:114
+msgid "Watch without enabling live browser reload on rebuild"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:115
+#, fuzzy
+msgid "Help for server"
+msgstr "Utilizar servidor proxy"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:116
+#, fuzzy
+msgid "Port for live reloading"
+msgstr "Dynamic port forwarding"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:117
+msgid "Interval to poll memory usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:118
+#, fuzzy
+msgid "Memory usage log file"
+msgstr "Erase obsolete files"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:119
+msgid "Navigate to changed content file on live browser reload"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:120
+msgid "Prevent HTTP caching"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:121
+msgid "Port on which the server will listen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:122
+#, fuzzy
+msgid "Render to destination directory"
+msgstr "Create any missing directories"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:123
+msgid "Reset the content draft status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:124
+msgid "Help for undraft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:125
+#, fuzzy
+msgid "Print the version number of Hugo"
+msgstr "Print linenumber"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:126
+#, fuzzy
+msgid "Help for version"
+msgstr "Nome do cliente"
 
 #: /tmp/fish/implicit/share/completions/i3-msg.fish:1
 msgid "Only send ipc message and suppress output"
@@ -34356,13 +35161,6 @@ msgstr ""
 msgid "Initialize packet and byte counters of a rule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/iptables.fish:25
-#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
-#, fuzzy
-msgid "Verbose output"
-msgstr "Verbose prompt"
-
 #: /tmp/fish/implicit/share/completions/iptables.fish:26
 msgid "Wait for the xtables lock"
 msgstr ""
@@ -34733,6 +35531,114 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/jest.fish:77
 msgid "Disable using watchman for file crawling"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:1
+#, fuzzy
+msgid "Enable debugger"
+msgstr "Enable debug"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:2
+#, fuzzy
+msgid "Output usage information"
+msgstr "Não pôde obter informação do usuário"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:3
+#, fuzzy
+msgid "Output version number"
+msgstr "Número da versão"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:4
+#, fuzzy
+msgid "Create a new JHipster application"
+msgstr "Create new project"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:5
+#, fuzzy
+msgid "Deploy the current application to AWS"
+msgstr "Delete obsolete package files"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:6
+msgid "Create pipeline scripts for popular CI tools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:7
+msgid "Create a new JHipster client-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:8
+msgid "Prepare Cloud Foundry deployment"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:9
+msgid ""
+"Create all required Docker deployment configuration for the selected "
+"applications"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:10
+msgid ""
+"Create a new JHipster entity: JPA entity, Spring server-side components and "
+"Angular client-side components"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:11
+#, fuzzy
+msgid "Create a JDL file from the existing entities"
+msgstr "Remove files after adding to archive"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:12
+#, fuzzy
+msgid "Deploy the current application to Heroku"
+msgstr "Delete obsolete package files"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:13
+msgid "Create entities from the JDL file passed in argument"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:14
+#, fuzzy
+msgid "Display information about your current project and system"
+msgstr "Display information about a local or remote item"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:15
+#, fuzzy
+msgid "Deploy the current application to Kubernetes"
+msgstr "Don't cache auth tokens"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:16
+msgid ""
+"Select languages from a list of available languages. The i18n files will be "
+"copied to the /webapp/i18n folder"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:17
+#, fuzzy
+msgid "Deploy the current application to OpenShift"
+msgstr "Display version and supported algorithms, and exit"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:18
+#, fuzzy
+msgid "Deploy the current application to Rancher"
+msgstr "Delete obsolete package files"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:19
+#, fuzzy
+msgid "Create a new JHipster server-side application"
+msgstr "Create a new directory under version control"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:20
+#, fuzzy
+msgid "Create a new Spring service bean"
+msgstr "Preserve environment"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:21
+msgid "Upgrade the JHipster version and the generated application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:22
+#, fuzzy
+msgid "Print command completion script"
+msgstr "Print commands to stderr"
 
 #: /tmp/fish/implicit/share/completions/jobs.fish:2
 #, fuzzy
@@ -52670,11 +53576,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:125
 msgid "Set default root object"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
-#, fuzzy
-msgid "Debug output"
-msgstr "Turn on debug output"
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:130
 msgid "Cache FILE containing MD5 values"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-08 16:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -107,12 +107,12 @@ msgstr ""
 msgid "%ls: There are no suitable jobs\n"
 msgstr ""
 
-#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82
+#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, c-format
 msgid "%ls: '%ls' is not a valid job specifier\n"
 msgstr ""
 
-#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89
+#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89 src/builtin_wait.cpp:163
 #, c-format
 msgid "%ls: Could not find job '%d'\n"
 msgstr ""
@@ -222,221 +222,225 @@ msgstr ""
 msgid "%ls: Key not specified\n"
 msgstr ""
 
-#: src/builtin.cpp:261
+#: src/builtin.cpp:262
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
 "\n"
 msgstr ""
 
-#: src/builtin.cpp:337
+#: src/builtin.cpp:338
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr ""
 
-#: src/builtin.cpp:371
+#: src/builtin.cpp:372
 #, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr ""
 
-#: src/builtin.cpp:409 src/builtin.cpp:459
+#: src/builtin.cpp:410 src/builtin.cpp:460
 msgid "Test a condition"
 msgstr ""
 
-#: src/builtin.cpp:410
+#: src/builtin.cpp:411
 msgid "Execute command if previous command suceeded"
 msgstr ""
 
-#: src/builtin.cpp:411
+#: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:412
+#: src/builtin.cpp:413
 msgid "Create a block of code"
 msgstr ""
 
-#: src/builtin.cpp:413
+#: src/builtin.cpp:414
 msgid "Send job to background"
 msgstr ""
 
-#: src/builtin.cpp:414
+#: src/builtin.cpp:415
 msgid "Handle fish key bindings"
 msgstr ""
 
-#: src/builtin.cpp:415
+#: src/builtin.cpp:416
 msgid "Temporarily block delivery of events"
 msgstr ""
 
-#: src/builtin.cpp:416
+#: src/builtin.cpp:417
 msgid "Stop the innermost loop"
 msgstr ""
 
-#: src/builtin.cpp:418
+#: src/builtin.cpp:419
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr ""
 
-#: src/builtin.cpp:419
+#: src/builtin.cpp:420
 msgid "Run a builtin command instead of a function"
 msgstr ""
 
-#: src/builtin.cpp:420 src/builtin.cpp:458
+#: src/builtin.cpp:421 src/builtin.cpp:459
 msgid "Conditionally execute a block of commands"
 msgstr ""
 
-#: src/builtin.cpp:421
+#: src/builtin.cpp:422
 msgid "Change working directory"
 msgstr ""
 
-#: src/builtin.cpp:422
+#: src/builtin.cpp:423
 msgid "Run a program instead of a function or builtin"
 msgstr ""
 
-#: src/builtin.cpp:423
+#: src/builtin.cpp:424
 msgid "Set or get the commandline"
 msgstr ""
 
-#: src/builtin.cpp:424
+#: src/builtin.cpp:425
 msgid "Edit command specific completions"
 msgstr ""
 
-#: src/builtin.cpp:425
+#: src/builtin.cpp:426
 msgid "Search for a specified string in a list"
 msgstr ""
 
-#: src/builtin.cpp:427
+#: src/builtin.cpp:428
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr ""
 
-#: src/builtin.cpp:428
+#: src/builtin.cpp:429
 msgid "Count the number of arguments"
 msgstr ""
 
-#: src/builtin.cpp:429
+#: src/builtin.cpp:430
 msgid "Remove job from job list"
 msgstr ""
 
-#: src/builtin.cpp:430
+#: src/builtin.cpp:431
 msgid "Print arguments"
 msgstr ""
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:432
 msgid "Evaluate block if condition is false"
 msgstr ""
 
-#: src/builtin.cpp:432
+#: src/builtin.cpp:433
 msgid "Emit an event"
 msgstr ""
 
-#: src/builtin.cpp:433
+#: src/builtin.cpp:434
 msgid "End a block of commands"
 msgstr ""
 
-#: src/builtin.cpp:434
+#: src/builtin.cpp:435
 msgid "Run command in current process"
 msgstr ""
 
-#: src/builtin.cpp:435
+#: src/builtin.cpp:436
 msgid "Exit the shell"
 msgstr ""
 
-#: src/builtin.cpp:436
+#: src/builtin.cpp:437
 msgid "Return an unsuccessful result"
 msgstr ""
 
-#: src/builtin.cpp:437
+#: src/builtin.cpp:438
 msgid "Send job to foreground"
 msgstr ""
 
-#: src/builtin.cpp:438
+#: src/builtin.cpp:439
 msgid "Perform a set of commands multiple times"
 msgstr ""
 
-#: src/builtin.cpp:439
+#: src/builtin.cpp:440
 msgid "Define a new function"
 msgstr ""
 
-#: src/builtin.cpp:440
+#: src/builtin.cpp:441
 msgid "List or remove functions"
 msgstr ""
 
-#: src/builtin.cpp:441
+#: src/builtin.cpp:442
 msgid "History of commands executed by user"
 msgstr ""
 
-#: src/builtin.cpp:442
+#: src/builtin.cpp:443
 msgid "Evaluate block if condition is true"
 msgstr ""
 
-#: src/builtin.cpp:443
+#: src/builtin.cpp:444
 msgid "Print currently running jobs"
 msgstr ""
 
-#: src/builtin.cpp:444
+#: src/builtin.cpp:445
 msgid "Evaluate math expressions"
 msgstr ""
 
-#: src/builtin.cpp:445
+#: src/builtin.cpp:446
 msgid "Negate exit status of job"
 msgstr ""
 
-#: src/builtin.cpp:446
+#: src/builtin.cpp:447
 msgid "Execute command if previous command failed"
 msgstr ""
 
-#: src/builtin.cpp:447
+#: src/builtin.cpp:448
 msgid "Prints formatted text"
 msgstr ""
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:449
 msgid "Print the working directory"
 msgstr ""
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:450
 msgid "Generate random number"
 msgstr ""
 
-#: src/builtin.cpp:450
+#: src/builtin.cpp:451
 msgid "Read a line of input into variables"
 msgstr ""
 
-#: src/builtin.cpp:451
+#: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr ""
 
-#: src/builtin.cpp:452
+#: src/builtin.cpp:453
 msgid "Stop the currently evaluated function"
 msgstr ""
 
-#: src/builtin.cpp:453
+#: src/builtin.cpp:454
 msgid "Handle environment variables"
 msgstr ""
 
-#: src/builtin.cpp:454
+#: src/builtin.cpp:455
 msgid "Set the terminal color"
 msgstr ""
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:456
 msgid "Evaluate contents of file"
 msgstr ""
 
-#: src/builtin.cpp:456
+#: src/builtin.cpp:457
 msgid "Return status information about fish"
 msgstr ""
 
-#: src/builtin.cpp:457
+#: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr ""
 
-#: src/builtin.cpp:460
+#: src/builtin.cpp:461
 msgid "Return a successful result"
 msgstr ""
 
-#: src/builtin.cpp:461
+#: src/builtin.cpp:462
 msgid "Set or get the shells resource usage limits"
 msgstr ""
 
-#: src/builtin.cpp:462
+#: src/builtin.cpp:463
+msgid "Wait for background processes completed"
+msgstr ""
+
+#: src/builtin.cpp:464
 msgid "Perform a command multiple times"
 msgstr ""
 
@@ -1460,58 +1464,58 @@ msgstr ""
 msgid "Your history will not be saved."
 msgstr ""
 
-#: src/proc.cpp:590
+#: src/proc.cpp:586
 #, c-format
 msgid "Job %d, "
 msgstr ""
 
-#: src/proc.cpp:591
+#: src/proc.cpp:587
 #, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 
-#: src/proc.cpp:599
+#: src/proc.cpp:595
 #, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 
-#: src/proc.cpp:769
+#: src/proc.cpp:779
 msgid "An error occured while reading output from code block"
 msgstr ""
 
-#: src/proc.cpp:846
+#: src/proc.cpp:856
 #, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr ""
 
-#: src/proc.cpp:875
+#: src/proc.cpp:885
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr ""
 
-#: src/proc.cpp:899 src/proc.cpp:908 src/proc.cpp:922
+#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
 msgid "Could not return shell to foreground"
 msgstr ""
 
-#: src/proc.cpp:1055
+#: src/proc.cpp:1065
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr ""
 
-#: src/proc.cpp:1065
+#: src/proc.cpp:1075
 msgid "Process argument list"
 msgstr ""
 
-#: src/proc.cpp:1066
+#: src/proc.cpp:1076
 msgid "Process name"
 msgstr ""
 
-#: src/proc.cpp:1069
+#: src/proc.cpp:1079
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr ""
 
-#: src/proc.cpp:1075
+#: src/proc.cpp:1085
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr ""
@@ -2433,6 +2437,211 @@ msgstr ""
 msgid "Prints the usage for a given subcommand"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/mdadm.fish:1
+#: /tmp/fish/explicit/share/completions/mdadm.fish:2
+msgid "Use original 0.90 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:3
+#: /tmp/fish/explicit/share/completions/mdadm.fish:4
+msgid "Use last 1.x format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:5
+msgid "Use 1.0 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:6
+msgid "Use 1.1 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:7
+msgid "Use 1.2 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:8
+msgid "Use DDF (Disk Data Format) format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:9
+msgid "Use Intel(R) Matrix Storage Manager format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:10
+msgid "JBOD"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:11
+#: /tmp/fish/explicit/share/completions/mdadm.fish:12
+#: /tmp/fish/explicit/share/completions/mdadm.fish:13
+msgid "Stripped volume (RAID 0)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:14
+#: /tmp/fish/explicit/share/completions/mdadm.fish:15
+#: /tmp/fish/explicit/share/completions/mdadm.fish:16
+msgid "Mirrored volume (RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:17
+#: /tmp/fish/explicit/share/completions/mdadm.fish:18
+msgid "Stripped volume with parity disk (RAID 4)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:19
+#: /tmp/fish/explicit/share/completions/mdadm.fish:20
+msgid "Stripped volume with distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:21
+#: /tmp/fish/explicit/share/completions/mdadm.fish:22
+msgid "Stripped volume with double distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:23
+#: /tmp/fish/explicit/share/completions/mdadm.fish:24
+msgid "Mirrored stripped volume (RAID 10)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:25
+#: /tmp/fish/explicit/share/completions/mdadm.fish:26
+msgid "Multiple access device, AKA multipath (deprecated)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:27
+msgid "Pseudo RAID layer for single device (akin faulty RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:28
+msgid "Container"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:29
+msgid "Alias of left-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:30
+msgid "Alias of right-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:31
+msgid "Alias of left-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:32
+msgid "Alias of right-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:33
+msgid "Alias of write-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:34
+msgid "Alias of read-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:35
+msgid "Alias of write-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:36
+msgid "Alias of read-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:37
+msgid "Alias of read-fixable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:38
+msgid "Use standard format (default)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:39
+msgid "Use a non-partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:40
+#: /tmp/fish/explicit/share/completions/mdadm.fish:41
+#: /tmp/fish/explicit/share/completions/mdadm.fish:42
+msgid "Use a partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:43
+msgid "Remove superblock misalignement from SPARC kernel 2.2"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:44
+msgid "Correct superblock summaries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:45
+msgid "Update array UUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:46
+msgid "Update array name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:47
+msgid "Update array nodes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:48
+msgid "Update array homehost"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:49
+msgid "Update array cluster name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:50
+msgid "Mark the array as dirty, thus forcing resync"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:51
+msgid "Reverse superblock endianness"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:52
+msgid "Refresh device size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:53
+msgid "Assume bitmap absence"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:54
+msgid "Reserve space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:55
+msgid "Free reserved space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:56
+msgid "Convert 0.90 metadata to 1.0"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:57
+msgid "Reset preferred minor to current one"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:58
+msgid "Abort currently running actions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:59
+msgid "Abort currently running actions, prevent their restart"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:60
+msgid "Scrub the array (i.e. check constistency)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:61
+msgid "Check, then resync"
+msgstr ""
+
 #: /tmp/fish/explicit/share/completions/set.fish:1
 msgid "Locale"
 msgstr ""
@@ -3308,6 +3517,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
 #: /tmp/fish/implicit/share/completions/asp.fish:6
 #: /tmp/fish/implicit/share/completions/bc.fish:7
+#: /tmp/fish/implicit/share/completions/bd.fish:4
 #: /tmp/fish/implicit/share/completions/bg.fish:1
 #: /tmp/fish/implicit/share/completions/bind.fish:4
 #: /tmp/fish/implicit/share/completions/block.fish:1
@@ -3901,7 +4111,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bzr.fish:1
 #: /tmp/fish/implicit/share/completions/climate.fish:1
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:17
-#: /tmp/fish/implicit/share/completions/cygport.fish:23
+#: /tmp/fish/implicit/share/completions/cygport.fish:25
 #: /tmp/fish/implicit/share/completions/godoc.fish:25
 #: /tmp/fish/implicit/share/completions/gofmt.fish:8
 #: /tmp/fish/implicit/share/completions/goimports.fish:6
@@ -5272,6 +5482,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-get.fish:24
 #: /tmp/fish/implicit/share/completions/configure.fish:3
 #: /tmp/fish/implicit/share/completions/gpg.fish:62
+#: /tmp/fish/implicit/share/completions/hugo.fish:5
 #: /tmp/fish/implicit/share/completions/make.fish:16
 #: /tmp/fish/implicit/share/completions/ping.fish:16
 #: /tmp/fish/implicit/share/completions/rpm.fish:3
@@ -5439,6 +5650,7 @@ msgid "Set a configuration option"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt.fish:8
+#: /tmp/fish/implicit/share/completions/hugo.fish:1
 #: /tmp/fish/implicit/share/completions/man.fish:14
 #: /tmp/fish/implicit/share/completions/modprobe.fish:2
 #: /tmp/fish/implicit/share/completions/yum.fish:13
@@ -8393,6 +8605,18 @@ msgstr ""
 msgid "Do not print the GNU welcome"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/bd.fish:1
+msgid "Classic mode: goes back to the first directory named as the string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:2
+msgid "Seems mode: goes back to the first directory containing string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:3
+msgid "Case insensitive move (implies seems mode)"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/bind.fish:1
 msgid "Show unavailable key bindings/erase all bindings"
 msgstr ""
@@ -9815,7 +10039,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/caddy.fish:24
 #: /tmp/fish/implicit/share/completions/canto.fish:2
-#: /tmp/fish/implicit/share/completions/cygport.fish:24
+#: /tmp/fish/implicit/share/completions/cygport.fish:26
 #: /tmp/fish/implicit/share/completions/grub-install.fish:33
 #: /tmp/fish/implicit/share/completions/lua.fish:4
 #: /tmp/fish/implicit/share/completions/magento.fish:23
@@ -12888,26 +13112,34 @@ msgid "Show project homepage URL"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:17
-msgid "Create packages"
+msgid "Create packages, marked as test"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:18
-msgid "Create source patches"
+msgid "Create packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:19
-msgid "Upload finished packages"
+msgid "Create source patches"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:20
-msgid "Send announcement email"
+msgid "Upload finished packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:21
-msgid "Delete working directory"
+msgid "Upload packages without marking !ready"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:22
+msgid "Send announcement email"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:23
+msgid "Delete working directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:24
 msgid "Same as prep build inst pkg"
 msgstr ""
 
@@ -30973,6 +31205,7 @@ msgid "Name of the output file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/highlight.fish:5
+#: /tmp/fish/implicit/share/completions/hugo.fish:57
 #: /tmp/fish/implicit/share/completions/tex.fish:10
 msgid "Output directory"
 msgstr ""
@@ -31014,6 +31247,481 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/htop.fish:7
 msgid "Sort column"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:2
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
+msgid "Debug output"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:3
+msgid "Enable logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:4
+msgid "Log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:6
+#: /tmp/fish/implicit/share/completions/iptables.fish:25
+#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
+msgid "Verbose output"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:7
+msgid "Verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:8
+msgid "Hostname and path to the root"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:9
+msgid "Include content marked as draft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:10
+msgid "Include expired content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:11
+msgid "Include content with publishdate in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:12
+msgid "Cache directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:13
+msgid "Canonicalize all relative URLs using baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:14
+msgid "Remove files from destination not found in static directories"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:15
+msgid "Content directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:16
+msgid "Destination directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:17
+msgid "Do not build 404 page"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:18
+msgid "Disable different kinds of pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:19
+msgid "Do not build RSS files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:20
+msgid "Do not build sitemap files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:21
+msgid "Add Git revision, date and author info to the pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:22
+msgid "Copy all files when static is changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:23
+msgid "Help for hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:24
+msgid "Print missing translations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:25
+msgid "Ignore the cache directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:26
+msgid "Layout directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:27
+msgid "Do not sync permission mode of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:28
+msgid "Do not sync modification time of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:29
+msgid "Pluralize titles in lists using inflect"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:30
+msgid "Preserve taxonomy names as written"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:31
+#: /tmp/fish/implicit/share/completions/hugo.fish:45
+msgid "Render to memory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:32
+#: /tmp/fish/implicit/share/completions/hugo.fish:58
+#: /tmp/fish/implicit/share/completions/hugo.fish:92
+#: /tmp/fish/implicit/share/completions/hugo.fish:103
+msgid "Source directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:33
+#: /tmp/fish/implicit/share/completions/hugo.fish:46
+msgid "Display memory and timing of different steps of the program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:34
+#: /tmp/fish/implicit/share/completions/hugo.fish:47
+msgid "Display metrics about template executions"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:35
+#: /tmp/fish/implicit/share/completions/hugo.fish:48
+msgid "Calculate some improvement hints when combined with --templateMetrics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:36
+msgid "Theme to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:37
+msgid "Themes directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:38
+msgid "Use /filename.html instead of /filename/"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:39
+msgid "Watch filesystem for changes and recreate as needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:40
+msgid "Benchmark Hugo by building the site a number of times"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:41
+msgid "Number of times to build the site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:42
+msgid "CPU profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:43
+msgid "Help for benchmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:44
+msgid "Memory profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:49
+msgid "Perform some verification checks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:50
+msgid "Help for check"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:51
+msgid "Check system ulimit settings"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:52
+msgid "Help for ulimit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:53
+msgid "Print the site configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:54
+msgid "Help for config"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:55
+msgid "Convert the content to different formats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:56
+msgid "Help for convert"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:59
+msgid "Enable less safe operations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:60
+msgid "Convert front matter to JSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:61
+msgid "Help for toJSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:62
+msgid "Convert front matter to TOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:63
+msgid "Help for toTOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:64
+msgid "Convert front matter to YAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:65
+msgid "Help for toYAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:66
+msgid "Print Hugo version and environment info"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:67
+msgid "Help for env"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:68
+msgid "Collection of several useful generators"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:69
+msgid "Help for gen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:70
+msgid "Generate shell autocompletion script for Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:71
+msgid "Autocompletion file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:72
+msgid "Help for autocomplete"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:73
+msgid "Autocompletion type"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:74
+msgid "Generate CSS stylesheet for the Chroma code highlighter"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:75
+msgid "Help for chromastyles"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:76
+msgid "Style used for highlighting lines"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:77
+msgid "Style used for line numbers"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:78
+msgid "Highlighter style"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:79
+msgid "Generate Markdown documentation for the Hugo CLI"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:80
+msgid "Doc directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:81
+msgid "Help for doc"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:82
+msgid "Generate man pages for the Hugo CLI"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:83
+msgid "Man pages directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:84
+msgid "Help for man"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:85
+msgid "Import your site from others"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:86
+msgid "Help for import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:87
+msgid "Import from Jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:88
+msgid "Allow import into non-empty target directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:89
+msgid "Help for jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:90
+msgid "List various types of content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:91
+msgid "Help for list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:93
+msgid "List all drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:94
+msgid "Help for drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:95
+msgid "List all expired posts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:96
+msgid "Help for expired"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:97
+msgid "List all posts dated in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:98
+msgid "Help for future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:99
+msgid "Create new content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:100
+msgid "Editor to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:101
+msgid "Help for new"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:102
+msgid "Content type to create"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:104
+msgid "Create a new site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:105
+msgid "Create site inside non-empty directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:106
+msgid "Config and front matter format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:107
+msgid "Help for site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:108
+msgid "Create a new theme"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:109
+msgid "Help for theme"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:110
+msgid "Start high performance web server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:111
+msgid "Append port to baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:112
+msgid "Interface to which the server will bind"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:113
+msgid "Enable full re-renders on changes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:114
+msgid "Watch without enabling live browser reload on rebuild"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:115
+msgid "Help for server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:116
+msgid "Port for live reloading"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:117
+msgid "Interval to poll memory usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:118
+msgid "Memory usage log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:119
+msgid "Navigate to changed content file on live browser reload"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:120
+msgid "Prevent HTTP caching"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:121
+msgid "Port on which the server will listen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:122
+msgid "Render to destination directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:123
+msgid "Reset the content draft status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:124
+msgid "Help for undraft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:125
+msgid "Print the version number of Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:126
+msgid "Help for version"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/i3-msg.fish:1
@@ -31530,12 +32238,6 @@ msgstr ""
 msgid "Initialize packet and byte counters of a rule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/iptables.fish:25
-#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
-msgid "Verbose output"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/iptables.fish:26
 msgid "Wait for the xtables lock"
 msgstr ""
@@ -31875,6 +32577,100 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/jest.fish:77
 msgid "Disable using watchman for file crawling"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:1
+msgid "Enable debugger"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:2
+msgid "Output usage information"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:3
+msgid "Output version number"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:4
+msgid "Create a new JHipster application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:5
+msgid "Deploy the current application to AWS"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:6
+msgid "Create pipeline scripts for popular CI tools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:7
+msgid "Create a new JHipster client-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:8
+msgid "Prepare Cloud Foundry deployment"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:9
+msgid ""
+"Create all required Docker deployment configuration for the selected "
+"applications"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:10
+msgid ""
+"Create a new JHipster entity: JPA entity, Spring server-side components and "
+"Angular client-side components"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:11
+msgid "Create a JDL file from the existing entities"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:12
+msgid "Deploy the current application to Heroku"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:13
+msgid "Create entities from the JDL file passed in argument"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:14
+msgid "Display information about your current project and system"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:15
+msgid "Deploy the current application to Kubernetes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:16
+msgid ""
+"Select languages from a list of available languages. The i18n files will be "
+"copied to the /webapp/i18n folder"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:17
+msgid "Deploy the current application to OpenShift"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:18
+msgid "Deploy the current application to Rancher"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:19
+msgid "Create a new JHipster server-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:20
+msgid "Create a new Spring service bean"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:21
+msgid "Upgrade the JHipster version and the generated application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:22
+msgid "Print command completion script"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/jobs.fish:2
@@ -48411,10 +49207,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:125
 msgid "Set default root object"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
-msgid "Debug output"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:130

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-08 16:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: shankerwangmiao <shankerwangmiao@gmail.com>\n"
 "Language: zh_CN\n"
@@ -100,12 +100,12 @@ msgstr "将任务 %d “%ls” 置于后台\n"
 msgid "%ls: There are no suitable jobs\n"
 msgstr "%ls：没有匹配的任务\n"
 
-#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82
+#: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, fuzzy, c-format
 msgid "%ls: '%ls' is not a valid job specifier\n"
 msgstr "%ls：“%ls” 不是一个任务\n"
 
-#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89
+#: src/builtin_bg.cpp:95 src/builtin_disown.cpp:89 src/builtin_wait.cpp:163
 #, fuzzy, c-format
 msgid "%ls: Could not find job '%d'\n"
 msgstr "%ls：找不到home目录 '%d'\n"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "%ls: Key not specified\n"
 msgstr "%ls：没有指定键\n"
 
-#: src/builtin.cpp:261
+#: src/builtin.cpp:262
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
@@ -224,218 +224,222 @@ msgstr ""
 "%ls: 键入 “help %ls” 以获取相关的文档\n"
 "\n"
 
-#: src/builtin.cpp:337
+#: src/builtin.cpp:338
 #, c-format
 msgid "%ls: Not inside of loop\n"
 msgstr "%ls：不在循环体内部\n"
 
-#: src/builtin.cpp:371
+#: src/builtin.cpp:372
 #, fuzzy, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr "%ls: 只在不活跃的进程上\n"
 
-#: src/builtin.cpp:409 src/builtin.cpp:459
+#: src/builtin.cpp:410 src/builtin.cpp:460
 #, fuzzy
 msgid "Test a condition"
 msgstr "设置配置选项"
 
-#: src/builtin.cpp:410
+#: src/builtin.cpp:411
 msgid "Execute command if previous command suceeded"
 msgstr "如果上一个命令成功，执行命令"
 
-#: src/builtin.cpp:411
+#: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:412
+#: src/builtin.cpp:413
 msgid "Create a block of code"
 msgstr "创建代码区块"
 
-#: src/builtin.cpp:413
+#: src/builtin.cpp:414
 msgid "Send job to background"
 msgstr "将任务置于后台"
 
-#: src/builtin.cpp:414
+#: src/builtin.cpp:415
 msgid "Handle fish key bindings"
 msgstr "处理 fish 键 绑定"
 
-#: src/builtin.cpp:415
+#: src/builtin.cpp:416
 msgid "Temporarily block delivery of events"
 msgstr "Temporarily block delivery of events"
 
-#: src/builtin.cpp:416
+#: src/builtin.cpp:417
 msgid "Stop the innermost loop"
 msgstr "停止最内层的循环"
 
-#: src/builtin.cpp:418
+#: src/builtin.cpp:419
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
 msgstr "暂时终止一个脚本的执行并运行一个交互式的 debug 提示符"
 
-#: src/builtin.cpp:419
+#: src/builtin.cpp:420
 msgid "Run a builtin command instead of a function"
 msgstr "执行内部命令而不是一个函数"
 
-#: src/builtin.cpp:420 src/builtin.cpp:458
+#: src/builtin.cpp:421 src/builtin.cpp:459
 msgid "Conditionally execute a block of commands"
 msgstr "有条件地执行一个命令区块"
 
-#: src/builtin.cpp:421
+#: src/builtin.cpp:422
 msgid "Change working directory"
 msgstr "改变工作目录（当前目录）"
 
-#: src/builtin.cpp:422
+#: src/builtin.cpp:423
 msgid "Run a program instead of a function or builtin"
 msgstr "执行一个程序，而不是一个函数或内部命令"
 
-#: src/builtin.cpp:423
+#: src/builtin.cpp:424
 msgid "Set or get the commandline"
 msgstr "设置或取得命令行"
 
-#: src/builtin.cpp:424
+#: src/builtin.cpp:425
 msgid "Edit command specific completions"
 msgstr "编辑命令相关的补全"
 
-#: src/builtin.cpp:425
+#: src/builtin.cpp:426
 msgid "Search for a specified string in a list"
 msgstr "在指定列表中搜索一个特定的字符串"
 
-#: src/builtin.cpp:427
+#: src/builtin.cpp:428
 msgid "Skip the rest of the current lap of the innermost loop"
 msgstr "跳过最内层循环的当前一轮的剩余部分"
 
-#: src/builtin.cpp:428
+#: src/builtin.cpp:429
 msgid "Count the number of arguments"
 msgstr "参数的个数的计数"
 
-#: src/builtin.cpp:429
+#: src/builtin.cpp:430
 msgid "Remove job from job list"
 msgstr ""
 
-#: src/builtin.cpp:430
+#: src/builtin.cpp:431
 #, fuzzy
 msgid "Print arguments"
 msgstr "打印单词计数"
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:432
 msgid "Evaluate block if condition is false"
 msgstr "条件为假时对区块求值"
 
-#: src/builtin.cpp:432
+#: src/builtin.cpp:433
 msgid "Emit an event"
 msgstr "触发一个事件️"
 
-#: src/builtin.cpp:433
+#: src/builtin.cpp:434
 msgid "End a block of commands"
 msgstr "结束一个命令块"
 
-#: src/builtin.cpp:434
+#: src/builtin.cpp:435
 msgid "Run command in current process"
 msgstr "在当前进程下执行命令"
 
-#: src/builtin.cpp:435
+#: src/builtin.cpp:436
 msgid "Exit the shell"
 msgstr "退出这个 shell"
 
-#: src/builtin.cpp:436
+#: src/builtin.cpp:437
 msgid "Return an unsuccessful result"
 msgstr ""
 
-#: src/builtin.cpp:437
+#: src/builtin.cpp:438
 msgid "Send job to foreground"
 msgstr "将任务带回到前台"
 
-#: src/builtin.cpp:438
+#: src/builtin.cpp:439
 msgid "Perform a set of commands multiple times"
 msgstr "多次执行一组指令"
 
-#: src/builtin.cpp:439
+#: src/builtin.cpp:440
 msgid "Define a new function"
 msgstr "定义一个新函数"
 
-#: src/builtin.cpp:440
+#: src/builtin.cpp:441
 msgid "List or remove functions"
 msgstr "列出或移除函数"
 
-#: src/builtin.cpp:441
+#: src/builtin.cpp:442
 msgid "History of commands executed by user"
 msgstr "用户执行的历史命令"
 
-#: src/builtin.cpp:442
+#: src/builtin.cpp:443
 msgid "Evaluate block if condition is true"
 msgstr "条件为真时对区块求值"
 
-#: src/builtin.cpp:443
+#: src/builtin.cpp:444
 msgid "Print currently running jobs"
 msgstr "列出当前运行的任务"
 
-#: src/builtin.cpp:444
+#: src/builtin.cpp:445
 msgid "Evaluate math expressions"
 msgstr ""
 
-#: src/builtin.cpp:445
+#: src/builtin.cpp:446
 msgid "Negate exit status of job"
 msgstr "负的任务退出代码（exit status）"
 
-#: src/builtin.cpp:446
+#: src/builtin.cpp:447
 msgid "Execute command if previous command failed"
 msgstr "如果前一条命令失败执行命令"
 
-#: src/builtin.cpp:447
+#: src/builtin.cpp:448
 #, fuzzy
 msgid "Prints formatted text"
 msgstr "显示命令类型"
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:449
 #, fuzzy
 msgid "Print the working directory"
 msgstr "显示工作目录"
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:450
 msgid "Generate random number"
 msgstr "生成随机数"
 
-#: src/builtin.cpp:450
+#: src/builtin.cpp:451
 msgid "Read a line of input into variables"
 msgstr "将输入的一行读入到变量中"
 
-#: src/builtin.cpp:451
+#: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr ""
 
-#: src/builtin.cpp:452
+#: src/builtin.cpp:453
 msgid "Stop the currently evaluated function"
 msgstr "停止当前求值的函数"
 
-#: src/builtin.cpp:453
+#: src/builtin.cpp:454
 msgid "Handle environment variables"
 msgstr "处理环境变量"
 
-#: src/builtin.cpp:454
+#: src/builtin.cpp:455
 msgid "Set the terminal color"
 msgstr "设置终端颜色"
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:456
 msgid "Evaluate contents of file"
 msgstr "对文件内容求值"
 
-#: src/builtin.cpp:456
+#: src/builtin.cpp:457
 msgid "Return status information about fish"
 msgstr "返回 fish 的状态信息"
 
-#: src/builtin.cpp:457
+#: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr ""
 
-#: src/builtin.cpp:460
+#: src/builtin.cpp:461
 msgid "Return a successful result"
 msgstr ""
 
-#: src/builtin.cpp:461
+#: src/builtin.cpp:462
 msgid "Set or get the shells resource usage limits"
 msgstr "显示或设置 shell 资源使用限制"
 
-#: src/builtin.cpp:462
+#: src/builtin.cpp:463
+msgid "Wait for background processes completed"
+msgstr ""
+
+#: src/builtin.cpp:464
 msgid "Perform a command multiple times"
 msgstr "多次执行一条命令"
 
@@ -729,8 +733,7 @@ msgstr ""
 #: src/builtin_set.cpp:66
 #, fuzzy, c-format
 msgid "%ls: Erase needs a variable name\n"
-msgstr ""
-"%ls：Erase 需要一个变量名\n"
+msgstr "%ls：Erase 需要一个变量名\n"
 
 #: src/builtin_set.cpp:67
 #, c-format
@@ -1469,60 +1472,60 @@ msgstr ""
 msgid "Your history will not be saved."
 msgstr ""
 
-#: src/proc.cpp:590
+#: src/proc.cpp:586
 #, c-format
 msgid "Job %d, "
 msgstr ""
 
-#: src/proc.cpp:591
+#: src/proc.cpp:587
 #, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 
-#: src/proc.cpp:599
+#: src/proc.cpp:595
 #, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
 
-#: src/proc.cpp:769
+#: src/proc.cpp:779
 msgid "An error occured while reading output from code block"
 msgstr ""
 
-#: src/proc.cpp:846
+#: src/proc.cpp:856
 #, fuzzy, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr "将任务 %d，“%ls” 发送到前台 pgid %d"
 
-#: src/proc.cpp:875
+#: src/proc.cpp:885
 #, fuzzy, c-format
 msgid "Could not send job %d ('%ls') to foreground"
 msgstr "将任务 %d，“%ls” 发送到前台"
 
-#: src/proc.cpp:899 src/proc.cpp:908 src/proc.cpp:922
+#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
 msgid "Could not return shell to foreground"
 msgstr ""
 
-#: src/proc.cpp:1055
+#: src/proc.cpp:1065
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
 msgstr ""
 
-#: src/proc.cpp:1065
+#: src/proc.cpp:1075
 #, fuzzy
 msgid "Process argument list"
 msgstr "打印单词计数"
 
-#: src/proc.cpp:1066
+#: src/proc.cpp:1076
 #, fuzzy
 msgid "Process name"
 msgstr "进程"
 
-#: src/proc.cpp:1069
+#: src/proc.cpp:1079
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
 msgstr ""
 
-#: src/proc.cpp:1075
+#: src/proc.cpp:1085
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
 msgstr ""
@@ -1886,7 +1889,8 @@ msgstr "%ls：应有一个参数，提供了 %d 个\n"
 msgid ""
 "%ls: Invalid combination of options,\n"
 "%ls\n"
-msgstr "%ls：非法的选项组合\n"
+msgstr ""
+"%ls：非法的选项组合\n"
 "%ls\n"
 
 #: src/builtin.h:45
@@ -2451,6 +2455,212 @@ msgstr ""
 
 #: /tmp/fish/explicit/share/completions/launchctl.fish:44
 msgid "Prints the usage for a given subcommand"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:1
+#: /tmp/fish/explicit/share/completions/mdadm.fish:2
+msgid "Use original 0.90 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:3
+#: /tmp/fish/explicit/share/completions/mdadm.fish:4
+msgid "Use last 1.x format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:5
+msgid "Use 1.0 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:6
+msgid "Use 1.1 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:7
+msgid "Use 1.2 format superblock"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:8
+msgid "Use DDF (Disk Data Format) format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:9
+msgid "Use Intel(R) Matrix Storage Manager format"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:10
+msgid "JBOD"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:11
+#: /tmp/fish/explicit/share/completions/mdadm.fish:12
+#: /tmp/fish/explicit/share/completions/mdadm.fish:13
+msgid "Stripped volume (RAID 0)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:14
+#: /tmp/fish/explicit/share/completions/mdadm.fish:15
+#: /tmp/fish/explicit/share/completions/mdadm.fish:16
+msgid "Mirrored volume (RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:17
+#: /tmp/fish/explicit/share/completions/mdadm.fish:18
+msgid "Stripped volume with parity disk (RAID 4)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:19
+#: /tmp/fish/explicit/share/completions/mdadm.fish:20
+msgid "Stripped volume with distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:21
+#: /tmp/fish/explicit/share/completions/mdadm.fish:22
+msgid "Stripped volume with double distributed parity (RAID 5)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:23
+#: /tmp/fish/explicit/share/completions/mdadm.fish:24
+msgid "Mirrored stripped volume (RAID 10)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:25
+#: /tmp/fish/explicit/share/completions/mdadm.fish:26
+msgid "Multiple access device, AKA multipath (deprecated)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:27
+msgid "Pseudo RAID layer for single device (akin faulty RAID 1)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:28
+msgid "Container"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:29
+msgid "Alias of left-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:30
+msgid "Alias of right-asymmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:31
+msgid "Alias of left-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:32
+msgid "Alias of right-symmetric"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:33
+msgid "Alias of write-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:34
+msgid "Alias of read-transient"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:35
+msgid "Alias of write-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:36
+msgid "Alias of read-persistent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:37
+msgid "Alias of read-fixable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:38
+msgid "Use standard format (default)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:39
+msgid "Use a non-partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:40
+#: /tmp/fish/explicit/share/completions/mdadm.fish:41
+#: /tmp/fish/explicit/share/completions/mdadm.fish:42
+msgid "Use a partitionable array"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:43
+msgid "Remove superblock misalignement from SPARC kernel 2.2"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:44
+msgid "Correct superblock summaries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:45
+msgid "Update array UUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:46
+msgid "Update array name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:47
+msgid "Update array nodes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:48
+msgid "Update array homehost"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:49
+msgid "Update array cluster name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:50
+msgid "Mark the array as dirty, thus forcing resync"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:51
+msgid "Reverse superblock endianness"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:52
+msgid "Refresh device size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:53
+msgid "Assume bitmap absence"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:54
+msgid "Reserve space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:55
+msgid "Free reserved space for bad block list"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:56
+msgid "Convert 0.90 metadata to 1.0"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:57
+msgid "Reset preferred minor to current one"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:58
+#, fuzzy
+msgid "Abort currently running actions"
+msgstr "列出当前运行的任务"
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:59
+msgid "Abort currently running actions, prevent their restart"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:60
+msgid "Scrub the array (i.e. check constistency)"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/mdadm.fish:61
+msgid "Check, then resync"
 msgstr ""
 
 #: /tmp/fish/explicit/share/completions/set.fish:1
@@ -3354,6 +3564,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
 #: /tmp/fish/implicit/share/completions/asp.fish:6
 #: /tmp/fish/implicit/share/completions/bc.fish:7
+#: /tmp/fish/implicit/share/completions/bd.fish:4
 #: /tmp/fish/implicit/share/completions/bg.fish:1
 #: /tmp/fish/implicit/share/completions/bind.fish:4
 #: /tmp/fish/implicit/share/completions/block.fish:1
@@ -3951,7 +4162,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bzr.fish:1
 #: /tmp/fish/implicit/share/completions/climate.fish:1
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:17
-#: /tmp/fish/implicit/share/completions/cygport.fish:23
+#: /tmp/fish/implicit/share/completions/cygport.fish:25
 #: /tmp/fish/implicit/share/completions/godoc.fish:25
 #: /tmp/fish/implicit/share/completions/gofmt.fish:8
 #: /tmp/fish/implicit/share/completions/goimports.fish:6
@@ -5326,6 +5537,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/apt-get.fish:24
 #: /tmp/fish/implicit/share/completions/configure.fish:3
 #: /tmp/fish/implicit/share/completions/gpg.fish:62
+#: /tmp/fish/implicit/share/completions/hugo.fish:5
 #: /tmp/fish/implicit/share/completions/make.fish:16
 #: /tmp/fish/implicit/share/completions/ping.fish:16
 #: /tmp/fish/implicit/share/completions/rpm.fish:3
@@ -5496,6 +5708,7 @@ msgid "Set a configuration option"
 msgstr "设置配置选项"
 
 #: /tmp/fish/implicit/share/completions/apt.fish:8
+#: /tmp/fish/implicit/share/completions/hugo.fish:1
 #: /tmp/fish/implicit/share/completions/man.fish:14
 #: /tmp/fish/implicit/share/completions/modprobe.fish:2
 #: /tmp/fish/implicit/share/completions/yum.fish:13
@@ -8494,6 +8707,18 @@ msgstr ""
 msgid "Do not print the GNU welcome"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/bd.fish:1
+msgid "Classic mode: goes back to the first directory named as the string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:2
+msgid "Seems mode: goes back to the first directory containing string"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/bd.fish:3
+msgid "Case insensitive move (implies seems mode)"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/bind.fish:1
 msgid "Show unavailable key bindings/erase all bindings"
 msgstr ""
@@ -9919,7 +10144,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/caddy.fish:24
 #: /tmp/fish/implicit/share/completions/canto.fish:2
-#: /tmp/fish/implicit/share/completions/cygport.fish:24
+#: /tmp/fish/implicit/share/completions/cygport.fish:26
 #: /tmp/fish/implicit/share/completions/grub-install.fish:33
 #: /tmp/fish/implicit/share/completions/lua.fish:4
 #: /tmp/fish/implicit/share/completions/magento.fish:23
@@ -13015,27 +13240,35 @@ msgid "Show project homepage URL"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:17
-msgid "Create packages"
+msgid "Create packages, marked as test"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:18
-msgid "Create source patches"
+msgid "Create packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:19
-msgid "Upload finished packages"
+msgid "Create source patches"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:20
-msgid "Send announcement email"
+msgid "Upload finished packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cygport.fish:21
+msgid "Upload packages without marking !ready"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:22
+msgid "Send announcement email"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/cygport.fish:23
 #, fuzzy
 msgid "Delete working directory"
 msgstr "改变工作目录（当前目录）"
 
-#: /tmp/fish/implicit/share/completions/cygport.fish:22
+#: /tmp/fish/implicit/share/completions/cygport.fish:24
 msgid "Same as prep build inst pkg"
 msgstr ""
 
@@ -31223,6 +31456,7 @@ msgid "Name of the output file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/highlight.fish:5
+#: /tmp/fish/implicit/share/completions/hugo.fish:57
 #: /tmp/fish/implicit/share/completions/tex.fish:10
 msgid "Output directory"
 msgstr ""
@@ -31265,6 +31499,505 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/htop.fish:7
 msgid "Sort column"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:2
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
+msgid "Debug output"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:3
+msgid "Enable logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:4
+msgid "Log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:6
+#: /tmp/fish/implicit/share/completions/iptables.fish:25
+#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
+#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
+msgid "Verbose output"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:7
+msgid "Verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:8
+msgid "Hostname and path to the root"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:9
+msgid "Include content marked as draft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:10
+msgid "Include expired content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:11
+msgid "Include content with publishdate in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:12
+#, fuzzy
+msgid "Cache directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:13
+msgid "Canonicalize all relative URLs using baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:14
+msgid "Remove files from destination not found in static directories"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:15
+#, fuzzy
+msgid "Content directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:16
+#, fuzzy
+msgid "Destination directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:17
+msgid "Do not build 404 page"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:18
+msgid "Disable different kinds of pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:19
+msgid "Do not build RSS files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:20
+msgid "Do not build sitemap files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:21
+msgid "Add Git revision, date and author info to the pages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:22
+msgid "Copy all files when static is changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:23
+msgid "Help for hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:24
+msgid "Print missing translations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:25
+#, fuzzy
+msgid "Ignore the cache directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:26
+#, fuzzy
+msgid "Layout directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:27
+msgid "Do not sync permission mode of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:28
+msgid "Do not sync modification time of files"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:29
+msgid "Pluralize titles in lists using inflect"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:30
+msgid "Preserve taxonomy names as written"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:31
+#: /tmp/fish/implicit/share/completions/hugo.fish:45
+msgid "Render to memory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:32
+#: /tmp/fish/implicit/share/completions/hugo.fish:58
+#: /tmp/fish/implicit/share/completions/hugo.fish:92
+#: /tmp/fish/implicit/share/completions/hugo.fish:103
+#, fuzzy
+msgid "Source directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:33
+#: /tmp/fish/implicit/share/completions/hugo.fish:46
+msgid "Display memory and timing of different steps of the program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:34
+#: /tmp/fish/implicit/share/completions/hugo.fish:47
+#, fuzzy
+msgid "Display metrics about template executions"
+msgstr "返回 fish 的状态信息"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:35
+#: /tmp/fish/implicit/share/completions/hugo.fish:48
+msgid "Calculate some improvement hints when combined with --templateMetrics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:36
+msgid "Theme to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:37
+#, fuzzy
+msgid "Themes directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:38
+msgid "Use /filename.html instead of /filename/"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:39
+msgid "Watch filesystem for changes and recreate as needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:40
+msgid "Benchmark Hugo by building the site a number of times"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:41
+msgid "Number of times to build the site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:42
+msgid "CPU profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:43
+msgid "Help for benchmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:44
+msgid "Memory profile file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:49
+msgid "Perform some verification checks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:50
+msgid "Help for check"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:51
+msgid "Check system ulimit settings"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:52
+msgid "Help for ulimit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:53
+#, fuzzy
+msgid "Print the site configuration"
+msgstr "列出当前运行的任务"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:54
+#, fuzzy
+msgid "Help for config"
+msgstr "设置配置选项"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:55
+msgid "Convert the content to different formats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:56
+msgid "Help for convert"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:59
+msgid "Enable less safe operations"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:60
+msgid "Convert front matter to JSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:61
+msgid "Help for toJSON"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:62
+msgid "Convert front matter to TOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:63
+msgid "Help for toTOML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:64
+msgid "Convert front matter to YAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:65
+msgid "Help for toYAML"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:66
+#, fuzzy
+msgid "Print Hugo version and environment info"
+msgstr "显示命令类型"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:67
+msgid "Help for env"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:68
+msgid "Collection of several useful generators"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:69
+msgid "Help for gen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:70
+msgid "Generate shell autocompletion script for Hugo"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:71
+msgid "Autocompletion file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:72
+msgid "Help for autocomplete"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:73
+msgid "Autocompletion type"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:74
+msgid "Generate CSS stylesheet for the Chroma code highlighter"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:75
+msgid "Help for chromastyles"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:76
+msgid "Style used for highlighting lines"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:77
+msgid "Style used for line numbers"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:78
+msgid "Highlighter style"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:79
+msgid "Generate Markdown documentation for the Hugo CLI"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:80
+#, fuzzy
+msgid "Doc directory"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:81
+msgid "Help for doc"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:82
+#, fuzzy
+msgid "Generate man pages for the Hugo CLI"
+msgstr "生成随机数"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:83
+#, fuzzy
+msgid "Man pages directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:84
+msgid "Help for man"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:85
+msgid "Import your site from others"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:86
+msgid "Help for import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:87
+msgid "Import from Jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:88
+#, fuzzy
+msgid "Allow import into non-empty target directory"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:89
+msgid "Help for jekyll"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:90
+msgid "List various types of content"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:91
+msgid "Help for list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:93
+#, fuzzy
+msgid "List all drafts"
+msgstr "结束一个命令块"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:94
+msgid "Help for drafts"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:95
+#, fuzzy
+msgid "List all expired posts"
+msgstr "结束一个命令块"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:96
+msgid "Help for expired"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:97
+msgid "List all posts dated in the future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:98
+msgid "Help for future"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:99
+#, fuzzy
+msgid "Create new content"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:100
+msgid "Editor to use"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:101
+msgid "Help for new"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:102
+msgid "Content type to create"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:104
+#, fuzzy
+msgid "Create a new site"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:105
+#, fuzzy
+msgid "Create site inside non-empty directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:106
+msgid "Config and front matter format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:107
+msgid "Help for site"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:108
+#, fuzzy
+msgid "Create a new theme"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:109
+msgid "Help for theme"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:110
+msgid "Start high performance web server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:111
+msgid "Append port to baseurl"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:112
+msgid "Interface to which the server will bind"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:113
+msgid "Enable full re-renders on changes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:114
+msgid "Watch without enabling live browser reload on rebuild"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:115
+msgid "Help for server"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:116
+msgid "Port for live reloading"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:117
+msgid "Interval to poll memory usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:118
+msgid "Memory usage log file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:119
+msgid "Navigate to changed content file on live browser reload"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:120
+msgid "Prevent HTTP caching"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:121
+msgid "Port on which the server will listen"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:122
+#, fuzzy
+msgid "Render to destination directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:123
+msgid "Reset the content draft status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:124
+msgid "Help for undraft"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:125
+#, fuzzy
+msgid "Print the version number of Hugo"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/hugo.fish:126
+#, fuzzy
+msgid "Help for version"
+msgstr "设置配置选项"
 
 #: /tmp/fish/implicit/share/completions/i3-msg.fish:1
 msgid "Only send ipc message and suppress output"
@@ -31789,12 +32522,6 @@ msgstr ""
 msgid "Initialize packet and byte counters of a rule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/iptables.fish:25
-#: /tmp/fish/implicit/share/completions/mkinitcpio.fish:18
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:126
-msgid "Verbose output"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/iptables.fish:26
 msgid "Wait for the xtables lock"
 msgstr ""
@@ -32142,6 +32869,105 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/jest.fish:77
 msgid "Disable using watchman for file crawling"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:1
+msgid "Enable debugger"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:2
+#, fuzzy
+msgid "Output usage information"
+msgstr "返回 fish 的状态信息"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:3
+#, fuzzy
+msgid "Output version number"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:4
+msgid "Create a new JHipster application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:5
+msgid "Deploy the current application to AWS"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:6
+msgid "Create pipeline scripts for popular CI tools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:7
+msgid "Create a new JHipster client-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:8
+msgid "Prepare Cloud Foundry deployment"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:9
+msgid ""
+"Create all required Docker deployment configuration for the selected "
+"applications"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:10
+msgid ""
+"Create a new JHipster entity: JPA entity, Spring server-side components and "
+"Angular client-side components"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:11
+msgid "Create a JDL file from the existing entities"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:12
+msgid "Deploy the current application to Heroku"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:13
+msgid "Create entities from the JDL file passed in argument"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:14
+#, fuzzy
+msgid "Display information about your current project and system"
+msgstr "返回 fish 的状态信息"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:15
+msgid "Deploy the current application to Kubernetes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:16
+msgid ""
+"Select languages from a list of available languages. The i18n files will be "
+"copied to the /webapp/i18n folder"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:17
+msgid "Deploy the current application to OpenShift"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:18
+msgid "Deploy the current application to Rancher"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:19
+msgid "Create a new JHipster server-side application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:20
+#, fuzzy
+msgid "Create a new Spring service bean"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:21
+msgid "Upgrade the JHipster version and the generated application"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/jhipster.fish:22
+#, fuzzy
+msgid "Print command completion script"
+msgstr "编辑命令相关的补全"
 
 #: /tmp/fish/implicit/share/completions/jobs.fish:2
 msgid "Show the process id of each process in the job"
@@ -48788,10 +49614,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:125
 msgid "Set default root object"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:127
-msgid "Debug output"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:130

--- a/share/completions/mdadm.fish
+++ b/share/completions/mdadm.fish
@@ -10,37 +10,37 @@
 #     as their absence has already been checked, because this absence caused evaluation of __fish_not_contain_opt
 
 function __fish_mdadm_metadata_options
-	echo -e "0\tUse original 0.90 format superblock"
-	echo -e "0.90\tUse original 0.90 format superblock"
-	echo -e "1\tUse last 1.x format superblock"
-	echo -e "default\tUse last 1.x format superblock"
-	echo -e "1.0\tUse 1.0 format superblock"
-	echo -e "1.1\tUse 1.1 format superblock"
-	echo -e "1.2\tUse 1.2 format superblock"
-	echo -e "ddf\tUse DDF (Disk Data Format) format"
-	echo -e "imsm\tUse Intel(R) Matrix Storage Manager format"
+	echo -e "0\t"(_ "Use original 0.90 format superblock")
+	echo -e "0.90\t"(_ "Use original 0.90 format superblock")
+	echo -e "1\t"(_ "Use last 1.x format superblock")
+	echo -e "default\t"(_ "Use last 1.x format superblock")
+	echo -e "1.0\t"(_ "Use 1.0 format superblock")
+	echo -e "1.1\t"(_ "Use 1.1 format superblock")
+	echo -e "1.2\t"(_ "Use 1.2 format superblock")
+	echo -e "ddf\t"(_ "Use DDF (Disk Data Format) format")
+	echo -e "imsm\t"(_ "Use Intel(R) Matrix Storage Manager format")
 end
 
 function __fish_mdadm_level_options
-	echo -e "linear\tJBOD"
-	echo -e "raid0\tStripped volume (RAID 0)"
-	echo -e "0\tStripped volume (RAID 0)"
-	echo -e "stripe\tStripped volume (RAID 0)"
-	echo -e "raid1\tMirrored volume (RAID 1)"
-	echo -e "1\tMirrored volume (RAID 1)"
-	echo -e "mirror\tMirrored volume (RAID 1)"
-	echo -e "raid4\tStripped volume with parity disk (RAID 4)"
-	echo -e "4\tStripped volume with parity disk (RAID 4)"
-	echo -e "raid5\tStripped volume with distributed parity (RAID 5)"
-	echo -e "5\tStripped volume with distributed parity (RAID 5)"
-	echo -e "raid6\tStripped volume with double distributed parity (RAID 5)"
-	echo -e "6\tStripped volume with double distributed parity (RAID 5)"
-	echo -e "raid10\tMirrored stripped volume (RAID 10)"
-	echo -e "10\tMirrored stripped volume (RAID 10)"
-	echo -e "multipath\tMultiple access device, AKA multipath (deprecated)"
-	echo -e "mp\tMultiple access device, AKA multipath (deprecated)"
-	echo -e "faulty\tPseudo RAID layer for single device (akin faulty RAID 1)"
-	echo -e "container\tContainer" # To be clarified
+	echo -e "linear\t"(_ "JBOD")
+	echo -e "raid0\t"(_ "Stripped volume (RAID 0)")
+	echo -e "0\t"(_ "Stripped volume (RAID 0)")
+	echo -e "stripe\t"(_ "Stripped volume (RAID 0)")
+	echo -e "raid1\t"(_ "Mirrored volume (RAID 1)")
+	echo -e "1\t"(_ "Mirrored volume (RAID 1)")
+	echo -e "mirror\t"(_ "Mirrored volume (RAID 1)")
+	echo -e "raid4\t"(_ "Stripped volume with parity disk (RAID 4)")
+	echo -e "4\t"(_ "Stripped volume with parity disk (RAID 4)")
+	echo -e "raid5\t"(_ "Stripped volume with distributed parity (RAID 5)")
+	echo -e "5\t"(_ "Stripped volume with distributed parity (RAID 5)")
+	echo -e "raid6\t"(_ "Stripped volume with double distributed parity (RAID 5)")
+	echo -e "6\t"(_ "Stripped volume with double distributed parity (RAID 5)")
+	echo -e "raid10\t"(_ "Mirrored stripped volume (RAID 10)")
+	echo -e "10\t"(_ "Mirrored stripped volume (RAID 10)")
+	echo -e "multipath\t"(_ "Multiple access device, AKA multipath (deprecated)")
+	echo -e "mp\t"(_ "Multiple access device, AKA multipath (deprecated)")
+	echo -e "faulty\t"(_ "Pseudo RAID layer for single device (akin faulty RAID 1)")
+	echo -e "container\t"(_ "Container") # To be clarified
 end
 
 function __fish_mdadm_layout_options # To be clarified
@@ -48,10 +48,10 @@ function __fish_mdadm_layout_options # To be clarified
 	echo -e "left-symmetric"
 	echo -e "right-asymmetric"
 	echo -e "right-symmetric"
-	echo -e "la\tAlias of left-asymmetric"
-	echo -e "ra\tAlias of right-asymmetric"
-	echo -e "ls\tAlias of left-symmetric"
-	echo -e "rs\tAlias of right-symmetric"
+	echo -e "la\t"(_ "Alias of left-asymmetric")
+	echo -e "ra\t"(_ "Alias of right-asymmetric")
+	echo -e "ls\t"(_ "Alias of left-symmetric")
+	echo -e "rs\t"(_ "Alias of right-symmetric")
 	echo -e "parity-first"
 	echo -e "parity-last"
 	echo -e "ddf-zero-restart"
@@ -63,16 +63,16 @@ function __fish_mdadm_layout_options # To be clarified
 	echo -e "right-asymmetric-6"
 	echo -e "parity-first-6"
 	echo -e "write-transient"
-	echo -e "wt\tAlias of write-transient"
+	echo -e "wt\t"(_ "Alias of write-transient")
 	echo -e "read-transient"
-	echo -e "rt\tAlias of read-transient"
+	echo -e "rt\t"(_ "Alias of read-transient")
 	echo -e "write-persistent"
-	echo -e "wp\tAlias of write-persistent"
+	echo -e "wp\t"(_ "Alias of write-persistent")
 	echo -e "read-persistent"
-	echo -e "rp\tAlias of read-persistent"
+	echo -e "rp\t"(_ "Alias of read-persistent")
 	echo -e "write-all"
 	echo -e "read-fixable"
-	echo -e "rf\tAlias of read-fixable"
+	echo -e "rf\t"(_ "Alias of read-fixable")
 	echo -e "clear"
 	echo -e "flush"
 	echo -e "none"
@@ -84,36 +84,36 @@ function __fish_mdadm_layout_options # To be clarified
 end
 
 function __fish_mdadm_level_options
-	echo -e "yes\tUse standard format (default)"
-	echo -e "md\tUse a non-partitionable array"
-	echo -e "mdp\tUse a partitionable array"
-	echo -e "part\tUse a partitionable array"
-	echo -e "p\tUse a partitionable array"
+	echo -e "yes\t"(_ "Use standard format (default)")
+	echo -e "md\t"(_ "Use a non-partitionable array")
+	echo -e "mdp\t"(_ "Use a partitionable array")
+	echo -e "part\t"(_ "Use a partitionable array")
+	echo -e "p\t"(_ "Use a partitionable array")
 end
 
 function __fish_mdadm_update_options
-	echo -e "sparc2.2\tRemove superblock misalignement from SPARC kernel 2.2"
-	echo -e "summaries\tCorrect superblock summaries"
-	echo -e "uuid\tUpdate array UUID"
-	echo -e "name\tUpdate array name"
-	echo -e "nodes\tUpdate array nodes"
-	echo -e "homehost\tUpdate array homehost"
-	echo -e "home-cluster\tUpdate array cluster name"
-	echo -e "resync\tMark the array as dirty, thus forcing resync"
-	echo -e "byteorder\tReverse superblock endianness"
-	echo -e "devicesize\tRefresh device size"
-	echo -e "no-bitmap\tAssume bitmap absence"
-	echo -e "bbl\tReserve space for bad block list"
-	echo -e "no-bbl\tFree reserved space for bad block list"
-	echo -e "metadata\tConvert 0.90 metadata to 1.0"
-	echo -e "super-minor\tReset preferred minor to current one"
+	echo -e "sparc2.2\t"(_ "Remove superblock misalignement from SPARC kernel 2.2")
+	echo -e "summaries\t"(_ "Correct superblock summaries")
+	echo -e "uuid\t"(_ "Update array UUID")
+	echo -e "name\t"(_ "Update array name")
+	echo -e "nodes\t"(_ "Update array nodes")
+	echo -e "homehost\t"(_ "Update array homehost")
+	echo -e "home-cluster\t"(_ "Update array cluster name")
+	echo -e "resync\t"(_ "Mark the array as dirty, thus forcing resync")
+	echo -e "byteorder\t"(_ "Reverse superblock endianness")
+	echo -e "devicesize\t"(_ "Refresh device size")
+	echo -e "no-bitmap\t"(_ "Assume bitmap absence")
+	echo -e "bbl\t"(_ "Reserve space for bad block list")
+	echo -e "no-bbl\t"(_ "Free reserved space for bad block list")
+	echo -e "metadata\t"(_ "Convert 0.90 metadata to 1.0")
+	echo -e "super-minor\t"(_ "Reset preferred minor to current one")
 end
 
 function __fish_mdadm_action_options
-	echo -e "idle\tAbort currently running actions"
-	echo -e "frozen\tAbort currently running actions, prevent their restart"
-	echo -e "check\tScrub the array (i.e. check constistency)"
-	echo -e "repair\tCheck, then resync"
+	echo -e "idle\t"(_ "Abort currently running actions")
+	echo -e "frozen\t"(_ "Abort currently running actions, prevent their restart")
+	echo -e "check\t"(_ "Scrub the array (i.e. check constistency)")
+	echo -e "repair\t"(_ "Check, then resync")
 end
 
 # In the next 7 lines, the tested option is maintained into the search list to prevent suggesting it if it has already been used, as they cannot be used twice


### PR DESCRIPTION
## Description

1. improved `mdadm` completions for increasing their localization;
2. translated the new strings in French;
3. updated the `.po` files with changes from other's commits (mainly `hugo` and `jhipster` completions)

Note: to improve localization, it could be very useful that
1. contributors adding, modifying or deleting displayed strings, update the `.po` files themselves, to keep the `msgid`s in sync with the code itself;
2. regarding completions, the tab-separated value should have their description localized, i.e. use `echo -e "value\t"(_ "Description")` instead of `echo -e "value\tDescription"`. If useful, I can provide vim search-and-replace commands for that.

Maybe adding this localization check in the TODOs checklist template below could make it.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
