### PR TITLE
Add fish startup flag `--no-config`, take 2

### DIFF
--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -67,6 +67,8 @@ class fish_cmd_opts_t {
 
 /// If we are doing profiling, the filename to output to.
 static const char *s_profiling_output_filename = NULL;
+/// Used to prevent loading of user configuration at startup
+static bool s_load_user_config = true;
 
 static bool has_suffix(const std::string &path, const char *suffix, bool ignore_case) {
     size_t pathlen = path.size(), suffixlen = strlen(suffix);
@@ -198,7 +200,7 @@ static int read_init(const struct config_paths_t &paths) {
     // If path_get_config returns false then we have no configuration directory and no custom config
     // to load.
     wcstring config_dir;
-    if (path_get_config(config_dir)) {
+    if (s_load_user_config && path_get_config(config_dir)) {
         source_config_in_directory(config_dir);
     }
 
@@ -230,6 +232,7 @@ static int fish_parse_opt(int argc, char **argv, fish_cmd_opts_t *opts) {
                                               {"no-execute", no_argument, NULL, 'n'},
                                               {"profile", required_argument, NULL, 'p'},
                                               {"private", no_argument, NULL, 'P'},
+                                              {"no-config", no_argument, NULL, 'N'},
                                               {"help", no_argument, NULL, 'h'},
                                               {"version", no_argument, NULL, 'v'},
                                               {NULL, 0, NULL, 0}};
@@ -278,6 +281,12 @@ static int fish_parse_opt(int argc, char **argv, fish_cmd_opts_t *opts) {
             }
             case 'n': {
                 no_exec = 1;
+                break;
+            }
+            case 'N': {
+                // debug(1, "disable user directory");
+                s_load_user_config = false;
+                path_disable_user_config();
                 break;
             }
             case 'p': {

--- a/src/path.h
+++ b/src/path.h
@@ -19,6 +19,9 @@
 /// \return whether the directory was returned successfully
 bool path_get_config(wcstring &path);
 
+/// Disables `path_get_config` going forward
+void path_disable_user_config();
+
 /// Returns the user data directory for fish. If the directory or one of its parents doesn't exist,
 /// they are first created.
 ///


### PR DESCRIPTION
This prevents fish from loading the user configuration file, both at
startup and at any point thereafter, in both interactive and
non-interactive modes.

As fish relies extensively on `$__fish_config_dir` for core
functionality (universal variables), this is achieved by creating a new
runtime path (using the existing code to do so) to serve as the user
config dir.

--- 

Either this or #5416 should be merged, depending on how far we want to take this.