### PR TITLE
Acquire tty if interactive when running builtins

### DIFF
--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -881,6 +881,17 @@ bool terminal_give_to_job(const job_t *j, bool cont) {
     return true;
 }
 
+pid_t terminal_acquire_before_builtin() {
+    pid_t selfpid = getpid();
+    pid_t current_owner = tcgetpgrp(STDIN_FILENO);
+    if (current_owner >= 0 && current_owner != selfpid) {
+        if (tcsetpgrp(STDIN_FILENO, selfpid) == 0) {
+            return current_owner;
+        }
+    }
+    return -1;
+}
+
 /// Returns control of the terminal to the shell, and saves the terminal attribute state to the job,
 /// so that we can restore the terminal ownership to the job at a later time.
 static bool terminal_return_from_job(job_t *j) {

--- a/src/proc.h
+++ b/src/proc.h
@@ -373,3 +373,7 @@ pid_t proc_wait_any();
 #endif
 
 bool terminal_give_to_job(const job_t *j, bool cont);
+
+/// Given that we are about to run a builtin, acquire the terminal if we do not own it. Returns the
+/// pid to restore after running the builtin, or -1 if there is no pid to restore.
+pid_t terminal_acquire_before_builtin();

--- a/tests/read.expect
+++ b/tests/read.expect
@@ -90,6 +90,14 @@ expect_prompt
 expect_marker 7
 print_var_contents foo
 
+# Verify we don't hang on `read | cat`. See #4540.
+send_line "read | cat"
+expect_read_prompt
+send_line -h "bar\r_marker 4540"
+expect_prompt
+expect_marker 4540
+
+
 # ==========
 # The fix for issue #2007 initially introduced a problem when using a function
 # to read from /dev/stdin when that is associated with the tty. These tests


### PR DESCRIPTION
When running a builtin, if we are an interactive shell and stdin is a tty,
then acquire ownership of the terminal via tcgetpgrp() before running the
builtin, and set it back after.

I don't know how principled this fix is because job control is quite confusing.
But it's certainly true that when running builtins interactively, we expect to own
the terminal, so I don't believe this can make anything worse.

Fixes #4540 