### PR TITLE
Remove caret redirection from tar completion

### DIFF
--- a/share/functions/__fish_complete_tar.fish
+++ b/share/functions/__fish_complete_tar.fish
@@ -7,7 +7,7 @@ function __fish_complete_tar -d "Peek inside of archives and list all files"
             case '-*f' '--file'
                 set -e args[1]
                 if test -f $args[1]
-                    set -l file_list (tar -atf $args[1] ^ /dev/null)
+                    set -l file_list (tar -atf $args[1] 2> /dev/null)
                     if test -n "$file_list"
                         printf (_ "%s\tArchived file\n") $file_list
                     end


### PR DESCRIPTION
This PR changes the tar completion script to use `2>` for stderr redirection, as caret redirection has been removed.