### PR TITLE
Add dynamic clang completions via clang --autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ fish 3.0 is a major release which brings with it both improvements in functional
 - Added completions for
   - `bd` (#4472)
   - `bower`
+  - `clang` and `clang++` (#4174)
   - `configure` (autoconf only)
   - `doas` (#5196)
   - `hjson`

--- a/share/completions/clang++.fish
+++ b/share/completions/clang++.fish
@@ -1,0 +1,5 @@
+# Multiple versions are often installed as clang++, clang++-7, clang++-8, etc.
+# They won't be autoloaded, but once clang++ is used once, they'll gain completions too.
+complete -p '*clang++*' -n '__fish_should_complete_switches' -xa '(__fish_clang_complete)'
+complete -p '*clang++*' -n 'not __fish_should_complete_switches' \
+	-xa '(__fish_complete_suffix \'{.o,.out,.c,.cpp,.so,.dylib}\')'

--- a/share/completions/clang.fish
+++ b/share/completions/clang.fish
@@ -1,0 +1,9 @@
+# Multiple versions are often installed as clang, clang-7, clang-8, etc.
+# They won't be autoloaded, but once clang++ is used once, they'll gain completions too.
+# This pattern unfortunately matches clang-format, etc. as well.
+complete -p '*clang*' -n '__fish_should_complete_switches' -xa '(__fish_clang_complete)'
+complete -c 'clang' -n 'not __fish_should_complete_switches' \
+	-xa "(__fish_complete_suffix '{.o,.out,.c,.cpp,.so,.dylib}')"
+# again but without the -x this time for the pattern-matched completion
+complete -p '*clang*' -n 'not __fish_should_complete_switches' \
+	-a "(__fish_complete_suffix '{.o,.out,.c,.cpp,.so,.dylib}')"

--- a/share/functions/__fish_clang_complete.fish
+++ b/share/functions/__fish_clang_complete.fish
@@ -1,0 +1,14 @@
+# This function is compatible with clang, clang++, and variations thereof, and is shared
+# by clang.fish and clang++.fish.
+# We dynamically query the head at `(commandline -o)[1]` to get the correct completions.
+function __fish_clang_complete
+	# If the result is for a value, clang only prints the value, so
+	# completions for `-std=` print `c++11` and not `-std=c++11` like we need. See #4174.
+	set -l prefix ""(string replace -fr -- '^(.*=)[^=]*' '$1' (commandline -ct))
+
+	# first get the completions from clang, with the prefix separated from the value by a comma
+	env (commandline -o)[1] --autocomplete=(commandline -ct | string replace -- "$prefix" "$prefix,") 2>/dev/null |
+	# and put it in a format that fish understands
+	string replace -r -- '^([^ ]+)\s*(.*)' "$prefix\$1\t\$2"
+end
+


### PR DESCRIPTION
Use clang/clang++'s own autocompletion support to complete arguments. It
is rather convoluted as clang generates autocompletions for a portion of
the current token rather than the entire token, e.g. while `--st` will
autocomplete to `--std=` (which is fine by fish), `--std=g` will
autocomplete to `gnu...` without the leading `--std=` which breaks fish'
support for the completion.

Additionally, on systems where clang/clang++ is the system compiler
(such as FreeBSD), it is very often for users to invoke a newer version
of clang/clang++ installed as clang[++]-NN instead of clang. Using a
monkey-patched version of `complete -p` to support that without breaking
(future) completions for commands like `clang-format`.

Closes #4174.
