### PR TITLE
Need help getting this test to match

### DIFF
--- a/tests/job_control.in
+++ b/tests/job_control.in
@@ -1,0 +1,14 @@
+# vim: ft=fish tw=80 :
+
+# Regression test for #4178
+set -l test (mktemp)
+echo 'function confirm
+	read -l answer < /dev/tty
+	echo "answer=|$answer|"
+end
+
+confirm' > $test
+
+set -l fish (status fish-path)
+echo yes | command $fish $test
+rm -f $test

--- a/tests/job_control.out
+++ b/tests/job_control.out
@@ -1,0 +1,3 @@
+[30m(B[m]0;fish /mnt/d/rand/fish[?2004h[30m(B[m[2m¶(B[m                                                                               ¶ [K]0;fish /mnt/d/rand/fish[32mread[30m(B[m> [Kyes
+[30m(B[m[30m(B[manswer=|yes|
+[?2004l


### PR DESCRIPTION
Added a regression test for #4178.

The output of the inner fish instance is always sent to the terminal even if the output is redirected to `grep` or similar. And there's always some trailing whitespace that doesn't appear in the `.out` file.