### PR TITLE
string-replace-fewer-backslashes -> regex-slashless

### DIFF
--- a/share/functions/fish_clipboard_paste.fish
+++ b/share/functions/fish_clipboard_paste.fish
@@ -26,7 +26,7 @@ function fish_clipboard_paste
     #
     # This eases pasting non-code (e.g. markdown or git commitishes).
     if __fish_commandline_is_singlequoted
-        if status test-feature string-replace-fewer-backslashes
+        if status test-feature regex-slashless
             set data (string replace -ra "(['\\\])" '\\\\$1' -- $data)
         else
             set data (string replace -ra "(['\\\])" '\\\\\\\$1' -- $data)

--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -1668,9 +1668,9 @@ Feature flags are how fish stages changes that might break scripts. Breaking cha
 You can see the current list of features via ``status features``::
 
     > status features
-    stderr-nocaret  on     3.0      ^ no longer redirects stderr
-    qmark-noglob    off    3.0      ? no longer globs
-    string-replace-fewer-backslashes        off     3.1     string replace -r needs fewer backslashes in the replacement
+    stderr-nocaret  on     3.0    ^ no longer redirects stderr
+    qmark-noglob    off    3.0    ? no longer globs
+    regex-slashless off    3.1    fewer \'s in string replace -r replacement
 
 There are two breaking changes in fish 3.0: caret ``^`` no longer redirects stderr, and question mark ``?`` is no longer a glob.
 

--- a/src/future_feature_flags.cpp
+++ b/src/future_feature_flags.cpp
@@ -13,7 +13,7 @@ features_t &mutable_fish_features() { return global_features; }
 const features_t::metadata_t features_t::metadata[features_t::flag_count] = {
     {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr"},
     {qmark_noglob, L"qmark-noglob", L"3.0", L"? no longer globs"},
-    {string_replace_backslash, L"string-replace-fewer-backslashes", L"3.1", L"string replace -r needs fewer backslashes in the replacement"},
+    {string_replace_backslash, L"regex-slashless", L"3.1", L"fewer \\'s in string replace -r"},
 };
 
 const struct features_t::metadata_t *features_t::metadata_for(const wchar_t *name) {

--- a/tests/invocation/features-string-backslashes-off.invoke
+++ b/tests/invocation/features-string-backslashes-off.invoke
@@ -1,1 +1,1 @@
---features 'no-string-replace-fewer-backslashes' -C 'string replace -ra "\\\\" "\\\\\\\\" -- "a\b\c"'
+--features 'no-regex-slashless' -C 'string replace -ra "\\\\" "\\\\\\\\" -- "a\b\c"'

--- a/tests/invocation/features-string-backslashes.invoke
+++ b/tests/invocation/features-string-backslashes.invoke
@@ -1,1 +1,1 @@
---features 'string-replace-fewer-backslashes' -C 'string replace -ra "\\\\" "\\\\\\\\" -- "a\b\c"'
+--features 'regex-slashless' -C 'string replace -ra "\\\\" "\\\\\\\\" -- "a\b\c"'

--- a/tests/status.out
+++ b/tests/status.out
@@ -6,6 +6,6 @@ test_function
 # Future Feature Flags
 stderr-nocaret	off	3.0	^ no longer redirects stderr
 qmark-noglob	off	3.0	? no longer globs
-string-replace-fewer-backslashes	off	3.1	string replace -r needs fewer backslashes in the replacement
+regex-slashless	off	3.1	fewer \'s in string replace -r
 1
 2


### PR DESCRIPTION
This renames the 'string-replace-fewer-backslashes' feature flag to 'regex-slashless', making it now about as long as the other feature flags' labels.

It was just too damn long. The `status features` table is not easy to read and it's a hardship to use in scripts. The flag names don't need to be entirely self-documenting, we also have a description field.

```text
stderr-nocaret	off	3.0	^ no longer redirects stderr
qmark-noglob	on	3.0	? no longer globs
string-replace-fewer-backslashes        off     3.1     string replace -r needs fewer backslash
es in the replacement
```
to
```text
stderr-nocaret	off	3.0	^ no longer redirects stderr
qmark-noglob	on	3.0	? no longer globs
regex-slashless	off	3.1	fewer \'s in string replace -r
```

The idea here was following the first two feature names which had the form of `word-wordword`.