### PR TITLE
Add required argument to history delete

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -739,7 +739,7 @@ class FishConfigHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
     def do_delete_history_item(self, history_item_text):
         # It's really lame that we always return success here
-        cmd = ('builtin history delete --exact -- %s; builtin history save' %
+        cmd = ('builtin history delete --case-sensitive --exact -- %s; builtin history save' %
                escape_fish_cmd(history_item_text))
         out, err = run_fish_cmd(cmd)
         return True


### PR DESCRIPTION
## Description
Fixes issue #4735
As described in the issue, `history delete --exact` seems to require an extra `--case-sensitive` argument.
There may be a better solution to the issue (can `--exact` imply `--case-sensitive`?), but this is the easy fix.

## TODOs:
- [x] (N/A) Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] (N/A) User-visible changes noted in CHANGELOG.md

I didn't find tests for the web config. Did I not search enough?
