### PR TITLE
Print token ending with cursor

### DIFF
--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -143,7 +143,7 @@ static void write_part(const wchar_t *begin, const wchar_t *end, int cut_at_curs
         tokenizer_t tok(buff.c_str(), TOK_ACCEPT_UNFINISHED);
         tok_t token;
         while (tok.next(&token)) {
-            if ((cut_at_cursor) && (token.offset + token.length >= pos)) break;
+            if ((cut_at_cursor) && (token.offset + token.length > pos)) break;
 
             if (token.type == TOK_STRING) {
                 wcstring tmp = tok.text_of(token);


### PR DESCRIPTION
## Description

The `commandline` builtin with cut-to-cursor and tokenize options should print the token ending with the cursor position and not ignore it.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
