### PR TITLE
[Ready] Update Mercurial completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ fish 3.0 is a major release which brings with it both improvements in functional
   - `ttx`
   - `unzip`
   - `xsv`
--  Lots of improvements to completions (especially `git`).
+-  Lots of improvements to completions (especially `git` and `hg`).
 -  Improved French translations.
 
 --

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -311,7 +311,7 @@ function __fish_hg_branches
 end
 
 function __fish_hg_merge_tools
-    for tool in internal:dump internal:fail internal:local internal:merge internal:merge-local internal:merge-other internal:merge3 internal:other internal:prompt internal:union
+    for tool in internal:dump internal:fail internal:forcedump internal:local internal:merge internal:merge-local internal:merge-other internal:merge3 internal:other internal:prompt internal:tagmerge internal:union
         printf "$tool\tmerge tool\n"
     end
     for line in (__fish_hg config merge-tools)

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -381,7 +381,7 @@ complete -c hg -l profile -d "print command execution profile"
 complete -c hg -l version -d "output version information and exit"
 complete -c hg -s h -l help -d "display help and exit"
 complete -c hg -l hidden -d "consider hidden changesets"
-complete -c hg -l color -x -a "true false always auto never" -d "when to colorize"
+complete -c hg -l color -x -a "true false always auto never debug" -d "when to colorize"
 complete -c hg -l pager -x -a "true false always auto never" -d "when to paginate"
 
 # subcommands

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -427,14 +427,14 @@ end
 
 # hg archive
 for cmd in ar arc arch archi archiv archive
-    complete -c hg -n "__fish_hg_using_command archive" -l no-decode -d "do not pass files through decoders"
-    complete -c hg -n "__fish_hg_using_command archive" -s p -l prefix -x -d "directory prefix for files in archive"
-    complete -c hg -n "__fish_hg_using_command archive" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision to distribute"
-    complete -c hg -n "__fish_hg_using_command archive" -s t -l type -x -d "type of distribution to create"
-    complete -c hg -n "__fish_hg_using_command archive" -s S -l subrepos -d "recurse into subrepositories"
-    complete -c hg -n "__fish_hg_using_command archive" -s I -l include -x -d "include names matching the given patterns"
-    complete -c hg -n "__fish_hg_using_command archive" -s X -l exclude -x -d "exclude names matching the given patterns"
-    complete -c hg -n "__fish_hg_using_command archive; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l no-decode -d "do not pass files through decoders"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s p -l prefix -x -d "directory prefix for files in archive"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision to distribute"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s t -l type -x -a "files tar tbz2 tgz uzip zip" -d "type of distribution to create"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
+    complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
 # hg backout

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -574,6 +574,22 @@ for cmd in conf confi config sh sho show showc showco showcon showconf showconfi
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
+# hg convert
+for cmd in conv conve conver convert
+    complete -c hg -n "__fish_hg_using_command $cmd" -s s -l source-type -x -a "hg cvs darcs git svn mtn gnuarch bzr p4" -d "source repository type"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s d -l dest-type -x -a "hg svn" -d "destination repository type"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -d "import up to this source revision"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s A -l authormap -r -d "remap usernames using this file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l filemap -r -d "remap file names using contents of file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l full -d "apply filemap changes by converting all files again"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l splicemap -r -d "splice synthesized history into place"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l branchmap -r -d "change branch names while converting"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l branchsort -d "try to sort changesets by branches"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l datesort -d "try to sort changesets by date"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l sourcesort -d "preserve source changesets order"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l closesort -d "try to reorder closed revisions"
+end
+
 # hg copy
 for cmd in cop copy cp
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_status -cmrd)"
@@ -608,6 +624,41 @@ for cmd in d di dif diff
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
+end
+
+# hg email
+for cmd in em ema emai email
+    complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_labels)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s g -l git -d "use git extended diff format"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l plain -d "omit hg patch header"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s o -l outgoing -d "send changes not found in the target repository"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s b -l bundle -d "send changes not in target as a binary bundle"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s B -l bookmark -x -a "(__fish_hg_bookmarks)" -d "send changes only reachable by given bookmark"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l bundlename -x -d "name of the bundle attachment file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "a revision to send"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l force -d "run even when remote repository is unrelated (with -b/--bundle)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l base -x -a "(__fish_hg_labels)" -d "a base changeset to specify instead of a destination (with -b/--bundle)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l intro -d "send an introduction email for a single patch"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l body -d "send patches as inline message text (default)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s a -l attach -d "send patches as attachments"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s i -l inline -d "send patches as inline attachments"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l bcc -x -d "email addresses of blind carbon copy recipients"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s c -l cc -x -d "email addresses of copy recipients"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l confirm -d "ask for confirmation before sending"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s d -l diffstat -d "add diffstat output to messages"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l date -x -d "use the given date as the sending date"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l desc -x -d "use the given file as the series description"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s f -l from -x -d "email address of sender"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s n -l test -d "print messages that would be sent"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s m -l mbox -r -d "write messages to mbox file instead of sending them"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l reply-to -x -d "email addresses replies should be sent to"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s s -l subject -x -d "subject of first message (intro or single patch)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l in-reply-to -x -d "message identifier to reply to"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l flag -x -d "flags to add in subject prefixes"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s t -l to -x -d "email addresses of recipients"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l ssh -x -d "specify ssh command to use"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l remotecmd -x -d "specify hg command to run on the remote side"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l insecure -d "do not verify server certificate (ignoring web.cacerts config)"
 end
 
 # hg export

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -419,7 +419,7 @@ for cmd in an ann anno annot annota annotat annotate bl bla blam blame
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l changeset -d "list the changeset"
     complete -c hg -n "__fish_hg_using_command $cmd" -s l -l line-number -d "show line number at the first appearance"
     complete -c hg -n "__fish_hg_using_command $cmd" -s w -l ignore-all-space -d "ignore white space when comparing lines"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s b -l ignore-space-change -x -d "changes in the amount of white space"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s b -l ignore-space-change -d "ignore changes in the amount of white space"
     complete -c hg -n "__fish_hg_using_command $cmd" -s B -l ignore-blank-lines -d "ignore changes whose lines are all blank"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
@@ -447,7 +447,7 @@ for cmd in ba bac back backo backou backout
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as commit message"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -x -d "read commit message from file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -r -d "read commit message from file"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l date -x -d "record the specified date as commit date"
     complete -c hg -n "__fish_hg_using_command $cmd" -s u -l user -x -d "record the specified user as committer"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
@@ -479,13 +479,13 @@ end
 
 # hg branch
 complete -c hg -n "__fish_hg_using_command branch" -f -a "(__fish_hg_branches)"
-complete -c hg -n "__fish_hg_using_command branch" -s f -l force -x -d "branch name even if it shadows an existing branch"
-complete -c hg -n "__fish_hg_using_command branch" -s C -l clean -x -d "branch name to parent branch name"
+complete -c hg -n "__fish_hg_using_command branch" -s f -l force -d "set branch name even if it shadows an existing branch"
+complete -c hg -n "__fish_hg_using_command branch" -s C -l clean -d "reset branch name to parent branch name"
 complete -c hg -n "__fish_hg_using_command branch; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 
 # hg branches
 for cmd in branche branches
