### PR TITLE
Better test errors with stack trace

### DIFF
--- a/src/builtin_test.cpp
+++ b/src/builtin_test.cpp
@@ -17,6 +17,7 @@
 #include "builtin.h"
 #include "common.h"
 #include "io.h"
+#include "parser.h"
 #include "wutil.h"  // IWYU pragma: keep
 
 using std::unique_ptr;
@@ -794,6 +795,7 @@ int builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         for (size_t i = 0; i < eval_errors.size(); i++) {
             streams.err.append_format(L"\t%ls\n", eval_errors.at(i).c_str());
         }
+        streams.err.append_format(L"\t%ls\n", parser.stack_trace().c_str());
     }
     return result ? STATUS_CMD_OK : STATUS_CMD_ERROR;
 }

--- a/tests/test_test.err
+++ b/tests/test_test.err
@@ -1,0 +1,41 @@
+test returned eval errors:
+	invalid integer 'banana'
+	in function 'is_two'
+	called on standard input
+	with parameter list 'banana'
+
+
+test returned eval errors:
+	invalid integer 'banana banana'
+	in function 'is_two'
+	called on standard input
+	with parameter list 'banana banana'
+
+
+test returned eval errors:
+	invalid integer ''
+	in function 'is_two'
+	called on standard input
+
+
+test returned eval errors:
+	invalid integer 'no one'
+	in function 'is_two'
+	called on standard input
+	with parameter list 'no one'
+
+
+test returned eval errors:
+	invalid integer 'everyone'
+	in function 'is_two'
+	called on standard input
+	with parameter list 'everyone'
+
+
+test returned eval errors:
+	invalid integer '0b10'
+	in function 'is_two'
+	called on standard input
+	with parameter list '0b10'
+
+

--- a/tests/test_test.in
+++ b/tests/test_test.in
@@ -1,0 +1,23 @@
+# Tests for the `test` builtin. TEST!
+function is_two
+    # TEST?
+    if test 2 -eq "$argv"
+        echo argv is two
+    else
+        echo argv is not two
+    end
+end
+
+is_two 5 # This is indeed not two
+is_two 2 # This fine specimen, on the other hand, is.
+is_two " 2 " # This is also two.
+
+# Consider the banana. It is not two.
+is_two banana
+is_two banana banana # While they are two bananas, they are not two itself.
+is_two # When no one is there to be two, is it still two?
+is_two "no one" # No one is not two.
+is_two everyone # is also not two.
+
+is_two 0b10
+is_two (printf '%d\n' 0x2) # Twobular!

--- a/tests/test_test.out
+++ b/tests/test_test.out
@@ -7,3 +7,4 @@ argv is not two
 argv is not two
 argv is not two
 argv is not two
+argv is two

--- a/tests/test_test.out
+++ b/tests/test_test.out
@@ -1,0 +1,9 @@
+argv is not two
+argv is two
+argv is two
+argv is not two
+argv is not two
+argv is not two
+argv is not two
+argv is not two
+argv is not two


### PR DESCRIPTION
## Description

It's really rather annoying that `test` sometimes prints stuff like this:

```
test returned eval errors:
	invalid integer '0b10'
```

without any indication of where it's coming from.

So just print a stack trace after, so it looks like

```
test returned eval errors:
	invalid integer '0b10'
	in function 'is_two'
	called on standard input
	with parameter list '0b10'
```

See e.g. #4614.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
