### PR TITLE
Copy test files with ADD_CUSTOM_COMMAND

### DIFF
--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -14,9 +14,15 @@ SET(TEST_ROOT_DIR ${TEST_DIR}/root)
 
 # Copy tests files.
 FILE(GLOB TESTS_FILES tests/*)
-FILE(COPY ${TESTS_FILES} DESTINATION tests/)
-
 ADD_CUSTOM_TARGET(tests_dir DEPENDS tests)
+
+ADD_CUSTOM_COMMAND(TARGET tests_dir
+                   PRE_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory
+                   ${CMAKE_SOURCE_DIR}/tests/ ${CMAKE_BINARY_DIR}/tests/
+                   COMMENT "Copying test files to binary dir"
+                   VERBATIM)
+
 ADD_DEPENDENCIES(fish_tests tests_dir)
 
 # Create the 'test' target.
@@ -33,7 +39,7 @@ ADD_CUSTOM_TARGET(test_low_level
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS fish_tests
   USES_TERMINAL)
-ADD_DEPENDENCIES(test test_low_level)
+ADD_DEPENDENCIES(test test_low_level tests_dir)
 
 # Make the directory in which to run tests.
 # Also symlink fish to where the tests expect it to be.


### PR DESCRIPTION
## Description

This will copy the files every time `ninja test` or `make test` is called, so the files are never out of sync.

Same principle as in pull request #4641 

Fixes issue #4633 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
