### PR TITLE
Fix warnings when compiling for macOS Mojave

### DIFF
--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -162,6 +162,7 @@ static int count_char(const wchar_t *str, wchar_t c) {
 ///
 wcstring builtin_help_get(parser_t &parser, io_streams_t &streams, const wchar_t *name) {
     UNUSED(parser);
+    UNUSED(streams);
     // This won't ever work if no_exec is set.
     if (no_exec) return wcstring();
 

--- a/src/builtin_test.cpp
+++ b/src/builtin_test.cpp
@@ -116,7 +116,7 @@ struct token_info_t {
     unsigned int flags;
 };
 
-const token_info_t * const token_for_string(const wcstring &str) {
+const token_info_t *token_for_string(const wcstring &str) {
     static const std::map<wcstring, const token_info_t> token_infos = {
         {L"", {test_unknown, 0}},
         {L"!", {test_bang, 0}},

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -186,7 +186,10 @@ const option_list_t &completion_entry_t::get_options() const {
 }
 
 description_func_t const_desc(const wcstring &s) {
-    return [=](const wcstring &ignored) { return s; };
+    return [=](const wcstring &ignored) {
+        UNUSED(ignored);
+        return s;
+    };
 }
 
 /// Clear the COMPLETE_AUTO_SPACE flag, and set COMPLETE_NO_SPACE appropriately depending on the

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -794,6 +794,7 @@ static void handle_term_size_change(const wcstring &op, const wcstring &var_name
                                     env_stack_t &vars) {
     UNUSED(op);
     UNUSED(var_name);
+    UNUSED(vars);
     invalidate_termsize(true);  // force fish to update its idea of the terminal size plus vars
 }
 
@@ -815,6 +816,7 @@ static void handle_function_path_change(const wcstring &op, const wcstring &var_
                                         env_stack_t &vars) {
     UNUSED(op);
     UNUSED(var_name);
+    UNUSED(vars);
     function_invalidate_path();
 }
 
@@ -822,6 +824,7 @@ static void handle_complete_path_change(const wcstring &op, const wcstring &var_
                                         env_stack_t &vars) {
     UNUSED(op);
     UNUSED(var_name);
+    UNUSED(vars);
     complete_invalidate_path();
 }
 
@@ -1614,9 +1617,14 @@ env_stack_t::env_stack_t(env_stack_t &&) = default;
 null_environment_t::null_environment_t() = default;
 null_environment_t::~null_environment_t() = default;
 maybe_t<env_var_t> null_environment_t::get(const wcstring &key, env_mode_flags_t mode) const {
+    UNUSED(key);
+    UNUSED(mode);
     return none();
 }
-wcstring_list_t null_environment_t::get_names(int flags) const { return {}; }
+wcstring_list_t null_environment_t::get_names(int flags) const {
+    UNUSED(flags);
+    return {};
+}
 
 env_stack_t env_stack_t::make_principal() {
     const env_stack_t &gl = env_stack_t::globals();
@@ -1650,12 +1658,16 @@ env_vars_snapshot_t::env_vars_snapshot_t(const environment_t &source, const wcha
 env_vars_snapshot_t::~env_vars_snapshot_t() = default;
 
 maybe_t<env_var_t> env_vars_snapshot_t::get(const wcstring &key, env_mode_flags_t mode) const {
+    UNUSED(mode);
     auto iter = vars.find(key);
     if (iter == vars.end()) return none();
     return iter->second;
 }
 
-wcstring_list_t env_vars_snapshot_t::get_names(int flags) const { return names; }
+wcstring_list_t env_vars_snapshot_t::get_names(int flags) const {
+    UNUSED(flags);
+    return names;
+}
 
 const wchar_t *const env_vars_snapshot_t::highlighting_keys[] = {
     L"PATH", L"CDPATH", L"fish_function_path", L"PWD", L"HOME", NULL};
@@ -1665,6 +1677,7 @@ const wchar_t *const env_vars_snapshot_t::completing_keys[] = {
 
 #if defined(__APPLE__) || defined(__CYGWIN__)
 static int check_runtime_path(const char *path) {
+    UNUSED(path);
     return 0;
 }
 #else

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -899,6 +899,7 @@ typedef expand_error_t (*expand_stage_t)(wcstring input,                  //!OCL
 static expand_error_t expand_stage_cmdsubst(wcstring input, std::vector<completion_t> *out,
                                             expand_flags_t flags, const environment_t &vars,
                                             parse_error_list_t *errors) {
+    UNUSED(vars);
     if (EXPAND_SKIP_CMDSUBST & flags) {
         wchar_t *begin, *end;
         if (parse_util_locate_cmdsubst(input.c_str(), &begin, &end, true) == 0) {
@@ -943,6 +944,7 @@ static expand_error_t expand_stage_variables(wcstring input, std::vector<complet
 static expand_error_t expand_stage_braces(wcstring input, std::vector<completion_t> *out,
                                           expand_flags_t flags, const environment_t &vars,
                                           parse_error_list_t *errors) {
+    UNUSED(vars);
     return expand_braces(input, flags, out, errors);
 }
 


### PR DESCRIPTION
I was mildly annoyed by the warnings when compiling so I fixed them. Also added -Werror to avoid commits like this in the future.