### PR TITLE
pacman: Recognize *.pkg.tar as valid package extension

### DIFF
--- a/share/completions/pacman.fish
+++ b/share/completions/pacman.fish
@@ -134,6 +134,4 @@ complete -c $progname -n "$files" -l machinereadable -d 'Show in machine readabl
 # Theoretically, pacman reads packages in all formats that libarchive supports
 # In practice, it's going to be tar.xz or tar.gz
 # Using "pkg.tar.*" here would change __fish_complete_suffix's descriptions to "unknown"
-complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar.xz)' -d 'Package file'
-complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar.gz)' -d 'Package file'
-complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar)' -d 'Package file'
+complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix .pkg.tar\{,.xz,.gz\})' -d 'Package file'

--- a/share/completions/pacman.fish
+++ b/share/completions/pacman.fish
@@ -136,3 +136,4 @@ complete -c $progname -n "$files" -l machinereadable -d 'Show in machine readabl
 # Using "pkg.tar.*" here would change __fish_complete_suffix's descriptions to "unknown"
 complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar.xz)' -d 'Package file'
 complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar.gz)' -d 'Package file'
+complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar)' -d 'Package file'


### PR DESCRIPTION
## Description

This adds the extension `.pkg.tar` as auto-completed extension for pacman packages.

~~Fixes issue #~~

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
