### PR TITLE
Remove read history, let `history delete` read search terms interactively

### DIFF
--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -103,25 +103,23 @@ function history --description "display or manipulate interactive command histor
 
         case delete # interactively delete history
             # TODO: Fix this to deal with history entries that have multiple lines.
+            set -l searchterm $argv
             if not set -q argv[1]
-                printf (_ "You must specify at least one search term when deleting entries\n") >&2
-                return 1
+                read -P"Search term: " searchterm
             end
 
             test -z "$search_mode"
             and set search_mode "--contains"
 
             if test $search_mode = "--exact"
-                builtin history delete $search_mode $_flag_case_sensitive $argv
+                builtin history delete $search_mode $_flag_case_sensitive $searchterm
                 return
             end
 
             # TODO: Fix this so that requesting history entries with a timestamp works:
             #   set -l found_items (builtin history search $search_mode $show_time -- $argv)
             set -l found_items
-            builtin history search $search_mode $_flag_case_sensitive --null -- $argv | while read -lz x
-                set found_items $found_items $x
-            end
+            set found_items (builtin history search $search_mode $_flag_case_sensitive --null -- $searchterm | string split0)
             if set -q found_items[1]
                 set -l found_items_count (count $found_items)
                 for i in (seq $found_items_count)

--- a/src/builtin_read.cpp
+++ b/src/builtin_read.cpp
@@ -63,7 +63,6 @@ static const struct woption long_options[] = {{L"array", no_argument, NULL, 'a'}
                                               {L"help", no_argument, NULL, 'h'},
                                               {L"line", no_argument, NULL, 'L'},
                                               {L"local", no_argument, NULL, 'l'},
-                                              {L"mode-name", required_argument, NULL, 'm'},
                                               {L"nchars", required_argument, NULL, 'n'},
                                               {L"null", no_argument, NULL, 'z'},
                                               {L"prompt", required_argument, NULL, 'p'},
@@ -115,12 +114,6 @@ static int parse_cmd_opts(read_cmd_opts_t &opts, int *optind,  //!OCLINT(high nc
             }
             case L'l': {
                 opts.place |= ENV_LOCAL;
-                break;
-            }
-            case L'm': {
-                streams.err.append_format(_(L"%ls: flags '--mode-name' / '-m' are now ignored. "
-                                            L"Set fish_history instead.\n"),
-                                          cmd);
                 break;
             }
             case L'n': {

--- a/src/builtin_read.cpp
+++ b/src/builtin_read.cpp
@@ -202,10 +202,8 @@ static int read_interactive(parser_t &parser, wcstring &buff, int nchars, bool s
                             const wchar_t *commandline) {
     int exit_res = STATUS_CMD_OK;
 
-    const auto &vars = parser.vars();
-    wcstring read_history_ID = history_session_id(vars);
-    if (!read_history_ID.empty()) read_history_ID += L"_read";
-    reader_push(parser, read_history_ID);
+    // Don't keep history
+    reader_push(parser, L"");
 
     reader_set_left_prompt(prompt);
     reader_set_right_prompt(right_prompt);


### PR DESCRIPTION
## Description

This removes `builtin read`s history, which is:

- undocumented
- possibly unexpected (we've recommended `mysql -p(read)` before, with the intention that these *not* show up in the history)

Then it uses `read` in `history delete` if no searchterms are given.

An alternative would be to add a flag to `read` to not keep history (`read --incognito` or `read --no-history`?), or to readd the `--mode-name` flag and expect that. I've not done so because I don't see the use in the read history, and I believe that the expectation usually is that it doesn't keep history.

Fixes issue #5791 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
