### PR TITLE
Fix handling of signals

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -360,10 +360,8 @@ static bool can_use_posix_spawn_for_job(const job_t *job, const process_t *proce
 
 void internal_exec(job_t *j, const io_chain_t &&all_ios) {
     // Do a regular launch -  but without forking first...
-    signal_block();
 
-    // setup_child_process makes sure signals are properly set up. It will also call
-    // signal_unblock.
+    // setup_child_process makes sure signals are properly set up.
 
     // PCA This is for handling exec. Passing all_ios here matches what fish 2.0.0 and 1.x did.
     // It's known to be wrong - for example, it means that redirections bound for subsequent


### PR DESCRIPTION
## Description

Currently, fish has a bug with signal handling.  I discovered this when testing a program in `gdb` that throws a SIGSEGV.  gdb wraps the program in a shell (which shell is determined by the SHELL environment variable).  The expected behavior is that when the test program segfaults, gdb should display the location of the segfault, etc.  Instead, what happens is that fish segfaults as well.  This can be reproduced as follows:

1. Open a new fish shell
2. Type `set -x SHELL (which fish)`
3. Run `gdb testprogram`
4. In gdb, type `run`

This can be traced back to 52d739c, which was a reversion of a previous reversion.  The behavior is correct at 4fe9d79 (before the revert), 35ee28f (immediately after the revert), and 0594735 (after other changes), but is broken at 52d739c (after reverting the revert).  Comparing 52d739c and 35ee28f, the two diffs should be exact opposites, but they are not.  This is because part of the code that was changed was moved to a different function, so the revert of the revert did not apply correctly.  This PR fixes that missed change, which also fixes the issue with gdb and fish not interacting correctly.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md