### PR TITLE
Added completions/translations for zfs and zpool

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-13 10:22+0100\n"
 "PO-Revision-Date: 2013-11-01 18:36+0100\n"
 "Last-Translator: Fabian Homborg\n"
 "Language-Team: deutsch <de@li.org>\n"
@@ -1890,9 +1890,11 @@ msgstr "Programmlink"
 #: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
 #: /tmp/fish/implicit/share/completions/fossil.fish:90
 #: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:206
-#: /tmp/fish/implicit/share/completions/git.fish:266
-#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:269
 msgid "File"
 msgstr "Datei"
 
@@ -2649,6 +2651,603 @@ msgstr "Pseudo-tty-Zuordnung erzwingen"
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/zfs.fish:1
+#, fuzzy
+msgid "ZFS filesystem"
+msgstr "Alle Dateisysteme anzeigen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:2
+#, fuzzy
+msgid "ZFS filesystem snapshot"
+msgstr "Alle Dateisysteme anzeigen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:3
+#, fuzzy
+msgid "ZFS block storage device"
+msgstr "Datei ist ein Block-Gerät"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:4
+msgid "ZFS snapshot bookmark"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:5
+msgid "Any ZFS dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:6
+#, fuzzy
+msgid "Dataset-specific value"
+msgstr "Angegebene Konfigurationsdatei benutzen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:7
+#, fuzzy
+msgid "Default ZFS value"
+msgstr "Datum festlegen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:8
+msgid "Value inherited from parent dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:9
+msgid "Value received by 'zfs receive'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:10
+#, fuzzy
+msgid "Value valid for the current mount"
+msgstr "Version anzeigen und beenden"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:11
+#, fuzzy
+msgid "Read-only value"
+msgstr "Nur lesen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:12
+#, fuzzy
+msgid "Dataset full name"
+msgstr "Dienstname"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:13
+#: /tmp/fish/explicit/share/completions/zpool.fish:2
+#: /tmp/fish/implicit/share/completions/minikube.fish:25
+#: /tmp/fish/implicit/share/completions/minikube.fish:26
+#: /tmp/fish/implicit/share/completions/minikube.fish:27
+#: /tmp/fish/implicit/share/completions/minikube.fish:28
+#, fuzzy
+msgid "Property"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:3
+#, fuzzy
+msgid "Property value"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:15
+#: /tmp/fish/explicit/share/completions/zpool.fish:4
+msgid "Property value origin"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:16
+#, fuzzy
+msgid "Identity type"
+msgstr "Datei identifizieren"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:17
+#, fuzzy
+msgid "Identity name"
+msgstr "Datei identifizieren"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:18
+#, fuzzy
+msgid "Space usage"
+msgstr "Quellpaket anzeigen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:19
+#, fuzzy
+msgid "Space quota"
+msgstr "Markierungszeichen festlegen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:20
+msgid "POSIX user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:21
+msgid "Samba user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:22
+#: /tmp/fish/explicit/share/completions/zfs.fish:25
+msgid "Both types"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:23
+msgid "POSIX group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:24
+#, fuzzy
+msgid "Samba group"
+msgstr "Auswahl per Gruppe"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:26
+#, fuzzy
+msgid "Also needs the permission to be allowed"
+msgstr "Auswahl, wie Passwortsätze verstümmelt werden"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:27
+msgid ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:28
+#: /tmp/fish/explicit/share/completions/zfs.fish:29
+#: /tmp/fish/explicit/share/completions/zfs.fish:33
+#: /tmp/fish/explicit/share/completions/zfs.fish:35
+msgid "Also needs the 'mount' permission"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:30
+msgid ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:31
+msgid "Also needs the 'create' and 'mount' permissions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:32
+msgid "Also needs the 'create' and 'mount' permissions in the new parent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:34
+msgid "For SMB and NFS shares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:36
+msgid "Allows changing any user property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:26
+#, fuzzy
+msgid "Volume block size"
+msgstr "Blockgröße festlegen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:38
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Inheritance of ACL entries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:39
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:2
+#, fuzzy
+msgid "Update access time on read"
+msgstr "Zugriffszeit behalten"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:40
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:3
+msgid "Is the dataset mountable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:41
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:4
+#, fuzzy
+msgid "Data checksum"
+msgstr "Quelldateien nicht löschen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:42
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:5
+#, fuzzy
+msgid "Compression algorithm"
+msgstr "Benutze angegebenen Kompressionsalgorithmus"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:43
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:6
+#, fuzzy
+msgid "Number of copies of data"
+msgstr "Alle Zeilen nummerieren"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:44
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:7
+#, fuzzy
+msgid "Deduplication"
+msgstr "Nicht doppelte Zeilen entfernen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:45
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:2
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:8
+msgid "Are contained device nodes openable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:46
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:3
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:9
+#, fuzzy
+msgid "Can contained executables be executed"
+msgstr "Befehle auf Standardfehlerausgabe ausgeben"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:47
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:10
+#, fuzzy
+msgid "Max number of filesystems and volumes"
+msgstr "Maximalanzahl geschachtelter Blöcke erreicht."
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:48
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:11
+#, fuzzy
+msgid "Mountpoint"
+msgstr "Einhängepunkt"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:49
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:12
+msgid "Which data to cache in ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:50
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:13
+msgid "Max size of dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:51
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:14
+#, fuzzy
+msgid "Max number of snapshots"
+msgstr "Anzahl gleichzeitiger Jobs"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:52
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:4
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:15
+#, fuzzy
+msgid "Read-only"
+msgstr "Nur lesen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:53
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:16
+#, fuzzy
+msgid "Suggest block size"
+msgstr "Blockgröße festlegen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:54
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:17
+msgid "How redundant are the metadata"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:55
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:18
+msgid "Max space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:56
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:19
+msgid "Min space guaranteed to dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:57
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:20
+msgid "Min space guaranteed to dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:58
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:21
+msgid "Which data to cache in L2ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:59
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:5
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:22
+msgid "Respect set-UID bit"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:60
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:23
+msgid "Share in NFS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:61
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:24
+msgid "Hint for handling of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:62
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:25
+#, fuzzy
+msgid "Hide .zfs directory"
+msgstr "Datei ist ein Verzeichnis"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:63
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:26
+msgid "Handle of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:64
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:27
+#, fuzzy
+msgid "Volume logical size"
+msgstr "Blockgröße festlegen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:65
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:38
+msgid "Managed from a non-global zone"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:66
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:31
+msgid "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:67
+#: /tmp/fish/explicit/share/completions/zfs.fish:74
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:6
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:32
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:40
+msgid "Mount with Non Blocking mandatory locks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:68
+#: /tmp/fish/explicit/share/completions/zfs.fish:77
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:33
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:43
+msgid "Share in Samba"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:69
+#: /tmp/fish/explicit/share/completions/zfs.fish:76
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:34
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:42
+msgid "Share as an iSCSI target"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:70
+#: /tmp/fish/explicit/share/completions/zfs.fish:79
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:35
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:45
+#, fuzzy
+msgid "On-disk version of filesystem"
+msgstr "Nur neuere Dateien speichern"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:71
+#: /tmp/fish/explicit/share/completions/zfs.fish:80
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:36
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:46
+msgid "Scan regular files for viruses on opening and closing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:72
+#: /tmp/fish/explicit/share/completions/zfs.fish:81
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:7
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:47
+#, fuzzy
+msgid "Extended attributes"
+msgstr "Saloppe Einhäng-Optionen tolerieren"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:73
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:39
+msgid "Use no ACL or POSIX ACL"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:75
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:9
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:41
+msgid "Sometimes update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:78
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:44
+#, fuzzy
+msgid "Hide volume snapshots"
+msgstr "Ein oder mehrere Paket(e) entfernen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:82
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:30
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:48
+msgid "How is ACL modified by chmod"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:83
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:49
+msgid "How to expose volumes to OS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:84
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+#, fuzzy
+msgid "Unicode normalization"
+msgstr "Alle Informationen ausgeben"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:85
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:2
+msgid "Reject non-UTF-8-compliant filenames"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:86
+#: /tmp/fish/explicit/share/completions/zfs.fish:87
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:9
+#, fuzzy
+msgid "Case sensitivity"
+msgstr "Groß-/Klein-Schreibung nicht unterscheiden"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:88
+#, fuzzy
+msgid "Space properties"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:89
+#: /tmp/fish/explicit/share/completions/zfs.fish:90
+#, fuzzy
+msgid "Dataset name"
+msgstr "Dienstname"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:1
+#, fuzzy
+msgid "Pool full name"
+msgstr "Dateiname ausgeben"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:5
+#, fuzzy
+msgid "Mirror of at least two devices"
+msgstr "Datei ist ein Block-Gerät"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:6
+#: /tmp/fish/explicit/share/completions/zpool.fish:7
+msgid "ZFS RAID-5 variant, single parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:8
+msgid "ZFS RAID-5 variant, double parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:9
+msgid "ZFS RAID-5 variant, triple parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:10
+msgid "Pseudo vdev for pool hot spares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:11
+#, fuzzy
+msgid "SLOG device"
+msgstr "Vertraute Schlüssel auflisten"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:12
+#, fuzzy
+msgid "L2ARC device"
+msgstr "Vertraute Schlüssel auflisten"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:13
+msgid "Physically allocated space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:2
+#, fuzzy
+msgid "Available space"
+msgstr "Pakete erneut installieren"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:16
+msgid "System boot partition size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:17
+msgid "Usage percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:18
+#, fuzzy
+msgid "Deduplication ratio"
+msgstr "Lese-/Schreib-Modus"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:19
+msgid "Amount of uninitialized space within the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:20
+msgid "Fragmentation percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:21
+msgid "Free pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:22
+msgid "Remaining pool space to be freed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:23
+msgid "Pool GUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:24
+#, fuzzy
+msgid "Current pool health"
+msgstr "Quellpaket anzeigen"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:25
+msgid "Total pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:26
+msgid "Used pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:27
+msgid "Pool sector size exponent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:28
+#: /tmp/fish/explicit/share/completions/zpool.fish:29
+#, fuzzy
+msgid "Alternate root directory"
+msgstr "Verzeichnis"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:30
+#: /tmp/fish/explicit/share/completions/zpool.fish:31
+#, fuzzy
+msgid "Import pool in read-only mode"
+msgstr "Nur lesen"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:32
+#: /tmp/fish/explicit/share/completions/zpool.fish:33
+#, fuzzy
+msgid "Automatic pool expansion on LUN growing"
+msgstr "Automatische Zeilenende-Verarbeitung"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:34
+#: /tmp/fish/explicit/share/completions/zpool.fish:35
+msgid "Automatic use of replacement device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:36
+msgid "Default bootable dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:37
+#, fuzzy
+msgid "Pool configuration cache"
+msgstr "Konfigurationsdatei ausgeben"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:38
+msgid "Comment about the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:39
+msgid "Threshold for writting a ditto copy of deduplicated blocks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:40
+msgid "Allow rights delegation on the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:41
+msgid "Behavior in case of catastrophic pool failure"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:42
+msgid "Display snapshots even if 'zfs list' does not use '-t'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:43
+#, fuzzy
+msgid "On-disk version of pool"
+msgstr "Größe der Dateien ausgeben"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:44
+msgid "%sEnable the %s feature\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:45
+#, fuzzy
+msgid "All properties"
+msgstr "Zeichensatzeigenschaften anzeigen"
+
 #: /tmp/fish/explicit/share/functions/abbr.fish:1
 #, fuzzy
 msgid "%s: Could not figure out what to do!\\n"
@@ -2786,6 +3385,146 @@ msgstr "Nicht vorhandene Dateien als leer behandeln"
 msgid "%s\\tArchived file\\n"
 msgstr ""
 
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:3
+#, fuzzy
+msgid "Achieved compression ratio"
+msgstr "Kompressionsraten ausgeben"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:4
+#, fuzzy
+msgid "Dataset creation time"
+msgstr "Vergleiche Monatsnamen"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:5
+msgid "Snapshot clones"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:6
+msgid "Marked for deferred destruction"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:7
+msgid "Total lower-level filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:9
+#, fuzzy
+msgid "Logical total space"
+msgstr "Log in Datei schreiben"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:11
+msgid "Logical used space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:12
+#, fuzzy
+msgid "Is currently mounted?"
+msgstr "Version anzeigen und beenden"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:13
+#, fuzzy
+msgid "Source snapshot"
+msgstr "Ja erzwingen"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:14
+msgid "Token for interrupted reception resumption"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:16
+#, fuzzy
+msgid "Total space"
+msgstr "Name des Patch"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:17
+#, fuzzy
+msgid "Achieved compression ratio of referenced space"
+msgstr "Zeige den für eine Nachricht benutzten Sitzungsschlüssel an"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:18
+msgid "Total lower-level snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:19
+#: /tmp/fish/implicit/share/completions/zfs.fish:71
+#: /tmp/fish/implicit/share/completions/zfs.fish:81
+msgid "Dataset type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:20
+msgid "Space used by dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:21
+msgid "Space used by children datasets"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:22
+msgid "Space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:23
+msgid "Space used by refreservation"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:24
+msgid "Space used by dataset snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:25
+msgid "Holds count"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:27
+msgid "Referenced data written since previous snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:28
+msgid "%sDataset space use by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:29
+msgid "%sDataset space use by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:30
+msgid "%sReferenced data written since snapshot %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:28
+msgid "%sMax usage by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:29
+msgid "%sMax usage by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:3
+#, fuzzy
+msgid "Allow overlay mount"
+msgstr "Nur lesen"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:4
+#, fuzzy
+msgid "SELinux context for the child filesystem"
+msgstr "Nur die Datenbank, nicht das Dateisystem aktualisieren"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:5
+#, fuzzy
+msgid "SELinux context for the filesystem being mounted"
+msgstr "Nur die Datenbank, nicht das Dateisystem aktualisieren"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:6
+#, fuzzy
+msgid "SELinux context for unlabeled files"
+msgstr "Bei unlesbaren Dateien nicht abbrechen"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:7
+msgid "SELinux context for the root inode of the filesystem"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Willkommen zu fish, der freundlichen interaktiven Shell"
@@ -2811,6 +3550,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/aptitude.fish:3
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:3
 #: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:63
 #: /tmp/fish/implicit/share/completions/wajig.fish:3
@@ -5408,7 +6149,10 @@ msgstr "Debug-Informationen ausgeben"
 #: /tmp/fish/implicit/share/completions/valgrind.fish:6
 #: /tmp/fish/implicit/share/completions/vi.fish:8
 #: /tmp/fish/implicit/share/completions/wget.fish:9
+#: /tmp/fish/implicit/share/completions/zfs.fish:42
+#: /tmp/fish/implicit/share/completions/zfs.fish:87
 #: /tmp/fish/implicit/share/completions/zip.fish:13
+#: /tmp/fish/implicit/share/completions/zpool.fish:140
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
 msgid "Verbose mode"
 msgstr "Ausführlicher Modus"
@@ -10470,7 +11214,7 @@ msgid "Show usage message and options"
 msgstr "Hilfe anzeigen und beenden"
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:380
+#: /tmp/fish/implicit/share/completions/git.fish:382
 #, fuzzy
 msgid "Show help message"
 msgstr "Hilfe anzeigen und beenden"
@@ -15509,7 +16253,7 @@ msgid "Ignore all white space"
 msgstr "white space (Worttrenner) ignorieren"
 
 #: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:325
+#: /tmp/fish/implicit/share/completions/git.fish:327
 msgid "Ignore changes whose lines are all blank"
 msgstr "Änderungen ignorieren, deren Zeilen alle leer sind"
 
@@ -15519,7 +16263,7 @@ msgid "Ignore changes whose lines match the REGEX"
 msgstr "Änderungen ignorieren, deren Zeilen alle leer sind"
 
 #: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:321
+#: /tmp/fish/implicit/share/completions/git.fish:323
 msgid "Treat all files as text"
 msgstr "Alle Dateien als Text behandeln"
 
@@ -17533,6 +18277,91 @@ msgstr ""
 msgid "X display to use"
 msgstr "Mail an Benutzer senden"
 
+#: /tmp/fish/implicit/share/completions/exercism.fish:1
+#, fuzzy
+msgid "Test if exercism has yet to be given the subcommand"
+msgstr "Test, ob an apt noch ein Unterbefehl gegeben werden muss"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:3
+#, fuzzy
+msgid "turn on verbose logging"
+msgstr "Angemeldete Benutzer auflisten"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:4
+#: /tmp/fish/implicit/share/completions/exercism.fish:19
+#: /tmp/fish/implicit/share/completions/ninja.fish:8
+#: /tmp/fish/implicit/share/completions/quilt.fish:1
+#, fuzzy
+msgid "show help"
+msgstr "Zeige versteckte Dateien"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:5
+#, fuzzy
+msgid "print the version"
+msgstr "Kernel-Version ausgeben"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:6
+#, fuzzy
+msgid "Writes config values to a JSON file."
+msgstr "Top-Server in Datei schreiben"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:7
+#, fuzzy
+msgid "Outputs useful debug information."
+msgstr "Magische Versionsinformation ignorieren"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:8
+#, fuzzy
+msgid "Downloads a solution given the ID of the latest iteration."
+msgstr "Einen aufgezeichneten Patch mit einer besseren Version ersetzen"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:9
+msgid "Fetches the next unsubmitted problem in each track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:10
+#, fuzzy
+msgid "Lists the available problems for a language track, given its ID."
+msgstr "Namen der verfügbaren Signale auflisten"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:11
+msgid ""
+"Opens exercism.io to your most recent iteration of a problem given the track "
+"ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:12
+msgid ""
+"Downloads the most recent iteration for each of your solutions on exercism."
+"io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:13
+msgid "Skips a problem given a track ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:14
+msgid "Fetches information about your progress with a given language track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:15
+msgid "Submits a new iteration to a problem on exercism.io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:16
+#, fuzzy
+msgid "Lists the available language tracks."
+msgstr "Namen der verfügbaren Signale auflisten"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:17
+msgid "REMOVED"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:18
+#, fuzzy
+msgid "Upgrades the CLI to the latest released version."
+msgstr "Abhängigkeiten an makefile anhängen"
+
 #: /tmp/fish/implicit/share/completions/exit.fish:2
 msgid "Quit with normal exit status"
 msgstr ""
@@ -18347,6 +19176,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:66
+#: /tmp/fish/implicit/share/completions/zfs.fish:76
 #, fuzzy
 msgid "Maximum recursion depth"
 msgstr "Maximale Größe des Programms im Arbeitsspeicher"
@@ -19745,9 +20576,9 @@ msgstr "Konfigurationsdatei benutzen"
 #: /tmp/fish/implicit/share/completions/fossil.fish:280
 #: /tmp/fish/implicit/share/completions/git.fish:64
 #: /tmp/fish/implicit/share/completions/git.fish:86
-#: /tmp/fish/implicit/share/completions/git.fish:244
-#: /tmp/fish/implicit/share/completions/git.fish:293
-#: /tmp/fish/implicit/share/completions/git.fish:294
+#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:296
 #, fuzzy
 msgid "Tag"
 msgstr "Ziel"
@@ -20196,7 +21027,7 @@ msgid "Limit number of tags"
 msgstr "Nur Anzahl von Treffern ausgeben"
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:281
-#: /tmp/fish/implicit/share/completions/git.fish:291
+#: /tmp/fish/implicit/share/completions/git.fish:293
 #, fuzzy
 msgid "List tags"
 msgstr "Kennzeichnung bearbeiten"
@@ -20307,6 +21138,7 @@ msgstr "Sämtliche Versions-Informationen ignorieren"
 #: /tmp/fish/implicit/share/completions/gsettings.fish:15
 #: /tmp/fish/implicit/share/completions/ncdu.fish:1
 #: /tmp/fish/implicit/share/completions/obnam.fish:12
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:4
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:5
 #: /tmp/fish/implicit/share/completions/pkginfo.fish:7
 #: /tmp/fish/implicit/share/completions/pkgmk.fish:17
@@ -26576,24 +27408,24 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:96
 #: /tmp/fish/implicit/share/completions/git.fish:108
 #: /tmp/fish/implicit/share/completions/git.fish:130
-#: /tmp/fish/implicit/share/completions/git.fish:134
-#: /tmp/fish/implicit/share/completions/git.fish:140
-#: /tmp/fish/implicit/share/completions/git.fish:183
-#: /tmp/fish/implicit/share/completions/git.fish:219
-#: /tmp/fish/implicit/share/completions/git.fish:222
-#: /tmp/fish/implicit/share/completions/git.fish:242
-#: /tmp/fish/implicit/share/completions/git.fish:265
-#: /tmp/fish/implicit/share/completions/git.fish:285
-#: /tmp/fish/implicit/share/completions/git.fish:307
+#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:221
+#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:244
+#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:309
 msgid "Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:23
-#: /tmp/fish/implicit/share/completions/git.fish:198
-#: /tmp/fish/implicit/share/completions/git.fish:210
-#: /tmp/fish/implicit/share/completions/git.fish:237
-#: /tmp/fish/implicit/share/completions/git.fish:250
-#: /tmp/fish/implicit/share/completions/git.fish:274
+#: /tmp/fish/implicit/share/completions/git.fish:200
+#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:276
 #: /tmp/fish/implicit/share/completions/mdadm.fish:12
 #: /tmp/fish/implicit/share/completions/update-eix-remote.fish:1
 #, fuzzy
@@ -26603,10 +27435,10 @@ msgstr "Erzwungene Beendigung"
 #: /tmp/fish/implicit/share/completions/git.fish:24
 #: /tmp/fish/implicit/share/completions/git.fish:41
 #: /tmp/fish/implicit/share/completions/git.fish:70
-#: /tmp/fish/implicit/share/completions/git.fish:199
-#: /tmp/fish/implicit/share/completions/git.fish:211
-#: /tmp/fish/implicit/share/completions/git.fish:238
-#: /tmp/fish/implicit/share/completions/git.fish:251
+#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:253
 #: /tmp/fish/implicit/share/completions/prt-get.fish:53
 #: /tmp/fish/implicit/share/completions/prt-get.fish:111
 #: /tmp/fish/implicit/share/completions/xz.fish:32
@@ -26615,12 +27447,12 @@ msgid "Be verbose"
 msgstr "Nicht überschreiben"
 
 #: /tmp/fish/implicit/share/completions/git.fish:25
-#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:215
 msgid "Append ref names and object names"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:26
-#: /tmp/fish/implicit/share/completions/git.fish:214
+#: /tmp/fish/implicit/share/completions/git.fish:216
 msgid "Force update of local branches"
 msgstr ""
 
@@ -26776,7 +27608,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:63
 #: /tmp/fish/implicit/share/completions/git.fish:85
 #: /tmp/fish/implicit/share/completions/git.fish:109
-#: /tmp/fish/implicit/share/completions/git.fish:184
+#: /tmp/fish/implicit/share/completions/git.fish:186
 msgid "Remote branch"
 msgstr ""
 
@@ -26808,7 +27640,7 @@ msgid "Allow adding otherwise ignored files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:257
+#: /tmp/fish/implicit/share/completions/git.fish:259
 #, fuzzy
 msgid "Interactive mode"
 msgstr "Im nicht interaktiven Modus ausführen"
@@ -26864,7 +27696,7 @@ msgid "Remote Branch"
 msgstr "Eine Platte umbenennen"
 
 #: /tmp/fish/implicit/share/completions/git.fish:84
-#: /tmp/fish/implicit/share/completions/git.fish:243
+#: /tmp/fish/implicit/share/completions/git.fish:245
 msgid "Head"
 msgstr ""
 
@@ -27048,968 +27880,971 @@ msgstr "Arbeitsverzeichnis wechseln"
 msgid "Compare two paths on the filesystem"
 msgstr "Archiv und Dateisystem vergleichen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:134
 msgid "Open diffs in a visual tool"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:136
 msgid "Visually show diff of changes in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:136
+#: /tmp/fish/implicit/share/completions/git.fish:138
 #, fuzzy
 msgid "Print lines matching a pattern"
 msgstr "Inhalte eines Paketes auflisten, das dem Muster entspricht"
 
-#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:139
 msgid "Create an empty git repository or reinitialize an existing one"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:138
+#: /tmp/fish/implicit/share/completions/git.fish:140
 msgid "Show commit shortlog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:139
+#: /tmp/fish/implicit/share/completions/git.fish:141
 msgid "Show commit logs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:141
+#: /tmp/fish/implicit/share/completions/git.fish:143
 msgid "Continue listing file history beyond renames"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:144
 #, fuzzy
 msgid "Don't print ref names"
 msgstr "Kopfzeile nicht ausgeben"
 
-#: /tmp/fish/implicit/share/completions/git.fish:143
+#: /tmp/fish/implicit/share/completions/git.fish:145
 #, fuzzy
 msgid "Print out ref names"
 msgstr "Kernel-Name ausgeben"
 
-#: /tmp/fish/implicit/share/completions/git.fish:144
+#: /tmp/fish/implicit/share/completions/git.fish:146
 msgid "Print ref name by which each commit was reached"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:145
+#: /tmp/fish/implicit/share/completions/git.fish:147
 msgid "Limit the number of commits before starting to show the commit output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:146
+#: /tmp/fish/implicit/share/completions/git.fish:148
 #, fuzzy
 msgid "Skip given number of commits"
 msgstr "Inode-Nummer der Dateien ausgeben"
 
-#: /tmp/fish/implicit/share/completions/git.fish:147
-#: /tmp/fish/implicit/share/completions/git.fish:148
+#: /tmp/fish/implicit/share/completions/git.fish:149
+#: /tmp/fish/implicit/share/completions/git.fish:150
 msgid "Show commits more recent than specified date"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:149
-#: /tmp/fish/implicit/share/completions/git.fish:150
+#: /tmp/fish/implicit/share/completions/git.fish:151
+#: /tmp/fish/implicit/share/completions/git.fish:152
 #, fuzzy
 msgid "Show commits older than specified date"
 msgstr "Dateisysteme des angegebenen Typs anzeigen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:151
+#: /tmp/fish/implicit/share/completions/git.fish:153
 msgid "Limit commits from given author"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:152
+#: /tmp/fish/implicit/share/completions/git.fish:154
 msgid "Limit commits from given committer"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:153
+#: /tmp/fish/implicit/share/completions/git.fish:155
 msgid "Limit commits to ones with reflog entries matching given pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:154
+#: /tmp/fish/implicit/share/completions/git.fish:156
 #, fuzzy
 msgid "Limit commits with message that match given pattern"
 msgstr "Inhalte eines Paketes auflisten, das dem Muster entspricht"
 
-#: /tmp/fish/implicit/share/completions/git.fish:155
+#: /tmp/fish/implicit/share/completions/git.fish:157
 msgid "Limit commits to ones that match all given --grep"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:156
-msgid "Limit commits to ones with message that don't match --grep"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:157
-#, fuzzy
-msgid "Case insensitive match"
-msgstr "Groß-/Klein-Schreibung nicht unterscheiden"
-
 #: /tmp/fish/implicit/share/completions/git.fish:158
-msgid "Patterns are basic regular expressions (default)"
+msgid "Limit commits to ones with message that don't match --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:159
 #, fuzzy
+msgid "Case insensitive match"
+msgstr "Groß-/Klein-Schreibung nicht unterscheiden"
+
+#: /tmp/fish/implicit/share/completions/git.fish:160
+msgid "Patterns are basic regular expressions (default)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:161
+#, fuzzy
 msgid "Patterns are extended regular expressions"
 msgstr "Muster ist ein erweiterter regulärer Ausdruck"
 
-#: /tmp/fish/implicit/share/completions/git.fish:160
+#: /tmp/fish/implicit/share/completions/git.fish:162
 #, fuzzy
 msgid "Patterns are fixed strings"
 msgstr "Muster ist eine feststehende Zeichenkette"
 
-#: /tmp/fish/implicit/share/completions/git.fish:161
+#: /tmp/fish/implicit/share/completions/git.fish:163
 msgid "Patterns are Perl-compatible regular expressions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:162
+#: /tmp/fish/implicit/share/completions/git.fish:164
 msgid "Stop when given path disappears from tree"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:163
+#: /tmp/fish/implicit/share/completions/git.fish:165
 #, fuzzy
 msgid "Print only merge commits"
 msgstr "Anzahl Zeilenendzeichen ausgeben"
 
-#: /tmp/fish/implicit/share/completions/git.fish:164
+#: /tmp/fish/implicit/share/completions/git.fish:166
 msgid "Don't print commits with more than one parent"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:165
+#: /tmp/fish/implicit/share/completions/git.fish:167
 msgid "Show only commit with at least the given number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:166
+#: /tmp/fish/implicit/share/completions/git.fish:168
 msgid "Show only commit with at most the given number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:167
+#: /tmp/fish/implicit/share/completions/git.fish:169
 msgid "Show only commit without a mimimum number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:168
+#: /tmp/fish/implicit/share/completions/git.fish:170
 msgid "Show only commit without a maximum number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:169
+#: /tmp/fish/implicit/share/completions/git.fish:171
 msgid "Follow only the first parent commit upon seeing a merge commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:170
+#: /tmp/fish/implicit/share/completions/git.fish:172
 msgid "Reverse meaning of ^ prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:171
+#: /tmp/fish/implicit/share/completions/git.fish:173
 msgid ""
 "Pretend as if all refs in refs/ are listed on the command line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:172
+#: /tmp/fish/implicit/share/completions/git.fish:174
 msgid ""
 "Pretend as if all refs are in refs/heads are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:173
+#: /tmp/fish/implicit/share/completions/git.fish:175
 msgid ""
 "Pretend as if all refs are in ref/tags are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:174
+#: /tmp/fish/implicit/share/completions/git.fish:176
 msgid ""
 "Pretend as if all refs in refs/remotes  are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:175
+#: /tmp/fish/implicit/share/completions/git.fish:177
 msgid ""
 "Pretend as if all refs matching shell glob are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:176
+#: /tmp/fish/implicit/share/completions/git.fish:178
 #, fuzzy
 msgid "Do not include refs matching given glob pattern"
 msgstr "Module einfügen, die den angegebenen Mustern entsprechen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:177
+#: /tmp/fish/implicit/share/completions/git.fish:179
 msgid ""
 "Pretend as if all objcets mentioned by reflogs are listed on the command "
 "line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:178
+#: /tmp/fish/implicit/share/completions/git.fish:180
 #, fuzzy
 msgid "Ignore invalid object names"
 msgstr "Umgebungsvariablen ignorieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:179
+#: /tmp/fish/implicit/share/completions/git.fish:181
 #, fuzzy
 msgid "Read commits from stdin"
 msgstr "Namen über Standardeingabe lesen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:180
+#: /tmp/fish/implicit/share/completions/git.fish:182
 msgid "Mark equivalent commits with = and inequivalent with +"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:181
+#: /tmp/fish/implicit/share/completions/git.fish:183
 msgid "Omit equivalent commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:182
+#: /tmp/fish/implicit/share/completions/git.fish:184
 msgid "Join two or more development histories together"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:187
 msgid "Autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:186
+#: /tmp/fish/implicit/share/completions/git.fish:188
 #, fuzzy
 msgid "Don't autocommit the merge"
 msgstr "Keinen Kommentar verwenden"
 
-#: /tmp/fish/implicit/share/completions/git.fish:187
+#: /tmp/fish/implicit/share/completions/git.fish:189
 msgid "Edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:188
+#: /tmp/fish/implicit/share/completions/git.fish:190
 msgid "Don't edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:189
+#: /tmp/fish/implicit/share/completions/git.fish:191
 msgid "Don't generate a merge commit if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:190
+#: /tmp/fish/implicit/share/completions/git.fish:192
 msgid "Generate a merge commit even if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:191
+#: /tmp/fish/implicit/share/completions/git.fish:193
 msgid "Refuse to merge unless fast-forward possible"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:192
+#: /tmp/fish/implicit/share/completions/git.fish:194
 msgid "Populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:193
+#: /tmp/fish/implicit/share/completions/git.fish:195
 msgid "Don't populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:194
+#: /tmp/fish/implicit/share/completions/git.fish:196
 #, fuzzy
 msgid "Show diffstat of the merge"
 msgstr "Änderungsdatum anzeigen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:195
+#: /tmp/fish/implicit/share/completions/git.fish:197
 msgid "Don't show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:196
+#: /tmp/fish/implicit/share/completions/git.fish:198
 msgid "Squash changes from other branch as a single commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:197
+#: /tmp/fish/implicit/share/completions/git.fish:199
 #, fuzzy
 msgid "Don't squash changes"
 msgstr "Änderungen nicht zusammenfassen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:200
-#: /tmp/fish/implicit/share/completions/git.fish:217
-#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:219
+#: /tmp/fish/implicit/share/completions/git.fish:241
 msgid "Force progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:203
 msgid "Force no progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:204
 #, fuzzy
 msgid "Set the commit message"
 msgstr "Geben Sie einen Titel für rss an"
 
-#: /tmp/fish/implicit/share/completions/git.fish:203
+#: /tmp/fish/implicit/share/completions/git.fish:205
 #, fuzzy
 msgid "Abort the current conflict resolution process"
 msgstr "Dienstkonfiguration neu laden"
 
-#: /tmp/fish/implicit/share/completions/git.fish:204
+#: /tmp/fish/implicit/share/completions/git.fish:206
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:205
+#: /tmp/fish/implicit/share/completions/git.fish:207
 #, fuzzy
 msgid "Use specific merge resolution program"
 msgstr "Angegebenen Message-Digest-Algorithmus verwenden"
 
-#: /tmp/fish/implicit/share/completions/git.fish:207
+#: /tmp/fish/implicit/share/completions/git.fish:209
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:210
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:209
+#: /tmp/fish/implicit/share/completions/git.fish:211
 msgid "Fetch from and merge with another repository or a local branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:214
 #, fuzzy
 msgid "Fetch all remotes"
 msgstr "Depot deaktivieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:215
+#: /tmp/fish/implicit/share/completions/git.fish:217
 #, fuzzy
 msgid "Keep downloaded pack"
 msgstr "Herunterladen von Paketen deaktivieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:216
+#: /tmp/fish/implicit/share/completions/git.fish:218
 #, fuzzy
 msgid "Disable automatic tag following"
 msgstr "Automatische Pufferzuordnung deaktivieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:218
-#: /tmp/fish/implicit/share/completions/git.fish:221
-#: /tmp/fish/implicit/share/completions/git.fish:241
+#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:243
 #, fuzzy
 msgid "Remote alias"
 msgstr "Pakete entfernen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:222
 msgid "Update remote refs along with associated objects"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:225
 msgid "Force-push branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:226
 msgid "Force-push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:225
+#: /tmp/fish/implicit/share/completions/git.fish:227
 msgid "Push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:226
+#: /tmp/fish/implicit/share/completions/git.fish:228
 msgid "Push all refs under refs/heads/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:227
+#: /tmp/fish/implicit/share/completions/git.fish:229
 msgid "Remove remote branches that don't have a local counterpart"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:228
+#: /tmp/fish/implicit/share/completions/git.fish:230
 msgid "Push all refs under refs/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:229
+#: /tmp/fish/implicit/share/completions/git.fish:231
 #, fuzzy
 msgid "Delete all listed refs from the remote repository"
 msgstr "Einen Eintrag aus dem Paketdepot entfernen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:230
+#: /tmp/fish/implicit/share/completions/git.fish:232
 msgid "Push all refs under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:231
+#: /tmp/fish/implicit/share/completions/git.fish:233
 msgid "Push all usual refs plus the ones under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:232
+#: /tmp/fish/implicit/share/completions/git.fish:234
 msgid "Do everything except actually send the updates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:233
+#: /tmp/fish/implicit/share/completions/git.fish:235
 #, fuzzy
 msgid "Produce machine-readable output"
 msgstr "Audio-Ausgabe"
 
-#: /tmp/fish/implicit/share/completions/git.fish:234
+#: /tmp/fish/implicit/share/completions/git.fish:236
 msgid "Force update of remote refs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:235
+#: /tmp/fish/implicit/share/completions/git.fish:237
 msgid ""
 "Force update of remote refs, stopping if other's changes would be overwritten"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:236
+#: /tmp/fish/implicit/share/completions/git.fish:238
 msgid "Add upstream (tracking) reference"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:242
 msgid "Forward-port local commits to the updated upstream head"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:245
+#: /tmp/fish/implicit/share/completions/git.fish:247
 #, fuzzy
 msgid "Restart the rebasing process"
 msgstr "Automatische Zeilenende-Verarbeitung"
 
-#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:248
 #, fuzzy
 msgid "Abort the rebase operation"
 msgstr "Simulation durchführen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:247
+#: /tmp/fish/implicit/share/completions/git.fish:249
 msgid "Keep the commits that don't cahnge anything"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:248
+#: /tmp/fish/implicit/share/completions/git.fish:250
 msgid "Restart the rebasing process by skipping the current patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:249
+#: /tmp/fish/implicit/share/completions/git.fish:251
 msgid "Use merging strategies to rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:254
 #, fuzzy
 msgid "Show diffstat of the rebase"
 msgstr "Status der Abhängigkeiten anzeigen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:253
+#: /tmp/fish/implicit/share/completions/git.fish:255
 msgid "Don't show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:254
+#: /tmp/fish/implicit/share/completions/git.fish:256
 msgid "Allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:255
+#: /tmp/fish/implicit/share/completions/git.fish:257
 msgid "Don't allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:256
+#: /tmp/fish/implicit/share/completions/git.fish:258
 #, fuzzy
 msgid "Force the rebase"
 msgstr "Ja erzwingen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:258
+#: /tmp/fish/implicit/share/completions/git.fish:260
 msgid "Try to recreate merges"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:259
+#: /tmp/fish/implicit/share/completions/git.fish:261
 #, fuzzy
 msgid "Rebase all reachable commits"
 msgstr "Nach Fertigstellung Logdatei löschen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:260
+#: /tmp/fish/implicit/share/completions/git.fish:262
 msgid "Automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:261
+#: /tmp/fish/implicit/share/completions/git.fish:263
 msgid "No automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:262
+#: /tmp/fish/implicit/share/completions/git.fish:264
 #, fuzzy
 msgid "No fast-forward"
 msgstr "Datum in Zukunft festlegen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:263
+#: /tmp/fish/implicit/share/completions/git.fish:265
 #, fuzzy
 msgid "Reset current HEAD to the specified state"
 msgstr "Fenster auf der angegebenen Anzeige erstellen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:264
+#: /tmp/fish/implicit/share/completions/git.fish:266
 #, fuzzy
 msgid "Reset files in working directory"
 msgstr "Arbeitsverzeichnis wechseln"
 
-#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:270
 msgid "Reflog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: /tmp/fish/implicit/share/completions/git.fish:271
 msgid "Revert an existing commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:270
+#: /tmp/fish/implicit/share/completions/git.fish:272
 #, fuzzy
 msgid "Remove files from the working tree and from the index"
 msgstr "Dateien nach Archivierung entfernen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:271
+#: /tmp/fish/implicit/share/completions/git.fish:273
 #, fuzzy
 msgid "Keep local copies"
 msgstr "Lokalen Zwischenspeicher und Pakete bereinigen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:272
+#: /tmp/fish/implicit/share/completions/git.fish:274
 msgid "Exit with a zero status even if no files matched"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:273
+#: /tmp/fish/implicit/share/completions/git.fish:275
 msgid "Allow recursive removal"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:275
+#: /tmp/fish/implicit/share/completions/git.fish:277
 msgid "Override the up-to-date check"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:276
+#: /tmp/fish/implicit/share/completions/git.fish:278
 #: /tmp/fish/implicit/share/completions/prt-get.fish:45
 #: /tmp/fish/implicit/share/completions/prt-get.fish:103
+#: /tmp/fish/implicit/share/completions/zfs.fish:40
+#: /tmp/fish/implicit/share/completions/zfs.fish:124
+#: /tmp/fish/implicit/share/completions/zfs.fish:132
 msgid "Dry run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:277
+#: /tmp/fish/implicit/share/completions/git.fish:279
 #, fuzzy
 msgid "Show the working tree status"
 msgstr "Versteckte Funktionen anzeigen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:278
+#: /tmp/fish/implicit/share/completions/git.fish:280
 msgid "Give the output in the short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:279
+#: /tmp/fish/implicit/share/completions/git.fish:281
 msgid "Show the branch and tracking info even in short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:280
+#: /tmp/fish/implicit/share/completions/git.fish:282
 msgid "Give the output in a stable, easy-to-parse format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:281
+#: /tmp/fish/implicit/share/completions/git.fish:283
 msgid "Terminate entries with null character"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:282
+#: /tmp/fish/implicit/share/completions/git.fish:284
 msgid "The untracked files handling mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:283
+#: /tmp/fish/implicit/share/completions/git.fish:285
 #, fuzzy
 msgid "Ignore changes to submodules"
 msgstr "Änderungen aufgrund von Tabulatorausweitung ignorieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:284
+#: /tmp/fish/implicit/share/completions/git.fish:286
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:286
+#: /tmp/fish/implicit/share/completions/git.fish:288
 msgid "Make an unsigned, annotated tag object"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:289
 #, fuzzy
 msgid "Make a GPG-signed tag"
 msgstr "Signatur erstellen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:288
+#: /tmp/fish/implicit/share/completions/git.fish:290
 #, fuzzy
 msgid "Remove a tag"
 msgstr "Schlüssel entfernen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:289
+#: /tmp/fish/implicit/share/completions/git.fish:291
 msgid "Verify signature of a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:290
+#: /tmp/fish/implicit/share/completions/git.fish:292
 msgid "Force overwriting exising tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:292
+#: /tmp/fish/implicit/share/completions/git.fish:294
 msgid "List tags that contain a commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:297
 #, fuzzy
 msgid "Stash away changes"
 msgstr "Lokale Änderungen patchen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:296
+#: /tmp/fish/implicit/share/completions/git.fish:298
 #, fuzzy
 msgid "List stashes"
 msgstr "Vertraute Schlüssel auflisten"
 
-#: /tmp/fish/implicit/share/completions/git.fish:297
+#: /tmp/fish/implicit/share/completions/git.fish:299
 msgid "Show the changes recorded in the stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:298
+#: /tmp/fish/implicit/share/completions/git.fish:300
 msgid "Apply and remove a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:299
+#: /tmp/fish/implicit/share/completions/git.fish:301
 msgid "Apply a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:300
+#: /tmp/fish/implicit/share/completions/git.fish:302
 #, fuzzy
 msgid "Remove all stashed states"
 msgstr "Pakete entfernen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:301
+#: /tmp/fish/implicit/share/completions/git.fish:303
 #, fuzzy
 msgid "Remove a single stashed state from the stash list"
 msgstr "Angegebenen Eintrag aus der --group-Liste entfernen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:302
+#: /tmp/fish/implicit/share/completions/git.fish:304
 #, fuzzy
 msgid "Create a stash"
 msgstr "Archiv erstellen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:303
+#: /tmp/fish/implicit/share/completions/git.fish:305
 msgid "Save a new stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:304
+#: /tmp/fish/implicit/share/completions/git.fish:306
 #, fuzzy
 msgid "Create a new branch from a stash"
 msgstr "Komprimierte Patche erstellen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:305
+#: /tmp/fish/implicit/share/completions/git.fish:307
 #, fuzzy
 msgid "Set and read git configuration variables"
 msgstr "Eine Konfigurationsdatei angeben"
 
-#: /tmp/fish/implicit/share/completions/git.fish:306
+#: /tmp/fish/implicit/share/completions/git.fish:308
 #, fuzzy
 msgid "Generate patch series to send upstream"
 msgstr "Paket aus Quelle generieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:308
+#: /tmp/fish/implicit/share/completions/git.fish:310
 msgid "Generate plain patches without diffstat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:309
+#: /tmp/fish/implicit/share/completions/git.fish:311
 #, fuzzy
 msgid "Suppress diff output"
 msgstr "Informationelle Ausgabe unterdrücken"
 
-#: /tmp/fish/implicit/share/completions/git.fish:310
+#: /tmp/fish/implicit/share/completions/git.fish:312
 msgid "Spend more time to create smaller diffs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:311
+#: /tmp/fish/implicit/share/completions/git.fish:313
 msgid "Generate diff with the 'patience' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:312
+#: /tmp/fish/implicit/share/completions/git.fish:314
 msgid "Generate diff with the 'histogram' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:313
+#: /tmp/fish/implicit/share/completions/git.fish:315
 msgid "Print all commits to stdout in mbox format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:314
-msgid "Show number of added/deleted lines in decimal notation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:315
-#, fuzzy
-msgid "Output only last line of the stat"
-msgstr "Nur die ersten von gleichen Zeilen ausgeben"
-
 #: /tmp/fish/implicit/share/completions/git.fish:316
-msgid "Output a condensed summary of extended header information"
+msgid "Show number of added/deleted lines in decimal notation"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:317
 #, fuzzy
-msgid "Disable rename detection"
-msgstr "Nicht auf die Veränderungszeiten der Dateien vertrauen"
+msgid "Output only last line of the stat"
+msgstr "Nur die ersten von gleichen Zeilen ausgeben"
 
 #: /tmp/fish/implicit/share/completions/git.fish:318
-msgid "Show full blob object names"
+msgid "Output a condensed summary of extended header information"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:319
+#, fuzzy
+msgid "Disable rename detection"
+msgstr "Nicht auf die Veränderungszeiten der Dateien vertrauen"
+
+#: /tmp/fish/implicit/share/completions/git.fish:320
+msgid "Show full blob object names"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:321
 msgid "Output a binary diff for use with git apply"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:320
+#: /tmp/fish/implicit/share/completions/git.fish:322
 msgid "Also inspect unmodified files as source for a copy"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:322
+#: /tmp/fish/implicit/share/completions/git.fish:324
 #, fuzzy
 msgid "Ignore changes in whitespace at EOL"
 msgstr "Änderung in der Anzahl von Worttrennern ignorieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: /tmp/fish/implicit/share/completions/git.fish:325
 #, fuzzy
 msgid "Ignore changes in amount of whitespace"
 msgstr "Änderung in der Anzahl von Worttrennern ignorieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:324
+#: /tmp/fish/implicit/share/completions/git.fish:326
 #, fuzzy
 msgid "Ignore whitespace when comparing lines"
 msgstr "Groß-/Kleinschreibung beim Dateinamenvergleich ignorieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:326
+#: /tmp/fish/implicit/share/completions/git.fish:328
 #, fuzzy
 msgid "Show whole surrounding functions of changes"
 msgstr "Versteckte Funktionen anzeigen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: /tmp/fish/implicit/share/completions/git.fish:329
 msgid "Allow an external diff helper to be executed"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:328
+#: /tmp/fish/implicit/share/completions/git.fish:330
 msgid "Disallow external diff helpers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:329
+#: /tmp/fish/implicit/share/completions/git.fish:331
 msgid "Disallow external text conversion filters for binary files (Default)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:330
+#: /tmp/fish/implicit/share/completions/git.fish:332
 msgid ""
 "Allow external text conversion filters for binary files (Resulting diff is "
 "unappliable)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:331
+#: /tmp/fish/implicit/share/completions/git.fish:333
 msgid "Do not show source or destination prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:332
+#: /tmp/fish/implicit/share/completions/git.fish:334
 msgid "Name output in [Patch n/m] format, even with a single patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:333
+#: /tmp/fish/implicit/share/completions/git.fish:335
 msgid "Name output in [Patch] format, even with multiple patches"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:334
+#: /tmp/fish/implicit/share/completions/git.fish:336
 msgid "Initialize, update or inspect submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:335
+#: /tmp/fish/implicit/share/completions/git.fish:337
 #, fuzzy
 msgid "Add a submodule"
 msgstr "Einem Modul eine symbolische Markierung hinzufügen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:336
+#: /tmp/fish/implicit/share/completions/git.fish:338
 msgid "Show submodule status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:337
-#: /tmp/fish/implicit/share/completions/git.fish:343
+#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:345
 msgid "Initialize all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:338
+#: /tmp/fish/implicit/share/completions/git.fish:340
 #, fuzzy
 msgid "Update all submodules"
 msgstr "Quellen aktualisieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:341
 #, fuzzy
 msgid "Show commit summary"
 msgstr "Zusammenfassung ausgeben"
 
-#: /tmp/fish/implicit/share/completions/git.fish:340
+#: /tmp/fish/implicit/share/completions/git.fish:342
 #, fuzzy
 msgid "Run command on each submodule"
 msgstr "Befehle aus dem Cache starten"
 
-#: /tmp/fish/implicit/share/completions/git.fish:341
+#: /tmp/fish/implicit/share/completions/git.fish:343
 msgid "Sync submodules' URL with .gitmodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:342
+#: /tmp/fish/implicit/share/completions/git.fish:344
 #, fuzzy
 msgid "Only print error messages"
 msgstr "Nur Anzahl von Treffern ausgeben"
 
-#: /tmp/fish/implicit/share/completions/git.fish:344
+#: /tmp/fish/implicit/share/completions/git.fish:346
 msgid "Checkout the superproject's commit on a detached HEAD in the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:345
+#: /tmp/fish/implicit/share/completions/git.fish:347
 msgid ""
 "Merge the superproject's commit into the current branch of the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:346
+#: /tmp/fish/implicit/share/completions/git.fish:348
 msgid "Rebase current branch onto the superproject's commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:347
+#: /tmp/fish/implicit/share/completions/git.fish:349
 msgid "Don't fetch new objects from the remote"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:348
+#: /tmp/fish/implicit/share/completions/git.fish:350
 msgid ""
 "Instead of using superproject's SHA-1, use the state of the submodule's "
 "remote-tracking branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:349
+#: /tmp/fish/implicit/share/completions/git.fish:351
 msgid ""
 "Throw away local changes when switching to a different commit and always run "
 "checkout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:350
+#: /tmp/fish/implicit/share/completions/git.fish:352
 msgid "Also add ignored submodule path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:351
+#: /tmp/fish/implicit/share/completions/git.fish:353
 #, fuzzy
 msgid "Remove even with local changes"
 msgstr "Lokale Änderungen patchen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:352
+#: /tmp/fish/implicit/share/completions/git.fish:354
 msgid "Use the commit stored in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:353
-msgid "Compare the commit in the index with submodule HEAD"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:354
-#, fuzzy
-msgid "Traverse submodules recursively"
-msgstr "Unterverzeichnisse rekursiv auflisten"
-
 #: /tmp/fish/implicit/share/completions/git.fish:355
-msgid "Show logs with difference each commit introduces"
+msgid "Compare the commit in the index with submodule HEAD"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:356
 #, fuzzy
+msgid "Traverse submodules recursively"
+msgstr "Unterverzeichnisse rekursiv auflisten"
+
+#: /tmp/fish/implicit/share/completions/git.fish:357
+msgid "Show logs with difference each commit introduces"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:358
+#, fuzzy
 msgid "Remove untracked files from the working tree"
 msgstr "Dateien nach Archivierung entfernen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:357
+#: /tmp/fish/implicit/share/completions/git.fish:359
 #, fuzzy
 msgid "Force run"
 msgstr "Erzwungene Beendigung"
 
-#: /tmp/fish/implicit/share/completions/git.fish:358
+#: /tmp/fish/implicit/share/completions/git.fish:360
 msgid "Show what would be done and clean files interactively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:359
+#: /tmp/fish/implicit/share/completions/git.fish:361
 msgid "Don't actually remove anything, just show what would be done"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:360
+#: /tmp/fish/implicit/share/completions/git.fish:362
 msgid "Be quiet, only report errors"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:361
+#: /tmp/fish/implicit/share/completions/git.fish:363
 msgid "Remove untracked directories in addition to untracked files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:362
+#: /tmp/fish/implicit/share/completions/git.fish:364
 msgid "Remove ignored files, as well"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:363
+#: /tmp/fish/implicit/share/completions/git.fish:365
 #, fuzzy
 msgid "Remove only ignored files"
 msgstr "Aktualisieren: nur geänderte Dateien"
 
-#: /tmp/fish/implicit/share/completions/git.fish:364
+#: /tmp/fish/implicit/share/completions/git.fish:366
 #, fuzzy
 msgid "Show what revision and author last modified each line of a file"
 msgstr "Letzte Revision anzeigen, bei der jede Zeile verändert wurde"
 
-#: /tmp/fish/implicit/share/completions/git.fish:365
-msgid "Show blank SHA-1 for boundary commits"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:366
-#, fuzzy
-msgid "Do not treat root commits as boundaries"
-msgstr "Entfernten Befehl nicht ausführen"
-
 #: /tmp/fish/implicit/share/completions/git.fish:367
-msgid "Include additional statistics"
+msgid "Show blank SHA-1 for boundary commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:368
 #, fuzzy
-msgid "Annotate only the given line range"
-msgstr "Kommentiere jede Zeile"
+msgid "Do not treat root commits as boundaries"
+msgstr "Entfernten Befehl nicht ausführen"
 
 #: /tmp/fish/implicit/share/completions/git.fish:369
-msgid "Show long rev"
+msgid "Include additional statistics"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:370
 #, fuzzy
+msgid "Annotate only the given line range"
+msgstr "Kommentiere jede Zeile"
+
+#: /tmp/fish/implicit/share/completions/git.fish:371
+msgid "Show long rev"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:372
+#, fuzzy
 msgid "Show raw timestamp"
 msgstr "Zeittyp anzeigen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:371
+#: /tmp/fish/implicit/share/completions/git.fish:373
 #, fuzzy
 msgid "Use revisions from named file instead of calling rev-list"
 msgstr "Angegebene Datei anstelle der Standardvertrauensdatenbank nutzen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:372
+#: /tmp/fish/implicit/share/completions/git.fish:374
 msgid "Walk history forward instead of backward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:373
+#: /tmp/fish/implicit/share/completions/git.fish:375
 msgid "Show in a format designed for machine consumption"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:374
+#: /tmp/fish/implicit/share/completions/git.fish:376
 #, fuzzy
 msgid "Show the porcelain format"
 msgstr "whatis-Information anzeigen"
 
-#: /tmp/fish/implicit/share/completions/git.fish:375
+#: /tmp/fish/implicit/share/completions/git.fish:377
 #, fuzzy
 msgid "Show the result incrementally"
 msgstr "Zeige Zeit"
 
-#: /tmp/fish/implicit/share/completions/git.fish:376
+#: /tmp/fish/implicit/share/completions/git.fish:378
 msgid "Instead of working tree, use the contents of the named file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:377
+#: /tmp/fish/implicit/share/completions/git.fish:379
 #, fuzzy
 msgid "Specifies the format used to output dates"
 msgstr "Zeitablauf für Zwischenspeicher angeben"
 
-#: /tmp/fish/implicit/share/completions/git.fish:378
+#: /tmp/fish/implicit/share/completions/git.fish:380
 msgid "Detect moved or copied lines within a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:379
+#: /tmp/fish/implicit/share/completions/git.fish:381
 msgid ""
 "Detect lines moved or copied from other files that were modified in the same "
 "commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:381
-msgid "Use the same output mode as git-annotate"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:382
-#, fuzzy
-msgid "Show the filename in the original commit"
-msgstr "Arbeitsverzeichnis wechseln"
-
 #: /tmp/fish/implicit/share/completions/git.fish:383
-msgid "Show the line number in the original commit"
+msgid "Use the same output mode as git-annotate"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:384
 #, fuzzy
-msgid "Suppress the author name and timestamp from the output"
-msgstr "Unterschlüssel erlauben, deren Zeitstempel in der Zukunft liegt"
+msgid "Show the filename in the original commit"
+msgstr "Arbeitsverzeichnis wechseln"
 
 #: /tmp/fish/implicit/share/completions/git.fish:385
-msgid "Show the author email instead of author name"
+msgid "Show the line number in the original commit"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:386
 #, fuzzy
+msgid "Suppress the author name and timestamp from the output"
+msgstr "Unterschlüssel erlauben, deren Zeitstempel in der Zukunft liegt"
+
+#: /tmp/fish/implicit/share/completions/git.fish:387
+msgid "Show the author email instead of author name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:388
+#, fuzzy
 msgid "Ignore whitespace changes"
 msgstr "white space (Worttrenner) ignorieren"
 
-#: /tmp/fish/implicit/share/completions/git.fish:387
+#: /tmp/fish/implicit/share/completions/git.fish:389
 #, fuzzy
 msgid "Custom command"
 msgstr "Jobbefehl"
@@ -28568,6 +29403,7 @@ msgid "List all keys with their fingerprints"
 msgstr "Alle Schlüssel mit ihren Fingerabdrücken ausgeben"
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
+#: /tmp/fish/implicit/share/completions/signify.fish:2
 #, fuzzy
 msgid "Generate a new key pair"
 msgstr "Ein neues Schlüsselpaar erstellen"
@@ -38447,14 +39283,6 @@ msgstr ""
 msgid "Display values currently set in the minikube config file"
 msgstr "Alle derzeit definierten Trap-Handler anzeigen"
 
-#: /tmp/fish/implicit/share/completions/minikube.fish:25
-#: /tmp/fish/implicit/share/completions/minikube.fish:26
-#: /tmp/fish/implicit/share/completions/minikube.fish:27
-#: /tmp/fish/implicit/share/completions/minikube.fish:28
-#, fuzzy
-msgid "Property"
-msgstr "Eigenschaft festlegen"
-
 #: /tmp/fish/implicit/share/completions/minikube.fish:29
 msgid "Go template format string for the config view output"
 msgstr ""
@@ -44641,12 +45469,6 @@ msgstr ""
 msgid "keep going until N jobs fail [default=1]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ninja.fish:8
-#: /tmp/fish/implicit/share/completions/quilt.fish:1
-#, fuzzy
-msgid "show help"
-msgstr "Zeige versteckte Dateien"
-
 #: /tmp/fish/implicit/share/completions/ninja.fish:9
 #, fuzzy
 msgid "enable debugging, specify debug mode"
@@ -48212,6 +49034,20 @@ msgstr "Warnungen über MFC deaktivieren"
 msgid "Extract script"
 msgstr "Datei auswerten"
 
+#: /tmp/fish/implicit/share/completions/pfctl.fish:1
+msgid "Show a filter parameter by modifier"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:2
+#, fuzzy
+msgid "Flush filter params specified by mod"
+msgstr "Nur angegebene Anzahl Zeichen vergleichen"
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:3
+#, fuzzy
+msgid "Table command"
+msgstr "Ende des Befehls"
+
 #: /tmp/fish/implicit/share/completions/pgrep.fish:1
 #, fuzzy
 msgid "Output delimiter"
@@ -48430,6 +49266,31 @@ msgstr ""
 msgid "omit the user's full name, remote host and idle time in short format"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:1
+#, fuzzy
+msgid "failsafe to overwrite"
+msgstr "Protokoll in Datei, überschreiben"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:2
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:3
+#, fuzzy
+msgid "Turn on stats"
+msgstr "Steuerung für Warnungen"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:3
+#, fuzzy
+msgid "Automated package installation"
+msgstr "Paket-Installationsreihenfolge nicht ändern"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:5
+#, fuzzy
+msgid "Update packages"
+msgstr "Pakete aktualisieren"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:6
+msgid "Fuzzy match"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:1
 #, fuzzy
 msgid "Upgrade"
@@ -48544,6 +49405,11 @@ msgstr "Eigenschaften auflisten, die dieses Paket bereitstellt"
 #: /tmp/fish/implicit/share/completions/pkg-config.fish:25
 msgid "List all modules the given packages requires for static linking"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:2
+#, fuzzy
+msgid "Delete unsed deps"
+msgstr "Auswahl löschen"
 
 #: /tmp/fish/implicit/share/completions/pkgfile.fish:3
 msgid "only show files in a {s}bin/ directory. Works with -s, -l"
@@ -53334,6 +54200,20 @@ msgstr ""
 msgid "Specifies layout variant used to choose component names"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/signify.fish:1
+msgid "Verify a signed checksum list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:3
+#, fuzzy
+msgid "Sign specified message"
+msgstr "Angegebene Datei ignorieren"
+
+#: /tmp/fish/implicit/share/completions/signify.fish:4
+#, fuzzy
+msgid "Verify a signed message and sig"
+msgstr "Hilfe anzeigen und beenden"
+
 #: /tmp/fish/implicit/share/completions/snap.fish:1
 #, fuzzy
 msgid "Test if snap has yet to be given the subcommand"
@@ -57480,11 +58360,13 @@ msgid "Monitor changes to objects"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:7
+#: /tmp/fish/implicit/share/completions/zfs.fish:17
 #, fuzzy
 msgid "Mount a filesystem"
 msgstr "Alle Dateisysteme anzeigen"
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:18
 #, fuzzy
 msgid "Unmount a filesystem"
 msgstr "Alle Dateisysteme anzeigen"
@@ -62483,6 +63365,685 @@ msgstr "Veraltete Paketdateien löschen"
 msgid "Delete all cache contents"
 msgstr "Nach Fertigstellung Logdatei löschen"
 
+#: /tmp/fish/implicit/share/completions/zfs.fish:1
+#, fuzzy
+msgid ""
+"Internal completion function for appending string to the ZFS commandline"
+msgstr "Alle möglichen Definitionen des angegebenen Namens ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:2
+#: /tmp/fish/implicit/share/completions/zpool.fish:2
+#, fuzzy
+msgid "Display a help message"
+msgstr "Handbuchseite anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:3
+#, fuzzy
+msgid "Create a volume or filesystem"
+msgstr "Archiv und Dateisystem vergleichen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:4
+msgid "Destroy a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:5
+#, fuzzy
+msgid "Create a snapshot"
+msgstr "Archiv erstellen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:6
+msgid "Roll back a filesystem to a previous snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:7
+#, fuzzy
+msgid "Create a clone of a snapshot"
+msgstr "Ein oder mehrere Paket(e) entfernen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:8
+msgid ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:9
+#, fuzzy
+msgid "Rename a dataset"
+msgstr "Eine Platte umbenennen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:10
+#, fuzzy
+msgid "List dataset properties"
+msgstr "Zeichensatzeigenschaften anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:11
+#, fuzzy
+msgid "Set a dataset property"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:12
+#, fuzzy
+msgid "Get one or several dataset properties"
+msgstr "Eigenschaft entfernen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:13
+msgid "Set a dataset property to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:14
+msgid "List upgradeable datasets, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:15
+msgid "Get dataset space consumed by each user"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:16
+msgid "Get dataset space consumed by each user group"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:19
+msgid "Share a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:20
+msgid "Stop sharing a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:21
+#, fuzzy
+msgid "Create a bookmark for a snapshot"
+msgstr "Komprimierte Patche erstellen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:22
+msgid "Output a stream representation of a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:23
+msgid ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:24
+msgid ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:25
+msgid "Revoke delegations of rights on a dataset from (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:26
+msgid "Put a named hold on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:27
+#, fuzzy
+msgid "List holds on a snapshot"
+msgstr "Auf Installierte begrenzen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:28
+#, fuzzy
+msgid "Remove a named hold from a snapshot"
+msgstr "Alle gz-Dateien aus dem Zwischenspeicher entfernen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:29
+msgid ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:30
+msgid "Execute a ZFS Channel Program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:31
+#: /tmp/fish/implicit/share/completions/zfs.fish:53
+#: /tmp/fish/implicit/share/completions/zfs.fish:58
+#, fuzzy
+msgid "Create all needed non-existing parent datasets"
+msgstr "Alle gz-Dateien aus dem Zwischenspeicher entfernen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:32
+#: /tmp/fish/implicit/share/completions/zfs.fish:33
+#, fuzzy
+msgid "Dataset property"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:34
+#, fuzzy
+msgid "Volume size"
+msgstr "Datei komprimieren"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:35
+#, fuzzy
+msgid "Create a sparse volume"
+msgstr "Neues Projekt erstellen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:36
+#, fuzzy
+msgid "Blocksize"
+msgstr "Blockgrösse"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:37
+#, fuzzy
+msgid "Recursively destroy children"
+msgstr "Rekursive Kopie"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:38
+msgid "Recursively destroy all dependents"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:39
+#, fuzzy
+msgid "Force unmounting"
+msgstr "Einhängen vortäuschen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:41
+#, fuzzy
+msgid "Print machine-parsable verbose information"
+msgstr "Ausführliche Informationen ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:43
+#, fuzzy
+msgid "Defer snapshot deletion"
+msgstr "Auswahl löschen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:44
+#, fuzzy
+msgid "Dataset to destroy"
+msgstr "Startmenge der Tastendrücke"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:45
+#, fuzzy
+msgid "Recursively snapshot children"
+msgstr "Sicherer Modus"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:46
+#: /tmp/fish/implicit/share/completions/zfs.fish:47
+#, fuzzy
+msgid "Snapshot property"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:48
+msgid "Dataset to snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:49
+msgid "Destroy later snapshot and bookmarks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:50
+msgid "Recursively destroy later snapshot, bookmarks and clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:51
+#, fuzzy
+msgid "Force unmounting of clones"
+msgstr "Keine Ausgabedateien erstellen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:52
+msgid "Snapshot to roll back to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:54
+#: /tmp/fish/implicit/share/completions/zfs.fish:55
+#, fuzzy
+msgid "Clone property"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:56
+msgid "Snapshot to clone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:57
+msgid "Clone to promote"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:59
+msgid "Recursively rename children snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:60
+#: /tmp/fish/implicit/share/completions/zfs.fish:62
+#: /tmp/fish/implicit/share/completions/zfs.fish:108
+#, fuzzy
+msgid "Force unmounting if needed"
+msgstr "Index-Neuerstellung erzwingen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:61
+#, fuzzy
+msgid "Do not remount filesystems during rename"
+msgstr "Im lokalen Dateisystem bleiben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:63
+#, fuzzy
+msgid "Dataset to rename"
+msgstr "Dienstname"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:64
+#: /tmp/fish/implicit/share/completions/zfs.fish:77
+#: /tmp/fish/implicit/share/completions/zfs.fish:94
+#: /tmp/fish/implicit/share/completions/zfs.fish:172
+#: /tmp/fish/implicit/share/completions/zpool.fish:59
+#: /tmp/fish/implicit/share/completions/zpool.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:99
+#, fuzzy
+msgid "Print output in a machine-parsable format"
+msgstr "Ausgabeformat für Profilierung"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:65
+#: /tmp/fish/implicit/share/completions/zfs.fish:75
+#: /tmp/fish/implicit/share/completions/zfs.fish:84
+#: /tmp/fish/implicit/share/completions/zfs.fish:89
+#, fuzzy
+msgid "Operate recursively on datasets"
+msgstr "Rekursiv arbeiten"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:105
+#, fuzzy
+msgid "Property to list"
+msgstr "Niedrigster Port, an dem gelauscht wird"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:68
+#: /tmp/fish/implicit/share/completions/zfs.fish:80
+#: /tmp/fish/implicit/share/completions/zfs.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:66
+#, fuzzy
+msgid "Print parsable (exact) values for numbers"
+msgstr "Alle Versionen ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:69
+#: /tmp/fish/implicit/share/completions/zfs.fish:97
+msgid "Property to use for sorting output by ascending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:70
+#: /tmp/fish/implicit/share/completions/zfs.fish:98
+msgid "Property to use for sorting output by descending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:72
+msgid "Dataset which properties is to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:73
+#: /tmp/fish/implicit/share/completions/zpool.fish:125
+#, fuzzy
+msgid "Property to set"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:74
+msgid "Dataset which property is to be setted"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:78
+#: /tmp/fish/implicit/share/completions/zpool.fish:68
+#, fuzzy
+msgid "Fields to display"
+msgstr "Grafikanzeige auswählen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:79
+#, fuzzy
+msgid "Property source to display"
+msgstr "Grafikanzeige auswählen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:82
+#, fuzzy
+msgid "Property to get"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:83
+msgid "Dataset which properties is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:85
+#, fuzzy
+msgid "Revert to the received value if available"
+msgstr "Fenster auf der angegebenen Anzeige erstellen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:86
+msgid "Dataset which properties is to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:88
+#, fuzzy
+msgid "Upgrade all eligible filesystems"
+msgstr "Alle Dateisysteme anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:90
+#, fuzzy
+msgid "Upgrade to the specified version"
+msgstr "Fenster auf der angegebenen Anzeige erstellen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:91
+#, fuzzy
+msgid "Filesystem to upgrade"
+msgstr "Dateisystemtyp ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:92
+#, fuzzy
+msgid "Print UID instead of user name"
+msgstr "Überschrift ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:93
+#, fuzzy
+msgid "Print GID instead of group name"
+msgstr "Überschrift ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:96
+#, fuzzy
+msgid "Field to display"
+msgstr "X Server-Anzeige"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:99
+#: /tmp/fish/implicit/share/completions/zfs.fish:100
+#, fuzzy
+msgid "Identity types to display"
+msgstr "Grafikanzeige auswählen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:101
+msgid "Translate S(amba)ID to POSIX ID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:102
+msgid "Dataset which space usage is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:103
+msgid "Temporary mount point property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:104
+#, fuzzy
+msgid "Report progress"
+msgstr "Fehlermeldungen unterdrücken"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:105
+#, fuzzy
+msgid "Mount all available ZFS filesystems"
+msgstr "Alle Dateisysteme anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:106
+msgid "Overlay mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:107
+#, fuzzy
+msgid "Filesystem to mount"
+msgstr "Dateisystemtyp ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:109
+#, fuzzy
+msgid "Unmount all available ZFS filesystems"
+msgstr "Alle Dateisysteme anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:110
+#, fuzzy
+msgid "Filesystem to unmount"
+msgstr "Dateisystemtyp ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:111
+#, fuzzy
+msgid "Share all eligible ZFS filesystems"
+msgstr "Alle Dateisysteme anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:112
+#, fuzzy
+msgid "Filesystem to share"
+msgstr "Dateisystemtyp ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:113
+#, fuzzy
+msgid "Unshare all shared ZFS filesystems"
+msgstr "Alle Dateisysteme anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:114
+#, fuzzy
+msgid "Filesystem to unshare"
+msgstr "Dateisystemtyp ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:115
+msgid "Snapshot to bookmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:116
+#, fuzzy
+msgid "Generate incremental stream from snapshot"
+msgstr "Neues inkrementelles GNU-Format benutzen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:117
+msgid ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:118
+#: /tmp/fish/implicit/share/completions/zfs.fish:127
+msgid "Include children in replication stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:119
+#: /tmp/fish/implicit/share/completions/zfs.fish:128
+#, fuzzy
+msgid "Generate a deduplicated stream"
+msgstr "Paket aus Quelle generieren"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:120
+#: /tmp/fish/implicit/share/completions/zfs.fish:129
+msgid "Allow the presence of larger blocks than 128 kiB"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:121
+#: /tmp/fish/implicit/share/completions/zfs.fish:130
+msgid "Generate a more compact stream by using WRITE_EMBEDDED records"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:122
+#: /tmp/fish/implicit/share/completions/zfs.fish:131
+#, fuzzy
+msgid "Print verbose information about the stream in a machine-parsable format"
+msgstr "Statusinformation über Fish zurückgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:123
+#, fuzzy
+msgid "Generate compressed stream"
+msgstr "Paket aus Quelle generieren"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:125
+#: /tmp/fish/implicit/share/completions/zfs.fish:133
+#, fuzzy
+msgid "Include dataset properties"
+msgstr "Datei ausschliessen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:126
+#: /tmp/fish/implicit/share/completions/zfs.fish:134
+#, fuzzy
+msgid "Print verbose information about the stream"
+msgstr "Sämtliche Versions-Informationen ignorieren"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:135
+#, fuzzy
+msgid "Dataset to send"
+msgstr "Mail an Benutzer senden"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:136
+#, fuzzy
+msgid ""
+"Print verbose information about the stream and the time spent processing it"
+msgstr "Statusinformation über Fish zurückgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:137
+#, fuzzy
+msgid "Dry run: do not actually receive the stream"
+msgstr "Alle gz-Dateien aus dem Zwischenspeicher entfernen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:138
+#, fuzzy
+msgid "Force rollback to the most recent snapshot"
+msgstr "Alle Quellpakete mit Version ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:139
+#, fuzzy
+msgid "Unmount the target filesystem"
+msgstr "Alle Dateisysteme anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:140
+msgid "Discard the first element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:141
+msgid "Discard all but the last element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:142
+msgid "Force the stream to be received as a clone of the given snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:143
+msgid "On transfer interruption, store a receive_resume_token for resumption"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:144
+msgid "Dataset to receive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:145
+#, fuzzy
+msgid "Delegate permissions only on the specified dataset"
+msgstr "Alle möglichen Definitionen des angegebenen Namens ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:146
+msgid "Delegate permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:147
+#, fuzzy
+msgid "User to delegate permissions to"
+msgstr "Alle Rechte extrahieren"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:148
+#, fuzzy
+msgid "Group to delegate permissions to"
+msgstr "Ausgabe in zwei Spalten"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:149
+#: /tmp/fish/implicit/share/completions/zfs.fish:150
+#, fuzzy
+msgid "Delegate permission to everyone"
+msgstr "Freistehende Umgebung bestätigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:151
+msgid "Delegate permissions only to the creator of later descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:152
+msgid "Create a permission set or add permissions to an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:153
+msgid "Dataset on which delegation is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:154
+#, fuzzy
+msgid "Remove permissions only on the specified dataset"
+msgstr "Einen Eintrag aus dem Paketdepot entfernen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:155
+msgid "Remove permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:156
+#, fuzzy
+msgid "User to remove permissions from"
+msgstr "Umgebung erhalten"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:157
+#, fuzzy
+msgid "Group to remove permissions from"
+msgstr "Ausgabe in zwei Spalten"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:158
+#: /tmp/fish/implicit/share/completions/zfs.fish:162
+#: /tmp/fish/implicit/share/completions/zfs.fish:163
+#, fuzzy
+msgid "Remove permission from everyone"
+msgstr "Alle Einträge aus der --group-Liste entfernen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:159
+msgid "Remove permissions only on later created descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:160
+#, fuzzy
+msgid "Remove a permission set or remove permissions from an existing one"
+msgstr "Alle gz-Dateien aus dem Zwischenspeicher entfernen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:161
+#, fuzzy
+msgid "Remove permissions recursively"
+msgstr "Rekursiv arbeiten"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:164
+msgid "Dataset on which delegation is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:165
+#, fuzzy
+msgid "Apply hold recursively"
+msgstr "Rekursiv arbeiten"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:166
+msgid "Snapshot on which hold is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:167
+#, fuzzy
+msgid "List holds recursively"
+msgstr "Rekursiv arbeiten"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:168
+msgid "Snapshot which holds are to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:169
+#, fuzzy
+msgid "Release hold recursively"
+msgstr "Rekursiv arbeiten"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:170
+msgid "Snapshot from which hold is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:171
+msgid "Display file type (à la ls -F)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:173
+#, fuzzy
+msgid "Display inode change time"
+msgstr "Zeilennummer anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:174
+msgid "Source snapshot for the diff"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:175
+#, fuzzy
+msgid "Execution timeout"
+msgstr "Rekursionsgrenze"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:176
+#, fuzzy
+msgid "Execution memory limit"
+msgstr "Rekursionsgrenze"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:177
+msgid "Pool which program will be executed on"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/zip.fish:1
 msgid "Freshen: only changed files"
 msgstr "Aktualisieren: nur geänderte Dateien"
@@ -62587,6 +64148,531 @@ msgstr "Verschlüsseln"
 #: /tmp/fish/implicit/share/completions/zip.fish:29
 msgid "Don't compress files with these suffixes"
 msgstr "Dateien mit diesen Endungen nicht komprimieren"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:1
+msgid ""
+"Internal completion function for appending string to the zpool commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:3
+msgid "Add new virtual devices to pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:4
+msgid "Attach virtual device to a pool device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:5
+msgid "Clear devices errors in pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:6
+#, fuzzy
+msgid "Create a new storage pool"
+msgstr "Neues Projekt erstellen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:7
+msgid "Destroy a storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:8
+msgid "Detach virtual device from a mirroring pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:9
+#, fuzzy
+msgid "Display pool event log"
+msgstr "Alle Änderungsprotokolle anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:10
+msgid "Export a pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:11
+#, fuzzy
+msgid "Get one or several pool properties"
+msgstr "Eigenschaft entfernen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:12
+#, fuzzy
+msgid "Display pool command history"
+msgstr "Hilfe anzeigen und beenden"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:13
+#, fuzzy
+msgid "List importable pools, or import some"
+msgstr "Verfügbare Liste ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:14
+#, fuzzy
+msgid "Display pool I/O stats"
+msgstr "Steuerzeichen anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:15
+#, fuzzy
+msgid "Remove ZFS label information from the specified device"
+msgstr "Profilierungsinformation in angegebene Datei ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:16
+msgid "List pools with health status and space usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:17
+#, fuzzy
+msgid "Take the specified devices offline"
+msgstr "Angegebenen Schlüsselserver verwenden"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:18
+#, fuzzy
+msgid "Bring the specified devices back online"
+msgstr "Angegebenen Schlüsselserver verwenden"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:19
+msgid "Reset pool GUID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:20
+#, fuzzy
+msgid "Remove virtual devices from pool"
+msgstr "Einen Eintrag aus dem Paketdepot entfernen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:21
+#, fuzzy
+msgid "Reopen pool devices"
+msgstr "Alle Namen ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:22
+#, fuzzy
+msgid "Replace a pool virtual device"
+msgstr "Datei ist ein Block-Gerät"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:23
+msgid "Start or stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:24
+#, fuzzy
+msgid "Set a pool property"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:25
+msgid "Create a pool by splitting an existing mirror one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:26
+#, fuzzy
+msgid "Display detailed pool health status"
+msgstr "URIs ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:27
+msgid "List upgradeable pools, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:28
+#: /tmp/fish/implicit/share/completions/zpool.fish:36
+#: /tmp/fish/implicit/share/completions/zpool.fish:45
+#: /tmp/fish/implicit/share/completions/zpool.fish:117
+#, fuzzy
+msgid "Force use of virtual device"
+msgstr "Inode-Nummer der Dateien ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:29
+#: /tmp/fish/implicit/share/completions/zpool.fish:130
+#, fuzzy
+msgid "Dry run: only display resulting configuration"
+msgstr "Dienstkonfiguration neu laden"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:30
+#: /tmp/fish/implicit/share/completions/zpool.fish:91
+#: /tmp/fish/implicit/share/completions/zpool.fish:100
+#: /tmp/fish/implicit/share/completions/zpool.fish:127
+#: /tmp/fish/implicit/share/completions/zpool.fish:135
+msgid "Display virtual device GUID instead of device name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:31
+#: /tmp/fish/implicit/share/completions/zpool.fish:92
+#: /tmp/fish/implicit/share/completions/zpool.fish:101
+#: /tmp/fish/implicit/share/completions/zpool.fish:128
+#: /tmp/fish/implicit/share/completions/zpool.fish:136
+#, fuzzy
+msgid "Resolve device path symbolic links"
+msgstr "Symbolische Verweise dereferenzieren"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:32
+#: /tmp/fish/implicit/share/completions/zpool.fish:93
+#: /tmp/fish/implicit/share/completions/zpool.fish:102
+#: /tmp/fish/implicit/share/completions/zpool.fish:129
+#: /tmp/fish/implicit/share/completions/zpool.fish:137
+#, fuzzy
+msgid "Display device full path"
+msgstr "Handbuchseite anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:33
+#: /tmp/fish/implicit/share/completions/zpool.fish:37
+#: /tmp/fish/implicit/share/completions/zpool.fish:48
+#: /tmp/fish/implicit/share/completions/zpool.fish:118
+#: /tmp/fish/implicit/share/completions/zpool.fish:132
+#, fuzzy
+msgid "Pool property"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:34
+#, fuzzy
+msgid "Pool to add virtual devices to"
+msgstr "Vertraute Schlüssel auflisten"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:35
+#: /tmp/fish/implicit/share/completions/zpool.fish:53
+#, fuzzy
+msgid "Virtual device to add"
+msgstr "Blockorientiertes Gerät"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:38
+msgid "Pool to attach virtual device to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:39
+#: /tmp/fish/implicit/share/completions/zpool.fish:43
+#, fuzzy
+msgid "Virtual device to operate on"
+msgstr "Bereichskontrolle"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:40
+#, fuzzy
+msgid "Initiate recovery mode"
+msgstr "Im nicht interaktiven Modus ausführen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:41
+#: /tmp/fish/implicit/share/completions/zpool.fish:85
+msgid ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:42
+msgid "Pool to clear errors on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:44
+msgid ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:46
+#, fuzzy
+msgid "Dry run, only display resulting configuration"
+msgstr "Dienstkonfiguration neu laden"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:47
+#, fuzzy
+msgid "Do not enable any feature on the new pool"
+msgstr "Nicht abbrechen, wenn die Signatur älter als der Schlüssel ist"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:49
+#, fuzzy
+msgid "Root filesystem property"
+msgstr "Eigenschaft festlegen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:50
+#: /tmp/fish/implicit/share/completions/zpool.fish:83
+msgid "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:51
+#, fuzzy
+msgid "Root filesystem mountpoint"
+msgstr "Lange Zeilen nicht umbrechen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:52
+#, fuzzy
+msgid "Set a different in-core pool name"
+msgstr "Benutzerschnittstelle auswählen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:54
+#: /tmp/fish/implicit/share/completions/zpool.fish:64
+msgid "Force unmounting of all contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:55
+msgid "Pool to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:56
+#, fuzzy
+msgid "Pool to detach device from"
+msgstr "Datei ist ein Block-Gerät"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:57
+msgid "Physical device to detach"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:58
+#, fuzzy
+msgid "Print verbose event information"
+msgstr "Ausführliche Informationen ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:60
+msgid "Output appended data as the log grows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:61
+#, fuzzy
+msgid "Clear all previous events"
+msgstr "Sämtliche Versions-Informationen ignorieren"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:62
+msgid "Pool to read events from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:63
+#, fuzzy
+msgid "Export all pools"
+msgstr "Alle Versionen ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:65
+#, fuzzy
+msgid "Pool to export"
+msgstr "Grafikanzeige auswählen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:69
+msgid "Properties to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:70
+#, fuzzy
+msgid "Pool to get properties of"
+msgstr "Zeichensatzeigenschaften anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:71
+msgid "Also display internal events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:72
+#, fuzzy
+msgid "Display log records using long format"
+msgstr "Startverzeichnis festlegen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:73
+#, fuzzy
+msgid "Pool to get command history of"
+msgstr "Keine Befehle ausführen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:74
+#, fuzzy
+msgid "Read configuration from specified cache file"
+msgstr "Konfigurationsdatei ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:75
+#, fuzzy
+msgid "Search for devices or files in specified directory"
+msgstr "Dateien in das Paketdepot übertragen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:76
+msgid "List or import destroyed pools only (requires -f for importation)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:77
+#: /tmp/fish/implicit/share/completions/zpool.fish:133
+#, fuzzy
+msgid "Mount properties for contained datasets"
+msgstr "Nur zutreffenden Teil anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:78
+#, fuzzy
+msgid "Properties of the imported pool"
+msgstr "Größe des freigegebenen Speicherpools festlegen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:79
+#, fuzzy
+msgid "Force import"
+msgstr "Farben benutzen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:80
+#, fuzzy
+msgid "Recovery mode"
+msgstr "Server-Modus"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:81
+#, fuzzy
+msgid "Search for and import all pools found"
+msgstr "Nach Ablaufzeit fragen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:82
+msgid "Ignore missing log device (risk of loss of last changes)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:84
+#, fuzzy
+msgid "Do not mount contained filesystems"
+msgstr "Im lokalen Dateisystem bleiben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:86
+msgid "Roll back to a previous TXG (hazardous)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:87
+msgid "TXG to roll back to (implies -FX)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:88
+#, fuzzy
+msgid "Specify, as the last argument, a temporary pool name"
+msgstr "Geben Sie einen Titel für rss an"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:89
+#, fuzzy
+msgid "Pool to import"
+msgstr "Zu importierendes Verzeichnis"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:90
+#: /tmp/fish/implicit/share/completions/zpool.fish:103
+#: /tmp/fish/implicit/share/completions/zpool.fish:142
+#, fuzzy
+msgid "Display a timestamp using specified format"
+msgstr "Profilierungsinformation in angegebene Datei ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:94
+#, fuzzy
+msgid "Omit statistics since boot"
+msgstr "Wortzählung ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:104
+#, fuzzy
+msgid "Print verbose statistics"
+msgstr "Ausführliche Informationen ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:96
+msgid "Pool to retrieve I/O stats from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:97
+msgid "Treat exported or foreign devices as inactive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:98
+#, fuzzy
+msgid "Device to clear ZFS label information from"
+msgstr "Alle Informationen ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:106
+#, fuzzy
+msgid "Pool to list properties of"
+msgstr "Zeichensatzeigenschaften anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:107
+msgid "Temporarily offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:108
+msgid "Pool to offline device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:109
+msgid "Physical device to offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:110
+#, fuzzy
+msgid "Expand the device to use all available space"
+msgstr "Liste der Quellpakete aktualisieren"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:111
+#, fuzzy
+msgid "Pool to bring device back online on"
+msgstr "Blockorientiertes Gerät"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:112
+msgid "Physical device to bring back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:113
+msgid "Pool which GUID is to be changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:114
+msgid "Pool to remove device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:115
+msgid "Physical device to remove"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:116
+#, fuzzy
+msgid "Pool which devices are to be reopened"
+msgstr "Dienststatus ausgeben"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:119
+#, fuzzy
+msgid "Pool to replace device"
+msgstr "Datei ist ein Zeichengerät"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:120
+msgid "Pool device to be replaced"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:121
+#, fuzzy
+msgid "Device to use for replacement"
+msgstr "Geräte-Sektion"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:122
+#, fuzzy
+msgid "Stop scrubbing"
+msgstr "Dienst anhalten"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:123
+#, fuzzy
+msgid "Pause scrubbing"
+msgstr "Version anzeigen und beenden"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:124
+msgid "Pool to start/stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:126
+msgid "Pool which property is to be set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:131
+msgid "Set altroot for newpool and automatically import it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:134
+#, fuzzy
+msgid "Pool to split"
+msgstr "Niedrigster Port, an dem gelauscht wird"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:138
+#: /tmp/fish/implicit/share/completions/zpool.fish:139
+#, fuzzy
+msgid "Display deduplication histogram"
+msgstr "Alle Änderungsprotokolle anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:141
+msgid "Only display status for unhealthy or unavailable pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:143
+#: /tmp/fish/implicit/share/completions/zpool.fish:147
+msgid "Pool which status is to be displayed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:144
+msgid "Upgrade all eligible pools, enabling all supported features"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:145
+#, fuzzy
+msgid "Display upgradeable ZFS versions"
+msgstr "Paketsatz anzeigen"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:146
+#, fuzzy
+msgid "Upgrade to the specified legacy version"
+msgstr "Fenster auf der angegebenen Anzeige erstellen"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:2
 msgid "Repo"
@@ -64243,6 +66329,31 @@ msgstr ""
 msgid "Complete wvdial peers"
 msgstr "Vergleiche FILE1 mit allen Operanden"
 
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#, fuzzy
+msgid "Completes with ZFS mountpoint properties"
+msgstr "Liste laufender screen-Sitzungen ausgeben"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_pools.fish:1
+#, fuzzy
+msgid "Completes with available ZFS pools"
+msgstr "Vergleiche FILE1 mit allen Operanden"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#, fuzzy
+msgid "Completes with ZFS read-only properties"
+msgstr "Verzeichnis-Präfix festlegen"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Completes with ZFS read-write properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr ""
@@ -64409,6 +66520,12 @@ msgstr "Das ganze Paketdepot prüfen"
 msgid "Test if current token is on Nth place"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_is_zfs_feature_enabled.fish:1
+msgid ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_list_current_token.fish:1
 msgid ""
 "List contents of token under the cursor if it is a directory, otherwise list "
@@ -64495,6 +66612,11 @@ msgid ""
 "current directory"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
+#, fuzzy
+msgid "Print a list of local groups"
+msgstr "Liste laufender screen-Sitzungen ausgeben"
+
 #: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr ""
@@ -64577,6 +66699,25 @@ msgstr "Wortzählung ausgeben"
 #, fuzzy
 msgid "Print X windows"
 msgstr "APM-Informationen ausgeben"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
+msgid "Lists ZFS bookmarks, if the feature is enabled"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
+#, fuzzy
+msgid "Lists ZFS filesystems"
+msgstr "Alle Dateisysteme anzeigen"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
+#, fuzzy
+msgid "Lists ZFS snapshots"
+msgstr "Vertraute Schlüssel auflisten"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
+#, fuzzy
+msgid "Lists ZFS volumes"
+msgstr "Nach Spalten auflisten"
 
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
@@ -64918,10 +67059,6 @@ msgstr "Verfügbare Liste ausgeben"
 #, fuzzy
 #~ msgid "Change to DIR"
 #~ msgstr "Wechsel zu Benutzer"
-
-#, fuzzy
-#~ msgid "number of jobs"
-#~ msgstr "Anzahl gleichzeitiger Jobs"
 
 #, fuzzy
 #~ msgid "Show a unit"

--- a/po/en.po
+++ b/po/en.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:00+0100\n"
-"PO-Revision-Date: 2014-11-15 09:00+0800\n"
+"POT-Creation-Date: 2017-12-13 09:58+0100\n"
+"PO-Revision-Date: 2017-12-13 10:20+0100\n"
 "Last-Translator: David Adam <zanchey@ucc.gu.uwa.edu.au>\n"
 "Language-Team: English <fish-users@lists.sourceforge.net>\n"
 "Language: en\n"
@@ -16,6 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Basepath: /home/david/src/fish-shell\n"
+"X-Generator: Poedit 1.8.11\n"
 
 #: src/autoload.cpp:96
 #, fuzzy, c-format
@@ -1841,9 +1842,11 @@ msgstr "Executable link"
 #: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
 #: /tmp/fish/implicit/share/completions/fossil.fish:90
 #: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:206
-#: /tmp/fish/implicit/share/completions/git.fish:266
-#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:269
 msgid "File"
 msgstr "File"
 
@@ -2557,6 +2560,555 @@ msgstr "Use Kerberos realm for authentication"
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/zfs.fish:1
+msgid "ZFS filesystem"
+msgstr "ZFS filesystem"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:2
+msgid "ZFS filesystem snapshot"
+msgstr "ZFS filesystem snapshot"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:3
+msgid "ZFS block storage device"
+msgstr "ZFS block storage device"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:4
+msgid "ZFS snapshot bookmark"
+msgstr "ZFS snapshot bookmark"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:5
+msgid "Any ZFS dataset"
+msgstr "Any ZFS dataset"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:6
+msgid "Dataset-specific value"
+msgstr "Dataset-specific value"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:7
+msgid "Default ZFS value"
+msgstr "Default ZFS value"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:8
+msgid "Value inherited from parent dataset"
+msgstr "Value inherited from parent dataset"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:9
+msgid "Value received by 'zfs receive'"
+msgstr "Value received by 'zfs receive'"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:10
+msgid "Value valid for the current mount"
+msgstr "Value valid for the current mount"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:11
+msgid "Read-only value"
+msgstr "Read-only value"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:12
+msgid "Dataset full name"
+msgstr "Dataset full name"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:13
+#: /tmp/fish/explicit/share/completions/zpool.fish:2
+#: /tmp/fish/implicit/share/completions/minikube.fish:25
+#: /tmp/fish/implicit/share/completions/minikube.fish:26
+#: /tmp/fish/implicit/share/completions/minikube.fish:27
+#: /tmp/fish/implicit/share/completions/minikube.fish:28
+msgid "Property"
+msgstr "Property"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:3
+msgid "Property value"
+msgstr "Property value"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:15
+#: /tmp/fish/explicit/share/completions/zpool.fish:4
+msgid "Property value origin"
+msgstr "Property value origin"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:16
+msgid "Identity type"
+msgstr "Identity type"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:17
+msgid "Identity name"
+msgstr "Identity name"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:18
+msgid "Space usage"
+msgstr "Space usage"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:19
+msgid "Space quota"
+msgstr "Space quota"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:20
+msgid "POSIX user"
+msgstr "POSIX user"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:21
+msgid "Samba user"
+msgstr "Samba user"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:22
+#: /tmp/fish/explicit/share/completions/zfs.fish:25
+msgid "Both types"
+msgstr "Both types"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:23
+msgid "POSIX group"
+msgstr "POSIX group"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:24
+msgid "Samba group"
+msgstr "Samba group"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:26
+msgid "Also needs the permission to be allowed"
+msgstr "Also needs the permission to be allowed"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:27
+msgid ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+msgstr ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:28
+#: /tmp/fish/explicit/share/completions/zfs.fish:29
+#: /tmp/fish/explicit/share/completions/zfs.fish:33
+#: /tmp/fish/explicit/share/completions/zfs.fish:35
+msgid "Also needs the 'mount' permission"
+msgstr "Also needs the 'mount' permission"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:30
+msgid ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+msgstr ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:31
+msgid "Also needs the 'create' and 'mount' permissions"
+msgstr "Also needs the 'create' and 'mount' permissions"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:32
+msgid "Also needs the 'create' and 'mount' permissions in the new parent"
+msgstr "Also needs the 'create' and 'mount' permissions in the new parent"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:34
+msgid "For SMB and NFS shares"
+msgstr "For SMB and NFS shares"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:36
+msgid "Allows changing any user property"
+msgstr "Allows changing any user property"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:26
+msgid "Volume block size"
+msgstr "Volume block size"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:38
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Inheritance of ACL entries"
+msgstr "Inheritance of ACL entries"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:39
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:2
+msgid "Update access time on read"
+msgstr "Update access time on read"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:40
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:3
+msgid "Is the dataset mountable"
+msgstr "Is the dataset mountable"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:41
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:4
+msgid "Data checksum"
+msgstr "Data checksum"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:42
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:5
+msgid "Compression algorithm"
+msgstr "Compression algorithm"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:43
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:6
+msgid "Number of copies of data"
+msgstr "Number of copies of data"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:44
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:7
+msgid "Deduplication"
+msgstr "Deduplication"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:45
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:2
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:8
+msgid "Are contained device nodes openable"
+msgstr "Are contained device nodes openable"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:46
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:3
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:9
+msgid "Can contained executables be executed"
+msgstr "Can contained executables be executed"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:47
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:10
+msgid "Max number of filesystems and volumes"
+msgstr "Max number of filesystems and volumes"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:48
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:11
+msgid "Mountpoint"
+msgstr "Mountpoint"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:49
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:12
+msgid "Which data to cache in ARC"
+msgstr "Which data to cache in ARC"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:50
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:13
+msgid "Max size of dataset and children"
+msgstr "Max size of dataset and children"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:51
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:14
+msgid "Max number of snapshots"
+msgstr "Max number of snapshots"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:52
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:4
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:15
+msgid "Read-only"
+msgstr "Read-only"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:53
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:16
+msgid "Suggest block size"
+msgstr "Suggest block size"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:54
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:17
+msgid "How redundant are the metadata"
+msgstr "How redundant are the metadata"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:55
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:18
+msgid "Max space used by dataset itself"
+msgstr "Max space used by dataset itself"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:56
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:19
+msgid "Min space guaranteed to dataset itself"
+msgstr "Min space guaranteed to dataset itself"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:57
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:20
+msgid "Min space guaranteed to dataset"
+msgstr "Min space guaranteed to dataset"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:58
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:21
+msgid "Which data to cache in L2ARC"
+msgstr "Which data to cache in L2ARC"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:59
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:5
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:22
+msgid "Respect set-UID bit"
+msgstr "Respect set-UID bit"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:60
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:23
+msgid "Share in NFS"
+msgstr "Share in NFS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:61
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:24
+msgid "Hint for handling of synchronous requests"
+msgstr "Hint for handling of synchronous requests"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:62
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:25
+msgid "Hide .zfs directory"
+msgstr "Hide .zfs directory"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:63
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:26
+msgid "Handle of synchronous requests"
+msgstr "Handle of synchronous requests"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:64
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:27
+msgid "Volume logical size"
+msgstr "Volume logical size"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:65
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:38
+msgid "Managed from a non-global zone"
+msgstr "Managed from a non-global zone"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:66
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:31
+msgid "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+msgstr "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:67
+#: /tmp/fish/explicit/share/completions/zfs.fish:74
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:6
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:32
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:40
+msgid "Mount with Non Blocking mandatory locks"
+msgstr "Mount with Non Blocking mandatory locks"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:68
+#: /tmp/fish/explicit/share/completions/zfs.fish:77
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:33
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:43
+msgid "Share in Samba"
+msgstr "Share in Samba"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:69
+#: /tmp/fish/explicit/share/completions/zfs.fish:76
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:34
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:42
+msgid "Share as an iSCSI target"
+msgstr "Share as an iSCSI target"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:70
+#: /tmp/fish/explicit/share/completions/zfs.fish:79
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:35
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:45
+msgid "On-disk version of filesystem"
+msgstr "On-disk version of filesystem"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:71
+#: /tmp/fish/explicit/share/completions/zfs.fish:80
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:36
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:46
+msgid "Scan regular files for viruses on opening and closing"
+msgstr "Scan regular files for viruses on opening and closing"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:72
+#: /tmp/fish/explicit/share/completions/zfs.fish:81
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:7
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:47
+msgid "Extended attributes"
+msgstr "Extended attributes"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:73
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:39
+msgid "Use no ACL or POSIX ACL"
+msgstr "Use no ACL or POSIX ACL"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:75
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:9
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:41
+msgid "Sometimes update access time on read"
+msgstr "Sometimes update access time on read"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:78
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:44
+msgid "Hide volume snapshots"
+msgstr "Hide volume snapshots"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:82
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:30
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:48
+msgid "How is ACL modified by chmod"
+msgstr "How is ACL modified by chmod"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:83
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:49
+msgid "How to expose volumes to OS"
+msgstr "How to expose volumes to OS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:84
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid "Unicode normalization"
+msgstr "Unicode normalization"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:85
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:2
+msgid "Reject non-UTF-8-compliant filenames"
+msgstr "Reject non-UTF-8-compliant filenames"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:86
+#: /tmp/fish/explicit/share/completions/zfs.fish:87
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:9
+msgid "Case sensitivity"
+msgstr "Case sensitivity"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:88
+msgid "Space properties"
+msgstr "Space properties"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:89
+#: /tmp/fish/explicit/share/completions/zfs.fish:90
+msgid "Dataset name"
+msgstr "Dataset name"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:1
+msgid "Pool full name"
+msgstr "Pool full name"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:5
+msgid "Mirror of at least two devices"
+msgstr "Mirror of at least two devices"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:6
+#: /tmp/fish/explicit/share/completions/zpool.fish:7
+msgid "ZFS RAID-5 variant, single parity"
+msgstr "ZFS RAID-5 variant, single parity"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:8
+msgid "ZFS RAID-5 variant, double parity"
+msgstr "ZFS RAID-5 variant, double parity"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:9
+msgid "ZFS RAID-5 variant, triple parity"
+msgstr "ZFS RAID-5 variant, triple parity"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:10
+msgid "Pseudo vdev for pool hot spares"
+msgstr "Pseudo vdev for pool hot spares"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:11
+msgid "SLOG device"
+msgstr "SLOG device"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:12
+msgid "L2ARC device"
+msgstr "L2ARC device"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:13
+msgid "Physically allocated space"
+msgstr "Physically allocated space"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:2
+msgid "Available space"
+msgstr "Available space"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:16
+msgid "System boot partition size"
+msgstr "System boot partition size"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:17
+msgid "Usage percentage of pool"
+msgstr "Usage percentage of pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:18
+msgid "Deduplication ratio"
+msgstr "Deduplication ratio"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:19
+msgid "Amount of uninitialized space within the pool"
+msgstr "Amount of uninitialized space within the pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:20
+msgid "Fragmentation percentage of pool"
+msgstr "Fragmentation percentage of pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:21
+msgid "Free pool space"
+msgstr "Free pool space"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:22
+msgid "Remaining pool space to be freed"
+msgstr "Remaining pool space to be freed"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:23
+msgid "Pool GUID"
+msgstr "Pool GUID"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:24
+msgid "Current pool health"
+msgstr "Current pool health"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:25
+msgid "Total pool space"
+msgstr "Total pool space"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:26
+msgid "Used pool space"
+msgstr "Used pool space"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:27
+msgid "Pool sector size exponent"
+msgstr "Pool sector size exponent"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:28
+#: /tmp/fish/explicit/share/completions/zpool.fish:29
+msgid "Alternate root directory"
+msgstr "Alternate root directory"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:30
+#: /tmp/fish/explicit/share/completions/zpool.fish:31
+msgid "Import pool in read-only mode"
+msgstr "Import pool in read-only mode"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:32
+#: /tmp/fish/explicit/share/completions/zpool.fish:33
+msgid "Automatic pool expansion on LUN growing"
+msgstr "Automatic pool expansion on LUN growing"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:34
+#: /tmp/fish/explicit/share/completions/zpool.fish:35
+msgid "Automatic use of replacement device"
+msgstr "Automatic use of replacement device"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:36
+msgid "Default bootable dataset"
+msgstr "Default bootable dataset"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:37
+msgid "Pool configuration cache"
+msgstr "Pool configuration cache"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:38
+msgid "Comment about the pool"
+msgstr "Comment about the pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:39
+msgid "Threshold for writting a ditto copy of deduplicated blocks"
+msgstr "Threshold for writting a ditto copy of deduplicated blocks"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:40
+msgid "Allow rights delegation on the pool"
+msgstr "Allow rights delegation on the pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:41
+msgid "Behavior in case of catastrophic pool failure"
+msgstr "Behavior in case of catastrophic pool failure"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:42
+msgid "Display snapshots even if 'zfs list' does not use '-t'"
+msgstr "Display snapshots even if 'zfs list' does not use '-t'"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:43
+msgid "On-disk version of pool"
+msgstr "On-disk version of pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:44
+msgid "%sEnable the %s feature\\n"
+msgstr "%sEnable the %s feature\\n"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:45
+msgid "All properties"
+msgstr "All properties"
+
 #: /tmp/fish/explicit/share/functions/abbr.fish:1
 #, fuzzy
 msgid "%s: Could not figure out what to do!\\n"
@@ -2689,6 +3241,135 @@ msgstr "Treat absent files as empty"
 msgid "%s\\tArchived file\\n"
 msgstr "%s\\tArchived file\\n"
 
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:3
+msgid "Achieved compression ratio"
+msgstr "Achieved compression ratio"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:4
+msgid "Dataset creation time"
+msgstr "Dataset creation time"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:5
+msgid "Snapshot clones"
+msgstr "Snapshot clones"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:6
+msgid "Marked for deferred destruction"
+msgstr "Marked for deferred destruction"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:7
+msgid "Total lower-level filesystems and volumes"
+msgstr "Total lower-level filesystems and volumes"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:9
+msgid "Logical total space"
+msgstr "Logical total space"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:11
+msgid "Logical used space"
+msgstr "Logical used space"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:12
+msgid "Is currently mounted?"
+msgstr "Is currently mounted?"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:13
+msgid "Source snapshot"
+msgstr "Source snapshot"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:14
+msgid "Token for interrupted reception resumption"
+msgstr "Token for interrupted reception resumption"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:16
+msgid "Total space"
+msgstr "Total space"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:17
+msgid "Achieved compression ratio of referenced space"
+msgstr "Achieved compression ratio of referenced space"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:18
+msgid "Total lower-level snapshots"
+msgstr "Total lower-level snapshots"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:19
+#: /tmp/fish/implicit/share/completions/zfs.fish:71
+#: /tmp/fish/implicit/share/completions/zfs.fish:81
+msgid "Dataset type"
+msgstr "Dataset type"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:20
+msgid "Space used by dataset and children"
+msgstr "Space used by dataset and children"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:21
+msgid "Space used by children datasets"
+msgstr "Space used by children datasets"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:22
+msgid "Space used by dataset itself"
+msgstr "Space used by dataset itself"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:23
+msgid "Space used by refreservation"
+msgstr "Space used by refreservation"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:24
+msgid "Space used by dataset snapshots"
+msgstr "Space used by dataset snapshots"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:25
+msgid "Holds count"
+msgstr "Holds count"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:27
+msgid "Referenced data written since previous snapshot"
+msgstr "Referenced data written since previous snapshot"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:28
+msgid "%sDataset space use by user %s\\n"
+msgstr "%sDataset space use by user %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:29
+msgid "%sDataset space use by group %s\\n"
+msgstr "%sDataset space use by group %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:30
+msgid "%sReferenced data written since snapshot %s\\n"
+msgstr "%sReferenced data written since snapshot %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:28
+msgid "%sMax usage by user %s\\n"
+msgstr "%sMax usage by user %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:29
+msgid "%sMax usage by group %s\\n"
+msgstr "%sMax usage by group %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:3
+msgid "Allow overlay mount"
+msgstr "Allow overlay mount"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:4
+msgid "SELinux context for the child filesystem"
+msgstr "SELinux context for the child filesystem"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:5
+msgid "SELinux context for the filesystem being mounted"
+msgstr "SELinux context for the filesystem being mounted"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:6
+msgid "SELinux context for unlabeled files"
+msgstr "SELinux context for unlabeled files"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:7
+msgid "SELinux context for the root inode of the filesystem"
+msgstr "SELinux context for the root inode of the filesystem"
+
 #: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Welcome to fish, the friendly interactive shell"
@@ -2713,6 +3394,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/aptitude.fish:3
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:3
 #: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:63
 #: /tmp/fish/implicit/share/completions/wajig.fish:3
@@ -5307,7 +5990,10 @@ msgstr "Print debugging info"
 #: /tmp/fish/implicit/share/completions/valgrind.fish:6
 #: /tmp/fish/implicit/share/completions/vi.fish:8
 #: /tmp/fish/implicit/share/completions/wget.fish:9
+#: /tmp/fish/implicit/share/completions/zfs.fish:42
+#: /tmp/fish/implicit/share/completions/zfs.fish:87
 #: /tmp/fish/implicit/share/completions/zip.fish:13
+#: /tmp/fish/implicit/share/completions/zpool.fish:140
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
 msgid "Verbose mode"
 msgstr "Verbose mode"
@@ -10314,7 +11000,7 @@ msgid "Show usage message and options"
 msgstr "Show this help message and exit"
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:380
+#: /tmp/fish/implicit/share/completions/git.fish:382
 #, fuzzy
 msgid "Show help message"
 msgstr "Show this help message and exit"
@@ -15367,7 +16053,7 @@ msgid "Ignore all white space"
 msgstr "Ignore all white space"
 
 #: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:325
+#: /tmp/fish/implicit/share/completions/git.fish:327
 msgid "Ignore changes whose lines are all blank"
 msgstr "Ignore changes whose lines are all blank"
 
@@ -15376,7 +16062,7 @@ msgid "Ignore changes whose lines match the REGEX"
 msgstr "Ignore changes whose lines match the REGEX"
 
 #: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:321
+#: /tmp/fish/implicit/share/completions/git.fish:323
 msgid "Treat all files as text"
 msgstr "Treat all files as text"
 
@@ -17398,6 +18084,91 @@ msgstr ""
 msgid "X display to use"
 msgstr "Send mail to user"
 
+#: /tmp/fish/implicit/share/completions/exercism.fish:1
+#, fuzzy
+msgid "Test if exercism has yet to be given the subcommand"
+msgstr "Test if apt has yet to be given the subcommand"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:3
+#, fuzzy
+msgid "turn on verbose logging"
+msgstr "List users logged in"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:4
+#: /tmp/fish/implicit/share/completions/exercism.fish:19
+#: /tmp/fish/implicit/share/completions/ninja.fish:8
+#: /tmp/fish/implicit/share/completions/quilt.fish:1
+#, fuzzy
+msgid "show help"
+msgstr "Show hidden"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:5
+#, fuzzy
+msgid "print the version"
+msgstr "Print node's version"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:6
+#, fuzzy
+msgid "Writes config values to a JSON file."
+msgstr "Write top servers to file"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:7
+#, fuzzy
+msgid "Outputs useful debug information."
+msgstr "Ignore version magic information"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:8
+#, fuzzy
+msgid "Downloads a solution given the ID of the latest iteration."
+msgstr "Update dependencies to their latest versions"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:9
+msgid "Fetches the next unsubmitted problem in each track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:10
+#, fuzzy
+msgid "Lists the available problems for a language track, given its ID."
+msgstr "List all available products"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:11
+msgid ""
+"Opens exercism.io to your most recent iteration of a problem given the track "
+"ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:12
+msgid ""
+"Downloads the most recent iteration for each of your solutions on exercism."
+"io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:13
+msgid "Skips a problem given a track ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:14
+msgid "Fetches information about your progress with a given language track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:15
+msgid "Submits a new iteration to a problem on exercism.io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:16
+#, fuzzy
+msgid "Lists the available language tracks."
+msgstr "List all available products"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:17
+msgid "REMOVED"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:18
+#, fuzzy
+msgid "Upgrades the CLI to the latest released version."
+msgstr "Update dependencies to their latest versions"
+
 #: /tmp/fish/implicit/share/completions/exit.fish:2
 msgid "Quit with normal exit status"
 msgstr ""
@@ -18208,9 +18979,10 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:8
-#, fuzzy
+#: /tmp/fish/implicit/share/completions/zfs.fish:66
+#: /tmp/fish/implicit/share/completions/zfs.fish:76
 msgid "Maximum recursion depth"
-msgstr "Maximum resident set size"
+msgstr "Maximum recursion depth"
 
 #: /tmp/fish/implicit/share/completions/find.fish:9
 msgid "Do not apply any tests or actions at levels less than specified level"
@@ -19617,9 +20389,9 @@ msgstr "List config files"
 #: /tmp/fish/implicit/share/completions/fossil.fish:280
 #: /tmp/fish/implicit/share/completions/git.fish:64
 #: /tmp/fish/implicit/share/completions/git.fish:86
-#: /tmp/fish/implicit/share/completions/git.fish:244
-#: /tmp/fish/implicit/share/completions/git.fish:293
-#: /tmp/fish/implicit/share/completions/git.fish:294
+#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:296
 msgid "Tag"
 msgstr "Tag"
 
@@ -20070,7 +20842,7 @@ msgid "Limit number of tags"
 msgstr "Only print number of matches"
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:281
-#: /tmp/fish/implicit/share/completions/git.fish:291
+#: /tmp/fish/implicit/share/completions/git.fish:293
 #, fuzzy
 msgid "List tags"
 msgstr "Edit tag"
@@ -20181,6 +20953,7 @@ msgstr "Print version information and exit"
 #: /tmp/fish/implicit/share/completions/gsettings.fish:15
 #: /tmp/fish/implicit/share/completions/ncdu.fish:1
 #: /tmp/fish/implicit/share/completions/obnam.fish:12
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:4
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:5
 #: /tmp/fish/implicit/share/completions/pkginfo.fish:7
 #: /tmp/fish/implicit/share/completions/pkgmk.fish:17
@@ -26429,24 +27202,24 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:96
 #: /tmp/fish/implicit/share/completions/git.fish:108
 #: /tmp/fish/implicit/share/completions/git.fish:130
-#: /tmp/fish/implicit/share/completions/git.fish:134
-#: /tmp/fish/implicit/share/completions/git.fish:140
-#: /tmp/fish/implicit/share/completions/git.fish:183
-#: /tmp/fish/implicit/share/completions/git.fish:219
-#: /tmp/fish/implicit/share/completions/git.fish:222
-#: /tmp/fish/implicit/share/completions/git.fish:242
-#: /tmp/fish/implicit/share/completions/git.fish:265
-#: /tmp/fish/implicit/share/completions/git.fish:285
-#: /tmp/fish/implicit/share/completions/git.fish:307
+#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:221
+#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:244
+#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:309
 msgid "Branch"
 msgstr "Branch"
 
 #: /tmp/fish/implicit/share/completions/git.fish:23
-#: /tmp/fish/implicit/share/completions/git.fish:198
-#: /tmp/fish/implicit/share/completions/git.fish:210
-#: /tmp/fish/implicit/share/completions/git.fish:237
-#: /tmp/fish/implicit/share/completions/git.fish:250
-#: /tmp/fish/implicit/share/completions/git.fish:274
+#: /tmp/fish/implicit/share/completions/git.fish:200
+#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:276
 #: /tmp/fish/implicit/share/completions/mdadm.fish:12
 #: /tmp/fish/implicit/share/completions/update-eix-remote.fish:1
 #, fuzzy
@@ -26456,10 +27229,10 @@ msgstr "Run quietly"
 #: /tmp/fish/implicit/share/completions/git.fish:24
 #: /tmp/fish/implicit/share/completions/git.fish:41
 #: /tmp/fish/implicit/share/completions/git.fish:70
-#: /tmp/fish/implicit/share/completions/git.fish:199
-#: /tmp/fish/implicit/share/completions/git.fish:211
-#: /tmp/fish/implicit/share/completions/git.fish:238
-#: /tmp/fish/implicit/share/completions/git.fish:251
+#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:253
 #: /tmp/fish/implicit/share/completions/prt-get.fish:53
 #: /tmp/fish/implicit/share/completions/prt-get.fish:111
 #: /tmp/fish/implicit/share/completions/xz.fish:32
@@ -26468,12 +27241,12 @@ msgid "Be verbose"
 msgstr "Do not be verbose"
 
 #: /tmp/fish/implicit/share/completions/git.fish:25
-#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:215
 msgid "Append ref names and object names"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:26
-#: /tmp/fish/implicit/share/completions/git.fish:214
+#: /tmp/fish/implicit/share/completions/git.fish:216
 msgid "Force update of local branches"
 msgstr ""
 
@@ -26630,7 +27403,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:63
 #: /tmp/fish/implicit/share/completions/git.fish:85
 #: /tmp/fish/implicit/share/completions/git.fish:109
-#: /tmp/fish/implicit/share/completions/git.fish:184
+#: /tmp/fish/implicit/share/completions/git.fish:186
 msgid "Remote branch"
 msgstr ""
 
@@ -26662,7 +27435,7 @@ msgid "Allow adding otherwise ignored files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:257
+#: /tmp/fish/implicit/share/completions/git.fish:259
 #, fuzzy
 msgid "Interactive mode"
 msgstr "Run in interactive mode"
@@ -26718,7 +27491,7 @@ msgid "Remote Branch"
 msgstr "Branch"
 
 #: /tmp/fish/implicit/share/completions/git.fish:84
-#: /tmp/fish/implicit/share/completions/git.fish:243
+#: /tmp/fish/implicit/share/completions/git.fish:245
 msgid "Head"
 msgstr ""
 
@@ -26903,974 +27676,977 @@ msgstr "Show all of the gems in the current bundle"
 msgid "Compare two paths on the filesystem"
 msgstr "Compare archive and filesystem"
 
-#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:134
 msgid "Open diffs in a visual tool"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:136
 msgid "Visually show diff of changes in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:136
+#: /tmp/fish/implicit/share/completions/git.fish:138
 #, fuzzy
 msgid "Print lines matching a pattern"
 msgstr "list all packages matching pattern"
 
-#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:139
 msgid "Create an empty git repository or reinitialize an existing one"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:138
+#: /tmp/fish/implicit/share/completions/git.fish:140
 msgid "Show commit shortlog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:139
+#: /tmp/fish/implicit/share/completions/git.fish:141
 msgid "Show commit logs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:141
+#: /tmp/fish/implicit/share/completions/git.fish:143
 msgid "Continue listing file history beyond renames"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:144
 #, fuzzy
 msgid "Don't print ref names"
 msgstr "Dont print header"
 
-#: /tmp/fish/implicit/share/completions/git.fish:143
+#: /tmp/fish/implicit/share/completions/git.fish:145
 #, fuzzy
 msgid "Print out ref names"
 msgstr "Print kernel name"
 
-#: /tmp/fish/implicit/share/completions/git.fish:144
+#: /tmp/fish/implicit/share/completions/git.fish:146
 msgid "Print ref name by which each commit was reached"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:145
+#: /tmp/fish/implicit/share/completions/git.fish:147
 msgid "Limit the number of commits before starting to show the commit output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:146
+#: /tmp/fish/implicit/share/completions/git.fish:148
 #, fuzzy
 msgid "Skip given number of commits"
 msgstr "Print inode number of files"
 
-#: /tmp/fish/implicit/share/completions/git.fish:147
-#: /tmp/fish/implicit/share/completions/git.fish:148
+#: /tmp/fish/implicit/share/completions/git.fish:149
+#: /tmp/fish/implicit/share/completions/git.fish:150
 msgid "Show commits more recent than specified date"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:149
-#: /tmp/fish/implicit/share/completions/git.fish:150
+#: /tmp/fish/implicit/share/completions/git.fish:151
+#: /tmp/fish/implicit/share/completions/git.fish:152
 #, fuzzy
 msgid "Show commits older than specified date"
 msgstr "Query packages with the specified group"
 
-#: /tmp/fish/implicit/share/completions/git.fish:151
+#: /tmp/fish/implicit/share/completions/git.fish:153
 msgid "Limit commits from given author"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:152
+#: /tmp/fish/implicit/share/completions/git.fish:154
 msgid "Limit commits from given committer"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:153
+#: /tmp/fish/implicit/share/completions/git.fish:155
 msgid "Limit commits to ones with reflog entries matching given pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:154
+#: /tmp/fish/implicit/share/completions/git.fish:156
 #, fuzzy
 msgid "Limit commits with message that match given pattern"
 msgstr "List contents of a package matching pattern"
 
-#: /tmp/fish/implicit/share/completions/git.fish:155
+#: /tmp/fish/implicit/share/completions/git.fish:157
 msgid "Limit commits to ones that match all given --grep"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:156
-msgid "Limit commits to ones with message that don't match --grep"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:157
-#, fuzzy
-msgid "Case insensitive match"
-msgstr "Case insensitive"
-
 #: /tmp/fish/implicit/share/completions/git.fish:158
-msgid "Patterns are basic regular expressions (default)"
+msgid "Limit commits to ones with message that don't match --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:159
 #, fuzzy
+msgid "Case insensitive match"
+msgstr "Case insensitive"
+
+#: /tmp/fish/implicit/share/completions/git.fish:160
+msgid "Patterns are basic regular expressions (default)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:161
+#, fuzzy
 msgid "Patterns are extended regular expressions"
 msgstr "Pattern is extended regexp"
 
-#: /tmp/fish/implicit/share/completions/git.fish:160
+#: /tmp/fish/implicit/share/completions/git.fish:162
 #, fuzzy
 msgid "Patterns are fixed strings"
 msgstr "Pattern is a fixed string"
 
-#: /tmp/fish/implicit/share/completions/git.fish:161
+#: /tmp/fish/implicit/share/completions/git.fish:163
 msgid "Patterns are Perl-compatible regular expressions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:162
+#: /tmp/fish/implicit/share/completions/git.fish:164
 msgid "Stop when given path disappears from tree"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:163
+#: /tmp/fish/implicit/share/completions/git.fish:165
 #, fuzzy
 msgid "Print only merge commits"
 msgstr "Print only left column"
 
-#: /tmp/fish/implicit/share/completions/git.fish:164
+#: /tmp/fish/implicit/share/completions/git.fish:166
 msgid "Don't print commits with more than one parent"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:165
+#: /tmp/fish/implicit/share/completions/git.fish:167
 msgid "Show only commit with at least the given number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:166
+#: /tmp/fish/implicit/share/completions/git.fish:168
 msgid "Show only commit with at most the given number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:167
+#: /tmp/fish/implicit/share/completions/git.fish:169
 msgid "Show only commit without a mimimum number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:168
+#: /tmp/fish/implicit/share/completions/git.fish:170
 msgid "Show only commit without a maximum number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:169
+#: /tmp/fish/implicit/share/completions/git.fish:171
 msgid "Follow only the first parent commit upon seeing a merge commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:170
+#: /tmp/fish/implicit/share/completions/git.fish:172
 msgid "Reverse meaning of ^ prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:171
+#: /tmp/fish/implicit/share/completions/git.fish:173
 msgid ""
 "Pretend as if all refs in refs/ are listed on the command line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:172
+#: /tmp/fish/implicit/share/completions/git.fish:174
 msgid ""
 "Pretend as if all refs are in refs/heads are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:173
+#: /tmp/fish/implicit/share/completions/git.fish:175
 msgid ""
 "Pretend as if all refs are in ref/tags are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:174
+#: /tmp/fish/implicit/share/completions/git.fish:176
 msgid ""
 "Pretend as if all refs in refs/remotes  are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:175
+#: /tmp/fish/implicit/share/completions/git.fish:177
 msgid ""
 "Pretend as if all refs matching shell glob are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:176
+#: /tmp/fish/implicit/share/completions/git.fish:178
 #, fuzzy
 msgid "Do not include refs matching given glob pattern"
 msgstr "Insert modules matching the given wildcard"
 
-#: /tmp/fish/implicit/share/completions/git.fish:177
+#: /tmp/fish/implicit/share/completions/git.fish:179
 msgid ""
 "Pretend as if all objcets mentioned by reflogs are listed on the command "
 "line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:178
+#: /tmp/fish/implicit/share/completions/git.fish:180
 #, fuzzy
 msgid "Ignore invalid object names"
 msgstr "Ignore environment variables"
 
-#: /tmp/fish/implicit/share/completions/git.fish:179
+#: /tmp/fish/implicit/share/completions/git.fish:181
 #, fuzzy
 msgid "Read commits from stdin"
 msgstr "Read names from stdin"
 
-#: /tmp/fish/implicit/share/completions/git.fish:180
+#: /tmp/fish/implicit/share/completions/git.fish:182
 msgid "Mark equivalent commits with = and inequivalent with +"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:181
+#: /tmp/fish/implicit/share/completions/git.fish:183
 msgid "Omit equivalent commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:182
+#: /tmp/fish/implicit/share/completions/git.fish:184
 msgid "Join two or more development histories together"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:187
 msgid "Autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:186
+#: /tmp/fish/implicit/share/completions/git.fish:188
 #, fuzzy
 msgid "Don't autocommit the merge"
 msgstr "Don't use a comment string"
 
-#: /tmp/fish/implicit/share/completions/git.fish:187
+#: /tmp/fish/implicit/share/completions/git.fish:189
 msgid "Edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:188
+#: /tmp/fish/implicit/share/completions/git.fish:190
 msgid "Don't edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:189
+#: /tmp/fish/implicit/share/completions/git.fish:191
 msgid "Don't generate a merge commit if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:190
+#: /tmp/fish/implicit/share/completions/git.fish:192
 msgid "Generate a merge commit even if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:191
+#: /tmp/fish/implicit/share/completions/git.fish:193
 msgid "Refuse to merge unless fast-forward possible"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:192
+#: /tmp/fish/implicit/share/completions/git.fish:194
 msgid "Populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:193
-msgid "Don't populate the log message with one-line descriptions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:194
-#, fuzzy
-msgid "Show diffstat of the merge"
-msgstr "Show modification time"
-
 #: /tmp/fish/implicit/share/completions/git.fish:195
-msgid "Don't show diffstat of the merge"
+msgid "Don't populate the log message with one-line descriptions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:196
 #, fuzzy
+msgid "Show diffstat of the merge"
+msgstr "Show modification time"
+
+#: /tmp/fish/implicit/share/completions/git.fish:197
+msgid "Don't show diffstat of the merge"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:198
+#, fuzzy
 msgid "Squash changes from other branch as a single commit"
 msgstr "Bring changes from the repository into the working copy"
 
-#: /tmp/fish/implicit/share/completions/git.fish:197
+#: /tmp/fish/implicit/share/completions/git.fish:199
 #, fuzzy
 msgid "Don't squash changes"
 msgstr "Don't summarize changes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:200
-#: /tmp/fish/implicit/share/completions/git.fish:217
-#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:219
+#: /tmp/fish/implicit/share/completions/git.fish:241
 msgid "Force progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:203
 msgid "Force no progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:204
 #, fuzzy
 msgid "Set the commit message"
 msgstr "Read commit message from file"
 
-#: /tmp/fish/implicit/share/completions/git.fish:203
+#: /tmp/fish/implicit/share/completions/git.fish:205
 #, fuzzy
 msgid "Abort the current conflict resolution process"
 msgstr "Write out the current configuration"
 
-#: /tmp/fish/implicit/share/completions/git.fish:204
+#: /tmp/fish/implicit/share/completions/git.fish:206
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:205
+#: /tmp/fish/implicit/share/completions/git.fish:207
 #, fuzzy
 msgid "Use specific merge resolution program"
 msgstr "Use specified message digest algorithm"
 
-#: /tmp/fish/implicit/share/completions/git.fish:207
+#: /tmp/fish/implicit/share/completions/git.fish:209
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:210
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:209
+#: /tmp/fish/implicit/share/completions/git.fish:211
 msgid "Fetch from and merge with another repository or a local branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:214
 #, fuzzy
 msgid "Fetch all remotes"
 msgstr "Refresh all repositories"
 
-#: /tmp/fish/implicit/share/completions/git.fish:215
+#: /tmp/fish/implicit/share/completions/git.fish:217
 #, fuzzy
 msgid "Keep downloaded pack"
 msgstr "Disable downloading packages"
 
-#: /tmp/fish/implicit/share/completions/git.fish:216
+#: /tmp/fish/implicit/share/completions/git.fish:218
 #, fuzzy
 msgid "Disable automatic tag following"
 msgstr "Disable automtic buffer allocation"
 
-#: /tmp/fish/implicit/share/completions/git.fish:218
-#: /tmp/fish/implicit/share/completions/git.fish:221
-#: /tmp/fish/implicit/share/completions/git.fish:241
+#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:243
 #, fuzzy
 msgid "Remote alias"
 msgstr "Remove packages"
 
-#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:222
 msgid "Update remote refs along with associated objects"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:225
 msgid "Force-push branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:226
 msgid "Force-push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:225
+#: /tmp/fish/implicit/share/completions/git.fish:227
 msgid "Push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:226
+#: /tmp/fish/implicit/share/completions/git.fish:228
 msgid "Push all refs under refs/heads/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:227
+#: /tmp/fish/implicit/share/completions/git.fish:229
 msgid "Remove remote branches that don't have a local counterpart"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:228
+#: /tmp/fish/implicit/share/completions/git.fish:230
 msgid "Push all refs under refs/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:229
+#: /tmp/fish/implicit/share/completions/git.fish:231
 #, fuzzy
 msgid "Delete all listed refs from the remote repository"
 msgstr "Delete selected patches from the repository. (UNSAFE!)"
 
-#: /tmp/fish/implicit/share/completions/git.fish:230
+#: /tmp/fish/implicit/share/completions/git.fish:232
 msgid "Push all refs under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:231
+#: /tmp/fish/implicit/share/completions/git.fish:233
 msgid "Push all usual refs plus the ones under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:232
+#: /tmp/fish/implicit/share/completions/git.fish:234
 msgid "Do everything except actually send the updates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:233
+#: /tmp/fish/implicit/share/completions/git.fish:235
 #, fuzzy
 msgid "Produce machine-readable output"
 msgstr "Give human-readable output"
 
-#: /tmp/fish/implicit/share/completions/git.fish:234
+#: /tmp/fish/implicit/share/completions/git.fish:236
 msgid "Force update of remote refs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:235
+#: /tmp/fish/implicit/share/completions/git.fish:237
 msgid ""
 "Force update of remote refs, stopping if other's changes would be overwritten"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:236
+#: /tmp/fish/implicit/share/completions/git.fish:238
 msgid "Add upstream (tracking) reference"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:242
 msgid "Forward-port local commits to the updated upstream head"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:245
+#: /tmp/fish/implicit/share/completions/git.fish:247
 #, fuzzy
 msgid "Restart the rebasing process"
 msgstr "Automatic line ending processing"
 
-#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:248
 #, fuzzy
 msgid "Abort the rebase operation"
 msgstr "force reassociation"
 
-#: /tmp/fish/implicit/share/completions/git.fish:247
+#: /tmp/fish/implicit/share/completions/git.fish:249
 msgid "Keep the commits that don't cahnge anything"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:248
+#: /tmp/fish/implicit/share/completions/git.fish:250
 msgid "Restart the rebasing process by skipping the current patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:249
+#: /tmp/fish/implicit/share/completions/git.fish:251
 msgid "Use merging strategies to rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:254
 #, fuzzy
 msgid "Show diffstat of the rebase"
 msgstr "Show state of dependencies"
 
-#: /tmp/fish/implicit/share/completions/git.fish:253
+#: /tmp/fish/implicit/share/completions/git.fish:255
 msgid "Don't show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:254
+#: /tmp/fish/implicit/share/completions/git.fish:256
 msgid "Allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:255
+#: /tmp/fish/implicit/share/completions/git.fish:257
 msgid "Don't allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:256
+#: /tmp/fish/implicit/share/completions/git.fish:258
 #, fuzzy
 msgid "Force the rebase"
 msgstr "Force new revision"
 
-#: /tmp/fish/implicit/share/completions/git.fish:258
+#: /tmp/fish/implicit/share/completions/git.fish:260
 msgid "Try to recreate merges"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:259
+#: /tmp/fish/implicit/share/completions/git.fish:261
 #, fuzzy
 msgid "Rebase all reachable commits"
 msgstr "Report on each commit"
 
-#: /tmp/fish/implicit/share/completions/git.fish:260
+#: /tmp/fish/implicit/share/completions/git.fish:262
 msgid "Automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:261
+#: /tmp/fish/implicit/share/completions/git.fish:263
 msgid "No automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:262
+#: /tmp/fish/implicit/share/completions/git.fish:264
 #, fuzzy
 msgid "No fast-forward"
 msgstr "Set date forward"
 
-#: /tmp/fish/implicit/share/completions/git.fish:263
+#: /tmp/fish/implicit/share/completions/git.fish:265
 #, fuzzy
 msgid "Reset current HEAD to the specified state"
 msgstr "Help for the specified builtin"
 
-#: /tmp/fish/implicit/share/completions/git.fish:264
+#: /tmp/fish/implicit/share/completions/git.fish:266
 #, fuzzy
 msgid "Reset files in working directory"
 msgstr "Change working directory"
 
-#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:270
 msgid "Reflog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: /tmp/fish/implicit/share/completions/git.fish:271
 #, fuzzy
 msgid "Revert an existing commit"
 msgstr "Report on each commit"
 
-#: /tmp/fish/implicit/share/completions/git.fish:270
+#: /tmp/fish/implicit/share/completions/git.fish:272
 #, fuzzy
 msgid "Remove files from the working tree and from the index"
 msgstr "Remove files after adding to archive"
 
-#: /tmp/fish/implicit/share/completions/git.fish:271
+#: /tmp/fish/implicit/share/completions/git.fish:273
 #, fuzzy
 msgid "Keep local copies"
 msgstr "Clean local caches"
 
-#: /tmp/fish/implicit/share/completions/git.fish:272
+#: /tmp/fish/implicit/share/completions/git.fish:274
 msgid "Exit with a zero status even if no files matched"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:273
+#: /tmp/fish/implicit/share/completions/git.fish:275
 msgid "Allow recursive removal"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:275
+#: /tmp/fish/implicit/share/completions/git.fish:277
 msgid "Override the up-to-date check"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:276
+#: /tmp/fish/implicit/share/completions/git.fish:278
 #: /tmp/fish/implicit/share/completions/prt-get.fish:45
 #: /tmp/fish/implicit/share/completions/prt-get.fish:103
+#: /tmp/fish/implicit/share/completions/zfs.fish:40
+#: /tmp/fish/implicit/share/completions/zfs.fish:124
+#: /tmp/fish/implicit/share/completions/zfs.fish:132
 msgid "Dry run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:277
+#: /tmp/fish/implicit/share/completions/git.fish:279
 #, fuzzy
 msgid "Show the working tree status"
 msgstr "Show the running containers"
 
-#: /tmp/fish/implicit/share/completions/git.fish:278
+#: /tmp/fish/implicit/share/completions/git.fish:280
 #, fuzzy
 msgid "Give the output in the short-format"
 msgstr "Give output suitable for get --context"
 
-#: /tmp/fish/implicit/share/completions/git.fish:279
+#: /tmp/fish/implicit/share/completions/git.fish:281
 msgid "Show the branch and tracking info even in short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:280
+#: /tmp/fish/implicit/share/completions/git.fish:282
 msgid "Give the output in a stable, easy-to-parse format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:281
+#: /tmp/fish/implicit/share/completions/git.fish:283
 msgid "Terminate entries with null character"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:282
+#: /tmp/fish/implicit/share/completions/git.fish:284
 msgid "The untracked files handling mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:283
+#: /tmp/fish/implicit/share/completions/git.fish:285
 #, fuzzy
 msgid "Ignore changes to submodules"
 msgstr "Ignore changes in case"
 
-#: /tmp/fish/implicit/share/completions/git.fish:284
+#: /tmp/fish/implicit/share/completions/git.fish:286
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:286
+#: /tmp/fish/implicit/share/completions/git.fish:288
 msgid "Make an unsigned, annotated tag object"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:289
 #, fuzzy
 msgid "Make a GPG-signed tag"
 msgstr "Make a signature"
 
-#: /tmp/fish/implicit/share/completions/git.fish:288
+#: /tmp/fish/implicit/share/completions/git.fish:290
 #, fuzzy
 msgid "Remove a tag"
 msgstr "Remove a key"
 
-#: /tmp/fish/implicit/share/completions/git.fish:289
+#: /tmp/fish/implicit/share/completions/git.fish:291
 msgid "Verify signature of a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:290
+#: /tmp/fish/implicit/share/completions/git.fish:292
 msgid "Force overwriting exising tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:292
+#: /tmp/fish/implicit/share/completions/git.fish:294
 msgid "List tags that contain a commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:297
 #, fuzzy
 msgid "Stash away changes"
 msgstr "Patch local changes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:296
+#: /tmp/fish/implicit/share/completions/git.fish:298
 #, fuzzy
 msgid "List stashes"
 msgstr "Lists the keys"
 
-#: /tmp/fish/implicit/share/completions/git.fish:297
+#: /tmp/fish/implicit/share/completions/git.fish:299
 #, fuzzy
 msgid "Show the changes recorded in the stash"
 msgstr "Query packages with the specified group"
 
-#: /tmp/fish/implicit/share/completions/git.fish:298
+#: /tmp/fish/implicit/share/completions/git.fish:300
 msgid "Apply and remove a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:299
+#: /tmp/fish/implicit/share/completions/git.fish:301
 msgid "Apply a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:300
+#: /tmp/fish/implicit/share/completions/git.fish:302
 #, fuzzy
 msgid "Remove all stashed states"
 msgstr "Remove the packages"
 
-#: /tmp/fish/implicit/share/completions/git.fish:301
+#: /tmp/fish/implicit/share/completions/git.fish:303
 #, fuzzy
 msgid "Remove a single stashed state from the stash list"
 msgstr "Remove a given entry from the --group list"
 
-#: /tmp/fish/implicit/share/completions/git.fish:302
+#: /tmp/fish/implicit/share/completions/git.fish:304
 #, fuzzy
 msgid "Create a stash"
 msgstr "Create archive"
 
-#: /tmp/fish/implicit/share/completions/git.fish:303
+#: /tmp/fish/implicit/share/completions/git.fish:305
 msgid "Save a new stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:304
+#: /tmp/fish/implicit/share/completions/git.fish:306
 #, fuzzy
 msgid "Create a new branch from a stash"
 msgstr "Create a patch from unrecorded changes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:305
+#: /tmp/fish/implicit/share/completions/git.fish:307
 #, fuzzy
 msgid "Set and read git configuration variables"
 msgstr "Query a configuration variables value"
 
-#: /tmp/fish/implicit/share/completions/git.fish:306
+#: /tmp/fish/implicit/share/completions/git.fish:308
 #, fuzzy
 msgid "Generate patch series to send upstream"
 msgstr "Generate package from source"
 
-#: /tmp/fish/implicit/share/completions/git.fish:308
+#: /tmp/fish/implicit/share/completions/git.fish:310
 msgid "Generate plain patches without diffstat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:309
+#: /tmp/fish/implicit/share/completions/git.fish:311
 #, fuzzy
 msgid "Suppress diff output"
 msgstr "Suppress informational output"
 
-#: /tmp/fish/implicit/share/completions/git.fish:310
+#: /tmp/fish/implicit/share/completions/git.fish:312
 msgid "Spend more time to create smaller diffs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:311
+#: /tmp/fish/implicit/share/completions/git.fish:313
 msgid "Generate diff with the 'patience' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:312
+#: /tmp/fish/implicit/share/completions/git.fish:314
 msgid "Generate diff with the 'histogram' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:313
+#: /tmp/fish/implicit/share/completions/git.fish:315
 msgid "Print all commits to stdout in mbox format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:314
-msgid "Show number of added/deleted lines in decimal notation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:315
-#, fuzzy
-msgid "Output only last line of the stat"
-msgstr "Output only first of equal lines"
-
 #: /tmp/fish/implicit/share/completions/git.fish:316
-msgid "Output a condensed summary of extended header information"
+msgid "Show number of added/deleted lines in decimal notation"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:317
 #, fuzzy
-msgid "Disable rename detection"
-msgstr "Disable file modification"
+msgid "Output only last line of the stat"
+msgstr "Output only first of equal lines"
 
 #: /tmp/fish/implicit/share/completions/git.fish:318
-msgid "Show full blob object names"
+msgid "Output a condensed summary of extended header information"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:319
+#, fuzzy
+msgid "Disable rename detection"
+msgstr "Disable file modification"
+
+#: /tmp/fish/implicit/share/completions/git.fish:320
+msgid "Show full blob object names"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:321
 msgid "Output a binary diff for use with git apply"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:320
+#: /tmp/fish/implicit/share/completions/git.fish:322
 msgid "Also inspect unmodified files as source for a copy"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:322
+#: /tmp/fish/implicit/share/completions/git.fish:324
 #, fuzzy
 msgid "Ignore changes in whitespace at EOL"
 msgstr "Ignore changes in the amount of white space"
 
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: /tmp/fish/implicit/share/completions/git.fish:325
 #, fuzzy
 msgid "Ignore changes in amount of whitespace"
 msgstr "Ignore changes in the amount of white space"
 
-#: /tmp/fish/implicit/share/completions/git.fish:324
+#: /tmp/fish/implicit/share/completions/git.fish:326
 #, fuzzy
 msgid "Ignore whitespace when comparing lines"
 msgstr "Ignore case when comparing file names"
 
-#: /tmp/fish/implicit/share/completions/git.fish:326
+#: /tmp/fish/implicit/share/completions/git.fish:328
 #, fuzzy
 msgid "Show whole surrounding functions of changes"
 msgstr "Show the running containers"
 
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: /tmp/fish/implicit/share/completions/git.fish:329
 msgid "Allow an external diff helper to be executed"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:328
+#: /tmp/fish/implicit/share/completions/git.fish:330
 msgid "Disallow external diff helpers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:329
+#: /tmp/fish/implicit/share/completions/git.fish:331
 msgid "Disallow external text conversion filters for binary files (Default)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:330
+#: /tmp/fish/implicit/share/completions/git.fish:332
 msgid ""
 "Allow external text conversion filters for binary files (Resulting diff is "
 "unappliable)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:331
+#: /tmp/fish/implicit/share/completions/git.fish:333
 msgid "Do not show source or destination prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:332
+#: /tmp/fish/implicit/share/completions/git.fish:334
 msgid "Name output in [Patch n/m] format, even with a single patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:333
+#: /tmp/fish/implicit/share/completions/git.fish:335
 msgid "Name output in [Patch] format, even with multiple patches"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:334
+#: /tmp/fish/implicit/share/completions/git.fish:336
 msgid "Initialize, update or inspect submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:335
+#: /tmp/fish/implicit/share/completions/git.fish:337
 #, fuzzy
 msgid "Add a submodule"
 msgstr "Add a symbolic tag to a module"
 
-#: /tmp/fish/implicit/share/completions/git.fish:336
+#: /tmp/fish/implicit/share/completions/git.fish:338
 msgid "Show submodule status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:337
-#: /tmp/fish/implicit/share/completions/git.fish:343
+#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:345
 msgid "Initialize all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:338
+#: /tmp/fish/implicit/share/completions/git.fish:340
 #, fuzzy
 msgid "Update all submodules"
 msgstr "Update sources"
 
-#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:341
 #, fuzzy
 msgid "Show commit summary"
 msgstr "Print summary"
 
-#: /tmp/fish/implicit/share/completions/git.fish:340
+#: /tmp/fish/implicit/share/completions/git.fish:342
 #, fuzzy
 msgid "Run command on each submodule"
 msgstr "Run commands from cache"
 
-#: /tmp/fish/implicit/share/completions/git.fish:341
+#: /tmp/fish/implicit/share/completions/git.fish:343
 msgid "Sync submodules' URL with .gitmodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:342
+#: /tmp/fish/implicit/share/completions/git.fish:344
 #, fuzzy
 msgid "Only print error messages"
 msgstr "Only print number of matches"
 
-#: /tmp/fish/implicit/share/completions/git.fish:344
+#: /tmp/fish/implicit/share/completions/git.fish:346
 msgid "Checkout the superproject's commit on a detached HEAD in the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:345
+#: /tmp/fish/implicit/share/completions/git.fish:347
 msgid ""
 "Merge the superproject's commit into the current branch of the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:346
+#: /tmp/fish/implicit/share/completions/git.fish:348
 msgid "Rebase current branch onto the superproject's commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:347
+#: /tmp/fish/implicit/share/completions/git.fish:349
 msgid "Don't fetch new objects from the remote"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:348
+#: /tmp/fish/implicit/share/completions/git.fish:350
 msgid ""
 "Instead of using superproject's SHA-1, use the state of the submodule's "
 "remote-tracking branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:349
+#: /tmp/fish/implicit/share/completions/git.fish:351
 msgid ""
 "Throw away local changes when switching to a different commit and always run "
 "checkout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:350
+#: /tmp/fish/implicit/share/completions/git.fish:352
 msgid "Also add ignored submodule path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:351
+#: /tmp/fish/implicit/share/completions/git.fish:353
 #, fuzzy
 msgid "Remove even with local changes"
 msgstr "Patch local changes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:352
+#: /tmp/fish/implicit/share/completions/git.fish:354
 msgid "Use the commit stored in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:353
-msgid "Compare the commit in the index with submodule HEAD"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:354
-#, fuzzy
-msgid "Traverse submodules recursively"
-msgstr "Descend recursively"
-
 #: /tmp/fish/implicit/share/completions/git.fish:355
-msgid "Show logs with difference each commit introduces"
+msgid "Compare the commit in the index with submodule HEAD"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:356
 #, fuzzy
+msgid "Traverse submodules recursively"
+msgstr "Descend recursively"
+
+#: /tmp/fish/implicit/share/completions/git.fish:357
+msgid "Show logs with difference each commit introduces"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:358
+#, fuzzy
 msgid "Remove untracked files from the working tree"
 msgstr "Remove files from version control"
 
-#: /tmp/fish/implicit/share/completions/git.fish:357
+#: /tmp/fish/implicit/share/completions/git.fish:359
 #, fuzzy
 msgid "Force run"
 msgstr "Forced quit"
 
-#: /tmp/fish/implicit/share/completions/git.fish:358
+#: /tmp/fish/implicit/share/completions/git.fish:360
 msgid "Show what would be done and clean files interactively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:359
+#: /tmp/fish/implicit/share/completions/git.fish:361
 msgid "Don't actually remove anything, just show what would be done"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:360
+#: /tmp/fish/implicit/share/completions/git.fish:362
 msgid "Be quiet, only report errors"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:361
+#: /tmp/fish/implicit/share/completions/git.fish:363
 msgid "Remove untracked directories in addition to untracked files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:362
+#: /tmp/fish/implicit/share/completions/git.fish:364
 msgid "Remove ignored files, as well"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:363
+#: /tmp/fish/implicit/share/completions/git.fish:365
 #, fuzzy
 msgid "Remove only ignored files"
 msgstr "Freshen: only changed files"
 
-#: /tmp/fish/implicit/share/completions/git.fish:364
+#: /tmp/fish/implicit/share/completions/git.fish:366
 #, fuzzy
 msgid "Show what revision and author last modified each line of a file"
 msgstr "Show last revision where each line was modified"
 
-#: /tmp/fish/implicit/share/completions/git.fish:365
-msgid "Show blank SHA-1 for boundary commits"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:366
-#, fuzzy
-msgid "Do not treat root commits as boundaries"
-msgstr "Do not execute remote command"
-
 #: /tmp/fish/implicit/share/completions/git.fish:367
-msgid "Include additional statistics"
+msgid "Show blank SHA-1 for boundary commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:368
 #, fuzzy
-msgid "Annotate only the given line range"
-msgstr "Annotate every line"
+msgid "Do not treat root commits as boundaries"
+msgstr "Do not execute remote command"
 
 #: /tmp/fish/implicit/share/completions/git.fish:369
-msgid "Show long rev"
+msgid "Include additional statistics"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:370
 #, fuzzy
+msgid "Annotate only the given line range"
+msgstr "Annotate every line"
+
+#: /tmp/fish/implicit/share/completions/git.fish:371
+msgid "Show long rev"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:372
+#, fuzzy
 msgid "Show raw timestamp"
 msgstr "Show time type"
 
-#: /tmp/fish/implicit/share/completions/git.fish:371
+#: /tmp/fish/implicit/share/completions/git.fish:373
 #, fuzzy
 msgid "Use revisions from named file instead of calling rev-list"
 msgstr "Use this config file instead of default"
 
-#: /tmp/fish/implicit/share/completions/git.fish:372
+#: /tmp/fish/implicit/share/completions/git.fish:374
 msgid "Walk history forward instead of backward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:373
+#: /tmp/fish/implicit/share/completions/git.fish:375
 msgid "Show in a format designed for machine consumption"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:374
+#: /tmp/fish/implicit/share/completions/git.fish:376
 #, fuzzy
 msgid "Show the porcelain format"
 msgstr "Show whatis information"
 
-#: /tmp/fish/implicit/share/completions/git.fish:375
+#: /tmp/fish/implicit/share/completions/git.fish:377
 #, fuzzy
 msgid "Show the result incrementally"
 msgstr "Show the time"
 
-#: /tmp/fish/implicit/share/completions/git.fish:376
+#: /tmp/fish/implicit/share/completions/git.fish:378
 msgid "Instead of working tree, use the contents of the named file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:377
+#: /tmp/fish/implicit/share/completions/git.fish:379
 #, fuzzy
 msgid "Specifies the format used to output dates"
 msgstr "Specify the remote shell to use"
 
-#: /tmp/fish/implicit/share/completions/git.fish:378
+#: /tmp/fish/implicit/share/completions/git.fish:380
 msgid "Detect moved or copied lines within a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:379
+#: /tmp/fish/implicit/share/completions/git.fish:381
 msgid ""
 "Detect lines moved or copied from other files that were modified in the same "
 "commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:381
+#: /tmp/fish/implicit/share/completions/git.fish:383
 #, fuzzy
 msgid "Use the same output mode as git-annotate"
 msgstr "Use the portable output format"
 
-#: /tmp/fish/implicit/share/completions/git.fish:382
+#: /tmp/fish/implicit/share/completions/git.fish:384
 #, fuzzy
 msgid "Show the filename in the original commit"
 msgstr "Change working directory"
 
-#: /tmp/fish/implicit/share/completions/git.fish:383
+#: /tmp/fish/implicit/share/completions/git.fish:385
 msgid "Show the line number in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:384
+#: /tmp/fish/implicit/share/completions/git.fish:386
 #, fuzzy
 msgid "Suppress the author name and timestamp from the output"
 msgstr "Allow subkeys that have a timestamp from the future"
 
-#: /tmp/fish/implicit/share/completions/git.fish:385
+#: /tmp/fish/implicit/share/completions/git.fish:387
 #, fuzzy
 msgid "Show the author email instead of author name"
 msgstr "Check out into dir instead of module name."
 
-#: /tmp/fish/implicit/share/completions/git.fish:386
+#: /tmp/fish/implicit/share/completions/git.fish:388
 #, fuzzy
 msgid "Ignore whitespace changes"
 msgstr "Ignore whitespace"
 
-#: /tmp/fish/implicit/share/completions/git.fish:387
+#: /tmp/fish/implicit/share/completions/git.fish:389
 #, fuzzy
 msgid "Custom command"
 msgstr "Job command"
@@ -28426,6 +29202,7 @@ msgid "List all keys with their fingerprints"
 msgstr "List all keys with their fingerprints"
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
+#: /tmp/fish/implicit/share/completions/signify.fish:2
 #, fuzzy
 msgid "Generate a new key pair"
 msgstr "Generate man page"
@@ -38220,14 +38997,6 @@ msgstr ""
 msgid "Display values currently set in the minikube config file"
 msgstr "Display all currently defined trap handlers"
 
-#: /tmp/fish/implicit/share/completions/minikube.fish:25
-#: /tmp/fish/implicit/share/completions/minikube.fish:26
-#: /tmp/fish/implicit/share/completions/minikube.fish:27
-#: /tmp/fish/implicit/share/completions/minikube.fish:28
-#, fuzzy
-msgid "Property"
-msgstr "Set property"
-
 #: /tmp/fish/implicit/share/completions/minikube.fish:29
 msgid "Go template format string for the config view output"
 msgstr ""
@@ -44422,12 +45191,6 @@ msgstr ""
 msgid "keep going until N jobs fail [default=1]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ninja.fish:8
-#: /tmp/fish/implicit/share/completions/quilt.fish:1
-#, fuzzy
-msgid "show help"
-msgstr "Show hidden"
-
 #: /tmp/fish/implicit/share/completions/ninja.fish:9
 msgid "enable debugging, specify debug mode"
 msgstr ""
@@ -47964,6 +48727,20 @@ msgstr "Disable warnings"
 msgid "Extract script"
 msgstr "Evaluate script"
 
+#: /tmp/fish/implicit/share/completions/pfctl.fish:1
+msgid "Show a filter parameter by modifier"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:2
+#, fuzzy
+msgid "Flush filter params specified by mod"
+msgstr "Compare only specified number of characters"
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:3
+#, fuzzy
+msgid "Table command"
+msgstr "Help for this command"
+
 #: /tmp/fish/implicit/share/completions/pgrep.fish:1
 #, fuzzy
 msgid "Output delimiter"
@@ -48182,6 +48959,31 @@ msgstr ""
 msgid "omit the user's full name, remote host and idle time in short format"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:1
+#, fuzzy
+msgid "failsafe to overwrite"
+msgstr "Log to file, overwrite"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:2
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:3
+#, fuzzy
+msgid "Turn on stats"
+msgstr "Warning control"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:3
+#, fuzzy
+msgid "Automated package installation"
+msgstr "Don't change the package installation order"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:5
+#, fuzzy
+msgid "Update packages"
+msgstr "Upgrade packages"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:6
+msgid "Fuzzy match"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:1
 #, fuzzy
 msgid "Upgrade"
@@ -48296,6 +49098,11 @@ msgstr "List capabilities this package provides"
 #: /tmp/fish/implicit/share/completions/pkg-config.fish:25
 msgid "List all modules the given packages requires for static linking"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:2
+#, fuzzy
+msgid "Delete unsed deps"
+msgstr "Delete selection"
 
 #: /tmp/fish/implicit/share/completions/pkgfile.fish:3
 msgid "only show files in a {s}bin/ directory. Works with -s, -l"
@@ -53055,6 +53862,20 @@ msgstr ""
 msgid "Specifies layout variant used to choose component names"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/signify.fish:1
+msgid "Verify a signed checksum list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:3
+#, fuzzy
+msgid "Sign specified message"
+msgstr "Ignore specified file"
+
+#: /tmp/fish/implicit/share/completions/signify.fish:4
+#, fuzzy
+msgid "Verify a signed message and sig"
+msgstr "Print help message and exit"
+
 #: /tmp/fish/implicit/share/completions/snap.fish:1
 #, fuzzy
 msgid "Test if snap has yet to be given the subcommand"
@@ -57176,11 +57997,13 @@ msgid "Monitor changes to objects"
 msgstr "Ignore changes in case"
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:7
+#: /tmp/fish/implicit/share/completions/zfs.fish:17
 #, fuzzy
 msgid "Mount a filesystem"
 msgstr "Show all filesystems"
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:18
 #, fuzzy
 msgid "Unmount a filesystem"
 msgstr "Show all filesystems"
@@ -62089,6 +62912,615 @@ msgstr "Delete cached header files"
 msgid "Delete all cache contents"
 msgstr "Delete all cache contents"
 
+#: /tmp/fish/implicit/share/completions/zfs.fish:1
+msgid ""
+"Internal completion function for appending string to the ZFS commandline"
+msgstr ""
+"Internal completion function for appending string to the ZFS commandline"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:2
+#: /tmp/fish/implicit/share/completions/zpool.fish:2
+msgid "Display a help message"
+msgstr "Display a help message"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:3
+msgid "Create a volume or filesystem"
+msgstr "Create a volume or filesystem"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:4
+msgid "Destroy a dataset"
+msgstr "Destroy a dataset"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:5
+msgid "Create a snapshot"
+msgstr "Create a snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:6
+msgid "Roll back a filesystem to a previous snapshot"
+msgstr "Roll back a filesystem to a previous snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:7
+msgid "Create a clone of a snapshot"
+msgstr "Create a clone of a snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:8
+msgid ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+msgstr ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:9
+msgid "Rename a dataset"
+msgstr "Rename a dataset"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:10
+msgid "List dataset properties"
+msgstr "List dataset properties"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:11
+msgid "Set a dataset property"
+msgstr "Set a dataset property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:12
+msgid "Get one or several dataset properties"
+msgstr "Get one or several dataset properties"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:13
+msgid "Set a dataset property to be inherited"
+msgstr "Set a dataset property to be inherited"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:14
+msgid "List upgradeable datasets, or upgrade one"
+msgstr "List upgradeable datasets, or upgrade one"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:15
+msgid "Get dataset space consumed by each user"
+msgstr "Get dataset space consumed by each user"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:16
+msgid "Get dataset space consumed by each user group"
+msgstr "Get dataset space consumed by each user group"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:19
+msgid "Share a given filesystem, or all of them"
+msgstr "Share a given filesystem, or all of them"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:20
+msgid "Stop sharing a given filesystem, or all of them"
+msgstr "Stop sharing a given filesystem, or all of them"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:21
+msgid "Create a bookmark for a snapshot"
+msgstr "Create a bookmark for a snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:22
+msgid "Output a stream representation of a dataset"
+msgstr "Output a stream representation of a dataset"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:23
+msgid ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+msgstr ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:24
+msgid ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+msgstr ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:25
+msgid "Revoke delegations of rights on a dataset from (groups of) users"
+msgstr "Revoke delegations of rights on a dataset from (groups of) users"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:26
+msgid "Put a named hold on a snapshot"
+msgstr "Put a named hold on a snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:27
+msgid "List holds on a snapshot"
+msgstr "List holds on a snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:28
+msgid "Remove a named hold from a snapshot"
+msgstr "Remove a named hold from a snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:29
+msgid ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+msgstr ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:30
+msgid "Execute a ZFS Channel Program"
+msgstr "Execute a ZFS Channel Program"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:31
+#: /tmp/fish/implicit/share/completions/zfs.fish:53
+#: /tmp/fish/implicit/share/completions/zfs.fish:58
+msgid "Create all needed non-existing parent datasets"
+msgstr "Create all needed non-existing parent datasets"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:32
+#: /tmp/fish/implicit/share/completions/zfs.fish:33
+msgid "Dataset property"
+msgstr "Dataset property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:34
+msgid "Volume size"
+msgstr "Volume size"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:35
+msgid "Create a sparse volume"
+msgstr "Create a sparse volume"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:36
+msgid "Blocksize"
+msgstr "Blocksize"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:37
+msgid "Recursively destroy children"
+msgstr "Recursively destroy children"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:38
+msgid "Recursively destroy all dependents"
+msgstr "Recursively destroy all dependents"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:39
+msgid "Force unmounting"
+msgstr "Force unmounting"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:41
+msgid "Print machine-parsable verbose information"
+msgstr "Print machine-parsable verbose information"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:43
+msgid "Defer snapshot deletion"
+msgstr "Defer snapshot deletion"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:44
+msgid "Dataset to destroy"
+msgstr "Dataset to destroy"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:45
+msgid "Recursively snapshot children"
+msgstr "Recursively snapshot children"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:46
+#: /tmp/fish/implicit/share/completions/zfs.fish:47
+msgid "Snapshot property"
+msgstr "Snapshot property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:48
+msgid "Dataset to snapshot"
+msgstr "Dataset to snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:49
+msgid "Destroy later snapshot and bookmarks"
+msgstr "Destroy later snapshot and bookmarks"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:50
+msgid "Recursively destroy later snapshot, bookmarks and clones"
+msgstr "Recursively destroy later snapshot, bookmarks and clones"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:51
+msgid "Force unmounting of clones"
+msgstr "Force unmounting of clones"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:52
+msgid "Snapshot to roll back to"
+msgstr "Snapshot to roll back to"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:54
+#: /tmp/fish/implicit/share/completions/zfs.fish:55
+msgid "Clone property"
+msgstr "Clone property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:56
+msgid "Snapshot to clone"
+msgstr "Snapshot to clone"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:57
+msgid "Clone to promote"
+msgstr "Clone to promote"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:59
+msgid "Recursively rename children snapshots"
+msgstr "Recursively rename children snapshots"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:60
+#: /tmp/fish/implicit/share/completions/zfs.fish:62
+#: /tmp/fish/implicit/share/completions/zfs.fish:108
+msgid "Force unmounting if needed"
+msgstr "Force unmounting if needed"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:61
+msgid "Do not remount filesystems during rename"
+msgstr "Do not remount filesystems during rename"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:63
+msgid "Dataset to rename"
+msgstr "Dataset to rename"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:64
+#: /tmp/fish/implicit/share/completions/zfs.fish:77
+#: /tmp/fish/implicit/share/completions/zfs.fish:94
+#: /tmp/fish/implicit/share/completions/zfs.fish:172
+#: /tmp/fish/implicit/share/completions/zpool.fish:59
+#: /tmp/fish/implicit/share/completions/zpool.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:99
+msgid "Print output in a machine-parsable format"
+msgstr "Print output in a machine-parsable format"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:65
+#: /tmp/fish/implicit/share/completions/zfs.fish:75
+#: /tmp/fish/implicit/share/completions/zfs.fish:84
+#: /tmp/fish/implicit/share/completions/zfs.fish:89
+msgid "Operate recursively on datasets"
+msgstr "Operate recursively on datasets"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:105
+msgid "Property to list"
+msgstr "Property to list"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:68
+#: /tmp/fish/implicit/share/completions/zfs.fish:80
+#: /tmp/fish/implicit/share/completions/zfs.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:66
+msgid "Print parsable (exact) values for numbers"
+msgstr "Print parsable (exact) values for numbers"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:69
+#: /tmp/fish/implicit/share/completions/zfs.fish:97
+msgid "Property to use for sorting output by ascending order"
+msgstr "Property to use for sorting output by ascending order"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:70
+#: /tmp/fish/implicit/share/completions/zfs.fish:98
+msgid "Property to use for sorting output by descending order"
+msgstr "Property to use for sorting output by descending order"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:72
+msgid "Dataset which properties is to be listed"
+msgstr "Dataset which properties is to be listed"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:73
+#: /tmp/fish/implicit/share/completions/zpool.fish:125
+msgid "Property to set"
+msgstr "Property to set"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:74
+msgid "Dataset which property is to be setted"
+msgstr "Dataset which property is to be setted"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:78
+#: /tmp/fish/implicit/share/completions/zpool.fish:68
+msgid "Fields to display"
+msgstr "Fields to display"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:79
+msgid "Property source to display"
+msgstr "Property source to display"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:82
+msgid "Property to get"
+msgstr "Property to get"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:83
+msgid "Dataset which properties is to be got"
+msgstr "Dataset which properties is to be got"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:85
+msgid "Revert to the received value if available"
+msgstr "Revert to the received value if available"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:86
+msgid "Dataset which properties is to be inherited"
+msgstr "Dataset which properties is to be inherited"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:88
+msgid "Upgrade all eligible filesystems"
+msgstr "Upgrade all eligible filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:90
+msgid "Upgrade to the specified version"
+msgstr "Upgrade to the specified version"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:91
+msgid "Filesystem to upgrade"
+msgstr "Filesystem to upgrade"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:92
+msgid "Print UID instead of user name"
+msgstr "Print UID instead of user name"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:93
+msgid "Print GID instead of group name"
+msgstr "Print GID instead of group name"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:96
+msgid "Field to display"
+msgstr "Field to display"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:99
+#: /tmp/fish/implicit/share/completions/zfs.fish:100
+msgid "Identity types to display"
+msgstr "Identity types to display"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:101
+msgid "Translate S(amba)ID to POSIX ID"
+msgstr "Translate S(amba)ID to POSIX ID"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:102
+msgid "Dataset which space usage is to be got"
+msgstr "Dataset which space usage is to be got"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:103
+msgid "Temporary mount point property"
+msgstr "Temporary mount point property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:104
+msgid "Report progress"
+msgstr "Report progress"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:105
+msgid "Mount all available ZFS filesystems"
+msgstr "Mount all available ZFS filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:106
+msgid "Overlay mount"
+msgstr "Overlay mount"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:107
+msgid "Filesystem to mount"
+msgstr "Filesystem to mount"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:109
+msgid "Unmount all available ZFS filesystems"
+msgstr "Unmount all available ZFS filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:110
+msgid "Filesystem to unmount"
+msgstr "Filesystem to unmount"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:111
+msgid "Share all eligible ZFS filesystems"
+msgstr "Share all eligible ZFS filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:112
+msgid "Filesystem to share"
+msgstr "Filesystem to share"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:113
+msgid "Unshare all shared ZFS filesystems"
+msgstr "Unshare all shared ZFS filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:114
+msgid "Filesystem to unshare"
+msgstr "Filesystem to unshare"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:115
+msgid "Snapshot to bookmark"
+msgstr "Snapshot to bookmark"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:116
+msgid "Generate incremental stream from snapshot"
+msgstr "Generate incremental stream from snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:117
+msgid ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+msgstr ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:118
+#: /tmp/fish/implicit/share/completions/zfs.fish:127
+msgid "Include children in replication stream"
+msgstr "Include children in replication stream"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:119
+#: /tmp/fish/implicit/share/completions/zfs.fish:128
+msgid "Generate a deduplicated stream"
+msgstr "Generate a deduplicated stream"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:120
+#: /tmp/fish/implicit/share/completions/zfs.fish:129
+msgid "Allow the presence of larger blocks than 128 kiB"
+msgstr "Allow the presence of larger blocks than 128 kiB"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:121
+#: /tmp/fish/implicit/share/completions/zfs.fish:130
+msgid "Generate a more compact stream by using WRITE_EMBEDDED records"
+msgstr "Generate a more compact stream by using WRITE_EMBEDDED records"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:122
+#: /tmp/fish/implicit/share/completions/zfs.fish:131
+msgid "Print verbose information about the stream in a machine-parsable format"
+msgstr ""
+"Print verbose information about the stream in a machine-parsable format"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:123
+msgid "Generate compressed stream"
+msgstr "Generate compressed stream"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:125
+#: /tmp/fish/implicit/share/completions/zfs.fish:133
+msgid "Include dataset properties"
+msgstr "Include dataset properties"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:126
+#: /tmp/fish/implicit/share/completions/zfs.fish:134
+msgid "Print verbose information about the stream"
+msgstr "Print verbose information about the stream"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:135
+msgid "Dataset to send"
+msgstr "Dataset to send"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:136
+msgid ""
+"Print verbose information about the stream and the time spent processing it"
+msgstr ""
+"Print verbose information about the stream and the time spent processing it"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:137
+msgid "Dry run: do not actually receive the stream"
+msgstr "Dry run: do not actually receive the stream"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:138
+msgid "Force rollback to the most recent snapshot"
+msgstr "Force rollback to the most recent snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:139
+msgid "Unmount the target filesystem"
+msgstr "Unmount the target filesystem"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:140
+msgid "Discard the first element of the path of the sent snapshot"
+msgstr "Discard the first element of the path of the sent snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:141
+msgid "Discard all but the last element of the path of the sent snapshot"
+msgstr "Discard all but the last element of the path of the sent snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:142
+msgid "Force the stream to be received as a clone of the given snapshot"
+msgstr "Force the stream to be received as a clone of the given snapshot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:143
+msgid "On transfer interruption, store a receive_resume_token for resumption"
+msgstr "On transfer interruption, store a receive_resume_token for resumption"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:144
+msgid "Dataset to receive"
+msgstr "Dataset to receive"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:145
+msgid "Delegate permissions only on the specified dataset"
+msgstr "Delegate permissions only on the specified dataset"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:146
+msgid "Delegate permissions only on the descendents dataset"
+msgstr "Delegate permissions only on the descendents dataset"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:147
+msgid "User to delegate permissions to"
+msgstr "User to delegate permissions to"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:148
+msgid "Group to delegate permissions to"
+msgstr "Group to delegate permissions to"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:149
+#: /tmp/fish/implicit/share/completions/zfs.fish:150
+msgid "Delegate permission to everyone"
+msgstr "Delegate permission to everyone"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:151
+msgid "Delegate permissions only to the creator of later descendent datasets"
+msgstr "Delegate permissions only to the creator of later descendent datasets"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:152
+msgid "Create a permission set or add permissions to an existing one"
+msgstr "Create a permission set or add permissions to an existing one"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:153
+msgid "Dataset on which delegation is to be applied"
+msgstr "Dataset on which delegation is to be applied"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:154
+msgid "Remove permissions only on the specified dataset"
+msgstr "Remove permissions only on the specified dataset"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:155
+msgid "Remove permissions only on the descendents dataset"
+msgstr "Remove permissions only on the descendents dataset"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:156
+msgid "User to remove permissions from"
+msgstr "User to remove permissions from"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:157
+msgid "Group to remove permissions from"
+msgstr "Group to remove permissions from"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:158
+#: /tmp/fish/implicit/share/completions/zfs.fish:162
+#: /tmp/fish/implicit/share/completions/zfs.fish:163
+msgid "Remove permission from everyone"
+msgstr "Remove permission from everyone"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:159
+msgid "Remove permissions only on later created descendent datasets"
+msgstr "Remove permissions only on later created descendent datasets"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:160
+msgid "Remove a permission set or remove permissions from an existing one"
+msgstr "Remove a permission set or remove permissions from an existing one"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:161
+msgid "Remove permissions recursively"
+msgstr "Remove permissions recursively"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:164
+msgid "Dataset on which delegation is to be removed"
+msgstr "Dataset on which delegation is to be removed"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:165
+msgid "Apply hold recursively"
+msgstr "Apply hold recursively"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:166
+msgid "Snapshot on which hold is to be applied"
+msgstr "Snapshot on which hold is to be applied"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:167
+msgid "List holds recursively"
+msgstr "List holds recursively"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:168
+msgid "Snapshot which holds are to be listed"
+msgstr "Snapshot which holds are to be listed"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:169
+msgid "Release hold recursively"
+msgstr "Release hold recursively"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:170
+msgid "Snapshot from which hold is to be removed"
+msgstr "Snapshot from which hold is to be removed"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:171
+msgid "Display file type (à la ls -F)"
+msgstr "Display file type (à la ls -F)"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:173
+msgid "Display inode change time"
+msgstr "Display inode change time"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:174
+msgid "Source snapshot for the diff"
+msgstr "Source snapshot for the diff"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:175
+msgid "Execution timeout"
+msgstr "Execution timeout"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:176
+msgid "Execution memory limit"
+msgstr "Execution memory limit"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:177
+msgid "Pool which program will be executed on"
+msgstr "Pool which program will be executed on"
+
 #: /tmp/fish/implicit/share/completions/zip.fish:1
 msgid "Freshen: only changed files"
 msgstr "Freshen: only changed files"
@@ -62193,6 +63625,473 @@ msgstr "Encrypt"
 #: /tmp/fish/implicit/share/completions/zip.fish:29
 msgid "Don't compress files with these suffixes"
 msgstr "Don't compress files with these suffixes"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:1
+msgid ""
+"Internal completion function for appending string to the zpool commandline"
+msgstr ""
+"Internal completion function for appending string to the zpool commandline"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:3
+msgid "Add new virtual devices to pool"
+msgstr "Add new virtual devices to pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:4
+msgid "Attach virtual device to a pool device"
+msgstr "Attach virtual device to a pool device"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:5
+msgid "Clear devices errors in pool"
+msgstr "Clear devices errors in pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:6
+msgid "Create a new storage pool"
+msgstr "Create a new storage pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:7
+msgid "Destroy a storage pool"
+msgstr "Destroy a storage pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:8
+msgid "Detach virtual device from a mirroring pool"
+msgstr "Detach virtual device from a mirroring pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:9
+msgid "Display pool event log"
+msgstr "Display pool event log"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:10
+msgid "Export a pool"
+msgstr "Export a pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:11
+msgid "Get one or several pool properties"
+msgstr "Get one or several pool properties"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:12
+msgid "Display pool command history"
+msgstr "Display pool command history"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:13
+msgid "List importable pools, or import some"
+msgstr "List importable pools, or import some"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:14
+msgid "Display pool I/O stats"
+msgstr "Display pool I/O stats"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:15
+msgid "Remove ZFS label information from the specified device"
+msgstr "Remove ZFS label information from the specified device"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:16
+msgid "List pools with health status and space usage"
+msgstr "List pools with health status and space usage"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:17
+msgid "Take the specified devices offline"
+msgstr "Take the specified devices offline"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:18
+msgid "Bring the specified devices back online"
+msgstr "Bring the specified devices back online"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:19
+msgid "Reset pool GUID"
+msgstr "Reset pool GUID"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:20
+msgid "Remove virtual devices from pool"
+msgstr "Remove virtual devices from pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:21
+msgid "Reopen pool devices"
+msgstr "Reopen pool devices"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:22
+msgid "Replace a pool virtual device"
+msgstr "Replace a pool virtual device"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:23
+msgid "Start or stop scrubbing"
+msgstr "Start or stop scrubbing"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:24
+msgid "Set a pool property"
+msgstr "Set a pool property"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:25
+msgid "Create a pool by splitting an existing mirror one"
+msgstr "Create a pool by splitting an existing mirror one"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:26
+msgid "Display detailed pool health status"
+msgstr "Display detailed pool health status"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:27
+msgid "List upgradeable pools, or upgrade one"
+msgstr "List upgradeable pools, or upgrade one"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:28
+#: /tmp/fish/implicit/share/completions/zpool.fish:36
+#: /tmp/fish/implicit/share/completions/zpool.fish:45
+#: /tmp/fish/implicit/share/completions/zpool.fish:117
+msgid "Force use of virtual device"
+msgstr "Force use of virtual device"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:29
+#: /tmp/fish/implicit/share/completions/zpool.fish:130
+msgid "Dry run: only display resulting configuration"
+msgstr "Dry run: only display resulting configuration"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:30
+#: /tmp/fish/implicit/share/completions/zpool.fish:91
+#: /tmp/fish/implicit/share/completions/zpool.fish:100
+#: /tmp/fish/implicit/share/completions/zpool.fish:127
+#: /tmp/fish/implicit/share/completions/zpool.fish:135
+msgid "Display virtual device GUID instead of device name"
+msgstr "Display virtual device GUID instead of device name"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:31
+#: /tmp/fish/implicit/share/completions/zpool.fish:92
+#: /tmp/fish/implicit/share/completions/zpool.fish:101
+#: /tmp/fish/implicit/share/completions/zpool.fish:128
+#: /tmp/fish/implicit/share/completions/zpool.fish:136
+msgid "Resolve device path symbolic links"
+msgstr "Resolve device path symbolic links"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:32
+#: /tmp/fish/implicit/share/completions/zpool.fish:93
+#: /tmp/fish/implicit/share/completions/zpool.fish:102
+#: /tmp/fish/implicit/share/completions/zpool.fish:129
+#: /tmp/fish/implicit/share/completions/zpool.fish:137
+msgid "Display device full path"
+msgstr "Display device full path"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:33
+#: /tmp/fish/implicit/share/completions/zpool.fish:37
+#: /tmp/fish/implicit/share/completions/zpool.fish:48
+#: /tmp/fish/implicit/share/completions/zpool.fish:118
+#: /tmp/fish/implicit/share/completions/zpool.fish:132
+msgid "Pool property"
+msgstr "Pool property"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:34
+msgid "Pool to add virtual devices to"
+msgstr "Pool to add virtual devices to"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:35
+#: /tmp/fish/implicit/share/completions/zpool.fish:53
+msgid "Virtual device to add"
+msgstr "Virtual device to add"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:38
+msgid "Pool to attach virtual device to"
+msgstr "Pool to attach virtual device to"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:39
+#: /tmp/fish/implicit/share/completions/zpool.fish:43
+msgid "Virtual device to operate on"
+msgstr "Virtual device to operate on"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:40
+msgid "Initiate recovery mode"
+msgstr "Initiate recovery mode"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:41
+#: /tmp/fish/implicit/share/completions/zpool.fish:85
+msgid ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+msgstr ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:42
+msgid "Pool to clear errors on"
+msgstr "Pool to clear errors on"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:44
+msgid ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+msgstr ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:46
+msgid "Dry run, only display resulting configuration"
+msgstr "Dry run, only display resulting configuration"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:47
+msgid "Do not enable any feature on the new pool"
+msgstr "Do not enable any feature on the new pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:49
+msgid "Root filesystem property"
+msgstr "Root filesystem property"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:50
+#: /tmp/fish/implicit/share/completions/zpool.fish:83
+msgid "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+msgstr "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:51
+msgid "Root filesystem mountpoint"
+msgstr "Root filesystem mountpoint"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:52
+msgid "Set a different in-core pool name"
+msgstr "Set a different in-core pool name"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:54
+#: /tmp/fish/implicit/share/completions/zpool.fish:64
+msgid "Force unmounting of all contained datasets"
+msgstr "Force unmounting of all contained datasets"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:55
+msgid "Pool to destroy"
+msgstr "Pool to destroy"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:56
+msgid "Pool to detach device from"
+msgstr "Pool to detach device from"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:57
+msgid "Physical device to detach"
+msgstr "Physical device to detach"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:58
+msgid "Print verbose event information"
+msgstr "Print verbose event information"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:60
+msgid "Output appended data as the log grows"
+msgstr "Output appended data as the log grows"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:61
+msgid "Clear all previous events"
+msgstr "Clear all previous events"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:62
+msgid "Pool to read events from"
+msgstr "Pool to read events from"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:63
+msgid "Export all pools"
+msgstr "Export all pools"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:65
+msgid "Pool to export"
+msgstr "Pool to export"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:69
+msgid "Properties to get"
+msgstr "Properties to get"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:70
+msgid "Pool to get properties of"
+msgstr "Pool to get properties of"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:71
+msgid "Also display internal events"
+msgstr "Also display internal events"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:72
+msgid "Display log records using long format"
+msgstr "Display log records using long format"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:73
+msgid "Pool to get command history of"
+msgstr "Pool to get command history of"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:74
+msgid "Read configuration from specified cache file"
+msgstr "Read configuration from specified cache file"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:75
+msgid "Search for devices or files in specified directory"
+msgstr "Search for devices or files in specified directory"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:76
+msgid "List or import destroyed pools only (requires -f for importation)"
+msgstr "List or import destroyed pools only (requires -f for importation)"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:77
+#: /tmp/fish/implicit/share/completions/zpool.fish:133
+msgid "Mount properties for contained datasets"
+msgstr "Mount properties for contained datasets"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:78
+msgid "Properties of the imported pool"
+msgstr "Properties of the imported pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:79
+msgid "Force import"
+msgstr "Force import"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:80
+msgid "Recovery mode"
+msgstr "Recovery mode"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:81
+msgid "Search for and import all pools found"
+msgstr "Search for and import all pools found"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:82
+msgid "Ignore missing log device (risk of loss of last changes)"
+msgstr "Ignore missing log device (risk of loss of last changes)"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:84
+msgid "Do not mount contained filesystems"
+msgstr "Do not mount contained filesystems"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:86
+msgid "Roll back to a previous TXG (hazardous)"
+msgstr "Roll back to a previous TXG (hazardous)"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:87
+msgid "TXG to roll back to (implies -FX)"
+msgstr "TXG to roll back to (implies -FX)"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:88
+msgid "Specify, as the last argument, a temporary pool name"
+msgstr "Specify, as the last argument, a temporary pool name"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:89
+msgid "Pool to import"
+msgstr "Pool to import"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:90
+#: /tmp/fish/implicit/share/completions/zpool.fish:103
+#: /tmp/fish/implicit/share/completions/zpool.fish:142
+msgid "Display a timestamp using specified format"
+msgstr "Display a timestamp using specified format"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:94
+msgid "Omit statistics since boot"
+msgstr "Omit statistics since boot"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:104
+msgid "Print verbose statistics"
+msgstr "Print verbose statistics"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:96
+msgid "Pool to retrieve I/O stats from"
+msgstr "Pool to retrieve I/O stats from"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:97
+msgid "Treat exported or foreign devices as inactive"
+msgstr "Treat exported or foreign devices as inactive"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:98
+msgid "Device to clear ZFS label information from"
+msgstr "Device to clear ZFS label information from"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:106
+msgid "Pool to list properties of"
+msgstr "Pool to list properties of"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:107
+msgid "Temporarily offline"
+msgstr "Temporarily offline"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:108
+msgid "Pool to offline device from"
+msgstr "Pool to offline device from"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:109
+msgid "Physical device to offline"
+msgstr "Physical device to offline"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:110
+msgid "Expand the device to use all available space"
+msgstr "Expand the device to use all available space"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:111
+msgid "Pool to bring device back online on"
+msgstr "Pool to bring device back online on"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:112
+msgid "Physical device to bring back online"
+msgstr "Physical device to bring back online"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:113
+msgid "Pool which GUID is to be changed"
+msgstr "Pool which GUID is to be changed"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:114
+msgid "Pool to remove device from"
+msgstr "Pool to remove device from"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:115
+msgid "Physical device to remove"
+msgstr "Physical device to remove"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:116
+msgid "Pool which devices are to be reopened"
+msgstr "Pool which devices are to be reopened"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:119
+msgid "Pool to replace device"
+msgstr "Pool to replace device"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:120
+msgid "Pool device to be replaced"
+msgstr "Pool device to be replaced"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:121
+msgid "Device to use for replacement"
+msgstr "Device to use for replacement"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:122
+msgid "Stop scrubbing"
+msgstr "Stop scrubbing"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:123
+msgid "Pause scrubbing"
+msgstr "Pause scrubbing"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:124
+msgid "Pool to start/stop scrubbing"
+msgstr "Pool to start/stop scrubbing"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:126
+msgid "Pool which property is to be set"
+msgstr "Pool which property is to be set"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:131
+msgid "Set altroot for newpool and automatically import it"
+msgstr "Set altroot for newpool and automatically import it"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:134
+msgid "Pool to split"
+msgstr "Pool to split"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:138
+#: /tmp/fish/implicit/share/completions/zpool.fish:139
+msgid "Display deduplication histogram"
+msgstr "Display deduplication histogram"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:141
+msgid "Only display status for unhealthy or unavailable pools"
+msgstr "Only display status for unhealthy or unavailable pools"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:143
+#: /tmp/fish/implicit/share/completions/zpool.fish:147
+msgid "Pool which status is to be displayed"
+msgstr "Pool which status is to be displayed"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:144
+msgid "Upgrade all eligible pools, enabling all supported features"
+msgstr "Upgrade all eligible pools, enabling all supported features"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:145
+msgid "Display upgradeable ZFS versions"
+msgstr "Display upgradeable ZFS versions"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:146
+msgid "Upgrade to the specified legacy version"
+msgstr "Upgrade to the specified legacy version"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:2
 msgid "Repo"
@@ -63796,6 +65695,30 @@ msgstr ""
 msgid "Complete wvdial peers"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+msgid "Completes with ZFS mountpoint properties"
+msgstr "Completes with ZFS mountpoint properties"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_pools.fish:1
+msgid "Completes with available ZFS pools"
+msgstr "Completes with available ZFS pools"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+msgid "Completes with ZFS read-only properties"
+msgstr "Completes with ZFS read-only properties"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Completes with ZFS read-write properties"
+msgstr "Completes with ZFS read-write properties"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+msgstr ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr "Launch fish's web based configuration"
@@ -63960,6 +65883,14 @@ msgstr "Checks the consistency of the repository"
 msgid "Test if current token is on Nth place"
 msgstr "Test if current token is on Nth place"
 
+#: /tmp/fish/implicit/share/functions/__fish_is_zfs_feature_enabled.fish:1
+msgid ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+msgstr ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+
 #: /tmp/fish/implicit/share/functions/__fish_list_current_token.fish:1
 msgid ""
 "List contents of token under the cursor if it is a directory, otherwise list "
@@ -64043,6 +65974,10 @@ msgid ""
 msgstr ""
 "Print a list of all function calls leading up to running the current command"
 
+#: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
+msgid "Print a list of local groups"
+msgstr "Print a list of local groups"
+
 #: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr "Print help message for the specified fish function or builtin"
@@ -64113,6 +66048,22 @@ msgstr "Print xrandr outputs"
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
 msgstr "Print X windows"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
+msgid "Lists ZFS bookmarks, if the feature is enabled"
+msgstr "Lists ZFS bookmarks, if the feature is enabled"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
+msgid "Lists ZFS filesystems"
+msgstr "Lists ZFS filesystems"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
+msgid "Lists ZFS snapshots"
+msgstr "Lists ZFS snapshots"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
+msgid "Lists ZFS volumes"
+msgstr "Lists ZFS volumes"
 
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
@@ -65604,9 +67555,6 @@ msgstr "Edit variable value"
 
 #~ msgid "File has sticky bit set"
 #~ msgstr "File has sticky bit set"
-
-#~ msgid "Change access time"
-#~ msgstr "Change access time"
 
 #~ msgid "Avoid comparing first N fields"
 #~ msgstr "Avoid comparing first N fields"

--- a/po/fr.po
+++ b/po/fr.po
@@ -74,12 +74,37 @@
 # to query (hors BDD)                                     obtenir
 # sparse file                                             fichier creux
 # to search                                               rechercher
+# array (RAID)                                            ensemble
+# snapshot                                                instantané
+# bookmark                                                marque-page
+# dataset                                                 jeu de données
+# property                                                paramètre
+# volume                                                  volume
+# to hint                                                 suggérer
+# a hint                                                  une suggestion
+# to hide                                                 masquer
+# vdev / virtual device                                   périphérique virtuel
+# to roll back to                                         restaurer depuis
+# to get                                                  obtenir
+# to scrub                                                vérifier
+# in-core                                                 interne
+# overlay mount                                           montage en sur-couche
+# bootable                                                amorçable
+# ditto                                                   doublon
+# pool                                                    pool
+# behavior                                                comportement
+# to defer                                                différer
+# lower-level                                             inférieur
+# upper-level                                             supérieur
+# child (arborescence)                                    enfant
+# hold                                                    verrou
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.2.8POT-Creation-Date: 2006-07-10 13:44-0400\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
-"PO-Revision-Date: 2017-10-09 16:43+0200\n"
+"POT-Creation-Date: 2017-12-13 10:22+0100\n"
+"PO-Revision-Date: 2017-12-18 16:07+0100\n"
 "Last-Translator: David Guyot <david.guyot@europecamions-interactive.com>\n"
 "Language-Team: français <david.guyot@europecamions-interactive.com>\n"
 "Language: fr\n"
@@ -1953,9 +1978,11 @@ msgstr "Lien exécutable"
 #: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
 #: /tmp/fish/implicit/share/completions/fossil.fish:90
 #: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:206
-#: /tmp/fish/implicit/share/completions/git.fish:266
-#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:269
 msgid "File"
 msgstr "Fichier"
 
@@ -2673,6 +2700,564 @@ msgstr ""
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/zfs.fish:1
+msgid "ZFS filesystem"
+msgstr "Système de fichiers ZFS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:2
+msgid "ZFS filesystem snapshot"
+msgstr "Instantané de système de fichiers ZFS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:3
+msgid "ZFS block storage device"
+msgstr "Périphérique de bloc ZFS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:4
+msgid "ZFS snapshot bookmark"
+msgstr "Marque-page d’instantané ZFS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:5
+msgid "Any ZFS dataset"
+msgstr "N’importe quel jeu de données ZFS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:6
+msgid "Dataset-specific value"
+msgstr "Valeur spécifique au jeu de données"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:7
+msgid "Default ZFS value"
+msgstr "Valeur par défaut de ZFS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:8
+msgid "Value inherited from parent dataset"
+msgstr "Valeur héritée du jeu de données parent"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:9
+msgid "Value received by 'zfs receive'"
+msgstr "Valeur reçue par 'zfs receive'"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:10
+msgid "Value valid for the current mount"
+msgstr "Valeur valide pour le montage actuel"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:11
+msgid "Read-only value"
+msgstr "Valeur en lecture seule"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:12
+msgid "Dataset full name"
+msgstr "Nom complet du jeu de données"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:13
+#: /tmp/fish/explicit/share/completions/zpool.fish:2
+#: /tmp/fish/implicit/share/completions/minikube.fish:25
+#: /tmp/fish/implicit/share/completions/minikube.fish:26
+#: /tmp/fish/implicit/share/completions/minikube.fish:27
+#: /tmp/fish/implicit/share/completions/minikube.fish:28
+msgid "Property"
+msgstr "Paramètre"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:3
+msgid "Property value"
+msgstr "Valeur du paramètre"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:15
+#: /tmp/fish/explicit/share/completions/zpool.fish:4
+msgid "Property value origin"
+msgstr "Origine de la valeur du paramètre"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:16
+msgid "Identity type"
+msgstr "Type d’identité"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:17
+msgid "Identity name"
+msgstr "Nom de l’identité"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:18
+msgid "Space usage"
+msgstr "Utilisation de l’espace"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:19
+msgid "Space quota"
+msgstr "Quota d’utilisation de l’espace"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:20
+msgid "POSIX user"
+msgstr "Utilisateur POSIX"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:21
+msgid "Samba user"
+msgstr "Utilisateur Samba"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:22
+#: /tmp/fish/explicit/share/completions/zfs.fish:25
+msgid "Both types"
+msgstr "Les deux types"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:23
+msgid "POSIX group"
+msgstr "Groupe POSIX"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:24
+msgid "Samba group"
+msgstr "Groupe Samba"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:26
+msgid "Also needs the permission to be allowed"
+msgstr "Nécessite également la permission à accorder"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:27
+msgid ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+msgstr ""
+"Nécessite également les permissions 'create' et 'mount' sur le système de "
+"fichiers originel"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:28
+#: /tmp/fish/explicit/share/completions/zfs.fish:29
+#: /tmp/fish/explicit/share/completions/zfs.fish:33
+#: /tmp/fish/explicit/share/completions/zfs.fish:35
+msgid "Also needs the 'mount' permission"
+msgstr "Nécessite également la permission 'mount'"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:30
+msgid ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+msgstr ""
+"Nécessite également les permissions 'promote' et 'mount' sur le système de "
+"fichiers originel"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:31
+msgid "Also needs the 'create' and 'mount' permissions"
+msgstr "Nécessite également les permissions 'create' et 'mount'"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:32
+msgid "Also needs the 'create' and 'mount' permissions in the new parent"
+msgstr ""
+"Nécessite également les permissions 'create' et 'mount' sur le nouveau parent"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:34
+msgid "For SMB and NFS shares"
+msgstr "Pour les partages SMB et NFS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:36
+msgid "Allows changing any user property"
+msgstr "Autorise le changement de tout paramètre utilisateur"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:26
+msgid "Volume block size"
+msgstr "Taille de bloc du volume"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:38
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Inheritance of ACL entries"
+msgstr "Héritage des entrées ACL"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:39
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:2
+msgid "Update access time on read"
+msgstr "Mettre à jour l’horodatage d’accès des fichiers lors de leur lecture"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:40
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:3
+msgid "Is the dataset mountable"
+msgstr "Le jeu de données peut-il être monté"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:41
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:4
+msgid "Data checksum"
+msgstr "Somme de contrôle"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:42
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:5
+msgid "Compression algorithm"
+msgstr "Aalgorithme de compression"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:43
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:6
+msgid "Number of copies of data"
+msgstr "Nombre de copies des données"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:44
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:7
+msgid "Deduplication"
+msgstr "Déduplication"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:45
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:2
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:8
+msgid "Are contained device nodes openable"
+msgstr "Les i-nœuds de périphériques inclus sont-ils ouvrables"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:46
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:3
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:9
+msgid "Can contained executables be executed"
+msgstr "Les exécutables inclus peuvent-ils être exécutés"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:47
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:10
+msgid "Max number of filesystems and volumes"
+msgstr "Nombre maximum de systèmes de fichiers et volumes"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:48
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:11
+msgid "Mountpoint"
+msgstr "Point de montage"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:49
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:12
+msgid "Which data to cache in ARC"
+msgstr "Quelles données cacher dans l’ARC"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:50
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:13
+msgid "Max size of dataset and children"
+msgstr "Taille maximale du jeu de données et de ses descendants"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:51
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:14
+msgid "Max number of snapshots"
+msgstr "Nombre maximum d’instantanés"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:52
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:4
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:15
+msgid "Read-only"
+msgstr "Lecture seule"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:53
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:16
+msgid "Suggest block size"
+msgstr "Suggérer une taille de bloc"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:54
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:17
+msgid "How redundant are the metadata"
+msgstr "À quel point les métadonnées sont-elles redondantes"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:55
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:18
+msgid "Max space used by dataset itself"
+msgstr "Espace maximal utilisé par le jeu de données lui-même"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:56
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:19
+msgid "Min space guaranteed to dataset itself"
+msgstr "Espace minimal garanti au jeu de données lui-même"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:57
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:20
+msgid "Min space guaranteed to dataset"
+msgstr "Espace minimal garanti au jeu de données"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:58
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:21
+msgid "Which data to cache in L2ARC"
+msgstr "Quelles données cacher dans le L2ARC"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:59
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:5
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:22
+msgid "Respect set-UID bit"
+msgstr "Respecter le bit setuid"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:60
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:23
+msgid "Share in NFS"
+msgstr "Partager par NFS"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:61
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:24
+msgid "Hint for handling of synchronous requests"
+msgstr "Suggestion pour la gestion des requêtes synchrones"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:62
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:25
+msgid "Hide .zfs directory"
+msgstr "Masquer le dossier .zfs"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:63
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:26
+msgid "Handle of synchronous requests"
+msgstr "Gestion des requêtes synchrones"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:64
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:27
+msgid "Volume logical size"
+msgstr "Taille du volume logique"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:65
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:38
+msgid "Managed from a non-global zone"
+msgstr "Géré depuis une zone non-globale"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:66
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:31
+msgid "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+msgstr ""
+"Le jeu de données peut-il être monté dans une zone avec les Trusted "
+"Extensions activées"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:67
+#: /tmp/fish/explicit/share/completions/zfs.fish:74
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:6
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:32
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:40
+msgid "Mount with Non Blocking mandatory locks"
+msgstr "Monter avec les verrous obligatoires non bloquants"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:68
+#: /tmp/fish/explicit/share/completions/zfs.fish:77
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:33
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:43
+msgid "Share in Samba"
+msgstr "Partager par Samba"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:69
+#: /tmp/fish/explicit/share/completions/zfs.fish:76
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:34
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:42
+msgid "Share as an iSCSI target"
+msgstr "Partager comme une cible iSCSI"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:70
+#: /tmp/fish/explicit/share/completions/zfs.fish:79
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:35
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:45
+msgid "On-disk version of filesystem"
+msgstr "Version sur disque du système de fichiers"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:71
+#: /tmp/fish/explicit/share/completions/zfs.fish:80
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:36
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:46
+msgid "Scan regular files for viruses on opening and closing"
+msgstr ""
+"Faire analyser par l’antivirus les fichiers standards à l’ouverture et à la "
+"fermeture"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:72
+#: /tmp/fish/explicit/share/completions/zfs.fish:81
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:7
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:47
+msgid "Extended attributes"
+msgstr "Attributs étendus"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:73
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:39
+msgid "Use no ACL or POSIX ACL"
+msgstr "N’utiliser aucune liste de contrôle d’accès ou leur version POSIX"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:75
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:9
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:41
+msgid "Sometimes update access time on read"
+msgstr ""
+"Mettre parfois à jour l’horodatage d’accès des fichiers lors de leur lecture"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:78
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:44
+msgid "Hide volume snapshots"
+msgstr "Masquer les instantanés de volume"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:82
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:30
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:48
+msgid "How is ACL modified by chmod"
+msgstr "Comment la liste de contrôle d’accès est-elle modifiée par 'chmod'"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:83
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:49
+msgid "How to expose volumes to OS"
+msgstr "Comment exposer les volumes au système d’exploitation"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:84
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid "Unicode normalization"
+msgstr "Normalisation Unicode"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:85
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:2
+msgid "Reject non-UTF-8-compliant filenames"
+msgstr "Rejeter les noms de fichiers incompatibles avec UTF-8"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:86
+#: /tmp/fish/explicit/share/completions/zfs.fish:87
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:9
+msgid "Case sensitivity"
+msgstr "Sensibilité à la casse"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:88
+msgid "Space properties"
+msgstr "Paramètre d’espace"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:89
+#: /tmp/fish/explicit/share/completions/zfs.fish:90
+msgid "Dataset name"
+msgstr "Nom du jeu de données"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:1
+msgid "Pool full name"
+msgstr "Nom complet du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:5
+msgid "Mirror of at least two devices"
+msgstr "Miroir d’au moins deux périphériques"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:6
+#: /tmp/fish/explicit/share/completions/zpool.fish:7
+msgid "ZFS RAID-5 variant, single parity"
+msgstr "Variante ZFS de RAID-5 à parité simple"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:8
+msgid "ZFS RAID-5 variant, double parity"
+msgstr "Variante ZFS de RAID-5 à parité double"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:9
+msgid "ZFS RAID-5 variant, triple parity"
+msgstr "Variante ZFS de RAID-5 à parité triple"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:10
+msgid "Pseudo vdev for pool hot spares"
+msgstr "Pseudo-périphérique virtuel pour les périphériques de rechange du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:11
+msgid "SLOG device"
+msgstr "Périphérique SLOG"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:12
+msgid "L2ARC device"
+msgstr "Périphérique L2ARC"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:13
+msgid "Physically allocated space"
+msgstr "Espace physiquement alloué"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:2
+msgid "Available space"
+msgstr "Espace disponible"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:16
+msgid "System boot partition size"
+msgstr "Taille de partition de démarrage du système"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:17
+msgid "Usage percentage of pool"
+msgstr "Pourcentage d’utilisation du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:18
+msgid "Deduplication ratio"
+msgstr "Taux de déduplication"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:19
+msgid "Amount of uninitialized space within the pool"
+msgstr "Quantité d’espace non-initialisé dans le pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:20
+msgid "Fragmentation percentage of pool"
+msgstr "Pourcentage de fragmentation du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:21
+msgid "Free pool space"
+msgstr "Espace du pool disponible"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:22
+msgid "Remaining pool space to be freed"
+msgstr "Espace du pool restant à rendre disponible"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:23
+msgid "Pool GUID"
+msgstr "GUID du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:24
+msgid "Current pool health"
+msgstr "État actuel du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:25
+msgid "Total pool space"
+msgstr "Espace total du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:26
+msgid "Used pool space"
+msgstr "Espace du pool utilisé"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:27
+msgid "Pool sector size exponent"
+msgstr "Exposant pour la taille des secteurs du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:28
+#: /tmp/fish/explicit/share/completions/zpool.fish:29
+msgid "Alternate root directory"
+msgstr "Dossier racine alternatif"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:30
+#: /tmp/fish/explicit/share/completions/zpool.fish:31
+msgid "Import pool in read-only mode"
+msgstr "Importer le pool en lecture seule"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:32
+#: /tmp/fish/explicit/share/completions/zpool.fish:33
+msgid "Automatic pool expansion on LUN growing"
+msgstr ""
+"Expansion automatique du pool en cas d’augmentation de la taille du LUN"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:34
+#: /tmp/fish/explicit/share/completions/zpool.fish:35
+msgid "Automatic use of replacement device"
+msgstr "Utilisation automatique du périphérique de remplacement"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:36
+msgid "Default bootable dataset"
+msgstr "Jeu de données amorçable par défaut"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:37
+msgid "Pool configuration cache"
+msgstr "Cache de configuration du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:38
+msgid "Comment about the pool"
+msgstr "Commentaire à propos du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:39
+msgid "Threshold for writting a ditto copy of deduplicated blocks"
+msgstr "Seuil d’écriture d’un doublon des blocs dédupliqués"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:40
+msgid "Allow rights delegation on the pool"
+msgstr "Autorise la délégation de droits sur le pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:41
+msgid "Behavior in case of catastrophic pool failure"
+msgstr "Comportement en cas de défaillance catastrophique du pool"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:42
+msgid "Display snapshots even if 'zfs list' does not use '-t'"
+msgstr "Afficher les instantanés même si 'zfs list' n’utilise pas '-t'"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:43
+msgid "On-disk version of pool"
+msgstr "Version sur disque du système de fichiers"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:44
+msgid "%sEnable the %s feature\\n"
+msgstr "%sActiver la fonctionnalité %s\\n"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:45
+msgid "All properties"
+msgstr "Tous les paramètres"
+
 #: /tmp/fish/explicit/share/functions/abbr.fish:1
 #, fuzzy
 msgid "%s: Could not figure out what to do!\\n"
@@ -2806,6 +3391,135 @@ msgstr ""
 msgid "%s\\tArchived file\\n"
 msgstr "%s\\tFichier archivé\\n"
 
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:3
+msgid "Achieved compression ratio"
+msgstr "Taux de compression attein"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:4
+msgid "Dataset creation time"
+msgstr "Horodatage de création du jeu de données"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:5
+msgid "Snapshot clones"
+msgstr "Clones d’instantanés"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:6
+msgid "Marked for deferred destruction"
+msgstr "Marquer pour destruction différée"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:7
+msgid "Total lower-level filesystems and volumes"
+msgstr "Nombre total de systèmes de fichiers et volumes inférieurs"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:9
+msgid "Logical total space"
+msgstr "Espace logique total"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:11
+msgid "Logical used space"
+msgstr "Espace logique utilisé"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:12
+msgid "Is currently mounted?"
+msgstr "Actuellement monté ?"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:13
+msgid "Source snapshot"
+msgstr "Instantané source"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:14
+msgid "Token for interrupted reception resumption"
+msgstr "Jeton pour la continuation d’une réception interrompue"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:16
+msgid "Total space"
+msgstr "Espace total"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:17
+msgid "Achieved compression ratio of referenced space"
+msgstr "Taux de compression atteint pour l’espace référencé"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:18
+msgid "Total lower-level snapshots"
+msgstr "Nombre total d’instantanés inférieurs"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:19
+#: /tmp/fish/implicit/share/completions/zfs.fish:71
+#: /tmp/fish/implicit/share/completions/zfs.fish:81
+msgid "Dataset type"
+msgstr "Type de jeu de données"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:20
+msgid "Space used by dataset and children"
+msgstr "Espace utilisé par le jeu de données et ses descendants"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:21
+msgid "Space used by children datasets"
+msgstr "Espace utilisé par les jeux de données descendants"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:22
+msgid "Space used by dataset itself"
+msgstr "Espace utilisé par le jeu de données lui-même"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:23
+msgid "Space used by refreservation"
+msgstr "Espace utilisé par refreservation"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:24
+msgid "Space used by dataset snapshots"
+msgstr "Espace utilisé par les instantanés du jeu de données"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:25
+msgid "Holds count"
+msgstr "Nombre de verrous"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:27
+msgid "Referenced data written since previous snapshot"
+msgstr "Quantité de données référencées écrites depuis le dernier instantané"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:28
+msgid "%sDataset space use by user %s\\n"
+msgstr "%sEspace du jeu de données utilisé par l’utilisateur %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:29
+msgid "%sDataset space use by group %s\\n"
+msgstr "%sEspace du jeu de données utilisé par le groupe %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:30
+msgid "%sReferenced data written since snapshot %s\\n"
+msgstr "%sQuantité de données référencées écrites depuis l’instantané %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:28
+msgid "%sMax usage by user %s\\n"
+msgstr "%sUtilisation maximale par l’utilisateur %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:29
+msgid "%sMax usage by group %s\\n"
+msgstr "%sUtilisation maximale par le groupe %s\\n"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:3
+msgid "Allow overlay mount"
+msgstr "Autoriser le montage avec sur-couche"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:4
+msgid "SELinux context for the child filesystem"
+msgstr "Contexte SELinux pour le système de fichiers descendant"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:5
+msgid "SELinux context for the filesystem being mounted"
+msgstr "Contexte SELinux pour le système de fichiers en montage"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:6
+msgid "SELinux context for unlabeled files"
+msgstr "Contexte SELinux pour les fichiers non étiquetés"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:7
+msgid "SELinux context for the root inode of the filesystem"
+msgstr "Contexte SELinux pour l’i-nœud racine du système de fichiers"
+
 #: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Bienvenue dans fish, le shell amical et interactif"
@@ -2830,6 +3544,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/aptitude.fish:3
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:3
 #: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:63
 #: /tmp/fish/implicit/share/completions/wajig.fish:3
@@ -5309,7 +6025,10 @@ msgstr "Afficher les infos de débogage"
 #: /tmp/fish/implicit/share/completions/valgrind.fish:6
 #: /tmp/fish/implicit/share/completions/vi.fish:8
 #: /tmp/fish/implicit/share/completions/wget.fish:9
+#: /tmp/fish/implicit/share/completions/zfs.fish:42
+#: /tmp/fish/implicit/share/completions/zfs.fish:87
 #: /tmp/fish/implicit/share/completions/zip.fish:13
+#: /tmp/fish/implicit/share/completions/zpool.fish:140
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
 msgid "Verbose mode"
 msgstr "Mode verbeux"
@@ -10136,7 +10855,7 @@ msgid "Show usage message and options"
 msgstr "Afficher un message relatif à l’utilisation et aux options"
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:380
+#: /tmp/fish/implicit/share/completions/git.fish:382
 msgid "Show help message"
 msgstr "Afficher un message d’aide"
 
@@ -14904,7 +15623,7 @@ msgid "Ignore all white space"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:325
+#: /tmp/fish/implicit/share/completions/git.fish:327
 msgid "Ignore changes whose lines are all blank"
 msgstr ""
 
@@ -14915,7 +15634,7 @@ msgstr ""
 "régulière spécifiée"
 
 #: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:321
+#: /tmp/fish/implicit/share/completions/git.fish:323
 msgid "Treat all files as text"
 msgstr "Traiter tous les fichiers comme du texte"
 
@@ -16792,6 +17511,89 @@ msgstr ""
 msgid "X display to use"
 msgstr "Affichage X à utiliser"
 
+#: /tmp/fish/implicit/share/completions/exercism.fish:1
+#, fuzzy
+msgid "Test if exercism has yet to be given the subcommand"
+msgstr "Vérifier si apt doit encore se faire donner la sous-commande"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:3
+#, fuzzy
+msgid "turn on verbose logging"
+msgstr "Demander une journalisation verbeuse"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:4
+#: /tmp/fish/implicit/share/completions/exercism.fish:19
+#: /tmp/fish/implicit/share/completions/ninja.fish:8
+#: /tmp/fish/implicit/share/completions/quilt.fish:1
+msgid "show help"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:5
+#, fuzzy
+msgid "print the version"
+msgstr "Afficher la version"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:6
+#, fuzzy
+msgid "Writes config values to a JSON file."
+msgstr "Écrire l’index dans un fichier"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:7
+#, fuzzy
+msgid "Outputs useful debug information."
+msgstr "Afficher les informations d’utilisation"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:8
+msgid "Downloads a solution given the ID of the latest iteration."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:9
+msgid "Fetches the next unsubmitted problem in each track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:10
+#, fuzzy
+msgid "Lists the available problems for a language track, given its ID."
+msgstr "Lister les ressources disponibles"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:11
+msgid ""
+"Opens exercism.io to your most recent iteration of a problem given the track "
+"ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:12
+msgid ""
+"Downloads the most recent iteration for each of your solutions on exercism."
+"io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:13
+msgid "Skips a problem given a track ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:14
+msgid "Fetches information about your progress with a given language track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:15
+msgid "Submits a new iteration to a problem on exercism.io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:16
+#, fuzzy
+msgid "Lists the available language tracks."
+msgstr "Lister les ressources disponibles"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:17
+msgid "REMOVED"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:18
+#, fuzzy
+msgid "Upgrades the CLI to the latest released version."
+msgstr "Mettre à jour les paquets installés vers leur dernière version"
+
 #: /tmp/fish/implicit/share/completions/exit.fish:2
 msgid "Quit with normal exit status"
 msgstr "Quitter avec un code de retour normal"
@@ -17578,6 +18380,8 @@ msgstr ""
 "l’exécution de find"
 
 #: /tmp/fish/implicit/share/completions/find.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:66
+#: /tmp/fish/implicit/share/completions/zfs.fish:76
 msgid "Maximum recursion depth"
 msgstr "Profondeur maximale de récursion"
 
@@ -18889,9 +19693,9 @@ msgstr "Lister les fichiers"
 #: /tmp/fish/implicit/share/completions/fossil.fish:280
 #: /tmp/fish/implicit/share/completions/git.fish:64
 #: /tmp/fish/implicit/share/completions/git.fish:86
-#: /tmp/fish/implicit/share/completions/git.fish:244
-#: /tmp/fish/implicit/share/completions/git.fish:293
-#: /tmp/fish/implicit/share/completions/git.fish:294
+#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:296
 msgid "Tag"
 msgstr ""
 
@@ -19296,7 +20100,7 @@ msgid "Limit number of tags"
 msgstr "Limiter le nombre d’étiquettes"
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:281
-#: /tmp/fish/implicit/share/completions/git.fish:291
+#: /tmp/fish/implicit/share/completions/git.fish:293
 msgid "List tags"
 msgstr "Lister les étiquettes"
 
@@ -19391,6 +20195,7 @@ msgstr "Afficher la version des fonctionnalités optionnelles"
 #: /tmp/fish/implicit/share/completions/gsettings.fish:15
 #: /tmp/fish/implicit/share/completions/ncdu.fish:1
 #: /tmp/fish/implicit/share/completions/obnam.fish:12
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:4
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:5
 #: /tmp/fish/implicit/share/completions/pkginfo.fish:7
 #: /tmp/fish/implicit/share/completions/pkgmk.fish:17
@@ -25529,24 +26334,24 @@ msgstr "Distant"
 #: /tmp/fish/implicit/share/completions/git.fish:96
 #: /tmp/fish/implicit/share/completions/git.fish:108
 #: /tmp/fish/implicit/share/completions/git.fish:130
-#: /tmp/fish/implicit/share/completions/git.fish:134
-#: /tmp/fish/implicit/share/completions/git.fish:140
-#: /tmp/fish/implicit/share/completions/git.fish:183
-#: /tmp/fish/implicit/share/completions/git.fish:219
-#: /tmp/fish/implicit/share/completions/git.fish:222
-#: /tmp/fish/implicit/share/completions/git.fish:242
-#: /tmp/fish/implicit/share/completions/git.fish:265
-#: /tmp/fish/implicit/share/completions/git.fish:285
-#: /tmp/fish/implicit/share/completions/git.fish:307
+#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:221
+#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:244
+#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:309
 msgid "Branch"
 msgstr "Branche"
 
 #: /tmp/fish/implicit/share/completions/git.fish:23
-#: /tmp/fish/implicit/share/completions/git.fish:198
-#: /tmp/fish/implicit/share/completions/git.fish:210
-#: /tmp/fish/implicit/share/completions/git.fish:237
-#: /tmp/fish/implicit/share/completions/git.fish:250
-#: /tmp/fish/implicit/share/completions/git.fish:274
+#: /tmp/fish/implicit/share/completions/git.fish:200
+#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:276
 #: /tmp/fish/implicit/share/completions/mdadm.fish:12
 #: /tmp/fish/implicit/share/completions/update-eix-remote.fish:1
 msgid "Be quiet"
@@ -25555,10 +26360,10 @@ msgstr "Être silencieux"
 #: /tmp/fish/implicit/share/completions/git.fish:24
 #: /tmp/fish/implicit/share/completions/git.fish:41
 #: /tmp/fish/implicit/share/completions/git.fish:70
-#: /tmp/fish/implicit/share/completions/git.fish:199
-#: /tmp/fish/implicit/share/completions/git.fish:211
-#: /tmp/fish/implicit/share/completions/git.fish:238
-#: /tmp/fish/implicit/share/completions/git.fish:251
+#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:253
 #: /tmp/fish/implicit/share/completions/prt-get.fish:53
 #: /tmp/fish/implicit/share/completions/prt-get.fish:111
 #: /tmp/fish/implicit/share/completions/xz.fish:32
@@ -25566,12 +26371,12 @@ msgid "Be verbose"
 msgstr "Être verbeux"
 
 #: /tmp/fish/implicit/share/completions/git.fish:25
-#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:215
 msgid "Append ref names and object names"
 msgstr "Ajouter les noms des références et ceux des objets"
 
 #: /tmp/fish/implicit/share/completions/git.fish:26
-#: /tmp/fish/implicit/share/completions/git.fish:214
+#: /tmp/fish/implicit/share/completions/git.fish:216
 msgid "Force update of local branches"
 msgstr "Forcer la mise à jour des branches locales"
 
@@ -25738,7 +26543,7 @@ msgstr "Affiche la dernière validation d’une branche"
 #: /tmp/fish/implicit/share/completions/git.fish:63
 #: /tmp/fish/implicit/share/completions/git.fish:85
 #: /tmp/fish/implicit/share/completions/git.fish:109
-#: /tmp/fish/implicit/share/completions/git.fish:184
+#: /tmp/fish/implicit/share/completions/git.fish:186
 msgid "Remote branch"
 msgstr "Branche distante"
 
@@ -25769,7 +26574,7 @@ msgid "Allow adding otherwise ignored files"
 msgstr "Autoriser l’ajout de fichiers normalement ignorés"
 
 #: /tmp/fish/implicit/share/completions/git.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:257
+#: /tmp/fish/implicit/share/completions/git.fish:259
 msgid "Interactive mode"
 msgstr "Mode interactif"
 
@@ -25824,7 +26629,7 @@ msgid "Remote Branch"
 msgstr "Branche distante"
 
 #: /tmp/fish/implicit/share/completions/git.fish:84
-#: /tmp/fish/implicit/share/completions/git.fish:243
+#: /tmp/fish/implicit/share/completions/git.fish:245
 msgid "Head"
 msgstr "Head"
 
@@ -25997,159 +26802,159 @@ msgstr "Afficher un diff des modifications dans l’index"
 msgid "Compare two paths on the filesystem"
 msgstr "Comparer deux chemins dans le système de fichiers"
 
-#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:134
 msgid "Open diffs in a visual tool"
 msgstr "Ouvrir les diffs dans un outil visuel"
 
-#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:136
 #, fuzzy
 msgid "Visually show diff of changes in the index"
 msgstr "Afficher explicitement les différences des changements dans l’index"
 
-#: /tmp/fish/implicit/share/completions/git.fish:136
+#: /tmp/fish/implicit/share/completions/git.fish:138
 msgid "Print lines matching a pattern"
 msgstr "Afficher les lignes correspondant à un motif"
 
-#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:139
 msgid "Create an empty git repository or reinitialize an existing one"
 msgstr "Créer un dépôt git vide ou réinitialiser un dépôt existant"
 
-#: /tmp/fish/implicit/share/completions/git.fish:138
+#: /tmp/fish/implicit/share/completions/git.fish:140
 msgid "Show commit shortlog"
 msgstr "Afficher le journal concis de la validation"
 
-#: /tmp/fish/implicit/share/completions/git.fish:139
+#: /tmp/fish/implicit/share/completions/git.fish:141
 msgid "Show commit logs"
 msgstr "Afficher les journaux des validations"
 
-#: /tmp/fish/implicit/share/completions/git.fish:141
+#: /tmp/fish/implicit/share/completions/git.fish:143
 msgid "Continue listing file history beyond renames"
 msgstr ""
 "Ne pas se contenter d’afficher les renommages, tout afficher de l’historique "
 "fichier"
 
-#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:144
 msgid "Don't print ref names"
 msgstr "Ne pas afficher les noms des références"
 
-#: /tmp/fish/implicit/share/completions/git.fish:143
+#: /tmp/fish/implicit/share/completions/git.fish:145
 msgid "Print out ref names"
 msgstr "Afficher les noms des références"
 
-#: /tmp/fish/implicit/share/completions/git.fish:144
+#: /tmp/fish/implicit/share/completions/git.fish:146
 msgid "Print ref name by which each commit was reached"
 msgstr "Afficher les noms des références atteintes par chaque validation"
 
-#: /tmp/fish/implicit/share/completions/git.fish:145
+#: /tmp/fish/implicit/share/completions/git.fish:147
 msgid "Limit the number of commits before starting to show the commit output"
 msgstr "Limiter le nombre de validations avant d’en afficher la sortie"
 
-#: /tmp/fish/implicit/share/completions/git.fish:146
+#: /tmp/fish/implicit/share/completions/git.fish:148
 msgid "Skip given number of commits"
 msgstr "Passer le nombre spécifié de validations"
 
-#: /tmp/fish/implicit/share/completions/git.fish:147
-#: /tmp/fish/implicit/share/completions/git.fish:148
+#: /tmp/fish/implicit/share/completions/git.fish:149
+#: /tmp/fish/implicit/share/completions/git.fish:150
 msgid "Show commits more recent than specified date"
 msgstr "Afficher les validations effectuées après une date spécifiée"
 
-#: /tmp/fish/implicit/share/completions/git.fish:149
-#: /tmp/fish/implicit/share/completions/git.fish:150
+#: /tmp/fish/implicit/share/completions/git.fish:151
+#: /tmp/fish/implicit/share/completions/git.fish:152
 msgid "Show commits older than specified date"
 msgstr "Afficher les validations effectuées avant une date spécifiée"
 
-#: /tmp/fish/implicit/share/completions/git.fish:151
+#: /tmp/fish/implicit/share/completions/git.fish:153
 msgid "Limit commits from given author"
 msgstr "Limiter aux validations de l’auteur spécifié"
 
-#: /tmp/fish/implicit/share/completions/git.fish:152
+#: /tmp/fish/implicit/share/completions/git.fish:154
 msgid "Limit commits from given committer"
 msgstr "Limiter aux validations du validateur spécifié"
 
-#: /tmp/fish/implicit/share/completions/git.fish:153
+#: /tmp/fish/implicit/share/completions/git.fish:155
 msgid "Limit commits to ones with reflog entries matching given pattern"
 msgstr ""
 "Limiter les validations à celles dont les entrées du reflog correspondent au "
 "motif spécifié"
 
-#: /tmp/fish/implicit/share/completions/git.fish:154
+#: /tmp/fish/implicit/share/completions/git.fish:156
 msgid "Limit commits with message that match given pattern"
 msgstr ""
 "Limiter les validations à celles dont le message correspond au motif spécifié"
 
-#: /tmp/fish/implicit/share/completions/git.fish:155
+#: /tmp/fish/implicit/share/completions/git.fish:157
 msgid "Limit commits to ones that match all given --grep"
 msgstr ""
 "Limiter les validations à celles correspondant à tous les --grep spécifiés"
 
-#: /tmp/fish/implicit/share/completions/git.fish:156
+#: /tmp/fish/implicit/share/completions/git.fish:158
 msgid "Limit commits to ones with message that don't match --grep"
 msgstr ""
 "Limiter les validations à celles dont le message ne correspond pas à --grep"
 
-#: /tmp/fish/implicit/share/completions/git.fish:157
+#: /tmp/fish/implicit/share/completions/git.fish:159
 msgid "Case insensitive match"
 msgstr "Correspondance insensible à la casse"
 
-#: /tmp/fish/implicit/share/completions/git.fish:158
+#: /tmp/fish/implicit/share/completions/git.fish:160
 msgid "Patterns are basic regular expressions (default)"
 msgstr "Les motifs sont des expressions régulières basiques (par défaut)"
 
-#: /tmp/fish/implicit/share/completions/git.fish:159
+#: /tmp/fish/implicit/share/completions/git.fish:161
 msgid "Patterns are extended regular expressions"
 msgstr "Les motifs sont des expressions régulières étendues"
 
-#: /tmp/fish/implicit/share/completions/git.fish:160
+#: /tmp/fish/implicit/share/completions/git.fish:162
 msgid "Patterns are fixed strings"
 msgstr "Les motifs sont des chaînes fixes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:161
+#: /tmp/fish/implicit/share/completions/git.fish:163
 msgid "Patterns are Perl-compatible regular expressions"
 msgstr "Les motifs sont des expressions régulières compatibles Perl"
 
-#: /tmp/fish/implicit/share/completions/git.fish:162
+#: /tmp/fish/implicit/share/completions/git.fish:164
 msgid "Stop when given path disappears from tree"
 msgstr "Arrêter lorsque le chemin spécifié disparaît de l’arborescence"
 
-#: /tmp/fish/implicit/share/completions/git.fish:163
+#: /tmp/fish/implicit/share/completions/git.fish:165
 msgid "Print only merge commits"
 msgstr "Afficher seulement les validations de fusion"
 
-#: /tmp/fish/implicit/share/completions/git.fish:164
+#: /tmp/fish/implicit/share/completions/git.fish:166
 msgid "Don't print commits with more than one parent"
 msgstr "Ne pas afficher les validations possédant plus d’un parent"
 
-#: /tmp/fish/implicit/share/completions/git.fish:165
+#: /tmp/fish/implicit/share/completions/git.fish:167
 msgid "Show only commit with at least the given number of parents"
 msgstr ""
 "N’afficher que les validations possédant au moins le nombre de parents "
 "spécifié"
 
-#: /tmp/fish/implicit/share/completions/git.fish:166
+#: /tmp/fish/implicit/share/completions/git.fish:168
 msgid "Show only commit with at most the given number of parents"
 msgstr ""
 "N’afficher que les validations possédant au plus le nombre de parents "
 "spécifié"
 
-#: /tmp/fish/implicit/share/completions/git.fish:167
+#: /tmp/fish/implicit/share/completions/git.fish:169
 msgid "Show only commit without a mimimum number of parents"
 msgstr "N’afficher que les validations sans nombre minimum de parents"
 
-#: /tmp/fish/implicit/share/completions/git.fish:168
+#: /tmp/fish/implicit/share/completions/git.fish:170
 msgid "Show only commit without a maximum number of parents"
 msgstr "N’afficher que les validations sans nombre maximum de parents"
 
-#: /tmp/fish/implicit/share/completions/git.fish:169
+#: /tmp/fish/implicit/share/completions/git.fish:171
 msgid "Follow only the first parent commit upon seeing a merge commit"
 msgstr ""
 "Suivre seulement la première validation parent jusqu’à atteindre une "
 "validation de fusion"
 
-#: /tmp/fish/implicit/share/completions/git.fish:170
+#: /tmp/fish/implicit/share/completions/git.fish:172
 msgid "Reverse meaning of ^ prefix"
 msgstr "Inverser la signification de ^"
 
-#: /tmp/fish/implicit/share/completions/git.fish:171
+#: /tmp/fish/implicit/share/completions/git.fish:173
 #, fuzzy
 msgid ""
 "Pretend as if all refs in refs/ are listed on the command line as <commit>"
@@ -26157,7 +26962,7 @@ msgstr ""
 "Prétendre que toutes les références dans refs/ sont listées sur la ligne de "
 "commande comme avec <commit>"
 
-#: /tmp/fish/implicit/share/completions/git.fish:172
+#: /tmp/fish/implicit/share/completions/git.fish:174
 #, fuzzy
 msgid ""
 "Pretend as if all refs are in refs/heads are listed on the command line as "
@@ -26166,7 +26971,7 @@ msgstr ""
 "Prétendre que toutes les références dans refs/heads sont listées sur la "
 "ligne de commande comme avec <commit>"
 
-#: /tmp/fish/implicit/share/completions/git.fish:173
+#: /tmp/fish/implicit/share/completions/git.fish:175
 #, fuzzy
 msgid ""
 "Pretend as if all refs are in ref/tags are listed on the command line as "
@@ -26175,7 +26980,7 @@ msgstr ""
 "Prétendre que toutes les références dans refs/tags sont listées sur la ligne "
 "de commande comme avec <commit>"
 
-#: /tmp/fish/implicit/share/completions/git.fish:174
+#: /tmp/fish/implicit/share/completions/git.fish:176
 #, fuzzy
 msgid ""
 "Pretend as if all refs in refs/remotes  are listed on the command line as "
@@ -26184,7 +26989,7 @@ msgstr ""
 "Prétendre que toutes les références dans refs/remotes sont listées sur la "
 "ligne de commande comme avec <commit>"
 
-#: /tmp/fish/implicit/share/completions/git.fish:175
+#: /tmp/fish/implicit/share/completions/git.fish:177
 #, fuzzy
 msgid ""
 "Pretend as if all refs matching shell glob are listed on the command line as "
@@ -26193,11 +26998,11 @@ msgstr ""
 "Prétendre que toutes les références correspondant au glob shell sont listées "
 "sur la ligne de commande comme avec <commit>"
 
-#: /tmp/fish/implicit/share/completions/git.fish:176
+#: /tmp/fish/implicit/share/completions/git.fish:178
 msgid "Do not include refs matching given glob pattern"
 msgstr "Ne pas inclure les références correspondant au motif glob spécifié"
 
-#: /tmp/fish/implicit/share/completions/git.fish:177
+#: /tmp/fish/implicit/share/completions/git.fish:179
 msgid ""
 "Pretend as if all objcets mentioned by reflogs are listed on the command "
 "line as <commit>"
@@ -26205,503 +27010,506 @@ msgstr ""
 "Prétendre que tous les objets mentionnés dans les reflog sont listés sur la "
 "ligne de commande comme avec <commit>"
 
-#: /tmp/fish/implicit/share/completions/git.fish:178
+#: /tmp/fish/implicit/share/completions/git.fish:180
 msgid "Ignore invalid object names"
 msgstr "Ignorer les noms invalides d’objets"
 
-#: /tmp/fish/implicit/share/completions/git.fish:179
+#: /tmp/fish/implicit/share/completions/git.fish:181
 msgid "Read commits from stdin"
 msgstr "Lire les validations depuis l’entrée standard"
 
-#: /tmp/fish/implicit/share/completions/git.fish:180
+#: /tmp/fish/implicit/share/completions/git.fish:182
 msgid "Mark equivalent commits with = and inequivalent with +"
 msgstr "Marquer les validations équivalentes avec = et non équivalentes avec +"
 
-#: /tmp/fish/implicit/share/completions/git.fish:181
+#: /tmp/fish/implicit/share/completions/git.fish:183
 msgid "Omit equivalent commits"
 msgstr "Ignorer les validations équivalentes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:182
+#: /tmp/fish/implicit/share/completions/git.fish:184
 msgid "Join two or more development histories together"
 msgstr "Fusionner plusieurs historiques de développement"
 
-#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:187
 msgid "Autocommit the merge"
 msgstr "Auto-valider la fusion"
 
-#: /tmp/fish/implicit/share/completions/git.fish:186
+#: /tmp/fish/implicit/share/completions/git.fish:188
 msgid "Don't autocommit the merge"
 msgstr "Ne pas auto-valider la fusion"
 
-#: /tmp/fish/implicit/share/completions/git.fish:187
+#: /tmp/fish/implicit/share/completions/git.fish:189
 msgid "Edit auto-generated merge message"
 msgstr "Éditer le message de fusion auto-généré"
 
-#: /tmp/fish/implicit/share/completions/git.fish:188
+#: /tmp/fish/implicit/share/completions/git.fish:190
 msgid "Don't edit auto-generated merge message"
 msgstr "Ne pas éditer le message de fusion auto-généré"
 
-#: /tmp/fish/implicit/share/completions/git.fish:189
+#: /tmp/fish/implicit/share/completions/git.fish:191
 msgid "Don't generate a merge commit if merge is fast-forward"
 msgstr ""
 "Ne pas générer de validation de fusion si la fusion est faite en avance "
 "rapide"
 
-#: /tmp/fish/implicit/share/completions/git.fish:190
+#: /tmp/fish/implicit/share/completions/git.fish:192
 msgid "Generate a merge commit even if merge is fast-forward"
 msgstr ""
 "Générer un validation de fusion même si la fusion est faite en avance rapide"
 
-#: /tmp/fish/implicit/share/completions/git.fish:191
+#: /tmp/fish/implicit/share/completions/git.fish:193
 msgid "Refuse to merge unless fast-forward possible"
 msgstr "Refuser la fusion sauf si une avance rapide est possible"
 
-#: /tmp/fish/implicit/share/completions/git.fish:192
+#: /tmp/fish/implicit/share/completions/git.fish:194
 msgid "Populate the log message with one-line descriptions"
 msgstr "Remplir le message de journal avec des descriptions sur une ligne"
 
-#: /tmp/fish/implicit/share/completions/git.fish:193
+#: /tmp/fish/implicit/share/completions/git.fish:195
 msgid "Don't populate the log message with one-line descriptions"
 msgstr ""
 "Ne pas remplir le message de journal avec des descriptions sur une ligne"
 
-#: /tmp/fish/implicit/share/completions/git.fish:194
+#: /tmp/fish/implicit/share/completions/git.fish:196
 msgid "Show diffstat of the merge"
 msgstr "Montrer le diffstat de la fusion"
 
-#: /tmp/fish/implicit/share/completions/git.fish:195
+#: /tmp/fish/implicit/share/completions/git.fish:197
 msgid "Don't show diffstat of the merge"
 msgstr "Ne pas montrer le diffstat de la fusion"
 
-#: /tmp/fish/implicit/share/completions/git.fish:196
+#: /tmp/fish/implicit/share/completions/git.fish:198
 msgid "Squash changes from other branch as a single commit"
 msgstr ""
 "Compresser les modifications depuis une autre branche comme une seule "
 "validation"
 
-#: /tmp/fish/implicit/share/completions/git.fish:197
+#: /tmp/fish/implicit/share/completions/git.fish:199
 msgid "Don't squash changes"
 msgstr "Ne pas compresser les modifications"
 
-#: /tmp/fish/implicit/share/completions/git.fish:200
-#: /tmp/fish/implicit/share/completions/git.fish:217
-#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:219
+#: /tmp/fish/implicit/share/completions/git.fish:241
 msgid "Force progress status"
 msgstr "Forcer l’affichage de la progression"
 
-#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:203
 msgid "Force no progress status"
 msgstr "Ne pas forcer l’affichage de la progression"
 
-#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:204
 msgid "Set the commit message"
 msgstr "Paramétrer le message de validation"
 
-#: /tmp/fish/implicit/share/completions/git.fish:203
+#: /tmp/fish/implicit/share/completions/git.fish:205
 msgid "Abort the current conflict resolution process"
 msgstr "Annuler la résolution de conflits en cours"
 
-#: /tmp/fish/implicit/share/completions/git.fish:204
+#: /tmp/fish/implicit/share/completions/git.fish:206
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 "Exécuter les outils de résolution de conflit pour résoudre les conflits de "
 "fusion"
 
-#: /tmp/fish/implicit/share/completions/git.fish:205
+#: /tmp/fish/implicit/share/completions/git.fish:207
 msgid "Use specific merge resolution program"
 msgstr "Utiliser un programme de résolution de fusion spécifique"
 
-#: /tmp/fish/implicit/share/completions/git.fish:207
+#: /tmp/fish/implicit/share/completions/git.fish:209
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr "Déplacer ou renommer un fichier, dossier ou lien symbolique"
 
-#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:210
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 "Éliminer tous les objets inatteignables de la base de données des objets"
 
-#: /tmp/fish/implicit/share/completions/git.fish:209
+#: /tmp/fish/implicit/share/completions/git.fish:211
 msgid "Fetch from and merge with another repository or a local branch"
 msgstr "Rapatrier et fusionner depuis un autre dépôt ou une branche locale"
 
-#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:214
 msgid "Fetch all remotes"
 msgstr "Rapatrier tous les dépôts distants"
 
-#: /tmp/fish/implicit/share/completions/git.fish:215
+#: /tmp/fish/implicit/share/completions/git.fish:217
 msgid "Keep downloaded pack"
 msgstr "Conserver le paquet téléchargé"
 
-#: /tmp/fish/implicit/share/completions/git.fish:216
+#: /tmp/fish/implicit/share/completions/git.fish:218
 msgid "Disable automatic tag following"
 msgstr "Désactiver le suivi automatique des étiquettes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:218
-#: /tmp/fish/implicit/share/completions/git.fish:221
-#: /tmp/fish/implicit/share/completions/git.fish:241
+#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:243
 msgid "Remote alias"
 msgstr "Alias distant"
 
-#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:222
 msgid "Update remote refs along with associated objects"
 msgstr ""
 "Mettre à jour les références distantes en même temps que les objets associés"
 
-#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:225
 msgid "Force-push branch"
 msgstr "Pousser autoritairement la branche"
 
-#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:226
 msgid "Force-push local branch to remote branch"
 msgstr "Pousser autoritairement la branche locale vers la branche distante"
 
-#: /tmp/fish/implicit/share/completions/git.fish:225
+#: /tmp/fish/implicit/share/completions/git.fish:227
 msgid "Push local branch to remote branch"
 msgstr "Pousser la branche locale vers la branche distante"
 
-#: /tmp/fish/implicit/share/completions/git.fish:226
+#: /tmp/fish/implicit/share/completions/git.fish:228
 msgid "Push all refs under refs/heads/"
 msgstr "Pousser toutes les références de refs/heads/"
 
-#: /tmp/fish/implicit/share/completions/git.fish:227
+#: /tmp/fish/implicit/share/completions/git.fish:229
 msgid "Remove remote branches that don't have a local counterpart"
 msgstr "Supprimer les branches distantes sans contrepartie locale"
 
-#: /tmp/fish/implicit/share/completions/git.fish:228
+#: /tmp/fish/implicit/share/completions/git.fish:230
 msgid "Push all refs under refs/"
 msgstr "Pousser toutes les références de refs/"
 
-#: /tmp/fish/implicit/share/completions/git.fish:229
+#: /tmp/fish/implicit/share/completions/git.fish:231
 msgid "Delete all listed refs from the remote repository"
 msgstr "Supprimer toutes les références listées du dépôt distant"
 
-#: /tmp/fish/implicit/share/completions/git.fish:230
+#: /tmp/fish/implicit/share/completions/git.fish:232
 msgid "Push all refs under refs/tags"
 msgstr "Pousser toutes les références de refs/tags"
 
-#: /tmp/fish/implicit/share/completions/git.fish:231
+#: /tmp/fish/implicit/share/completions/git.fish:233
 #, fuzzy
 msgid "Push all usual refs plus the ones under refs/tags"
 msgstr "Pousser toutes les références de refs/tags"
 
-#: /tmp/fish/implicit/share/completions/git.fish:232
+#: /tmp/fish/implicit/share/completions/git.fish:234
 msgid "Do everything except actually send the updates"
 msgstr "Tout faire sauf l’envoi proprement dit des mises à jour"
 
-#: /tmp/fish/implicit/share/completions/git.fish:233
+#: /tmp/fish/implicit/share/completions/git.fish:235
 msgid "Produce machine-readable output"
 msgstr "Produire une sortie lisible par un programme"
 
-#: /tmp/fish/implicit/share/completions/git.fish:234
+#: /tmp/fish/implicit/share/completions/git.fish:236
 msgid "Force update of remote refs"
 msgstr "Forcer la mise à jour des références distantes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:235
+#: /tmp/fish/implicit/share/completions/git.fish:237
 msgid ""
 "Force update of remote refs, stopping if other's changes would be overwritten"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:236
+#: /tmp/fish/implicit/share/completions/git.fish:238
 msgid "Add upstream (tracking) reference"
 msgstr "Ajouter une référence amont (suivi)"
 
-#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:242
 msgid "Forward-port local commits to the updated upstream head"
 msgstr ""
 "Reporter les validations locales sur le sommet mis à jour d’une branche"
 
-#: /tmp/fish/implicit/share/completions/git.fish:245
+#: /tmp/fish/implicit/share/completions/git.fish:247
 msgid "Restart the rebasing process"
 msgstr "Redémarrer le processus de rebasage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:248
 msgid "Abort the rebase operation"
 msgstr "Annuler le rebasage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:247
+#: /tmp/fish/implicit/share/completions/git.fish:249
 msgid "Keep the commits that don't cahnge anything"
 msgstr "Conserver les modifications sans effet"
 
-#: /tmp/fish/implicit/share/completions/git.fish:248
+#: /tmp/fish/implicit/share/completions/git.fish:250
 msgid "Restart the rebasing process by skipping the current patch"
 msgstr "Redémarrer le processus de rebasage en passant le patch actuel"
 
-#: /tmp/fish/implicit/share/completions/git.fish:249
+#: /tmp/fish/implicit/share/completions/git.fish:251
 msgid "Use merging strategies to rebase"
 msgstr "Utiliser des stratégies de fusion pour le rebasage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:254
 msgid "Show diffstat of the rebase"
 msgstr "Afficher le diffstat du rebasage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:253
+#: /tmp/fish/implicit/share/completions/git.fish:255
 msgid "Don't show diffstat of the rebase"
 msgstr "Ne pas afficher le diffstat du rebasage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:254
+#: /tmp/fish/implicit/share/completions/git.fish:256
 msgid "Allow the pre-rebase hook to run"
 msgstr "Autoriser l’exécution du crochet pré-rebasage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:255
+#: /tmp/fish/implicit/share/completions/git.fish:257
 msgid "Don't allow the pre-rebase hook to run"
 msgstr "Refuser l’exécution du crochet pré-rebasage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:256
+#: /tmp/fish/implicit/share/completions/git.fish:258
 msgid "Force the rebase"
 msgstr "Forcer le rebasage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:258
+#: /tmp/fish/implicit/share/completions/git.fish:260
 msgid "Try to recreate merges"
 msgstr "Tenter de re-créer les fusions"
 
-#: /tmp/fish/implicit/share/completions/git.fish:259
+#: /tmp/fish/implicit/share/completions/git.fish:261
 msgid "Rebase all reachable commits"
 msgstr "Rebaser toutes les validations atteignables"
 
-#: /tmp/fish/implicit/share/completions/git.fish:260
+#: /tmp/fish/implicit/share/completions/git.fish:262
 msgid "Automatic squashing"
 msgstr "Compression automatique"
 
-#: /tmp/fish/implicit/share/completions/git.fish:261
+#: /tmp/fish/implicit/share/completions/git.fish:263
 msgid "No automatic squashing"
 msgstr "Pas de compression automatique"
 
-#: /tmp/fish/implicit/share/completions/git.fish:262
+#: /tmp/fish/implicit/share/completions/git.fish:264
 msgid "No fast-forward"
 msgstr "Pas d’avance rapide"
 
-#: /tmp/fish/implicit/share/completions/git.fish:263
+#: /tmp/fish/implicit/share/completions/git.fish:265
 msgid "Reset current HEAD to the specified state"
 msgstr "Réinitialiser la HEAD actuelle vers l’état spécifié"
 
-#: /tmp/fish/implicit/share/completions/git.fish:264
+#: /tmp/fish/implicit/share/completions/git.fish:266
 msgid "Reset files in working directory"
 msgstr "Réinitialiser les fichiers du dossier de travail"
 
-#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:270
 msgid "Reflog"
 msgstr "Reflog"
 
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: /tmp/fish/implicit/share/completions/git.fish:271
 msgid "Revert an existing commit"
 msgstr "Inverser une validation existante"
 
-#: /tmp/fish/implicit/share/completions/git.fish:270
+#: /tmp/fish/implicit/share/completions/git.fish:272
 msgid "Remove files from the working tree and from the index"
 msgstr "Supprimer des fichiers de la copie de travail et de l’index"
 
-#: /tmp/fish/implicit/share/completions/git.fish:271
+#: /tmp/fish/implicit/share/completions/git.fish:273
 msgid "Keep local copies"
 msgstr "Conserver les copies locales"
 
-#: /tmp/fish/implicit/share/completions/git.fish:272
+#: /tmp/fish/implicit/share/completions/git.fish:274
 msgid "Exit with a zero status even if no files matched"
 msgstr ""
 "Terminer avec un code de retour de zéro même si aucun fichier n’a correspondu"
 
-#: /tmp/fish/implicit/share/completions/git.fish:273
+#: /tmp/fish/implicit/share/completions/git.fish:275
 msgid "Allow recursive removal"
 msgstr "Autoriser la suppression récursive"
 
-#: /tmp/fish/implicit/share/completions/git.fish:275
+#: /tmp/fish/implicit/share/completions/git.fish:277
 msgid "Override the up-to-date check"
 msgstr "Outrepasser la vérification d’actualité"
 
-#: /tmp/fish/implicit/share/completions/git.fish:276
+#: /tmp/fish/implicit/share/completions/git.fish:278
 #: /tmp/fish/implicit/share/completions/prt-get.fish:45
 #: /tmp/fish/implicit/share/completions/prt-get.fish:103
+#: /tmp/fish/implicit/share/completions/zfs.fish:40
+#: /tmp/fish/implicit/share/completions/zfs.fish:124
+#: /tmp/fish/implicit/share/completions/zfs.fish:132
 msgid "Dry run"
 msgstr "Exécution à blanc"
 
-#: /tmp/fish/implicit/share/completions/git.fish:277
+#: /tmp/fish/implicit/share/completions/git.fish:279
 msgid "Show the working tree status"
 msgstr "Afficher l’état de la copie de travail"
 
-#: /tmp/fish/implicit/share/completions/git.fish:278
+#: /tmp/fish/implicit/share/completions/git.fish:280
 msgid "Give the output in the short-format"
 msgstr "Mettre la sortie au format concis"
 
-#: /tmp/fish/implicit/share/completions/git.fish:279
+#: /tmp/fish/implicit/share/completions/git.fish:281
 msgid "Show the branch and tracking info even in short-format"
 msgstr "Afficher la branche et les informations de suivi même en format concis"
 
-#: /tmp/fish/implicit/share/completions/git.fish:280
+#: /tmp/fish/implicit/share/completions/git.fish:282
 msgid "Give the output in a stable, easy-to-parse format"
 msgstr "Mettre la sortie à un format stable, facile à analyser"
 
-#: /tmp/fish/implicit/share/completions/git.fish:281
+#: /tmp/fish/implicit/share/completions/git.fish:283
 msgid "Terminate entries with null character"
 msgstr "Terminer les entrées avec un caractère null"
 
-#: /tmp/fish/implicit/share/completions/git.fish:282
+#: /tmp/fish/implicit/share/completions/git.fish:284
 msgid "The untracked files handling mode"
 msgstr "Le mode de traitement des fichiers non suivis"
 
-#: /tmp/fish/implicit/share/completions/git.fish:283
+#: /tmp/fish/implicit/share/completions/git.fish:285
 msgid "Ignore changes to submodules"
 msgstr "Ignorer les changements apportés aux sous-modules"
 
-#: /tmp/fish/implicit/share/completions/git.fish:284
+#: /tmp/fish/implicit/share/completions/git.fish:286
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr "Créer, lister, supprimer ou vérifier une étiquette signée avec GPG"
 
-#: /tmp/fish/implicit/share/completions/git.fish:286
+#: /tmp/fish/implicit/share/completions/git.fish:288
 msgid "Make an unsigned, annotated tag object"
 msgstr "Créer une étiquette non-signée et annotée"
 
-#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:289
 msgid "Make a GPG-signed tag"
 msgstr "Créer une étiquette signée avec GPG"
 
-#: /tmp/fish/implicit/share/completions/git.fish:288
+#: /tmp/fish/implicit/share/completions/git.fish:290
 msgid "Remove a tag"
 msgstr "Supprimer une étiquette"
 
-#: /tmp/fish/implicit/share/completions/git.fish:289
+#: /tmp/fish/implicit/share/completions/git.fish:291
 msgid "Verify signature of a tag"
 msgstr "Vérifier la signature d’une étiquette"
 
-#: /tmp/fish/implicit/share/completions/git.fish:290
+#: /tmp/fish/implicit/share/completions/git.fish:292
 msgid "Force overwriting exising tag"
 msgstr "Forcer le remplacement de l’étiquette pré-existante"
 
-#: /tmp/fish/implicit/share/completions/git.fish:292
+#: /tmp/fish/implicit/share/completions/git.fish:294
 msgid "List tags that contain a commit"
 msgstr "Lister les étiquettes contenant une validation"
 
-#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:297
 msgid "Stash away changes"
 msgstr "Remiser les modifications"
 
-#: /tmp/fish/implicit/share/completions/git.fish:296
+#: /tmp/fish/implicit/share/completions/git.fish:298
 msgid "List stashes"
 msgstr "Lister les remisages"
 
-#: /tmp/fish/implicit/share/completions/git.fish:297
+#: /tmp/fish/implicit/share/completions/git.fish:299
 msgid "Show the changes recorded in the stash"
 msgstr "Afficher les modifications remisées"
 
-#: /tmp/fish/implicit/share/completions/git.fish:298
+#: /tmp/fish/implicit/share/completions/git.fish:300
 msgid "Apply and remove a single stashed state"
 msgstr "Appliquer et supprimer un état remisé"
 
-#: /tmp/fish/implicit/share/completions/git.fish:299
+#: /tmp/fish/implicit/share/completions/git.fish:301
 msgid "Apply a single stashed state"
 msgstr "Appliquer un état remisé"
 
-#: /tmp/fish/implicit/share/completions/git.fish:300
+#: /tmp/fish/implicit/share/completions/git.fish:302
 msgid "Remove all stashed states"
 msgstr "Supprimer tous les états remisés"
 
-#: /tmp/fish/implicit/share/completions/git.fish:301
+#: /tmp/fish/implicit/share/completions/git.fish:303
 msgid "Remove a single stashed state from the stash list"
 msgstr "Supprimer un état remisé"
 
-#: /tmp/fish/implicit/share/completions/git.fish:302
+#: /tmp/fish/implicit/share/completions/git.fish:304
 msgid "Create a stash"
 msgstr "Créer un remisage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:303
+#: /tmp/fish/implicit/share/completions/git.fish:305
 msgid "Save a new stash"
 msgstr "Sauvegarder un nouveau remisage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:304
+#: /tmp/fish/implicit/share/completions/git.fish:306
 msgid "Create a new branch from a stash"
 msgstr "Créer une nouvelle branche depuis un remisage"
 
-#: /tmp/fish/implicit/share/completions/git.fish:305
+#: /tmp/fish/implicit/share/completions/git.fish:307
 msgid "Set and read git configuration variables"
 msgstr "Paramétrer et lire les variables de configuration git"
 
-#: /tmp/fish/implicit/share/completions/git.fish:306
+#: /tmp/fish/implicit/share/completions/git.fish:308
 msgid "Generate patch series to send upstream"
 msgstr "Générer les patchs à envoyer en amont"
 
-#: /tmp/fish/implicit/share/completions/git.fish:308
+#: /tmp/fish/implicit/share/completions/git.fish:310
 msgid "Generate plain patches without diffstat"
 msgstr "Générer des patchs bruts, sans diffstat"
 
-#: /tmp/fish/implicit/share/completions/git.fish:309
+#: /tmp/fish/implicit/share/completions/git.fish:311
 msgid "Suppress diff output"
 msgstr "Masquer la sortie diff"
 
-#: /tmp/fish/implicit/share/completions/git.fish:310
+#: /tmp/fish/implicit/share/completions/git.fish:312
 msgid "Spend more time to create smaller diffs"
 msgstr "Passer plus de temps afin de créer des diffs plus petits"
 
-#: /tmp/fish/implicit/share/completions/git.fish:311
+#: /tmp/fish/implicit/share/completions/git.fish:313
 msgid "Generate diff with the 'patience' algorithm"
 msgstr "Générer le diff avec l’algorithme « patience »"
 
-#: /tmp/fish/implicit/share/completions/git.fish:312
+#: /tmp/fish/implicit/share/completions/git.fish:314
 msgid "Generate diff with the 'histogram' algorithm"
 msgstr "Générer le diff avec l’algorithme « histogram »"
 
-#: /tmp/fish/implicit/share/completions/git.fish:313
+#: /tmp/fish/implicit/share/completions/git.fish:315
 msgid "Print all commits to stdout in mbox format"
 msgstr "Afficher toutes les validations sur l’entrée standard au format mbox"
 
-#: /tmp/fish/implicit/share/completions/git.fish:314
+#: /tmp/fish/implicit/share/completions/git.fish:316
 msgid "Show number of added/deleted lines in decimal notation"
 msgstr ""
 "Afficher le nombre de lignes ajoutées et supprimées en notation décimale"
 
-#: /tmp/fish/implicit/share/completions/git.fish:315
+#: /tmp/fish/implicit/share/completions/git.fish:317
 msgid "Output only last line of the stat"
 msgstr "N’afficher que la dernière ligne du format --stat"
 
-#: /tmp/fish/implicit/share/completions/git.fish:316
+#: /tmp/fish/implicit/share/completions/git.fish:318
 msgid "Output a condensed summary of extended header information"
 msgstr "Afficher un résumé concis des en-têtes informatives étendues"
 
-#: /tmp/fish/implicit/share/completions/git.fish:317
+#: /tmp/fish/implicit/share/completions/git.fish:319
 msgid "Disable rename detection"
 msgstr "Désactiver la détection des renommages"
 
-#: /tmp/fish/implicit/share/completions/git.fish:318
+#: /tmp/fish/implicit/share/completions/git.fish:320
 msgid "Show full blob object names"
 msgstr "Afficher les noms complets des objets blob"
 
-#: /tmp/fish/implicit/share/completions/git.fish:319
+#: /tmp/fish/implicit/share/completions/git.fish:321
 msgid "Output a binary diff for use with git apply"
 msgstr "Afficher un diff binaire à utiliser avec git apply"
 
-#: /tmp/fish/implicit/share/completions/git.fish:320
+#: /tmp/fish/implicit/share/completions/git.fish:322
 msgid "Also inspect unmodified files as source for a copy"
 msgstr "Inspecter également les fichiers non modifiés comme source pour copie"
 
-#: /tmp/fish/implicit/share/completions/git.fish:322
+#: /tmp/fish/implicit/share/completions/git.fish:324
 msgid "Ignore changes in whitespace at EOL"
 msgstr "Ignorer les modifications dans les blancs en fin de ligne"
 
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: /tmp/fish/implicit/share/completions/git.fish:325
 msgid "Ignore changes in amount of whitespace"
 msgstr "Ignorer les modifications du nombre de blancs"
 
-#: /tmp/fish/implicit/share/completions/git.fish:324
+#: /tmp/fish/implicit/share/completions/git.fish:326
 msgid "Ignore whitespace when comparing lines"
 msgstr "Ignorer les blancs lors de la comparaison des lignes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:326
+#: /tmp/fish/implicit/share/completions/git.fish:328
 #, fuzzy
 msgid "Show whole surrounding functions of changes"
 msgstr "Afficher toutes les fonctions aux environs des changements"
 
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: /tmp/fish/implicit/share/completions/git.fish:329
 msgid "Allow an external diff helper to be executed"
 msgstr "Autoriser l’exécution d’un assistant diff externe"
 
-#: /tmp/fish/implicit/share/completions/git.fish:328
+#: /tmp/fish/implicit/share/completions/git.fish:330
 msgid "Disallow external diff helpers"
 msgstr "Refuser les assistants diff externes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:329
+#: /tmp/fish/implicit/share/completions/git.fish:331
 msgid "Disallow external text conversion filters for binary files (Default)"
 msgstr ""
 "Refuser les filtres externes de conversion de texte pour les fichiers "
 "binaires (par défaut)"
 
-#: /tmp/fish/implicit/share/completions/git.fish:330
+#: /tmp/fish/implicit/share/completions/git.fish:332
 msgid ""
 "Allow external text conversion filters for binary files (Resulting diff is "
 "unappliable)"
@@ -26709,77 +27517,77 @@ msgstr ""
 "Autoriser les filtres externes de conversion de texte pour les fichiers "
 "binaires (le diff résultant est inapplicable)"
 
-#: /tmp/fish/implicit/share/completions/git.fish:331
+#: /tmp/fish/implicit/share/completions/git.fish:333
 msgid "Do not show source or destination prefix"
 msgstr "Ne pas afficher les préfixes source et destination"
 
-#: /tmp/fish/implicit/share/completions/git.fish:332
+#: /tmp/fish/implicit/share/completions/git.fish:334
 msgid "Name output in [Patch n/m] format, even with a single patch"
 msgstr "Afficher le nom au format [Patch n/m], même pour un patch isolé"
 
-#: /tmp/fish/implicit/share/completions/git.fish:333
+#: /tmp/fish/implicit/share/completions/git.fish:335
 msgid "Name output in [Patch] format, even with multiple patches"
 msgstr "Afficher le nom au format [Patch n/m], même pour de multiples patchs"
 
-#: /tmp/fish/implicit/share/completions/git.fish:334
+#: /tmp/fish/implicit/share/completions/git.fish:336
 msgid "Initialize, update or inspect submodules"
 msgstr "Initialiser, mettre à jour ou inspecter des sous-modules"
 
-#: /tmp/fish/implicit/share/completions/git.fish:335
+#: /tmp/fish/implicit/share/completions/git.fish:337
 msgid "Add a submodule"
 msgstr "Ajouter un sous-module"
 
-#: /tmp/fish/implicit/share/completions/git.fish:336
+#: /tmp/fish/implicit/share/completions/git.fish:338
 msgid "Show submodule status"
 msgstr "Afficher l’état du sous-module"
 
-#: /tmp/fish/implicit/share/completions/git.fish:337
-#: /tmp/fish/implicit/share/completions/git.fish:343
+#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:345
 msgid "Initialize all submodules"
 msgstr "Initialiser tous les sous-modules"
 
-#: /tmp/fish/implicit/share/completions/git.fish:338
+#: /tmp/fish/implicit/share/completions/git.fish:340
 msgid "Update all submodules"
 msgstr "Mettre à jour tous les sous-modules"
 
-#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:341
 msgid "Show commit summary"
 msgstr "Afficher le résumé des validations"
 
-#: /tmp/fish/implicit/share/completions/git.fish:340
+#: /tmp/fish/implicit/share/completions/git.fish:342
 msgid "Run command on each submodule"
 msgstr "Exécuter la commande dans chaque sous-module"
 
-#: /tmp/fish/implicit/share/completions/git.fish:341
+#: /tmp/fish/implicit/share/completions/git.fish:343
 msgid "Sync submodules' URL with .gitmodules"
 msgstr "Synchroniser les URL des sous-modules avec .gitmodules"
 
-#: /tmp/fish/implicit/share/completions/git.fish:342
+#: /tmp/fish/implicit/share/completions/git.fish:344
 msgid "Only print error messages"
 msgstr "N’afficher que les messages d’erreur"
 
-#: /tmp/fish/implicit/share/completions/git.fish:344
+#: /tmp/fish/implicit/share/completions/git.fish:346
 msgid "Checkout the superproject's commit on a detached HEAD in the submodule"
 msgstr ""
 "Vérifier la validation du superprojet sur la HEAD détachée dans le sous-"
 "module"
 
-#: /tmp/fish/implicit/share/completions/git.fish:345
+#: /tmp/fish/implicit/share/completions/git.fish:347
 msgid ""
 "Merge the superproject's commit into the current branch of the submodule"
 msgstr ""
 "Fusionner la validation du superprojet dans la branche actuelle du sous-"
 "module"
 
-#: /tmp/fish/implicit/share/completions/git.fish:346
+#: /tmp/fish/implicit/share/completions/git.fish:348
 msgid "Rebase current branch onto the superproject's commit"
 msgstr "Rebaser la branche actuelle sur la validation du superprojet"
 
-#: /tmp/fish/implicit/share/completions/git.fish:347
+#: /tmp/fish/implicit/share/completions/git.fish:349
 msgid "Don't fetch new objects from the remote"
 msgstr "Ne pas rapatrier de nouveaux objets depuis le serveur distant"
 
-#: /tmp/fish/implicit/share/completions/git.fish:348
+#: /tmp/fish/implicit/share/completions/git.fish:350
 #, fuzzy
 msgid ""
 "Instead of using superproject's SHA-1, use the state of the submodule's "
@@ -26788,7 +27596,7 @@ msgstr ""
 "Au lieu d’utiliser la somme SHA-1 du superprojet, utiliser l’état de la "
 "branche de suivi du sous-module"
 
-#: /tmp/fish/implicit/share/completions/git.fish:349
+#: /tmp/fish/implicit/share/completions/git.fish:351
 msgid ""
 "Throw away local changes when switching to a different commit and always run "
 "checkout"
@@ -26796,128 +27604,128 @@ msgstr ""
 "Se débarrasser des modifications locales en passant à une autre validation, "
 "et toujours exécuter checkout"
 
-#: /tmp/fish/implicit/share/completions/git.fish:350
+#: /tmp/fish/implicit/share/completions/git.fish:352
 #, fuzzy
 msgid "Also add ignored submodule path"
 msgstr "Ajouter également le chemin du sous-module ignoré"
 
-#: /tmp/fish/implicit/share/completions/git.fish:351
+#: /tmp/fish/implicit/share/completions/git.fish:353
 msgid "Remove even with local changes"
 msgstr "Supprimer même en cas de modifications locales"
 
-#: /tmp/fish/implicit/share/completions/git.fish:352
+#: /tmp/fish/implicit/share/completions/git.fish:354
 msgid "Use the commit stored in the index"
 msgstr "Utiliser la validation présente dans l’index"
 
-#: /tmp/fish/implicit/share/completions/git.fish:353
+#: /tmp/fish/implicit/share/completions/git.fish:355
 msgid "Compare the commit in the index with submodule HEAD"
 msgstr ""
 "Comparer la validation présente dans l’index avec la HEAD du sous-module"
 
-#: /tmp/fish/implicit/share/completions/git.fish:354
+#: /tmp/fish/implicit/share/completions/git.fish:356
 msgid "Traverse submodules recursively"
 msgstr "Opérer récursivement sur les sous-modules"
 
-#: /tmp/fish/implicit/share/completions/git.fish:355
+#: /tmp/fish/implicit/share/completions/git.fish:357
 msgid "Show logs with difference each commit introduces"
 msgstr ""
 "Afficher les journaux avec les différences introduites par les différentes "
 "validations"
 
-#: /tmp/fish/implicit/share/completions/git.fish:356
+#: /tmp/fish/implicit/share/completions/git.fish:358
 msgid "Remove untracked files from the working tree"
 msgstr "Supprimer tous les fichiers non suivis de la copie de travail"
 
-#: /tmp/fish/implicit/share/completions/git.fish:357
+#: /tmp/fish/implicit/share/completions/git.fish:359
 msgid "Force run"
 msgstr "Forcer l’exécution"
 
-#: /tmp/fish/implicit/share/completions/git.fish:358
+#: /tmp/fish/implicit/share/completions/git.fish:360
 msgid "Show what would be done and clean files interactively"
 msgstr "Montrer ce qui serait fait et nettoyer les fichiers interactivement"
 
-#: /tmp/fish/implicit/share/completions/git.fish:359
+#: /tmp/fish/implicit/share/completions/git.fish:361
 msgid "Don't actually remove anything, just show what would be done"
 msgstr "Ne rien supprimer effectivement, montrer seulement ce qui serait fait"
 
-#: /tmp/fish/implicit/share/completions/git.fish:360
+#: /tmp/fish/implicit/share/completions/git.fish:362
 msgid "Be quiet, only report errors"
 msgstr "Être silencieux, ne communiquer que les erreurs"
 
-#: /tmp/fish/implicit/share/completions/git.fish:361
+#: /tmp/fish/implicit/share/completions/git.fish:363
 msgid "Remove untracked directories in addition to untracked files"
 msgstr "Supprimer les dossiers non suivis en plus des fichiers non suivis"
 
-#: /tmp/fish/implicit/share/completions/git.fish:362
+#: /tmp/fish/implicit/share/completions/git.fish:364
 msgid "Remove ignored files, as well"
 msgstr "Supprimer également les fichiers ignorés"
 
-#: /tmp/fish/implicit/share/completions/git.fish:363
+#: /tmp/fish/implicit/share/completions/git.fish:365
 msgid "Remove only ignored files"
 msgstr "Ne supprimer que les fichiers ignorés"
 
-#: /tmp/fish/implicit/share/completions/git.fish:364
+#: /tmp/fish/implicit/share/completions/git.fish:366
 msgid "Show what revision and author last modified each line of a file"
 msgstr ""
 "Afficher la dernière révision, avec son auteur, ayant modifié chaque ligne"
 
-#: /tmp/fish/implicit/share/completions/git.fish:365
+#: /tmp/fish/implicit/share/completions/git.fish:367
 msgid "Show blank SHA-1 for boundary commits"
 msgstr "Montrer une somme SHA-1 blanche pour les validations de limite"
 
-#: /tmp/fish/implicit/share/completions/git.fish:366
+#: /tmp/fish/implicit/share/completions/git.fish:368
 msgid "Do not treat root commits as boundaries"
 msgstr "Ne pas traiter les validations racine comme des limites"
 
-#: /tmp/fish/implicit/share/completions/git.fish:367
+#: /tmp/fish/implicit/share/completions/git.fish:369
 msgid "Include additional statistics"
 msgstr "Inclure des statistiques supplémentaires"
 
-#: /tmp/fish/implicit/share/completions/git.fish:368
+#: /tmp/fish/implicit/share/completions/git.fish:370
 msgid "Annotate only the given line range"
 msgstr "N’annoter que l’intervalle de lignes spécifié"
 
-#: /tmp/fish/implicit/share/completions/git.fish:369
+#: /tmp/fish/implicit/share/completions/git.fish:371
 msgid "Show long rev"
 msgstr "Afficher intégralement la révision"
 
-#: /tmp/fish/implicit/share/completions/git.fish:370
+#: /tmp/fish/implicit/share/completions/git.fish:372
 msgid "Show raw timestamp"
 msgstr "Afficher l’horodatage brut"
 
-#: /tmp/fish/implicit/share/completions/git.fish:371
+#: /tmp/fish/implicit/share/completions/git.fish:373
 msgid "Use revisions from named file instead of calling rev-list"
 msgstr "Utiliser les révisions du fichier précisé au lieu d’appeler rev-list"
 
-#: /tmp/fish/implicit/share/completions/git.fish:372
+#: /tmp/fish/implicit/share/completions/git.fish:374
 msgid "Walk history forward instead of backward"
 msgstr "Parcourir l’historique en avançant plutôt qu’en reculant"
 
-#: /tmp/fish/implicit/share/completions/git.fish:373
+#: /tmp/fish/implicit/share/completions/git.fish:375
 msgid "Show in a format designed for machine consumption"
 msgstr "Afficher dans un format conçu pour un traitement informatique"
 
-#: /tmp/fish/implicit/share/completions/git.fish:374
+#: /tmp/fish/implicit/share/completions/git.fish:376
 msgid "Show the porcelain format"
 msgstr "Afficher le format porcelaine"
 
-#: /tmp/fish/implicit/share/completions/git.fish:375
+#: /tmp/fish/implicit/share/completions/git.fish:377
 msgid "Show the result incrementally"
 msgstr "Afficher le résultat de manière incrémentale"
 
-#: /tmp/fish/implicit/share/completions/git.fish:376
+#: /tmp/fish/implicit/share/completions/git.fish:378
 msgid "Instead of working tree, use the contents of the named file"
 msgstr "Utiliser le contenu du fichier précisé, pas la copie de travail"
 
-#: /tmp/fish/implicit/share/completions/git.fish:377
+#: /tmp/fish/implicit/share/completions/git.fish:379
 msgid "Specifies the format used to output dates"
 msgstr "Spécifier le format d’affichage des dates"
 
-#: /tmp/fish/implicit/share/completions/git.fish:378
+#: /tmp/fish/implicit/share/completions/git.fish:380
 msgid "Detect moved or copied lines within a file"
 msgstr "Détecter les lignes déplacées ou dupliquées dans un fichier"
 
-#: /tmp/fish/implicit/share/completions/git.fish:379
+#: /tmp/fish/implicit/share/completions/git.fish:381
 #, fuzzy
 msgid ""
 "Detect lines moved or copied from other files that were modified in the same "
@@ -26926,31 +27734,31 @@ msgstr ""
 "Détecter les lignes déplacées ou copiées depuis d’autres fichiers, eux-mêmes "
 "modifiés par la même validation"
 
-#: /tmp/fish/implicit/share/completions/git.fish:381
+#: /tmp/fish/implicit/share/completions/git.fish:383
 msgid "Use the same output mode as git-annotate"
 msgstr "Utiliser le même affichage que git-annotate"
 
-#: /tmp/fish/implicit/share/completions/git.fish:382
+#: /tmp/fish/implicit/share/completions/git.fish:384
 msgid "Show the filename in the original commit"
 msgstr "Afficher le nom du fichier dans la validation originelle"
 
-#: /tmp/fish/implicit/share/completions/git.fish:383
+#: /tmp/fish/implicit/share/completions/git.fish:385
 msgid "Show the line number in the original commit"
 msgstr "Afficher le numéro de ligne dans la validation originelle"
 
-#: /tmp/fish/implicit/share/completions/git.fish:384
+#: /tmp/fish/implicit/share/completions/git.fish:386
 msgid "Suppress the author name and timestamp from the output"
 msgstr "Masquer le nom de l’auteur et l’horodatage de la sortie"
 
-#: /tmp/fish/implicit/share/completions/git.fish:385
+#: /tmp/fish/implicit/share/completions/git.fish:387
 msgid "Show the author email instead of author name"
 msgstr "Afficher l’adresse email de l’auteur au lieu de son nom"
 
-#: /tmp/fish/implicit/share/completions/git.fish:386
+#: /tmp/fish/implicit/share/completions/git.fish:388
 msgid "Ignore whitespace changes"
 msgstr "Ignorer les modifications dans les blancs"
 
-#: /tmp/fish/implicit/share/completions/git.fish:387
+#: /tmp/fish/implicit/share/completions/git.fish:389
 msgid "Custom command"
 msgstr "Commande personnalisée"
 
@@ -27463,6 +28271,7 @@ msgid "List all keys with their fingerprints"
 msgstr "Lister toutes les clés avec leurs empreintes"
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
+#: /tmp/fish/implicit/share/completions/signify.fish:2
 msgid "Generate a new key pair"
 msgstr "Générer une nouvelle paire de clés"
 
@@ -36820,13 +37629,6 @@ msgstr ""
 msgid "Display values currently set in the minikube config file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/minikube.fish:25
-#: /tmp/fish/implicit/share/completions/minikube.fish:26
-#: /tmp/fish/implicit/share/completions/minikube.fish:27
-#: /tmp/fish/implicit/share/completions/minikube.fish:28
-msgid "Property"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/minikube.fish:29
 msgid "Go template format string for the config view output"
 msgstr ""
@@ -42828,11 +43630,6 @@ msgstr ""
 msgid "keep going until N jobs fail [default=1]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ninja.fish:8
-#: /tmp/fish/implicit/share/completions/quilt.fish:1
-msgid "show help"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/ninja.fish:9
 #, fuzzy
 msgid "enable debugging, specify debug mode"
@@ -46138,6 +46935,20 @@ msgstr "Désactiver les avertissements"
 msgid "Extract script"
 msgstr "Extraire le script"
 
+#: /tmp/fish/implicit/share/completions/pfctl.fish:1
+msgid "Show a filter parameter by modifier"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:2
+#, fuzzy
+msgid "Flush filter params specified by mod"
+msgstr "Le fichier est la cible de n liens"
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:3
+#, fuzzy
+msgid "Table command"
+msgstr "Désactiver cette commande"
+
 #: /tmp/fish/implicit/share/completions/pgrep.fish:1
 msgid "Output delimiter"
 msgstr "Délimiteur de sortie"
@@ -46357,6 +47168,32 @@ msgstr ""
 msgid "omit the user's full name, remote host and idle time in short format"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:1
+#, fuzzy
+msgid "failsafe to overwrite"
+msgstr ""
+"Journaliser les entrées dans le fichier spécifié, en écrasant son contenu"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:2
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:3
+#, fuzzy
+msgid "Turn on stats"
+msgstr "Activer l’horodatage"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:3
+#, fuzzy
+msgid "Automated package installation"
+msgstr "Emplacement secondaire du cache des paquets"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:5
+#, fuzzy
+msgid "Update packages"
+msgstr "Mettre à jour le ou les paquet(s)"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:6
+msgid "Fuzzy match"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:1
 msgid "Upgrade"
 msgstr "Mettre à jour"
@@ -46461,6 +47298,11 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/pkg-config.fish:25
 msgid "List all modules the given packages requires for static linking"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:2
+#, fuzzy
+msgid "Delete unsed deps"
+msgstr "Supprimer les fichiers trouvés"
 
 #: /tmp/fish/implicit/share/completions/pkgfile.fish:3
 msgid "only show files in a {s}bin/ directory. Works with -s, -l"
@@ -50949,6 +51791,21 @@ msgstr ""
 msgid "Specifies layout variant used to choose component names"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/signify.fish:1
+#, fuzzy
+msgid "Verify a signed checksum list"
+msgstr "Forcer une taille de bloc fixe pour la somme de contrôle"
+
+#: /tmp/fish/implicit/share/completions/signify.fish:3
+#, fuzzy
+msgid "Sign specified message"
+msgstr "Utiliser le format unifié"
+
+#: /tmp/fish/implicit/share/completions/signify.fish:4
+#, fuzzy
+msgid "Verify a signed message and sig"
+msgstr "Afficher un message d’utilisation et quitter"
+
 #: /tmp/fish/implicit/share/completions/snap.fish:1
 #, fuzzy
 msgid "Test if snap has yet to be given the subcommand"
@@ -54854,10 +55711,12 @@ msgid "Monitor changes to objects"
 msgstr "Surveiller les modifications des objets"
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:7
+#: /tmp/fish/implicit/share/completions/zfs.fish:17
 msgid "Mount a filesystem"
 msgstr "Monter un système de fichiers"
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:18
 msgid "Unmount a filesystem"
 msgstr ""
 
@@ -59477,6 +60336,640 @@ msgstr "Supprimer les fichiers d’en-tête en cache"
 msgid "Delete all cache contents"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/zfs.fish:1
+msgid ""
+"Internal completion function for appending string to the ZFS commandline"
+msgstr ""
+"Fonction de complétion interne pour la concaténation de chaîne à la ligne de "
+"commande ZFS"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:2
+#: /tmp/fish/implicit/share/completions/zpool.fish:2
+msgid "Display a help message"
+msgstr "Afficher l’aide"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:3
+msgid "Create a volume or filesystem"
+msgstr "Créer un volume ou un système de fichiers"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:4
+msgid "Destroy a dataset"
+msgstr "Détruire un jeu de données"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:5
+msgid "Create a snapshot"
+msgstr "Créer un instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:6
+msgid "Roll back a filesystem to a previous snapshot"
+msgstr "Restaurer un système de fichiers depuis un instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:7
+msgid "Create a clone of a snapshot"
+msgstr "Créer un clone ou un instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:8
+msgid ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+msgstr ""
+"Promouvoir un clone de système de fichiers pour le rendre indépendant de son "
+"instantané d’origine"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:9
+msgid "Rename a dataset"
+msgstr "Renommer un jeu de données"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:10
+msgid "List dataset properties"
+msgstr "Lister les paramètres d’un jeu de données"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:11
+msgid "Set a dataset property"
+msgstr "Régler un paramètre de jeu de données"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:12
+msgid "Get one or several dataset properties"
+msgstr "Obtenir un ou plusieurs paramètres d’un jeu de données"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:13
+msgid "Set a dataset property to be inherited"
+msgstr "Régler un paramètre de jeu de données pour qu’il ait sa valeur héritée"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:14
+msgid "List upgradeable datasets, or upgrade one"
+msgstr ""
+"Lister les jeux de données pouvant être mis à jour, ou en mettre un à jour"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:15
+msgid "Get dataset space consumed by each user"
+msgstr "Obtenir l’espace du jeu de données utilisé par chaque utilisateur"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:16
+msgid "Get dataset space consumed by each user group"
+msgstr "Obtenir l’espace du jeu de données utilisé par chaque groupe"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:19
+msgid "Share a given filesystem, or all of them"
+msgstr ""
+"Partager un système de fichiers donné, ou tous les systèmes de fichiers"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:20
+msgid "Stop sharing a given filesystem, or all of them"
+msgstr ""
+"Arrêter le partage d’un système de fichiers donné, ou de tous les systèmes "
+"de fichiers"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:21
+msgid "Create a bookmark for a snapshot"
+msgstr "Créer un marque-page pour un instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:22
+msgid "Output a stream representation of a dataset"
+msgstr "Afficher un flux représentant un jeu de données"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:23
+msgid ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+msgstr ""
+"Écrire sur le disque un jeu de données d’après le flux le représentant, reçu "
+"sur l’entrée standard"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:24
+msgid ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+msgstr ""
+"Déléguer, ou afficher les délégations, des droits sur un jeu de données à un "
+"utilisateur ou un groupe"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:25
+msgid "Revoke delegations of rights on a dataset from (groups of) users"
+msgstr ""
+"Révoquer les délégations de droits sur un jeu de données d’un utilisateur ou "
+"d’un groupe"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:26
+msgid "Put a named hold on a snapshot"
+msgstr "Placer un verrou nommé sur un instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:27
+msgid "List holds on a snapshot"
+msgstr "Lister les verrous sur un instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:28
+msgid "Remove a named hold from a snapshot"
+msgstr "Supprimer un verrou nommé d’un instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:29
+msgid ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+msgstr ""
+"Lister les fichiers modifiés entre un instantané, et un système de fichiers "
+"ou un instantané antérieur"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:30
+#, fuzzy
+msgid "Execute a ZFS Channel Program"
+msgstr "Exécuter un programme de canal ZFS"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:31
+#: /tmp/fish/implicit/share/completions/zfs.fish:53
+#: /tmp/fish/implicit/share/completions/zfs.fish:58
+msgid "Create all needed non-existing parent datasets"
+msgstr "Créer tous les jeux de données parents manquants"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:32
+#: /tmp/fish/implicit/share/completions/zfs.fish:33
+msgid "Dataset property"
+msgstr "Paramètre du jeu de données"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:34
+msgid "Volume size"
+msgstr "Taille du volume"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:35
+msgid "Create a sparse volume"
+msgstr "Créer un volume creux"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:36
+msgid "Blocksize"
+msgstr "Taille de bloc"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:37
+msgid "Recursively destroy children"
+msgstr "Détruire récursivement les enfants"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:38
+msgid "Recursively destroy all dependents"
+msgstr "Détruire récursivement tous les descendants"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:39
+msgid "Force unmounting"
+msgstr "Forcer le démontage"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:41
+msgid "Print machine-parsable verbose information"
+msgstr ""
+"Afficher les informations détaillées dans un format utilisable par un "
+"programme"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:43
+msgid "Defer snapshot deletion"
+msgstr "Différer la destruction de l’instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:44
+msgid "Dataset to destroy"
+msgstr "Jeu de données à détruire"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:45
+msgid "Recursively snapshot children"
+msgstr "Créer récursivement un instantané des enfants"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:46
+#: /tmp/fish/implicit/share/completions/zfs.fish:47
+msgid "Snapshot property"
+msgstr "Paramètre de l’instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:48
+msgid "Dataset to snapshot"
+msgstr "Jeu de données dont l’instantané est à créer"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:49
+msgid "Destroy later snapshot and bookmarks"
+msgstr "Détruire les instantanés et marque-pages plus récents"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:50
+msgid "Recursively destroy later snapshot, bookmarks and clones"
+msgstr ""
+"Détruire récursivement les instantanés, marque-pages et clones postérieurs"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:51
+msgid "Force unmounting of clones"
+msgstr "Forcer le démontage des clones"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:52
+msgid "Snapshot to roll back to"
+msgstr "Instantané à restaurer"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:54
+#: /tmp/fish/implicit/share/completions/zfs.fish:55
+msgid "Clone property"
+msgstr "Paramètre du clone"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:56
+msgid "Snapshot to clone"
+msgstr "Instantané à cloner"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:57
+msgid "Clone to promote"
+msgstr "Clone à promouvoir"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:59
+msgid "Recursively rename children snapshots"
+msgstr "Renommer récursivement les instantanés enfants"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:60
+#: /tmp/fish/implicit/share/completions/zfs.fish:62
+#: /tmp/fish/implicit/share/completions/zfs.fish:108
+msgid "Force unmounting if needed"
+msgstr "Forcer le démontage si nécessaire"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:61
+msgid "Do not remount filesystems during rename"
+msgstr "Ne pas remonter les systèmes de fichiers pendant le renommage"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:63
+msgid "Dataset to rename"
+msgstr "Jeu de données à renommer"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:64
+#: /tmp/fish/implicit/share/completions/zfs.fish:77
+#: /tmp/fish/implicit/share/completions/zfs.fish:94
+#: /tmp/fish/implicit/share/completions/zfs.fish:172
+#: /tmp/fish/implicit/share/completions/zpool.fish:59
+#: /tmp/fish/implicit/share/completions/zpool.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:99
+msgid "Print output in a machine-parsable format"
+msgstr "Afficher dans un format utilisable par un programme"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:65
+#: /tmp/fish/implicit/share/completions/zfs.fish:75
+#: /tmp/fish/implicit/share/completions/zfs.fish:84
+#: /tmp/fish/implicit/share/completions/zfs.fish:89
+msgid "Operate recursively on datasets"
+msgstr "Opérer récursivement sur les jeux de données"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:105
+msgid "Property to list"
+msgstr "Paramètres à lister"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:68
+#: /tmp/fish/implicit/share/completions/zfs.fish:80
+#: /tmp/fish/implicit/share/completions/zfs.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:66
+msgid "Print parsable (exact) values for numbers"
+msgstr "Afficher les nombres dans un format exact, utilisable par un programme"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:69
+#: /tmp/fish/implicit/share/completions/zfs.fish:97
+msgid "Property to use for sorting output by ascending order"
+msgstr "Propriété à utiliser pour trier la sortie par ordre croissant"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:70
+#: /tmp/fish/implicit/share/completions/zfs.fish:98
+msgid "Property to use for sorting output by descending order"
+msgstr "Propriété à utiliser pour trier la sortie par ordre décroissant"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:72
+msgid "Dataset which properties is to be listed"
+msgstr "Jeu de données dont les paramètres sont à lister"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:73
+#: /tmp/fish/implicit/share/completions/zpool.fish:125
+msgid "Property to set"
+msgstr "Paramètre à régler"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:74
+msgid "Dataset which property is to be setted"
+msgstr "Jeu de données dont le paramètre est à régler"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:78
+#: /tmp/fish/implicit/share/completions/zpool.fish:68
+msgid "Fields to display"
+msgstr "Champs à afficher"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:79
+msgid "Property source to display"
+msgstr "Source de paramètre à afficher"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:82
+msgid "Property to get"
+msgstr "Paramètre à récupérer"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:83
+msgid "Dataset which properties is to be got"
+msgstr "Jeu de données dont les paramètres sont à récupérer"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:85
+msgid "Revert to the received value if available"
+msgstr "Revenir à la valeur reçue, le cas échéant"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:86
+msgid "Dataset which properties is to be inherited"
+msgstr "Jeu de données dont les paramètres sont à régler à leur valeur héritée"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:88
+msgid "Upgrade all eligible filesystems"
+msgstr "Mettre à jours tous les systèmes de fichiers éligibles"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:90
+msgid "Upgrade to the specified version"
+msgstr "Mettre à jour vers la version spécifiée"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:91
+msgid "Filesystem to upgrade"
+msgstr "Système de fichiers à mettre à jour"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:92
+msgid "Print UID instead of user name"
+msgstr "Afficher l’UID au lieu du nom de l’utilisateur"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:93
+msgid "Print GID instead of group name"
+msgstr "Afficher le GID au lieu du nom de groupe"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:96
+msgid "Field to display"
+msgstr "Champ à afficher"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:99
+#: /tmp/fish/implicit/share/completions/zfs.fish:100
+msgid "Identity types to display"
+msgstr "Types d’identité à afficher"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:101
+msgid "Translate S(amba)ID to POSIX ID"
+msgstr "Transcrire l’identifiant Samba en identifiant POSIX"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:102
+msgid "Dataset which space usage is to be got"
+msgstr "Jeu de données dont l’utilisation est à récupérer"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:103
+msgid "Temporary mount point property"
+msgstr "Paramètre de point de montage temporaire"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:104
+msgid "Report progress"
+msgstr "Communiquer la progression"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:105
+msgid "Mount all available ZFS filesystems"
+msgstr "Monter tous les systèmes de fichiers ZFS disponibles"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:106
+msgid "Overlay mount"
+msgstr "Montage avec sur-couche"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:107
+msgid "Filesystem to mount"
+msgstr "Système de fichiers à monter"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:109
+msgid "Unmount all available ZFS filesystems"
+msgstr "Démonter tous les systèmes de fichiers ZFS disponibles"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:110
+msgid "Filesystem to unmount"
+msgstr "Système de fichiers à démonter"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:111
+msgid "Share all eligible ZFS filesystems"
+msgstr "Partager tous les systèmes de fichiers éligibles"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:112
+msgid "Filesystem to share"
+msgstr "Système de fichiers à partager"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:113
+msgid "Unshare all shared ZFS filesystems"
+msgstr "Arrêter le partage de tous les systèmes de fichiers partagés"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:114
+msgid "Filesystem to unshare"
+msgstr "Système de fichiers dont le partage doit être arrêté"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:115
+msgid "Snapshot to bookmark"
+msgstr "Instantané pour lequel créer le marque-page"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:116
+msgid "Generate incremental stream from snapshot"
+msgstr "Générer un flux incrémental depuis un instantané"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:117
+msgid ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+msgstr ""
+"Générer un flux incrémental depuis un instantané, même avec des instantanés "
+"intermédiaires"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:118
+#: /tmp/fish/implicit/share/completions/zfs.fish:127
+msgid "Include children in replication stream"
+msgstr "Inclure les enfants dans le flux de réplication"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:119
+#: /tmp/fish/implicit/share/completions/zfs.fish:128
+msgid "Generate a deduplicated stream"
+msgstr "Générer un flux dédupliqué"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:120
+#: /tmp/fish/implicit/share/completions/zfs.fish:129
+msgid "Allow the presence of larger blocks than 128 kiB"
+msgstr "Autoriser la présence de blocs de plus de 128 kio"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:121
+#: /tmp/fish/implicit/share/completions/zfs.fish:130
+msgid "Generate a more compact stream by using WRITE_EMBEDDED records"
+msgstr ""
+"Générer un flux plus compact en utilisant des enregistrements WRITE_EMBEDDED"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:122
+#: /tmp/fish/implicit/share/completions/zfs.fish:131
+msgid "Print verbose information about the stream in a machine-parsable format"
+msgstr ""
+"Afficher des informations détaillées sur le flux dans un format utilisable "
+"par un programme"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:123
+msgid "Generate compressed stream"
+msgstr "Générer un flux compressé"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:125
+#: /tmp/fish/implicit/share/completions/zfs.fish:133
+msgid "Include dataset properties"
+msgstr "Inclure les paramètres de jeu de données"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:126
+#: /tmp/fish/implicit/share/completions/zfs.fish:134
+msgid "Print verbose information about the stream"
+msgstr "Afficher des informations détaillées sur le flux"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:135
+msgid "Dataset to send"
+msgstr "Jeu de données à envoyer"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:136
+msgid ""
+"Print verbose information about the stream and the time spent processing it"
+msgstr ""
+"Afficher des informations détaillées sur le flux et sur le temps passé à le "
+"traiter"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:137
+msgid "Dry run: do not actually receive the stream"
+msgstr "Exécution à blanc : ne pas recevoir réellement de flux"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:138
+msgid "Force rollback to the most recent snapshot"
+msgstr "Forcer la restauration depuis l’instantané le plus récent"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:139
+msgid "Unmount the target filesystem"
+msgstr "Démonter le système de fichiers cible"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:140
+msgid "Discard the first element of the path of the sent snapshot"
+msgstr "Ignorer le premier élément du chemin de l’instantané envoyé"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:141
+msgid "Discard all but the last element of the path of the sent snapshot"
+msgstr ""
+"Ignorer tous les éléments, sauf le dernier, du chemin de l’instantané envoyé"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:142
+msgid "Force the stream to be received as a clone of the given snapshot"
+msgstr "Force le flux à être reçu comme un clone de l’instantané spécifié"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:143
+msgid "On transfer interruption, store a receive_resume_token for resumption"
+msgstr ""
+"En cas d’interruption du transfert, enregistrer un jeton "
+"receive_resume_token pour continuation"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:144
+msgid "Dataset to receive"
+msgstr "Jeu de données à recevoir"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:145
+msgid "Delegate permissions only on the specified dataset"
+msgstr "Déléguer les permissions seulement sur le jeu de données spécifié"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:146
+msgid "Delegate permissions only on the descendents dataset"
+msgstr "Déléguer les permissions seulement sur les descendants"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:147
+msgid "User to delegate permissions to"
+msgstr "Utilisateur auquel déléguer les permissions"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:148
+msgid "Group to delegate permissions to"
+msgstr "Groupe auquel déléguer les permissions"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:149
+#: /tmp/fish/implicit/share/completions/zfs.fish:150
+msgid "Delegate permission to everyone"
+msgstr "Déléguer la permission à tout le monde"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:151
+msgid "Delegate permissions only to the creator of later descendent datasets"
+msgstr ""
+"Déléguer les permissions au seul créateur des jeux de données descendants "
+"créés ultérieurement"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:152
+msgid "Create a permission set or add permissions to an existing one"
+msgstr ""
+"Créer un jeu de permissions ou ajouter des permissions à un jeu existant"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:153
+msgid "Dataset on which delegation is to be applied"
+msgstr "Jeu de données sur lequel appliquer la délégation"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:154
+msgid "Remove permissions only on the specified dataset"
+msgstr "Retirer les permissions seulement sur le jeu de données spécifié"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:155
+msgid "Remove permissions only on the descendents dataset"
+msgstr "Retirer les permissions seulement sur les jeux de données descendants"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:156
+msgid "User to remove permissions from"
+msgstr "Utilisateur auquel retirer les permissions"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:157
+msgid "Group to remove permissions from"
+msgstr "Groupe auquel retirer les permissions"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:158
+#: /tmp/fish/implicit/share/completions/zfs.fish:162
+#: /tmp/fish/implicit/share/completions/zfs.fish:163
+msgid "Remove permission from everyone"
+msgstr "Retirer les permissions à tout le monde"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:159
+msgid "Remove permissions only on later created descendent datasets"
+msgstr ""
+"Retirer les permissions seulement sur les jeux de données descendants créés "
+"ultérieurement"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:160
+msgid "Remove a permission set or remove permissions from an existing one"
+msgstr ""
+"Retirer un jeu de permissions ou retirer des permissions d’un jeu existant"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:161
+msgid "Remove permissions recursively"
+msgstr "Retirer les permissions récursivement"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:164
+msgid "Dataset on which delegation is to be removed"
+msgstr "Jeu de données sur lequel la délégation est à retirer"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:165
+msgid "Apply hold recursively"
+msgstr "Appliquer le verrou récursivement"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:166
+msgid "Snapshot on which hold is to be applied"
+msgstr "Instantané sur lequel appliquer le verrou"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:167
+msgid "List holds recursively"
+msgstr "Lister les verrous récursivement"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:168
+msgid "Snapshot which holds are to be listed"
+msgstr "Instantané duquel lister les verrous"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:169
+msgid "Release hold recursively"
+msgstr "Relâcher le verrou récursivement"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:170
+msgid "Snapshot from which hold is to be removed"
+msgstr "Instantané duquel retirer le verrou"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:171
+msgid "Display file type (à la ls -F)"
+msgstr "Afficher le type de fichier (à la ls -F)"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:173
+msgid "Display inode change time"
+msgstr "Afficher l’horodatage de modification de l’i-nœud"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:174
+msgid "Source snapshot for the diff"
+msgstr "Instantané source pour le diff"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:175
+msgid "Execution timeout"
+msgstr "Délai d’attente pour l’exécution"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:176
+msgid "Execution memory limit"
+msgstr "Limite de mémoire pour l’exécution"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:177
+msgid "Pool which program will be executed on"
+msgstr "Pool sur lequel le programme sera exécuté"
+
 #: /tmp/fish/implicit/share/completions/zip.fish:1
 msgid "Freshen: only changed files"
 msgstr ""
@@ -59586,6 +61079,485 @@ msgstr "Chiffrer"
 #: /tmp/fish/implicit/share/completions/zip.fish:29
 msgid "Don't compress files with these suffixes"
 msgstr "Ne pas compresser les fichiers dont le suffixe est spécifié"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:1
+msgid ""
+"Internal completion function for appending string to the zpool commandline"
+msgstr ""
+"Fonction de complétion interne pour la concaténation de chaîne à la ligne de "
+"commande zpool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:3
+msgid "Add new virtual devices to pool"
+msgstr "Ajouter de nouveaux périphériques virtuels au pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:4
+msgid "Attach virtual device to a pool device"
+msgstr "Attacher un périphérique virtuel à un pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:5
+msgid "Clear devices errors in pool"
+msgstr "Effacer les erreurs de périphérique d’un pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:6
+msgid "Create a new storage pool"
+msgstr "Créer un nouveau pool de stockage"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:7
+msgid "Destroy a storage pool"
+msgstr "Détruire un pool de stockage"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:8
+msgid "Detach virtual device from a mirroring pool"
+msgstr "Détache un périphérique virtuel d’un pool en miroir"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:9
+msgid "Display pool event log"
+msgstr "Afficher le journal des événements d’un pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:10
+msgid "Export a pool"
+msgstr "Exporter un pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:11
+msgid "Get one or several pool properties"
+msgstr "Obtenir un ou des paramètres d’un pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:12
+msgid "Display pool command history"
+msgstr "Afficher l’historique des commandes du pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:13
+msgid "List importable pools, or import some"
+msgstr "Lister les pools importables, ou en importer"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:14
+msgid "Display pool I/O stats"
+msgstr "Afficher les statistiques d’E/S du pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:15
+msgid "Remove ZFS label information from the specified device"
+msgstr "Supprimer l’étiquette des informations ZFS du périphérique spécifié"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:16
+msgid "List pools with health status and space usage"
+msgstr ""
+"Lister les pools avec leur état de santé et leurs statistiques d’utilisation"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:17
+msgid "Take the specified devices offline"
+msgstr "Mettre hors-ligne les périphériques spécifiés"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:18
+msgid "Bring the specified devices back online"
+msgstr "Remettre en ligne les périphériques spécifiés"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:19
+msgid "Reset pool GUID"
+msgstr "Réinitialiser le GUID du pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:20
+msgid "Remove virtual devices from pool"
+msgstr "Supprimer des périphériques virtuels du pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:21
+msgid "Reopen pool devices"
+msgstr "Rouvrir les périphériques du pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:22
+msgid "Replace a pool virtual device"
+msgstr "Remplacer un périphérique virtuel d’un pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:23
+msgid "Start or stop scrubbing"
+msgstr "Démarrer ou arrêter la vérification (scrub)"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:24
+msgid "Set a pool property"
+msgstr "Régler un paramètre de pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:25
+msgid "Create a pool by splitting an existing mirror one"
+msgstr "Créer un pool par division d’un en miroir existant"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:26
+msgid "Display detailed pool health status"
+msgstr "Afficher un état de santé détaillé du pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:27
+msgid "List upgradeable pools, or upgrade one"
+msgstr "Lister les pools pouvant être mis à jour, ou en mettre un à jour"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:28
+#: /tmp/fish/implicit/share/completions/zpool.fish:36
+#: /tmp/fish/implicit/share/completions/zpool.fish:45
+#: /tmp/fish/implicit/share/completions/zpool.fish:117
+msgid "Force use of virtual device"
+msgstr "Forcer l’utilisation du périphérique virtuel"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:29
+#: /tmp/fish/implicit/share/completions/zpool.fish:130
+msgid "Dry run: only display resulting configuration"
+msgstr ""
+"Exécution à blanc : se contenter d’afficher la configuration résultante"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:30
+#: /tmp/fish/implicit/share/completions/zpool.fish:91
+#: /tmp/fish/implicit/share/completions/zpool.fish:100
+#: /tmp/fish/implicit/share/completions/zpool.fish:127
+#: /tmp/fish/implicit/share/completions/zpool.fish:135
+msgid "Display virtual device GUID instead of device name"
+msgstr "Afficher les GUID des périphériques virtuels au lieu de leurs noms"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:31
+#: /tmp/fish/implicit/share/completions/zpool.fish:92
+#: /tmp/fish/implicit/share/completions/zpool.fish:101
+#: /tmp/fish/implicit/share/completions/zpool.fish:128
+#: /tmp/fish/implicit/share/completions/zpool.fish:136
+msgid "Resolve device path symbolic links"
+msgstr "Suivre les liens symboliques des chemins de périphérique"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:32
+#: /tmp/fish/implicit/share/completions/zpool.fish:93
+#: /tmp/fish/implicit/share/completions/zpool.fish:102
+#: /tmp/fish/implicit/share/completions/zpool.fish:129
+#: /tmp/fish/implicit/share/completions/zpool.fish:137
+msgid "Display device full path"
+msgstr "Afficher le chemin de périphérique complet"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:33
+#: /tmp/fish/implicit/share/completions/zpool.fish:37
+#: /tmp/fish/implicit/share/completions/zpool.fish:48
+#: /tmp/fish/implicit/share/completions/zpool.fish:118
+#: /tmp/fish/implicit/share/completions/zpool.fish:132
+msgid "Pool property"
+msgstr "Paramètre de pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:34
+msgid "Pool to add virtual devices to"
+msgstr "Pool auquel ajouter les périphériques virtuels"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:35
+#: /tmp/fish/implicit/share/completions/zpool.fish:53
+msgid "Virtual device to add"
+msgstr "Périphérique virtuel à ajouter"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:38
+msgid "Pool to attach virtual device to"
+msgstr "Pool auquel attacher le périphérique virtuel"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:39
+#: /tmp/fish/implicit/share/completions/zpool.fish:43
+msgid "Virtual device to operate on"
+msgstr "Périphérique virtuel sur lequel opérer"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:40
+msgid "Initiate recovery mode"
+msgstr "Démarrer le mode récupération"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:41
+#: /tmp/fish/implicit/share/completions/zpool.fish:85
+msgid ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+msgstr ""
+"Exécution à blanc : déterminer si la récupération est possible, sans la "
+"tenter"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:42
+msgid "Pool to clear errors on"
+msgstr "Pool duquel effacer les erreurs"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:44
+msgid ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+msgstr ""
+"Créer un pool sur tout le disque, mais avec une partition système EFI (ESP) "
+"pour supporter le démarrage du système avec un UEFI"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:46
+msgid "Dry run, only display resulting configuration"
+msgstr ""
+"Exécution à blanc : se contenter d’afficher la configuration résultante"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:47
+msgid "Do not enable any feature on the new pool"
+msgstr "N’activer aucune fonctionnalité sur le nouveau pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:49
+msgid "Root filesystem property"
+msgstr "Paramètre de système de fichiers racine"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:50
+#: /tmp/fish/implicit/share/completions/zpool.fish:83
+msgid "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+msgstr "Équivalent à \"-o cachefile=none,altroot=ROOT\""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:51
+msgid "Root filesystem mountpoint"
+msgstr "Point de montage du système de fichiers racine"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:52
+msgid "Set a different in-core pool name"
+msgstr "Paramétrer un nom de pool interne différent"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:54
+#: /tmp/fish/implicit/share/completions/zpool.fish:64
+msgid "Force unmounting of all contained datasets"
+msgstr "Forcer le démontage de tous les jeux de données inclus"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:55
+msgid "Pool to destroy"
+msgstr "Pool à détruire"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:56
+msgid "Pool to detach device from"
+msgstr "Pool duquel détacher un périphérique"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:57
+msgid "Physical device to detach"
+msgstr "Périphérique physique à détacher"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:58
+msgid "Print verbose event information"
+msgstr "Afficher les informations d’événement détaillées"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:60
+msgid "Output appended data as the log grows"
+msgstr "Afficher les données ajoutées lorsque le journal grossit"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:61
+msgid "Clear all previous events"
+msgstr "Effacer tous les événements précédents"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:62
+msgid "Pool to read events from"
+msgstr "Pool duquel lire les événements"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:63
+msgid "Export all pools"
+msgstr "Exporter tous les pools"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:65
+msgid "Pool to export"
+msgstr "Pool à exporter"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:69
+msgid "Properties to get"
+msgstr "Paramètres à obtenir"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:70
+msgid "Pool to get properties of"
+msgstr "Pool duquel obtenir les paramètres"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:71
+msgid "Also display internal events"
+msgstr "Afficher également les événements internes"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:72
+msgid "Display log records using long format"
+msgstr "Afficher les enregistrement de journal au format long"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:73
+msgid "Pool to get command history of"
+msgstr "Pool duquel obtenir l’historique des commandes"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:74
+msgid "Read configuration from specified cache file"
+msgstr "Lire la configuration depuis le fichier de cache spécifié"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:75
+msgid "Search for devices or files in specified directory"
+msgstr "Chercher les périphériques et fichiers dans le dossier spécifié"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:76
+msgid "List or import destroyed pools only (requires -f for importation)"
+msgstr ""
+"Lister ou importer les seuls pools détruits (requiert -f pour l’importation)"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:77
+#: /tmp/fish/implicit/share/completions/zpool.fish:133
+msgid "Mount properties for contained datasets"
+msgstr "Paramètres de montage pour les jeux de données inclus"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:78
+msgid "Properties of the imported pool"
+msgstr "Paramètres du pool importé"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:79
+msgid "Force import"
+msgstr "Forcer l’import"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:80
+msgid "Recovery mode"
+msgstr "Mode récupération"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:81
+msgid "Search for and import all pools found"
+msgstr "Rechercher tous les pools existants et les importer"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:82
+msgid "Ignore missing log device (risk of loss of last changes)"
+msgstr ""
+"Ignorer les périphériques de journal manquants (risque de perte des "
+"dernières modifications)"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:84
+msgid "Do not mount contained filesystems"
+msgstr "Ne pas monter les systèmes de fichiers inclus"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:86
+msgid "Roll back to a previous TXG (hazardous)"
+msgstr "Revenir à un groupe de transaction (TXG) précédent (dangereux)"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:87
+msgid "TXG to roll back to (implies -FX)"
+msgstr "Groupe de transaction auquel revenir (implique -FX)"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:88
+msgid "Specify, as the last argument, a temporary pool name"
+msgstr "Spécifier, comme dernier argument, un nom de pool temporaire"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:89
+msgid "Pool to import"
+msgstr "Pool à importer"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:90
+#: /tmp/fish/implicit/share/completions/zpool.fish:103
+#: /tmp/fish/implicit/share/completions/zpool.fish:142
+msgid "Display a timestamp using specified format"
+msgstr "Afficher un horodatage en utilisant le format spécifié"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:94
+msgid "Omit statistics since boot"
+msgstr "Omettre les statistiques depuis le démarrage"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:104
+msgid "Print verbose statistics"
+msgstr "Afficher les statistiques détaillées"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:96
+msgid "Pool to retrieve I/O stats from"
+msgstr "Pool duquel récupérer les statistiques d’E/S"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:97
+msgid "Treat exported or foreign devices as inactive"
+msgstr "Considérer les périphériques exportés ou étrangers comme inactifs"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:98
+msgid "Device to clear ZFS label information from"
+msgstr "Périphérique duquel effacer l’étiquette des informations ZFS"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:106
+msgid "Pool to list properties of"
+msgstr "Pool duquel lister les paramètres"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:107
+msgid "Temporarily offline"
+msgstr "Temporairement hors-ligne"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:108
+msgid "Pool to offline device from"
+msgstr "Pool duquel mettre hors-ligne les périphériques"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:109
+msgid "Physical device to offline"
+msgstr "Périphérique physique à mettre hors-ligne"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:110
+msgid "Expand the device to use all available space"
+msgstr "Étendre le périphérique pour en utiliser tout l’espace disponible"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:111
+msgid "Pool to bring device back online on"
+msgstr "Pool duquel remettre en ligne le périphérique"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:112
+msgid "Physical device to bring back online"
+msgstr "Périphérique physique à remettre en ligne"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:113
+msgid "Pool which GUID is to be changed"
+msgstr "Pool duquel changer le GUID"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:114
+msgid "Pool to remove device from"
+msgstr "Pool duquel supprimer un périphérique"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:115
+msgid "Physical device to remove"
+msgstr "Périphérique physique à supprimer"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:116
+msgid "Pool which devices are to be reopened"
+msgstr "Pool duquel rouvrir les périphériques"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:119
+msgid "Pool to replace device"
+msgstr "Pool duquel remplacer un périphérique"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:120
+msgid "Pool device to be replaced"
+msgstr "Périphérique du pool à remplacer"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:121
+msgid "Device to use for replacement"
+msgstr "Périphérique à utiliser en remplacement"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:122
+msgid "Stop scrubbing"
+msgstr "Arrêter la vérification"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:123
+msgid "Pause scrubbing"
+msgstr "Mettre en pause la vérification"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:124
+msgid "Pool to start/stop scrubbing"
+msgstr "Pool duquel lancer ou arrêter la vérification"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:126
+msgid "Pool which property is to be set"
+msgstr "Pool duquel régler le paramètre"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:131
+msgid "Set altroot for newpool and automatically import it"
+msgstr ""
+"Paramétrer altroot pour le nouveau pool, puis l’importer automatiquement"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:134
+msgid "Pool to split"
+msgstr "Pool à diviser"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:138
+#: /tmp/fish/implicit/share/completions/zpool.fish:139
+msgid "Display deduplication histogram"
+msgstr "Afficher l’histogramme de déduplication"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:141
+msgid "Only display status for unhealthy or unavailable pools"
+msgstr ""
+"Afficher l’état seulement pour les pools en mauvaise santé ou indisponibles"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:143
+#: /tmp/fish/implicit/share/completions/zpool.fish:147
+msgid "Pool which status is to be displayed"
+msgstr "Pool duquel afficher l’état"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:144
+msgid "Upgrade all eligible pools, enabling all supported features"
+msgstr ""
+"Mettre à jour tous les pools éligibles, en en activant toutes les "
+"fonctionnalités supportées"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:145
+msgid "Display upgradeable ZFS versions"
+msgstr "Afficher les versions de ZFS pouvant êtres mises à jour"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:146
+msgid "Upgrade to the specified legacy version"
+msgstr "Mettre à jour vers la version obsolète spécifiée"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:2
 msgid "Repo"
@@ -61060,6 +63032,30 @@ msgstr ""
 msgid "Complete wvdial peers"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+msgid "Completes with ZFS mountpoint properties"
+msgstr "Complète avec les paramètres ZFS de point de montage"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_pools.fish:1
+msgid "Completes with available ZFS pools"
+msgstr "Complète avec les pools ZFS disponibles"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+msgid "Completes with ZFS read-only properties"
+msgstr "Complète avec les paramètres ZFS en lecture seule"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Completes with ZFS read-write properties"
+msgstr "Complète avec les paramètres ZFS en lecture-écriture"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+msgstr ""
+"Complète avec les paramètres ZFS pouvant être réglés seulement à la création "
+"du système de fichiers, et qui ne peuvent alors plus qu’être lus"
+
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr ""
@@ -61220,6 +63216,15 @@ msgstr "Vérifier si le dossier actuel est un dépôt git"
 msgid "Test if current token is on Nth place"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_is_zfs_feature_enabled.fish:1
+msgid ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+msgstr ""
+"Renvoie 0 si la fonctionnalité ZFS spécifiée est disponible ou activée pour "
+"le chemin complet donné (zpool ou jeu de données), ou pour tout objet ZFS si "
+"aucun n’est spécifié"
+
 #: /tmp/fish/implicit/share/functions/__fish_list_current_token.fish:1
 msgid ""
 "List contents of token under the cursor if it is a directory, otherwise list "
@@ -61297,6 +63302,11 @@ msgid ""
 "current directory"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
+#, fuzzy
+msgid "Print a list of local groups"
+msgstr "Lister les mises à jour disponibles"
+
 #: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr "Afficher une aide pour la fonction (intégrée) de fish spécifiée"
@@ -61367,6 +63377,22 @@ msgstr "Afficher les sorties xrandr"
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
 msgstr "Afficher les fenêtres X"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
+msgid "Lists ZFS bookmarks, if the feature is enabled"
+msgstr "Liste les marque-pages ZFS, si la fonctionnalité est activée"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
+msgid "Lists ZFS filesystems"
+msgstr "Liste les systèmes de fichiers ZFS"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
+msgid "Lists ZFS snapshots"
+msgstr "Liste les instantanés ZFS"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
+msgid "Lists ZFS volumes"
+msgstr "Liste les volumess ZFS"
 
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
@@ -61683,9 +63709,6 @@ msgstr ""
 
 #~ msgid "Change to DIR"
 #~ msgstr "Aller dans le dossier spécifié"
-
-#~ msgid "number of jobs"
-#~ msgstr "Nombre de tâches"
 
 #~ msgid "Show a unit"
 #~ msgstr "Afficher une unité"

--- a/po/nb.po
+++ b/po/nb.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 2.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-13 10:22+0100\n"
 "Last-Translator: Andreas Nordal <andreas.nordal_4@hotmail.com>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
@@ -1810,9 +1810,11 @@ msgstr ""
 #: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
 #: /tmp/fish/implicit/share/completions/fossil.fish:90
 #: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:206
-#: /tmp/fish/implicit/share/completions/git.fish:266
-#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:269
 msgid "File"
 msgstr ""
 
@@ -2498,6 +2500,553 @@ msgstr ""
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/zfs.fish:1
+msgid "ZFS filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:2
+msgid "ZFS filesystem snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:3
+msgid "ZFS block storage device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:4
+msgid "ZFS snapshot bookmark"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:5
+msgid "Any ZFS dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:6
+msgid "Dataset-specific value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:7
+msgid "Default ZFS value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:8
+msgid "Value inherited from parent dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:9
+msgid "Value received by 'zfs receive'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:10
+msgid "Value valid for the current mount"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:11
+msgid "Read-only value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:12
+msgid "Dataset full name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:13
+#: /tmp/fish/explicit/share/completions/zpool.fish:2
+#: /tmp/fish/implicit/share/completions/minikube.fish:25
+#: /tmp/fish/implicit/share/completions/minikube.fish:26
+#: /tmp/fish/implicit/share/completions/minikube.fish:27
+#: /tmp/fish/implicit/share/completions/minikube.fish:28
+msgid "Property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:3
+msgid "Property value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:15
+#: /tmp/fish/explicit/share/completions/zpool.fish:4
+msgid "Property value origin"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:16
+msgid "Identity type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:17
+msgid "Identity name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:18
+msgid "Space usage"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:19
+msgid "Space quota"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:20
+msgid "POSIX user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:21
+msgid "Samba user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:22
+#: /tmp/fish/explicit/share/completions/zfs.fish:25
+msgid "Both types"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:23
+msgid "POSIX group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:24
+msgid "Samba group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:26
+msgid "Also needs the permission to be allowed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:27
+msgid ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:28
+#: /tmp/fish/explicit/share/completions/zfs.fish:29
+#: /tmp/fish/explicit/share/completions/zfs.fish:33
+#: /tmp/fish/explicit/share/completions/zfs.fish:35
+msgid "Also needs the 'mount' permission"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:30
+msgid ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:31
+msgid "Also needs the 'create' and 'mount' permissions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:32
+msgid "Also needs the 'create' and 'mount' permissions in the new parent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:34
+msgid "For SMB and NFS shares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:36
+msgid "Allows changing any user property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:26
+msgid "Volume block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:38
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Inheritance of ACL entries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:39
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:2
+msgid "Update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:40
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:3
+msgid "Is the dataset mountable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:41
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:4
+msgid "Data checksum"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:42
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:5
+msgid "Compression algorithm"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:43
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:6
+msgid "Number of copies of data"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:44
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:7
+msgid "Deduplication"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:45
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:2
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:8
+msgid "Are contained device nodes openable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:46
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:3
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:9
+msgid "Can contained executables be executed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:47
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:10
+msgid "Max number of filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:48
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:11
+msgid "Mountpoint"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:49
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:12
+msgid "Which data to cache in ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:50
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:13
+msgid "Max size of dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:51
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:14
+msgid "Max number of snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:52
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:4
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:15
+msgid "Read-only"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:53
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:16
+msgid "Suggest block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:54
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:17
+msgid "How redundant are the metadata"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:55
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:18
+msgid "Max space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:56
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:19
+msgid "Min space guaranteed to dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:57
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:20
+msgid "Min space guaranteed to dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:58
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:21
+msgid "Which data to cache in L2ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:59
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:5
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:22
+msgid "Respect set-UID bit"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:60
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:23
+msgid "Share in NFS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:61
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:24
+msgid "Hint for handling of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:62
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:25
+msgid "Hide .zfs directory"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:63
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:26
+msgid "Handle of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:64
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:27
+msgid "Volume logical size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:65
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:38
+msgid "Managed from a non-global zone"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:66
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:31
+msgid "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:67
+#: /tmp/fish/explicit/share/completions/zfs.fish:74
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:6
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:32
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:40
+msgid "Mount with Non Blocking mandatory locks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:68
+#: /tmp/fish/explicit/share/completions/zfs.fish:77
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:33
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:43
+msgid "Share in Samba"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:69
+#: /tmp/fish/explicit/share/completions/zfs.fish:76
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:34
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:42
+msgid "Share as an iSCSI target"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:70
+#: /tmp/fish/explicit/share/completions/zfs.fish:79
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:35
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:45
+msgid "On-disk version of filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:71
+#: /tmp/fish/explicit/share/completions/zfs.fish:80
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:36
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:46
+msgid "Scan regular files for viruses on opening and closing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:72
+#: /tmp/fish/explicit/share/completions/zfs.fish:81
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:7
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:47
+msgid "Extended attributes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:73
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:39
+msgid "Use no ACL or POSIX ACL"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:75
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:9
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:41
+msgid "Sometimes update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:78
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:44
+msgid "Hide volume snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:82
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:30
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:48
+msgid "How is ACL modified by chmod"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:83
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:49
+msgid "How to expose volumes to OS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:84
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid "Unicode normalization"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:85
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:2
+msgid "Reject non-UTF-8-compliant filenames"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:86
+#: /tmp/fish/explicit/share/completions/zfs.fish:87
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:9
+msgid "Case sensitivity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:88
+msgid "Space properties"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:89
+#: /tmp/fish/explicit/share/completions/zfs.fish:90
+msgid "Dataset name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:1
+msgid "Pool full name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:5
+msgid "Mirror of at least two devices"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:6
+#: /tmp/fish/explicit/share/completions/zpool.fish:7
+msgid "ZFS RAID-5 variant, single parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:8
+msgid "ZFS RAID-5 variant, double parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:9
+msgid "ZFS RAID-5 variant, triple parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:10
+msgid "Pseudo vdev for pool hot spares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:11
+msgid "SLOG device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:12
+msgid "L2ARC device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:13
+msgid "Physically allocated space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:2
+msgid "Available space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:16
+msgid "System boot partition size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:17
+msgid "Usage percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:18
+msgid "Deduplication ratio"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:19
+msgid "Amount of uninitialized space within the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:20
+msgid "Fragmentation percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:21
+msgid "Free pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:22
+msgid "Remaining pool space to be freed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:23
+msgid "Pool GUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:24
+msgid "Current pool health"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:25
+msgid "Total pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:26
+msgid "Used pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:27
+msgid "Pool sector size exponent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:28
+#: /tmp/fish/explicit/share/completions/zpool.fish:29
+msgid "Alternate root directory"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:30
+#: /tmp/fish/explicit/share/completions/zpool.fish:31
+msgid "Import pool in read-only mode"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:32
+#: /tmp/fish/explicit/share/completions/zpool.fish:33
+msgid "Automatic pool expansion on LUN growing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:34
+#: /tmp/fish/explicit/share/completions/zpool.fish:35
+msgid "Automatic use of replacement device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:36
+msgid "Default bootable dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:37
+msgid "Pool configuration cache"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:38
+msgid "Comment about the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:39
+msgid "Threshold for writting a ditto copy of deduplicated blocks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:40
+msgid "Allow rights delegation on the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:41
+msgid "Behavior in case of catastrophic pool failure"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:42
+msgid "Display snapshots even if 'zfs list' does not use '-t'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:43
+msgid "On-disk version of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:44
+msgid "%sEnable the %s feature\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:45
+msgid "All properties"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/abbr.fish:1
 msgid "%s: Could not figure out what to do!\\n"
 msgstr ""
@@ -2627,6 +3176,135 @@ msgstr ""
 msgid "%s\\tArchived file\\n"
 msgstr ""
 
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:3
+msgid "Achieved compression ratio"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:4
+msgid "Dataset creation time"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:5
+msgid "Snapshot clones"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:6
+msgid "Marked for deferred destruction"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:7
+msgid "Total lower-level filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:9
+msgid "Logical total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:11
+msgid "Logical used space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:12
+msgid "Is currently mounted?"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:13
+msgid "Source snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:14
+msgid "Token for interrupted reception resumption"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:16
+msgid "Total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:17
+msgid "Achieved compression ratio of referenced space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:18
+msgid "Total lower-level snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:19
+#: /tmp/fish/implicit/share/completions/zfs.fish:71
+#: /tmp/fish/implicit/share/completions/zfs.fish:81
+msgid "Dataset type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:20
+msgid "Space used by dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:21
+msgid "Space used by children datasets"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:22
+msgid "Space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:23
+msgid "Space used by refreservation"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:24
+msgid "Space used by dataset snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:25
+msgid "Holds count"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:27
+msgid "Referenced data written since previous snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:28
+msgid "%sDataset space use by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:29
+msgid "%sDataset space use by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:30
+msgid "%sReferenced data written since snapshot %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:28
+msgid "%sMax usage by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:29
+msgid "%sMax usage by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:3
+msgid "Allow overlay mount"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:4
+msgid "SELinux context for the child filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:5
+msgid "SELinux context for the filesystem being mounted"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:6
+msgid "SELinux context for unlabeled files"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:7
+msgid "SELinux context for the root inode of the filesystem"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr ""
@@ -2651,6 +3329,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/aptitude.fish:3
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:3
 #: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:63
 #: /tmp/fish/implicit/share/completions/wajig.fish:3
@@ -5056,7 +5736,10 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/valgrind.fish:6
 #: /tmp/fish/implicit/share/completions/vi.fish:8
 #: /tmp/fish/implicit/share/completions/wget.fish:9
+#: /tmp/fish/implicit/share/completions/zfs.fish:42
+#: /tmp/fish/implicit/share/completions/zfs.fish:87
 #: /tmp/fish/implicit/share/completions/zip.fish:13
+#: /tmp/fish/implicit/share/completions/zpool.fish:140
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
 msgid "Verbose mode"
 msgstr ""
@@ -9701,7 +10384,7 @@ msgid "Show usage message and options"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:380
+#: /tmp/fish/implicit/share/completions/git.fish:382
 msgid "Show help message"
 msgstr ""
 
@@ -14370,7 +15053,7 @@ msgid "Ignore all white space"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:325
+#: /tmp/fish/implicit/share/completions/git.fish:327
 msgid "Ignore changes whose lines are all blank"
 msgstr ""
 
@@ -14379,7 +15062,7 @@ msgid "Ignore changes whose lines match the REGEX"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:321
+#: /tmp/fish/implicit/share/completions/git.fish:323
 msgid "Treat all files as text"
 msgstr ""
 
@@ -16220,6 +16903,81 @@ msgstr ""
 msgid "X display to use"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/exercism.fish:1
+msgid "Test if exercism has yet to be given the subcommand"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:3
+msgid "turn on verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:4
+#: /tmp/fish/implicit/share/completions/exercism.fish:19
+#: /tmp/fish/implicit/share/completions/ninja.fish:8
+#: /tmp/fish/implicit/share/completions/quilt.fish:1
+msgid "show help"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:5
+msgid "print the version"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:6
+msgid "Writes config values to a JSON file."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:7
+msgid "Outputs useful debug information."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:8
+msgid "Downloads a solution given the ID of the latest iteration."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:9
+msgid "Fetches the next unsubmitted problem in each track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:10
+msgid "Lists the available problems for a language track, given its ID."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:11
+msgid ""
+"Opens exercism.io to your most recent iteration of a problem given the track "
+"ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:12
+msgid ""
+"Downloads the most recent iteration for each of your solutions on exercism."
+"io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:13
+msgid "Skips a problem given a track ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:14
+msgid "Fetches information about your progress with a given language track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:15
+msgid "Submits a new iteration to a problem on exercism.io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:16
+msgid "Lists the available language tracks."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:17
+msgid "REMOVED"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:18
+msgid "Upgrades the CLI to the latest released version."
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/exit.fish:2
 msgid "Quit with normal exit status"
 msgstr ""
@@ -16967,6 +17725,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:66
+#: /tmp/fish/implicit/share/completions/zfs.fish:76
 msgid "Maximum recursion depth"
 msgstr ""
 
@@ -18214,9 +18974,9 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/fossil.fish:280
 #: /tmp/fish/implicit/share/completions/git.fish:64
 #: /tmp/fish/implicit/share/completions/git.fish:86
-#: /tmp/fish/implicit/share/completions/git.fish:244
-#: /tmp/fish/implicit/share/completions/git.fish:293
-#: /tmp/fish/implicit/share/completions/git.fish:294
+#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:296
 msgid "Tag"
 msgstr ""
 
@@ -18617,7 +19377,7 @@ msgid "Limit number of tags"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:281
-#: /tmp/fish/implicit/share/completions/git.fish:291
+#: /tmp/fish/implicit/share/completions/git.fish:293
 msgid "List tags"
 msgstr ""
 
@@ -18710,6 +19470,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gsettings.fish:15
 #: /tmp/fish/implicit/share/completions/ncdu.fish:1
 #: /tmp/fish/implicit/share/completions/obnam.fish:12
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:4
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:5
 #: /tmp/fish/implicit/share/completions/pkginfo.fish:7
 #: /tmp/fish/implicit/share/completions/pkgmk.fish:17
@@ -24818,24 +25579,24 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:96
 #: /tmp/fish/implicit/share/completions/git.fish:108
 #: /tmp/fish/implicit/share/completions/git.fish:130
-#: /tmp/fish/implicit/share/completions/git.fish:134
-#: /tmp/fish/implicit/share/completions/git.fish:140
-#: /tmp/fish/implicit/share/completions/git.fish:183
-#: /tmp/fish/implicit/share/completions/git.fish:219
-#: /tmp/fish/implicit/share/completions/git.fish:222
-#: /tmp/fish/implicit/share/completions/git.fish:242
-#: /tmp/fish/implicit/share/completions/git.fish:265
-#: /tmp/fish/implicit/share/completions/git.fish:285
-#: /tmp/fish/implicit/share/completions/git.fish:307
+#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:221
+#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:244
+#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:309
 msgid "Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:23
-#: /tmp/fish/implicit/share/completions/git.fish:198
-#: /tmp/fish/implicit/share/completions/git.fish:210
-#: /tmp/fish/implicit/share/completions/git.fish:237
-#: /tmp/fish/implicit/share/completions/git.fish:250
-#: /tmp/fish/implicit/share/completions/git.fish:274
+#: /tmp/fish/implicit/share/completions/git.fish:200
+#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:276
 #: /tmp/fish/implicit/share/completions/mdadm.fish:12
 #: /tmp/fish/implicit/share/completions/update-eix-remote.fish:1
 msgid "Be quiet"
@@ -24844,10 +25605,10 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:24
 #: /tmp/fish/implicit/share/completions/git.fish:41
 #: /tmp/fish/implicit/share/completions/git.fish:70
-#: /tmp/fish/implicit/share/completions/git.fish:199
-#: /tmp/fish/implicit/share/completions/git.fish:211
-#: /tmp/fish/implicit/share/completions/git.fish:238
-#: /tmp/fish/implicit/share/completions/git.fish:251
+#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:253
 #: /tmp/fish/implicit/share/completions/prt-get.fish:53
 #: /tmp/fish/implicit/share/completions/prt-get.fish:111
 #: /tmp/fish/implicit/share/completions/xz.fish:32
@@ -24855,12 +25616,12 @@ msgid "Be verbose"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:25
-#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:215
 msgid "Append ref names and object names"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:26
-#: /tmp/fish/implicit/share/completions/git.fish:214
+#: /tmp/fish/implicit/share/completions/git.fish:216
 msgid "Force update of local branches"
 msgstr ""
 
@@ -25008,7 +25769,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:63
 #: /tmp/fish/implicit/share/completions/git.fish:85
 #: /tmp/fish/implicit/share/completions/git.fish:109
-#: /tmp/fish/implicit/share/completions/git.fish:184
+#: /tmp/fish/implicit/share/completions/git.fish:186
 msgid "Remote branch"
 msgstr ""
 
@@ -25037,7 +25798,7 @@ msgid "Allow adding otherwise ignored files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:257
+#: /tmp/fish/implicit/share/completions/git.fish:259
 msgid "Interactive mode"
 msgstr ""
 
@@ -25088,7 +25849,7 @@ msgid "Remote Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:84
-#: /tmp/fish/implicit/share/completions/git.fish:243
+#: /tmp/fish/implicit/share/completions/git.fish:245
 msgid "Head"
 msgstr ""
 
@@ -25253,893 +26014,896 @@ msgstr ""
 msgid "Compare two paths on the filesystem"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:134
 msgid "Open diffs in a visual tool"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:136
 msgid "Visually show diff of changes in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:136
+#: /tmp/fish/implicit/share/completions/git.fish:138
 msgid "Print lines matching a pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:139
 msgid "Create an empty git repository or reinitialize an existing one"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:138
+#: /tmp/fish/implicit/share/completions/git.fish:140
 msgid "Show commit shortlog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:139
+#: /tmp/fish/implicit/share/completions/git.fish:141
 msgid "Show commit logs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:141
+#: /tmp/fish/implicit/share/completions/git.fish:143
 msgid "Continue listing file history beyond renames"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:144
 msgid "Don't print ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:143
+#: /tmp/fish/implicit/share/completions/git.fish:145
 msgid "Print out ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:144
+#: /tmp/fish/implicit/share/completions/git.fish:146
 msgid "Print ref name by which each commit was reached"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:145
+#: /tmp/fish/implicit/share/completions/git.fish:147
 msgid "Limit the number of commits before starting to show the commit output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:146
-msgid "Skip given number of commits"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:147
 #: /tmp/fish/implicit/share/completions/git.fish:148
-msgid "Show commits more recent than specified date"
+msgid "Skip given number of commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:149
 #: /tmp/fish/implicit/share/completions/git.fish:150
-msgid "Show commits older than specified date"
+msgid "Show commits more recent than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:151
-msgid "Limit commits from given author"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/git.fish:152
-msgid "Limit commits from given committer"
+msgid "Show commits older than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:153
-msgid "Limit commits to ones with reflog entries matching given pattern"
+msgid "Limit commits from given author"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:154
-msgid "Limit commits with message that match given pattern"
+msgid "Limit commits from given committer"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:155
-msgid "Limit commits to ones that match all given --grep"
+msgid "Limit commits to ones with reflog entries matching given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:156
-msgid "Limit commits to ones with message that don't match --grep"
+msgid "Limit commits with message that match given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:157
-msgid "Case insensitive match"
+msgid "Limit commits to ones that match all given --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:158
-msgid "Patterns are basic regular expressions (default)"
+msgid "Limit commits to ones with message that don't match --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:159
-msgid "Patterns are extended regular expressions"
+msgid "Case insensitive match"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:160
-msgid "Patterns are fixed strings"
+msgid "Patterns are basic regular expressions (default)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:161
-msgid "Patterns are Perl-compatible regular expressions"
+msgid "Patterns are extended regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:162
-msgid "Stop when given path disappears from tree"
+msgid "Patterns are fixed strings"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:163
-msgid "Print only merge commits"
+msgid "Patterns are Perl-compatible regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:164
-msgid "Don't print commits with more than one parent"
+msgid "Stop when given path disappears from tree"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:165
-msgid "Show only commit with at least the given number of parents"
+msgid "Print only merge commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:166
-msgid "Show only commit with at most the given number of parents"
+msgid "Don't print commits with more than one parent"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:167
-msgid "Show only commit without a mimimum number of parents"
+msgid "Show only commit with at least the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:168
-msgid "Show only commit without a maximum number of parents"
+msgid "Show only commit with at most the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:169
-msgid "Follow only the first parent commit upon seeing a merge commit"
+msgid "Show only commit without a mimimum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:170
-msgid "Reverse meaning of ^ prefix"
+msgid "Show only commit without a maximum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:171
+msgid "Follow only the first parent commit upon seeing a merge commit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:172
+msgid "Reverse meaning of ^ prefix"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:173
 msgid ""
 "Pretend as if all refs in refs/ are listed on the command line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:172
+#: /tmp/fish/implicit/share/completions/git.fish:174
 msgid ""
 "Pretend as if all refs are in refs/heads are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:173
+#: /tmp/fish/implicit/share/completions/git.fish:175
 msgid ""
 "Pretend as if all refs are in ref/tags are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:174
+#: /tmp/fish/implicit/share/completions/git.fish:176
 msgid ""
 "Pretend as if all refs in refs/remotes  are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:175
+#: /tmp/fish/implicit/share/completions/git.fish:177
 msgid ""
 "Pretend as if all refs matching shell glob are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:176
+#: /tmp/fish/implicit/share/completions/git.fish:178
 msgid "Do not include refs matching given glob pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:177
+#: /tmp/fish/implicit/share/completions/git.fish:179
 msgid ""
 "Pretend as if all objcets mentioned by reflogs are listed on the command "
 "line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:178
+#: /tmp/fish/implicit/share/completions/git.fish:180
 msgid "Ignore invalid object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:179
+#: /tmp/fish/implicit/share/completions/git.fish:181
 msgid "Read commits from stdin"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:180
+#: /tmp/fish/implicit/share/completions/git.fish:182
 msgid "Mark equivalent commits with = and inequivalent with +"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:181
+#: /tmp/fish/implicit/share/completions/git.fish:183
 msgid "Omit equivalent commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:182
+#: /tmp/fish/implicit/share/completions/git.fish:184
 msgid "Join two or more development histories together"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:187
 msgid "Autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:186
+#: /tmp/fish/implicit/share/completions/git.fish:188
 msgid "Don't autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:187
+#: /tmp/fish/implicit/share/completions/git.fish:189
 msgid "Edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:188
+#: /tmp/fish/implicit/share/completions/git.fish:190
 msgid "Don't edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:189
+#: /tmp/fish/implicit/share/completions/git.fish:191
 msgid "Don't generate a merge commit if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:190
+#: /tmp/fish/implicit/share/completions/git.fish:192
 msgid "Generate a merge commit even if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:191
+#: /tmp/fish/implicit/share/completions/git.fish:193
 msgid "Refuse to merge unless fast-forward possible"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:192
+#: /tmp/fish/implicit/share/completions/git.fish:194
 msgid "Populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:193
+#: /tmp/fish/implicit/share/completions/git.fish:195
 msgid "Don't populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:194
+#: /tmp/fish/implicit/share/completions/git.fish:196
 msgid "Show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:195
+#: /tmp/fish/implicit/share/completions/git.fish:197
 msgid "Don't show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:196
+#: /tmp/fish/implicit/share/completions/git.fish:198
 msgid "Squash changes from other branch as a single commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:197
+#: /tmp/fish/implicit/share/completions/git.fish:199
 msgid "Don't squash changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:200
-#: /tmp/fish/implicit/share/completions/git.fish:217
-#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:219
+#: /tmp/fish/implicit/share/completions/git.fish:241
 msgid "Force progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:203
 msgid "Force no progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:204
 msgid "Set the commit message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:203
+#: /tmp/fish/implicit/share/completions/git.fish:205
 msgid "Abort the current conflict resolution process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:204
+#: /tmp/fish/implicit/share/completions/git.fish:206
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:205
+#: /tmp/fish/implicit/share/completions/git.fish:207
 msgid "Use specific merge resolution program"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:207
+#: /tmp/fish/implicit/share/completions/git.fish:209
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:210
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:209
+#: /tmp/fish/implicit/share/completions/git.fish:211
 msgid "Fetch from and merge with another repository or a local branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:214
 msgid "Fetch all remotes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:215
+#: /tmp/fish/implicit/share/completions/git.fish:217
 msgid "Keep downloaded pack"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:216
+#: /tmp/fish/implicit/share/completions/git.fish:218
 msgid "Disable automatic tag following"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:218
-#: /tmp/fish/implicit/share/completions/git.fish:221
-#: /tmp/fish/implicit/share/completions/git.fish:241
+#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:243
 msgid "Remote alias"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:222
 msgid "Update remote refs along with associated objects"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:225
 msgid "Force-push branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:226
 msgid "Force-push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:225
+#: /tmp/fish/implicit/share/completions/git.fish:227
 msgid "Push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:226
+#: /tmp/fish/implicit/share/completions/git.fish:228
 msgid "Push all refs under refs/heads/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:227
+#: /tmp/fish/implicit/share/completions/git.fish:229
 msgid "Remove remote branches that don't have a local counterpart"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:228
+#: /tmp/fish/implicit/share/completions/git.fish:230
 msgid "Push all refs under refs/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:229
+#: /tmp/fish/implicit/share/completions/git.fish:231
 msgid "Delete all listed refs from the remote repository"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:230
+#: /tmp/fish/implicit/share/completions/git.fish:232
 msgid "Push all refs under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:231
+#: /tmp/fish/implicit/share/completions/git.fish:233
 msgid "Push all usual refs plus the ones under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:232
+#: /tmp/fish/implicit/share/completions/git.fish:234
 msgid "Do everything except actually send the updates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:233
+#: /tmp/fish/implicit/share/completions/git.fish:235
 msgid "Produce machine-readable output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:234
+#: /tmp/fish/implicit/share/completions/git.fish:236
 msgid "Force update of remote refs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:235
+#: /tmp/fish/implicit/share/completions/git.fish:237
 msgid ""
 "Force update of remote refs, stopping if other's changes would be overwritten"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:236
+#: /tmp/fish/implicit/share/completions/git.fish:238
 msgid "Add upstream (tracking) reference"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:242
 msgid "Forward-port local commits to the updated upstream head"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:245
+#: /tmp/fish/implicit/share/completions/git.fish:247
 msgid "Restart the rebasing process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:248
 msgid "Abort the rebase operation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:247
+#: /tmp/fish/implicit/share/completions/git.fish:249
 msgid "Keep the commits that don't cahnge anything"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:248
+#: /tmp/fish/implicit/share/completions/git.fish:250
 msgid "Restart the rebasing process by skipping the current patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:249
+#: /tmp/fish/implicit/share/completions/git.fish:251
 msgid "Use merging strategies to rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:254
 msgid "Show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:253
+#: /tmp/fish/implicit/share/completions/git.fish:255
 msgid "Don't show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:254
+#: /tmp/fish/implicit/share/completions/git.fish:256
 msgid "Allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:255
+#: /tmp/fish/implicit/share/completions/git.fish:257
 msgid "Don't allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:256
+#: /tmp/fish/implicit/share/completions/git.fish:258
 msgid "Force the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:258
+#: /tmp/fish/implicit/share/completions/git.fish:260
 msgid "Try to recreate merges"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:259
+#: /tmp/fish/implicit/share/completions/git.fish:261
 msgid "Rebase all reachable commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:260
+#: /tmp/fish/implicit/share/completions/git.fish:262
 msgid "Automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:261
+#: /tmp/fish/implicit/share/completions/git.fish:263
 msgid "No automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:262
+#: /tmp/fish/implicit/share/completions/git.fish:264
 msgid "No fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:263
+#: /tmp/fish/implicit/share/completions/git.fish:265
 msgid "Reset current HEAD to the specified state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:264
+#: /tmp/fish/implicit/share/completions/git.fish:266
 msgid "Reset files in working directory"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:270
 msgid "Reflog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: /tmp/fish/implicit/share/completions/git.fish:271
 msgid "Revert an existing commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:270
+#: /tmp/fish/implicit/share/completions/git.fish:272
 msgid "Remove files from the working tree and from the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:271
+#: /tmp/fish/implicit/share/completions/git.fish:273
 msgid "Keep local copies"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:272
+#: /tmp/fish/implicit/share/completions/git.fish:274
 msgid "Exit with a zero status even if no files matched"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:273
+#: /tmp/fish/implicit/share/completions/git.fish:275
 msgid "Allow recursive removal"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:275
+#: /tmp/fish/implicit/share/completions/git.fish:277
 msgid "Override the up-to-date check"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:276
+#: /tmp/fish/implicit/share/completions/git.fish:278
 #: /tmp/fish/implicit/share/completions/prt-get.fish:45
 #: /tmp/fish/implicit/share/completions/prt-get.fish:103
+#: /tmp/fish/implicit/share/completions/zfs.fish:40
+#: /tmp/fish/implicit/share/completions/zfs.fish:124
+#: /tmp/fish/implicit/share/completions/zfs.fish:132
 msgid "Dry run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:277
+#: /tmp/fish/implicit/share/completions/git.fish:279
 msgid "Show the working tree status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:278
+#: /tmp/fish/implicit/share/completions/git.fish:280
 msgid "Give the output in the short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:279
+#: /tmp/fish/implicit/share/completions/git.fish:281
 msgid "Show the branch and tracking info even in short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:280
+#: /tmp/fish/implicit/share/completions/git.fish:282
 msgid "Give the output in a stable, easy-to-parse format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:281
+#: /tmp/fish/implicit/share/completions/git.fish:283
 msgid "Terminate entries with null character"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:282
+#: /tmp/fish/implicit/share/completions/git.fish:284
 msgid "The untracked files handling mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:283
+#: /tmp/fish/implicit/share/completions/git.fish:285
 msgid "Ignore changes to submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:284
+#: /tmp/fish/implicit/share/completions/git.fish:286
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:286
+#: /tmp/fish/implicit/share/completions/git.fish:288
 msgid "Make an unsigned, annotated tag object"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:289
 msgid "Make a GPG-signed tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:288
+#: /tmp/fish/implicit/share/completions/git.fish:290
 msgid "Remove a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:289
+#: /tmp/fish/implicit/share/completions/git.fish:291
 msgid "Verify signature of a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:290
+#: /tmp/fish/implicit/share/completions/git.fish:292
 msgid "Force overwriting exising tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:292
+#: /tmp/fish/implicit/share/completions/git.fish:294
 msgid "List tags that contain a commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:297
 msgid "Stash away changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:296
+#: /tmp/fish/implicit/share/completions/git.fish:298
 msgid "List stashes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:297
+#: /tmp/fish/implicit/share/completions/git.fish:299
 msgid "Show the changes recorded in the stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:298
+#: /tmp/fish/implicit/share/completions/git.fish:300
 msgid "Apply and remove a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:299
+#: /tmp/fish/implicit/share/completions/git.fish:301
 msgid "Apply a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:300
+#: /tmp/fish/implicit/share/completions/git.fish:302
 msgid "Remove all stashed states"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:301
+#: /tmp/fish/implicit/share/completions/git.fish:303
 msgid "Remove a single stashed state from the stash list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:302
+#: /tmp/fish/implicit/share/completions/git.fish:304
 msgid "Create a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:303
+#: /tmp/fish/implicit/share/completions/git.fish:305
 msgid "Save a new stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:304
+#: /tmp/fish/implicit/share/completions/git.fish:306
 msgid "Create a new branch from a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:305
+#: /tmp/fish/implicit/share/completions/git.fish:307
 msgid "Set and read git configuration variables"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:306
+#: /tmp/fish/implicit/share/completions/git.fish:308
 msgid "Generate patch series to send upstream"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:308
+#: /tmp/fish/implicit/share/completions/git.fish:310
 msgid "Generate plain patches without diffstat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:309
+#: /tmp/fish/implicit/share/completions/git.fish:311
 msgid "Suppress diff output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:310
+#: /tmp/fish/implicit/share/completions/git.fish:312
 msgid "Spend more time to create smaller diffs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:311
+#: /tmp/fish/implicit/share/completions/git.fish:313
 msgid "Generate diff with the 'patience' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:312
+#: /tmp/fish/implicit/share/completions/git.fish:314
 msgid "Generate diff with the 'histogram' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:313
+#: /tmp/fish/implicit/share/completions/git.fish:315
 msgid "Print all commits to stdout in mbox format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:314
+#: /tmp/fish/implicit/share/completions/git.fish:316
 msgid "Show number of added/deleted lines in decimal notation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:315
+#: /tmp/fish/implicit/share/completions/git.fish:317
 msgid "Output only last line of the stat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:316
+#: /tmp/fish/implicit/share/completions/git.fish:318
 msgid "Output a condensed summary of extended header information"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:317
+#: /tmp/fish/implicit/share/completions/git.fish:319
 msgid "Disable rename detection"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:318
+#: /tmp/fish/implicit/share/completions/git.fish:320
 msgid "Show full blob object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:319
+#: /tmp/fish/implicit/share/completions/git.fish:321
 msgid "Output a binary diff for use with git apply"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:320
+#: /tmp/fish/implicit/share/completions/git.fish:322
 msgid "Also inspect unmodified files as source for a copy"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:322
+#: /tmp/fish/implicit/share/completions/git.fish:324
 msgid "Ignore changes in whitespace at EOL"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: /tmp/fish/implicit/share/completions/git.fish:325
 msgid "Ignore changes in amount of whitespace"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:324
+#: /tmp/fish/implicit/share/completions/git.fish:326
 msgid "Ignore whitespace when comparing lines"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:326
+#: /tmp/fish/implicit/share/completions/git.fish:328
 msgid "Show whole surrounding functions of changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: /tmp/fish/implicit/share/completions/git.fish:329
 msgid "Allow an external diff helper to be executed"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:328
+#: /tmp/fish/implicit/share/completions/git.fish:330
 msgid "Disallow external diff helpers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:329
+#: /tmp/fish/implicit/share/completions/git.fish:331
 msgid "Disallow external text conversion filters for binary files (Default)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:330
+#: /tmp/fish/implicit/share/completions/git.fish:332
 msgid ""
 "Allow external text conversion filters for binary files (Resulting diff is "
 "unappliable)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:331
+#: /tmp/fish/implicit/share/completions/git.fish:333
 msgid "Do not show source or destination prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:332
+#: /tmp/fish/implicit/share/completions/git.fish:334
 msgid "Name output in [Patch n/m] format, even with a single patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:333
+#: /tmp/fish/implicit/share/completions/git.fish:335
 msgid "Name output in [Patch] format, even with multiple patches"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:334
+#: /tmp/fish/implicit/share/completions/git.fish:336
 msgid "Initialize, update or inspect submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:335
+#: /tmp/fish/implicit/share/completions/git.fish:337
 msgid "Add a submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:336
+#: /tmp/fish/implicit/share/completions/git.fish:338
 msgid "Show submodule status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:337
-#: /tmp/fish/implicit/share/completions/git.fish:343
+#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:345
 msgid "Initialize all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:338
+#: /tmp/fish/implicit/share/completions/git.fish:340
 msgid "Update all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:341
 msgid "Show commit summary"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:340
+#: /tmp/fish/implicit/share/completions/git.fish:342
 msgid "Run command on each submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:341
+#: /tmp/fish/implicit/share/completions/git.fish:343
 msgid "Sync submodules' URL with .gitmodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:342
+#: /tmp/fish/implicit/share/completions/git.fish:344
 msgid "Only print error messages"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:344
+#: /tmp/fish/implicit/share/completions/git.fish:346
 msgid "Checkout the superproject's commit on a detached HEAD in the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:345
+#: /tmp/fish/implicit/share/completions/git.fish:347
 msgid ""
 "Merge the superproject's commit into the current branch of the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:346
+#: /tmp/fish/implicit/share/completions/git.fish:348
 msgid "Rebase current branch onto the superproject's commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:347
+#: /tmp/fish/implicit/share/completions/git.fish:349
 msgid "Don't fetch new objects from the remote"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:348
+#: /tmp/fish/implicit/share/completions/git.fish:350
 msgid ""
 "Instead of using superproject's SHA-1, use the state of the submodule's "
 "remote-tracking branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:349
+#: /tmp/fish/implicit/share/completions/git.fish:351
 msgid ""
 "Throw away local changes when switching to a different commit and always run "
 "checkout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:350
+#: /tmp/fish/implicit/share/completions/git.fish:352
 msgid "Also add ignored submodule path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:351
+#: /tmp/fish/implicit/share/completions/git.fish:353
 msgid "Remove even with local changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:352
+#: /tmp/fish/implicit/share/completions/git.fish:354
 msgid "Use the commit stored in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:353
+#: /tmp/fish/implicit/share/completions/git.fish:355
 msgid "Compare the commit in the index with submodule HEAD"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:354
+#: /tmp/fish/implicit/share/completions/git.fish:356
 msgid "Traverse submodules recursively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:355
+#: /tmp/fish/implicit/share/completions/git.fish:357
 msgid "Show logs with difference each commit introduces"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:356
+#: /tmp/fish/implicit/share/completions/git.fish:358
 msgid "Remove untracked files from the working tree"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:357
+#: /tmp/fish/implicit/share/completions/git.fish:359
 msgid "Force run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:358
+#: /tmp/fish/implicit/share/completions/git.fish:360
 msgid "Show what would be done and clean files interactively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:359
+#: /tmp/fish/implicit/share/completions/git.fish:361
 msgid "Don't actually remove anything, just show what would be done"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:360
+#: /tmp/fish/implicit/share/completions/git.fish:362
 msgid "Be quiet, only report errors"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:361
+#: /tmp/fish/implicit/share/completions/git.fish:363
 msgid "Remove untracked directories in addition to untracked files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:362
+#: /tmp/fish/implicit/share/completions/git.fish:364
 msgid "Remove ignored files, as well"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:363
+#: /tmp/fish/implicit/share/completions/git.fish:365
 msgid "Remove only ignored files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:364
+#: /tmp/fish/implicit/share/completions/git.fish:366
 msgid "Show what revision and author last modified each line of a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:365
+#: /tmp/fish/implicit/share/completions/git.fish:367
 msgid "Show blank SHA-1 for boundary commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:366
+#: /tmp/fish/implicit/share/completions/git.fish:368
 msgid "Do not treat root commits as boundaries"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:367
+#: /tmp/fish/implicit/share/completions/git.fish:369
 msgid "Include additional statistics"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:368
+#: /tmp/fish/implicit/share/completions/git.fish:370
 msgid "Annotate only the given line range"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:369
+#: /tmp/fish/implicit/share/completions/git.fish:371
 msgid "Show long rev"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:370
+#: /tmp/fish/implicit/share/completions/git.fish:372
 msgid "Show raw timestamp"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:371
+#: /tmp/fish/implicit/share/completions/git.fish:373
 msgid "Use revisions from named file instead of calling rev-list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:372
+#: /tmp/fish/implicit/share/completions/git.fish:374
 msgid "Walk history forward instead of backward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:373
+#: /tmp/fish/implicit/share/completions/git.fish:375
 msgid "Show in a format designed for machine consumption"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:374
+#: /tmp/fish/implicit/share/completions/git.fish:376
 msgid "Show the porcelain format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:375
+#: /tmp/fish/implicit/share/completions/git.fish:377
 msgid "Show the result incrementally"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:376
+#: /tmp/fish/implicit/share/completions/git.fish:378
 msgid "Instead of working tree, use the contents of the named file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:377
+#: /tmp/fish/implicit/share/completions/git.fish:379
 msgid "Specifies the format used to output dates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:378
+#: /tmp/fish/implicit/share/completions/git.fish:380
 msgid "Detect moved or copied lines within a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:379
+#: /tmp/fish/implicit/share/completions/git.fish:381
 msgid ""
 "Detect lines moved or copied from other files that were modified in the same "
 "commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:381
+#: /tmp/fish/implicit/share/completions/git.fish:383
 msgid "Use the same output mode as git-annotate"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:382
+#: /tmp/fish/implicit/share/completions/git.fish:384
 msgid "Show the filename in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:383
+#: /tmp/fish/implicit/share/completions/git.fish:385
 msgid "Show the line number in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:384
+#: /tmp/fish/implicit/share/completions/git.fish:386
 msgid "Suppress the author name and timestamp from the output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:385
+#: /tmp/fish/implicit/share/completions/git.fish:387
 msgid "Show the author email instead of author name"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:386
+#: /tmp/fish/implicit/share/completions/git.fish:388
 msgid "Ignore whitespace changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:387
+#: /tmp/fish/implicit/share/completions/git.fish:389
 msgid "Custom command"
 msgstr ""
 
@@ -26634,6 +27398,7 @@ msgid "List all keys with their fingerprints"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
+#: /tmp/fish/implicit/share/completions/signify.fish:2
 msgid "Generate a new key pair"
 msgstr ""
 
@@ -35557,13 +36322,6 @@ msgstr ""
 msgid "Display values currently set in the minikube config file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/minikube.fish:25
-#: /tmp/fish/implicit/share/completions/minikube.fish:26
-#: /tmp/fish/implicit/share/completions/minikube.fish:27
-#: /tmp/fish/implicit/share/completions/minikube.fish:28
-msgid "Property"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/minikube.fish:29
 msgid "Go template format string for the config view output"
 msgstr ""
@@ -41528,11 +42286,6 @@ msgstr ""
 msgid "keep going until N jobs fail [default=1]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ninja.fish:8
-#: /tmp/fish/implicit/share/completions/quilt.fish:1
-msgid "show help"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/ninja.fish:9
 msgid "enable debugging, specify debug mode"
 msgstr ""
@@ -44809,6 +45562,18 @@ msgstr ""
 msgid "Extract script"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pfctl.fish:1
+msgid "Show a filter parameter by modifier"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:2
+msgid "Flush filter params specified by mod"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:3
+msgid "Table command"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pgrep.fish:1
 msgid "Output delimiter"
 msgstr ""
@@ -45017,6 +45782,27 @@ msgstr ""
 msgid "omit the user's full name, remote host and idle time in short format"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:1
+msgid "failsafe to overwrite"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:2
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:3
+msgid "Turn on stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:3
+msgid "Automated package installation"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:5
+msgid "Update packages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:6
+msgid "Fuzzy match"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:1
 msgid "Upgrade"
 msgstr ""
@@ -45119,6 +45905,10 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkg-config.fish:25
 msgid "List all modules the given packages requires for static linking"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:2
+msgid "Delete unsed deps"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkgfile.fish:3
@@ -49454,6 +50244,18 @@ msgstr ""
 msgid "Specifies layout variant used to choose component names"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/signify.fish:1
+msgid "Verify a signed checksum list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:3
+msgid "Sign specified message"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:4
+msgid "Verify a signed message and sig"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/snap.fish:1
 msgid "Test if snap has yet to be given the subcommand"
 msgstr ""
@@ -53254,10 +54056,12 @@ msgid "Monitor changes to objects"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:7
+#: /tmp/fish/implicit/share/completions/zfs.fish:17
 msgid "Mount a filesystem"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:18
 msgid "Unmount a filesystem"
 msgstr ""
 
@@ -57789,6 +58593,604 @@ msgstr ""
 msgid "Delete all cache contents"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/zfs.fish:1
+msgid ""
+"Internal completion function for appending string to the ZFS commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:2
+#: /tmp/fish/implicit/share/completions/zpool.fish:2
+msgid "Display a help message"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:3
+msgid "Create a volume or filesystem"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:4
+msgid "Destroy a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:5
+msgid "Create a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:6
+msgid "Roll back a filesystem to a previous snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:7
+msgid "Create a clone of a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:8
+msgid ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:9
+msgid "Rename a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:10
+msgid "List dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:11
+msgid "Set a dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:12
+msgid "Get one or several dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:13
+msgid "Set a dataset property to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:14
+msgid "List upgradeable datasets, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:15
+msgid "Get dataset space consumed by each user"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:16
+msgid "Get dataset space consumed by each user group"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:19
+msgid "Share a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:20
+msgid "Stop sharing a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:21
+msgid "Create a bookmark for a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:22
+msgid "Output a stream representation of a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:23
+msgid ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:24
+msgid ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:25
+msgid "Revoke delegations of rights on a dataset from (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:26
+msgid "Put a named hold on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:27
+msgid "List holds on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:28
+msgid "Remove a named hold from a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:29
+msgid ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:30
+msgid "Execute a ZFS Channel Program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:31
+#: /tmp/fish/implicit/share/completions/zfs.fish:53
+#: /tmp/fish/implicit/share/completions/zfs.fish:58
+msgid "Create all needed non-existing parent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:32
+#: /tmp/fish/implicit/share/completions/zfs.fish:33
+msgid "Dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:34
+msgid "Volume size"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:35
+msgid "Create a sparse volume"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:36
+msgid "Blocksize"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:37
+msgid "Recursively destroy children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:38
+msgid "Recursively destroy all dependents"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:39
+msgid "Force unmounting"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:41
+msgid "Print machine-parsable verbose information"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:43
+msgid "Defer snapshot deletion"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:44
+msgid "Dataset to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:45
+msgid "Recursively snapshot children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:46
+#: /tmp/fish/implicit/share/completions/zfs.fish:47
+msgid "Snapshot property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:48
+msgid "Dataset to snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:49
+msgid "Destroy later snapshot and bookmarks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:50
+msgid "Recursively destroy later snapshot, bookmarks and clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:51
+msgid "Force unmounting of clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:52
+msgid "Snapshot to roll back to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:54
+#: /tmp/fish/implicit/share/completions/zfs.fish:55
+msgid "Clone property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:56
+msgid "Snapshot to clone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:57
+msgid "Clone to promote"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:59
+msgid "Recursively rename children snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:60
+#: /tmp/fish/implicit/share/completions/zfs.fish:62
+#: /tmp/fish/implicit/share/completions/zfs.fish:108
+msgid "Force unmounting if needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:61
+msgid "Do not remount filesystems during rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:63
+msgid "Dataset to rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:64
+#: /tmp/fish/implicit/share/completions/zfs.fish:77
+#: /tmp/fish/implicit/share/completions/zfs.fish:94
+#: /tmp/fish/implicit/share/completions/zfs.fish:172
+#: /tmp/fish/implicit/share/completions/zpool.fish:59
+#: /tmp/fish/implicit/share/completions/zpool.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:99
+msgid "Print output in a machine-parsable format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:65
+#: /tmp/fish/implicit/share/completions/zfs.fish:75
+#: /tmp/fish/implicit/share/completions/zfs.fish:84
+#: /tmp/fish/implicit/share/completions/zfs.fish:89
+msgid "Operate recursively on datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:105
+msgid "Property to list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:68
+#: /tmp/fish/implicit/share/completions/zfs.fish:80
+#: /tmp/fish/implicit/share/completions/zfs.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:66
+msgid "Print parsable (exact) values for numbers"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:69
+#: /tmp/fish/implicit/share/completions/zfs.fish:97
+msgid "Property to use for sorting output by ascending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:70
+#: /tmp/fish/implicit/share/completions/zfs.fish:98
+msgid "Property to use for sorting output by descending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:72
+msgid "Dataset which properties is to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:73
+#: /tmp/fish/implicit/share/completions/zpool.fish:125
+msgid "Property to set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:74
+msgid "Dataset which property is to be setted"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:78
+#: /tmp/fish/implicit/share/completions/zpool.fish:68
+msgid "Fields to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:79
+msgid "Property source to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:82
+msgid "Property to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:83
+msgid "Dataset which properties is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:85
+msgid "Revert to the received value if available"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:86
+msgid "Dataset which properties is to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:88
+msgid "Upgrade all eligible filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:90
+msgid "Upgrade to the specified version"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:91
+msgid "Filesystem to upgrade"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:92
+msgid "Print UID instead of user name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:93
+msgid "Print GID instead of group name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:96
+msgid "Field to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:99
+#: /tmp/fish/implicit/share/completions/zfs.fish:100
+msgid "Identity types to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:101
+msgid "Translate S(amba)ID to POSIX ID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:102
+msgid "Dataset which space usage is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:103
+msgid "Temporary mount point property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:104
+msgid "Report progress"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:105
+msgid "Mount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:106
+msgid "Overlay mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:107
+msgid "Filesystem to mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:109
+msgid "Unmount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:110
+msgid "Filesystem to unmount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:111
+msgid "Share all eligible ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:112
+msgid "Filesystem to share"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:113
+msgid "Unshare all shared ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:114
+msgid "Filesystem to unshare"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:115
+msgid "Snapshot to bookmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:116
+msgid "Generate incremental stream from snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:117
+msgid ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:118
+#: /tmp/fish/implicit/share/completions/zfs.fish:127
+msgid "Include children in replication stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:119
+#: /tmp/fish/implicit/share/completions/zfs.fish:128
+msgid "Generate a deduplicated stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:120
+#: /tmp/fish/implicit/share/completions/zfs.fish:129
+msgid "Allow the presence of larger blocks than 128 kiB"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:121
+#: /tmp/fish/implicit/share/completions/zfs.fish:130
+msgid "Generate a more compact stream by using WRITE_EMBEDDED records"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:122
+#: /tmp/fish/implicit/share/completions/zfs.fish:131
+msgid "Print verbose information about the stream in a machine-parsable format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:123
+msgid "Generate compressed stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:125
+#: /tmp/fish/implicit/share/completions/zfs.fish:133
+msgid "Include dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:126
+#: /tmp/fish/implicit/share/completions/zfs.fish:134
+msgid "Print verbose information about the stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:135
+msgid "Dataset to send"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:136
+msgid ""
+"Print verbose information about the stream and the time spent processing it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:137
+msgid "Dry run: do not actually receive the stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:138
+msgid "Force rollback to the most recent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:139
+msgid "Unmount the target filesystem"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:140
+msgid "Discard the first element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:141
+msgid "Discard all but the last element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:142
+msgid "Force the stream to be received as a clone of the given snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:143
+msgid "On transfer interruption, store a receive_resume_token for resumption"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:144
+msgid "Dataset to receive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:145
+msgid "Delegate permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:146
+msgid "Delegate permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:147
+msgid "User to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:148
+msgid "Group to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:149
+#: /tmp/fish/implicit/share/completions/zfs.fish:150
+msgid "Delegate permission to everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:151
+msgid "Delegate permissions only to the creator of later descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:152
+msgid "Create a permission set or add permissions to an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:153
+msgid "Dataset on which delegation is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:154
+msgid "Remove permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:155
+msgid "Remove permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:156
+msgid "User to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:157
+msgid "Group to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:158
+#: /tmp/fish/implicit/share/completions/zfs.fish:162
+#: /tmp/fish/implicit/share/completions/zfs.fish:163
+msgid "Remove permission from everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:159
+msgid "Remove permissions only on later created descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:160
+msgid "Remove a permission set or remove permissions from an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:161
+msgid "Remove permissions recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:164
+msgid "Dataset on which delegation is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:165
+msgid "Apply hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:166
+msgid "Snapshot on which hold is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:167
+msgid "List holds recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:168
+msgid "Snapshot which holds are to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:169
+msgid "Release hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:170
+msgid "Snapshot from which hold is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:171
+msgid "Display file type (à la ls -F)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:173
+msgid "Display inode change time"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:174
+msgid "Source snapshot for the diff"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:175
+msgid "Execution timeout"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:176
+msgid "Execution memory limit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:177
+msgid "Pool which program will be executed on"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/zip.fish:1
 msgid "Freshen: only changed files"
 msgstr ""
@@ -57891,6 +59293,469 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zip.fish:29
 msgid "Don't compress files with these suffixes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:1
+msgid ""
+"Internal completion function for appending string to the zpool commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:3
+msgid "Add new virtual devices to pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:4
+msgid "Attach virtual device to a pool device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:5
+msgid "Clear devices errors in pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:6
+msgid "Create a new storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:7
+msgid "Destroy a storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:8
+msgid "Detach virtual device from a mirroring pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:9
+msgid "Display pool event log"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:10
+msgid "Export a pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:11
+msgid "Get one or several pool properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:12
+msgid "Display pool command history"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:13
+msgid "List importable pools, or import some"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:14
+msgid "Display pool I/O stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:15
+msgid "Remove ZFS label information from the specified device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:16
+msgid "List pools with health status and space usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:17
+msgid "Take the specified devices offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:18
+msgid "Bring the specified devices back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:19
+msgid "Reset pool GUID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:20
+msgid "Remove virtual devices from pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:21
+msgid "Reopen pool devices"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:22
+msgid "Replace a pool virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:23
+msgid "Start or stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:24
+msgid "Set a pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:25
+msgid "Create a pool by splitting an existing mirror one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:26
+msgid "Display detailed pool health status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:27
+msgid "List upgradeable pools, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:28
+#: /tmp/fish/implicit/share/completions/zpool.fish:36
+#: /tmp/fish/implicit/share/completions/zpool.fish:45
+#: /tmp/fish/implicit/share/completions/zpool.fish:117
+msgid "Force use of virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:29
+#: /tmp/fish/implicit/share/completions/zpool.fish:130
+msgid "Dry run: only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:30
+#: /tmp/fish/implicit/share/completions/zpool.fish:91
+#: /tmp/fish/implicit/share/completions/zpool.fish:100
+#: /tmp/fish/implicit/share/completions/zpool.fish:127
+#: /tmp/fish/implicit/share/completions/zpool.fish:135
+msgid "Display virtual device GUID instead of device name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:31
+#: /tmp/fish/implicit/share/completions/zpool.fish:92
+#: /tmp/fish/implicit/share/completions/zpool.fish:101
+#: /tmp/fish/implicit/share/completions/zpool.fish:128
+#: /tmp/fish/implicit/share/completions/zpool.fish:136
+msgid "Resolve device path symbolic links"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:32
+#: /tmp/fish/implicit/share/completions/zpool.fish:93
+#: /tmp/fish/implicit/share/completions/zpool.fish:102
+#: /tmp/fish/implicit/share/completions/zpool.fish:129
+#: /tmp/fish/implicit/share/completions/zpool.fish:137
+msgid "Display device full path"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:33
+#: /tmp/fish/implicit/share/completions/zpool.fish:37
+#: /tmp/fish/implicit/share/completions/zpool.fish:48
+#: /tmp/fish/implicit/share/completions/zpool.fish:118
+#: /tmp/fish/implicit/share/completions/zpool.fish:132
+msgid "Pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:34
+msgid "Pool to add virtual devices to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:35
+#: /tmp/fish/implicit/share/completions/zpool.fish:53
+msgid "Virtual device to add"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:38
+msgid "Pool to attach virtual device to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:39
+#: /tmp/fish/implicit/share/completions/zpool.fish:43
+msgid "Virtual device to operate on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:40
+msgid "Initiate recovery mode"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:41
+#: /tmp/fish/implicit/share/completions/zpool.fish:85
+msgid ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:42
+msgid "Pool to clear errors on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:44
+msgid ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:46
+msgid "Dry run, only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:47
+msgid "Do not enable any feature on the new pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:49
+msgid "Root filesystem property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:50
+#: /tmp/fish/implicit/share/completions/zpool.fish:83
+msgid "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:51
+msgid "Root filesystem mountpoint"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:52
+msgid "Set a different in-core pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:54
+#: /tmp/fish/implicit/share/completions/zpool.fish:64
+msgid "Force unmounting of all contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:55
+msgid "Pool to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:56
+msgid "Pool to detach device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:57
+msgid "Physical device to detach"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:58
+msgid "Print verbose event information"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:60
+msgid "Output appended data as the log grows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:61
+msgid "Clear all previous events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:62
+msgid "Pool to read events from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:63
+msgid "Export all pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:65
+msgid "Pool to export"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:69
+msgid "Properties to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:70
+msgid "Pool to get properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:71
+msgid "Also display internal events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:72
+msgid "Display log records using long format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:73
+msgid "Pool to get command history of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:74
+msgid "Read configuration from specified cache file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:75
+msgid "Search for devices or files in specified directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:76
+msgid "List or import destroyed pools only (requires -f for importation)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:77
+#: /tmp/fish/implicit/share/completions/zpool.fish:133
+msgid "Mount properties for contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:78
+msgid "Properties of the imported pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:79
+msgid "Force import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:80
+msgid "Recovery mode"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:81
+msgid "Search for and import all pools found"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:82
+msgid "Ignore missing log device (risk of loss of last changes)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:84
+msgid "Do not mount contained filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:86
+msgid "Roll back to a previous TXG (hazardous)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:87
+msgid "TXG to roll back to (implies -FX)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:88
+msgid "Specify, as the last argument, a temporary pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:89
+msgid "Pool to import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:90
+#: /tmp/fish/implicit/share/completions/zpool.fish:103
+#: /tmp/fish/implicit/share/completions/zpool.fish:142
+msgid "Display a timestamp using specified format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:94
+msgid "Omit statistics since boot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:104
+msgid "Print verbose statistics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:96
+msgid "Pool to retrieve I/O stats from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:97
+msgid "Treat exported or foreign devices as inactive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:98
+msgid "Device to clear ZFS label information from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:106
+msgid "Pool to list properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:107
+msgid "Temporarily offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:108
+msgid "Pool to offline device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:109
+msgid "Physical device to offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:110
+msgid "Expand the device to use all available space"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:111
+msgid "Pool to bring device back online on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:112
+msgid "Physical device to bring back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:113
+msgid "Pool which GUID is to be changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:114
+msgid "Pool to remove device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:115
+msgid "Physical device to remove"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:116
+msgid "Pool which devices are to be reopened"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:119
+msgid "Pool to replace device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:120
+msgid "Pool device to be replaced"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:121
+msgid "Device to use for replacement"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:122
+msgid "Stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:123
+msgid "Pause scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:124
+msgid "Pool to start/stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:126
+msgid "Pool which property is to be set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:131
+msgid "Set altroot for newpool and automatically import it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:134
+msgid "Pool to split"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:138
+#: /tmp/fish/implicit/share/completions/zpool.fish:139
+msgid "Display deduplication histogram"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:141
+msgid "Only display status for unhealthy or unavailable pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:143
+#: /tmp/fish/implicit/share/completions/zpool.fish:147
+msgid "Pool which status is to be displayed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:144
+msgid "Upgrade all eligible pools, enabling all supported features"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:145
+msgid "Display upgradeable ZFS versions"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:146
+msgid "Upgrade to the specified legacy version"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:2
@@ -59359,6 +61224,28 @@ msgstr ""
 msgid "Complete wvdial peers"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+msgid "Completes with ZFS mountpoint properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_pools.fish:1
+msgid "Completes with available ZFS pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+msgid "Completes with ZFS read-only properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Completes with ZFS read-write properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr ""
@@ -59516,6 +61403,12 @@ msgstr ""
 msgid "Test if current token is on Nth place"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_is_zfs_feature_enabled.fish:1
+msgid ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_list_current_token.fish:1
 msgid ""
 "List contents of token under the cursor if it is a directory, otherwise list "
@@ -59592,6 +61485,10 @@ msgid ""
 "current directory"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
+msgid "Print a list of local groups"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr ""
@@ -59658,6 +61555,22 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
+msgid "Lists ZFS bookmarks, if the feature is enabled"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
+msgid "Lists ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
+msgid "Lists ZFS snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
+msgid "Lists ZFS volumes"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1

--- a/po/nn.po
+++ b/po/nn.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 2.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-13 10:22+0100\n"
 "Last-Translator: Andreas Nordal <andreas.nordal_4@hotmail.com>\n"
 "Language: nn\n"
 "MIME-Version: 1.0\n"
@@ -1810,9 +1810,11 @@ msgstr ""
 #: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
 #: /tmp/fish/implicit/share/completions/fossil.fish:90
 #: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:206
-#: /tmp/fish/implicit/share/completions/git.fish:266
-#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:269
 msgid "File"
 msgstr ""
 
@@ -2498,6 +2500,553 @@ msgstr ""
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/zfs.fish:1
+msgid "ZFS filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:2
+msgid "ZFS filesystem snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:3
+msgid "ZFS block storage device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:4
+msgid "ZFS snapshot bookmark"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:5
+msgid "Any ZFS dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:6
+msgid "Dataset-specific value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:7
+msgid "Default ZFS value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:8
+msgid "Value inherited from parent dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:9
+msgid "Value received by 'zfs receive'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:10
+msgid "Value valid for the current mount"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:11
+msgid "Read-only value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:12
+msgid "Dataset full name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:13
+#: /tmp/fish/explicit/share/completions/zpool.fish:2
+#: /tmp/fish/implicit/share/completions/minikube.fish:25
+#: /tmp/fish/implicit/share/completions/minikube.fish:26
+#: /tmp/fish/implicit/share/completions/minikube.fish:27
+#: /tmp/fish/implicit/share/completions/minikube.fish:28
+msgid "Property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:3
+msgid "Property value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:15
+#: /tmp/fish/explicit/share/completions/zpool.fish:4
+msgid "Property value origin"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:16
+msgid "Identity type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:17
+msgid "Identity name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:18
+msgid "Space usage"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:19
+msgid "Space quota"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:20
+msgid "POSIX user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:21
+msgid "Samba user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:22
+#: /tmp/fish/explicit/share/completions/zfs.fish:25
+msgid "Both types"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:23
+msgid "POSIX group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:24
+msgid "Samba group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:26
+msgid "Also needs the permission to be allowed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:27
+msgid ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:28
+#: /tmp/fish/explicit/share/completions/zfs.fish:29
+#: /tmp/fish/explicit/share/completions/zfs.fish:33
+#: /tmp/fish/explicit/share/completions/zfs.fish:35
+msgid "Also needs the 'mount' permission"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:30
+msgid ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:31
+msgid "Also needs the 'create' and 'mount' permissions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:32
+msgid "Also needs the 'create' and 'mount' permissions in the new parent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:34
+msgid "For SMB and NFS shares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:36
+msgid "Allows changing any user property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:26
+msgid "Volume block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:38
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Inheritance of ACL entries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:39
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:2
+msgid "Update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:40
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:3
+msgid "Is the dataset mountable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:41
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:4
+msgid "Data checksum"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:42
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:5
+msgid "Compression algorithm"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:43
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:6
+msgid "Number of copies of data"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:44
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:7
+msgid "Deduplication"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:45
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:2
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:8
+msgid "Are contained device nodes openable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:46
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:3
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:9
+msgid "Can contained executables be executed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:47
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:10
+msgid "Max number of filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:48
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:11
+msgid "Mountpoint"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:49
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:12
+msgid "Which data to cache in ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:50
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:13
+msgid "Max size of dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:51
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:14
+msgid "Max number of snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:52
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:4
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:15
+msgid "Read-only"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:53
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:16
+msgid "Suggest block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:54
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:17
+msgid "How redundant are the metadata"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:55
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:18
+msgid "Max space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:56
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:19
+msgid "Min space guaranteed to dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:57
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:20
+msgid "Min space guaranteed to dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:58
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:21
+msgid "Which data to cache in L2ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:59
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:5
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:22
+msgid "Respect set-UID bit"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:60
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:23
+msgid "Share in NFS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:61
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:24
+msgid "Hint for handling of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:62
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:25
+msgid "Hide .zfs directory"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:63
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:26
+msgid "Handle of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:64
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:27
+msgid "Volume logical size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:65
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:38
+msgid "Managed from a non-global zone"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:66
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:31
+msgid "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:67
+#: /tmp/fish/explicit/share/completions/zfs.fish:74
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:6
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:32
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:40
+msgid "Mount with Non Blocking mandatory locks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:68
+#: /tmp/fish/explicit/share/completions/zfs.fish:77
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:33
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:43
+msgid "Share in Samba"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:69
+#: /tmp/fish/explicit/share/completions/zfs.fish:76
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:34
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:42
+msgid "Share as an iSCSI target"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:70
+#: /tmp/fish/explicit/share/completions/zfs.fish:79
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:35
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:45
+msgid "On-disk version of filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:71
+#: /tmp/fish/explicit/share/completions/zfs.fish:80
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:36
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:46
+msgid "Scan regular files for viruses on opening and closing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:72
+#: /tmp/fish/explicit/share/completions/zfs.fish:81
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:7
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:47
+msgid "Extended attributes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:73
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:39
+msgid "Use no ACL or POSIX ACL"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:75
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:9
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:41
+msgid "Sometimes update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:78
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:44
+msgid "Hide volume snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:82
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:30
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:48
+msgid "How is ACL modified by chmod"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:83
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:49
+msgid "How to expose volumes to OS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:84
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid "Unicode normalization"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:85
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:2
+msgid "Reject non-UTF-8-compliant filenames"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:86
+#: /tmp/fish/explicit/share/completions/zfs.fish:87
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:9
+msgid "Case sensitivity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:88
+msgid "Space properties"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:89
+#: /tmp/fish/explicit/share/completions/zfs.fish:90
+msgid "Dataset name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:1
+msgid "Pool full name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:5
+msgid "Mirror of at least two devices"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:6
+#: /tmp/fish/explicit/share/completions/zpool.fish:7
+msgid "ZFS RAID-5 variant, single parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:8
+msgid "ZFS RAID-5 variant, double parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:9
+msgid "ZFS RAID-5 variant, triple parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:10
+msgid "Pseudo vdev for pool hot spares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:11
+msgid "SLOG device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:12
+msgid "L2ARC device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:13
+msgid "Physically allocated space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:2
+msgid "Available space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:16
+msgid "System boot partition size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:17
+msgid "Usage percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:18
+msgid "Deduplication ratio"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:19
+msgid "Amount of uninitialized space within the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:20
+msgid "Fragmentation percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:21
+msgid "Free pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:22
+msgid "Remaining pool space to be freed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:23
+msgid "Pool GUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:24
+msgid "Current pool health"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:25
+msgid "Total pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:26
+msgid "Used pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:27
+msgid "Pool sector size exponent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:28
+#: /tmp/fish/explicit/share/completions/zpool.fish:29
+msgid "Alternate root directory"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:30
+#: /tmp/fish/explicit/share/completions/zpool.fish:31
+msgid "Import pool in read-only mode"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:32
+#: /tmp/fish/explicit/share/completions/zpool.fish:33
+msgid "Automatic pool expansion on LUN growing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:34
+#: /tmp/fish/explicit/share/completions/zpool.fish:35
+msgid "Automatic use of replacement device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:36
+msgid "Default bootable dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:37
+msgid "Pool configuration cache"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:38
+msgid "Comment about the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:39
+msgid "Threshold for writting a ditto copy of deduplicated blocks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:40
+msgid "Allow rights delegation on the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:41
+msgid "Behavior in case of catastrophic pool failure"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:42
+msgid "Display snapshots even if 'zfs list' does not use '-t'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:43
+msgid "On-disk version of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:44
+msgid "%sEnable the %s feature\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:45
+msgid "All properties"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/abbr.fish:1
 msgid "%s: Could not figure out what to do!\\n"
 msgstr ""
@@ -2627,6 +3176,135 @@ msgstr ""
 msgid "%s\\tArchived file\\n"
 msgstr ""
 
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:3
+msgid "Achieved compression ratio"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:4
+msgid "Dataset creation time"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:5
+msgid "Snapshot clones"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:6
+msgid "Marked for deferred destruction"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:7
+msgid "Total lower-level filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:9
+msgid "Logical total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:11
+msgid "Logical used space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:12
+msgid "Is currently mounted?"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:13
+msgid "Source snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:14
+msgid "Token for interrupted reception resumption"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:16
+msgid "Total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:17
+msgid "Achieved compression ratio of referenced space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:18
+msgid "Total lower-level snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:19
+#: /tmp/fish/implicit/share/completions/zfs.fish:71
+#: /tmp/fish/implicit/share/completions/zfs.fish:81
+msgid "Dataset type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:20
+msgid "Space used by dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:21
+msgid "Space used by children datasets"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:22
+msgid "Space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:23
+msgid "Space used by refreservation"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:24
+msgid "Space used by dataset snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:25
+msgid "Holds count"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:27
+msgid "Referenced data written since previous snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:28
+msgid "%sDataset space use by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:29
+msgid "%sDataset space use by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:30
+msgid "%sReferenced data written since snapshot %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:28
+msgid "%sMax usage by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:29
+msgid "%sMax usage by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:3
+msgid "Allow overlay mount"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:4
+msgid "SELinux context for the child filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:5
+msgid "SELinux context for the filesystem being mounted"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:6
+msgid "SELinux context for unlabeled files"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:7
+msgid "SELinux context for the root inode of the filesystem"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr ""
@@ -2651,6 +3329,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/aptitude.fish:3
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:3
 #: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:63
 #: /tmp/fish/implicit/share/completions/wajig.fish:3
@@ -5056,7 +5736,10 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/valgrind.fish:6
 #: /tmp/fish/implicit/share/completions/vi.fish:8
 #: /tmp/fish/implicit/share/completions/wget.fish:9
+#: /tmp/fish/implicit/share/completions/zfs.fish:42
+#: /tmp/fish/implicit/share/completions/zfs.fish:87
 #: /tmp/fish/implicit/share/completions/zip.fish:13
+#: /tmp/fish/implicit/share/completions/zpool.fish:140
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
 msgid "Verbose mode"
 msgstr ""
@@ -9701,7 +10384,7 @@ msgid "Show usage message and options"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:380
+#: /tmp/fish/implicit/share/completions/git.fish:382
 msgid "Show help message"
 msgstr ""
 
@@ -14370,7 +15053,7 @@ msgid "Ignore all white space"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:325
+#: /tmp/fish/implicit/share/completions/git.fish:327
 msgid "Ignore changes whose lines are all blank"
 msgstr ""
 
@@ -14379,7 +15062,7 @@ msgid "Ignore changes whose lines match the REGEX"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:321
+#: /tmp/fish/implicit/share/completions/git.fish:323
 msgid "Treat all files as text"
 msgstr ""
 
@@ -16220,6 +16903,81 @@ msgstr ""
 msgid "X display to use"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/exercism.fish:1
+msgid "Test if exercism has yet to be given the subcommand"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:3
+msgid "turn on verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:4
+#: /tmp/fish/implicit/share/completions/exercism.fish:19
+#: /tmp/fish/implicit/share/completions/ninja.fish:8
+#: /tmp/fish/implicit/share/completions/quilt.fish:1
+msgid "show help"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:5
+msgid "print the version"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:6
+msgid "Writes config values to a JSON file."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:7
+msgid "Outputs useful debug information."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:8
+msgid "Downloads a solution given the ID of the latest iteration."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:9
+msgid "Fetches the next unsubmitted problem in each track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:10
+msgid "Lists the available problems for a language track, given its ID."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:11
+msgid ""
+"Opens exercism.io to your most recent iteration of a problem given the track "
+"ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:12
+msgid ""
+"Downloads the most recent iteration for each of your solutions on exercism."
+"io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:13
+msgid "Skips a problem given a track ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:14
+msgid "Fetches information about your progress with a given language track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:15
+msgid "Submits a new iteration to a problem on exercism.io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:16
+msgid "Lists the available language tracks."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:17
+msgid "REMOVED"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:18
+msgid "Upgrades the CLI to the latest released version."
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/exit.fish:2
 msgid "Quit with normal exit status"
 msgstr ""
@@ -16967,6 +17725,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:66
+#: /tmp/fish/implicit/share/completions/zfs.fish:76
 msgid "Maximum recursion depth"
 msgstr ""
 
@@ -18214,9 +18974,9 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/fossil.fish:280
 #: /tmp/fish/implicit/share/completions/git.fish:64
 #: /tmp/fish/implicit/share/completions/git.fish:86
-#: /tmp/fish/implicit/share/completions/git.fish:244
-#: /tmp/fish/implicit/share/completions/git.fish:293
-#: /tmp/fish/implicit/share/completions/git.fish:294
+#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:296
 msgid "Tag"
 msgstr ""
 
@@ -18617,7 +19377,7 @@ msgid "Limit number of tags"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:281
-#: /tmp/fish/implicit/share/completions/git.fish:291
+#: /tmp/fish/implicit/share/completions/git.fish:293
 msgid "List tags"
 msgstr ""
 
@@ -18710,6 +19470,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gsettings.fish:15
 #: /tmp/fish/implicit/share/completions/ncdu.fish:1
 #: /tmp/fish/implicit/share/completions/obnam.fish:12
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:4
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:5
 #: /tmp/fish/implicit/share/completions/pkginfo.fish:7
 #: /tmp/fish/implicit/share/completions/pkgmk.fish:17
@@ -24818,24 +25579,24 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:96
 #: /tmp/fish/implicit/share/completions/git.fish:108
 #: /tmp/fish/implicit/share/completions/git.fish:130
-#: /tmp/fish/implicit/share/completions/git.fish:134
-#: /tmp/fish/implicit/share/completions/git.fish:140
-#: /tmp/fish/implicit/share/completions/git.fish:183
-#: /tmp/fish/implicit/share/completions/git.fish:219
-#: /tmp/fish/implicit/share/completions/git.fish:222
-#: /tmp/fish/implicit/share/completions/git.fish:242
-#: /tmp/fish/implicit/share/completions/git.fish:265
-#: /tmp/fish/implicit/share/completions/git.fish:285
-#: /tmp/fish/implicit/share/completions/git.fish:307
+#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:221
+#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:244
+#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:309
 msgid "Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:23
-#: /tmp/fish/implicit/share/completions/git.fish:198
-#: /tmp/fish/implicit/share/completions/git.fish:210
-#: /tmp/fish/implicit/share/completions/git.fish:237
-#: /tmp/fish/implicit/share/completions/git.fish:250
-#: /tmp/fish/implicit/share/completions/git.fish:274
+#: /tmp/fish/implicit/share/completions/git.fish:200
+#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:276
 #: /tmp/fish/implicit/share/completions/mdadm.fish:12
 #: /tmp/fish/implicit/share/completions/update-eix-remote.fish:1
 msgid "Be quiet"
@@ -24844,10 +25605,10 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:24
 #: /tmp/fish/implicit/share/completions/git.fish:41
 #: /tmp/fish/implicit/share/completions/git.fish:70
-#: /tmp/fish/implicit/share/completions/git.fish:199
-#: /tmp/fish/implicit/share/completions/git.fish:211
-#: /tmp/fish/implicit/share/completions/git.fish:238
-#: /tmp/fish/implicit/share/completions/git.fish:251
+#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:253
 #: /tmp/fish/implicit/share/completions/prt-get.fish:53
 #: /tmp/fish/implicit/share/completions/prt-get.fish:111
 #: /tmp/fish/implicit/share/completions/xz.fish:32
@@ -24855,12 +25616,12 @@ msgid "Be verbose"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:25
-#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:215
 msgid "Append ref names and object names"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:26
-#: /tmp/fish/implicit/share/completions/git.fish:214
+#: /tmp/fish/implicit/share/completions/git.fish:216
 msgid "Force update of local branches"
 msgstr ""
 
@@ -25008,7 +25769,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:63
 #: /tmp/fish/implicit/share/completions/git.fish:85
 #: /tmp/fish/implicit/share/completions/git.fish:109
-#: /tmp/fish/implicit/share/completions/git.fish:184
+#: /tmp/fish/implicit/share/completions/git.fish:186
 msgid "Remote branch"
 msgstr ""
 
@@ -25037,7 +25798,7 @@ msgid "Allow adding otherwise ignored files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:257
+#: /tmp/fish/implicit/share/completions/git.fish:259
 msgid "Interactive mode"
 msgstr ""
 
@@ -25088,7 +25849,7 @@ msgid "Remote Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:84
-#: /tmp/fish/implicit/share/completions/git.fish:243
+#: /tmp/fish/implicit/share/completions/git.fish:245
 msgid "Head"
 msgstr ""
 
@@ -25253,893 +26014,896 @@ msgstr ""
 msgid "Compare two paths on the filesystem"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:134
 msgid "Open diffs in a visual tool"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:136
 msgid "Visually show diff of changes in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:136
+#: /tmp/fish/implicit/share/completions/git.fish:138
 msgid "Print lines matching a pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:139
 msgid "Create an empty git repository or reinitialize an existing one"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:138
+#: /tmp/fish/implicit/share/completions/git.fish:140
 msgid "Show commit shortlog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:139
+#: /tmp/fish/implicit/share/completions/git.fish:141
 msgid "Show commit logs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:141
+#: /tmp/fish/implicit/share/completions/git.fish:143
 msgid "Continue listing file history beyond renames"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:144
 msgid "Don't print ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:143
+#: /tmp/fish/implicit/share/completions/git.fish:145
 msgid "Print out ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:144
+#: /tmp/fish/implicit/share/completions/git.fish:146
 msgid "Print ref name by which each commit was reached"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:145
+#: /tmp/fish/implicit/share/completions/git.fish:147
 msgid "Limit the number of commits before starting to show the commit output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:146
-msgid "Skip given number of commits"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:147
 #: /tmp/fish/implicit/share/completions/git.fish:148
-msgid "Show commits more recent than specified date"
+msgid "Skip given number of commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:149
 #: /tmp/fish/implicit/share/completions/git.fish:150
-msgid "Show commits older than specified date"
+msgid "Show commits more recent than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:151
-msgid "Limit commits from given author"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/git.fish:152
-msgid "Limit commits from given committer"
+msgid "Show commits older than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:153
-msgid "Limit commits to ones with reflog entries matching given pattern"
+msgid "Limit commits from given author"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:154
-msgid "Limit commits with message that match given pattern"
+msgid "Limit commits from given committer"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:155
-msgid "Limit commits to ones that match all given --grep"
+msgid "Limit commits to ones with reflog entries matching given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:156
-msgid "Limit commits to ones with message that don't match --grep"
+msgid "Limit commits with message that match given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:157
-msgid "Case insensitive match"
+msgid "Limit commits to ones that match all given --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:158
-msgid "Patterns are basic regular expressions (default)"
+msgid "Limit commits to ones with message that don't match --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:159
-msgid "Patterns are extended regular expressions"
+msgid "Case insensitive match"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:160
-msgid "Patterns are fixed strings"
+msgid "Patterns are basic regular expressions (default)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:161
-msgid "Patterns are Perl-compatible regular expressions"
+msgid "Patterns are extended regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:162
-msgid "Stop when given path disappears from tree"
+msgid "Patterns are fixed strings"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:163
-msgid "Print only merge commits"
+msgid "Patterns are Perl-compatible regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:164
-msgid "Don't print commits with more than one parent"
+msgid "Stop when given path disappears from tree"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:165
-msgid "Show only commit with at least the given number of parents"
+msgid "Print only merge commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:166
-msgid "Show only commit with at most the given number of parents"
+msgid "Don't print commits with more than one parent"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:167
-msgid "Show only commit without a mimimum number of parents"
+msgid "Show only commit with at least the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:168
-msgid "Show only commit without a maximum number of parents"
+msgid "Show only commit with at most the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:169
-msgid "Follow only the first parent commit upon seeing a merge commit"
+msgid "Show only commit without a mimimum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:170
-msgid "Reverse meaning of ^ prefix"
+msgid "Show only commit without a maximum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:171
+msgid "Follow only the first parent commit upon seeing a merge commit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:172
+msgid "Reverse meaning of ^ prefix"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:173
 msgid ""
 "Pretend as if all refs in refs/ are listed on the command line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:172
+#: /tmp/fish/implicit/share/completions/git.fish:174
 msgid ""
 "Pretend as if all refs are in refs/heads are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:173
+#: /tmp/fish/implicit/share/completions/git.fish:175
 msgid ""
 "Pretend as if all refs are in ref/tags are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:174
+#: /tmp/fish/implicit/share/completions/git.fish:176
 msgid ""
 "Pretend as if all refs in refs/remotes  are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:175
+#: /tmp/fish/implicit/share/completions/git.fish:177
 msgid ""
 "Pretend as if all refs matching shell glob are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:176
+#: /tmp/fish/implicit/share/completions/git.fish:178
 msgid "Do not include refs matching given glob pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:177
+#: /tmp/fish/implicit/share/completions/git.fish:179
 msgid ""
 "Pretend as if all objcets mentioned by reflogs are listed on the command "
 "line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:178
+#: /tmp/fish/implicit/share/completions/git.fish:180
 msgid "Ignore invalid object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:179
+#: /tmp/fish/implicit/share/completions/git.fish:181
 msgid "Read commits from stdin"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:180
+#: /tmp/fish/implicit/share/completions/git.fish:182
 msgid "Mark equivalent commits with = and inequivalent with +"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:181
+#: /tmp/fish/implicit/share/completions/git.fish:183
 msgid "Omit equivalent commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:182
+#: /tmp/fish/implicit/share/completions/git.fish:184
 msgid "Join two or more development histories together"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:187
 msgid "Autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:186
+#: /tmp/fish/implicit/share/completions/git.fish:188
 msgid "Don't autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:187
+#: /tmp/fish/implicit/share/completions/git.fish:189
 msgid "Edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:188
+#: /tmp/fish/implicit/share/completions/git.fish:190
 msgid "Don't edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:189
+#: /tmp/fish/implicit/share/completions/git.fish:191
 msgid "Don't generate a merge commit if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:190
+#: /tmp/fish/implicit/share/completions/git.fish:192
 msgid "Generate a merge commit even if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:191
+#: /tmp/fish/implicit/share/completions/git.fish:193
 msgid "Refuse to merge unless fast-forward possible"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:192
+#: /tmp/fish/implicit/share/completions/git.fish:194
 msgid "Populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:193
+#: /tmp/fish/implicit/share/completions/git.fish:195
 msgid "Don't populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:194
+#: /tmp/fish/implicit/share/completions/git.fish:196
 msgid "Show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:195
+#: /tmp/fish/implicit/share/completions/git.fish:197
 msgid "Don't show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:196
+#: /tmp/fish/implicit/share/completions/git.fish:198
 msgid "Squash changes from other branch as a single commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:197
+#: /tmp/fish/implicit/share/completions/git.fish:199
 msgid "Don't squash changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:200
-#: /tmp/fish/implicit/share/completions/git.fish:217
-#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:219
+#: /tmp/fish/implicit/share/completions/git.fish:241
 msgid "Force progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:203
 msgid "Force no progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:204
 msgid "Set the commit message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:203
+#: /tmp/fish/implicit/share/completions/git.fish:205
 msgid "Abort the current conflict resolution process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:204
+#: /tmp/fish/implicit/share/completions/git.fish:206
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:205
+#: /tmp/fish/implicit/share/completions/git.fish:207
 msgid "Use specific merge resolution program"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:207
+#: /tmp/fish/implicit/share/completions/git.fish:209
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:210
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:209
+#: /tmp/fish/implicit/share/completions/git.fish:211
 msgid "Fetch from and merge with another repository or a local branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:214
 msgid "Fetch all remotes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:215
+#: /tmp/fish/implicit/share/completions/git.fish:217
 msgid "Keep downloaded pack"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:216
+#: /tmp/fish/implicit/share/completions/git.fish:218
 msgid "Disable automatic tag following"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:218
-#: /tmp/fish/implicit/share/completions/git.fish:221
-#: /tmp/fish/implicit/share/completions/git.fish:241
+#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:243
 msgid "Remote alias"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:222
 msgid "Update remote refs along with associated objects"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:225
 msgid "Force-push branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:226
 msgid "Force-push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:225
+#: /tmp/fish/implicit/share/completions/git.fish:227
 msgid "Push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:226
+#: /tmp/fish/implicit/share/completions/git.fish:228
 msgid "Push all refs under refs/heads/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:227
+#: /tmp/fish/implicit/share/completions/git.fish:229
 msgid "Remove remote branches that don't have a local counterpart"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:228
+#: /tmp/fish/implicit/share/completions/git.fish:230
 msgid "Push all refs under refs/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:229
+#: /tmp/fish/implicit/share/completions/git.fish:231
 msgid "Delete all listed refs from the remote repository"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:230
+#: /tmp/fish/implicit/share/completions/git.fish:232
 msgid "Push all refs under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:231
+#: /tmp/fish/implicit/share/completions/git.fish:233
 msgid "Push all usual refs plus the ones under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:232
+#: /tmp/fish/implicit/share/completions/git.fish:234
 msgid "Do everything except actually send the updates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:233
+#: /tmp/fish/implicit/share/completions/git.fish:235
 msgid "Produce machine-readable output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:234
+#: /tmp/fish/implicit/share/completions/git.fish:236
 msgid "Force update of remote refs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:235
+#: /tmp/fish/implicit/share/completions/git.fish:237
 msgid ""
 "Force update of remote refs, stopping if other's changes would be overwritten"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:236
+#: /tmp/fish/implicit/share/completions/git.fish:238
 msgid "Add upstream (tracking) reference"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:242
 msgid "Forward-port local commits to the updated upstream head"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:245
+#: /tmp/fish/implicit/share/completions/git.fish:247
 msgid "Restart the rebasing process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:248
 msgid "Abort the rebase operation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:247
+#: /tmp/fish/implicit/share/completions/git.fish:249
 msgid "Keep the commits that don't cahnge anything"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:248
+#: /tmp/fish/implicit/share/completions/git.fish:250
 msgid "Restart the rebasing process by skipping the current patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:249
+#: /tmp/fish/implicit/share/completions/git.fish:251
 msgid "Use merging strategies to rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:254
 msgid "Show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:253
+#: /tmp/fish/implicit/share/completions/git.fish:255
 msgid "Don't show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:254
+#: /tmp/fish/implicit/share/completions/git.fish:256
 msgid "Allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:255
+#: /tmp/fish/implicit/share/completions/git.fish:257
 msgid "Don't allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:256
+#: /tmp/fish/implicit/share/completions/git.fish:258
 msgid "Force the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:258
+#: /tmp/fish/implicit/share/completions/git.fish:260
 msgid "Try to recreate merges"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:259
+#: /tmp/fish/implicit/share/completions/git.fish:261
 msgid "Rebase all reachable commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:260
+#: /tmp/fish/implicit/share/completions/git.fish:262
 msgid "Automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:261
+#: /tmp/fish/implicit/share/completions/git.fish:263
 msgid "No automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:262
+#: /tmp/fish/implicit/share/completions/git.fish:264
 msgid "No fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:263
+#: /tmp/fish/implicit/share/completions/git.fish:265
 msgid "Reset current HEAD to the specified state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:264
+#: /tmp/fish/implicit/share/completions/git.fish:266
 msgid "Reset files in working directory"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:270
 msgid "Reflog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: /tmp/fish/implicit/share/completions/git.fish:271
 msgid "Revert an existing commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:270
+#: /tmp/fish/implicit/share/completions/git.fish:272
 msgid "Remove files from the working tree and from the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:271
+#: /tmp/fish/implicit/share/completions/git.fish:273
 msgid "Keep local copies"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:272
+#: /tmp/fish/implicit/share/completions/git.fish:274
 msgid "Exit with a zero status even if no files matched"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:273
+#: /tmp/fish/implicit/share/completions/git.fish:275
 msgid "Allow recursive removal"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:275
+#: /tmp/fish/implicit/share/completions/git.fish:277
 msgid "Override the up-to-date check"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:276
+#: /tmp/fish/implicit/share/completions/git.fish:278
 #: /tmp/fish/implicit/share/completions/prt-get.fish:45
 #: /tmp/fish/implicit/share/completions/prt-get.fish:103
+#: /tmp/fish/implicit/share/completions/zfs.fish:40
+#: /tmp/fish/implicit/share/completions/zfs.fish:124
+#: /tmp/fish/implicit/share/completions/zfs.fish:132
 msgid "Dry run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:277
+#: /tmp/fish/implicit/share/completions/git.fish:279
 msgid "Show the working tree status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:278
+#: /tmp/fish/implicit/share/completions/git.fish:280
 msgid "Give the output in the short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:279
+#: /tmp/fish/implicit/share/completions/git.fish:281
 msgid "Show the branch and tracking info even in short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:280
+#: /tmp/fish/implicit/share/completions/git.fish:282
 msgid "Give the output in a stable, easy-to-parse format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:281
+#: /tmp/fish/implicit/share/completions/git.fish:283
 msgid "Terminate entries with null character"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:282
+#: /tmp/fish/implicit/share/completions/git.fish:284
 msgid "The untracked files handling mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:283
+#: /tmp/fish/implicit/share/completions/git.fish:285
 msgid "Ignore changes to submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:284
+#: /tmp/fish/implicit/share/completions/git.fish:286
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:286
+#: /tmp/fish/implicit/share/completions/git.fish:288
 msgid "Make an unsigned, annotated tag object"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:289
 msgid "Make a GPG-signed tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:288
+#: /tmp/fish/implicit/share/completions/git.fish:290
 msgid "Remove a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:289
+#: /tmp/fish/implicit/share/completions/git.fish:291
 msgid "Verify signature of a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:290
+#: /tmp/fish/implicit/share/completions/git.fish:292
 msgid "Force overwriting exising tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:292
+#: /tmp/fish/implicit/share/completions/git.fish:294
 msgid "List tags that contain a commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:297
 msgid "Stash away changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:296
+#: /tmp/fish/implicit/share/completions/git.fish:298
 msgid "List stashes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:297
+#: /tmp/fish/implicit/share/completions/git.fish:299
 msgid "Show the changes recorded in the stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:298
+#: /tmp/fish/implicit/share/completions/git.fish:300
 msgid "Apply and remove a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:299
+#: /tmp/fish/implicit/share/completions/git.fish:301
 msgid "Apply a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:300
+#: /tmp/fish/implicit/share/completions/git.fish:302
 msgid "Remove all stashed states"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:301
+#: /tmp/fish/implicit/share/completions/git.fish:303
 msgid "Remove a single stashed state from the stash list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:302
+#: /tmp/fish/implicit/share/completions/git.fish:304
 msgid "Create a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:303
+#: /tmp/fish/implicit/share/completions/git.fish:305
 msgid "Save a new stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:304
+#: /tmp/fish/implicit/share/completions/git.fish:306
 msgid "Create a new branch from a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:305
+#: /tmp/fish/implicit/share/completions/git.fish:307
 msgid "Set and read git configuration variables"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:306
+#: /tmp/fish/implicit/share/completions/git.fish:308
 msgid "Generate patch series to send upstream"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:308
+#: /tmp/fish/implicit/share/completions/git.fish:310
 msgid "Generate plain patches without diffstat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:309
+#: /tmp/fish/implicit/share/completions/git.fish:311
 msgid "Suppress diff output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:310
+#: /tmp/fish/implicit/share/completions/git.fish:312
 msgid "Spend more time to create smaller diffs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:311
+#: /tmp/fish/implicit/share/completions/git.fish:313
 msgid "Generate diff with the 'patience' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:312
+#: /tmp/fish/implicit/share/completions/git.fish:314
 msgid "Generate diff with the 'histogram' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:313
+#: /tmp/fish/implicit/share/completions/git.fish:315
 msgid "Print all commits to stdout in mbox format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:314
+#: /tmp/fish/implicit/share/completions/git.fish:316
 msgid "Show number of added/deleted lines in decimal notation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:315
+#: /tmp/fish/implicit/share/completions/git.fish:317
 msgid "Output only last line of the stat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:316
+#: /tmp/fish/implicit/share/completions/git.fish:318
 msgid "Output a condensed summary of extended header information"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:317
+#: /tmp/fish/implicit/share/completions/git.fish:319
 msgid "Disable rename detection"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:318
+#: /tmp/fish/implicit/share/completions/git.fish:320
 msgid "Show full blob object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:319
+#: /tmp/fish/implicit/share/completions/git.fish:321
 msgid "Output a binary diff for use with git apply"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:320
+#: /tmp/fish/implicit/share/completions/git.fish:322
 msgid "Also inspect unmodified files as source for a copy"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:322
+#: /tmp/fish/implicit/share/completions/git.fish:324
 msgid "Ignore changes in whitespace at EOL"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: /tmp/fish/implicit/share/completions/git.fish:325
 msgid "Ignore changes in amount of whitespace"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:324
+#: /tmp/fish/implicit/share/completions/git.fish:326
 msgid "Ignore whitespace when comparing lines"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:326
+#: /tmp/fish/implicit/share/completions/git.fish:328
 msgid "Show whole surrounding functions of changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: /tmp/fish/implicit/share/completions/git.fish:329
 msgid "Allow an external diff helper to be executed"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:328
+#: /tmp/fish/implicit/share/completions/git.fish:330
 msgid "Disallow external diff helpers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:329
+#: /tmp/fish/implicit/share/completions/git.fish:331
 msgid "Disallow external text conversion filters for binary files (Default)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:330
+#: /tmp/fish/implicit/share/completions/git.fish:332
 msgid ""
 "Allow external text conversion filters for binary files (Resulting diff is "
 "unappliable)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:331
+#: /tmp/fish/implicit/share/completions/git.fish:333
 msgid "Do not show source or destination prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:332
+#: /tmp/fish/implicit/share/completions/git.fish:334
 msgid "Name output in [Patch n/m] format, even with a single patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:333
+#: /tmp/fish/implicit/share/completions/git.fish:335
 msgid "Name output in [Patch] format, even with multiple patches"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:334
+#: /tmp/fish/implicit/share/completions/git.fish:336
 msgid "Initialize, update or inspect submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:335
+#: /tmp/fish/implicit/share/completions/git.fish:337
 msgid "Add a submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:336
+#: /tmp/fish/implicit/share/completions/git.fish:338
 msgid "Show submodule status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:337
-#: /tmp/fish/implicit/share/completions/git.fish:343
+#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:345
 msgid "Initialize all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:338
+#: /tmp/fish/implicit/share/completions/git.fish:340
 msgid "Update all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:341
 msgid "Show commit summary"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:340
+#: /tmp/fish/implicit/share/completions/git.fish:342
 msgid "Run command on each submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:341
+#: /tmp/fish/implicit/share/completions/git.fish:343
 msgid "Sync submodules' URL with .gitmodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:342
+#: /tmp/fish/implicit/share/completions/git.fish:344
 msgid "Only print error messages"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:344
+#: /tmp/fish/implicit/share/completions/git.fish:346
 msgid "Checkout the superproject's commit on a detached HEAD in the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:345
+#: /tmp/fish/implicit/share/completions/git.fish:347
 msgid ""
 "Merge the superproject's commit into the current branch of the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:346
+#: /tmp/fish/implicit/share/completions/git.fish:348
 msgid "Rebase current branch onto the superproject's commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:347
+#: /tmp/fish/implicit/share/completions/git.fish:349
 msgid "Don't fetch new objects from the remote"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:348
+#: /tmp/fish/implicit/share/completions/git.fish:350
 msgid ""
 "Instead of using superproject's SHA-1, use the state of the submodule's "
 "remote-tracking branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:349
+#: /tmp/fish/implicit/share/completions/git.fish:351
 msgid ""
 "Throw away local changes when switching to a different commit and always run "
 "checkout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:350
+#: /tmp/fish/implicit/share/completions/git.fish:352
 msgid "Also add ignored submodule path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:351
+#: /tmp/fish/implicit/share/completions/git.fish:353
 msgid "Remove even with local changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:352
+#: /tmp/fish/implicit/share/completions/git.fish:354
 msgid "Use the commit stored in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:353
+#: /tmp/fish/implicit/share/completions/git.fish:355
 msgid "Compare the commit in the index with submodule HEAD"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:354
+#: /tmp/fish/implicit/share/completions/git.fish:356
 msgid "Traverse submodules recursively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:355
+#: /tmp/fish/implicit/share/completions/git.fish:357
 msgid "Show logs with difference each commit introduces"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:356
+#: /tmp/fish/implicit/share/completions/git.fish:358
 msgid "Remove untracked files from the working tree"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:357
+#: /tmp/fish/implicit/share/completions/git.fish:359
 msgid "Force run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:358
+#: /tmp/fish/implicit/share/completions/git.fish:360
 msgid "Show what would be done and clean files interactively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:359
+#: /tmp/fish/implicit/share/completions/git.fish:361
 msgid "Don't actually remove anything, just show what would be done"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:360
+#: /tmp/fish/implicit/share/completions/git.fish:362
 msgid "Be quiet, only report errors"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:361
+#: /tmp/fish/implicit/share/completions/git.fish:363
 msgid "Remove untracked directories in addition to untracked files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:362
+#: /tmp/fish/implicit/share/completions/git.fish:364
 msgid "Remove ignored files, as well"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:363
+#: /tmp/fish/implicit/share/completions/git.fish:365
 msgid "Remove only ignored files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:364
+#: /tmp/fish/implicit/share/completions/git.fish:366
 msgid "Show what revision and author last modified each line of a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:365
+#: /tmp/fish/implicit/share/completions/git.fish:367
 msgid "Show blank SHA-1 for boundary commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:366
+#: /tmp/fish/implicit/share/completions/git.fish:368
 msgid "Do not treat root commits as boundaries"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:367
+#: /tmp/fish/implicit/share/completions/git.fish:369
 msgid "Include additional statistics"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:368
+#: /tmp/fish/implicit/share/completions/git.fish:370
 msgid "Annotate only the given line range"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:369
+#: /tmp/fish/implicit/share/completions/git.fish:371
 msgid "Show long rev"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:370
+#: /tmp/fish/implicit/share/completions/git.fish:372
 msgid "Show raw timestamp"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:371
+#: /tmp/fish/implicit/share/completions/git.fish:373
 msgid "Use revisions from named file instead of calling rev-list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:372
+#: /tmp/fish/implicit/share/completions/git.fish:374
 msgid "Walk history forward instead of backward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:373
+#: /tmp/fish/implicit/share/completions/git.fish:375
 msgid "Show in a format designed for machine consumption"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:374
+#: /tmp/fish/implicit/share/completions/git.fish:376
 msgid "Show the porcelain format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:375
+#: /tmp/fish/implicit/share/completions/git.fish:377
 msgid "Show the result incrementally"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:376
+#: /tmp/fish/implicit/share/completions/git.fish:378
 msgid "Instead of working tree, use the contents of the named file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:377
+#: /tmp/fish/implicit/share/completions/git.fish:379
 msgid "Specifies the format used to output dates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:378
+#: /tmp/fish/implicit/share/completions/git.fish:380
 msgid "Detect moved or copied lines within a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:379
+#: /tmp/fish/implicit/share/completions/git.fish:381
 msgid ""
 "Detect lines moved or copied from other files that were modified in the same "
 "commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:381
+#: /tmp/fish/implicit/share/completions/git.fish:383
 msgid "Use the same output mode as git-annotate"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:382
+#: /tmp/fish/implicit/share/completions/git.fish:384
 msgid "Show the filename in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:383
+#: /tmp/fish/implicit/share/completions/git.fish:385
 msgid "Show the line number in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:384
+#: /tmp/fish/implicit/share/completions/git.fish:386
 msgid "Suppress the author name and timestamp from the output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:385
+#: /tmp/fish/implicit/share/completions/git.fish:387
 msgid "Show the author email instead of author name"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:386
+#: /tmp/fish/implicit/share/completions/git.fish:388
 msgid "Ignore whitespace changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:387
+#: /tmp/fish/implicit/share/completions/git.fish:389
 msgid "Custom command"
 msgstr ""
 
@@ -26634,6 +27398,7 @@ msgid "List all keys with their fingerprints"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
+#: /tmp/fish/implicit/share/completions/signify.fish:2
 msgid "Generate a new key pair"
 msgstr ""
 
@@ -35557,13 +36322,6 @@ msgstr ""
 msgid "Display values currently set in the minikube config file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/minikube.fish:25
-#: /tmp/fish/implicit/share/completions/minikube.fish:26
-#: /tmp/fish/implicit/share/completions/minikube.fish:27
-#: /tmp/fish/implicit/share/completions/minikube.fish:28
-msgid "Property"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/minikube.fish:29
 msgid "Go template format string for the config view output"
 msgstr ""
@@ -41528,11 +42286,6 @@ msgstr ""
 msgid "keep going until N jobs fail [default=1]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ninja.fish:8
-#: /tmp/fish/implicit/share/completions/quilt.fish:1
-msgid "show help"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/ninja.fish:9
 msgid "enable debugging, specify debug mode"
 msgstr ""
@@ -44809,6 +45562,18 @@ msgstr ""
 msgid "Extract script"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pfctl.fish:1
+msgid "Show a filter parameter by modifier"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:2
+msgid "Flush filter params specified by mod"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:3
+msgid "Table command"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pgrep.fish:1
 msgid "Output delimiter"
 msgstr ""
@@ -45017,6 +45782,27 @@ msgstr ""
 msgid "omit the user's full name, remote host and idle time in short format"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:1
+msgid "failsafe to overwrite"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:2
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:3
+msgid "Turn on stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:3
+msgid "Automated package installation"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:5
+msgid "Update packages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:6
+msgid "Fuzzy match"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:1
 msgid "Upgrade"
 msgstr ""
@@ -45119,6 +45905,10 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkg-config.fish:25
 msgid "List all modules the given packages requires for static linking"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:2
+msgid "Delete unsed deps"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkgfile.fish:3
@@ -49454,6 +50244,18 @@ msgstr ""
 msgid "Specifies layout variant used to choose component names"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/signify.fish:1
+msgid "Verify a signed checksum list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:3
+msgid "Sign specified message"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:4
+msgid "Verify a signed message and sig"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/snap.fish:1
 msgid "Test if snap has yet to be given the subcommand"
 msgstr ""
@@ -53254,10 +54056,12 @@ msgid "Monitor changes to objects"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:7
+#: /tmp/fish/implicit/share/completions/zfs.fish:17
 msgid "Mount a filesystem"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:18
 msgid "Unmount a filesystem"
 msgstr ""
 
@@ -57789,6 +58593,604 @@ msgstr ""
 msgid "Delete all cache contents"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/zfs.fish:1
+msgid ""
+"Internal completion function for appending string to the ZFS commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:2
+#: /tmp/fish/implicit/share/completions/zpool.fish:2
+msgid "Display a help message"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:3
+msgid "Create a volume or filesystem"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:4
+msgid "Destroy a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:5
+msgid "Create a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:6
+msgid "Roll back a filesystem to a previous snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:7
+msgid "Create a clone of a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:8
+msgid ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:9
+msgid "Rename a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:10
+msgid "List dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:11
+msgid "Set a dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:12
+msgid "Get one or several dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:13
+msgid "Set a dataset property to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:14
+msgid "List upgradeable datasets, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:15
+msgid "Get dataset space consumed by each user"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:16
+msgid "Get dataset space consumed by each user group"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:19
+msgid "Share a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:20
+msgid "Stop sharing a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:21
+msgid "Create a bookmark for a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:22
+msgid "Output a stream representation of a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:23
+msgid ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:24
+msgid ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:25
+msgid "Revoke delegations of rights on a dataset from (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:26
+msgid "Put a named hold on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:27
+msgid "List holds on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:28
+msgid "Remove a named hold from a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:29
+msgid ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:30
+msgid "Execute a ZFS Channel Program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:31
+#: /tmp/fish/implicit/share/completions/zfs.fish:53
+#: /tmp/fish/implicit/share/completions/zfs.fish:58
+msgid "Create all needed non-existing parent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:32
+#: /tmp/fish/implicit/share/completions/zfs.fish:33
+msgid "Dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:34
+msgid "Volume size"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:35
+msgid "Create a sparse volume"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:36
+msgid "Blocksize"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:37
+msgid "Recursively destroy children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:38
+msgid "Recursively destroy all dependents"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:39
+msgid "Force unmounting"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:41
+msgid "Print machine-parsable verbose information"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:43
+msgid "Defer snapshot deletion"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:44
+msgid "Dataset to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:45
+msgid "Recursively snapshot children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:46
+#: /tmp/fish/implicit/share/completions/zfs.fish:47
+msgid "Snapshot property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:48
+msgid "Dataset to snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:49
+msgid "Destroy later snapshot and bookmarks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:50
+msgid "Recursively destroy later snapshot, bookmarks and clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:51
+msgid "Force unmounting of clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:52
+msgid "Snapshot to roll back to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:54
+#: /tmp/fish/implicit/share/completions/zfs.fish:55
+msgid "Clone property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:56
+msgid "Snapshot to clone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:57
+msgid "Clone to promote"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:59
+msgid "Recursively rename children snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:60
+#: /tmp/fish/implicit/share/completions/zfs.fish:62
+#: /tmp/fish/implicit/share/completions/zfs.fish:108
+msgid "Force unmounting if needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:61
+msgid "Do not remount filesystems during rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:63
+msgid "Dataset to rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:64
+#: /tmp/fish/implicit/share/completions/zfs.fish:77
+#: /tmp/fish/implicit/share/completions/zfs.fish:94
+#: /tmp/fish/implicit/share/completions/zfs.fish:172
+#: /tmp/fish/implicit/share/completions/zpool.fish:59
+#: /tmp/fish/implicit/share/completions/zpool.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:99
+msgid "Print output in a machine-parsable format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:65
+#: /tmp/fish/implicit/share/completions/zfs.fish:75
+#: /tmp/fish/implicit/share/completions/zfs.fish:84
+#: /tmp/fish/implicit/share/completions/zfs.fish:89
+msgid "Operate recursively on datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:105
+msgid "Property to list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:68
+#: /tmp/fish/implicit/share/completions/zfs.fish:80
+#: /tmp/fish/implicit/share/completions/zfs.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:66
+msgid "Print parsable (exact) values for numbers"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:69
+#: /tmp/fish/implicit/share/completions/zfs.fish:97
+msgid "Property to use for sorting output by ascending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:70
+#: /tmp/fish/implicit/share/completions/zfs.fish:98
+msgid "Property to use for sorting output by descending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:72
+msgid "Dataset which properties is to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:73
+#: /tmp/fish/implicit/share/completions/zpool.fish:125
+msgid "Property to set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:74
+msgid "Dataset which property is to be setted"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:78
+#: /tmp/fish/implicit/share/completions/zpool.fish:68
+msgid "Fields to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:79
+msgid "Property source to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:82
+msgid "Property to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:83
+msgid "Dataset which properties is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:85
+msgid "Revert to the received value if available"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:86
+msgid "Dataset which properties is to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:88
+msgid "Upgrade all eligible filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:90
+msgid "Upgrade to the specified version"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:91
+msgid "Filesystem to upgrade"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:92
+msgid "Print UID instead of user name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:93
+msgid "Print GID instead of group name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:96
+msgid "Field to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:99
+#: /tmp/fish/implicit/share/completions/zfs.fish:100
+msgid "Identity types to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:101
+msgid "Translate S(amba)ID to POSIX ID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:102
+msgid "Dataset which space usage is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:103
+msgid "Temporary mount point property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:104
+msgid "Report progress"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:105
+msgid "Mount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:106
+msgid "Overlay mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:107
+msgid "Filesystem to mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:109
+msgid "Unmount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:110
+msgid "Filesystem to unmount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:111
+msgid "Share all eligible ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:112
+msgid "Filesystem to share"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:113
+msgid "Unshare all shared ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:114
+msgid "Filesystem to unshare"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:115
+msgid "Snapshot to bookmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:116
+msgid "Generate incremental stream from snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:117
+msgid ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:118
+#: /tmp/fish/implicit/share/completions/zfs.fish:127
+msgid "Include children in replication stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:119
+#: /tmp/fish/implicit/share/completions/zfs.fish:128
+msgid "Generate a deduplicated stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:120
+#: /tmp/fish/implicit/share/completions/zfs.fish:129
+msgid "Allow the presence of larger blocks than 128 kiB"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:121
+#: /tmp/fish/implicit/share/completions/zfs.fish:130
+msgid "Generate a more compact stream by using WRITE_EMBEDDED records"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:122
+#: /tmp/fish/implicit/share/completions/zfs.fish:131
+msgid "Print verbose information about the stream in a machine-parsable format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:123
+msgid "Generate compressed stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:125
+#: /tmp/fish/implicit/share/completions/zfs.fish:133
+msgid "Include dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:126
+#: /tmp/fish/implicit/share/completions/zfs.fish:134
+msgid "Print verbose information about the stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:135
+msgid "Dataset to send"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:136
+msgid ""
+"Print verbose information about the stream and the time spent processing it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:137
+msgid "Dry run: do not actually receive the stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:138
+msgid "Force rollback to the most recent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:139
+msgid "Unmount the target filesystem"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:140
+msgid "Discard the first element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:141
+msgid "Discard all but the last element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:142
+msgid "Force the stream to be received as a clone of the given snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:143
+msgid "On transfer interruption, store a receive_resume_token for resumption"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:144
+msgid "Dataset to receive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:145
+msgid "Delegate permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:146
+msgid "Delegate permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:147
+msgid "User to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:148
+msgid "Group to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:149
+#: /tmp/fish/implicit/share/completions/zfs.fish:150
+msgid "Delegate permission to everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:151
+msgid "Delegate permissions only to the creator of later descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:152
+msgid "Create a permission set or add permissions to an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:153
+msgid "Dataset on which delegation is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:154
+msgid "Remove permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:155
+msgid "Remove permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:156
+msgid "User to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:157
+msgid "Group to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:158
+#: /tmp/fish/implicit/share/completions/zfs.fish:162
+#: /tmp/fish/implicit/share/completions/zfs.fish:163
+msgid "Remove permission from everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:159
+msgid "Remove permissions only on later created descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:160
+msgid "Remove a permission set or remove permissions from an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:161
+msgid "Remove permissions recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:164
+msgid "Dataset on which delegation is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:165
+msgid "Apply hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:166
+msgid "Snapshot on which hold is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:167
+msgid "List holds recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:168
+msgid "Snapshot which holds are to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:169
+msgid "Release hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:170
+msgid "Snapshot from which hold is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:171
+msgid "Display file type (à la ls -F)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:173
+msgid "Display inode change time"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:174
+msgid "Source snapshot for the diff"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:175
+msgid "Execution timeout"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:176
+msgid "Execution memory limit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:177
+msgid "Pool which program will be executed on"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/zip.fish:1
 msgid "Freshen: only changed files"
 msgstr ""
@@ -57891,6 +59293,469 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zip.fish:29
 msgid "Don't compress files with these suffixes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:1
+msgid ""
+"Internal completion function for appending string to the zpool commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:3
+msgid "Add new virtual devices to pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:4
+msgid "Attach virtual device to a pool device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:5
+msgid "Clear devices errors in pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:6
+msgid "Create a new storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:7
+msgid "Destroy a storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:8
+msgid "Detach virtual device from a mirroring pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:9
+msgid "Display pool event log"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:10
+msgid "Export a pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:11
+msgid "Get one or several pool properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:12
+msgid "Display pool command history"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:13
+msgid "List importable pools, or import some"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:14
+msgid "Display pool I/O stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:15
+msgid "Remove ZFS label information from the specified device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:16
+msgid "List pools with health status and space usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:17
+msgid "Take the specified devices offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:18
+msgid "Bring the specified devices back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:19
+msgid "Reset pool GUID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:20
+msgid "Remove virtual devices from pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:21
+msgid "Reopen pool devices"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:22
+msgid "Replace a pool virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:23
+msgid "Start or stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:24
+msgid "Set a pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:25
+msgid "Create a pool by splitting an existing mirror one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:26
+msgid "Display detailed pool health status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:27
+msgid "List upgradeable pools, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:28
+#: /tmp/fish/implicit/share/completions/zpool.fish:36
+#: /tmp/fish/implicit/share/completions/zpool.fish:45
+#: /tmp/fish/implicit/share/completions/zpool.fish:117
+msgid "Force use of virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:29
+#: /tmp/fish/implicit/share/completions/zpool.fish:130
+msgid "Dry run: only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:30
+#: /tmp/fish/implicit/share/completions/zpool.fish:91
+#: /tmp/fish/implicit/share/completions/zpool.fish:100
+#: /tmp/fish/implicit/share/completions/zpool.fish:127
+#: /tmp/fish/implicit/share/completions/zpool.fish:135
+msgid "Display virtual device GUID instead of device name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:31
+#: /tmp/fish/implicit/share/completions/zpool.fish:92
+#: /tmp/fish/implicit/share/completions/zpool.fish:101
+#: /tmp/fish/implicit/share/completions/zpool.fish:128
+#: /tmp/fish/implicit/share/completions/zpool.fish:136
+msgid "Resolve device path symbolic links"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:32
+#: /tmp/fish/implicit/share/completions/zpool.fish:93
+#: /tmp/fish/implicit/share/completions/zpool.fish:102
+#: /tmp/fish/implicit/share/completions/zpool.fish:129
+#: /tmp/fish/implicit/share/completions/zpool.fish:137
+msgid "Display device full path"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:33
+#: /tmp/fish/implicit/share/completions/zpool.fish:37
+#: /tmp/fish/implicit/share/completions/zpool.fish:48
+#: /tmp/fish/implicit/share/completions/zpool.fish:118
+#: /tmp/fish/implicit/share/completions/zpool.fish:132
+msgid "Pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:34
+msgid "Pool to add virtual devices to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:35
+#: /tmp/fish/implicit/share/completions/zpool.fish:53
+msgid "Virtual device to add"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:38
+msgid "Pool to attach virtual device to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:39
+#: /tmp/fish/implicit/share/completions/zpool.fish:43
+msgid "Virtual device to operate on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:40
+msgid "Initiate recovery mode"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:41
+#: /tmp/fish/implicit/share/completions/zpool.fish:85
+msgid ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:42
+msgid "Pool to clear errors on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:44
+msgid ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:46
+msgid "Dry run, only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:47
+msgid "Do not enable any feature on the new pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:49
+msgid "Root filesystem property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:50
+#: /tmp/fish/implicit/share/completions/zpool.fish:83
+msgid "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:51
+msgid "Root filesystem mountpoint"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:52
+msgid "Set a different in-core pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:54
+#: /tmp/fish/implicit/share/completions/zpool.fish:64
+msgid "Force unmounting of all contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:55
+msgid "Pool to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:56
+msgid "Pool to detach device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:57
+msgid "Physical device to detach"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:58
+msgid "Print verbose event information"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:60
+msgid "Output appended data as the log grows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:61
+msgid "Clear all previous events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:62
+msgid "Pool to read events from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:63
+msgid "Export all pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:65
+msgid "Pool to export"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:69
+msgid "Properties to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:70
+msgid "Pool to get properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:71
+msgid "Also display internal events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:72
+msgid "Display log records using long format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:73
+msgid "Pool to get command history of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:74
+msgid "Read configuration from specified cache file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:75
+msgid "Search for devices or files in specified directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:76
+msgid "List or import destroyed pools only (requires -f for importation)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:77
+#: /tmp/fish/implicit/share/completions/zpool.fish:133
+msgid "Mount properties for contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:78
+msgid "Properties of the imported pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:79
+msgid "Force import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:80
+msgid "Recovery mode"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:81
+msgid "Search for and import all pools found"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:82
+msgid "Ignore missing log device (risk of loss of last changes)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:84
+msgid "Do not mount contained filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:86
+msgid "Roll back to a previous TXG (hazardous)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:87
+msgid "TXG to roll back to (implies -FX)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:88
+msgid "Specify, as the last argument, a temporary pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:89
+msgid "Pool to import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:90
+#: /tmp/fish/implicit/share/completions/zpool.fish:103
+#: /tmp/fish/implicit/share/completions/zpool.fish:142
+msgid "Display a timestamp using specified format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:94
+msgid "Omit statistics since boot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:104
+msgid "Print verbose statistics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:96
+msgid "Pool to retrieve I/O stats from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:97
+msgid "Treat exported or foreign devices as inactive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:98
+msgid "Device to clear ZFS label information from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:106
+msgid "Pool to list properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:107
+msgid "Temporarily offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:108
+msgid "Pool to offline device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:109
+msgid "Physical device to offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:110
+msgid "Expand the device to use all available space"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:111
+msgid "Pool to bring device back online on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:112
+msgid "Physical device to bring back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:113
+msgid "Pool which GUID is to be changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:114
+msgid "Pool to remove device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:115
+msgid "Physical device to remove"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:116
+msgid "Pool which devices are to be reopened"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:119
+msgid "Pool to replace device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:120
+msgid "Pool device to be replaced"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:121
+msgid "Device to use for replacement"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:122
+msgid "Stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:123
+msgid "Pause scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:124
+msgid "Pool to start/stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:126
+msgid "Pool which property is to be set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:131
+msgid "Set altroot for newpool and automatically import it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:134
+msgid "Pool to split"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:138
+#: /tmp/fish/implicit/share/completions/zpool.fish:139
+msgid "Display deduplication histogram"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:141
+msgid "Only display status for unhealthy or unavailable pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:143
+#: /tmp/fish/implicit/share/completions/zpool.fish:147
+msgid "Pool which status is to be displayed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:144
+msgid "Upgrade all eligible pools, enabling all supported features"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:145
+msgid "Display upgradeable ZFS versions"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:146
+msgid "Upgrade to the specified legacy version"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:2
@@ -59359,6 +61224,28 @@ msgstr ""
 msgid "Complete wvdial peers"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+msgid "Completes with ZFS mountpoint properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_pools.fish:1
+msgid "Completes with available ZFS pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+msgid "Completes with ZFS read-only properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Completes with ZFS read-write properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr ""
@@ -59516,6 +61403,12 @@ msgstr ""
 msgid "Test if current token is on Nth place"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_is_zfs_feature_enabled.fish:1
+msgid ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_list_current_token.fish:1
 msgid ""
 "List contents of token under the cursor if it is a directory, otherwise list "
@@ -59592,6 +61485,10 @@ msgid ""
 "current directory"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
+msgid "Print a list of local groups"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr ""
@@ -59658,6 +61555,22 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
+msgid "Lists ZFS bookmarks, if the feature is enabled"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
+msgid "Lists ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
+msgid "Lists ZFS snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
+msgid "Lists ZFS volumes"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-13 10:22+0100\n"
 "PO-Revision-Date: 2017-01-07 10:24:59+0000\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
@@ -1828,9 +1828,11 @@ msgstr "Link wykonywalny"
 #: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
 #: /tmp/fish/implicit/share/completions/fossil.fish:90
 #: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:206
-#: /tmp/fish/implicit/share/completions/git.fish:266
-#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:269
 msgid "File"
 msgstr "Plik"
 
@@ -2530,6 +2532,565 @@ msgstr ""
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/zfs.fish:1
+msgid "ZFS filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:2
+msgid "ZFS filesystem snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:3
+#, fuzzy
+msgid "ZFS block storage device"
+msgstr "Nie określono bloków"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:4
+msgid "ZFS snapshot bookmark"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:5
+msgid "Any ZFS dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:6
+msgid "Dataset-specific value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:7
+msgid "Default ZFS value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:8
+msgid "Value inherited from parent dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:9
+msgid "Value received by 'zfs receive'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:10
+#, fuzzy
+msgid "Value valid for the current mount"
+msgstr "Zatrzymaj obecnie używaną funkcję"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:11
+msgid "Read-only value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:12
+msgid "Dataset full name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:13
+#: /tmp/fish/explicit/share/completions/zpool.fish:2
+#: /tmp/fish/implicit/share/completions/minikube.fish:25
+#: /tmp/fish/implicit/share/completions/minikube.fish:26
+#: /tmp/fish/implicit/share/completions/minikube.fish:27
+#: /tmp/fish/implicit/share/completions/minikube.fish:28
+msgid "Property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:3
+msgid "Property value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:15
+#: /tmp/fish/explicit/share/completions/zpool.fish:4
+msgid "Property value origin"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:16
+msgid "Identity type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:17
+#, fuzzy
+msgid "Identity name"
+msgstr "Nazwa procesu"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:18
+msgid "Space usage"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:19
+msgid "Space quota"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:20
+msgid "POSIX user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:21
+msgid "Samba user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:22
+#: /tmp/fish/explicit/share/completions/zfs.fish:25
+msgid "Both types"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:23
+msgid "POSIX group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:24
+msgid "Samba group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:26
+msgid "Also needs the permission to be allowed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:27
+msgid ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:28
+#: /tmp/fish/explicit/share/completions/zfs.fish:29
+#: /tmp/fish/explicit/share/completions/zfs.fish:33
+#: /tmp/fish/explicit/share/completions/zfs.fish:35
+msgid "Also needs the 'mount' permission"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:30
+msgid ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:31
+msgid "Also needs the 'create' and 'mount' permissions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:32
+msgid "Also needs the 'create' and 'mount' permissions in the new parent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:34
+msgid "For SMB and NFS shares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:36
+msgid "Allows changing any user property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:26
+msgid "Volume block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:38
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Inheritance of ACL entries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:39
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:2
+msgid "Update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:40
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:3
+msgid "Is the dataset mountable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:41
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:4
+msgid "Data checksum"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:42
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:5
+msgid "Compression algorithm"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:43
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:6
+msgid "Number of copies of data"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:44
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:7
+msgid "Deduplication"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:45
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:2
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:8
+msgid "Are contained device nodes openable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:46
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:3
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:9
+msgid "Can contained executables be executed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:47
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:10
+msgid "Max number of filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:48
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:11
+msgid "Mountpoint"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:49
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:12
+msgid "Which data to cache in ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:50
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:13
+msgid "Max size of dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:51
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:14
+#, fuzzy
+msgid "Max number of snapshots"
+msgstr "Wylicz liczbę argumentów"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:52
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:4
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:15
+msgid "Read-only"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:53
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:16
+msgid "Suggest block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:54
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:17
+msgid "How redundant are the metadata"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:55
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:18
+msgid "Max space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:56
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:19
+msgid "Min space guaranteed to dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:57
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:20
+msgid "Min space guaranteed to dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:58
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:21
+msgid "Which data to cache in L2ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:59
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:5
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:22
+msgid "Respect set-UID bit"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:60
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:23
+msgid "Share in NFS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:61
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:24
+msgid "Hint for handling of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:62
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:25
+#, fuzzy
+msgid "Hide .zfs directory"
+msgstr "Zwróć katalog roboczy"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:63
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:26
+msgid "Handle of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:64
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:27
+msgid "Volume logical size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:65
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:38
+msgid "Managed from a non-global zone"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:66
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:31
+msgid "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:67
+#: /tmp/fish/explicit/share/completions/zfs.fish:74
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:6
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:32
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:40
+msgid "Mount with Non Blocking mandatory locks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:68
+#: /tmp/fish/explicit/share/completions/zfs.fish:77
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:33
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:43
+msgid "Share in Samba"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:69
+#: /tmp/fish/explicit/share/completions/zfs.fish:76
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:34
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:42
+msgid "Share as an iSCSI target"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:70
+#: /tmp/fish/explicit/share/completions/zfs.fish:79
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:35
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:45
+msgid "On-disk version of filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:71
+#: /tmp/fish/explicit/share/completions/zfs.fish:80
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:36
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:46
+msgid "Scan regular files for viruses on opening and closing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:72
+#: /tmp/fish/explicit/share/completions/zfs.fish:81
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:7
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:47
+msgid "Extended attributes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:73
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:39
+msgid "Use no ACL or POSIX ACL"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:75
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:9
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:41
+msgid "Sometimes update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:78
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:44
+msgid "Hide volume snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:82
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:30
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:48
+msgid "How is ACL modified by chmod"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:83
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:49
+msgid "How to expose volumes to OS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:84
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+#, fuzzy
+msgid "Unicode normalization"
+msgstr "Zwróć informacje o fish"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:85
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:2
+msgid "Reject non-UTF-8-compliant filenames"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:86
+#: /tmp/fish/explicit/share/completions/zfs.fish:87
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:9
+msgid "Case sensitivity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:88
+msgid "Space properties"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:89
+#: /tmp/fish/explicit/share/completions/zfs.fish:90
+#, fuzzy
+msgid "Dataset name"
+msgstr "Nazwa procesu"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:1
+#, fuzzy
+msgid "Pool full name"
+msgstr "Wypisz argumenty"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:5
+msgid "Mirror of at least two devices"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:6
+#: /tmp/fish/explicit/share/completions/zpool.fish:7
+msgid "ZFS RAID-5 variant, single parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:8
+msgid "ZFS RAID-5 variant, double parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:9
+msgid "ZFS RAID-5 variant, triple parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:10
+msgid "Pseudo vdev for pool hot spares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:11
+msgid "SLOG device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:12
+msgid "L2ARC device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:13
+msgid "Physically allocated space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:2
+#, fuzzy
+msgid "Available space"
+msgstr "Zmienna"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:16
+msgid "System boot partition size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:17
+msgid "Usage percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:18
+#, fuzzy
+msgid "Deduplication ratio"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:19
+msgid "Amount of uninitialized space within the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:20
+msgid "Fragmentation percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:21
+msgid "Free pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:22
+msgid "Remaining pool space to be freed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:23
+msgid "Pool GUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:24
+msgid "Current pool health"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:25
+msgid "Total pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:26
+msgid "Used pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:27
+msgid "Pool sector size exponent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:28
+#: /tmp/fish/explicit/share/completions/zpool.fish:29
+#, fuzzy
+msgid "Alternate root directory"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:30
+#: /tmp/fish/explicit/share/completions/zpool.fish:31
+msgid "Import pool in read-only mode"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:32
+#: /tmp/fish/explicit/share/completions/zpool.fish:33
+msgid "Automatic pool expansion on LUN growing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:34
+#: /tmp/fish/explicit/share/completions/zpool.fish:35
+msgid "Automatic use of replacement device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:36
+msgid "Default bootable dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:37
+#, fuzzy
+msgid "Pool configuration cache"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:38
+msgid "Comment about the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:39
+msgid "Threshold for writting a ditto copy of deduplicated blocks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:40
+msgid "Allow rights delegation on the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:41
+msgid "Behavior in case of catastrophic pool failure"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:42
+msgid "Display snapshots even if 'zfs list' does not use '-t'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:43
+msgid "On-disk version of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:44
+msgid "%sEnable the %s feature\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:45
+msgid "All properties"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/abbr.fish:1
 #, fuzzy
 msgid "%s: Could not figure out what to do!\\n"
@@ -2669,6 +3230,135 @@ msgstr ""
 msgid "%s\\tArchived file\\n"
 msgstr ""
 
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:3
+msgid "Achieved compression ratio"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:4
+msgid "Dataset creation time"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:5
+msgid "Snapshot clones"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:6
+msgid "Marked for deferred destruction"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:7
+msgid "Total lower-level filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:9
+msgid "Logical total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:11
+msgid "Logical used space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:12
+msgid "Is currently mounted?"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:13
+msgid "Source snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:14
+msgid "Token for interrupted reception resumption"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:16
+msgid "Total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:17
+msgid "Achieved compression ratio of referenced space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:18
+msgid "Total lower-level snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:19
+#: /tmp/fish/implicit/share/completions/zfs.fish:71
+#: /tmp/fish/implicit/share/completions/zfs.fish:81
+msgid "Dataset type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:20
+msgid "Space used by dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:21
+msgid "Space used by children datasets"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:22
+msgid "Space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:23
+msgid "Space used by refreservation"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:24
+msgid "Space used by dataset snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:25
+msgid "Holds count"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:27
+msgid "Referenced data written since previous snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:28
+msgid "%sDataset space use by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:29
+msgid "%sDataset space use by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:30
+msgid "%sReferenced data written since snapshot %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:28
+msgid "%sMax usage by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:29
+msgid "%sMax usage by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:3
+msgid "Allow overlay mount"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:4
+msgid "SELinux context for the child filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:5
+msgid "SELinux context for the filesystem being mounted"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:6
+msgid "SELinux context for unlabeled files"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:7
+msgid "SELinux context for the root inode of the filesystem"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr ""
@@ -2694,6 +3384,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/aptitude.fish:3
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:3
 #: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:63
 #: /tmp/fish/implicit/share/completions/wajig.fish:3
@@ -5121,7 +5813,10 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/valgrind.fish:6
 #: /tmp/fish/implicit/share/completions/vi.fish:8
 #: /tmp/fish/implicit/share/completions/wget.fish:9
+#: /tmp/fish/implicit/share/completions/zfs.fish:42
+#: /tmp/fish/implicit/share/completions/zfs.fish:87
 #: /tmp/fish/implicit/share/completions/zip.fish:13
+#: /tmp/fish/implicit/share/completions/zpool.fish:140
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
 msgid "Verbose mode"
 msgstr ""
@@ -9818,7 +10513,7 @@ msgid "Show usage message and options"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:380
+#: /tmp/fish/implicit/share/completions/git.fish:382
 msgid "Show help message"
 msgstr ""
 
@@ -14522,7 +15217,7 @@ msgid "Ignore all white space"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:325
+#: /tmp/fish/implicit/share/completions/git.fish:327
 msgid "Ignore changes whose lines are all blank"
 msgstr ""
 
@@ -14531,7 +15226,7 @@ msgid "Ignore changes whose lines match the REGEX"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:321
+#: /tmp/fish/implicit/share/completions/git.fish:323
 msgid "Treat all files as text"
 msgstr ""
 
@@ -16384,6 +17079,84 @@ msgstr ""
 msgid "X display to use"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/exercism.fish:1
+msgid "Test if exercism has yet to be given the subcommand"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:3
+msgid "turn on verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:4
+#: /tmp/fish/implicit/share/completions/exercism.fish:19
+#: /tmp/fish/implicit/share/completions/ninja.fish:8
+#: /tmp/fish/implicit/share/completions/quilt.fish:1
+msgid "show help"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:5
+#, fuzzy
+msgid "print the version"
+msgstr "Zwróć katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:6
+msgid "Writes config values to a JSON file."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:7
+#, fuzzy
+msgid "Outputs useful debug information."
+msgstr "Zwróć informacje o fish"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:8
+msgid "Downloads a solution given the ID of the latest iteration."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:9
+msgid "Fetches the next unsubmitted problem in each track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:10
+msgid "Lists the available problems for a language track, given its ID."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:11
+msgid ""
+"Opens exercism.io to your most recent iteration of a problem given the track "
+"ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:12
+msgid ""
+"Downloads the most recent iteration for each of your solutions on exercism."
+"io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:13
+msgid "Skips a problem given a track ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:14
+msgid "Fetches information about your progress with a given language track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:15
+msgid "Submits a new iteration to a problem on exercism.io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:16
+#, fuzzy
+msgid "Lists the available language tracks."
+msgstr "Zwraca sformatowany tekst"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:17
+msgid "REMOVED"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:18
+msgid "Upgrades the CLI to the latest released version."
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/exit.fish:2
 msgid "Quit with normal exit status"
 msgstr ""
@@ -17142,6 +17915,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:66
+#: /tmp/fish/implicit/share/completions/zfs.fish:76
 msgid "Maximum recursion depth"
 msgstr ""
 
@@ -18400,9 +19175,9 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/fossil.fish:280
 #: /tmp/fish/implicit/share/completions/git.fish:64
 #: /tmp/fish/implicit/share/completions/git.fish:86
-#: /tmp/fish/implicit/share/completions/git.fish:244
-#: /tmp/fish/implicit/share/completions/git.fish:293
-#: /tmp/fish/implicit/share/completions/git.fish:294
+#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:296
 msgid "Tag"
 msgstr ""
 
@@ -18808,7 +19583,7 @@ msgid "Limit number of tags"
 msgstr "Wylicz liczbę argumentów"
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:281
-#: /tmp/fish/implicit/share/completions/git.fish:291
+#: /tmp/fish/implicit/share/completions/git.fish:293
 msgid "List tags"
 msgstr ""
 
@@ -18903,6 +19678,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gsettings.fish:15
 #: /tmp/fish/implicit/share/completions/ncdu.fish:1
 #: /tmp/fish/implicit/share/completions/obnam.fish:12
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:4
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:5
 #: /tmp/fish/implicit/share/completions/pkginfo.fish:7
 #: /tmp/fish/implicit/share/completions/pkgmk.fish:17
@@ -25027,24 +25803,24 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:96
 #: /tmp/fish/implicit/share/completions/git.fish:108
 #: /tmp/fish/implicit/share/completions/git.fish:130
-#: /tmp/fish/implicit/share/completions/git.fish:134
-#: /tmp/fish/implicit/share/completions/git.fish:140
-#: /tmp/fish/implicit/share/completions/git.fish:183
-#: /tmp/fish/implicit/share/completions/git.fish:219
-#: /tmp/fish/implicit/share/completions/git.fish:222
-#: /tmp/fish/implicit/share/completions/git.fish:242
-#: /tmp/fish/implicit/share/completions/git.fish:265
-#: /tmp/fish/implicit/share/completions/git.fish:285
-#: /tmp/fish/implicit/share/completions/git.fish:307
+#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:221
+#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:244
+#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:309
 msgid "Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:23
-#: /tmp/fish/implicit/share/completions/git.fish:198
-#: /tmp/fish/implicit/share/completions/git.fish:210
-#: /tmp/fish/implicit/share/completions/git.fish:237
-#: /tmp/fish/implicit/share/completions/git.fish:250
-#: /tmp/fish/implicit/share/completions/git.fish:274
+#: /tmp/fish/implicit/share/completions/git.fish:200
+#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:276
 #: /tmp/fish/implicit/share/completions/mdadm.fish:12
 #: /tmp/fish/implicit/share/completions/update-eix-remote.fish:1
 #, fuzzy
@@ -25054,10 +25830,10 @@ msgstr "Przymusowe wyjście"
 #: /tmp/fish/implicit/share/completions/git.fish:24
 #: /tmp/fish/implicit/share/completions/git.fish:41
 #: /tmp/fish/implicit/share/completions/git.fish:70
-#: /tmp/fish/implicit/share/completions/git.fish:199
-#: /tmp/fish/implicit/share/completions/git.fish:211
-#: /tmp/fish/implicit/share/completions/git.fish:238
-#: /tmp/fish/implicit/share/completions/git.fish:251
+#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:253
 #: /tmp/fish/implicit/share/completions/prt-get.fish:53
 #: /tmp/fish/implicit/share/completions/prt-get.fish:111
 #: /tmp/fish/implicit/share/completions/xz.fish:32
@@ -25065,12 +25841,12 @@ msgid "Be verbose"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:25
-#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:215
 msgid "Append ref names and object names"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:26
-#: /tmp/fish/implicit/share/completions/git.fish:214
+#: /tmp/fish/implicit/share/completions/git.fish:216
 msgid "Force update of local branches"
 msgstr ""
 
@@ -25218,7 +25994,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:63
 #: /tmp/fish/implicit/share/completions/git.fish:85
 #: /tmp/fish/implicit/share/completions/git.fish:109
-#: /tmp/fish/implicit/share/completions/git.fish:184
+#: /tmp/fish/implicit/share/completions/git.fish:186
 msgid "Remote branch"
 msgstr ""
 
@@ -25247,7 +26023,7 @@ msgid "Allow adding otherwise ignored files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:257
+#: /tmp/fish/implicit/share/completions/git.fish:259
 #, fuzzy
 msgid "Interactive mode"
 msgstr "Tylko dla zadań interaktywnych"
@@ -25299,7 +26075,7 @@ msgid "Remote Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:84
-#: /tmp/fish/implicit/share/completions/git.fish:243
+#: /tmp/fish/implicit/share/completions/git.fish:245
 msgid "Head"
 msgstr ""
 
@@ -25465,896 +26241,899 @@ msgstr ""
 msgid "Compare two paths on the filesystem"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:134
 msgid "Open diffs in a visual tool"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:136
 msgid "Visually show diff of changes in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:136
+#: /tmp/fish/implicit/share/completions/git.fish:138
 msgid "Print lines matching a pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:139
 msgid "Create an empty git repository or reinitialize an existing one"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:138
+#: /tmp/fish/implicit/share/completions/git.fish:140
 msgid "Show commit shortlog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:139
+#: /tmp/fish/implicit/share/completions/git.fish:141
 msgid "Show commit logs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:141
+#: /tmp/fish/implicit/share/completions/git.fish:143
 msgid "Continue listing file history beyond renames"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:144
 msgid "Don't print ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:143
+#: /tmp/fish/implicit/share/completions/git.fish:145
 msgid "Print out ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:144
+#: /tmp/fish/implicit/share/completions/git.fish:146
 msgid "Print ref name by which each commit was reached"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:145
+#: /tmp/fish/implicit/share/completions/git.fish:147
 msgid "Limit the number of commits before starting to show the commit output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:146
-msgid "Skip given number of commits"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:147
 #: /tmp/fish/implicit/share/completions/git.fish:148
-msgid "Show commits more recent than specified date"
+msgid "Skip given number of commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:149
 #: /tmp/fish/implicit/share/completions/git.fish:150
-msgid "Show commits older than specified date"
+msgid "Show commits more recent than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:151
-msgid "Limit commits from given author"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/git.fish:152
-msgid "Limit commits from given committer"
+msgid "Show commits older than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:153
-msgid "Limit commits to ones with reflog entries matching given pattern"
+msgid "Limit commits from given author"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:154
-msgid "Limit commits with message that match given pattern"
+msgid "Limit commits from given committer"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:155
-msgid "Limit commits to ones that match all given --grep"
+msgid "Limit commits to ones with reflog entries matching given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:156
-msgid "Limit commits to ones with message that don't match --grep"
+msgid "Limit commits with message that match given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:157
-msgid "Case insensitive match"
+msgid "Limit commits to ones that match all given --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:158
-msgid "Patterns are basic regular expressions (default)"
+msgid "Limit commits to ones with message that don't match --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:159
-msgid "Patterns are extended regular expressions"
+msgid "Case insensitive match"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:160
-msgid "Patterns are fixed strings"
+msgid "Patterns are basic regular expressions (default)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:161
-msgid "Patterns are Perl-compatible regular expressions"
+msgid "Patterns are extended regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:162
-msgid "Stop when given path disappears from tree"
+msgid "Patterns are fixed strings"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:163
-msgid "Print only merge commits"
+msgid "Patterns are Perl-compatible regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:164
-msgid "Don't print commits with more than one parent"
+msgid "Stop when given path disappears from tree"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:165
-msgid "Show only commit with at least the given number of parents"
+msgid "Print only merge commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:166
-msgid "Show only commit with at most the given number of parents"
+msgid "Don't print commits with more than one parent"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:167
-msgid "Show only commit without a mimimum number of parents"
+msgid "Show only commit with at least the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:168
-msgid "Show only commit without a maximum number of parents"
+msgid "Show only commit with at most the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:169
-msgid "Follow only the first parent commit upon seeing a merge commit"
+msgid "Show only commit without a mimimum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:170
-msgid "Reverse meaning of ^ prefix"
+msgid "Show only commit without a maximum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:171
+msgid "Follow only the first parent commit upon seeing a merge commit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:172
+msgid "Reverse meaning of ^ prefix"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:173
 msgid ""
 "Pretend as if all refs in refs/ are listed on the command line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:172
+#: /tmp/fish/implicit/share/completions/git.fish:174
 msgid ""
 "Pretend as if all refs are in refs/heads are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:173
+#: /tmp/fish/implicit/share/completions/git.fish:175
 msgid ""
 "Pretend as if all refs are in ref/tags are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:174
+#: /tmp/fish/implicit/share/completions/git.fish:176
 msgid ""
 "Pretend as if all refs in refs/remotes  are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:175
+#: /tmp/fish/implicit/share/completions/git.fish:177
 msgid ""
 "Pretend as if all refs matching shell glob are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:176
+#: /tmp/fish/implicit/share/completions/git.fish:178
 msgid "Do not include refs matching given glob pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:177
+#: /tmp/fish/implicit/share/completions/git.fish:179
 msgid ""
 "Pretend as if all objcets mentioned by reflogs are listed on the command "
 "line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:178
+#: /tmp/fish/implicit/share/completions/git.fish:180
 msgid "Ignore invalid object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:179
+#: /tmp/fish/implicit/share/completions/git.fish:181
 msgid "Read commits from stdin"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:180
+#: /tmp/fish/implicit/share/completions/git.fish:182
 msgid "Mark equivalent commits with = and inequivalent with +"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:181
+#: /tmp/fish/implicit/share/completions/git.fish:183
 msgid "Omit equivalent commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:182
+#: /tmp/fish/implicit/share/completions/git.fish:184
 msgid "Join two or more development histories together"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:187
 msgid "Autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:186
+#: /tmp/fish/implicit/share/completions/git.fish:188
 msgid "Don't autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:187
+#: /tmp/fish/implicit/share/completions/git.fish:189
 msgid "Edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:188
+#: /tmp/fish/implicit/share/completions/git.fish:190
 msgid "Don't edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:189
+#: /tmp/fish/implicit/share/completions/git.fish:191
 msgid "Don't generate a merge commit if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:190
+#: /tmp/fish/implicit/share/completions/git.fish:192
 msgid "Generate a merge commit even if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:191
+#: /tmp/fish/implicit/share/completions/git.fish:193
 msgid "Refuse to merge unless fast-forward possible"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:192
+#: /tmp/fish/implicit/share/completions/git.fish:194
 msgid "Populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:193
+#: /tmp/fish/implicit/share/completions/git.fish:195
 msgid "Don't populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:194
+#: /tmp/fish/implicit/share/completions/git.fish:196
 msgid "Show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:195
+#: /tmp/fish/implicit/share/completions/git.fish:197
 msgid "Don't show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:196
+#: /tmp/fish/implicit/share/completions/git.fish:198
 msgid "Squash changes from other branch as a single commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:197
+#: /tmp/fish/implicit/share/completions/git.fish:199
 msgid "Don't squash changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:200
-#: /tmp/fish/implicit/share/completions/git.fish:217
-#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:219
+#: /tmp/fish/implicit/share/completions/git.fish:241
 msgid "Force progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:203
 msgid "Force no progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:204
 msgid "Set the commit message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:203
+#: /tmp/fish/implicit/share/completions/git.fish:205
 msgid "Abort the current conflict resolution process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:204
+#: /tmp/fish/implicit/share/completions/git.fish:206
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:205
+#: /tmp/fish/implicit/share/completions/git.fish:207
 msgid "Use specific merge resolution program"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:207
+#: /tmp/fish/implicit/share/completions/git.fish:209
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:210
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:209
+#: /tmp/fish/implicit/share/completions/git.fish:211
 msgid "Fetch from and merge with another repository or a local branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:214
 msgid "Fetch all remotes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:215
+#: /tmp/fish/implicit/share/completions/git.fish:217
 msgid "Keep downloaded pack"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:216
+#: /tmp/fish/implicit/share/completions/git.fish:218
 msgid "Disable automatic tag following"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:218
-#: /tmp/fish/implicit/share/completions/git.fish:221
-#: /tmp/fish/implicit/share/completions/git.fish:241
+#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:243
 msgid "Remote alias"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:222
 msgid "Update remote refs along with associated objects"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:225
 msgid "Force-push branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:226
 msgid "Force-push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:225
+#: /tmp/fish/implicit/share/completions/git.fish:227
 msgid "Push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:226
+#: /tmp/fish/implicit/share/completions/git.fish:228
 msgid "Push all refs under refs/heads/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:227
+#: /tmp/fish/implicit/share/completions/git.fish:229
 msgid "Remove remote branches that don't have a local counterpart"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:228
+#: /tmp/fish/implicit/share/completions/git.fish:230
 msgid "Push all refs under refs/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:229
+#: /tmp/fish/implicit/share/completions/git.fish:231
 msgid "Delete all listed refs from the remote repository"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:230
+#: /tmp/fish/implicit/share/completions/git.fish:232
 msgid "Push all refs under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:231
+#: /tmp/fish/implicit/share/completions/git.fish:233
 msgid "Push all usual refs plus the ones under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:232
+#: /tmp/fish/implicit/share/completions/git.fish:234
 msgid "Do everything except actually send the updates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:233
+#: /tmp/fish/implicit/share/completions/git.fish:235
 msgid "Produce machine-readable output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:234
+#: /tmp/fish/implicit/share/completions/git.fish:236
 msgid "Force update of remote refs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:235
+#: /tmp/fish/implicit/share/completions/git.fish:237
 msgid ""
 "Force update of remote refs, stopping if other's changes would be overwritten"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:236
+#: /tmp/fish/implicit/share/completions/git.fish:238
 msgid "Add upstream (tracking) reference"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:242
 msgid "Forward-port local commits to the updated upstream head"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:245
+#: /tmp/fish/implicit/share/completions/git.fish:247
 msgid "Restart the rebasing process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:248
 msgid "Abort the rebase operation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:247
+#: /tmp/fish/implicit/share/completions/git.fish:249
 msgid "Keep the commits that don't cahnge anything"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:248
+#: /tmp/fish/implicit/share/completions/git.fish:250
 msgid "Restart the rebasing process by skipping the current patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:249
+#: /tmp/fish/implicit/share/completions/git.fish:251
 msgid "Use merging strategies to rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:254
 msgid "Show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:253
+#: /tmp/fish/implicit/share/completions/git.fish:255
 msgid "Don't show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:254
+#: /tmp/fish/implicit/share/completions/git.fish:256
 msgid "Allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:255
+#: /tmp/fish/implicit/share/completions/git.fish:257
 msgid "Don't allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:256
+#: /tmp/fish/implicit/share/completions/git.fish:258
 msgid "Force the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:258
+#: /tmp/fish/implicit/share/completions/git.fish:260
 msgid "Try to recreate merges"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:259
+#: /tmp/fish/implicit/share/completions/git.fish:261
 msgid "Rebase all reachable commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:260
+#: /tmp/fish/implicit/share/completions/git.fish:262
 msgid "Automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:261
+#: /tmp/fish/implicit/share/completions/git.fish:263
 msgid "No automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:262
+#: /tmp/fish/implicit/share/completions/git.fish:264
 msgid "No fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:263
+#: /tmp/fish/implicit/share/completions/git.fish:265
 msgid "Reset current HEAD to the specified state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:264
+#: /tmp/fish/implicit/share/completions/git.fish:266
 #, fuzzy
 msgid "Reset files in working directory"
 msgstr "Zwróć katalog roboczy"
 
-#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:270
 msgid "Reflog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: /tmp/fish/implicit/share/completions/git.fish:271
 msgid "Revert an existing commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:270
+#: /tmp/fish/implicit/share/completions/git.fish:272
 msgid "Remove files from the working tree and from the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:271
+#: /tmp/fish/implicit/share/completions/git.fish:273
 msgid "Keep local copies"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:272
+#: /tmp/fish/implicit/share/completions/git.fish:274
 msgid "Exit with a zero status even if no files matched"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:273
+#: /tmp/fish/implicit/share/completions/git.fish:275
 msgid "Allow recursive removal"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:275
+#: /tmp/fish/implicit/share/completions/git.fish:277
 msgid "Override the up-to-date check"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:276
+#: /tmp/fish/implicit/share/completions/git.fish:278
 #: /tmp/fish/implicit/share/completions/prt-get.fish:45
 #: /tmp/fish/implicit/share/completions/prt-get.fish:103
+#: /tmp/fish/implicit/share/completions/zfs.fish:40
+#: /tmp/fish/implicit/share/completions/zfs.fish:124
+#: /tmp/fish/implicit/share/completions/zfs.fish:132
 msgid "Dry run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:277
+#: /tmp/fish/implicit/share/completions/git.fish:279
 msgid "Show the working tree status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:278
+#: /tmp/fish/implicit/share/completions/git.fish:280
 msgid "Give the output in the short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:279
+#: /tmp/fish/implicit/share/completions/git.fish:281
 msgid "Show the branch and tracking info even in short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:280
+#: /tmp/fish/implicit/share/completions/git.fish:282
 msgid "Give the output in a stable, easy-to-parse format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:281
+#: /tmp/fish/implicit/share/completions/git.fish:283
 msgid "Terminate entries with null character"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:282
+#: /tmp/fish/implicit/share/completions/git.fish:284
 msgid "The untracked files handling mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:283
+#: /tmp/fish/implicit/share/completions/git.fish:285
 msgid "Ignore changes to submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:284
+#: /tmp/fish/implicit/share/completions/git.fish:286
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:286
+#: /tmp/fish/implicit/share/completions/git.fish:288
 msgid "Make an unsigned, annotated tag object"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:289
 msgid "Make a GPG-signed tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:288
+#: /tmp/fish/implicit/share/completions/git.fish:290
 msgid "Remove a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:289
+#: /tmp/fish/implicit/share/completions/git.fish:291
 msgid "Verify signature of a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:290
+#: /tmp/fish/implicit/share/completions/git.fish:292
 msgid "Force overwriting exising tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:292
+#: /tmp/fish/implicit/share/completions/git.fish:294
 msgid "List tags that contain a commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:297
 msgid "Stash away changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:296
+#: /tmp/fish/implicit/share/completions/git.fish:298
 msgid "List stashes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:297
+#: /tmp/fish/implicit/share/completions/git.fish:299
 msgid "Show the changes recorded in the stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:298
+#: /tmp/fish/implicit/share/completions/git.fish:300
 msgid "Apply and remove a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:299
+#: /tmp/fish/implicit/share/completions/git.fish:301
 msgid "Apply a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:300
+#: /tmp/fish/implicit/share/completions/git.fish:302
 msgid "Remove all stashed states"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:301
+#: /tmp/fish/implicit/share/completions/git.fish:303
 msgid "Remove a single stashed state from the stash list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:302
+#: /tmp/fish/implicit/share/completions/git.fish:304
 msgid "Create a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:303
+#: /tmp/fish/implicit/share/completions/git.fish:305
 msgid "Save a new stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:304
+#: /tmp/fish/implicit/share/completions/git.fish:306
 msgid "Create a new branch from a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:305
+#: /tmp/fish/implicit/share/completions/git.fish:307
 msgid "Set and read git configuration variables"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:306
+#: /tmp/fish/implicit/share/completions/git.fish:308
 msgid "Generate patch series to send upstream"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:308
+#: /tmp/fish/implicit/share/completions/git.fish:310
 msgid "Generate plain patches without diffstat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:309
+#: /tmp/fish/implicit/share/completions/git.fish:311
 msgid "Suppress diff output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:310
+#: /tmp/fish/implicit/share/completions/git.fish:312
 msgid "Spend more time to create smaller diffs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:311
+#: /tmp/fish/implicit/share/completions/git.fish:313
 msgid "Generate diff with the 'patience' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:312
+#: /tmp/fish/implicit/share/completions/git.fish:314
 msgid "Generate diff with the 'histogram' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:313
+#: /tmp/fish/implicit/share/completions/git.fish:315
 msgid "Print all commits to stdout in mbox format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:314
+#: /tmp/fish/implicit/share/completions/git.fish:316
 msgid "Show number of added/deleted lines in decimal notation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:315
+#: /tmp/fish/implicit/share/completions/git.fish:317
 msgid "Output only last line of the stat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:316
+#: /tmp/fish/implicit/share/completions/git.fish:318
 msgid "Output a condensed summary of extended header information"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:317
+#: /tmp/fish/implicit/share/completions/git.fish:319
 msgid "Disable rename detection"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:318
+#: /tmp/fish/implicit/share/completions/git.fish:320
 msgid "Show full blob object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:319
+#: /tmp/fish/implicit/share/completions/git.fish:321
 msgid "Output a binary diff for use with git apply"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:320
+#: /tmp/fish/implicit/share/completions/git.fish:322
 msgid "Also inspect unmodified files as source for a copy"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:322
+#: /tmp/fish/implicit/share/completions/git.fish:324
 msgid "Ignore changes in whitespace at EOL"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: /tmp/fish/implicit/share/completions/git.fish:325
 msgid "Ignore changes in amount of whitespace"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:324
+#: /tmp/fish/implicit/share/completions/git.fish:326
 msgid "Ignore whitespace when comparing lines"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:326
+#: /tmp/fish/implicit/share/completions/git.fish:328
 msgid "Show whole surrounding functions of changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: /tmp/fish/implicit/share/completions/git.fish:329
 msgid "Allow an external diff helper to be executed"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:328
+#: /tmp/fish/implicit/share/completions/git.fish:330
 msgid "Disallow external diff helpers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:329
+#: /tmp/fish/implicit/share/completions/git.fish:331
 msgid "Disallow external text conversion filters for binary files (Default)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:330
+#: /tmp/fish/implicit/share/completions/git.fish:332
 msgid ""
 "Allow external text conversion filters for binary files (Resulting diff is "
 "unappliable)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:331
+#: /tmp/fish/implicit/share/completions/git.fish:333
 msgid "Do not show source or destination prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:332
+#: /tmp/fish/implicit/share/completions/git.fish:334
 msgid "Name output in [Patch n/m] format, even with a single patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:333
+#: /tmp/fish/implicit/share/completions/git.fish:335
 msgid "Name output in [Patch] format, even with multiple patches"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:334
+#: /tmp/fish/implicit/share/completions/git.fish:336
 msgid "Initialize, update or inspect submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:335
+#: /tmp/fish/implicit/share/completions/git.fish:337
 msgid "Add a submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:336
+#: /tmp/fish/implicit/share/completions/git.fish:338
 msgid "Show submodule status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:337
-#: /tmp/fish/implicit/share/completions/git.fish:343
+#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:345
 msgid "Initialize all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:338
+#: /tmp/fish/implicit/share/completions/git.fish:340
 msgid "Update all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:341
 msgid "Show commit summary"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:340
+#: /tmp/fish/implicit/share/completions/git.fish:342
 #, fuzzy
 msgid "Run command on each submodule"
 msgstr "Uruchom komendę w obecnym procesie"
 
-#: /tmp/fish/implicit/share/completions/git.fish:341
+#: /tmp/fish/implicit/share/completions/git.fish:343
 msgid "Sync submodules' URL with .gitmodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:342
+#: /tmp/fish/implicit/share/completions/git.fish:344
 msgid "Only print error messages"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:344
+#: /tmp/fish/implicit/share/completions/git.fish:346
 msgid "Checkout the superproject's commit on a detached HEAD in the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:345
+#: /tmp/fish/implicit/share/completions/git.fish:347
 msgid ""
 "Merge the superproject's commit into the current branch of the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:346
+#: /tmp/fish/implicit/share/completions/git.fish:348
 msgid "Rebase current branch onto the superproject's commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:347
+#: /tmp/fish/implicit/share/completions/git.fish:349
 msgid "Don't fetch new objects from the remote"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:348
+#: /tmp/fish/implicit/share/completions/git.fish:350
 msgid ""
 "Instead of using superproject's SHA-1, use the state of the submodule's "
 "remote-tracking branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:349
+#: /tmp/fish/implicit/share/completions/git.fish:351
 msgid ""
 "Throw away local changes when switching to a different commit and always run "
 "checkout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:350
+#: /tmp/fish/implicit/share/completions/git.fish:352
 msgid "Also add ignored submodule path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:351
+#: /tmp/fish/implicit/share/completions/git.fish:353
 msgid "Remove even with local changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:352
+#: /tmp/fish/implicit/share/completions/git.fish:354
 msgid "Use the commit stored in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:353
+#: /tmp/fish/implicit/share/completions/git.fish:355
 msgid "Compare the commit in the index with submodule HEAD"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:354
+#: /tmp/fish/implicit/share/completions/git.fish:356
 msgid "Traverse submodules recursively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:355
+#: /tmp/fish/implicit/share/completions/git.fish:357
 msgid "Show logs with difference each commit introduces"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:356
+#: /tmp/fish/implicit/share/completions/git.fish:358
 msgid "Remove untracked files from the working tree"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:357
+#: /tmp/fish/implicit/share/completions/git.fish:359
 #, fuzzy
 msgid "Force run"
 msgstr "Przymusowe wyjście"
 
-#: /tmp/fish/implicit/share/completions/git.fish:358
+#: /tmp/fish/implicit/share/completions/git.fish:360
 msgid "Show what would be done and clean files interactively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:359
+#: /tmp/fish/implicit/share/completions/git.fish:361
 msgid "Don't actually remove anything, just show what would be done"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:360
+#: /tmp/fish/implicit/share/completions/git.fish:362
 msgid "Be quiet, only report errors"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:361
+#: /tmp/fish/implicit/share/completions/git.fish:363
 msgid "Remove untracked directories in addition to untracked files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:362
+#: /tmp/fish/implicit/share/completions/git.fish:364
 msgid "Remove ignored files, as well"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:363
+#: /tmp/fish/implicit/share/completions/git.fish:365
 msgid "Remove only ignored files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:364
+#: /tmp/fish/implicit/share/completions/git.fish:366
 msgid "Show what revision and author last modified each line of a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:365
+#: /tmp/fish/implicit/share/completions/git.fish:367
 msgid "Show blank SHA-1 for boundary commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:366
+#: /tmp/fish/implicit/share/completions/git.fish:368
 msgid "Do not treat root commits as boundaries"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:367
+#: /tmp/fish/implicit/share/completions/git.fish:369
 msgid "Include additional statistics"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:368
+#: /tmp/fish/implicit/share/completions/git.fish:370
 msgid "Annotate only the given line range"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:369
+#: /tmp/fish/implicit/share/completions/git.fish:371
 msgid "Show long rev"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:370
+#: /tmp/fish/implicit/share/completions/git.fish:372
 msgid "Show raw timestamp"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:371
+#: /tmp/fish/implicit/share/completions/git.fish:373
 msgid "Use revisions from named file instead of calling rev-list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:372
+#: /tmp/fish/implicit/share/completions/git.fish:374
 msgid "Walk history forward instead of backward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:373
+#: /tmp/fish/implicit/share/completions/git.fish:375
 msgid "Show in a format designed for machine consumption"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:374
+#: /tmp/fish/implicit/share/completions/git.fish:376
 msgid "Show the porcelain format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:375
+#: /tmp/fish/implicit/share/completions/git.fish:377
 msgid "Show the result incrementally"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:376
+#: /tmp/fish/implicit/share/completions/git.fish:378
 msgid "Instead of working tree, use the contents of the named file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:377
+#: /tmp/fish/implicit/share/completions/git.fish:379
 msgid "Specifies the format used to output dates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:378
+#: /tmp/fish/implicit/share/completions/git.fish:380
 msgid "Detect moved or copied lines within a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:379
+#: /tmp/fish/implicit/share/completions/git.fish:381
 msgid ""
 "Detect lines moved or copied from other files that were modified in the same "
 "commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:381
+#: /tmp/fish/implicit/share/completions/git.fish:383
 msgid "Use the same output mode as git-annotate"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:382
+#: /tmp/fish/implicit/share/completions/git.fish:384
 msgid "Show the filename in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:383
+#: /tmp/fish/implicit/share/completions/git.fish:385
 msgid "Show the line number in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:384
+#: /tmp/fish/implicit/share/completions/git.fish:386
 msgid "Suppress the author name and timestamp from the output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:385
+#: /tmp/fish/implicit/share/completions/git.fish:387
 msgid "Show the author email instead of author name"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:386
+#: /tmp/fish/implicit/share/completions/git.fish:388
 msgid "Ignore whitespace changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:387
+#: /tmp/fish/implicit/share/completions/git.fish:389
 msgid "Custom command"
 msgstr ""
 
@@ -26850,6 +27629,7 @@ msgid "List all keys with their fingerprints"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
+#: /tmp/fish/implicit/share/completions/signify.fish:2
 #, fuzzy
 msgid "Generate a new key pair"
 msgstr "Zwróć losową liczbę"
@@ -35899,13 +36679,6 @@ msgstr ""
 msgid "Display values currently set in the minikube config file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/minikube.fish:25
-#: /tmp/fish/implicit/share/completions/minikube.fish:26
-#: /tmp/fish/implicit/share/completions/minikube.fish:27
-#: /tmp/fish/implicit/share/completions/minikube.fish:28
-msgid "Property"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/minikube.fish:29
 msgid "Go template format string for the config view output"
 msgstr ""
@@ -41880,11 +42653,6 @@ msgstr ""
 msgid "keep going until N jobs fail [default=1]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ninja.fish:8
-#: /tmp/fish/implicit/share/completions/quilt.fish:1
-msgid "show help"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/ninja.fish:9
 msgid "enable debugging, specify debug mode"
 msgstr ""
@@ -45173,6 +45941,19 @@ msgstr ""
 msgid "Extract script"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pfctl.fish:1
+msgid "Show a filter parameter by modifier"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:2
+msgid "Flush filter params specified by mod"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:3
+#, fuzzy
+msgid "Table command"
+msgstr "Stan Komenda"
+
 #: /tmp/fish/implicit/share/completions/pgrep.fish:1
 msgid "Output delimiter"
 msgstr ""
@@ -45381,6 +46162,29 @@ msgstr ""
 msgid "omit the user's full name, remote host and idle time in short format"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:1
+#, fuzzy
+msgid "failsafe to overwrite"
+msgstr "Wymuszono zatrzymanie"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:2
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:3
+msgid "Turn on stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:3
+msgid "Automated package installation"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:5
+#, fuzzy
+msgid "Update packages"
+msgstr "Stwórz blok kodu"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:6
+msgid "Fuzzy match"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:1
 msgid "Upgrade"
 msgstr ""
@@ -45483,6 +46287,10 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkg-config.fish:25
 msgid "List all modules the given packages requires for static linking"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:2
+msgid "Delete unsed deps"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkgfile.fish:3
@@ -49868,6 +50676,19 @@ msgstr ""
 msgid "Specifies layout variant used to choose component names"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/signify.fish:1
+msgid "Verify a signed checksum list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:3
+#, fuzzy
+msgid "Sign specified message"
+msgstr "Zwraca sformatowany tekst"
+
+#: /tmp/fish/implicit/share/completions/signify.fish:4
+msgid "Verify a signed message and sig"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/snap.fish:1
 msgid "Test if snap has yet to be given the subcommand"
 msgstr ""
@@ -53716,10 +54537,12 @@ msgid "Monitor changes to objects"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:7
+#: /tmp/fish/implicit/share/completions/zfs.fish:17
 msgid "Mount a filesystem"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:18
 msgid "Unmount a filesystem"
 msgstr ""
 
@@ -58287,6 +59110,621 @@ msgstr ""
 msgid "Delete all cache contents"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/zfs.fish:1
+msgid ""
+"Internal completion function for appending string to the ZFS commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:2
+#: /tmp/fish/implicit/share/completions/zpool.fish:2
+#, fuzzy
+msgid "Display a help message"
+msgstr "Wypisz argumenty"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:3
+#, fuzzy
+msgid "Create a volume or filesystem"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:4
+msgid "Destroy a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:5
+#, fuzzy
+msgid "Create a snapshot"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:6
+msgid "Roll back a filesystem to a previous snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:7
+#, fuzzy
+msgid "Create a clone of a snapshot"
+msgstr "Stwórz blok kodu"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:8
+msgid ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:9
+msgid "Rename a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:10
+msgid "List dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:11
+msgid "Set a dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:12
+msgid "Get one or several dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:13
+msgid "Set a dataset property to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:14
+msgid "List upgradeable datasets, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:15
+msgid "Get dataset space consumed by each user"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:16
+msgid "Get dataset space consumed by each user group"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:19
+msgid "Share a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:20
+msgid "Stop sharing a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:21
+msgid "Create a bookmark for a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:22
+msgid "Output a stream representation of a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:23
+msgid ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:24
+msgid ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:25
+msgid "Revoke delegations of rights on a dataset from (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:26
+msgid "Put a named hold on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:27
+msgid "List holds on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:28
+msgid "Remove a named hold from a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:29
+msgid ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:30
+msgid "Execute a ZFS Channel Program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:31
+#: /tmp/fish/implicit/share/completions/zfs.fish:53
+#: /tmp/fish/implicit/share/completions/zfs.fish:58
+msgid "Create all needed non-existing parent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:32
+#: /tmp/fish/implicit/share/completions/zfs.fish:33
+msgid "Dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:34
+msgid "Volume size"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:35
+#, fuzzy
+msgid "Create a sparse volume"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:36
+msgid "Blocksize"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:37
+msgid "Recursively destroy children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:38
+msgid "Recursively destroy all dependents"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:39
+#, fuzzy
+msgid "Force unmounting"
+msgstr "Wymuszono zatrzymanie"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:41
+#, fuzzy
+msgid "Print machine-parsable verbose information"
+msgstr "Zwróć katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:43
+msgid "Defer snapshot deletion"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:44
+msgid "Dataset to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:45
+msgid "Recursively snapshot children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:46
+#: /tmp/fish/implicit/share/completions/zfs.fish:47
+msgid "Snapshot property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:48
+msgid "Dataset to snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:49
+msgid "Destroy later snapshot and bookmarks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:50
+msgid "Recursively destroy later snapshot, bookmarks and clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:51
+msgid "Force unmounting of clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:52
+msgid "Snapshot to roll back to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:54
+#: /tmp/fish/implicit/share/completions/zfs.fish:55
+msgid "Clone property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:56
+msgid "Snapshot to clone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:57
+msgid "Clone to promote"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:59
+msgid "Recursively rename children snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:60
+#: /tmp/fish/implicit/share/completions/zfs.fish:62
+#: /tmp/fish/implicit/share/completions/zfs.fish:108
+msgid "Force unmounting if needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:61
+msgid "Do not remount filesystems during rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:63
+msgid "Dataset to rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:64
+#: /tmp/fish/implicit/share/completions/zfs.fish:77
+#: /tmp/fish/implicit/share/completions/zfs.fish:94
+#: /tmp/fish/implicit/share/completions/zfs.fish:172
+#: /tmp/fish/implicit/share/completions/zpool.fish:59
+#: /tmp/fish/implicit/share/completions/zpool.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:99
+msgid "Print output in a machine-parsable format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:65
+#: /tmp/fish/implicit/share/completions/zfs.fish:75
+#: /tmp/fish/implicit/share/completions/zfs.fish:84
+#: /tmp/fish/implicit/share/completions/zfs.fish:89
+msgid "Operate recursively on datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:105
+msgid "Property to list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:68
+#: /tmp/fish/implicit/share/completions/zfs.fish:80
+#: /tmp/fish/implicit/share/completions/zfs.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:66
+#, fuzzy
+msgid "Print parsable (exact) values for numbers"
+msgstr "Zwróć katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:69
+#: /tmp/fish/implicit/share/completions/zfs.fish:97
+msgid "Property to use for sorting output by ascending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:70
+#: /tmp/fish/implicit/share/completions/zfs.fish:98
+msgid "Property to use for sorting output by descending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:72
+msgid "Dataset which properties is to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:73
+#: /tmp/fish/implicit/share/completions/zpool.fish:125
+msgid "Property to set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:74
+msgid "Dataset which property is to be setted"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:78
+#: /tmp/fish/implicit/share/completions/zpool.fish:68
+msgid "Fields to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:79
+#, fuzzy
+msgid "Property source to display"
+msgstr "Zwróć katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:82
+msgid "Property to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:83
+msgid "Dataset which properties is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:85
+msgid "Revert to the received value if available"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:86
+msgid "Dataset which properties is to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:88
+msgid "Upgrade all eligible filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:90
+#, fuzzy
+msgid "Upgrade to the specified version"
+msgstr "Szukaj określonego ciągu znaków w liście"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:91
+msgid "Filesystem to upgrade"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:92
+msgid "Print UID instead of user name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:93
+msgid "Print GID instead of group name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:96
+msgid "Field to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:99
+#: /tmp/fish/implicit/share/completions/zfs.fish:100
+msgid "Identity types to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:101
+msgid "Translate S(amba)ID to POSIX ID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:102
+msgid "Dataset which space usage is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:103
+msgid "Temporary mount point property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:104
+#, fuzzy
+msgid "Report progress"
+msgstr "Proces potomny"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:105
+msgid "Mount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:106
+msgid "Overlay mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:107
+msgid "Filesystem to mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:109
+msgid "Unmount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:110
+msgid "Filesystem to unmount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:111
+msgid "Share all eligible ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:112
+msgid "Filesystem to share"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:113
+msgid "Unshare all shared ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:114
+msgid "Filesystem to unshare"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:115
+msgid "Snapshot to bookmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:116
+msgid "Generate incremental stream from snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:117
+msgid ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:118
+#: /tmp/fish/implicit/share/completions/zfs.fish:127
+msgid "Include children in replication stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:119
+#: /tmp/fish/implicit/share/completions/zfs.fish:128
+#, fuzzy
+msgid "Generate a deduplicated stream"
+msgstr "Zwróć losową liczbę"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:120
+#: /tmp/fish/implicit/share/completions/zfs.fish:129
+msgid "Allow the presence of larger blocks than 128 kiB"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:121
+#: /tmp/fish/implicit/share/completions/zfs.fish:130
+msgid "Generate a more compact stream by using WRITE_EMBEDDED records"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:122
+#: /tmp/fish/implicit/share/completions/zfs.fish:131
+#, fuzzy
+msgid "Print verbose information about the stream in a machine-parsable format"
+msgstr "Zwróć informacje o fish"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:123
+#, fuzzy
+msgid "Generate compressed stream"
+msgstr "Zwróć losową liczbę"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:125
+#: /tmp/fish/implicit/share/completions/zfs.fish:133
+#, fuzzy
+msgid "Include dataset properties"
+msgstr "Katalog"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:126
+#: /tmp/fish/implicit/share/completions/zfs.fish:134
+#, fuzzy
+msgid "Print verbose information about the stream"
+msgstr "Zwróć informacje o fish"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:135
+msgid "Dataset to send"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:136
+#, fuzzy
+msgid ""
+"Print verbose information about the stream and the time spent processing it"
+msgstr "Zwróć informacje o fish"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:137
+msgid "Dry run: do not actually receive the stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:138
+msgid "Force rollback to the most recent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:139
+msgid "Unmount the target filesystem"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:140
+msgid "Discard the first element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:141
+msgid "Discard all but the last element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:142
+msgid "Force the stream to be received as a clone of the given snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:143
+msgid "On transfer interruption, store a receive_resume_token for resumption"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:144
+msgid "Dataset to receive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:145
+msgid "Delegate permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:146
+msgid "Delegate permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:147
+msgid "User to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:148
+msgid "Group to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:149
+#: /tmp/fish/implicit/share/completions/zfs.fish:150
+msgid "Delegate permission to everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:151
+msgid "Delegate permissions only to the creator of later descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:152
+msgid "Create a permission set or add permissions to an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:153
+msgid "Dataset on which delegation is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:154
+msgid "Remove permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:155
+msgid "Remove permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:156
+msgid "User to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:157
+msgid "Group to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:158
+#: /tmp/fish/implicit/share/completions/zfs.fish:162
+#: /tmp/fish/implicit/share/completions/zfs.fish:163
+msgid "Remove permission from everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:159
+msgid "Remove permissions only on later created descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:160
+msgid "Remove a permission set or remove permissions from an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:161
+msgid "Remove permissions recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:164
+msgid "Dataset on which delegation is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:165
+msgid "Apply hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:166
+msgid "Snapshot on which hold is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:167
+msgid "List holds recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:168
+msgid "Snapshot which holds are to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:169
+msgid "Release hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:170
+msgid "Snapshot from which hold is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:171
+msgid "Display file type (à la ls -F)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:173
+msgid "Display inode change time"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:174
+msgid "Source snapshot for the diff"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:175
+msgid "Execution timeout"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:176
+msgid "Execution memory limit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:177
+msgid "Pool which program will be executed on"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/zip.fish:1
 msgid "Freshen: only changed files"
 msgstr ""
@@ -58391,6 +59829,483 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/zip.fish:29
 msgid "Don't compress files with these suffixes"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:1
+msgid ""
+"Internal completion function for appending string to the zpool commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:3
+msgid "Add new virtual devices to pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:4
+msgid "Attach virtual device to a pool device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:5
+msgid "Clear devices errors in pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:6
+#, fuzzy
+msgid "Create a new storage pool"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:7
+msgid "Destroy a storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:8
+msgid "Detach virtual device from a mirroring pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:9
+msgid "Display pool event log"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:10
+msgid "Export a pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:11
+msgid "Get one or several pool properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:12
+#, fuzzy
+msgid "Display pool command history"
+msgstr "Zwraca sformatowany tekst"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:13
+msgid "List importable pools, or import some"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:14
+msgid "Display pool I/O stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:15
+msgid "Remove ZFS label information from the specified device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:16
+msgid "List pools with health status and space usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:17
+#, fuzzy
+msgid "Take the specified devices offline"
+msgstr "Edytuj sugestie do określonej komendy"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:18
+msgid "Bring the specified devices back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:19
+msgid "Reset pool GUID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:20
+msgid "Remove virtual devices from pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:21
+msgid "Reopen pool devices"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:22
+msgid "Replace a pool virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:23
+msgid "Start or stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:24
+msgid "Set a pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:25
+msgid "Create a pool by splitting an existing mirror one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:26
+msgid "Display detailed pool health status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:27
+msgid "List upgradeable pools, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:28
+#: /tmp/fish/implicit/share/completions/zpool.fish:36
+#: /tmp/fish/implicit/share/completions/zpool.fish:45
+#: /tmp/fish/implicit/share/completions/zpool.fish:117
+msgid "Force use of virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:29
+#: /tmp/fish/implicit/share/completions/zpool.fish:130
+msgid "Dry run: only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:30
+#: /tmp/fish/implicit/share/completions/zpool.fish:91
+#: /tmp/fish/implicit/share/completions/zpool.fish:100
+#: /tmp/fish/implicit/share/completions/zpool.fish:127
+#: /tmp/fish/implicit/share/completions/zpool.fish:135
+msgid "Display virtual device GUID instead of device name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:31
+#: /tmp/fish/implicit/share/completions/zpool.fish:92
+#: /tmp/fish/implicit/share/completions/zpool.fish:101
+#: /tmp/fish/implicit/share/completions/zpool.fish:128
+#: /tmp/fish/implicit/share/completions/zpool.fish:136
+#, fuzzy
+msgid "Resolve device path symbolic links"
+msgstr "Nawiązanie symboliczne"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:32
+#: /tmp/fish/implicit/share/completions/zpool.fish:93
+#: /tmp/fish/implicit/share/completions/zpool.fish:102
+#: /tmp/fish/implicit/share/completions/zpool.fish:129
+#: /tmp/fish/implicit/share/completions/zpool.fish:137
+msgid "Display device full path"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:33
+#: /tmp/fish/implicit/share/completions/zpool.fish:37
+#: /tmp/fish/implicit/share/completions/zpool.fish:48
+#: /tmp/fish/implicit/share/completions/zpool.fish:118
+#: /tmp/fish/implicit/share/completions/zpool.fish:132
+msgid "Pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:34
+msgid "Pool to add virtual devices to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:35
+#: /tmp/fish/implicit/share/completions/zpool.fish:53
+msgid "Virtual device to add"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:38
+msgid "Pool to attach virtual device to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:39
+#: /tmp/fish/implicit/share/completions/zpool.fish:43
+msgid "Virtual device to operate on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:40
+#, fuzzy
+msgid "Initiate recovery mode"
+msgstr "Tylko dla zadań interaktywnych"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:41
+#: /tmp/fish/implicit/share/completions/zpool.fish:85
+msgid ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:42
+msgid "Pool to clear errors on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:44
+msgid ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:46
+msgid "Dry run, only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:47
+msgid "Do not enable any feature on the new pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:49
+msgid "Root filesystem property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:50
+#: /tmp/fish/implicit/share/completions/zpool.fish:83
+msgid "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:51
+msgid "Root filesystem mountpoint"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:52
+msgid "Set a different in-core pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:54
+#: /tmp/fish/implicit/share/completions/zpool.fish:64
+msgid "Force unmounting of all contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:55
+msgid "Pool to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:56
+msgid "Pool to detach device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:57
+msgid "Physical device to detach"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:58
+#, fuzzy
+msgid "Print verbose event information"
+msgstr "Zwróć katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:60
+msgid "Output appended data as the log grows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:61
+msgid "Clear all previous events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:62
+msgid "Pool to read events from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:63
+msgid "Export all pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:65
+msgid "Pool to export"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:69
+msgid "Properties to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:70
+msgid "Pool to get properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:71
+msgid "Also display internal events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:72
+#, fuzzy
+msgid "Display log records using long format"
+msgstr "Zwróć katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:73
+msgid "Pool to get command history of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:74
+#, fuzzy
+msgid "Read configuration from specified cache file"
+msgstr "Zmień katalog roboczy"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:75
+#, fuzzy
+msgid "Search for devices or files in specified directory"
+msgstr "Nawiązanie symboliczne do katalogu"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:76
+msgid "List or import destroyed pools only (requires -f for importation)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:77
+#: /tmp/fish/implicit/share/completions/zpool.fish:133
+msgid "Mount properties for contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:78
+msgid "Properties of the imported pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:79
+#, fuzzy
+msgid "Force import"
+msgstr "Wymuszono zatrzymanie"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:80
+#, fuzzy
+msgid "Recovery mode"
+msgstr "Tylko dla zadań interaktywnych"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:81
+msgid "Search for and import all pools found"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:82
+msgid "Ignore missing log device (risk of loss of last changes)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:84
+msgid "Do not mount contained filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:86
+msgid "Roll back to a previous TXG (hazardous)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:87
+msgid "TXG to roll back to (implies -FX)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:88
+msgid "Specify, as the last argument, a temporary pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:89
+msgid "Pool to import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:90
+#: /tmp/fish/implicit/share/completions/zpool.fish:103
+#: /tmp/fish/implicit/share/completions/zpool.fish:142
+msgid "Display a timestamp using specified format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:94
+msgid "Omit statistics since boot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:104
+#, fuzzy
+msgid "Print verbose statistics"
+msgstr "Zwraca sformatowany tekst"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:96
+msgid "Pool to retrieve I/O stats from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:97
+msgid "Treat exported or foreign devices as inactive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:98
+#, fuzzy
+msgid "Device to clear ZFS label information from"
+msgstr "Zwróć informacje o fish"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:106
+msgid "Pool to list properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:107
+msgid "Temporarily offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:108
+msgid "Pool to offline device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:109
+msgid "Physical device to offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:110
+msgid "Expand the device to use all available space"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:111
+msgid "Pool to bring device back online on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:112
+msgid "Physical device to bring back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:113
+msgid "Pool which GUID is to be changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:114
+msgid "Pool to remove device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:115
+msgid "Physical device to remove"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:116
+msgid "Pool which devices are to be reopened"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:119
+msgid "Pool to replace device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:120
+msgid "Pool device to be replaced"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:121
+msgid "Device to use for replacement"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:122
+msgid "Stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:123
+msgid "Pause scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:124
+msgid "Pool to start/stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:126
+msgid "Pool which property is to be set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:131
+msgid "Set altroot for newpool and automatically import it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:134
+msgid "Pool to split"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:138
+#: /tmp/fish/implicit/share/completions/zpool.fish:139
+msgid "Display deduplication histogram"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:141
+msgid "Only display status for unhealthy or unavailable pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:143
+#: /tmp/fish/implicit/share/completions/zpool.fish:147
+msgid "Pool which status is to be displayed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:144
+msgid "Upgrade all eligible pools, enabling all supported features"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:145
+msgid "Display upgradeable ZFS versions"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:146
+#, fuzzy
+msgid "Upgrade to the specified legacy version"
+msgstr "Szukaj określonego ciągu znaków w liście"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:2
 msgid "Repo"
@@ -59862,6 +61777,28 @@ msgstr ""
 msgid "Complete wvdial peers"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+msgid "Completes with ZFS mountpoint properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_pools.fish:1
+msgid "Completes with available ZFS pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+msgid "Completes with ZFS read-only properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Completes with ZFS read-write properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr ""
@@ -60019,6 +61956,12 @@ msgstr ""
 msgid "Test if current token is on Nth place"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_is_zfs_feature_enabled.fish:1
+msgid ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_list_current_token.fish:1
 msgid ""
 "List contents of token under the cursor if it is a directory, otherwise list "
@@ -60097,6 +62040,11 @@ msgid ""
 "current directory"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
+#, fuzzy
+msgid "Print a list of local groups"
+msgstr "Zwraca sformatowany tekst"
+
 #: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr ""
@@ -60166,6 +62114,22 @@ msgstr "Wypisz argumenty"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
+msgid "Lists ZFS bookmarks, if the feature is enabled"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
+msgid "Lists ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
+msgid "Lists ZFS snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
+msgid "Lists ZFS volumes"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-13 10:22+0100\n"
 "PO-Revision-Date: 2015-10-11 20:35-0300\n"
 "Last-Translator: Fábio Nogueira <deb-user-ba@ubuntu.com>\n"
 "Language-Team: Português Brasileiro <>\n"
@@ -1860,9 +1860,11 @@ msgstr "Link para executável"
 #: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
 #: /tmp/fish/implicit/share/completions/fossil.fish:90
 #: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:206
-#: /tmp/fish/implicit/share/completions/git.fish:266
-#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:269
 msgid "File"
 msgstr "Arquivo"
 
@@ -2620,6 +2622,603 @@ msgstr "Use Kerberos realm for authentication"
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/zfs.fish:1
+#, fuzzy
+msgid "ZFS filesystem"
+msgstr "Show all filesystems"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:2
+#, fuzzy
+msgid "ZFS filesystem snapshot"
+msgstr "Show all filesystems"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:3
+#, fuzzy
+msgid "ZFS block storage device"
+msgstr "File is block device"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:4
+msgid "ZFS snapshot bookmark"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:5
+msgid "Any ZFS dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:6
+#, fuzzy
+msgid "Dataset-specific value"
+msgstr "Use specific conffile"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:7
+#, fuzzy
+msgid "Default ZFS value"
+msgstr "Set date"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:8
+msgid "Value inherited from parent dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:9
+msgid "Value received by 'zfs receive'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:10
+#, fuzzy
+msgid "Value valid for the current mount"
+msgstr "Sets an index list for the next track"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:11
+#, fuzzy
+msgid "Read-only value"
+msgstr "Read only"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:12
+#, fuzzy
+msgid "Dataset full name"
+msgstr "Service name"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:13
+#: /tmp/fish/explicit/share/completions/zpool.fish:2
+#: /tmp/fish/implicit/share/completions/minikube.fish:25
+#: /tmp/fish/implicit/share/completions/minikube.fish:26
+#: /tmp/fish/implicit/share/completions/minikube.fish:27
+#: /tmp/fish/implicit/share/completions/minikube.fish:28
+#, fuzzy
+msgid "Property"
+msgstr "Set property"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:3
+#, fuzzy
+msgid "Property value"
+msgstr "Set property"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:15
+#: /tmp/fish/explicit/share/completions/zpool.fish:4
+msgid "Property value origin"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:16
+#, fuzzy
+msgid "Identity type"
+msgstr "Arquivo de identificação"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:17
+#, fuzzy
+msgid "Identity name"
+msgstr "Arquivo de identificação"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:18
+#, fuzzy
+msgid "Space usage"
+msgstr "Show source package"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:19
+#, fuzzy
+msgid "Space quota"
+msgstr "Set quote char"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:20
+msgid "POSIX user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:21
+msgid "Samba user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:22
+#: /tmp/fish/explicit/share/completions/zfs.fish:25
+msgid "Both types"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:23
+msgid "POSIX group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:24
+#, fuzzy
+msgid "Samba group"
+msgstr "Select by group"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:26
+#, fuzzy
+msgid "Also needs the permission to be allowed"
+msgstr "Selects how passphrases are mangled"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:27
+msgid ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:28
+#: /tmp/fish/explicit/share/completions/zfs.fish:29
+#: /tmp/fish/explicit/share/completions/zfs.fish:33
+#: /tmp/fish/explicit/share/completions/zfs.fish:35
+msgid "Also needs the 'mount' permission"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:30
+msgid ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:31
+msgid "Also needs the 'create' and 'mount' permissions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:32
+msgid "Also needs the 'create' and 'mount' permissions in the new parent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:34
+msgid "For SMB and NFS shares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:36
+msgid "Allows changing any user property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:26
+#, fuzzy
+msgid "Volume block size"
+msgstr "Set block size"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:38
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Inheritance of ACL entries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:39
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:2
+#, fuzzy
+msgid "Update access time on read"
+msgstr "Keep access time"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:40
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:3
+msgid "Is the dataset mountable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:41
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:4
+#, fuzzy
+msgid "Data checksum"
+msgstr "Do not change any files"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:42
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:5
+#, fuzzy
+msgid "Compression algorithm"
+msgstr "Use specified compression algorithm"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:43
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:6
+#, fuzzy
+msgid "Number of copies of data"
+msgstr "Number all lines"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:44
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:7
+#, fuzzy
+msgid "Deduplication"
+msgstr "Remove non-duplicate lines"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:45
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:2
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:8
+msgid "Are contained device nodes openable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:46
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:3
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:9
+#, fuzzy
+msgid "Can contained executables be executed"
+msgstr "Print commands to stderr"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:47
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:10
+#, fuzzy
+msgid "Max number of filesystems and volumes"
+msgstr "Maximum number of nested blocks reached."
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:48
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:11
+#, fuzzy
+msgid "Mountpoint"
+msgstr "Ponto de montagem"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:49
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:12
+msgid "Which data to cache in ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:50
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:13
+msgid "Max size of dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:51
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:14
+#, fuzzy
+msgid "Max number of snapshots"
+msgstr "Number of concurrent jobs"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:52
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:4
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:15
+#, fuzzy
+msgid "Read-only"
+msgstr "Read only"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:53
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:16
+#, fuzzy
+msgid "Suggest block size"
+msgstr "Set block size"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:54
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:17
+msgid "How redundant are the metadata"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:55
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:18
+msgid "Max space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:56
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:19
+msgid "Min space guaranteed to dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:57
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:20
+msgid "Min space guaranteed to dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:58
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:21
+msgid "Which data to cache in L2ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:59
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:5
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:22
+msgid "Respect set-UID bit"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:60
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:23
+msgid "Share in NFS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:61
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:24
+msgid "Hint for handling of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:62
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:25
+#, fuzzy
+msgid "Hide .zfs directory"
+msgstr "File is directory"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:63
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:26
+msgid "Handle of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:64
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:27
+#, fuzzy
+msgid "Volume logical size"
+msgstr "Set block size"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:65
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:38
+msgid "Managed from a non-global zone"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:66
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:31
+msgid "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:67
+#: /tmp/fish/explicit/share/completions/zfs.fish:74
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:6
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:32
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:40
+msgid "Mount with Non Blocking mandatory locks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:68
+#: /tmp/fish/explicit/share/completions/zfs.fish:77
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:33
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:43
+msgid "Share in Samba"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:69
+#: /tmp/fish/explicit/share/completions/zfs.fish:76
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:34
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:42
+msgid "Share as an iSCSI target"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:70
+#: /tmp/fish/explicit/share/completions/zfs.fish:79
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:35
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:45
+#, fuzzy
+msgid "On-disk version of filesystem"
+msgstr "Armazenar apenas arquivos novos"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:71
+#: /tmp/fish/explicit/share/completions/zfs.fish:80
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:36
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:46
+msgid "Scan regular files for viruses on opening and closing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:72
+#: /tmp/fish/explicit/share/completions/zfs.fish:81
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:7
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:47
+#, fuzzy
+msgid "Extended attributes"
+msgstr "Tolerate sloppy mount options"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:73
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:39
+msgid "Use no ACL or POSIX ACL"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:75
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:9
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:41
+msgid "Sometimes update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:78
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:44
+#, fuzzy
+msgid "Hide volume snapshots"
+msgstr "Remove one or more packages"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:82
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:30
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:48
+msgid "How is ACL modified by chmod"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:83
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:49
+msgid "How to expose volumes to OS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:84
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+#, fuzzy
+msgid "Unicode normalization"
+msgstr "Print extra info"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:85
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:2
+msgid "Reject non-UTF-8-compliant filenames"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:86
+#: /tmp/fish/explicit/share/completions/zfs.fish:87
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:9
+#, fuzzy
+msgid "Case sensitivity"
+msgstr "Case insensitive"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:88
+#, fuzzy
+msgid "Space properties"
+msgstr "Set property"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:89
+#: /tmp/fish/explicit/share/completions/zfs.fish:90
+#, fuzzy
+msgid "Dataset name"
+msgstr "Set volume name"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:1
+#, fuzzy
+msgid "Pool full name"
+msgstr "Print filename"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:5
+#, fuzzy
+msgid "Mirror of at least two devices"
+msgstr "Copy module file to stdout"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:6
+#: /tmp/fish/explicit/share/completions/zpool.fish:7
+msgid "ZFS RAID-5 variant, single parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:8
+msgid "ZFS RAID-5 variant, double parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:9
+msgid "ZFS RAID-5 variant, triple parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:10
+msgid "Pseudo vdev for pool hot spares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:11
+#, fuzzy
+msgid "SLOG device"
+msgstr "Print byte offset of matches"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:12
+#, fuzzy
+msgid "L2ARC device"
+msgstr "Print byte offset of matches"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:13
+msgid "Physically allocated space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:2
+#, fuzzy
+msgid "Available space"
+msgstr "Variável"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:16
+msgid "System boot partition size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:17
+msgid "Usage percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:18
+#, fuzzy
+msgid "Deduplication ratio"
+msgstr "Read/Write mode"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:19
+msgid "Amount of uninitialized space within the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:20
+msgid "Fragmentation percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:21
+msgid "Free pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:22
+msgid "Remaining pool space to be freed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:23
+msgid "Pool GUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:24
+#, fuzzy
+msgid "Current pool health"
+msgstr "Show source package"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:25
+msgid "Total pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:26
+msgid "Used pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:27
+msgid "Pool sector size exponent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:28
+#: /tmp/fish/explicit/share/completions/zpool.fish:29
+#, fuzzy
+msgid "Alternate root directory"
+msgstr "Directory"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:30
+#: /tmp/fish/explicit/share/completions/zpool.fish:31
+#, fuzzy
+msgid "Import pool in read-only mode"
+msgstr "Read only"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:32
+#: /tmp/fish/explicit/share/completions/zpool.fish:33
+#, fuzzy
+msgid "Automatic pool expansion on LUN growing"
+msgstr "Automatic line ending processing"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:34
+#: /tmp/fish/explicit/share/completions/zpool.fish:35
+msgid "Automatic use of replacement device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:36
+msgid "Default bootable dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:37
+#, fuzzy
+msgid "Pool configuration cache"
+msgstr "Dump configuration file"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:38
+msgid "Comment about the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:39
+msgid "Threshold for writting a ditto copy of deduplicated blocks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:40
+msgid "Allow rights delegation on the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:41
+msgid "Behavior in case of catastrophic pool failure"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:42
+msgid "Display snapshots even if 'zfs list' does not use '-t'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:43
+#, fuzzy
+msgid "On-disk version of pool"
+msgstr "Mostra tamanhos de arquivos"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:44
+msgid "%sEnable the %s feature\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:45
+#, fuzzy
+msgid "All properties"
+msgstr "Display font properties"
+
 #: /tmp/fish/explicit/share/functions/abbr.fish:1
 #, fuzzy
 msgid "%s: Could not figure out what to do!\\n"
@@ -2761,6 +3360,147 @@ msgstr "Treat absent files as empty"
 msgid "%s\\tArchived file\\n"
 msgstr ""
 
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:3
+#, fuzzy
+msgid "Achieved compression ratio"
+msgstr "Print compression ratios"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:4
+#, fuzzy
+msgid "Dataset creation time"
+msgstr "Compare month names"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:5
+msgid "Snapshot clones"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:6
+msgid "Marked for deferred destruction"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:7
+msgid "Total lower-level filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:9
+#, fuzzy
+msgid "Logical total space"
+msgstr "Log to tracefile"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:11
+msgid "Logical used space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:12
+#, fuzzy
+msgid "Is currently mounted?"
+msgstr "Display version and exit"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:13
+#, fuzzy
+msgid "Source snapshot"
+msgstr "Force yes"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:14
+msgid "Token for interrupted reception resumption"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:16
+#, fuzzy
+msgid "Total space"
+msgstr "Name of patch"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:17
+#, fuzzy
+msgid "Achieved compression ratio of referenced space"
+msgstr "Display the session key used for one message"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:18
+#, fuzzy
+msgid "Total lower-level snapshots"
+msgstr "Print path to command"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:19
+#: /tmp/fish/implicit/share/completions/zfs.fish:71
+#: /tmp/fish/implicit/share/completions/zfs.fish:81
+msgid "Dataset type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:20
+msgid "Space used by dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:21
+msgid "Space used by children datasets"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:22
+msgid "Space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:23
+msgid "Space used by refreservation"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:24
+msgid "Space used by dataset snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:25
+msgid "Holds count"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:27
+msgid "Referenced data written since previous snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:28
+msgid "%sDataset space use by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:29
+msgid "%sDataset space use by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:30
+msgid "%sReferenced data written since snapshot %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:28
+msgid "%sMax usage by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:29
+msgid "%sMax usage by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:3
+#, fuzzy
+msgid "Allow overlay mount"
+msgstr "Read only"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:4
+#, fuzzy
+msgid "SELinux context for the child filesystem"
+msgstr "Update only the database, not the filesystem"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:5
+#, fuzzy
+msgid "SELinux context for the filesystem being mounted"
+msgstr "Update only the database, not the filesystem"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:6
+#, fuzzy
+msgid "SELinux context for unlabeled files"
+msgstr "Don't exit on unreadable files"
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:7
+msgid "SELinux context for the root inode of the filesystem"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Bem-vindo ao fish, o friendly interactive shell"
@@ -2787,6 +3527,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/aptitude.fish:3
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:3
 #: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:63
 #: /tmp/fish/implicit/share/completions/wajig.fish:3
@@ -5411,7 +6153,10 @@ msgstr "Print debugging info"
 #: /tmp/fish/implicit/share/completions/valgrind.fish:6
 #: /tmp/fish/implicit/share/completions/vi.fish:8
 #: /tmp/fish/implicit/share/completions/wget.fish:9
+#: /tmp/fish/implicit/share/completions/zfs.fish:42
+#: /tmp/fish/implicit/share/completions/zfs.fish:87
 #: /tmp/fish/implicit/share/completions/zip.fish:13
+#: /tmp/fish/implicit/share/completions/zpool.fish:140
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
 msgid "Verbose mode"
 msgstr "Modo detalhado"
@@ -10666,7 +11411,7 @@ msgid "Show usage message and options"
 msgstr "Load the media and exit"
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:380
+#: /tmp/fish/implicit/share/completions/git.fish:382
 #, fuzzy
 msgid "Show help message"
 msgstr "Load the media and exit"
@@ -15794,7 +16539,7 @@ msgid "Ignore all white space"
 msgstr "Ignorar todos os espaços em branco"
 
 #: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:325
+#: /tmp/fish/implicit/share/completions/git.fish:327
 #, fuzzy
 msgid "Ignore changes whose lines are all blank"
 msgstr "Ignore changes whose lines are all blank"
@@ -15804,7 +16549,7 @@ msgid "Ignore changes whose lines match the REGEX"
 msgstr "Ignore changes whose lines match the REGEX"
 
 #: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:321
+#: /tmp/fish/implicit/share/completions/git.fish:323
 #, fuzzy
 msgid "Treat all files as text"
 msgstr "Treat all files as text"
@@ -17844,6 +18589,91 @@ msgstr ""
 msgid "X display to use"
 msgstr "Send mail to user"
 
+#: /tmp/fish/implicit/share/completions/exercism.fish:1
+#, fuzzy
+msgid "Test if exercism has yet to be given the subcommand"
+msgstr "Test if apt has yet to be given the subcommand"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:3
+#, fuzzy
+msgid "turn on verbose logging"
+msgstr "List users logged in"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:4
+#: /tmp/fish/implicit/share/completions/exercism.fish:19
+#: /tmp/fish/implicit/share/completions/ninja.fish:8
+#: /tmp/fish/implicit/share/completions/quilt.fish:1
+#, fuzzy
+msgid "show help"
+msgstr "Mostra tudo"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:5
+#, fuzzy
+msgid "print the version"
+msgstr "Print PKG versions"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:6
+#, fuzzy
+msgid "Writes config values to a JSON file."
+msgstr "Write top servers to file"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:7
+#, fuzzy
+msgid "Outputs useful debug information."
+msgstr "Ignore version magic information"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:8
+#, fuzzy
+msgid "Downloads a solution given the ID of the latest iteration."
+msgstr "Updates packages to the best version available"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:9
+msgid "Fetches the next unsubmitted problem in each track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:10
+#, fuzzy
+msgid "Lists the available problems for a language track, given its ID."
+msgstr "List names of available signals"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:11
+msgid ""
+"Opens exercism.io to your most recent iteration of a problem given the track "
+"ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:12
+msgid ""
+"Downloads the most recent iteration for each of your solutions on exercism."
+"io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:13
+msgid "Skips a problem given a track ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:14
+msgid "Fetches information about your progress with a given language track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:15
+msgid "Submits a new iteration to a problem on exercism.io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:16
+#, fuzzy
+msgid "Lists the available language tracks."
+msgstr "List names of available signals"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:17
+msgid "REMOVED"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:18
+#, fuzzy
+msgid "Upgrades the CLI to the latest released version."
+msgstr "Updates packages to the best version available"
+
 #: /tmp/fish/implicit/share/completions/exit.fish:2
 msgid "Quit with normal exit status"
 msgstr ""
@@ -18662,6 +19492,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:66
+#: /tmp/fish/implicit/share/completions/zfs.fish:76
 #, fuzzy
 msgid "Maximum recursion depth"
 msgstr "Maximum resident set size"
@@ -20073,9 +20905,9 @@ msgstr "Listar arquivos swap"
 #: /tmp/fish/implicit/share/completions/fossil.fish:280
 #: /tmp/fish/implicit/share/completions/git.fish:64
 #: /tmp/fish/implicit/share/completions/git.fish:86
-#: /tmp/fish/implicit/share/completions/git.fish:244
-#: /tmp/fish/implicit/share/completions/git.fish:293
-#: /tmp/fish/implicit/share/completions/git.fish:294
+#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:296
 #, fuzzy
 msgid "Tag"
 msgstr "Target"
@@ -20527,7 +21359,7 @@ msgid "Limit number of tags"
 msgstr "Only print number of matches"
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:281
-#: /tmp/fish/implicit/share/completions/git.fish:291
+#: /tmp/fish/implicit/share/completions/git.fish:293
 #, fuzzy
 msgid "List tags"
 msgstr "Edit tag"
@@ -20638,6 +21470,7 @@ msgstr "Ignore all version information"
 #: /tmp/fish/implicit/share/completions/gsettings.fish:15
 #: /tmp/fish/implicit/share/completions/ncdu.fish:1
 #: /tmp/fish/implicit/share/completions/obnam.fish:12
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:4
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:5
 #: /tmp/fish/implicit/share/completions/pkginfo.fish:7
 #: /tmp/fish/implicit/share/completions/pkgmk.fish:17
@@ -26896,24 +27729,24 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:96
 #: /tmp/fish/implicit/share/completions/git.fish:108
 #: /tmp/fish/implicit/share/completions/git.fish:130
-#: /tmp/fish/implicit/share/completions/git.fish:134
-#: /tmp/fish/implicit/share/completions/git.fish:140
-#: /tmp/fish/implicit/share/completions/git.fish:183
-#: /tmp/fish/implicit/share/completions/git.fish:219
-#: /tmp/fish/implicit/share/completions/git.fish:222
-#: /tmp/fish/implicit/share/completions/git.fish:242
-#: /tmp/fish/implicit/share/completions/git.fish:265
-#: /tmp/fish/implicit/share/completions/git.fish:285
-#: /tmp/fish/implicit/share/completions/git.fish:307
+#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:221
+#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:244
+#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:309
 msgid "Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:23
-#: /tmp/fish/implicit/share/completions/git.fish:198
-#: /tmp/fish/implicit/share/completions/git.fish:210
-#: /tmp/fish/implicit/share/completions/git.fish:237
-#: /tmp/fish/implicit/share/completions/git.fish:250
-#: /tmp/fish/implicit/share/completions/git.fish:274
+#: /tmp/fish/implicit/share/completions/git.fish:200
+#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:276
 #: /tmp/fish/implicit/share/completions/mdadm.fish:12
 #: /tmp/fish/implicit/share/completions/update-eix-remote.fish:1
 #, fuzzy
@@ -26923,10 +27756,10 @@ msgstr "Run quietly"
 #: /tmp/fish/implicit/share/completions/git.fish:24
 #: /tmp/fish/implicit/share/completions/git.fish:41
 #: /tmp/fish/implicit/share/completions/git.fish:70
-#: /tmp/fish/implicit/share/completions/git.fish:199
-#: /tmp/fish/implicit/share/completions/git.fish:211
-#: /tmp/fish/implicit/share/completions/git.fish:238
-#: /tmp/fish/implicit/share/completions/git.fish:251
+#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:253
 #: /tmp/fish/implicit/share/completions/prt-get.fish:53
 #: /tmp/fish/implicit/share/completions/prt-get.fish:111
 #: /tmp/fish/implicit/share/completions/xz.fish:32
@@ -26935,12 +27768,12 @@ msgid "Be verbose"
 msgstr "Do not overwrite"
 
 #: /tmp/fish/implicit/share/completions/git.fish:25
-#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:215
 msgid "Append ref names and object names"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:26
-#: /tmp/fish/implicit/share/completions/git.fish:214
+#: /tmp/fish/implicit/share/completions/git.fish:216
 msgid "Force update of local branches"
 msgstr ""
 
@@ -27097,7 +27930,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:63
 #: /tmp/fish/implicit/share/completions/git.fish:85
 #: /tmp/fish/implicit/share/completions/git.fish:109
-#: /tmp/fish/implicit/share/completions/git.fish:184
+#: /tmp/fish/implicit/share/completions/git.fish:186
 msgid "Remote branch"
 msgstr ""
 
@@ -27129,7 +27962,7 @@ msgid "Allow adding otherwise ignored files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:257
+#: /tmp/fish/implicit/share/completions/git.fish:259
 #, fuzzy
 msgid "Interactive mode"
 msgstr "Run in interactive mode"
@@ -27185,7 +28018,7 @@ msgid "Remote Branch"
 msgstr "Rename a disc"
 
 #: /tmp/fish/implicit/share/completions/git.fish:84
-#: /tmp/fish/implicit/share/completions/git.fish:243
+#: /tmp/fish/implicit/share/completions/git.fish:245
 msgid "Head"
 msgstr ""
 
@@ -27372,973 +28205,976 @@ msgstr "Do not ever ascend to the parent directory"
 msgid "Compare two paths on the filesystem"
 msgstr "Compare archive and filesystem"
 
-#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:134
 msgid "Open diffs in a visual tool"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:136
 msgid "Visually show diff of changes in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:136
+#: /tmp/fish/implicit/share/completions/git.fish:138
 #, fuzzy
 msgid "Print lines matching a pattern"
 msgstr "List contents of a package matching pattern"
 
-#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:139
 msgid "Create an empty git repository or reinitialize an existing one"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:138
+#: /tmp/fish/implicit/share/completions/git.fish:140
 msgid "Show commit shortlog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:139
+#: /tmp/fish/implicit/share/completions/git.fish:141
 msgid "Show commit logs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:141
+#: /tmp/fish/implicit/share/completions/git.fish:143
 msgid "Continue listing file history beyond renames"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:144
 #, fuzzy
 msgid "Don't print ref names"
 msgstr "Dont print header"
 
-#: /tmp/fish/implicit/share/completions/git.fish:143
+#: /tmp/fish/implicit/share/completions/git.fish:145
 #, fuzzy
 msgid "Print out ref names"
 msgstr "Print kernel name"
 
-#: /tmp/fish/implicit/share/completions/git.fish:144
+#: /tmp/fish/implicit/share/completions/git.fish:146
 msgid "Print ref name by which each commit was reached"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:145
+#: /tmp/fish/implicit/share/completions/git.fish:147
 msgid "Limit the number of commits before starting to show the commit output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:146
+#: /tmp/fish/implicit/share/completions/git.fish:148
 #, fuzzy
 msgid "Skip given number of commits"
 msgstr "Mostra inode dos arquivos"
 
-#: /tmp/fish/implicit/share/completions/git.fish:147
-#: /tmp/fish/implicit/share/completions/git.fish:148
+#: /tmp/fish/implicit/share/completions/git.fish:149
+#: /tmp/fish/implicit/share/completions/git.fish:150
 msgid "Show commits more recent than specified date"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:149
-#: /tmp/fish/implicit/share/completions/git.fish:150
+#: /tmp/fish/implicit/share/completions/git.fish:151
+#: /tmp/fish/implicit/share/completions/git.fish:152
 #, fuzzy
 msgid "Show commits older than specified date"
 msgstr "Query packages with the specified group"
 
-#: /tmp/fish/implicit/share/completions/git.fish:151
+#: /tmp/fish/implicit/share/completions/git.fish:153
 msgid "Limit commits from given author"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:152
+#: /tmp/fish/implicit/share/completions/git.fish:154
 msgid "Limit commits from given committer"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:153
+#: /tmp/fish/implicit/share/completions/git.fish:155
 msgid "Limit commits to ones with reflog entries matching given pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:154
+#: /tmp/fish/implicit/share/completions/git.fish:156
 #, fuzzy
 msgid "Limit commits with message that match given pattern"
 msgstr "List contents of a package matching pattern"
 
-#: /tmp/fish/implicit/share/completions/git.fish:155
+#: /tmp/fish/implicit/share/completions/git.fish:157
 msgid "Limit commits to ones that match all given --grep"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:156
-msgid "Limit commits to ones with message that don't match --grep"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:157
-#, fuzzy
-msgid "Case insensitive match"
-msgstr "Case insensitive"
-
 #: /tmp/fish/implicit/share/completions/git.fish:158
-msgid "Patterns are basic regular expressions (default)"
+msgid "Limit commits to ones with message that don't match --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:159
 #, fuzzy
+msgid "Case insensitive match"
+msgstr "Case insensitive"
+
+#: /tmp/fish/implicit/share/completions/git.fish:160
+msgid "Patterns are basic regular expressions (default)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:161
+#, fuzzy
 msgid "Patterns are extended regular expressions"
 msgstr "Pattern is extended regexp"
 
-#: /tmp/fish/implicit/share/completions/git.fish:160
+#: /tmp/fish/implicit/share/completions/git.fish:162
 #, fuzzy
 msgid "Patterns are fixed strings"
 msgstr "Pattern is a fixed string"
 
-#: /tmp/fish/implicit/share/completions/git.fish:161
+#: /tmp/fish/implicit/share/completions/git.fish:163
 msgid "Patterns are Perl-compatible regular expressions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:162
+#: /tmp/fish/implicit/share/completions/git.fish:164
 msgid "Stop when given path disappears from tree"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:163
+#: /tmp/fish/implicit/share/completions/git.fish:165
 #, fuzzy
 msgid "Print only merge commits"
 msgstr "Print only left column"
 
-#: /tmp/fish/implicit/share/completions/git.fish:164
+#: /tmp/fish/implicit/share/completions/git.fish:166
 msgid "Don't print commits with more than one parent"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:165
+#: /tmp/fish/implicit/share/completions/git.fish:167
 msgid "Show only commit with at least the given number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:166
+#: /tmp/fish/implicit/share/completions/git.fish:168
 msgid "Show only commit with at most the given number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:167
+#: /tmp/fish/implicit/share/completions/git.fish:169
 msgid "Show only commit without a mimimum number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:168
+#: /tmp/fish/implicit/share/completions/git.fish:170
 msgid "Show only commit without a maximum number of parents"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:169
+#: /tmp/fish/implicit/share/completions/git.fish:171
 msgid "Follow only the first parent commit upon seeing a merge commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:170
+#: /tmp/fish/implicit/share/completions/git.fish:172
 msgid "Reverse meaning of ^ prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:171
+#: /tmp/fish/implicit/share/completions/git.fish:173
 msgid ""
 "Pretend as if all refs in refs/ are listed on the command line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:172
+#: /tmp/fish/implicit/share/completions/git.fish:174
 msgid ""
 "Pretend as if all refs are in refs/heads are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:173
+#: /tmp/fish/implicit/share/completions/git.fish:175
 msgid ""
 "Pretend as if all refs are in ref/tags are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:174
+#: /tmp/fish/implicit/share/completions/git.fish:176
 msgid ""
 "Pretend as if all refs in refs/remotes  are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:175
+#: /tmp/fish/implicit/share/completions/git.fish:177
 msgid ""
 "Pretend as if all refs matching shell glob are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:176
+#: /tmp/fish/implicit/share/completions/git.fish:178
 #, fuzzy
 msgid "Do not include refs matching given glob pattern"
 msgstr "Insert modules matching the given wildcard"
 
-#: /tmp/fish/implicit/share/completions/git.fish:177
+#: /tmp/fish/implicit/share/completions/git.fish:179
 msgid ""
 "Pretend as if all objcets mentioned by reflogs are listed on the command "
 "line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:178
+#: /tmp/fish/implicit/share/completions/git.fish:180
 #, fuzzy
 msgid "Ignore invalid object names"
 msgstr "Ignore environment variables"
 
-#: /tmp/fish/implicit/share/completions/git.fish:179
+#: /tmp/fish/implicit/share/completions/git.fish:181
 #, fuzzy
 msgid "Read commits from stdin"
 msgstr "Read names from stdin"
 
-#: /tmp/fish/implicit/share/completions/git.fish:180
+#: /tmp/fish/implicit/share/completions/git.fish:182
 msgid "Mark equivalent commits with = and inequivalent with +"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:181
+#: /tmp/fish/implicit/share/completions/git.fish:183
 msgid "Omit equivalent commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:182
+#: /tmp/fish/implicit/share/completions/git.fish:184
 msgid "Join two or more development histories together"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:187
 msgid "Autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:186
+#: /tmp/fish/implicit/share/completions/git.fish:188
 #, fuzzy
 msgid "Don't autocommit the merge"
 msgstr "Don't use a comment string"
 
-#: /tmp/fish/implicit/share/completions/git.fish:187
+#: /tmp/fish/implicit/share/completions/git.fish:189
 msgid "Edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:188
+#: /tmp/fish/implicit/share/completions/git.fish:190
 msgid "Don't edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:189
+#: /tmp/fish/implicit/share/completions/git.fish:191
 msgid "Don't generate a merge commit if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:190
+#: /tmp/fish/implicit/share/completions/git.fish:192
 msgid "Generate a merge commit even if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:191
+#: /tmp/fish/implicit/share/completions/git.fish:193
 msgid "Refuse to merge unless fast-forward possible"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:192
+#: /tmp/fish/implicit/share/completions/git.fish:194
 msgid "Populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:193
-msgid "Don't populate the log message with one-line descriptions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:194
-#, fuzzy
-msgid "Show diffstat of the merge"
-msgstr "Mostra horário de modificação"
-
 #: /tmp/fish/implicit/share/completions/git.fish:195
-msgid "Don't show diffstat of the merge"
+msgid "Don't populate the log message with one-line descriptions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:196
 #, fuzzy
+msgid "Show diffstat of the merge"
+msgstr "Mostra horário de modificação"
+
+#: /tmp/fish/implicit/share/completions/git.fish:197
+msgid "Don't show diffstat of the merge"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:198
+#, fuzzy
 msgid "Squash changes from other branch as a single commit"
 msgstr "Bring changes from the repository into the working copy"
 
-#: /tmp/fish/implicit/share/completions/git.fish:197
+#: /tmp/fish/implicit/share/completions/git.fish:199
 #, fuzzy
 msgid "Don't squash changes"
 msgstr "Don't summarize changes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:200
-#: /tmp/fish/implicit/share/completions/git.fish:217
-#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:219
+#: /tmp/fish/implicit/share/completions/git.fish:241
 msgid "Force progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:203
 msgid "Force no progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:204
 #, fuzzy
 msgid "Set the commit message"
 msgstr "Read commit message from file"
 
-#: /tmp/fish/implicit/share/completions/git.fish:203
+#: /tmp/fish/implicit/share/completions/git.fish:205
 #, fuzzy
 msgid "Abort the current conflict resolution process"
 msgstr "Reload service configuration"
 
-#: /tmp/fish/implicit/share/completions/git.fish:204
+#: /tmp/fish/implicit/share/completions/git.fish:206
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:205
+#: /tmp/fish/implicit/share/completions/git.fish:207
 #, fuzzy
 msgid "Use specific merge resolution program"
 msgstr "Use specified message digest algorithm"
 
-#: /tmp/fish/implicit/share/completions/git.fish:207
+#: /tmp/fish/implicit/share/completions/git.fish:209
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:210
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:209
+#: /tmp/fish/implicit/share/completions/git.fish:211
 msgid "Fetch from and merge with another repository or a local branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:214
 #, fuzzy
 msgid "Fetch all remotes"
 msgstr "Read-only repository mode"
 
-#: /tmp/fish/implicit/share/completions/git.fish:215
+#: /tmp/fish/implicit/share/completions/git.fish:217
 #, fuzzy
 msgid "Keep downloaded pack"
 msgstr "Disable downloading packages"
 
-#: /tmp/fish/implicit/share/completions/git.fish:216
+#: /tmp/fish/implicit/share/completions/git.fish:218
 #, fuzzy
 msgid "Disable automatic tag following"
 msgstr "Disable automtic buffer allocation"
 
-#: /tmp/fish/implicit/share/completions/git.fish:218
-#: /tmp/fish/implicit/share/completions/git.fish:221
-#: /tmp/fish/implicit/share/completions/git.fish:241
+#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:243
 #, fuzzy
 msgid "Remote alias"
 msgstr "Remove packages"
 
-#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:222
 msgid "Update remote refs along with associated objects"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:225
 msgid "Force-push branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:226
 msgid "Force-push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:225
+#: /tmp/fish/implicit/share/completions/git.fish:227
 msgid "Push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:226
+#: /tmp/fish/implicit/share/completions/git.fish:228
 msgid "Push all refs under refs/heads/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:227
+#: /tmp/fish/implicit/share/completions/git.fish:229
 msgid "Remove remote branches that don't have a local counterpart"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:228
+#: /tmp/fish/implicit/share/completions/git.fish:230
 msgid "Push all refs under refs/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:229
+#: /tmp/fish/implicit/share/completions/git.fish:231
 #, fuzzy
 msgid "Delete all listed refs from the remote repository"
 msgstr "Specify the repository URL"
 
-#: /tmp/fish/implicit/share/completions/git.fish:230
+#: /tmp/fish/implicit/share/completions/git.fish:232
 msgid "Push all refs under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:231
+#: /tmp/fish/implicit/share/completions/git.fish:233
 msgid "Push all usual refs plus the ones under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:232
+#: /tmp/fish/implicit/share/completions/git.fish:234
 msgid "Do everything except actually send the updates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:233
+#: /tmp/fish/implicit/share/completions/git.fish:235
 #, fuzzy
 msgid "Produce machine-readable output"
 msgstr "Give human-readable output"
 
-#: /tmp/fish/implicit/share/completions/git.fish:234
+#: /tmp/fish/implicit/share/completions/git.fish:236
 msgid "Force update of remote refs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:235
+#: /tmp/fish/implicit/share/completions/git.fish:237
 msgid ""
 "Force update of remote refs, stopping if other's changes would be overwritten"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:236
+#: /tmp/fish/implicit/share/completions/git.fish:238
 msgid "Add upstream (tracking) reference"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:242
 msgid "Forward-port local commits to the updated upstream head"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:245
+#: /tmp/fish/implicit/share/completions/git.fish:247
 #, fuzzy
 msgid "Restart the rebasing process"
 msgstr "Automatic line ending processing"
 
-#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:248
 #, fuzzy
 msgid "Abort the rebase operation"
 msgstr "Force name/rev association"
 
-#: /tmp/fish/implicit/share/completions/git.fish:247
+#: /tmp/fish/implicit/share/completions/git.fish:249
 msgid "Keep the commits that don't cahnge anything"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:248
+#: /tmp/fish/implicit/share/completions/git.fish:250
 msgid "Restart the rebasing process by skipping the current patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:249
+#: /tmp/fish/implicit/share/completions/git.fish:251
 msgid "Use merging strategies to rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:254
 #, fuzzy
 msgid "Show diffstat of the rebase"
 msgstr "Show state of dependencies"
 
-#: /tmp/fish/implicit/share/completions/git.fish:253
+#: /tmp/fish/implicit/share/completions/git.fish:255
 msgid "Don't show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:254
+#: /tmp/fish/implicit/share/completions/git.fish:256
 msgid "Allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:255
+#: /tmp/fish/implicit/share/completions/git.fish:257
 msgid "Don't allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:256
+#: /tmp/fish/implicit/share/completions/git.fish:258
 #, fuzzy
 msgid "Force the rebase"
 msgstr "Force new revision"
 
-#: /tmp/fish/implicit/share/completions/git.fish:258
+#: /tmp/fish/implicit/share/completions/git.fish:260
 msgid "Try to recreate merges"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:259
+#: /tmp/fish/implicit/share/completions/git.fish:261
 #, fuzzy
 msgid "Rebase all reachable commits"
 msgstr "Report on each commit"
 
-#: /tmp/fish/implicit/share/completions/git.fish:260
+#: /tmp/fish/implicit/share/completions/git.fish:262
 msgid "Automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:261
+#: /tmp/fish/implicit/share/completions/git.fish:263
 msgid "No automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:262
+#: /tmp/fish/implicit/share/completions/git.fish:264
 #, fuzzy
 msgid "No fast-forward"
 msgstr "Set date forward"
 
-#: /tmp/fish/implicit/share/completions/git.fish:263
+#: /tmp/fish/implicit/share/completions/git.fish:265
 #, fuzzy
 msgid "Reset current HEAD to the specified state"
 msgstr "Help for the specified builtin"
 
-#: /tmp/fish/implicit/share/completions/git.fish:264
+#: /tmp/fish/implicit/share/completions/git.fish:266
 #, fuzzy
 msgid "Reset files in working directory"
 msgstr "Change working directory"
 
-#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:270
 msgid "Reflog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: /tmp/fish/implicit/share/completions/git.fish:271
 #, fuzzy
 msgid "Revert an existing commit"
 msgstr "Report on each commit"
 
-#: /tmp/fish/implicit/share/completions/git.fish:270
+#: /tmp/fish/implicit/share/completions/git.fish:272
 #, fuzzy
 msgid "Remove files from the working tree and from the index"
 msgstr "Remove files after adding to archive"
 
-#: /tmp/fish/implicit/share/completions/git.fish:271
+#: /tmp/fish/implicit/share/completions/git.fish:273
 #, fuzzy
 msgid "Keep local copies"
 msgstr "Clean local caches and packages"
 
-#: /tmp/fish/implicit/share/completions/git.fish:272
+#: /tmp/fish/implicit/share/completions/git.fish:274
 msgid "Exit with a zero status even if no files matched"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:273
+#: /tmp/fish/implicit/share/completions/git.fish:275
 msgid "Allow recursive removal"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:275
+#: /tmp/fish/implicit/share/completions/git.fish:277
 msgid "Override the up-to-date check"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:276
+#: /tmp/fish/implicit/share/completions/git.fish:278
 #: /tmp/fish/implicit/share/completions/prt-get.fish:45
 #: /tmp/fish/implicit/share/completions/prt-get.fish:103
+#: /tmp/fish/implicit/share/completions/zfs.fish:40
+#: /tmp/fish/implicit/share/completions/zfs.fish:124
+#: /tmp/fish/implicit/share/completions/zfs.fish:132
 msgid "Dry run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:277
+#: /tmp/fish/implicit/share/completions/git.fish:279
 #, fuzzy
 msgid "Show the working tree status"
 msgstr "Show hidden functions"
 
-#: /tmp/fish/implicit/share/completions/git.fish:278
+#: /tmp/fish/implicit/share/completions/git.fish:280
 #, fuzzy
 msgid "Give the output in the short-format"
 msgstr "Give output suitable for get --context"
 
-#: /tmp/fish/implicit/share/completions/git.fish:279
+#: /tmp/fish/implicit/share/completions/git.fish:281
 msgid "Show the branch and tracking info even in short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:280
+#: /tmp/fish/implicit/share/completions/git.fish:282
 msgid "Give the output in a stable, easy-to-parse format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:281
+#: /tmp/fish/implicit/share/completions/git.fish:283
 msgid "Terminate entries with null character"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:282
+#: /tmp/fish/implicit/share/completions/git.fish:284
 msgid "The untracked files handling mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:283
+#: /tmp/fish/implicit/share/completions/git.fish:285
 #, fuzzy
 msgid "Ignore changes to submodules"
 msgstr "Ignore changes in case"
 
-#: /tmp/fish/implicit/share/completions/git.fish:284
+#: /tmp/fish/implicit/share/completions/git.fish:286
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:286
+#: /tmp/fish/implicit/share/completions/git.fish:288
 msgid "Make an unsigned, annotated tag object"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:289
 #, fuzzy
 msgid "Make a GPG-signed tag"
 msgstr "Make a signature"
 
-#: /tmp/fish/implicit/share/completions/git.fish:288
+#: /tmp/fish/implicit/share/completions/git.fish:290
 #, fuzzy
 msgid "Remove a tag"
 msgstr "Remove a key"
 
-#: /tmp/fish/implicit/share/completions/git.fish:289
+#: /tmp/fish/implicit/share/completions/git.fish:291
 msgid "Verify signature of a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:290
+#: /tmp/fish/implicit/share/completions/git.fish:292
 msgid "Force overwriting exising tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:292
+#: /tmp/fish/implicit/share/completions/git.fish:294
 msgid "List tags that contain a commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:297
 #, fuzzy
 msgid "Stash away changes"
 msgstr "Patch local changes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:296
+#: /tmp/fish/implicit/share/completions/git.fish:298
 #, fuzzy
 msgid "List stashes"
 msgstr "Lista as chaves"
 
-#: /tmp/fish/implicit/share/completions/git.fish:297
+#: /tmp/fish/implicit/share/completions/git.fish:299
 #, fuzzy
 msgid "Show the changes recorded in the stash"
 msgstr "Query packages with the specified group"
 
-#: /tmp/fish/implicit/share/completions/git.fish:298
+#: /tmp/fish/implicit/share/completions/git.fish:300
 msgid "Apply and remove a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:299
+#: /tmp/fish/implicit/share/completions/git.fish:301
 msgid "Apply a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:300
+#: /tmp/fish/implicit/share/completions/git.fish:302
 #, fuzzy
 msgid "Remove all stashed states"
 msgstr "Remove packages"
 
-#: /tmp/fish/implicit/share/completions/git.fish:301
+#: /tmp/fish/implicit/share/completions/git.fish:303
 #, fuzzy
 msgid "Remove a single stashed state from the stash list"
 msgstr "Remove a given entry from the --group list"
 
-#: /tmp/fish/implicit/share/completions/git.fish:302
+#: /tmp/fish/implicit/share/completions/git.fish:304
 #, fuzzy
 msgid "Create a stash"
 msgstr "Create archive"
 
-#: /tmp/fish/implicit/share/completions/git.fish:303
+#: /tmp/fish/implicit/share/completions/git.fish:305
 msgid "Save a new stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:304
+#: /tmp/fish/implicit/share/completions/git.fish:306
 #, fuzzy
 msgid "Create a new branch from a stash"
 msgstr "Create compressed patches"
 
-#: /tmp/fish/implicit/share/completions/git.fish:305
+#: /tmp/fish/implicit/share/completions/git.fish:307
 #, fuzzy
 msgid "Set and read git configuration variables"
 msgstr "Specify a configuration file"
 
-#: /tmp/fish/implicit/share/completions/git.fish:306
+#: /tmp/fish/implicit/share/completions/git.fish:308
 #, fuzzy
 msgid "Generate patch series to send upstream"
 msgstr "Generate package from source"
 
-#: /tmp/fish/implicit/share/completions/git.fish:308
+#: /tmp/fish/implicit/share/completions/git.fish:310
 msgid "Generate plain patches without diffstat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:309
+#: /tmp/fish/implicit/share/completions/git.fish:311
 #, fuzzy
 msgid "Suppress diff output"
 msgstr "Suppress informational output"
 
-#: /tmp/fish/implicit/share/completions/git.fish:310
+#: /tmp/fish/implicit/share/completions/git.fish:312
 msgid "Spend more time to create smaller diffs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:311
+#: /tmp/fish/implicit/share/completions/git.fish:313
 msgid "Generate diff with the 'patience' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:312
+#: /tmp/fish/implicit/share/completions/git.fish:314
 msgid "Generate diff with the 'histogram' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:313
+#: /tmp/fish/implicit/share/completions/git.fish:315
 msgid "Print all commits to stdout in mbox format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:314
-msgid "Show number of added/deleted lines in decimal notation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:315
-#, fuzzy
-msgid "Output only last line of the stat"
-msgstr "Output only first of equal lines"
-
 #: /tmp/fish/implicit/share/completions/git.fish:316
-msgid "Output a condensed summary of extended header information"
+msgid "Show number of added/deleted lines in decimal notation"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:317
 #, fuzzy
-msgid "Disable rename detection"
-msgstr "Don't trust the file modification times"
+msgid "Output only last line of the stat"
+msgstr "Output only first of equal lines"
 
 #: /tmp/fish/implicit/share/completions/git.fish:318
-msgid "Show full blob object names"
+msgid "Output a condensed summary of extended header information"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:319
+#, fuzzy
+msgid "Disable rename detection"
+msgstr "Don't trust the file modification times"
+
+#: /tmp/fish/implicit/share/completions/git.fish:320
+msgid "Show full blob object names"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:321
 msgid "Output a binary diff for use with git apply"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:320
+#: /tmp/fish/implicit/share/completions/git.fish:322
 msgid "Also inspect unmodified files as source for a copy"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:322
+#: /tmp/fish/implicit/share/completions/git.fish:324
 #, fuzzy
 msgid "Ignore changes in whitespace at EOL"
 msgstr "Ignore changes in the amount of white space"
 
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: /tmp/fish/implicit/share/completions/git.fish:325
 #, fuzzy
 msgid "Ignore changes in amount of whitespace"
 msgstr "Ignore changes in the amount of white space"
 
-#: /tmp/fish/implicit/share/completions/git.fish:324
+#: /tmp/fish/implicit/share/completions/git.fish:326
 #, fuzzy
 msgid "Ignore whitespace when comparing lines"
 msgstr "Ignore case when comparing file names"
 
-#: /tmp/fish/implicit/share/completions/git.fish:326
+#: /tmp/fish/implicit/share/completions/git.fish:328
 #, fuzzy
 msgid "Show whole surrounding functions of changes"
 msgstr "Show hidden functions"
 
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: /tmp/fish/implicit/share/completions/git.fish:329
 msgid "Allow an external diff helper to be executed"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:328
+#: /tmp/fish/implicit/share/completions/git.fish:330
 msgid "Disallow external diff helpers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:329
+#: /tmp/fish/implicit/share/completions/git.fish:331
 msgid "Disallow external text conversion filters for binary files (Default)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:330
+#: /tmp/fish/implicit/share/completions/git.fish:332
 msgid ""
 "Allow external text conversion filters for binary files (Resulting diff is "
 "unappliable)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:331
+#: /tmp/fish/implicit/share/completions/git.fish:333
 msgid "Do not show source or destination prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:332
+#: /tmp/fish/implicit/share/completions/git.fish:334
 msgid "Name output in [Patch n/m] format, even with a single patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:333
+#: /tmp/fish/implicit/share/completions/git.fish:335
 msgid "Name output in [Patch] format, even with multiple patches"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:334
+#: /tmp/fish/implicit/share/completions/git.fish:336
 msgid "Initialize, update or inspect submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:335
+#: /tmp/fish/implicit/share/completions/git.fish:337
 #, fuzzy
 msgid "Add a submodule"
 msgstr "Add a symbolic tag to a module"
 
-#: /tmp/fish/implicit/share/completions/git.fish:336
+#: /tmp/fish/implicit/share/completions/git.fish:338
 msgid "Show submodule status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:337
-#: /tmp/fish/implicit/share/completions/git.fish:343
+#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:345
 msgid "Initialize all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:338
+#: /tmp/fish/implicit/share/completions/git.fish:340
 #, fuzzy
 msgid "Update all submodules"
 msgstr "Update sources"
 
-#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:341
 #, fuzzy
 msgid "Show commit summary"
 msgstr "Print summary"
 
-#: /tmp/fish/implicit/share/completions/git.fish:340
+#: /tmp/fish/implicit/share/completions/git.fish:342
 #, fuzzy
 msgid "Run command on each submodule"
 msgstr "Run commands from cache"
 
-#: /tmp/fish/implicit/share/completions/git.fish:341
+#: /tmp/fish/implicit/share/completions/git.fish:343
 msgid "Sync submodules' URL with .gitmodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:342
+#: /tmp/fish/implicit/share/completions/git.fish:344
 #, fuzzy
 msgid "Only print error messages"
 msgstr "Only print number of matches"
 
-#: /tmp/fish/implicit/share/completions/git.fish:344
+#: /tmp/fish/implicit/share/completions/git.fish:346
 msgid "Checkout the superproject's commit on a detached HEAD in the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:345
+#: /tmp/fish/implicit/share/completions/git.fish:347
 msgid ""
 "Merge the superproject's commit into the current branch of the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:346
+#: /tmp/fish/implicit/share/completions/git.fish:348
 msgid "Rebase current branch onto the superproject's commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:347
+#: /tmp/fish/implicit/share/completions/git.fish:349
 msgid "Don't fetch new objects from the remote"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:348
+#: /tmp/fish/implicit/share/completions/git.fish:350
 msgid ""
 "Instead of using superproject's SHA-1, use the state of the submodule's "
 "remote-tracking branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:349
+#: /tmp/fish/implicit/share/completions/git.fish:351
 msgid ""
 "Throw away local changes when switching to a different commit and always run "
 "checkout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:350
+#: /tmp/fish/implicit/share/completions/git.fish:352
 msgid "Also add ignored submodule path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:351
+#: /tmp/fish/implicit/share/completions/git.fish:353
 #, fuzzy
 msgid "Remove even with local changes"
 msgstr "Patch local changes"
 
-#: /tmp/fish/implicit/share/completions/git.fish:352
+#: /tmp/fish/implicit/share/completions/git.fish:354
 msgid "Use the commit stored in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:353
-msgid "Compare the commit in the index with submodule HEAD"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:354
-#, fuzzy
-msgid "Traverse submodules recursively"
-msgstr "Descend recursively"
-
 #: /tmp/fish/implicit/share/completions/git.fish:355
-msgid "Show logs with difference each commit introduces"
+msgid "Compare the commit in the index with submodule HEAD"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:356
 #, fuzzy
+msgid "Traverse submodules recursively"
+msgstr "Descend recursively"
+
+#: /tmp/fish/implicit/share/completions/git.fish:357
+msgid "Show logs with difference each commit introduces"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:358
+#, fuzzy
 msgid "Remove untracked files from the working tree"
 msgstr "Place files or directories under version control"
 
-#: /tmp/fish/implicit/share/completions/git.fish:357
+#: /tmp/fish/implicit/share/completions/git.fish:359
 #, fuzzy
 msgid "Force run"
 msgstr "Saída forçada"
 
-#: /tmp/fish/implicit/share/completions/git.fish:358
+#: /tmp/fish/implicit/share/completions/git.fish:360
 msgid "Show what would be done and clean files interactively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:359
+#: /tmp/fish/implicit/share/completions/git.fish:361
 msgid "Don't actually remove anything, just show what would be done"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:360
+#: /tmp/fish/implicit/share/completions/git.fish:362
 msgid "Be quiet, only report errors"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:361
+#: /tmp/fish/implicit/share/completions/git.fish:363
 msgid "Remove untracked directories in addition to untracked files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:362
+#: /tmp/fish/implicit/share/completions/git.fish:364
 msgid "Remove ignored files, as well"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:363
+#: /tmp/fish/implicit/share/completions/git.fish:365
 #, fuzzy
 msgid "Remove only ignored files"
 msgstr "Freshen: only changed files"
 
-#: /tmp/fish/implicit/share/completions/git.fish:364
+#: /tmp/fish/implicit/share/completions/git.fish:366
 #, fuzzy
 msgid "Show what revision and author last modified each line of a file"
 msgstr "Show last revision where each line was modified"
 
-#: /tmp/fish/implicit/share/completions/git.fish:365
-msgid "Show blank SHA-1 for boundary commits"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:366
-#, fuzzy
-msgid "Do not treat root commits as boundaries"
-msgstr "Do not execute remote command"
-
 #: /tmp/fish/implicit/share/completions/git.fish:367
-msgid "Include additional statistics"
+msgid "Show blank SHA-1 for boundary commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:368
 #, fuzzy
-msgid "Annotate only the given line range"
-msgstr "Annotate every line"
+msgid "Do not treat root commits as boundaries"
+msgstr "Do not execute remote command"
 
 #: /tmp/fish/implicit/share/completions/git.fish:369
-msgid "Show long rev"
+msgid "Include additional statistics"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:370
 #, fuzzy
+msgid "Annotate only the given line range"
+msgstr "Annotate every line"
+
+#: /tmp/fish/implicit/share/completions/git.fish:371
+msgid "Show long rev"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:372
+#, fuzzy
 msgid "Show raw timestamp"
 msgstr "Show time type"
 
-#: /tmp/fish/implicit/share/completions/git.fish:371
+#: /tmp/fish/implicit/share/completions/git.fish:373
 #, fuzzy
 msgid "Use revisions from named file instead of calling rev-list"
 msgstr "Use specified file instead of the default trustdb"
 
-#: /tmp/fish/implicit/share/completions/git.fish:372
+#: /tmp/fish/implicit/share/completions/git.fish:374
 msgid "Walk history forward instead of backward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:373
+#: /tmp/fish/implicit/share/completions/git.fish:375
 msgid "Show in a format designed for machine consumption"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:374
+#: /tmp/fish/implicit/share/completions/git.fish:376
 #, fuzzy
 msgid "Show the porcelain format"
 msgstr "Show whatis information"
 
-#: /tmp/fish/implicit/share/completions/git.fish:375
+#: /tmp/fish/implicit/share/completions/git.fish:377
 #, fuzzy
 msgid "Show the result incrementally"
 msgstr "Show the time"
 
-#: /tmp/fish/implicit/share/completions/git.fish:376
+#: /tmp/fish/implicit/share/completions/git.fish:378
 msgid "Instead of working tree, use the contents of the named file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:377
+#: /tmp/fish/implicit/share/completions/git.fish:379
 #, fuzzy
 msgid "Specifies the format used to output dates"
 msgstr "Specify the repository URL"
 
-#: /tmp/fish/implicit/share/completions/git.fish:378
+#: /tmp/fish/implicit/share/completions/git.fish:380
 msgid "Detect moved or copied lines within a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:379
+#: /tmp/fish/implicit/share/completions/git.fish:381
 msgid ""
 "Detect lines moved or copied from other files that were modified in the same "
 "commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:381
+#: /tmp/fish/implicit/share/completions/git.fish:383
 #, fuzzy
 msgid "Use the same output mode as git-annotate"
 msgstr "Use the portable output format"
 
-#: /tmp/fish/implicit/share/completions/git.fish:382
+#: /tmp/fish/implicit/share/completions/git.fish:384
 #, fuzzy
 msgid "Show the filename in the original commit"
 msgstr "Change working directory"
 
-#: /tmp/fish/implicit/share/completions/git.fish:383
-msgid "Show the line number in the original commit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:384
-#, fuzzy
-msgid "Suppress the author name and timestamp from the output"
-msgstr "Allow subkeys that have a timestamp from the future"
-
 #: /tmp/fish/implicit/share/completions/git.fish:385
-msgid "Show the author email instead of author name"
+msgid "Show the line number in the original commit"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:386
 #, fuzzy
+msgid "Suppress the author name and timestamp from the output"
+msgstr "Allow subkeys that have a timestamp from the future"
+
+#: /tmp/fish/implicit/share/completions/git.fish:387
+msgid "Show the author email instead of author name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:388
+#, fuzzy
 msgid "Ignore whitespace changes"
 msgstr "Ignore whitespace"
 
-#: /tmp/fish/implicit/share/completions/git.fish:387
+#: /tmp/fish/implicit/share/completions/git.fish:389
 #, fuzzy
 msgid "Custom command"
 msgstr "Job command"
@@ -28893,6 +29729,7 @@ msgid "List all keys with their fingerprints"
 msgstr "List all keys with their fingerprints"
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
+#: /tmp/fish/implicit/share/completions/signify.fish:2
 #, fuzzy
 msgid "Generate a new key pair"
 msgstr "Generate a new key pair"
@@ -38810,14 +39647,6 @@ msgstr ""
 msgid "Display values currently set in the minikube config file"
 msgstr "Display all currently defined trap handlers"
 
-#: /tmp/fish/implicit/share/completions/minikube.fish:25
-#: /tmp/fish/implicit/share/completions/minikube.fish:26
-#: /tmp/fish/implicit/share/completions/minikube.fish:27
-#: /tmp/fish/implicit/share/completions/minikube.fish:28
-#, fuzzy
-msgid "Property"
-msgstr "Set property"
-
 #: /tmp/fish/implicit/share/completions/minikube.fish:29
 msgid "Go template format string for the config view output"
 msgstr ""
@@ -45016,12 +45845,6 @@ msgstr ""
 msgid "keep going until N jobs fail [default=1]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ninja.fish:8
-#: /tmp/fish/implicit/share/completions/quilt.fish:1
-#, fuzzy
-msgid "show help"
-msgstr "Mostra tudo"
-
 #: /tmp/fish/implicit/share/completions/ninja.fish:9
 #, fuzzy
 msgid "enable debugging, specify debug mode"
@@ -48613,6 +49436,20 @@ msgstr "Disable warnings about MFC"
 msgid "Extract script"
 msgstr "Extract script"
 
+#: /tmp/fish/implicit/share/completions/pfctl.fish:1
+msgid "Show a filter parameter by modifier"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:2
+#, fuzzy
+msgid "Flush filter params specified by mod"
+msgstr "Compare only specified number of characters"
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:3
+#, fuzzy
+msgid "Table command"
+msgstr "Set prompt command"
+
 #: /tmp/fish/implicit/share/completions/pgrep.fish:1
 #, fuzzy
 msgid "Output delimiter"
@@ -48831,6 +49668,31 @@ msgstr ""
 msgid "omit the user's full name, remote host and idle time in short format"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:1
+#, fuzzy
+msgid "failsafe to overwrite"
+msgstr "Log to file, overwrite"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:2
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:3
+#, fuzzy
+msgid "Turn on stats"
+msgstr "Warning control"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:3
+#, fuzzy
+msgid "Automated package installation"
+msgstr "Don't change the package installation order"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:5
+#, fuzzy
+msgid "Update packages"
+msgstr "Upgrade packages"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:6
+msgid "Fuzzy match"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:1
 #, fuzzy
 msgid "Upgrade"
@@ -48945,6 +49807,11 @@ msgstr "List capabilities this package provides"
 #: /tmp/fish/implicit/share/completions/pkg-config.fish:25
 msgid "List all modules the given packages requires for static linking"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:2
+#, fuzzy
+msgid "Delete unsed deps"
+msgstr "Delete selection"
 
 #: /tmp/fish/implicit/share/completions/pkgfile.fish:3
 msgid "only show files in a {s}bin/ directory. Works with -s, -l"
@@ -53809,6 +54676,20 @@ msgstr ""
 msgid "Specifies layout variant used to choose component names"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/signify.fish:1
+msgid "Verify a signed checksum list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:3
+#, fuzzy
+msgid "Sign specified message"
+msgstr "Ignore specified file"
+
+#: /tmp/fish/implicit/share/completions/signify.fish:4
+#, fuzzy
+msgid "Verify a signed message and sig"
+msgstr "Load the media and exit"
+
 #: /tmp/fish/implicit/share/completions/snap.fish:1
 #, fuzzy
 msgid "Test if snap has yet to be given the subcommand"
@@ -57961,11 +58842,13 @@ msgid "Monitor changes to objects"
 msgstr "Ignore changes in case"
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:7
+#: /tmp/fish/implicit/share/completions/zfs.fish:17
 #, fuzzy
 msgid "Mount a filesystem"
 msgstr "Show all filesystems"
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:18
 #, fuzzy
 msgid "Unmount a filesystem"
 msgstr "Show all filesystems"
@@ -62953,6 +63836,689 @@ msgstr "Delete obsolete package files"
 msgid "Delete all cache contents"
 msgstr "Delete the logfile when done"
 
+#: /tmp/fish/implicit/share/completions/zfs.fish:1
+#, fuzzy
+msgid ""
+"Internal completion function for appending string to the ZFS commandline"
+msgstr "Print all possible definitions of the specified name"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:2
+#: /tmp/fish/implicit/share/completions/zpool.fish:2
+#, fuzzy
+msgid "Display a help message"
+msgstr "Display man page"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:3
+#, fuzzy
+msgid "Create a volume or filesystem"
+msgstr "Compare archive and filesystem"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:4
+msgid "Destroy a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:5
+#, fuzzy
+msgid "Create a snapshot"
+msgstr "Create archive"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:6
+msgid "Roll back a filesystem to a previous snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:7
+#, fuzzy
+msgid "Create a clone of a snapshot"
+msgstr "Remove one or more packages"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:8
+msgid ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:9
+#, fuzzy
+msgid "Rename a dataset"
+msgstr "Rename a disc"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:10
+#, fuzzy
+msgid "List dataset properties"
+msgstr "Disable automatic properties"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:11
+#, fuzzy
+msgid "Set a dataset property"
+msgstr "Set property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:12
+#, fuzzy
+msgid "Get one or several dataset properties"
+msgstr "Operate on revision property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:13
+msgid "Set a dataset property to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:14
+msgid "List upgradeable datasets, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:15
+msgid "Get dataset space consumed by each user"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:16
+msgid "Get dataset space consumed by each user group"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:19
+msgid "Share a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:20
+msgid "Stop sharing a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:21
+#, fuzzy
+msgid "Create a bookmark for a snapshot"
+msgstr "Create compressed patches"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:22
+msgid "Output a stream representation of a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:23
+msgid ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:24
+msgid ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:25
+msgid "Revoke delegations of rights on a dataset from (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:26
+#, fuzzy
+msgid "Put a named hold on a snapshot"
+msgstr "Print path to command"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:27
+#, fuzzy
+msgid "List holds on a snapshot"
+msgstr "Print path to command"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:28
+#, fuzzy
+msgid "Remove a named hold from a snapshot"
+msgstr "Remove all gz files from cache"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:29
+msgid ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:30
+msgid "Execute a ZFS Channel Program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:31
+#: /tmp/fish/implicit/share/completions/zfs.fish:53
+#: /tmp/fish/implicit/share/completions/zfs.fish:58
+#, fuzzy
+msgid "Create all needed non-existing parent datasets"
+msgstr "Remove files after adding to archive"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:32
+#: /tmp/fish/implicit/share/completions/zfs.fish:33
+#, fuzzy
+msgid "Dataset property"
+msgstr "Set property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:34
+#, fuzzy
+msgid "Volume size"
+msgstr "Compress file"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:35
+#, fuzzy
+msgid "Create a sparse volume"
+msgstr "Create new project"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:36
+#, fuzzy
+msgid "Blocksize"
+msgstr "Tamanho do bloco"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:37
+#, fuzzy
+msgid "Recursively destroy children"
+msgstr "Recursively copy"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:38
+msgid "Recursively destroy all dependents"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:39
+#, fuzzy
+msgid "Force unmounting"
+msgstr "Fake mounting"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:41
+#, fuzzy
+msgid "Print machine-parsable verbose information"
+msgstr "Print verbose info"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:43
+#, fuzzy
+msgid "Defer snapshot deletion"
+msgstr "Delete selection"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:44
+#, fuzzy
+msgid "Dataset to destroy"
+msgstr "Initial set of keystrokes"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:45
+#, fuzzy
+msgid "Recursively snapshot children"
+msgstr "Secure mode"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:46
+#: /tmp/fish/implicit/share/completions/zfs.fish:47
+#, fuzzy
+msgid "Snapshot property"
+msgstr "Set property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:48
+msgid "Dataset to snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:49
+msgid "Destroy later snapshot and bookmarks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:50
+msgid "Recursively destroy later snapshot, bookmarks and clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:51
+#, fuzzy
+msgid "Force unmounting of clones"
+msgstr "Do not create output files"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:52
+msgid "Snapshot to roll back to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:54
+#: /tmp/fish/implicit/share/completions/zfs.fish:55
+#, fuzzy
+msgid "Clone property"
+msgstr "Set property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:56
+msgid "Snapshot to clone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:57
+msgid "Clone to promote"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:59
+msgid "Recursively rename children snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:60
+#: /tmp/fish/implicit/share/completions/zfs.fish:62
+#: /tmp/fish/implicit/share/completions/zfs.fish:108
+#, fuzzy
+msgid "Force unmounting if needed"
+msgstr "Force rebuilding index"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:61
+#, fuzzy
+msgid "Do not remount filesystems during rename"
+msgstr "Stay in local filesystem"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:63
+#, fuzzy
+msgid "Dataset to rename"
+msgstr "Service name"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:64
+#: /tmp/fish/implicit/share/completions/zfs.fish:77
+#: /tmp/fish/implicit/share/completions/zfs.fish:94
+#: /tmp/fish/implicit/share/completions/zfs.fish:172
+#: /tmp/fish/implicit/share/completions/zpool.fish:59
+#: /tmp/fish/implicit/share/completions/zpool.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:99
+#, fuzzy
+msgid "Print output in a machine-parsable format"
+msgstr "Profiling output format"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:65
+#: /tmp/fish/implicit/share/completions/zfs.fish:75
+#: /tmp/fish/implicit/share/completions/zfs.fish:84
+#: /tmp/fish/implicit/share/completions/zfs.fish:89
+#, fuzzy
+msgid "Operate recursively on datasets"
+msgstr "Operate recursively"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:105
+#, fuzzy
+msgid "Property to list"
+msgstr "Minimum port to listen to"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:68
+#: /tmp/fish/implicit/share/completions/zfs.fish:80
+#: /tmp/fish/implicit/share/completions/zfs.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:66
+#, fuzzy
+msgid "Print parsable (exact) values for numbers"
+msgstr "Print all versions"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:69
+#: /tmp/fish/implicit/share/completions/zfs.fish:97
+msgid "Property to use for sorting output by ascending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:70
+#: /tmp/fish/implicit/share/completions/zfs.fish:98
+msgid "Property to use for sorting output by descending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:72
+msgid "Dataset which properties is to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:73
+#: /tmp/fish/implicit/share/completions/zpool.fish:125
+#, fuzzy
+msgid "Property to set"
+msgstr "Set property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:74
+msgid "Dataset which property is to be setted"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:78
+#: /tmp/fish/implicit/share/completions/zpool.fish:68
+#, fuzzy
+msgid "Fields to display"
+msgstr "Select display"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:79
+#, fuzzy
+msgid "Property source to display"
+msgstr "Select display"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:82
+#, fuzzy
+msgid "Property to get"
+msgstr "Set property"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:83
+msgid "Dataset which properties is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:85
+#, fuzzy
+msgid "Revert to the received value if available"
+msgstr "Help for the specified builtin"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:86
+msgid "Dataset which properties is to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:88
+#, fuzzy
+msgid "Upgrade all eligible filesystems"
+msgstr "Show all filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:90
+#, fuzzy
+msgid "Upgrade to the specified version"
+msgstr "Help for the specified builtin"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:91
+#, fuzzy
+msgid "Filesystem to upgrade"
+msgstr "Print filesystem type"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:92
+#, fuzzy
+msgid "Print UID instead of user name"
+msgstr "Link files instead of copying"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:93
+#, fuzzy
+msgid "Print GID instead of group name"
+msgstr "Link files instead of copying"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:96
+#, fuzzy
+msgid "Field to display"
+msgstr "X server display"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:99
+#: /tmp/fish/implicit/share/completions/zfs.fish:100
+#, fuzzy
+msgid "Identity types to display"
+msgstr "Select display"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:101
+msgid "Translate S(amba)ID to POSIX ID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:102
+msgid "Dataset which space usage is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:103
+msgid "Temporary mount point property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:104
+#, fuzzy
+msgid "Report progress"
+msgstr "Suppress error messages"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:105
+#, fuzzy
+msgid "Mount all available ZFS filesystems"
+msgstr "Show all filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:106
+#, fuzzy
+msgid "Overlay mount"
+msgstr "Lazy unmount"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:107
+#, fuzzy
+msgid "Filesystem to mount"
+msgstr "Print filesystem type"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:109
+#, fuzzy
+msgid "Unmount all available ZFS filesystems"
+msgstr "Show all filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:110
+#, fuzzy
+msgid "Filesystem to unmount"
+msgstr "Print filesystem type"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:111
+#, fuzzy
+msgid "Share all eligible ZFS filesystems"
+msgstr "Show all filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:112
+#, fuzzy
+msgid "Filesystem to share"
+msgstr "Print filesystem type"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:113
+#, fuzzy
+msgid "Unshare all shared ZFS filesystems"
+msgstr "Show all filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:114
+#, fuzzy
+msgid "Filesystem to unshare"
+msgstr "Print filesystem type"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:115
+msgid "Snapshot to bookmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:116
+#, fuzzy
+msgid "Generate incremental stream from snapshot"
+msgstr "Use new incremental GNU format"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:117
+msgid ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:118
+#: /tmp/fish/implicit/share/completions/zfs.fish:127
+msgid "Include children in replication stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:119
+#: /tmp/fish/implicit/share/completions/zfs.fish:128
+#, fuzzy
+msgid "Generate a deduplicated stream"
+msgstr "Generate package from source"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:120
+#: /tmp/fish/implicit/share/completions/zfs.fish:129
+msgid "Allow the presence of larger blocks than 128 kiB"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:121
+#: /tmp/fish/implicit/share/completions/zfs.fish:130
+msgid "Generate a more compact stream by using WRITE_EMBEDDED records"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:122
+#: /tmp/fish/implicit/share/completions/zfs.fish:131
+#, fuzzy
+msgid "Print verbose information about the stream in a machine-parsable format"
+msgstr "Output extra information about the work being done"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:123
+#, fuzzy
+msgid "Generate compressed stream"
+msgstr "Generate package from source"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:125
+#: /tmp/fish/implicit/share/completions/zfs.fish:133
+#, fuzzy
+msgid "Include dataset properties"
+msgstr "Exceto arquivo"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:126
+#: /tmp/fish/implicit/share/completions/zfs.fish:134
+#, fuzzy
+msgid "Print verbose information about the stream"
+msgstr "Ignore all version information"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:135
+#, fuzzy
+msgid "Dataset to send"
+msgstr "Send mail to user"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:136
+#, fuzzy
+msgid ""
+"Print verbose information about the stream and the time spent processing it"
+msgstr "Output extra information about the work being done"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:137
+#, fuzzy
+msgid "Dry run: do not actually receive the stream"
+msgstr "Remove all gz files from cache"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:138
+#, fuzzy
+msgid "Force rollback to the most recent snapshot"
+msgstr "Updates packages to the best version available"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:139
+#, fuzzy
+msgid "Unmount the target filesystem"
+msgstr "Show all filesystems"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:140
+#, fuzzy
+msgid "Discard the first element of the path of the sent snapshot"
+msgstr "Print time of last boot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:141
+#, fuzzy
+msgid "Discard all but the last element of the path of the sent snapshot"
+msgstr "Print time of last boot"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:142
+msgid "Force the stream to be received as a clone of the given snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:143
+msgid "On transfer interruption, store a receive_resume_token for resumption"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:144
+msgid "Dataset to receive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:145
+#, fuzzy
+msgid "Delegate permissions only on the specified dataset"
+msgstr "Print all possible definitions of the specified name"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:146
+msgid "Delegate permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:147
+#, fuzzy
+msgid "User to delegate permissions to"
+msgstr "Set default file permission mask"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:148
+#, fuzzy
+msgid "Group to delegate permissions to"
+msgstr "Extract all permissions"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:149
+#: /tmp/fish/implicit/share/completions/zfs.fish:150
+#, fuzzy
+msgid "Delegate permission to everyone"
+msgstr "Assert freestanding environment"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:151
+msgid "Delegate permissions only to the creator of later descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:152
+msgid "Create a permission set or add permissions to an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:153
+msgid "Dataset on which delegation is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:154
+#, fuzzy
+msgid "Remove permissions only on the specified dataset"
+msgstr "Specify the repository URL"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:155
+msgid "Remove permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:156
+#, fuzzy
+msgid "User to remove permissions from"
+msgstr "Preserve environment"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:157
+#, fuzzy
+msgid "Group to remove permissions from"
+msgstr "Extract all permissions"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:158
+#: /tmp/fish/implicit/share/completions/zfs.fish:162
+#: /tmp/fish/implicit/share/completions/zfs.fish:163
+#, fuzzy
+msgid "Remove permission from everyone"
+msgstr "Remove all entries from the --group list"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:159
+msgid "Remove permissions only on later created descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:160
+#, fuzzy
+msgid "Remove a permission set or remove permissions from an existing one"
+msgstr "Remove files after adding to archive"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:161
+#, fuzzy
+msgid "Remove permissions recursively"
+msgstr "Operate recursively"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:164
+msgid "Dataset on which delegation is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:165
+#, fuzzy
+msgid "Apply hold recursively"
+msgstr "Operate recursively"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:166
+msgid "Snapshot on which hold is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:167
+#, fuzzy
+msgid "List holds recursively"
+msgstr "Operate recursively"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:168
+msgid "Snapshot which holds are to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:169
+#, fuzzy
+msgid "Release hold recursively"
+msgstr "Operate recursively"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:170
+msgid "Snapshot from which hold is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:171
+msgid "Display file type (à la ls -F)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:173
+#, fuzzy
+msgid "Display inode change time"
+msgstr "Display line number"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:174
+msgid "Source snapshot for the diff"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:175
+#, fuzzy
+msgid "Execution timeout"
+msgstr "Recursion limit"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:176
+#, fuzzy
+msgid "Execution memory limit"
+msgstr "Recursion limit"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:177
+msgid "Pool which program will be executed on"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/zip.fish:1
 msgid "Freshen: only changed files"
 msgstr "Freshen: only changed files"
@@ -63060,6 +64626,532 @@ msgstr "Encrypt"
 #, fuzzy
 msgid "Don't compress files with these suffixes"
 msgstr "Don't compress files with these suffixes"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:1
+msgid ""
+"Internal completion function for appending string to the zpool commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:3
+msgid "Add new virtual devices to pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:4
+msgid "Attach virtual device to a pool device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:5
+msgid "Clear devices errors in pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:6
+#, fuzzy
+msgid "Create a new storage pool"
+msgstr "Create new project"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:7
+msgid "Destroy a storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:8
+msgid "Detach virtual device from a mirroring pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:9
+#, fuzzy
+msgid "Display pool event log"
+msgstr "Display all changelogs"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:10
+msgid "Export a pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:11
+#, fuzzy
+msgid "Get one or several pool properties"
+msgstr "Operate on revision property"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:12
+#, fuzzy
+msgid "Display pool command history"
+msgstr "Display help and exit"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:13
+#, fuzzy
+msgid "List importable pools, or import some"
+msgstr "Print available list"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:14
+#, fuzzy
+msgid "Display pool I/O stats"
+msgstr "Display control chars"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:15
+#, fuzzy
+msgid "Remove ZFS label information from the specified device"
+msgstr "Display change information for the package"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:16
+msgid "List pools with health status and space usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:17
+#, fuzzy
+msgid "Take the specified devices offline"
+msgstr "Use specified keyserver"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:18
+#, fuzzy
+msgid "Bring the specified devices back online"
+msgstr "Use specified keyserver"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:19
+msgid "Reset pool GUID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:20
+#, fuzzy
+msgid "Remove virtual devices from pool"
+msgstr "Create a local copy of another repository"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:21
+#, fuzzy
+msgid "Reopen pool devices"
+msgstr "Imprimir todos os nomes"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:22
+#, fuzzy
+msgid "Replace a pool virtual device"
+msgstr "File is block device"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:23
+msgid "Start or stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:24
+#, fuzzy
+msgid "Set a pool property"
+msgstr "Set property"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:25
+msgid "Create a pool by splitting an existing mirror one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:26
+#, fuzzy
+msgid "Display detailed pool health status"
+msgstr "Print the URIs"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:27
+msgid "List upgradeable pools, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:28
+#: /tmp/fish/implicit/share/completions/zpool.fish:36
+#: /tmp/fish/implicit/share/completions/zpool.fish:45
+#: /tmp/fish/implicit/share/completions/zpool.fish:117
+#, fuzzy
+msgid "Force use of virtual device"
+msgstr "Mostra inode dos arquivos"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:29
+#: /tmp/fish/implicit/share/completions/zpool.fish:130
+#, fuzzy
+msgid "Dry run: only display resulting configuration"
+msgstr "Reload service configuration"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:30
+#: /tmp/fish/implicit/share/completions/zpool.fish:91
+#: /tmp/fish/implicit/share/completions/zpool.fish:100
+#: /tmp/fish/implicit/share/completions/zpool.fish:127
+#: /tmp/fish/implicit/share/completions/zpool.fish:135
+msgid "Display virtual device GUID instead of device name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:31
+#: /tmp/fish/implicit/share/completions/zpool.fish:92
+#: /tmp/fish/implicit/share/completions/zpool.fish:101
+#: /tmp/fish/implicit/share/completions/zpool.fish:128
+#: /tmp/fish/implicit/share/completions/zpool.fish:136
+#, fuzzy
+msgid "Resolve device path symbolic links"
+msgstr "Dereferense symbolic links"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:32
+#: /tmp/fish/implicit/share/completions/zpool.fish:93
+#: /tmp/fish/implicit/share/completions/zpool.fish:102
+#: /tmp/fish/implicit/share/completions/zpool.fish:129
+#: /tmp/fish/implicit/share/completions/zpool.fish:137
+#, fuzzy
+msgid "Display device full path"
+msgstr "Display man page"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:33
+#: /tmp/fish/implicit/share/completions/zpool.fish:37
+#: /tmp/fish/implicit/share/completions/zpool.fish:48
+#: /tmp/fish/implicit/share/completions/zpool.fish:118
+#: /tmp/fish/implicit/share/completions/zpool.fish:132
+#, fuzzy
+msgid "Pool property"
+msgstr "Set property"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:34
+#, fuzzy
+msgid "Pool to add virtual devices to"
+msgstr "Print byte offset of matches"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:35
+#: /tmp/fish/implicit/share/completions/zpool.fish:53
+#, fuzzy
+msgid "Virtual device to add"
+msgstr "Dispositivo bloco"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:38
+msgid "Pool to attach virtual device to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:39
+#: /tmp/fish/implicit/share/completions/zpool.fish:43
+#, fuzzy
+msgid "Virtual device to operate on"
+msgstr "Division control"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:40
+#, fuzzy
+msgid "Initiate recovery mode"
+msgstr "Run in interactive mode"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:41
+#: /tmp/fish/implicit/share/completions/zpool.fish:85
+msgid ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:42
+msgid "Pool to clear errors on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:44
+msgid ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:46
+#, fuzzy
+msgid "Dry run, only display resulting configuration"
+msgstr "Reload service configuration"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:47
+#, fuzzy
+msgid "Do not enable any feature on the new pool"
+msgstr "Do not fail if signature is older than key"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:49
+#, fuzzy
+msgid "Root filesystem property"
+msgstr "Set property"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:50
+#: /tmp/fish/implicit/share/completions/zpool.fish:83
+msgid "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:51
+#, fuzzy
+msgid "Root filesystem mountpoint"
+msgstr "Do not fold long lines"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:52
+#, fuzzy
+msgid "Set a different in-core pool name"
+msgstr "Select frontend interface"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:54
+#: /tmp/fish/implicit/share/completions/zpool.fish:64
+msgid "Force unmounting of all contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:55
+msgid "Pool to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:56
+#, fuzzy
+msgid "Pool to detach device from"
+msgstr "File is block device"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:57
+msgid "Physical device to detach"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:58
+#, fuzzy
+msgid "Print verbose event information"
+msgstr "Print verbose info"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:60
+msgid "Output appended data as the log grows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:61
+#, fuzzy
+msgid "Clear all previous events"
+msgstr "Ignore externals definitions"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:62
+msgid "Pool to read events from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:63
+#, fuzzy
+msgid "Export all pools"
+msgstr "Report on all tags"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:65
+#, fuzzy
+msgid "Pool to export"
+msgstr "Select display"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:69
+msgid "Properties to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:70
+#, fuzzy
+msgid "Pool to get properties of"
+msgstr "Disable automatic properties"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:71
+msgid "Also display internal events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:72
+#, fuzzy
+msgid "Display log records using long format"
+msgstr "List contents of directory using long format"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:73
+#, fuzzy
+msgid "Pool to get command history of"
+msgstr "Do not execute commands"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:74
+#, fuzzy
+msgid "Read configuration from specified cache file"
+msgstr "Dump configuration file"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:75
+#, fuzzy
+msgid "Search for devices or files in specified directory"
+msgstr "Verificar arquivos no repositório"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:76
+msgid "List or import destroyed pools only (requires -f for importation)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:77
+#: /tmp/fish/implicit/share/completions/zpool.fish:133
+#, fuzzy
+msgid "Mount properties for contained datasets"
+msgstr "Show only matching part"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:78
+#, fuzzy
+msgid "Properties of the imported pool"
+msgstr "Set size of freed memory pool"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:79
+#, fuzzy
+msgid "Force import"
+msgstr "Usa cores"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:80
+#, fuzzy
+msgid "Recovery mode"
+msgstr "Server mode"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:81
+#, fuzzy
+msgid "Search for and import all pools found"
+msgstr "Prompt for an expiration time"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:82
+msgid "Ignore missing log device (risk of loss of last changes)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:84
+#, fuzzy
+msgid "Do not mount contained filesystems"
+msgstr "Stay in local filesystem"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:86
+msgid "Roll back to a previous TXG (hazardous)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:87
+msgid "TXG to roll back to (implies -FX)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:88
+#, fuzzy
+msgid "Specify, as the last argument, a temporary pool name"
+msgstr "Specify the title of rss"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:89
+#, fuzzy
+msgid "Pool to import"
+msgstr "Dir to import"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:90
+#: /tmp/fish/implicit/share/completions/zpool.fish:103
+#: /tmp/fish/implicit/share/completions/zpool.fish:142
+#, fuzzy
+msgid "Display a timestamp using specified format"
+msgstr "Output profiling information to specified file"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:94
+#, fuzzy
+msgid "Omit statistics since boot"
+msgstr "Print word counts"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:104
+#, fuzzy
+msgid "Print verbose statistics"
+msgstr "Print verbose info"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:96
+msgid "Pool to retrieve I/O stats from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:97
+msgid "Treat exported or foreign devices as inactive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:98
+#, fuzzy
+msgid "Device to clear ZFS label information from"
+msgstr "Print extra info"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:106
+#, fuzzy
+msgid "Pool to list properties of"
+msgstr "Display font properties"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:107
+msgid "Temporarily offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:108
+msgid "Pool to offline device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:109
+msgid "Physical device to offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:110
+#, fuzzy
+msgid "Expand the device to use all available space"
+msgstr "Update list of source packages"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:111
+#, fuzzy
+msgid "Pool to bring device back online on"
+msgstr "Dispositivo bloco"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:112
+msgid "Physical device to bring back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:113
+msgid "Pool which GUID is to be changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:114
+#, fuzzy
+msgid "Pool to remove device from"
+msgstr "Forçar cópia completa de segurança"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:115
+msgid "Physical device to remove"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:116
+#, fuzzy
+msgid "Pool which devices are to be reopened"
+msgstr "Print service status"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:119
+#, fuzzy
+msgid "Pool to replace device"
+msgstr "File is character device"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:120
+msgid "Pool device to be replaced"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:121
+#, fuzzy
+msgid "Device to use for replacement"
+msgstr "Device section"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:122
+#, fuzzy
+msgid "Stop scrubbing"
+msgstr "Stop service"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:123
+#, fuzzy
+msgid "Pause scrubbing"
+msgstr "Display version and exit"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:124
+msgid "Pool to start/stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:126
+msgid "Pool which property is to be set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:131
+msgid "Set altroot for newpool and automatically import it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:134
+#, fuzzy
+msgid "Pool to split"
+msgstr "Minimum port to listen to"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:138
+#: /tmp/fish/implicit/share/completions/zpool.fish:139
+#, fuzzy
+msgid "Display deduplication histogram"
+msgstr "Display all changelogs"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:141
+msgid "Only display status for unhealthy or unavailable pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:143
+#: /tmp/fish/implicit/share/completions/zpool.fish:147
+msgid "Pool which status is to be displayed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:144
+msgid "Upgrade all eligible pools, enabling all supported features"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:145
+#, fuzzy
+msgid "Display upgradeable ZFS versions"
+msgstr "Display package record"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:146
+#, fuzzy
+msgid "Upgrade to the specified legacy version"
+msgstr "Help for the specified builtin"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:2
 msgid "Repo"
@@ -64706,6 +66798,30 @@ msgstr ""
 msgid "Complete wvdial peers"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#, fuzzy
+msgid "Completes with ZFS mountpoint properties"
+msgstr "Print a list of running screen sessions"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_pools.fish:1
+msgid "Completes with available ZFS pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#, fuzzy
+msgid "Completes with ZFS read-only properties"
+msgstr "Set directory prefix"
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Completes with ZFS read-write properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr ""
@@ -64881,6 +66997,12 @@ msgstr "Check the entire repository"
 msgid "Test if current token is on Nth place"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_is_zfs_feature_enabled.fish:1
+msgid ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_list_current_token.fish:1
 msgid ""
 "List contents of token under the cursor if it is a directory, otherwise list "
@@ -64970,6 +67092,11 @@ msgid ""
 msgstr ""
 "Print a list of all function calls leading up to running the current command"
 
+#: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
+#, fuzzy
+msgid "Print a list of local groups"
+msgstr "Print a list of all accepted color names"
+
 #: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
 #, fuzzy
 msgid "Print help message for the specified fish function or builtin"
@@ -65053,6 +67180,25 @@ msgstr "Print word counts"
 #, fuzzy
 msgid "Print X windows"
 msgstr "Print APM info"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
+msgid "Lists ZFS bookmarks, if the feature is enabled"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
+#, fuzzy
+msgid "Lists ZFS filesystems"
+msgstr "Show all filesystems"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
+#, fuzzy
+msgid "Lists ZFS snapshots"
+msgstr "Lista as chaves"
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
+#, fuzzy
+msgid "Lists ZFS volumes"
+msgstr "Lista por colunas"
 
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 #, fuzzy
@@ -65390,10 +67536,6 @@ msgstr "Erase variable"
 #, fuzzy
 #~ msgid "Change to DIR"
 #~ msgstr "Alterar para usuário"
-
-#, fuzzy
-#~ msgid "number of jobs"
-#~ msgstr "Number of concurrent jobs"
 
 #, fuzzy
 #~ msgid "Show a unit"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-13 10:22+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1814,9 +1814,11 @@ msgstr ""
 #: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
 #: /tmp/fish/implicit/share/completions/fossil.fish:90
 #: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:206
-#: /tmp/fish/implicit/share/completions/git.fish:266
-#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:269
 msgid "File"
 msgstr ""
 
@@ -2502,6 +2504,553 @@ msgstr ""
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/zfs.fish:1
+msgid "ZFS filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:2
+msgid "ZFS filesystem snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:3
+msgid "ZFS block storage device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:4
+msgid "ZFS snapshot bookmark"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:5
+msgid "Any ZFS dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:6
+msgid "Dataset-specific value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:7
+msgid "Default ZFS value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:8
+msgid "Value inherited from parent dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:9
+msgid "Value received by 'zfs receive'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:10
+msgid "Value valid for the current mount"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:11
+msgid "Read-only value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:12
+msgid "Dataset full name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:13
+#: /tmp/fish/explicit/share/completions/zpool.fish:2
+#: /tmp/fish/implicit/share/completions/minikube.fish:25
+#: /tmp/fish/implicit/share/completions/minikube.fish:26
+#: /tmp/fish/implicit/share/completions/minikube.fish:27
+#: /tmp/fish/implicit/share/completions/minikube.fish:28
+msgid "Property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:3
+msgid "Property value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:15
+#: /tmp/fish/explicit/share/completions/zpool.fish:4
+msgid "Property value origin"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:16
+msgid "Identity type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:17
+msgid "Identity name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:18
+msgid "Space usage"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:19
+msgid "Space quota"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:20
+msgid "POSIX user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:21
+msgid "Samba user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:22
+#: /tmp/fish/explicit/share/completions/zfs.fish:25
+msgid "Both types"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:23
+msgid "POSIX group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:24
+msgid "Samba group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:26
+msgid "Also needs the permission to be allowed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:27
+msgid ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:28
+#: /tmp/fish/explicit/share/completions/zfs.fish:29
+#: /tmp/fish/explicit/share/completions/zfs.fish:33
+#: /tmp/fish/explicit/share/completions/zfs.fish:35
+msgid "Also needs the 'mount' permission"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:30
+msgid ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:31
+msgid "Also needs the 'create' and 'mount' permissions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:32
+msgid "Also needs the 'create' and 'mount' permissions in the new parent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:34
+msgid "For SMB and NFS shares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:36
+msgid "Allows changing any user property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:26
+msgid "Volume block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:38
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Inheritance of ACL entries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:39
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:2
+msgid "Update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:40
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:3
+msgid "Is the dataset mountable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:41
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:4
+msgid "Data checksum"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:42
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:5
+msgid "Compression algorithm"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:43
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:6
+msgid "Number of copies of data"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:44
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:7
+msgid "Deduplication"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:45
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:2
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:8
+msgid "Are contained device nodes openable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:46
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:3
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:9
+msgid "Can contained executables be executed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:47
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:10
+msgid "Max number of filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:48
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:11
+msgid "Mountpoint"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:49
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:12
+msgid "Which data to cache in ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:50
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:13
+msgid "Max size of dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:51
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:14
+msgid "Max number of snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:52
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:4
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:15
+msgid "Read-only"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:53
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:16
+msgid "Suggest block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:54
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:17
+msgid "How redundant are the metadata"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:55
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:18
+msgid "Max space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:56
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:19
+msgid "Min space guaranteed to dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:57
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:20
+msgid "Min space guaranteed to dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:58
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:21
+msgid "Which data to cache in L2ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:59
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:5
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:22
+msgid "Respect set-UID bit"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:60
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:23
+msgid "Share in NFS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:61
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:24
+msgid "Hint for handling of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:62
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:25
+msgid "Hide .zfs directory"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:63
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:26
+msgid "Handle of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:64
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:27
+msgid "Volume logical size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:65
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:38
+msgid "Managed from a non-global zone"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:66
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:31
+msgid "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:67
+#: /tmp/fish/explicit/share/completions/zfs.fish:74
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:6
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:32
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:40
+msgid "Mount with Non Blocking mandatory locks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:68
+#: /tmp/fish/explicit/share/completions/zfs.fish:77
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:33
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:43
+msgid "Share in Samba"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:69
+#: /tmp/fish/explicit/share/completions/zfs.fish:76
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:34
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:42
+msgid "Share as an iSCSI target"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:70
+#: /tmp/fish/explicit/share/completions/zfs.fish:79
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:35
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:45
+msgid "On-disk version of filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:71
+#: /tmp/fish/explicit/share/completions/zfs.fish:80
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:36
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:46
+msgid "Scan regular files for viruses on opening and closing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:72
+#: /tmp/fish/explicit/share/completions/zfs.fish:81
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:7
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:47
+msgid "Extended attributes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:73
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:39
+msgid "Use no ACL or POSIX ACL"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:75
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:9
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:41
+msgid "Sometimes update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:78
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:44
+msgid "Hide volume snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:82
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:30
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:48
+msgid "How is ACL modified by chmod"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:83
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:49
+msgid "How to expose volumes to OS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:84
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid "Unicode normalization"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:85
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:2
+msgid "Reject non-UTF-8-compliant filenames"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:86
+#: /tmp/fish/explicit/share/completions/zfs.fish:87
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:9
+msgid "Case sensitivity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:88
+msgid "Space properties"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:89
+#: /tmp/fish/explicit/share/completions/zfs.fish:90
+msgid "Dataset name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:1
+msgid "Pool full name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:5
+msgid "Mirror of at least two devices"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:6
+#: /tmp/fish/explicit/share/completions/zpool.fish:7
+msgid "ZFS RAID-5 variant, single parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:8
+msgid "ZFS RAID-5 variant, double parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:9
+msgid "ZFS RAID-5 variant, triple parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:10
+msgid "Pseudo vdev for pool hot spares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:11
+msgid "SLOG device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:12
+msgid "L2ARC device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:13
+msgid "Physically allocated space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:2
+msgid "Available space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:16
+msgid "System boot partition size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:17
+msgid "Usage percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:18
+msgid "Deduplication ratio"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:19
+msgid "Amount of uninitialized space within the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:20
+msgid "Fragmentation percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:21
+msgid "Free pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:22
+msgid "Remaining pool space to be freed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:23
+msgid "Pool GUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:24
+msgid "Current pool health"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:25
+msgid "Total pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:26
+msgid "Used pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:27
+msgid "Pool sector size exponent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:28
+#: /tmp/fish/explicit/share/completions/zpool.fish:29
+msgid "Alternate root directory"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:30
+#: /tmp/fish/explicit/share/completions/zpool.fish:31
+msgid "Import pool in read-only mode"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:32
+#: /tmp/fish/explicit/share/completions/zpool.fish:33
+msgid "Automatic pool expansion on LUN growing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:34
+#: /tmp/fish/explicit/share/completions/zpool.fish:35
+msgid "Automatic use of replacement device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:36
+msgid "Default bootable dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:37
+msgid "Pool configuration cache"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:38
+msgid "Comment about the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:39
+msgid "Threshold for writting a ditto copy of deduplicated blocks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:40
+msgid "Allow rights delegation on the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:41
+msgid "Behavior in case of catastrophic pool failure"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:42
+msgid "Display snapshots even if 'zfs list' does not use '-t'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:43
+msgid "On-disk version of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:44
+msgid "%sEnable the %s feature\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:45
+msgid "All properties"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/abbr.fish:1
 msgid "%s: Could not figure out what to do!\\n"
 msgstr ""
@@ -2631,6 +3180,135 @@ msgstr ""
 msgid "%s\\tArchived file\\n"
 msgstr ""
 
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:3
+msgid "Achieved compression ratio"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:4
+msgid "Dataset creation time"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:5
+msgid "Snapshot clones"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:6
+msgid "Marked for deferred destruction"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:7
+msgid "Total lower-level filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:9
+msgid "Logical total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:11
+msgid "Logical used space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:12
+msgid "Is currently mounted?"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:13
+msgid "Source snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:14
+msgid "Token for interrupted reception resumption"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:16
+msgid "Total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:17
+msgid "Achieved compression ratio of referenced space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:18
+msgid "Total lower-level snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:19
+#: /tmp/fish/implicit/share/completions/zfs.fish:71
+#: /tmp/fish/implicit/share/completions/zfs.fish:81
+msgid "Dataset type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:20
+msgid "Space used by dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:21
+msgid "Space used by children datasets"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:22
+msgid "Space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:23
+msgid "Space used by refreservation"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:24
+msgid "Space used by dataset snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:25
+msgid "Holds count"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:27
+msgid "Referenced data written since previous snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:28
+msgid "%sDataset space use by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:29
+msgid "%sDataset space use by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:30
+msgid "%sReferenced data written since snapshot %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:28
+msgid "%sMax usage by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:29
+msgid "%sMax usage by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:3
+msgid "Allow overlay mount"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:4
+msgid "SELinux context for the child filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:5
+msgid "SELinux context for the filesystem being mounted"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:6
+msgid "SELinux context for unlabeled files"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:7
+msgid "SELinux context for the root inode of the filesystem"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr ""
@@ -2655,6 +3333,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/aptitude.fish:3
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:3
 #: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:63
 #: /tmp/fish/implicit/share/completions/wajig.fish:3
@@ -5060,7 +5740,10 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/valgrind.fish:6
 #: /tmp/fish/implicit/share/completions/vi.fish:8
 #: /tmp/fish/implicit/share/completions/wget.fish:9
+#: /tmp/fish/implicit/share/completions/zfs.fish:42
+#: /tmp/fish/implicit/share/completions/zfs.fish:87
 #: /tmp/fish/implicit/share/completions/zip.fish:13
+#: /tmp/fish/implicit/share/completions/zpool.fish:140
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
 msgid "Verbose mode"
 msgstr ""
@@ -9705,7 +10388,7 @@ msgid "Show usage message and options"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:380
+#: /tmp/fish/implicit/share/completions/git.fish:382
 msgid "Show help message"
 msgstr ""
 
@@ -14374,7 +15057,7 @@ msgid "Ignore all white space"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:325
+#: /tmp/fish/implicit/share/completions/git.fish:327
 msgid "Ignore changes whose lines are all blank"
 msgstr ""
 
@@ -14383,7 +15066,7 @@ msgid "Ignore changes whose lines match the REGEX"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:321
+#: /tmp/fish/implicit/share/completions/git.fish:323
 msgid "Treat all files as text"
 msgstr ""
 
@@ -16224,6 +16907,81 @@ msgstr ""
 msgid "X display to use"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/exercism.fish:1
+msgid "Test if exercism has yet to be given the subcommand"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:3
+msgid "turn on verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:4
+#: /tmp/fish/implicit/share/completions/exercism.fish:19
+#: /tmp/fish/implicit/share/completions/ninja.fish:8
+#: /tmp/fish/implicit/share/completions/quilt.fish:1
+msgid "show help"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:5
+msgid "print the version"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:6
+msgid "Writes config values to a JSON file."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:7
+msgid "Outputs useful debug information."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:8
+msgid "Downloads a solution given the ID of the latest iteration."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:9
+msgid "Fetches the next unsubmitted problem in each track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:10
+msgid "Lists the available problems for a language track, given its ID."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:11
+msgid ""
+"Opens exercism.io to your most recent iteration of a problem given the track "
+"ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:12
+msgid ""
+"Downloads the most recent iteration for each of your solutions on exercism."
+"io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:13
+msgid "Skips a problem given a track ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:14
+msgid "Fetches information about your progress with a given language track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:15
+msgid "Submits a new iteration to a problem on exercism.io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:16
+msgid "Lists the available language tracks."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:17
+msgid "REMOVED"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:18
+msgid "Upgrades the CLI to the latest released version."
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/exit.fish:2
 msgid "Quit with normal exit status"
 msgstr ""
@@ -16971,6 +17729,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:66
+#: /tmp/fish/implicit/share/completions/zfs.fish:76
 msgid "Maximum recursion depth"
 msgstr ""
 
@@ -18218,9 +18978,9 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/fossil.fish:280
 #: /tmp/fish/implicit/share/completions/git.fish:64
 #: /tmp/fish/implicit/share/completions/git.fish:86
-#: /tmp/fish/implicit/share/completions/git.fish:244
-#: /tmp/fish/implicit/share/completions/git.fish:293
-#: /tmp/fish/implicit/share/completions/git.fish:294
+#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:296
 msgid "Tag"
 msgstr ""
 
@@ -18621,7 +19381,7 @@ msgid "Limit number of tags"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:281
-#: /tmp/fish/implicit/share/completions/git.fish:291
+#: /tmp/fish/implicit/share/completions/git.fish:293
 msgid "List tags"
 msgstr ""
 
@@ -18714,6 +19474,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gsettings.fish:15
 #: /tmp/fish/implicit/share/completions/ncdu.fish:1
 #: /tmp/fish/implicit/share/completions/obnam.fish:12
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:4
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:5
 #: /tmp/fish/implicit/share/completions/pkginfo.fish:7
 #: /tmp/fish/implicit/share/completions/pkgmk.fish:17
@@ -24822,24 +25583,24 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:96
 #: /tmp/fish/implicit/share/completions/git.fish:108
 #: /tmp/fish/implicit/share/completions/git.fish:130
-#: /tmp/fish/implicit/share/completions/git.fish:134
-#: /tmp/fish/implicit/share/completions/git.fish:140
-#: /tmp/fish/implicit/share/completions/git.fish:183
-#: /tmp/fish/implicit/share/completions/git.fish:219
-#: /tmp/fish/implicit/share/completions/git.fish:222
-#: /tmp/fish/implicit/share/completions/git.fish:242
-#: /tmp/fish/implicit/share/completions/git.fish:265
-#: /tmp/fish/implicit/share/completions/git.fish:285
-#: /tmp/fish/implicit/share/completions/git.fish:307
+#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:221
+#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:244
+#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:309
 msgid "Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:23
-#: /tmp/fish/implicit/share/completions/git.fish:198
-#: /tmp/fish/implicit/share/completions/git.fish:210
-#: /tmp/fish/implicit/share/completions/git.fish:237
-#: /tmp/fish/implicit/share/completions/git.fish:250
-#: /tmp/fish/implicit/share/completions/git.fish:274
+#: /tmp/fish/implicit/share/completions/git.fish:200
+#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:276
 #: /tmp/fish/implicit/share/completions/mdadm.fish:12
 #: /tmp/fish/implicit/share/completions/update-eix-remote.fish:1
 msgid "Be quiet"
@@ -24848,10 +25609,10 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:24
 #: /tmp/fish/implicit/share/completions/git.fish:41
 #: /tmp/fish/implicit/share/completions/git.fish:70
-#: /tmp/fish/implicit/share/completions/git.fish:199
-#: /tmp/fish/implicit/share/completions/git.fish:211
-#: /tmp/fish/implicit/share/completions/git.fish:238
-#: /tmp/fish/implicit/share/completions/git.fish:251
+#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:253
 #: /tmp/fish/implicit/share/completions/prt-get.fish:53
 #: /tmp/fish/implicit/share/completions/prt-get.fish:111
 #: /tmp/fish/implicit/share/completions/xz.fish:32
@@ -24859,12 +25620,12 @@ msgid "Be verbose"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:25
-#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:215
 msgid "Append ref names and object names"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:26
-#: /tmp/fish/implicit/share/completions/git.fish:214
+#: /tmp/fish/implicit/share/completions/git.fish:216
 msgid "Force update of local branches"
 msgstr ""
 
@@ -25012,7 +25773,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:63
 #: /tmp/fish/implicit/share/completions/git.fish:85
 #: /tmp/fish/implicit/share/completions/git.fish:109
-#: /tmp/fish/implicit/share/completions/git.fish:184
+#: /tmp/fish/implicit/share/completions/git.fish:186
 msgid "Remote branch"
 msgstr ""
 
@@ -25041,7 +25802,7 @@ msgid "Allow adding otherwise ignored files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:257
+#: /tmp/fish/implicit/share/completions/git.fish:259
 msgid "Interactive mode"
 msgstr ""
 
@@ -25092,7 +25853,7 @@ msgid "Remote Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:84
-#: /tmp/fish/implicit/share/completions/git.fish:243
+#: /tmp/fish/implicit/share/completions/git.fish:245
 msgid "Head"
 msgstr ""
 
@@ -25257,893 +26018,896 @@ msgstr ""
 msgid "Compare two paths on the filesystem"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:134
 msgid "Open diffs in a visual tool"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:136
 msgid "Visually show diff of changes in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:136
+#: /tmp/fish/implicit/share/completions/git.fish:138
 msgid "Print lines matching a pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:139
 msgid "Create an empty git repository or reinitialize an existing one"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:138
+#: /tmp/fish/implicit/share/completions/git.fish:140
 msgid "Show commit shortlog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:139
+#: /tmp/fish/implicit/share/completions/git.fish:141
 msgid "Show commit logs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:141
+#: /tmp/fish/implicit/share/completions/git.fish:143
 msgid "Continue listing file history beyond renames"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:144
 msgid "Don't print ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:143
+#: /tmp/fish/implicit/share/completions/git.fish:145
 msgid "Print out ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:144
+#: /tmp/fish/implicit/share/completions/git.fish:146
 msgid "Print ref name by which each commit was reached"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:145
+#: /tmp/fish/implicit/share/completions/git.fish:147
 msgid "Limit the number of commits before starting to show the commit output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:146
-msgid "Skip given number of commits"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:147
 #: /tmp/fish/implicit/share/completions/git.fish:148
-msgid "Show commits more recent than specified date"
+msgid "Skip given number of commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:149
 #: /tmp/fish/implicit/share/completions/git.fish:150
-msgid "Show commits older than specified date"
+msgid "Show commits more recent than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:151
-msgid "Limit commits from given author"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/git.fish:152
-msgid "Limit commits from given committer"
+msgid "Show commits older than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:153
-msgid "Limit commits to ones with reflog entries matching given pattern"
+msgid "Limit commits from given author"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:154
-msgid "Limit commits with message that match given pattern"
+msgid "Limit commits from given committer"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:155
-msgid "Limit commits to ones that match all given --grep"
+msgid "Limit commits to ones with reflog entries matching given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:156
-msgid "Limit commits to ones with message that don't match --grep"
+msgid "Limit commits with message that match given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:157
-msgid "Case insensitive match"
+msgid "Limit commits to ones that match all given --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:158
-msgid "Patterns are basic regular expressions (default)"
+msgid "Limit commits to ones with message that don't match --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:159
-msgid "Patterns are extended regular expressions"
+msgid "Case insensitive match"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:160
-msgid "Patterns are fixed strings"
+msgid "Patterns are basic regular expressions (default)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:161
-msgid "Patterns are Perl-compatible regular expressions"
+msgid "Patterns are extended regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:162
-msgid "Stop when given path disappears from tree"
+msgid "Patterns are fixed strings"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:163
-msgid "Print only merge commits"
+msgid "Patterns are Perl-compatible regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:164
-msgid "Don't print commits with more than one parent"
+msgid "Stop when given path disappears from tree"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:165
-msgid "Show only commit with at least the given number of parents"
+msgid "Print only merge commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:166
-msgid "Show only commit with at most the given number of parents"
+msgid "Don't print commits with more than one parent"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:167
-msgid "Show only commit without a mimimum number of parents"
+msgid "Show only commit with at least the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:168
-msgid "Show only commit without a maximum number of parents"
+msgid "Show only commit with at most the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:169
-msgid "Follow only the first parent commit upon seeing a merge commit"
+msgid "Show only commit without a mimimum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:170
-msgid "Reverse meaning of ^ prefix"
+msgid "Show only commit without a maximum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:171
+msgid "Follow only the first parent commit upon seeing a merge commit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:172
+msgid "Reverse meaning of ^ prefix"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:173
 msgid ""
 "Pretend as if all refs in refs/ are listed on the command line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:172
+#: /tmp/fish/implicit/share/completions/git.fish:174
 msgid ""
 "Pretend as if all refs are in refs/heads are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:173
+#: /tmp/fish/implicit/share/completions/git.fish:175
 msgid ""
 "Pretend as if all refs are in ref/tags are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:174
+#: /tmp/fish/implicit/share/completions/git.fish:176
 msgid ""
 "Pretend as if all refs in refs/remotes  are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:175
+#: /tmp/fish/implicit/share/completions/git.fish:177
 msgid ""
 "Pretend as if all refs matching shell glob are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:176
+#: /tmp/fish/implicit/share/completions/git.fish:178
 msgid "Do not include refs matching given glob pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:177
+#: /tmp/fish/implicit/share/completions/git.fish:179
 msgid ""
 "Pretend as if all objcets mentioned by reflogs are listed on the command "
 "line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:178
+#: /tmp/fish/implicit/share/completions/git.fish:180
 msgid "Ignore invalid object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:179
+#: /tmp/fish/implicit/share/completions/git.fish:181
 msgid "Read commits from stdin"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:180
+#: /tmp/fish/implicit/share/completions/git.fish:182
 msgid "Mark equivalent commits with = and inequivalent with +"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:181
+#: /tmp/fish/implicit/share/completions/git.fish:183
 msgid "Omit equivalent commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:182
+#: /tmp/fish/implicit/share/completions/git.fish:184
 msgid "Join two or more development histories together"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:187
 msgid "Autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:186
+#: /tmp/fish/implicit/share/completions/git.fish:188
 msgid "Don't autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:187
+#: /tmp/fish/implicit/share/completions/git.fish:189
 msgid "Edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:188
+#: /tmp/fish/implicit/share/completions/git.fish:190
 msgid "Don't edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:189
+#: /tmp/fish/implicit/share/completions/git.fish:191
 msgid "Don't generate a merge commit if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:190
+#: /tmp/fish/implicit/share/completions/git.fish:192
 msgid "Generate a merge commit even if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:191
+#: /tmp/fish/implicit/share/completions/git.fish:193
 msgid "Refuse to merge unless fast-forward possible"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:192
+#: /tmp/fish/implicit/share/completions/git.fish:194
 msgid "Populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:193
+#: /tmp/fish/implicit/share/completions/git.fish:195
 msgid "Don't populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:194
+#: /tmp/fish/implicit/share/completions/git.fish:196
 msgid "Show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:195
+#: /tmp/fish/implicit/share/completions/git.fish:197
 msgid "Don't show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:196
+#: /tmp/fish/implicit/share/completions/git.fish:198
 msgid "Squash changes from other branch as a single commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:197
+#: /tmp/fish/implicit/share/completions/git.fish:199
 msgid "Don't squash changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:200
-#: /tmp/fish/implicit/share/completions/git.fish:217
-#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:219
+#: /tmp/fish/implicit/share/completions/git.fish:241
 msgid "Force progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:203
 msgid "Force no progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:204
 msgid "Set the commit message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:203
+#: /tmp/fish/implicit/share/completions/git.fish:205
 msgid "Abort the current conflict resolution process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:204
+#: /tmp/fish/implicit/share/completions/git.fish:206
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:205
+#: /tmp/fish/implicit/share/completions/git.fish:207
 msgid "Use specific merge resolution program"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:207
+#: /tmp/fish/implicit/share/completions/git.fish:209
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:210
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:209
+#: /tmp/fish/implicit/share/completions/git.fish:211
 msgid "Fetch from and merge with another repository or a local branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:214
 msgid "Fetch all remotes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:215
+#: /tmp/fish/implicit/share/completions/git.fish:217
 msgid "Keep downloaded pack"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:216
+#: /tmp/fish/implicit/share/completions/git.fish:218
 msgid "Disable automatic tag following"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:218
-#: /tmp/fish/implicit/share/completions/git.fish:221
-#: /tmp/fish/implicit/share/completions/git.fish:241
+#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:243
 msgid "Remote alias"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:222
 msgid "Update remote refs along with associated objects"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:225
 msgid "Force-push branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:226
 msgid "Force-push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:225
+#: /tmp/fish/implicit/share/completions/git.fish:227
 msgid "Push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:226
+#: /tmp/fish/implicit/share/completions/git.fish:228
 msgid "Push all refs under refs/heads/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:227
+#: /tmp/fish/implicit/share/completions/git.fish:229
 msgid "Remove remote branches that don't have a local counterpart"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:228
+#: /tmp/fish/implicit/share/completions/git.fish:230
 msgid "Push all refs under refs/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:229
+#: /tmp/fish/implicit/share/completions/git.fish:231
 msgid "Delete all listed refs from the remote repository"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:230
+#: /tmp/fish/implicit/share/completions/git.fish:232
 msgid "Push all refs under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:231
+#: /tmp/fish/implicit/share/completions/git.fish:233
 msgid "Push all usual refs plus the ones under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:232
+#: /tmp/fish/implicit/share/completions/git.fish:234
 msgid "Do everything except actually send the updates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:233
+#: /tmp/fish/implicit/share/completions/git.fish:235
 msgid "Produce machine-readable output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:234
+#: /tmp/fish/implicit/share/completions/git.fish:236
 msgid "Force update of remote refs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:235
+#: /tmp/fish/implicit/share/completions/git.fish:237
 msgid ""
 "Force update of remote refs, stopping if other's changes would be overwritten"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:236
+#: /tmp/fish/implicit/share/completions/git.fish:238
 msgid "Add upstream (tracking) reference"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:242
 msgid "Forward-port local commits to the updated upstream head"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:245
+#: /tmp/fish/implicit/share/completions/git.fish:247
 msgid "Restart the rebasing process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:248
 msgid "Abort the rebase operation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:247
+#: /tmp/fish/implicit/share/completions/git.fish:249
 msgid "Keep the commits that don't cahnge anything"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:248
+#: /tmp/fish/implicit/share/completions/git.fish:250
 msgid "Restart the rebasing process by skipping the current patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:249
+#: /tmp/fish/implicit/share/completions/git.fish:251
 msgid "Use merging strategies to rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:254
 msgid "Show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:253
+#: /tmp/fish/implicit/share/completions/git.fish:255
 msgid "Don't show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:254
+#: /tmp/fish/implicit/share/completions/git.fish:256
 msgid "Allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:255
+#: /tmp/fish/implicit/share/completions/git.fish:257
 msgid "Don't allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:256
+#: /tmp/fish/implicit/share/completions/git.fish:258
 msgid "Force the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:258
+#: /tmp/fish/implicit/share/completions/git.fish:260
 msgid "Try to recreate merges"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:259
+#: /tmp/fish/implicit/share/completions/git.fish:261
 msgid "Rebase all reachable commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:260
+#: /tmp/fish/implicit/share/completions/git.fish:262
 msgid "Automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:261
+#: /tmp/fish/implicit/share/completions/git.fish:263
 msgid "No automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:262
+#: /tmp/fish/implicit/share/completions/git.fish:264
 msgid "No fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:263
+#: /tmp/fish/implicit/share/completions/git.fish:265
 msgid "Reset current HEAD to the specified state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:264
+#: /tmp/fish/implicit/share/completions/git.fish:266
 msgid "Reset files in working directory"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:270
 msgid "Reflog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: /tmp/fish/implicit/share/completions/git.fish:271
 msgid "Revert an existing commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:270
+#: /tmp/fish/implicit/share/completions/git.fish:272
 msgid "Remove files from the working tree and from the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:271
+#: /tmp/fish/implicit/share/completions/git.fish:273
 msgid "Keep local copies"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:272
+#: /tmp/fish/implicit/share/completions/git.fish:274
 msgid "Exit with a zero status even if no files matched"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:273
+#: /tmp/fish/implicit/share/completions/git.fish:275
 msgid "Allow recursive removal"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:275
+#: /tmp/fish/implicit/share/completions/git.fish:277
 msgid "Override the up-to-date check"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:276
+#: /tmp/fish/implicit/share/completions/git.fish:278
 #: /tmp/fish/implicit/share/completions/prt-get.fish:45
 #: /tmp/fish/implicit/share/completions/prt-get.fish:103
+#: /tmp/fish/implicit/share/completions/zfs.fish:40
+#: /tmp/fish/implicit/share/completions/zfs.fish:124
+#: /tmp/fish/implicit/share/completions/zfs.fish:132
 msgid "Dry run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:277
+#: /tmp/fish/implicit/share/completions/git.fish:279
 msgid "Show the working tree status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:278
+#: /tmp/fish/implicit/share/completions/git.fish:280
 msgid "Give the output in the short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:279
+#: /tmp/fish/implicit/share/completions/git.fish:281
 msgid "Show the branch and tracking info even in short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:280
+#: /tmp/fish/implicit/share/completions/git.fish:282
 msgid "Give the output in a stable, easy-to-parse format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:281
+#: /tmp/fish/implicit/share/completions/git.fish:283
 msgid "Terminate entries with null character"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:282
+#: /tmp/fish/implicit/share/completions/git.fish:284
 msgid "The untracked files handling mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:283
+#: /tmp/fish/implicit/share/completions/git.fish:285
 msgid "Ignore changes to submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:284
+#: /tmp/fish/implicit/share/completions/git.fish:286
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:286
+#: /tmp/fish/implicit/share/completions/git.fish:288
 msgid "Make an unsigned, annotated tag object"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:289
 msgid "Make a GPG-signed tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:288
+#: /tmp/fish/implicit/share/completions/git.fish:290
 msgid "Remove a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:289
+#: /tmp/fish/implicit/share/completions/git.fish:291
 msgid "Verify signature of a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:290
+#: /tmp/fish/implicit/share/completions/git.fish:292
 msgid "Force overwriting exising tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:292
+#: /tmp/fish/implicit/share/completions/git.fish:294
 msgid "List tags that contain a commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:297
 msgid "Stash away changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:296
+#: /tmp/fish/implicit/share/completions/git.fish:298
 msgid "List stashes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:297
+#: /tmp/fish/implicit/share/completions/git.fish:299
 msgid "Show the changes recorded in the stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:298
+#: /tmp/fish/implicit/share/completions/git.fish:300
 msgid "Apply and remove a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:299
+#: /tmp/fish/implicit/share/completions/git.fish:301
 msgid "Apply a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:300
+#: /tmp/fish/implicit/share/completions/git.fish:302
 msgid "Remove all stashed states"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:301
+#: /tmp/fish/implicit/share/completions/git.fish:303
 msgid "Remove a single stashed state from the stash list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:302
+#: /tmp/fish/implicit/share/completions/git.fish:304
 msgid "Create a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:303
+#: /tmp/fish/implicit/share/completions/git.fish:305
 msgid "Save a new stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:304
+#: /tmp/fish/implicit/share/completions/git.fish:306
 msgid "Create a new branch from a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:305
+#: /tmp/fish/implicit/share/completions/git.fish:307
 msgid "Set and read git configuration variables"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:306
+#: /tmp/fish/implicit/share/completions/git.fish:308
 msgid "Generate patch series to send upstream"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:308
+#: /tmp/fish/implicit/share/completions/git.fish:310
 msgid "Generate plain patches without diffstat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:309
+#: /tmp/fish/implicit/share/completions/git.fish:311
 msgid "Suppress diff output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:310
+#: /tmp/fish/implicit/share/completions/git.fish:312
 msgid "Spend more time to create smaller diffs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:311
+#: /tmp/fish/implicit/share/completions/git.fish:313
 msgid "Generate diff with the 'patience' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:312
+#: /tmp/fish/implicit/share/completions/git.fish:314
 msgid "Generate diff with the 'histogram' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:313
+#: /tmp/fish/implicit/share/completions/git.fish:315
 msgid "Print all commits to stdout in mbox format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:314
+#: /tmp/fish/implicit/share/completions/git.fish:316
 msgid "Show number of added/deleted lines in decimal notation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:315
+#: /tmp/fish/implicit/share/completions/git.fish:317
 msgid "Output only last line of the stat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:316
+#: /tmp/fish/implicit/share/completions/git.fish:318
 msgid "Output a condensed summary of extended header information"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:317
+#: /tmp/fish/implicit/share/completions/git.fish:319
 msgid "Disable rename detection"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:318
+#: /tmp/fish/implicit/share/completions/git.fish:320
 msgid "Show full blob object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:319
+#: /tmp/fish/implicit/share/completions/git.fish:321
 msgid "Output a binary diff for use with git apply"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:320
+#: /tmp/fish/implicit/share/completions/git.fish:322
 msgid "Also inspect unmodified files as source for a copy"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:322
+#: /tmp/fish/implicit/share/completions/git.fish:324
 msgid "Ignore changes in whitespace at EOL"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: /tmp/fish/implicit/share/completions/git.fish:325
 msgid "Ignore changes in amount of whitespace"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:324
+#: /tmp/fish/implicit/share/completions/git.fish:326
 msgid "Ignore whitespace when comparing lines"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:326
+#: /tmp/fish/implicit/share/completions/git.fish:328
 msgid "Show whole surrounding functions of changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: /tmp/fish/implicit/share/completions/git.fish:329
 msgid "Allow an external diff helper to be executed"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:328
+#: /tmp/fish/implicit/share/completions/git.fish:330
 msgid "Disallow external diff helpers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:329
+#: /tmp/fish/implicit/share/completions/git.fish:331
 msgid "Disallow external text conversion filters for binary files (Default)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:330
+#: /tmp/fish/implicit/share/completions/git.fish:332
 msgid ""
 "Allow external text conversion filters for binary files (Resulting diff is "
 "unappliable)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:331
+#: /tmp/fish/implicit/share/completions/git.fish:333
 msgid "Do not show source or destination prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:332
+#: /tmp/fish/implicit/share/completions/git.fish:334
 msgid "Name output in [Patch n/m] format, even with a single patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:333
+#: /tmp/fish/implicit/share/completions/git.fish:335
 msgid "Name output in [Patch] format, even with multiple patches"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:334
+#: /tmp/fish/implicit/share/completions/git.fish:336
 msgid "Initialize, update or inspect submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:335
+#: /tmp/fish/implicit/share/completions/git.fish:337
 msgid "Add a submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:336
+#: /tmp/fish/implicit/share/completions/git.fish:338
 msgid "Show submodule status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:337
-#: /tmp/fish/implicit/share/completions/git.fish:343
+#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:345
 msgid "Initialize all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:338
+#: /tmp/fish/implicit/share/completions/git.fish:340
 msgid "Update all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:341
 msgid "Show commit summary"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:340
+#: /tmp/fish/implicit/share/completions/git.fish:342
 msgid "Run command on each submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:341
+#: /tmp/fish/implicit/share/completions/git.fish:343
 msgid "Sync submodules' URL with .gitmodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:342
+#: /tmp/fish/implicit/share/completions/git.fish:344
 msgid "Only print error messages"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:344
+#: /tmp/fish/implicit/share/completions/git.fish:346
 msgid "Checkout the superproject's commit on a detached HEAD in the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:345
+#: /tmp/fish/implicit/share/completions/git.fish:347
 msgid ""
 "Merge the superproject's commit into the current branch of the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:346
+#: /tmp/fish/implicit/share/completions/git.fish:348
 msgid "Rebase current branch onto the superproject's commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:347
+#: /tmp/fish/implicit/share/completions/git.fish:349
 msgid "Don't fetch new objects from the remote"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:348
+#: /tmp/fish/implicit/share/completions/git.fish:350
 msgid ""
 "Instead of using superproject's SHA-1, use the state of the submodule's "
 "remote-tracking branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:349
+#: /tmp/fish/implicit/share/completions/git.fish:351
 msgid ""
 "Throw away local changes when switching to a different commit and always run "
 "checkout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:350
+#: /tmp/fish/implicit/share/completions/git.fish:352
 msgid "Also add ignored submodule path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:351
+#: /tmp/fish/implicit/share/completions/git.fish:353
 msgid "Remove even with local changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:352
+#: /tmp/fish/implicit/share/completions/git.fish:354
 msgid "Use the commit stored in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:353
+#: /tmp/fish/implicit/share/completions/git.fish:355
 msgid "Compare the commit in the index with submodule HEAD"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:354
+#: /tmp/fish/implicit/share/completions/git.fish:356
 msgid "Traverse submodules recursively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:355
+#: /tmp/fish/implicit/share/completions/git.fish:357
 msgid "Show logs with difference each commit introduces"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:356
+#: /tmp/fish/implicit/share/completions/git.fish:358
 msgid "Remove untracked files from the working tree"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:357
+#: /tmp/fish/implicit/share/completions/git.fish:359
 msgid "Force run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:358
+#: /tmp/fish/implicit/share/completions/git.fish:360
 msgid "Show what would be done and clean files interactively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:359
+#: /tmp/fish/implicit/share/completions/git.fish:361
 msgid "Don't actually remove anything, just show what would be done"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:360
+#: /tmp/fish/implicit/share/completions/git.fish:362
 msgid "Be quiet, only report errors"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:361
+#: /tmp/fish/implicit/share/completions/git.fish:363
 msgid "Remove untracked directories in addition to untracked files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:362
+#: /tmp/fish/implicit/share/completions/git.fish:364
 msgid "Remove ignored files, as well"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:363
+#: /tmp/fish/implicit/share/completions/git.fish:365
 msgid "Remove only ignored files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:364
+#: /tmp/fish/implicit/share/completions/git.fish:366
 msgid "Show what revision and author last modified each line of a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:365
+#: /tmp/fish/implicit/share/completions/git.fish:367
 msgid "Show blank SHA-1 for boundary commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:366
+#: /tmp/fish/implicit/share/completions/git.fish:368
 msgid "Do not treat root commits as boundaries"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:367
+#: /tmp/fish/implicit/share/completions/git.fish:369
 msgid "Include additional statistics"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:368
+#: /tmp/fish/implicit/share/completions/git.fish:370
 msgid "Annotate only the given line range"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:369
+#: /tmp/fish/implicit/share/completions/git.fish:371
 msgid "Show long rev"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:370
+#: /tmp/fish/implicit/share/completions/git.fish:372
 msgid "Show raw timestamp"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:371
+#: /tmp/fish/implicit/share/completions/git.fish:373
 msgid "Use revisions from named file instead of calling rev-list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:372
+#: /tmp/fish/implicit/share/completions/git.fish:374
 msgid "Walk history forward instead of backward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:373
+#: /tmp/fish/implicit/share/completions/git.fish:375
 msgid "Show in a format designed for machine consumption"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:374
+#: /tmp/fish/implicit/share/completions/git.fish:376
 msgid "Show the porcelain format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:375
+#: /tmp/fish/implicit/share/completions/git.fish:377
 msgid "Show the result incrementally"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:376
+#: /tmp/fish/implicit/share/completions/git.fish:378
 msgid "Instead of working tree, use the contents of the named file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:377
+#: /tmp/fish/implicit/share/completions/git.fish:379
 msgid "Specifies the format used to output dates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:378
+#: /tmp/fish/implicit/share/completions/git.fish:380
 msgid "Detect moved or copied lines within a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:379
+#: /tmp/fish/implicit/share/completions/git.fish:381
 msgid ""
 "Detect lines moved or copied from other files that were modified in the same "
 "commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:381
+#: /tmp/fish/implicit/share/completions/git.fish:383
 msgid "Use the same output mode as git-annotate"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:382
+#: /tmp/fish/implicit/share/completions/git.fish:384
 msgid "Show the filename in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:383
+#: /tmp/fish/implicit/share/completions/git.fish:385
 msgid "Show the line number in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:384
+#: /tmp/fish/implicit/share/completions/git.fish:386
 msgid "Suppress the author name and timestamp from the output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:385
+#: /tmp/fish/implicit/share/completions/git.fish:387
 msgid "Show the author email instead of author name"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:386
+#: /tmp/fish/implicit/share/completions/git.fish:388
 msgid "Ignore whitespace changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:387
+#: /tmp/fish/implicit/share/completions/git.fish:389
 msgid "Custom command"
 msgstr ""
 
@@ -26638,6 +27402,7 @@ msgid "List all keys with their fingerprints"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
+#: /tmp/fish/implicit/share/completions/signify.fish:2
 msgid "Generate a new key pair"
 msgstr ""
 
@@ -35561,13 +36326,6 @@ msgstr ""
 msgid "Display values currently set in the minikube config file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/minikube.fish:25
-#: /tmp/fish/implicit/share/completions/minikube.fish:26
-#: /tmp/fish/implicit/share/completions/minikube.fish:27
-#: /tmp/fish/implicit/share/completions/minikube.fish:28
-msgid "Property"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/minikube.fish:29
 msgid "Go template format string for the config view output"
 msgstr ""
@@ -41532,11 +42290,6 @@ msgstr ""
 msgid "keep going until N jobs fail [default=1]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ninja.fish:8
-#: /tmp/fish/implicit/share/completions/quilt.fish:1
-msgid "show help"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/ninja.fish:9
 msgid "enable debugging, specify debug mode"
 msgstr ""
@@ -44813,6 +45566,18 @@ msgstr ""
 msgid "Extract script"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pfctl.fish:1
+msgid "Show a filter parameter by modifier"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:2
+msgid "Flush filter params specified by mod"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:3
+msgid "Table command"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pgrep.fish:1
 msgid "Output delimiter"
 msgstr ""
@@ -45021,6 +45786,27 @@ msgstr ""
 msgid "omit the user's full name, remote host and idle time in short format"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:1
+msgid "failsafe to overwrite"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:2
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:3
+msgid "Turn on stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:3
+msgid "Automated package installation"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:5
+msgid "Update packages"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:6
+msgid "Fuzzy match"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:1
 msgid "Upgrade"
 msgstr ""
@@ -45123,6 +45909,10 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkg-config.fish:25
 msgid "List all modules the given packages requires for static linking"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:2
+msgid "Delete unsed deps"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkgfile.fish:3
@@ -49458,6 +50248,18 @@ msgstr ""
 msgid "Specifies layout variant used to choose component names"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/signify.fish:1
+msgid "Verify a signed checksum list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:3
+msgid "Sign specified message"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:4
+msgid "Verify a signed message and sig"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/snap.fish:1
 msgid "Test if snap has yet to be given the subcommand"
 msgstr ""
@@ -53258,10 +54060,12 @@ msgid "Monitor changes to objects"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:7
+#: /tmp/fish/implicit/share/completions/zfs.fish:17
 msgid "Mount a filesystem"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:18
 msgid "Unmount a filesystem"
 msgstr ""
 
@@ -57793,6 +58597,604 @@ msgstr ""
 msgid "Delete all cache contents"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/zfs.fish:1
+msgid ""
+"Internal completion function for appending string to the ZFS commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:2
+#: /tmp/fish/implicit/share/completions/zpool.fish:2
+msgid "Display a help message"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:3
+msgid "Create a volume or filesystem"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:4
+msgid "Destroy a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:5
+msgid "Create a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:6
+msgid "Roll back a filesystem to a previous snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:7
+msgid "Create a clone of a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:8
+msgid ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:9
+msgid "Rename a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:10
+msgid "List dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:11
+msgid "Set a dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:12
+msgid "Get one or several dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:13
+msgid "Set a dataset property to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:14
+msgid "List upgradeable datasets, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:15
+msgid "Get dataset space consumed by each user"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:16
+msgid "Get dataset space consumed by each user group"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:19
+msgid "Share a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:20
+msgid "Stop sharing a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:21
+msgid "Create a bookmark for a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:22
+msgid "Output a stream representation of a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:23
+msgid ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:24
+msgid ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:25
+msgid "Revoke delegations of rights on a dataset from (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:26
+msgid "Put a named hold on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:27
+msgid "List holds on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:28
+msgid "Remove a named hold from a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:29
+msgid ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:30
+msgid "Execute a ZFS Channel Program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:31
+#: /tmp/fish/implicit/share/completions/zfs.fish:53
+#: /tmp/fish/implicit/share/completions/zfs.fish:58
+msgid "Create all needed non-existing parent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:32
+#: /tmp/fish/implicit/share/completions/zfs.fish:33
+msgid "Dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:34
+msgid "Volume size"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:35
+msgid "Create a sparse volume"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:36
+msgid "Blocksize"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:37
+msgid "Recursively destroy children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:38
+msgid "Recursively destroy all dependents"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:39
+msgid "Force unmounting"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:41
+msgid "Print machine-parsable verbose information"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:43
+msgid "Defer snapshot deletion"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:44
+msgid "Dataset to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:45
+msgid "Recursively snapshot children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:46
+#: /tmp/fish/implicit/share/completions/zfs.fish:47
+msgid "Snapshot property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:48
+msgid "Dataset to snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:49
+msgid "Destroy later snapshot and bookmarks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:50
+msgid "Recursively destroy later snapshot, bookmarks and clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:51
+msgid "Force unmounting of clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:52
+msgid "Snapshot to roll back to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:54
+#: /tmp/fish/implicit/share/completions/zfs.fish:55
+msgid "Clone property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:56
+msgid "Snapshot to clone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:57
+msgid "Clone to promote"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:59
+msgid "Recursively rename children snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:60
+#: /tmp/fish/implicit/share/completions/zfs.fish:62
+#: /tmp/fish/implicit/share/completions/zfs.fish:108
+msgid "Force unmounting if needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:61
+msgid "Do not remount filesystems during rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:63
+msgid "Dataset to rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:64
+#: /tmp/fish/implicit/share/completions/zfs.fish:77
+#: /tmp/fish/implicit/share/completions/zfs.fish:94
+#: /tmp/fish/implicit/share/completions/zfs.fish:172
+#: /tmp/fish/implicit/share/completions/zpool.fish:59
+#: /tmp/fish/implicit/share/completions/zpool.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:99
+msgid "Print output in a machine-parsable format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:65
+#: /tmp/fish/implicit/share/completions/zfs.fish:75
+#: /tmp/fish/implicit/share/completions/zfs.fish:84
+#: /tmp/fish/implicit/share/completions/zfs.fish:89
+msgid "Operate recursively on datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:105
+msgid "Property to list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:68
+#: /tmp/fish/implicit/share/completions/zfs.fish:80
+#: /tmp/fish/implicit/share/completions/zfs.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:66
+msgid "Print parsable (exact) values for numbers"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:69
+#: /tmp/fish/implicit/share/completions/zfs.fish:97
+msgid "Property to use for sorting output by ascending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:70
+#: /tmp/fish/implicit/share/completions/zfs.fish:98
+msgid "Property to use for sorting output by descending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:72
+msgid "Dataset which properties is to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:73
+#: /tmp/fish/implicit/share/completions/zpool.fish:125
+msgid "Property to set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:74
+msgid "Dataset which property is to be setted"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:78
+#: /tmp/fish/implicit/share/completions/zpool.fish:68
+msgid "Fields to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:79
+msgid "Property source to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:82
+msgid "Property to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:83
+msgid "Dataset which properties is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:85
+msgid "Revert to the received value if available"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:86
+msgid "Dataset which properties is to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:88
+msgid "Upgrade all eligible filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:90
+msgid "Upgrade to the specified version"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:91
+msgid "Filesystem to upgrade"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:92
+msgid "Print UID instead of user name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:93
+msgid "Print GID instead of group name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:96
+msgid "Field to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:99
+#: /tmp/fish/implicit/share/completions/zfs.fish:100
+msgid "Identity types to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:101
+msgid "Translate S(amba)ID to POSIX ID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:102
+msgid "Dataset which space usage is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:103
+msgid "Temporary mount point property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:104
+msgid "Report progress"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:105
+msgid "Mount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:106
+msgid "Overlay mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:107
+msgid "Filesystem to mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:109
+msgid "Unmount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:110
+msgid "Filesystem to unmount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:111
+msgid "Share all eligible ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:112
+msgid "Filesystem to share"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:113
+msgid "Unshare all shared ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:114
+msgid "Filesystem to unshare"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:115
+msgid "Snapshot to bookmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:116
+msgid "Generate incremental stream from snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:117
+msgid ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:118
+#: /tmp/fish/implicit/share/completions/zfs.fish:127
+msgid "Include children in replication stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:119
+#: /tmp/fish/implicit/share/completions/zfs.fish:128
+msgid "Generate a deduplicated stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:120
+#: /tmp/fish/implicit/share/completions/zfs.fish:129
+msgid "Allow the presence of larger blocks than 128 kiB"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:121
+#: /tmp/fish/implicit/share/completions/zfs.fish:130
+msgid "Generate a more compact stream by using WRITE_EMBEDDED records"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:122
+#: /tmp/fish/implicit/share/completions/zfs.fish:131
+msgid "Print verbose information about the stream in a machine-parsable format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:123
+msgid "Generate compressed stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:125
+#: /tmp/fish/implicit/share/completions/zfs.fish:133
+msgid "Include dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:126
+#: /tmp/fish/implicit/share/completions/zfs.fish:134
+msgid "Print verbose information about the stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:135
+msgid "Dataset to send"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:136
+msgid ""
+"Print verbose information about the stream and the time spent processing it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:137
+msgid "Dry run: do not actually receive the stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:138
+msgid "Force rollback to the most recent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:139
+msgid "Unmount the target filesystem"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:140
+msgid "Discard the first element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:141
+msgid "Discard all but the last element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:142
+msgid "Force the stream to be received as a clone of the given snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:143
+msgid "On transfer interruption, store a receive_resume_token for resumption"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:144
+msgid "Dataset to receive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:145
+msgid "Delegate permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:146
+msgid "Delegate permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:147
+msgid "User to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:148
+msgid "Group to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:149
+#: /tmp/fish/implicit/share/completions/zfs.fish:150
+msgid "Delegate permission to everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:151
+msgid "Delegate permissions only to the creator of later descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:152
+msgid "Create a permission set or add permissions to an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:153
+msgid "Dataset on which delegation is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:154
+msgid "Remove permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:155
+msgid "Remove permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:156
+msgid "User to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:157
+msgid "Group to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:158
+#: /tmp/fish/implicit/share/completions/zfs.fish:162
+#: /tmp/fish/implicit/share/completions/zfs.fish:163
+msgid "Remove permission from everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:159
+msgid "Remove permissions only on later created descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:160
+msgid "Remove a permission set or remove permissions from an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:161
+msgid "Remove permissions recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:164
+msgid "Dataset on which delegation is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:165
+msgid "Apply hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:166
+msgid "Snapshot on which hold is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:167
+msgid "List holds recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:168
+msgid "Snapshot which holds are to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:169
+msgid "Release hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:170
+msgid "Snapshot from which hold is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:171
+msgid "Display file type (à la ls -F)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:173
+msgid "Display inode change time"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:174
+msgid "Source snapshot for the diff"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:175
+msgid "Execution timeout"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:176
+msgid "Execution memory limit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:177
+msgid "Pool which program will be executed on"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/zip.fish:1
 msgid "Freshen: only changed files"
 msgstr ""
@@ -57895,6 +59297,469 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zip.fish:29
 msgid "Don't compress files with these suffixes"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:1
+msgid ""
+"Internal completion function for appending string to the zpool commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:3
+msgid "Add new virtual devices to pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:4
+msgid "Attach virtual device to a pool device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:5
+msgid "Clear devices errors in pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:6
+msgid "Create a new storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:7
+msgid "Destroy a storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:8
+msgid "Detach virtual device from a mirroring pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:9
+msgid "Display pool event log"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:10
+msgid "Export a pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:11
+msgid "Get one or several pool properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:12
+msgid "Display pool command history"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:13
+msgid "List importable pools, or import some"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:14
+msgid "Display pool I/O stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:15
+msgid "Remove ZFS label information from the specified device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:16
+msgid "List pools with health status and space usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:17
+msgid "Take the specified devices offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:18
+msgid "Bring the specified devices back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:19
+msgid "Reset pool GUID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:20
+msgid "Remove virtual devices from pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:21
+msgid "Reopen pool devices"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:22
+msgid "Replace a pool virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:23
+msgid "Start or stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:24
+msgid "Set a pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:25
+msgid "Create a pool by splitting an existing mirror one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:26
+msgid "Display detailed pool health status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:27
+msgid "List upgradeable pools, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:28
+#: /tmp/fish/implicit/share/completions/zpool.fish:36
+#: /tmp/fish/implicit/share/completions/zpool.fish:45
+#: /tmp/fish/implicit/share/completions/zpool.fish:117
+msgid "Force use of virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:29
+#: /tmp/fish/implicit/share/completions/zpool.fish:130
+msgid "Dry run: only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:30
+#: /tmp/fish/implicit/share/completions/zpool.fish:91
+#: /tmp/fish/implicit/share/completions/zpool.fish:100
+#: /tmp/fish/implicit/share/completions/zpool.fish:127
+#: /tmp/fish/implicit/share/completions/zpool.fish:135
+msgid "Display virtual device GUID instead of device name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:31
+#: /tmp/fish/implicit/share/completions/zpool.fish:92
+#: /tmp/fish/implicit/share/completions/zpool.fish:101
+#: /tmp/fish/implicit/share/completions/zpool.fish:128
+#: /tmp/fish/implicit/share/completions/zpool.fish:136
+msgid "Resolve device path symbolic links"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:32
+#: /tmp/fish/implicit/share/completions/zpool.fish:93
+#: /tmp/fish/implicit/share/completions/zpool.fish:102
+#: /tmp/fish/implicit/share/completions/zpool.fish:129
+#: /tmp/fish/implicit/share/completions/zpool.fish:137
+msgid "Display device full path"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:33
+#: /tmp/fish/implicit/share/completions/zpool.fish:37
+#: /tmp/fish/implicit/share/completions/zpool.fish:48
+#: /tmp/fish/implicit/share/completions/zpool.fish:118
+#: /tmp/fish/implicit/share/completions/zpool.fish:132
+msgid "Pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:34
+msgid "Pool to add virtual devices to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:35
+#: /tmp/fish/implicit/share/completions/zpool.fish:53
+msgid "Virtual device to add"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:38
+msgid "Pool to attach virtual device to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:39
+#: /tmp/fish/implicit/share/completions/zpool.fish:43
+msgid "Virtual device to operate on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:40
+msgid "Initiate recovery mode"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:41
+#: /tmp/fish/implicit/share/completions/zpool.fish:85
+msgid ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:42
+msgid "Pool to clear errors on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:44
+msgid ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:46
+msgid "Dry run, only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:47
+msgid "Do not enable any feature on the new pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:49
+msgid "Root filesystem property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:50
+#: /tmp/fish/implicit/share/completions/zpool.fish:83
+msgid "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:51
+msgid "Root filesystem mountpoint"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:52
+msgid "Set a different in-core pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:54
+#: /tmp/fish/implicit/share/completions/zpool.fish:64
+msgid "Force unmounting of all contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:55
+msgid "Pool to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:56
+msgid "Pool to detach device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:57
+msgid "Physical device to detach"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:58
+msgid "Print verbose event information"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:60
+msgid "Output appended data as the log grows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:61
+msgid "Clear all previous events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:62
+msgid "Pool to read events from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:63
+msgid "Export all pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:65
+msgid "Pool to export"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:69
+msgid "Properties to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:70
+msgid "Pool to get properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:71
+msgid "Also display internal events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:72
+msgid "Display log records using long format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:73
+msgid "Pool to get command history of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:74
+msgid "Read configuration from specified cache file"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:75
+msgid "Search for devices or files in specified directory"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:76
+msgid "List or import destroyed pools only (requires -f for importation)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:77
+#: /tmp/fish/implicit/share/completions/zpool.fish:133
+msgid "Mount properties for contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:78
+msgid "Properties of the imported pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:79
+msgid "Force import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:80
+msgid "Recovery mode"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:81
+msgid "Search for and import all pools found"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:82
+msgid "Ignore missing log device (risk of loss of last changes)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:84
+msgid "Do not mount contained filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:86
+msgid "Roll back to a previous TXG (hazardous)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:87
+msgid "TXG to roll back to (implies -FX)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:88
+msgid "Specify, as the last argument, a temporary pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:89
+msgid "Pool to import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:90
+#: /tmp/fish/implicit/share/completions/zpool.fish:103
+#: /tmp/fish/implicit/share/completions/zpool.fish:142
+msgid "Display a timestamp using specified format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:94
+msgid "Omit statistics since boot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:104
+msgid "Print verbose statistics"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:96
+msgid "Pool to retrieve I/O stats from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:97
+msgid "Treat exported or foreign devices as inactive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:98
+msgid "Device to clear ZFS label information from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:106
+msgid "Pool to list properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:107
+msgid "Temporarily offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:108
+msgid "Pool to offline device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:109
+msgid "Physical device to offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:110
+msgid "Expand the device to use all available space"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:111
+msgid "Pool to bring device back online on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:112
+msgid "Physical device to bring back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:113
+msgid "Pool which GUID is to be changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:114
+msgid "Pool to remove device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:115
+msgid "Physical device to remove"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:116
+msgid "Pool which devices are to be reopened"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:119
+msgid "Pool to replace device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:120
+msgid "Pool device to be replaced"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:121
+msgid "Device to use for replacement"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:122
+msgid "Stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:123
+msgid "Pause scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:124
+msgid "Pool to start/stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:126
+msgid "Pool which property is to be set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:131
+msgid "Set altroot for newpool and automatically import it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:134
+msgid "Pool to split"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:138
+#: /tmp/fish/implicit/share/completions/zpool.fish:139
+msgid "Display deduplication histogram"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:141
+msgid "Only display status for unhealthy or unavailable pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:143
+#: /tmp/fish/implicit/share/completions/zpool.fish:147
+msgid "Pool which status is to be displayed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:144
+msgid "Upgrade all eligible pools, enabling all supported features"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:145
+msgid "Display upgradeable ZFS versions"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:146
+msgid "Upgrade to the specified legacy version"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:2
@@ -59363,6 +61228,28 @@ msgstr ""
 msgid "Complete wvdial peers"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+msgid "Completes with ZFS mountpoint properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_pools.fish:1
+msgid "Completes with available ZFS pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+msgid "Completes with ZFS read-only properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Completes with ZFS read-write properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr ""
@@ -59520,6 +61407,12 @@ msgstr ""
 msgid "Test if current token is on Nth place"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_is_zfs_feature_enabled.fish:1
+msgid ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_list_current_token.fish:1
 msgid ""
 "List contents of token under the cursor if it is a directory, otherwise list "
@@ -59596,6 +61489,10 @@ msgid ""
 "current directory"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
+msgid "Print a list of local groups"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr ""
@@ -59662,6 +61559,22 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
+msgid "Lists ZFS bookmarks, if the feature is enabled"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
+msgid "Lists ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
+msgid "Lists ZFS snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
+msgid "Lists ZFS volumes"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-07 15:04+0100\n"
+"POT-Creation-Date: 2017-12-13 10:22+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: shankerwangmiao <shankerwangmiao@gmail.com>\n"
 "Language: zh_CN\n"
@@ -1827,9 +1827,11 @@ msgstr ""
 #: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
 #: /tmp/fish/implicit/share/completions/fossil.fish:90
 #: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:206
-#: /tmp/fish/implicit/share/completions/git.fish:266
-#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:269
 msgid "File"
 msgstr ""
 
@@ -2522,6 +2524,561 @@ msgstr ""
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
+#: /tmp/fish/explicit/share/completions/zfs.fish:1
+msgid "ZFS filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:2
+msgid "ZFS filesystem snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:3
+msgid "ZFS block storage device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:4
+msgid "ZFS snapshot bookmark"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:5
+msgid "Any ZFS dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:6
+msgid "Dataset-specific value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:7
+msgid "Default ZFS value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:8
+msgid "Value inherited from parent dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:9
+msgid "Value received by 'zfs receive'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:10
+#, fuzzy
+msgid "Value valid for the current mount"
+msgstr "停止当前求值的函数"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:11
+msgid "Read-only value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:12
+msgid "Dataset full name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:13
+#: /tmp/fish/explicit/share/completions/zpool.fish:2
+#: /tmp/fish/implicit/share/completions/minikube.fish:25
+#: /tmp/fish/implicit/share/completions/minikube.fish:26
+#: /tmp/fish/implicit/share/completions/minikube.fish:27
+#: /tmp/fish/implicit/share/completions/minikube.fish:28
+msgid "Property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:3
+msgid "Property value"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:15
+#: /tmp/fish/explicit/share/completions/zpool.fish:4
+msgid "Property value origin"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:16
+msgid "Identity type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:17
+msgid "Identity name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:18
+msgid "Space usage"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:19
+msgid "Space quota"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:20
+msgid "POSIX user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:21
+msgid "Samba user"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:22
+#: /tmp/fish/explicit/share/completions/zfs.fish:25
+msgid "Both types"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:23
+msgid "POSIX group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:24
+msgid "Samba group"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:26
+msgid "Also needs the permission to be allowed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:27
+msgid ""
+"Also needs the 'create' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:28
+#: /tmp/fish/explicit/share/completions/zfs.fish:29
+#: /tmp/fish/explicit/share/completions/zfs.fish:33
+#: /tmp/fish/explicit/share/completions/zfs.fish:35
+msgid "Also needs the 'mount' permission"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:30
+msgid ""
+"Also needs the 'promote' and 'mount' permissions in the origin filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:31
+msgid "Also needs the 'create' and 'mount' permissions"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:32
+msgid "Also needs the 'create' and 'mount' permissions in the new parent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:34
+msgid "For SMB and NFS shares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:36
+msgid "Allows changing any user property"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:26
+msgid "Volume block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:38
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Inheritance of ACL entries"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:39
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:2
+msgid "Update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:40
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:3
+msgid "Is the dataset mountable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:41
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:4
+msgid "Data checksum"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:42
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:5
+msgid "Compression algorithm"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:43
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:6
+msgid "Number of copies of data"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:44
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:7
+msgid "Deduplication"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:45
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:2
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:8
+msgid "Are contained device nodes openable"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:46
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:3
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:9
+msgid "Can contained executables be executed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:47
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:10
+msgid "Max number of filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:48
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:11
+msgid "Mountpoint"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:49
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:12
+msgid "Which data to cache in ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:50
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:13
+msgid "Max size of dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:51
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:14
+#, fuzzy
+msgid "Max number of snapshots"
+msgstr "参数的个数的计数"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:52
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:4
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:15
+msgid "Read-only"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:53
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:16
+msgid "Suggest block size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:54
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:17
+msgid "How redundant are the metadata"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:55
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:18
+msgid "Max space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:56
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:19
+msgid "Min space guaranteed to dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:57
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:20
+msgid "Min space guaranteed to dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:58
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:21
+msgid "Which data to cache in L2ARC"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:59
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:5
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:22
+msgid "Respect set-UID bit"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:60
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:23
+msgid "Share in NFS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:61
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:24
+msgid "Hint for handling of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:62
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:25
+#, fuzzy
+msgid "Hide .zfs directory"
+msgstr "显示工作目录"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:63
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:26
+msgid "Handle of synchronous requests"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:64
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:27
+msgid "Volume logical size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:65
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:38
+msgid "Managed from a non-global zone"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:66
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:31
+msgid "Can the dataset be mounted in a zone with Trusted Extensions enabled"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:67
+#: /tmp/fish/explicit/share/completions/zfs.fish:74
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:6
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:32
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:40
+msgid "Mount with Non Blocking mandatory locks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:68
+#: /tmp/fish/explicit/share/completions/zfs.fish:77
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:33
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:43
+msgid "Share in Samba"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:69
+#: /tmp/fish/explicit/share/completions/zfs.fish:76
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:34
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:42
+msgid "Share as an iSCSI target"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:70
+#: /tmp/fish/explicit/share/completions/zfs.fish:79
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:35
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:45
+msgid "On-disk version of filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:71
+#: /tmp/fish/explicit/share/completions/zfs.fish:80
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:36
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:46
+msgid "Scan regular files for viruses on opening and closing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:72
+#: /tmp/fish/explicit/share/completions/zfs.fish:81
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:7
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:37
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:47
+msgid "Extended attributes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:73
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:39
+msgid "Use no ACL or POSIX ACL"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:75
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:9
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:41
+msgid "Sometimes update access time on read"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:78
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:44
+msgid "Hide volume snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:82
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:30
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:48
+msgid "How is ACL modified by chmod"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:83
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:49
+msgid "How to expose volumes to OS"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:84
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+#, fuzzy
+msgid "Unicode normalization"
+msgstr "返回 fish 的状态信息"
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:85
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:2
+msgid "Reject non-UTF-8-compliant filenames"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:86
+#: /tmp/fish/explicit/share/completions/zfs.fish:87
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:9
+msgid "Case sensitivity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:88
+msgid "Space properties"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zfs.fish:89
+#: /tmp/fish/explicit/share/completions/zfs.fish:90
+msgid "Dataset name"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:1
+#, fuzzy
+msgid "Pool full name"
+msgstr "打印单词计数"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:5
+msgid "Mirror of at least two devices"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:6
+#: /tmp/fish/explicit/share/completions/zpool.fish:7
+msgid "ZFS RAID-5 variant, single parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:8
+msgid "ZFS RAID-5 variant, double parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:9
+msgid "ZFS RAID-5 variant, triple parity"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:10
+msgid "Pseudo vdev for pool hot spares"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:11
+msgid "SLOG device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:12
+msgid "L2ARC device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:13
+msgid "Physically allocated space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:14
+#: /tmp/fish/explicit/share/completions/zpool.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:2
+msgid "Available space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:16
+msgid "System boot partition size"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:17
+msgid "Usage percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:18
+#, fuzzy
+msgid "Deduplication ratio"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:19
+msgid "Amount of uninitialized space within the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:20
+msgid "Fragmentation percentage of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:21
+msgid "Free pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:22
+msgid "Remaining pool space to be freed"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:23
+msgid "Pool GUID"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:24
+msgid "Current pool health"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:25
+msgid "Total pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:26
+msgid "Used pool space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:27
+msgid "Pool sector size exponent"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:28
+#: /tmp/fish/explicit/share/completions/zpool.fish:29
+#, fuzzy
+msgid "Alternate root directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:30
+#: /tmp/fish/explicit/share/completions/zpool.fish:31
+msgid "Import pool in read-only mode"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:32
+#: /tmp/fish/explicit/share/completions/zpool.fish:33
+msgid "Automatic pool expansion on LUN growing"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:34
+#: /tmp/fish/explicit/share/completions/zpool.fish:35
+msgid "Automatic use of replacement device"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:36
+msgid "Default bootable dataset"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:37
+#, fuzzy
+msgid "Pool configuration cache"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:38
+msgid "Comment about the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:39
+msgid "Threshold for writting a ditto copy of deduplicated blocks"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:40
+msgid "Allow rights delegation on the pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:41
+msgid "Behavior in case of catastrophic pool failure"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:42
+msgid "Display snapshots even if 'zfs list' does not use '-t'"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:43
+msgid "On-disk version of pool"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:44
+msgid "%sEnable the %s feature\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/completions/zpool.fish:45
+msgid "All properties"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/abbr.fish:1
 #, fuzzy
 msgid "%s: Could not figure out what to do!\\n"
@@ -2660,6 +3217,135 @@ msgstr ""
 msgid "%s\\tArchived file\\n"
 msgstr ""
 
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:3
+msgid "Achieved compression ratio"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:4
+msgid "Dataset creation time"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:5
+msgid "Snapshot clones"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:6
+msgid "Marked for deferred destruction"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:7
+msgid "Total lower-level filesystems and volumes"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:8
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:9
+msgid "Logical total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:10
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:11
+msgid "Logical used space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:12
+msgid "Is currently mounted?"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:13
+msgid "Source snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:14
+msgid "Token for interrupted reception resumption"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:15
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:16
+msgid "Total space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:17
+msgid "Achieved compression ratio of referenced space"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:18
+msgid "Total lower-level snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:19
+#: /tmp/fish/implicit/share/completions/zfs.fish:71
+#: /tmp/fish/implicit/share/completions/zfs.fish:81
+msgid "Dataset type"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:20
+msgid "Space used by dataset and children"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:21
+msgid "Space used by children datasets"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:22
+msgid "Space used by dataset itself"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:23
+msgid "Space used by refreservation"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:24
+msgid "Space used by dataset snapshots"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:25
+msgid "Holds count"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:27
+msgid "Referenced data written since previous snapshot"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:28
+msgid "%sDataset space use by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:29
+msgid "%sDataset space use by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_ro_properties.fish:30
+msgid "%sReferenced data written since snapshot %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:28
+msgid "%sMax usage by user %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_rw_properties.fish:29
+msgid "%sMax usage by group %s\\n"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:3
+msgid "Allow overlay mount"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:4
+msgid "SELinux context for the child filesystem"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:5
+msgid "SELinux context for the filesystem being mounted"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:6
+msgid "SELinux context for unlabeled files"
+msgstr ""
+
+#: /tmp/fish/explicit/share/functions/__fish_complete_zfs_write_once_properties.fish:7
+msgid "SELinux context for the root inode of the filesystem"
+msgstr ""
+
 #: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr ""
@@ -2685,6 +3371,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/aptitude.fish:3
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:3
 #: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
+#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:1
 #: /tmp/fish/implicit/share/completions/prt-get.fish:63
 #: /tmp/fish/implicit/share/completions/wajig.fish:3
@@ -5113,7 +5801,10 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/valgrind.fish:6
 #: /tmp/fish/implicit/share/completions/vi.fish:8
 #: /tmp/fish/implicit/share/completions/wget.fish:9
+#: /tmp/fish/implicit/share/completions/zfs.fish:42
+#: /tmp/fish/implicit/share/completions/zfs.fish:87
 #: /tmp/fish/implicit/share/completions/zip.fish:13
+#: /tmp/fish/implicit/share/completions/zpool.fish:140
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
 msgid "Verbose mode"
 msgstr ""
@@ -9809,7 +10500,7 @@ msgid "Show usage message and options"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:380
+#: /tmp/fish/implicit/share/completions/git.fish:382
 msgid "Show help message"
 msgstr ""
 
@@ -14507,7 +15198,7 @@ msgid "Ignore all white space"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:325
+#: /tmp/fish/implicit/share/completions/git.fish:327
 msgid "Ignore changes whose lines are all blank"
 msgstr ""
 
@@ -14516,7 +15207,7 @@ msgid "Ignore changes whose lines match the REGEX"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:321
+#: /tmp/fish/implicit/share/completions/git.fish:323
 msgid "Treat all files as text"
 msgstr ""
 
@@ -16371,6 +17062,84 @@ msgstr ""
 msgid "X display to use"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/exercism.fish:1
+msgid "Test if exercism has yet to be given the subcommand"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:3
+msgid "turn on verbose logging"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:4
+#: /tmp/fish/implicit/share/completions/exercism.fish:19
+#: /tmp/fish/implicit/share/completions/ninja.fish:8
+#: /tmp/fish/implicit/share/completions/quilt.fish:1
+msgid "show help"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:5
+#, fuzzy
+msgid "print the version"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:6
+msgid "Writes config values to a JSON file."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:7
+#, fuzzy
+msgid "Outputs useful debug information."
+msgstr "返回 fish 的状态信息"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:8
+msgid "Downloads a solution given the ID of the latest iteration."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:9
+msgid "Fetches the next unsubmitted problem in each track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:10
+msgid "Lists the available problems for a language track, given its ID."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:11
+msgid ""
+"Opens exercism.io to your most recent iteration of a problem given the track "
+"ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:12
+msgid ""
+"Downloads the most recent iteration for each of your solutions on exercism."
+"io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:13
+msgid "Skips a problem given a track ID and problem slug."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:14
+msgid "Fetches information about your progress with a given language track."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:15
+msgid "Submits a new iteration to a problem on exercism.io."
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:16
+#, fuzzy
+msgid "Lists the available language tracks."
+msgstr "显示命令类型"
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:17
+msgid "REMOVED"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/exercism.fish:18
+msgid "Upgrades the CLI to the latest released version."
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/exit.fish:2
 msgid "Quit with normal exit status"
 msgstr ""
@@ -17131,6 +17900,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:66
+#: /tmp/fish/implicit/share/completions/zfs.fish:76
 msgid "Maximum recursion depth"
 msgstr ""
 
@@ -18389,9 +19160,9 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/fossil.fish:280
 #: /tmp/fish/implicit/share/completions/git.fish:64
 #: /tmp/fish/implicit/share/completions/git.fish:86
-#: /tmp/fish/implicit/share/completions/git.fish:244
-#: /tmp/fish/implicit/share/completions/git.fish:293
-#: /tmp/fish/implicit/share/completions/git.fish:294
+#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:296
 msgid "Tag"
 msgstr ""
 
@@ -18796,7 +19567,7 @@ msgid "Limit number of tags"
 msgstr "参数的个数的计数"
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:281
-#: /tmp/fish/implicit/share/completions/git.fish:291
+#: /tmp/fish/implicit/share/completions/git.fish:293
 msgid "List tags"
 msgstr ""
 
@@ -18890,6 +19661,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gsettings.fish:15
 #: /tmp/fish/implicit/share/completions/ncdu.fish:1
 #: /tmp/fish/implicit/share/completions/obnam.fish:12
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:4
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:5
 #: /tmp/fish/implicit/share/completions/pkginfo.fish:7
 #: /tmp/fish/implicit/share/completions/pkgmk.fish:17
@@ -25013,24 +25785,24 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:96
 #: /tmp/fish/implicit/share/completions/git.fish:108
 #: /tmp/fish/implicit/share/completions/git.fish:130
-#: /tmp/fish/implicit/share/completions/git.fish:134
-#: /tmp/fish/implicit/share/completions/git.fish:140
-#: /tmp/fish/implicit/share/completions/git.fish:183
-#: /tmp/fish/implicit/share/completions/git.fish:219
-#: /tmp/fish/implicit/share/completions/git.fish:222
-#: /tmp/fish/implicit/share/completions/git.fish:242
-#: /tmp/fish/implicit/share/completions/git.fish:265
-#: /tmp/fish/implicit/share/completions/git.fish:285
-#: /tmp/fish/implicit/share/completions/git.fish:307
+#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:221
+#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:244
+#: /tmp/fish/implicit/share/completions/git.fish:267
+#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:309
 msgid "Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:23
-#: /tmp/fish/implicit/share/completions/git.fish:198
-#: /tmp/fish/implicit/share/completions/git.fish:210
-#: /tmp/fish/implicit/share/completions/git.fish:237
-#: /tmp/fish/implicit/share/completions/git.fish:250
-#: /tmp/fish/implicit/share/completions/git.fish:274
+#: /tmp/fish/implicit/share/completions/git.fish:200
+#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:276
 #: /tmp/fish/implicit/share/completions/mdadm.fish:12
 #: /tmp/fish/implicit/share/completions/update-eix-remote.fish:1
 msgid "Be quiet"
@@ -25039,10 +25811,10 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:24
 #: /tmp/fish/implicit/share/completions/git.fish:41
 #: /tmp/fish/implicit/share/completions/git.fish:70
-#: /tmp/fish/implicit/share/completions/git.fish:199
-#: /tmp/fish/implicit/share/completions/git.fish:211
-#: /tmp/fish/implicit/share/completions/git.fish:238
-#: /tmp/fish/implicit/share/completions/git.fish:251
+#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:253
 #: /tmp/fish/implicit/share/completions/prt-get.fish:53
 #: /tmp/fish/implicit/share/completions/prt-get.fish:111
 #: /tmp/fish/implicit/share/completions/xz.fish:32
@@ -25050,12 +25822,12 @@ msgid "Be verbose"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:25
-#: /tmp/fish/implicit/share/completions/git.fish:213
+#: /tmp/fish/implicit/share/completions/git.fish:215
 msgid "Append ref names and object names"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:26
-#: /tmp/fish/implicit/share/completions/git.fish:214
+#: /tmp/fish/implicit/share/completions/git.fish:216
 msgid "Force update of local branches"
 msgstr ""
 
@@ -25203,7 +25975,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:63
 #: /tmp/fish/implicit/share/completions/git.fish:85
 #: /tmp/fish/implicit/share/completions/git.fish:109
-#: /tmp/fish/implicit/share/completions/git.fish:184
+#: /tmp/fish/implicit/share/completions/git.fish:186
 msgid "Remote branch"
 msgstr ""
 
@@ -25232,7 +26004,7 @@ msgid "Allow adding otherwise ignored files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:72
-#: /tmp/fish/implicit/share/completions/git.fish:257
+#: /tmp/fish/implicit/share/completions/git.fish:259
 #, fuzzy
 msgid "Interactive mode"
 msgstr "只在不活跃的进程上"
@@ -25284,7 +26056,7 @@ msgid "Remote Branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:84
-#: /tmp/fish/implicit/share/completions/git.fish:243
+#: /tmp/fish/implicit/share/completions/git.fish:245
 msgid "Head"
 msgstr ""
 
@@ -25449,896 +26221,899 @@ msgstr ""
 msgid "Compare two paths on the filesystem"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:133
+#: /tmp/fish/implicit/share/completions/git.fish:134
 msgid "Open diffs in a visual tool"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:135
+#: /tmp/fish/implicit/share/completions/git.fish:136
 msgid "Visually show diff of changes in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:136
+#: /tmp/fish/implicit/share/completions/git.fish:138
 msgid "Print lines matching a pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:137
+#: /tmp/fish/implicit/share/completions/git.fish:139
 msgid "Create an empty git repository or reinitialize an existing one"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:138
+#: /tmp/fish/implicit/share/completions/git.fish:140
 msgid "Show commit shortlog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:139
+#: /tmp/fish/implicit/share/completions/git.fish:141
 msgid "Show commit logs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:141
+#: /tmp/fish/implicit/share/completions/git.fish:143
 msgid "Continue listing file history beyond renames"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:142
+#: /tmp/fish/implicit/share/completions/git.fish:144
 msgid "Don't print ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:143
+#: /tmp/fish/implicit/share/completions/git.fish:145
 msgid "Print out ref names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:144
+#: /tmp/fish/implicit/share/completions/git.fish:146
 msgid "Print ref name by which each commit was reached"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:145
+#: /tmp/fish/implicit/share/completions/git.fish:147
 msgid "Limit the number of commits before starting to show the commit output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:146
-msgid "Skip given number of commits"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:147
 #: /tmp/fish/implicit/share/completions/git.fish:148
-msgid "Show commits more recent than specified date"
+msgid "Skip given number of commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:149
 #: /tmp/fish/implicit/share/completions/git.fish:150
-msgid "Show commits older than specified date"
+msgid "Show commits more recent than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:151
-msgid "Limit commits from given author"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/git.fish:152
-msgid "Limit commits from given committer"
+msgid "Show commits older than specified date"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:153
-msgid "Limit commits to ones with reflog entries matching given pattern"
+msgid "Limit commits from given author"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:154
-msgid "Limit commits with message that match given pattern"
+msgid "Limit commits from given committer"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:155
-msgid "Limit commits to ones that match all given --grep"
+msgid "Limit commits to ones with reflog entries matching given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:156
-msgid "Limit commits to ones with message that don't match --grep"
+msgid "Limit commits with message that match given pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:157
-msgid "Case insensitive match"
+msgid "Limit commits to ones that match all given --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:158
-msgid "Patterns are basic regular expressions (default)"
+msgid "Limit commits to ones with message that don't match --grep"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:159
-msgid "Patterns are extended regular expressions"
+msgid "Case insensitive match"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:160
-msgid "Patterns are fixed strings"
+msgid "Patterns are basic regular expressions (default)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:161
-msgid "Patterns are Perl-compatible regular expressions"
+msgid "Patterns are extended regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:162
-msgid "Stop when given path disappears from tree"
+msgid "Patterns are fixed strings"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:163
-msgid "Print only merge commits"
+msgid "Patterns are Perl-compatible regular expressions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:164
-msgid "Don't print commits with more than one parent"
+msgid "Stop when given path disappears from tree"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:165
-msgid "Show only commit with at least the given number of parents"
+msgid "Print only merge commits"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:166
-msgid "Show only commit with at most the given number of parents"
+msgid "Don't print commits with more than one parent"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:167
-msgid "Show only commit without a mimimum number of parents"
+msgid "Show only commit with at least the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:168
-msgid "Show only commit without a maximum number of parents"
+msgid "Show only commit with at most the given number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:169
-msgid "Follow only the first parent commit upon seeing a merge commit"
+msgid "Show only commit without a mimimum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:170
-msgid "Reverse meaning of ^ prefix"
+msgid "Show only commit without a maximum number of parents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:171
+msgid "Follow only the first parent commit upon seeing a merge commit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:172
+msgid "Reverse meaning of ^ prefix"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/git.fish:173
 msgid ""
 "Pretend as if all refs in refs/ are listed on the command line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:172
+#: /tmp/fish/implicit/share/completions/git.fish:174
 msgid ""
 "Pretend as if all refs are in refs/heads are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:173
+#: /tmp/fish/implicit/share/completions/git.fish:175
 msgid ""
 "Pretend as if all refs are in ref/tags are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:174
+#: /tmp/fish/implicit/share/completions/git.fish:176
 msgid ""
 "Pretend as if all refs in refs/remotes  are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:175
+#: /tmp/fish/implicit/share/completions/git.fish:177
 msgid ""
 "Pretend as if all refs matching shell glob are listed on the command line as "
 "<commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:176
+#: /tmp/fish/implicit/share/completions/git.fish:178
 msgid "Do not include refs matching given glob pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:177
+#: /tmp/fish/implicit/share/completions/git.fish:179
 msgid ""
 "Pretend as if all objcets mentioned by reflogs are listed on the command "
 "line as <commit>"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:178
+#: /tmp/fish/implicit/share/completions/git.fish:180
 msgid "Ignore invalid object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:179
+#: /tmp/fish/implicit/share/completions/git.fish:181
 msgid "Read commits from stdin"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:180
+#: /tmp/fish/implicit/share/completions/git.fish:182
 msgid "Mark equivalent commits with = and inequivalent with +"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:181
+#: /tmp/fish/implicit/share/completions/git.fish:183
 msgid "Omit equivalent commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:182
+#: /tmp/fish/implicit/share/completions/git.fish:184
 msgid "Join two or more development histories together"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:185
+#: /tmp/fish/implicit/share/completions/git.fish:187
 msgid "Autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:186
+#: /tmp/fish/implicit/share/completions/git.fish:188
 msgid "Don't autocommit the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:187
+#: /tmp/fish/implicit/share/completions/git.fish:189
 msgid "Edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:188
+#: /tmp/fish/implicit/share/completions/git.fish:190
 msgid "Don't edit auto-generated merge message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:189
+#: /tmp/fish/implicit/share/completions/git.fish:191
 msgid "Don't generate a merge commit if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:190
+#: /tmp/fish/implicit/share/completions/git.fish:192
 msgid "Generate a merge commit even if merge is fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:191
+#: /tmp/fish/implicit/share/completions/git.fish:193
 msgid "Refuse to merge unless fast-forward possible"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:192
+#: /tmp/fish/implicit/share/completions/git.fish:194
 msgid "Populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:193
+#: /tmp/fish/implicit/share/completions/git.fish:195
 msgid "Don't populate the log message with one-line descriptions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:194
+#: /tmp/fish/implicit/share/completions/git.fish:196
 msgid "Show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:195
+#: /tmp/fish/implicit/share/completions/git.fish:197
 msgid "Don't show diffstat of the merge"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:196
+#: /tmp/fish/implicit/share/completions/git.fish:198
 msgid "Squash changes from other branch as a single commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:197
+#: /tmp/fish/implicit/share/completions/git.fish:199
 msgid "Don't squash changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:200
-#: /tmp/fish/implicit/share/completions/git.fish:217
-#: /tmp/fish/implicit/share/completions/git.fish:239
+#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:219
+#: /tmp/fish/implicit/share/completions/git.fish:241
 msgid "Force progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:201
+#: /tmp/fish/implicit/share/completions/git.fish:203
 msgid "Force no progress status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:202
+#: /tmp/fish/implicit/share/completions/git.fish:204
 msgid "Set the commit message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:203
+#: /tmp/fish/implicit/share/completions/git.fish:205
 msgid "Abort the current conflict resolution process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:204
+#: /tmp/fish/implicit/share/completions/git.fish:206
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:205
+#: /tmp/fish/implicit/share/completions/git.fish:207
 msgid "Use specific merge resolution program"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:207
+#: /tmp/fish/implicit/share/completions/git.fish:209
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:208
+#: /tmp/fish/implicit/share/completions/git.fish:210
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:209
+#: /tmp/fish/implicit/share/completions/git.fish:211
 msgid "Fetch from and merge with another repository or a local branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:212
+#: /tmp/fish/implicit/share/completions/git.fish:214
 msgid "Fetch all remotes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:215
+#: /tmp/fish/implicit/share/completions/git.fish:217
 msgid "Keep downloaded pack"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:216
+#: /tmp/fish/implicit/share/completions/git.fish:218
 msgid "Disable automatic tag following"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:218
-#: /tmp/fish/implicit/share/completions/git.fish:221
-#: /tmp/fish/implicit/share/completions/git.fish:241
+#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:243
 msgid "Remote alias"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:220
+#: /tmp/fish/implicit/share/completions/git.fish:222
 msgid "Update remote refs along with associated objects"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:223
+#: /tmp/fish/implicit/share/completions/git.fish:225
 msgid "Force-push branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:224
+#: /tmp/fish/implicit/share/completions/git.fish:226
 msgid "Force-push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:225
+#: /tmp/fish/implicit/share/completions/git.fish:227
 msgid "Push local branch to remote branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:226
+#: /tmp/fish/implicit/share/completions/git.fish:228
 msgid "Push all refs under refs/heads/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:227
+#: /tmp/fish/implicit/share/completions/git.fish:229
 msgid "Remove remote branches that don't have a local counterpart"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:228
+#: /tmp/fish/implicit/share/completions/git.fish:230
 msgid "Push all refs under refs/"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:229
+#: /tmp/fish/implicit/share/completions/git.fish:231
 msgid "Delete all listed refs from the remote repository"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:230
+#: /tmp/fish/implicit/share/completions/git.fish:232
 msgid "Push all refs under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:231
+#: /tmp/fish/implicit/share/completions/git.fish:233
 msgid "Push all usual refs plus the ones under refs/tags"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:232
+#: /tmp/fish/implicit/share/completions/git.fish:234
 msgid "Do everything except actually send the updates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:233
+#: /tmp/fish/implicit/share/completions/git.fish:235
 msgid "Produce machine-readable output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:234
+#: /tmp/fish/implicit/share/completions/git.fish:236
 msgid "Force update of remote refs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:235
+#: /tmp/fish/implicit/share/completions/git.fish:237
 msgid ""
 "Force update of remote refs, stopping if other's changes would be overwritten"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:236
+#: /tmp/fish/implicit/share/completions/git.fish:238
 msgid "Add upstream (tracking) reference"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:240
+#: /tmp/fish/implicit/share/completions/git.fish:242
 msgid "Forward-port local commits to the updated upstream head"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:245
+#: /tmp/fish/implicit/share/completions/git.fish:247
 msgid "Restart the rebasing process"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:246
+#: /tmp/fish/implicit/share/completions/git.fish:248
 msgid "Abort the rebase operation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:247
+#: /tmp/fish/implicit/share/completions/git.fish:249
 msgid "Keep the commits that don't cahnge anything"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:248
+#: /tmp/fish/implicit/share/completions/git.fish:250
 msgid "Restart the rebasing process by skipping the current patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:249
+#: /tmp/fish/implicit/share/completions/git.fish:251
 msgid "Use merging strategies to rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:252
+#: /tmp/fish/implicit/share/completions/git.fish:254
 msgid "Show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:253
+#: /tmp/fish/implicit/share/completions/git.fish:255
 msgid "Don't show diffstat of the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:254
+#: /tmp/fish/implicit/share/completions/git.fish:256
 msgid "Allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:255
+#: /tmp/fish/implicit/share/completions/git.fish:257
 msgid "Don't allow the pre-rebase hook to run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:256
+#: /tmp/fish/implicit/share/completions/git.fish:258
 msgid "Force the rebase"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:258
+#: /tmp/fish/implicit/share/completions/git.fish:260
 msgid "Try to recreate merges"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:259
+#: /tmp/fish/implicit/share/completions/git.fish:261
 msgid "Rebase all reachable commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:260
+#: /tmp/fish/implicit/share/completions/git.fish:262
 msgid "Automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:261
+#: /tmp/fish/implicit/share/completions/git.fish:263
 msgid "No automatic squashing"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:262
+#: /tmp/fish/implicit/share/completions/git.fish:264
 msgid "No fast-forward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:263
+#: /tmp/fish/implicit/share/completions/git.fish:265
 msgid "Reset current HEAD to the specified state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:264
+#: /tmp/fish/implicit/share/completions/git.fish:266
 #, fuzzy
 msgid "Reset files in working directory"
 msgstr "显示工作目录"
 
-#: /tmp/fish/implicit/share/completions/git.fish:268
+#: /tmp/fish/implicit/share/completions/git.fish:270
 msgid "Reflog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: /tmp/fish/implicit/share/completions/git.fish:271
 msgid "Revert an existing commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:270
+#: /tmp/fish/implicit/share/completions/git.fish:272
 msgid "Remove files from the working tree and from the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:271
+#: /tmp/fish/implicit/share/completions/git.fish:273
 msgid "Keep local copies"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:272
+#: /tmp/fish/implicit/share/completions/git.fish:274
 msgid "Exit with a zero status even if no files matched"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:273
+#: /tmp/fish/implicit/share/completions/git.fish:275
 msgid "Allow recursive removal"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:275
+#: /tmp/fish/implicit/share/completions/git.fish:277
 msgid "Override the up-to-date check"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:276
+#: /tmp/fish/implicit/share/completions/git.fish:278
 #: /tmp/fish/implicit/share/completions/prt-get.fish:45
 #: /tmp/fish/implicit/share/completions/prt-get.fish:103
+#: /tmp/fish/implicit/share/completions/zfs.fish:40
+#: /tmp/fish/implicit/share/completions/zfs.fish:124
+#: /tmp/fish/implicit/share/completions/zfs.fish:132
 msgid "Dry run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:277
+#: /tmp/fish/implicit/share/completions/git.fish:279
 msgid "Show the working tree status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:278
+#: /tmp/fish/implicit/share/completions/git.fish:280
 msgid "Give the output in the short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:279
+#: /tmp/fish/implicit/share/completions/git.fish:281
 msgid "Show the branch and tracking info even in short-format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:280
+#: /tmp/fish/implicit/share/completions/git.fish:282
 msgid "Give the output in a stable, easy-to-parse format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:281
+#: /tmp/fish/implicit/share/completions/git.fish:283
 msgid "Terminate entries with null character"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:282
+#: /tmp/fish/implicit/share/completions/git.fish:284
 msgid "The untracked files handling mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:283
+#: /tmp/fish/implicit/share/completions/git.fish:285
 msgid "Ignore changes to submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:284
+#: /tmp/fish/implicit/share/completions/git.fish:286
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:286
+#: /tmp/fish/implicit/share/completions/git.fish:288
 msgid "Make an unsigned, annotated tag object"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:287
+#: /tmp/fish/implicit/share/completions/git.fish:289
 msgid "Make a GPG-signed tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:288
+#: /tmp/fish/implicit/share/completions/git.fish:290
 msgid "Remove a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:289
+#: /tmp/fish/implicit/share/completions/git.fish:291
 msgid "Verify signature of a tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:290
+#: /tmp/fish/implicit/share/completions/git.fish:292
 msgid "Force overwriting exising tag"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:292
+#: /tmp/fish/implicit/share/completions/git.fish:294
 msgid "List tags that contain a commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:295
+#: /tmp/fish/implicit/share/completions/git.fish:297
 msgid "Stash away changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:296
+#: /tmp/fish/implicit/share/completions/git.fish:298
 msgid "List stashes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:297
+#: /tmp/fish/implicit/share/completions/git.fish:299
 msgid "Show the changes recorded in the stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:298
+#: /tmp/fish/implicit/share/completions/git.fish:300
 msgid "Apply and remove a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:299
+#: /tmp/fish/implicit/share/completions/git.fish:301
 msgid "Apply a single stashed state"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:300
+#: /tmp/fish/implicit/share/completions/git.fish:302
 msgid "Remove all stashed states"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:301
+#: /tmp/fish/implicit/share/completions/git.fish:303
 msgid "Remove a single stashed state from the stash list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:302
+#: /tmp/fish/implicit/share/completions/git.fish:304
 msgid "Create a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:303
+#: /tmp/fish/implicit/share/completions/git.fish:305
 msgid "Save a new stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:304
+#: /tmp/fish/implicit/share/completions/git.fish:306
 msgid "Create a new branch from a stash"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:305
+#: /tmp/fish/implicit/share/completions/git.fish:307
 #, fuzzy
 msgid "Set and read git configuration variables"
 msgstr "将输入的一行读入到变量中"
 
-#: /tmp/fish/implicit/share/completions/git.fish:306
+#: /tmp/fish/implicit/share/completions/git.fish:308
 msgid "Generate patch series to send upstream"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:308
+#: /tmp/fish/implicit/share/completions/git.fish:310
 msgid "Generate plain patches without diffstat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:309
+#: /tmp/fish/implicit/share/completions/git.fish:311
 msgid "Suppress diff output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:310
+#: /tmp/fish/implicit/share/completions/git.fish:312
 msgid "Spend more time to create smaller diffs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:311
+#: /tmp/fish/implicit/share/completions/git.fish:313
 msgid "Generate diff with the 'patience' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:312
+#: /tmp/fish/implicit/share/completions/git.fish:314
 msgid "Generate diff with the 'histogram' algorithm"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:313
+#: /tmp/fish/implicit/share/completions/git.fish:315
 msgid "Print all commits to stdout in mbox format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:314
+#: /tmp/fish/implicit/share/completions/git.fish:316
 msgid "Show number of added/deleted lines in decimal notation"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:315
+#: /tmp/fish/implicit/share/completions/git.fish:317
 msgid "Output only last line of the stat"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:316
+#: /tmp/fish/implicit/share/completions/git.fish:318
 msgid "Output a condensed summary of extended header information"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:317
+#: /tmp/fish/implicit/share/completions/git.fish:319
 msgid "Disable rename detection"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:318
+#: /tmp/fish/implicit/share/completions/git.fish:320
 msgid "Show full blob object names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:319
+#: /tmp/fish/implicit/share/completions/git.fish:321
 msgid "Output a binary diff for use with git apply"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:320
+#: /tmp/fish/implicit/share/completions/git.fish:322
 msgid "Also inspect unmodified files as source for a copy"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:322
+#: /tmp/fish/implicit/share/completions/git.fish:324
 msgid "Ignore changes in whitespace at EOL"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: /tmp/fish/implicit/share/completions/git.fish:325
 msgid "Ignore changes in amount of whitespace"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:324
+#: /tmp/fish/implicit/share/completions/git.fish:326
 msgid "Ignore whitespace when comparing lines"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:326
+#: /tmp/fish/implicit/share/completions/git.fish:328
 msgid "Show whole surrounding functions of changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: /tmp/fish/implicit/share/completions/git.fish:329
 msgid "Allow an external diff helper to be executed"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:328
+#: /tmp/fish/implicit/share/completions/git.fish:330
 msgid "Disallow external diff helpers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:329
+#: /tmp/fish/implicit/share/completions/git.fish:331
 msgid "Disallow external text conversion filters for binary files (Default)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:330
+#: /tmp/fish/implicit/share/completions/git.fish:332
 msgid ""
 "Allow external text conversion filters for binary files (Resulting diff is "
 "unappliable)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:331
+#: /tmp/fish/implicit/share/completions/git.fish:333
 msgid "Do not show source or destination prefix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:332
+#: /tmp/fish/implicit/share/completions/git.fish:334
 msgid "Name output in [Patch n/m] format, even with a single patch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:333
+#: /tmp/fish/implicit/share/completions/git.fish:335
 msgid "Name output in [Patch] format, even with multiple patches"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:334
+#: /tmp/fish/implicit/share/completions/git.fish:336
 msgid "Initialize, update or inspect submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:335
+#: /tmp/fish/implicit/share/completions/git.fish:337
 msgid "Add a submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:336
+#: /tmp/fish/implicit/share/completions/git.fish:338
 msgid "Show submodule status"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:337
-#: /tmp/fish/implicit/share/completions/git.fish:343
+#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:345
 msgid "Initialize all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:338
+#: /tmp/fish/implicit/share/completions/git.fish:340
 msgid "Update all submodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:339
+#: /tmp/fish/implicit/share/completions/git.fish:341
 msgid "Show commit summary"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:340
+#: /tmp/fish/implicit/share/completions/git.fish:342
 #, fuzzy
 msgid "Run command on each submodule"
 msgstr "在当前进程下执行命令"
 
-#: /tmp/fish/implicit/share/completions/git.fish:341
+#: /tmp/fish/implicit/share/completions/git.fish:343
 msgid "Sync submodules' URL with .gitmodules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:342
+#: /tmp/fish/implicit/share/completions/git.fish:344
 msgid "Only print error messages"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:344
+#: /tmp/fish/implicit/share/completions/git.fish:346
 msgid "Checkout the superproject's commit on a detached HEAD in the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:345
+#: /tmp/fish/implicit/share/completions/git.fish:347
 msgid ""
 "Merge the superproject's commit into the current branch of the submodule"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:346
+#: /tmp/fish/implicit/share/completions/git.fish:348
 msgid "Rebase current branch onto the superproject's commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:347
+#: /tmp/fish/implicit/share/completions/git.fish:349
 msgid "Don't fetch new objects from the remote"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:348
+#: /tmp/fish/implicit/share/completions/git.fish:350
 msgid ""
 "Instead of using superproject's SHA-1, use the state of the submodule's "
 "remote-tracking branch"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:349
+#: /tmp/fish/implicit/share/completions/git.fish:351
 msgid ""
 "Throw away local changes when switching to a different commit and always run "
 "checkout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:350
+#: /tmp/fish/implicit/share/completions/git.fish:352
 msgid "Also add ignored submodule path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:351
+#: /tmp/fish/implicit/share/completions/git.fish:353
 msgid "Remove even with local changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:352
+#: /tmp/fish/implicit/share/completions/git.fish:354
 msgid "Use the commit stored in the index"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:353
+#: /tmp/fish/implicit/share/completions/git.fish:355
 msgid "Compare the commit in the index with submodule HEAD"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:354
+#: /tmp/fish/implicit/share/completions/git.fish:356
 msgid "Traverse submodules recursively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:355
+#: /tmp/fish/implicit/share/completions/git.fish:357
 msgid "Show logs with difference each commit introduces"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:356
+#: /tmp/fish/implicit/share/completions/git.fish:358
 msgid "Remove untracked files from the working tree"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:357
+#: /tmp/fish/implicit/share/completions/git.fish:359
 msgid "Force run"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:358
+#: /tmp/fish/implicit/share/completions/git.fish:360
 msgid "Show what would be done and clean files interactively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:359
+#: /tmp/fish/implicit/share/completions/git.fish:361
 msgid "Don't actually remove anything, just show what would be done"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:360
+#: /tmp/fish/implicit/share/completions/git.fish:362
 msgid "Be quiet, only report errors"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:361
+#: /tmp/fish/implicit/share/completions/git.fish:363
 msgid "Remove untracked directories in addition to untracked files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:362
+#: /tmp/fish/implicit/share/completions/git.fish:364
 msgid "Remove ignored files, as well"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:363
+#: /tmp/fish/implicit/share/completions/git.fish:365
 msgid "Remove only ignored files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:364
+#: /tmp/fish/implicit/share/completions/git.fish:366
 msgid "Show what revision and author last modified each line of a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:365
+#: /tmp/fish/implicit/share/completions/git.fish:367
 msgid "Show blank SHA-1 for boundary commits"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:366
+#: /tmp/fish/implicit/share/completions/git.fish:368
 msgid "Do not treat root commits as boundaries"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:367
+#: /tmp/fish/implicit/share/completions/git.fish:369
 msgid "Include additional statistics"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:368
+#: /tmp/fish/implicit/share/completions/git.fish:370
 msgid "Annotate only the given line range"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:369
+#: /tmp/fish/implicit/share/completions/git.fish:371
 msgid "Show long rev"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:370
+#: /tmp/fish/implicit/share/completions/git.fish:372
 msgid "Show raw timestamp"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:371
+#: /tmp/fish/implicit/share/completions/git.fish:373
 msgid "Use revisions from named file instead of calling rev-list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:372
+#: /tmp/fish/implicit/share/completions/git.fish:374
 msgid "Walk history forward instead of backward"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:373
+#: /tmp/fish/implicit/share/completions/git.fish:375
 msgid "Show in a format designed for machine consumption"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:374
+#: /tmp/fish/implicit/share/completions/git.fish:376
 msgid "Show the porcelain format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:375
+#: /tmp/fish/implicit/share/completions/git.fish:377
 msgid "Show the result incrementally"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:376
+#: /tmp/fish/implicit/share/completions/git.fish:378
 msgid "Instead of working tree, use the contents of the named file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:377
+#: /tmp/fish/implicit/share/completions/git.fish:379
 msgid "Specifies the format used to output dates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:378
+#: /tmp/fish/implicit/share/completions/git.fish:380
 msgid "Detect moved or copied lines within a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:379
+#: /tmp/fish/implicit/share/completions/git.fish:381
 msgid ""
 "Detect lines moved or copied from other files that were modified in the same "
 "commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:381
+#: /tmp/fish/implicit/share/completions/git.fish:383
 msgid "Use the same output mode as git-annotate"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:382
+#: /tmp/fish/implicit/share/completions/git.fish:384
 msgid "Show the filename in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:383
+#: /tmp/fish/implicit/share/completions/git.fish:385
 msgid "Show the line number in the original commit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:384
+#: /tmp/fish/implicit/share/completions/git.fish:386
 msgid "Suppress the author name and timestamp from the output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:385
+#: /tmp/fish/implicit/share/completions/git.fish:387
 msgid "Show the author email instead of author name"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:386
+#: /tmp/fish/implicit/share/completions/git.fish:388
 msgid "Ignore whitespace changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/git.fish:387
+#: /tmp/fish/implicit/share/completions/git.fish:389
 #, fuzzy
 msgid "Custom command"
 msgstr "命令"
@@ -26836,6 +27611,7 @@ msgid "List all keys with their fingerprints"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
+#: /tmp/fish/implicit/share/completions/signify.fish:2
 #, fuzzy
 msgid "Generate a new key pair"
 msgstr "生成随机数"
@@ -35885,13 +36661,6 @@ msgstr ""
 msgid "Display values currently set in the minikube config file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/minikube.fish:25
-#: /tmp/fish/implicit/share/completions/minikube.fish:26
-#: /tmp/fish/implicit/share/completions/minikube.fish:27
-#: /tmp/fish/implicit/share/completions/minikube.fish:28
-msgid "Property"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/minikube.fish:29
 msgid "Go template format string for the config view output"
 msgstr ""
@@ -41865,11 +42634,6 @@ msgstr ""
 msgid "keep going until N jobs fail [default=1]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ninja.fish:8
-#: /tmp/fish/implicit/share/completions/quilt.fish:1
-msgid "show help"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/ninja.fish:9
 msgid "enable debugging, specify debug mode"
 msgstr ""
@@ -45158,6 +45922,19 @@ msgstr ""
 msgid "Extract script"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pfctl.fish:1
+msgid "Show a filter parameter by modifier"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:2
+msgid "Flush filter params specified by mod"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pfctl.fish:3
+#, fuzzy
+msgid "Table command"
+msgstr "状态\t命令"
+
 #: /tmp/fish/implicit/share/completions/pgrep.fish:1
 msgid "Output delimiter"
 msgstr ""
@@ -45366,6 +46143,28 @@ msgstr ""
 msgid "omit the user's full name, remote host and idle time in short format"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:1
+msgid "failsafe to overwrite"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:2
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:3
+msgid "Turn on stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:3
+msgid "Automated package installation"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:5
+#, fuzzy
+msgid "Update packages"
+msgstr "创建代码区块"
+
+#: /tmp/fish/implicit/share/completions/pkg_add.fish:6
+msgid "Fuzzy match"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/pkgadd.fish:1
 msgid "Upgrade"
 msgstr ""
@@ -45468,6 +46267,10 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkg-config.fish:25
 msgid "List all modules the given packages requires for static linking"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/pkg_delete.fish:2
+msgid "Delete unsed deps"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pkgfile.fish:3
@@ -49843,6 +50646,19 @@ msgstr ""
 msgid "Specifies layout variant used to choose component names"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/signify.fish:1
+msgid "Verify a signed checksum list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/signify.fish:3
+#, fuzzy
+msgid "Sign specified message"
+msgstr "显示命令类型"
+
+#: /tmp/fish/implicit/share/completions/signify.fish:4
+msgid "Verify a signed message and sig"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/snap.fish:1
 msgid "Test if snap has yet to be given the subcommand"
 msgstr ""
@@ -53688,10 +54504,12 @@ msgid "Monitor changes to objects"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:7
+#: /tmp/fish/implicit/share/completions/zfs.fish:17
 msgid "Mount a filesystem"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/udisksctl.fish:8
+#: /tmp/fish/implicit/share/completions/zfs.fish:18
 msgid "Unmount a filesystem"
 msgstr ""
 
@@ -58259,6 +59077,620 @@ msgstr ""
 msgid "Delete all cache contents"
 msgstr ""
 
+#: /tmp/fish/implicit/share/completions/zfs.fish:1
+msgid ""
+"Internal completion function for appending string to the ZFS commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:2
+#: /tmp/fish/implicit/share/completions/zpool.fish:2
+#, fuzzy
+msgid "Display a help message"
+msgstr "打印单词计数"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:3
+#, fuzzy
+msgid "Create a volume or filesystem"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:4
+msgid "Destroy a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:5
+#, fuzzy
+msgid "Create a snapshot"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:6
+msgid "Roll back a filesystem to a previous snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:7
+#, fuzzy
+msgid "Create a clone of a snapshot"
+msgstr "创建代码区块"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:8
+msgid ""
+"Promotes a clone file system to no longer be dependent on its \"origin\" "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:9
+msgid "Rename a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:10
+msgid "List dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:11
+msgid "Set a dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:12
+msgid "Get one or several dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:13
+msgid "Set a dataset property to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:14
+msgid "List upgradeable datasets, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:15
+msgid "Get dataset space consumed by each user"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:16
+msgid "Get dataset space consumed by each user group"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:19
+msgid "Share a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:20
+msgid "Stop sharing a given filesystem, or all of them"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:21
+msgid "Create a bookmark for a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:22
+msgid "Output a stream representation of a dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:23
+msgid ""
+"Write on disk a dataset from the stream representation given on standard "
+"input"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:24
+msgid ""
+"Delegate, or display delegations of, rights on a dataset to (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:25
+msgid "Revoke delegations of rights on a dataset from (groups of) users"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:26
+msgid "Put a named hold on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:27
+msgid "List holds on a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:28
+msgid "Remove a named hold from a snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:29
+msgid ""
+"List changed files between a snapshot, and a filesystem or a previous "
+"snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:30
+msgid "Execute a ZFS Channel Program"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:31
+#: /tmp/fish/implicit/share/completions/zfs.fish:53
+#: /tmp/fish/implicit/share/completions/zfs.fish:58
+msgid "Create all needed non-existing parent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:32
+#: /tmp/fish/implicit/share/completions/zfs.fish:33
+msgid "Dataset property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:34
+msgid "Volume size"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:35
+#, fuzzy
+msgid "Create a sparse volume"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:36
+msgid "Blocksize"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:37
+msgid "Recursively destroy children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:38
+msgid "Recursively destroy all dependents"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:39
+#, fuzzy
+msgid "Force unmounting"
+msgstr "只在不活跃的进程上"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:41
+#, fuzzy
+msgid "Print machine-parsable verbose information"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:43
+msgid "Defer snapshot deletion"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:44
+msgid "Dataset to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:45
+msgid "Recursively snapshot children"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:46
+#: /tmp/fish/implicit/share/completions/zfs.fish:47
+msgid "Snapshot property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:48
+msgid "Dataset to snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:49
+msgid "Destroy later snapshot and bookmarks"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:50
+msgid "Recursively destroy later snapshot, bookmarks and clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:51
+msgid "Force unmounting of clones"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:52
+msgid "Snapshot to roll back to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:54
+#: /tmp/fish/implicit/share/completions/zfs.fish:55
+msgid "Clone property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:56
+msgid "Snapshot to clone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:57
+msgid "Clone to promote"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:59
+msgid "Recursively rename children snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:60
+#: /tmp/fish/implicit/share/completions/zfs.fish:62
+#: /tmp/fish/implicit/share/completions/zfs.fish:108
+msgid "Force unmounting if needed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:61
+msgid "Do not remount filesystems during rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:63
+msgid "Dataset to rename"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:64
+#: /tmp/fish/implicit/share/completions/zfs.fish:77
+#: /tmp/fish/implicit/share/completions/zfs.fish:94
+#: /tmp/fish/implicit/share/completions/zfs.fish:172
+#: /tmp/fish/implicit/share/completions/zpool.fish:59
+#: /tmp/fish/implicit/share/completions/zpool.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:99
+msgid "Print output in a machine-parsable format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:65
+#: /tmp/fish/implicit/share/completions/zfs.fish:75
+#: /tmp/fish/implicit/share/completions/zfs.fish:84
+#: /tmp/fish/implicit/share/completions/zfs.fish:89
+msgid "Operate recursively on datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:67
+#: /tmp/fish/implicit/share/completions/zpool.fish:105
+msgid "Property to list"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:68
+#: /tmp/fish/implicit/share/completions/zfs.fish:80
+#: /tmp/fish/implicit/share/completions/zfs.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:66
+#, fuzzy
+msgid "Print parsable (exact) values for numbers"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:69
+#: /tmp/fish/implicit/share/completions/zfs.fish:97
+msgid "Property to use for sorting output by ascending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:70
+#: /tmp/fish/implicit/share/completions/zfs.fish:98
+msgid "Property to use for sorting output by descending order"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:72
+msgid "Dataset which properties is to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:73
+#: /tmp/fish/implicit/share/completions/zpool.fish:125
+msgid "Property to set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:74
+msgid "Dataset which property is to be setted"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:78
+#: /tmp/fish/implicit/share/completions/zpool.fish:68
+msgid "Fields to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:79
+#, fuzzy
+msgid "Property source to display"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:82
+msgid "Property to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:83
+msgid "Dataset which properties is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:85
+msgid "Revert to the received value if available"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:86
+msgid "Dataset which properties is to be inherited"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:88
+msgid "Upgrade all eligible filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:90
+#, fuzzy
+msgid "Upgrade to the specified version"
+msgstr "在指定列表中搜索一个特定的字符串"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:91
+msgid "Filesystem to upgrade"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:92
+msgid "Print UID instead of user name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:93
+msgid "Print GID instead of group name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:96
+msgid "Field to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:99
+#: /tmp/fish/implicit/share/completions/zfs.fish:100
+msgid "Identity types to display"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:101
+msgid "Translate S(amba)ID to POSIX ID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:102
+msgid "Dataset which space usage is to be got"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:103
+msgid "Temporary mount point property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:104
+#, fuzzy
+msgid "Report progress"
+msgstr "进程"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:105
+msgid "Mount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:106
+msgid "Overlay mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:107
+msgid "Filesystem to mount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:109
+msgid "Unmount all available ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:110
+msgid "Filesystem to unmount"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:111
+msgid "Share all eligible ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:112
+msgid "Filesystem to share"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:113
+msgid "Unshare all shared ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:114
+msgid "Filesystem to unshare"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:115
+msgid "Snapshot to bookmark"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:116
+msgid "Generate incremental stream from snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:117
+msgid ""
+"Generate incremental stream from snapshot, even with intermediary snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:118
+#: /tmp/fish/implicit/share/completions/zfs.fish:127
+msgid "Include children in replication stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:119
+#: /tmp/fish/implicit/share/completions/zfs.fish:128
+#, fuzzy
+msgid "Generate a deduplicated stream"
+msgstr "生成随机数"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:120
+#: /tmp/fish/implicit/share/completions/zfs.fish:129
+msgid "Allow the presence of larger blocks than 128 kiB"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:121
+#: /tmp/fish/implicit/share/completions/zfs.fish:130
+msgid "Generate a more compact stream by using WRITE_EMBEDDED records"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:122
+#: /tmp/fish/implicit/share/completions/zfs.fish:131
+#, fuzzy
+msgid "Print verbose information about the stream in a machine-parsable format"
+msgstr "返回 fish 的状态信息"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:123
+#, fuzzy
+msgid "Generate compressed stream"
+msgstr "生成随机数"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:125
+#: /tmp/fish/implicit/share/completions/zfs.fish:133
+msgid "Include dataset properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:126
+#: /tmp/fish/implicit/share/completions/zfs.fish:134
+#, fuzzy
+msgid "Print verbose information about the stream"
+msgstr "返回 fish 的状态信息"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:135
+msgid "Dataset to send"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:136
+#, fuzzy
+msgid ""
+"Print verbose information about the stream and the time spent processing it"
+msgstr "返回 fish 的状态信息"
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:137
+msgid "Dry run: do not actually receive the stream"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:138
+msgid "Force rollback to the most recent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:139
+msgid "Unmount the target filesystem"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:140
+msgid "Discard the first element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:141
+msgid "Discard all but the last element of the path of the sent snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:142
+msgid "Force the stream to be received as a clone of the given snapshot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:143
+msgid "On transfer interruption, store a receive_resume_token for resumption"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:144
+msgid "Dataset to receive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:145
+msgid "Delegate permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:146
+msgid "Delegate permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:147
+msgid "User to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:148
+msgid "Group to delegate permissions to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:149
+#: /tmp/fish/implicit/share/completions/zfs.fish:150
+msgid "Delegate permission to everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:151
+msgid "Delegate permissions only to the creator of later descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:152
+msgid "Create a permission set or add permissions to an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:153
+msgid "Dataset on which delegation is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:154
+msgid "Remove permissions only on the specified dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:155
+msgid "Remove permissions only on the descendents dataset"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:156
+msgid "User to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:157
+msgid "Group to remove permissions from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:158
+#: /tmp/fish/implicit/share/completions/zfs.fish:162
+#: /tmp/fish/implicit/share/completions/zfs.fish:163
+msgid "Remove permission from everyone"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:159
+msgid "Remove permissions only on later created descendent datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:160
+msgid "Remove a permission set or remove permissions from an existing one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:161
+msgid "Remove permissions recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:164
+msgid "Dataset on which delegation is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:165
+msgid "Apply hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:166
+msgid "Snapshot on which hold is to be applied"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:167
+msgid "List holds recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:168
+msgid "Snapshot which holds are to be listed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:169
+msgid "Release hold recursively"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:170
+msgid "Snapshot from which hold is to be removed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:171
+msgid "Display file type (à la ls -F)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:173
+msgid "Display inode change time"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:174
+msgid "Source snapshot for the diff"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:175
+msgid "Execution timeout"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:176
+msgid "Execution memory limit"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zfs.fish:177
+msgid "Pool which program will be executed on"
+msgstr ""
+
 #: /tmp/fish/implicit/share/completions/zip.fish:1
 msgid "Freshen: only changed files"
 msgstr ""
@@ -58362,6 +59794,482 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/zip.fish:29
 msgid "Don't compress files with these suffixes"
 msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:1
+msgid ""
+"Internal completion function for appending string to the zpool commandline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:3
+msgid "Add new virtual devices to pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:4
+msgid "Attach virtual device to a pool device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:5
+msgid "Clear devices errors in pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:6
+#, fuzzy
+msgid "Create a new storage pool"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:7
+msgid "Destroy a storage pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:8
+msgid "Detach virtual device from a mirroring pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:9
+msgid "Display pool event log"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:10
+msgid "Export a pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:11
+msgid "Get one or several pool properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:12
+#, fuzzy
+msgid "Display pool command history"
+msgstr "显示命令类型"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:13
+msgid "List importable pools, or import some"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:14
+msgid "Display pool I/O stats"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:15
+msgid "Remove ZFS label information from the specified device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:16
+msgid "List pools with health status and space usage"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:17
+#, fuzzy
+msgid "Take the specified devices offline"
+msgstr "编辑命令相关的补全"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:18
+msgid "Bring the specified devices back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:19
+msgid "Reset pool GUID"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:20
+msgid "Remove virtual devices from pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:21
+msgid "Reopen pool devices"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:22
+msgid "Replace a pool virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:23
+msgid "Start or stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:24
+msgid "Set a pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:25
+msgid "Create a pool by splitting an existing mirror one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:26
+msgid "Display detailed pool health status"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:27
+msgid "List upgradeable pools, or upgrade one"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:28
+#: /tmp/fish/implicit/share/completions/zpool.fish:36
+#: /tmp/fish/implicit/share/completions/zpool.fish:45
+#: /tmp/fish/implicit/share/completions/zpool.fish:117
+msgid "Force use of virtual device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:29
+#: /tmp/fish/implicit/share/completions/zpool.fish:130
+msgid "Dry run: only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:30
+#: /tmp/fish/implicit/share/completions/zpool.fish:91
+#: /tmp/fish/implicit/share/completions/zpool.fish:100
+#: /tmp/fish/implicit/share/completions/zpool.fish:127
+#: /tmp/fish/implicit/share/completions/zpool.fish:135
+msgid "Display virtual device GUID instead of device name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:31
+#: /tmp/fish/implicit/share/completions/zpool.fish:92
+#: /tmp/fish/implicit/share/completions/zpool.fish:101
+#: /tmp/fish/implicit/share/completions/zpool.fish:128
+#: /tmp/fish/implicit/share/completions/zpool.fish:136
+msgid "Resolve device path symbolic links"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:32
+#: /tmp/fish/implicit/share/completions/zpool.fish:93
+#: /tmp/fish/implicit/share/completions/zpool.fish:102
+#: /tmp/fish/implicit/share/completions/zpool.fish:129
+#: /tmp/fish/implicit/share/completions/zpool.fish:137
+msgid "Display device full path"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:33
+#: /tmp/fish/implicit/share/completions/zpool.fish:37
+#: /tmp/fish/implicit/share/completions/zpool.fish:48
+#: /tmp/fish/implicit/share/completions/zpool.fish:118
+#: /tmp/fish/implicit/share/completions/zpool.fish:132
+msgid "Pool property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:34
+msgid "Pool to add virtual devices to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:35
+#: /tmp/fish/implicit/share/completions/zpool.fish:53
+msgid "Virtual device to add"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:38
+msgid "Pool to attach virtual device to"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:39
+#: /tmp/fish/implicit/share/completions/zpool.fish:43
+msgid "Virtual device to operate on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:40
+#, fuzzy
+msgid "Initiate recovery mode"
+msgstr "只在不活跃的进程上"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:41
+#: /tmp/fish/implicit/share/completions/zpool.fish:85
+msgid ""
+"Dry run: only determine if the recovery is possible, without attempting it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:42
+msgid "Pool to clear errors on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:44
+msgid ""
+"Create whole disk pool with EFI System partition to support booting system "
+"with UEFI firmware"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:46
+msgid "Dry run, only display resulting configuration"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:47
+msgid "Do not enable any feature on the new pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:49
+msgid "Root filesystem property"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:50
+#: /tmp/fish/implicit/share/completions/zpool.fish:83
+msgid "Equivalent to \"-o cachefile=none,altroot=ROOT\""
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:51
+msgid "Root filesystem mountpoint"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:52
+msgid "Set a different in-core pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:54
+#: /tmp/fish/implicit/share/completions/zpool.fish:64
+msgid "Force unmounting of all contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:55
+msgid "Pool to destroy"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:56
+msgid "Pool to detach device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:57
+msgid "Physical device to detach"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:58
+#, fuzzy
+msgid "Print verbose event information"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:60
+msgid "Output appended data as the log grows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:61
+msgid "Clear all previous events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:62
+msgid "Pool to read events from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:63
+msgid "Export all pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:65
+msgid "Pool to export"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:69
+msgid "Properties to get"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:70
+msgid "Pool to get properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:71
+msgid "Also display internal events"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:72
+#, fuzzy
+msgid "Display log records using long format"
+msgstr "显示工作目录"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:73
+msgid "Pool to get command history of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:74
+#, fuzzy
+msgid "Read configuration from specified cache file"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:75
+#, fuzzy
+msgid "Search for devices or files in specified directory"
+msgstr "改变工作目录（当前目录）"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:76
+msgid "List or import destroyed pools only (requires -f for importation)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:77
+#: /tmp/fish/implicit/share/completions/zpool.fish:133
+msgid "Mount properties for contained datasets"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:78
+msgid "Properties of the imported pool"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:79
+#, fuzzy
+msgid "Force import"
+msgstr "只在不活跃的进程上"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:80
+#, fuzzy
+msgid "Recovery mode"
+msgstr "只在不活跃的进程上"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:81
+msgid "Search for and import all pools found"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:82
+msgid "Ignore missing log device (risk of loss of last changes)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:84
+msgid "Do not mount contained filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:86
+msgid "Roll back to a previous TXG (hazardous)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:87
+msgid "TXG to roll back to (implies -FX)"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:88
+msgid "Specify, as the last argument, a temporary pool name"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:89
+msgid "Pool to import"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:90
+#: /tmp/fish/implicit/share/completions/zpool.fish:103
+#: /tmp/fish/implicit/share/completions/zpool.fish:142
+msgid "Display a timestamp using specified format"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:94
+msgid "Omit statistics since boot"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:95
+#: /tmp/fish/implicit/share/completions/zpool.fish:104
+#, fuzzy
+msgid "Print verbose statistics"
+msgstr "显示命令类型"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:96
+msgid "Pool to retrieve I/O stats from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:97
+msgid "Treat exported or foreign devices as inactive"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:98
+#, fuzzy
+msgid "Device to clear ZFS label information from"
+msgstr "返回 fish 的状态信息"
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:106
+msgid "Pool to list properties of"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:107
+msgid "Temporarily offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:108
+msgid "Pool to offline device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:109
+msgid "Physical device to offline"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:110
+msgid "Expand the device to use all available space"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:111
+msgid "Pool to bring device back online on"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:112
+msgid "Physical device to bring back online"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:113
+msgid "Pool which GUID is to be changed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:114
+msgid "Pool to remove device from"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:115
+msgid "Physical device to remove"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:116
+msgid "Pool which devices are to be reopened"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:119
+msgid "Pool to replace device"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:120
+msgid "Pool device to be replaced"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:121
+msgid "Device to use for replacement"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:122
+msgid "Stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:123
+msgid "Pause scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:124
+msgid "Pool to start/stop scrubbing"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:126
+msgid "Pool which property is to be set"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:131
+msgid "Set altroot for newpool and automatically import it"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:134
+msgid "Pool to split"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:138
+#: /tmp/fish/implicit/share/completions/zpool.fish:139
+msgid "Display deduplication histogram"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:141
+msgid "Only display status for unhealthy or unavailable pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:143
+#: /tmp/fish/implicit/share/completions/zpool.fish:147
+msgid "Pool which status is to be displayed"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:144
+msgid "Upgrade all eligible pools, enabling all supported features"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:145
+msgid "Display upgradeable ZFS versions"
+msgstr ""
+
+#: /tmp/fish/implicit/share/completions/zpool.fish:146
+#, fuzzy
+msgid "Upgrade to the specified legacy version"
+msgstr "在指定列表中搜索一个特定的字符串"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:2
 msgid "Repo"
@@ -59836,6 +61744,28 @@ msgstr ""
 msgid "Complete wvdial peers"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_mountpoint_properties.fish:1
+msgid "Completes with ZFS mountpoint properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_pools.fish:1
+msgid "Completes with available ZFS pools"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_ro_properties.fish:1
+msgid "Completes with ZFS read-only properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_rw_properties.fish:1
+msgid "Completes with ZFS read-write properties"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_complete_zfs_write_once_properties.fish:1
+msgid ""
+"Completes with ZFS properties which can only be written at filesystem "
+"creation, and only be read thereafter"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr ""
@@ -59993,6 +61923,12 @@ msgstr ""
 msgid "Test if current token is on Nth place"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_is_zfs_feature_enabled.fish:1
+msgid ""
+"Returns 0 if the given ZFS feature is available or enabled for the given "
+"full-path target (zpool or dataset), or any target if none given"
+msgstr ""
+
 #: /tmp/fish/implicit/share/functions/__fish_list_current_token.fish:1
 msgid ""
 "List contents of token under the cursor if it is a directory, otherwise list "
@@ -60071,6 +62007,11 @@ msgid ""
 "current directory"
 msgstr ""
 
+#: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
+#, fuzzy
+msgid "Print a list of local groups"
+msgstr "显示命令类型"
+
 #: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr ""
@@ -60140,6 +62081,22 @@ msgstr "打印单词计数"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
+msgid "Lists ZFS bookmarks, if the feature is enabled"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
+msgid "Lists ZFS filesystems"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
+msgid "Lists ZFS snapshots"
+msgstr ""
+
+#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
+msgid "Lists ZFS volumes"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1

--- a/share/completions/zfs.fish
+++ b/share/completions/zfs.fish
@@ -1,0 +1,479 @@
+# Fish completions for the OpenZFS zfs command
+# Possible enhancements:
+# - add a test to propose iSCSI and Trusted Extensions completions only when such system is present;
+# - Illumos man pages suggests that it does not support nbmand nor atime mount option, so these properties should be proposed only when available
+# - generally, propose properties only when the current OS and ZFS versions support them;
+# - for the promote command, propose only eligible filesystems;
+# - for the rollback command, propose only the most recent snapshot for each dataset, as it will not accept an intermediary snapshot;
+# - for the release command, complete with existing tags;
+# - for the diff command, complete the destination dataset of the diff;
+# - for the program command, complete the script to be executed
+# - for commands accepting several arguments of different types, propose arguments in the right order: for get, once the ZFS parameters have been given, only propose datasets
+
+set OS ""
+if passwd --help >/dev/null ^&1
+    set OS "Linux"
+else # Not Linux, so use the ugly uname
+    set -l os_type (uname)
+    switch $os_type
+        case Darwin
+            set OS "macOS"
+        case FreeBSD
+            set OS "FreeBSD"
+        case SunOS
+            set OS "SunOS"
+        # Others?
+        case "*"
+            set OS "unknown"
+    end
+end
+
+function __fish_zfs_append -d "Internal completion function for appending string to the ZFS commandline"
+    set str (commandline -tc| sed -ne "s/\(.*,\)[^,]*/\1/p"|sed -e "s/--.*=//")
+    printf "%s\n" "$str"$argv
+end
+
+# Does the current invocation need a command?
+function __fish_zfs_needs_command
+    set -l bookmark ""
+    if __fish_is_zfs_feature_enabled "feature@bookmarks"
+        set -l bookmark "|bookmark"
+    end
+    if commandline -c | grep -E -q " (\?|create|destroy|snap(shot)?|rollback|clone|promote|rename|list|set|get|inherit|upgrade|(user|group)space|(un?)?mount|(un)?share$bookmark|send|receive|recv|(un)?allow|holds?|release|diff|program) "
+        return 1
+    else
+        return 0
+    end
+end
+
+function __fish_zfs_using_command # ZFS command whose completions are looked for
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -eq 1 # The token can only be 'zfs', so skip
+        return 2
+    end
+    if test $cmd[2] = $argv
+        return 0
+    else
+        return 1
+    end
+end
+
+function __fish_zfs_list_dataset_types
+    echo -e "filesystem\t"(_ "ZFS filesystem")
+    echo -e "snapshot\t"(_ "ZFS filesystem snapshot")
+    echo -e "volume\t"(_ "ZFS block storage device")
+    echo -e "bookmark\t"(_ "ZFS snapshot bookmark")
+    echo -e "all\t"(_ "Any ZFS dataset")
+end
+
+function __fish_zfs_list_source_types
+    echo -e "local\t"(_ "Dataset-specific value")
+    echo -e "default\t"(_ "Default ZFS value")
+    echo -e "inherited\t"(_ "Value inherited from parent dataset")
+    echo -e "received\t"(_ "Value received by 'zfs receive'")
+    echo -e "temporary\t"(_ "Value valid for the current mount")
+    echo -e "none\t"(_ "Read-only value")
+end
+
+function __fish_zfs_list_get_fields
+    echo -e "name\t"(_ "Dataset full name")
+    echo -e "property\t"(_ "Property")
+    echo -e "value\t"(_ "Property value")
+    echo -e "source\t"(_ "Property value origin")
+end
+
+function __fish_zfs_list_space_fields
+    echo -e "type\t"(_ "Identity type")
+    echo -e "name\t"(_ "Identity name")
+    echo -e "used\t"(_ "Space usage")
+    echo -e "quota\t"(_ "Space quota")
+end
+
+function __fish_zfs_list_userspace_types
+    echo -e "posixuser\t"(_ "POSIX user")
+    echo -e "smbuser\t"(_ "Samba user")
+    echo -e "all\t"(_ "Both types")
+end
+
+function __fish_zfs_list_groupspace_types
+    echo -e "posixgroup\t"(_ "POSIX group")
+    echo -e "smbgroup\t"(_ "Samba group")
+    echo -e "all\t"(_ "Both types")
+end
+
+function __fish_zfs_list_permissions
+    echo -e "allow\t"(_ "Also needs the permission to be allowed")
+    echo -e "clone\t"(_ "Also needs the 'create' and 'mount' permissions in the origin filesystem")
+    echo -e "create\t"(_ "Also needs the 'mount' permission")
+    echo -e "destroy\t"(_ "Also needs the 'mount' permission")
+    echo -e "mount"
+    echo -e "promote\t"(_ "Also needs the 'promote' and 'mount' permissions in the origin filesystem")
+    echo -e "receive\t"(_ "Also needs the 'create' and 'mount' permissions")
+    echo -e "rename\t"(_ "Also needs the 'create' and 'mount' permissions in the new parent")
+    echo -e "rollback\t"(_ "Also needs the 'mount' permission")
+    echo -e "send"
+    echo -e "share\t"(_ "For SMB and NFS shares")
+    echo -e "snapshot\t"(_ "Also needs the 'mount' permission")
+    echo -e "groupquota"
+    echo -e "groupused"
+    echo -e "userprop\t"(_ "Allows changing any user property")
+    echo -e "userquota"
+    echo -e "userused"
+    # The remaining code of the function is almost a duplicate of __fish_complete_zfs_rw_properties and __fish_complete_zfs_ro_properties, but almost only, hence the duplication
+    # RO properties
+    echo -e "volblocksize\t"(_ "Volume block size") 
+    # R/W properties
+    echo -e "aclinherit\t"(_ "Inheritance of ACL entries")" (discard, noallow, restricted, passthrough, passthrough-x)"
+    echo -e "atime\t"(_ "Update access time on read")" (on, off)"
+    echo -e "canmount\t"(_ "Is the dataset mountable")" (on, off, noauto)"
+    set -l additional_cksum_algs ''
+    set -l additional_dedup_algs ''
+    if test $OS = 'FreeBSD'; or test $OS = 'SunOS'
+        set additional_cksum_algs ", noparity"
+    end
+    if __fish_is_zfs_feature_enabled "feature@sha512"
+        set additional_cksum_algs "$additional_cksum_algs, sha512"
+        set additional_dedup_algs ", sha512[,verify]"
+    end
+    if __fish_is_zfs_feature_enabled "feature@skein"
+        set additional_cksum_algs "$additional_cksum_algs, skein"
+        set additional_dedup_algs "$additional_dedup_algs, skein[,verify]"
+    end
+    if __fish_is_zfs_feature_enabled "feature@edonr"
+        set additional_cksum_algs "$additional_cksum_algs, edonr"
+        set additional_dedup_algs "$additional_dedup_algs, edonr[,verify]"
+    end
+    echo -e "checksum\t"(_ "Data checksum")" (on, off, fletcher2, fletcher4, sha256$additional_cksum_algs)"
+    set -e additional_cksum_algs
+    set -l additional_compress_algs ''
+    if __fish_is_zfs_feature_enabled "feature@lz4_compress"
+        set additional_compress_algs ", lz4"
+    end
+    echo -e "compression\t"(_ "Compression algorithm")" (on, off, lzjb$additional_compress_algs, gzip, gzip-[1-9], zle)"
+    set -e additional_compress_algs
+    echo -e "copies\t"(_ "Number of copies of data")" (1, 2, 3)"
+    echo -e "dedup\t"(_ "Deduplication")" (on, off, verify, sha256[,verify]$additional_dedup_algs)"
+    set -e additional_dedup_algs
+    echo -e "devices\t"(_ "Are contained device nodes openable")" (on, off)"
+    echo -e "exec\t"(_ "Can contained executables be executed")" (on, off)"
+    echo -e "filesystem_limit\t"(_ "Max number of filesystems and volumes")" (COUNT, none)"
+    echo -e "mountpoint\t"(_ "Mountpoint")" (PATH, none, legacy)"
+    echo -e "primarycache\t"(_ "Which data to cache in ARC")" (all, none, metadata)"
+    echo -e "quota\t"(_ "Max size of dataset and children")" (SIZE, none)"
+    echo -e "snapshot_limit\t"(_ "Max number of snapshots")" (COUNT, none)"
+    echo -e "readonly\t"(_ "Read-only")" (on, off)"
+    echo -e "recordsize\t"(_ "Suggest block size")" (SIZE)"
+    echo -e "redundant_metadata\t"(_ "How redundant are the metadata")" (all, most)"
+    echo -e "refquota\t"(_ "Max space used by dataset itself")" (SIZE, none)"
+    echo -e "refreservation\t"(_ "Min space guaranteed to dataset itself")" (SIZE, none)"
+    echo -e "reservation\t"(_ "Min space guaranteed to dataset")" (SIZE, none)"
+    echo -e "secondarycache\t"(_ "Which data to cache in L2ARC")" (all, none, metadata)"
+    echo -e "setuid\t"(_ "Respect set-UID bit")" (on, off)"
+    echo -e "sharenfs\t"(_ "Share in NFS")" (on, off, OPTS)"
+    echo -e "logbias\t"(_ "Hint for handling of synchronous requests")" (latency, throughput)"
+    echo -e "snapdir\t"(_ "Hide .zfs directory")" (hidden, visible)"
+    echo -e "sync\t"(_ "Handle of synchronous requests")" (standard, always, disabled)"
+    echo -e "volsize\t"(_ "Volume logical size")" (SIZE)"
+    if test $OS = "SunOS"
+        echo -e "zoned\t"(_ "Managed from a non-global zone")" (on, off)"
+        echo -e "mlslabel\t"(_ "Can the dataset be mounted in a zone with Trusted Extensions enabled")" (LABEL, none)"
+        echo -e "nbmand\t"(_ "Mount with Non Blocking mandatory locks")" (on, off)"
+        echo -e "sharesmb\t"(_ "Share in Samba")" (on, off)"
+        echo -e "shareiscsi\t"(_ "Share as an iSCSI target")" (on, off)"
+        echo -e "version\t"(_ "On-disk version of filesystem")" (1, 2, current)"
+        echo -e "vscan\t"(_ "Scan regular files for viruses on opening and closing")" (on, off)"
+        echo -e "xattr\t"(_ "Extended attributes")" (on, off, sa)"
+    else if test $OS = "Linux"
+        echo -e "acltype\t"(_ "Use no ACL or POSIX ACL")" (noacl, posixacl)"
+        echo -e "nbmand\t"(_ "Mount with Non Blocking mandatory locks")" (on, off)"
+        echo -e "relatime\t"(_ "Sometimes update access time on read")" (on, off)"
+        echo -e "shareiscsi\t"(_ "Share as an iSCSI target")" (on, off)"
+        echo -e "sharesmb\t"(_ "Share in Samba")" (on, off)"
+        echo -e "snapdev\t"(_ "Hide volume snapshots")" (hidden, visible)"
+        echo -e "version\t"(_ "On-disk version of filesystem")" (1, 2, current)"
+        echo -e "vscan\t"(_ "Scan regular files for viruses on opening and closing")" (on, off)"
+        echo -e "xattr\t"(_ "Extended attributes")" (on, off, sa)"
+    else if test $OS = "FreeBSD"
+        echo -e "aclmode\t"(_ "How is ACL modified by chmod")" (discard, groupmask, passthrough, restricted)"
+        echo -e "volmode\t"(_ "How to expose volumes to OS")" (default, geom, dev, none)"
+    end
+    # Write-once properties
+    echo -e "normalization\t"(_ "Unicode normalization")" (none, formC, formD, formKC, formKD)"
+    echo -e "utf8only\t"(_ "Reject non-UTF-8-compliant filenames")" (on, off)"
+    if test $OS = "Linux"
+        echo -e "casesensitivity\t"(_ "Case sensitivity")" (sensitive, insensitive)"
+    else # FreeBSD, SunOS and virtually all others
+        echo -e "casesensitivity\t"(_ "Case sensitivity")" (sensitive, insensitive, mixed)"
+    end
+    # Permissions set; if none are found, or if permission sets are not supported, no output is expected, even an error
+    for i in (zpool list -o name -H); zfs allow $i; end | grep -o '@[[:alnum:]]*' | sort | uniq
+end
+
+complete -c zfs -f -n '__fish_zfs_needs_command' -s '?' -a '?' -d 'Display a help message'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'create' -d 'Create a volume or filesystem'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'destroy' -d 'Destroy a dataset'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'snapshot snap' -d 'Create a snapshot'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'rollback' -d 'Roll back a filesystem to a previous snapshot'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'clone' -d 'Create a clone of a snapshot'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'promote' -d 'Promotes a clone file system to no longer be dependent on its "origin" snapshot'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'rename' -d 'Rename a dataset'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'list' -d 'List dataset properties'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'set' -d 'Set a dataset property'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'get' -d 'Get one or several dataset properties'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'inherit' -d 'Set a dataset property to be inherited'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'upgrade' -d 'List upgradeable datasets, or upgrade one'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'userspace' -d 'Get dataset space consumed by each user'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'groupspace' -d 'Get dataset space consumed by each user group'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'mount' -d 'Mount a filesystem'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'unmount umount' -d 'Unmount a filesystem'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'share' -d 'Share a given filesystem, or all of them'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'unshare' -d 'Stop sharing a given filesystem, or all of them'
+if __fish_is_zfs_feature_enabled 'feature@bookmarks'
+    complete -c zfs -f -n '__fish_zfs_needs_command' -a 'bookmark' -d 'Create a bookmark for a snapshot'
+end
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'send' -d 'Output a stream representation of a dataset'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'receive recv' -d 'Write on disk a dataset from the stream representation given on standard input'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'allow' -d 'Delegate, or display delegations of, rights on a dataset to (groups of) users'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'unallow' -d 'Revoke delegations of rights on a dataset from (groups of) users'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'hold' -d 'Put a named hold on a snapshot'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'holds' -d 'List holds on a snapshot'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'release' -d 'Remove a named hold from a snapshot'
+complete -c zfs -f -n '__fish_zfs_needs_command' -a 'diff' -d 'List changed files between a snapshot, and a filesystem or a previous snapshot'
+if test $OS = 'SunOS' # This is currently only supported under Illumos, but that will probably change
+    complete -c zfs -f -n '__fish_zfs_needs_command' -a 'program' -d 'Execute a ZFS Channel Program'
+end
+
+# Completions hereafter try to follow the man pages commands order, for maintainability, at the cost of multiple if statements
+
+# create completions
+complete -c zfs -f -n '__fish_zfs_using_command create' -s p -d 'Create all needed non-existing parent datasets'
+if test $OS = 'Linux' # Only Linux supports the comma-separated format; others need multiple -o calls
+    complete -c zfs -x -n '__fish_zfs_using_command create' -s o -d 'Dataset property' -a '(__fish_zfs_append (__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties))'
+else
+    complete -c zfs -x -n '__fish_zfs_using_command create' -s o -d 'Dataset property' -a '(__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties)'
+end
+# create completions for volumes; as -V is necessary to zfs to recognize a volume creation request, we use it as a condition to propose volume creation completions
+# If -V is typed after -s or -b, zfs should accept it, but fish won't propose -s or -b, but, as these options are for volumes only, it seems reasonable to expect the user to ask for a volume, with -V, before giving its characteristics with -s or -b
+complete -c zfs -x -n '__fish_zfs_using_command create' -s V -d 'Volume size'
+complete -c zfs -f -n '__fish_zfs_using_command create; and __fish_contains_opt -s V' -s s -d 'Create a sparse volume'
+complete -c zfs -x -n '__fish_zfs_using_command create; and __fish_contains_opt -s V' -s b -d 'Blocksize'
+
+# destroy completions; as the dataset is the last item, we can't know yet if it's a snapshot, a bookmark or something else, so we can't separate snapshot-specific options from others
+complete -c zfs -f -n '__fish_zfs_using_command destroy' -s r -d 'Recursively destroy children'
+complete -c zfs -f -n '__fish_zfs_using_command destroy' -s R -d 'Recursively destroy all dependents'
+complete -c zfs -f -n '__fish_zfs_using_command destroy' -s f -d 'Force unmounting'
+complete -c zfs -f -n '__fish_zfs_using_command destroy' -s n -d 'Dry run'
+complete -c zfs -f -n '__fish_zfs_using_command destroy' -s p -d 'Print machine-parsable verbose information'
+complete -c zfs -f -n '__fish_zfs_using_command destroy' -s v -d 'Verbose mode'
+complete -c zfs -f -n '__fish_zfs_using_command destroy' -s d -d 'Defer snapshot deletion'
+complete -c zfs -x -n '__fish_zfs_using_command destroy' -d 'Dataset to destroy' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes; __fish_print_zfs_snapshots; __fish_print_zfs_bookmarks)'
+
+# snapshot completions
+complete -c zfs -f -n '__fish_zfs_using_command snapshot; or __fish_zfs_using_command snap' -s r -d 'Recursively snapshot children'
+if test $OS = 'Linux' # Only Linux supports the comma-separated format; others need multiple -o calls
+    complete -c zfs -x -n '__fish_zfs_using_command snapshot; or __fish_zfs_using_command snap' -s o -d 'Snapshot property' -a '(__fish_zfs_append (__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties))'
+else
+    complete -c zfs -x -n '__fish_zfs_using_command snapshot; or __fish_zfs_using_command snap' -s o -d 'Snapshot property' -a '(__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties)'
+end
+complete -c zfs -x -n '__fish_zfs_using_command snapshot; or __fish_zfs_using_command snap' -d 'Dataset to snapshot' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes)'
+
+# rollback completions
+complete -c zfs -f -n '__fish_zfs_using_command rollback' -s r -d 'Destroy later snapshot and bookmarks'
+complete -c zfs -f -n '__fish_zfs_using_command rollback' -s R -d 'Recursively destroy later snapshot, bookmarks and clones'
+complete -c zfs -f -n '__fish_zfs_using_command rollback; and __fish_contains_opt -s R' -s f -d 'Force unmounting of clones'
+complete -c zfs -x -n '__fish_zfs_using_command rollback' -d 'Snapshot to roll back to' -a '(__fish_print_zfs_snapshots)'
+
+# clone completions
+complete -c zfs -f -n '__fish_zfs_using_command clone' -s p -d 'Create all needed non-existing parent datasets'
+if test $OS = 'Linux' # Only Linux supports the comma-separated format; others need multiple -o calls
+    complete -c zfs -x -n '__fish_zfs_using_command clone' -s o -d 'Clone property' -a '(__fish_zfs_append (__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties))'
+else
+    complete -c zfs -x -n '__fish_zfs_using_command clone' -s o -d 'Clone property' -a '(__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties)'
+end
+complete -c zfs -x -n '__fish_zfs_using_command clone' -d 'Snapshot to clone' -a '(__fish_print_zfs_snapshots)'
+
+# promote completions
+complete -c zfs -x -n '__fish_zfs_using_command promote' -d 'Clone to promote' -a '(__fish_print_zfs_filesystems)'
+
+# rename completions; as the dataset is the last item, we can't know yet if it's a snapshot or not, we can't separate snapshot-specific option from others
+complete -c zfs -f -n '__fish_zfs_using_command rename' -s p -d 'Create all needed non-existing parent datasets'
+complete -c zfs -f -n '__fish_zfs_using_command rename' -s r -d 'Recursively rename children snapshots'
+if test $OS = 'Linux'
+    complete -c zfs -f -n '__fish_zfs_using_command rename' -s f -d 'Force unmounting if needed'
+else if test $OS = 'FreeBSD'
+    complete -c zfs -f -n '__fish_zfs_using_command rename' -s u -d 'Do not remount filesystems during rename'
+    complete -c zfs -f -n '__fish_zfs_using_command rename; and __fish_not_contain_opt -s u' -s f -d 'Force unmounting if needed'
+end
+complete -c zfs -x -n '__fish_zfs_using_command rename' -d 'Dataset to rename' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes; __fish_print_zfs_snapshots)'
+
+# list completions
+complete -c zfs -f -n '__fish_zfs_using_command list' -s H -d 'Print output in a machine-parsable format'
+complete -c zfs -f -n '__fish_zfs_using_command list' -s r -d 'Operate recursively on datasets'
+complete -c zfs -x -n '__fish_zfs_using_command list; and __fish_contains_opt -s r' -s d -d 'Maximum recursion depth'
+complete -c zfs -x -n '__fish_zfs_using_command list' -s o -d 'Property to list' -a '(__fish_zfs_append (__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties; __fish_complete_zfs_ro_properties; echo -e "name\t"(_ "Dataset name")"; echo -e "space\t"(_ "Space properties")"))'
+complete -c zfs -f -n '__fish_zfs_using_command list' -s p -d 'Print parsable (exact) values for numbers'
+complete -c zfs -x -n '__fish_zfs_using_command list; and __fish_not_contain_opt -s S' -s s -d 'Property to use for sorting output by ascending order' -a '(__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties; __fish_complete_zfs_ro_properties; echo -e "name\t"(_ "Dataset name"))'
+complete -c zfs -x -n '__fish_zfs_using_command list; and __fish_not_contain_opt -s s' -s S -d 'Property to use for sorting output by descending order' -a '(__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties; __fish_complete_zfs_ro_properties; echo -e "name\t"(_ "Dataset name"))'
+complete -c zfs -x -n '__fish_zfs_using_command list' -s t -d 'Dataset type' -a '(__fish_zfs_list_dataset_types)'
+complete -c zfs -x -n '__fish_zfs_using_command list' -d 'Dataset which properties is to be listed' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes; __fish_print_zfs_snapshots)'
+
+# set completions
+complete -c zfs -x -n '__fish_zfs_using_command set' -d 'Property to set' -a '(__fish_complete_zfs_rw_properties)'
+complete -c zfs -x -n '__fish_zfs_using_command set; and string match -q -r "zfs set \S+ " (commandline -c)' -d 'Dataset which property is to be setted' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes; __fish_print_zfs_snapshots)'
+
+# get completions
+complete -c zfs -f -n '__fish_zfs_using_command get' -s r -d 'Operate recursively on datasets'
+complete -c zfs -x -n '__fish_zfs_using_command get; and __fish_contains_opt -s r' -s d -d 'Maximum recursion depth'
+complete -c zfs -f -n '__fish_zfs_using_command get' -s H -d 'Print output in a machine-parsable format'
+complete -c zfs -x -n '__fish_zfs_using_command get' -s o -d 'Fields to display' -a '(__fish_zfs_append (__fish_zfs_list_get_fields))'
+complete -c zfs -x -n '__fish_zfs_using_command get' -s s -d 'Property source to display' -a '(__fish_zfs_append (__fish_zfs_list_source_types))'
+complete -c zfs -f -n '__fish_zfs_using_command get' -s p -d 'Print parsable (exact) values for numbers'
+complete -c zfs -x -n '__fish_zfs_using_command get' -s t -d 'Dataset type' -a '(__fish_zfs_append (__fish_zfs_list_dataset_types))'
+complete -c zfs -x -n '__fish_zfs_using_command get' -d 'Property to get' -a '(__fish_zfs_append (__fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties; __fish_complete_zfs_ro_properties; echo "all"))'
+complete -c zfs -x -n '__fish_zfs_using_command get' -d 'Dataset which properties is to be got' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes; __fish_print_zfs_snapshots)'
+
+# inherit completions
+complete -c zfs -f -n '__fish_zfs_using_command inherit' -s r -d 'Operate recursively on datasets'
+complete -c zfs -f -n '__fish_zfs_using_command inherit' -s S -d 'Revert to the received value if available'
+complete -c zfs -x -n '__fish_zfs_using_command inherit' -d 'Dataset which properties is to be inherited' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes; __fish_print_zfs_snapshots)'
+
+# upgrade completions
+complete -c zfs -f -n '__fish_zfs_using_command upgrade; and __fish_not_contain_opt -s a -s r -s V' -s v -d 'Verbose mode'
+complete -c zfs -f -n '__fish_zfs_using_command upgrade; and __fish_not_contain_opt -s v' -s a -d 'Upgrade all eligible filesystems'
+complete -c zfs -f -n '__fish_zfs_using_command upgrade; and __fish_not_contain_opt -s v' -s r -d 'Operate recursively on datasets'
+complete -c zfs -x -n '__fish_zfs_using_command upgrade; and __fish_not_contain_opt -s v' -s V -d 'Upgrade to the specified version'
+complete -c zfs -x -n '__fish_zfs_using_command upgrade; and __fish_not_contain_opt -s a' -d 'Filesystem to upgrade' -a '(__fish_print_zfs_filesystems)'
+
+# userspace/groupspace completions
+complete -c zfs -f -n '__fish_zfs_using_command userspace' -s n -d 'Print UID instead of user name'
+complete -c zfs -f -n '__fish_zfs_using_command groupspace' -s n -d 'Print GID instead of group name'
+complete -c zfs -f -n '__fish_zfs_using_command userspace; or __fish_zfs_using_command groupspace' -s H -d 'Print output in a machine-parsable format'
+complete -c zfs -f -n '__fish_zfs_using_command userspace; or __fish_zfs_using_command groupspace' -s p -d 'Print parsable (exact) values for numbers'
+complete -c zfs -x -n '__fish_zfs_using_command userspace; or __fish_zfs_using_command groupspace' -s o -d 'Field to display' -a '(__fish_zfs_append (__fish_zfs_list_space_fields))'
+complete -c zfs -x -n '__fish_zfs_using_command userspace; or __fish_zfs_using_command groupspace; and __fish_not_contain_opt -s S' -s s -d 'Property to use for sorting output by ascending order' -a '__fish_zfs_list_space_fields'
+complete -c zfs -x -n '__fish_zfs_using_command userspace; or __fish_zfs_using_command groupspace; and __fish_not_contain_opt -s s' -s S -d 'Property to use for sorting output by descending order' -a '__fish_zfs_list_space_fields'
+complete -c zfs -x -n '__fish_zfs_using_command userspace' -s t -d 'Identity types to display' -a '(__fish_zfs_append (__fish_zfs_list_userspace_types))'
+complete -c zfs -x -n '__fish_zfs_using_command groupspace' -s t -d 'Identity types to display' -a '(__fish_zfs_append (__fish_zfs_list_groupspace_types))'
+complete -c zfs -f -n '__fish_zfs_using_command userspace; or __fish_zfs_using_command groupspace' -s i -d 'Translate S(amba)ID to POSIX ID'
+complete -c zfs -x -n '__fish_zfs_using_command userspace; or __fish_zfs_using_command groupspace' -d 'Dataset which space usage is to be got' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_snapshots)'
+
+# mount completions
+complete -c zfs -x -n '__fish_zfs_using_command mount' -s o -d 'Temporary mount point property' -a '(__fish_zfs_append (__fish_complete_zfs_mountpoint_properties))'
+complete -c zfs -f -n '__fish_zfs_using_command mount' -s v -d 'Report progress'
+complete -c zfs -f -n '__fish_zfs_using_command mount' -s a -d 'Mount all available ZFS filesystems'
+if test $OS = 'Linux'; or test $OS = 'SunOS'
+    complete -c zfs -f -n '__fish_zfs_using_command mount' -s O -d 'Overlay mount'
+end
+complete -c zfs -x -n '__fish_zfs_using_command mount; and __fish_not_contain_opt -s a' -d 'Filesystem to mount' -a '(__fish_print_zfs_filesystems)'
+
+# unmount completions
+complete -c zfs -f -n '__fish_zfs_using_command unmount; or __fish_zfs_using_command umount' -s f -d 'Force unmounting if needed'
+complete -c zfs -f -n '__fish_zfs_using_command unmount; or __fish_zfs_using_command umount' -s a -d 'Unmount all available ZFS filesystems'
+complete -c zfs -x -n '__fish_zfs_using_command unmount; or __fish_zfs_using_command umount; and __fish_not_contain_opt -s a' -d 'Filesystem to unmount' -a '(__fish_print_zfs_filesystems; __fish_print_mounted)'
+
+# share completions
+complete -c zfs -f -n '__fish_zfs_using_command share' -s a -d 'Share all eligible ZFS filesystems'
+complete -c zfs -x -n '__fish_zfs_using_command share; and __fish_not_contain_opt -s a' -d 'Filesystem to share' -a '(__fish_print_zfs_filesystems)'
+
+# unshare completions
+complete -c zfs -f -n '__fish_zfs_using_command unshare' -s a -d 'Unshare all shared ZFS filesystems'
+complete -c zfs -x -n '__fish_zfs_using_command unshare; and __fish_not_contain_opt -s a' -d 'Filesystem to unshare' -a '(__fish_print_zfs_filesystems; __fish_print_mounted)'
+
+# bookmark completions
+if __fish_is_zfs_feature_enabled 'feature@bookmarks'
+    complete -c zfs -x -n '__fish_zfs_using_command bookmark' -d 'Snapshot to bookmark' -a '(__fish_print_zfs_snapshots)'
+end
+
+# send completions
+complete -c zfs -x -n '__fish_zfs_using_command send' -s i -d 'Generate incremental stream from snapshot' -a '(__fish_print_zfs_snapshots; __fish_print_zfs_bookmarks)'
+complete -c zfs -x -n '__fish_zfs_using_command send' -s I -d 'Generate incremental stream from snapshot, even with intermediary snapshots' -a '(__fish_print_zfs_snapshots)'
+if test $OS = 'SunOS'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s R -l replicate -d 'Include children in replication stream'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s D -l dedup -d 'Generate a deduplicated stream'
+    complete -c zfs -f -n '__fish_zfs_using_command send; and __fish_is_zfs_feature_enabled "feature@large_blocks"' -s L -l large-block -d 'Allow the presence of larger blocks than 128 kiB'
+    complete -c zfs -f -n '__fish_zfs_using_command send; and __fish_is_zfs_feature_enabled "feature@embedded_data"' -s e -l embed -d 'Generate a more compact stream by using WRITE_EMBEDDED records'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s P -l parsable -d 'Print verbose information about the stream in a machine-parsable format'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s c -l compressed -d 'Generate compressed stream'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s n -l dryrun -d 'Dry run'
+    complete -c zfs -f -n '__fish_zfs_using_command send; and __fish_not_contain_opt -s R' -s p -l props -d 'Include dataset properties'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s v -l verbose -d 'Print verbose information about the stream'
+else
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s R -d 'Include children in replication stream'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s D -d 'Generate a deduplicated stream'
+    complete -c zfs -f -n '__fish_zfs_using_command send; and __fish_is_zfs_feature_enabled "feature@large_blocks"' -s L -d 'Allow the presence of larger blocks than 128 kiB'
+    complete -c zfs -f -n '__fish_zfs_using_command send; and __fish_is_zfs_feature_enabled "feature@embedded_data"' -s e -d 'Generate a more compact stream by using WRITE_EMBEDDED records'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s P -d 'Print verbose information about the stream in a machine-parsable format'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s n -d 'Dry run'
+    complete -c zfs -f -n '__fish_zfs_using_command send; and __fish_not_contain_opt -s R' -s p -d 'Include dataset properties'
+    complete -c zfs -f -n '__fish_zfs_using_command send' -s v -d 'Print verbose information about the stream'
+end
+complete -c zfs -x -n '__fish_zfs_using_command send' -d 'Dataset to send' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes; __fish_print_zfs_snapshots)'
+
+# receive completions
+complete -c zfs -f -n '__fish_zfs_using_command receive; or __fish_zfs_using_command recv' -s v -d 'Print verbose information about the stream and the time spent processing it'
+complete -c zfs -f -n '__fish_zfs_using_command receive; or __fish_zfs_using_command recv' -s n -d 'Dry run: do not actually receive the stream'
+complete -c zfs -f -n '__fish_zfs_using_command receive; or __fish_zfs_using_command recv' -s F -d 'Force rollback to the most recent snapshot'
+complete -c zfs -f -n '__fish_zfs_using_command receive; or __fish_zfs_using_command recv' -s u -d 'Unmount the target filesystem'
+complete -c zfs -f -n '__fish_zfs_using_command receive; or __fish_zfs_using_command recv; and __fish_not_contain_opt -s e' -s d -d 'Discard the first element of the path of the sent snapshot'
+complete -c zfs -f -n '__fish_zfs_using_command receive; or __fish_zfs_using_command recv; and __fish_not_contain_opt -s d' -s e -d 'Discard all but the last element of the path of the sent snapshot'
+if test $OS = "SunOS"
+    complete -c zfs -x -n '__fish_zfs_using_command receive; or __fish_zfs_using_command recv' -s o -d 'Force the stream to be received as a clone of the given snapshot' -a 'origin'
+end
+if __fish_is_zfs_feature_enabled "feature@extensible_dataset"
+    complete -c zfs -f -n '__fish_zfs_using_command receive; or __fish_zfs_using_command recv' -s s -d 'On transfer interruption, store a receive_resume_token for resumption'
+end
+complete -c zfs -x -n '__fish_zfs_using_command receive; or __fish_zfs_using_command recv' -d 'Dataset to receive' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes; __fish_print_zfs_snapshots)'
+
+# allow completions
+complete -c zfs -f -n '__fish_zfs_using_command allow; and __fish_not_contain_opt -s d' -s l -d 'Delegate permissions only on the specified dataset'
+complete -c zfs -f -n '__fish_zfs_using_command allow; and __fish_not_contain_opt -s l' -s d -d 'Delegate permissions only on the descendents dataset'
+complete -c zfs -x -n '__fish_zfs_using_command allow; and __fish_not_contain_opt -s e' -s u -d 'User to delegate permissions to' -a '(__fish_zfs_append (__fish_complete_users))'
+complete -c zfs -x -n '__fish_zfs_using_command allow; and __fish_not_contain_opt -s e' -s g -d 'Group to delegate permissions to' -a '(__fish_zfs_append (__fish_complete_groups))'
+if test $OS = "SunOS"; or test $OS = "FreeBSD"
+    complete -c zfs -f -n '__fish_zfs_using_command allow; and __fish_not_contain_opt -s u -s g -s e' -a 'everyone' -d 'Delegate permission to everyone'
+end
+complete -c zfs -x -n '__fish_zfs_using_command allow; and __fish_not_contain_opt -s u -s g everyone' -s e -d 'Delegate permission to everyone'
+complete -c zfs -x -n '__fish_zfs_using_command allow; and __fish_not_contain_opt -s l -s d -s e -s g -s u -s s' -s c -d 'Delegate permissions only to the creator of later descendent datasets' -a '(__fish_zfs_append (__fish_zfs_list_permissions))'
+complete -c zfs -x -n '__fish_zfs_using_command allow; and __fish_not_contain_opt -s l -s d -s e -s g -s u -s c' -s s -d 'Create a permission set or add permissions to an existing one'
+complete -c zfs -x -n '__fish_zfs_using_command allow' -d 'Dataset on which delegation is to be applied' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes)'
+
+# unallow completions
+complete -c zfs -f -n '__fish_zfs_using_command unallow; and __fish_not_contain_opt -s d' -s l -d 'Remove permissions only on the specified dataset'
+complete -c zfs -f -n '__fish_zfs_using_command unallow; and __fish_not_contain_opt -s l' -s d -d 'Remove permissions only on the descendents dataset'
+complete -c zfs -x -n '__fish_zfs_using_command unallow; and __fish_not_contain_opt -s e' -s u -d 'User to remove permissions from' -a '(__fish_zfs_append (__fish_complete_users))'
+complete -c zfs -x -n '__fish_zfs_using_command unallow; and __fish_not_contain_opt -s e' -s g -d 'Group to remove permissions from' -a '(__fish_zfs_append (__fish_complete_groups))'
+complete -c zfs -x -n '__fish_zfs_using_command unallow; and __fish_not_contain_opt -s u -s g everyone' -s e -d 'Remove permission from everyone'
+complete -c zfs -x -n '__fish_zfs_using_command unallow; and __fish_not_contain_opt -s l -s d -s e -s g -s u -s s' -s c -d 'Remove permissions only on later created descendent datasets' -a '(__fish_zfs_append (__fish_zfs_list_permissions))'
+complete -c zfs -x -n '__fish_zfs_using_command unallow; and __fish_not_contain_opt -s l -s d -s e -s g -s u -s c' -s s -d 'Remove a permission set or remove permissions from an existing one'
+if test $OS = 'SunOS'
+    complete -c zfs -f -n '__fish_zfs_using_command unallow' -s r -d 'Remove permissions recursively'
+    complete -c zfs -f -n '__fish_zfs_using_command unallow; and __fish_not_contain_opt -s u -s g -s e' -a 'everyone' -d 'Remove permission from everyone'
+else if test $OS = 'FreeBSD'
+    complete -c zfs -f -n '__fish_zfs_using_command unallow; and __fish_not_contain_opt -s u -s g -s e' -a 'everyone' -d 'Remove permission from everyone'
+end
+complete -c zfs -x -n '__fish_zfs_using_command unallow' -d 'Dataset on which delegation is to be removed' -a '(__fish_print_zfs_filesystems; __fish_print_zfs_volumes)'
+
+# hold completions
+complete -c zfs -f -n '__fish_zfs_using_command hold' -s r -d 'Apply hold recursively'
+complete -c zfs -x -n '__fish_zfs_using_command hold' -d 'Snapshot on which hold is to be applied' -a '(__fish_print_zfs_snapshots)'
+
+# holds completions
+complete -c zfs -f -n '__fish_zfs_using_command holds' -s r -d 'List holds recursively'
+complete -c zfs -x -n '__fish_zfs_using_command holds' -d 'Snapshot which holds are to be listed' -a '(__fish_print_zfs_snapshots)'
+
+# release completions
+complete -c zfs -f -n '__fish_zfs_using_command release' -s r -d 'Release hold recursively'
+complete -c zfs -x -n '__fish_zfs_using_command release' -d 'Snapshot from which hold is to be removed' -a '(__fish_print_zfs_snapshots)'
+
+# diff completions
+complete -c zfs -f -n '__fish_zfs_using_command diff' -s F -d 'Display file type (à la ls -F)'
+complete -c zfs -f -n '__fish_zfs_using_command diff' -s H -d 'Print output in a machine-parsable format'
+complete -c zfs -f -n '__fish_zfs_using_command diff' -s t -d 'Display inode change time'
+complete -c zfs -x -n '__fish_zfs_using_command diff' -d 'Source snapshot for the diff' -a '(__fish_print_zfs_snapshots)'
+
+# program completions
+if test $OS = 'SunOS' # This is currently only supported under Illumos, but that will probably change
+    complete -c zfs -x -n '__fish_zfs_using_command program' -s t -d 'Execution timeout'
+    complete -c zfs -x -n '__fish_zfs_using_command program' -s t -d 'Execution memory limit'
+    complete -c zfs -x -n '__fish_zfs_using_command program' -d 'Pool which program will be executed on' -a '(__fish_complete_zfs_pools)'
+end

--- a/share/completions/zpool.fish
+++ b/share/completions/zpool.fish
@@ -5,21 +5,18 @@
 # - this has been written mainly from manpages, which are known to be out-of-sync with the real feature set; some discrepancies have been addressed, but it is highly likely that others still lie
 
 set OS ""
-if passwd --help >/dev/null ^&1
-    set OS "Linux"
-else # Not Linux, so use the ugly uname
-    set -l os_type (uname)
-    switch $os_type
-        case Darwin
-            set OS "macOS"
-        case FreeBSD
-            set OS "FreeBSD"
-        case SunOS
-            set OS "SunOS"
-        # Others?
-        case "*"
-            set OS "unknown"
-    end
+switch (uname)
+    case Linux
+        set OS "Linux"
+    case Darwin
+        set OS "macOS"
+    case FreeBSD
+        set OS "FreeBSD"
+    case SunOS
+        set OS "SunOS"
+    # Others?
+    case "*"
+        set OS "unknown"
 end
 
 # Does the current invocation need a command?
@@ -134,7 +131,7 @@ end
 
 function __fish_zpool_list_ro_properties
     echo -e "alloc\t"(_ "Physically allocated space")
-    if test $OS = 'SunOS'; or test $OS = 'Linux'
+    if contains -- $OS SunOS Linux
         echo -e "available\t"(_ "Available space")
         echo -e "avail\t"(_ "Available space")
     end
@@ -291,7 +288,7 @@ complete -c zpool -x -n '__fish_zpool_using_command export' -d 'Pool to export' 
 # get completions
 complete -c zpool -f -n '__fish_zpool_using_command get' -s p -d 'Print parsable (exact) values for numbers'
 complete -c zpool -f -n '__fish_zpool_using_command get' -s H -d 'Print output in a machine-parsable format'
-if test $OS = 'FreeBSD'; or test $OS = 'SunOS'
+if contains -- $OS FreeBSD SunOS
     complete -c zpool -x -n '__fish_zpool_using_command get' -s o -d 'Fields to display' -a '(__fish_zpool_append (__fish_zpool_list_get_fields))'
 end
 complete -c zpool -x -n '__fish_zpool_using_command get' -d 'Properties to get' -a '(__fish_zpool_append (__fish_zpool_list_importtime_properties; __fish_zpool_list_rw_properties; __fish_zpool_list_writeonce_properties; __fish_zpool_list_ro_properties; __fish_zpool_list_device_properties; echo -e "all\t"(_ "All properties")))'

--- a/share/completions/zpool.fish
+++ b/share/completions/zpool.fish
@@ -1,0 +1,424 @@
+# Fish completions for the OpenZFS zpool command
+# Possible improvements:
+# - whenever possible, propose designation of vdevs using their GUID
+# - for eligible commands, with arguments of different types, only propose second type completions after the first have been selected; for instance, only propose pool members for offline command
+# - this has been written mainly from manpages, which are known to be out-of-sync with the real feature set; some discrepancies have been addressed, but it is highly likely that others still lie
+
+set OS ""
+if passwd --help >/dev/null ^&1
+    set OS "Linux"
+else # Not Linux, so use the ugly uname
+    set -l os_type (uname)
+    switch $os_type
+        case Darwin
+            set OS "macOS"
+        case FreeBSD
+            set OS "FreeBSD"
+        case SunOS
+            set OS "SunOS"
+        # Others?
+        case "*"
+            set OS "unknown"
+    end
+end
+
+# Does the current invocation need a command?
+function __fish_zpool_needs_command
+    if commandline -c | grep -E -q " (\?|add|attach|clear|create|destroy|detach|events|get|history|import|iostat|labelclear|list|offline|online|reguid|reopen|remove|replace|scrub|set|split|status|upgrade) "
+        return 1
+    else
+        return 0
+    end
+end
+
+function __fish_zpool_using_command # zpool command whose completions are looked for
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -eq 1 # The token can only be 'zpool', so skip
+        return 2
+    end
+    if test $cmd[2] = $argv
+        return 0
+    else
+        return 1
+    end
+end
+
+function __fish_zpool_append -d "Internal completion function for appending string to the zpool commandline"
+    set str (commandline -tc| sed -ne "s/\(.*,\)[^,]*/\1/p"|sed -e "s/--.*=//")
+    printf "%s\n" "$str"$argv
+end
+
+function __fish_zpool_list_used_vdevs -a pool
+    if test -z "$pool"
+        zpool list -H -v | grep -E "^\s" | cut -f2 | grep -x -E -v "(spare|log|cache|mirror|raidz.?)"
+    else
+        zpool list -H -v $pool | grep -E "^\s" | cut -f2 | grep -x -E -v "(spare|log|cache|mirror|raidz.?)"
+    end
+end
+
+function __fish_zpool_list_available_vdevs
+    if test $OS = 'Linux'
+        find /dev -type b | cut -d'/' -f3
+    else if test $OS = 'FreeBSD'
+        for i in (camcontrol devlist | cut -d "(" -f 2 | cut -d "," -f 1); ls /dev | grep "^$i"; end
+    else if test $OS = 'SunOS'
+        ls /dev/dsk
+    end
+end
+
+function __fish_zpool_complete_vdevs
+    # As this function is to be called for completions only when necessary, we don't need to verify that it is relevant for the specified command; this is to be decided by calling, or not, the current function for command completions
+    # We can display the physical devices, as they are relevant whereas we are in a vdev definition or not
+    __fish_zpool_list_available_vdevs
+    # First, reverse token list to analyze it from the end
+    set -l reversedTokens ""
+    for i in (commandline -co)
+        set reversedTokens "$i $reversedTokens"
+    end
+    set -l tokens 0
+    for i in (echo "$reversedTokens" | sed "s/ /\n/g")
+        switch $i
+            case spare log cache # At least 1 item expected
+                if test $tokens -ge 1
+                    __fish_zpool_list_vdev_types
+                end
+                return
+            case mirror raidz raidz1 # At least 2 items expected
+                if test $tokens -ge 2
+                    __fish_zpool_list_vdev_types
+                end
+                return
+            case raidz2 # At least 3 items expected
+                if test $tokens -ge 3
+                    __fish_zpool_list_vdev_types
+                end
+                return
+            case raidz3 # At least 4 items expected
+                if test $tokens -ge 4
+                    __fish_zpool_list_vdev_types
+                end
+                return
+            # Here, we accept any possible zpool command; this way, the developper will not have to augment or reduce the list when adding the current function to or removing it from the completions for the said command
+            case \? add attach clear create destroy detach events get history import iostat labelclear list offline online reguid reopen remove replace scrub set split status upgrade
+                __fish_zpool_list_vdev_types
+                return
+            case "" # Au cas où
+                echo "" > /dev/null
+            case "*"
+                if echo "$i" | grep -q -E '^((-.*)|(.*(=|,).*))$' # The token is an option or an option argument; as no option uses a vdev as its argument, we can abandon commandline parsing
+                    __fish_zpool_list_vdev_types
+                    return
+                end
+        end
+        set tokens (math $tokens+1)
+    end
+end
+
+function __fish_zpool_list_get_fields
+    echo -e "name\t"(_ "Pool full name")
+    echo -e "property\t"(_ "Property")
+    echo -e "value\t"(_ "Property value")
+    echo -e "source\t"(_ "Property value origin")
+end
+
+function __fish_zpool_list_vdev_types
+    echo -e "mirror\t"(_ "Mirror of at least two devices")
+    echo -e "raidz\t"(_ "ZFS RAID-5 variant, single parity")
+    echo -e "raidz1\t"(_ "ZFS RAID-5 variant, single parity")
+    echo -e "raidz2\t"(_ "ZFS RAID-5 variant, double parity")
+    echo -e "raidz3\t"(_ "ZFS RAID-5 variant, triple parity")
+    echo -e "spare\t"(_ "Pseudo vdev for pool hot spares")
+    echo -e "log\t"(_ "SLOG device")
+    echo -e "cache\t"(_ "L2ARC device")
+end
+
+function __fish_zpool_list_ro_properties
+    echo -e "alloc\t"(_ "Physically allocated space")
+    if test $OS = 'SunOS'; or test $OS = 'Linux'
+        echo -e "available\t"(_ "Available space")
+        echo -e "avail\t"(_ "Available space")
+    end
+    if test $OS = 'SunOS'
+        echo -e "bootsize\t"(_ "System boot partition size")
+    end
+    echo -e "capacity\t"(_ "Usage percentage of pool")
+    echo -e "dedupratio\t"(_ "Deduplication ratio") 
+    echo -e "expandsize\t"(_ "Amount of uninitialized space within the pool")
+    echo -e "fragmentation\t"(_ "Fragmentation percentage of pool")
+    echo -e "free\t"(_ "Free pool space")
+    echo -e "freeing\t"(_ "Remaining pool space to be freed")
+    echo -e "guid\t"(_ "Pool GUID")
+    echo -e "health\t"(_ "Current pool health")
+    echo -e "size\t"(_ "Total pool space")
+    echo -e "used\t"(_ "Used pool space")
+    # Unsupported features
+    for i in (zpool list -o all | head -n1 | tr -s "[:blank:]" | tr ' ' '\n' | tr "[:upper:]" "[:lower:]" | grep unsupported); echo $i; end
+end
+
+function __fish_zpool_list_device_properties
+    echo -e "ashift\t"(_ "Pool sector size exponent")" (COUNT)"
+end
+
+function __fish_zpool_list_writeonce_properties
+    echo -e "altroot\t"(_ "Alternate root directory")" (PATH)"
+end
+
+function __fish_zpool_list_importtime_properties
+    echo -e "altroot\t"(_ "Alternate root directory")" (PATH)"
+    echo -e "readonly\t"(_ "Import pool in read-only mode")" (on, off)"
+    echo -e "rdonly\t"(_ "Import pool in read-only mode")" (on, off)"
+end
+
+function __fish_zpool_list_rw_properties
+    echo -e "autoexpand\t"(_ "Automatic pool expansion on LUN growing")" (on, off)"
+    echo -e "expand\t"(_ "Automatic pool expansion on LUN growing")" (on, off)"
+    echo -e "autoreplace\t"(_ "Automatic use of replacement device")" (on, off)"
+    echo -e "replace\t"(_ "Automatic use of replacement device")" (on, off)"
+    echo -e "bootfs\t"(_ "Default bootable dataset")" (POOL/DATASET)"
+    echo -e "cachefile\t"(_ "Pool configuration cache")" (PATH, none, '')"
+    echo -e "comment\t"(_ "Comment about the pool")" (COMMENT)"
+    echo -e "dedupditto\t"(_ "Threshold for writting a ditto copy of deduplicated blocks")" (COUNT)"
+    echo -e "delegation\t"(_ "Allow rights delegation on the pool")" (on, off)"
+    echo -e "failmode\t"(_ "Behavior in case of catastrophic pool failure")" (wait, continue, panic)"
+    echo -e "listsnaps\t"(_ "Display snapshots even if 'zfs list' does not use '-t'")" (on, off)"
+    echo -e "version\t"(_ "On-disk version of pool")" (VERSION)"
+    # Feature properties
+    for featureLong in (zpool list -o all | tr -s "[:blank:]" | tr ' ' '\n' | tr "[:upper:]" "[:lower:]" | grep '^feature@')
+        set -l featureShort (echo $featureLong | sed -e 's/feature@\(.*\)/\1/g')
+        set featureLong (echo -e "$featureLong\t")
+        printf (_ "%sEnable the %s feature\n") $featureLong $featureShort
+    end
+end
+
+complete -c zpool -f -n '__fish_zpool_needs_command' -s '?' -d 'Display a help message'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'add' -d 'Add new virtual devices to pool'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'attach' -d 'Attach virtual device to a pool device'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'clear' -d 'Clear devices errors in pool'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'create' -d 'Create a new storage pool'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'destroy' -d 'Destroy a storage pool'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'detach' -d 'Detach virtual device from a mirroring pool'
+if test $OS = 'Linux'
+    complete -c zpool -f -n '__fish_zpool_needs_command' -a 'events' -d 'Display pool event log'
+end
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'export' -d 'Export a pool'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'get' -d 'Get one or several pool properties'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'history' -d 'Display pool command history'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'import' -d 'List importable pools, or import some'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'iostat' -d 'Display pool I/O stats'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'labelclear' -d 'Remove ZFS label information from the specified device'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'list' -d 'List pools with health status and space usage'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'offline' -d 'Take the specified devices offline'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'online' -d 'Bring the specified devices back online'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'reguid' -d 'Reset pool GUID'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'remove' -d 'Remove virtual devices from pool'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'reopen' -d 'Reopen pool devices'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'replace' -d 'Replace a pool virtual device'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'scrub' -d 'Start or stop scrubbing'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'set' -d 'Set a pool property'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'split' -d 'Create a pool by splitting an existing mirror one'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'status' -d 'Display detailed pool health status'
+complete -c zpool -f -n '__fish_zpool_needs_command' -a 'upgrade' -d 'List upgradeable pools, or upgrade one'
+
+# add completions
+complete -c zpool -f -n '__fish_zpool_using_command add' -s f -d 'Force use of virtual device'
+complete -c zpool -f -n '__fish_zpool_using_command add' -s n -d 'Dry run: only display resulting configuration'
+if test $OS = 'Linux'
+    complete -c zpool -f -n '__fish_zpool_using_command add' -s g -d 'Display virtual device GUID instead of device name'
+    complete -c zpool -f -n '__fish_zpool_using_command add' -s L -d 'Resolve device path symbolic links'
+    complete -c zpool -f -n '__fish_zpool_using_command add' -s P -d 'Display device full path'
+    complete -c zpool -x -n '__fish_zpool_using_command add' -s o -d 'Pool property' -a '(__fish_zpool_list_device_properties)'
+end
+complete -c zpool -x -n '__fish_zpool_using_command add' -d 'Pool to add virtual devices to' -a '(__fish_complete_zfs_pools)'
+complete -c zpool -x -n '__fish_zpool_using_command add' -d 'Virtual device to add' -a '(__fish_zpool_complete_vdevs)'
+
+# attach completions
+complete -c zpool -f -n '__fish_zpool_using_command attach' -s f -d 'Force use of virtual device'
+if test $OS = 'Linux'
+    complete -c zpool -x -n '__fish_zpool_using_command attach' -s o -d 'Pool property' -a '(__fish_zpool_list_device_properties)'
+end
+complete -c zpool -x -n '__fish_zpool_using_command attach' -d 'Pool to attach virtual device to' -a '(__fish_complete_zfs_pools)'
+complete -c zpool -x -n '__fish_zpool_using_command attach' -d 'Virtual device to operate on' -a '(__fish_zpool_list_available_vdevs)'
+
+# clear completions
+if test $OS = 'FreeBSD'
+    complete -c zpool -f -n '__fish_zpool_using_command clear' -s F -d 'Initiate recovery mode'
+    complete -c zpool -f -n '__fish_zpool_using_command clear; and __fish_contains_opt -s F' -s n -d 'Dry run: only determine if the recovery is possible, without attempting it'
+end
+complete -c zpool -x -n '__fish_zpool_using_command clear' -d 'Pool to clear errors on' -a '(__fish_complete_zfs_pools)'
+complete -c zpool -f -n '__fish_zpool_using_command clear' -d 'Virtual device to operate on' -a '(__fish_zpool_list_used_vdevs)'
+
+# create completions
+if test $OS = 'SunOS'
+    complete -c zpool -f -n '__fish_zpool_using_command create' -s B -d 'Create whole disk pool with EFI System partition to support booting system with UEFI firmware'
+else
+    complete -c zpool -f -n '__fish_zpool_using_command create' -s f -d 'Force use of virtual device'
+end
+complete -c zpool -f -n '__fish_zpool_using_command create' -s n -d 'Dry run, only display resulting configuration'
+complete -c zpool -f -n '__fish_zpool_using_command create' -s d -d 'Do not enable any feature on the new pool'
+complete -c zpool -x -n '__fish_zpool_using_command create' -s o -d 'Pool property' -a '(__fish_zpool_list_writeonce_properties; __fish_zpool_list_rw_properties)'
+complete -c zpool -x -n '__fish_zpool_using_command create' -s O -d 'Root filesystem property' -a '(__fish_complete_zfs_ro_properties; __fish_complete_zfs_rw_properties; __fish_complete_zfs_write_once_properties)'
+complete -c zpool -r -n '__fish_zpool_using_command create' -s R -d 'Equivalent to "-o cachefile=none,altroot=ROOT"'
+complete -c zpool -x -n '__fish_zpool_using_command create' -s m -d 'Root filesystem mountpoint' -a 'legacy none'
+if test $OS = 'Linux'
+    complete -c zpool -x -n '__fish_zpool_using_command create' -s t -d 'Set a different in-core pool name'
+end
+complete -c zpool -x -n '__fish_zpool_using_command create' -d 'Virtual device to add' -a '(__fish_zpool_complete_vdevs)'
+
+# destroy completions
+complete -c zpool -f -n '__fish_zpool_using_command destroy' -s f -d 'Force unmounting of all contained datasets'
+complete -c zpool -x -n '__fish_zpool_using_command destroy' -d 'Pool to destroy' -a '(__fish_complete_zfs_pools)'
+
+# detach completions
+complete -c zpool -x -n '__fish_zpool_using_command clear' -d 'Pool to detach device from' -a '(__fish_complete_zfs_pools)'
+complete -c zpool -x -n '__fish_zpool_using_command clear' -d 'Physical device to detach' -a '(__fish_zpool_list_used_vdevs)'
+
+# events completions
+if test $OS = 'Linux'
+    complete -c zpool -f -n '__fish_zpool_using_command events' -s v -d 'Print verbose event information'
+    complete -c zpool -f -n '__fish_zpool_using_command events' -s H -d 'Print output in a machine-parsable format'
+    complete -c zpool -f -n '__fish_zpool_using_command events' -s f -d 'Output appended data as the log grows'
+    complete -c zpool -f -n '__fish_zpool_using_command events' -s c -d 'Clear all previous events'
+    complete -c zpool -f -n '__fish_zpool_using_command events' -d 'Pool to read events from' -a '(__fish_complete_zfs_pools)'
+end
+
+# export completions
+if test $OS = 'Linux'
+    complete -c zpool -f -n '__fish_zpool_using_command export' -s a -d 'Export all pools'
+end
+complete -c zpool -f -n '__fish_zpool_using_command export' -s f -d 'Force unmounting of all contained datasets'
+complete -c zpool -x -n '__fish_zpool_using_command export' -d 'Pool to export' -a '(__fish_complete_zfs_pools)'
+
+# get completions
+complete -c zpool -f -n '__fish_zpool_using_command get' -s p -d 'Print parsable (exact) values for numbers'
+complete -c zpool -f -n '__fish_zpool_using_command get' -s H -d 'Print output in a machine-parsable format'
+if test $OS = 'FreeBSD'; or test $OS = 'SunOS'
+    complete -c zpool -x -n '__fish_zpool_using_command get' -s o -d 'Fields to display' -a '(__fish_zpool_append (__fish_zpool_list_get_fields))'
+end
+complete -c zpool -x -n '__fish_zpool_using_command get' -d 'Properties to get' -a '(__fish_zpool_append (__fish_zpool_list_importtime_properties; __fish_zpool_list_rw_properties; __fish_zpool_list_writeonce_properties; __fish_zpool_list_ro_properties; __fish_zpool_list_device_properties; echo -e "all\t"(_ "All properties")))'
+complete -c zpool -x -n '__fish_zpool_using_command get' -d 'Pool to get properties of' -a '(__fish_complete_zfs_pools)'
+
+# history completions
+complete -c zpool -f -n '__fish_zpool_using_command history' -s i -d 'Also display internal events'
+complete -c zpool -f -n '__fish_zpool_using_command history' -s l -d 'Display log records using long format'
+complete -c zpool -f -n '__fish_zpool_using_command history' -d 'Pool to get command history of' -a '(__fish_complete_zfs_pools)'
+
+# import completions
+complete -c zpool -r -n '__fish_zpool_using_command import; and __fish_not_contain_opt -s d' -s c -d 'Read configuration from specified cache file'
+complete -c zpool -r -n '__fish_zpool_using_command import; and __fish_not_contain_opt -s c' -s d -d 'Search for devices or files in specified directory'
+complete -c zpool -f -n '__fish_zpool_using_command import' -s D -d 'List or import destroyed pools only (requires -f for importation)'
+complete -c zpool -x -n '__fish_zpool_using_command import' -s o -d 'Mount properties for contained datasets' -a '(__fish_zpool_append (__fish_complete_zfs_mountpoint_properties))'
+complete -c zpool -x -n '__fish_zpool_using_command import' -s o -d 'Properties of the imported pool' -a '(__fish_complete_zfs_mountpoint_properties; __fish_zpool_list_importtime_properties; __fish_zpool_list_rw_properties)'
+complete -c zpool -f -n '__fish_zpool_using_command import' -s f -d 'Force import'
+complete -c zpool -f -n '__fish_zpool_using_command import' -s F -d 'Recovery mode'
+complete -c zpool -f -n '__fish_zpool_using_command import' -s a -d 'Search for and import all pools found'
+complete -c zpool -f -n '__fish_zpool_using_command import' -s m -d 'Ignore missing log device (risk of loss of last changes)'
+complete -c zpool -r -n '__fish_zpool_using_command import' -s R -d 'Equivalent to "-o cachefile=none,altroot=ROOT"'
+complete -c zpool -f -n '__fish_zpool_using_command import' -s N -d 'Do not mount contained filesystems'
+complete -c zpool -f -n '__fish_zpool_using_command import; and __fish_contains_opt -s F' -s n -d 'Dry run: only determine if the recovery is possible, without attempting it'
+if test $OS = 'Linux'
+    complete -c zpool -f -n '__fish_zpool_using_command import; and __fish_contains_opt -s F' -s X -d 'Roll back to a previous TXG (hazardous)'
+    complete -c zpool -r -n '__fish_zpool_using_command import' -s T -d 'TXG to roll back to (implies -FX)'
+    complete -c zpool -f -n '__fish_zpool_using_command import' -s t -d 'Specify, as the last argument, a temporary pool name'
+end
+complete -c zpool -f -n '__fish_zpool_using_command import; and __fish_not_contain_opt -s a' -d 'Pool to import' -a '(__fish_complete_zfs_pools)'
+
+# iostat completions
+complete -c zpool -x -n '__fish_zpool_using_command iostat' -s T -d 'Display a timestamp using specified format'
+if test $OS = 'Linux'
+    complete -c zpool -f -n '__fish_zpool_using_command iostat' -s g -d 'Display virtual device GUID instead of device name'
+    complete -c zpool -f -n '__fish_zpool_using_command iostat' -s L -d 'Resolve device path symbolic links'
+    complete -c zpool -f -n '__fish_zpool_using_command iostat' -s P -d 'Display device full path'
+    complete -c zpool -f -n '__fish_zpool_using_command iostat' -s y -d 'Omit statistics since boot'
+end
+complete -c zpool -f -n '__fish_zpool_using_command iostat' -s v -d 'Print verbose statistics'
+complete -c zpool -f -n '__fish_zpool_using_command iostat' -d 'Pool to retrieve I/O stats from' -a '(__fish_complete_zfs_pools)'
+
+# labelclear completions
+complete -c zpool -f -n '__fish_zpool_using_command labelclear' -s f -d 'Treat exported or foreign devices as inactive'
+complete -c zpool -x -n '__fish_zpool_using_command labelclear' -d 'Device to clear ZFS label information from' -a '(__fish_zpool_list_available_vdevs)'
+
+# list completions
+complete -c zpool -f -n '__fish_zpool_using_command list' -s H -d 'Print output in a machine-parsable format'
+if test $OS = 'Linux'
+    complete -c zpool -f -n '__fish_zpool_using_command list' -s g -d 'Display virtual device GUID instead of device name'
+    complete -c zpool -f -n '__fish_zpool_using_command list' -s L -d 'Resolve device path symbolic links'
+end
+complete -c zpool -f -n '__fish_zpool_using_command list' -s P -d 'Display device full path'
+complete -c zpool -x -n '__fish_zpool_using_command list' -s T -d 'Display a timestamp using specified format'
+complete -c zpool -f -n '__fish_zpool_using_command list' -s v -d 'Print verbose statistics'
+complete -c zpool -x -n '__fish_zpool_using_command list' -s o -d 'Property to list' -a '(__fish_zpool_append (__fish_zpool_list_importtime_properties; __fish_zpool_list_rw_properties; __fish_zpool_list_writeonce_properties; __fish_zpool_list_ro_properties; __fish_zpool_list_device_properties))'
+complete -c zpool -f -n '__fish_zpool_using_command list' -d 'Pool to list properties of' -a '(__fish_complete_zfs_pools)'
+
+# offline completions
+complete -c zpool -f -n '__fish_zpool_using_command offline' -s t -d 'Temporarily offline'
+complete -c zpool -x -n '__fish_zpool_using_command offline' -d 'Pool to offline device from' -a '(__fish_complete_zfs_pools)'
+complete -c zpool -x -n '__fish_zpool_using_command offline' -d 'Physical device to offline' -a '(__fish_zpool_list_used_vdevs)'
+
+# online completions
+complete -c zpool -f -n '__fish_zpool_using_command online' -s e -d 'Expand the device to use all available space'
+complete -c zpool -x -n '__fish_zpool_using_command online' -d 'Pool to bring device back online on' -a '(__fish_complete_zfs_pools)'
+complete -c zpool -x -n '__fish_zpool_using_command online' -d 'Physical device to bring back online' -a '(__fish_zpool_list_used_vdevs)'
+
+# reguid completions
+complete -c zpool -x -n '__fish_zpool_using_command reguid' -d 'Pool which GUID is to be changed' -a '(__fish_complete_zfs_pools)'
+
+# remove completions
+complete -c zpool -x -n '__fish_zpool_using_command remove' -d 'Pool to remove device from' -a '(__fish_complete_zfs_pools)'
+complete -c zpool -x -n '__fish_zpool_using_command remove' -d 'Physical device to remove' -a '(__fish_zpool_list_used_vdevs)'
+
+# reopen completions
+complete -c zpool -x -n '__fish_zpool_using_command reopen' -d 'Pool which devices are to be reopened' -a '(__fish_complete_zfs_pools)'
+
+# replace completions
+complete -c zpool -f -n '__fish_zpool_using_command replace' -s f -d 'Force use of virtual device'
+if test $OS = 'Linux'
+    complete -c zpool -x -n '__fish_zpool_using_command replace' -s o -d 'Pool property' -a '(__fish_zpool_list_device_properties)'
+end
+complete -c zpool -x -n '__fish_zpool_using_command replace' -d 'Pool to replace device' -a '(__fish_complete_zfs_pools)'
+complete -c zpool -x -n '__fish_zpool_using_command replace' -d 'Pool device to be replaced' -a '(__fish_zpool_list_used_vdevs)'
+complete -c zpool -f -n '__fish_zpool_using_command replace' -d 'Device to use for replacement' -a '(__fish_zpool_list_available_vdevs)'
+
+# scrub completions
+complete -c zpool -f -n '__fish_zpool_using_command scrub' -s s -d 'Stop scrubbing'
+if test $OS = 'SunOS'
+    complete -c zpool -f -n '__fish_zpool_using_command scrub' -s p -d 'Pause scrubbing'
+end
+complete -c zpool -x -n '__fish_zpool_using_command scrub' -d 'Pool to start/stop scrubbing' -a '(__fish_complete_zfs_pools)'
+
+# set completions
+complete -c zpool -x -n '__fish_zpool_using_command set' -d 'Property to set' -a '(__fish_zpool_list_rw_properties)'
+complete -c zpool -x -n '__fish_zpool_using_command set' -d 'Pool which property is to be set' -a '(__fish_complete_zfs_pools)'
+
+# split completions
+if test $OS = 'Linux'
+    complete -c zpool -f -n '__fish_zpool_using_command split' -s g -d 'Display virtual device GUID instead of device name'
+    complete -c zpool -f -n '__fish_zpool_using_command split' -s L -d 'Resolve device path symbolic links'
+    complete -c zpool -f -n '__fish_zpool_using_command split' -s P -d 'Display device full path'
+end
+complete -c zpool -f -n '__fish_zpool_using_command split' -s n -d 'Dry run: only display resulting configuration'
+complete -c zpool -r -n '__fish_zpool_using_command split' -s R -d 'Set altroot for newpool and automatically import it'
+complete -c zpool -x -n '__fish_zpool_using_command split' -s o -d 'Pool property' -a '(__fish_zpool_list_writeonce_properties; __fish_zpool_list_rw_properties)'
+if test $OS = 'FreeBSD'
+    complete -c zpool -x -n '__fish_zpool_using_command split; and __fish_contains_opt -s R' -s o -d 'Mount properties for contained datasets' -a '(__fish_zpool_append (__fish_complete_zfs_mountpoint_properties))'
+end
+complete -c zpool -x -n '__fish_zpool_using_command split' -d 'Pool to split' -a '(__fish_complete_zfs_pools)'
+
+# status completions
+if test $OS = 'Linux'
+    complete -c zpool -f -n '__fish_zpool_using_command status' -s g -d 'Display virtual device GUID instead of device name'
+    complete -c zpool -f -n '__fish_zpool_using_command status' -s L -d 'Resolve device path symbolic links'
+    complete -c zpool -f -n '__fish_zpool_using_command status' -s P -d 'Display device full path'
+    complete -c zpool -f -n '__fish_zpool_using_command status' -s D -d 'Display deduplication histogram'
+else if test $OS = 'SunOS'
+    complete -c zpool -f -n '__fish_zpool_using_command status' -s D -d 'Display deduplication histogram'
+end
+complete -c zpool -f -n '__fish_zpool_using_command status' -s v -d 'Verbose mode'
+complete -c zpool -f -n '__fish_zpool_using_command status' -s x -d 'Only display status for unhealthy or unavailable pools'
+complete -c zpool -x -n '__fish_zpool_using_command status' -s T -d 'Display a timestamp using specified format'
+complete -c zpool -f -n '__fish_zpool_using_command status' -d 'Pool which status is to be displayed' -a '(__fish_complete_zfs_pools)'
+
+# upgrade completions
+complete -c zpool -f -n '__fish_zpool_using_command upgrade' -s a -d 'Upgrade all eligible pools, enabling all supported features'
+complete -c zpool -f -n '__fish_zpool_using_command upgrade' -s v -d 'Display upgradeable ZFS versions'
+complete -c zpool -x -n '__fish_zpool_using_command upgrade' -s V -d 'Upgrade to the specified legacy version'
+complete -c zpool -f -n '__fish_zpool_using_command upgrade; and __fish_not_contain_opt -s a' -d 'Pool which status is to be displayed' -a '(__fish_complete_zfs_pools)'

--- a/share/functions/__fish_complete_zfs_mountpoint_properties.fish
+++ b/share/functions/__fish_complete_zfs_mountpoint_properties.fish
@@ -1,21 +1,18 @@
 function __fish_complete_zfs_mountpoint_properties -d "Completes with ZFS mountpoint properties"
 	set -l OS ""
-	if passwd --help >/dev/null ^&1
-		set OS "Linux"
-	else # Not Linux, so use the ugly uname
-		set -l os_type (uname)
-		switch $os_type
-			case Darwin
-				set OS "macOS"
-			case FreeBSD
-				set OS "FreeBSD"
-			case SunOS
-				set OS "SunOS"
-			# Others?
-			case "*"
-				set OS "unknown"
-		end
-	end
+    switch (uname)
+        case Linux
+            set OS "Linux"
+        case Darwin
+            set OS "macOS"
+        case FreeBSD
+            set OS "FreeBSD"
+        case SunOS
+            set OS "SunOS"
+        # Others?
+        case "*"
+            set OS "unknown"
+    end
 	echo -e "atime\t"(_ "Update access time on read")" (on, off)"
 	echo -e "devices\t"(_ "Are contained device nodes openable")" (on, off)"
 	echo -e "exec\t"(_ "Can contained executables be executed")" (on, off)"

--- a/share/functions/__fish_complete_zfs_mountpoint_properties.fish
+++ b/share/functions/__fish_complete_zfs_mountpoint_properties.fish
@@ -1,0 +1,32 @@
+function __fish_complete_zfs_mountpoint_properties -d "Completes with ZFS mountpoint properties"
+	set -l OS ""
+	if passwd --help >/dev/null ^&1
+		set OS "Linux"
+	else # Not Linux, so use the ugly uname
+		set -l os_type (uname)
+		switch $os_type
+			case Darwin
+				set OS "macOS"
+			case FreeBSD
+				set OS "FreeBSD"
+			case SunOS
+				set OS "SunOS"
+			# Others?
+			case "*"
+				set OS "unknown"
+		end
+	end
+	echo -e "atime\t"(_ "Update access time on read")" (on, off)"
+	echo -e "devices\t"(_ "Are contained device nodes openable")" (on, off)"
+	echo -e "exec\t"(_ "Can contained executables be executed")" (on, off)"
+	echo -e "readonly\t"(_ "Read-only")" (on, off)"
+	echo -e "setuid\t"(_ "Respect set-UID bit")" (on, off)"
+	if test $OS = "SunOS"
+		echo -e "nbmand\t"(_ "Mount with Non Blocking mandatory locks")" (on, off)"
+		echo -e "xattr\t"(_ "Extended attributes")" (on, off, sa)"
+	else if test $OS = "Linux"
+		echo -e "nbmand\t"(_ "Mount with Non Blocking mandatory locks")" (on, off)"
+		echo -e "relatime\t"(_ "Sometimes update access time on read")" (on, off)"
+		echo -e "xattr\t"(_ "Extended attributes")" (on, off, sa)"
+	end		
+end

--- a/share/functions/__fish_complete_zfs_pools.fish
+++ b/share/functions/__fish_complete_zfs_pools.fish
@@ -1,3 +1,3 @@
 function __fish_complete_zfs_pools -d "Completes with available ZFS pools"
-	zpool list -o name,comment -H | sed -e 's/\t-//g'
+	zpool list -o name,comment -H | string replace -a \t'-' ''
 end

--- a/share/functions/__fish_complete_zfs_pools.fish
+++ b/share/functions/__fish_complete_zfs_pools.fish
@@ -1,0 +1,3 @@
+function __fish_complete_zfs_pools -d "Completes with available ZFS pools"
+	zpool list -o name,comment -H | sed -e 's/\t-//g'
+end

--- a/share/functions/__fish_complete_zfs_ro_properties.fish
+++ b/share/functions/__fish_complete_zfs_ro_properties.fish
@@ -40,7 +40,7 @@ function __fish_complete_zfs_ro_properties -d "Completes with ZFS read-only prop
     end
 	# Autogenerate written@$SNAPSHOT list
     for snapshot in (__fish_print_zfs_snapshots)
-        set tabAndBefore (echo -e "written@$snapshot\t")
+        set -l tabAndBefore (echo -e "written@$snapshot\t")
         printf (_ "%sReferenced data written since snapshot %s\n") $tabAndBefore $snapshot
     end
 end

--- a/share/functions/__fish_complete_zfs_ro_properties.fish
+++ b/share/functions/__fish_complete_zfs_ro_properties.fish
@@ -1,0 +1,46 @@
+function __fish_complete_zfs_ro_properties -d "Completes with ZFS read-only properties"
+	echo -e "available\t"(_ "Available space")
+	echo -e "avail\t"(_ "Available space")
+	echo -e "compressratio\t"(_ "Achieved compression ratio")
+	echo -e "creation\t"(_ "Dataset creation time")
+	echo -e "clones\t"(_ "Snapshot clones")
+	echo -e "defer_destroy\t"(_ "Marked for deferred destruction")
+	echo -e "filesystem_count\t"(_ "Total lower-level filesystems and volumes")
+	echo -e "logicalreferenced\t"(_ "Logical total space")
+	echo -e "lrefer\t"(_ "Logical total space")
+	echo -e "logicalused\t"(_ "Logical used space")
+	echo -e "lused\t"(_ "Logical used space")
+	echo -e "mounted\t"(_ "Is currently mounted?")
+	echo -e "origin\t"(_ "Source snapshot")
+	if __fish_is_zfs_feature_enabled "feature@extensible_dataset"
+		echo -e "receive_resume_token\t"(_ "Token for interrupted reception resumption")
+	end
+	echo -e "referenced\t"(_ "Total space")
+	echo -e "refer\t"(_ "Total space")
+	echo -e "refcompressratio\t"(_ "Achieved compression ratio of referenced space")
+	echo -e "snapshot_count\t"(_ "Total lower-level snapshots")
+	echo -e "type\t"(_ "Dataset type")
+	echo -e "used\t"(_ "Space used by dataset and children")
+	echo -e "usedbychildren\t"(_ "Space used by children datasets")
+	echo -e "usedbydataset\t"(_ "Space used by dataset itself")
+	echo -e "usedbyrefreservation\t"(_ "Space used by refreservation")
+	echo -e "usedbysnapshots\t"(_ "Space used by dataset snapshots")
+	echo -e "userrefs\t"(_ "Holds count") 
+	echo -e "volblocksize\t"(_ "Volume block size") 
+	echo -e "written\t"(_ "Referenced data written since previous snapshot")
+	# Autogenerate userused@$USER list; only usernames are supported by the completion, but the zfs command supports more formats
+    for user in (__fish_print_users)
+        set -l tabAndBefore (echo -e "userused@$user\t")
+        printf (_ "%sDataset space use by user %s\n") $tabAndBefore $user
+    end
+	# Autogenerate groupused@$USER list
+    for group in (__fish_print_groups)
+        set -l tabAndBefore (echo -e "groupused@$group\t")
+        printf (_ "%sDataset space use by group %s\n") $tabAndBefore $group
+    end
+	# Autogenerate written@$SNAPSHOT list
+    for snapshot in (__fish_print_zfs_snapshots)
+        set tabAndBefore (echo -e "written@$snapshot\t")
+        printf (_ "%sReferenced data written since snapshot %s\n") $tabAndBefore $snapshot
+    end
+end

--- a/share/functions/__fish_complete_zfs_rw_properties.fish
+++ b/share/functions/__fish_complete_zfs_rw_properties.fish
@@ -1,26 +1,23 @@
 function __fish_complete_zfs_rw_properties -d "Completes with ZFS read-write properties"
 	set -l OS ""
-	if passwd --help >/dev/null ^&1
-		set OS "Linux"
-	else # Not Linux, so use the ugly uname
-		set -l os_type (uname)
-		switch $os_type
-			case Darwin
-				set OS "macOS"
-			case FreeBSD
-				set OS "FreeBSD"
-			case SunOS
-				set OS "SunOS"
-			# Others?
-			case "*"
-				set OS "unknown"
-		end
+    switch (uname)
+        case Linux
+            set OS "Linux"
+        case Darwin
+            set OS "macOS"
+        case FreeBSD
+            set OS "FreeBSD"
+        case SunOS
+            set OS "SunOS"
+        # Others?
+        case "*"
+            set OS "unknown"
 	end
 	echo -e "aclinherit\t"(_ "Inheritance of ACL entries")" (discard, noallow, restricted, passthrough, passthrough-x)"
 	echo -e "atime\t"(_ "Update access time on read")" (on, off)"
 	echo -e "canmount\t"(_ "Is the dataset mountable")" (on, off, noauto)"
 	set -l additional_algs ''
-    if test $OS = 'FreeBSD'; or test $OS = 'SunOS'
+    if contains -- $OS FreeBSD SunOS
 		set additional_algs "$additional_algs, noparity"
     end
 	if __fish_is_zfs_feature_enabled "feature@sha512"
@@ -96,5 +93,5 @@ function __fish_complete_zfs_rw_properties -d "Completes with ZFS read-write pro
 		echo -e "volmode\t"(_ "How to expose volumes to OS")" (default, geom, dev, none)"
 	end		
 	# User properties; the /dev/null redirection masks the possible "no datasets available"
-	zfs list -o all ^/dev/null | head -n 1 | string replace -a -r "\s+" "\n" | grep ":" | tr '[:upper:]' '[:lower:]'
+	zfs list -o all ^/dev/null | head -n 1 | string replace -a -r "\s+" "\n" | string match -e ":" | string lower
 end

--- a/share/functions/__fish_complete_zfs_rw_properties.fish
+++ b/share/functions/__fish_complete_zfs_rw_properties.fish
@@ -1,0 +1,100 @@
+function __fish_complete_zfs_rw_properties -d "Completes with ZFS read-write properties"
+	set -l OS ""
+	if passwd --help >/dev/null ^&1
+		set OS "Linux"
+	else # Not Linux, so use the ugly uname
+		set -l os_type (uname)
+		switch $os_type
+			case Darwin
+				set OS "macOS"
+			case FreeBSD
+				set OS "FreeBSD"
+			case SunOS
+				set OS "SunOS"
+			# Others?
+			case "*"
+				set OS "unknown"
+		end
+	end
+	echo -e "aclinherit\t"(_ "Inheritance of ACL entries")" (discard, noallow, restricted, passthrough, passthrough-x)"
+	echo -e "atime\t"(_ "Update access time on read")" (on, off)"
+	echo -e "canmount\t"(_ "Is the dataset mountable")" (on, off, noauto)"
+	set -l additional_algs ''
+    if test $OS = 'FreeBSD'; or test $OS = 'SunOS'
+		set additional_algs "$additional_algs, noparity"
+    end
+	if __fish_is_zfs_feature_enabled "feature@sha512"
+		set additional_algs "$additional_algs, sha512"
+	end
+	if __fish_is_zfs_feature_enabled "feature@skein"
+		set additional_algs "$additional_algs, skein"
+	end
+	if __fish_is_zfs_feature_enabled "feature@edonr"
+		set additional_algs "$additional_algs, edonr"
+	end
+	echo -e "checksum\t"(_ "Data checksum")" (on, off, fletcher2, fletcher4, sha256$additional_algs)"
+	if __fish_is_zfs_feature_enabled "feature@lz4_compress"
+		set additional_algs ", lz4"
+	end
+	echo -e "compression\t"(_ "Compression algorithm")" (on, off, lzjb$additional_algs, gzip, gzip-[1-9], zle)"
+	set -e additional_algs
+	echo -e "copies\t"(_ "Number of copies of data")" (1, 2, 3)"
+	echo -e "dedup\t"(_ "Deduplication")" (on, off, verify, sha256[,verify])"
+	echo -e "devices\t"(_ "Are contained device nodes openable")" (on, off)"
+	echo -e "exec\t"(_ "Can contained executables be executed")" (on, off)"
+	echo -e "filesystem_limit\t"(_ "Max number of filesystems and volumes")" (COUNT, none)"
+	echo -e "mountpoint\t"(_ "Mountpoint")" (PATH, none, legacy)"
+	echo -e "primarycache\t"(_ "Which data to cache in ARC")" (all, none, metadata)"
+	echo -e "quota\t"(_ "Max size of dataset and children")" (SIZE, none)"
+	echo -e "snapshot_limit\t"(_ "Max number of snapshots")" (COUNT, none)"
+	echo -e "readonly\t"(_ "Read-only")" (on, off)"
+	echo -e "recordsize\t"(_ "Suggest block size")" (SIZE)"
+	echo -e "redundant_metadata\t"(_ "How redundant are the metadata")" (all, most)"
+	echo -e "refquota\t"(_ "Max space used by dataset itself")" (SIZE, none)"
+	echo -e "refreservation\t"(_ "Min space guaranteed to dataset itself")" (SIZE, none)"
+	echo -e "reservation\t"(_ "Min space guaranteed to dataset")" (SIZE, none)"
+	echo -e "secondarycache\t"(_ "Which data to cache in L2ARC")" (all, none, metadata)"
+	echo -e "setuid\t"(_ "Respect set-UID bit")" (on, off)"
+	echo -e "sharenfs\t"(_ "Share in NFS")" (on, off, OPTS)"
+	echo -e "logbias\t"(_ "Hint for handling of synchronous requests")" (latency, throughput)"
+	echo -e "snapdir\t"(_ "Hide .zfs directory")" (hidden, visible)"
+	echo -e "sync\t"(_ "Handle of synchronous requests")" (standard, always, disabled)"
+	echo -e "volsize\t"(_ "Volume logical size")" (SIZE)"
+
+	# Autogenerate userquota@$USER list; only usernames are supported by the completion, but the zfs command supports more formats
+    for user in (__fish_print_users)
+        set -l tabAndBefore (echo -e "userquota@$user\t")
+        printf (_ "%sMax usage by user %s\n") $tabAndBefore $user
+    end
+	# Autogenerate groupquota@$USER list
+    for group in (__fish_print_groups)
+        set -l tabAndBefore (echo -e "groupquota@$group\t")
+        printf (_ "%sMax usage by group %s\n") $tabAndBefore $group
+    end
+	if test $OS = "SunOS"
+		echo -e "aclmode\t"(_ "How is ACL modified by chmod")" (discard, groupmask, passthrough, restricted)"
+		echo -e "mlslabel\t"(_ "Can the dataset be mounted in a zone with Trusted Extensions enabled")" (LABEL, none)"
+		echo -e "nbmand\t"(_ "Mount with Non Blocking mandatory locks")" (on, off)"
+		echo -e "sharesmb\t"(_ "Share in Samba")" (on, off)"
+		echo -e "shareiscsi\t"(_ "Share as an iSCSI target")" (on, off)"
+		echo -e "version\t"(_ "On-disk version of filesystem")" (1, 2, current)"
+		echo -e "vscan\t"(_ "Scan regular files for viruses on opening and closing")" (on, off)"
+		echo -e "xattr\t"(_ "Extended attributes")" (on, off, sa)"
+		echo -e "zoned\t"(_ "Managed from a non-global zone")" (on, off)"
+	else if test $OS = "Linux"
+		echo -e "acltype\t"(_ "Use no ACL or POSIX ACL")" (noacl, posixacl)"
+		echo -e "nbmand\t"(_ "Mount with Non Blocking mandatory locks")" (on, off)"
+		echo -e "relatime\t"(_ "Sometimes update access time on read")" (on, off)"
+		echo -e "shareiscsi\t"(_ "Share as an iSCSI target")" (on, off)"
+		echo -e "sharesmb\t"(_ "Share in Samba")" (on, off)"
+		echo -e "snapdev\t"(_ "Hide volume snapshots")" (hidden, visible)"
+		echo -e "version\t"(_ "On-disk version of filesystem")" (1, 2, current)"
+		echo -e "vscan\t"(_ "Scan regular files for viruses on opening and closing")" (on, off)"
+		echo -e "xattr\t"(_ "Extended attributes")" (on, off, sa)"
+	else if test $OS = "FreeBSD"
+		echo -e "aclmode\t"(_ "How is ACL modified by chmod")" (discard, groupmask, passthrough, restricted)"
+		echo -e "volmode\t"(_ "How to expose volumes to OS")" (default, geom, dev, none)"
+	end		
+	# User properties; the /dev/null redirection masks the possible "no datasets available"
+	zfs list -o all ^/dev/null | head -n 1 | string replace -a -r "\s+" "\n" | grep ":" | tr '[:upper:]' '[:lower:]'
+end

--- a/share/functions/__fish_complete_zfs_write_once_properties.fish
+++ b/share/functions/__fish_complete_zfs_write_once_properties.fish
@@ -1,26 +1,23 @@
 function __fish_complete_zfs_write_once_properties -d "Completes with ZFS properties which can only be written at filesystem creation, and only be read thereafter"
 	set -l OS ""
-	if passwd --help >/dev/null ^&1
-		set OS "Linux"
-	else # Not Linux, so use the ugly uname
-		set -l os_type (uname)
-		switch $os_type
-			case Darwin
-				set OS "macOS"
-			case FreeBSD
-				set OS "FreeBSD"
-			case SunOS
-				set OS "SunOS"
-			# Others?
-			case "*"
-				set OS "unknown"
-		end
-	end
+    switch (uname)
+        case Linux
+            set OS "Linux"
+        case Darwin
+            set OS "macOS"
+        case FreeBSD
+            set OS "FreeBSD"
+        case SunOS
+            set OS "SunOS"
+        # Others?
+        case "*"
+            set OS "unknown"
+    end
 	echo -e "normalization\t"(_ "Unicode normalization")" (none, formC, formD, formKC, formKD)"
 	echo -e "utf8only\t"(_ "Reject non-UTF-8-compliant filenames")" (on, off)"
 	if test $OS = "Linux"
 		echo -e "overlay\t"(_ "Allow overlay mount")" (on, off)"
-		if command -s sestatus >/dev/null ^&1 # SELinux is enabled
+		if command -sq sestatus # SELinux is enabled
 			echo -e "context\t"(_ "SELinux context for the child filesystem")
 			echo -e "fscontext\t"(_ "SELinux context for the filesystem being mounted")
 			echo -e "defcontext\t"(_ "SELinux context for unlabeled files")

--- a/share/functions/__fish_complete_zfs_write_once_properties.fish
+++ b/share/functions/__fish_complete_zfs_write_once_properties.fish
@@ -1,0 +1,33 @@
+function __fish_complete_zfs_write_once_properties -d "Completes with ZFS properties which can only be written at filesystem creation, and only be read thereafter"
+	set -l OS ""
+	if passwd --help >/dev/null ^&1
+		set OS "Linux"
+	else # Not Linux, so use the ugly uname
+		set -l os_type (uname)
+		switch $os_type
+			case Darwin
+				set OS "macOS"
+			case FreeBSD
+				set OS "FreeBSD"
+			case SunOS
+				set OS "SunOS"
+			# Others?
+			case "*"
+				set OS "unknown"
+		end
+	end
+	echo -e "normalization\t"(_ "Unicode normalization")" (none, formC, formD, formKC, formKD)"
+	echo -e "utf8only\t"(_ "Reject non-UTF-8-compliant filenames")" (on, off)"
+	if test $OS = "Linux"
+		echo -e "overlay\t"(_ "Allow overlay mount")" (on, off)"
+		if command -s sestatus >/dev/null ^&1 # SELinux is enabled
+			echo -e "context\t"(_ "SELinux context for the child filesystem")
+			echo -e "fscontext\t"(_ "SELinux context for the filesystem being mounted")
+			echo -e "defcontext\t"(_ "SELinux context for unlabeled files")
+			echo -e "rootcontext\t"(_ "SELinux context for the root inode of the filesystem")
+		end
+		echo -e "casesensitivity\t"(_ "Case sensitivity")" (sensitive, insensitive)"
+	else
+		echo -e "casesensitivity\t"(_ "Case sensitivity")" (sensitive, insensitive, mixed)"
+	end
+end

--- a/share/functions/__fish_is_zfs_feature_enabled.fish
+++ b/share/functions/__fish_is_zfs_feature_enabled.fish
@@ -1,18 +1,16 @@
 function __fish_is_zfs_feature_enabled -a feature target -d "Returns 0 if the given ZFS feature is available or enabled for the given full-path target (zpool or dataset), or any target if none given"
-	set -l pool (echo "$target" | cut -d '/' -f1)
+    set -l pool (string replace -r '/.*' '' -- $target)
     set -l feature_name ""
-    set -l pattern "[[:space:]]"
     if test -z "$pool"
-        set pattern "$pattern$feature$pattern"
-        set feature_name (zpool get all -H | grep "$pattern")
+        set feature_name (zpool get all -H | string match -r "\s$feature\s")
     else
-        set pattern "$pool$pattern$feature$pattern"
-        set feature_name (zpool get all -H $pool | grep "$pattern")
+        set feature_name (zpool get all -H $pool | string match -r "$pool\s$feature\s")
     end
-	if test $status -ne 0 # No such feature
-		return 1
-	end
-	set -l state (echo $feature_name | cut -f3)
-    echo "$feature_name" | grep -q -E "(active|enabled)"
+    if test $status -ne 0 # No such feature
+        return 1
+    end
+    echo $feature_name | read -l _ _ state _
+    set -l state (echo $feature_name | cut -f3)
+    string match -qr '(active|enabled)' -- $state
     return $status
 end

--- a/share/functions/__fish_is_zfs_feature_enabled.fish
+++ b/share/functions/__fish_is_zfs_feature_enabled.fish
@@ -1,0 +1,18 @@
+function __fish_is_zfs_feature_enabled -a feature target -d "Returns 0 if the given ZFS feature is available or enabled for the given full-path target (zpool or dataset), or any target if none given"
+	set -l pool (echo "$target" | cut -d '/' -f1)
+    set -l feature_name ""
+    set -l pattern "[[:space:]]"
+    if test -z "$pool"
+        set pattern "$pattern$feature$pattern"
+        set feature_name (zpool get all -H | grep "$pattern")
+    else
+        set pattern "$pool$pattern$feature$pattern"
+        set feature_name (zpool get all -H $pool | grep "$pattern")
+    end
+	if test $status -ne 0 # No such feature
+		return 1
+	end
+	set -l state (echo $feature_name | cut -f3)
+    echo "$feature_name" | grep -q -E "(active|enabled)"
+    return $status
+end

--- a/share/functions/__fish_print_groups.fish
+++ b/share/functions/__fish_print_groups.fish
@@ -1,0 +1,7 @@
+# This should be used where you want group names without a description. If you also want
+# a description, such as when getting a list of groups for a completion, you probably want
+# __fish_complete_groups.
+function __fish_print_groups --description "Print a list of local groups"
+    # Leave the heavy lifting to __fish_complete_groups but strip the descriptions.
+    __fish_complete_groups | string replace -r '^([^\t]*)\t.*' '$1'
+end

--- a/share/functions/__fish_print_zfs_bookmarks.fish
+++ b/share/functions/__fish_print_zfs_bookmarks.fish
@@ -1,0 +1,5 @@
+function __fish_print_zfs_bookmarks -d "Lists ZFS bookmarks, if the feature is enabled"
+	if __fish_is_zfs_feature_enabled 'feature@bookmarks'
+		zfs list -t bookmark -o name -H
+	end
+end

--- a/share/functions/__fish_print_zfs_filesystems.fish
+++ b/share/functions/__fish_print_zfs_filesystems.fish
@@ -1,0 +1,3 @@
+function __fish_print_zfs_filesystems -d "Lists ZFS filesystems"
+	zfs list -t filesystem -o name -H
+end

--- a/share/functions/__fish_print_zfs_snapshots.fish
+++ b/share/functions/__fish_print_zfs_snapshots.fish
@@ -1,0 +1,3 @@
+function __fish_print_zfs_snapshots -d "Lists ZFS snapshots"
+	zfs list -t snapshot -o name -H
+end

--- a/share/functions/__fish_print_zfs_volumes.fish
+++ b/share/functions/__fish_print_zfs_volumes.fish
@@ -1,0 +1,3 @@
+function __fish_print_zfs_volumes -d "Lists ZFS volumes"
+	zfs list -t volume -o name -H
+end


### PR DESCRIPTION
## Description

This PR adds completions for the OpenZFS `zfs` and `zpool` commands. It also updates the `*.po` files and adds corresponding translations for French, my mother tongue. There are merge conflicts, but they only belong, AFAIK, in conflicting metadata in `*.po` files, due to the POT regeneration I did while others did it on their side. This is only related to POT timestamp, which can be solved using either version, and to translators notes which I added in `fr.po`, which can be solved using my version, as there is nothing semantically conflicting here.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
