### PR TITLE
Use eval to split $EDITOR and $VISUAL

### DIFF
--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -15,14 +15,17 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
     end
 
     # Edit the command line with the users preferred editor or vim or emacs.
+    # Guard against the possibility that VISUAL or EDITOR contains spaces - see #5348.
     commandline -b >$f
     if set -q VISUAL
         __fish_disable_bracketed_paste
-        $VISUAL $f
+        eval set -l visual_cmd $VISUAL
+        $visual_cmd $f
         __fish_enable_bracketed_paste
     else if set -q EDITOR
         __fish_disable_bracketed_paste
-        $EDITOR $f
+        eval set -l editor_cmd $EDITOR
+        $editor_cmd $f
         __fish_enable_bracketed_paste
     else
         echo

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -35,9 +35,9 @@ function funced --description 'Edit function definition'
     else if set -q _flag_editor
         set editor $_flag_editor
     else if set -q VISUAL
-        set editor $VISUAL
+        eval set editor $VISUAL
     else if set -q EDITOR
-        set editor $EDITOR
+        eval set editor $EDITOR
     else
         set editor fish
     end


### PR DESCRIPTION
Guard against the possibility that $EDIOTR and $VISUAL contain spaces by
running them through eval, before using them in funced and command line
editing.

Fixes #5348