### PR TITLE
fix `dirh` output with reversed $dirnext

### DIFF
--- a/share/functions/dirh.fish
+++ b/share/functions/dirh.fish
@@ -22,8 +22,9 @@ function dirh --description "Print the current directory history (the prev and n
 
     set -l dirc (count $dirnext)
     if test $dirc -gt 0
+        set -l dirnext_rev $dirnext[-1..1]
         for i in (seq $dirc)
-            printf '%2d) %s\n' $i $dirnext[$i]
+            printf '%2d) %s\n' $i $dirnext_rev[$i]
         end
     end
     echo


### PR DESCRIPTION
## Description

**Before:**

The order of the variable `$dirnext` output by the `dirh` function is reversed.

```
$ cd Desktop
$ cd a
$ cd b
$ cd c
$ dirh
 4) /Users/jakalada
 3) /Users/jakalada/Desktop
 2) /Users/jakalada/Desktop/a
 1) /Users/jakalada/Desktop/a/b
    /Users/jakalada/Desktop/a/b/c
$ prevd
$ prevd
$ prevd
$ dirh
 1) /Users/jakalada
    /Users/jakalada/Desktop
 1) /Users/jakalada/Desktop/a/b/c
 2) /Users/jakalada/Desktop/a/b
 3) /Users/jakalada/Desktop/a
$ nextd 3                            # select "3) /Users/jakalada/Desktop/a"
$ dirh
 4) /Users/jakalada
 3) /Users/jakalada/Desktop
 2) /Users/jakalada/Desktop/a
 1) /Users/jakalada/Desktop/a/b
    /Users/jakalada/Desktop/a/b/c    # oops! unexpected.
```

**After:**

Fixed.

```
$ dirh
 1) /Users/jakalada
    /Users/jakalada/Desktop
 1) /Users/jakalada/Desktop/a
 2) /Users/jakalada/Desktop/a/b
 3) /Users/jakalada/Desktop/a/b/c
$ nextd 3                             # select "3) /Users/jakalada/Desktop/a/b/c"
$ dirh
 4) /Users/jakalada
 3) /Users/jakalada/Desktop
 2) /Users/jakalada/Desktop/a
 1) /Users/jakalada/Desktop/a/b
    /Users/jakalada/Desktop/a/b/c     # expected!
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
