### PR TITLE
completions: [git] Do not decorate reflog

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -335,7 +335,7 @@ function __fish_git_possible_commithash
 end
 
 function __fish_git_reflog
-    command git reflog ^/dev/null | string replace -r '[0-9a-f]* (.+@\{[0-9]+\}): (.*)$' '$1\t$2'
+    command git reflog --no-decorate ^/dev/null | string replace -r '[0-9a-f]* [(.+@\{[0-9]+\}): (.*)$' '$1\t$2'
 end
 
 # general options


### PR DESCRIPTION
Removes decorations from reflog output (if the user has `log.decorate` specified in their gitconfig file).

**Before**
![image](https://user-images.githubusercontent.com/7656560/37117098-2b830b92-2248-11e8-8fde-a48521814a46.png)

**After**
![image](https://user-images.githubusercontent.com/7656560/37116995-c868c006-2247-11e8-969a-76964801cb2f.png)
