### PR TITLE
Don't mmap history files on remote file systems

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1015,6 +1015,7 @@ bool history_t::load_old_if_needed() {
     if (loaded_old) return true;
     loaded_old = true;
 
+    time_profiler_t profiler("load_old");  //!OCLINT(side-effect)
     bool ok = false;
     if (map_file(name, &mmap_start, &mmap_length, &mmap_file_id)) {
         // Here we've mapped the file.

--- a/src/history.h
+++ b/src/history.h
@@ -134,29 +134,29 @@ class history_t {
     history_item_list_t new_items;
 
     // The index of the first new item that we have not yet written.
-    size_t first_unwritten_new_item_index;
+    size_t first_unwritten_new_item_index{0};
 
     // Whether we have a pending item. If so, the most recently added item is ignored by
     // item_at_index.
-    bool has_pending_item;
+    bool has_pending_item{false};
 
     // Whether we should disable saving to the file for a time.
-    uint32_t disable_automatic_save_counter;
+    uint32_t disable_automatic_save_counter{0};
 
     // Deleted item contents.
     std::unordered_set<wcstring> deleted_items;
 
     // The mmaped region for the history file.
-    const char *mmap_start;
+    const char *mmap_start{nullptr};
 
     // The size of the mmap'd region.
-    size_t mmap_length;
+    size_t mmap_length{0};
 
     // The type of file we mmap'd.
-    history_file_type_t mmap_type;
+    history_file_type_t mmap_type{history_file_type_t(-1)};
 
     // The file ID of the file we mmap'd.
-    file_id_t mmap_file_id;
+    file_id_t mmap_file_id{kInvalidFileID};
 
     // The boundary timestamp distinguishes old items from new items. Items whose timestamps are <=
     // the boundary are considered "old". Items whose timestemps are > the boundary are new, and are
@@ -165,22 +165,26 @@ class history_t {
     time_t boundary_timestamp;
 
     // How many items we add until the next vacuum. Initially a random value.
-    int countdown_to_vacuum;
+    int countdown_to_vacuum{-1};
 
-    // Figure out the offsets of our mmap data.
-    void populate_from_mmap(void);
+    // Whether we've loaded old items.
+    bool loaded_old{false};
 
     // List of old items, as offsets into out mmap data.
     std::deque<size_t> old_item_offsets;
 
-    // Whether we've loaded old items.
-    bool loaded_old;
+    // Whether we're in maximum chaos mode, useful for testing.
+    // This causes things like locks to fail.
+    bool chaos_mode{false};
 
-    // Loads old if necessary.
-    bool load_old_if_needed(void);
+    // Figure out the offsets of our mmap data.
+    void populate_from_mmap();
 
-    // Memory maps the history file if necessary.
-    bool mmap_if_needed(void);
+    // Loads old items if necessary.
+    bool load_old_if_needed();
+
+    // Reads the history file if necessary.
+    bool mmap_if_needed();
 
     // Deletes duplicates in new_items.
     void compact_new_items();
@@ -209,9 +213,6 @@ class history_t {
     // Like map_file but takes a file descriptor
     bool map_fd(int fd, const char **out_map_start, size_t *out_map_len) const;
 
-    // Whether we're in maximum chaos mode, useful for testing.
-    bool chaos_mode;
-
     // Implementation of item_at_index and items_at_indexes
     history_item_t item_at_index_assume_locked(size_t idx);
 
@@ -223,7 +224,7 @@ class history_t {
 
     // Determines whether the history is empty. Unfortunately this cannot be const, since it may
     // require populating the history.
-    bool is_empty(void);
+    bool is_empty();
 
     // Add a new history item to the end. If pending is set, the item will not be returned by
     // item_at_index until a call to resolve_pending(). Pending items are tracked with an offset
@@ -320,25 +321,25 @@ class history_search_t {
     void skip_matches(const wcstring_list_t &skips);
 
     // Finds the next search term (forwards in time). Returns true if one was found.
-    bool go_forwards(void);
+    bool go_forwards();
 
     // Finds the previous search result (backwards in time). Returns true if one was found.
-    bool go_backwards(void);
+    bool go_backwards();
 
     // Goes to the end (forwards).
-    void go_to_end(void);
+    void go_to_end();
 
     // Returns if we are at the end. We start out at the end.
-    bool is_at_end(void) const;
+    bool is_at_end() const;
 
     // Goes to the beginning (backwards).
-    void go_to_beginning(void);
+    void go_to_beginning();
 
     // Returns the current search result item. asserts if there is no current item.
-    history_item_t current_item(void) const;
+    history_item_t current_item() const;
 
     // Returns the current search result item contents. asserts if there is no current item.
-    wcstring current_string(void) const;
+    wcstring current_string() const;
 
     // Constructor.
     history_search_t(history_t &hist, const wcstring &str,

--- a/src/history.h
+++ b/src/history.h
@@ -169,10 +169,6 @@ class history_t {
     // List of old items, as offsets into out mmap data.
     std::deque<size_t> old_item_offsets;
 
-    // Whether we're in maximum chaos mode, useful for testing.
-    // This causes things like locks to fail.
-    bool chaos_mode{false};
-
     // Figure out the offsets of our file contents.
     void populate_from_file_contents();
 
@@ -207,6 +203,13 @@ class history_t {
    public:
     explicit history_t(wcstring name);
     ~history_t();
+
+    // Whether we're in maximum chaos mode, useful for testing.
+    // This causes things like locks to fail.
+    static bool chaos_mode;
+
+    // Whether to force the read path instead of mmap. This is useful for testing.
+    static bool never_mmap;
 
     // Returns history with the given name, creating it if necessary.
     static history_t &history_with_name(const wcstring &name);

--- a/src/reader.h
+++ b/src/reader.h
@@ -101,7 +101,7 @@ void reader_run_command(const wcstring &buff);
 const wchar_t *reader_get_buffer();
 
 /// Returns the current reader's history.
-history_t *reader_get_history(void);
+history_t *reader_get_history();
 
 /// Set the string of characters in the command buffer, as well as the cursor position.
 ///

--- a/src/wildcard.cpp
+++ b/src/wildcard.cpp
@@ -689,7 +689,7 @@ void wildcard_expander_t::expand_intermediate_segment(const wcstring &base_dir, 
             continue;
         }
 
-        const file_id_t file_id = file_id_t::file_id_from_stat(&buf);
+        const file_id_t file_id = file_id_t::from_stat(buf);
         if (!this->visited_files.insert(file_id).second) {
             // Symlink loop! This directory was already visited, so skip it.
             continue;

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -620,25 +620,23 @@ unsigned long long fish_wcstoull(const wchar_t *str, const wchar_t **endptr, int
     return result;
 }
 
-file_id_t file_id_t::file_id_from_stat(const struct stat *buf) {
-    assert(buf != NULL);
-
+file_id_t file_id_t::from_stat(const struct stat &buf) {
     file_id_t result = {};
-    result.device = buf->st_dev;
-    result.inode = buf->st_ino;
-    result.size = buf->st_size;
-    result.change_seconds = buf->st_ctime;
-    result.mod_seconds = buf->st_mtime;
+    result.device = buf.st_dev;
+    result.inode = buf.st_ino;
+    result.size = buf.st_size;
+    result.change_seconds = buf.st_ctime;
+    result.mod_seconds = buf.st_mtime;
 
 #ifdef HAVE_STRUCT_STAT_ST_CTIME_NSEC
-    result.change_nanoseconds = buf->st_ctime_nsec;
-    result.mod_nanoseconds = buf->st_mtime_nsec;
+    result.change_nanoseconds = buf.st_ctime_nsec;
+    result.mod_nanoseconds = buf.st_mtime_nsec;
 #elif defined(__APPLE__)
-    result.change_nanoseconds = buf->st_ctimespec.tv_nsec;
-    result.mod_nanoseconds = buf->st_mtimespec.tv_nsec;
+    result.change_nanoseconds = buf.st_ctimespec.tv_nsec;
+    result.mod_nanoseconds = buf.st_mtimespec.tv_nsec;
 #elif defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || defined(_XOPEN_SOURCE)
-    result.change_nanoseconds = buf->st_ctim.tv_nsec;
-    result.mod_nanoseconds = buf->st_mtim.tv_nsec;
+    result.change_nanoseconds = buf.st_ctim.tv_nsec;
+    result.mod_nanoseconds = buf.st_mtim.tv_nsec;
 #else
     result.change_nanoseconds = 0;
     result.mod_nanoseconds = 0;
@@ -651,7 +649,7 @@ file_id_t file_id_for_fd(int fd) {
     file_id_t result = kInvalidFileID;
     struct stat buf = {};
     if (fd >= 0 && 0 == fstat(fd, &buf)) {
-        result = file_id_t::file_id_from_stat(&buf);
+        result = file_id_t::from_stat(buf);
     }
     return result;
 }
@@ -660,7 +658,7 @@ file_id_t file_id_for_path(const wcstring &path) {
     file_id_t result = kInvalidFileID;
     struct stat buf = {};
     if (0 == wstat(path, &buf)) {
-        result = file_id_t::file_id_from_stat(&buf);
+        result = file_id_t::from_stat(buf);
     }
     return result;
 }

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -28,6 +28,10 @@ int make_fd_nonblocking(int fd);
 /// Mark an fd as blocking; returns errno or 0 on success.
 int make_fd_blocking(int fd);
 
+/// Check if an fd is on a remote filesystem (NFS, SMB, CFS)
+/// Return 1 if remote, 0 if local, -1 on error or if not implemented on this platform.
+int fd_check_is_remote(int fd);
+
 /// Wide character version of opendir(). Note that opendir() is guaranteed to set close-on-exec by
 /// POSIX (hooray).
 DIR *wopendir(const wcstring &name);

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -137,7 +137,7 @@ struct file_id_t {
     // Used to permit these as keys in std::map.
     bool operator<(const file_id_t &rhs) const;
 
-    static file_id_t file_id_from_stat(const struct stat *buf);
+    static file_id_t from_stat(const struct stat &buf);
 
    private:
     int compare_file_id(const file_id_t &rhs) const;


### PR DESCRIPTION
This merges some changes to history that may help to mitigate the crashes seen in #5088 . These SIGBUS crashes occur when reading a memory mapping whose underlying file was truncated. It's not clear why this should occur more often on NFS (or ever). However memory mapping over NFS is sketchy anyways so this is desirable regardless.