### PR TITLE
Improve the size of completions page to show the entire multi-line prompt

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -346,7 +346,7 @@ static prompt_layout_t calc_prompt_layout(const wchar_t *prompt, prompt_type_t w
     return prompt_layout;
 }
 
-static size_t calc_prompt_lines(const wcstring &prompt) {
+size_t calc_prompt_lines(const wcstring &prompt) {
     // Hack for the common case where there's no newline at all. I don't know if a newline can
     // appear in an escape sequence, so if we detect a newline we have to defer to
     // calc_prompt_width_and_lines.

--- a/src/screen.h
+++ b/src/screen.h
@@ -240,4 +240,7 @@ class cached_esc_sequences_t {
 // change by calling `cached_esc_sequences.clear()`.
 extern cached_esc_sequences_t cached_esc_sequences;
 
+// Calculates the number of prompt lines.
+size_t calc_prompt_lines(const wcstring &prompt);
+
 #endif


### PR DESCRIPTION
## Description
### Problem
When editing multi lines and selecting completions, the page of completions hides the lines except the bottom line.
I think it is uncomfortable not to be able to see the entire lines even after selecting the completion.

### What I changed
I changed to show the entire lines when selecting completions.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
