### PR TITLE
Honor dirprev scope

### DIFF
--- a/share/functions/cd.fish
+++ b/share/functions/cd.fish
@@ -42,14 +42,20 @@ function cd --description "Change directory"
         set -q dirprev[$MAX_DIR_HIST]
         and set -e dirprev[1]
 
-        # If dirprev is set as a universal variable, honour its scope.
-        # Otherwise, set it as a global variable.
+        # If dirprev, dirnext, __fish_cd_direction
+        # are set as universal variables, honour their scope.
+
         set -U -q dirprev
         and set -U -a dirprev $previous
         or set -g -a dirprev $previous
 
-        set -e dirnext
-        set -g __fish_cd_direction prev
+        set -U -q dirnext
+        and set -U -e dirnext
+        or set -e dirnext
+
+        set -U -q __fish_cd_direction
+        and set -U __fish_cd_direction prev
+        or set -g __fish_cd_direction prev
     end
 
     return $cd_status

--- a/share/functions/cd.fish
+++ b/share/functions/cd.fish
@@ -41,7 +41,13 @@ function cd --description "Change directory"
         or set -l dirprev
         set -q dirprev[$MAX_DIR_HIST]
         and set -e dirprev[1]
-        set -g -a dirprev $previous
+
+        # If dirprev is set as a universal variable, honour its scope.
+        # Otherwise, set it as a global variable.
+        set -U -q dirprev
+        and set -U -a dirprev $previous
+        or set -g -a dirprev $previous
+
         set -e dirnext
         set -g __fish_cd_direction prev
     end


### PR DESCRIPTION
Honor the scope of the `dirprev` variable if it is universal
and avoid to shadow it with a global. This enables to share
the `cd` history between sessions.