### PR TITLE
Default `string split` to removing empty entries with option to keep

### DIFF
--- a/src/wcstringutil.h
+++ b/src/wcstringutil.h
@@ -28,7 +28,7 @@ wcstring_range wcstring_tok(wcstring& str, const wcstring& needle,
 /// If the needle is empty, split on individual elements (characters).
 template <typename ITER>
 void split_about(ITER haystack_start, ITER haystack_end, ITER needle_start, ITER needle_end,
-                 wcstring_list_t* output, long max) {
+                 wcstring_list_t* output, long max, bool keep_empty = false) {
     long remaining = max;
     ITER haystack_cursor = haystack_start;
     while (remaining > 0 && haystack_cursor != haystack_end) {
@@ -41,7 +41,10 @@ void split_about(ITER haystack_start, ITER haystack_end, ITER needle_start, ITER
         if (split_point == haystack_end) {  // not found
             break;
         }
-        output->push_back(wcstring(haystack_cursor, split_point));
+        wcstring result = wcstring(haystack_cursor, split_point);
+        if (keep_empty || result.size() > 0) {
+            output->push_back(std::move(result));
+        }
         remaining--;
         // Need to skip over the needle for the next search note that the needle may be empty.
         haystack_cursor = split_point + std::distance(needle_start, needle_end);


### PR DESCRIPTION
The official fish documentation makes no mention of how `string split` treats
empty tokens, e.g. splitting 'key1##key2' on '#' or (more confusingly)
splitting '/path' on '/'. With this commit, `string split` by default excludes
zero-length substrings from the resulting array, but gains a new
`--keep-empty/-k` option to explicitly include them in the results.

Author's note: I'm unsure if there is any code out there that will be broken
by this. Whether we default to keeping empty substrings or not, I believe we
need to officially document it one way or the other for fish 3.0. My
preference is to exclude empty substrings because there isn't much you can do
with them and they can result in unexpected (but wholly correct) output
depending on the nature of the input, e.g. while `string split 'key1##key2'
'#'` returning an empty string in the middle makes sense, `string split
/some/path/to/a/file /` returning an empty string at the start of the array is
less obvious.
