### PR TITLE
Guard against pgid == 0

### DIFF
--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -158,8 +158,6 @@ bool set_child_group(job_t *j, pid_t child_pid) {
 }
 
 bool maybe_assign_terminal(const job_t *j) {
-    assert(j->pgid > 1 && "maybe_assign_terminal() called on job with invalid pgid!");
-
     if (j->get_flag(job_flag_t::TERMINAL) && j->is_foreground()) {  //!OCLINT(early exit)
         if (tcgetpgrp(STDIN_FILENO) == j->pgid) {
             // We've already assigned the process group control of the terminal when the first


### PR DESCRIPTION
This happens in firejail, and it means that we can't use it as an
argument to most pgid-taking functions.

E.g. `wait(0)` means to wait for the _current_ process group,
`tcsetpgrp(0)` doesn't work etc.

So we just stop doing this stuff and hope it works.

Fixes #5295.

I can confirm this makes `firejail --shell=/path/to/fish` work - without it, the outer shell that starts would busy-wait because it waited on pgroup 0, which is "the current process group".

I have no idea what else breaks.