### PR TITLE
Disable syntax highlighting when pasting

### DIFF
--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -170,6 +170,7 @@ function __fish_commandline_insert_escaped --description 'Insert the first arg e
 end
 
 function __fish_start_bracketed_paste
+    commandline -f disable-highlighting
     # Save the last bind mode so we can restore it.
     set -g __fish_last_bind_mode $fish_bind_mode
     # If the token is currently single-quoted,
@@ -179,6 +180,7 @@ function __fish_start_bracketed_paste
 end
 
 function __fish_stop_bracketed_paste
+    commandline -f enable-highlighting
     # Restore the last bind mode.
     set fish_bind_mode $__fish_last_bind_mode
     set -e __fish_paste_quoted

--- a/sphinx_doc_src/cmds/bind.rst
+++ b/sphinx_doc_src/cmds/bind.rst
@@ -102,7 +102,11 @@ The following special input functions are available:
 
 - ``delete-char``, delete one character to the right of the cursor
 
+- ``disable-highlighting`` turns off syntax-highlighting
+
 - ``downcase-word``, make the current word lowercase
+
+- ``enable-highlighting`` turns syntax-highlighting on
 
 - ``end-of-buffer``, moves to the end of the buffer, i.e. the end of the first line
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -116,6 +116,8 @@ static const input_function_metadata_t input_function_metadata[] = {
     {readline_cmd_t::repaint_mode, L"repaint-mode"},
     {readline_cmd_t::repaint, L"repaint"},
     {readline_cmd_t::force_repaint, L"force-repaint"},
+    {readline_cmd_t::enable_highlighting, L"enable-highlighting"},
+    {readline_cmd_t::disable_highlighting, L"disable-highlighting"},
     {readline_cmd_t::up_line, L"up-line"},
     {readline_cmd_t::down_line, L"down-line"},
     {readline_cmd_t::suppress_autosuggestion, L"suppress-autosuggestion"},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -51,6 +51,8 @@ enum class readline_cmd_t {
     repaint_mode,
     repaint,
     force_repaint,
+    enable_highlighting,
+    disable_highlighting,
     up_line,
     down_line,
     suppress_autosuggestion,

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -337,6 +337,8 @@ class reader_data_t : public std::enable_shared_from_this<reader_data_t> {
     bool suppress_autosuggestion{false};
     /// Whether abbreviations are expanded.
     bool expand_abbreviations{false};
+    /// Whether highlighting is enabled.
+    bool highlighting{true};
     /// Silent mode used for password input on the read command
     bool silent{false};
     /// The representation of the current screen contents.
@@ -2051,6 +2053,7 @@ static std::function<highlight_result_t(void)> get_highlight_performer(
 /// \param no_io if true, do a highlight that does not perform I/O, synchronously. If false, perform
 ///        an asynchronous highlight in the background, which may perform disk I/O.
 void reader_data_t::super_highlight_me_plenty(int match_highlight_pos_adjust, bool no_io) {
+    if (!highlighting) return;
     const editable_line_t *el = &command_line;
     assert(el != NULL);
     long match_highlight_pos = (long)el->position + match_highlight_pos_adjust;
@@ -2506,6 +2509,12 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 screen_reset_needed = false;
                 repaint();
             }
+            break;
+        }
+        case rl::disable_highlighting:
+        case rl::enable_highlighting: {
+            highlighting = c == rl::enable_highlighting;
+            super_highlight_me_plenty();
             break;
         }
         case rl::complete:


### PR DESCRIPTION
This adds a new pair of bind functions {en,dis}able-highlighting, that
en/dis-able highlighting, respectively.

We use these to turn off highlighting when we start bracketed paste,
and we turn it on again when we stop it.

This is by far the simplest solution to the issue of bracketed paste
being slow.

Fixes #5866.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed - I have no idea how I'd test this.
- [ ] User-visible changes noted in CHANGELOG.md
