### PR TITLE
Test the emoji width at compiletime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,10 +128,47 @@ SET_SOURCE_FILES_PROPERTIES(src/fish_version.cpp
                             ${CMAKE_CURRENT_BINARY_DIR}/${FBVF})
 
 OPTION(INTERNAL_WCWIDTH "use fallback wcwidth" ON)
+# Override the emoji width detection by picking unicode9 width.
+# We don't provide an option to pick unicode8 width because we'd already detect that,
+# or your terminal is worse than your system wcwidth.
+#
+# Note that this sets the "guessed_emoji_width", so it can still be overridden via $fish_emoji_width.
+OPTION(USE_UNICODE9_WIDTH "set the default emoji width to 2 (the unicode 9 value)" OFF)
 IF(INTERNAL_WCWIDTH)
-    ADD_DEFINITIONS(-DHAVE_BROKEN_WCWIDTH=1)
+  IF(NOT USE_UNICODE9_WIDTH)
+    # Compile and run a small program that checks an emoji for its width.
+    # Note that this relies on a unicode locale, and assumes that the terminal's wcwidth
+    # uses the unicode 9 widths IFF the system's does.
+    #
+    # So there's a bunch of assumptions, but this heuristic should still improve things.
+    try_run(WCW_RUN_RESULT
+      WCW_COMPILE_RESULT
+      ${CMAKE_CURRENT_BINARY_DIR}/
+      ${CMAKE_CURRENT_SOURCE_DIR}/test_wcwidth.cpp
+      RUN_OUTPUT_VARIABLE WCW_OUTPUT)
+    # If this refused to compile or run, we error out, because there's something wrong with the system. 
+    if("${WCW_COMPILE_RESULT}" AND ("${WCW_RUN_RESULT}" EQUAL 0))
+      # If the value is < 1 or > 2, most likely the locale is C.
+      # Since that happens a bunch, fall back to unicode 8 like before.
+      if("${WCW_OUTPUT}" LESS 1 OR "{WCW_OUTPUT}" GREATER 2)
+        MESSAGE(WARNING "wcwidth returned unusable results. Most likely you don't have a unicode locale set. Guessing you don't have unicode9 support.")
+        SET(DEFAULT_EMOJI_WIDTH 1)
+      ELSE()
+        # If the value is 1 or 2, we use it.
+        SET(DEFAULT_EMOJI_WIDTH ${WCW_OUTPUT})
+      ENDIF()
+    ELSE()
+      MESSAGE(FATAL_ERROR "WCWIDTH FAILED!")
+    ENDIF()
+  ELSE()
+    SET(DEFAULT_EMOJI_WIDTH 2)
+  ENDIF()
+
+  MESSAGE("EMOJI WIDTH SET TO ${DEFAULT_EMOJI_WIDTH}")
+  ADD_DEFINITIONS(-DDEFAULT_EMOJI_WIDTH=${DEFAULT_EMOJI_WIDTH})
+  ADD_DEFINITIONS(-DHAVE_BROKEN_WCWIDTH=1)
 ELSE()
