### PR TITLE
Convert job list to a deque again and clean up transparent invalidations of job iterators

### DIFF
--- a/src/builtin_bg.cpp
+++ b/src/builtin_bg.cpp
@@ -51,19 +51,19 @@ int builtin_bg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
     if (optind == argc) {
         // No jobs were specified so use the most recent (i.e., last) job.
-        job_t *j;
-        job_iterator_t jobs;
-        while ((j = jobs.next())) {
+        job_t *job = nullptr;
+        for (auto j : jobs()) {
             if (j->is_stopped() && j->get_flag(job_flag_t::JOB_CONTROL) && (!j->is_completed())) {
+                job = j.get();
                 break;
             }
         }
 
-        if (!j) {
+        if (!job) {
             streams.err.append_format(_(L"%ls: There are no suitable jobs\n"), cmd);
             retval = STATUS_CMD_ERROR;
         } else {
-            retval = send_to_bg(parser, streams, j);
+            retval = send_to_bg(parser, streams, job);
         }
 
         return retval;

--- a/src/builtin_fg.cpp
+++ b/src/builtin_fg.cpp
@@ -32,20 +32,20 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         return STATUS_CMD_OK;
     }
 
-    job_t *j = NULL;
-
+    job_t *job = nullptr;
     if (optind == argc) {
         // Select last constructed job (I.e. first job in the job que) that is possible to put in
         // the foreground.
-        job_iterator_t jobs;
-        while ((j = jobs.next())) {
+
+        for (auto j : jobs()) {
             if (j->is_constructed() && (!j->is_completed()) &&
                 ((j->is_stopped() || (!j->is_foreground())) &&
                  j->get_flag(job_flag_t::JOB_CONTROL))) {
+                job = j.get();
                 break;
             }
         }
-        if (!j) {
+        if (!job) {
             streams.err.append_format(_(L"%ls: There are no suitable jobs\n"), cmd);
         }
     } else if (optind + 1 < argc) {
@@ -57,8 +57,8 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
         pid = fish_wcstoi(argv[optind]);
         if (!(errno || pid < 0)) {
-            j = job_t::from_pid(pid);
-            if (j) found_job = true;
+            job = job_t::from_pid(pid);
+            if (job) found_job = true;
         }
 
         if (found_job) {
@@ -69,46 +69,46 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
         builtin_print_help(parser, streams, cmd, streams.err);
 
-        j = 0;
+        job = 0;
     } else {
         int pid = abs(fish_wcstoi(argv[optind]));
         if (errno) {
             streams.err.append_format(BUILTIN_ERR_NOT_NUMBER, cmd, argv[optind]);
             builtin_print_help(parser, streams, cmd, streams.err);
         } else {
-            j = job_t::from_pid(pid);
-            if (!j || !j->is_constructed() || j->is_completed()) {
+            job = job_t::from_pid(pid);
+            if (!job || !job->is_constructed() || job->is_completed()) {
                 streams.err.append_format(_(L"%ls: No suitable job: %d\n"), cmd, pid);
-                j = 0;
-            } else if (!j->get_flag(job_flag_t::JOB_CONTROL)) {
+                job = nullptr;
+            } else if (!job->get_flag(job_flag_t::JOB_CONTROL)) {
                 streams.err.append_format(_(L"%ls: Can't put job %d, '%ls' to foreground because "
                                             L"it is not under job control\n"),
-                                          cmd, pid, j->command_wcstr());
-                j = 0;
+                                          cmd, pid, job->command_wcstr());
+                job = 0;
             }
         }
     }
 
-    if (!j) {
+    if (!job) {
         return STATUS_INVALID_ARGS;
     }
 
     if (streams.err_is_redirected) {
-        streams.err.append_format(FG_MSG, j->job_id, j->command_wcstr());
+        streams.err.append_format(FG_MSG, job->job_id, job->command_wcstr());
     } else {
         // If we aren't redirecting, send output to real stderr, since stuff in sb_err won't get
         // printed until the command finishes.
-        fwprintf(stderr, FG_MSG, j->job_id, j->command_wcstr());
+        fwprintf(stderr, FG_MSG, job->job_id, job->command_wcstr());
     }
 
-    const wcstring ft = tok_first(j->command());
+    const wcstring ft = tok_first(job->command());
     //For compatibility with fish 2.0's $_, now replaced with `status current-command`
     if (!ft.empty()) env_set_one(L"_", ENV_EXPORT, ft);
-    reader_write_title(j->command());
+    reader_write_title(job->command());
 
-    j->promote();
-    j->set_flag(job_flag_t::FOREGROUND, true);
+    job->promote();
+    job->set_flag(job_flag_t::FOREGROUND, true);
 
-    j->continue_job(j->is_stopped());
+    job->continue_job(job->is_stopped());
     return STATUS_CMD_OK;
 }

--- a/src/builtin_jobs.cpp
+++ b/src/builtin_jobs.cpp
@@ -174,11 +174,9 @@ int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
     if (print_last) {
         // Ignore unconstructed jobs, i.e. ourself.
-        job_iterator_t jobs;
-        const job_t *j;
-        while ((j = jobs.next())) {
+        for (auto j : jobs()) {
             if (j->is_constructed() && !j->is_completed()) {
-                builtin_jobs_print(j, mode, !streams.out_is_redirected, streams);
+                builtin_jobs_print(j.get(), mode, !streams.out_is_redirected, streams);
                 return STATUS_CMD_ERROR;
             }
         }
@@ -217,12 +215,10 @@ int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 }
             }
         } else {
-            job_iterator_t jobs;
-            const job_t *j;
-            while ((j = jobs.next())) {
+            for (auto j : jobs()) {
                 // Ignore unconstructed jobs, i.e. ourself.
                 if (j->is_constructed() && !j->is_completed()) {
-                    builtin_jobs_print(j, mode, !found && !streams.out_is_redirected, streams);
+                    builtin_jobs_print(j.get(), mode, !found && !streams.out_is_redirected, streams);
                     found = true;
                 }
             }

--- a/src/builtin_wait.cpp
+++ b/src/builtin_wait.cpp
@@ -15,10 +15,7 @@
 /// If a specified process has already finished but the job hasn't, parser_t::job_get_from_pid()
 /// doesn't work properly, so use this function in wait command.
 static job_id_t get_job_id_from_pid(pid_t pid) {
-    job_t *j;
-    job_iterator_t jobs;
-
-    while ((j = jobs.next()) != nullptr) {
+    for (auto j : jobs()) {
         if (j->pgid == pid) {
             return j->job_id;
         }
@@ -33,8 +30,7 @@ static job_id_t get_job_id_from_pid(pid_t pid) {
 }
 
 static bool all_jobs_finished() {
-    job_iterator_t jobs;
-    while (job_t *j = jobs.next()) {
+    for (auto j : jobs()) {
         // If any job is not completed, return false.
         // If there are stopped jobs, they are ignored.
         if (j->is_constructed() && !j->is_completed() && !j->is_stopped()) {
@@ -45,14 +41,13 @@ static bool all_jobs_finished() {
 }
 
 static bool any_jobs_finished(size_t jobs_len) {
-    job_iterator_t jobs;
     bool no_jobs_running = true;
 
     // If any job is removed from list, return true.
-    if (jobs_len != jobs.count()) {
+    if (jobs_len != jobs().size()) {
         return true;
     }
-    while (job_t *j = jobs.next()) {
+    for (auto j : jobs()) {
         // If any job is completed, return true.
         if (j->is_constructed() && (j->is_completed() || j->is_stopped())) {
             return true;
@@ -69,8 +64,7 @@ static bool any_jobs_finished(size_t jobs_len) {
 }
 
 static int wait_for_backgrounds(bool any_flag) {
-    job_iterator_t jobs;
-    size_t jobs_len = jobs.count();
+    size_t jobs_len = jobs().size();
 
     while ((!any_flag && !all_jobs_finished()) || (any_flag && !any_jobs_finished(jobs_len))) {
         pid_t pid = proc_wait_any();
@@ -142,10 +136,9 @@ static bool match_pid(const wcstring &cmd, const wchar_t *proc) {
 
 /// It should search the job list for something matching the given proc.
 static bool find_job_by_name(const wchar_t *proc, std::vector<job_id_t> &ids) {
-    job_iterator_t jobs;
     bool found = false;
 
-    while (const job_t *j = jobs.next()) {
+    for (const auto j : jobs()) {
         if (j->command_is_empty()) continue;
 
         if (match_pid(j->command(), proc)) {
@@ -178,7 +171,6 @@ static bool find_job_by_name(const wchar_t *proc, std::vector<job_id_t> &ids) {
 int builtin_wait(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     ASSERT_IS_MAIN_THREAD();
     int retval = STATUS_CMD_OK;
-    job_iterator_t jobs;
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     bool any_flag = false;  // flag for -n option

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -577,7 +577,7 @@ void parser_t::job_promote(job_t *job) {
     assert(loc != my_job_list.end());
 
     // Move the job to the beginning.
-    my_job_list.splice(my_job_list.begin(), my_job_list, loc);
+    std::rotate(my_job_list.begin(), loc, my_job_list.end());
 }
 
 job_t *parser_t::job_get(job_id_t id) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -567,19 +567,6 @@ void parser_t::job_add(shared_ptr<job_t> job) {
     this->my_job_list.push_front(std::move(job));
 }
 
-bool parser_t::job_remove(job_t *job) {
-    for (auto iter = my_job_list.begin(); iter != my_job_list.end(); ++iter) {
-        if (iter->get() == job) {
-            my_job_list.erase(iter);
-            return true;
-        }
-    }
-
-    debug(1, _(L"Job inconsistency"));
-    sanity_lose();
-    return false;
-}
-
 void parser_t::job_promote(job_t *job) {
     job_list_t::iterator loc;
     for (loc = my_job_list.begin(); loc != my_job_list.end(); ++loc) {
@@ -601,20 +588,17 @@ job_t *parser_t::job_get(job_id_t id) {
 }
 
 job_t *parser_t::job_get_from_pid(pid_t pid) const {
-    job_iterator_t jobs;
-    job_t *job;
-
     pid_t pgid = getpgid(pid);
 
     if (pgid == -1) {
         return 0;
     }
 
-    while ((job = jobs.next())) {
+    for (auto job : jobs()) {
         if (job->pgid == pgid) {
             for (const process_ptr_t &p : job->processes) {
                 if (p->pid == pid) {
-                    return job;
+                    return job.get();
                 }
             }
         }

--- a/src/parser.h
+++ b/src/parser.h
@@ -293,9 +293,6 @@ class parser_t {
     /// Return the function name for the specified stack frame. Default is one (current frame).
     const wchar_t *get_function_name(int level = 1);
 
-    /// Removes a job.
-    bool job_remove(job_t *job);
-
     /// Promotes a job to the front of the list.
     void job_promote(job_t *job);
 

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -114,11 +114,10 @@ void job_t::promote() {
 }
 
 void proc_destroy() {
-    job_list_t &jobs = parser_t::principal_parser().job_list();
-    for (auto job = jobs.begin(); job != jobs.end();) {
-        debug(2, L"freeing leaked job %ls", (*job)->command_wcstr());
-        job = jobs.erase(job);
+    for (const auto job : jobs()) {
+        debug(2, L"freeing leaked job %ls", job->command_wcstr());
     }
+    jobs().clear();
 }
 
 void proc_set_last_status(int s) {
@@ -616,12 +615,11 @@ static bool process_clean_after_marking(bool allow_interactive) {
         }
 
         for (const process_ptr_t &p : j->processes) {
-            int s;
-            if (!p->completed) continue;
+            if (!p->completed || !p->pid) {
+                continue;
+            }
 
-            if (!p->pid) continue;
-
-            s = p->status;
+            int s = p->status;
 
             // TODO: The generic process-exit event is useless and unused.
             // Remove this in future.

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -606,7 +606,7 @@ static bool process_clean_after_marking(bool allow_interactive) {
 
     bool erased = false;
     const size_t job_count = jobs().size();
-    for (auto itr = jobs().begin(); itr != jobs().end(); itr = (erased ? itr : (std::advance(itr, 1), itr)), erased = false) {
+    for (auto itr = jobs().begin(); itr != jobs().end(); itr = erased ? itr : itr + 1, erased = false) {
         job_t *j = itr->get();
         // If we are reaping only jobs who do not need status messages sent to the console, do not
         // consider reaping jobs that need status messages.

--- a/src/proc.h
+++ b/src/proc.h
@@ -11,7 +11,7 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <list>
+#include <deque>
 #include <memory>
 #include <vector>
 
@@ -300,7 +300,7 @@ extern bool is_login;
 extern int is_event;
 
 // List of jobs. We sometimes mutate this while iterating - hence it must be a list, not a vector
-typedef std::list<shared_ptr<job_t>> job_list_t;
+typedef std::deque<shared_ptr<job_t>> job_list_t;
 
 bool job_list_is_empty(void);
 

--- a/src/proc.h
+++ b/src/proc.h
@@ -304,27 +304,8 @@ typedef std::list<shared_ptr<job_t>> job_list_t;
 
 bool job_list_is_empty(void);
 
-/// A class to aid iteration over jobs list
-class job_iterator_t {
-    job_list_t *const job_list;
-    job_list_t::iterator current, end;
-
-   public:
-    void reset(void);
-
-    job_t *next() {
-        job_t *job = NULL;
-        if (current != end) {
-            job = current->get();
-            ++current;
-        }
-        return job;
-    }
-
-    explicit job_iterator_t(job_list_t &jobs);
-    job_iterator_t();
-    size_t count() const;
-};
+/// A helper function to more easily access the job list
+job_list_t &jobs();
 
 /// Whether a universal variable barrier roundtrip has already been made for the currently executing
 /// command. Such a roundtrip only needs to be done once on a given command, unless a universal

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2272,8 +2272,7 @@ void reader_bg_job_warning() {
     fputws(_(L"There are still jobs active:\n"), stdout);
     fputws(_(L"\n   PID  Command\n"), stdout);
 
-    job_iterator_t jobs;
-    while (job_t *j = jobs.next()) {
+    for (auto j : jobs()) {
         if (!j->is_completed()) {
             fwprintf(stdout, L"%6d  %ls\n", j->processes[0]->pid, j->command_wcstr());
         }
@@ -2297,8 +2296,7 @@ static void handle_end_loop() {
         }
 
         bool bg_jobs = false;
-        job_iterator_t jobs;
-        while (const job_t *j = jobs.next()) {
+        for (const auto j : jobs()) {
             if (!j->is_completed()) {
                 bg_jobs = true;
                 break;


### PR DESCRIPTION
The usage of `job_iterator_t` decoupled from the actual underlying collection/iterators led to an extremely messy situation where iterators could be transparently invalidated if we were not using a linked list. (e.g. `proc.cpp` iterates jobs, and mid-iteration calls `parser::job_remove(j)` with the job (and not the iterator to the job), causing an invisible invalidation of the pre-existing local iterators.

After cleaning that up, converted the job list itself to a dequeue again which had previously shown tangible speed benefits (which makes sense given how often the job list is traversed and the horrible memory access patterns for `std::list`).

Most of the reasons for using `job_iterator_t` vanished when we adopted C++11. The syntax of range-based for loop is arguably superior to that of the custom `job_iterator_t` type, and access to the underlying iterators remains when it's necessary to manipulate the list while iterating it.