### PR TITLE
Create function to retrieve tmpdir

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <paths.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -2442,3 +2443,25 @@ std::string get_executable_path(const char *argv0) {
     return std::string(argv0 ? argv0 : "");
 }
 
+/// Return a path to a directory where we can store temporary files.
+std::string get_path_to_tmp_dir() {
+    char *env_tmpdir = getenv("TMPDIR");
+    if (env_tmpdir) {
+        return env_tmpdir;
+    }
+#if defined(_CS_DARWIN_USER_TEMP_DIR)
+    char osx_tmpdir[PATH_MAX];
+    size_t n = confstr(_CS_DARWIN_USER_TEMP_DIR, osx_tmpdir, PATH_MAX);
+    if (0 < n && n <= PATH_MAX) {
+        return osx_tmpdir;
+    } else {
+        return "/tmp";
+    }
+#elif defined(P_tmpdir)
+    return P_tmpdir;
+#elif defined(_PATH_TMP)
+    return _PATH_TMP;
+#else
+    return "/tmp";
+#endif
+}

--- a/src/common.h
+++ b/src/common.h
@@ -19,6 +19,11 @@
 #include "fallback.h"  // IWYU pragma: keep
 #include "maybe.h"
 
+// PATH_MAX may not exist.
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 // Define a symbol we can use elsewhere in our code to determine if we're being built on MS Windows
 // under Cygwin.
 #if defined(_WIN32) || defined(_WIN64) || defined(WIN32) || defined(__CYGWIN__) || \
@@ -946,6 +951,8 @@ static const wchar_t *enum_to_str(T enum_val, const enum_map<T> map[]) {
 };
 
 void redirect_tty_output();
+
+std::string get_path_to_tmp_dir();
 
 // Minimum allowed terminal size and default size if the detected size is not reasonable.
 #define MIN_TERM_COL 20

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -1741,7 +1741,7 @@ wcstring env_get_runtime_path() {
         auto pwuid = getpwuid(geteuid());
         const char *uname = pwuid ? pwuid->pw_name : NULL;
         // /tmp/fish.user
-        std::string tmpdir = "/tmp/fish.";
+        std::string tmpdir = get_path_to_tmp_dir() + "/fish.";
         if (uname) {
             tmpdir.append(uname);
         }


### PR DESCRIPTION
## Description

`/tmp` isn't present / writeable on every system. Instead of always
using `/tmp`, try to use standard environment variables and
configuration to find a temporary directory.

Adapted from #3974, with updates based on those comments.

Fixes issue #3845.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
