### PR TITLE
Fix typo when setting fish_color_error

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -46,7 +46,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
         set -q fish_color_param || set -U fish_color_param 00afff
         set -q fish_color_redirection || set -U fish_color_redirection 00afff
         set -q fish_color_comment || set -U fish_color_comment 990000
-        set -q fish_color_errorset -U fish_color_error ff0000
+        set -q fish_color_error || set -U fish_color_error ff0000
         set -q fish_color_escape || set -U fish_color_escape 00a6b2
         set -q fish_color_operator || set -U fish_color_operator 00a6b2
         set -q fish_color_end || set -U fish_color_end 009900


### PR DESCRIPTION
## Description

It appears to me that this should have caused an error when initially setting the fish error color, though error colors appear to behave as expected.

Not being familiar with the fish-shell codebase, I can't provide many more details regarding the impact or the test coverage of the problem area.

## TODOs:
<!-- Just check off what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
