### PR TITLE
Fix the FAQ questions in the sidebar of user_doc/html/index.html

### DIFF
--- a/build_tools/build_toc_txt.sh
+++ b/build_tools/build_toc_txt.sh
@@ -12,5 +12,6 @@ for i in $@; do
 	NAME=`basename $NAME .hdr.in`
   env sed <$i >>toc.txt -n \
     -e 's,.*\\page *\([^ ]*\) *\(.*\)$,- <a href="'$NAME'.html" id="toc-'$NAME'">\2</a>,p' \
-    -e 's,.*\\section *\([^ ]*\) *\([^-]*\)\(.*\)$,  - <a href="'$NAME'.html#\1">\2</a>,p'
+    -e 's,.*\\section *\([^ ]*\) *\(.*\) - .*$,  - <a href="'$NAME'.html#\1">\2</a>,p' \
+    -e 's,.*\\section *\([^ ]*\) *\(.*\)$,  - <a href="'$NAME'.html#\1">\2</a>,p'
 done


### PR DESCRIPTION
## Description
`
-e 's,.*\\section *\([^ ]*\) *\([^-]*\)\(.*\)$,  - <a href="'$NAME'.html#\1">\2</a>,p'` 
correctly reduces the size of the TOC in the command listing for expressing like:

``\section umask umask - set or get the file creation mode mask``

But it fails for questions in the FAQ with a `-` symbol like:

 ``\section faq-cd-minus How can I use `-` as a shortcut for `cd -`?``

It only prints this in the TOC:
> How can I use `

Please see: https://fishshell.com/docs/current/index.html

This new regex could fail for a question with a lonely `-`, but I don't know how to do better than that.

Samuel