### PR TITLE
Tweak the error message for `history delete --exact foo`

### DIFF
--- a/src/builtin_history.cpp
+++ b/src/builtin_history.cpp
@@ -264,7 +264,7 @@ int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
             }
             if (!opts.case_sensitive) {
                 streams.err.append_format(
-                    _(L"builtin history delete only supports --case-sensitive\n"));
+                    _(L"builtin history delete --exact requires --case-sensitive\n"));
                 status = STATUS_INVALID_ARGS;
                 break;
             }


### PR DESCRIPTION
The old message made it sound like the `--exact` flag wasn't supported.

I'd just commit this to master but I don't know if we need to do anything on the localization front here, or if updated strings just get handled automatically.
