### PR TITLE
print --help to stdout like other builtins

### DIFF
--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1305,7 +1305,7 @@ int builtin_string(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     }
 
     if (wcscmp(argv[1], L"-h") == 0 || wcscmp(argv[1], L"--help") == 0) {
-        builtin_print_help(parser, streams, L"string", streams.err);
+        builtin_print_help(parser, streams, L"string", streams.out);
         return STATUS_CMD_OK;
     }
 


### PR DESCRIPTION
## Description

Other builtins print --help to stdout so string should as well.

Found when `string -h | less -R` unexpectedly returned a pager with nothing in it.
