### PR TITLE
Fix fish-shell issue #4993 - support pathname completion for open -a

### DIFF
--- a/share/completions/open.fish
+++ b/share/completions/open.fish
@@ -1,5 +1,5 @@
 if test (uname) = 'Darwin' # OS X
-	complete -c open -s a -d 'Open APP, or open FILE(s), if supplied, with APP' -x -a "(mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /Developer/Applications 'kMDItemKind==Application' | sed -E 's/.+\/(.+)\.app/\1/g')"
+	complete -c open -s a -d 'Open APP, or open FILE(s), if supplied, with APP' -r -a "(mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /Developer/Applications 'kMDItemKind==Application' | sed -E 's/.+\/(.+)\.app/\1/g')"
 	complete -c open -s b -d 'Bundle Identifier of APP to open, or to be used to open FILE' -x -a "(mdls (mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /Developer/Applications 'kMDItemKind==Application') -name kMDItemCFBundleIdentifier | sed -E 's/kMDItemCFBundleIdentifier = \"(.+)\"/\1/g')"
 	complete -c open -s e -d 'Open FILE(s) with /Applications/TextEdit'
 	complete -c open -s t -d 'Open FILE(s) with default text editor from LaunchServices'


### PR DESCRIPTION

## Description

When using `open -a` on macos, it's possible to enter a complete path name. Fish Shell should support the user there as well and offer path name completion with <tab> key.

Fixes issue #4993 

## TODOs:

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
