### PR TITLE
Use mandoc when nroff not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  - nothing yet...
 - Lots of improvements to completions.
 - fish_clipboard_* now supports wayland by means of [wl-clipboard](https://github.com/bugaevc/wl-clipboard).
+- mandoc can now be used to format the output from `--help` if nroff is not installed
 
 ---
 


### PR DESCRIPTION
## Description
[mandoc](https://mandoc.bsd.lv/) is a set of tools that don't rely on roff to display man pages native to the *BSD ecosystem. This change allows users with mandoc to view the manual pages used in the builtin help commands if they don't have roff installed.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.md