-    complete -c hg -n "__fish_hg_using_command $cmd" -s c -l closed -x -d "normal and closed branches"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s c -l closed -d "show normal and closed branches"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
@@ -538,7 +538,7 @@ for cmd in com comm commi commit ci
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as commit message"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -x -d "read commit message from file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -r -d "read commit message from file"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l date -x -d "record the specified date as commit date"
     complete -c hg -n "__fish_hg_using_command $cmd" -s u -l user -x -d "record the specified user as committer"
     complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
@@ -548,7 +548,7 @@ end
 # hg config
 for cmd in conf confi config sh sho show showc showco showcon showconf showconfi showconfig
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_config_entries)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s u -l untrusted -x -d "untrusted configuration options"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s u -l untrusted -d "show untrusted configuration options"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
@@ -574,7 +574,7 @@ for cmd in d di dif diff
     complete -c hg -n "__fish_hg_using_command $cmd" -s p -l show-function -d "show which function each change is in"
     complete -c hg -n "__fish_hg_using_command $cmd" -l reverse -d "produce a diff that undoes the changes"
     complete -c hg -n "__fish_hg_using_command $cmd" -s w -l ignore-all-space -d "ignore white space when comparing lines"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s b -l ignore-space-change -x -d "changes in the amount of white space"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s b -l ignore-space-change -d "ignore changes in the amount of white space"
     complete -c hg -n "__fish_hg_using_command $cmd" -s B -l ignore-blank-lines -d "ignore changes whose lines are all blank"
     complete -c hg -n "__fish_hg_using_command $cmd" -s U -l unified -x -d "number of lines of context to show"
     complete -c hg -n "__fish_hg_using_command $cmd" -l stat -d "output diffstat-style summary of changes"
@@ -588,7 +588,7 @@ end
 for cmd in exp expo expor export
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_labels)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s o -l output -x -d "print output to file with formatted name"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l switch-parent -x -d "against the second parent"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l switch-parent -d "diff against the second parent"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revisions to export"
     complete -c hg -n "__fish_hg_using_command $cmd" -s a -l text -d "treat all files as text"
     complete -c hg -n "__fish_hg_using_command $cmd" -s g -l git -d "use git extended diff format"
@@ -611,8 +611,8 @@ for cmd in gra graf graft
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l continue -d "resume interrupted graft"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
     complete -c hg -n "__fish_hg_using_command $cmd" -l log -d "append graft info to log message"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s D -l currentdate -x -d "the current date as commit date"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s U -l currentuser -x -d "the current user as committer"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s D -l currentdate -d "record the current date as commit date"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s U -l currentuser -d "record the current user as committer"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l date -x -d "record the specified date as commit date"
     complete -c hg -n "__fish_hg_using_command $cmd" -s u -l user -x -d "record the specified user as committer"
     complete -c hg -n "__fish_hg_using_command $cmd" -s t -l tool -x -a "(__fish_hg_merge_tools)" -d "specify merge tool"
@@ -654,7 +654,7 @@ for cmd in hel help
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_help_topics)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l extension -d "only help for extensions"
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l command -d "show only help for commands"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keyword -x -d "show topics matching keyword"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keyword -d "show topics matching keyword"
 end
 
 # hg histedit
@@ -690,11 +690,11 @@ for cmd in im imp impo impor import patc patch
     complete -c hg -n "__fish_hg_using_command $cmd" -s p -l strip -x -d "directory strip option for patch"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
     complete -c hg -n "__fish_hg_using_command $cmd" -l no-commit -d "don't commit, just update the working directory"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l bypass -x -d "apply patch without touching the working directory"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l bypass -d "apply patch without touching the working directory"
     complete -c hg -n "__fish_hg_using_command $cmd" -l exact -d "apply patch to the nodes from which it was generated"
     complete -c hg -n "__fish_hg_using_command $cmd" -l import-branch -d "use any branch information in patch (implied by --exact)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as commit message"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -x -d "read commit message from file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -r -d "read commit message from file"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l date -x -d "record the specified date as commit date"
     complete -c hg -n "__fish_hg_using_command $cmd" -s u -l user -x -d "record the specified user as committer"
     complete -c hg -n "__fish_hg_using_command $cmd" -s s -l similarity -x -d "guess renamed files by similarity (0<=s<=100)"
@@ -706,7 +706,7 @@ for cmd in inc inco incom incomi incomin incoming in
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_sources)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "run even if remote repository is unrelated"
     complete -c hg -n "__fish_hg_using_command $cmd" -s n -l newest-first -d "show newest record first"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l bundle -x -d "file to store the bundles into"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l bundle -r -d "file to store the bundles into"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -d "a remote changeset intended to be added"
     complete -c hg -n "__fish_hg_using_command $cmd" -s B -l bookmarks -d "compare bookmarks"
     complete -c hg -n "__fish_hg_using_command $cmd" -s b -l branch -x -d "a specific branch you would like to pull"
@@ -746,7 +746,7 @@ end
 # hg log
 for cmd in log histo histor history
     complete -c hg -n "__fish_hg_using_command "$cmd -f -a "(__fish_hg_status -cmrd)"
-    complete -c hg -n "__fish_hg_using_command "$cmd -s f -l follow -x -d "follow changeset history, or file history across copies and renames"
+    complete -c hg -n "__fish_hg_using_command "$cmd -s f -l follow -d "follow changeset history, or file history across copies and renames"
     complete -c hg -n "__fish_hg_using_command "$cmd -s d -l date -x -d "show revisions matching date spec"
     complete -c hg -n "__fish_hg_using_command "$cmd -s C -l copies -d "show copied files"
     complete -c hg -n "__fish_hg_using_command "$cmd -s k -l keyword -x -d "do case-insensitive search for a given text"
@@ -896,7 +896,7 @@ for cmd in qdi qdif qdiff
     complete -c hg -n "__fish_hg_using_command $cmd" -s w -l ignore-all-space -d "ignore white space when comparing lines"
     complete -c hg -n "__fish_hg_using_command $cmd" -s b -l ignore-space-change -d "ignore changes in the amount of white space"
     complete -c hg -n "__fish_hg_using_command $cmd" -s B -l ignore-blank-lines -d "ignore changes whose lines are all blank"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s U -l unified -d "number of lines of context to show"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s U -l unified -x -d "number of lines of context to show"
     complete -c hg -n "__fish_hg_using_command $cmd" -l stat -d "output diffstat-style summary of changes"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
@@ -1149,22 +1149,22 @@ end
 
 # hg serve
 for cmd in se ser serv serve
