### PR TITLE
Fix completion descriptions for functions

### DIFF
--- a/src/builtin_functions.cpp
+++ b/src/builtin_functions.cpp
@@ -124,8 +124,8 @@ static wcstring functions_def(const wcstring &name) {
     CHECK(!name.empty(), L"");  //!OCLINT(multiple unary operator)
     wcstring out;
     wcstring desc, def;
-    function_get_desc(name, &desc);
-    function_get_definition(name, &def);
+    function_get_desc(name, desc);
+    function_get_definition(name, def);
     event_t search(EVENT_ANY);
     search.function_name = name;
     std::vector<std::shared_ptr<event_t>> ev;
@@ -243,7 +243,7 @@ static int report_function_metadata(const wchar_t *funcname, bool verbose, io_st
             path = L"stdin";
         }
         shadows_scope = props->shadow_scope ? L"scope-shadowing" : L"no-scope-shadowing";
-        function_get_desc(funcname, &description);
+        function_get_desc(funcname, description);
         description = escape_string(description, ESCAPE_NO_QUOTED);
     }
 

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -644,9 +644,9 @@ void completer_t::complete_cmd_desc(const wcstring &str) {
 /// Returns a description for the specified function, or an empty string if none.
 static wcstring complete_function_desc(const wcstring &fn) {
     wcstring result;
-    bool has_description = function_get_desc(fn, &result);
+    bool has_description = function_get_desc(fn, result);
     if (!has_description) {
-        function_get_definition(fn, &result);
+        function_get_definition(fn, result);
     }
     return result;
 }

--- a/src/function.h
+++ b/src/function.h
@@ -59,12 +59,12 @@ std::shared_ptr<const function_properties_t> function_get_properties(const wcstr
 /// Returns by reference the definition of the function with the name \c name. Returns true if
 /// successful, false if no function with the given name exists.
 /// This does not trigger autoloading.
-bool function_get_definition(const wcstring &name, wcstring *out_definition);
+bool function_get_definition(const wcstring &name, wcstring &out_definition);
 
 /// Returns by reference the description of the function with the name \c name. Returns true if the
 /// function exists and has a nonempty description, false if it does not.
 /// This does not trigger autoloading.
-bool function_get_desc(const wcstring &name, wcstring *out_desc);
+bool function_get_desc(const wcstring &name, wcstring &out_desc);
 
 /// Sets the description of the function with the name \c name.
 void function_set_desc(const wcstring &name, const wcstring &desc);

--- a/src/tnode.h
+++ b/src/tnode.h
@@ -107,6 +107,9 @@ class tnode_t {
     }
 
     wcstring get_source(const wcstring &str) const {
+        if (!nodeptr) {
+            return L"";
+        }
         return nodeptr->get_source(str);
     }
 

--- a/src/wildcard.cpp
+++ b/src/wildcard.cpp
@@ -119,7 +119,8 @@ static enum fuzzy_match_type_t wildcard_match_internal(const wchar_t *str, const
                     return fuzzy_match_none;
                 }
 
-                // Common case of * at the end. In that case we can early out since we know it will match.
+                // Common case of * at the end. In that case we can early out since we know it will
+                // match.
                 if (wc_x[1] == L'\0') {
                     return fuzzy_match_exact;
                 }
@@ -137,7 +138,7 @@ static enum fuzzy_match_type_t wildcard_match_internal(const wchar_t *str, const
                 wc_x++;
                 str_x++;
                 continue;
-            } else if (*str_x != 0 && *str_x == *wc_x) { // ordinary character
+            } else if (*str_x != 0 && *str_x == *wc_x) {  // ordinary character
                 wc_x++;
                 str_x++;
                 continue;
@@ -156,7 +157,8 @@ static enum fuzzy_match_type_t wildcard_match_internal(const wchar_t *str, const
 }
 
 // This does something horrible refactored from an even more horrible function.
-static wcstring resolve_description(wcstring *completion, const wchar_t *explicit_desc,
+static wcstring resolve_description(const wchar_t *full_completion, wcstring *completion,
+                                    const wchar_t *explicit_desc,
                                     wcstring (*desc_func)(const wcstring &)) {
     size_t complete_sep_loc = completion->find(PROG_COMPLETE_SEP);
     if (complete_sep_loc != wcstring::npos) {
@@ -166,7 +168,7 @@ static wcstring resolve_description(wcstring *completion, const wchar_t *explici
         return description;
     }
 
-    const wcstring func_result = (desc_func ? desc_func(*completion) : wcstring());
+    const wcstring func_result = (desc_func ? desc_func(full_completion) : wcstring());
     if (!func_result.empty()) {
         return func_result;
     }
@@ -241,7 +243,8 @@ static bool wildcard_complete_internal(const wchar_t *str, const wchar_t *wc,
         // the wildcard.
         assert(!full_replacement || wcslen(wc) <= wcslen(str));
         wcstring out_completion = full_replacement ? params.orig : str + wcslen(wc);
-        wcstring out_desc = resolve_description(&out_completion, params.desc, params.desc_func);
+        wcstring out_desc =
+            resolve_description(str, &out_completion, params.desc, params.desc_func);
 
         // Note: out_completion may be empty if the completion really is empty, e.g. tab-completing
         // 'foo' when a file 'foo' exists.
@@ -323,8 +326,8 @@ bool wildcard_complete(const wcstring &str, const wchar_t *wc, const wchar_t *de
 }
 
 bool wildcard_match(const wcstring &str, const wcstring &wc, bool leading_dots_fail_to_match) {
-    enum fuzzy_match_type_t match = wildcard_match_internal(
-        str.c_str(), wc.c_str(), leading_dots_fail_to_match);
+    enum fuzzy_match_type_t match =
+        wildcard_match_internal(str.c_str(), wc.c_str(), leading_dots_fail_to_match);
     return match != fuzzy_match_none;
 }
 
@@ -427,7 +430,8 @@ static bool wildcard_test_flags_then_complete(const wcstring &filepath, const wc
         return false;
     }
 
-    if (is_windows_subsystem_for_linux() && string_suffixes_string_case_insensitive(L".dll", filename)) {
+    if (is_windows_subsystem_for_linux() &&
+        string_suffixes_string_case_insensitive(L".dll", filename)) {
         return false;
     }
 


### PR DESCRIPTION
At some point the completion code was refactored and in the event where
no explicit function description was passed into `resolve_description()`
it would attempt to use the `desc_func` parameter but pass in the
_remaining_ part of the completion rather than the full text, which
would obviously fail.

e.g. if completing `foo<TAB>`, for function `foobar` it would attempt to
find the description for a function named `bar` instead of `foodbar`.

Closes #5206.