### PR TITLE
Add --no-color switch to git branch commands

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -19,11 +19,11 @@ function __fish_git_recent_commits
 end
 
 function __fish_git_local_branches
-    command git branch | string trim -c ' *'
+    command git branch --no-color | string trim -c ' *'
 end
 
 function __fish_git_remote_branches
-    command git branch --remote | string trim -c ' *'
+    command git branch --no-color --remote | string trim -c ' *'
 end
 
 function __fish_git_branches


### PR DESCRIPTION
## Description

Add `--no-color` switch to git branch/checkout commands so that fish doesn't output `\e\[31` and `e\[m` escape sequences, for example:

![image](https://user-images.githubusercontent.com/69970/34550091-e895373a-f0c2-11e7-81f1-805b2bdce028.png)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
