### PR TITLE
[string] Chunk reads

### DIFF
--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -87,7 +87,7 @@ static const wchar_t *string_get_arg_stdin(wcstring *storage, const io_streams_t
     }
 
     // Split the buffer around '\n' found and return first part.
-    *storage = str2wcstring(buffer.c_str(), pos);
+    *storage = str2wcstring(buffer, pos);
     buffer.erase(0, pos + 1);
     return storage->c_str();
 }

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -37,6 +37,10 @@
 class parser_t;
 
 #define STRING_ERR_MISSING _(L"%ls: Expected argument\n")
+
+// How many bytes we read() at once.
+// Bash uses 128 here, so we do too (see READ_CHUNK_SIZE).
+// This should be about the size of a line.
 #define STRING_CHUNK_SIZE 128
 
 static void string_error(io_streams_t &streams, const wchar_t *fmt, ...) {

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -71,12 +71,12 @@ static const wchar_t *string_get_arg_stdin(wcstring *storage, const io_streams_t
             // If we still have buffer contents, flush them.
             if (buffer.empty()) return NULL;
             *storage = str2wcstring(buffer);
-            buffer = "";
+            buffer.clear();
             return storage->c_str();
         }
         if (n == -1) {    // handle errors
             *storage = str2wcstring(buffer);
-            buffer = "";
+            buffer.clear();
             return NULL;
         }
         buffer.append(buf, n);

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -63,8 +63,8 @@ static const wchar_t *string_get_arg_stdin(wcstring *storage, const io_streams_t
     static std::string buffer;
 
     // Read in chunks from fd until buffer has a line.
-    std::string::iterator pos;
-    while ((pos = std::find (buffer.begin(), buffer.end(), '\n')) == buffer.end ()) {
+    size_t pos;
+    while ((pos = buffer.find('\n')) == std::string::npos) {
         char buf[STRING_CHUNK_SIZE];
         int n = read_blocked(streams.stdin_fd, buf, STRING_CHUNK_SIZE);
         if (n == 0) {
@@ -82,10 +82,10 @@ static const wchar_t *string_get_arg_stdin(wcstring *storage, const io_streams_t
         buffer.append(buf, n);
     }
 
-  // Split the buffer around '\n' found and return first part.
-  *storage = str2wcstring(buffer.c_str(), std::distance(buffer.begin(), pos));
-  buffer = std::string(pos + 1, buffer.end());
-  return storage->c_str();
+    // Split the buffer around '\n' found and return first part.
+    *storage = str2wcstring(buffer.c_str(), pos);
+    buffer.erase(0, pos + 1);
+    return storage->c_str();
 }
 
 static const wchar_t *string_get_arg_argv(int *argidx, wchar_t **argv) {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -290,6 +290,11 @@ wcstring str2wcstring(const std::string &in) {
     return str2wcs_internal(in.data(), in.size());
 }
 
+wcstring str2wcstring(const std::string &in, size_t len) {
+    // Handles embedded nulls!
+    return str2wcs_internal(in.data(), len);
+}
+
 char *wcs2str(const wchar_t *in) {
     if (!in) return NULL;
     size_t desired_size = MAX_UTF8_BYTES * wcslen(in) + 1;

--- a/src/common.h
+++ b/src/common.h
@@ -285,6 +285,7 @@ int fgetws2(wcstring *s, FILE *f);
 wcstring str2wcstring(const char *in);
 wcstring str2wcstring(const char *in, size_t len);
 wcstring str2wcstring(const std::string &in);
+wcstring str2wcstring(const std::string &in, size_t len);
 
 /// Returns a newly allocated multibyte character string equivalent of the specified wide character
 /// string.


### PR DESCRIPTION
## Description

Profiling with callgrind revealed that about 60% of the time in a `something | string match` call
was actually spent in `string_get_arg_stdin()`,
because it was calling `read` one byte at a time.

This makes it read in chunks similar to builtin read.

This increases performance for `getent hosts | string match -v '0.0.0.0*'` from about 300ms to about 30ms (i.e. 90%).
At that point it's _actually_ quicker than `grep`.

To improve performance even more, we'd have to cut down on str2wcstring.

Fixes issue #4604.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
