### PR TITLE
Introduce littlecheck, a new test driver for fish scripts

### DIFF
--- a/build_tools/littlecheck.py
+++ b/build_tools/littlecheck.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python
+
+""" Command line test driver. """
+
+from __future__ import unicode_literals
+
+import argparse
+import io
+import re
+import shlex
+import subprocess
+import sys
+
+# A regex showing how to run the file.
+RUN_RE = re.compile(r"#\s*RUN:\s+(.*)\n")
+
+# A regex capturing lines that should be checked against stdout.
+CHECK_STDOUT_RE = re.compile(r"#\s*CHECK:\s+(.*)\n")
+
+# A regex capturing lines that should be checked against stderr.
+CHECK_STDERR_RE = re.compile(r"#\s*CHECKERR:\s+(.*)\n")
+
+
+class Config(object):
+    def __init__(self):
+        # Whether to have verbose output.
+        self.verbose = False
+        # Whether output gets ANSI colorization.
+        self.colorize = False
+
+    def colors(self):
+        """ Return a dictionary mapping color names to ANSI escapes """
+
+        def ansic(n):
+            return "\033[%dm" % n if self.colorize else ""
+
+        return {
+            "NORMAL": ansic(39),
+            "BLACK": ansic(30),
+            "RED": ansic(31),
+            "GREEN": ansic(32),
+            "YELLOW": ansic(33),
+            "BLUE": ansic(34),
+            "MAGENTA": ansic(35),
+            "CYAN": ansic(36),
+            "LIGHTGRAY": ansic(37),
+            "DARKGRAY": ansic(90),
+            "LIGHTRED": ansic(91),
+            "LIGHTGREEN": ansic(92),
+            "LIGHTYELLOW": ansic(93),
+            "LIGHTBLUE": ansic(94),
+            "LIGHTMAGENTA": ansic(95),
+            "LIGHTCYAN": ansic(96),
+            "WHITE": ansic(97),
+        }
+
+
+def output(*args):
+    print("".join(args) + "\n")
+
+
+class CheckerError(Exception):
+    """Exception subclass for check line parsing.
+
+    Attributes:
+      line: the Line object on which the exception occurred.
+    """
+
+    def __init__(self, message, line=None):
+        super(CheckerError, self).__init__(message)
+        self.line = line
+
+
+class Line(object):
+    """ A line that remembers where it came from. """
+
+    def __init__(self, text, number, file):
+        self.text = text
+        self.number = number
+        self.file = file
+
+    def subline(self, text):
+        """ Return a substring of our line with the given text, preserving number and file. """
+        return Line(text, self.number, self.file)
+
+    @staticmethod
+    def readfile(file, name):
+        return [Line(text, idx + 1, name) for idx, text in enumerate(file)]
+
+    def is_empty_space(self):
+        return not self.text or self.text.isspace()
+
+
+class RunCmd(object):
+    """ A command to run on a given Checker.
+    
+    Attributes:
+        args: Unexpanded shell command as a string.
+    """
+
+    def __init__(self, args, line):
+        self.args = args
+        self.line = line
+
+    @staticmethod
+    def parse(line):
+        if not shlex.split(line.text):
+            raise CheckerError("Invalid RUN command", line)
+        return RunCmd(line.text, line)
+
+
+class TestFailure(object):
+    def __init__(self, line, check, testrun):
+        self.line = line
+        self.check = check
+        self.testrun = testrun
+
+    def message(self):
+        fields = self.testrun.config.colors()
+        fields["name"] = self.testrun.name
+        fields["subbed_command"] = self.testrun.subbed_command
+        if self.line:
+            fields.update(
+                {
+                    "output_file": self.line.file,
+                    "output_lineno": self.line.number,
+                    "output_line": self.line.text.rstrip("\n"),
+                }
+            )
+        if self.check:
+            fields.update(
+                {
+                    "input_file": self.check.line.file,
+                    "input_lineno": self.check.line.number,
+                    "input_line": self.check.line.text,
+                }
+            )
+        fmtstr = "{RED}Failure in {name}:{NORMAL}\n"
+        if self.line and self.check:
+            fmtstr += (
+                "  Output line {output_file}:{output_lineno}: {output_line}\n"
+                + "  failed to match line {input_lineno}: {input_line}\n"
+            )
+        elif self.check:
+            fmtstr += (
+                "Missing output for check:\n"
+                + "  {input_file}:{input_lineno}: {input_line}\n"
+            )
+        else:
+            fmtstr += (
+                "Extra output after checks:\n"
+                + "  Output line {output_file}:{output_lineno}: {output_line}\n"
+            )
+        fmtstr += "When running command:\n  {subbed_command}"
+        return fmtstr.format(**fields)
+
+    def print_message(self):
+        """ Print our message to stdout. """
+        print(self.message())
+
+
+def perform_substitution(input_str, subs):
+    """ Perform the substitutions described by subs to str
+        Return the substituted string.
+    """
+    # Sort our substitutions into a list of tuples (key, value), descending by length.
+    # It needs to be descending because we need to try longer substitutions first.
+    subs_ordered = sorted(subs.items(), key=lambda s: len(s[0]), reverse=True)
+
+    def subber(m):
+        # We get the entire sequence of characters.
+        # Replace just the prefix and return it.
+        text = m.group(1)
+        for key, replacement in subs_ordered:
+            if text.startswith(key):
+                return replacement + text[len(key) :]
+        raise CheckerError("Unknown substitution: " + m.group(0))
+
+    return re.sub(r"%(%|[a-zA-Z0-9_-]+)", subber, input_str)
+
+
+class TestRun(object):
+    def __init__(self, name, runcmd, checker, subs, config):
+        self.name = name
+        self.runcmd = runcmd
+        self.subbed_command = perform_substitution(runcmd.args, subs)
+        self.checker = checker
+        self.subs = subs
+        self.config = config
+
+    def check(self, lines, checks):
+        # Reverse our lines and checks so we can pop off the end.
+        lineq = lines[::-1]
+        checkq = checks[::-1]
+        while lineq and checkq:
+            line = lineq[-1]
+            check = checkq[-1]
+            if check.regex.match(line.text):
+                # This line matched this checker, continue on.
+                lineq.pop()
+                checkq.pop()
+            elif line.is_empty_space():
+                # Skip all whitespace input lines.
+                lineq.pop()
+            else:
+                # Failed to match.
+                return TestFailure(line, check, self)
+        # Drain empties.
+        while lineq and lineq[-1].is_empty_space():
+            lineq.pop()
+        # If there's still lines or checkers, we have a failure.
+        # Otherwise it's success.
+        if lineq:
+            return TestFailure(lineq[-1], None, self)
+        elif checkq:
+            return TestFailure(None, checkq[-1], self)
+        else:
+            return None
+
+    def run(self):
+        def split_by_newlines(s):
+            """ Decode a string and split it by newlines only,
+                retaining the newlines.
+            """
+            return [s + "\n" for s in s.decode("utf-8").split("\n")]
+
+        PIPE = subprocess.PIPE
+        if self.config.verbose:
+            print(self.subbed_command)
+        proc = subprocess.Popen(
+            self.subbed_command, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True
+        )
+        stdout, stderr = proc.communicate()
+        outlines = [
+            Line(text, idx + 1, "stdout")
+            for idx, text in enumerate(split_by_newlines(stdout))
+        ]
+        errlines = [
+            Line(text, idx + 1, "stderr")
+            for idx, text in enumerate(split_by_newlines(stderr))
+        ]
+        failure = self.check(outlines, self.checker.outchecks)
+        if not failure:
+            failure = self.check(errlines, self.checker.errchecks)
+        return failure
+
+
+class CheckCmd(object):
+    def __init__(self, line, regex):
+        self.line = line
+        self.regex = regex
+
+    @staticmethod
+    def parse(line):
+        # type: (Line) -> CheckCmd
+        # Everything inside {{}} is a regular expression.
+        # Everything outside of it is a literal string.
+        # Split around {{...}}. Then every odd index will be a regex, and
+        # evens will be literals.
+        # Note that if {{...}} appears first we will get an empty string in
+        # the split array, so the {{...}} matches are always at odd indexes.
+        bracket_re = re.compile(
+            r"""
+                \{\{   # Two open brackets
+                (.*?)  # Nongreedy capture
+                \}\}   # Two close brackets
+            """,
+            re.VERBOSE,
+        )
+        pieces = bracket_re.split(line.text)
+        even = True
+        re_strings = []
+        for piece in pieces:
+            if even:
+                # piece is a literal string.
+                re_strings.append(re.escape(piece))
+            else:
+                # piece is a regex (found inside {{...}}).
+                # Verify the regex can be compiled.
+                try:
+                    re.compile(piece)
+                except re.error:
+                    raise CheckerError("Invalid regular expression: '%s'" % piece, line)
+                re_strings.append(piece)
+            even = not even
+        # Enclose each piece in a non-capturing group.
+        # This ensures that lower-precedence operators don't trip up catenation.
+        # For example: {{b|c}}d would result in /b|cd/ which is different.
+        # Backreferences are assumed to match across the entire string.
+        re_strings = ["(?:%s)" % s for s in re_strings]
+        # Anchor at beginning and end (allowing arbitrary whitespace), and maybe
+        # a terminating newline.
+        # We need the anchors because Python's match() matches an arbitrary prefix,
+        # not the entire string.
+        re_strings = [r"^\s*"] + re_strings + [r"\s*\n?$"]
+        full_re = re.compile("".join(re_strings))
+        return CheckCmd(line, full_re)
+
+
+class Checker(object):
+    def __init__(self, name, lines):
+        self.name = name
+        # Helper to yield subline containing group1 from all matching lines.
+        def group1s(regex):
+            for line in lines:
+                m = regex.match(line.text)
+                if m:
+                    yield line.subline(m.group(1))
+
+        # Find run commands.
+        self.runcmds = [RunCmd.parse(sl) for sl in group1s(RUN_RE)]
+        if not self.runcmds:
+            raise CheckerError("No runlines ('# RUN') found")
+
+        # Find check cmds.
+        self.outchecks = [CheckCmd.parse(sl) for sl in group1s(CHECK_STDOUT_RE)]
+        self.errchecks = [CheckCmd.parse(sl) for sl in group1s(CHECK_STDERR_RE)]
+
+
+def check_file(input_file, name, subs, config, failure_handler):
+    """ Check a single file. Return a True on success, False on error. """
+    success = True
+    lines = Line.readfile(input_file, name)
+    checker = Checker(name, lines)
+    for runcmd in checker.runcmds:
+        failure = TestRun(name, runcmd, checker, subs, config).run()
+        if failure:
+            failure_handler(failure)
+            success = False
+    return success
+
+
+def check_path(path, subs, config, failure_handler):
+    with io.open(path, encoding="utf-8") as fd:
+        return check_file(fd, path, subs, config, failure_handler)
+
+
+def parse_subs(subs):
+    """ Given a list of input substitutions like 'foo=bar',
+       return a dictionary like {foo:bar}, or exit if invalid.
+    """
+    result = {}
+    for sub in subs:
+        try:
+            key, val = sub.split("=", 1)
+            if not key:
+                print("Invalid substitution %s: empty key" % sub)
+                sys.exit(1)
+            if not val:
+                print("Invalid substitution %s: empty value" % sub)
+                sys.exit(1)
+            result[key] = val
+        except ValueError:
+            print("Invalid substitution %s: equal sign not found" % sub)
+            sys.exit(1)
+    return result
+
+
+def get_argparse():
+    """ Return a littlecheck argument parser. """
+    parser = argparse.ArgumentParser(
+        description="littlecheck: command line tool tester."
+    )
+    parser.add_argument(
+        "-s",
+        "--substitute",
+        type=str,
+        help="Add a new substitution for RUN lines. Example: bash=/bin/bash",
+        action="append",
+        default=[],
+    )
+    parser.add_argument("file", nargs="+", help="File to check")
+    return parser
+
+
+def main():
+    args = get_argparse().parse_args()
+    # Default substitution is %% -> %
+    def_subs = {"%": "%"}
+    def_subs.update(parse_subs(args.substitute))
+
+    success = True
+    config = Config()
+    config.colorize = sys.stdout.isatty()
+    for path in args.file:
+        subs = def_subs.copy()
+        subs["s"] = path
+        if not check_path(path, subs, config, TestFailure.print_message):
+            success = False
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -26,6 +26,9 @@ IF(NOT FISH_IN_TREE_BUILD)
     ADD_DEPENDENCIES(fish_tests tests_dir)
 ENDIF()
 
