### PR TITLE
Prompts with pipestatus

### DIFF
--- a/share/functions/__fish_pipestatus_with_signal.fish
+++ b/share/functions/__fish_pipestatus_with_signal.fish
@@ -1,0 +1,5 @@
+function __fish_pipestatus_with_signal --description "Print arguments from \$pipestatus replacing values with signal names where appropriate"
+    for pstat in $argv
+        echo (__fish_status_to_signal $pstat)
+    end
+end

--- a/share/functions/__fish_pipestatus_with_signal.fish
+++ b/share/functions/__fish_pipestatus_with_signal.fish
@@ -1,5 +1,5 @@
 function __fish_pipestatus_with_signal --description "Print arguments from \$pipestatus replacing values with signal names where appropriate"
     for pstat in $argv
-        echo (__fish_status_to_signal $pstat)
+         __fish_status_to_signal $pstat
     end
 end

--- a/share/functions/__fish_print_pipestatus.fish
+++ b/share/functions/__fish_print_pipestatus.fish
@@ -1,0 +1,19 @@
+function __fish_print_pipestatus --description "Print pipestatus for prompt"
+    # maybe these could be in global variables similar to __fish_color_status to allow
+    # users to set the variables to modify the braces/separator/color used
+    set -l left_brace $argv[1]
+    set -l right_brace $argv[2]
+    set -l separator $argv[3]
+    set -l brace_sep_color $argv[4]
+    set -l status_color $argv[5]
+    set -e argv[1 2 3 4 5]
+
+    # only output $pipestatus if there was a pipe and any part of it had non-zero exit status
+    if set -q argv[2] && string match -qvr '^0$' $argv
+        set -l sep (set_color normal){$brace_sep_color}{$separator}(set_color normal){$status_color}
+        set -l last_pipestatus_string (string join "$sep" (__fish_pipestatus_with_signal $argv))
+        printf "%s%s%s%s%s%s%s%s%s" $brace_sep_color $left_brace (set_color normal) \
+               $status_color $last_pipestatus_string (set_color normal) $brace_sep_color \
+               $right_brace (set_color normal)
+    end
+end

--- a/share/functions/__fish_print_pipestatus.fish
+++ b/share/functions/__fish_print_pipestatus.fish
@@ -1,19 +1,35 @@
 function __fish_print_pipestatus --description "Print pipestatus for prompt"
-    # maybe these could be in global variables similar to __fish_color_status to allow
-    # users to set the variables to modify the braces/separator/color used
-    set -l left_brace $argv[1]
-    set -l right_brace $argv[2]
-    set -l separator $argv[3]
-    set -l brace_sep_color $argv[4]
-    set -l status_color $argv[5]
+
+    # allow users to customize these variables
+    if not set -q __fish_prompt_pipestatus_left_brace
+        set -g __fish_prompt_pipestatus_left_brace $argv[1]
+    end
+
+    if not set -q __fish_prompt_pipestatus_right_brace
+        set -g __fish_prompt_pipestatus_right_brace $argv[2]
+    end
+
+    if not set -q __fish_prompt_pipestatus_separator
+        set -g __fish_prompt_pipestatus_separator $argv[3]
+    end
+
+    if not set -q __fish_prompt_pipestatus_brace_sep_color
+        set -g __fish_prompt_pipestatus_brace_sep_color $argv[4]
+    end
+
+    if not set -q __fish_prompt_pipestatus_color
+        set -g __fish_prompt_pipestatus_color $argv[5]
+    end
+
     set -e argv[1 2 3 4 5]
 
     # only output $pipestatus if there was a pipe and any part of it had non-zero exit status
     if set -q argv[2] && string match -qvr '^0$' $argv
-        set -l sep (set_color normal){$brace_sep_color}{$separator}(set_color normal){$status_color}
+        set -l sep (set_color normal){$__fish_prompt_pipestatus_brace_sep_color}{$__fish_prompt_pipestatus_separator}(set_color normal){$__fish_prompt_pipestatus_color}
         set -l last_pipestatus_string (string join "$sep" (__fish_pipestatus_with_signal $argv))
