### PR TITLE
Add backtraces to test errors

### DIFF
--- a/src/builtin_test.cpp
+++ b/src/builtin_test.cpp
@@ -864,7 +864,7 @@ int builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (!eval_errors.empty()) {
         if (!should_suppress_stderr_for_tests()) {
             for (size_t i = 0; i < eval_errors.size(); i++) {
-                streams.err.append_format(L"\t%ls\n", eval_errors.at(i).c_str());
+                streams.err.append_format(L"%ls\n", eval_errors.at(i).c_str());
             }
         }
         return STATUS_INVALID_ARGS;


### PR DESCRIPTION
## Description

As you know, `test` has some sharp edges.

And worst of all, whenever you have hit one of them in a large script, it's hard to find because it'll only tell you "Missing argument at index 2" or "\tThe argument is invalid: 'w'".

This adds a backtrace to that, like our other builtins, so you can find the darn bugger.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
