### PR TITLE
Introduce `fish_prompt_pwd_dir_end`

### DIFF
--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -11,15 +11,17 @@ function prompt_pwd --description "Print the current working directory, shortene
     # This allows overriding fish_prompt_pwd_dir_length from the outside (global or universal) without leaking it
     set -q fish_prompt_pwd_dir_length
     or set -l fish_prompt_pwd_dir_length 1
+    set -q fish_prompt_pwd_dir_end
+    or set -l fish_prompt_pwd_dir_end 0
 
     # Replace $HOME with "~"
     set realhome ~
     set -l tmp (string replace -r '^'"$realhome"'($|/)' '~$1' $PWD)
 
-    if [ $fish_prompt_pwd_dir_length -eq 0 ]
+    if [ $fish_prompt_pwd_dir_length -eq 0 -a $fish_prompt_pwd_dir_end -eq 0 ]
         echo $tmp
     else
         # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
-        string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
+        string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*(.{'"$fish_prompt_pwd_dir_end"'})/' '$1$2/' $tmp
     end
 end


### PR DESCRIPTION
## Description

I love the super-short `prompt_pwd`, but in many situations I do have a folder structure like `/work{1,2,3,4}/foo/bar{1,2}` and from `/w/f/b` it's impossible to know where I am.

This introduces an option which makes it keep the `fish_prompt_pwd_dir_end` last characters of each component, so with that variable set to `1`, the above example becomes `/w1/fo/b2`.

It's a straightforward generalization of the current implementation, and with the default value being `0`, it doesn't change anything by default. It's not possible to achieve this behaviour from the outside by pre-/post-processing, hence this PR. Let me know if you're interested in this, and I'll add the documentation/changelog info to this PR. Otherwise, I'll just carry a copy of this function around :smile:

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
