### PR TITLE
[WIP] Use ncurses for handling window size

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -67,8 +67,9 @@ static pid_t initial_fg_process_group = -1;
 /// This struct maintains the current state of the terminal size. It is updated on demand after
 /// receiving a SIGWINCH. Do not touch this struct directly, it's managed with a rwlock. Use
 /// common_get_width()/common_get_height().
-static fish_mutex_t termsize_lock;
-static struct winsize termsize = {USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX};
+// static fish_mutex_t termsize_lock;
+// static struct winsize termsize = {USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX};
+// Must use volatile bool and not std::atomic<bool> because we interact with this in a signal handler
 static volatile bool termsize_valid = false;
 
 static char *wcs2str_internal(const wchar_t *in, char *out);
@@ -1527,9 +1528,9 @@ bool unescape_string(const wcstring &input, wcstring *output, unescape_flags_t e
 /// the tty since it is possible the terminal size changed while an external command was running.
 void invalidate_termsize(bool invalidate_vars) {
     termsize_valid = false;
-    if (invalidate_vars) {
-        termsize.ws_col = termsize.ws_row = USHRT_MAX;
-    }
+    // if (invalidate_vars) {
+    //     termsize.ws_col = termsize.ws_row = USHRT_MAX;
+    // }
 }
 
 /// Handle SIGWINCH. This is also invoked when the shell regains control of the tty since it is
@@ -1543,88 +1544,73 @@ void common_handle_winch(int signal) {
 
 /// Validate the new terminal size. Fallback to the env vars if necessary. Ensure the values are
 /// sane and if not fallback to a default of 80x24.
-static void validate_new_termsize(struct winsize *new_termsize) {
-    if (new_termsize->ws_col == 0 || new_termsize->ws_row == 0) {
-#ifdef HAVE_WINSIZE
-        if (shell_is_interactive()) {
-            debug(1, _(L"Current terminal parameters have rows and/or columns set to zero."));
-            debug(1, _(L"The stty command can be used to correct this "
-                       L"(e.g., stty rows 80 columns 24)."));
-        }
-#endif
-        // Fallback to the environment vars.
-        maybe_t<env_var_t> col_var = env_get(L"COLUMNS");
-        maybe_t<env_var_t> row_var = env_get(L"LINES");
-        if (!col_var.missing_or_empty() && !row_var.missing_or_empty()) {
-            // Both vars have to have valid values.
-            int col = fish_wcstoi(col_var->as_string().c_str());
-            bool col_ok = errno == 0 && col > 0 && col <= USHRT_MAX;
-            int row = fish_wcstoi(row_var->as_string().c_str());
-            bool row_ok = errno == 0 && row > 0 && row <= USHRT_MAX;
-            if (col_ok && row_ok) {
-                new_termsize->ws_col = col;
-                new_termsize->ws_row = row;
-            }
-        }
-    }
-
-    if (new_termsize->ws_col < MIN_TERM_COL || new_termsize->ws_row < MIN_TERM_ROW) {
-        if (shell_is_interactive()) {
-            debug(1, _(L"Current terminal parameters set terminal size to unreasonable value."));
-            debug(1, _(L"Defaulting terminal size to 80x24."));
-        }
-        new_termsize->ws_col = DFLT_TERM_COL;
-        new_termsize->ws_row = DFLT_TERM_ROW;
-    }
-}
+// static void validate_new_termsize(struct termsize &new_termsize) {
+//     if (new_termsize.ws_col == 0 || new_termsize.ws_row == 0) {
+// #ifdef HAVE_WINSIZE
+//         if (shell_is_interactive()) {
+//             debug(1, _(L"Current terminal parameters have rows and/or columns set to zero."));
+//             debug(1, _(L"The stty command can be used to correct this "
+//                        L"(e.g., stty rows 80 columns 24)."));
+//         }
+// #endif
+//         // Fallback to the environment vars.
+//         maybe_t<env_var_t> col_var = env_get(L"COLUMNS");
+//         maybe_t<env_var_t> row_var = env_get(L"LINES");
+//         if (!col_var.missing_or_empty() && !row_var.missing_or_empty()) {
+//             // Both vars have to have valid values.
+//             int col = fish_wcstoi(col_var->as_string().c_str());
+//             bool col_ok = errno == 0 && col > 0 && col <= USHRT_MAX;
+//             int row = fish_wcstoi(row_var->as_string().c_str());
+//             bool row_ok = errno == 0 && row > 0 && row <= USHRT_MAX;
+//             if (col_ok && row_ok) {
+//                 new_termsize.ws_col = col;
+//                 new_termsize.ws_row = row;
+//             }
+//         }
+//     }
+//
+//     if (new_termsize.ws_col < MIN_TERM_COL || new_termsize.ws_row < MIN_TERM_ROW) {
+//         if (shell_is_interactive()) {
+//             debug(1, _(L"Current terminal parameters set terminal size to unreasonable value."));
+//             debug(1, _(L"Defaulting terminal size to 80x24."));
+//         }
+//         new_termsize.ws_col = DFLT_TERM_COL;
+//         new_termsize.ws_row = DFLT_TERM_ROW;
+//     }
+// }
 
 /// Export the new terminal size as env vars and to the kernel if possible.
-static void export_new_termsize(struct winsize *new_termsize) {
-    wchar_t buf[64];
-
-    auto cols = env_get(L"COLUMNS", ENV_EXPORT);
-    swprintf(buf, 64, L"%d", (int)new_termsize->ws_col);
-    env_set_one(L"COLUMNS", ENV_GLOBAL | (cols.missing_or_empty() ? ENV_DEFAULT : ENV_EXPORT), buf);
-
-    auto lines = env_get(L"LINES", ENV_EXPORT);
-    swprintf(buf, 64, L"%d", (int)new_termsize->ws_row);
-    env_set_one(L"LINES", ENV_GLOBAL | (lines.missing_or_empty() ? ENV_DEFAULT : ENV_EXPORT), buf);
-
-#ifdef HAVE_WINSIZE
-    // Only write the new terminal size if we are in the foreground (#4477)
-    if (tcgetpgrp(STDOUT_FILENO) == getpgrp()) {
-        ioctl(STDOUT_FILENO, TIOCSWINSZ, new_termsize);
-    }
-#endif
-}
+// static void export_new_termsize(const struct termsize new_termsize) {
+//     // Only write the new terminal size if we are in the foreground (#4477)
+//     if (tcgetpgrp(STDOUT_FILENO) == getpgrp()) {
+//         // ioctl(STDOUT_FILENO, TIOCSWINSZ, new_termsize);
+//         // if (resizeterm(new_termsize.ws_row, new_termsize.ws_col) != OK) {
+//         if (wresize(curscr, new_termsize.ws_row, new_termsize.ws_col) != OK) {
+//             debug(0, "Failed to set terminal size!\n");
+//         }
+//     }
+// }
 
 /// Updates termsize as needed, and returns a copy of the winsize.
-struct winsize get_current_winsize() {
-    scoped_lock guard(termsize_lock);
-
-    if (termsize_valid) return termsize;
-
-    struct winsize new_termsize = {0, 0, 0, 0};
-#ifdef HAVE_WINSIZE
-    errno = 0;
-    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &new_termsize) != -1 &&
-        new_termsize.ws_col == termsize.ws_col && new_termsize.ws_row == termsize.ws_row) {
+struct termsize get_current_termsize() {
+    if (!termsize_valid) {
+        endwin();
+        refresh();
         termsize_valid = true;
-        return termsize;
     }
-#endif
+    struct termsize new_termsize;
+    getmaxyx(curscr, new_termsize.ws_row, new_termsize.ws_col);
+    // comment this out to have your entire terminal spammed with termsize dumps to test resize handling
+    // debug(0, L"curscr: 0x%p, getmaxyx: cols: %d, rows: %d", curscr, new_termsize.ws_col, new_termsize.ws_row);
+    // validate_new_termsize(new_termsize);
+    // export_new_termsize(new_termsize);
 
-    validate_new_termsize(&new_termsize);
-    export_new_termsize(&new_termsize);
-    termsize.ws_col = new_termsize.ws_col;
-    termsize.ws_row = new_termsize.ws_row;
-    termsize_valid = true;
-    return termsize;
+    return new_termsize;
 }
 
-int common_get_width() { return get_current_winsize().ws_col; }
+int common_get_width() { return get_current_termsize().ws_col; }
 
-int common_get_height() { return get_current_winsize().ws_row; }
+int common_get_height() { return get_current_termsize().ws_row; }
 
 bool string_prefixes_string(const wchar_t *proposed_prefix, const wcstring &value) {
     size_t prefix_size = wcslen(proposed_prefix);

--- a/src/common.h
+++ b/src/common.h
@@ -17,6 +17,19 @@
 #include <sys/ioctl.h>  // IWYU pragma: keep
 #endif
 
+#if HAVE_CURSES_H
+#include <curses.h>
+#elif HAVE_NCURSES_H
+#include <ncurses.h>
+#elif HAVE_NCURSES_CURSES_H
+#include <ncurses/curses.h>
+#endif
+// #if HAVE_TERM_H
+// #include <term.h>
+// #elif HAVE_NCURSES_TERM_H
+// #include <ncurses/term.h>
+// #endif
+
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -825,6 +838,12 @@ static const wchar_t *enum_to_str(T enum_val, const enum_map<T> map[]) {
 
 void redirect_tty_output();
 
+// Member names mimic those of TIOCGWINSZ's `struct winsize`
+struct termsize {
+    int ws_row;
+    int ws_col;
+};
+
 // Minimum allowed terminal size and default size if the detected size is not reasonable.
 #define MIN_TERM_COL 20
 #define MIN_TERM_ROW 2
@@ -833,7 +852,7 @@ void redirect_tty_output();
 #define DFLT_TERM_COL_STR L"80"
 #define DFLT_TERM_ROW_STR L"24"
 void invalidate_termsize(bool invalidate_vars = false);
-struct winsize get_current_winsize();
+struct termsize get_current_termsize();
 
 bool valid_var_name_char(wchar_t chr);
 bool valid_var_name(const wchar_t *str);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -690,17 +690,17 @@ static void setup_path() {
         env_set(L"PATH", ENV_GLOBAL | ENV_EXPORT, value);
     }
 }
-
-/// If they don't already exist initialize the `COLUMNS` and `LINES` env vars to reasonable
-/// defaults. They will be updated later by the `get_current_winsize()` function if they need to be
-/// adjusted.
-static void env_set_termsize() {
-    auto cols = env_get(L"COLUMNS");
-    if (cols.missing_or_empty()) env_set_one(L"COLUMNS", ENV_GLOBAL, DFLT_TERM_COL_STR);
-
-    auto rows = env_get(L"LINES");
-    if (rows.missing_or_empty()) env_set_one(L"LINES", ENV_GLOBAL, DFLT_TERM_ROW_STR);
-}
+//
+// /// If they don't already exist initialize the `COLUMNS` and `LINES` env vars to reasonable
+// /// defaults. They will be updated later by the `get_current_winsize()` function if they need to be
+// /// adjusted.
+// static void env_set_termsize() {
+//     auto cols = env_get(L"COLUMNS");
+//     if (cols.missing_or_empty()) env_set_one(L"COLUMNS", ENV_GLOBAL, DFLT_TERM_COL_STR);
+//
+//     auto rows = env_get(L"LINES");
+//     if (rows.missing_or_empty()) env_set_one(L"LINES", ENV_GLOBAL, DFLT_TERM_ROW_STR);
+// }
 
 bool env_set_pwd() {
     wcstring cwd = wgetcwd();
@@ -902,8 +902,8 @@ static void setup_var_dispatch_table() {
     var_dispatch_table.emplace(L"fish_term24bit", handle_fish_term_change);
     var_dispatch_table.emplace(L"fish_escape_delay_ms", handle_escape_delay_change);
     var_dispatch_table.emplace(L"fish_emoji_width", handle_change_emoji_width);
-    var_dispatch_table.emplace(L"LINES", handle_term_size_change);
-    var_dispatch_table.emplace(L"COLUMNS", handle_term_size_change);
+    // var_dispatch_table.emplace(L"LINES", handle_term_size_change);
+    // var_dispatch_table.emplace(L"COLUMNS", handle_term_size_change);
     var_dispatch_table.emplace(L"fish_complete_path", handle_complete_path_change);
     var_dispatch_table.emplace(L"fish_function_path", handle_function_path_change);
     var_dispatch_table.emplace(L"fish_read_limit", handle_read_limit_change);
@@ -1027,7 +1027,7 @@ void env_init(const struct config_paths_t *paths /* or NULL */) {
     }
 
     env_set_pwd();         // initialize the PWD variable
-    env_set_termsize();    // initialize the terminal size variables
+    // env_set_termsize();    // initialize the terminal size variables
     env_set_read_limit();  // initialize the read_byte_limit
 
     // Set g_use_posix_spawn. Default to true.

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -378,6 +378,8 @@ int main(int argc, char **argv) {
     proc_init();
     builtin_init();
     misc_init();
+    // reader_init() calls getwindowsize(), so initscr() must be called first
+    initscr();
     reader_init();
 
     parser_t &parser = parser_t::principal_parser();
@@ -450,6 +452,7 @@ int main(int argc, char **argv) {
     }
 
     history_save_all();
+    endwin();
     proc_destroy();
     exit_without_destructors(exit_status);
     return EXIT_FAILURE;  // above line should always exit

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -801,7 +801,7 @@ void reader_init() {
 
     // We do this not because we actually need the window size but for its side-effect of correctly
     // setting the COLUMNS and LINES env vars.
-    get_current_winsize();
+    get_current_termsize();
 }
 
 /// Restore the term mode if we own the terminal. It's important we do this before


### PR DESCRIPTION
This commit drops direct handling of window size, including the
TIOCGWINSZ ioctl and reading/writing of the LINES and COLUMNS
environment variables, all of which are already performed by (n)curses.

As we already have a dependency on ncurses, it doesn't make sense to
make use of its APIs and reduce the NIH code in fish, relying on a
library developed and maintained by people most concerned with terminals
is probably the right way to go.

* Lightly tested only at this time.
* Most old code was commented out and not removed.
* Build system still checks for TIOCGWINSZ.
* SIGWINCH handlers left in place since not all versions of (n)curses
  handle SIGWINCH and supply a KEY_RESIZE input when the terminal is
  resized.
* Performance might be improved by no longer obtaining a mutex to obtain
  the screen size since a single atomic read/write is performed to the
  invalidation volatile bool variable as ncurses handles state
  internally, presuming that the `getmaxyx()` ncurses call is
  thread-safe.