### PR TITLE
Fix range expansion with negative ends

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -228,6 +228,12 @@ static size_t parse_slice(const wchar_t *in, wchar_t **end_ptr, std::vector<long
             i2 = i2 < size ? i2 : size;
             // debug( 0, L"Push range idx %d %d", i1, i2 );
             short direction = i2 < i1 ? -1 : 1;
+            // If only the beginning is negative, always go reverse.
+            // If only the end, always go forward.
+            // Prevents `[x..-1]` from going reverse if less than x elements are there.
+            if (tmp1 > -1 != tmp > -1) {
+                direction = tmp1 > -1 ? -1 : 1;
+            }
             for (long jjj = i1; jjj * direction <= i2 * direction; jjj += direction) {
                 // debug(0, L"Expand range [subst]: %i\n", jjj);
                 idx.push_back(jjj);

--- a/tests/expansion.in
+++ b/tests/expansion.in
@@ -65,7 +65,7 @@ expansion "$$foo"
 expansion $$foo
 expansion "prefix$$foo"
 expansion prefix$$foo
-expansion $foo[-5..2]
+expansion $foo[-5..2] # No result, because the starting index is invalid and we force-reverse.
 expansion $foo[-2..-1]
 expansion $foo[-10..-5]
 expansion (printf '%s\n' $foo)[-5..2]
@@ -87,6 +87,7 @@ set -l foo a b c
 expansion $foo[17]
 expansion $foo[-17]
 expansion $foo[17..18]
+expansion $foo[4..-2]
 
 echo "$foo[d]"
 echo $foo[d]

--- a/tests/expansion.out
+++ b/tests/expansion.out
@@ -36,10 +36,10 @@
 2 baz quux
 1 prefixbaz quux  fooest
 2 prefixbaz prefixquux
-2 bar 
+0
 2  fooest
 0
-2 bar 
+0
 2  fooest
 0
 1 
@@ -51,6 +51,7 @@
 1 
 0
 1 
+0
 0
 0
 0


### PR DESCRIPTION
If just one of the range ends is negative, this now forces direction away from it.

I.e. if the beginning is negative, we go in reverse.
If the end is negative, we go forwards.

This fixes cases like

    $var[2..-1]

if $var only has one element.

If this gets enough testing quickly, I'd still love to include it in 3.0.

Fixes issue #4897.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
