### PR TITLE
Fix incorrect behavior of command-not-found on openSUSE Leap 15

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -302,7 +302,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
 
         # First check if we are on OpenSUSE since SUSE's handler has no options
         # but the same name and path as Ubuntu's.
-        if contains -- suse $os
+        if string match -q "*suse*" $os
             or contains -- sles $os
             and type -q command-not-found
             function __fish_command_not_found_handler --on-event fish_command_not_found


### PR DESCRIPTION
## Description

This PR fixes an incorrect behavior of whenever we type a command that is not found on openSUSE Leap 15. This is due to the fact that in /etc/osrelease the var ID_LIKE has now value "suse opensuse" instead of only "suse". The fix changes the version checking to a wildcard match instead of trying to locate the element "suse" inside an array.

Fixes issue #5391 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages. - N/A
- [x] Tests have been added for regressions fixed - N/A
- [x] User-visible changes noted in CHANGELOG.md - N/A
