### PR TITLE
Screen completions

### DIFF
--- a/share/completions/screen.fish
+++ b/share/completions/screen.fish
@@ -21,7 +21,7 @@ end
 
 function __fish_complete_screen_general_list -d "Get the socket list"
     set -l escaped (string escape --style=regex $argv)
-    screen -list | string match -r '^\t.*\(.*\)\s*\('$escaped'\)\s*$'| string replace -r '\t(.*)\s+\((.*)\)\s*\((.*)\)' '$1\t$2 $3'
+    screen -list | string match -r '^\t.*\('$escaped'\)\s*$' | string replace -r '\t(.*)\s+(\(.*\))?\s*\((.*)\)' '$1\t$3'
 end
 
 function __fish_complete_screen_detached -d "Print a list of detached screen sessions"

--- a/share/completions/screen.fish
+++ b/share/completions/screen.fish
@@ -50,7 +50,6 @@ end
 # detect socket directory for mac users
 __fish_detect_screen_socket_dir
 
-complete -c screen -x
 complete -c screen -s a -d 'Include all capabilitys'
 complete -c screen -s A -d 'Adapt window size'
 complete -c screen -s c -r -d 'Specify init file'

--- a/share/completions/screen.fish
+++ b/share/completions/screen.fish
@@ -56,8 +56,8 @@ complete -c screen -s c -r -d 'Specify init file'
 complete -c screen -s d -d 'Detach screen' -a '(__fish_complete_screen)' -x
 complete -c screen -s D -d 'Detach screen' -a '(__fish_complete_screen)' -x
 complete -c screen -s r -d 'Reattach session' -a '(__fish_complete_screen)' -x
-complete -c screen -s R -d 'Reattach/create session'
-complete -c screen -o RR -d 'Reattach/create any session'
+complete -c screen -s R -d 'Reattach/create session' -a '(__fish_complete_screen)' -x
+complete -c screen -o RR -d 'Reattach/create any session' -a '(__fish_complete_screen)' -x
 complete -c screen -s e -x -d 'Escape character'
 complete -c screen -s f -d 'Flow control on'
 complete -c screen -o fn -d 'Flow control off'


### PR DESCRIPTION
## Description

I made some changes to completions for screen. They are:
- Fix session name completions on non-Ubuntu Linux distros
- Add session name completions for `-R` and `-RR` options
- Allow completion of paths to an "initial executable"

A couple of things that I also noticed but don't know how to fix:
- Combinations of detaching/reattaching options don't work (e.g., `$ screen -dR <TAB>` won't show completions)
- If you type something like `$ screen -d<TAB>` (note the lack of a space after `-d`), the completion will add the session name directly onto the `-d` but screen requires a space between the option and the session name.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