-    complete -c hg -n "__fish_hg_using_command $cmd" -s A -l accesslog -x -d "name of access log file to write to"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s A -l accesslog -r -d "name of access log file to write to"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l daemon -d "run server in background"
     complete -c hg -n "__fish_hg_using_command $cmd" -l daemon-pipefds -x -d "used internally by daemon mode"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s E -l errorlog -x -d "name of error log file to write to"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s E -l errorlog -r -d "name of error log file to write to"
     complete -c hg -n "__fish_hg_using_command $cmd" -s p -l port -x -d "port to listen on (default: 8000)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s a -l address -x -d "address to listen on (default: all interfaces)"
     complete -c hg -n "__fish_hg_using_command $cmd" -l prefix -x -d "prefix path to serve from (default: server root)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s n -l name -x -d "name to show in web pages (default: working directory)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l web-conf -x -d "name of the hgweb config file (see \"hg help hgweb\")"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l pid-file -x -d "name of file to write process ID to"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l web-conf -r -d "name of the hgweb config file (see 'hg help hgweb')"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l pid-file -r -d "name of file to write process ID to"
     complete -c hg -n "__fish_hg_using_command $cmd" -l stdio -d "for remote clients"
     complete -c hg -n "__fish_hg_using_command $cmd" -l cmdserver -x -d "for remote clients"
     complete -c hg -n "__fish_hg_using_command $cmd" -s t -l templates -x -d "web templates to use"
     complete -c hg -n "__fish_hg_using_command $cmd" -l style -x -d "template style to use"
     complete -c hg -n "__fish_hg_using_command $cmd" -s 6 -l ipv6 -d "use IPv6 in addition to IPv4"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l certificate -x -d "SSL certificate file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l certificate -r -d "SSL certificate file"
     complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
@@ -1203,7 +1203,7 @@ end
 
 # hg summary
 for cmd in su sum summ summa summar summary
-    complete -c hg -n "__fish_hg_using_command $cmd" -l remote -x -d "check for push and pull"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l remote -d "check for push and pull"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
@@ -1223,7 +1223,7 @@ complete -c hg -n "__fish_hg_using_command tags; and __fish_hg_mq_enabled" -l mq
 
 # hg unbundle
 for cmd in un unb unbu unbun unbund unbundl unbundle
-    complete -c hg -n "__fish_hg_using_command $cmd" -s u -l update -x -d "update to new branch head if changesets were unbundled"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s u -l update -d "update to new branch head if changesets were unbundled"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -470,7 +470,7 @@ end
 for cmd in bo boo book bookm bookma bookmar bookmark bookmarks
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_bookmarks)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "force"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision for bookmark action"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l delete -d "delete a given bookmark"
     complete -c hg -n "__fish_hg_using_command $cmd" -s m -l rename -x -a "(__fish_hg_bookmarks)" -d "rename a given bookmark"
     complete -c hg -n "__fish_hg_using_command $cmd" -s i -l inactive -d "mark a bookmark inactive"
@@ -499,7 +499,7 @@ for cmd in bu bun bund bundl bundle
     complete -c hg -n "__fish_hg_using_command $cmd" -s t -l type -x -d "bundle compression type to use (default: bzip2)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l ssh -x -d "specify ssh command to use"
     complete -c hg -n "__fish_hg_using_command $cmd" -l remotecmd -x -d "specify hg command to run on the remote side"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l insecure -d "do not verify server certificate (ignoring web.cacerts"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l insecure -d "do not verify server certificate (ignoring web.cacerts config)"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
@@ -517,10 +517,10 @@ end
 # hg clone
 for cmd in cl clo clon clone
     complete -c hg -n "__fish_hg_using_command $cmd" -r -a "(__fish_hg_sources)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s U -l noupdate -d "the clone will include an empty working copy (only a repository)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s u -l updaterev -x -d "revision, tag or branch to check out"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -d "include the specified changeset"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s b -l branch -x -d "clone only the specified branch"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s U -l noupdate -d "the clone will include an empty working directory (only a repository)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s u -l updaterev -x -d "revision, tag, or branch to check out"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -d "do not clone everything, but include this changeset and its ancestors"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s b -l branch -x -d "do not clone everything, but include this branch's changesets and their ancestors"
     complete -c hg -n "__fish_hg_using_command $cmd" -l pull -d "use pull protocol to copy metadata"
     complete -c hg -n "__fish_hg_using_command $cmd" -l uncompressed -d "use uncompressed transfer (fast over LAN)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l ssh -x -d "specify ssh command to use"
@@ -532,7 +532,7 @@ end
 for cmd in com comm commi commit ci
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -amr)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s A -l addremove -d "mark new/missing files as added/removed before committing"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l close-branch -d "mark a branch as closed, hiding it from the branch list"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l close-branch -d "mark a branch head as closed"
     complete -c hg -n "__fish_hg_using_command $cmd" -l amend -d "amend the parent of the working directory"
     complete -c hg -n "__fish_hg_using_command $cmd" -s s -l secret -d "use the secret phase for committing"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
@@ -651,7 +651,7 @@ end
 # hg help
 for cmd in hel help
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_help_topics)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l extension -d "only help for extensions"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l extension -d "show only help for extensions"
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l command -d "show only help for commands"
     complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keyword -d "show topics matching keyword"
 end
@@ -690,7 +690,7 @@ for cmd in im imp impo impor import patc patch
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
     complete -c hg -n "__fish_hg_using_command $cmd" -l no-commit -d "don't commit, just update the working directory"
     complete -c hg -n "__fish_hg_using_command $cmd" -l bypass -d "apply patch without touching the working directory"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l exact -d "apply patch to the nodes from which it was generated"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l exact -d "abort if patch would apply lossily"
     complete -c hg -n "__fish_hg_using_command $cmd" -l import-branch -d "use any branch information in patch (implied by --exact)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as commit message"
     complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -r -d "read commit message from file"
@@ -748,7 +748,7 @@ for cmd in log histo histor history
     complete -c hg -n "__fish_hg_using_command "$cmd -s d -l date -x -d "show revisions matching date spec"
     complete -c hg -n "__fish_hg_using_command "$cmd -s C -l copies -d "show copied files"
     complete -c hg -n "__fish_hg_using_command "$cmd -s k -l keyword -x -d "do case-insensitive search for a given text"
-    complete -c hg -n "__fish_hg_using_command "$cmd -s r -l rev -x -a "(__fish_hg_labels)" -d "show the specified revision or range"
+    complete -c hg -n "__fish_hg_using_command "$cmd -s r -l rev -x -a "(__fish_hg_labels)" -d "show the specified revision or revset"
     complete -c hg -n "__fish_hg_using_command "$cmd -l removed -d "include revisions where files were removed"
     complete -c hg -n "__fish_hg_using_command "$cmd -s u -l user -x -d "revisions committed by user"
     complete -c hg -n "__fish_hg_using_command "$cmd -s b -l branch -x -a "(__fish_hg_branches)" -d "show changesets within the given named branch"