+# Copy littlecheck.py
+CONFIGURE_FILE(build_tools/littlecheck.py littlecheck.py COPYONLY)
+
 # Create the 'test' target.
 # Set a policy so CMake stops complaining about the name 'test'.
 CMAKE_POLICY(PUSH)

--- a/tests/printf.check
+++ b/tests/printf.check
@@ -1,31 +1,53 @@
+# RUN: %fish %s
+
 printf "Hello %d %i %f %F %g %G\n" 1 2 3 4 5 6
+# CHECK: Hello 1 2 3.000000 4.000000 5 6
 
 printf "%x %X %o %llu\n" 10 11 8 -1
+# CHECK: a B 10 18446744073709551615
+
 # %a has OS-dependent output - see #1139
 #printf "%a %A\n" 14 15
 
 printf "%c %s\n" a hello
+# CHECK: a hello
+
 printf "%c%c%c\n" hello … o
+# CHECK: h…o
+
 printf "%e %E\n" 5 6
+# CHECK: 5.000000e+00 6.000000E+00
 
 printf "%20d\n" 50
+# CHECK:                   50
+
 printf "%-20d%d\n" 5 10
+# CHECK: 5                   10
 
 printf "%*d\n" 10 100
+# CHECK:       100
 
 printf "%%\"\\\n"
 printf "%s\b%s\n" x y
