### PR TITLE
__fish_complete_man.fish: escape for regex

### DIFF
--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -10,7 +10,8 @@ function __fish_complete_man
             case '-**'
 
             case '*'
-                set section $prev[1]
+                set section (string escape --style=regex $prev[1])
+                set section (string replace --all / \\/ $section)
         end
         set -e prev[1]
     end


### PR DESCRIPTION
Previously, using special regex characters or slashes would result in an
error message, when pressing tab in a command-line such as
"man /usr/bin/time ".

Escape control characters and slashes (that are used as regex delimiters).

The case with the regex control character is quite hypothetical but can be
reproduced by pressing tab after typing "man \( ".