### PR TITLE
Convert job list to a dequeue

### DIFF
--- a/src/builtin_bg.cpp
+++ b/src/builtin_bg.cpp
@@ -51,19 +51,19 @@ int builtin_bg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
     if (optind == argc) {
         // No jobs were specified so use the most recent (i.e., last) job.
-        job_t *j;
-        job_iterator_t jobs;
-        while ((j = jobs.next())) {
+        job_t *job = nullptr;
+        for (auto j : jobs()) {
             if (j->is_stopped() && j->get_flag(job_flag_t::JOB_CONTROL) && (!j->is_completed())) {
+                job = j.get();
                 break;
             }
         }
 
-        if (!j) {
+        if (!job) {
             streams.err.append_format(_(L"%ls: There are no suitable jobs\n"), cmd);
             retval = STATUS_CMD_ERROR;
         } else {
-            retval = send_to_bg(parser, streams, j);
+            retval = send_to_bg(parser, streams, job);
         }
 
         return retval;

--- a/src/builtin_bg.cpp
+++ b/src/builtin_bg.cpp
@@ -52,7 +52,7 @@ int builtin_bg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (optind == argc) {
         // No jobs were specified so use the most recent (i.e., last) job.
         job_t *job = nullptr;
-        for (auto j : jobs()) {
+        for (const auto &j : jobs()) {
             if (j->is_stopped() && j->get_flag(job_flag_t::JOB_CONTROL) && (!j->is_completed())) {
                 job = j.get();
                 break;

--- a/src/builtin_disown.cpp
+++ b/src/builtin_disown.cpp
@@ -65,7 +65,7 @@ int builtin_disown(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         // Foreground jobs can be disowned.
         // Even jobs that aren't under job control can be disowned!
         job_t *job = nullptr;
-        for (auto j : jobs()) {
+        for (const auto &j : jobs()) {
             if (j->is_constructed() && (!j->is_completed())) {
                 job = j.get();
                 break;
@@ -104,7 +104,7 @@ int builtin_disown(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         }
 
         // Disown all target jobs
-        for (auto j : jobs) {
+        for (const auto &j : jobs) {
             retval |= disown_job(cmd, parser, streams, j);
         }
     }

--- a/src/builtin_fg.cpp
+++ b/src/builtin_fg.cpp
@@ -35,8 +35,8 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
     job_t *job = nullptr;
     if (optind == argc) {
-        // Select last constructed job (I.e. first job in the job que) that is possible to put in
-        // the foreground.
+        // Select last constructed job (i.e. first job in the job queue) that can be brought
+        // to the foreground.
 
         for (auto j : jobs()) {
             if (j->is_constructed() && (!j->is_completed()) &&
@@ -51,15 +51,12 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         }
     } else if (optind + 1 < argc) {
         // Specifying more than one job to put to the foreground is a syntax error, we still
-        // try to locate the job argv[1], since we want to know if this is an ambigous job
-        // specification or if this is an malformed job id.
-        int pid;
+        // try to locate the job $argv[1], since we need to determine which error message to
+        // emit (ambigous job specification vs malformed job id).
         bool found_job = false;
-
-        pid = fish_wcstoi(argv[optind]);
-        if (!(errno || pid < 0)) {
-            job = job_t::from_pid(pid);
-            if (job) found_job = true;
+        int pid = fish_wcstoi(argv[optind]);
+        if (errno == 0 && pid > 0) {
+            found_job = (job_t::from_pid(pid) != nullptr);
         }
 
         if (found_job) {
@@ -68,9 +65,8 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
             streams.err.append_format(_(L"%ls: '%ls' is not a job\n"), cmd, argv[optind]);
         }
 
+        job = nullptr;
         builtin_print_error_trailer(parser, streams.err, cmd);
-
-        job = 0;
     } else {
         int pid = abs(fish_wcstoi(argv[optind]));
         if (errno) {
@@ -85,7 +81,7 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 streams.err.append_format(_(L"%ls: Can't put job %d, '%ls' to foreground because "
                                             L"it is not under job control\n"),
                                           cmd, pid, job->command_wcstr());
-                job = 0;
+                job = nullptr;
             }
         }
     }

--- a/src/builtin_fg.cpp
+++ b/src/builtin_fg.cpp
@@ -38,7 +38,7 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         // Select last constructed job (i.e. first job in the job queue) that can be brought
         // to the foreground.
 
-        for (auto j : jobs()) {
+        for (const auto &j : jobs()) {
             if (j->is_constructed() && (!j->is_completed()) &&
                 ((j->is_stopped() || (!j->is_foreground())) &&
                  j->get_flag(job_flag_t::JOB_CONTROL))) {

--- a/src/builtin_jobs.cpp
+++ b/src/builtin_jobs.cpp
@@ -174,11 +174,9 @@ int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
     if (print_last) {
         // Ignore unconstructed jobs, i.e. ourself.
-        job_iterator_t jobs;
-        const job_t *j;
-        while ((j = jobs.next())) {
+        for (auto j : jobs()) {
             if (j->is_constructed() && !j->is_completed()) {
-                builtin_jobs_print(j, mode, !streams.out_is_redirected, streams);
+                builtin_jobs_print(j.get(), mode, !streams.out_is_redirected, streams);
                 return STATUS_CMD_ERROR;
             }
         }
@@ -217,12 +215,10 @@ int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 }
             }
         } else {
-            job_iterator_t jobs;
-            const job_t *j;
-            while ((j = jobs.next())) {
+            for (auto j : jobs()) {
                 // Ignore unconstructed jobs, i.e. ourself.
                 if (j->is_constructed() && !j->is_completed()) {
-                    builtin_jobs_print(j, mode, !found && !streams.out_is_redirected, streams);
+                    builtin_jobs_print(j.get(), mode, !found && !streams.out_is_redirected, streams);
                     found = true;
                 }
             }

--- a/src/builtin_jobs.cpp
+++ b/src/builtin_jobs.cpp
@@ -174,7 +174,7 @@ int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
     if (print_last) {
         // Ignore unconstructed jobs, i.e. ourself.
-        for (auto j : jobs()) {
+        for (const auto &j : jobs()) {
             if (j->is_constructed() && !j->is_completed()) {
                 builtin_jobs_print(j.get(), mode, !streams.out_is_redirected, streams);
                 return STATUS_CMD_ERROR;
@@ -215,7 +215,7 @@ int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 }
             }
         } else {
-            for (auto j : jobs()) {
+            for (const auto &j : jobs()) {
                 // Ignore unconstructed jobs, i.e. ourself.
                 if (j->is_constructed() && !j->is_completed()) {
                     builtin_jobs_print(j.get(), mode, !found && !streams.out_is_redirected, streams);

--- a/src/builtin_wait.cpp
+++ b/src/builtin_wait.cpp
@@ -16,7 +16,7 @@
 /// If a specified process has already finished but the job hasn't, parser_t::job_get_from_pid()
 /// doesn't work properly, so use this function in wait command.
 static job_id_t get_job_id_from_pid(pid_t pid) {
-    for (auto j : jobs()) {
+    for (const auto &j : jobs()) {
         if (j->pgid == pid) {
             return j->job_id;
         }
@@ -31,7 +31,7 @@ static job_id_t get_job_id_from_pid(pid_t pid) {
 }
 
 static bool all_jobs_finished() {
-    for (auto j : jobs()) {
+    for (const auto &j : jobs()) {
         // If any job is not completed, return false.
         // If there are stopped jobs, they are ignored.
         if (j->is_constructed() && !j->is_completed() && !j->is_stopped()) {
@@ -48,7 +48,7 @@ static bool any_jobs_finished(size_t jobs_len) {
     if (jobs_len != jobs().size()) {
         return true;
     }
-    for (auto j : jobs()) {
+    for (const auto &j : jobs()) {
         // If any job is completed, return true.
         if (j->is_constructed() && (j->is_completed() || j->is_stopped())) {
             return true;
@@ -139,7 +139,7 @@ static bool match_pid(const wcstring &cmd, const wchar_t *proc) {
 static bool find_job_by_name(const wchar_t *proc, std::vector<job_id_t> &ids) {
     bool found = false;
 
-    for (const auto j : jobs()) {
+    for (const auto &j : jobs()) {
         if (j->command_is_empty()) continue;
 
         if (match_pid(j->command(), proc)) {

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -785,7 +785,7 @@ parse_execution_result_t parse_execution_context_t::populate_plain_process(
     static uint32_t last_exec_run_counter =  -1;
     if (process_type == process_type_t::exec && shell_is_interactive()) {
         bool have_bg = false;
-        for (const auto bg : jobs()) {
+        for (const auto &bg : jobs()) {
             // The assumption here is that if it is a foreground job,
             // it's related to us.
             // This stops us from asking if we're doing `exec` inside a function.

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -784,10 +784,8 @@ parse_execution_result_t parse_execution_context_t::populate_plain_process(
     // Protect against exec with background processes running
     static uint32_t last_exec_run_counter =  -1;
     if (process_type == process_type_t::exec && shell_is_interactive()) {
-        job_iterator_t jobs;
         bool have_bg = false;
-        const job_t *bg = nullptr;
-        while ((bg = jobs.next())) {
+        for (const auto bg : jobs()) {
             // The assumption here is that if it is a foreground job,
             // it's related to us.
             // This stops us from asking if we're doing `exec` inside a function.
@@ -1130,6 +1128,16 @@ parse_execution_result_t parse_execution_context_t::populate_job_from_job_node(
     return result;
 }
 
+static bool remove_job(job_t *job) {
+    for (auto j = jobs().begin(); j != jobs().end(); ++j) {
+        if (j->get() == job) {
+            jobs().erase(j);
+            return true;
+        }
+    }
+    return false;
+}
+
 parse_execution_result_t parse_execution_context_t::run_1_job(tnode_t<g::job> job_node,
                                                               const block_t *associated_block) {
     if (should_cancel_execution(associated_block)) {
@@ -1253,7 +1261,7 @@ parse_execution_result_t parse_execution_context_t::run_1_job(tnode_t<g::job> jo
 
         // Actually execute the job.
         if (!exec_job(*this->parser, job)) {
-            parser->job_remove(job.get());
+            remove_job(job.get());
         }
 
         // Only external commands require a new fishd barrier.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -570,19 +570,6 @@ void parser_t::job_add(shared_ptr<job_t> job) {
     this->my_job_list.push_front(std::move(job));
 }
 
-bool parser_t::job_remove(job_t *job) {
-    for (auto iter = my_job_list.begin(); iter != my_job_list.end(); ++iter) {
-        if (iter->get() == job) {
-            my_job_list.erase(iter);
-            return true;
-        }
-    }
-
-    debug(1, _(L"Job inconsistency"));
-    sanity_lose();
-    return false;
-}
-
 void parser_t::job_promote(job_t *job) {
     job_list_t::iterator loc;
     for (loc = my_job_list.begin(); loc != my_job_list.end(); ++loc) {
@@ -604,20 +591,17 @@ job_t *parser_t::job_get(job_id_t id) {
 }
 
 job_t *parser_t::job_get_from_pid(pid_t pid) const {
-    job_iterator_t jobs;
-    job_t *job;
-
     pid_t pgid = getpgid(pid);
 
     if (pgid == -1) {
         return 0;
     }
 
-    while ((job = jobs.next())) {
+    for (auto job : jobs()) {
         if (job->pgid == pgid) {
             for (const process_ptr_t &p : job->processes) {
                 if (p->pid == pid) {
-                    return job;
+                    return job.get();
                 }
             }
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -580,7 +580,7 @@ void parser_t::job_promote(job_t *job) {
     assert(loc != my_job_list.end());
 
     // Move the job to the beginning.
-    my_job_list.splice(my_job_list.begin(), my_job_list, loc);
+    std::rotate(my_job_list.begin(), loc, my_job_list.end());
 }
 
 job_t *parser_t::job_get(job_id_t id) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -597,7 +597,7 @@ job_t *parser_t::job_get_from_pid(pid_t pid) const {
         return 0;
     }
 
-    for (auto job : jobs()) {
+    for (const auto &job : jobs()) {
         if (job->pgid == pgid) {
             for (const process_ptr_t &p : job->processes) {
                 if (p->pid == pid) {

--- a/src/parser.h
+++ b/src/parser.h
@@ -288,9 +288,6 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     /// Return the function name for the specified stack frame. Default is one (current frame).
     const wchar_t *get_function_name(int level = 1);
 
-    /// Removes a job.
-    bool job_remove(job_t *job);
-
     /// Promotes a job to the front of the list.
     void job_promote(job_t *job);
 

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -475,7 +475,7 @@ static bool process_clean_after_marking(bool allow_interactive) {
 
     bool erased = false;
     const bool only_one_job = jobs().size() == 1;
-    for (auto itr = jobs().begin(); itr != jobs().end(); itr = (erased ? itr : (std::advance(itr, 1), itr)), erased = false) {
+    for (auto itr = jobs().begin(); itr != jobs().end(); itr = erased ? itr : itr + 1, erased = false) {
         job_t *j = itr->get();
         // If we are reaping only jobs who do not need status messages sent to the console, do not
         // consider reaping jobs that need status messages.

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -473,10 +473,9 @@ static bool process_clean_after_marking(bool allow_interactive) {
     // don't try to print in that case (#3222)
     const bool interactive = allow_interactive && cur_term != NULL;
 
-    bool erased = false;
+    static std::vector<job_t *> erase_list;
     const bool only_one_job = jobs().size() == 1;
-    for (auto itr = jobs().begin(); itr != jobs().end(); itr = erased ? itr : itr + 1, erased = false) {
-        job_t *j = itr->get();
+    for (const auto &j : jobs()) {
         // If we are reaping only jobs who do not need status messages sent to the console, do not
         // consider reaping jobs that need status messages.
         if ((!j->get_flag(job_flag_t::SKIP_NOTIFICATION)) && (!interactive) &&
@@ -554,7 +553,7 @@ static bool process_clean_after_marking(bool allow_interactive) {
         if (j->is_completed()) {
             if (!j->is_foreground() && !j->get_flag(job_flag_t::NOTIFIED) &&
                 !j->get_flag(job_flag_t::SKIP_NOTIFICATION)) {
-                print_job_status(j, JOB_ENDED);
+                print_job_status(j.get(), JOB_ENDED);
                 found = true;
             }
             // TODO: The generic process-exit event is useless and unused.
@@ -568,22 +567,52 @@ static bool process_clean_after_marking(bool allow_interactive) {
             }
             proc_fire_event(L"JOB_EXIT", event_type_t::job_exit, j->job_id, 0);
 
-            itr = jobs().erase(itr);
-            erased = true;
+            erase_list.push_back(j.get());
         } else if (j->is_stopped() && !j->get_flag(job_flag_t::NOTIFIED)) {
             // Notify the user about newly stopped jobs.
             if (!j->get_flag(job_flag_t::SKIP_NOTIFICATION)) {
-                print_job_status(j, JOB_STOPPED);
+                print_job_status(j.get(), JOB_STOPPED);
                 found = true;
             }
             j->set_flag(job_flag_t::NOTIFIED, true);
         }
     }
 
-    if (found) fflush(stdout);
+    if (!erase_list.empty()) {
+        // The intersection of the two lists is typically O(m*n), but we know the order
+        // of the entries in erase_list is the same as their matches in jobs(), so we can
+        // use that to our advantage.
+        auto to_erase = erase_list.begin();
+        jobs().erase(std::remove_if(jobs().begin(), jobs().end(),
+                    [&to_erase](const shared_ptr<job_t> &j) {
+            if (to_erase == erase_list.end()) {
+                return false;
+            }
+            if (*to_erase == j.get()) {
+                ++to_erase;
+                return true;
+            }
+            return false;
+        }), jobs().end());
+
+        if (should_debug(2)) {
+            // Assertions prevent the application from continuing in case of invalid state. If we
+            // did not remove all objects from the list, it's not bad enough to abort and die, but
+            // leave this check here so that we can be alerted to the situtaion if running at a
+            // higher debug level. Or just remove it. But I wouldn't want to be the person that has
+            // to debug this without even this soft assertion in place when some C++ standard
+            // library decides to make std::remove_if iterate backwards or in random order!
+            assert(to_erase == erase_list.end()
+                && "Not all jobs slated for erasure have been erased!");
+        }
+    }
+    erase_list.clear();
+
+    if (found) {
+        fflush(stdout);
+    }
 
     locked = false;
-
     return found;
 }
 

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -107,10 +107,10 @@ void job_t::promote() {
 }
 
 void proc_destroy() {
-    for (auto job = jobs().begin(); job != jobs().end(); ++job) {
-        debug(2, L"freeing leaked job %ls", (*job)->command_wcstr());
-        job = jobs().erase(job);
+    for (const auto job : jobs()) {
+        debug(2, L"freeing leaked job %ls", job->command_wcstr());
     }
+    jobs().clear();
 }
 
 void proc_set_last_statuses(statuses_t s) {
@@ -485,12 +485,11 @@ static bool process_clean_after_marking(bool allow_interactive) {
         }
 
         for (const process_ptr_t &p : j->processes) {
-            if (!p->completed) continue;
-
-            if (!p->pid) continue;
+            if (!p->completed || !p->pid) {
+                continue;
+            }
 
             auto s = p->status;
-
             // TODO: The generic process-exit event is useless and unused.
             // Remove this in future.
             // Update: This event is used for cleaning up the psub temporary files and folders.

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -491,13 +491,6 @@ static bool process_clean_after_marking(bool allow_interactive) {
             }
 
             auto s = p->status;
-            // TODO: The generic process-exit event is useless and unused.
-            // Remove this in future.
-            // Update: This event is used for cleaning up the psub temporary files and folders.
-            // Removing it breaks the psub tests as a result.
-            proc_fire_event(L"PROCESS_EXIT", event_type_t::exit, p->pid,
-                            (s.signal_exited() ? -1 : s.exit_code()));
-
             // Ignore signal SIGPIPE.We issue it ourselves to the pipe writer when the pipe reader
             // dies.
             if (!s.signal_exited() || s.signal_code() == SIGPIPE) {
@@ -557,15 +550,6 @@ static bool process_clean_after_marking(bool allow_interactive) {
                 !j->get_flag(job_flag_t::SKIP_NOTIFICATION)) {
                 print_job_status(j.get(), JOB_ENDED);
                 found = true;
-            }
-            // TODO: The generic process-exit event is useless and unused.
-            // Remove this in future.
-            // Don't fire the exit-event for jobs with pgid INVALID_PID.
-            // That's our "sentinel" pgid, for jobs that don't (yet) have a pgid,
-            // or jobs that consist entirely of builtins (and hence don't have a process).
-            // This causes issues if fish is PID 2, which is quite common on WSL. See #4582.
-            if (j->pgid != INVALID_PID) {
-                proc_fire_event(L"JOB_EXIT", event_type_t::exit, -j->pgid, 0);
             }
 
             erase_list.push_back(j);

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -107,7 +107,7 @@ void job_t::promote() {
 }
 
 void proc_destroy() {
-    for (const auto job : jobs()) {
+    for (const auto &job : jobs()) {
         debug(2, L"freeing leaked job %ls", job->command_wcstr());
     }
     jobs().clear();
@@ -372,7 +372,7 @@ static void process_mark_finished_children(bool block_ok) {
 
     // We got some changes. Since we last checked we received SIGCHLD, and or HUP/INT.
     // Update the hup/int generations and reap any reapable processes.
-    for (const auto j : jobs()) {
+    for (const auto &j : jobs()) {
         for (const auto &proc : j->processes) {
             if (auto mtopic = j->reap_topic_for_process(proc.get())) {
                 // Update the signal hup/int gen.
@@ -645,7 +645,7 @@ unsigned long proc_get_jiffies(process_t *p) {
 
 /// Update the CPU time for all jobs.
 void proc_update_jiffies() {
-    for (auto job : jobs()) {
+    for (const auto &job : jobs()) {
         for (process_ptr_t &p : job->processes) {
             gettimeofday(&p->last_time, 0);
             p->last_jiffies = proc_get_jiffies(p.get());
@@ -880,7 +880,7 @@ void job_t::continue_job(bool send_sigcont) {
 void proc_sanity_check() {
     const job_t *fg_job = NULL;
 
-    for (const auto j : jobs()) {
+    for (const auto &j : jobs()) {
         if (!j->is_constructed()) continue;
 
         // More than one foreground job?
@@ -937,7 +937,7 @@ void proc_wait_any() {
 }
 
 void hup_background_jobs() {
-    for (auto j : jobs()) {
+    for (const auto &j : jobs()) {
         // Make sure we don't try to SIGHUP the calling builtin
         if (j->pgid == INVALID_PID || !j->get_flag(job_flag_t::JOB_CONTROL)) {
             continue;

--- a/src/proc.h
+++ b/src/proc.h
@@ -12,7 +12,7 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <list>
+#include <deque>
 #include <memory>
 #include <vector>
 
@@ -451,8 +451,8 @@ extern bool is_login;
 /// nesting level.
 extern int is_event;
 
-// List of jobs. We sometimes mutate this while iterating - hence it must be a list, not a vector
-typedef std::list<shared_ptr<job_t>> job_list_t;
+// List of jobs.
+typedef std::deque<shared_ptr<job_t>> job_list_t;
 
 bool job_list_is_empty(void);
 

--- a/src/proc.h
+++ b/src/proc.h
@@ -456,27 +456,8 @@ typedef std::list<shared_ptr<job_t>> job_list_t;
 
 bool job_list_is_empty(void);
 
-/// A class to aid iteration over jobs list
-class job_iterator_t {
-    job_list_t *const job_list;
-    job_list_t::iterator current, end;
-
-   public:
-    void reset(void);
-
-    job_t *next() {
-        job_t *job = NULL;
-        if (current != end) {
-            job = current->get();
-            ++current;
-        }
-        return job;
-    }
-
-    explicit job_iterator_t(job_list_t &jobs);
-    job_iterator_t();
-    size_t count() const;
-};
+/// A helper function to more easily access the job list
+job_list_t &jobs();
 
 /// Whether a universal variable barrier roundtrip has already been made for the currently executing
 /// command. Such a roundtrip only needs to be done once on a given command, unless a universal

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2229,8 +2229,7 @@ void reader_bg_job_warning() {
     std::fputws(_(L"There are still jobs active:\n"), stdout);
     std::fputws(_(L"\n   PID  Command\n"), stdout);
 
-    job_iterator_t jobs;
-    while (job_t *j = jobs.next()) {
+    for (auto j : jobs()) {
         if (!j->is_completed()) {
             std::fwprintf(stdout, L"%6d  %ls\n", j->processes[0]->pid, j->command_wcstr());
         }
@@ -2254,8 +2253,7 @@ static void handle_end_loop() {
         }
 
         bool bg_jobs = false;
-        job_iterator_t jobs;
-        while (const job_t *j = jobs.next()) {
+        for (const auto j : jobs()) {
             if (!j->is_completed()) {
                 bg_jobs = true;
                 break;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2229,7 +2229,7 @@ void reader_bg_job_warning() {
     std::fputws(_(L"There are still jobs active:\n"), stdout);
     std::fputws(_(L"\n   PID  Command\n"), stdout);
 
-    for (auto j : jobs()) {
+    for (const auto &j : jobs()) {
         if (!j->is_completed()) {
             std::fwprintf(stdout, L"%6d  %ls\n", j->processes[0]->pid, j->command_wcstr());
         }
@@ -2253,7 +2253,7 @@ static void handle_end_loop() {
         }
 
         bool bg_jobs = false;
-        for (const auto j : jobs()) {
+        for (const auto &j : jobs()) {
             if (!j->is_completed()) {
                 bg_jobs = true;
                 break;

--- a/tests/signal.out
+++ b/tests/signal.out
@@ -1,17 +1,8 @@
 ALRM received
 command false:
-PROCESS_EXIT 1
-JOB_EXIT 0
 command true:
-PROCESS_EXIT 0
-JOB_EXIT 0
 command false | true:
-PROCESS_EXIT 1
-PROCESS_EXIT 0
-JOB_EXIT 0
 This is the process whose exit event shuld be blocked
 This should come before the event handler
-PROCESS_EXIT 0
-JOB_EXIT 0
 Now event handler should have run
 PROCESS_EXIT 0


### PR DESCRIPTION
Picking up where #5452 left off (you can't reopen a pull request if there have been force pushes :/)

I integrated the suggestions from @ridiculousfish and did the extremely tedious work on updating the fork to rebase with the recent changes to `proc.cpp`.

@ridiculousfish: 624787a4b11fa023802ae78fdac3fe840b740728 separated the jobs to be erased to their own list, but I really don't like it. It's a wholly needless repeat enumeration of the job list that is run extremely often (just add a `debug(1, ...` in there to see) but doesn't actually introduce any real safety benefits.