### PR TITLE
WIP Add undo

### DIFF
--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -107,7 +107,8 @@ static void replace_part(const wchar_t *begin, const wchar_t *end, const wchar_t
         }
     }
     out.append(end);
-    reader_set_buffer(out, out_pos);
+    // If we append or insert, the edits should be coalesced in the undo stack.
+    reader_set_buffer(out, out_pos, append_mode != REPLACE_MODE);
 }
 
 /// Output the specified selection.

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -1189,7 +1189,7 @@ void env_stack_t::set_termsize() {
 void env_stack_t::set_pwd_from_getcwd() {
     wcstring cwd = wgetcwd();
     if (cwd.empty()) {
-        debug(0,
+        FLOG(error,
               _(L"Could not determine current working directory. Is your locale set correctly?"));
         return;
     }

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -885,8 +885,9 @@ expand_result_t expander_t::stage_cmdsubst(wcstring input, std::vector<completio
             case 0:
                 append_completion(out, std::move(input));
                 break;
-            case 1: /* fallthroughs intentional */
+            case 1:
                 append_cmdsub_error(errors, start, L"Command substitutions not allowed");
+               /* intentionally falls through */
             case -1:
             default:
                 return expand_result_t::error;

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -1208,6 +1208,7 @@ static struct wcsfilecmp_test {
                         {L"a0", L"a00", -1},
                         {L"a00b", L"a0b", -1},
                         {L"a0b", L"a00b", 1},
+                        {L"a-b", L"azb", 1},
                         {NULL, NULL, 0}};
 
 /// Verify the behavior of the `wcsfilecmp()` function.

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -31,6 +31,7 @@
 #include "common.h"
 #include "env.h"
 #include "fallback.h"  // IWYU pragma: keep
+#include "flog.h"
 #include "global_safety.h"
 #include "history.h"
 #include "io.h"
@@ -1860,7 +1861,7 @@ wcstring history_session_id(const environment_t &vars) {
         } else if (valid_var_name(session_id)) {
             result = session_id;
         } else {
-            debug(0,
+            FLOGF(error,
                   _(L"History session ID '%ls' is not a valid variable name. "
                     L"Falling back to `%ls`."),
                   session_id.c_str(), result.c_str());

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -132,7 +132,10 @@ static const input_function_metadata_t input_function_metadata[] = {
     {readline_cmd_t::reverse_repeat_jump, L"repeat-jump-reverse"},
     {readline_cmd_t::func_and, L"and"},
     {readline_cmd_t::expand_abbr, L"expand-abbr"},
-    {readline_cmd_t::cancel, L"cancel"}};
+    {readline_cmd_t::undo, L"undo"},
+    {readline_cmd_t::redo, L"redo"},
+    {readline_cmd_t::cancel, L"cancel"},
+};
 
 static_assert(sizeof(input_function_metadata) / sizeof(input_function_metadata[0]) ==
                   input_function_count,

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -66,6 +66,8 @@ enum class readline_cmd_t {
     func_and,
     expand_abbr,
     cancel,
+    undo,
+    redo,
     repeat_jump,
     reverse_repeat_jump,
 };

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1414,6 +1414,8 @@ void reader_data_t::accept_autosuggestion(bool full, move_word_style_t style) {
         // Accepting an autosuggestion clears the pager.
         clear_pager();
 
+        add_undo();
+
         // Accept the autosuggestion.
         if (full) {
             // Just take the whole thing.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -529,7 +529,7 @@ class reader_data_t : public std::enable_shared_from_this<reader_data_t> {
     void set_command_line_and_position(editable_line_t *el, const wcstring &new_str, size_t pos);
     void replace_current_token(const wcstring &new_token);
     void update_command_line_from_history_search();
-    void set_buffer_maintaining_pager(const wcstring &b, size_t pos);
+    void set_buffer_maintaining_pager(const wcstring &b, size_t pos, bool coalesce = false);
     void remove_backward();
 };
 
@@ -1950,7 +1950,8 @@ void reader_data_t::move_word(editable_line_t *el, bool move_right, bool erase,
 }
 
 /// Sets the command line contents, without clearing the pager.
-void reader_data_t::set_buffer_maintaining_pager(const wcstring &b, size_t pos) {
+void reader_data_t::set_buffer_maintaining_pager(const wcstring &b, size_t pos, bool coalesce) {
+    add_undo(coalesce);
     // Callers like to pass us pointers into ourselves, so be careful! I don't know if we can use
     // operator= with a pointer to our interior, so use an intermediate.
     size_t command_line_len = b.size();
@@ -3540,12 +3541,12 @@ void reader_sanity_check() {
 }
 
 /// Sets the command line contents, clearing the pager.
-void reader_set_buffer(const wcstring &b, size_t pos) {
+void reader_set_buffer(const wcstring &b, size_t pos, bool coalesce) {
     reader_data_t *data = current_data_or_null();
     if (!data) return;
 
     data->clear_pager();
-    data->set_buffer_maintaining_pager(b, pos);
+    data->set_buffer_maintaining_pager(b, pos, coalesce);
 }
 
 size_t reader_get_cursor_pos() {

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -3256,6 +3256,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 // Put back into the other stack, e.g. from undo to redo.
                 rl.push_back(old, pos);
                 ul.pop_back();
+            } else {
+                flash();
             }
             break;
         }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1134,10 +1134,6 @@ void reader_data_t::remove_backward() {
 
     if (el->position <= 0) return;
 
-    if (el == &command_line) {
-        add_undo(true);
-    }
-
     // Fake composed character sequences by continuing to delete until we delete a character of
     // width at least 1.
     int width;
@@ -2733,6 +2729,11 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             break;
         }
         case rl::backward_delete_char: {
+            editable_line_t *el = active_edit_line();
+            if (el == &command_line) {
+                add_undo();
+            }
+
             remove_backward();
             break;
         }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -339,7 +339,25 @@ struct undo_list_t {
     bool empty() {
         return lines.empty();
     }
+    size_t pos_back() {
+        if (coalesce) {
+            if (positions.size() > 1) {
+                return *(positions.end() - 2);
+            }
+            return 0;
+        }
+        return positions.back();
+    }
+
     wcstring back() {
+        if (coalesce) {
+            // Skip a pending entry
+            if (lines.size() > 1) {
+                wcstring ntl = *(lines.end() - 2);
+                return *(lines.end() - 2);
+            }
+            return L"";
+        }
         return lines.back();
     }
     void clear() {
@@ -3257,7 +3275,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 wcstring old = command_line.text;
                 size_t pos = command_line.position;
                 command_line.text = ul.back();
-                update_buff_pos(&command_line, ul.positions.back());
+                update_buff_pos(&command_line, ul.pos_back());
                 command_line_changed(&command_line);
                 super_highlight_me_plenty();
                 // TODO: Is this necessary?

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -319,19 +319,14 @@ struct highlight_result_t {
 struct undo_list_t {
     std::deque<wcstring> lines;
     std::deque<size_t> positions;
-    wcstring pending = L"";
-    size_t pending_pos = 0;
     bool coalesce = false;
-    void push_back(wcstring line, size_t pos, bool coalesce = false) {
-        if (!coalesce) {
-            lines.push_back(pending);
-            positions.push_back(pending_pos);
-            lines.push_back(line);
-            positions.push_back(pos);
-        } else {
-            pending = line;
-            pending_pos = pos;
+    void push_back(wcstring line, size_t pos, bool new_coalesce = false) {
+        if (coalesce && !empty()) {
+            pop_back();
         }
+        lines.push_back(line);
+        positions.push_back(pos);
+        coalesce = new_coalesce;
     }
     void pop_back() {
         lines.pop_back();
@@ -346,8 +341,6 @@ struct undo_list_t {
     void clear() {
         lines.clear();
         positions.clear();
-        pending = L"";
-        pending_pos = 0;
         coalesce = false;
     }
 };

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -324,8 +324,12 @@ struct undo_list_t {
         if (coalesce && !empty()) {
             pop_back();
         }
-        lines.push_back(line);
-        positions.push_back(pos);
+        // Ignore duplicated sequences - fully deduplicating would be weird,
+        // but so would an undo that doesn't change anything.
+        if (empty() || back() != line) {
+            lines.push_back(line);
+            positions.push_back(pos);
+        }
         coalesce = new_coalesce;
     }
     void pop_back() {
@@ -427,9 +431,7 @@ class reader_data_t : public std::enable_shared_from_this<reader_data_t> {
     jump_precision_t last_jump_precision{jump_precision_t::to};
 
     void add_undo(wcstring str, size_t pos, bool coalesce = false) {
-        if (undo.empty() || undo.back() != str) {
-            undo.push_back(str, pos, coalesce);
-        }
+        undo.push_back(str, pos, coalesce);
     }
 
     void add_undo(bool coalesce = false) {

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -3273,7 +3273,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 // TODO: Is this necessary?
                 repaint();
                 // Put back into the other stack, e.g. from undo to redo.
-                if (c == rl::undo) {
+                if (is_undo) {
                     rl.push_front(old, pos);
                     ul.pop_back();
                 } else {

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -319,24 +319,18 @@ struct highlight_result_t {
 struct undo_list_t {
     std::deque<wcstring> lines;
     std::deque<size_t> positions;
-    wcstring pending;
-    size_t pending_pos;
-    bool have_pending = false;
+    wcstring pending = L"";
+    size_t pending_pos = 0;
     bool coalesce = false;
     void push_back(wcstring line, size_t pos, bool coalesce = false) {
-        if (!coalesce && have_pending) {
+        if (!coalesce) {
             lines.push_back(pending);
             positions.push_back(pending_pos);
-            have_pending = false;
-        }
-        if (coalesce) {
-            pending = line;
-            pending_pos = pos;
-            have_pending = true;
-        }
-        if (!coalesce) {
             lines.push_back(line);
             positions.push_back(pos);
+        } else {
+            pending = line;
+            pending_pos = pos;
         }
     }
     void pop_back() {

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -343,6 +343,13 @@ struct undo_list_t {
     wcstring back() {
         return lines.back();
     }
+    void clear() {
+        lines.clear();
+        positions.clear();
+        pending = L"";
+        pending_pos = 0;
+        coalesce = false;
+    }
 };
 
 }  // namespace
@@ -2811,6 +2818,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 // Finished command, execute it. Don't add items that start with a leading
                 // space.
                 const editable_line_t *el = &command_line;
+                undo.clear();
+                redo.clear();
                 if (history != NULL && !el->empty() && el->text.at(0) != L' ') {
                     history->add_pending_with_file_detection(el->text, vars.get_pwd_slash());
                 }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -339,26 +339,15 @@ struct undo_list_t {
             positions.push_back(pos);
         }
     }
-    void push_front(wcstring line, size_t pos) {
-        lines.push_front(line);
-        positions.push_front(pos);
-    }
     void pop_back() {
         lines.pop_back();
         positions.pop_back();
-    }
-    void pop_front() {
-        lines.pop_front();
-        positions.pop_front();
     }
     bool empty() {
         return lines.empty();
     }
     wcstring back() {
         return lines.back();
-    }
-    wcstring front() {
-        return lines.front();
     }
 };
 
@@ -3258,28 +3247,21 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
         }
         case rl::redo:
         case rl::undo: {
-            // Redo is basically reversed - we go front to back, where undo goes back to front.
-            // So all the redo operations use front, all the undo ones use back.
             bool is_undo = c == rl::undo;
             undo_list_t &ul = is_undo ? undo : redo;
             undo_list_t &rl = is_undo ? redo : undo;
             if (!ul.empty()) {
                 wcstring old = command_line.text;
                 size_t pos = command_line.position;
-                command_line.text = is_undo ? ul.back() : ul.front();
-                update_buff_pos(&command_line, is_undo ? ul.positions.back() : ul.positions.front());
+                command_line.text = ul.back();
+                update_buff_pos(&command_line, ul.positions.back());
                 command_line_changed(&command_line);
                 super_highlight_me_plenty();
                 // TODO: Is this necessary?
                 repaint();
                 // Put back into the other stack, e.g. from undo to redo.
-                if (is_undo) {
-                    rl.push_front(old, pos);
-                    ul.pop_back();
-                } else {
-                    rl.push_back(old, pos);
-                    ul.pop_front();
-                }
+                rl.push_back(old, pos);
+                ul.pop_back();
             }
             break;
         }

--- a/src/reader.h
+++ b/src/reader.h
@@ -101,7 +101,7 @@ history_t *reader_get_history();
 /// \param b the new buffer value
 /// \param p the cursor position. If \c p is larger than the length of the command line, the cursor
 /// is placed on the last character.
-void reader_set_buffer(const wcstring &b, size_t p = -1);
+void reader_set_buffer(const wcstring &b, size_t p = -1, bool coalesce = false);
 
 /// Get the current cursor position in the command line. If interactive mode is uninitialized,
 /// return (size_t)-1.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -62,8 +62,9 @@ int wcsfilecmp(const wchar_t *a, const wchar_t *b) {
 
         wint_t al = towupper(*a);
         wint_t bl = towupper(*b);
-        if (al == L'-') al += 48;
-        if (bl == L'-') bl += 48;
+        // Sort dashes after Z - see #5634
+        if (al == L'-') al = L'[';
+        if (bl == L'-') bl = L'[';
 
         if (al < bl) {
             retval = -1;


### PR DESCRIPTION
We add two "undo_list_t", one for undo and one for redo.

If we do anything that changes the commandline, we add an undo
element, if we undo, we add a redo element.

Also we coalesce small changes like normal string insertions and
single-character deletions.

This is only lightly tested and might not work for everything. In particular I'm not sure if I caught everything or how it works for weirder bindings.

I'd just like to know that the general idea is solid.

Fixes #1367.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
