### PR TITLE
vi key bindings: fix `"*y`

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -261,7 +261,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind $argv visual -m default x kill-selection end-selection force-repaint
     bind $argv visual -m default X kill-whole-line end-selection force-repaint
     bind $argv visual -m default y kill-selection yank end-selection force-repaint
-    bind $argv visual -m default '"*y' "commandline -s | xsel -p" end-selection force-repaint
+    bind $argv visual -m default '"*y' "commandline -s | xsel -p; commandline -f end-selection force-repaint"
 
     bind $argv visual -m default \cc end-selection force-repaint
     bind $argv visual -m default \e end-selection force-repaint


### PR DESCRIPTION
## Description

I've had some issues with the `"*y"` key binding, apparently something goes wrong here when trying to paste something into my clipboard, it simply didn't do anything and the visual selection started to get confused (selection didn't really end but persisted throughout later commands). I've come up with this as a fix. Not quite sure if this exposes a deeper issue that is going on here, but for now this makes it work for me.