### PR TITLE
Guess an emoji width of 2 for glibc >= 2.26

### DIFF
--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -255,11 +255,21 @@ int g_fish_ambiguous_width = 1;
 // Width of emoji characters.
 int g_fish_emoji_width = 0;
 
-// 1 is the typical emoji width in Unicode 8.
-// 2 is typical in Unicode 9, which for glibc has been introduced in 2.26.
-#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 26)
+// Try to detect if we have a unicode 9 supporting libc (currently only glibc)
+// For glibc, this was introduced in version 2.26
+#if defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 26)
+#define UNICODE_9 1
+#endif
+#else
+#define UNICODE_9 0
+#endif
+
+// Unicode 9 typically uses a width of 2.
+#if UNICODE_9
 int g_guessed_fish_emoji_width = 2;
 #else
+// 1 is the typical emoji width in Unicode 8.
 int g_guessed_fish_emoji_width = 1;
 #endif
 

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -256,7 +256,12 @@ int g_fish_ambiguous_width = 1;
 int g_fish_emoji_width = 0;
 
 // 1 is the typical emoji width in Unicode 8.
+// 2 is typical in Unicode 9, which for glibc has been introduced in 2.26.
+#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 26)
+int g_guessed_fish_emoji_width = 2;
+#else
 int g_guessed_fish_emoji_width = 1;
+#endif
 
 int fish_get_emoji_width(wchar_t c) {
     (void)c;


### PR DESCRIPTION
## Description

That was when Glibc introduced Unicode 9 support, so everything since
then should use the new width.

I have no idea how to detect it for other operating systems or libcs.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
