### PR TITLE
Add additional conditions for CentOS 7

### DIFF
--- a/fish.spec.in
+++ b/fish.spec.in
@@ -11,13 +11,13 @@ URL:                    https://fishshell.com/
 Source0:                %{name}_@VERSION@.orig.tar.gz
 BuildRequires:          ncurses-devel gettext gcc-c++ autoconf
 
-%if (0%{?rhel_version} && 0%{?rhel_version} < 800) || (0%{?centos_ver} && 0%{?centos_ver} < 8)
+%if 0%{?rhel} < 8
 BuildRequires: cmake3
 %else
 BuildRequires: cmake
 %endif
 
-%if 0%{?opensuse_bs} && ((0%{?rhel_version} && 0%{?rhel_version} < 700) || (0%{?centos_ver} && 0%{?centos_ver} < 7))
+%if 0%{?opensuse_bs} && 0%{?rhel} < 7
 BuildRequires: gcc48 gcc48-c++
 %endif
 
@@ -40,7 +40,7 @@ is simple but incompatible with other shell languages.
 %setup -q -n %{name}-@VERSION@
 
 %build
-%if 0%{?opensuse_bs} && ((0%{?rhel_version} && 0%{?rhel_version} < 700) || (0%{?centos_ver} && 0%{?centos_ver} < 7))
+%if 0%{?opensuse_bs} && 0%{?rhel} < 7
 export CC=gcc48
 export CXX=g++48
 EXTRA_CMAKE_FLAGS="-DCURSES_EXTRA_LIBRARY=tinfo"
@@ -54,7 +54,7 @@ export CXXFLAGS="$CXXFLAGS -march=i686"
 EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DBUILD_SHARED_LIBS:BOOL=OFF"
 # CMake macros define the wrong sysconfdir arguments
 EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DCMAKE_INSTALL_SYSCONFDIR=%{_sysconfdir}"
-%if (0%{?rhel_version} && 0%{?rhel_version} < 800) || (0%{?centos_ver} && 0%{?centos_ver} < 8)
+%if 0%{?rhel} < 8
 %cmake3 $EXTRA_CMAKE_FLAGS
 %else
 %cmake $EXTRA_CMAKE_FLAGS

--- a/fish.spec.in
+++ b/fish.spec.in
@@ -11,13 +11,13 @@ URL:                    https://fishshell.com/
 Source0:                %{name}_@VERSION@.orig.tar.gz
 BuildRequires:          ncurses-devel gettext gcc-c++ autoconf
 
-%if 0%{?rhel_version} && 0%{?rhel_version} && 0%{?rhel_version} < 800
+%if (0%{?rhel_version} && 0%{?rhel_version} < 800) || (0%{?centos_ver} && 0%{?centos_ver} < 8)
 BuildRequires: cmake3
 %else
 BuildRequires: cmake
 %endif
 
-%if 0%{?opensuse_bs} && 0%{?rhel_version} && 0%{?rhel_version} < 700
+%if 0%{?opensuse_bs} && ((0%{?rhel_version} && 0%{?rhel_version} < 700) || (0%{?centos_ver} && 0%{?centos_ver} < 7))
 BuildRequires: gcc48 gcc48-c++
 %endif
 
@@ -40,7 +40,7 @@ is simple but incompatible with other shell languages.
 %setup -q -n %{name}-@VERSION@
 
 %build
-%if 0%{?opensuse_bs} && 0%{?rhel_version} && 0%{?rhel_version} < 700
+%if 0%{?opensuse_bs} && ((0%{?rhel_version} && 0%{?rhel_version} < 700) || (0%{?centos_ver} && 0%{?centos_ver} < 7))
 export CC=gcc48
 export CXX=g++48
 EXTRA_CMAKE_FLAGS="-DCURSES_EXTRA_LIBRARY=tinfo"
@@ -54,7 +54,7 @@ export CXXFLAGS="$CXXFLAGS -march=i686"
 EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DBUILD_SHARED_LIBS:BOOL=OFF"
 # CMake macros define the wrong sysconfdir arguments
 EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DCMAKE_INSTALL_SYSCONFDIR=%{_sysconfdir}"
-%if 0%{?rhel_version} && 0%{?rhel_version} < 800
+%if (0%{?rhel_version} && 0%{?rhel_version} < 800) || (0%{?centos_ver} && 0%{?centos_ver} < 8)
 %cmake3 $EXTRA_CMAKE_FLAGS
 %else
 %cmake $EXTRA_CMAKE_FLAGS


### PR DESCRIPTION
## Description

CentOS 7 does not have rhel_version as one of its macros, so trying to build results in CMake errors, since we get `cmake` instead of`cmake3`. These additional conditions allow the spec to build
successfully on CentOS 7.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages: There are no usage changes.
- [x] Tests have been added for regressions fixed: There don't appear to be tests for RPM builds.
- [x] User-visible changes noted in CHANGELOG.md: No changes made to Fish itself, just the build infrastructure.