### PR TITLE
Move abbr_old to __fish_abbr_old

### DIFF
--- a/share/functions/__fish_abbr_old.fish
+++ b/share/functions/__fish_abbr_old.fish
@@ -1,4 +1,4 @@
-function abbr_old --description "Manage abbreviations using old fish 2.x scheme."
+function __fish_abbr_old --description "Manage abbreviations using old fish 2.x scheme."
     # parse arguments
     set -l mode
     set -l mode_flag # the flag that was specified, for better errors

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -8,7 +8,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
         # Perform transitions relevant to going from fish 2.x to 3.x.
 
         # Migrate old universal abbreviations to the new scheme.
-        abbr_old | source
+        __fish_abbr_old | source
 
         set -U __fish_init_3_x
     end


### PR DESCRIPTION
I don't think `abbr_old` was ever something that we wanted to expose to users by default, so this commit moves it to an internal name.