### PR TITLE
Add modified completion for git diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This section is for changes merged to the `major` branch that are not also merge
   - `bd` (#4472)
   - `jhipster` (#4472)
 - Improved completions for
-  - `git` (#4395, #4396)
+  - `git` (#4395, #4396, #4592)
 
 --
 

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -446,12 +446,14 @@ complete -c git -n '__fish_git_needs_command' -a diff -d 'Show changes between c
 complete -c git -n '__fish_git_using_command diff' -a '(__fish_git_ranges)' -d 'Branch'
 complete -c git -n '__fish_git_using_command diff' -l cached -d 'Show diff of changes in the index'
 complete -c git -n '__fish_git_using_command diff' -l no-index -d 'Compare two paths on the filesystem'
+complete -f -c git -n '__fish_git_using_command diff' -a '(__fish_git_modified_files)' -d 'File'
 # TODO options
 
 ### difftool
 complete -c git -n '__fish_git_needs_command' -a difftool -d 'Open diffs in a visual tool'
 complete -c git -n '__fish_git_using_command difftool' -a '(__fish_git_ranges)' -d 'Branch'
 complete -c git -n '__fish_git_using_command difftool' -l cached -d 'Visually show diff of changes in the index'
+complete -f -c git -n '__fish_git_using_command difftool' -a '(__fish_git_modified_files)' -d 'File'
 # TODO options
 
 


### PR DESCRIPTION
## Description

I add the modified file completion for `git diff` and `git difftool`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