@@ -830,9 +830,9 @@ end
 # hg pull
 for cmd in pul pull
     complete -c hg -n "__fish_hg_using_command $cmd" -r -a "(__fish_hg_sources)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s u -l update -d "update to new branch head if changesets were pulled"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s u -l update -d "update to new branch head if new descendants were pulled"
     complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "run even when remote repository is unrelated"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -d "a remote changeset inteded to be added"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -d "a remote changeset intended to be added"
     complete -c hg -n "__fish_hg_using_command $cmd" -s B -l bookmark -x -d "bookmark to pull"
     complete -c hg -n "__fish_hg_using_command $cmd" -s b -l branch -x -d "a specific branch you would like to pull"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l ssh -x -d "specify ssh command to use"
@@ -1092,7 +1092,7 @@ end
 for cmd in rem remo remov remove rm
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_status -c)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s A -l after -d "record delete for missing files"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "remove (and delete) file even if added or modified"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "forget added files, delete modified files"
     complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
@@ -1189,9 +1189,9 @@ end
 for cmd in str stri strip
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_labels)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "strip specified revision"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "force removal of changesets, discard uncommitted changes"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l no-backup -d "no backups"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keep -d "do not modify working copy during strip"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "force removal of changesets, discard uncommitted changes (no backup)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l no-backup -d "do not save backup bundle"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keep -d "do not modify working directory during strip"
     complete -c hg -n "__fish_hg_using_command $cmd" -s B -l bookmark -x -a "(__fish_hg_bookmarks)" -d "remove revs only reachable from given bookmark"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
@@ -1207,7 +1207,7 @@ complete -c hg -n "__fish_hg_using_command tag" -s f -l force -d "force tag"
 complete -c hg -n "__fish_hg_using_command tag" -s l -l local -d "make the tag local"
 complete -c hg -n "__fish_hg_using_command tag" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision to tag"
 complete -c hg -n "__fish_hg_using_command tag" -l remove -d "remove a tag"
-complete -c hg -n "__fish_hg_using_command tag" -s e -l edit -d "edit commit message"
+complete -c hg -n "__fish_hg_using_command tag" -s e -l edit -d "invoke editor on commit messages"
 complete -c hg -n "__fish_hg_using_command tag" -s m -l message -x -d "use <text> as commit message"
 complete -c hg -n "__fish_hg_using_command tag" -s d -l date -x -d "record the specified date as commit date"
 complete -c hg -n "__fish_hg_using_command tag" -s u -l user -x -d "record the specified user as committer"
@@ -1226,7 +1226,7 @@ end
 for cmd in up upd upda updat update che chec check checko checkou checkout co
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_labels)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s C -l clean -d "discard uncommitted changes (no backup)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s c -l check -d "update across branches if no uncommitted changes"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s c -l check -d "require clean working directory"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l date -x -d "tipmost revision matching date"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -1197,7 +1197,7 @@ end
 
 # hg revert
 for cmd in rev reve rever revert
-    complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -camr)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -camrd)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s a -l all -d "revert all changes when no arguments given"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l date -x -d "tipmost revision matching date"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revert to the specified revision"

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -564,7 +564,7 @@ end
 
 # hg diff
 for cmd in d di dif diff
-    complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -m)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -amr)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision"
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l change -x -a "(__fish_hg_labels)" -d "change made by revision"
     complete -c hg -n "__fish_hg_using_command $cmd" -s a -l text -d "treat all files as text"

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -380,7 +380,7 @@ end
 
 # global options
 complete -c hg -s R -l repository -x -d "repository root directory or name of overlay bundle file"
-complete -c hg -l cwd -x -d "change working directory"
+complete -c hg -l cwd -x -a "(__fish_complete_directories (commandline -ct))" -d "change working directory"
 complete -c hg -s y -l noninteractive -d "do not prompt, automatically pick the first choice for all prompts"
 complete -c hg -s q -l quiet -d "suppress output"
 complete -c hg -s v -l verbose -d "enable additional output"

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -421,6 +421,7 @@ for cmd in an ann anno annot annota annotat annotate bl bla blam blame
     complete -c hg -n "__fish_hg_using_command $cmd" -s w -l ignore-all-space -d "ignore white space when comparing lines"
     complete -c hg -n "__fish_hg_using_command $cmd" -s b -l ignore-space-change -d "ignore changes in the amount of white space"
     complete -c hg -n "__fish_hg_using_command $cmd" -s B -l ignore-blank-lines -d "ignore changes whose lines are all blank"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s Z -l ignore-space-at-eol -d "ignore changes in whitespace at EOL"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
@@ -442,7 +443,9 @@ end
 for cmd in ba bac back backo backou backout
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_labels)"
     complete -c hg -n "__fish_hg_using_command $cmd" -l merge -d "merge with old dirstate parent after backout"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l no-commit -d "do not commit"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision to backout"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
     complete -c hg -n "__fish_hg_using_command $cmd" -s t -l tool -x -a "(__fish_hg_merge_tools)" -d "specify merge tool"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
@@ -522,7 +525,7 @@ for cmd in cl clo clon clone
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -d "do not clone everything, but include this changeset and its ancestors"
     complete -c hg -n "__fish_hg_using_command $cmd" -s b -l branch -x -d "do not clone everything, but include this branch's changesets and their ancestors"
     complete -c hg -n "__fish_hg_using_command $cmd" -l pull -d "use pull protocol to copy metadata"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l uncompressed -d "use uncompressed transfer (fast over LAN)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l stream -d "clone with minimal data processing"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l ssh -x -d "specify ssh command to use"
     complete -c hg -n "__fish_hg_using_command $cmd" -l remotecmd -x -d "specify hg command to run on the remote side"
     complete -c hg -n "__fish_hg_using_command $cmd" -l insecure -d "do not verify server certificate (ignoring web.cacerts config)"
@@ -535,6 +538,8 @@ for cmd in com comm commi commit ci
     complete -c hg -n "__fish_hg_using_command $cmd" -l close-branch -d "mark a branch head as closed"
     complete -c hg -n "__fish_hg_using_command $cmd" -l amend -d "amend the parent of the working directory"
     complete -c hg -n "__fish_hg_using_command $cmd" -s s -l secret -d "use the secret phase for committing"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s i -l interactive -d "use interactive mode"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as commit message"
