### PR TITLE
Document that snippets are run before system config

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -1280,7 +1280,6 @@ On startup, Fish evaluates a number of configuration files, which can be used to
 
 Configuration files are evaluated in the following order:
 - Configuration shipped with fish, which should not be edited, in `$__fish_data_dir/config.fish` (usually `/usr/share/fish/config.fish`).
-- System-wide configuration files, where administrators can include initialization that should be run for all users on the system - similar to `/etc/profile` for POSIX-style shells - in `$__fish_sysconf_dir` (usually `/etc/fish/config.fish`);
 - Configuration snippets in files ending in `.fish`, in the directories:
   - `$__fish_config_dir/conf.d` (by default, `~/.config/fish/conf.d/`)
   - `$__fish_sysconf_dir/conf.d` (by default, `/etc/fish/conf.d`)
@@ -1289,6 +1288,7 @@ Configuration files are evaluated in the following order:
   If there are multiple files with the same name in these directories, only the first will be executed.
   They are executed in order of their filename, sorted (like globs) in a natural order (i.e. "01" sorts before "2").
 
+- System-wide configuration files, where administrators can include initialization that should be run for all users on the system - similar to `/etc/profile` for POSIX-style shells - in `$__fish_sysconf_dir` (usually `/etc/fish/config.fish`);
 - User initialization, usually in `~/.config/fish/config.fish` (controlled by the `XDG_CONFIG_HOME` environment variable, and accessible as `$__fish_config_dir`).
 
 These paths are controlled by parameters set at build, install, or run time, and may vary from the defaults listed above.


### PR DESCRIPTION
## Description

From my reading of the source and experimenting, the documented initialisation order does not match the actual initialisation order.

Putting logging into various files, fish shows the following on startup:

```
loaded user snippet
loaded system config.fish
loaded user config.fish
Welcome to fish, the friendly interactive shell
```

However the [documentation][] says that system config.fish is sourced before snippets.

Looking at the source, the [initialisation logic][] loads the shared config.fish followed by the system config.fish, and the [shared config.fish][] loads the snippets.

[documentation]: https://github.com/fish-shell/fish-shell/blob/df28f7669891d88f68b4f237750bfab73c526e9d/doc_src/index.hdr.in#L1281-L1292
[initialisation logic]: https://github.com/fish-shell/fish-shell/blob/df28f7669891d88f68b4f237750bfab73c526e9d/src/fish.cpp#L194-L195
[shared config.fish]: https://github.com/fish-shell/fish-shell/blob/df28f7669891d88f68b4f237750bfab73c526e9d/share/config.fish#L282-L294

I'm not sure which is the intended behaviour here, so defaulting to the way things actually work.

Related question: if I wanted to configure the system environment to provide additional `PATH` entries to be visible to user snippets, what's the intended method of doing so? It seems like control is handed directly from the shared config.fish to the user snippets.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
