### PR TITLE
Add Travis check for style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,17 @@ matrix:
     - os: osx
       before_install:
         - brew update
+        - brew upgrade cmake
         - brew install pcre2 # use system PCRE2
   fast_finish: true
 
 script:
-  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/prefix . || cat CMakeFiles/CMakeError.log &&
-    make -j2 &&
-    make install &&
-    make test SHOW_INTERACTIVE_LOG=1
+  - mkdir build; cd build # This dancing around can be avoided with cmake -S / -B, but that requires CMake 3.13
+  - cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/prefix || cat build/CMakeFiles/CMakeError.log
+  - cd ..
+  - cmake --build build -j 2 &&
+    cmake --build build --target install &&
+    SHOW_INTERACTIVE_LOG=1 cmake --build build --target test
 
 notifications:
   # Some items are encrypted so that notifications from other repositories

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   include:
     - os: linux
       compiler: gcc
+      python: 3.7
       addons:
         apt:
           packages:
@@ -43,7 +44,9 @@ matrix:
       before_install:
         - brew update
         - brew upgrade cmake
-        - brew install pcre2 # use system PCRE2
+        - brew install clang-format black pcre2 # use system PCRE2
+      env:
+        - TRAVIS_CHECK_STYLE=1
   fast_finish: true
 
 script:
@@ -53,6 +56,14 @@ script:
   - cmake --build build -j 2 &&
     cmake --build build --target install &&
     SHOW_INTERACTIVE_LOG=1 cmake --build build --target test
+  - if [[ -n "$TRAVIS_CHECK_STYLE" ]] ; then
+      PATH=$HOME/prefix/bin:$PATH build_tools/style.fish --all;
+      if [[ -n $(git status --porcelain --untracked-files=no) ]]; then
+        echo "Current source tree has unstyled changes - exiting with failure";
+        git diff;
+        exit 1;
+      fi;
+    fi
 
 notifications:
   # Some items are encrypted so that notifications from other repositories

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2554,7 +2554,6 @@ struct autoload_tester_t {
 
         run(L"rm -Rf %ls", p1.c_str());
         run(L"rm -Rf %ls", p2.c_str());
-
     }
 };
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -666,13 +666,11 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
         const size_t shared_prefix = line_shared_prefix(o_line, s_line);
         size_t skip_prefix = shared_prefix;
         if (shared_prefix < o_line.indentation) {
-            if (o_line.indentation > s_line.indentation
-                && s_line.indentation != s_line.size()
-                && !has_cleared_screen && clr_eol && clr_eos) {
+            if (o_line.indentation > s_line.indentation && s_line.indentation != s_line.size() &&
+                !has_cleared_screen && clr_eol && clr_eos) {
                 s_set_color(scr, vars, highlight_spec_t{});
                 s_move(scr, 0, (int)i);
-                s_write_mbs(scr,
-                            should_clear_screen_this_line ? clr_eos : clr_eol);
+                s_write_mbs(scr, should_clear_screen_this_line ? clr_eos : clr_eol);
                 has_cleared_screen = should_clear_screen_this_line;
                 has_cleared_line = true;
             }
@@ -683,8 +681,9 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
             // over the shared prefix of what we want to output now, and what we output before, to
             // avoid repeatedly outputting it.
             if (skip_prefix > 0) {
-                size_t skip_width = shared_prefix < skip_prefix ? skip_prefix
-                    : fish_wcswidth(&o_line.text.at(0), shared_prefix);
+                size_t skip_width = shared_prefix < skip_prefix
+                                        ? skip_prefix
+                                        : fish_wcswidth(&o_line.text.at(0), shared_prefix);
                 if (skip_width > skip_remaining) skip_remaining = skip_width;
             }
 
@@ -719,21 +718,20 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
         }
 
         // Now actually output stuff.
-        for (; ; j++) {
+        for (;; j++) {
             bool done = j >= o_line.size();
             // Clear the screen if we have not done so yet.
             // If we are about to output into the last column, clear the screen first. If we clear
             // the screen after we output into the last column, it can erase the last character due
             // to the sticky right cursor. If we clear the screen too early, we can defeat soft
             // wrapping.
-            if (should_clear_screen_this_line && !has_cleared_screen
-                && (done || j + 1 == (size_t)screen_width)) {
+            if (should_clear_screen_this_line && !has_cleared_screen &&
+                (done || j + 1 == (size_t)screen_width)) {
                 s_move(scr, current_width, (int)i);
                 s_write_mbs(scr, clr_eos);
                 has_cleared_screen = true;
             }
-            if (done)
-                break;
+            if (done) break;
 
             perform_any_impending_soft_wrap(scr, current_width, (int)i);
             s_move(scr, current_width, (int)i);


### PR DESCRIPTION
This PR enables style checking on all Travis builds. It currently fails, but I'll push a commit that passes shortly.

Unfortunately, `clang-format` output is not stable across versions, and the version available on Travis' Linux images is very old, so this uses the macOS build.

I am in two minds about merging this - on the one hand, it would help to remind those making PRs to run `build_tools/style.fish`, but on the other might lead to even more thrashing around with "fixup! style change" commits which pollute `git blame`.

Your thoughts, as always, are appreciated.