-printf "abc\rdef\n"
-printf "Msg1\fMsg2\n"
-printf "foo\vbar\vbaz\n"
-printf "\111 \x50 \u0051 \U00000052"
+# CHECK: %"\nxy
 
+printf "abc\rdef\n"
+# CHECK: abc{{\r}}def
+
+printf "Msg1\fMsg2\n"
+# CHECK: Msg1{{\f}}Msg2
+
+printf "foo\vbar\vbaz\n"
+# CHECK: foobarbaz
+
+printf "\111 \x50 \u0051 \U00000052"
 echo
-echo "Test escapes"
+# CHECK: I P Q R
 
 # \c escape means "stop printing"
 printf 'a\cb'
 echo
+# CHECK: a
 
 # Bogus printf specifier, should produce no stdout
 printf "%5" 10 2>/dev/null
@@ -33,12 +55,18 @@ printf "%5" 10 2>/dev/null
 # Octal escapes produce literal bytes, not characters
 # \376 is 0xFE
 printf '\376' | display_bytes
+# CHECK: 0000000 376
+# CHECK: 0000001
 
 # Verify that floating point conversions and output work correctly with
 # different combinations of locales and floating point strings. See issue
 # #3334. This starts by assuming an locale using english conventions.
 printf '%e\n' "1.23"  # should succeed, output should be 1.230000e+00
