### PR TITLE
Work around a segfault in the parser on some macOS builds. Fixes #4678.

### DIFF
--- a/src/tnode.h
+++ b/src/tnode.h
@@ -132,7 +132,9 @@ class tnode_t {
     template <node_offset_t Index>
     const parse_node_t &get_child_node() const {
         assert(nodeptr && "receiver is missing in get_child_node");
-        return *tree->get_child(*nodeptr, Index);
+        const parse_node_t *child = tree->get_child(*nodeptr, Index);
+        assert(child && "no child at given index");
+        return *child;
     }
 
     /// If the child at the given index has the given type, return it; otherwise return an empty
@@ -143,7 +145,7 @@ class tnode_t {
         static_assert(child_type_possible_at_index<Type, ChildType, Index>(),
                       "Cannot contain a child of this type");
         const parse_node_t *child = nullptr;
-        if (nodeptr) child = &get_child_node<Index>();
+        if (nodeptr) child = tree->get_child(*nodeptr, Index);
         if (child && child->type == ChildType::token) return {tree, child};
         return {};
     }


### PR DESCRIPTION
## Description

- Change `try_get_child` to use `tree->get_child` instead of `get_child_node`.
- Asserts that `get_child_node` cannot return a reference to nullptr.

This works for me, as far as I can tell, I don't get a segfault when building with `brew sh`, and if I only add the assert (and leave `try_get_child`), I hit it when launching the shell (even without brew sh)

That said, I don't know if this respects the intended semantics of these functions. I checked their callsites to make sure nothing looked obviously wrong, but it's hard to know without much familiarity with the code.

Fixes issue #4678

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- N/A Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- N/A User-visible changes noted in CHANGELOG.md

I'm not sure which construct is triggering it, so it's not clear how to add an automated test for it. Even if I did know, it would obviously not be reliable due to the nature of the bug.