### PR TITLE
pcre2 -> regex

### DIFF
--- a/doc_src/string.txt
+++ b/doc_src/string.txt
@@ -48,7 +48,7 @@ The following subcommands are available.
 
 `--style=regex` escapes an input string for literal matching within a regex expression. The string is first converted to UTF-8 before being encoded.
 
-`string unescape` performs the inverse of the `string escape` command. If the string to be unescaped is not properly formatted it is ignored. For example, doing `string unescape --style=var (string escape --style=var $str)` will return the original string. There is no support for unescaping pcre2.
+`string unescape` performs the inverse of the `string escape` command. If the string to be unescaped is not properly formatted it is ignored. For example, doing `string unescape --style=var (string escape --style=var $str)` will return the original string. There is no support for unescaping `--style=regex`.
 
 \subsection string-join "join" subcommand
 


### PR DESCRIPTION
The style name was changed from `pcre2` to `regex`.