### PR TITLE
Pass final Fish exit status to fish_exit event

### DIFF
--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -440,7 +440,10 @@ int main(int argc, char **argv) {
     // TODO: The generic process-exit event is useless and unused.
     // Remove this in future.
     proc_fire_event(L"PROCESS_EXIT", EVENT_EXIT, getpid(), exit_status);
-    event_fire_generic(L"fish_exit");
+
+    // Trigger any exit handlers.
+    wcstring_list_t event_args = {to_string<int>(exit_status)};
+    event_fire_generic(L"fish_exit", &event_args);
 
     restore_term_mode();
     restore_term_foreground_process_group();


### PR DESCRIPTION
## Description

For `fish_exit` to be a suitable replacement for `--on-process-exit`, we need to be able to provide scripts with access to the shell's final exit code.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md