### PR TITLE
Split command substitutions on NUL if one is found

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1242,9 +1242,11 @@ static int exec_subshell_internal(const wcstring &cmd, wcstring_list_t *lst, boo
     const char *end = begin + io_buffer->out_buffer_size();
     if (split_output) {
         const char *cursor = begin;
+        // Use NUL if one is found, newline otherwise.
+        const char sep = memchr(cursor, '\0', end - cursor) ? '\0' : '\n';
         while (cursor < end) {
             // Look for the next separator.
-            const char *stop = (const char *)memchr(cursor, '\n', end - cursor);
+            const char *stop = (const char *)memchr(cursor, sep, end - cursor);
             const bool hit_separator = (stop != NULL);
             if (!hit_separator) {
                 // If it's not found, just use the end.

--- a/tests/nul.in
+++ b/tests/nul.in
@@ -1,0 +1,16 @@
+# Check that splitting on NUL works
+set -l var (printf '%s\0' "one line" two\nlines banana)
+string escape -- $var
+echo $var[2]
+
+echo
+
+# This is split into one element - keeping the trailing newline.
+set -l var (printf '%s\n' "one line" two\nlines banana; printf '\0')
+string escape -- $var
+
+echo
+
+# This is still split on newlines
+set -l var (printf '%s\n' "one line" two\nlines banana)
+string escape -- $var

--- a/tests/nul.out
+++ b/tests/nul.out
@@ -1,0 +1,12 @@
+'one line'
+two\nlines
+banana
+two
+lines
+
+one\ line\ntwo\nlines\nbanana\n
+
+'one line'
+two
+lines
+banana


### PR DESCRIPTION
## Description:

Currently, there is no easy way to use e.g. `find -print0` in command substitutions.

What this does is check if a NUL is in the comsub output and then split on that instead of newline,
which makes `something (find -print0)` just work.

The one fly in the ointment is if there is a command that uses NULs to separate its output,
but doesn't print a trailing NUL if there is just one "thing" to print.
That would cause us to fall back to splitting on newlines, which might do the wrong thing.

So far, everything I've tested (`find`, `git config -z`) seemed to print a trailing NUL.

This implements a proposal by @cben.

Fixes #3164.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md


----

This does one extra `memchr` per command substitution, which is probably not significant. But maybe there's an easy way to use that result if there is a NUL?