### PR TITLE
Sorin theme: Don't run git merge quietly

### DIFF
--- a/share/tools/web_config/sample_prompts/sorin.fish
+++ b/share/tools/web_config/sample_prompts/sorin.fish
@@ -25,11 +25,6 @@ function fish_right_prompt
 
         git name-rev --name-only HEAD
 
-        # Merging state
-        git merge -q 2>/dev/null
-        or printf ':'(set_color red)'merge'
-        printf ' '
-
         # Symbols
         if set -l count (command git rev-list --count --left-right $upstream...HEAD 2>/dev/null)
             echo $count | read -l ahead behind


### PR DESCRIPTION
## Description

(fyi: Today's my first day using fish. = I'm an utter noob.)

I was rebasing my local branch on top of the remote and while doing so noticed that a merge commit was created each time no matter what I did!
(This of course meant that the number of commits in my branch virtually doubled each time.)

I was able to track this down to this sorin theme.
Please don't just call `git merge` like that as it's a mutating operation and can easily destroy the delicate state of any git repository.

There might be other options to retain the previous behaviour, but this PR is surely the fastest and most secure "hotfix".

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

Let me know what you think and if anything needs to be done for this.
I'd just like to spare other users the hassle of this issue as quickly as possible. :slightly_smiling_face: 