### PR TITLE
Fix brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This section is for changes merged to the `major` branch that are not also merge
 - `set x[1] x[2] a b` is no longer valid syntax (#4236).
 - For loop control variables are no longer local to the for block (#1935).
 - A literal `{}` now expands to itself, rather than nothing. This makes working with `find -exec` easier. (#1109, #4632)
+- Successive commas in brace expansions are handled in less surprising manner (`{,,,}` expands to four empty strings rather than an empty string, a comma and an empty string again). (#3002, #4632).
 
 ## Notable fixes and improvements
 - `wait` builtin is added for waiting on processes (#4498).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This section is for changes merged to the `major` branch that are not also merge
 - `read` now requires at least one var name (#4220).
 - `set x[1] x[2] a b` is no longer valid syntax (#4236).
 - For loop control variables are no longer local to the for block (#1935).
+- A literal `{}` now expands to itself, rather than nothing. This makes working with `find -exec` easier. (#1109, #4632)
 
 ## Notable fixes and improvements
 - `wait` builtin is added for waiting on processes (#4498).

--- a/doc_src/faq.hdr
+++ b/doc_src/faq.hdr
@@ -24,7 +24,6 @@
 - <a href='#faq-titlebar'>I'm seeing weird output before each prompt when using screen. What's wrong?</a>
 - <a href='#faq-greeting'>How do I change the greeting message?</a>
 - <a href='#faq-history'>Why doesn't history substitution ("!$" etc.) work?</a>
-- <a href='#faq-find-braces'>Why do I get a missing argument error with `find ... {}`?</a>
 - <a href='#faq-cd-minus'>How can I use `-` as a shortcut for `cd -`?</a>
 - <a href='#faq-uninstalling'>How do I uninstall fish?</a>
 - <a href='#faq-third-party'>Where can I find extra tools for fish?</a>
@@ -243,21 +242,6 @@ Fish history recall is very simple yet effective:
   - If you want to reuse several arguments from the same line ("!!:3*" and the like), consider recalling the whole line and removing what you don't need (@key{Alt,D} and @key{Alt,Backspace} are your friends).
 
 See <a href='index.html#editor'>documentation</a> for more details about line editing in fish.
-
-<hr>
-\section faq-find-braces Why do I get a missing argument error with `find ... {}`?
-
-Running `find ... -exec ... {}` produces an error:
-
-    find: missing argument to '-exec'
-
-The problem is caused by the empty braces, which are subject to <a href="index.html#expand-brace">brace expansion</a>.
-
-Quote the empty braces to achieve the desired effect:
-
-\fish{cli-dark}
-find ... -exec ... '{{}}'
-\endfish
 
 <hr>
 \section faq-cd-minus How can I use `-` as a shortcut for `cd -`?

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -514,6 +514,17 @@ echo foo-{}
 
 echo foo-{$undefinedvar}
 # Output is an empty line - see <a href="#cartesian-product">the cartesian product section</a>
+\endfish
+
+If there is nothing between a brace and a comma or two commas, it's interpreted as an empty element.
+
+So:
+\fish
+echo {,,/usr}/bin
+# Output /bin /bin /usr/bin
+\endfish
+
+To use a "," as an element, <a href="#quotes">quote</a> or <a href="#escapes">escape</a> it.
 
 \subsection expand-variable Variable expansion
 

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -506,6 +506,14 @@ mv *.{c,h} src/
 # Moves all files with the suffix '.c' or '.h' to the subdirectory src.
 \endfish
 
+A literal "{}" will not be used as a brace expansion:
+
+\fish
+echo foo-{}
+# Outputs foo-{}
+
+echo foo-{$undefinedvar}
+# Output is an empty line - see <a href="#cartesian-product">the cartesian product section</a>
 
 \subsection expand-variable Variable expansion
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1354,9 +1354,7 @@ static bool unescape_string_internal(const wchar_t *const input, const size_t in
                     break;
                 }
                 case L',': {
-                    // If the last character was a separator, then treat this as a literal comma.
-                    if (unescape_special && bracket_count > 0 &&
-                        string_last_char(result) != BRACKET_SEP) {
+                    if (unescape_special && bracket_count > 0) {
                         to_append_or_none = BRACKET_SEP;
                     }
                     break;

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -980,6 +980,15 @@ static expand_error_t expand_brackets(const wcstring &instr, expand_flags_t flag
         }
     }
 
+    // Expand a literal "{}" to itself because it is useless otherwise,
+    // and this eases e.g. `find -exec {}`. See #1109.
+    if (bracket_begin + 1 == bracket_end) {
+        wcstring newstr = instr;
+        newstr.at(bracket_begin - in) = L'{';
+        newstr.at(bracket_end - in) = L'}';
+        return expand_brackets(newstr, flags, out, errors);
+    }
+
     if (syntax_error) {
         append_syntax_error(errors, SOURCE_LOCATION_UNKNOWN, _(L"Mismatched brackets"));
         return EXPAND_ERROR;

--- a/tests/test1.in
+++ b/tests/test1.in
@@ -15,6 +15,10 @@ logmsg Bracket expansion
 echo x-{1}
 echo x-{1,2}
 echo foo-{1,2{3,4}}
+echo foo-{} # literal "{}" expands to itself
+echo foo-{{},{}} # the inner "{}" expand to themselves, the outer pair expands normally.
+echo foo-{""} # still expands to foo-
+echo foo-{$undefinedvar} # still expands to nothing
 
 logmsg Escaped newlines
 echo foo\ bar

--- a/tests/test1.in
+++ b/tests/test1.in
@@ -22,6 +22,7 @@ echo foo-{""} # still expands to foo-
 echo foo-{$undefinedvar} # still expands to nothing
 
 echo foo-{,,,} # four empty items in the braces.
+echo foo-{,\,,} # an empty item, a "," and an empty item.
 
 logmsg Escaped newlines
 echo foo\ bar

--- a/tests/test1.in
+++ b/tests/test1.in
@@ -15,10 +15,13 @@ logmsg Bracket expansion
 echo x-{1}
 echo x-{1,2}
 echo foo-{1,2{3,4}}
+
 echo foo-{} # literal "{}" expands to itself
 echo foo-{{},{}} # the inner "{}" expand to themselves, the outer pair expands normally.
 echo foo-{""} # still expands to foo-
 echo foo-{$undefinedvar} # still expands to nothing
+
+echo foo-{,,,} # four empty items in the braces.
 
 logmsg Escaped newlines
 echo foo\ bar

--- a/tests/test1.out
+++ b/tests/test1.out
@@ -16,6 +16,7 @@ foo-{} foo-{}
 foo-
 
 foo- foo- foo- foo-
+foo- foo-, foo-
 
 ####################
 # Escaped newlines

--- a/tests/test1.out
+++ b/tests/test1.out
@@ -11,6 +11,10 @@
 x-1
 x-1 x-2
 foo-1 foo-23 foo-24
+foo-{}
+foo-{} foo-{}
+foo-
+
 
 ####################
 # Escaped newlines

--- a/tests/test1.out
+++ b/tests/test1.out
@@ -14,8 +14,8 @@ foo-1 foo-23 foo-24
 foo-{}
 foo-{} foo-{}
 foo-
-foo- foo- foo- foo-
 
+foo- foo- foo- foo-
 
 ####################
 # Escaped newlines

--- a/tests/test1.out
+++ b/tests/test1.out
@@ -14,6 +14,7 @@ foo-1 foo-23 foo-24
 foo-{}
 foo-{} foo-{}
 foo-
+foo- foo- foo- foo-
 
 
 ####################


### PR DESCRIPTION
## Description

This is a double-whammy to remove some of the annoyances from brace/bracket-expansion (the code calls it "brackets", I've only ever heard "braces" elsewhere).

It changes a _literal_ `{}` to expand to itself, which fixes issue #1109, and makes `find -exec` nicer to use.

It also changes it so successive commas in braces are seen as successive empty items, rather than alternating between an empty item and a literal ",". So `x{,,,}y` is no longer seen as `xy x,y xy` (because the second "," is seen as a literal "," rather than a separator), but as "xy xy xy xy". That fixes #3002. (To get the literal comma, it can be `\\` escaped or quoted still)

Both of these are in the "theoretically backwards-incompatible, but unlikely to break stuff" category. The former especially will only break code that does useless stuff - currently a `{}` could be removed everywhere without any changes, so why have it at all?

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages - the first has been, the second behavior was never documented AFAICT.
- [X] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
