### PR TITLE
Add builds.sr.ht files

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -1,0 +1,23 @@
+image: alpine/edge
+packages:
+  - cmake
+  - ninja
+  - ncurses-dev
+  - pcre2-dev
+  - expect
+sources:
+  - https://git.sr.ht/~faho/fish
+tasks:
+  - build: |
+          cd fish
+          mkdir build || :
+          cd build
+          cmake -G Ninja .. \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_INSTALL_DATADIR=share \
+          -DCMAKE_INSTALL_DOCDIR=share/doc/fish \
+          -DCMAKE_INSTALL_SYSCONFDIR=/etc
+          ninja
+  - test: |
+          cd fish/build
+          env SHOW_INTERACTIVE_LOG=1 ninja test

--- a/.builds/arch.yml
+++ b/.builds/arch.yml
@@ -1,0 +1,21 @@
+image: archlinux
+packages:
+  - cmake
+  - ninja
+  - expect
+sources:
+  - https://git.sr.ht/~faho/fish
+tasks:
+  - build: |
+          cd fish
+          mkdir build || :
+          cd build
+          cmake -G Ninja .. \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_INSTALL_DATADIR=share \
+          -DCMAKE_INSTALL_DOCDIR=share/doc/fish \
+          -DCMAKE_INSTALL_SYSCONFDIR=/etc
+          ninja
+  - test: |
+          cd fish/build
+          env SHOW_INTERACTIVE_LOG=1 ninja test

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,0 +1,25 @@
+image: freebsd/latest
+packages:
+  - ncurses
+  - gcc
+  - gettext
+  - expect
+  - cmake
+  - gmake
+  - pcre2
+sources:
+  - https://git.sr.ht/~faho/fish
+tasks:
+  - build: |
+          cd fish
+          mkdir build || :
+          cd build
+          cmake .. \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCMAKE_INSTALL_DATADIR=share \
+          -DCMAKE_INSTALL_DOCDIR=share/doc/fish \
+          -DCMAKE_INSTALL_SYSCONFDIR=/etc
+          gmake -j2
+  - test: |
+          cd fish/build
+          gmake test SHOW_INTERACTIVE_LOG=1

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,9 @@
 /debian/* export-ignore
 /.github export-ignore
 /.github/* export-ignore
+/.builds export-ignore
+/.builds/* export-ignore
+/.travis.yml export-ignore
 
 # for linguist; let github identify our project as C++ instead of C due to pcre2
 /pcre2-10.32/ linguist-vendored


### PR DESCRIPTION
These enable builds and tests on builds.sr.ht for freebsd and arch, and alpine (which uses musl). See https://builds.sr.ht/~faho, where they are currently passing (also apparently NetBSD will be added soon).

All are built using cmake, as we want to drop the autotools build.

I'm not saying that we need to move to sr.ht/sourcehut, or that we need to add it automatically. I've been running these on-demand for a while.

It's just that keeping track of the commit that adds support, and rebasing it on top of whatever change I want to test is starting to bore me, so I'd like to have the integration added.