### PR TITLE
Slightly restructure man.fish for clarity

### DIFF
--- a/share/functions/man.fish
+++ b/share/functions/man.fish
@@ -6,25 +6,23 @@ end
 function man --description "Format and display the on-line manual pages"
     # Work around the "builtin" manpage that everything symlinks to,
     # by prepending our fish datadir to man. This also ensures that man gives fish's
-    # man pages priority, without having to put fish's bin directories first in $PATH
+    # man pages priority, without having to put fish's bin directories first in $PATH.
 
+    # Preserve the existing MANPATH, and default to the system path (the empty string).
     set -l manpath
     if set -q MANPATH
         set manpath $MANPATH
-    else if command -qs manpath
-        set manpath (command manpath)
+    else
+        set manpath ''
     end
-    # Notice local exported copy of the variable.
+    # Notice the shadowing local exported copy of the variable.
     set -lx MANPATH $manpath
 
-    set -l fish_manpath (dirname $__fish_data_dir)/fish/man
-    if test -d "$fish_manpath" -a -n "$MANPATH"
-        set MANPATH $fish_manpath:$MANPATH
-        # Invoke man with this manpath, and we're done.
-        command man $argv
-        return
+    # Prepend fish's man directory if available.
+    set -l fish_manpath (dirname $__fish_datadir)/fish/man
+    if test -d $fish_manpath
+        set MANPATH $fish_manpath $MANPATH
     end
 
-    # If fish's man pages could not be found, just invoke man normally
     command man $argv
 end


### PR DESCRIPTION
man.fish can be clarified a bit, by removing a superfluous early return. Additionally, performance can be
(ever so slightly) improved, by using the empty string to suffix an extra colon when `$MANPATH` is empty, as described in `manpath(1)`. As `man` will internally call `manpath` as it starts, this eliminates a redundancy.

Additionally this makes fish's `$MANPATH` override work even when `manpath` is absent from `$PATH`, if that were to happen for some reason.