### PR TITLE
fix highlighting option for redirections

### DIFF
--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -1077,6 +1077,9 @@ const highlighter_t::color_array_t &highlighter_t::highlight() {
                 break;
 
             case parse_token_type_pipe:
+                this->color_node(node, highlight_spec_redirection);
+                break;
+
             case parse_token_type_background:
             case parse_token_type_end:
             case symbol_optional_background: {


### PR DESCRIPTION
## Description

Currently the highlighter treats redirections in a way
that highlights them like separators. This patch sets the
`$fish_color_redirection` as the used color for redirections.