-        printf "%s%s%s%s%s%s%s%s%s%s" (set_color normal )$brace_sep_color $left_brace \
-               (set_color normal) $status_color $last_pipestatus_string (set_color normal) \
-               $brace_sep_color $right_brace (set_color normal)
+        printf "%s%s%s%s%s%s%s%s%s%s" (set_color normal) $__fish_prompt_pipestatus_brace_sep_color \
+            $__fish_prompt_pipestatus_left_brace (set_color normal) $__fish_prompt_pipestatus_color \
+            $last_pipestatus_string (set_color normal) $__fish_prompt_pipestatus_brace_sep_color \
+            $__fish_prompt_pipestatus_right_brace (set_color normal)
     end
 end

--- a/share/functions/__fish_print_pipestatus.fish
+++ b/share/functions/__fish_print_pipestatus.fish
@@ -12,8 +12,8 @@ function __fish_print_pipestatus --description "Print pipestatus for prompt"
     if set -q argv[2] && string match -qvr '^0$' $argv
         set -l sep (set_color normal){$brace_sep_color}{$separator}(set_color normal){$status_color}
         set -l last_pipestatus_string (string join "$sep" (__fish_pipestatus_with_signal $argv))
-        printf "%s%s%s%s%s%s%s%s%s" $brace_sep_color $left_brace (set_color normal) \
-               $status_color $last_pipestatus_string (set_color normal) $brace_sep_color \
-               $right_brace (set_color normal)
+        printf "%s%s%s%s%s%s%s%s%s%s" (set_color normal )$brace_sep_color $left_brace \
+               (set_color normal) $status_color $last_pipestatus_string (set_color normal) \
+               $brace_sep_color $right_brace (set_color normal)
     end
 end

--- a/share/functions/__fish_print_pipestatus.fish
+++ b/share/functions/__fish_print_pipestatus.fish
@@ -1,35 +1,19 @@
 function __fish_print_pipestatus --description "Print pipestatus for prompt"
-
-    # allow users to customize these variables
-    if not set -q __fish_prompt_pipestatus_left_brace
-        set -g __fish_prompt_pipestatus_left_brace $argv[1]
-    end
-
-    if not set -q __fish_prompt_pipestatus_right_brace
-        set -g __fish_prompt_pipestatus_right_brace $argv[2]
-    end
-
-    if not set -q __fish_prompt_pipestatus_separator
-        set -g __fish_prompt_pipestatus_separator $argv[3]
-    end
-
-    if not set -q __fish_prompt_pipestatus_brace_sep_color
-        set -g __fish_prompt_pipestatus_brace_sep_color $argv[4]
-    end
-
-    if not set -q __fish_prompt_pipestatus_color
-        set -g __fish_prompt_pipestatus_color $argv[5]
-    end
-
+    # maybe these could be in global variables similar to __fish_color_status to allow
+    # users to set the variables to modify the braces/separator/color used
+    set -l left_brace $argv[1]
+    set -l right_brace $argv[2]
+    set -l separator $argv[3]
+    set -l brace_sep_color $argv[4]
+    set -l status_color $argv[5]
     set -e argv[1 2 3 4 5]
 
     # only output $pipestatus if there was a pipe and any part of it had non-zero exit status
     if set -q argv[2] && string match -qvr '^0$' $argv
-        set -l sep (set_color normal){$__fish_prompt_pipestatus_brace_sep_color}{$__fish_prompt_pipestatus_separator}(set_color normal){$__fish_prompt_pipestatus_color}
+        set -l sep (set_color normal){$brace_sep_color}{$separator}(set_color normal){$status_color}
         set -l last_pipestatus_string (string join "$sep" (__fish_pipestatus_with_signal $argv))
-        printf "%s%s%s%s%s%s%s%s%s%s" (set_color normal) $__fish_prompt_pipestatus_brace_sep_color \
-            $__fish_prompt_pipestatus_left_brace (set_color normal) $__fish_prompt_pipestatus_color \
-            $last_pipestatus_string (set_color normal) $__fish_prompt_pipestatus_brace_sep_color \
-            $__fish_prompt_pipestatus_right_brace (set_color normal)
+        printf "%s%s%s%s%s%s%s%s%s%s" (set_color normal )$brace_sep_color $left_brace \
+               (set_color normal) $status_color $last_pipestatus_string (set_color normal) \
+               $brace_sep_color $right_brace (set_color normal)
     end
 end

