### PR TITLE
Fix Informative VCS sample prompt invalid state

### DIFF
--- a/share/tools/web_config/sample_prompts/informative_vcs.fish
+++ b/share/tools/web_config/sample_prompts/informative_vcs.fish
@@ -38,8 +38,8 @@ function fish_prompt --description 'Write out the prompt'
     if not set -q __fish_git_prompt_char_untrackedfiles
         set -g __fish_git_prompt_char_untrackedfiles "…"
     end
-    if not set -q __fish_git_prompt_char_conflictedstate
-        set -g __fish_git_prompt_char_conflictedstate "✖"
+    if not set -q __fish_git_prompt_char_invalidstate
+        set -g __fish_git_prompt_char_invalidstate "✖"
     end
     if not set -q __fish_git_prompt_char_cleanstate
         set -g __fish_git_prompt_char_cleanstate "✔"


### PR DESCRIPTION
## Description

The Informative VCS sample prompt currently sets the `__fish_git_prompt_char_conflictedstate` variable which is unused.
It should instead set the `__fish_git_prompt_char_invalidstate` variable.