### PR TITLE
Add new `string` subcommand `string collect`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ max_line_length = 100
 [{Makefile,*.in}]
 indent_style = tab
 
-[*.md]
+[*.{md,rst}]
 trim_trailing_whitespace = false
 
 [*.{sh,ac}]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - The `--debug` option has been extended to allow specifying categories. Categories may be listed via `fish --print-debug-categories`.
 - `string replace` had an additional round of escaping in the replacement (not the match!), so escaping backslashes would require `string replace -ra '([ab])' '\\\\\\\$1' a`. A new feature flag `string-replace-fewer-backslashes` can be used to disable this, so that it becomes `string replace -ra '([ab])' '\\\\$1' a` (#5556).
 - Some parser errors did not set `$status` to non-zero. This has been corrected (b2a1da602f79878f4b0adc4881216c928a542608).
+- `string` has a new `collect` subcommand that disables newline-splitting on its input. This is meant to be used as the end of a command substitution pipeline to produce a single output argument potentially containing newlines, such as `set contents (cat filename | string collect)`. It also supports a `--trim-newline` flag to trim a single trailing newline from the output (#159).
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, so things like `git reset HEAD@{0}` now work (#5869).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - The `--debug` option has been extended to allow specifying categories. Categories may be listed via `fish --print-debug-categories`.
 - `string replace` had an additional round of escaping in the replacement (not the match!), so escaping backslashes would require `string replace -ra '([ab])' '\\\\\\\$1' a`. A new feature flag `string-replace-fewer-backslashes` can be used to disable this, so that it becomes `string replace -ra '([ab])' '\\\\$1' a` (#5556).
 - Some parser errors did not set `$status` to non-zero. This has been corrected (b2a1da602f79878f4b0adc4881216c928a542608).
-- `string` has a new `collect` subcommand that disables newline-splitting on its input. This is meant to be used as the end of a command substitution pipeline to produce a single output argument potentially containing newlines, such as `set contents (cat filename | string collect)`. It also supports a `--trim-newline` flag to trim a single trailing newline from the output (#159).
+- `string` has a new `collect` subcommand that disables newline-splitting on its input. This is meant to be used as the end of a command substitution pipeline to produce a single output argument potentially containing internal newlines, such as `set output (some-cmd | string collect)`. Any trailing newlines are trimmed, just like `"$(cmd)"` substitution in sh. It also supports a `--no-trim-newlines` flag to disable trailing newline trimming, which may be useful when doing something like `set contents (cat filename | string collect -N)` (#159).
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, so things like `git reset HEAD@{0}` now work (#5869).

--- a/share/completions/string.fish
+++ b/share/completions/string.fish
@@ -1,7 +1,7 @@
 # Completion for builtin string
 # This follows a strict command-then-options approach, so we can just test the number of tokens
 complete -f -c string
-complete -f -c string -n "test (count (commandline -opc)) -ge 2; and not contains -- (commandline -opc)[2] escape" -s q -l quiet -d "Do not print output"
+complete -f -c string -n "test (count (commandline -opc)) -ge 2; and not contains -- (commandline -opc)[2] escape collect" -s q -l quiet -d "Do not print output"
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "lower"
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "upper"
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "length"
@@ -13,6 +13,8 @@ complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "split0"
 complete -x -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr split0\?\$ -- (commandline -opc)[2]' -s m -l max -a "(seq 1 10)" -d "Specify maximum number of splits"
 complete -f -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr split0\?\$ -- (commandline -opc)[2]' -s r -l right -d "Split right-to-left"
 complete -f -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr split0\?\$ -- (commandline -opc)[2]' -s n -l no-empty -d "Empty results excluded"
+complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "collect"
+complete -f -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr collect\$ -- (commandline -opc)[2]' -s n -l trim-newline -d "Remove trailing newline"
 
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "join"
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "join0"

--- a/share/completions/string.fish
+++ b/share/completions/string.fish
@@ -14,7 +14,7 @@ complete -x -c string -n 'test (count (commandline -opc)) -ge 2; and string matc
 complete -f -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr split0\?\$ -- (commandline -opc)[2]' -s r -l right -d "Split right-to-left"
 complete -f -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr split0\?\$ -- (commandline -opc)[2]' -s n -l no-empty -d "Empty results excluded"
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "collect"
-complete -f -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr collect\$ -- (commandline -opc)[2]' -s n -l trim-newline -d "Remove trailing newline"
+complete -f -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr collect\$ -- (commandline -opc)[2]' -s N -l no-trim-newlines -d "Don't trim trailing newlines"
 
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "join"
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a "join0"

--- a/sphinx_doc_src/cmds/string.rst
+++ b/sphinx_doc_src/cmds/string.rst
@@ -6,7 +6,7 @@ string - manipulate strings
 Synopsis
 --------
 
-``string collect [(-n | --trim-newline)] [STRING...]``
+``string collect [(-N | --no-trim-newlines)] [STRING...]``
 
 ``string escape [(-n | --no-quoted)] [--style=xxx] [STRING...]``
 
@@ -53,13 +53,13 @@ The following subcommands are available.
 "collect" subcommand
 --------------------
 
-``string collect [(-n | --trim-newline)] [STRING...]``
+``string collect [(-N | --no-trim-newlines)] [STRING...]``
 
 ``string collect`` collects its input into a single output argument, without splitting the output when used in a command substitution. This is useful when trying to collect multiline output from another command into a variable. Exit status: 0 if any output argument is non-empty, or 1 otherwise.
 
 If invoked with multiple arguments instead of input, ``string collect`` preserves each argument separately, where the number of output arguments is equal to the number of arguments given to ``string collect``.
 
-``--trim-newline`` trims a single trailing newline off of each output argument. This is useful when collecting the output from another command as the trailing newline is frequently not desired.
+Any trailing newlines on the input are trimmed, just as with ``"$(cmd)"`` substitution in sh. ``--no-trim-newlines`` can be used to disable this behavior, which may be useful when running a command such as ``set contents (cat filename | string collect -N)``.
 
 "escape" and "unescape" subcommands
 -----------------------------------
@@ -352,7 +352,7 @@ Examples
     three
     "
     
-    >_ echo \"(ech one\ntwo\nthree | string collect -n)\"
+    >_ echo \"(echo one\ntwo\nthree | string collect -N)\"
     "one
     two
     three"

--- a/sphinx_doc_src/cmds/string.rst
+++ b/sphinx_doc_src/cmds/string.rst
@@ -6,6 +6,8 @@ string - manipulate strings
 Synopsis
 --------
 
+``string collect [(-n | --trim-newline)] [STRING...]``
+
 ``string escape [(-n | --no-quoted)] [--style=xxx] [STRING...]``
 
 ``string join [(-q | --quiet)] SEP [STRING...]``
@@ -47,6 +49,17 @@ Arguments beginning with ``-`` are normally interpreted as switches; ``--`` caus
 Most subcommands accept a ``-q`` or ``--quiet`` switch, which suppresses the usual output but exits with the documented status.
 
 The following subcommands are available.
+
+"collect" subcommand
+--------------------
+
+``string collect [(-n | --trim-newline)] [STRING...]``
+
+``string collect`` collects its input into a single output argument, without splitting the output when used in a command substitution. This is useful when trying to collect multiline output from another command into a variable. Exit status: 0 if any output argument is non-empty, or 1 otherwise.
+
+If invoked with multiple arguments instead of input, ``string collect`` preserves each argument separately, where the number of output arguments is equal to the number of arguments given to ``string collect``.
+
+``--trim-newline`` trims a single trailing newline off of each output argument. This is useful when collecting the output from another command as the trailing newline is frequently not desired.
 
 "escape" and "unescape" subcommands
 -----------------------------------
@@ -327,6 +340,22 @@ Examples
 
     >_ string escape --style=var 'a1 b2'\\u6161
     a1_20b2__c_E6_85_A1
+
+
+
+
+::
+
+    >_ echo \"(echo one\ntwo\nthree | string collect)\"
+    "one
+    two
+    three
+    "
+    
+    >_ echo \"(ech one\ntwo\nthree | string collect -n)\"
+    "one
+    two
+    three"
 
 
 Match Glob Examples

--- a/tests/string.err
+++ b/tests/string.err
@@ -309,3 +309,9 @@ string repeat: Unknown option '-l'
 
 ####################
 # string split0 in functions
+
+####################
+# string collect
+
+####################
+# string collect in functions

--- a/tests/string.in
+++ b/tests/string.in
@@ -392,4 +392,31 @@ function dualsplit
 end
 count (dualsplit)
 
+logmsg string collect
+count (echo one\ntwo\nthree\nfour | string collect)
+count (echo one | string collect)
+echo [(echo one\ntwo\nthree | string collect)]
+echo [(echo one\ntwo\nthree | string collect -n)]
+printf '[%s]\n' (string collect one\n\n two\n)
+printf '[%s]\n' (string collect -n one\n\n two\n)
+printf '[%s]\n' (string collect --trim-newline one\n\n two\n)
+# string collect returns 0 when it has any output, otherwise 1
+string collect >/dev/null; and echo unexpected success; or echo expected failure
+echo -n | string collect >/dev/null; and echo unexpected success; or echo expected failure
+echo | string collect >/dev/null; and echo expected success; or echo unexpected failure
+echo | string collect -n >/dev/null; and echo unexpected success; or echo expected failure
+string collect a >/dev/null; and echo expected success; or echo unexpected failure
+string collect '' >/dev/null; and echo unexpected success; or echo expected failure
+string collect -n \n >/dev/null; and echo unexpected success; or echo expected failure
+
+logmsg string collect in functions
+# This function outputs some newline-separated content, and some
+# explicitly un-separated content.
+function dualcollect
+  echo alpha
+  echo beta
+  echo gamma\ndelta\nomega | string collect
+end
+count (dualcollect)
+
 exit 0

--- a/tests/string.in
+++ b/tests/string.in
@@ -396,18 +396,18 @@ logmsg string collect
 count (echo one\ntwo\nthree\nfour | string collect)
 count (echo one | string collect)
 echo [(echo one\ntwo\nthree | string collect)]
-echo [(echo one\ntwo\nthree | string collect -n)]
+echo [(echo one\ntwo\nthree | string collect -N)]
 printf '[%s]\n' (string collect one\n\n two\n)
-printf '[%s]\n' (string collect -n one\n\n two\n)
-printf '[%s]\n' (string collect --trim-newline one\n\n two\n)
+printf '[%s]\n' (string collect -N one\n\n two\n)
+printf '[%s]\n' (string collect --no-trim-newlines one\n\n two\n)
 # string collect returns 0 when it has any output, otherwise 1
 string collect >/dev/null; and echo unexpected success; or echo expected failure
 echo -n | string collect >/dev/null; and echo unexpected success; or echo expected failure
-echo | string collect >/dev/null; and echo expected success; or echo unexpected failure
-echo | string collect -n >/dev/null; and echo unexpected success; or echo expected failure
+echo | string collect -N >/dev/null; and echo expected success; or echo unexpected failure
+echo | string collect >/dev/null; and echo unexpected success; or echo expected failure
 string collect a >/dev/null; and echo expected success; or echo unexpected failure
-string collect '' >/dev/null; and echo unexpected success; or echo expected failure
-string collect -n \n >/dev/null; and echo unexpected success; or echo expected failure
+string collect -N '' >/dev/null; and echo unexpected success; or echo expected failure
+string collect \n\n >/dev/null; and echo unexpected success; or echo expected failure
 
 logmsg string collect in functions
 # This function outputs some newline-separated content, and some

--- a/tests/string.out
+++ b/tests/string.out
@@ -490,22 +490,23 @@ Split something
 1
 [one
 two
-three
-]
+three]
 [one
 two
-three]
+three
+]
+[one]
+[two]
 [one
 
 ]
 [two
 ]
 [one
+
 ]
-[two]
-[one
+[two
 ]
-[two]
 expected failure
 expected failure
 expected success

--- a/tests/string.out
+++ b/tests/string.out
@@ -483,3 +483,37 @@ Split something
 ####################
 # string split0 in functions
 4
+
+####################
+# string collect
+1
+1
+[one
+two
+three
+]
+[one
+two
+three]
+[one
+
+]
+[two
+]
+[one
+]
+[two]
+[one
+]
+[two]
+expected failure
+expected failure
+expected success
+expected failure
+expected success
+expected failure
+expected failure
+
+####################
+# string collect in functions
+3


### PR DESCRIPTION
## Description

The `string` command now has a new subcommand `string collect`. This behaves quite similarly to `string split0 -m 0` in that it doesn't perform any splitting of its input, and disables implicit splitting of its output, but it makes more conceptual sense. It also has an optional flag `--trim-newline` that trims a single trailing newline off of the output, as we usually don't want a trailing newline when capturing output from a command.

This is intended to solve the use-case described in #159, though I'm not sure that issue should actually be closed (I think there is benefit in having dedicated syntax for this, such as `"$(foo)"`).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for new features
- [X] User-visible changes noted in CHANGELOG.md