### PR TITLE
Always pass in the working directory in path_get_cdpath

### DIFF
--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -4916,6 +4916,19 @@ void test_normalize_path() {
     do_test(normalize_path(L"foo/../foo") == L"foo");
     do_test(normalize_path(L"foo/../foo/") == L"foo");
     do_test(normalize_path(L"foo/././bar/.././baz") == L"foo/baz");
+
+    do_test(path_normalize_for_cd(L"/", L"..") == L"/..");
+    do_test(path_normalize_for_cd(L"/abc/", L"..") == L"/");
+    do_test(path_normalize_for_cd(L"/abc/def/", L"..") == L"/abc");
+    do_test(path_normalize_for_cd(L"/abc/def/", L"../..") == L"/");
+    do_test(path_normalize_for_cd(L"/abc///def/", L"../..") == L"/");
+    do_test(path_normalize_for_cd(L"/abc///def/", L"../..") == L"/");
+    do_test(path_normalize_for_cd(L"/abc///def///", L"../..") == L"/");
+    do_test(path_normalize_for_cd(L"/abc///def///", L"..") == L"/abc");
+    do_test(path_normalize_for_cd(L"/abc///def///", L"..") == L"/abc");
+    do_test(path_normalize_for_cd(L"/abc/def/", L"./././/..") == L"/abc");
+    do_test(path_normalize_for_cd(L"/abc/def/", L"../../../") == L"/../");
+    do_test(path_normalize_for_cd(L"/abc/def/", L"../ghi/..") == L"/abc/ghi/..");
 }
 
 /// Main test.

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -1021,7 +1021,7 @@ static bool command_is_valid(const wcstring &cmd, enum parse_statement_decoratio
 
     // Implicit cd
     if (!is_valid && implicit_cd_ok) {
-        is_valid = path_can_be_implicit_cd(cmd, NULL, working_directory, vars);
+        is_valid = path_can_be_implicit_cd(cmd, working_directory, NULL, vars);
     }
 
     // Return what we got.

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -809,7 +809,8 @@ parse_execution_result_t parse_execution_context_t::populate_plain_process(
                 !args.try_get_child<g::redirection, 0>()) {
                 // Ok, no arguments or redirections; check to see if the command is a directory.
                 wcstring implicit_cd_path;
-                use_implicit_cd = path_can_be_implicit_cd(cmd, &implicit_cd_path);
+                use_implicit_cd =
+                    path_can_be_implicit_cd(cmd, env_get_pwd_slash(), &implicit_cd_path);
             }
         }
 

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -162,7 +162,7 @@ bool path_get_cdpath(const wcstring &dir, wcstring *out, const wcstring &wd,
     int err = ENOENT;
     if (dir.empty()) return false;
 
-    assert(wd.empty() || wd.back() == L'/');
+    assert(!wd.empty() && wd.back() == L'/');
 
     wcstring_list_t paths;
     if (dir.at(0) == L'/') {
@@ -171,10 +171,7 @@ bool path_get_cdpath(const wcstring &dir, wcstring *out, const wcstring &wd,
     } else if (string_prefixes_string(L"./", dir) || string_prefixes_string(L"../", dir) ||
                dir == L"." || dir == L"..") {
         // Path is relative to the working directory.
-        wcstring path;
-        if (!wd.empty()) path.append(wd);
-        path.append(dir);
-        paths.push_back(path);
+        paths.push_back(path_normalize_for_cd(wd, dir));
     } else {
         // Respect CDPATH.
         wcstring_list_t cdpathsv;
@@ -218,7 +215,7 @@ bool path_get_cdpath(const wcstring &dir, wcstring *out, const wcstring &wd,
     return success;
 }
 
-bool path_can_be_implicit_cd(const wcstring &path, wcstring *out_path, const wcstring &wd,
+bool path_can_be_implicit_cd(const wcstring &path, const wcstring &wd, wcstring *out_path,
                              const env_vars_snapshot_t &vars) {
     wcstring exp_path = path;
     expand_tilde(exp_path);

--- a/src/path.h
+++ b/src/path.h
@@ -56,19 +56,17 @@ wcstring_list_t path_get_paths(const wcstring &cmd);
 ///
 /// \param dir The name of the directory.
 /// \param out_or_NULL If non-NULL, return the path to the resolved directory
-/// \param wd The working directory, or NULL to use the default. The working directory should have a
-/// slash appended at the end.
+/// \param wd The working directory, which should have a slash appended at the end.
 /// \param vars The environment variable snapshot to use (for the CDPATH variable)
 /// \return 0 if the command can not be found, the path of the command otherwise. The path should be
 /// free'd with free().
-bool path_get_cdpath(const wcstring &dir, wcstring *out_or_NULL, const wcstring &wd = L"",
+bool path_get_cdpath(const wcstring &dir, wcstring *out_or_NULL, const wcstring &wd,
                      const env_vars_snapshot_t &vars = env_vars_snapshot_t::current());
 
 /// Returns whether the path can be used for an implicit cd command; if so, also returns the path by
 /// reference (if desired). This requires it to start with one of the allowed prefixes (., .., ~)
 /// and resolve to a directory.
-bool path_can_be_implicit_cd(const wcstring &path, wcstring *out_path = NULL,
-                             const wcstring &wd = L"",
+bool path_can_be_implicit_cd(const wcstring &path, const wcstring &wd, wcstring *out_path = NULL,
                              const env_vars_snapshot_t &vars = env_vars_snapshot_t::current());
 
 /// Remove double slashes and trailing slashes from a path, e.g. transform foo//bar/ into foo/bar.

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -74,6 +74,12 @@ maybe_t<wcstring> wrealpath(const wcstring &pathname);
 /// 3. Remove /./ in the middle.
 wcstring normalize_path(const wcstring &path);
 
+/// Given an input path \p path and a working directory \p wd, do a "normalizing join" in a way
+/// appropriate for cd. That is, return effectively wd + path while resolving leading ../s from
+/// path. The intent here is to allow 'cd' out of a directory which may no longer exist, without
+/// allowing 'cd' into a directory that may not exist; see #5341.
+wcstring path_normalize_for_cd(const wcstring &wd, const wcstring &path);
+
 /// Wide character version of readdir().
 bool wreaddir(DIR *dir, wcstring &out_name);
 bool wreaddir_resolving(DIR *dir, const std::wstring &dir_path, wcstring &out_name,


### PR DESCRIPTION
If the user is in a directory which has been unlinked, it is possible
for the path .. to not exist, relative to the working directory.
Always pass in the working directory (potentially virtual) to
path_get_cdpath; this ensures we check absolute paths and are immune
from issues if the working directory has been unlinked.

Also introduce a new function path_normalize_for_cd which normalizes the
"join point" of a path and a working directory. This allows us to 'cd' out of
a non-existent directory, but not cd into such a directory.

Fixes #5341
