### PR TITLE
Optimize git completions by skipping expensive git commands when they can't match

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -67,16 +67,24 @@ function __fish_git_remotes
 end
 
 function __fish_git_modified_files
+    set -l matching_files *(commandline -ct)*
+    if not set -q matching_files[1]
+        return
+    end
     # git diff --name-only hands us filenames relative to the git toplevel
     set -l root (command git rev-parse --show-toplevel ^/dev/null)
     # Print files from the current $PWD as-is, prepend all others with ":/" (relative to toplevel in git-speak)
     # This is a bit simplistic but finding the lowest common directory and then replacing everything else in $PWD with ".." is a bit annoying
-    string replace -- "$PWD/" "" "$root/"(command git diff --name-only $argv ^/dev/null) | string replace "$root/" ":/"
+    string replace -- "$PWD/" "" "$root/"(command git -C $root diff --name-only $argv -- $matching_files ^/dev/null) | string replace "$root/" ":/"
 end
 
 function __fish_git_add_files
+    set -l matching_files *(commandline -ct)*
+    if not set -q matching_files[1]
+        return
+    end
     set -l root (command git rev-parse --show-toplevel ^/dev/null)
-    string replace -- "$PWD/" "" "$root/"(command git -C $root ls-files -mo --exclude-standard ^/dev/null) | string replace "$root/" ":/"
+    string replace -- "$PWD/" "" "$root/"(command git -C $root ls-files -mo --exclude-standard -- $matching_files ^/dev/null) | string replace "$root/" ":/"
 end
 
 function __fish_git_ranges
@@ -258,7 +266,7 @@ function __fish_git_possible_commithash
 end
 
 function __fish_git_reflog
-	command git reflog ^/dev/null | string replace -r '[0-9a-f]* (.+@\{[0-9]+\}): (.*)$' '$1\t$2'
+    command git reflog ^/dev/null | string replace -r '[0-9a-f]* (.+@\{[0-9]+\}): (.*)$' '$1\t$2'
 end
 
 # general options


### PR DESCRIPTION
## Description

This patch checks if the current token could match any files before executing the expensive `git diff --name-only` command in __fish_git_modified_files, and feeds the files it could match into the `git diff` command.

A similar optimization is performed for the `git ls-files` command in `__fish_git_add_files` at the request of @faho in gitter. It also adds `-C $root` to the `git diff` arguments, also at the request of @faho.

This speeds up `git checkout` completion a decent amount for me in practice.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

I don't think any of these apply since it's purely an optimization and shouldn't change semantics.