### PR TITLE
Switch to runtime check for /proc/self/stat

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -128,9 +128,6 @@ IF(STRUCT_WINSIZE GREATER -1 AND HAVE_TIOCGWINSZ EQUAL 1)
 ENDIF()
 CMAKE_POP_CHECK_STATE()
 
-IF(EXISTS "/proc/self/stat")
-  SET(HAVE__PROC_SELF_STAT 1)
-ENDIF()
 CHECK_TYPE_SIZE("wchar_t[8]" WCHAR_T_BITS LANGUAGE CXX)
 
 # Solaris, NetBSD and X/Open-conforming systems have a fixed-args tparm

--- a/config_cmake.h.in
+++ b/config_cmake.h.in
@@ -127,9 +127,6 @@
 /* Define to 1 if the _nl_msg_cat_cntr symbol is exported. */
 #cmakedefine HAVE__NL_MSG_CAT_CNTR 1
 
-/* Define to 1 if you have the file `/proc/self/stat'. */
-#cmakedefine HAVE__PROC_SELF_STAT 1
-
 /* Define to 1 if the _sys_errs array is available. */
 #cmakedefine HAVE__SYS__ERRS 1
 

--- a/src/builtin_eval.cpp
+++ b/src/builtin_eval.cpp
@@ -3,9 +3,6 @@
 
 #include <errno.h>
 #include <stddef.h>
-#ifdef HAVE__PROC_SELF_STAT
-#include <sys/time.h>
-#endif
 
 #include "builtin.h"
 #include "common.h"

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -560,6 +560,10 @@ void misc_init() {
         fflush(stdout);
         setvbuf(stdout, NULL, _IONBF, 0);
     }
+    // Check for /proc/self/stat to see if we are running with Linux-style procfs
+    if (access("/proc/self/stat", R_OK) == 0) {
+        have_proc_stat = true;
+    }
 }
 
 /// Ensure the content of the magic path env vars is reasonable. Specifically, that empty path

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -72,6 +72,7 @@ bool is_login = false;
 int is_event = 0;
 job_control_t job_control_mode = job_control_t::interactive;
 int no_exec = 0;
+bool have_proc_stat = false;
 
 static int is_interactive = -1;
 
@@ -617,13 +618,12 @@ bool job_reap(bool allow_interactive) {
     return found;
 }
 
-#ifdef HAVE__PROC_SELF_STAT
-
 /// Maximum length of a /proc/[PID]/stat filename.
 #define FN_SIZE 256
 
 /// Get the CPU time for the specified process.
 unsigned long proc_get_jiffies(process_t *p) {
+    if (! have_proc_stat) return 0;
     if (p->pid <= 0) return 0;
 
     wchar_t fn[FN_SIZE];
@@ -665,8 +665,6 @@ void proc_update_jiffies() {
         }
     }
 }
-
-#endif
 
 // Return control of the terminal to a job's process group. restore_attrs is true if we are restoring
 // a previously-stopped job, in which case we need to restore terminal attributes.

--- a/src/proc.h
+++ b/src/proc.h
@@ -228,12 +228,10 @@ class process_t {
     bool stopped{false};
     /// Reported status value.
     proc_status_t status{};
-#ifdef HAVE__PROC_SELF_STAT
     /// Last time of cpu time check.
     struct timeval last_time {};
     /// Number of jiffies spent in process at last cpu time check.
     unsigned long last_jiffies{0};
-#endif
 };
 
 typedef std::unique_ptr<process_t> process_ptr_t;
@@ -492,7 +490,6 @@ bool job_reap(bool interactive);
 /// Mark a process as failed to execute (and therefore completed).
 void job_mark_process_as_failed(const std::shared_ptr<job_t> &job, const process_t *p);
 
-#ifdef HAVE__PROC_SELF_STAT
 /// Use the procfs filesystem to look up how many jiffies of cpu time was used by this process. This
 /// function is only available on systems with the procfs file entry 'stat', i.e. Linux.
 unsigned long proc_get_jiffies(process_t *p);
@@ -500,7 +497,6 @@ unsigned long proc_get_jiffies(process_t *p);
 /// Update process time usage for all processes by calling the proc_get_jiffies function for every
 /// process of every job.
 void proc_update_jiffies();
-#endif
 
 /// Perform a set of simple sanity checks on the job list. This includes making sure that only one
 /// job is in the foreground, that every process is in a valid state, etc.
@@ -554,5 +550,7 @@ void add_disowned_pgid(pid_t pgid);
 /// -1 should not be used; it is a possible return value of the getpgid()
 ///   function
 enum { INVALID_PID  = -2 };
+
+extern bool have_proc_stat;
 
 #endif

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1976,9 +1976,9 @@ void reader_run_command(parser_t &parser, const wcstring &cmd) {
     // For compatibility with fish 2.0's $_, now replaced with `status current-command`
     parser.vars().set_one(L"_", ENV_GLOBAL, program_name);
 
-#ifdef HAVE__PROC_SELF_STAT
-    proc_update_jiffies();
-#endif
+    if (have_proc_stat) {
+        proc_update_jiffies();
+    }
 }
 
 parser_test_error_bits_t reader_shell_test(const wcstring &b) {


### PR DESCRIPTION
Removes a compile-time check that may have affected cross-compilation.

I'd appreciate your review!
