### PR TITLE
Don't start keepalive process if the first or last process is internal

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -569,9 +569,17 @@ void exec_job(parser_t &parser, job_t *j) {
     // program to exit before continuing in the pipeline, causing the group leader to exit.
     if (j->get_flag(JOB_CONTROL) && !exec_error) {
         for (const process_ptr_t &p : j->processes) {
-            if (p->type != EXTERNAL && (!p->is_last_in_job || !p->is_first_in_job)) {
-                needs_keepalive = true;
-                break;
+            if (p->type != EXTERNAL) {
+                // But if a(nother) builtin is first or last, then we are the pgroup leader.
+                if (p->is_last_in_job || p->is_first_in_job) {
+                    needs_keepalive = false;
+                    j->pgid = getpgrp();
+                    break;
+                } else {
+                    // We need to keep checking until we get the last process,
+                    // so no break here.
+                    needs_keepalive = true;
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Currently, fish spawns a keepalive process when a non-external
process (a block/builtin/function) is inside a pipeline.

This keepalive process is then made the process group leader, which
theoretically stops the process group from being coopted by PID
reuse (which I'm still not sure can actually happen).

But if a non-external process is first or last in the pipeline, then
fish itself needs to read/write to the terminal, so it should remain
pgroup leader, and therefore the keepalive process is not needed.

Fixes #4540.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
