### PR TITLE
Underline every valid entered path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - $PATH is no longer reordered in child fishes (#5456).
 - `eval` is now implemented internally rather than being a function; as such, the evaluated code now shares the same argument scope as `eval` rather than being executed in a new scope (#4443).
 - An issue resulting in a certain class of parser errors not resulting in a non-zero `$status` has been corrected (3e055f).
+- fish now underlines every valid entered path instead of just the last one.
 
 ### Syntax changes and new commands
 - None yet.

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -4417,7 +4417,7 @@ static void test_highlighting() {
 
     highlight_tests.push_back({
         {L"cat", highlight_role_t::command},
-        {L"/dev/null", highlight_role_t::param},
+        {L"/dev/null", param_valid_path},
         {L"|", highlight_role_t::statement_terminator},
         // This is bogus, but we used to use "less" here and that doesn't have to be installed.
         {L"cat", highlight_role_t::command},

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -1265,11 +1265,8 @@ const highlighter_t::color_array_t &highlighter_t::highlight() {
         // Must be an argument with source.
         if (node.type != symbol_argument || !node.has_source()) continue;
 
-        // See if this node contains the cursor. We check <= source_length so that, when backspacing
-        // (and the cursor is just beyond the last token), we may still underline it.
-        if (this->cursor_pos >= node.source_start &&
-            this->cursor_pos - node.source_start <= node.source_length &&
-            node_is_potential_path(buff, node, vars, working_directory)) {
+        // Underline every valid path.
+        if (node_is_potential_path(buff, node, vars, working_directory)) {
             // It is, underline it.
             for (size_t i = node.source_start; i < node.source_start + node.source_length; i++) {
                 // Don't color highlight_role_t::error because it looks dorky. For example,


### PR DESCRIPTION
## Description

### Before patch

![Screenshot from 2019-05-12 13-47-57](https://user-images.githubusercontent.com/9713907/57581773-94c31f80-74bc-11e9-9066-6b08122fa91d.png)

### After patch

![Screenshot from 2019-05-12 13-49-12](https://user-images.githubusercontent.com/9713907/57581787-be7c4680-74bc-11e9-8489-6deb3efc498b.png)

---

All credits goes to @floam (https://github.com/fish-shell/fish-shell/issues/847#issuecomment-436619815).

Fixes issue #847 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