@@ -549,6 +554,9 @@ end
 for cmd in conf confi config sh sho show showc showco showcon showconf showconfi showconfig
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_config_entries)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s u -l untrusted -d "show untrusted configuration options"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "edit user config"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l local -d "edit repository config"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s g -l global -d "edit global config"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
@@ -570,14 +578,18 @@ for cmd in d di dif diff
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l change -x -a "(__fish_hg_labels)" -d "change made by revision"
     complete -c hg -n "__fish_hg_using_command $cmd" -s a -l text -d "treat all files as text"
     complete -c hg -n "__fish_hg_using_command $cmd" -s g -l git -d "use git extended diff format"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l binary -d "generate binary diffs in git mode (default)"
     complete -c hg -n "__fish_hg_using_command $cmd" -l nodates -d "omit dates from diff headers"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l noprefix -d "omit a/ and b/ prefixes from filenames"
     complete -c hg -n "__fish_hg_using_command $cmd" -s p -l show-function -d "show which function each change is in"
     complete -c hg -n "__fish_hg_using_command $cmd" -l reverse -d "produce a diff that undoes the changes"
     complete -c hg -n "__fish_hg_using_command $cmd" -s w -l ignore-all-space -d "ignore white space when comparing lines"
     complete -c hg -n "__fish_hg_using_command $cmd" -s b -l ignore-space-change -d "ignore changes in the amount of white space"
     complete -c hg -n "__fish_hg_using_command $cmd" -s B -l ignore-blank-lines -d "ignore changes whose lines are all blank"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s Z -l ignore-space-at-eol -d "ignore changes in whitespace at EOL"
     complete -c hg -n "__fish_hg_using_command $cmd" -s U -l unified -x -d "number of lines of context to show"
     complete -c hg -n "__fish_hg_using_command $cmd" -l stat -d "output diffstat-style summary of changes"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l root -x -d "produce diffs relative to subdirectory"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
@@ -587,11 +599,13 @@ end
 # hg export
 for cmd in exp expo expor export
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_labels)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s B -l bookmark -x -a "(__fish_hg_bookmarks)" -d "export changes only reachable by given bookmark"
     complete -c hg -n "__fish_hg_using_command $cmd" -s o -l output -x -d "print output to file with formatted name"
     complete -c hg -n "__fish_hg_using_command $cmd" -l switch-parent -d "diff against the second parent"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revisions to export"
     complete -c hg -n "__fish_hg_using_command $cmd" -s a -l text -d "treat all files as text"
     complete -c hg -n "__fish_hg_using_command $cmd" -s g -l git -d "use git extended diff format"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l binary -d "generate binary diffs in git mode (default)"
     complete -c hg -n "__fish_hg_using_command $cmd" -l nodates -d "omit dates from diff headers"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
@@ -599,8 +613,10 @@ end
 # hg forget
 for cmd in fo for forg forge forget
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_status -ca)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s i -l interactive -d "use interactive mode"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s n -l dry-run -d "do not perform actions, just print output"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
@@ -609,8 +625,12 @@ for cmd in gra graf graft
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_labels)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revisions to graft"
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l continue -d "resume interrupted graft"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l stop -d "stop interrupted graft"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l abort -d "abort interrupted graft"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
     complete -c hg -n "__fish_hg_using_command $cmd" -l log -d "append graft info to log message"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l no-commit -d "don't commit, just apply the changes in working directory"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "force graft"
     complete -c hg -n "__fish_hg_using_command $cmd" -s D -l currentdate -d "record the current date as commit date"
     complete -c hg -n "__fish_hg_using_command $cmd" -s U -l currentuser -d "record the current user as committer"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l date -x -d "record the specified date as commit date"
@@ -625,6 +645,7 @@ for cmd in gre grep
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -cmrd)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s 0 -l print0 -d "end fields with NUL"
     complete -c hg -n "__fish_hg_using_command $cmd" -l all -d "print all revisions that match"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l diff -d "print all revisions when the term was introduced or removed"
     complete -c hg -n "__fish_hg_using_command $cmd" -s a -l text -d "treat all files as text"
     complete -c hg -n "__fish_hg_using_command $cmd" -s f -l follow -d "follow changeset history, or file history across copies and renames"
     complete -c hg -n "__fish_hg_using_command $cmd" -s i -l ignore-case -d "ignore case when matching"
@@ -654,6 +675,7 @@ for cmd in hel help
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l extension -d "show only help for extensions"
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l command -d "show only help for commands"
     complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keyword -d "show topics matching keyword"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s s -l system -x -d "show help for specific platform(s)"
 end
 
 # hg histedit
@@ -661,6 +683,7 @@ for cmd in histe histed histedi histedit
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_labels)"
     complete -c hg -n "__fish_hg_using_command $cmd" -l commands -r -d "read history edits from the specified file"
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l continue -d "continue an edit already in progress"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l edit-plan -d "edit remaining actions list"
     complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keep -d "don't strip old nodes after edit is complete"
     complete -c hg -n "__fish_hg_using_command $cmd" -l abort -d "abort an edit in progress"
     complete -c hg -n "__fish_hg_using_command $cmd" -s o -l outgoing -d "changesets not found in destination"
@@ -690,7 +713,9 @@ for cmd in im imp impo impor import patc patch
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
     complete -c hg -n "__fish_hg_using_command $cmd" -l no-commit -d "don't commit, just update the working directory"
     complete -c hg -n "__fish_hg_using_command $cmd" -l bypass -d "apply patch without touching the working directory"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l partial -d "commit even if some hunks fail"
     complete -c hg -n "__fish_hg_using_command $cmd" -l exact -d "abort if patch would apply lossily"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l prefix -r -d "apply patch to subdirectory"
     complete -c hg -n "__fish_hg_using_command $cmd" -l import-branch -d "use any branch information in patch (implied by --exact)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as commit message"
     complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -r -d "read commit message from file"
@@ -777,6 +802,7 @@ for cmd in me mer merg merge
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_labels)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision to merge"
     complete -c hg -n "__fish_hg_using_command $cmd" -s P -l preview -d "review revisions to merge (no merge is performed)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l abort -d "abort the ongoing merge"
     complete -c hg -n "__fish_hg_using_command $cmd" -s t -l tool -x -a "(__fish_hg_merge_tools)" -d "specify merge tool"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
@@ -1096,6 +1122,7 @@ for cmd in rem remo remov remove rm
     complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s n -l dry-run -d "do not perform actions, just print output"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
@@ -1131,6 +1158,7 @@ for cmd in rev reve rever revert
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l date -x -d "tipmost revision matching date"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revert to the specified revision"
     complete -c hg -n "__fish_hg_using_command $cmd" -s C -l no-backup -d "do not save backup copies of files"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s i -l interactive -d "interactively select the changes"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s n -l dry-run -d "do not perform actions, just print output"
@@ -1146,7 +1174,7 @@ end
 for cmd in se ser serv serve
     complete -c hg -n "__fish_hg_using_command $cmd" -s A -l accesslog -r -d "name of access log file to write to"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l daemon -d "run server in background"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l daemon-pipefds -x -d "used internally by daemon mode"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l daemon-postexec -x -d "used internally by daemon mode"
     complete -c hg -n "__fish_hg_using_command $cmd" -s E -l errorlog -r -d "name of error log file to write to"
     complete -c hg -n "__fish_hg_using_command $cmd" -s p -l port -x -d "port to listen on (default: 8000)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s a -l address -x -d "address to listen on (default: all interfaces)"
