### PR TITLE
Add ability to autosave functions at the end of funced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This section is for changes merged to the `major` branch that are not also merge
 - `string` reads from stdin faster (#4610)
 - `cd` tab completions no longer descend into the deepest unambiguous path (#4649)
 - Setting `$PATH` no longer warns on non-existent directories, allowing for a single $PATH to be shared across machines (e.g. via dotfiles).
+- `funced` now has a `-s` and `--save` option to automatically save the edited function after successfully editing (#4668).
 
 ## Other significant changes
 - Command substitution output is now limited to 10 MB by default (#3822).

--- a/doc_src/funced.txt
+++ b/doc_src/funced.txt
@@ -16,3 +16,5 @@ If there is no function called `NAME` a new function will be created with the sp
 - `-e command` or `--editor command` Open the function body inside the text editor given by the command (for example, `-e vi`). The special command `fish` will use the built-in editor (same as specifying `-i`).
 
 - `-i` or `--interactive` Force opening the function body in the built-in editor even if `$VISUAL` or `$EDITOR` is defined.
+
+- `-s` or `--save` Automatically save the function after successfully editing it.

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -12,7 +12,7 @@ function __funced_md5
 end
 
 function funced --description 'Edit function definition'
-    set -l options 'h/help' 'e/editor=' 'i/interactive'
+    set -l options 'h/help' 'e/editor=' 'i/interactive' 's/save'
     argparse -n funced --min-args=1 --max-args=1 $options -- $argv
     or return
 
@@ -65,6 +65,9 @@ function funced --description 'Edit function definition'
             echo -n $cmd | fish_indent | read -lz cmd
             eval "$cmd"
         end
+        if set -q _flag_save
+            funcsave $funcname
+        end
         return 0
     end
 
@@ -115,6 +118,8 @@ function funced --description 'Edit function definition'
                     continue
                 end
                 echo (_ "Cancelled function editing")
+            else if set -q _flag_save
+                funcsave $funcname
             end
         end
         break


### PR DESCRIPTION
## Description

This adds a flag to `funced` to automatically execute a `funcsave` after successfully editing a function.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] User-visible changes noted in CHANGELOG.md
- [ ] Tests have been added for regressions fixed