+# CHECK: 1.230000e+00
+
 printf '%e\n' "2,34"  # should fail
+# CHECK: 2.000000e+00
+# CHECKERR: 2,34: value not completely converted
 
 # Try to use one of several locales that use a comma as the decimal mark
 # rather than the period used in english speaking locales. If we don't find
@@ -63,16 +91,28 @@ else
     echo '3,450000e+00'
     echo '4,560000e+00'
 end
+# CHECK: 3,450000e+00
+# CHECK: 4,560000e+00
 
 # Verify long long ints are handled correctly. See issue #3352.
 printf 'long hex1 %x\n' 498216206234
+# CHECK: long hex1 73ffffff9a
 printf 'long hex2 %X\n' 498216206234
+# CHECK: long hex2 73FFFFFF9A
 printf 'long hex3 %X\n' 0xABCDEF1234567890
+# CHECK: long hex3 ABCDEF1234567890
 printf 'long hex4 %X\n' 0xABCDEF12345678901
+# CHECKERR: 0xABCDEF12345678901: Number out of range
 printf 'long decimal %d\n' 498216206594
+# CHECK: long hex4 long decimal 498216206594
 printf 'long signed %d\n' -498216206595
+# CHECK: long signed -498216206595
 printf 'long signed to unsigned %u\n' -498216206596