@@ -1160,6 +1188,7 @@ for cmd in se ser serv serve
     complete -c hg -n "__fish_hg_using_command $cmd" -l style -x -d "template style to use"
     complete -c hg -n "__fish_hg_using_command $cmd" -s 6 -l ipv6 -d "use IPv6 in addition to IPv4"
     complete -c hg -n "__fish_hg_using_command $cmd" -l certificate -r -d "SSL certificate file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l print-url -d "start and print only the URL"
     complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
@@ -1227,8 +1256,10 @@ for cmd in up upd upda updat update che chec check checko checkou checkout co
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_labels)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s C -l clean -d "discard uncommitted changes (no backup)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l check -d "require clean working directory"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s m -l merge -d "merge uncommitted changes"
     complete -c hg -n "__fish_hg_using_command $cmd" -s d -l date -x -d "tipmost revision matching date"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "revision"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s t -l tool -x -a "(__fish_hg_merge_tools)" -d "specify merge tool"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -919,8 +919,8 @@ for cmd in qcl qclo qclon qclone
     complete -c hg -n "__fish_hg_using_command $cmd" -s U -l noupdate -d "do not update the new working directories"
     complete -c hg -n "__fish_hg_using_command $cmd" -l uncompressed -d "use uncompressed transfer (fast over LAN)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s p -l patches -d "location of source patch repository"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l ssh -d "specify ssh command to use"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l remotecmd -d "specify hg command to run on the remote side"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l ssh -x -d "specify ssh command to use"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l remotecmd -x -d "specify hg command to run on the remote side"
     complete -c hg -n "__fish_hg_using_command $cmd" -l insecure -d "do not verify server certificate (ignoring web.cacerts config)"
 end
 
@@ -935,14 +935,18 @@ for cmd in qdi qdif qdiff
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -mrd --rev .^)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s a -l text -d "treat all files as text"
     complete -c hg -n "__fish_hg_using_command $cmd" -s g -l git -d "use git extended diff format"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l binary -d "generate binary diffs in git mode (default)"
     complete -c hg -n "__fish_hg_using_command $cmd" -l nodates -d "omit dates from diff headers"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l noprefix -d "omit a/ and b/ prefixes from filenames"
     complete -c hg -n "__fish_hg_using_command $cmd" -s p -l show-function -d "show which function each change is in"
     complete -c hg -n "__fish_hg_using_command $cmd" -l reverse -d "produce a diff that undoes the changes"
     complete -c hg -n "__fish_hg_using_command $cmd" -s w -l ignore-all-space -d "ignore white space when comparing lines"
     complete -c hg -n "__fish_hg_using_command $cmd" -s b -l ignore-space-change -d "ignore changes in the amount of white space"
     complete -c hg -n "__fish_hg_using_command $cmd" -s B -l ignore-blank-lines -d "ignore changes whose lines are all blank"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s Z -l ignore-space-at-eol -d "ignore changes in whitespace at EOL"
     complete -c hg -n "__fish_hg_using_command $cmd" -s U -l unified -x -d "number of lines of context to show"
     complete -c hg -n "__fish_hg_using_command $cmd" -l stat -d "output diffstat-style summary of changes"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l root -x -d "produce diffs relative to subdirectory"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
 end
@@ -956,10 +960,10 @@ end
 # hg qfold
 for cmd in qfo qfol qfold
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_patches)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "edit patch header"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
     complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keep -d "keep folded patch files"
     complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as commit message"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -x -d "read commit message from file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -r -d "read commit message from file"
 end
 
 # hg qgoto
@@ -973,7 +977,7 @@ end
 # hg qguard
 for cmd in qgu qgua qguar qguard
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_patches)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l list -d "all patches and guards"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l list -d "list all patches and guards"
     complete -c hg -n "__fish_hg_using_command $cmd" -s n -l none -d "drop all guards"
 end
 
@@ -985,7 +989,7 @@ end
 # hg qimport
 for cmd in qim qimp qimpo qimpor qimport
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l existing -d "import file in patch directory"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s n -l name -d "name of patch file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s n -l name -x -d "name of patch file"
     complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "overwrite existing files"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "place existing revisions under mq control"
     complete -c hg -n "__fish_hg_using_command $cmd" -s g -l git -d "use git extended diff format"
@@ -993,16 +997,16 @@ for cmd in qim qimp qimpo qimpor qimport
 end
 
 # hg qnew
-complete -c hg -n "__fish_hg_using_command qnew" -s e -l edit -d "edit commit message"
+complete -c hg -n "__fish_hg_using_command qnew" -s e -l edit -d "invoke editor on commit messages"
 complete -c hg -n "__fish_hg_using_command qnew" -s g -l git -d "use git extended diff format"
 complete -c hg -n "__fish_hg_using_command qnew" -s U -l currentuser -d "add \"From: <current user>\" to patch"
 complete -c hg -n "__fish_hg_using_command qnew" -s u -l user -x -d "add \"From: <USER>\" to patch"
 complete -c hg -n "__fish_hg_using_command qnew" -s D -l currentdate -d "add \"Date: <current date>\" to patch"
 complete -c hg -n "__fish_hg_using_command qnew" -s d -l date -x -d "add \"Date: <DATE>\" to patch"
-complete -c hg -n "__fish_hg_using_command qnew" -s I -l include -d "include names matching the given patterns"
-complete -c hg -n "__fish_hg_using_command qnew" -s X -l exclude -d "exclude names matching the given patterns"
-complete -c hg -n "__fish_hg_using_command qnew" -s m -l message -d "use text as commit message"
-complete -c hg -n "__fish_hg_using_command qnew" -s l -l logfile -d "read commit message from file"
+complete -c hg -n "__fish_hg_using_command qnew" -s I -l include -x -d "include names matching the given patterns"
+complete -c hg -n "__fish_hg_using_command qnew" -s X -l exclude -x -d "exclude names matching the given patterns"
+complete -c hg -n "__fish_hg_using_command qnew" -s m -l message -x -d "use text as commit message"
+complete -c hg -n "__fish_hg_using_command qnew" -s l -l logfile -r -d "read commit message from file"
 complete -c hg -n "__fish_hg_using_command qnew" -s i -l interactive -d "interactively record a new patch"
 
 # hg qnext
@@ -1068,7 +1072,7 @@ end
 # hg qrefresh
 for cmd in qref qrefr qrefre qrefres qrefresh
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -amr)"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "edit commit message"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
     complete -c hg -n "__fish_hg_using_command $cmd" -s g -l git -d "use git extended diff format"
     complete -c hg -n "__fish_hg_using_command $cmd" -s s -l short -d "refresh only files already in the patch and specified files"
     complete -c hg -n "__fish_hg_using_command $cmd" -s U -l currentuser -d "add/update author field in patch with current user"
