### PR TITLE
add job expansion wrapper for disown

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -288,3 +288,8 @@ end
 function wait --wraps wait
     builtin wait (__fish_expand_pid_args $argv)
 end
+
+function disown --wraps disown
+    builtin disown (__fish_expand_pid_args $argv)
+end
+


### PR DESCRIPTION
## Description

Add job expansion wrapper for `disown` as well as `bg`, `fg`, `wait` and `kill`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
