### PR TITLE
Enhance configuration of pager colors

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -1024,15 +1024,31 @@ The following variables are available to change the highlighting colors in fish:
 
 Additionally, the following variables are available to change the highlighting in the completion pager:
 
+- `fish_pager_color_progress`, the color of the progress bar at the bottom left corner
+
+- `fish_pager_color_background`, the background color of a line
+
 - `fish_pager_color_prefix`, the color of the prefix string, i.e. the string that is to be completed
 
 - `fish_pager_color_completion`, the color of the completion itself
 
 - `fish_pager_color_description`, the color of the completion description
 
-- `fish_pager_color_progress`, the color of the progress bar at the bottom left corner
+- `fish_pager_color_secondary_background`, `fish_pager_color_background` of every second unselected completion. Defaults to `fish_pager_color_background`
 
-- `fish_pager_color_secondary`, the background color of the every second completion
+- `fish_pager_color_secondary_ prefix`, `fish_pager_color_prefix` of every second unselected completion. Defaults to `fish_pager_color_prefix`
+
+- `fish_pager_color_secondary_completion`, `fish_pager_color_completion` of every second unselected completion. Defaults to `fish_pager_color_completion`
+
+- `fish_pager_color_secondary_description`, `fish_pager_color_description` of every second unselected completion. Defaults to `fish_pager_color_description`
+
+- `fish_pager_color_selected_background`, `fish_pager_color_background` of the selected completion. Defaults to `fish_color_search_match`
+
+- `fish_pager_color_selected_ prefix`, `fish_pager_color_prefix` of the selected completion. Defaults to `fish_pager_color_prefix`
+
+- `fish_pager_color_selected_completion`, `fish_pager_color_completion` of the selected completion. Defaults to `fish_pager_color_completion`
+
+- `fish_pager_color_selected_description`, `fish_pager_color_description` of the selected completion. Defaults to `fish_pager_color_description`
 
 Example:
 

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -42,27 +42,68 @@ namespace g = grammar;
 /// Number of elements in the highlight_var array.
 #define VAR_COUNT (sizeof(highlight_var) / sizeof(wchar_t *))
 static const wchar_t *const highlight_var[] = {
-    [highlight_spec_normal]                 = L"fish_color_normal",
-    [highlight_spec_error]                  = L"fish_color_error",
-    [highlight_spec_command]                = L"fish_color_command",
-    [highlight_spec_statement_terminator]   = L"fish_color_end",
-    [highlight_spec_param]                  = L"fish_color_param",
-    [highlight_spec_comment]                = L"fish_color_comment",
-    [highlight_spec_match]                  = L"fish_color_match",
-    [highlight_spec_search_match]           = L"fish_color_search_match",
-    [highlight_spec_operator]               = L"fish_color_operator",
-    [highlight_spec_escape]                 = L"fish_color_escape",
-    [highlight_spec_quote]                  = L"fish_color_quote",
-    [highlight_spec_redirection]            = L"fish_color_redirection",
-    [highlight_spec_autosuggestion]         = L"fish_color_autosuggestion",
-    [highlight_spec_selection]              = L"fish_color_selection",
-    [highlight_spec_pager_prefix]           = L"fish_pager_color_prefix",
-    [highlight_spec_pager_completion]       = L"fish_pager_color_completion",
-    [highlight_spec_pager_description]      = L"fish_pager_color_description",
-    [highlight_spec_pager_progress]         = L"fish_pager_color_progress",
-    [highlight_spec_pager_secondary]        = L"fish_pager_color_secondary",
+    [highlight_spec_normal]                       = L"fish_color_normal",
+    [highlight_spec_error]                        = L"fish_color_error",
+    [highlight_spec_command]                      = L"fish_color_command",
+    [highlight_spec_statement_terminator]         = L"fish_color_end",
+    [highlight_spec_param]                        = L"fish_color_param",
+    [highlight_spec_comment]                      = L"fish_color_comment",
+    [highlight_spec_match]                        = L"fish_color_match",
+    [highlight_spec_search_match]                 = L"fish_color_search_match",
+    [highlight_spec_operator]                     = L"fish_color_operator",
+    [highlight_spec_escape]                       = L"fish_color_escape",
+    [highlight_spec_quote]                        = L"fish_color_quote",
+    [highlight_spec_redirection]                  = L"fish_color_redirection",
+    [highlight_spec_autosuggestion]               = L"fish_color_autosuggestion",
+    [highlight_spec_selection]                    = L"fish_color_selection",
+    [highlight_spec_pager_progress]               = L"fish_pager_color_progress",
+    [highlight_spec_pager_background]             = L"fish_pager_color_background",
+    [highlight_spec_pager_prefix]                 = L"fish_pager_color_prefix",
+    [highlight_spec_pager_completion]             = L"fish_pager_color_completion",
+    [highlight_spec_pager_description]            = L"fish_pager_color_description",
+    [highlight_spec_pager_secondary_background]   = L"fish_pager_color_secondary_background",
+    [highlight_spec_pager_secondary_prefix]       = L"fish_pager_color_secondary_prefix",
+    [highlight_spec_pager_secondary_completion]   = L"fish_pager_color_secondary_completion",
+    [highlight_spec_pager_secondary_description]  = L"fish_pager_color_secondary_description",
+    [highlight_spec_pager_selected_background]    = L"fish_pager_color_selected_background",
+    [highlight_spec_pager_selected_prefix]        = L"fish_pager_color_selected_prefix",
+    [highlight_spec_pager_selected_completion]    = L"fish_pager_color_selected_completion",
+    [highlight_spec_pager_selected_description]   = L"fish_pager_color_selected_description",
 };
 static_assert(VAR_COUNT == HIGHLIGHT_SPEC_MAX, "Every color spec has a corresponding env var");
