### PR TITLE
Fix overzealous cd tab completion

### DIFF
--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -1031,6 +1031,9 @@ void completer_t::complete_param_expand(const wcstring &str, bool do_file,
     if (!do_file) flags |= EXPAND_SKIP_WILDCARDS;
 
     if (handle_as_special_cd && do_file) {
+        if (this->type() == COMPLETE_AUTOSUGGEST) {
+            flags |= EXPAND_SPECIAL_FOR_CD_AUTOSUGGEST;
+        }
         flags |= DIRECTORIES_ONLY | EXPAND_SPECIAL_FOR_CD | EXPAND_NO_DESCRIPTIONS;
     }
 

--- a/src/expand.h
+++ b/src/expand.h
@@ -46,9 +46,12 @@ enum {
     /// Do expansions specifically to support cd. This means using CDPATH as a list of potential
     /// working directories.
     EXPAND_SPECIAL_FOR_CD = 1 << 11,
+    /// Do expansions specifically for cd autosuggestion. This is to differentiate between cd
+    /// completions and cd autosuggestions.
+    EXPAND_SPECIAL_FOR_CD_AUTOSUGGEST = 1 << 12,
     /// Do expansions specifically to support external command completions. This means using PATH as
     /// a list of potential working directories.
-    EXPAND_SPECIAL_FOR_COMMAND = 1 << 12
+    EXPAND_SPECIAL_FOR_COMMAND = 1 << 13
 };
 typedef int expand_flags_t;
 

--- a/src/wildcard.cpp
+++ b/src/wildcard.cpp
@@ -586,7 +586,9 @@ class wildcard_expander_t {
 
             // Hack. Implement EXPAND_SPECIAL_FOR_CD by descending the deepest unique hierarchy we
             // can, and then appending any components to each new result.
-            if (flags & EXPAND_SPECIAL_FOR_CD) {
+            // Only descend deepest unique for cd autosuggest and not for cd tab completion
+            // (issue #4402).
+            if (flags & EXPAND_SPECIAL_FOR_CD && flags & EXPAND_SPECIAL_FOR_CD_AUTOSUGGEST) {
                 wcstring unique_hierarchy = this->descend_unique_hierarchy(abs_path);
                 if (!unique_hierarchy.empty()) {
                     for (size_t i = before; i < after; i++) {


### PR DESCRIPTION
## Description

Changed cd completion to differentiate between cd autosuggest and cd tab
completion. cd autosuggest will find deepest unique hierarchy and cd tab
completion will not.

Fixes issue #4402 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
