### PR TITLE
Don't execute completions automatically if head does not exist

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1193,11 +1193,9 @@ static std::function<autosuggestion_result_t(void)> get_autosuggestion_performer
         }
         wcstring head(first_char, first_space);
 
-        // Ideally, we should use function_exists and not function_exists_no_autoload here,
-        // but we're not running on the main thread, so....?
         if (!function_exists_no_autoload(head.c_str(), vars) && !builtin_exists(head)
                 && !path_get_path(head, nullptr)) {
-            debug(0, L"Skipping autosuggestions to prevent error output without even typing in <TAB>");
+            // debug(0, L"Skipping autosuggestions to prevent error output without even typing in <TAB>");
             return nothing;
         }
 


### PR DESCRIPTION
This fixes the issues with fish automatically spewing error output to the
console caused by autoloaded completions attempting to generate results
to provide the autosuggestion thread with data.

What we do is prevent completions from being considered as an
autosuggestion source if the command being typed out is not a
fully-formed head that exists. This only addresses *automatically*
generated errors, such as that when typing in `zfs` or `git` at the
prompt on an installation that does not have these utilities. This does
_not_ prevent errors caused by typing in `zfs <TAB>` or `git <TAB>` when
these tools are not installed.

Closes #2365 and possibly others; it has many duplicates such as #4688.