### PR TITLE
Revert "Revert "Restore sanity to line continuations""

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -19,12 +19,12 @@ function __fish_git_recent_commits
 end
 
 function __fish_git_branches
-    command git branch --no-color -a $argv ^/dev/null \
+    command git branch --no-color -a $argv ^/dev/null |
     # Filter out detached heads and such ("(HEAD detached at SOMESHA)", localized).
-    | string match -v '\* (*)' | string match -r -v ' -> ' | string trim -c "* " \
+    string match -v '\* (*)' | string match -r -v ' -> ' | string trim -c "* " |
     # We assume anything that's not remote is a local branch.
-    | string replace -r '^(?!remotes/)(.*)' '$1\tLocal Branch' \
-    | string replace -r "^remotes/(.*)" '$1\tRemote Branch'
+    string replace -r '^(?!remotes/)(.*)' '$1\tLocal Branch' |
+    string replace -r "^remotes/(.*)" '$1\tRemote Branch'
 end
 
 function __fish_git_tags

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -60,9 +60,9 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
                 if test -r "$config"
                     set paths $paths (
                     # Keep only Include lines and remove Include syntax
-                    string replace -rfi '^\s*Include\s+' '' <$config \
+                    string replace -rfi '^\s*Include\s+' '' <$config  |
                     # Normalize whitespace
-                    | string trim | string replace -r -a '\s+' ' ')
+                    string trim | string replace -r -a '\s+' ' ')
                 end
             end
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -416,11 +416,12 @@ maybe_t<tok_t> tokenizer_t::tok_next() {
         return none();
     }
 
+    bool line_continued = false;
     // Consume non-newline whitespace. If we get an escaped newline, mark it and continue past it.
     for (;;) {
         if (this->buff[0] == L'\\' && this->buff[1] == L'\n') {
+            line_continued = true;
             this->buff += 2;
-            this->continue_line_after_comment = true;
         } else if (iswspace_not_nl(this->buff[0])) {
             this->buff++;
         } else {
@@ -428,14 +429,11 @@ maybe_t<tok_t> tokenizer_t::tok_next() {
         }
     }
 
-    while (*this->buff == L'#') {
+    if (*this->buff == L'#') {
         // We have a comment, walk over the comment.
         const wchar_t *comment_start = this->buff;
         while (this->buff[0] != L'\n' && this->buff[0] != L'\0') this->buff++;
         size_t comment_len = this->buff - comment_start;
-
-        // If we are going to continue after the comment, skip any trailing newline.
-        if (this->buff[0] == L'\n' && this->continue_line_after_comment) this->buff++;
 
         // Maybe return the comment.
         if (this->show_comments) {
@@ -445,11 +443,12 @@ maybe_t<tok_t> tokenizer_t::tok_next() {
             result.length = comment_len;
             return result;
         }
+        if (line_continued) {
+            return none();
+        }
         while (iswspace_not_nl(this->buff[0])) this->buff++;
     }
 
-    // We made it past the comments and ate any trailing newlines we wanted to ignore.
-    this->continue_line_after_comment = false;
     size_t start_pos = this->buff - this->start;
 
     tok_t result;
@@ -468,8 +467,7 @@ maybe_t<tok_t> tokenizer_t::tok_next() {
             // Hack: when we get a newline, swallow as many as we can. This compresses multiple
             // subsequent newlines into a single one.
             if (!this->show_blank_lines) {
-                while (*this->buff == L'\n' || *this->buff == 13 /* CR */ || *this->buff == ' ' ||
-                       *this->buff == '\t') {
+                while (is_whitespace(*this->buff)) {
                     this->buff++;
                 }
             }

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -104,8 +104,6 @@ class tokenizer_t {
     bool show_comments{false};
     /// Whether all blank lines are returned.
     bool show_blank_lines{false};
-    /// Whether to continue the previous line after the comment.
-    bool continue_line_after_comment{false};
 
     tok_t call_error(tokenizer_error *error_type, const wchar_t *token_start,
                      const wchar_t *error_loc);


### PR DESCRIPTION
This reverts commit 0f6c763d9e5c8b2ab6b44de5cc2dcaeb41e9d62c which
reverted the incorrect line continuation behavior, but had to be put on
hold until our fish scripts could be audited to ensure they don't break
on this change.

@faho @zanchey can you please merge when you see fit?