+# CHECK: long signed to unsigned 18446743575493345020
 
 # Verify numeric conversion still happens even if it couldn't be fully converted
 printf '%d\n' 15.1
+# CHECK: 15
+# CHECKERR: 15.1: value not completely converted
 echo $status
+# CHECK: 1

--- a/tests/printf.err
+++ b/tests/printf.err
@@ -1,3 +1,0 @@
-2,34: value not completely converted
-0xABCDEF12345678901: Number out of range
-15.1: value not completely converted

--- a/tests/printf.out
+++ b/tests/printf.out
@@ -1,29 +1,0 @@
-Hello 1 2 3.000000 4.000000 5 6
-a B 10 18446744073709551615
-a hello
-h…o
-5.000000e+00 6.000000E+00
-                  50
-5                   10
-       100
-%"\nxy
-abcdef
-Msg1Msg2
-foobarbaz
-I P Q R
-Test escapes
-a
-0000000 376
-0000001
-1.230000e+00
-2.000000e+00
-3,450000e+00
-4,560000e+00
-long hex1 73ffffff9a
-long hex2 73FFFFFF9A
-long hex3 ABCDEF1234567890
-long hex4 long decimal 498216206594
-long signed -498216206595
-long signed to unsigned 18446743575493345020
-15
-1

--- a/tests/test.fish
+++ b/tests/test.fish
@@ -15,7 +15,7 @@ cd (dirname (status -f))
 if set -q argv[1]
     set files_to_test $argv.in
 else
-    set files_to_test *.in
+    set files_to_test *.in *.check
 end
 
 # These env vars should not be inherited from the user environment because they can affect the
@@ -29,7 +29,7 @@ or exit
 
 say -o cyan "Testing high level script functionality"
 
-function test_file
+function test_in_file
     set -l file $argv[1]
     set -l base (basename $file .in)
 
@@ -69,10 +69,24 @@ function test_file
     end
 end
 
+function test_littlecheck_file
+    set -l file $argv[1]
+    echo "Testing file $file"
+    ../littlecheck.py -s fish=../test/root/bin/fish $file
+end
+
 set -l failed
 for i in $files_to_test
-    if not test_file $i
-        set failed $failed $i
+    if string match --quiet '*.check' $i
+        if not test_littlecheck_file $i
+            # littlecheck test
+            set failed $failed $i
+        end
+    else
+        # .in test
+        if not test_in_file $i
+            set failed $failed $i
+        end
     end
 end
 


### PR DESCRIPTION
This is an effort to improve the fish script tests, the '.in/.out/.err' tests.

Problems with the current test driver:

- Writing new tests is annoying, because it requires juggling three files
- Tests are hard to understand because the commands are so separated from their expected output
- The 'out' and 'err' files can only match literally
- The diff output is hard to understand

I could not find a suitable replacement, so I wrote one, inspired by LLVM's testers [lit](http://llvm.org/docs/CommandGuide/lit.html) and [FileCheck](https://www.llvm.org/docs/CommandGuide/FileCheck.html). I call it littlecheck. [Here's the repo](https://github.com/ridiculousfish/littlecheck).

The big idea is to embed the expected output directly within the test script itself, in fish comments. Each line of expected output can be right underneath the line that produced it - [example](https://github.com/ridiculousfish/fish-shell/blob/littlecheck/tests/printf.check):

```bash
printf "%c %s\n" a hello
# CHECK: a hello
```

Each test needs only one file. When a test fails the output is pretty nice:

<img width="469" alt="Screen Shot 2019-06-09 at 12 02 44 PM" src="https://user-images.githubusercontent.com/920838/59162941-7f86e400-8aae-11e9-9586-4881d7e40281.png">

I'm quite happy with how this turned out. One downside is that it makes Python a dependency for running the tests. However we already rely on Python in other places, so this seems acceptable to me.

If we like this plan then we can start porting all the '.in' tests to littlecheck.