### PR TITLE
completions: [go] Lookup pkgs from GOPATH

### DIFF
--- a/share/completions/go.fish
+++ b/share/completions/go.fish
@@ -1,34 +1,37 @@
 # go is a tool for managing Go source code.
 # See: https://golang.org
 
-function __fish__go_buildflags_completions -d 'Complete go build commands' --argument-names cmd
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -s a -d 'force rebuild'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -s n -d 'print the commands but do not run them'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -s p -r -d 'number parallel builds (default=#cpus)'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -o race -d 'enable data race detection'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -s v -d 'print packages being built'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -o work -d 'print and preserve work directory'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -s x -d 'print the commands'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -o ccflags -r -d 'c compiler flags'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -o compiler -x -d 'name of compiler to use, as in runtime' -a 'gccgo gc'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -o gccgoflags -r -d 'gccgo compiler/linker flags'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -o gcflags -r -d 'go compiler flags'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -o installsuffix -r -d 'suffix for installation directory'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -o ldflags -r -d 'linker flags'
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -o tags -r -d 'build tags'
-end
+# Completions for go build commands
+set -l __go_cmds_w_buildflags build get install run test
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -s a -d 'force rebuild'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -s n -d 'print the commands but do not run them'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -s p -r -d 'number parallel builds (default=#cpus)'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o race -d 'enable data race detection'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -s v -d 'print packages being built'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o work -d 'print and preserve work directory'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -s x -d 'print the commands'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o ccflags -r -d 'c compiler flags'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o compiler -x -d 'name of compiler to use, as in runtime' -a 'gccgo gc'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o gccgoflags -r -d 'gccgo compiler/linker flags'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o gcflags -r -d 'go compiler flags'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o installsuffix -r -d 'suffix for installation directory'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o ldflags -r -d 'linker flags'
+complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o tags -r -d 'build tags'
 
-function __fish_complete_go_files -d 'Complete go' --argument-names cmd
-        complete -c go -n "__fish_seen_subcommand_from $cmd" -x -a "(
-                __fish_complete_suffix .go
-        )
-        "
-end
+
+# Completions for go cmds that takes file arguments
+complete -c go -n "__fish_seen_subcommand_from build compile fix fmt install run test vet" -x -a "(
+            __fish_complete_suffix .go
+    )" --description 'File'
+
+# Completions for go cmds that takes pkg arguments
+complete -c go -n "__fish_seen_subcommand_from build doc fix fmt install test vet" -x -a "(
+            go list -e -f '{{.ImportPath}}	{{or .Doc \"Go package\"}}' (commandline -ct)... ^/dev/null
+    )" --description 'Package'
+
 
 # build
 complete -c go -n '__fish_use_subcommand' -a build -d 'compile packages and dependencies'
-__fish__go_buildflags_completions build
-__fish_complete_go_files build
 
 # clean
 complete -c go -n '__fish_use_subcommand' -a clean -d 'remove object files'
@@ -58,7 +61,6 @@ complete -c go -n '__fish_use_subcommand' -a get -d 'download and install packag
 complete -c go -n '__fish_seen_subcommand_from get' -s d -d "stop after downloading the packages; don't install"
 complete -c go -n '__fish_seen_subcommand_from get' -o fix -d "run fix tool on packages before resolving dependencies or building"
 complete -c go -n '__fish_seen_subcommand_from get' -s u -d "update remote packages"
-__fish__go_buildflags_completions get
 
 # help
 complete -c go -n '__fish_use_subcommand' -a help -d 'get help on topic'
@@ -66,7 +68,6 @@ complete -c go -n '__fish_seen_subcommand_from help' -xa 'build clean doc env fi
 
 # install
 complete -c go -n '__fish_use_subcommand' -a install -d 'compile and install packages and dependencies'
-__fish__go_buildflags_completions install
 
 # list
 complete -c go -n '__fish_use_subcommand' -a list -d 'list packages'
@@ -77,21 +78,16 @@ complete -c go -n '__fish_seen_subcommand_from list' -o tags -r -d 'list of buil
 
 # run
 complete -c go -n '__fish_use_subcommand' -a run -d 'compile and run Go program'
-__fish__go_buildflags_completions run
-__fish_complete_go_files run
 
 # test
 complete -c go -n '__fish_use_subcommand' -a test -d 'test packages'
 complete -c go -n '__fish_seen_subcommand_from test' -s c -r -d "compile the test binary to pkg.test but do not run it"
 complete -c go -n '__fish_seen_subcommand_from test' -s i -d "install dependent packages, but don't run tests"
-__fish__go_buildflags_completions test
-__fish_complete_go_files test
 
 # tool
 complete -c go -n '__fish_use_subcommand' -a tool -d 'run specified go tool'
 complete -c go -n '__fish_seen_subcommand_from tool' -a 'addr2line api asm cgo compile dist fix link nm objdump pack pprof prof vet yacc' -d "target tool"
 complete -c go -n '__fish_seen_subcommand_from tool' -s n -d "print the command that would be executed but not execute it"
-__fish_complete_go_files compile
 
 # version
 complete -c go -f -n '__fish_use_subcommand' -a version -d 'print Go version'


### PR DESCRIPTION
## Description
As defined in the `go help packages`:
>   Many commands apply to a set of packages:
>     go action [packages]
>   Usually, [packages] is a list of import paths.

This patch introduces automatic lookup of said packages from GOPATH
using `go list`, and provides them as options to go subcmds.

The `go package` completion returns both cmd and description.
E.g. `go doc f<tab>` gives
> flag (These examples demonstrate more intricate uses of the flag package.)
> fmt (Package fmt implements formatted I/O with functions analogous to C's printf and scanf.)

Also aligned with `fish_indent`

Amends previously closed pull request: #4978

## TODOs:
- [*] Changes to fish usage are reflected in user documentation/manpages.
- [*] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
