### PR TITLE
function: restore '%self' functionality for --on-process-exit

### DIFF
--- a/doc_src/function.txt
+++ b/doc_src/function.txt
@@ -25,7 +25,10 @@ The following options are available:
 
 - `-j PGID` or `--on-job-exit PGID` tells fish to run this function when the job with group ID PGID exits. Instead of PGID, the string 'caller' can be specified. This is only legal when in a command substitution, and will result in the handler being triggered by the exit of the job which created this command substitution.
 
-- `-p PID` or `--on-process-exit PID` tells fish to run this function when the fish child process with process ID PID exits.
+- `-p PID` or `--on-process-exit PID` tells fish to run this function when the fish child process
+  with process ID PID exits. Instead of PID, the string "`self`" (or, for backward compatibility,
+  "`%self`") can be specified as an alias for `$fish_pid`, and the function will be run when the
+  current fish instance exits.
 
 - `-s` or `--on-signal SIGSPEC` tells fish to run this function when the signal SIGSPEC is delivered. SIGSPEC can be a signal number, or the signal name, such as SIGHUP (or just HUP).
 

--- a/src/builtin_function.cpp
+++ b/src/builtin_function.cpp
@@ -115,6 +115,11 @@ static int parse_cmd_opts(function_cmd_opts_t &opts, int *optind,  //!OCLINT(hig
                     }
                     e.type = EVENT_JOB_ID;
                     e.param1.job_id = job_id;
+                } else if ((opt == 'p') && ((wcscasecmp(w.woptarg, L"%self") == 0) ||
+                                            (wcscasecmp(w.woptarg, L"self") == 0))) {
+                    pid = getpid();
+                    e.type = EVENT_EXIT;
+                    e.param1.pid = pid;
                 } else {
                     pid = fish_wcstoi(w.woptarg);
                     if (errno || pid < 0) {


### PR DESCRIPTION
This PR restores "`%self`" as an argument for `--on-process`/`--on-process-exit`.

It also adds "`self`" as a more sensible alias, but perhaps this could be dropped in favour of using `$fish_pid`.