### PR TITLE
Added const to methods which 'ought to be const' based on Const Checker

### DIFF
--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -612,7 +612,7 @@ class string_matcher_t {
 
     virtual ~string_matcher_t() = default;
     virtual bool report_matches(const wcstring &arg) = 0;
-    int match_count() { return total_matched; }
+    int match_count() const { return total_matched; }
 };
 
 class wildcard_matcher_t : public string_matcher_t {
@@ -884,7 +884,7 @@ class string_replacer_t {
         : argv0(argv0_), opts(std::move(opts_)), total_replaced(0), streams(streams_) {}
 
     virtual ~string_replacer_t() = default;
-    int replace_count() { return total_replaced; }
+    int replace_count() const { return total_replaced; }
     virtual bool replace_matches(const wcstring &arg) = 0;
 };
 

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -1171,7 +1171,7 @@ class universal_notifier_notifyd_t : public universal_notifier_t {
         }
     }
 
-    int notification_fd() { return notify_fd; }
+    int notification_fd() const { return notify_fd; }
 
     bool notification_fd_became_readable(int fd) {
         // notifyd notifications come in as 32 bit values. We don't care about the value. We set
@@ -1253,7 +1253,7 @@ class universal_notifier_named_pipe_t : public universal_notifier_t {
         }
     }
 
-    int notification_fd() override {
+    int notification_fd() const override {
         if (polling_due_to_readable_fd) {
             // We are in polling mode because we think our fd is readable. This means that, if we
             // return it to be select()'d on, we'll be called back immediately. So don't return it.
@@ -1411,7 +1411,7 @@ universal_notifier_t::universal_notifier_t() = default;
 
 universal_notifier_t::~universal_notifier_t() = default;
 
-int universal_notifier_t::notification_fd() { return -1; }
+int universal_notifier_t::notification_fd() const { return -1; }
 
 void universal_notifier_t::post_notification() {}
 

--- a/src/env_universal_common.h
+++ b/src/env_universal_common.h
@@ -154,7 +154,7 @@ class universal_notifier_t {
     virtual unsigned long usec_delay_between_polls() const;
 
     // Returns the fd from which to watch for events, or -1 if none.
-    virtual int notification_fd();
+    virtual int notification_fd() const;
 
     // The notification_fd is readable; drain it. Returns true if a notification is considered to
     // have been posted.

--- a/src/lru.h
+++ b/src/lru.h
@@ -283,8 +283,8 @@ class lru_cache_t {
 
         explicit iterator(const lru_link_t *val) : node(val) {}
         void operator++() { node = node->prev; }
-        bool operator==(const iterator &other) { return node == other.node; }
-        bool operator!=(const iterator &other) { return !(*this == other); }
+        bool operator==(const iterator &other) const { return node == other.node; }
+        bool operator!=(const iterator &other) const { return !(*this == other); }
         value_type operator*() const {
             const lru_node_t *dnode = static_cast<const lru_node_t *>(node);
             return {*dnode->key, dnode->value};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -601,7 +601,7 @@ job_t *parser_t::job_get(job_id_t id) {
     return NULL;
 }
 
-job_t *parser_t::job_get_from_pid(pid_t pid) {
+job_t *parser_t::job_get_from_pid(pid_t pid) const {
     job_iterator_t jobs;
     job_t *job;
 
@@ -708,7 +708,7 @@ template int parser_t::eval_node(parsed_source_ref_t, tnode_t<grammar::job_list>
                                  const io_chain_t &, enum block_type_t);
 
 bool parser_t::detect_errors_in_argument_list(const wcstring &arg_list_src, wcstring *out,
-                                              const wchar_t *prefix) {
+                                              const wchar_t *prefix) const {
     bool errored = false;
     parse_error_list_t errors;
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -303,7 +303,7 @@ class parser_t {
     job_t *job_get(job_id_t job_id);
 
     /// Returns the job with the given pid.
-    job_t *job_get_from_pid(pid_t pid);
+    job_t *job_get_from_pid(pid_t pid) const;
 
     /// Returns a new profile item if profiling is active. The caller should fill it in. The
     /// parser_t will clean it up.
@@ -315,7 +315,7 @@ class parser_t {
     /// Detect errors in the specified string when parsed as an argument list. Returns true if an
     /// error occurred.
     bool detect_errors_in_argument_list(const wcstring &arg_list_src, wcstring *out_err,
-                                        const wchar_t *prefix);
+                                        const wchar_t *prefix) const;
 
     /// Tell the parser that the specified function may not be run if not inside of a conditional
     /// block. This is to remove some possibilities of infinite recursion.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -250,7 +250,7 @@ class reader_data_t {
     void pager_selection_changed();
 
     /// Expand abbreviations at the current cursor position, minus backtrack_amt.
-    bool expand_abbreviation_as_necessary(size_t cursor_backtrack);
+    bool expand_abbreviation_as_necessary(size_t cursor_backtrack) const;
 
     /// Constructor
     reader_data_t()
@@ -622,7 +622,7 @@ bool reader_expand_abbreviation_in_command(const wcstring &cmdline, size_t curso
 /// Expand abbreviations at the current cursor position, minus the given  cursor backtrack. This may
 /// change the command line but does NOT repaint it. This is to allow the caller to coalesce
 /// repaints.
-bool reader_data_t::expand_abbreviation_as_necessary(size_t cursor_backtrack) {
+bool reader_data_t::expand_abbreviation_as_necessary(size_t cursor_backtrack) const {
     bool result = false;
     editable_line_t *el = data->active_edit_line();
     if (this->expand_abbreviations && el == &data->command_line) {


### PR DESCRIPTION
I double checked that everything compiled without issue. These methods were found to by our Const Checker research tool. Let me know if these methods should not be const. Thanks!