### PR TITLE
Make `help` work on MacOS High Sierra without trampoline

### DIFF
--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -21,10 +21,6 @@ function help --description 'Show help for the fish shell'
     set -l fish_browser
     set -l graphical_browsers htmlview x-www-browser firefox galeon mozilla konqueror epiphany opera netscape rekonq google-chrome chromium-browser
 
-    # On mac we may have to write a temporary file that redirects to the desired
-    # help page, since `open` will drop fragments from file URIs (issue #4480).
-    set -l need_trampoline
-
     if set -q fish_help_browser[1]
         # User has set a fish-specific help browser. This overrides the
         # browser that may be defined by $BROWSER. The fish_help_browser
@@ -65,11 +61,10 @@ function help --description 'Show help for the fish shell'
                 set fish_browser xdg-open
             end
 
-            # On OS X, we go through open by default
+            # On OS X, we go through osascript by default
             if test (uname) = Darwin
-                if type -q open
-                    set fish_browser open
-                    set need_trampoline 1
+                if type -q osascript
+                    set fish_browser osascript
                 end
             end
         end
@@ -137,22 +132,23 @@ function help --description 'Show help for the fish shell'
         # Go to the web. Only include one dot in the version string
         set -l version_string (echo $version| cut -d . -f 1,2)
         set page_url https://fishshell.com/docs/$version_string/$fish_help_page
-        # We don't need a trampoline for a remote URL.
-        set need_trampoline
     end
 
-    if set -q need_trampoline[1]
-        # If string replace doesn't replace anything, we don't actually need a
-        # trampoline (they're only needed if there's a fragment in the path)
-        if set -l clean_url (string replace '\\#' '#' $page_url)
-            # Write a temporary file that will redirect where we want.
-            set -q TMPDIR
-            or set -l TMPDIR /tmp
-            set -l tmpdir (mktemp -d $TMPDIR/help.XXXXXX)
-            set -l tmpname $tmpdir/help.html
-            echo '<meta http-equiv="refresh" content="0;URL=\''$clean_url'\'" />' > $tmpname
-            set page_url file://$tmpname
-        end
+    # OS X /usr/bin/open swallows fragments (anchors), so use osascript
+    # Eval is just a cheesy way of removing the hash escaping
+    if test "$fish_browser" = osascript
+        set -l opencmd 'set URL of document 1 to "'(eval echo $page_url)'"'
+        osascript \
+            -e 'tell application "Safari"' \
+            -e '    tell front window' \
+            -e '        set current tab to (make new tab)' \
+            -e '        set index to 1' \
+            -e '    end tell' \
+            -e      $opencmd \
+            -e '    activate' \
+            -e 'end tell'
+
+        return
     end
 
     if test $wsl -eq 1


### PR DESCRIPTION
## Description

On MacOS, commit 42fa84157 has moved from using Applescript `open location` for `help xxx` to open the right page, using instead trampoline. Since this involves creating a new directory in /tmp for each execution of `help`, I find it a better idea to fix the Applescript instead. This is what this pull request is about. The key issue that triggered #42fa84 is that Applescript `open location` silently discard `xxxxx` at the end of  `file:///path/to/commands.html/xxxx`, which I directly checked using Script Editor. So this pull request taps into Safari scripting dictionary to get the job done.
