### PR TITLE
Emit error on failure to unset variable because it doesn't exist

### DIFF
--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -628,11 +628,7 @@ static int builtin_set_erase(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
 
     if (idx_count == 0) {  // unset the var
         retval = env_remove(dest, scope);
-        // Temporarily swallowing ENV_NOT_FOUND errors to prevent
-        // breaking all tests that unset variables that aren't set.
-        if (retval != ENV_NOT_FOUND) {
-            handle_env_return(retval, cmd, dest, streams);
-        }
+        handle_env_return(retval, cmd, dest, streams);
     } else {  // remove just the specified indexes of the var
         const auto dest_var = env_get(dest, scope);
         if (!dest_var) return STATUS_CMD_ERROR;


### PR DESCRIPTION
Commit 01452da5bf17224106b3b0117eb7bd978d75863d added support for
distinguishing between different `set -e` errors but silenced error
output for the case where `set -e VAR` failed because `VAR` was not
already defined.

This commit removes that check and allows warnings to be emitted if the
variable does not exist.

Added when updating `set -e` to emit an error when attempting to unset a
protected variable, but not activated prior to discussion.