### PR TITLE
 brew.fish: Add `update-reset` subcommand completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - The completions for `configure` now correctly offer directories. (#5518)
 - The `man` completions won't interpret the argument as a regex anymore. (#5566)
 - Killing the terminal while fish is in vi-normal mode will no longer send it spinning and eating CPU. (#5528)
+- `brew.fish`: Add `update-reset` subcommand completion
 
 
 # fish 3.0.0 (released December 28, 2018)

--- a/share/completions/brew.fish
+++ b/share/completions/brew.fish
@@ -356,6 +356,9 @@ complete -f -c brew -n '__fish_brew_using_command untap' -a '(__fish_brew_taps)'
 complete -f -c brew -n '__fish_brew_needs_command' -a update -d 'Fetch newest version of Homebrew and formulas'
 complete -f -c brew -n '__fish_brew_using_command update' -l rebase -d 'Use git pull --rebase'
 
+# update-reset
+complete -f -c brew -n '__fish_brew_needs_command' -a update-reset -d 'Reset all Homebrew taps to upstream state'
+
 # upgrade
 complete -f -c brew -n '__fish_brew_needs_command' -a upgrade -d 'Upgrade outdated brews'
 complete -f -c brew -n '__fish_brew_using_command upgrade' -a '(__fish_brew_outdated_formulas)'
@@ -431,6 +434,7 @@ complete -f -c brew -n '__fish_brew_is_subcommand_cask homepage' -a '(__fish_bre
 # info
 complete -f -c brew -n '__fish_brew_needs_cask_action' -a 'info abv' -d 'Dislay info about cask'
 complete -f -c brew -n '__fish_brew_is_subcommand_cask info' -a '(__fish_brew_casks)'
+
 # adv
 complete -f -c brew -n '__fish_brew_is_subcommand_cask abv' -a '(__fish_brew_casks)'
 
@@ -475,9 +479,11 @@ complete -f -c brew -n '__fish_brew_is_subcommand_cask style' -a '(__fish_brew_c
 complete -f -c brew -n '__fish_brew_needs_cask_action' -a 'remove rm uninstall' -d 'Uninstall cask'
 complete -f -c brew -n '__fish_brew_is_subcommand_cask uninstall' -l force -d 'Force the uninstall'
 complete -f -c brew -n '__fish_brew_is_subcommand_cask uninstall' -a '(__fish_brew_casks_installed)'
+
 # remove
 complete -f -c brew -n '__fish_brew_is_subcommand_cask remove' -l force -d 'Force the uninstall'
 complete -f -c brew -n '__fish_brew_is_subcommand_cask remove' -a '(__fish_brew_casks_installed)'
+
 # rm
 complete -f -c brew -n '__fish_brew_is_subcommand_cask rm' -l force -d 'Force the uninstall'
 complete -f -c brew -n '__fish_brew_is_subcommand_cask rm' -a '(__fish_brew_casks_installed)'


### PR DESCRIPTION
## Description

I've added a missing completion to the `brew.fish` completion file.  Did this via the web, hence two commits.  Also, added some newlines to where it was missing.

I hope that you might be able to squash before merge.  If not, I'll do it if requested.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
