### PR TITLE
pacaur: recognize *.pkg.tar as valid package extension

### DIFF
--- a/share/completions/pacaur.fish
+++ b/share/completions/pacaur.fish
@@ -163,5 +163,4 @@ complete -c $progname -n "$files" -l machinereadable -d 'Show in machine readabl
 # Theoretically, pacman reads packages in all formats that libarchive supports
 # In practice, it's going to be tar.xz or tar.gz
 # Using "pkg.tar.*" here would change __fish_complete_suffix's descriptions to "unknown"
-complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar.xz)' -d 'Package file'
-complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar.gz)' -d 'Package file'
+complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix .pkg.tar\{,.xz,.gz\})' -d 'Package file'


### PR DESCRIPTION
## Description

Make pacaur recognize .pkg.tar as valid package extension. This change was done to pacman in https://github.com/fish-shell/fish-shell/pull/5005