+
+// Table used to fetch fallback highlights in case the specified one
+// wasn't set.
+static const highlight_spec_t fallbacks[] = {
+    [highlight_spec_normal]                       = highlight_spec_normal,
+    [highlight_spec_error]                        = highlight_spec_normal,
+    [highlight_spec_command]                      = highlight_spec_normal,
+    [highlight_spec_statement_terminator]         = highlight_spec_normal,
+    [highlight_spec_param]                        = highlight_spec_normal,
+    [highlight_spec_comment]                      = highlight_spec_normal,
+    [highlight_spec_match]                        = highlight_spec_normal,
+    [highlight_spec_search_match]                 = highlight_spec_normal,
+    [highlight_spec_operator]                     = highlight_spec_normal,
+    [highlight_spec_escape]                       = highlight_spec_normal,
+    [highlight_spec_quote]                        = highlight_spec_normal,
+    [highlight_spec_redirection]                  = highlight_spec_normal,
+    [highlight_spec_autosuggestion]               = highlight_spec_normal,
+    [highlight_spec_selection]                    = highlight_spec_normal,
+    [highlight_spec_pager_progress]               = highlight_spec_normal,
+    [highlight_spec_pager_background]             = highlight_spec_normal,
+    [highlight_spec_pager_prefix]                 = highlight_spec_normal,
+    [highlight_spec_pager_completion]             = highlight_spec_normal,
+    [highlight_spec_pager_description]            = highlight_spec_normal,
+    [highlight_spec_pager_secondary_background]   = highlight_spec_pager_background,
+    [highlight_spec_pager_secondary_prefix]       = highlight_spec_pager_prefix,
+    [highlight_spec_pager_secondary_completion]   = highlight_spec_pager_completion,
+    [highlight_spec_pager_secondary_description]  = highlight_spec_pager_description,
+    [highlight_spec_pager_selected_background]    = highlight_spec_search_match,
+    [highlight_spec_pager_selected_prefix]        = highlight_spec_pager_prefix,
+    [highlight_spec_pager_selected_completion]    = highlight_spec_pager_completion,
+    [highlight_spec_pager_selected_description]   = highlight_spec_pager_description,
+};
+static_assert(sizeof(fallbacks) / sizeof(fallbacks[0]) == HIGHLIGHT_SPEC_MAX, "No missing fallbacks");
 
 /// Determine if the filesystem containing the given fd is case insensitive for lookups regardless
 /// of whether it preserves the case when saving a pathname.
@@ -270,6 +311,7 @@ rgb_color_t highlight_get_color(highlight_spec_t highlight, bool is_background) 
 
     // debug( 1, L"%d -> %d -> %ls", highlight, idx, val );
 
+    if (!var) var = vars.get(highlight_var[fallbacks[idx]]);
     if (!var) var = vars.get(highlight_var[0]);
 
     if (var) result = parse_color(*var, treat_as_background);

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -41,28 +41,28 @@ namespace g = grammar;
 
 /// Number of elements in the highlight_var array.
 #define VAR_COUNT (sizeof(highlight_var) / sizeof(wchar_t *))
