### PR TITLE
Add till/repeat/reverse jump bindings

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -207,8 +207,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
 
     bind f forward-jump
     bind F backward-jump
-    bind t forward-jump and backward-char
-    bind T backward-jump and forward-char
+    bind t forward-jump-till
+    bind T backward-jump-till
+    bind ';' repeat-jump
+    bind , repeat-jump-reverse
 
     # in emacs yank means paste
     bind p yank
@@ -245,9 +247,9 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind $argv visual o swap-selection-start-stop force-repaint
 
     bind $argv visual f forward-jump
-    bind $argv visual t forward-jump backward-char
+    bind $argv visual t forward-jump-till
     bind $argv visual F backward-jump
-    bind $argv visual T backward-jump forward-char
+    bind $argv visual T backward-jump-till
 
     for key in $eol_keys
         bind $argv visual $key end-of-line

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -120,6 +120,10 @@ static const input_function_metadata_t input_function_metadata[] = {
     {R_KILL_SELECTION, L"kill-selection"},
     {R_FORWARD_JUMP, L"forward-jump"},
     {R_BACKWARD_JUMP, L"backward-jump"},
+    {R_FORWARD_JUMP_TILL, L"forward-jump-till"},
+    {R_BACKWARD_JUMP_TILL, L"backward-jump-till"},
+    {R_REPEAT_JUMP, L"repeat-jump"},
+    {R_REVERSE_REPEAT_JUMP, L"repeat-jump-reverse"},
     {R_AND, L"and"},
     {R_CANCEL, L"cancel"}};
 
@@ -176,7 +180,15 @@ void input_set_bind_mode(const wcstring &bm) {
 
 /// Returns the arity of a given input function.
 static int input_function_arity(int function) {
-    return (function == R_FORWARD_JUMP || function == R_BACKWARD_JUMP) ? 1 : 0;
+    switch (function) {
+        case R_FORWARD_JUMP:
+        case R_BACKWARD_JUMP:
+        case R_FORWARD_JUMP_TILL:
+        case R_BACKWARD_JUMP_TILL:
+            return 1;
+        default:
+            return 0;
+    }
 }
 
 /// Sets the return status of the most recently executed input function.

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -67,15 +67,19 @@ enum {
     R_KILL_SELECTION,
     R_FORWARD_JUMP,
     R_BACKWARD_JUMP,
+    R_FORWARD_JUMP_TILL,
+    R_BACKWARD_JUMP_TILL,
     R_AND,
     R_CANCEL,
+    R_REPEAT_JUMP,
+    R_REVERSE_REPEAT_JUMP,
 
     R_TIMEOUT,  // we didn't get interactive input within wait_on_escape_ms
 
     // The range of key codes for inputrc-style keyboard functions that are passed on to the caller
     // of input_read().
     R_BEGIN_INPUT_FUNCTIONS = R_BEGINNING_OF_LINE,
-    R_END_INPUT_FUNCTIONS = R_CANCEL + 1
+    R_END_INPUT_FUNCTIONS = R_REVERSE_REPEAT_JUMP + 1
 };
 
 /// Init the library.

--- a/tests/bind.expect
+++ b/tests/bind.expect
@@ -112,6 +112,54 @@ expect_prompt -re {\r\nMORE\r\n} {
     puts stderr "vi mode delete char, default timeout: long delay"
 }
 
+# Test jumping forward til before a character with t
+send "echo MORE-TEXT-IS-NICE"
+send "\033"
+# Delay needed to allow fish to transition to vi "normal" mode.
+sleep 0.250
+send "0tTD\r"
+expect_prompt -re {\r\nMORE\r\n} {
+    puts "vi mode forward-jump-till character, default timeout: long delay"
+} unmatched {
+    puts stderr "vi mode forward-jump-till character, default timeout: long delay"
+}
+
+# Test jumping backward til before a character with T
+send "echo MORE-TEXT-IS-NICE"
+send "\033"
+# Delay needed to allow fish to transition to vi "normal" mode.
+sleep 0.250
+send "TSD\r"
+expect_prompt -re {\r\nMORE-TEXT-IS\r\n} {
+    puts "vi mode backward-jump-till character, default timeout: long delay"
+} unmatched {
+    puts stderr "vi mode backward-jump-till character, default timeout: long delay"
+}
+
+# Test jumping backward with F and repeating
+send "echo MORE-TEXT-IS-NICE"
+send "\033"
+# Delay needed to allow fish to transition to vi "normal" mode.
+sleep 0.250
+send "F-;D\r"
+expect_prompt -re {\r\nMORE-TEXT\r\n} {
+    puts "vi mode backward-jump-to character and repeat, default timeout: long delay"
+} unmatched {
+    puts stderr "vi mode backward-jump-to character and repeat, default timeout: long delay"
+}
+
+# Test jumping backward with F w/reverse jump
+send "echo MORE-TEXT-IS-NICE"
+send "\033"
+# Delay needed to allow fish to transition to vi "normal" mode.
+sleep 0.250
+send "F-F-,D\r"
+expect_prompt -re {\r\nMORE-TEXT-IS\r\n} {
+    puts "vi mode backward-jump-to character, and reverse, default timeout: long delay"
+} unmatched {
+    puts stderr "vi mode backward-jump-to character, and reverse, default timeout: long delay"
+}
+
 # Verify that changing the escape timeout has an effect.
 send "set -g fish_escape_delay_ms 200\r"
 expect_prompt

--- a/tests/bind.expect.out
+++ b/tests/bind.expect.out
@@ -7,6 +7,10 @@ vi-mode default timeout set correctly
 vi replace line, default timeout: long delay
 vi mode replace char, default timeout: long delay
 vi mode delete char, default timeout: long delay
+vi mode forward-jump-till character, default timeout: long delay
+vi mode backward-jump-till character, default timeout: long delay
+vi mode backward-jump-to character and repeat, default timeout: long delay
+vi mode backward-jump-to character, and reverse, default timeout: long delay
 vi replace line, 100ms timeout: long delay
 vi replace line, 100ms timeout: short delay
 t-binding success


### PR DESCRIPTION
## Description

Gave fish a try and it's amazing, but the vi bindings are only **almost** perfect.  

I'm hardwired to use `;` and `,` to repeat previous jumps in vi and bash's vi-mode, but these seem to be missing in fish.  The way T and t bindings are implemented in the fish script, it's kinda difficult to persist enough to cleanly implement repeats/reversals of all varieties of jump, so I moved all jump motions directly into fish.

These changes:

- Add builtin support for:
  - Jumping to the character before the target
  - Repeating the previous jump (same direction, same 'till-ness).
  - Repeating the previous jump in the reverse direction.
- Enhance vi bindings with the built in jumps and repeat/reversal jumps.

## TODOs:

- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
- [x] Lint/format.
