### PR TITLE
Support %self again

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1040,6 +1040,7 @@ static void escape_string_script(const wchar_t *orig_in, size_t in_len, wcstring
                 case L'|':
                 case L';':
                 case L'"':
+                case L'%':
                 case L'~': {
                     bool char_is_normal = (c == L'~' && no_tilde) || (c == L'^' && no_caret) ||
                                           (c == L'?' && no_qmark);
@@ -1395,6 +1396,17 @@ static bool unescape_string_internal(const wchar_t *const input, const size_t in
                 case L'~': {
                     if (unescape_special && (input_position == 0)) {
                         to_append_or_none = HOME_DIRECTORY;
+                    }
+                    break;
+                }
+                case L'%': {
+                    // Note that this only recognizes %self if the string is literally %self.
+                    // %self/foo will NOT match this.
+                    if (unescape_special && input_position == 0 &&
+                        !wcscmp(input, PROCESS_EXPAND_SELF_STR)) {
+                        to_append_or_none = PROCESS_EXPAND_SELF;
+                        input_position +=
+                            wcslen(PROCESS_EXPAND_SELF_STR) - 1;  // skip over 'self' part.
                     }
                     break;
                 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -924,7 +924,7 @@ void env_init(const struct config_paths_t *paths /* or NULL */) {
     wcstring version = str2wcstring(get_fish_version());
     env_set_one(L"version", ENV_GLOBAL, version);
 
-    // Set the $fish_pid variable (%self replacement)
+    // Set the $fish_pid variable.
     env_set_one(L"fish_pid", ENV_GLOBAL, to_string<long>(getpid()));
 
     // Set the $hostname variable

--- a/src/expand.h
+++ b/src/expand.h
@@ -61,6 +61,8 @@ class completion_t;
 enum {
     /// Character representing a home directory.
     HOME_DIRECTORY = EXPAND_RESERVED_BASE,
+    /// Character representing process expansion for %self.
+    PROCESS_EXPAND_SELF,
     /// Character representing variable expansion.
     VARIABLE_EXPAND,
     /// Character representing variable expansion into a single element.
@@ -94,6 +96,9 @@ enum expand_error_t {
     /// Ok, a wildcard in the string matched a file.
     EXPAND_WILDCARD_MATCH
 };
+
+/// The string represented by PROCESS_EXPAND_SELF
+#define PROCESS_EXPAND_SELF_STR L"%self"
 
 /// Perform various forms of expansion on in, such as tilde expansion (\~USER becomes the users home
 /// directory), variable expansion (\$VAR_NAME becomes the value of the environment variable

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2472,7 +2472,6 @@ static void test_complete() {
     do_test(completions.at(1).completion == L"zero");
     do_test((completions.at(1).flags & COMPLETE_NO_SPACE) != 0);
 
-
     // Test wraps.
     do_test(comma_join(complete_get_wrap_targets(L"wrapper1")) == L"");
     complete_add_wrapper(L"wrapper1", L"wrapper2");
@@ -4084,6 +4083,13 @@ static void test_highlighting() {
         {L"true", highlight_spec_command},
         {L";", highlight_spec_statement_terminator},
         {L"end", highlight_spec_command},
+    });
+
+    highlight_tests.push_back({
+        {L"echo", highlight_spec_command},
+        {L"%self", highlight_spec_operator},
+        {L"not%self", highlight_spec_param},
+        {L"self%not", highlight_spec_param},
     });
 
     // Verify variables and wildcards in commands using /bin/cat.

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -444,6 +444,12 @@ static void color_string_internal(const wcstring &buffstr, highlight_spec_t base
     const size_t buff_len = buffstr.size();
     std::fill(colors, colors + buff_len, base_color);
 
+    // Hacky support for %self which must be an unquoted literal argument.
+    if (buffstr == PROCESS_EXPAND_SELF_STR) {
+        std::fill_n(colors, wcslen(PROCESS_EXPAND_SELF_STR), highlight_spec_operator);
+        return;
+    }
+
     enum { e_unquoted, e_single_quoted, e_double_quoted } mode = e_unquoted;
     int bracket_count = 0;
     for (size_t in_pos = 0; in_pos < buff_len; in_pos++) {
@@ -692,8 +698,8 @@ class highlighter_t {
 
    public:
     // Constructor
-    highlighter_t(const wcstring &str, size_t pos, const env_vars_snapshot_t &ev,
-                  wcstring wd, bool can_do_io)
+    highlighter_t(const wcstring &str, size_t pos, const env_vars_snapshot_t &ev, wcstring wd,
+                  bool can_do_io)
         : buff(str),
           cursor_pos(pos),
           vars(ev),

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -121,6 +121,7 @@ bool is_potential_path(const wcstring &potential_path_fragment, const wcstring_l
     for (size_t i = 0; i < path_with_magic.size(); i++) {
         wchar_t c = path_with_magic.at(i);
         switch (c) {
+            case PROCESS_EXPAND_SELF:
             case VARIABLE_EXPAND:
             case VARIABLE_EXPAND_SINGLE:
             case BRACE_BEGIN:

--- a/tests/expansion.err
+++ b/tests/expansion.err
@@ -9,6 +9,9 @@ echo ()[d]
         ^
 
 ####################
+# Percent self
+
+####################
 # Catch your breath
 fish: $) is not a valid variable in fish.
 echo $$paren

--- a/tests/expansion.in
+++ b/tests/expansion.in
@@ -101,6 +101,11 @@ echo $foo[d]
 echo ()[1]
 echo ()[d]
 
+logmsg Percent self
+echo %selfNOT NOT%self \%self "%self" '%self'
+echo %self | string match -qr '^\\d+$'
+echo "All digits: $status"
+
 logmsg Catch your breath
 set paren ')'
 echo $$paren

--- a/tests/expansion.out
+++ b/tests/expansion.out
@@ -64,6 +64,11 @@
 
 
 ####################
+# Percent self
+%selfNOT NOT%self %self %self %self
+All digits: 0
+
+####################
 # Catch your breath
 
 ####################


### PR DESCRIPTION
This restores support for `%self`. Other types of process and job expansion are not supported; only the literal argument `%self` expands.

I hope this will be sufficient to address #4230 