### PR TITLE
Overhaul process reaping and terminal control

### DIFF
--- a/src/builtin_disown.cpp
+++ b/src/builtin_disown.cpp
@@ -24,7 +24,7 @@ static int disown_job(const wchar_t *cmd, parser_t &parser, io_streams_t &stream
     }
 
     // Stopped disowned jobs must be manually signaled; explain how to do so.
-    if (job_is_stopped(j)) {
+    if (j->is_stopped()) {
         killpg(j->pgid, SIGCONT);
         const wchar_t *fmt =
             _(L"%ls: job %d ('%ls') was stopped and has been signalled to continue.\n");
@@ -58,7 +58,7 @@ int builtin_disown(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         // Even jobs that aren't under job control can be disowned!
         job_iterator_t jobs;
         while ((j = jobs.next())) {
-            if (j->get_flag(JOB_CONSTRUCTED) && (!job_is_completed(j))) {
+            if (j->is_constructed() && (!j->is_completed())) {
                 break;
             }
         }

--- a/src/builtin_fg.cpp
+++ b/src/builtin_fg.cpp
@@ -39,9 +39,9 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         // the foreground.
         job_iterator_t jobs;
         while ((j = jobs.next())) {
-            if (j->get_flag(JOB_CONSTRUCTED) && (!job_is_completed(j)) &&
-                ((job_is_stopped(j) || (!j->get_flag(JOB_FOREGROUND))) &&
-                 j->get_flag(JOB_CONTROL))) {
+            if (j->is_constructed() && (!j->is_completed()) &&
+                ((j->is_stopped() || (!j->is_foreground())) &&
+                 j->get_flag(job_flag_t::JOB_CONTROL))) {
                 break;
             }
         }
@@ -57,7 +57,7 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
         pid = fish_wcstoi(argv[optind]);
         if (!(errno || pid < 0)) {
-            j = job_get_from_pid(pid);
+            j = job_t::from_pid(pid);
             if (j) found_job = 1;
         }
 
@@ -76,11 +76,11 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
             streams.err.append_format(BUILTIN_ERR_NOT_NUMBER, cmd, argv[optind]);
             builtin_print_help(parser, streams, cmd, streams.err);
         } else {
-            j = job_get_from_pid(pid);
-            if (!j || !j->get_flag(JOB_CONSTRUCTED) || job_is_completed(j)) {
+            j = job_t::from_pid(pid);
+            if (!j || !j->is_constructed() || j->is_completed()) {
                 streams.err.append_format(_(L"%ls: No suitable job: %d\n"), cmd, pid);
                 j = 0;
-            } else if (!j->get_flag(JOB_CONTROL)) {
+            } else if (!j->get_flag(job_flag_t::JOB_CONTROL)) {
                 streams.err.append_format(_(L"%ls: Can't put job %d, '%ls' to foreground because "
                                             L"it is not under job control\n"),
                                           cmd, pid, j->command_wcstr());
@@ -106,9 +106,9 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (!ft.empty()) env_set_one(L"_", ENV_EXPORT, ft);
     reader_write_title(j->command());
 
-    job_promote(j);
-    j->set_flag(JOB_FOREGROUND, true);
+    j->promote();
+    j->set_flag(job_flag_t::FOREGROUND, true);
 
-    job_continue(j, job_is_stopped(j));
+    j->continue_job(j->is_stopped());
     return STATUS_CMD_OK;
 }

--- a/src/builtin_functions.cpp
+++ b/src/builtin_functions.cpp
@@ -170,7 +170,7 @@ static wcstring functions_def(const wcstring &name) {
                 break;
             }
             case EVENT_JOB_ID: {
-                const job_t *j = job_get(next->param1.job_id);
+                const job_t *j = job_t::from_job_id(next->param1.job_id);
                 if (j) append_format(out, L" --on-job-exit %d", j->pgid);
                 break;
             }

--- a/src/builtin_wait.cpp
+++ b/src/builtin_wait.cpp
@@ -37,7 +37,7 @@ static bool all_jobs_finished() {
     while (job_t *j = jobs.next()) {
         // If any job is not completed, return false.
         // If there are stopped jobs, they are ignored.
-        if ((j->flags & JOB_CONSTRUCTED) && !job_is_completed(j) && !job_is_stopped(j)) {
+        if (j->is_constructed() && !j->is_completed() && !j->is_stopped()) {
             return false;
         }
     }
@@ -54,11 +54,11 @@ static bool any_jobs_finished(size_t jobs_len) {
     }
     while (job_t *j = jobs.next()) {
         // If any job is completed, return true.
-        if ((j->flags & JOB_CONSTRUCTED) && (job_is_completed(j) || job_is_stopped(j))) {
+        if (j->is_constructed() && (j->is_completed() || j->is_stopped())) {
             return true;
         }
         // Check for jobs running exist or not.
-        if ((j->flags & JOB_CONSTRUCTED) && !job_is_stopped(j)) {
+        if (j->is_constructed() && !j->is_stopped()) {
             no_jobs_running = false;
         }
     }
@@ -83,10 +83,10 @@ static int wait_for_backgrounds(bool any_flag) {
 
 static bool all_specified_jobs_finished(const std::vector<job_id_t> &ids) {
     for (auto id : ids) {
-        if (job_t *j = job_get(id)) {
+        if (job_t *j = job_t::from_job_id(id)) {
             // If any specified job is not completed, return false.
             // If there are stopped jobs, they are ignored.
-            if ((j->flags & JOB_CONSTRUCTED) && !job_is_completed(j) && !job_is_stopped(j)) {
+            if (j->is_constructed() && !j->is_completed() && !j->is_stopped()) {
                 return false;
             }
         }
@@ -96,9 +96,9 @@ static bool all_specified_jobs_finished(const std::vector<job_id_t> &ids) {
 
 static bool any_specified_jobs_finished(const std::vector<job_id_t> &ids) {
     for (auto id : ids) {
-        if (job_t *j = job_get(id)) {
+        if (job_t *j = job_t::from_job_id(id)) {
             // If any specified job is completed, return true.
-            if ((j->flags & JOB_CONSTRUCTED) && (job_is_completed(j) || job_is_stopped(j))) {
+            if (j->is_constructed() && (j->is_completed() || j->is_stopped())) {
                 return true;
             }
         } else {

--- a/src/common.h
+++ b/src/common.h
@@ -18,6 +18,7 @@
 #endif
 
 #include <algorithm>
+#include <functional>
 #include <iterator>
 #include <memory>
 #include <mutex>
@@ -1088,5 +1089,18 @@ struct hash<const wcstring> {
 
 /// Get the absolute path to the fish executable itself
 std::string get_executable_path(const char *fallback);
+
+/// A RAII wrapper for resources that don't recur, so we don't have to create a separate RAII
+/// wrapper for each function. Avoids needing to call "return cleanup()" or similar / everywhere.
+struct cleanup_t {
+private:
+    const std::function<void()> cleanup;
+public:
+    cleanup_t(std::function<void()> exit_actions)
+        : cleanup{exit_actions} {}
+    ~cleanup_t() {
+        cleanup();
+    }
+};
 
 #endif

--- a/src/enum_set.h
+++ b/src/enum_set.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <bitset>
+
+template <typename T>
+class enum_set_t {
+   private:
+    using base_type_t = typename std::underlying_type<T>::type;
+    std::bitset<8 * sizeof(base_type_t)> bitmask{0};
+    static int index_of(T t) { return static_cast<base_type_t>(t); }
+
+   public:
+    bool get(T t) const { return bitmask.test(index_of(t)); }
+
+    void set(T t, bool v) {
+        if (v) {
+            bitmask.set(index_of(t));
+        } else {
+            bitmask.reset(index_of(t));
+        }
+    }
+
+    void set(T t) { bitmask.set(index_of(t)); }
+
+    void clear(T t) { bitmask.reset(index_of(t)); }
+};

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -375,22 +375,22 @@ static void init_locale() {
         const auto var = env_get(var_name, ENV_EXPORT);
         const std::string &name = wcs2string(var_name);
         if (var.missing_or_empty()) {
-            debug(2, L"locale var %s missing or empty", name.c_str());
+            debug(5, L"locale var %s missing or empty", name.c_str());
             unsetenv(name.c_str());
         } else {
             const std::string value = wcs2string(var->as_string());
-            debug(2, L"locale var %s='%s'", name.c_str(), value.c_str());
+            debug(5, L"locale var %s='%s'", name.c_str(), value.c_str());
             setenv(name.c_str(), value.c_str(), 1);
         }
     }
 
     char *locale = setlocale(LC_ALL, "");
     fish_setlocale();
-    debug(2, L"init_locale() setlocale(): '%s'", locale);
+    debug(5, L"init_locale() setlocale(): '%s'", locale);
 
     const char *new_msg_locale = setlocale(LC_MESSAGES, NULL);
-    debug(3, L"old LC_MESSAGES locale: '%s'", old_msg_locale);
-    debug(3, L"new LC_MESSAGES locale: '%s'", new_msg_locale);
+    debug(5, L"old LC_MESSAGES locale: '%s'", old_msg_locale);
+    debug(5, L"new LC_MESSAGES locale: '%s'", new_msg_locale);
 #ifdef HAVE__NL_MSG_CAT_CNTR
     if (strcmp(old_msg_locale, new_msg_locale)) {
         // Make change known to GNU gettext.

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -129,7 +129,7 @@ wcstring event_get_desc(const event_t &e) {
                 result = format_string(_(L"exit handler for process %d"), e.param1.pid);
             } else {
                 // In events, PGIDs are stored as negative PIDs
-                job_t *j = job_get_from_pid(-e.param1.pid);
+                job_t *j = job_t::from_pid(-e.param1.pid);
                 if (j)
                     result = format_string(_(L"exit handler for job %d, '%ls'"), j->job_id,
                                            j->command_wcstr());
@@ -140,7 +140,7 @@ wcstring event_get_desc(const event_t &e) {
             break;
         }
         case EVENT_JOB_ID: {
-            job_t *j = job_get(e.param1.job_id);
+            job_t *j = job_t::from_job_id(e.param1.job_id);
             if (j) {
                 result = format_string(_(L"exit handler for job %d, '%ls'"), j->job_id,
                                        j->command_wcstr());
@@ -211,7 +211,7 @@ static wcstring event_desc_compact(const event_t &event) {
                 res = format_string(L"EVENT_EXIT(pid %d)", event.param1.pid);
             } else {
                 // In events, PGIDs are stored as negative PIDs
-                job_t *j = job_get_from_pid(-event.param1.pid);
+                job_t *j = job_t::from_pid(-event.param1.pid);
                 if (j)
                     res = format_string(L"EVENT_EXIT(jobid %d: \"%ls\")", j->job_id,
                                         j->command_wcstr());
@@ -221,7 +221,7 @@ static wcstring event_desc_compact(const event_t &event) {
             break;
         }
         case EVENT_JOB_ID: {
-            job_t *j = job_get(event.param1.job_id);
+            job_t *j = job_t::from_job_id(event.param1.job_id);
             if (j)
                 res =
                     format_string(L"EVENT_JOB_ID(job %d: \"%ls\")", j->job_id, j->command_wcstr());

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -388,7 +388,7 @@ void internal_exec(job_t *j, const io_chain_t &&all_ios) {
 
 static void on_process_created(job_t *j, pid_t child_pid) {
     // We only need to do this the first time a child is forked/spawned
-    if (j->pgid != -2) {
+    if (j->pgid != INVALID_PID) {
         return;
     }
 
@@ -724,9 +724,9 @@ static bool exec_external_command(job_t *j, process_t *p, const io_chain_t &proc
         }
 #else
         // In do_fork, the pid of the child process is used as the group leader if j->pgid
-        // == 2 above, posix_spawn assigned the new group a pgid equal to its own id if
-        // j->pgid == 2 so this is what we do instead of calling set_child_group:
-        if (j->pgid == -2) {
+        // invalid, posix_spawn assigned the new group a pgid equal to its own id if
+        // j->pgid was invalid, so this is what we do instead of calling set_child_group
+        if (j->pgid == INVALID_PID) {
             j->pgid = pid;
         }
 #endif

--- a/src/exec.h
+++ b/src/exec.h
@@ -26,7 +26,7 @@
 /// command-specific completions.
 class job_t;
 class parser_t;
-void exec_job(parser_t &parser, job_t *j);
+void exec_job(parser_t &parser, std::shared_ptr<job_t> j);
 
 /// Evaluate the expression cmd in a subshell, add the outputs into the list l. On return, the
 /// status flag as returned bu \c proc_gfet_last_status will not be changed.

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -389,7 +389,6 @@ static bool input_mapping_is_match(const input_mapping_t &m) {
     const wcstring &str = m.seq;
 
     assert(str.size() > 0 && "zero-length input string passed to input_mapping_is_match!");
-    debug(4, L"trying to match mapping %ls", escape_string(m.seq.c_str(), ESCAPE_ALL).c_str());
 
     bool timed = false;
     for (size_t i = 0; i < str.size(); ++i) {

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -772,7 +772,7 @@ parse_execution_result_t parse_execution_context_t::populate_plain_process(
         bool have_bg = false;
         const job_t *bg = nullptr;
         while ((bg = jobs.next())) {
-            if (!job_is_completed(bg)) {
+            if (!bg->is_completed()) {
                 have_bg = true;
                 break;
             }
@@ -975,7 +975,7 @@ bool parse_execution_context_t::determine_io_chain(tnode_t<g::arguments_or_redir
 
 parse_execution_result_t parse_execution_context_t::populate_not_process(
     job_t *job, process_t *proc, tnode_t<g::not_statement> not_statement) {
-    job->set_flag(JOB_NEGATE, !job->get_flag(JOB_NEGATE));
+    job->set_flag(job_flag_t::NEGATE, !job->get_flag(job_flag_t::NEGATE));
     return this->populate_job_process(job, proc,
                                       not_statement.require_get_child<g::statement, 1>());
 }
@@ -1184,15 +1184,15 @@ parse_execution_result_t parse_execution_context_t::run_1_job(tnode_t<g::job> jo
 
     shared_ptr<job_t> job = std::make_shared<job_t>(acquire_job_id(), block_io);
     job->tmodes = tmodes;
-    job->set_flag(JOB_CONTROL,
+    job->set_flag(job_flag_t::JOB_CONTROL,
                   (job_control_mode == JOB_CONTROL_ALL) ||
                       ((job_control_mode == JOB_CONTROL_INTERACTIVE) && shell_is_interactive()));
 
-    job->set_flag(JOB_FOREGROUND, !job_node_is_background(job_node));
+    job->set_flag(job_flag_t::FOREGROUND, !job_node_is_background(job_node));
 
-    job->set_flag(JOB_TERMINAL, job->get_flag(JOB_CONTROL) && !is_event);
+    job->set_flag(job_flag_t::TERMINAL, job->get_flag(job_flag_t::JOB_CONTROL) && !is_event);
 
-    job->set_flag(JOB_SKIP_NOTIFICATION,
+    job->set_flag(job_flag_t::SKIP_NOTIFICATION,
                   is_subshell || is_block || is_event || !shell_is_interactive());
 
     // Tell the current block what its job is. This has to happen before we populate it (#1394).

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -786,7 +786,7 @@ parse_execution_result_t parse_execution_context_t::populate_plain_process(
                 return parse_execution_errored;
             }
             else {
-                kill_background_jobs();
+                hup_background_jobs();
             }
         }
     }

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -1230,7 +1230,7 @@ parse_execution_result_t parse_execution_context_t::run_1_job(tnode_t<g::job> jo
         }
 
         // Actually execute the job.
-        exec_job(*this->parser, job.get());
+        exec_job(*this->parser, job);
 
         // Only external commands require a new fishd barrier.
         if (job_contained_external_command) {

--- a/src/parse_productions.cpp
+++ b/src/parse_productions.cpp
@@ -362,7 +362,8 @@ const production_element_t *parse_productions::production_for_token(parse_token_
                                                                     const parse_token_t &input1,
                                                                     const parse_token_t &input2,
                                                                     parse_node_tag_t *out_tag) {
-    debug(5, "Resolving production for %ls with input token <%ls>",
+    // this is **extremely** chatty
+    debug(6, "Resolving production for %ls with input token <%ls>",
           token_type_description(node_type), input1.describe().c_str());
 
     // Fetch the function to resolve the list of productions.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -591,7 +591,7 @@ void parser_t::job_promote(job_t *job) {
     assert(loc != my_job_list.end());
 
     // Move the job to the beginning.
-    my_job_list.splice(my_job_list.begin(), my_job_list, loc);
+    std::rotate(my_job_list.begin(), loc, my_job_list.end());
 }
 
 job_t *parser_t::job_get(job_id_t id) {

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -33,7 +33,7 @@ const wcstring_list_t dflt_pathsv({L"/bin", L"/usr/bin", PREFIX L"/bin"});
 
 static bool path_get_path_core(const wcstring &cmd, wcstring *out_path,
                                const maybe_t<env_var_t> &bin_path_var) {
-    debug(3, L"path_get_path( '%ls' )", cmd.c_str());
+    debug(5, L"path_get_path( '%ls' )", cmd.c_str());
 
     // If the command has a slash, it must be an absolute or relative path and thus we don't bother
     // looking for a matching command.
@@ -124,7 +124,7 @@ bool path_get_path(const wcstring &cmd, wcstring *out_path) {
 }
 
 wcstring_list_t path_get_paths(const wcstring &cmd) {
-    debug(3, L"path_get_paths('%ls')", cmd.c_str());
+    debug(5, L"path_get_paths('%ls')", cmd.c_str());
     wcstring_list_t paths;
 
     // If the command has a slash, it must be an absolute or relative path and thus we don't bother

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -64,7 +64,7 @@ static void debug_safe_int(int level, const char *format, int val) {
 /// Returns true on sucess, false on failiure.
 bool child_set_group(job_t *j, process_t *p) {
     bool retval = true;
-    if (j->get_flag(JOB_CONTROL)) {
+    if (j->get_flag(job_flag_t::JOB_CONTROL)) {
         if (j->pgid == INVALID_PID) {
             j->pgid = p->pid;
         }
@@ -104,7 +104,7 @@ bool child_set_group(job_t *j, process_t *p) {
 /// group in the case of JOB_CONTROL, and we can give the new process group control of the terminal
 /// if it's to run in the foreground.
 bool set_child_group(job_t *j, pid_t child_pid) {
-    if (j->get_flag(JOB_CONTROL)) {
+    if (j->get_flag(job_flag_t::JOB_CONTROL)) {
         assert (j->pgid != INVALID_PID
                 && "set_child_group called with JOB_CONTROL before job pgid determined!");
 
@@ -135,7 +135,7 @@ bool set_child_group(job_t *j, pid_t child_pid) {
 bool maybe_assign_terminal(const job_t *j) {
     assert(j->pgid > 1 && "maybe_assign_terminal() called on job with invalid pgid!");
 
-    if (j->get_flag(JOB_TERMINAL) && j->get_flag(JOB_FOREGROUND)) {  //!OCLINT(early exit)
+    if (j->get_flag(job_flag_t::TERMINAL) && j->is_foreground()) {  //!OCLINT(early exit)
         if (tcgetpgrp(STDIN_FILENO) == j->pgid) {
             // We've already assigned the process group control of the terminal when the first
             // process in the job was started. There's no need to do so again, and on some platforms
@@ -338,7 +338,7 @@ bool fork_actions_make_spawn_properties(posix_spawnattr_t *attr,
 
     bool should_set_process_group_id = false;
     int desired_process_group_id = 0;
-    if (j->get_flag(JOB_CONTROL)) {
+    if (j->get_flag(job_flag_t::JOB_CONTROL)) {
         should_set_process_group_id = true;
 
         // set_child_group puts each job into its own process group

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -65,8 +65,7 @@ static void debug_safe_int(int level, const char *format, int val) {
 bool child_set_group(job_t *j, process_t *p) {
     bool retval = true;
     if (j->get_flag(JOB_CONTROL)) {
-        // New jobs have the pgid set to -2
-        if (j->pgid == -2) {
+        if (j->pgid == INVALID_PID) {
             j->pgid = p->pid;
         }
         if (setpgid(p->pid, j->pgid) < 0) {
@@ -106,7 +105,7 @@ bool child_set_group(job_t *j, process_t *p) {
 /// if it's to run in the foreground.
 bool set_child_group(job_t *j, pid_t child_pid) {
     if (j->get_flag(JOB_CONTROL)) {
-        assert (j->pgid != -2
+        assert (j->pgid != INVALID_PID
                 && "set_child_group called with JOB_CONTROL before job pgid determined!");
 
         // The parent sets the child's group. This incurs the well-known unavoidable race with the
@@ -345,7 +344,7 @@ bool fork_actions_make_spawn_properties(posix_spawnattr_t *attr,
         // set_child_group puts each job into its own process group
         // do the same here if there is no PGID yet (i.e. PGID == -2)
         desired_process_group_id = j->pgid;
-        if (desired_process_group_id == -2) {
+        if (desired_process_group_id == INVALID_PID) {
             desired_process_group_id = 0;
         }
     }

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -515,6 +515,8 @@ static int process_clean_after_marking(bool allow_interactive) {
 
             // TODO: The generic process-exit event is useless and unused.
             // Remove this in future.
+            // Update: This event is used for cleaning up the psub temporary files and folders.
+            // Removing it breaks the psub tests as a result.
             proc_fire_event(L"PROCESS_EXIT", EVENT_EXIT, p->pid,
                             (WIFSIGNALED(s) ? -1 : WEXITSTATUS(s)));
 

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -384,7 +384,7 @@ static bool process_mark_finished_children(bool block_on_fg) {
         // A job can have pgrp INVALID_PID if it consists solely of builtins that perform no IO
         if (j->pgid == INVALID_PID || !j->get_flag(JOB_CONSTRUCTED)) {
             // Job has not been fully constructed yet
-            debug(4, "Skipping wait on incomplete job %d", j->pgid);
+            debug(5, "Skipping wait on incomplete job %d (%ls)", j->job_id, j->preview().c_str());
             continue;
         }
 
@@ -724,7 +724,7 @@ static int select_try(job_t *j) {
             // fwprintf( stderr, L"fd %d on job %ls\n", fd, j->command );
             FD_SET(fd, &fds);
             maxfd = maxi(maxfd, fd);
-            debug(3, L"select_try on %d", fd);
+            debug(4, L"select_try on %d", fd);
         }
     }
 
@@ -737,7 +737,7 @@ static int select_try(job_t *j) {
 
         retval = select(maxfd + 1, &fds, 0, 0, &tv);
         if (retval == 0) {
-            debug(3, L"select_try hit timeout");
+            debug(4, L"select_try hit timeout");
         }
         return retval > 0;
     }
@@ -761,7 +761,7 @@ static void read_try(job_t *j) {
     }
 
     if (buff) {
-        debug(3, L"proc::read_try('%ls')", j->command_wcstr());
+        debug(4, L"proc::read_try('%ls')", j->command_wcstr());
         while (1) {
             char b[BUFFER_SIZE];
             long len = read_blocked(buff->pipe_fd[0], b, BUFFER_SIZE);

--- a/src/proc.h
+++ b/src/proc.h
@@ -11,7 +11,7 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <list>
+#include <deque>
 #include <memory>
 #include <vector>
 
@@ -243,7 +243,7 @@ extern bool is_login;
 extern int is_event;
 
 // List of jobs. We sometimes mutate this while iterating - hence it must be a list, not a vector
-typedef std::list<shared_ptr<job_t>> job_list_t;
+typedef std::deque<shared_ptr<job_t>> job_list_t;
 
 bool job_list_is_empty(void);
 

--- a/src/proc.h
+++ b/src/proc.h
@@ -192,6 +192,15 @@ class job_t {
     /// Sets the command.
     void set_command(const wcstring &cmd) { command_str = cmd; }
 
+    /// Returns a truncated version of the job string. Used when a message has already been emitted
+    /// containing the full job string and job id, but using the job id alone would be confusing
+    /// due to reuse of freed job ids. Prevents overloading the debug comments with the full,
+    /// untruncated job string when we don't care what the job is, only which of the currently
+    /// running jobs it is.
+    wcstring preview() const {
+        return processes.empty() ? L"" : processes[0]->argv0() + wcstring(L" ...");
+    }
+
     /// All the processes in this job.
     process_list_t processes;
 

--- a/src/proc.h
+++ b/src/proc.h
@@ -386,7 +386,12 @@ int proc_format_status(int status);
 /// Wait for any process finishing.
 pid_t proc_wait_any();
 
-bool terminal_give_to_job(const job_t *j, bool cont);
+/// Give ownership of the terminal to the specified job.
+///
+/// \param j The job to give the terminal to.
+/// \param restore_attrs If this variable is set, we are giving back control to a job that was previously
+/// stopped. In that case, we need to set the terminal attributes to those saved in the job.
+bool terminal_give_to_job(const job_t *j, bool restore_attrs);
 
 /// Given that we are about to run a builtin, acquire the terminal if it is owned by the given job.
 /// Returns the pid to restore after running the builtin, or -1 if there is no pid to restore.

--- a/src/proc.h
+++ b/src/proc.h
@@ -163,10 +163,17 @@ enum class job_flag_t {
     SKIP_NOTIFICATION,
     /// Whether the exit status should be negated. This flag can only be set by the not builtin.
     NEGATE,
-    /// Whether the job is under job control.
+    /// Whether the job is under job control, i.e. has its own pgrp.
     JOB_CONTROL,
     /// Whether the job wants to own the terminal when in the foreground.
     TERMINAL,
+    /// This job was created via a recursive call to exec_job upon evaluation of a function.
+    /// Ideally it should not be a top-level job, and there are places where it won't be treated
+    /// as such.
+    NESTED,
+    /// This job shares a pgrp with a not-yet-constructed job, so we can't waitpid on its pgid
+    /// directly. Hack to work around fucntions starting new jobs. See `exec_job()`.
+    WAIT_BY_PROCESS
 };
 
 typedef int job_id_t;

--- a/src/proc.h
+++ b/src/proc.h
@@ -404,6 +404,9 @@ int proc_format_status(int status);
 /// Wait for any process finishing.
 pid_t proc_wait_any();
 
+/// Terminate all background jobs
+void hup_background_jobs();
+
 /// Give ownership of the terminal to the specified job.
 ///
 /// \param j The job to give the terminal to.

--- a/src/proc.h
+++ b/src/proc.h
@@ -370,10 +370,17 @@ int proc_format_status(int status);
 /// Wait for any process finishing.
 pid_t proc_wait_any();
 
-#endif
-
 bool terminal_give_to_job(const job_t *j, bool cont);
 
 /// Given that we are about to run a builtin, acquire the terminal if it is owned by the given job.
 /// Returns the pid to restore after running the builtin, or -1 if there is no pid to restore.
 pid_t terminal_acquire_before_builtin(int job_pgid);
+
+
+/// 0 should not be used; although it is not a valid PGID in userspace,
+///   the Linux kernel will use it for kernel processes.
+/// -1 should not be used; it is a possible return value of the getpgid()
+///   function
+enum { INVALID_PID  = -2 };
+
+#endif

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1780,7 +1780,7 @@ static void reader_interactive_init() {
                 // Try stopping us.
                 int ret = killpg(shell_pgid, SIGTTIN);
                 if (ret < 0) {
-                    wperror(L"killpg");
+                    wperror(L"killpg(shell_pgid, SIGTTIN)");
                     exit_without_destructors(1);
                 }
             }
@@ -2251,16 +2251,6 @@ void reader_bg_job_warning() {
     fputws(_(L"Use 'disown PID' to remove jobs from the list without terminating them.\n"), stdout);
 }
 
-void kill_background_jobs() {
-    job_iterator_t jobs;
-    while (job_t *j = jobs.next()) {
-        if (!j->is_completed()) {
-            if (j->is_stopped()) j->signal(SIGCONT);
-            j->signal(SIGHUP);
-        }
-    }
-}
-
 /// This function is called when the main loop notices that end_loop has been set while in
 /// interactive mode. It checks if it is ok to exit.
 static void handle_end_loop() {
@@ -2293,7 +2283,7 @@ static void handle_end_loop() {
     }
 
     // Kill remaining jobs before exiting.
-    kill_background_jobs();
+    hup_background_jobs();
 }
 
 static bool selection_is_at_top() {

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2242,7 +2242,7 @@ void reader_bg_job_warning() {
 
     job_iterator_t jobs;
     while (job_t *j = jobs.next()) {
-        if (!job_is_completed(j)) {
+        if (!j->is_completed()) {
             fwprintf(stdout, L"%6d  %ls\n", j->processes[0]->pid, j->command_wcstr());
         }
     }
@@ -2254,9 +2254,9 @@ void reader_bg_job_warning() {
 void kill_background_jobs() {
     job_iterator_t jobs;
     while (job_t *j = jobs.next()) {
-        if (!job_is_completed(j)) {
-            if (job_is_stopped(j)) job_signal(j, SIGCONT);
-            job_signal(j, SIGHUP);
+        if (!j->is_completed()) {
+            if (j->is_stopped()) j->signal(SIGCONT);
+            j->signal(SIGHUP);
         }
     }
 }
@@ -2277,7 +2277,7 @@ static void handle_end_loop() {
         bool bg_jobs = false;
         job_iterator_t jobs;
         while (const job_t *j = jobs.next()) {
-            if (!job_is_completed(j)) {
+            if (!j->is_completed()) {
                 bg_jobs = true;
                 break;
             }

--- a/src/reader.h
+++ b/src/reader.h
@@ -227,9 +227,6 @@ wcstring completion_apply_to_command_line(const wcstring &val_str, complete_flag
                                           const wcstring &command_line, size_t *inout_cursor_pos,
                                           bool append_only);
 
-/// Terminate all background jobs
-void kill_background_jobs();
-
 /// Print warning with list of backgrounded jobs
 void reader_bg_job_warning();
 

--- a/src/signal.h
+++ b/src/signal.h
@@ -40,4 +40,17 @@ bool signal_is_blocked();
 
 /// Returns signals with non-default handlers.
 void get_signals_with_handlers(sigset_t *set);
+
+/// A RAII wrapper for signal_block/signal_unblock that triggers a signal block on creation, and then
+/// automatically releases the block when the object is destroyed, handling control flow and exceptions.
+struct signal_block_t {
+    signal_block_t() {
+        signal_block();
+    }
+
+    ~signal_block_t() {
+        signal_unblock();
+    }
+};
+
 #endif


### PR DESCRIPTION
I _believe_ this finally safely does away with the keepalive process. I think the problem is that we were waiting on all child processes in `process_mark_finished_children` which caused premature reaping of terminated processes before their process group could be joined by new processes in the same job.

Additionally, there was a deadlock in `try_select` that didn't show up until that change was made.

This should fix #4178 (which manifests in two *entirely* different ways depending on whether connected over SSH and FreeBSD vs Linux) and quite likely some other issues as well.

~~This branch should likely be squash-merged.~~

---

Partially addresses #206.

Closes #3805. Closes #3952. Closes #4178. Closes #4238. Closes #4929. Closes #5210. 