### PR TITLE
Add notion of "default" bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ fish 3.0 is a major release which brings with it both improvements in functional
 - `test` and `[` now support floating point values in numeric comparisons.
 - Autosuggestions try to avoid arguments that are already present in the command line.
 - Variables may be used inside commands (#154).
+- Bare `bind` invocations in config.fish now work. The `fish_user_key_bindings` function is no longer necessary, but will still be executed if it exists (#5191).
 
 ## Other significant changes
 - Command substitution output is now limited to 10 MB by default (#3822).

--- a/doc_src/bind.txt
+++ b/doc_src/bind.txt
@@ -3,12 +3,14 @@
 \subsection bind-synopsis Synopsis
 \fish{synopsis}
 bind [(-M | --mode) MODE] [(-m | --sets-mode) NEW_MODE]
+     [--default | --user]
      [(-s | --silent)] [(-k | --key)] SEQUENCE COMMAND [COMMAND...]
-bind [(-M | --mode) MODE] [(-k | --key)] SEQUENCE
-bind (-K | --key-names) [(-a | --all)]
+bind [(-M | --mode) MODE] [(-k | --key)] [--default] [--user] SEQUENCE
+bind (-K | --key-names) [(-a | --all)] [--default] [--user]
 bind (-f | --function-names)
 bind (-L | --list-modes)
 bind (-e | --erase) [(-M | --mode) MODE]
+     [--default] [--user]
      (-a | --all | [(-k | --key)] SEQUENCE [SEQUENCE...])
 \endfish
 
@@ -32,7 +34,7 @@ When multiple `COMMAND`s are provided, they are all run in the specified order w
 
 If no `SEQUENCE` is provided, all bindings (or just the bindings in the specified `MODE`) are printed. If `SEQUENCE` is provided without `COMMAND`, just the binding matching that sequence is printed.
 
-Key bindings are not saved between sessions by default. **Bare `bind` statements in <a href="index.html#initialization">config.fish</a> won't have any effect because it is sourced before the default keybindings are setup.** To save custom keybindings, put the `bind` statements into a function called `fish_user_key_bindings`, which will be <a href="tutorial.html#tut_autoload">autoloaded</a>.
+To save custom keybindings, put the `bind` statements into <a href="index.html#initialization">config.fish</a>. Alternatively, fish also automatically executes a function called `fish_user_key_bindings` if it exists.
 
 Key bindings may use "modes", which mimics Vi's modal input behavior. The default mode is "default", and every bind applies to a single mode. The mode can be viewed/changed with the `$fish_bind_mode` variable.
 
@@ -53,6 +55,8 @@ The following parameters are available:
 - `-e` or `--erase` Erase the binding with the given sequence and mode instead of defining a new one. Multiple sequences can be specified with this flag. Specifying `-a` or `--all` with `-M` or `--mode` erases all binds in the given mode regardless of sequence. Specifying `-a` or `--all` without `-M` or `--mode` erases all binds in all modes regardless of sequence.
 
 - `-a` or `--all` See `--erase` and `--key-names`
+
+- `--default` and `--user` specify if bind should operate on user or default bindings. User bindings take precedence over default bindings when fish looks up mappings. By default, all `bind` invocations work on the "user" level except for listing, which will show both levels by default. All invocations except for inserting new bindings can operate on both levels at the same time. `--default` should only be used in full binding sets (like when working on `fish_default_key_bindings`).
 
 \subsection bind-functions Special input functions
 The following special input functions are available:

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -9,103 +9,103 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
         return 1
     end
 
-    bind $argv \cy yank
+    bind --default $argv \cy yank
     or return # protect against invalid $argv
-    bind $argv \ey yank-pop
+    bind --default $argv \ey yank-pop
 
     # Left/Right arrow
-    bind $argv -k right forward-char
-    bind $argv -k left backward-char
-    bind $argv \e\[C forward-char
-    bind $argv \e\[D backward-char
+    bind --default $argv -k right forward-char
+    bind --default $argv -k left backward-char
+    bind --default $argv \e\[C forward-char
+    bind --default $argv \e\[D backward-char
     # Some terminals output these when they're in in keypad mode.
-    bind $argv \eOC forward-char
-    bind $argv \eOD backward-char
+    bind --default $argv \eOC forward-char
+    bind --default $argv \eOD backward-char
 
-    bind $argv -k ppage beginning-of-history
-    bind $argv -k npage end-of-history
+    bind --default $argv -k ppage beginning-of-history
+    bind --default $argv -k npage end-of-history
 
     # Interaction with the system clipboard.
-    bind $argv \cx fish_clipboard_copy
-    bind $argv \cv fish_clipboard_paste
+    bind --default $argv \cx fish_clipboard_copy
+    bind --default $argv \cv fish_clipboard_paste
 
-    bind $argv \e cancel
-    bind $argv \t complete
-    bind $argv \cs pager-toggle-search
+    bind --default $argv \e cancel
+    bind --default $argv \t complete
+    bind --default $argv \cs pager-toggle-search
     # shift-tab does a tab complete followed by a search.
-    bind $argv --key btab complete-and-search
+    bind --default $argv --key btab complete-and-search
 
-    bind $argv \e\n "commandline -i \n"
-    bind $argv \e\r "commandline -i \n"
+    bind --default $argv \e\n "commandline -i \n"
+    bind --default $argv \e\r "commandline -i \n"
 
-    bind $argv -k down down-or-search
-    bind $argv -k up up-or-search
-    bind $argv \e\[A up-or-search
-    bind $argv \e\[B down-or-search
-    bind $argv \eOA up-or-search
-    bind $argv \eOB down-or-search
+    bind --default $argv -k down down-or-search
+    bind --default $argv -k up up-or-search
+    bind --default $argv \e\[A up-or-search
+    bind --default $argv \e\[B down-or-search
+    bind --default $argv \eOA up-or-search
+    bind --default $argv \eOB down-or-search
 
     # Alt-left/Alt-right
-    bind $argv \e\eOC nextd-or-forward-word
-    bind $argv \e\eOD prevd-or-backward-word
-    bind $argv \e\e\[C nextd-or-forward-word
-    bind $argv \e\e\[D prevd-or-backward-word
-    bind $argv \eO3C nextd-or-forward-word
-    bind $argv \eO3D prevd-or-backward-word
-    bind $argv \e\[3C nextd-or-forward-word
-    bind $argv \e\[3D prevd-or-backward-word
-    bind $argv \e\[1\;3C nextd-or-forward-word
-    bind $argv \e\[1\;3D prevd-or-backward-word
-    bind $argv \e\[1\;9C nextd-or-forward-word #iTerm2
-    bind $argv \e\[1\;9D prevd-or-backward-word #iTerm2
+    bind --default $argv \e\eOC nextd-or-forward-word
+    bind --default $argv \e\eOD prevd-or-backward-word
+    bind --default $argv \e\e\[C nextd-or-forward-word
+    bind --default $argv \e\e\[D prevd-or-backward-word
+    bind --default $argv \eO3C nextd-or-forward-word
+    bind --default $argv \eO3D prevd-or-backward-word
+    bind --default $argv \e\[3C nextd-or-forward-word
+    bind --default $argv \e\[3D prevd-or-backward-word
+    bind --default $argv \e\[1\;3C nextd-or-forward-word
+    bind --default $argv \e\[1\;3D prevd-or-backward-word
+    bind --default $argv \e\[1\;9C nextd-or-forward-word #iTerm2
+    bind --default $argv \e\[1\;9D prevd-or-backward-word #iTerm2
 
     # Alt-up/Alt-down
-    bind $argv \e\eOA history-token-search-backward
-    bind $argv \e\eOB history-token-search-forward
-    bind $argv \e\e\[A history-token-search-backward
-    bind $argv \e\e\[B history-token-search-forward
-    bind $argv \eO3A history-token-search-backward
-    bind $argv \eO3B history-token-search-forward
-    bind $argv \e\[3A history-token-search-backward
-    bind $argv \e\[3B history-token-search-forward
-    bind $argv \e\[1\;3A history-token-search-backward
-    bind $argv \e\[1\;3B history-token-search-forward
-    bind $argv \e\[1\;9A history-token-search-backward # iTerm2
-    bind $argv \e\[1\;9B history-token-search-forward # iTerm2
+    bind --default $argv \e\eOA history-token-search-backward
+    bind --default $argv \e\eOB history-token-search-forward
+    bind --default $argv \e\e\[A history-token-search-backward
+    bind --default $argv \e\e\[B history-token-search-forward
+    bind --default $argv \eO3A history-token-search-backward
+    bind --default $argv \eO3B history-token-search-forward
+    bind --default $argv \e\[3A history-token-search-backward
+    bind --default $argv \e\[3B history-token-search-forward
+    bind --default $argv \e\[1\;3A history-token-search-backward
+    bind --default $argv \e\[1\;3B history-token-search-forward
+    bind --default $argv \e\[1\;9A history-token-search-backward # iTerm2
+    bind --default $argv \e\[1\;9B history-token-search-forward # iTerm2
     # Bash compatibility
     # https://github.com/fish-shell/fish-shell/issues/89
-    bind $argv \e. history-token-search-backward
+    bind --default $argv \e. history-token-search-backward
 
-    bind $argv \el __fish_list_current_token
-    bind $argv \ew 'set tok (commandline -pt); if test $tok[1]; echo; whatis $tok[1]; commandline -f repaint; end'
+    bind --default $argv \el __fish_list_current_token
+    bind --default $argv \ew 'set tok (commandline -pt); if test $tok[1]; echo; whatis $tok[1]; commandline -f repaint; end'
     # ncurses > 6.0 sends a "delete scrollback" sequence along with clear.
     # This string replace removes it.
-    bind $argv \cl 'echo -n (clear | string replace \e\[3J ""); commandline -f repaint'
-    bind $argv \cc __fish_cancel_commandline
-    bind $argv \cu backward-kill-line
-    bind $argv \cw backward-kill-path-component
-    bind $argv \e\[F end-of-line
-    bind $argv \e\[H beginning-of-line
+    bind --default $argv \cl 'echo -n (clear | string replace \e\[3J ""); commandline -f repaint'
+    bind --default $argv \cc __fish_cancel_commandline
+    bind --default $argv \cu backward-kill-line
+    bind --default $argv \cw backward-kill-path-component
+    bind --default $argv \e\[F end-of-line
+    bind --default $argv \e\[H beginning-of-line
 
-    bind $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
-    bind $argv \cd delete-or-exit
+    bind --default $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
+    bind --default $argv \cd delete-or-exit
 
     # Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh).
-    bind $argv -k f1 __fish_man_page
-    bind $argv \eh __fish_man_page
+    bind --default $argv -k f1 __fish_man_page
+    bind --default $argv \eh __fish_man_page
 
     # This will make sure the output of the current command is paged using the default pager when
     # you press Meta-p.
     # If none is set, less will be used.
-    bind $argv \ep '__fish_paginate'
+    bind --default $argv \ep '__fish_paginate'
 
     # Make it easy to turn an unexecuted command into a comment in the shell history. Also,
     # remove the commenting chars so the command can be further edited then executed.
-    bind $argv \e\# __fish_toggle_comment_commandline
+    bind --default $argv \e\# __fish_toggle_comment_commandline
 
     # The [meta-e] and [meta-v] keystrokes invoke an external editor on the command buffer.
-    bind \ee edit_command_buffer
-    bind \ev edit_command_buffer
+    bind --default $argv \ee edit_command_buffer
+    bind --default $argv \ev edit_command_buffer
 
     # Support for "bracketed paste"
     # The way it works is that we acknowledge our support by printing
@@ -135,17 +135,17 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
 
     # Exclude paste mode or there'll be an additional binding after switching between emacs and vi
     for mode in (bind --list-modes | string match -v paste)
-        bind -M $mode -m paste \e\[200~ '__fish_start_bracketed_paste'
+        bind --default -M $mode -m paste \e\[200~ '__fish_start_bracketed_paste'
     end
     # This sequence ends paste-mode and returns to the previous mode we have saved before.
-    bind -M paste \e\[201~ '__fish_stop_bracketed_paste'
+    bind --default -M paste \e\[201~ '__fish_stop_bracketed_paste'
     # In paste-mode, everything self-inserts except for the sequence to get out of it
-    bind -M paste "" self-insert
+    bind --default -M paste "" self-insert
     # Without this, a \r will overwrite the other text, rendering it invisible - which makes the exercise kinda pointless.
     # TODO: Test this in windows (\r\n line endings)
-    bind -M paste \r "commandline -i \n"
-    bind -M paste "'" "__fish_commandline_insert_escaped \' \$__fish_paste_quoted"
-    bind -M paste \\ "__fish_commandline_insert_escaped \\\ \$__fish_paste_quoted"
+    bind --default -M paste \r "commandline -i \n"
+    bind --default -M paste "'" "__fish_commandline_insert_escaped \' \$__fish_paste_quoted"
+    bind --default -M paste \\ "__fish_commandline_insert_escaped \\\ \$__fish_paste_quoted"
 end
 
 function __fish_commandline_insert_escaped --description 'Insert the first arg escaped if a second arg is given'

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -6,7 +6,7 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
     end
 
     if not set -q argv[1]
-        bind --erase --all # clear earlier bindings, if any
+        bind --erase --all --default # clear earlier bindings, if any
         if test "$fish_key_bindings" != "fish_default_key_bindings"
             # Allow the user to set the variable universally
             set -q fish_key_bindings
@@ -28,76 +28,76 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
     or return # protect against invalid $argv
 
     # This is the default binding, i.e. the one used if no other binding matches
-    bind $argv "" self-insert
+    bind --default $argv "" self-insert
     or exit # protect against invalid $argv
 
-    bind $argv \n execute
-    bind $argv \r execute
+    bind --default $argv \n execute
+    bind --default $argv \r execute
 
-    bind $argv \ck kill-line
+    bind --default $argv \ck kill-line
 
-    bind $argv \eOC forward-char
-    bind $argv \eOD backward-char
-    bind $argv \e\[C forward-char
-    bind $argv \e\[D backward-char
-    bind $argv -k right forward-char
-    bind $argv -k left backward-char
+    bind --default $argv \eOC forward-char
+    bind --default $argv \eOD backward-char
+    bind --default $argv \e\[C forward-char
+    bind --default $argv \e\[D backward-char
+    bind --default $argv -k right forward-char
+    bind --default $argv -k left backward-char
 
-    bind $argv -k dc delete-char
-    bind $argv -k backspace backward-delete-char
-    bind $argv \x7f backward-delete-char
+    bind --default $argv -k dc delete-char
+    bind --default $argv -k backspace backward-delete-char
+    bind --default $argv \x7f backward-delete-char
 
     # for PuTTY
     # https://github.com/fish-shell/fish-shell/issues/180
-    bind $argv \e\[1~ beginning-of-line
-    bind $argv \e\[3~ delete-char
-    bind $argv \e\[4~ end-of-line
+    bind --default $argv \e\[1~ beginning-of-line
+    bind --default $argv \e\[3~ delete-char
+    bind --default $argv \e\[4~ end-of-line
 
     # OS X SnowLeopard doesn't have these keys. Don't show an annoying error message.
-    bind $argv -k home beginning-of-line 2>/dev/null
-    bind $argv -k end end-of-line 2>/dev/null
-    bind $argv \e\[3\;2~ backward-delete-char # Mavericks Terminal.app shift-ctrl-delete
+    bind --default $argv -k home beginning-of-line 2>/dev/null
+    bind --default $argv -k end end-of-line 2>/dev/null
+    bind --default $argv \e\[3\;2~ backward-delete-char # Mavericks Terminal.app shift-ctrl-delete
 
-    bind $argv \ca beginning-of-line
-    bind $argv \ce end-of-line
-    bind $argv \ch backward-delete-char
-    bind $argv \cp up-or-search
-    bind $argv \cn down-or-search
-    bind $argv \cf forward-char
-    bind $argv \cb backward-char
-    bind $argv \ct transpose-chars
-    bind $argv \et transpose-words
-    bind $argv \eu upcase-word
+    bind --default $argv \ca beginning-of-line
+    bind --default $argv \ce end-of-line
+    bind --default $argv \ch backward-delete-char
+    bind --default $argv \cp up-or-search
+    bind --default $argv \cn down-or-search
+    bind --default $argv \cf forward-char
+    bind --default $argv \cb backward-char
+    bind --default $argv \ct transpose-chars
+    bind --default $argv \et transpose-words
+    bind --default $argv \eu upcase-word
 
     # This clashes with __fish_list_current_token
-    # bind $argv \el downcase-word
-    bind $argv \ec capitalize-word
+    # bind --default $argv \el downcase-word
+    bind --default $argv \ec capitalize-word
     # One of these is alt+backspace.
-    bind $argv \e\x7f backward-kill-word
-    bind $argv \e\b backward-kill-word
-    bind $argv \eb backward-word
-    bind $argv \ef forward-word
-    bind $argv \e\[1\;5C forward-word
-    bind $argv \e\[1\;5D backward-word
-    bind $argv \e\< beginning-of-buffer
-    bind $argv \e\> end-of-buffer
+    bind --default $argv \e\x7f backward-kill-word
+    bind --default $argv \e\b backward-kill-word
+    bind --default $argv \eb backward-word
+    bind --default $argv \ef forward-word
+    bind --default $argv \e\[1\;5C forward-word
+    bind --default $argv \e\[1\;5D backward-word
+    bind --default $argv \e\< beginning-of-buffer
+    bind --default $argv \e\> end-of-buffer
 
-    bind $argv \ed kill-word
+    bind --default $argv \ed kill-word
 
     # Ignore some known-bad control sequences
     # https://github.com/fish-shell/fish-shell/issues/1917
-    bind $argv \e\[I 'begin;end'
-    bind $argv \e\[O 'begin;end'
+    bind --default $argv \e\[I 'begin;end'
+    bind --default $argv \e\[O 'begin;end'
 
     # term-specific special bindings
     switch "$TERM"
         case 'rxvt*'
-            bind $argv \e\[8~ end-of-line
-            bind $argv \eOc forward-word
-            bind $argv \eOd backward-word
+            bind --default $argv \e\[8~ end-of-line
+            bind --default $argv \eOc forward-word
+            bind --default $argv \eOd backward-word
         case 'xterm-256color'
             # Microsoft's conemu uses xterm-256color plus
             # the following to tell a console to paste:
-            bind $argv \e\x20ep fish_clipboard_paste
+            bind --default $argv \e\x20ep fish_clipboard_paste
     end
 end

--- a/share/functions/fish_hybrid_key_bindings.fish
+++ b/share/functions/fish_hybrid_key_bindings.fish
@@ -1,5 +1,5 @@
 function fish_hybrid_key_bindings --description "Vi-style bindings that inherit emacs-style bindings in all modes"
-    bind --erase --all # clear earlier bindings, if any
+    bind --erase --all --default # clear earlier bindings, if any
 
     if test "$fish_key_bindings" != "fish_hybrid_key_bindings"
         # Allow the user to set the variable universally

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -61,217 +61,217 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
         __fish_shared_key_bindings -M $mode
     end
 
-    bind $argv insert \r execute
-    bind $argv insert \n execute
+    bind --default $argv insert \r execute
+    bind --default $argv insert \n execute
 
-    bind $argv insert "" self-insert
+    bind --default $argv insert "" self-insert
 
     # Add way to kill current command line while in insert mode.
-    bind $argv insert \cc __fish_cancel_commandline
+    bind --default $argv insert \cc __fish_cancel_commandline
     # Add a way to switch from insert to normal (command) mode.
     # Note if we are paging, we want to stay in insert mode
     # See #2871
-    bind $argv insert \e "if commandline -P; commandline -f cancel; else; set fish_bind_mode default; commandline -f backward-char force-repaint; end"
+    bind --default $argv insert \e "if commandline -P; commandline -f cancel; else; set fish_bind_mode default; commandline -f backward-char force-repaint; end"
 
     # Default (command) mode
-    bind :q exit
-    bind -m insert \cc __fish_cancel_commandline
-    bind $argv default h backward-char
-    bind $argv default l forward-char
-    bind -m insert \n execute
-    bind -m insert \r execute
-    bind -m insert i force-repaint
-    bind -m insert I beginning-of-line force-repaint
-    bind -m insert a forward-char force-repaint
-    bind -m insert A end-of-line force-repaint
-    bind -m visual v begin-selection force-repaint
+    bind --default :q exit
+    bind --default -m insert \cc __fish_cancel_commandline
+    bind --default $argv default h backward-char
+    bind --default $argv default l forward-char
+    bind --default -m insert \n execute
+    bind --default -m insert \r execute
+    bind --default -m insert i force-repaint
+    bind --default -m insert I beginning-of-line force-repaint
+    bind --default -m insert a forward-char force-repaint
+    bind --default -m insert A end-of-line force-repaint
+    bind --default -m visual v begin-selection force-repaint
 
-    #bind -m insert o "commandline -a \n" down-line force-repaint
-    #bind -m insert O beginning-of-line "commandline -i \n" up-line force-repaint # doesn't work
+    #bind --default -m insert o "commandline -a \n" down-line force-repaint
+    #bind --default -m insert O beginning-of-line "commandline -i \n" up-line force-repaint # doesn't work
 
-    bind gg beginning-of-buffer
-    bind G end-of-buffer
+    bind --default gg beginning-of-buffer
+    bind --default G end-of-buffer
 
     for key in $eol_keys
-        bind $key end-of-line
+        bind --default $key end-of-line
     end
     for key in $bol_keys
-        bind $key beginning-of-line
+        bind --default $key beginning-of-line
     end
 
-    bind u history-search-backward
-    bind \cr history-search-forward
+    bind --default u history-search-backward
+    bind --default \cr history-search-forward
 
-    bind [ history-token-search-backward
-    bind ] history-token-search-forward
+    bind --default [ history-token-search-backward
+    bind --default ] history-token-search-forward
 
-    bind k up-or-search
-    bind j down-or-search
-    bind b backward-word
-    bind B backward-bigword
-    bind ge backward-word
-    bind gE backward-bigword
-    bind w forward-word forward-char
-    bind W forward-bigword forward-char
-    bind e forward-char forward-word backward-char
-    bind E forward-bigword backward-char
+    bind --default k up-or-search
+    bind --default j down-or-search
+    bind --default b backward-word
+    bind --default B backward-bigword
+    bind --default ge backward-word
+    bind --default gE backward-bigword
+    bind --default w forward-word forward-char
+    bind --default W forward-bigword forward-char
+    bind --default e forward-char forward-word backward-char
+    bind --default E forward-bigword backward-char
 
     # OS X SnowLeopard doesn't have these keys. Don't show an annoying error message.
     # Vi/Vim doesn't support these keys in insert mode but that seems silly so we do so anyway.
-    bind $argv insert -k home beginning-of-line 2>/dev/null
-    bind $argv default -k home beginning-of-line 2>/dev/null
-    bind $argv insert -k end end-of-line 2>/dev/null
-    bind $argv default -k end end-of-line 2>/dev/null
+    bind --default $argv insert -k home beginning-of-line 2>/dev/null
+    bind --default $argv default -k home beginning-of-line 2>/dev/null
+    bind --default $argv insert -k end end-of-line 2>/dev/null
+    bind --default $argv default -k end end-of-line 2>/dev/null
 
     # Vi moves the cursor back if, after deleting, it is at EOL.
     # To emulate that, move forward, then backward, which will be a NOP
     # if there is something to move forward to.
-    bind $argv default x delete-char forward-char backward-char
-    bind $argv default X backward-delete-char
-    bind $argv insert -k dc delete-char forward-char backward-char
-    bind $argv default -k dc delete-char forward-char backward-char
+    bind --default $argv default x delete-char forward-char backward-char
+    bind --default $argv default X backward-delete-char
+    bind --default $argv insert -k dc delete-char forward-char backward-char
+    bind --default $argv default -k dc delete-char forward-char backward-char
 
     # Backspace deletes a char in insert mode, but not in normal/default mode.
-    bind $argv insert -k backspace backward-delete-char
-    bind $argv default -k backspace backward-char
-    bind $argv insert \ch backward-delete-char
-    bind $argv default \ch backward-char
-    bind $argv insert \x7f backward-delete-char
-    bind $argv default \x7f backward-char
-    bind $argv insert \e\[3\;2~ backward-delete-char # Mavericks Terminal.app shift-ctrl-delete
-    bind $argv default \e\[3\;2~ backward-delete-char # Mavericks Terminal.app shift-ctrl-delete
+    bind --default $argv insert -k backspace backward-delete-char
+    bind --default $argv default -k backspace backward-char
+    bind --default $argv insert \ch backward-delete-char
+    bind --default $argv default \ch backward-char
+    bind --default $argv insert \x7f backward-delete-char
+    bind --default $argv default \x7f backward-char
+    bind --default $argv insert \e\[3\;2~ backward-delete-char # Mavericks Terminal.app shift-ctrl-delete
+    bind --default $argv default \e\[3\;2~ backward-delete-char # Mavericks Terminal.app shift-ctrl-delete
 
-    bind dd kill-whole-line
-    bind D kill-line
-    bind d\$ kill-line
-    bind d\^ backward-kill-line
-    bind dw kill-word
-    bind dW kill-bigword
-    bind diw forward-char forward-char backward-word kill-word
-    bind diW forward-char forward-char backward-bigword kill-bigword
-    bind daw forward-char forward-char backward-word kill-word
-    bind daW forward-char forward-char backward-bigword kill-bigword
-    bind de kill-word
-    bind dE kill-bigword
-    bind db backward-kill-word
-    bind dB backward-kill-bigword
-    bind dge backward-kill-word
-    bind dgE backward-kill-bigword
-    bind df begin-selection forward-jump kill-selection end-selection
-    bind dt begin-selection forward-jump backward-char kill-selection end-selection
-    bind dF begin-selection backward-jump kill-selection end-selection
-    bind dT begin-selection backward-jump forward-char kill-selection end-selection
+    bind --default dd kill-whole-line
+    bind --default D kill-line
+    bind --default d\$ kill-line
+    bind --default d\^ backward-kill-line
+    bind --default dw kill-word
+    bind --default dW kill-bigword
+    bind --default diw forward-char forward-char backward-word kill-word
+    bind --default diW forward-char forward-char backward-bigword kill-bigword
+    bind --default daw forward-char forward-char backward-word kill-word
+    bind --default daW forward-char forward-char backward-bigword kill-bigword
+    bind --default de kill-word
+    bind --default dE kill-bigword
+    bind --default db backward-kill-word
+    bind --default dB backward-kill-bigword
+    bind --default dge backward-kill-word
+    bind --default dgE backward-kill-bigword
+    bind --default df begin-selection forward-jump kill-selection end-selection
+    bind --default dt begin-selection forward-jump backward-char kill-selection end-selection
+    bind --default dF begin-selection backward-jump kill-selection end-selection
+    bind --default dT begin-selection backward-jump forward-char kill-selection end-selection
 
-    bind -m insert s delete-char force-repaint
-    bind -m insert S kill-whole-line force-repaint
-    bind -m insert cc kill-whole-line force-repaint
-    bind -m insert C kill-line force-repaint
-    bind -m insert c\$ kill-line force-repaint
-    bind -m insert c\^ backward-kill-line force-repaint
-    bind -m insert cw kill-word force-repaint
-    bind -m insert cW kill-bigword force-repaint
-    bind -m insert ciw forward-char forward-char backward-word kill-word force-repaint
-    bind -m insert ciW forward-char forward-char backward-bigword kill-bigword force-repaint
-    bind -m insert caw forward-char forward-char backward-word kill-word force-repaint
-    bind -m insert caW forward-char forward-char backward-bigword kill-bigword force-repaint
-    bind -m insert ce kill-word force-repaint
-    bind -m insert cE kill-bigword force-repaint
-    bind -m insert cb backward-kill-word force-repaint
-    bind -m insert cB backward-kill-bigword force-repaint
-    bind -m insert cge backward-kill-word force-repaint
-    bind -m insert cgE backward-kill-bigword force-repaint
+    bind --default -m insert s delete-char force-repaint
+    bind --default -m insert S kill-whole-line force-repaint
+    bind --default -m insert cc kill-whole-line force-repaint
+    bind --default -m insert C kill-line force-repaint
+    bind --default -m insert c\$ kill-line force-repaint
+    bind --default -m insert c\^ backward-kill-line force-repaint
+    bind --default -m insert cw kill-word force-repaint
+    bind --default -m insert cW kill-bigword force-repaint
+    bind --default -m insert ciw forward-char forward-char backward-word kill-word force-repaint
+    bind --default -m insert ciW forward-char forward-char backward-bigword kill-bigword force-repaint
+    bind --default -m insert caw forward-char forward-char backward-word kill-word force-repaint
+    bind --default -m insert caW forward-char forward-char backward-bigword kill-bigword force-repaint
+    bind --default -m insert ce kill-word force-repaint
+    bind --default -m insert cE kill-bigword force-repaint
+    bind --default -m insert cb backward-kill-word force-repaint
+    bind --default -m insert cB backward-kill-bigword force-repaint
+    bind --default -m insert cge backward-kill-word force-repaint
+    bind --default -m insert cgE backward-kill-bigword force-repaint
 
-    bind '~' capitalize-word
-    bind gu downcase-word
-    bind gU upcase-word
+    bind --default '~' capitalize-word
+    bind --default gu downcase-word
+    bind --default gU upcase-word
 
-    bind J end-of-line delete-char
-    bind K 'man (commandline -t) 2>/dev/null; or echo -n \a'
+    bind --default J end-of-line delete-char
+    bind --default K 'man (commandline -t) 2>/dev/null; or echo -n \a'
 
-    bind yy kill-whole-line yank
-    bind Y kill-whole-line yank
-    bind y\$ kill-line yank
-    bind y\^ backward-kill-line yank
-    bind yw kill-word yank
-    bind yW kill-bigword yank
-    bind yiw forward-char forward-char backward-word kill-word yank
-    bind yiW forward-char forward-char backward-bigword kill-bigword yank
-    bind yaw forward-char forward-char backward-word kill-word yank
-    bind yaW forward-char forward-char backward-bigword kill-bigword yank
-    bind ye kill-word yank
-    bind yE kill-bigword yank
-    bind yb backward-kill-word yank
-    bind yB backward-kill-bigword yank
-    bind yge backward-kill-word yank
-    bind ygE backward-kill-bigword yank
+    bind --default yy kill-whole-line yank
+    bind --default Y kill-whole-line yank
+    bind --default y\$ kill-line yank
+    bind --default y\^ backward-kill-line yank
+    bind --default yw kill-word yank
+    bind --default yW kill-bigword yank
+    bind --default yiw forward-char forward-char backward-word kill-word yank
+    bind --default yiW forward-char forward-char backward-bigword kill-bigword yank
+    bind --default yaw forward-char forward-char backward-word kill-word yank
+    bind --default yaW forward-char forward-char backward-bigword kill-bigword yank
+    bind --default ye kill-word yank
+    bind --default yE kill-bigword yank
+    bind --default yb backward-kill-word yank
+    bind --default yB backward-kill-bigword yank
+    bind --default yge backward-kill-word yank
+    bind --default ygE backward-kill-bigword yank
 
-    bind f forward-jump
-    bind F backward-jump
-    bind t forward-jump-till
-    bind T backward-jump-till
-    bind ';' repeat-jump
-    bind , repeat-jump-reverse
+    bind --default f forward-jump
+    bind --default F backward-jump
+    bind --default t forward-jump-till
+    bind --default T backward-jump-till
+    bind --default ';' repeat-jump
+    bind --default , repeat-jump-reverse
 
     # in emacs yank means paste
-    bind p yank
-    bind P backward-char yank
-    bind gp yank-pop
+    bind --default p yank
+    bind --default P backward-char yank
+    bind --default gp yank-pop
 
-    bind '"*p' "commandline -i ( xsel -p; echo )[1]"
-    bind '"*P' backward-char "commandline -i ( xsel -p; echo )[1]"
+    bind --default '"*p' "commandline -i ( xsel -p; echo )[1]"
+    bind --default '"*P' backward-char "commandline -i ( xsel -p; echo )[1]"
 
     #
     # Lowercase r, enters replace_one mode
     #
-    bind -m replace_one r force-repaint
-    bind $argv replace_one -m default '' delete-char self-insert backward-char force-repaint
-    bind $argv replace_one -m default \e cancel force-repaint
+    bind --default -m replace_one r force-repaint
+    bind --default $argv replace_one -m default '' delete-char self-insert backward-char force-repaint
+    bind --default $argv replace_one -m default \e cancel force-repaint
 
     #
     # visual mode
     #
-    bind $argv visual h backward-char
-    bind $argv visual l forward-char
+    bind --default $argv visual h backward-char
+    bind --default $argv visual l forward-char
 
-    bind $argv visual k up-line
-    bind $argv visual j down-line
+    bind --default $argv visual k up-line
+    bind --default $argv visual j down-line
 
-    bind $argv visual b backward-word
-    bind $argv visual B backward-bigword
-    bind $argv visual ge backward-word
-    bind $argv visual gE backward-bigword
-    bind $argv visual w forward-word
-    bind $argv visual W forward-bigword
-    bind $argv visual e forward-word
-    bind $argv visual E forward-bigword
-    bind $argv visual o swap-selection-start-stop force-repaint
+    bind --default $argv visual b backward-word
+    bind --default $argv visual B backward-bigword
+    bind --default $argv visual ge backward-word
+    bind --default $argv visual gE backward-bigword
+    bind --default $argv visual w forward-word
+    bind --default $argv visual W forward-bigword
+    bind --default $argv visual e forward-word
+    bind --default $argv visual E forward-bigword
+    bind --default $argv visual o swap-selection-start-stop force-repaint
 
-    bind $argv visual f forward-jump
-    bind $argv visual t forward-jump-till
-    bind $argv visual F backward-jump
-    bind $argv visual T backward-jump-till
+    bind --default $argv visual f forward-jump
+    bind --default $argv visual t forward-jump-till
+    bind --default $argv visual F backward-jump
+    bind --default $argv visual T backward-jump-till
 
     for key in $eol_keys
-        bind $argv visual $key end-of-line
+        bind --default $argv visual $key end-of-line
     end
     for key in $bol_keys
-        bind $argv visual $key beginning-of-line
+        bind --default $argv visual $key beginning-of-line
     end
 
-    bind $argv visual -m insert c kill-selection end-selection force-repaint
-    bind $argv visual -m default d kill-selection end-selection force-repaint
-    bind $argv visual -m default x kill-selection end-selection force-repaint
-    bind $argv visual -m default X kill-whole-line end-selection force-repaint
-    bind $argv visual -m default y kill-selection yank end-selection force-repaint
-    bind $argv visual -m default '"*y' "commandline -s | xsel -p; commandline -f end-selection force-repaint"
+    bind --default $argv visual -m insert c kill-selection end-selection force-repaint
+    bind --default $argv visual -m default d kill-selection end-selection force-repaint
+    bind --default $argv visual -m default x kill-selection end-selection force-repaint
+    bind --default $argv visual -m default X kill-whole-line end-selection force-repaint
+    bind --default $argv visual -m default y kill-selection yank end-selection force-repaint
+    bind --default $argv visual -m default '"*y' "commandline -s | xsel -p; commandline -f end-selection force-repaint"
 
-    bind $argv visual -m default \cc end-selection force-repaint
-    bind $argv visual -m default \e end-selection force-repaint
+    bind --default $argv visual -m default \cc end-selection force-repaint
+    bind --default $argv visual -m default \e end-selection force-repaint
 
     # Make it easy to turn an unexecuted command into a comment in the shell history. Also, remove
     # the commenting chars so the command can be further edited then executed.
-    bind $argv default \# __fish_toggle_comment_commandline
-    bind $argv visual \# __fish_toggle_comment_commandline
+    bind --default $argv default \# __fish_toggle_comment_commandline
+    bind --default $argv visual \# __fish_toggle_comment_commandline
 
     # Set the cursor shape
     # After executing once, this will have defined functions listening for the variable.

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -14,7 +14,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
         set rebind false
         set -e argv[1]
     else
-        bind --erase --all # clear earlier bindings, if any
+        bind --erase --all --default # clear earlier bindings, if any
     end
 
     # Silence warnings about unavailable keys. See #4431, 4188

--- a/src/builtin_bind.cpp
+++ b/src/builtin_bind.cpp
@@ -255,13 +255,18 @@ bool builtin_bind_t::insert(int optind, int argc, wchar_t **argv, bool user,
 
 /// List all current bind modes.
 void builtin_bind_t::list_modes(io_streams_t &streams) {
-    const std::vector<input_mapping_name_t> lst = input_mapping_get_names();
+    // List all known modes, even if they are only in default bindings.
+    const std::vector<input_mapping_name_t> lst = input_mapping_get_names(true);
+    const std::vector<input_mapping_name_t> def_lst = input_mapping_get_names(false);
     // A set accomplishes two things for us here:
     // - It removes duplicates (no twenty "default" entries).
     // - It sorts it, which makes it nicer on the user.
     std::set<wcstring> modes;
 
     for (const input_mapping_name_t &binding : lst) {
+        modes.insert(binding.mode);
+    }
+    for (const input_mapping_name_t &binding : def_lst) {
         modes.insert(binding.mode);
     }
     for (const auto &mode : modes) {

--- a/src/builtin_bind.cpp
+++ b/src/builtin_bind.cpp
@@ -205,7 +205,6 @@ bool builtin_bind_t::add(const wchar_t *seq, const wchar_t *const *cmds, size_t 
 bool builtin_bind_t::erase(wchar_t **seq, bool all, const wchar_t *mode, bool use_terminfo, bool user,
                                io_streams_t &streams) {
     if (all) {
-        // TODO: Respect user setting!
         input_mapping_clear(mode, user);
         return false;
     }
@@ -217,12 +216,12 @@ bool builtin_bind_t::erase(wchar_t **seq, bool all, const wchar_t *mode, bool us
         if (use_terminfo) {
             wcstring seq2;
             if (get_terminfo_sequence(*seq++, &seq2, streams)) {
-                input_mapping_erase(seq2, mode);
+                input_mapping_erase(seq2, mode, user);
             } else {
                 res = true;
             }
         } else {
-            input_mapping_erase(*seq++, mode);
+            input_mapping_erase(*seq++, mode, user);
         }
     }
 

--- a/src/builtin_bind.h
+++ b/src/builtin_bind.h
@@ -16,7 +16,7 @@ public:
 private:
 	bind_cmd_opts_t *opts;
 
-	void list(const wchar_t *bind_mode, io_streams_t &streams);
+	void list(const wchar_t *bind_mode, bool user, io_streams_t &streams);
 	void key_names(bool all, io_streams_t &streams);
 	void function_names(io_streams_t &streams);
 	bool add(const wchar_t *seq, const wchar_t *const *cmds, size_t cmds_len,
@@ -28,7 +28,7 @@ private:
 	bool insert(int optind, int argc, wchar_t **argv, bool def,
 								 io_streams_t &streams);
 	void list_modes(io_streams_t &streams);
-	bool list_one(const wcstring &seq, const wcstring &bind_mode, io_streams_t &streams);
+	bool list_one(const wcstring &seq, const wcstring &bind_mode, bool user, io_streams_t &streams);
 };
 
 inline int builtin_bind(parser_t &parser, io_streams_t &streams, wchar_t **argv) {

--- a/src/builtin_bind.h
+++ b/src/builtin_bind.h
@@ -17,15 +17,15 @@ private:
 	bind_cmd_opts_t *opts;
 
 	void list(const wchar_t *bind_mode, io_streams_t &streams);
-	void key_names(int all, io_streams_t &streams);
+	void key_names(bool all, io_streams_t &streams);
 	void function_names(io_streams_t &streams);
 	bool add(const wchar_t *seq, const wchar_t *const *cmds, size_t cmds_len,
-								 const wchar_t *mode, const wchar_t *sets_mode, int terminfo,
+             const wchar_t *mode, const wchar_t *sets_mode, bool terminfo, bool def,
 								 io_streams_t &streams);
-	bool erase(wchar_t **seq, int all, const wchar_t *mode, int use_terminfo,
+	bool erase(wchar_t **seq, bool all, const wchar_t *mode, bool use_terminfo, bool def,
 								 io_streams_t &streams);
 	bool get_terminfo_sequence(const wchar_t *seq, wcstring *out_seq, io_streams_t &streams);
-	bool insert(int optind, int argc, wchar_t **argv,
+	bool insert(int optind, int argc, wchar_t **argv, bool def,
 								 io_streams_t &streams);
 	void list_modes(io_streams_t &streams);
 	bool list_one(const wcstring &seq, const wcstring &bind_mode, io_streams_t &streams);

--- a/src/builtin_bind.h
+++ b/src/builtin_bind.h
@@ -25,10 +25,11 @@ private:
 	bool erase(wchar_t **seq, bool all, const wchar_t *mode, bool use_terminfo, bool def,
 								 io_streams_t &streams);
 	bool get_terminfo_sequence(const wchar_t *seq, wcstring *out_seq, io_streams_t &streams);
-	bool insert(int optind, int argc, wchar_t **argv, bool def,
+	bool insert(int optind, int argc, wchar_t **argv,
 								 io_streams_t &streams);
 	void list_modes(io_streams_t &streams);
 	bool list_one(const wcstring &seq, const wcstring &bind_mode, bool user, io_streams_t &streams);
+	bool list_one(const wcstring &seq, const wcstring &bind_mode, bool user, bool def, io_streams_t &streams);
 };
 
 inline int builtin_bind(parser_t &parser, io_streams_t &streams, wchar_t **argv) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -529,10 +529,10 @@ wint_t input_readch(bool allow_commands) {
     }
 }
 
-std::vector<input_mapping_name_t> input_mapping_get_names() {
+std::vector<input_mapping_name_t> input_mapping_get_names(bool user) {
     // Sort the mappings by the user specification order, so we can return them in the same order
     // that the user specified them in.
-    std::vector<input_mapping_t> local_list = mapping_list;
+    std::vector<input_mapping_t> local_list = user ? mapping_list : default_mapping_list;
     std::sort(local_list.begin(), local_list.end(), specification_order_is_less_than);
     std::vector<input_mapping_name_t> result;
     result.reserve(local_list.size());
@@ -570,21 +570,12 @@ bool input_mapping_erase(const wcstring &sequence, const wcstring &mode, bool us
     return result;
 }
 
-bool input_mapping_get(const wcstring &sequence, const wcstring &mode, wcstring_list_t *out_cmds,
+bool input_mapping_get(const wcstring &sequence, const wcstring &mode, wcstring_list_t *out_cmds, bool user,
                        wcstring *out_sets_mode) {
     bool result = false;
-    for (std::vector<input_mapping_t>::const_iterator it = mapping_list.begin(),
-                                                      end = mapping_list.end();
-         it != end; ++it) {
-        if (sequence == it->seq && mode == it->mode) {
-            *out_cmds = it->commands;
-            *out_sets_mode = it->sets_mode;
-            result = true;
-            break;
-        }
-    }
-    for (std::vector<input_mapping_t>::const_iterator it = default_mapping_list.begin(),
-                                                      end = default_mapping_list.end();
+    auto& ml = user ? mapping_list : default_mapping_list;
+    for (std::vector<input_mapping_t>::const_iterator it = ml.begin(),
+                                                      end = ml.end();
          it != end; ++it) {
         if (sequence == it->seq && mode == it->mode) {
             *out_cmds = it->commands;

--- a/src/input.h
+++ b/src/input.h
@@ -48,11 +48,11 @@ void input_queue_ch(wint_t ch);
 /// \param command an input function that will be run whenever the key sequence occurs
 void input_mapping_add(const wchar_t *sequence, const wchar_t *command,
                        const wchar_t *mode = DEFAULT_BIND_MODE,
-                       const wchar_t *new_mode = DEFAULT_BIND_MODE);
+                       const wchar_t *new_mode = DEFAULT_BIND_MODE, bool user = true);
 
 void input_mapping_add(const wchar_t *sequence, const wchar_t *const *commands, size_t commands_len,
                        const wchar_t *mode = DEFAULT_BIND_MODE,
-                       const wchar_t *new_mode = DEFAULT_BIND_MODE);
+                       const wchar_t *new_mode = DEFAULT_BIND_MODE, bool user = true);
 
 struct input_mapping_name_t {
     wcstring seq;
@@ -62,8 +62,11 @@ struct input_mapping_name_t {
 /// Returns all mapping names and modes.
 std::vector<input_mapping_name_t> input_mapping_get_names();
 
+/// Erase all bindings
+void input_mapping_clear(const wchar_t *mode = NULL, bool user = true);
+
 /// Erase binding for specified key sequence.
-bool input_mapping_erase(const wcstring &sequence, const wcstring &mode = DEFAULT_BIND_MODE);
+bool input_mapping_erase(const wcstring &sequence, const wcstring &mode = DEFAULT_BIND_MODE, bool user = true);
 
 /// Gets the command bound to the specified key sequence in the specified mode. Returns true if it
 /// exists, false if not.

--- a/src/input.h
+++ b/src/input.h
@@ -60,7 +60,7 @@ struct input_mapping_name_t {
 };
 
 /// Returns all mapping names and modes.
-std::vector<input_mapping_name_t> input_mapping_get_names();
+std::vector<input_mapping_name_t> input_mapping_get_names(bool user = true);
 
 /// Erase all bindings
 void input_mapping_clear(const wchar_t *mode = NULL, bool user = true);
@@ -70,7 +70,7 @@ bool input_mapping_erase(const wcstring &sequence, const wcstring &mode = DEFAUL
 
 /// Gets the command bound to the specified key sequence in the specified mode. Returns true if it
 /// exists, false if not.
-bool input_mapping_get(const wcstring &sequence, const wcstring &mode, wcstring_list_t *out_cmds,
+bool input_mapping_get(const wcstring &sequence, const wcstring &mode, wcstring_list_t *out_cmds, bool user,
                        wcstring *out_new_mode);
 
 /// Return the current bind mode.

--- a/tests/bind.err
+++ b/tests/bind.err
@@ -2,3 +2,4 @@
 bind: mode name 'bad bind mode' is not valid. See `help identifiers`.
 # Verify that an invalid bind mode target is rejected.
 bind: mode name 'bind-mode' is not valid. See `help identifiers`.
+bind: No binding found for sequence '\t'

--- a/tests/bind.in
+++ b/tests/bind.in
@@ -10,17 +10,19 @@ bind -M bind-mode \cX true
 # This should succeed and result in a success, zero, status.
 bind -M bind_mode \cX true
 
+### HACK: All full bind listings need to have the \x7f -> backward-delete-char
+# binding explicitly removed, because on some systems that's backspace, on others not.
 echo \# Listing bindings
-bind
-bind --user --default
+bind | string match -v '*backward-delete-char'
+bind --user --default | string match -v '*backward-delete-char'
 echo \# Default only
-bind --default
+bind --default | string match -v '*backward-delete-char'
 echo \# User only
-bind --user
+bind --user | string match -v '*backward-delete-char'
 
 echo \# Adding bindings
 bind \t 'echo banana'
-bind
+bind | string match -v '*backward-delete-char'
 echo \# Erasing bindings
 bind --erase \t
 bind \t

--- a/tests/bind.in
+++ b/tests/bind.in
@@ -9,3 +9,23 @@ bind -M bind-mode \cX true
 
 # This should succeed and result in a success, zero, status.
 bind -M bind_mode \cX true
+
+echo \# Listing bindings
+bind
+bind --user --default
+echo \# Default only
+bind --default
+echo \# User only
+bind --user
+
+echo \# Adding bindings
+bind \t 'echo banana'
+bind
+echo \# Erasing bindings
+bind --erase \t
+bind \t
+bind \t 'echo wurst'
+bind --erase --user --default \t
+bind \t
+
+exit 0

--- a/tests/bind.out
+++ b/tests/bind.out
@@ -6,7 +6,6 @@ bind --default \t complete
 bind --default \cc commandline\ \'\'
 bind --default \cd exit
 bind --default \ce bind
-bind --default  backward-delete-char
 bind --default \e\[A up-line
 bind --default \e\[B down-line
 bind --default \e\[C forward-char
@@ -19,7 +18,6 @@ bind --default \t complete
 bind --default \cc commandline\ \'\'
 bind --default \cd exit
 bind --default \ce bind
-bind --default  backward-delete-char
 bind --default \e\[A up-line
 bind --default \e\[B down-line
 bind --default \e\[C forward-char
@@ -33,7 +31,6 @@ bind --default \t complete
 bind --default \cc commandline\ \'\'
 bind --default \cd exit
 bind --default \ce bind
-bind --default  backward-delete-char
 bind --default \e\[A up-line
 bind --default \e\[B down-line
 bind --default \e\[C forward-char
@@ -48,7 +45,6 @@ bind --default \t complete
 bind --default \cc commandline\ \'\'
 bind --default \cd exit
 bind --default \ce bind
-bind --default  backward-delete-char
 bind --default \e\[A up-line
 bind --default \e\[B down-line
 bind --default \e\[C forward-char

--- a/tests/bind.out
+++ b/tests/bind.out
@@ -1,0 +1,59 @@
+# Listing bindings
+bind --default '' self-insert
+bind --default \n execute
+bind --default \r execute
+bind --default \t complete
+bind --default \cc commandline\ \'\'
+bind --default \cd exit
+bind --default \ce bind
+bind --default  backward-delete-char
+bind --default \e\[A up-line
+bind --default \e\[B down-line
+bind --default \e\[C forward-char
+bind --default \e\[D backward-char
+bind -M bind_mode \cx true
+bind --default '' self-insert
+bind --default \n execute
+bind --default \r execute
+bind --default \t complete
+bind --default \cc commandline\ \'\'
+bind --default \cd exit
+bind --default \ce bind
+bind --default  backward-delete-char
+bind --default \e\[A up-line
+bind --default \e\[B down-line
+bind --default \e\[C forward-char
+bind --default \e\[D backward-char
+bind -M bind_mode \cx true
+# Default only
+bind --default '' self-insert
+bind --default \n execute
+bind --default \r execute
+bind --default \t complete
+bind --default \cc commandline\ \'\'
+bind --default \cd exit
+bind --default \ce bind
+bind --default  backward-delete-char
+bind --default \e\[A up-line
+bind --default \e\[B down-line
+bind --default \e\[C forward-char
+bind --default \e\[D backward-char
+# User only
+bind -M bind_mode \cx true
+# Adding bindings
+bind --default '' self-insert
+bind --default \n execute
+bind --default \r execute
+bind --default \t complete
+bind --default \cc commandline\ \'\'
+bind --default \cd exit
+bind --default \ce bind
+bind --default  backward-delete-char
+bind --default \e\[A up-line
+bind --default \e\[B down-line
+bind --default \e\[C forward-char
+bind --default \e\[D backward-char
+bind -M bind_mode \cx true
+bind \t 'echo banana'
+# Erasing bindings
+bind --default \t complete


### PR DESCRIPTION
## Description

As alluded to in #5191, this adds the idea of "default" and "user" bindings to `bind`. A user binding (done with `bind` without any special option) will override a default binding (done with `bind --default`), until it is erased (and the default becomes active again).

What this allows is for us to erase _just_ the default bindings when the user switches the bind set, which allows for `bind` statements in e.g. config.fish to just work.

There's some open questions here, mainly how much we should separate the two binding "levels". I chose to just always require `--default` before showing or doing anything to default bindings, so a bare `bind` will probably show nothing to most people. This was mainly for ease of implementation - I could just add a "bool user" to everything.

Fixes #5191.
Fixes #3699.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
