### PR TITLE
Preliminary implementation of fish_continuation_prompt hook.

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1226,3 +1226,15 @@ int exec_subshell(const wcstring &cmd, parser_t &parser, bool apply_exit_status,
     ASSERT_IS_MAIN_THREAD();
     return exec_subshell_internal(cmd, parser, NULL, apply_exit_status, is_subcmd);
 }
+
+wcstring exec_command_string(const wcstring &cmd, parser_t &parser,
+    bool add_newlines) {
+    wcstring_list_t output_list;
+    wcstring output;
+    exec_subshell(cmd, parser,output_list, false);
+    for (size_t i = 0; i < output_list .size(); i++) {
+        if (add_newlines && i > 0) output += L'\n';
+        output += output_list.at(i);
+    }
+    return output;
+}

--- a/src/exec.h
+++ b/src/exec.h
@@ -28,6 +28,8 @@ int exec_subshell(const wcstring &cmd, parser_t &parser, wcstring_list_t &output
 int exec_subshell(const wcstring &cmd, parser_t &parser, bool preserve_exit_status,
                   bool is_subcmd = false);
 
+wcstring exec_command_string(const wcstring &cmd, parser_t &parser, bool add_newlines = false);
+
 /// Loops over close until the syscall was run without being interrupted.
 void exec_close(int fd);
 

--- a/src/reader.h
+++ b/src/reader.h
@@ -182,6 +182,9 @@ void reader_set_test_function(test_function_t func);
 /// Specify string of shell commands to be run in order to generate the prompt.
 void reader_set_left_prompt(const wcstring &prompt);
 
+/// Specify string of shell commands to be run in order to generate the continuation prompt.
+void reader_set_continuation_prompt(const wcstring &prompt);
+
 /// Specify string of shell commands to be run in order to generate the right prompt.
 void reader_set_right_prompt(const wcstring &prompt);
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -27,6 +27,9 @@
 
 class page_rendering_t;
 
+// LEFT_PROMPT_IN_ARRAY==1 might be cleaner but needs work
+#define LEFT_PROMPT_IN_ARRAY 0
+
 /// A class representing a single line of a screen.
 struct line_t {
     std::vector<wchar_t> text;
@@ -124,8 +127,12 @@ class screen_t {
     screen_data_t desired;
     /// The internal representation of the actual screen contents.
     screen_data_t actual;
+#if ! LEFT_PROMPT_IN_ARRAY
     /// A string containing the prompt which was last printed to the screen.
-    wcstring actual_left_prompt;
+    wcstring actual_left_prompt; // FIXME maybe replace with left_prompts[0]
+#endif
+    std::vector<wcstring> left_prompts;
+    std::vector<size_t> left_prompt_widths;
     /// Last right prompt width.
     size_t last_right_prompt_width;
     /// The actual width of the screen at the time of the last screen write.
@@ -148,6 +155,10 @@ class screen_t {
     /// These status buffers are used to check if any output has occurred other than from fish's
     /// main loop, in which case we need to redraw.
     struct stat prev_buff_1, prev_buff_2, post_buff_1, post_buff_2;
+    /// The prompt commands.
+    wcstring left_prompt;
+    wcstring continuation_prompt;
+    wcstring right_prompt;
 
     /// \return the outputter for this screen.
     outputter_t &outp() { return outp_; }


### PR DESCRIPTION
This adds support for a `fish_continuation_prompt` function that returns the prompt used for continuation lines (those after the initial input line).

The `fish_continuation_prompt` function is called with 2 arguments: The width in columns of the initial prompt; and a sequence number (1 for the first continuation line).

Here is a simple example, which returns `".....NN$ "`.  (It needs tweaking to handle the case that the repeat argument is negative.)

    function fish_continuation_prompt --description 'Write out the prompt for continuation lines'
      set num (printf '.%d$ ' $argv[2])
      echo -nes (string repeat -N --count (math $argv[1] - (string length $num)) ".") $num
    end

The default is equivalent to: `printf "%*s" $argv[1] ' '`

Fixes issue #3382

This is a prototype, with limited testing. Notably, I have not tested long input lines with wrap-around or very long prompts.  Feedback is needed before polishing.

The `LEFT_PROMPT_IN_ARRAY` flag is an experiment I did to use a single array for _all_ the left prompts: left_prompts[0] is the left prompt of the initial input line. It seems more elegant that way, but I didn't follow through with that approach.