--- a/share/functions/__fish_print_pipestatus.fish
+++ b/share/functions/__fish_print_pipestatus.fish
@@ -1,6 +1,4 @@
 function __fish_print_pipestatus --description "Print pipestatus for prompt"
-    # maybe these could be in global variables similar to __fish_color_status to allow
-    # users to set the variables to modify the braces/separator/color used
     set -l left_brace $argv[1]
     set -l right_brace $argv[2]
     set -l separator $argv[3]

--- a/share/functions/__fish_status_to_signal.fish
+++ b/share/functions/__fish_status_to_signal.fish
@@ -1,0 +1,22 @@
+function __fish_status_to_signal --description "Print signal name from argument (\$status), or just argument"
+    if test (count $argv) -ne 1
+        echo "expected single argument as integer from \$status" >&2
+        return 1
+    end
+
+    if test $argv[1] -gt 128
+        set -l signals SIGHUP SIGINT SIGQUIT SIGILL SIGTRAP SIGABRT SIGBUS \
+            SIGFPE SIGKILL SIGUSR1 SIGSEGV SIGUSR2 SIGPIPE SIGALRM \
+            SIGTERM SIGSTKFLT SIGCHLD SIGCONT SIGSTOP SIGTSTP \
+            SIGTTIN SIGTTOU SIGURG SIGXCPU SIGXFSZ SIGVTALRM \
+            SIGPROF SIGWINCH SIGIO SIGPWR SIGSYS
+        set -l sigix (math $argv[1] - 128)
+        if test $sigix -le (count $signals)
+            echo $signals[$sigix]
+            return 0
+        end
+    end
+
+    echo $argv[1]
+    return 0
+end

--- a/share/tools/web_config/sample_prompts/classic_status.fish
+++ b/share/tools/web_config/sample_prompts/classic_status.fish
@@ -6,11 +6,7 @@ function fish_prompt --description "Write out the prompt"
     set -l last_pipestatus $pipestatus
     set -l last_status $status
 
-    # only output $pipestatus if there was a pipe and any part of it had non-zero exit status
-    if test (count $last_pipestatus) -gt 1 && string match -qvr '^0$' $last_pipestatus
-        set -l last_pipestatus_string (string join "|" (__fish_pipestatus_with_signal $last_pipestatus))
-        printf "%s[%s]%s " (set_color yellow --bold) $last_pipestatus_string (set_color normal)
-    end
+    __fish_print_pipestatus "[" "] " "|" (set_color yellow) (set_color --bold yellow) $last_pipestatus
 
     if test $last_status -ne 0
         printf "%s(%s)%s " (set_color red --bold) (__fish_status_to_signal $last_status) (set_color normal)

--- a/share/tools/web_config/sample_prompts/classic_status.fish
+++ b/share/tools/web_config/sample_prompts/classic_status.fish
@@ -7,15 +7,9 @@ function fish_prompt --description "Write out the prompt"
     set -l last_status $status
 
     # only output $pipestatus if there was a pipe and any part of it had non-zero exit status
-    # TODO maybe have a common function that returns true if all array elements match a certain value?
-    if test (count $last_pipestatus) -gt 1
-        for pstat in $last_pipestatus
-            if test $pstat -ne 0
-                set -l last_pipestatus_string (string join "|" (__fish_pipestatus_with_signal $last_pipestatus))
-                printf "%s[%s]%s " (set_color yellow --bold) $last_pipestatus_string (set_color normal)
-                break
-            end
-        end
+    if test (count $last_pipestatus) -gt 1 && string match -qvr '^0$' $last_pipestatus
+        set -l last_pipestatus_string (string join "|" (__fish_pipestatus_with_signal $last_pipestatus))
+        printf "%s[%s]%s " (set_color yellow --bold) $last_pipestatus_string (set_color normal)
     end
 
     if test $last_status -ne 0

--- a/share/tools/web_config/sample_prompts/classic_status.fish
+++ b/share/tools/web_config/sample_prompts/classic_status.fish
@@ -3,10 +3,23 @@
 
 function fish_prompt --description "Write out the prompt"
     # Save our status
+    set -l last_pipestatus $pipestatus
     set -l last_status $status
 
