### PR TITLE
Updating adb completion script to enable tab-completing device file paths for shell and pull commands.

### DIFF
--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -58,6 +58,21 @@ function __fish_adb_list_uninstallable_packages
     __fish_adb_run_command pm list packages -3 | string replace 'package:' ''
 end
 
+function __fish_adb_list_files
+   set -l token (commandline -ct)
+
+   # Have tab complete show initial / if nothing on current token
+   if test -z "$token"
+       set token "/"
+   end
+
+   # Return list of directories suffixed with '/'
+   __fish_adb_run_command find -H "$token*" -maxdepth 0 -type d 2>/dev/null | awk '{print $1"/"}'
+   # Return list of files
+   __fish_adb_run_command find -H "$token*" -maxdepth 0 -type f 2>/dev/null
+end
+
+
 # Generic options, must come before command
 complete -n '__fish_adb_no_subcommand' -c adb -s s -x -a "(__fish_adb_get_devices)" -d 'Device to communicate with'
 complete -n '__fish_adb_no_subcommand' -c adb -s d -d 'Communicate with first USB device'
@@ -143,3 +158,7 @@ complete -n '__fish_seen_subcommand_from sideload' -c adb -xa '(__fish_complete_
 
 # reconnect
 complete -n '__fish_seen_subcommand_from reconnect' -c adb -x -a 'device' -d 'Kick current connection from device side and make it reconnect.'
+
+# commands that accept listing device files
+complete -n '__fish_seen_subcommand_from shell' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'
+complete -n '__fish_seen_subcommand_from pull' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'


### PR DESCRIPTION
## Description
This patch updates the adb completion script so that someone can tab complete device file paths when using adb pull or adb shell. For example, one can type:
`adb pull /sd` hit tab, and complete the file path for the path on device.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