-
-/// The environment variables used to specify the color of different tokens. This matches the order
-/// in highlight_spec_t.
-static const wchar_t *const highlight_var[] = {L"fish_color_normal",
-                                               L"fish_color_error",
-                                               L"fish_color_command",
-                                               L"fish_color_end",
-                                               L"fish_color_param",
-                                               L"fish_color_comment",
-                                               L"fish_color_match",
-                                               L"fish_color_search_match",
-                                               L"fish_color_operator",
-                                               L"fish_color_escape",
-                                               L"fish_color_quote",
-                                               L"fish_color_redirection",
-                                               L"fish_color_autosuggestion",
-                                               L"fish_color_selection",
-                                               L"fish_pager_color_prefix",
-                                               L"fish_pager_color_completion",
-                                               L"fish_pager_color_description",
-                                               L"fish_pager_color_progress",
-                                               L"fish_pager_color_secondary"};
+static const wchar_t *const highlight_var[] = {
+    [highlight_spec_normal]                 = L"fish_color_normal",
+    [highlight_spec_error]                  = L"fish_color_error",
+    [highlight_spec_command]                = L"fish_color_command",
+    [highlight_spec_statement_terminator]   = L"fish_color_end",
+    [highlight_spec_param]                  = L"fish_color_param",
+    [highlight_spec_comment]                = L"fish_color_comment",
+    [highlight_spec_match]                  = L"fish_color_match",
+    [highlight_spec_search_match]           = L"fish_color_search_match",
+    [highlight_spec_operator]               = L"fish_color_operator",
+    [highlight_spec_escape]                 = L"fish_color_escape",
+    [highlight_spec_quote]                  = L"fish_color_quote",
+    [highlight_spec_redirection]            = L"fish_color_redirection",
+    [highlight_spec_autosuggestion]         = L"fish_color_autosuggestion",
+    [highlight_spec_selection]              = L"fish_color_selection",
+    [highlight_spec_pager_prefix]           = L"fish_pager_color_prefix",
+    [highlight_spec_pager_completion]       = L"fish_pager_color_completion",
+    [highlight_spec_pager_description]      = L"fish_pager_color_description",
+    [highlight_spec_pager_progress]         = L"fish_pager_color_progress",
+    [highlight_spec_pager_secondary]        = L"fish_pager_color_secondary",
+};
+static_assert(VAR_COUNT == HIGHLIGHT_SPEC_MAX, "Every color spec has a corresponding env var");
 
 /// Determine if the filesystem containing the given fd is case insensitive for lookups regardless
 /// of whether it preserves the case when saving a pathname.

--- a/src/highlight.h
+++ b/src/highlight.h
@@ -39,6 +39,9 @@ enum {
     highlight_spec_pager_progress,
     highlight_spec_pager_secondary,
 
+    // Used to double check a data structure in highlight.cpp
+    HIGHLIGHT_SPEC_MAX,
+
     HIGHLIGHT_SPEC_PRIMARY_MASK = 0xFF,
 
     // The following values are modifiers.

--- a/src/highlight.h
+++ b/src/highlight.h
@@ -33,11 +33,20 @@ enum {
     highlight_spec_selection,
 
     // Pager support.
+    // NOTE: pager.cpp relies on these being in this order.
+    highlight_spec_pager_progress,
+    highlight_spec_pager_background,
     highlight_spec_pager_prefix,
     highlight_spec_pager_completion,
     highlight_spec_pager_description,
-    highlight_spec_pager_progress,
-    highlight_spec_pager_secondary,
+    highlight_spec_pager_secondary_background,
+    highlight_spec_pager_secondary_prefix,
+    highlight_spec_pager_secondary_completion,
+    highlight_spec_pager_secondary_description,
+    highlight_spec_pager_selected_background,
+    highlight_spec_pager_selected_prefix,
+    highlight_spec_pager_selected_completion,
+    highlight_spec_pager_selected_description,
 
     // Used to double check a data structure in highlight.cpp
     HIGHLIGHT_SPEC_MAX,


### PR DESCRIPTION
This PR contains two commits, each of them attempts to have their own nice commit messages, but I'll summarize here too:

- First we cleanup how highlight specs are connected to environment variables. Before there was a requirement of the developers (and reviewers) to make sure everything two different tables agree. Now we add compile time checks to ensure the tables are the same, and make it clearer which highlight specs correspond to which environment variables.
- Next we add some new highlight specs to configure how the pager is formatted.
  - Added configs were:
    - Secondary background/prefix/completion/description: these will be applied to all the secondary lines in the pager
    - Selected background/prefix/completion/description: these will be applied to all the selected lines in the pager
  - Tidbits on implementation:
    - In order to implement this I additionally added a table that indicates what a given highlight spec should default to. This is so that the secondary/selected pager specs can default to the normal pager specs (i.e. you don't /need/ to specify the secondary/selected configs if you don't want to)
    - I calculate the correct color by using offsets. These offsets require that the pager highlight specs have a certain form (each category in default/secondary/selected must have a contiguous section of background/prefix/completion/description)

Fixes issue #2442. Inspiration was taken from Chris Mansley (unsure why I can't tag him right now), so thanks man!

Example configuration can be seen below:
![](https://media.giphy.com/media/1zl1YirhMf7xG4YxLf/giphy.gif)

Should I update some docs? Where if so?