### PR TITLE
completions: ninja: "ninja -f" should be followed by a *.ninja file.

### DIFF
--- a/share/completions/ninja.fish
+++ b/share/completions/ninja.fish
@@ -1,7 +1,7 @@
 complete -c ninja -f -a '(__fish_print_ninja_targets)' -d target
 complete -x -c ninja -s t -x -a "(__fish_print_ninja_tools)" -d subtool
 complete -x -c ninja -s C -x -a "(__fish_complete_directories (commandline -ct))" -d "change to specified directory"
-complete -c ninja -s f -x -d "specify build file [default=build.ninja]"
+complete -c ninja -s f -x -a "(__fish_complete_suffix .ninja)" -d "specify build file [default=build.ninja]"
 complete -f -c ninja -s n -d "dry run"
 complete -f -c ninja -s v -d "show all command lines while building"
 complete -f -c ninja -s j -d "number of jobs to run in parallel [default derived from CPUs]"


### PR DESCRIPTION
## Description

completions: ninja: "ninja -f" should be followed by a *.ninja file.

fish should glob *.ninja files and use them as completion candidates. Without this patch, `ninja -f <TAB><TAB>` will make no difference which is not really good.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
