### PR TITLE
git_version_gen: add support for out-of-tree tarballs

### DIFF
--- a/build_tools/git_version_gen.sh
+++ b/build_tools/git_version_gen.sh
@@ -9,7 +9,9 @@ set -e
 # Find the fish git directory as two levels up from script directory.
 GIT_DIR="$( cd "$( dirname $( dirname "$0" ) )" && pwd )"
 
-FBVF=FISH-BUILD-VERSION-FILE
+# Set the output directory as either the first param or cwd.
+test -n "$1" && OUTPUT_DIR=$1/ || OUTPUT_DIR=
+FBVF=${OUTPUT_DIR}FISH-BUILD-VERSION-FILE
 DEF_VER=unknown
 
 # First see if there is a version file (included in release tarballs),
@@ -32,9 +34,9 @@ fi
 # It looks like FISH_BUILD_VERSION="2.7.1-621-ga2f065e6"
 test "$VN" = "$VC" || {
 	echo >&2 "FISH_BUILD_VERSION=$VN"
-	echo "FISH_BUILD_VERSION=\"$VN\"" >$FBVF
+	echo "FISH_BUILD_VERSION=\"$VN\"" >${FBVF}
 }
 
 # Output the fish-build-version-witness.txt
 # See https://cmake.org/cmake/help/v3.4/policy/CMP0058.html
-date +%s > fish-build-version-witness.txt
+date +%s > ${OUTPUT_DIR}fish-build-version-witness.txt

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -44,7 +44,8 @@ ENDIF(${CMAKE_GENERATOR} STREQUAL Ninja)
 
 # Set up the version targets
 ADD_CUSTOM_TARGET(CHECK-FISH-BUILD-VERSION-FILE
-                  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build_tools/git_version_gen.sh
+                  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build_tools/git_version_gen.sh ${CMAKE_CURRENT_BINARY_DIR}
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                   BYPRODUCTS ${CFBVF-BYPRODUCTS})
 
 ADD_CUSTOM_COMMAND(OUTPUT ${FBVF-OUTPUT}


### PR DESCRIPTION
This PR closes #4122, but I'd appreciate if others could check it. In particular, I'm not sure that it satisfies the criteria in `cmake/Version.cmake` for Ninja.