@@ -1078,7 +1082,7 @@ for cmd in qref qrefr qrefre qrefres qrefresh
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as commit message"
-    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -x -d "read commit message from file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -r -d "read commit message from file"
     complete -c hg -n "__fish_hg_using_command $cmd" -s i -l interactive -d "interactively select changes to refresh"
 end
 

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -644,8 +644,7 @@ for cmd in hea head heads
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "show only heads which are descendants of STARTREV"
     complete -c hg -n "__fish_hg_using_command $cmd" -s t -l topo -d "show topological heads only"
     complete -c hg -n "__fish_hg_using_command $cmd" -s c -l closed -d "show normal and closed branch heads"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l style -x -d "display using template map file"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l template -x -d "display with template"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s T -l template -x -d "display with template"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
@@ -716,8 +715,7 @@ for cmd in inc inco incom incomi incomin incoming in
     complete -c hg -n "__fish_hg_using_command $cmd" -s M -l no-merges -d "do not show merges"
     complete -c hg -n "__fish_hg_using_command $cmd" -l stat -d "output diffstat-style summary of changes"
     complete -c hg -n "__fish_hg_using_command $cmd" -s G -l graph -d "show the revision DAG"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l style -x -d "display using template map file"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l template -x -d "display with template"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s T -l template -x -d "display with template"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l ssh -x -d "specify ssh command to use"
     complete -c hg -n "__fish_hg_using_command $cmd" -l remotecmd -x -d "specify hg command to run on the remote side"
     complete -c hg -n "__fish_hg_using_command $cmd" -l insecure -d "do not verify server certificate (ignoring web.cacerts config)"
@@ -761,8 +759,7 @@ for cmd in log histo histor history
     complete -c hg -n "__fish_hg_using_command "$cmd -s M -l no-merges -d "do not show merges"
     complete -c hg -n "__fish_hg_using_command "$cmd -l stat -d "output diffstat-style summary of changes"
     complete -c hg -n "__fish_hg_using_command "$cmd -s G -l graph -d "show the revision DAG"
-    complete -c hg -n "__fish_hg_using_command "$cmd -l style -x -d "display using template map file"
-    complete -c hg -n "__fish_hg_using_command "$cmd -l template -x -d "display with template"
+    complete -c hg -n "__fish_hg_using_command "$cmd -s T -l template -x -d "display with template"
     complete -c hg -n "__fish_hg_using_command "$cmd -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command "$cmd -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command "$cmd"; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
@@ -798,8 +795,7 @@ for cmd in o ou out outg outgo outgoi outgoin outgoing
     complete -c hg -n "__fish_hg_using_command $cmd" -s M -l no-merges -d "do not show merges"
     complete -c hg -n "__fish_hg_using_command $cmd" -l stat -d "output diffstat-style summary of changes"
     complete -c hg -n "__fish_hg_using_command $cmd" -s G -l graph -d "show the revision DAG"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l style -x -d "display using template map file"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l template -x -d "display with template"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s T -l template -x -d "display with template"
     complete -c hg -n "__fish_hg_using_command $cmd" -s e -l ssh -x -d "specify ssh command to use"
     complete -c hg -n "__fish_hg_using_command $cmd" -l remotecmd -x -d "specify hg command to run on the remote side"
     complete -c hg -n "__fish_hg_using_command $cmd" -l insecure -d "do not verify server certificate (ignoring web.cacerts config)"
@@ -811,8 +807,7 @@ end
 for cmd in par pare paren parent parents
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -cmrd)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "show parents of the specified revision"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l style -x -d "display using template map file"
-    complete -c hg -n "__fish_hg_using_command $cmd" -l template -x -d "display with template"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s T -l template -x -d "display with template"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -54,13 +54,13 @@ function __fish_hg_commands
             case bisect
                 printf "$command\tsubdivision search of changesets\n"
             case bookmarks
-                printf "$command\ttrack a line of development with movable markers\n"
+                printf "$command\tcreate a new bookmark or list existing bookmarks\n"
             case branch
                 printf "$command\tset or show the current branch name\n"
             case branches
                 printf "$command\tlist repository named branches\n"
             case bundle
-                printf "$command\tcreate a changegroup file\n"
+                printf "$command\tcreate a bundle file\n"
             case cat
                 printf "$command\toutput the current or given revision of files\n"
             case churn
@@ -77,16 +77,20 @@ function __fish_hg_commands
                 printf "$command\tmark files as copied for the next commit\n"
             case diff
                 printf "$command\tdiff repository (or selected files)\n"
+            case email
+                printf "$command\tsend changesets by email\n"
             case export
                 printf "$command\tdump the header and diffs for one or more changesets\n"
             case extdiff
                 printf "$command\tuse external program to diff repository (or selected files)\n"
+            case files
+                printf "$command\tlist tracked files\n"
             case forget
                 printf "$command\tforget the specified files on the next commit\n"
             case graft
                 printf "$command\tcopy changes from other branches onto the current branch\n"
             case grep
-                printf "$command\tsearch for a pattern in specified files and revisions\n"
+                printf "$command\tsearch revision history for a pattern in specified files\n"
             case heads
                 printf "$command\tshow branch heads\n"
             case help
@@ -94,7 +98,7 @@ function __fish_hg_commands
             case histedit
                 printf "$command\tinteractively edit changeset history\n"
             case identify
-                printf "$command\tidentify the working copy or specified revision\n"
+                printf "$command\tidentify the working directory or specified revision\n"
             case import
                 printf "$command\timport an ordered set of patches\n"
             case incoming
@@ -108,7 +112,7 @@ function __fish_hg_commands
             case manifest
                 printf "$command\toutput the current or given revision of the project manifest\n"
             case merge
-                printf "$command\tmerge working directory with another revision\n"
+                printf "$command\tmerge another revision into working directory\n"
             case outgoing
                 printf "$command\tshow changesets not found in the destination\n"
             case parents
@@ -175,6 +179,8 @@ function __fish_hg_commands
                 printf "$command\tprint the name of the current patch\n"
             case qunapplied
                 printf "$command\tprint the patches not yet applied\n"
+            case rebase
+                printf "$command\tmove changeset (and descendants) to a different branch\n"
             case record
                 printf "$command\tinteractively select changes to commit\n"
             case recover
@@ -193,6 +199,8 @@ function __fish_hg_commands
                 printf "$command\tprint the root (top) of the current working directory\n"
             case serve
                 printf "$command\tstart stand-alone webserver\n"
+            case shelve
+                printf "$command\tsave and set aside changes from the working directory\n"
             case status
                 printf "$command\tshow changed files in the working directory\n"
             case strip
@@ -206,7 +214,9 @@ function __fish_hg_commands
             case tip
                 # deprecated
             case unbundle
-                printf "$command\tapply one or more changegroup files\n"
+                printf "$command\tapply one or more bundle files\n"
+            case unshelve
+                printf "$command\trestore a shelved change to the working directory\n"
             case update
                 printf "$command\tupdate working directory (or switch revisions)\n"
             case verify

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -327,6 +327,10 @@ function __fish_hg_sources
     end
 end
 
+function __fish_hg_shelves
+    printf "%s\tshelve\n" (__fish_hg shelve -ql)
+end
+
 function __fish_hg_mq_enabled
     if set -l line (__fish_hg config extensions.hgext.mq)
         set -l parts (string split "=" -m 1 $line)
