### PR TITLE
Made ip output colored

### DIFF
--- a/share/functions/ip.fish
+++ b/share/functions/ip.fish
@@ -1,9 +1,14 @@
 #
 # Enable ip colored output if this is available
+# But only when writing to stdout
 #
 
 if command ip -c l >/dev/null 2>/dev/null
     function ip
-        command ip -c $argv
+        if isatty stdout
+            command ip -c $argv
+        else
+            command ip $argv
+        end
     end
 end

--- a/share/functions/ip.fish
+++ b/share/functions/ip.fish
@@ -3,12 +3,14 @@
 # But only when writing to stdout
 #
 
-if command ip -c l >/dev/null 2>/dev/null
-    function ip
-        if isatty stdout
-            command ip -c $argv
-        else
-            command ip $argv
+if command -s ip >/dev/null
+    if command ip -c l >/dev/null 2>/dev/null
+        function ip
+            if isatty stdout
+                command ip -c $argv
+            else
+                command ip $argv
+            end
         end
     end
 end

--- a/share/functions/ip.fish
+++ b/share/functions/ip.fish
@@ -3,14 +3,12 @@
 # But only when writing to stdout
 #
 
-if command -s ip >/dev/null
-    if command ip -c l >/dev/null 2>/dev/null
-        function ip
-            if isatty stdout
-                command ip -c $argv
-            else
-                command ip $argv
-            end
+if command -sq ip; and command ip -c l >/dev/null 2>/dev/null
+    function ip
+        if isatty stdout
+            command ip -c $argv
+        else
+            command ip $argv
         end
     end
 end

--- a/share/functions/ip.fish
+++ b/share/functions/ip.fish
@@ -1,0 +1,9 @@
+#
+# Enable ip colored output if this is available
+#
+
+if command ip -c l >/dev/null 2>/dev/null
+    function ip
+        command ip -c $argv
+    end
+end


### PR DESCRIPTION
## Description

This PR adds a fish function that passes calls to `ip` to `ip -c` in order to make the output colored. This is similar to what is already done with grep and helps the user to quickly find the relevant information.

Fixes issue #5340

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
