### PR TITLE
builtin_string: JIT pcre2 regex

### DIFF
--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -693,6 +693,9 @@ struct compiled_regex_t {
             return;
         }
 
+        // Maybe enable JIT. This does nothing if JIT is not available.
+        pcre2_jit_compile(code, PCRE2_JIT_COMPLETE);
+
         match = pcre2_match_data_create_from_pattern(code, 0);
         assert(match);
     }


### PR DESCRIPTION
This seems to be quite a trivial optimization. In my tests, I can't
find an expression that is slower, and speedups range from 10-40%.

According to https://pcre.org/current/doc/html/pcre2jit.html, jit
should simply work if it is available, and fall back if not.

(This is with pcre2 10.32 on archlinux x86_64)