### PR TITLE
Allow string to work with embedded NULs

### DIFF
--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -681,8 +681,8 @@ static int string_length(parser_t &parser, io_streams_t &streams, int argc, wcha
 
     int nnonempty = 0;
     arg_iterator_t aiter(argv, optind, streams);
-    while (const wchar_t *arg = aiter.next()) {
-        size_t n = wcslen(arg);
+    while (auto arg = aiter.nextstr()) {
+        size_t n = arg->length();
         if (n > 0) {
             nnonempty++;
         }

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1256,20 +1256,19 @@ static int string_sub(parser_t &parser, io_streams_t &streams, int argc, wchar_t
 
     int nsub = 0;
     arg_iterator_t aiter(argv, optind, streams);
-    while (const wchar_t *arg = aiter.next()) {
+    while (auto s = aiter.nextstr()) {
         typedef wcstring::size_type size_type;
         size_type pos = 0;
         size_type count = wcstring::npos;
-        wcstring s(arg);
         if (opts.start > 0) {
             pos = static_cast<size_type>(opts.start - 1);
         } else if (opts.start < 0) {
             assert(opts.start != LONG_MIN);  // checked above
             size_type n = static_cast<size_type>(-opts.start);
-            pos = n > s.length() ? 0 : s.length() - n;
+            pos = n > s->length() ? 0 : s->length() - n;
         }
-        if (pos > s.length()) {
-            pos = s.length();
+        if (pos > s->length()) {
+            pos = s->length();
         }
 
         if (opts.length >= 0) {
@@ -1278,7 +1277,7 @@ static int string_sub(parser_t &parser, io_streams_t &streams, int argc, wchar_t
 
         // Note that std::string permits count to extend past end of string.
         if (!opts.quiet) {
-            streams.out.append(s.substr(pos, count));
+            streams.out.append(s->substr(pos, count));
             streams.out.append(L'\n');
         }
         nsub++;

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -517,8 +517,8 @@ static int string_escape_url(options_t &opts, int optind, wchar_t **argv, io_str
     escape_flags_t flags = 0;
 
     arg_iterator_t aiter(argv, optind, streams);
-    while (const wchar_t *arg = aiter.next()) {
-        streams.out.append(escape_string(arg, flags, STRING_STYLE_URL));
+    while (auto arg = aiter.nextstr()) {
+        streams.out.append(escape_string(*arg, flags, STRING_STYLE_URL));
         streams.out.append(L'\n');
         nesc++;
     }
@@ -533,8 +533,8 @@ static int string_escape_var(options_t &opts, int optind, wchar_t **argv, io_str
     escape_flags_t flags = 0;
 
     arg_iterator_t aiter(argv, optind, streams);
-    while (const wchar_t *arg = aiter.next()) {
-        streams.out.append(escape_string(arg, flags, STRING_STYLE_VAR));
+    while (auto arg = aiter.nextstr()) {
+        streams.out.append(escape_string(*arg, flags, STRING_STYLE_VAR));
         streams.out.append(L'\n');
         nesc++;
     }

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -656,12 +656,12 @@ static int string_join(parser_t &parser, io_streams_t &streams, int argc, wchar_
     const wchar_t *sep = opts.arg1;
     int nargs = 0;
     arg_iterator_t aiter(argv, optind, streams);
-    while (const wchar_t *arg = aiter.next()) {
+    while (auto arg = aiter.nextstr()) {
         if (!opts.quiet) {
             if (nargs > 0) {
                 streams.out.append(sep);
             }
-            streams.out.append(arg);
+            streams.out.append(*arg);
         }
         nargs++;
     }

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1303,25 +1303,23 @@ static int string_trim(parser_t &parser, io_streams_t &streams, int argc, wchar_
 
     size_t ntrim = 0;
 
-    wcstring argstr;
     arg_iterator_t aiter(argv, optind, streams);
-    while (const wchar_t *arg = aiter.next()) {
-        argstr = arg;
+    while (auto arg = aiter.nextstr()) {
         // Begin and end are respectively the first character to keep on the left, and first
         // character to trim on the right. The length is thus end - start.
-        size_t begin = 0, end = argstr.size();
+        size_t begin = 0, end = arg->size();
         if (opts.right) {
-            size_t last_to_keep = argstr.find_last_not_of(opts.chars_to_trim);
+            size_t last_to_keep = arg->find_last_not_of(opts.chars_to_trim);
             end = (last_to_keep == wcstring::npos) ? 0 : last_to_keep + 1;
         }
         if (opts.left) {
-            size_t first_to_keep = argstr.find_first_not_of(opts.chars_to_trim);
+            size_t first_to_keep = arg->find_first_not_of(opts.chars_to_trim);
             begin = (first_to_keep == wcstring::npos ? end : first_to_keep);
         }
-        assert(begin <= end && end <= argstr.size());
-        ntrim += argstr.size() - (end - begin);
+        assert(begin <= end && end <= arg->size());
+        ntrim += arg->size() - (end - begin);
         if (!opts.quiet) {
-            streams.out.append(wcstring(argstr, begin, end - begin));
+            streams.out.append(wcstring(*arg, begin, end - begin));
             streams.out.append(L'\n');
         }
     }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -943,7 +943,7 @@ static void escape_string_script(const wchar_t *orig_in, size_t in_len, wcstring
         return;
     }
 
-    while (*in != 0) {
+    for (size_t i = 0; i < in_len; i++) {
         if ((*in >= ENCODE_DIRECT_BASE) && (*in < ENCODE_DIRECT_BASE + 256)) {
             int val = *in - ENCODE_DIRECT_BASE;
             int tmp;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -857,23 +857,21 @@ static bool unescape_string_url(const wchar_t *in, wcstring *out) {
 static void escape_string_var(const wcstring &in, wcstring &out) {
     bool prev_was_hex_encoded = false;
     for (auto c1 : in) {
-        // This silliness is so we get the correct result whether chars are signed or unsigned.
-        unsigned int c2 = (unsigned int)c1 & 0xFF;
-        if (!(c2 & 0x80) && isalnum(c2) && (!prev_was_hex_encoded || !is_hex_digit(c2))) {
+        if (c1 >= 0 && c1 <= 127 && isalnum(c1) && (!prev_was_hex_encoded || !is_hex_digit(c1))) {
             // ASCII alphanumerics don't need to be encoded.
             if (prev_was_hex_encoded) {
                 out.push_back(L'_');
                 prev_was_hex_encoded = false;
             }
-            out.push_back((wchar_t)c2);
-        } else if (c2 == '_') {
+            out.push_back(c1);
+        } else if (c1 == L'_') {
             // Underscores are encoded by doubling them.
             out.append(L"__");
             prev_was_hex_encoded = false;
         } else {
             // All other chars need to have their UTF-8 representation encoded in hex.
             wchar_t buf[4];
-            swprintf(buf, sizeof buf / sizeof buf[0], L"_%02X", c2);
+            swprintf(buf, sizeof buf / sizeof buf[0], L"_%02X", c1);
             out.append(buf);
             prev_was_hex_encoded = true;
         }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1109,7 +1109,7 @@ wcstring escape_string(const wcstring &in, escape_flags_t flags, escape_string_s
             break;
         }
         case STRING_STYLE_URL: {
-            DIE("STRING_STYLE_URL not implemented");
+            escape_string_url(in.c_str(), result);
             break;
         }
         case STRING_STYLE_VAR: {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -804,9 +804,8 @@ wcstring reformat_for_screen(const wcstring &msg) {
 }
 
 /// Escape a string in a fashion suitable for using as a URL. Store the result in out_str.
-static void escape_string_url(const wchar_t *orig_in, wcstring &out) {
-    const std::string &in = wcs2string(orig_in);
-    for (auto c1 : in) {
+static void escape_string_url(wcstring in, wcstring &out) {
+    for (auto& c1 : in) {
         // This silliness is so we get the correct result whether chars are signed or unsigned.
         unsigned int c2 = (unsigned int)c1 & 0xFF;
         if (!(c2 & 0x80) &&
@@ -855,9 +854,8 @@ static bool unescape_string_url(const wchar_t *in, wcstring *out) {
 }
 
 /// Escape a string in a fashion suitable for using as a fish var name. Store the result in out_str.
-static void escape_string_var(const wchar_t *orig_in, wcstring &out) {
+static void escape_string_var(const wcstring in, wcstring &out) {
     bool prev_was_hex_encoded = false;
-    const std::string &in = wcs2string(orig_in);
     for (auto c1 : in) {
         // This silliness is so we get the correct result whether chars are signed or unsigned.
         unsigned int c2 = (unsigned int)c1 & 0xFF;
@@ -1109,11 +1107,11 @@ wcstring escape_string(const wcstring &in, escape_flags_t flags, escape_string_s
             break;
         }
         case STRING_STYLE_URL: {
-            escape_string_url(in.c_str(), result);
+            escape_string_url(in, result);
             break;
         }
         case STRING_STYLE_VAR: {
-            escape_string_var(in.c_str(), result);
+            escape_string_var(in, result);
             break;
         }
     }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -804,7 +804,7 @@ wcstring reformat_for_screen(const wcstring &msg) {
 }
 
 /// Escape a string in a fashion suitable for using as a URL. Store the result in out_str.
-static void escape_string_url(wcstring in, wcstring &out) {
+static void escape_string_url(const wcstring &in, wcstring &out) {
     for (auto& c1 : in) {
         // This silliness is so we get the correct result whether chars are signed or unsigned.
         unsigned int c2 = (unsigned int)c1 & 0xFF;
@@ -854,7 +854,7 @@ static bool unescape_string_url(const wchar_t *in, wcstring *out) {
 }
 
 /// Escape a string in a fashion suitable for using as a fish var name. Store the result in out_str.
-static void escape_string_var(const wcstring in, wcstring &out) {
+static void escape_string_var(const wcstring &in, wcstring &out) {
     bool prev_was_hex_encoded = false;
     for (auto c1 : in) {
         // This silliness is so we get the correct result whether chars are signed or unsigned.

--- a/tests/string.err
+++ b/tests/string.err
@@ -291,3 +291,6 @@ string repeat -l fakearg
 
 ####################
 # string match -r "a*b([xy]+)" abc abxc bye aaabyz kaabxz abbxy abcx caabxyxz
+
+####################
+# Check NUL

--- a/tests/string.in
+++ b/tests/string.in
@@ -329,4 +329,15 @@ or echo strings not converted to uppercase
 string upper -q ABC DEF
 and echo uppercasing a uppercase string did not fail as expected
 
+logmsg 'Check NUL'
+# Note: We do `string escape` at the end to make a `\0` literal visible.
+printf 'a\0b' | string escape
+printf 'a\0c' | string match -e 'a' | string escape
+printf 'a\0d' | string split '' | string escape
+printf 'a\0b' | string match -r '.*b$' | string escape
+printf 'a\0b' | string replace b g | string escape
+printf 'a\0b' | string replace -r b g | string escape
+# TODO: These do not yet work!
+# printf 'a\0b' | string match '*b' | string escape
+
 exit 0

--- a/tests/string.out
+++ b/tests/string.out
@@ -422,3 +422,14 @@ bxy
 xy
 aabxyx
 xyx
+
+####################
+# Check NUL
+a\x00b
+a\x00c
+a
+\x00
+d
+a\x00b
+a\x00g
+a\x00g


### PR DESCRIPTION
## Description

As discussed in #4605, at the very least `string escape` should be able to handle embedded NUL bytes, to escape them.

This switches all string subcommands over to using wcstring, and thereby allows most of it to handle NULs.

The one exception I know of is glob-mode for `match`, which needs some changes in wildcard.

It also removes some duplicate code - e.g. `tolower` and `toupper` differed only in one line, and the various escaping styles each had their own function. This results in a net 90 lines removed :grinning:.

Fixes issue #4605 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
