### PR TITLE
Extend `type --path` to print path to script defining named function

### DIFF
--- a/doc_src/type.txt
+++ b/doc_src/type.txt
@@ -17,7 +17,7 @@ The following options are available:
 
 - `-t` or `--type` prints `function`, `builtin`, or `file` if `NAME` is a shell function, builtin, or disk file, respectively.
 
-- `-p` or `--path` returns the name of the disk file that would be executed, or nothing if `type  -t  name` would not return `file`.
+- `-p` or `--path` prints the path to `NAME` if `NAME` resolves to an executable file in <tt>$PATH</tt>, the path to the script containing the definition of the function `NAME` if `NAME` resolves to a function loaded from a file on disk (i.e. not interactively defined at the prompt), or nothing otherwise.
 
 - `-P` or `--force-path` returns the path to the executable file `NAME`, presuming `NAME` is found in <tt>$PATH</tt>, or nothing otherwise. `--force-path` explicitly resolves only the path to executable files in <tt>$PATH</tt>, regardless of whether `$NAME` is shadowed by a function or builtin with the same name.
 

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -56,6 +56,15 @@ function type --description 'Print the type of a command'
                         end
                     case type
                         echo (_ 'function')
+                    case path
+                        set -l func_path (functions --details $i)
+                        switch $func_path
+                            case "n/a"
+                            case "stdin"
+                                break;
+                            case "*"
+                                echo $func_path
+                        end
                 end
                 if test $multi != yes
                     continue


### PR DESCRIPTION
*Filing as a PR in case I'm missing something; I'll merge it in a few days if there are no objections.*

Expands the utility of `type -p foo` by allowing it to print the path to
the script that defines `foo` when `foo` is a valid function that was
sourced from a path on disk (rather than interactively defined).

This does not change the behavior of `type -P`/`type --force-path`,
which should have already been used if the desire was to resolve the
path to an executable file (otherwise the output would have been blank
if a function was shadowing an executable file of the same name), so no
backwards compatibility issues are expected.