### PR TITLE
small typo in the tutorial. stderr is redirected using 2> rather than >2

### DIFF
--- a/doc_src/tutorial.hdr
+++ b/doc_src/tutorial.hdr
@@ -172,7 +172,7 @@ You can pipe between commands with the usual vertical bar:
 <outp>       1       2      12</outp>
 \endfish
 
-stdin and stdout can be redirected via the familiar &lt; and &gt;. stderr is redirected with a &gt;2.
+stdin and stdout can be redirected via the familiar &lt; and &gt;. stderr is redirected with a 2&gt;.
 
 \fish{cli-dark}
 >_ grep fish < /etc/shells > ~/output.txt 2> ~/errors.txt


### PR DESCRIPTION
## Description

Fixing a small typo in how stderr is described.