### PR TITLE
Replace Doxygen reference in README with Sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Compiling fish requires:
 * PCRE2 (headers and libraries) - a copy is included with fish
 * gettext (headers and libraries) - optional, for translation support
 
-Doxygen (1.8.7 or later) is also optionally required to build the documentation from a cloned git repository.
+Sphinx is also optionally required to build the documentation from a cloned git repository.
 
 ### Building from source (all platforms) - Makefile generator
 

--- a/build_tools/make_tarball.sh
+++ b/build_tools/make_tarball.sh
@@ -2,7 +2,7 @@
 
 # Script to generate a tarball
 # We use git to output a tree. But we also want to build the user documentation
-# and put that in the tarball, so that nobody needs to have doxygen installed
+# and put that in the tarball, so that nobody needs to have sphinx installed
 # to build it.
 # Outputs to $FISH_ARTEFACT_PATH or ~/fish_built by default
 


### PR DESCRIPTION
## Description

I was really confused when I didn't get documentation after running `cmake` because the README was still giving bad instructions.

I'm not sure if there's any minimum Sphinx version needed that we should list.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.md
