### PR TITLE
Remove bc from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:latest
 
 # Build dependency
 RUN yum update -y &&\
-  yum install -y autoconf automake bc clang gcc-c++ make ncurses-devel &&\
+  yum install -y autoconf automake clang gcc-c++ make ncurses-devel &&\
   yum clean all
 
 # Test dependency


### PR DESCRIPTION
## Description

As math is now a builtin bc is no longer required.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
