### PR TITLE
fish_git_prompt: Add branch prefix and suffix

### DIFF
--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -661,7 +661,7 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
                     set branch unknown
                 end
             end
-            set branch "($branch)"
+            set branch "$__fish_git_prompt_char_branch_prefix$branch$__fish_git_prompt_char_branch_suffix"
         end
     end
 
@@ -703,6 +703,8 @@ end
 
 function __fish_git_prompt_validate_chars --description "fish_git_prompt helper, checks char variables"
 
+    __fish_git_prompt_set_char __fish_git_prompt_char_branch_prefix '('
+    __fish_git_prompt_set_char __fish_git_prompt_char_branch_suffix ')'
     __fish_git_prompt_set_char __fish_git_prompt_char_cleanstate '✔'
     __fish_git_prompt_set_char __fish_git_prompt_char_dirtystate '*' '✚'
     __fish_git_prompt_set_char __fish_git_prompt_char_invalidstate '#' '✖'

--- a/sphinx_doc_src/cmds/fish_git_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_git_prompt.rst
@@ -88,6 +88,11 @@ Colors used with showcolorhints:
 - ``$__fish_git_prompt_color_branch_detached`` (red)
 - ``$__fish_git_prompt_color_flags`` (--bold blue)
 
+Variables used to surround the prompt, defaults to brackets `(master|✔)`:
+
+- ``$__fish_git_prompt_char_branch_prefix`` ('', `(`)
+- ``$__fish_git_prompt_char_branch_suffix`` ('', `)`)
+
 Note that all colors can also have a corresponding "_done" color. E.g. ``$__fish_git_prompt_color_upstream_done``, used right _after_ the upstream.
 
 See also fish_vcs_prompt, which will call all supported vcs-prompt functions, including git, hg and svn.


### PR DESCRIPTION
## Description

By default, the branch is being parsed as `(master|v)`. This may not be
preferred behaviour for some people.

Adding two variables which will have a character/string prefixing and
suffixing the branch name could come in handy, if one wishes remove
these or change the character.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] ~Tests have been added for regressions fixed~
- [ ] ~User-visible changes noted in CHANGELOG.md~
