### PR TITLE
Remove Python "ambiguous" shebangs for Fedora 30/RHEL 8 compatibility

### DIFF
--- a/fish.spec.in
+++ b/fish.spec.in
@@ -74,6 +74,13 @@ make %{?_smp_mflags}
 %else
 %make_install
 %endif
+
+# Fixes ERROR: ambiguous python shebang in F30/RHEL 8
+%if 0%{?fedora} > 29 || 0%{?rhel} && 0%{?rhel} > 7
+find %{buildroot}/usr/share/fish/tools -type f -name "*.py" -exec sed -i '1s:#!/usr/bin/env python$:#!/usr/bin/python3:' {} ';'
+find %{buildroot}/usr/share/fish/tools -type f -name "*.py" -exec sed -i '1s:#!/usr/bin/python$:#!/usr/bin/python3:' {} ';'
+%endif
+
 %find_lang %{name}
 
 %check

--- a/fish.spec.in
+++ b/fish.spec.in
@@ -74,13 +74,6 @@ make %{?_smp_mflags}
 %else
 %make_install
 %endif
-
-# Fixes ERROR: ambiguous python shebang in F30/RHEL 8
-%if 0%{?fedora} > 29 || 0%{?rhel} && 0%{?rhel} > 7
-find %{buildroot}/usr/share/fish/tools -type f -name "*.py" -exec sed -i '1s:#!/usr/bin/env python$:#!/usr/bin/python3:' {} ';'
-find %{buildroot}/usr/share/fish/tools -type f -name "*.py" -exec sed -i '1s:#!/usr/bin/python$:#!/usr/bin/python3:' {} ';'
-%endif
-
 %find_lang %{name}
 
 %check

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Run me like this: ./create_manpage_completions.py /usr/share/man/man{1,8}/* > man_completions.fish

--- a/share/tools/deroff.py
+++ b/share/tools/deroff.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """ Deroff.py, ported to Python from the venerable deroff.c """

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import unicode_literals
 from __future__ import print_function
 import binascii


### PR DESCRIPTION
## Description

Starting with Fedora 30 and RHEL 8, ambiguous python shebangs will now throw errors during the RPM build process instead of just warnings, since these systems have moved to Python 3 by default, and Python 2 may not be available in the future.

See [this page](https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error) for more details.

While RHEL 8 isn't explicitly called out here, the error does appear in the current RHEL 8 beta when building these RPMs.
