### PR TITLE
Quote the value of $manpath to prevent setting it to the empty array.

### DIFF
--- a/share/functions/man.fish
+++ b/share/functions/man.fish
@@ -10,7 +10,7 @@ function man --description "Format and display the on-line manual pages"
         set manpath (command manpath)
     end
     # Notice local exported copy of the variable.
-    set -lx MANPATH $manpath
+    set -lx MANPATH "$manpath"
 
     set -l fish_manpath (dirname $__fish_data_dir)/fish/man
     if test -d "$fish_manpath" -a -n "$MANPATH"


### PR DESCRIPTION
If $manpath isn't set by the conditionals at the beginning of the man builtin, $MANPATH is set to the empty array, and getenv() will later return it as ASCII code 29 (which is intended fish shell behavior), breaking OpenBSD mandoc's fallback to the default manpath.

This is especially worth fixing because it's quite difficult to debug.
`man` can't find any manual pages in fish, but it can find manual pages in every other shell.
`ktrace man` can't reproduce the failed mandoc lookup, because it's actually running /usr/bin/man.
If someone tries `which man` (forgetting that `type` exists for distinguishing between functions and executable commands), /usr/bin/man shows up.

Couldn't have figured this out without @doy (🍻). 

Not attached to this particular fix, obviously, only that the bug gets fixed.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
