### PR TITLE
cdh: Only replace home directory with ~ at the start of paths

### DIFF
--- a/share/functions/cdh.fish
+++ b/share/functions/cdh.fish
@@ -54,7 +54,7 @@ function cdh --description "Menu based cd command"
             set dir_color (set_color $fish_color_history_current)
         end
 
-        set -l home_dir (string match -r "$HOME(/.*|\$)" "$dir")
+        set -l home_dir (string match -r "^$HOME(/.*|\$)" "$dir")
         if set -q home_dir[2]
             set dir "~$home_dir[2]"
         end


### PR DESCRIPTION
Fixes the display of paths that don't start with the home directory, but contain the value of `$HOME` as a substring. For example, without this fix:

  * `/tmp/home/<my username>` is just shown as `~` in the menu
  * `/tmp/home/<my username>/other-dir` is displayed as `~/other-dir`

This is only a visual issue: switching to affected directories, as well as other features such as highlighting the CWD and removing duplicates, are unaffected because they are based on raw paths.

