### PR TITLE
Fix the total page count in the history tab

### DIFF
--- a/share/tools/web_config/js/controllers.js
+++ b/share/tools/web_config/js/controllers.js
@@ -255,7 +255,7 @@ controllers.controller("historyController", function($scope, $http, $timeout) {
         if ($scope.filteredItemPages[0].length === 0) {
             return "None";
         }
-        return ($scope.currentPage + 1) + " / " + ($scope.filteredItemPages.length + 1);
+        return ($scope.currentPage + 1) + " / " + $scope.filteredItemPages.length;
     };
 
     $scope.prevPage = function () {


### PR DESCRIPTION
## Description
`$scope.filteredItemPages.length` is exactly the total number of pages, no need to increment.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
