### PR TITLE
Restore legacy CMD_DURATION and FISH_VERSION variables

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -939,9 +939,9 @@ The user can change the settings of `fish` by changing the values of certain var
 
 - `USER`, the current username. This variable can be changed by the user.
 
-- `cmd_duration`, the runtime of the last command in milliseconds.
+- `CMD_DURATION`, the runtime of the last command in milliseconds.
 
-- `version`, the version of the currently running fish
+- `version`, the version of the currently running fish (also available as `FISH_VERSION` for backward compatibility).
 
 - `SHLVL`, the level of nesting of shells
 
@@ -949,7 +949,7 @@ The user can change the settings of `fish` by changing the values of certain var
 
 The names of these variables are mostly derived from the csh family of shells and differ from the ones used by Bourne style shells such as bash.
 
-Variables whose name are in uppercase are exported to the commands started by fish, while those in lowercase are not exported. This rule is not enforced by fish, but it is good coding practice to use casing to distinguish between exported and unexported variables. `fish` also uses several variables internally. Such variables are prefixed with the string `__FISH` or `__fish.` These should never be used by the user. Changing their value may break fish.
+Variables whose name are in uppercase are generally exported to the commands started by fish, while those in lowercase are not exported (`CMD_DURATION` is an exception, for historical reasons). This rule is not enforced by fish, but it is good coding practice to use casing to distinguish between exported and unexported variables. `fish` also uses several variables internally. Such variables are prefixed with the string `__FISH` or `__fish.` These should never be used by the user. Changing their value may break fish.
 
 \subsection variables-status The status variable
 

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -296,8 +296,9 @@ bool string_set_contains(const T &set, const wchar_t *val) {
 
 /// Check if a variable may not be set using the set command.
 static bool is_read_only(const wchar_t *val) {
-    const string_set_t env_read_only = {L"PWD", L"SHLVL", L"history", L"status", L"version",
-        L"fish_pid", L"hostname", L"_", L"fish_private_mode"};
+    const string_set_t env_read_only = {
+        L"PWD",          L"SHLVL",    L"history",  L"status", L"version",
+        L"FISH_VERSION", L"fish_pid", L"hostname", L"_",      L"fish_private_mode"};
     return string_set_contains(env_read_only, val) ||
         (in_private_mode() && wcscmp(L"fish_history", val) == 0);
 }
@@ -899,6 +900,7 @@ void env_init(const struct config_paths_t *paths /* or NULL */) {
     // Set up the version variable.
     wcstring version = str2wcstring(get_fish_version());
     env_set_one(L"version", ENV_GLOBAL, version);
+    env_set_one(L"FISH_VERSION", ENV_GLOBAL, version);
 
     // Set the $fish_pid variable.
     env_set_one(L"fish_pid", ENV_GLOBAL, to_string<long>(getpid()));

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -78,7 +78,7 @@
 
 // Name of the variable that tells how long it took, in milliseconds, for the previous
 // interactive command to complete.
-#define ENV_cmd_duration L"cmd_duration"
+#define ENV_CMD_DURATION L"CMD_DURATION"
 
 /// Maximum length of prefix string when printing completion list. Longer prefixes will be
 /// ellipsized.
@@ -906,7 +906,7 @@ void reader_init() {
     // Ensure this var is present even before an interactive command is run so that if it is used
     // in a function like `fish_prompt` or `fish_right_prompt` it is defined at the time the first
     // prompt is written.
-    env_set_one(ENV_cmd_duration, ENV_UNEXPORT, L"0");
+    env_set_one(ENV_CMD_DURATION, ENV_UNEXPORT, L"0");
 
     // Save the initial terminal mode.
     tcgetattr(STDIN_FILENO, &terminal_mode_on_startup);
@@ -2008,7 +2008,7 @@ void set_env_cmd_duration(struct timeval *after, struct timeval *before) {
     }
 
     swprintf(buf, 16, L"%d", (secs * 1000) + (usecs / 1000));
-    env_set_one(ENV_cmd_duration, ENV_UNEXPORT, buf);
+    env_set_one(ENV_CMD_DURATION, ENV_UNEXPORT, buf);
 }
 
 void reader_run_command(parser_t &parser, const wcstring &cmd) {


### PR DESCRIPTION
I've got to make this quick - it's me, @zanchey from the future!

I've travelled back in time to make one last-ditch attempt to head a problem off. After we released fish 3.0, GitHub was inundated with people asking why their prompts stopped working, or their strangely-written scripts started deleting files. It turns out that removing `CMD_DURATION` and `FISH_VERSION` broke a whole bunch of existing code, and telling them that it was to improve internal consistency won me no friends. I thought about just leaving the old names, but then there were going to be confused new users wondering why they didn't make any sense.

Anyway, this commit restores the two versions of the two variables. They cost almost nothing to keep around and I think the backward compatibility is worth it. This is the last time I'll speak up about it and I won't be upset if nobody else thinks this is worth a go - I promise.

Gotta go, the @zanchey from your timeline sounds like they've managed to get the child back to sleep - the winning lotto numbers are encoded in the second paragraph!