### PR TITLE
Fix git checkout completion

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -19,11 +19,11 @@ function __fish_git_recent_commits
 end
 
 function __fish_git_local_branches
-    command git branch | string trim -c ' *'
+    command git branch --no-color | string trim -c ' *'
 end
 
 function __fish_git_remote_branches
-    command git branch --remote | string trim -c ' *'
+    command git branch --no-color --remote | string trim -c ' *'
 end
 
 function __fish_git_branches


### PR DESCRIPTION
## Description

When git is configured to output color (via color.ui=always for example)
the output of a `git checkout` completion contains ANSI color codes, because `git branch` is colorized.

This patch fixes the call to always add `--no-color` so it doesn't depend on the git configuration.

## TODOs:
- [ N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
