### PR TITLE
Keep the order for $PATH and $MANPATH when reading /etc/paths

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -173,7 +173,8 @@ if status --is-login
         # executable for fish; see
         # https://opensource.apple.com/source/shell_cmds/shell_cmds-203/path_helper/path_helper.c.auto.html .
         function __fish_macos_set_env -d "set an environment variable like path_helper does (macOS only)"
-            set -l result
+            # Keep the components already there so we don't change the order
+            set -l result $$argv
 
             for path_file in $argv[2] $argv[3]/*
                 if [ -f $path_file ]
@@ -182,12 +183,6 @@ if status --is-login
                             set -a result $entry
                         end
                     end <$path_file
-                end
-            end
-
-            for entry in $$argv[1]
-                if not contains -- $entry $result
-                    set result $result $entry
                 end
             end
 

--- a/share/config.fish
+++ b/share/config.fish
@@ -173,8 +173,9 @@ if status --is-login
         # executable for fish; see
         # https://opensource.apple.com/source/shell_cmds/shell_cmds-203/path_helper/path_helper.c.auto.html .
         function __fish_macos_set_env -d "set an environment variable like path_helper does (macOS only)"
+            # The first argument is the variable name, the others are the files.
             # Keep the components already there so we don't change the order
-            set -l result $$argv
+            set -l result $$argv[1]
 
             for path_file in $argv[2] $argv[3]/*
                 if [ -f $path_file ]


### PR DESCRIPTION
Should fix #5456.

This PR is so that someone on macOS can actually confirm that this works since I can't test it. I could create an /etc/paths, but I don't have path_helper and so I can't compare how it should work.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
- [ ] Have someone on macOS test this