### PR TITLE
Only invoke path_helper in login shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - The `man` completions won't interpret the argument as a regex anymore. (#5566)
 - Killing the terminal while fish is in vi-normal mode will no longer send it spinning and eating CPU. (#5528)
 - `brew.fish`: Add `update-reset` subcommand completion
+- The `path_helper` on macOS now only runs in login shells, matching the bash implementation.
 
 
 # fish 3.0.0 (released December 28, 2018)

--- a/share/config.fish
+++ b/share/config.fish
@@ -186,40 +186,6 @@ if not set -q __fish_init_2_3_0
     set -U __fish_init_2_3_0
 end
 
-# macOS-ism: Emulate calling path_helper.
-if command -sq /usr/libexec/path_helper
-    # Adapt construct_path from the macOS /usr/libexec/path_helper
-    # executable for fish; see
-    # https://opensource.apple.com/source/shell_cmds/shell_cmds-203/path_helper/path_helper.c.auto.html .
-    function __fish_macos_set_env -d "set an environment variable like path_helper does (macOS only)"
-        set -l result
-
-        for path_file in $argv[2] $argv[3]/*
-            if test -f $path_file
-                while read -l entry
-                    if not contains $entry $result
-                        set result $result $entry
-                    end
-                end <$path_file
-            end
-        end
-
-        for entry in $$argv[1]
-            if not contains $entry $result
-                set result $result $entry
-            end
-        end
-
-        set -xg $argv[1] $result
-    end
-
-    __fish_macos_set_env 'PATH' '/etc/paths' '/etc/paths.d'
-    if [ -n "$MANPATH" ]
-        __fish_macos_set_env 'MANPATH' '/etc/manpaths' '/etc/manpaths.d'
-    end
-    functions -e __fish_macos_set_env
-end
-
 
 #
 # Some things should only be done for login terminals
@@ -227,6 +193,40 @@ end
 #
 
 if status --is-login
+    # macOS-ism: Emulate calling path_helper.
+    if command -sq /usr/libexec/path_helper
+        # Adapt construct_path from the macOS /usr/libexec/path_helper
+        # executable for fish; see
+        # https://opensource.apple.com/source/shell_cmds/shell_cmds-203/path_helper/path_helper.c.auto.html .
+        function __fish_macos_set_env -d "set an environment variable like path_helper does (macOS only)"
+            set -l result
+
+            for path_file in $argv[2] $argv[3]/*
+                if test -f $path_file
+                    while read -l entry
+                        if not contains $entry $result
+                            set result $result $entry
+                        end
+                    end <$path_file
+                end
+            end
+
+            for entry in $$argv[1]
+                if not contains $entry $result
+                    set result $result $entry
+                end
+            end
+
+            set -xg $argv[1] $result
+        end
+
+        __fish_macos_set_env 'PATH' '/etc/paths' '/etc/paths.d'
+        if [ -n "$MANPATH" ]
+            __fish_macos_set_env 'MANPATH' '/etc/manpaths' '/etc/manpaths.d'
+        end
+        functions -e __fish_macos_set_env
+    end
+
     #
     # Put linux consoles in unicode mode.
     #


### PR DESCRIPTION
Matches upstream path_helper which is invoked in /etc/profile and only
applies to login shells. Enables running interactive, non-login shells
with altered PATH values.

Reverts change in c0f832a7, which reverts change in adbaddf.

## Description

The macOS `path_helper` prepends all system specified paths:
```
$ PATH=/foo /usr/libexec/path_helper -s
PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/foo"; export PATH;
```

It's sometimes useful to run a shell with an altered path, for example to inject custom entries ahead of, or instead of, system entries. On bash this is possible since the path_helper is only run in a login shell:

```
$ PATH=/foo `which bash` -i -c 'echo $PATH'
/foo

$ PATH=/foo `which bash` -l -i -c 'echo $PATH'
/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/foo
```

This makes fish behave equivalently.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
