### PR TITLE
Revert "Revert "Fix unsafe locale usage in `wcstod_l` fallback""

### DIFF
--- a/osx/config.h
+++ b/osx/config.h
@@ -181,6 +181,9 @@
 /* Define to 1 if you have the `wcsndup' function. */
 /* #undef HAVE_WCSNDUP */
 
+/* Define to 1 if you have the `wcstod_l' function. */
+#define HAVE_WCSTOD_L 1
+
 /* Define to 1 if the winsize struct and TIOCGWINSZ macro exist */
 #define HAVE_WINSIZE 1
 

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -394,13 +394,13 @@ int flock(int fd, int op) {
 // For platforms without wcstod_l C extension, wrap wcstod after changing the
 // thread-specific locale.
 double fish_compat::wcstod_l(const wchar_t *enptr, wchar_t **endptr, locale_t loc) {
-    char *saved_locale = strdup(setlocale(LC_NUMERIC, NULL));
-    // Yes, this is hardcoded to use the "C" locale.
-    // That's the only thing we need, and uselocale(loc) broke in my testing.
-    setlocale(LC_NUMERIC, "C");
+    // Create and use a new, thread-specific locale
+    locale_t locale = newlocale(LC_NUMERIC, "C", nullptr);
+    locale_t prev_locale = uselocale(locale);
     double ret = wcstod(enptr, endptr);
-    setlocale(LC_NUMERIC, saved_locale);
-    free(saved_locale);
+    // Restore the old locale before freeing the locale we created and are still using
+    uselocale(prev_locale);
+    freelocale(locale);
     return ret;
 }
 #endif // defined(wcstod_l)


### PR DESCRIPTION
This reverts commit c15a702f18d5cee8a4e54c486f90467e8729a62e.

Pursuant to the on-going discussion at [0], I'm opening a PR to restore
the correct/safe implementation of the `wcstod_l` fallback so we don't
forget about it.

[0]: https://github.com/fish-shell/fish-shell/commit/3444e1db18bcd1b9f7425a31895298c3864d294c
