### PR TITLE
Resolution git branch tab completion visualization error, on `git checkout`

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -19,11 +19,11 @@ function __fish_git_recent_commits
 end
 
 function __fish_git_local_branches
-    command git branch | string trim -c ' *'
+    command git branch --no-color | string trim -c ' *'
 end
 
 function __fish_git_remote_branches
-    command git branch --remote | string trim -c ' *'
+    command git branch --no-color --remote | string trim -c ' *'
 end
 
 function __fish_git_branches


### PR DESCRIPTION
![ubuntu_2018-01-03_13-47-01](https://user-images.githubusercontent.com/1395329/34521257-1eed302a-f08d-11e7-90de-5123ffda6862.png)

## Description

Added `--no-color` to git completion function

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
