### PR TITLE
Remove option to use system wcwidth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,13 +127,6 @@ SET_SOURCE_FILES_PROPERTIES(src/fish_version.cpp
                             PROPERTIES OBJECT_DEPENDS
                             ${CMAKE_CURRENT_BINARY_DIR}/${FBVF})
 
-OPTION(INTERNAL_WCWIDTH "use fallback wcwidth" ON)
-IF(INTERNAL_WCWIDTH)
-    ADD_DEFINITIONS(-DHAVE_BROKEN_WCWIDTH=1)
-ELSE()
-    ADD_DEFINITIONS(-DHAVE_BROKEN_WCWIDTH=0)
-ENDIF()
-
 # Enable thread-safe errno on Solaris (#5611)
 ADD_DEFINITIONS(-D_REENTRANT)
 

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -267,15 +267,6 @@ int fish_get_emoji_width(wchar_t c) {
 
 // Big hack to use our versions of wcswidth where we know them to be broken, which is
 // EVERYWHERE (https://github.com/fish-shell/fish-shell/issues/2199)
-#ifndef HAVE_BROKEN_WCWIDTH
-#define HAVE_BROKEN_WCWIDTH 1
-#endif
-
-#if !HAVE_BROKEN_WCWIDTH
-int fish_wcwidth(wchar_t wc) { return wcwidth(wc); }
-int fish_wcswidth(const wchar_t *str, size_t n) { return wcswidth(str, n); }
-#else
-
 #include "widecharwidth/widechar_width.h"
 
 int fish_wcwidth(wchar_t wc) {
@@ -331,8 +322,6 @@ int fish_wcswidth(const wchar_t *str, size_t n) {
     }
     return result;
 }
-
-#endif  // HAVE_BROKEN_WCWIDTH
 
 #ifndef HAVE_FLOCK
 /*	$NetBSD: flock.c,v 1.6 2008/04/28 20:24:12 martin Exp $	*/


### PR DESCRIPTION
As it turns out it didn't work much better, and it fell behind in
support when it comes to things that wcwidth traditionally can't
express like variation selectors and hangul combining characters, but
also simply $fish_*_width.

I've had to tell a few people now to rebuild with widecharwidth after
sending them on a fool's errand to set X variable.

So keeping this option is doing our users a disservice.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
