### PR TITLE
Make "-q" always check for existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - mandoc can now be used to format the output from `--help` if nroff is not installed
 - New color options for the pager have been added (#5524).
 - The default escape delay (to differentiate between the escape key and an alt-combination) has been reduced to 30ms, down from 300ms for the default mode and 100ms for vi-mode (#3904).
+- In the interest of consistency, `builtin -q` and `command -q` can now be used to query if a builtin or command exists (#5631).
 
 
 =======

--- a/doc_src/builtin.txt
+++ b/doc_src/builtin.txt
@@ -2,7 +2,8 @@
 
 \subsection builtin-synopsis Synopsis
 \fish{synopsis}
-builtin BUILTINNAME [OPTIONS...]
+builtin [OPTIONS...] BUILTINNAME
+builtin --query BUILTINNAMES...
 \endfish
 
 \subsection builtin-description Description
@@ -12,6 +13,7 @@ builtin BUILTINNAME [OPTIONS...]
 The following parameters are available:
 
 - `-n` or `--names` List the names of all defined builtins
+- `-q` or `--query` tests if any of the specified builtins exists.
 
 
 \subsection builtin-example Example

--- a/doc_src/command.txt
+++ b/doc_src/command.txt
@@ -13,7 +13,7 @@ The following options are available:
 
 - `-a` or `--all` returns all the external commands that are found in `$PATH` in the order they are found.
 
-- `-q` or `--quiet`, in conjunction with `-s`, silences the output and prints nothing, setting only the exit code.
+- `-q` or `--quiet`, silences the output and prints nothing, setting only the exit code. Implies `--search`.
 
 - `-s` or `--search` returns the name of the external command that would be executed, or nothing if no file with the specified name could be found in the `$PATH`.
 
@@ -27,4 +27,4 @@ For basic compatibility with POSIX `command`, the `-v` flag is recognized as an 
 
 `command -s ls` returns the path to the `ls` program.
 
-`command -sq git; and command git log` runs `git log` only if `git` exists.
+`command -q git; and command git log` runs `git log` only if `git` exists.

--- a/src/builtin_command.cpp
+++ b/src/builtin_command.cpp
@@ -87,7 +87,8 @@ int builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         return STATUS_CMD_OK;
     }
 
-    if (!opts.find_path && !opts.all_paths) {
+    // Quiet implies find_path.
+    if (!opts.find_path && !opts.all_paths && !opts.quiet) {
         builtin_print_help(parser, streams, cmd, streams.out);
         return STATUS_INVALID_ARGS;
     }
@@ -101,7 +102,7 @@ int builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 if (!opts.quiet) streams.out.append_format(L"%ls\n", path.c_str());
                 ++found;
             }
-        } else {
+        } else { // Either find_path explicitly or just quiet.
             wcstring path;
             if (path_get_path(command_name, &path, parser.vars())) {
                 if (!opts.quiet) streams.out.append_format(L"%ls\n", path.c_str());

--- a/tests/test_builtinbuiltin.err
+++ b/tests/test_builtinbuiltin.err
@@ -1,0 +1,2 @@
+builtin: Invalid combination of options,
+--query and --names are mutually exclusive

--- a/tests/test_builtinbuiltin.in
+++ b/tests/test_builtinbuiltin.in
@@ -1,0 +1,7 @@
+# Tests for the "builtin" builtin/keyword.
+builtin -q string; and echo String exists
+builtin -q; and echo None exists
+builtin -q string echo banana; and echo Some of these exist
+builtin -nq string
+echo $status
+exit 0

--- a/tests/test_builtinbuiltin.out
+++ b/tests/test_builtinbuiltin.out
@@ -1,0 +1,3 @@
+String exists
+Some of these exist
+2


### PR DESCRIPTION
## Description

Recently I had the weird experience of having to explain to someone how to check if a thing-you-can-call exists (i.e. a function, builtin, command, or any of them).

And what I had to say was:

```fish
functions -q $thing # for a function
builtin -n | string match -q $thing # for a builtin
command -sq $thing # for a command
type -q $thing # for any of the above
```

It seems to be a fairly straightforward improvement to usability to just add a "-q" option to all of these.

So this PR adds "-q"/"--query" to `builtin` and allows `command -q $thing` to work by making "-q" imply "-s".

For historical reasons the long form to "command" is still "--quiet", but that's not a large problem.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