-    ADD_DEFINITIONS(-DHAVE_BROKEN_WCWIDTH=0)
+  ADD_DEFINITIONS(-DHAVE_BROKEN_WCWIDTH=0)
 ENDIF()
 
 # Enable thread-safe errno on Solaris (#5611)

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -549,7 +549,7 @@ static void init_path_vars() {
 
 /// Update the value of g_guessed_fish_emoji_width
 static void guess_emoji_width() {
-    wcstring term;
+    wcstring term = L"";
     auto &vars = env_stack_t::globals();
     if (auto term_var = vars.get(L"TERM_PROGRAM")) {
         term = term_var->as_string();
@@ -561,14 +561,16 @@ static void guess_emoji_width() {
         version = strtod(narrow_version.c_str(), NULL);
     }
 
-    // iTerm2 defaults to Unicode 8 sizes.
-    // See https://gitlab.com/gnachman/iterm2/wikis/unicodeversionswitching
 
     if (term == L"Apple_Terminal" && version >= 400) {
         // Apple Terminal on High Sierra
+        // TODO: We can probably remove this if it overlaps with
+        // system wcwidth() having unicode 9 sizes.
         g_guessed_fish_emoji_width = 2;
         debug(2, "default emoji width: 2 for %ls", term.c_str());
-    } else {
+    } else if (term == L"iTerm.app") {
+        // iTerm2 defaults to Unicode 8 sizes.
+        // See https://gitlab.com/gnachman/iterm2/wikis/unicodeversionswitching
         g_guessed_fish_emoji_width = 1;
         debug(2, "default emoji width: 1");
     }

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -255,8 +255,11 @@ int g_fish_ambiguous_width = 1;
 // Width of emoji characters.
 int g_fish_emoji_width = 0;
 
-// 1 is the typical emoji width in Unicode 8.
-int g_guessed_fish_emoji_width = 1;
+// We've compiled a small program that checks the width of
+// a character.
+// 1 is the typical emoji width in Unicode 8,
+// 2 in Unicode 9 and up.
+int g_guessed_fish_emoji_width = DEFAULT_EMOJI_WIDTH;
 
 int fish_get_emoji_width(wchar_t c) {
     (void)c;

--- a/test_wcwidth.cpp
+++ b/test_wcwidth.cpp
@@ -1,0 +1,10 @@
+#include <wchar.h>
+#include <iostream>
+
+int main(int argc, char** argv) {
+    // This initializes the locale according to the environment variables.
+    // That means if the environment isn't set up for unicode, this whole excercise is pointless.
+    setlocale(LC_ALL, "");
+    std::cout << wcwidth(L'😃');
+    return 0;
+}

--- a/test_wcwidth.cpp
+++ b/test_wcwidth.cpp
@@ -39,8 +39,8 @@ int main(int argc, char** argv) {
                                  "tr_TR.UTF-8", "uk_UA.UTF-8", "uz_UZ.UTF-8", "wa_BE.UTF-8", "xh_ZA.UTF-8", "yi_US.UTF-8",
                                  "zh_CN.UTF-8", "zh_HK.UTF-8", "zh_SG.UTF-8", "zh_TW.UTF-8", "zu_ZA.UTF-8"
         };
-        for (auto loc : locales) {
-            auto ret = setlocale(LC_ALL, loc);
+        for (const char *loc : locales) {
+            const char *ret = setlocale(LC_ALL, loc);
             if (ret) break;
         }
     }

--- a/test_wcwidth.cpp
+++ b/test_wcwidth.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <wchar.h>
 #include <iostream>
 
@@ -5,6 +6,44 @@ int main(int argc, char** argv) {
     // This initializes the locale according to the environment variables.
     // That means if the environment isn't set up for unicode, this whole excercise is pointless.
     setlocale(LC_ALL, "");
+
+    // The locale is C, so try to get UTF-8 somehow.
+    // Note that we don't handle locales with other encodings. I've never seen one used on purpose,
+    // the biggest problem is the POSIX default.
+    if (strcmp(setlocale(LC_ALL, NULL),"C") == 0) {
+        // The list of all UTF-8 locales in glibc 2.28.
+        // We try C.UTF-8 first, but even that's not guaranteed to be there.
+        const char* locales[] = {"C.UTF-8", "aa_DJ.UTF-8", "af_ZA.UTF-8", "an_ES.UTF-8", "ar_BH.UTF-8", "ar_DZ.UTF-8",
+                                 "ar_EG.UTF-8", "ar_IQ.UTF-8", "ar_JO.UTF-8", "ar_KW.UTF-8", "ar_LB.UTF-8", "ar_LY.UTF-8",
+                                 "ar_MA.UTF-8", "ar_OM.UTF-8", "ar_QA.UTF-8", "ar_SA.UTF-8", "ar_SD.UTF-8", "ar_SY.UTF-8",
+                                 "ar_TN.UTF-8", "ar_YE.UTF-8", "ast_ES.UTF-8", "be_BY.UTF-8", "bg_BG.UTF-8", "bhb_IN.UTF-8",
+                                 "br_FR.UTF-8", "bs_BA.UTF-8", "ca_AD.UTF-8", "ca_ES.UTF-8", "ca_FR.UTF-8", "ca_IT.UTF-8",
+                                 "cs_CZ.UTF-8", "cy_GB.UTF-8", "da_DK.UTF-8", "de_AT.UTF-8", "de_BE.UTF-8", "de_CH.UTF-8",
+                                 "de_DE.UTF-8", "de_IT.UTF-8", "de_LI.UTF-8", "de_LU.UTF-8", "el_GR.UTF-8", "el_CY.UTF-8",
+                                 "en_AU.UTF-8", "en_BW.UTF-8", "en_CA.UTF-8", "en_DK.UTF-8", "en_GB.UTF-8", "en_HK.UTF-8",
+                                 "en_IE.UTF-8", "en_NZ.UTF-8", "en_PH.UTF-8", "en_SC.UTF-8", "en_SG.UTF-8", "en_US.UTF-8",
+                                 "en_ZA.UTF-8", "en_ZW.UTF-8", "es_AR.UTF-8", "es_BO.UTF-8", "es_CL.UTF-8", "es_CO.UTF-8",
+                                 "es_CR.UTF-8", "es_DO.UTF-8", "es_EC.UTF-8", "es_ES.UTF-8", "es_GT.UTF-8", "es_HN.UTF-8",
+                                 "es_MX.UTF-8", "es_NI.UTF-8", "es_PA.UTF-8", "es_PE.UTF-8", "es_PR.UTF-8", "es_PY.UTF-8",
+                                 "es_SV.UTF-8", "es_US.UTF-8", "es_UY.UTF-8", "es_VE.UTF-8", "et_EE.UTF-8", "eu_ES.UTF-8",
+                                 "fi_FI.UTF-8", "fo_FO.UTF-8", "fr_BE.UTF-8", "fr_CA.UTF-8", "fr_CH.UTF-8", "fr_FR.UTF-8",
+                                 "fr_LU.UTF-8", "ga_IE.UTF-8", "gd_GB.UTF-8", "gl_ES.UTF-8", "gv_GB.UTF-8", "he_IL.UTF-8",
+                                 "hr_HR.UTF-8", "hsb_DE.UTF-8", "hu_HU.UTF-8", "id_ID.UTF-8", "is_IS.UTF-8", "it_CH.UTF-8",
+                                 "it_IT.UTF-8", "ja_JP.UTF-8", "ka_GE.UTF-8", "kk_KZ.UTF-8", "kl_GL.UTF-8", "ko_KR.UTF-8",
+                                 "ku_TR.UTF-8", "kw_GB.UTF-8", "lg_UG.UTF-8", "lt_LT.UTF-8", "lv_LV.UTF-8", "mg_MG.UTF-8",
+                                 "mi_NZ.UTF-8", "mk_MK.UTF-8", "ms_MY.UTF-8", "mt_MT.UTF-8", "nb_NO.UTF-8", "nl_BE.UTF-8",
+                                 "nl_NL.UTF-8", "nn_NO.UTF-8", "oc_FR.UTF-8", "om_KE.UTF-8", "pl_PL.UTF-8", "pt_BR.UTF-8",
+                                 "pt_PT.UTF-8", "ro_RO.UTF-8", "ru_RU.UTF-8", "ru_UA.UTF-8", "sk_SK.UTF-8", "sl_SI.UTF-8",
+                                 "so_DJ.UTF-8", "so_KE.UTF-8", "so_SO.UTF-8", "sq_AL.UTF-8", "st_ZA.UTF-8", "sv_FI.UTF-8",
+                                 "sv_SE.UTF-8", "tcy_IN.UTF-8", "tg_TJ.UTF-8", "th_TH.UTF-8", "tl_PH.UTF-8", "tr_CY.UTF-8",
+                                 "tr_TR.UTF-8", "uk_UA.UTF-8", "uz_UZ.UTF-8", "wa_BE.UTF-8", "xh_ZA.UTF-8", "yi_US.UTF-8",
+                                 "zh_CN.UTF-8", "zh_HK.UTF-8", "zh_SG.UTF-8", "zh_TW.UTF-8", "zu_ZA.UTF-8"
+        };
+        for (auto loc : locales) {
+            auto ret = setlocale(LC_ALL, loc);
+            if (ret) break;
+        }
+    }
     std::cout << wcwidth(L'😃');
     return 0;
 }


### PR DESCRIPTION
Since Unicode 9, the width of some characters changed to 2.

Depending on the system, it might have support for it, or it might
not.

Instead of hardcoding specific glibc etc versions, we compile a small
program and check an actual value (the one for "😃", U+1F603 "Grinning Face With Big Eyes").

To skip the check, the USE_UNICODE9_WIDTH option can be used to default emoji width to 2.

The intention is to, in most cases, make setting $fish_emoji_width
unnecessary, but since it sets the "guessed_emoji_width", that variable still takes precedence if it is set.

Unfortunately this approach has some caveats:

- It relies on the locale being set to a unicode-supporting one.
  (C.UTF-8 is unfortunately not standard, so we can't use it)
- It relies on the terminal's wcwidth having unicode9 support IFF the
  system wcwidth does.

Some results:

Ubuntu Xenial (16.04) on Travis correctly detects 1 (glibc is 2.23,
the cut-off for unicode9 support is 2.26).

Archlinux detects 2.

macOS should mostly be unaffected as we have special heuristics for
iTerm and Terminal.app. Since the result is 2 for macOS 10.13.3, we could probably drop the Terminal.app check. iTerm defaults to unicode8 widths, and we might want to emit the special escape that switches it to unicode9 (https://gitlab.com/gnachman/iterm2/wikis/unicodeversionswitching).

Alpine edge (which uses musl) also returns 2.

NetBSD returns -1, even with LC_ALL set to utf-8, OpenIndiana/Illumos/Solaris/SunOS returns 1 (with the default en_US.UTF-8 locale).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
