### PR TITLE
Issue #4926

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1911,7 +1911,10 @@ void reader_run_command(parser_t &parser, const wcstring &cmd) {
     job_reap(1);
 
     gettimeofday(&time_after, NULL);
-    set_env_cmd_duration(&time_after, &time_before);
+    
+    // update the execution duration iff a command is requested for execution
+    // issue - #4926
+    if (!ft.empty()) set_env_cmd_duration(&time_after, &time_before);
 
     term_steal();
 


### PR DESCRIPTION
Suppress update of CMD_DURATION environment variable if no command is requested for execution

## Description

Environment variable CMD_DURATION will not be updated unless the user wishes to execute a non-empty command inside the fish shell.

Fixes issue #4926 

## TODOs:
<!-- Just check off what-what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
