### PR TITLE
Make wcwidth configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,13 @@ SET_SOURCE_FILES_PROPERTIES(src/fish_version.cpp
                             PROPERTIES OBJECT_DEPENDS
                             ${CMAKE_CURRENT_BINARY_DIR}/${FBVF})
 
+OPTION(BROKEN_WCWIDTH "use fallback wcwidth" ON)
+IF(BROKEN_WCWIDTH)
+    add_definitions(-DHAVE_BROKEN_WCWIDTH=1)
+ELSE()
+    add_definitions(-DHAVE_BROKEN_WCWIDTH=0)
+ENDIF()
+
 # Set up PCRE2
 INCLUDE(cmake/PCRE2.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,8 @@ SET_SOURCE_FILES_PROPERTIES(src/fish_version.cpp
                             PROPERTIES OBJECT_DEPENDS
                             ${CMAKE_CURRENT_BINARY_DIR}/${FBVF})
 
-OPTION(BROKEN_WCWIDTH "use fallback wcwidth" ON)
-IF(BROKEN_WCWIDTH)
+OPTION(ENABLE_INTERNAL_WCWIDTH "use fallback wcwidth" ON)
+IF(ENABLE_INTERNAL_WCWIDTH)
     add_definitions(-DHAVE_BROKEN_WCWIDTH=1)
 ELSE()
     add_definitions(-DHAVE_BROKEN_WCWIDTH=0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,8 @@ SET_SOURCE_FILES_PROPERTIES(src/fish_version.cpp
                             PROPERTIES OBJECT_DEPENDS
                             ${CMAKE_CURRENT_BINARY_DIR}/${FBVF})
 
-OPTION(ENABLE_INTERNAL_WCWIDTH "use fallback wcwidth" ON)
-IF(ENABLE_INTERNAL_WCWIDTH)
+OPTION(INTERNAL_WCWIDTH "use fallback wcwidth" ON)
+IF(INTERNAL_WCWIDTH)
     add_definitions(-DHAVE_BROKEN_WCWIDTH=1)
 ELSE()
     add_definitions(-DHAVE_BROKEN_WCWIDTH=0)

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ AC_SUBST(HAVE_DOXYGEN)
 AC_SUBST(LDFLAGS_FISH)
 AC_SUBST(WCHAR_T_BITS)
 AC_SUBST(EXTRA_PCRE2)
+AC_SUBST(HAVE_BROKEN_WCWIDTH)
 
 #
 # If needed, run autoconf to regenerate the configure file
@@ -598,6 +599,20 @@ AC_ARG_WITH(
   [included_pcre2=$withval],
   [included_pcre2=auto]
 )
+
+HAVE_BROKEN_WCWIDTH=
+AC_ARG_ENABLE(
+    [wcwidth],
+    AS_HELP_STRING(
+        [--disable-wcwidth],
+        [use system wcwidth instead of the bundled version]
+        ))
+
+if test "x$enable_wcwidth" != "xno"; then
+      AC_DEFINE([HAVE_BROKEN_WCWIDTH], [1], [banana])
+else
+      AC_DEFINE([HAVE_BROKEN_WCWIDTH], [0], [banana])
+fi
 
 if test "x$included_pcre2" != "xyes"; then
 

--- a/configure.ac
+++ b/configure.ac
@@ -604,7 +604,7 @@ HAVE_BROKEN_WCWIDTH=
 AC_ARG_ENABLE(
     [wcwidth],
     AS_HELP_STRING(
-        [--disable-wcwidth],
+        [--disable-internal-wcwidth],
         [use system wcwidth instead of the bundled version]
         ))
 


### PR DESCRIPTION
This adds the cmake option ~~"BROKEN_WCWIDTH"~~ "~~ENABLE_~~INTERNAL_WCWIDTH" (to be set to "ON" or
"OFF") and the configure option --[en,dis]able-internal-wcwidth.

Both default to enabling our fallback, but can be set to use the system's wcwidth again.

Sequel to #4554.
See #4571, #4539, #4609.

On my system, this would fix #4306.

Ideally, this would default to using the system wcwidth instead - as noted in #4571, it doesn't really matter whether we get the width "right". What matters is that we get the same width that the terminal gets, and that's much more likely with a shared implementation. I have gotten vte, urxvt, st and xterm to disagree with my right-prompt, which causes an interesting stair-case effect that makes fish nigh-unusable.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

As previously noted, I suck at build systems, so someone checking this would be much appreciated.