### PR TITLE
add xclip support for clipboard copy and paste functions

### DIFF
--- a/share/functions/fish_clipboard_copy.fish
+++ b/share/functions/fish_clipboard_copy.fish
@@ -5,5 +5,7 @@ function fish_clipboard_copy
         # Silence error so no error message shows up
         # if e.g. X isn't running.
         commandline | xsel --clipboard 2>/dev/null
+    else if type -q xclip
+        commandline | xclip -selection clipboard 2>/dev/null
     end
 end

--- a/share/functions/fish_clipboard_paste.fish
+++ b/share/functions/fish_clipboard_paste.fish
@@ -9,6 +9,10 @@ function fish_clipboard_paste
         if not set data (xsel --clipboard 2>/dev/null)
             return 1
         end
+    else if type -q xclip
+        if not set data (xclip -selection clipboard -o 2>/dev/null)
+            return 1
+        end
     end
     # Also split on \r to turn it into a newline,
     # otherwise the output looks really confusing.


### PR DESCRIPTION
## Description
New feature.
Basic, add xclip support for clipboard copy and paste functions

Fixes issue #5017 

## TODOs:
May need to indicate an optional dependency to xclip and provide information in the wiki. Let me know if I can help. Nothing else has been done so far.
