### PR TITLE
Fix broken link on index page

### DIFF
--- a/doc_src/index.hdr.in
+++ b/doc_src/index.hdr.in
@@ -1093,7 +1093,7 @@ The user can change the settings of `fish` by changing the values of certain var
 
 - `fish_ambiguous_width` controls the computed width of ambiguous East Asian characters. This should be set to 1 if your terminal emulator renders these characters as single-width (typical), or 2 if double-width.
 
-- `fish_escape_delay_ms` overrides the default timeout of 30ms after seeing an escape character before giving up on matching a key binding. See the documentation for the <a href='bind.html#special-case-escape'>bind</a> builtin command. This delay facilitates using escape as a meta key.
+- `fish_escape_delay_ms` overrides the default timeout of 30ms after seeing an escape character before giving up on matching a key binding. See the documentation for the <a href='commands.html#special-case-escape'>bind</a> builtin command. This delay facilitates using escape as a meta key.
 
 - `fish_greeting`, the greeting message printed on startup.
 


### PR DESCRIPTION
## Description

Just a quick fix for a broken link in the documentation.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
