### PR TITLE
Replace "env" with "expr" in the test manpage

### DIFF
--- a/doc_src/test.txt
+++ b/doc_src/test.txt
@@ -78,7 +78,7 @@ When using a variable as an argument for a test operator you should almost alway
 
 - `NUM1 -le NUM2` returns true if `NUM1` is less than or equal to `NUM2`.
 
-Note that only integers are supported. For more complex mathematical operations, including fractions, the `expr` program may be useful. Consult the documentation for your operating system.
+Both integers and floating point numbers are supported.
 
 \subsection test-combinators Operators to combine expressions
 

--- a/doc_src/test.txt
+++ b/doc_src/test.txt
@@ -78,7 +78,7 @@ When using a variable as an argument for a test operator you should almost alway
 
 - `NUM1 -le NUM2` returns true if `NUM1` is less than or equal to `NUM2`.
 
-Note that only integers are supported. For more complex mathematical operations, including fractions, the `env` program may be useful. Consult the documentation for your operating system.
+Note that only integers are supported. For more complex mathematical operations, including fractions, the `expr` program may be useful. Consult the documentation for your operating system.
 
 \subsection test-combinators Operators to combine expressions
 


### PR DESCRIPTION
## Description

I'm pretty sure `env` isn't capable of comparing numbers and the author meant `expr`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
