### PR TITLE
fish_git_prompt: optionally show stash state in informative mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   - `cf`
   - `bosh`
   - `vagrant`
+- The git prompt in informative mode now shows the number of stashes if enabled.
 
 ### For distributors and developers
 - The autotools-based build system and legacy Xcode build systems have been removed, leaving only the CMake build system. All distributors and developers must migrate to the CMake build.


### PR DESCRIPTION
## Description
Since `fish_git_prompt` was adapted from the zsh and bash versions, they added a display for the number of stashed changes (magicmonty/bash-git-prompt#32). Previously, setting `__fish_git_prompt_showstashstate` unintuitively would only have an effect if informative mode was not enabled.
This change shows the number of stashes in informative mode when this variable is set.

We count the lines of the file instead of using `git stash list` because the latter is extraordinarily slow.

Note that the common `git stash apply` leaves a stash in the list - to reduce the number of stashes, `git stash pop` is the right command.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.md
