### PR TITLE
Rename Fisherman to Fisher in FAQ

### DIFF
--- a/doc_src/faq.hdr
+++ b/doc_src/faq.hdr
@@ -292,7 +292,7 @@ Fish reserves the <a href="http://www.unicode.org/faq/private_use.html">Unicode 
 
 The fish user community extends fish in unique and useful ways via scripts that aren't always appropriate for bundling with the fish package. Typically because they solve a niche problem unlikely to appeal to a broad audience. You can find those extensions, including prompts, themes and useful functions, in various third-party repositories. These include:
 
-- <a href="https://github.com/fisherman/fisherman">Fisherman</a>
+- <a href="https://github.com/jorgebucaran/fisher">Fisher</a>
 - <a href="https://github.com/tuvistavie/fundle">Fundle</a>
 - <a href="https://github.com/oh-my-fish/oh-my-fish">Oh My Fish</a>
 - <a href="https://github.com/justinmayer/tacklebox">Tacklebox</a>


### PR DESCRIPTION
## Description

Fisherman became Fisher and moved to a new repo. The previous link still worked, but the name and URL change was needed to avoid confusion. This only affects the documentation.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