@@ -617,6 +621,16 @@ for cmd in exp expo expor export
     complete -c hg -n "__fish_hg_using_command $cmd" -s g -l git -d "use git extended diff format"
     complete -c hg -n "__fish_hg_using_command $cmd" -l binary -d "generate binary diffs in git mode (default)"
     complete -c hg -n "__fish_hg_using_command $cmd" -l nodates -d "omit dates from diff headers"
+    complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
+end
+
+# hg files
+for cmd in fi fil file files
+    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "search the repository as it is in REV"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s 0 -l print0 -d "end filenames with NUL, for use with xargs"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
@@ -1099,6 +1113,26 @@ for cmd in qu qun quna qunap qunapp qunappl qunappli qunapplie qunapplied
     complete -c hg -n "__fish_hg_using_command $cmd" -s s -l summary -d "print first line of patch header"
 end
 
+# hg rebase
+for cmd in reb reba rebas rebase
+    complete -c hg -n "__fish_hg_using_command $cmd" -s s -l source -x -a "(__fish_hg_labels)" -d "rebase the specified changeset and descendants"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s b -l base -x -a "(__fish_hg_labels)" -d "rebase everything from branching point of specified changeset"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "rebase these revisions"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s d -l dest -x -a "(__fish_hg_labels)" -d "rebase onto the specified changeset"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l collapse -d "collapse the rebased changesets"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as collapse commit message"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l logfile -r -d "read collapse commit message from file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keep -d "keep original changesets"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l keepbranches -d "keep original branch names"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s t -l tool -x -a "(__fish_hg_merge_tools)" -d "specify merge tool"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s c -l continue -d "continue an interrupted rebase"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s a -l abort -d "abort an interrupted rebase"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s n -l dry-run -d "do not perform actions, just print output"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l confirm -d "ask before applying actions"
+    complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
+end
+
 # hg record
 for cmd in recor record
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -amr)"
@@ -1203,6 +1237,26 @@ for cmd in se ser serv serve
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 
+# hg shelve
+for cmd in she shel shelv shelve
+    complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_status -amrd)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s A -l addremove -d "mark new/missing files as added/removed before shelving"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s u -l unknown -d "store unknown files in the shelve"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l cleanup -d "delete all shelved changes"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l date -x -d "shelve with the specified commit date"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s d -l delete -d "delete the named shelved change(s)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s e -l edit -d "invoke editor on commit messages"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s l -l list -d "list current shelves"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s m -l message -x -d "use text as shelve message"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s n -l name -x -d "use the given name for the shelved commit"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s p -l patch -d "output patches for changes (provide the names of the shelved changes as positional arguments)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s i -l interactive -d "interactive mode, only works while creating a shelve"
+    complete -c hg -n "__fish_hg_using_command $cmd" -l stat -d "output diffstat-style summary of changes (provide the names of the shelved changes as positional arguments)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
+    complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
+end
+
 # hg status
 for cmd in st sta stat statu status
     complete -c hg -n "__fish_hg_using_command $cmd" -s A -l all -d "show status of all files"
@@ -1258,6 +1312,17 @@ complete -c hg -n "__fish_hg_using_command tags; and __fish_hg_mq_enabled" -l mq
 # hg unbundle
 for cmd in un unb unbu unbun unbund unbundl unbundle
     complete -c hg -n "__fish_hg_using_command $cmd" -s u -l update -d "update to new branch head if changesets were unbundled"
+    complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
+end
+
+# hg unshelve
+for cmd in uns unsh unshe unshel unshelv unshelve
+    complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_shelves)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s a -l abort -d "abort an incomplete unshelve operation"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s c -l continue -d "continue an incomplete unshelve operation"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s k -l keep -d "keep shelve after unshelving"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s n -l name -x -a "(__fish_hg_shelves)" -d "restore shelved change with given name"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s t -l tool -x -a "(__fish_hg_merge_tools)" -d "specify merge tool"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -399,6 +399,7 @@ complete -c hg -n "__fish_hg_using_command add; and __fish_hg_mq_enabled" -l mq 
 for cmd in addr addre addrem addremo addremov addremove
     complete -c hg -n "__fish_hg_using_command $cmd" -f -a "(__fish_hg_status -ud)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s s -l similarity -x -d "guess renamed files by similarity (0<=s<=100)"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s n -l dry-run -d "do not perform actions, just print output"
@@ -1097,6 +1098,7 @@ for cmd in rem remo remov remove rm
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_status -c)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s A -l after -d "record delete for missing files"
     complete -c hg -n "__fish_hg_using_command $cmd" -s f -l force -d "remove (and delete) file even if added or modified"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
     complete -c hg -n "__fish_hg_using_command $cmd" -s I -l include -x -d "include names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd" -s X -l exclude -x -d "exclude names matching the given patterns"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
@@ -1163,6 +1165,7 @@ for cmd in se ser serv serve
     complete -c hg -n "__fish_hg_using_command $cmd" -l style -x -d "template style to use"
     complete -c hg -n "__fish_hg_using_command $cmd" -s 6 -l ipv6 -d "use IPv6 in addition to IPv4"
     complete -c hg -n "__fish_hg_using_command $cmd" -l certificate -x -d "SSL certificate file"
+    complete -c hg -n "__fish_hg_using_command $cmd" -s S -l subrepos -d "recurse into subrepositories"
     complete -c hg -n "__fish_hg_using_command $cmd; and __fish_hg_mq_enabled" -l mq -d "operate on patch repository"
 end
 

--- a/share/completions/hg.fish
+++ b/share/completions/hg.fish
@@ -406,7 +406,7 @@ for cmd in addr addre addrem addremo addremov addremove
 end
 
 # hg annotate
-for cmd in an ann anno annot annota annotat annotate
+for cmd in an ann anno annot annota annotat annotate bl bla blam blame
     complete -c hg -n "__fish_hg_using_command $cmd" -x -a "(__fish_hg_status -cmdr)"
     complete -c hg -n "__fish_hg_using_command $cmd" -s r -l rev -x -a "(__fish_hg_labels)" -d "annotate the specified revision"
     complete -c hg -n "__fish_hg_using_command $cmd" -l no-follow -d "don't follow copies and renames"


### PR DESCRIPTION
## Description

This update is based on hg 4.7, but most of the things this PR adds come from earlier versions. For example, -Z/--ignore-space-at-eol is from 4.4 and -i/--interactive for commit and revert was there since forever, just marked experimental until 4.5 (in case of revert).

Overall:

- new commands: convert, email, files, rebase, shelve, unshelve
- new flags (e.g. --interactive, --abort and --dry-run)
- updated command and flag descriptions
- completing more files for hg diff and revert
- completing hg blame as hg annotate and completing abbreviations of hg archive
- --style replaced by -T/--template
- more appropriate `complete` flags (-f, -r and -x)

Feedback is always welcome.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] User-visible changes noted in CHANGELOG.md