+    # only output $pipestatus if there was a pipe and any part of it had non-zero exit status
+    # TODO maybe have a common function that returns true if all array elements match a certain value?
+    if test (count $last_pipestatus) -gt 1
+        for pstat in $last_pipestatus
+            if test $pstat -ne 0
+                set -l last_pipestatus_string (string join "|" (__fish_pipestatus_with_signal $last_pipestatus))
+                printf "%s[%s]%s " (set_color yellow --bold) $last_pipestatus_string (set_color normal)
+                break
+            end
+        end
+    end
+
     if test $last_status -ne 0
-        printf "%s(%d)%s " (set_color red --bold) $last_status (set_color normal)
+        printf "%s(%s)%s " (set_color red --bold) (__fish_status_to_signal $last_status) (set_color normal)
     end
 
     set -l color_cwd

--- a/share/tools/web_config/sample_prompts/classic_vcs.fish
+++ b/share/tools/web_config/sample_prompts/classic_vcs.fish
@@ -3,6 +3,7 @@
 # vim: set noet:
 
 function fish_prompt --description 'Write out the prompt'
+    set -l last_pipestatus $pipestatus
     set -l last_status $status
     set -l normal (set_color normal)
 
@@ -62,9 +63,9 @@ function fish_prompt --description 'Write out the prompt'
             set suffix '>'
     end
 
-    set -l prompt_status
+    set -l prompt_status (__fish_print_pipestatus "[" "] " "|" (set_color yellow) (set_color --bold yellow) $last_pipestatus)
     if test $last_status -ne 0
-        set prompt_status ' ' (set_color $fish_color_status) "[$last_status]" "$normal"
+        set prompt_status " $prompt_status" (set_color $fish_color_status) "[$last_status]" "$normal"
     end
 
     echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $fish_color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "

--- a/share/tools/web_config/sample_prompts/informative.fish
+++ b/share/tools/web_config/sample_prompts/informative.fish
@@ -4,6 +4,7 @@
 
 function fish_prompt --description 'Write out the prompt'
     #Save the return status of the previous command
+    set -l last_pipestatus $pipestatus
     set stat $status
 
     if not set -q __fish_prompt_normal
@@ -39,8 +40,8 @@ function fish_prompt --description 'Write out the prompt'
             if not set -q __fish_prompt_cwd
                 set -g __fish_prompt_cwd (set_color $fish_color_cwd)
             end
-
-            printf '[%s] %s%s@%s %s%s %s(%s)%s \f\r> ' (date "+%H:%M:%S") "$__fish_color_blue" $USER (prompt_hostname) "$__fish_prompt_cwd" "$PWD" "$__fish_color_status" "$stat" "$__fish_prompt_normal"
+            set -l pipestatus_string (__fish_print_pipestatus "[" "] " "|" (set_color yellow) (set_color --bold yellow) $last_pipestatus)
+            printf '[%s] %s%s@%s %s%s %s%s(%s)%s \f\r> ' (date "+%H:%M:%S") "$__fish_color_blue" $USER (prompt_hostname) "$__fish_prompt_cwd" "$PWD" "$pipestatus_string" "$__fish_color_status" "$stat" "$__fish_prompt_normal"
 
     end
 end

--- a/share/tools/web_config/sample_prompts/informative_vcs.fish
+++ b/share/tools/web_config/sample_prompts/informative_vcs.fish
@@ -4,6 +4,7 @@
 
 
 function fish_prompt --description 'Write out the prompt'
+    set -l last_pipestatus $pipestatus
     set -l last_status $status
 
     if not set -q __fish_git_prompt_show_informative_status
@@ -87,6 +88,9 @@ function fish_prompt --description 'Write out the prompt'
     set_color normal
 
     printf '%s ' (fish_vcs_prompt)
+
+    set -l pipestatus_string (__fish_print_pipestatus "[" "] " "|" (set_color yellow) (set_color --bold yellow) $last_pipestatus)
+    echo -n "$pipestatus_string"
 
     if not test $last_status -eq 0
         set_color $fish_color_error


### PR DESCRIPTION
## Add `$pipestatus` to one or more stock prompts

I added it to `classic_status.fish` as a starting point. I am open to suggestions on which (if any) stock prompts you think would benefit from it. Also any suggestions on how it should look please.
I added 2 functions to make it easier. This is an example if its output:
![image](https://user-images.githubusercontent.com/10374626/53437307-1266ab80-39f5-11e9-946e-79e42d2900cb.png)
## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
