### PR TITLE
Fix the build on Clang-6.0

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -606,7 +606,7 @@ wcstring vformat_string(const wchar_t *format, va_list va_orig);
 void append_format(wcstring &str, const wchar_t *format, ...);
 void append_formatv(wcstring &str, const wchar_t *format, va_list ap);
 
-#ifdef __cpp_lib_make_unique
+#if defined(__cpp_lib_make_unique) || (__cplusplus >= 201402L)
 using std::make_unique;
 #else
 /// make_unique implementation


### PR DESCRIPTION
## Description

Clang-6.0 does not define __cpp_lib_make_unique even though it does
define std::make_unique.  Use the standard library's std::make_unique
for any C++14 toolchain.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.md
