### PR TITLE
Improve the contrast of the pager for solarized dark theme.

### DIFF
--- a/share/tools/web_config/js/colorutils.js
+++ b/share/tools/web_config/js/colorutils.js
@@ -307,7 +307,7 @@ var color_scheme_solarized_dark = {
     quote: solarized.base00,
     redirection: solarized.violet,
     search_match: 'bryellow --background=black',
-    fish_pager_color_completion: 'cyan',
+    fish_pager_color_completion: 'B3A06D',
     fish_pager_color_description: 'B3A06D',
     fish_pager_color_prefix: 'cyan --underline',
     fish_pager_color_progress: 'brwhite --background=cyan',


### PR DESCRIPTION
## Description

By setting fish_pager_color_completion to `B3A06D`, the pager gets more visual contrast.

![2018-11-30_fri_07 48 51](https://user-images.githubusercontent.com/748856/49275825-ed2ed380-f4bf-11e8-93d6-eaed4aa5e379.png)

![2018-11-30_fri_07 48 57](https://user-images.githubusercontent.com/748856/49275826-ed2ed380-f4bf-11e8-826d-6083f94304b7.png)

![2018-11-30_fri_07 49 24](https://user-images.githubusercontent.com/748856/49275827-ed2ed380-f4bf-11e8-981b-4ec35521c6d8.png)