### PR TITLE
alias: Fix `string` args being parsed as options

### DIFF
--- a/share/functions/alias.fish
+++ b/share/functions/alias.fish
@@ -19,7 +19,7 @@ function alias --description 'Creates a function wrapping a command'
         for func in (functions -n)
             set -l output (functions $func | string match -r -- "^function .* --description 'alias (.*)'")
             if set -q output[2]
-                set output (string replace -r '^'$func'[= ]' '' -- $output[2])
+                set output (string replace -r -- '^'$func'[= ]' '' $output[2])
                 echo alias $func (string escape -- $output[1])
             end
         end
@@ -47,10 +47,10 @@ function alias --description 'Creates a function wrapping a command'
     # Extract the first command from the body. This is supposed to replace all non-escaped (i.e.
     # preceded by an odd number of `\`) spaces with a newline so it splits on them. See issue #2220
     # for why the following borderline incomprehensible code exists.
-    set -l tmp (string replace -ra "([^\\\ ])((\\\\\\\)*) " '$1\n' $body)
-    set first_word (string trim $tmp[1])
+    set -l tmp (string replace -ra -- "([^\\\ ])((\\\\\\\)*) " '$1\n' $body)
+    set first_word (string trim -- $tmp[1])
     # If the user does something like `alias x 'foo; bar'` we need to strip the semicolon.
-    set base_command (string trim -c ';' $first_word)
+    set base_command (string trim -c ';' -- $first_word)
     if set -q tmp[2]
         set body $tmp[2..-1]
     else
@@ -66,8 +66,8 @@ function alias --description 'Creates a function wrapping a command'
             set prefix command
         end
     end
-    set -l cmd_string (string escape "alias $argv")
-    set wrapped_cmd (string join ' ' $first_word $body | string escape)
+    set -l cmd_string (string escape -- "alias $argv")
+    set wrapped_cmd (string join ' ' -- $first_word $body | string escape)
     echo "function $name --wraps $wrapped_cmd --description $cmd_string; $prefix $first_word $body \$argv; end" | source
     #echo "function $name --wraps $wrapped_cmd --description $cmd_string; $prefix $first_word $body \$argv; end"
 end


### PR DESCRIPTION
Fixes:
```
string join: Unknown option '-C'
/usr/local/Cellar/fish/HEAD-973533e/share/fish/functions/alias.fish (line 2):
string join ' ' $first_word $body | string escape
^
in command substitution
	called on line 71 of file /usr/local/Cellar/fish/HEAD-973533e/share/fish/functions/alias.fish

in function 'alias'
	called on line 58 of file ~/.config/fish/conf.d/20-aliases.fish
	with parameter list 'tree tree -C'

from sourcing file ~/.config/fish/conf.d/20-aliases.fish
	called on line 233 of file /usr/local/Cellar/fish/HEAD-973533e/share/fish/config.fish

from sourcing file /usr/local/Cellar/fish/HEAD-973533e/share/fish/config.fish
	called during startup


       string

   Synopsis
       string escape [(-n | --no-quoted)] [--style=xxx] [STRING...]
       string join [(-q | --quiet)] SEP [STRING...]
       string length [(-q | --quiet)] [STRING...]
       string lower [(-q | --quiet)] [STRING...]
       string match [(-a | --all)] [(-e | --entire)] [(-i | --ignore-case)] [(-r | --regex)]
                    [(-n | --index)] [(-q | --quiet)] [(-v | --invert)] PATTERN [STRING...]
       string repeat [(-n | --count) COUNT] [(-m | --max) MAX] [(-N | --no-newline)]
                     [(-q | --quiet)] [STRING...]
       string replace [(-a | --all)] [(-f | --filter)] [(-i | --ignore-case)] [(-r | --regex)]
                      [(-q | --quiet)] PATTERN REPLACEMENT [STRING...]
       string split [(-m | --max) MAX] [(-r | --right)] [(-q | --quiet)] SEP
                    [STRING...]
       string sub [(-s | --start) START] [(-l | --length) LENGTH] [(-q | --quiet)]
                  [STRING...]
       string trim [(-l | --left)] [(-r | --right)] [(-c | --chars CHARS)]
                   [(-q | --quiet)] [STRING...]
       string unescape [--style=xxx] [STRING...]
       string upper [(-q | --quiet)] [STRING...]

string: Type 'help string' for related documentation

- (line 1): function: Unexpected positional argument 'alias tree tree -C'
function tree --wraps  --description 'alias tree tree -C'; command tree -C $argv; end
^
from sourcing file -
	called on line 72 of file /usr/local/Cellar/fish/HEAD-973533e/share/fish/functions/alias.fish

in function 'alias'
	called on line 58 of file ~/.config/fish/conf.d/20-aliases.fish
	with parameter list 'tree tree -C'
```

And also adds `--` to some other invocations of the `string` command to be on the safe side.