### PR TITLE
doc_src/set.txt: -U affects only the user running the command, not all users

### DIFF
--- a/doc_src/set.txt
+++ b/doc_src/set.txt
@@ -29,7 +29,7 @@ The following options control variable scope:
 
 - `-g` or `--global` causes the specified shell variable to be given a global scope. Non-global variables disappear when the block they belong to ends
 
-- `-U` or `--universal` causes the specified shell variable to be given a universal scope. If this option is supplied, the variable will be shared between all the current users fish instances on the current computer, and will be preserved across restarts of the shell.
+- `-U` or `--universal` causes the specified shell variable to be given a universal scope. If this option is supplied, the variable will be shared between all the current user's fish instances on the current computer, and will be preserved across restarts of the shell.
 
 - `-x` or `--export` causes the specified shell variable to be exported to child processes (making it an "environment variable")
 


### PR DESCRIPTION
## Description

A grammar mistake in the documentation makes it misleading. This patch fixes it.

No issue exists for this documentation bug.

## TODOs:

This is a documentation only change. Hence none of the below are necessary.

<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
