### PR TITLE
Update completions for go

### DIFF
--- a/share/completions/go.fish
+++ b/share/completions/go.fish
@@ -89,8 +89,9 @@ __fish_complete_go_files test
 
 # tool
 complete -c go -n '__fish_use_subcommand' -a tool -d 'run specified go tool'
-complete -c go -f -n '__fish_seen_subcommand_from tool' -a '5a 5c 5g 5l 6a 6c 6g 6l addr2line api cgo cov dist fix nm objdump pack pprof prof vet yacc' -d "target tool"
+complete -c go -n '__fish_seen_subcommand_from tool' -a 'addr2line api asm cgo compile dist fix link nm objdump pack pprof prof vet yacc' -d "target tool"
 complete -c go -n '__fish_seen_subcommand_from tool' -s n -d "print the command that would be executed but not execute it"
+__fish_complete_go_files compile
 
 # version
 complete -c go -f -n '__fish_use_subcommand' -a version -d 'print Go version'


### PR DESCRIPTION
## Description

The tool subcommand had a "-f" flag to disallow file completions which is wrong: most of the tools there require a file/directory argument.

Since we're here, also remote obsolete tools that have long disappeared from toolchain, and limit "go tool compile" to only match Go source files.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md