### PR TITLE
Fix the build on FreeBSD ARM and ARM64

### DIFF
--- a/src/wgetopt.h
+++ b/src/wgetopt.h
@@ -177,7 +177,7 @@ struct woption {
     int *flag;
     /// If \c flag is non-null, this is the value that flag will be set to. Otherwise, this is the
     /// return-value of the function call.
-    int val;
+    wchar_t val;
 };
 
 // Names for the values of the `has_arg' field of `struct option'.


### PR DESCRIPTION
Downstream bug:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=224254

Fixes #4589

## Description

Unusually, `wchar_t` is unsigned on FreeBSD/arm and FreeBSD/arm64.  That causes errors like
```
rc/builtin_argparse.cpp:447:40: error: non-constant-expression cannot be narrowed from type 'wchar_t' to 'int' in initializer list [-Wc++11-narrowing]
                                       opt_spec->short_flag};
                                       ^~~~~~~~~~~~~~~~~~~~
src/builtin_argparse.cpp:447:40: note: insert an explicit cast to silence this issue
                                       opt_spec->short_flag};
                                       ^~~~~~~~~~~~~~~~~~~~
                                       static_cast<int>(   )
1 error generated.
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
