### PR TITLE
Makefile completion improvements

### DIFF
--- a/share/completions/make.fish
+++ b/share/completions/make.fish
@@ -1,11 +1,14 @@
 # Completions for make
 function __fish_complete_make_targets
-    set directory (string replace -r '^make .*(-C ?|--directory[= ]?)([^ ]*) .*$' '$2' -- $argv)
-    if test $status -eq 0 -a -d $directory
-        __fish_print_make_targets $directory
-    else
-        __fish_print_make_targets
+    set directory (string replace -r '^make .*(-C ?|--directory(=| +))([^ ]*) .*$' '$3' -- $argv)
+    if not test $status -eq 0 -a -d $directory
+        set directory ''
     end
+    set file (string replace -r '^make .*(-f ?|--file=(=| +))([^ ]*) .*$' '$3' -- $argv)
+    if not test $status -eq 0 -a -f $file
+        set file ''
+    end
+    __fish_print_make_targets "$directory" "$file"
 end
 
 # This completion reenables file completion on

--- a/share/completions/make.fish
+++ b/share/completions/make.fish
@@ -4,7 +4,7 @@ function __fish_complete_make_targets
     if not test $status -eq 0 -a -d $directory
         set directory ''
     end
-    set file (string replace -r '^make .*(-f ?|--file=(=| +))([^ ]*) .*$' '$3' -- $argv)
+    set file (string replace -r '^make .*(-f ?|--file(=| +))([^ ]*) .*$' '$3' -- $argv)
     if not test $status -eq 0 -a -f $file
         set file ''
     end

--- a/share/functions/__fish_print_make_targets.fish
+++ b/share/functions/__fish_print_make_targets.fish
@@ -1,10 +1,19 @@
-function __fish_print_make_targets --argument directory
+function __fish_print_make_targets --argument-names directory file
     # Since we filter based on localized text, we need to ensure the
     # text will be using the correct locale.
     set -lx LC_ALL C
 
     if test -z "$directory"
         set directory '.'
+    end
+
+    if test -z "$file"
+        for standard_file in $directory/{GNUmakefile,Makefile,makefile}
+            if test -f $standard_file
+                set file $standard_file
+                break
+            end
+        end
     end
 
     set -l bsd_make
@@ -14,15 +23,10 @@ function __fish_print_make_targets --argument directory
         set bsd_make 1
     end
 
-    for file in $directory/{GNUmakefile,Makefile,makefile}
-        if test -f $file
-            if test "$bsd_make" = 0
-                make -C $directory -prRn | awk -v RS= -F: '/^# Files/,/^# Finished Make data base/ {if ($1 !~ "^[#.]") {print $1}}' ^/dev/null
-            else
-                make -C $directory -d g1 -rn >/dev/null ^| awk -F, '/^#\*\*\* Input graph:/,/^$/ {if ($1 !~ "^#... ") {gsub(/# /,"",$1); print $1}}' ^/dev/null
-            end
-            break
-        end
+    if test "$bsd_make" = 0
+        make -C "$directory" -f "$file" -prRn | awk -v RS= -F: '/^# Files/,/^# Finished Make data base/ {if ($1 !~ "^[#.]") {print $1}}' ^/dev/null
+    else
+        make -C "$directory" -f "$file" -d g1 -rn >/dev/null ^| awk -F, '/^#\*\*\* Input graph:/,/^$/ {if ($1 !~ "^#... ") {gsub(/# /,"",$1); print $1}}' ^/dev/null
     end
 end
 

--- a/share/functions/__fish_print_make_targets.fish
+++ b/share/functions/__fish_print_make_targets.fish
@@ -24,7 +24,8 @@ function __fish_print_make_targets --argument-names directory file
     end
 
     if test "$bsd_make" = 0
-        make -C "$directory" -f "$file" -prRn | awk -v RS= -F: '/^# Files/,/^# Finished Make data base/ {if ($1 !~ "^[#.]") {print $1}}' ^/dev/null
+        # https://stackoverflow.com/a/26339924
+        make -C "$directory" -f "$file" -pRrq : ^/dev/null | awk -v RS= -F: '/^# Files/,/^# Finished Make data base/ {if ($1 !~ "^[#.]") {print $1}}' ^/dev/null
     else
         make -C "$directory" -f "$file" -d g1 -rn >/dev/null ^| awk -F, '/^#\*\*\* Input graph:/,/^$/ {if ($1 !~ "^#... ") {gsub(/# /,"",$1); print $1}}' ^/dev/null
     end


### PR DESCRIPTION
I added to the Makefile completion by detecting the `--file` argument in the commandline when completing the `make` command to only show targets from that file. When I did this though I noticed that it was printing targets from both the `--file` argument and `Makefile` in some cases (on non-BSD), so I updated the `make` invocation in `__fish_print_make_targets` according to [this StackOverflow answer](https://stackoverflow.com/a/26339924).

Fixes issue #4826

I wasn't really sure where to put tests or docs for this kind of thing, let me know if I need to add any of that.