### PR TITLE
New 'spacer' highlight role, used for indentation.

### DIFF
--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -298,6 +298,7 @@ static const char *highlight_role_to_string(highlight_role_t role) {
         TEST_ROLE(pager_selected_prefix)
         TEST_ROLE(pager_selected_completion)
         TEST_ROLE(pager_selected_description)
+        TEST_ROLE(spacer);
         default:
             DIE("UNKNOWN ROLE");
     }
@@ -402,6 +403,9 @@ static const wchar_t *html_class_name_for_color(highlight_spec_t spec) {
     switch (spec.foreground) {
         case highlight_role_t::normal: {
             return P(normal);
+        }
+        case highlight_role_t::spacer: {
+            return P(spacer);
         }
         case highlight_role_t::error: {
             return P(error);

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -43,6 +43,8 @@ static const wchar_t *get_highlight_var_name(highlight_role_t role) {
     switch (role) {
         case highlight_role_t::normal:
             return L"fish_color_normal";
+        case highlight_role_t::spacer:
+            return L"fish_color_spacer";
         case highlight_role_t::error:
             return L"fish_color_error";
         case highlight_role_t::command:
@@ -104,6 +106,8 @@ static const wchar_t *get_highlight_var_name(highlight_role_t role) {
 static highlight_role_t get_fallback(highlight_role_t role) {
     switch (role) {
         case highlight_role_t::normal:
+            return highlight_role_t::normal;
+        case highlight_role_t::spacer:
             return highlight_role_t::normal;
         case highlight_role_t::error:
             return highlight_role_t::normal;

--- a/src/highlight.h
+++ b/src/highlight.h
@@ -43,6 +43,8 @@ enum class highlight_role_t : uint8_t {
     pager_selected_prefix,
     pager_selected_completion,
     pager_selected_description,
+
+    spacer,
 };
 
 /// Simply value type describing how a character should be highlighted..


### PR DESCRIPTION
(This request is a prototype, and I don't pretend it is suitable for merging yet.)

I'm working on a [proposed specificaton](https://gitlab.com/PerBothner/terminal-specifications/blob/master/proposals/semantic-prompts.md) for enhanced "shell integration".
One goal is precise delineation of the actual user input, and distinguishing it from prompts, indentation, and  other shell-generated output.  One reason is styling flexibility.  Another reason is to support smart selection/copying that only includes the actual input,

![Screenshot from 2019-05-30 11-20-40](https://user-images.githubusercontent.com/10293361/58654651-4475fb00-82cd-11e9-8f41-67747f05d69a.png)

This screenshot shows what we're looking for.  It uses the [DomTerm](https://domterm.org) terminal emulator, which I'm using to prototype the specification.  The input line as a whole has a light yellow-brown background, while the prompts are light green.  The actual user input is in a light yellow.  Notice the two spaces in yellow after "exists" - these were explicitly typed, so part of the actual input.

(The yellow-brown after "-f" is a bug - it should be light-yellow - and is an example of where the patch needs work.)

## Description

The goal is to reliably distinguish explicit (user input) spaces, from non-input "background spacing". There are various ways to deal with this.  In terms of protocol, one option is to define a pair of escape sequences to delimit "non-input background".  Alternatively, one can require the shell to write explicit spaces for user input, and use cursor movement (along with erase sequences) for background spacing. I think the latter is preferable.

In terms of the Fish implementation, a simple and flexible encoding is to define a new `highlight_role_t` which I have called `spacer`. It is trivial for `s_desired_append_char` to write the indentation using the new `spacer` role.

However, `s_update` is trickier, and needs more work.  This initial patch handles the simple/common case, but (as mentioned above) has glitches and needs work.  However, before digging into that, I'm hoping for some feedback on the basic idea.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Fix glitches when desired output has spacing and existing output doesn't.
- [ ] Consider the separate but related change of printing the right prompt on the _last_ input line, rather than the _first_.  This would make it easy to select/copy the input without including the prompt.
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
