### PR TITLE
Add a --private option to launch fish in private mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ fish 3.0 is a major release which brings with it both improvements in functional
 ### Syntax/semantic changes and new builtins
 - fish now supports `&&`, `||`, and `!` (#4620).
 - Variables may be used as commands (#154).
+- fish may be started in private mode via `fish --private` or `fish -P`. Private mode fish sessions do not have access to the history file and any commands evaluated in private mode are not persisted for future sessions. A session variable `$fish_private_mode` can be queried to detect private mode and adjust the behavior of scripts accordingly to respect the user's wish for privacy.
 - A new feature flags mechanism is added for staging deprecations and breaking changes. Feature flags may be specified at launch with `fish --features ...` or by setting the universal `fish_features` variable. (#4940)
 - `wait` builtin is added for waiting on processes (#4498).
 - `math` is now a builtin rather than a wrapper around `bc` (#3157). The default scale is now 6, so that floating point computations produce decimals (#4478).

--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -1360,6 +1360,9 @@ When fish waits for input, it will display a prompt by evaluating the `fish_prom
 
 If a function named `fish_greeting` exists, it will be run when entering interactive mode. Otherwise, if an environment variable named `fish_greeting` exists, it will be printed.
 
+\subsection private-mode Private mode
+
+fish supports launching in private mode via `fish --private` (or `fish -P` for short). In private mode, old history is not available and any interactive commands you execute will not be appended to the global history file, making it useful both for avoiding inadvertently leaking personal information (e.g. for screencasts) and when dealing with sensitive information to prevent it being persisted to disk. You can query the global variable `fish_private_mode` (`if set -q fish_private_mode ...`) if you would like to respect the user's wish for privacy and alter the behavior of your own fish scripts.
 
 \subsection event Event handlers
 

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -36,6 +36,11 @@ function __fish_config_interactive -d "Initializations that should be performed 
         set -U fish_greeting "$line1$line2"
     end
 
+    if set -q fish_private_mode
+        set -l line (_ "fish is running in private mode, history will not be persisted.")
+        set -g fish_greeting $fish_greeting.\n$line
+    end
+
     #
     # If we are starting up for the first time, set various defaults.
     #

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -296,7 +296,8 @@ bool string_set_contains(const T &set, const wchar_t *val) {
 
 /// Check if a variable may not be set using the set command.
 static bool is_read_only(const wchar_t *val) {
-    const string_set_t env_read_only = {L"PWD", L"SHLVL", L"history", L"status", L"version", L"fish_pid", L"hostname", L"_"};
+    const string_set_t env_read_only = {L"PWD", L"SHLVL", L"history", L"status", L"version",
+        L"fish_pid", L"hostname", L"_", L"fish_private_mode"};
     return string_set_contains(env_read_only, val) ||
         (in_private_mode() && wcscmp(L"fish_history", val) == 0);
 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -297,7 +297,8 @@ bool string_set_contains(const T &set, const wchar_t *val) {
 /// Check if a variable may not be set using the set command.
 static bool is_read_only(const wchar_t *val) {
     const string_set_t env_read_only = {L"PWD", L"SHLVL", L"history", L"status", L"version", L"fish_pid", L"hostname", L"_"};
-    return string_set_contains(env_read_only, val);
+    return string_set_contains(env_read_only, val) ||
+        (in_private_mode() && wcscmp(L"fish_history", val) == 0);
 }
 
 static bool is_read_only(const wcstring &val) { return is_read_only(val.c_str()); }

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -218,7 +218,7 @@ int run_command_list(std::vector<std::string> *cmds, const io_chain_t &io) {
 
 /// Parse the argument list, return the index of the first non-flag arguments.
 static int fish_parse_opt(int argc, char **argv, fish_cmd_opts_t *opts) {
-    static const char * const short_opts = "+hilnvc:C:p:d:f:D:";
+    static const char * const short_opts = "+hPilnvc:C:p:d:f:D:";
     static const struct option long_opts[] = {{"command", required_argument, NULL, 'c'},
                                               {"init-command", required_argument, NULL, 'C'},
                                               {"features", required_argument, NULL, 'f'},
@@ -228,6 +228,7 @@ static int fish_parse_opt(int argc, char **argv, fish_cmd_opts_t *opts) {
                                               {"login", no_argument, NULL, 'l'},
                                               {"no-execute", no_argument, NULL, 'n'},
                                               {"profile", required_argument, NULL, 'p'},
+                                              {"private", no_argument, NULL, 'P'},
                                               {"help", no_argument, NULL, 'h'},
                                               {"version", no_argument, NULL, 'v'},
                                               {NULL, 0, NULL, 0}};
@@ -281,6 +282,10 @@ static int fish_parse_opt(int argc, char **argv, fish_cmd_opts_t *opts) {
             case 'p': {
                 s_profiling_output_filename = optarg;
                 g_profiling_active = true;
+                break;
+            }
+            case 'P': {
+                start_private_mode();
                 break;
             }
             case 'v': {

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1986,3 +1986,14 @@ void history_t::resolve_pending() {
     scoped_lock locker(lock);
     this->has_pending_item = false;
 }
+
+
+static bool private_mode = false;
+void start_private_mode() {
+    private_mode = true;
+    env_set_one(L"fish_history", ENV_GLOBAL, L"");
+}
+
+bool in_private_mode() {
+    return private_mode;
+}

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1992,6 +1992,7 @@ static bool private_mode = false;
 void start_private_mode() {
     private_mode = true;
     env_set_one(L"fish_history", ENV_GLOBAL, L"");
+    env_set_one(L"fish_private_mode", ENV_GLOBAL, L"1");
 }
 
 bool in_private_mode() {

--- a/src/history.h
+++ b/src/history.h
@@ -367,4 +367,9 @@ path_list_t valid_paths(const path_list_t &paths, const wcstring &working_direct
 /// return true if all paths in the list are valid
 /// Returns true for if paths is empty
 bool all_paths_are_valid(const path_list_t &paths, const wcstring &working_directory);
+
+/// Sets private mode on. Once in private mode, it cannot be turned off.
+void start_private_mode();
+/// Queries private mode status.
+bool in_private_mode();
 #endif


### PR DESCRIPTION
In private mode, access to previous history is blocked and new history
is directed immediately to /dev/null. Note that in this current
implementation, history is available _within_ the private session, but
cannot (well, should not) leak from it.

This mode can be used when it is not desirable for commandline history
to leak into a session, e.g. via autocomplete or when it is desirable to
test the behavior of fish in the absence of history items without
permanently clearing the history.

I'm sure there are a lot more features that can be incorporated into
private mode, such as restricting access to certain user-specific
configuration files, etc.

This addresses a lot of the concerns raised in #1363 (which was later
changed to track mosh-specific problems). See also #102.

(Note that $fish_history is not used as that causes data to persist to
disk.)