### PR TITLE
Fix man autocomplete when a section is set

### DIFF
--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -15,6 +15,12 @@ function __fish_complete_man
         set -e prev[1]
     end
 
+    set -l exclude_fish_commands
+    # Only include fish commands when section is empty or 1
+    if test -z "$section" -o "$section" = "1"
+      set -e exclude_fish_commands
+    end
+
     set section $section"[^)]*"
     # If we don't have a token but a section, list all pages for that section.
     # Don't do it for all sections because that would be overwhelming.
@@ -63,8 +69,10 @@ function __fish_complete_man
                 '
 
         # Fish commands are not given by apropos
-        set -l files $__fish_datadir/man/man1/*.1
-        string replace -r '.*/([^/]+)\.1$' '$1\t1: fish command' -- $files
+        if not set -ql exclude_fish_commands
+          set -l files $__fish_datadir/man/man1/*.1
+          string replace -r '.*/([^/]+)\.1$' '$1\t1: fish command' -- $files
+        end
     else
         return 1
     end


### PR DESCRIPTION
## Description

Updates man autocomplete so fish commands are only included when the section is empty or 1.

I'm uncertain how to write a test for this change. Any suggested tests I should take a look at?

Fixes issue #4774.

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
