### PR TITLE
Variables as commands are in fact supported, eval docs should not state otherwise

### DIFF
--- a/sphinx_doc_src/cmds/eval.rst
+++ b/sphinx_doc_src/cmds/eval.rst
@@ -15,16 +15,17 @@ Description
 
 If your command does not need access to stdin, consider using ``source`` instead.
 
+If no piping or other compound shell constructs are required, variable-expansion-as-command, as in  ``set cmd ls; $cmd``, is also an option.
+
+
 Example
 -------
 
-The following code will call the ls command. Note that ``fish`` does not support the use of shell variables as direct commands; ``eval`` can be used to work around this.
-
-
+The following code will call the ls command and truncate each filename to the first 12 characters.
 
 ::
 
-    set cmd ls
+    set cmd ls \| cut -c 1-12
     eval $cmd
 
 

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -1370,9 +1370,7 @@ void completer_t::perform() {
 
     // If we are completing a variable name or a tilde expansion user name, we do that and return.
     // No need for any other completions.
-    // Unconditionally complete variables and processes. This is a little weird since we will
-    // happily complete variables even in e.g. command position, despite the fact that they are
-    // invalid there. */
+    // Unconditionally complete variables and processes.
     const wcstring current_token = tok_begin;
     if (try_complete_variable(current_token) || try_complete_user(current_token)) {
         return;


### PR DESCRIPTION
Provide an example that somewhat justifies eval's existence in light of this change.

Also correct similar misinformation found in a comment.

## Description

As msuqdi suggested in issue #5816 (which this fixes)

We also have some "variables may not be commands" messages lying around in .po files (pl, zh_CN,de,fr,nb,pt_BR,sv,en,and nn). I haven't included these as I was unsure, but am happy to revise the pull request to do so.
