### PR TITLE
do not depend on bash being installed in /bin

### DIFF
--- a/build_tools/git_version_gen.sh
+++ b/build_tools/git_version_gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Originally from the git sources (GIT-VERSION-GEN)
 # Presumably (C) Junio C Hamano <junkio@cox.net>
 # Reused under GPL v2.0


### PR DESCRIPTION
Fixes issue #

Fix a bashismn in a shell script. This won't work on systems that to not have `bash` in `/bin` (e.g. FreeBSD).