### PR TITLE
Intermediate slashes with $PATH

### DIFF
--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -644,7 +644,7 @@ void completer_t::complete_cmd(const wcstring &str_cmd, bool use_function, bool 
     if (use_command) {
         expand_error_t result = expand_string(str_cmd, &this->completions,
                                               EXPAND_SPECIAL_FOR_COMMAND | EXPAND_FOR_COMPLETIONS |
-                                                  EXECUTABLES_ONLY | this->expand_flags(),
+                                                  this->expand_flags(),
                                               NULL);
         if (result != EXPAND_ERROR && this->wants_descriptions()) {
             this->complete_cmd_desc(str_cmd);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -1336,16 +1336,13 @@ static expand_error_t expand_stage_wildcards(const wcstring &input, std::vector<
             // `munge_colon_delimited_array()` for these special env vars. Thus we do not
             // special-case them here.
             //
-            // We ignore the path if we start with ./ or /. Also ignore it if we are doing command
-            // completion and we contain a dot-dot.
+            // We ignore the path if we start with / or ./
             if (string_prefixes_string(L"/", path_to_expand) ||
                 string_prefixes_string(L"./", path_to_expand) ||
-                string_prefixes_string(L"../", path_to_expand) ||
-                (for_command && string_suffixes_string(L"/..", path_to_expand)) ||
-                (for_command && path_to_expand.find(L"/../") != wcstring::npos)) {
+                string_prefixes_string(L"../", path_to_expand)) {
                 effective_working_dirs.push_back(working_dir);
             } else {
-                // At this point we know that path does not contain dot-dot
+                // Also search working directory if we are expanding command with slashes.
                 if (for_command && path_to_expand.find(L"/") != wcstring::npos)
                     effective_working_dirs.push_back(working_dir);
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -1345,6 +1345,10 @@ static expand_error_t expand_stage_wildcards(const wcstring &input, std::vector<
                 (for_command && path_to_expand.find(L"/../") != wcstring::npos)) {
                 effective_working_dirs.push_back(working_dir);
             } else {
+                // At this point we know that path does not contain dot-dot
+                if (for_command && path_to_expand.find(L"/") != wcstring::npos)
+                    effective_working_dirs.push_back(working_dir);
+
                 // Get the PATH/CDPATH and CWD. Perhaps these should be passed in. An empty CDPATH
                 // implies just the current directory, while an empty PATH is left empty.
                 const wchar_t *name = for_cd ? L"CDPATH" : L"PATH";

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -1328,24 +1328,21 @@ static expand_error_t expand_stage_wildcards(const wcstring &input, std::vector<
             effective_working_dirs.push_back(working_dir);
         } else {
             // Either EXPAND_SPECIAL_FOR_COMMAND or EXPAND_SPECIAL_FOR_CD. We can handle these
-            // mostly the same. There's the following differences:
+            // mostly the same.
             //
-            // 1. An empty CDPATH should be treated as '.', but an empty PATH should be left empty
+            // An empty CDPATH should be treated as '.', but an empty PATH should be left empty
             // (no commands can be found). Also, an empty element in either is treated as '.' for
             // consistency with POSIX shells. Note that we rely on the latter by having called
             // `munge_colon_delimited_array()` for these special env vars. Thus we do not
             // special-case them here.
             //
-            // 2. PATH is only "one level," while CDPATH is multiple levels. That is, input like
-            // 'foo/bar' should resolve against CDPATH, but not PATH.
-            //
-            // In either case, we ignore the path if we start with ./ or /. Also ignore it if we are
-            // doing command completion and we contain a slash, per IEEE 1003.1, chapter 8 under
-            // PATH.
+            // We ignore the path if we start with ./ or /. Also ignore it if we are doing command
+            // completion and we contain a dot-dot.
             if (string_prefixes_string(L"/", path_to_expand) ||
                 string_prefixes_string(L"./", path_to_expand) ||
                 string_prefixes_string(L"../", path_to_expand) ||
-                (for_command && path_to_expand.find(L'/') != wcstring::npos)) {
+                (for_command && string_suffixes_string(L"/..", path_to_expand)) ||
+                (for_command && path_to_expand.find(L"/../") != wcstring::npos)) {
                 effective_working_dirs.push_back(working_dir);
             } else {
                 // Get the PATH/CDPATH and CWD. Perhaps these should be passed in. An empty CDPATH

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -122,7 +122,8 @@ wcstring_list_t path_get_paths(const wcstring &cmd) {
     debug(3, L"path_get_paths('%ls')", cmd.c_str());
     wcstring_list_t paths;
 
-    // Don't bother looking for a matching command if it is an absolute or relative path, or has a dot-dot.
+    // Don't bother looking for a matching command if it is an absolute or relative path,
+    // or has a dot-dot.
     if (string_prefixes_string(L"/", cmd) ||
         string_prefixes_string(L"./", cmd) ||
         string_prefixes_string(L"../", cmd) ||

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -35,9 +35,13 @@ static bool path_get_path_core(const wcstring &cmd, wcstring *out_path,
                                const maybe_t<env_var_t> &bin_path_var) {
     debug(3, L"path_get_path( '%ls' )", cmd.c_str());
 
-    // If the command has a slash, it must be an absolute or relative path and thus we don't bother
-    // looking for a matching command.
-    if (cmd.find(L'/') != wcstring::npos) {
+    // Don't bother looking for a matching command if it is an absolute or relative path,
+    // or has a dot-dot.
+    if (string_prefixes_string(L"/", cmd) ||
+        string_prefixes_string(L"./", cmd) ||
+        string_prefixes_string(L"../", cmd) ||
+        string_suffixes_string(L"/..", cmd) ||
+        cmd.find(L"/../") != wcstring::npos) {
         if (waccess(cmd, X_OK) != 0) {
             return false;
         }
@@ -118,9 +122,12 @@ wcstring_list_t path_get_paths(const wcstring &cmd) {
     debug(3, L"path_get_paths('%ls')", cmd.c_str());
     wcstring_list_t paths;
 
-    // If the command has a slash, it must be an absolute or relative path and thus we don't bother
-    // looking for matching commands in the PATH var.
-    if (cmd.find(L'/') != wcstring::npos) {
+    // Don't bother looking for a matching command if it is an absolute or relative path, or has a dot-dot.
+    if (string_prefixes_string(L"/", cmd) ||
+        string_prefixes_string(L"./", cmd) ||
+        string_prefixes_string(L"../", cmd) ||
+        string_suffixes_string(L"/..", cmd) ||
+        cmd.find(L"/../") != wcstring::npos) {
         struct stat buff;
         if (wstat(cmd, &buff)) return paths;
         if (!S_ISREG(buff.st_mode)) return paths;

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -51,9 +51,7 @@ static bool path_get_path_core(const wcstring &cmd, wcstring *out_path,
 
         if (string_prefixes_string(L"/", cmd) ||
             string_prefixes_string(L"./", cmd) ||
-            string_prefixes_string(L"../", cmd) ||
-            string_suffixes_string(L"/..", cmd) ||
-            cmd.find(L"/../") != wcstring::npos) {
+            string_prefixes_string(L"../", cmd)) {
             return false;
         }
     }
@@ -138,9 +136,7 @@ wcstring_list_t path_get_paths(const wcstring &cmd) {
 
         if (string_prefixes_string(L"/", cmd) ||
             string_prefixes_string(L"./", cmd) ||
-            string_prefixes_string(L"../", cmd) ||
-            string_suffixes_string(L"/..", cmd) ||
-            cmd.find(L"/../") != wcstring::npos) {
+            string_prefixes_string(L"../", cmd)) {
             return paths;
         }
     }

--- a/tests/test6.in
+++ b/tests/test6.in
@@ -118,49 +118,73 @@ begin
 
   # Verify that we can expand commands when PATH has parens
   set -l PATH $parened_path $PATH
-  set -l completed (complete -C__test6_ | cut -f 1 -d \t)
-  if test "$completed" = '__test6_(paren)_command'
-    echo "Command completion with parened PATHs test passed"
-  else
-    echo "Command completion with parened PATHs test failed. Expected __test6_(paren)_command, got $completed" >&2
+  begin
+    set -l completed (complete -C__test6_ | cut -f 1 -d \t)
+    set -l expected '__test6_(paren)_command'
+    if test "$completed" = "$expected"
+      echo "Command completion with parened PATHs test passed"
+    else
+      echo "Command completion with parened PATHs test failed." \
+           "Expected '$expected', got '$completed'" >&2
+    end
   end
 
   # Verify that commands with intermediate slashes expand with respect to PATH
-  set -l completed (complete -Csubdir/__test6_subdir | cut -f 1 -d \t)
-  if test "$completed" = 'subdir/__test6_subdir_(paren)_command'
-    echo "Command completion with intermediate slashes test passed"
-  else
-    echo "Command completion with intermediate slashes test failed. Expected 'subdir/__test6_subdir_(paren)_command', got $completed" >&2
+  begin
+    set -l completed (complete -Csubdir/__test6_subdir | cut -f 1 -d \t)
+    set -l expected 'subdir/__test6_subdir_(paren)_command'
+    if test "$completed" = "$expected"
+      echo "Command completion with intermediate slashes test passed"
+    else
+      echo "Command completion with intermediate slashes test failed:" \
+           "expected '$expected', got '$completed'" >&2
+    end
   end
 
   # Verify that commands with intermediate dot-dot do NOT expand with respect to PATH
-  set -l completed (complete -Csubdir/../subdir/__test6_subdir)
-  if test -z "$completed"
-    echo "Command completion with intermediate dot-dot test passed"
-  else
-    echo "Command completion with intermediate dot-dot test failed: should output nothing, instead got $completed" >&2
+  # Note that in real world subdir may be a simlink
+  begin
+    set -l completed (complete -Csubdir/../subdir/__test6_subdir | \
+                      cut -f 1 -d \t | cut -f 1,4 -d /)
+    set -l expected (complete -Csubdir/__test6_subdir | cut -f 1 -d \t)
+    if test "$completed" = "$expected"
+      echo "Command completion with intermediate dot-dot test passed"
+    else
+      echo "Command completion with intermediate dot-dot test failed:" \
+           "expected '$expected', got '$completed'" >&2
+    end
   end
 
-  # Verify that commands with dot-dot suffix do NOT expand with respect to PATH
-  set -l completed (complete -Csubdir/..)
-  if test -z "$completed"
-    echo "Command completion with dot-dot suffix test passed"
-  else
-    echo "Command completion with dot-dot suffix test failed: should output nothing, instead got $completed" >&2
+  # Verify that commands with dot-dot suffix expand with respect to PATH
+  begin
+    set -l completed (complete -Csubdir/subdir/.. | cut -f 1 -d \t)
+    set -l expected "subdir/subdir/../"
+    if test "$completed" = "$expected"
+      echo "Command completion with dot-dot suffix test passed"
+    else
+      echo "Command completion with dot-dot suffix test failed:" \
+           "expected '$expected', got '$completed'" >&2
+    end
   end
 
   # Verify that relative path is used instead of searching in PATH
   # subdir/executable -> /bin/echo
   # subdir/subdir/executable -> /bin/echo
-  set -l PATH $parened_path/subdir $PATH
-  pushd $parened_path
-  set -l echo_output (subdir/executable "passed")
-  if test "$echo_output" = "passed"
-    echo "Relative path instead of searching in PATH test passed"
-  else
-    echo "Executable from PATH was used, test failed"
+  begin
+    set -l PATH $parened_path/subdir
+    pushd $parened_path
+
+    set -l wanted subdir/executable
+    set -l found (command -s $wanted)
+    if test $found = $wanted
+      and test (subdir/executable "passed") = "passed"
+      echo "Relative path instead of searching in PATH test passed"
+    else
+      echo "Executable from PATH was used, test failed:" \
+           "wanted '$wanted', instead found '$found'" >&2
+    end
+    popd
   end
-  popd
 
   rm -rf $parened_path
 end

--- a/tests/test6.in
+++ b/tests/test6.in
@@ -103,13 +103,15 @@ end
 # Test command expansion with parened PATHs (#952)
 begin
   set -l parened_path $PWD/'test6.tmp2.(paren).dir'
-  set -l parened_subpath $parened_path/subdir
   if not begin
         rm -rf $parened_path
         and mkdir $parened_path
-        and mkdir $parened_subpath
+        and mkdir $parened_path/subdir
+        and mkdir $parened_path/subdir/subdir
         and ln -s /bin/ls $parened_path/'__test6_(paren)_command'
-        and ln -s /bin/ls $parened_subpath/'__test6_subdir_(paren)_command'
+        and ln -s /bin/ls $parened_path/subdir/'__test6_subdir_(paren)_command'
+        and ln -s /bin/echo $parened_path/subdir/executable
+        and ln -s /bin/ls $parened_path/subdir/subdir/executable
       end
     echo "error: could not create command expansion temp environment" >&2
   end
@@ -146,6 +148,19 @@ begin
   else
     echo "Command completion with dot-dot suffix test failed: should output nothing, instead got $completed" >&2
   end
+
+  # Verify that relative path is used instead of searching in PATH
+  # subdir/executable -> /bin/echo
+  # subdir/subdir/executable -> /bin/echo
+  set -l PATH $parened_path/subdir $PATH
+  pushd $parened_path
+  set -l echo_output (subdir/executable "passed")
+  if test "$echo_output" = "passed"
+    echo "Relative path instead of searching in PATH test passed"
+  else
+    echo "Executable from PATH was used, test failed"
+  end
+  popd
 
   rm -rf $parened_path
 end

--- a/tests/test6.in
+++ b/tests/test6.in
@@ -82,18 +82,18 @@ if begin; rm -rf test6.tmp.dir; and mkdir test6.tmp.dir; end
         echo "no implicit cd complete"
     end
     if complete -C"command $dir" | grep "^$dir/.*Directory" >/dev/null
-        echo "implicit cd complete incorrect after 'command'"
+        echo "dir completion works after 'command'"
     else
-        echo "no implicit cd complete after 'command'"
+        echo "no dir completion after 'command'"
     end
     popd
     if begin
             set -l PATH $PWD/test6.tmp.dir $PATH ^/dev/null
             complete -C$dir | grep "^$dir/.*Directory" >/dev/null
         end
-        echo "incorrect implicit cd from PATH"
+        echo "dir completion works from PATH"
     else
-        echo "PATH does not cause incorrect implicit cd"
+        echo "PATH does not cause dir completion"
     end
     rm -rf test6.tmp.dir
 else
@@ -106,14 +106,14 @@ begin
   set -l parened_subpath $parened_path/subdir
   if not begin
         rm -rf $parened_path
-	    and mkdir $parened_path
-		and mkdir $parened_subpath
-	    and ln -s /bin/ls $parened_path/'__test6_(paren)_command'
-	    and ln -s /bin/ls $parened_subpath/'__test6_subdir_(paren)_command'
+        and mkdir $parened_path
+        and mkdir $parened_subpath
+        and ln -s /bin/ls $parened_path/'__test6_(paren)_command'
+        and ln -s /bin/ls $parened_subpath/'__test6_subdir_(paren)_command'
       end
     echo "error: could not create command expansion temp environment" >&2
   end
-  
+
   # Verify that we can expand commands when PATH has parens
   set -l PATH $parened_path $PATH
   set -l completed (complete -C__test6_ | cut -f 1 -d \t)
@@ -122,14 +122,30 @@ begin
   else
     echo "Command completion with parened PATHs test failed. Expected __test6_(paren)_command, got $completed" >&2
   end
-  
-  # Verify that commands with intermediate slashes do NOT expand with respect to PATH
-  set -l completed (complete -Csubdir/__test6_subdir)
-  if test -z "$completed"
-    echo "Command completion with intermediate slashes passed"
+
+  # Verify that commands with intermediate slashes expand with respect to PATH
+  set -l completed (complete -Csubdir/__test6_subdir | cut -f 1 -d \t)
+  if test "$completed" = 'subdir/__test6_subdir_(paren)_command'
+    echo "Command completion with intermediate slashes test passed"
   else
-    echo "Command completion with intermediate slashes: should output nothing, instead got $completed" >&2
+    echo "Command completion with intermediate slashes test failed. Expected 'subdir/__test6_subdir_(paren)_command', got $completed" >&2
   end
-  
-  rm -rf $parened_path
+
+  # Verify that commands with intermediate dot-dot do NOT expand with respect to PATH
+  set -l completed (complete -Csubdir/../subdir/__test6_subdir)
+  if test -z "$completed"
+    echo "Command completion with intermediate dot-dot test passed"
+  else
+    echo "Command completion with intermediate dot-dot test failed: should output nothing, instead got $completed" >&2
+  end
+
+  # Verify that commands with dot-dot suffix do NOT expand with respect to PATH
+  set -l completed (complete -Csubdir/..)
+  if test -z "$completed"
+    echo "Command completion with dot-dot suffix test passed"
+  else
+    echo "Command completion with dot-dot suffix test failed: should output nothing, instead got $completed" >&2
+  end
+
+  #rm -rf $parened_path
 end

--- a/tests/test6.in
+++ b/tests/test6.in
@@ -82,16 +82,16 @@ if begin; rm -rf test6.tmp.dir; and mkdir test6.tmp.dir; end
         echo "no implicit cd complete"
     end
     if complete -C"command $dir" | grep "^$dir/.*Directory" >/dev/null
-        echo "dir completion works after 'command'"
+        echo "implicit cd complete incorrect after 'command'"
     else
-        echo "no dir completion after 'command'"
+        echo "no implicit cd complete after 'command'"
     end
     popd
     if begin
             set -l PATH $PWD/test6.tmp.dir $PATH ^/dev/null
             complete -C$dir | grep "^$dir/.*Directory" >/dev/null
         end
-        echo "dir completion works from PATH"
+        echo "PATH causes dir completion"
     else
         echo "PATH does not cause dir completion"
     end

--- a/tests/test6.in
+++ b/tests/test6.in
@@ -147,5 +147,5 @@ begin
     echo "Command completion with dot-dot suffix test failed: should output nothing, instead got $completed" >&2
   end
 
-  #rm -rf $parened_path
+  rm -rf $parened_path
 end

--- a/tests/test6.out
+++ b/tests/test6.out
@@ -41,8 +41,8 @@ Expect no output 2:
 Expect --backup --backup=: --backup --backup=
 Expect --backup=all  --backup=none  --backup=simple: --backup=all --backup=none --backup=simple
 implicit cd complete works
-dir completion works after 'command'
-dir completion works from PATH
+no implicit cd complete after 'command'
+PATH causes dir completion
 Command completion with parened PATHs test passed
 Command completion with intermediate slashes test passed
 Command completion with intermediate dot-dot test passed

--- a/tests/test6.out
+++ b/tests/test6.out
@@ -47,3 +47,4 @@ Command completion with parened PATHs test passed
 Command completion with intermediate slashes test passed
 Command completion with intermediate dot-dot test passed
 Command completion with dot-dot suffix test passed
+Relative path instead of searching in PATH test passed

--- a/tests/test6.out
+++ b/tests/test6.out
@@ -41,7 +41,9 @@ Expect no output 2:
 Expect --backup --backup=: --backup --backup=
 Expect --backup=all  --backup=none  --backup=simple: --backup=all --backup=none --backup=simple
 implicit cd complete works
-no implicit cd complete after 'command'
-PATH does not cause incorrect implicit cd
+dir completion works after 'command'
+dir completion works from PATH
 Command completion with parened PATHs test passed
-Command completion with intermediate slashes passed
+Command completion with intermediate slashes test passed
+Command completion with intermediate dot-dot test passed
+Command completion with dot-dot suffix test passed


### PR DESCRIPTION
## Description

Briefly, this PR allows intermediate slashes when expanding command and searching `$PATH`, though the path is ignored if it contains `..` (dot-dot).

Command completion expands directories now.  There was also a single test that didn't expect such behavior from completions for `command` built-in.

Similar behavior can be seen in `rc` shell from Plan 9, but the whole system does fundamentally different path processing.  As far as I know, `rc` simply appends file path to all directories in `$PATH` until it finds an executable.

I don't think my modifications are breaking something, but I'm still not sure about it.

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added
- [ ] User-visible changes noted in `CHANGELOG.md`
