### PR TITLE
Update tutorial.hdr

### DIFF
--- a/doc_src/tutorial.hdr
+++ b/doc_src/tutorial.hdr
@@ -523,7 +523,7 @@ A `fish` function is a list of commands, which may optionally take arguments. Un
   end
 >_ say_hello
 <outp>Hello</outp>
->_ say_hello everybody!
+>_ say_hello Hello everybody!
 <outp>Hello everybody!</outp>
 \endfish
 


### PR DESCRIPTION
Missing argument to `say_hello`

## Description

One of the sample calls to `say_hello` is missing the `Hello` argument.

Fixes issue #

No issue in the issue tracker that I could find.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
