### PR TITLE
Clear ONLCR to/and optimize general x movement

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -53,6 +53,8 @@ bool curses_initialized = false;
 
 /// Does the terminal have the "eat_newline_glitch".
 bool term_has_xn = false;
+/// Does the terminal have the "eat_newline_glitch".
+bool term_has_am = false;
 
 /// Universal variables global instance. Initialized in env_init.
 static env_universal_t *s_universal_variables = NULL;

--- a/src/env.h
+++ b/src/env.h
@@ -299,7 +299,8 @@ class env_stack_t final : public env_scoped_t {
 extern int g_fork_count;
 extern bool g_use_posix_spawn;
 
-extern bool term_has_xn;  // does the terminal have the "eat_newline_glitch"
+extern bool term_has_am;  // does the terminal have the "eat_newline_glitch" part 1
+extern bool term_has_xn;  // does the terminal have the "eat_newline_glitch" part 2
 
 /// Synchronizes all universal variable changes: writes everything out, reads stuff in.
 void env_universal_barrier();

--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -481,6 +481,7 @@ static void init_curses(const environment_t &vars) {
 
     can_set_term_title = does_term_support_setting_title(vars);
     term_has_xn = tigetflag((char *)"xenl") == 1;  // does terminal have the eat_newline_glitch
+    term_has_am = tigetflag((char *)"am") == 1;  // does terminal have the eat_newline_glitch
     update_fish_color_support(vars);
     // Invalidate the cached escape sequences since they may no longer be valid.
     cached_layouts.clear();

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -994,6 +994,8 @@ void reader_init() {
     shell_modes.c_iflag &= ~IXON;   // disable flow control
     shell_modes.c_iflag &= ~IXOFF;  // disable flow control
 
+    shell_modes.c_iflag &= ~ONLCR;  // disable return to x0 on \n
+
     shell_modes.c_lflag &= ~ICANON;  // turn off canonical mode
     shell_modes.c_lflag &= ~ECHO;    // turn off echo mode
     shell_modes.c_lflag &= ~IEXTEN;  // turn off handling of discard and lnext characters

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -994,7 +994,7 @@ void reader_init() {
     shell_modes.c_iflag &= ~IXON;   // disable flow control
     shell_modes.c_iflag &= ~IXOFF;  // disable flow control
 
-    shell_modes.c_iflag &= ~ONLCR;  // disable return to x0 on \n
+    shell_modes.c_oflag &= ~ONLCR;  // disable return to x0 on \n
 
     shell_modes.c_lflag &= ~ICANON;  // turn off canonical mode
     shell_modes.c_lflag &= ~ECHO;    // turn off echo mode

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -453,33 +453,23 @@ static void s_move(screen_t *s, int new_x, int new_y) {
         s->actual.cursor.x = 0;
     }
 
-    int i;
-    int x_steps, y_steps;
-
-    const char *str;
     auto &outp = s->outp();
 
-    y_steps = new_y - s->actual.cursor.y;
+    int x_steps = new_x - s->actual.cursor.x;
+    int y_steps = new_y - s->actual.cursor.y;
 
-    if (y_steps > 0 && (std::strcmp(cursor_down, "\n") == 0)) {
-        // This is very strange - it seems some (all?) consoles use a simple newline as the cursor
-        // down escape. This will of course move the cursor to the beginning of the line as well as
-        // moving it down one step. The cursor_up does not have this behavior...
-        s->actual.cursor.x = 0;
-    }
-
+    const char *str = "";
     if (y_steps < 0) {
         str = cursor_up;
-    } else {
+    } else if (y_steps > 0) {
         str = cursor_down;
     }
 
-    for (i = 0; i < abs(y_steps); i++) {
+    for (int i = 0; i < abs(y_steps); i++) {
         writembs(outp, str);
     }
 
-    x_steps = new_x - s->actual.cursor.x;
-
+    // If we're moving to the x-zero, we can skip individual x-steps by simply issuing CR
     if (x_steps && new_x == 0) {
         outp.push_back('\r');
         x_steps = 0;
@@ -489,7 +479,7 @@ static void s_move(screen_t *s, int new_x, int new_y) {
     if (x_steps < 0) {
         str = cursor_left;
         multi_str = parm_left_cursor;
-    } else {
+    } else if (x_steps > 0) {
         str = cursor_right;
         multi_str = parm_right_cursor;
     }
@@ -502,7 +492,7 @@ static void s_move(screen_t *s, int new_x, int new_y) {
         char *multi_param = tparm((char *)multi_str, abs(x_steps));
         writembs(outp, multi_param);
     } else {
-        for (i = 0; i < abs(x_steps); i++) {
+        for (int i = 0; i < abs(x_steps); i++) {
             writembs(outp, str);
         }
     }


### PR DESCRIPTION
This isn't as much a performance improvement as a code cleanup issue, as
one could argue whether we move to zero more often than not after a
newline in interactive mode.

Thanks to @PerBothner for figuring out why ~ONLCR didn't work last time
around (3f820f0) to work around the issue pointed out by @nbuwe in
#4505.