### PR TITLE
Prevent not-yet-loaded functions from loaded when erased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `test` (aka `[`) now prints a stacktrace on error, making the offending call easier to find (#5771).
 - The default read limit has been increased to 100MiB (#5267).
 - `math` now also understands `x` for multiplication, provided it is followed by whitespace (#5906).
+- `functions --erase` now also prevents fish from autoloading a function for the first time (#5951).
 
 ### Interactive improvements
 - Major improvements in performance and functionality to the 'sorin' sample prompt (#5411).

--- a/sphinx_doc_src/cmds/functions.rst
+++ b/sphinx_doc_src/cmds/functions.rst
@@ -26,7 +26,7 @@ The following options are available:
 
 - ``-d DESCRIPTION`` or ``--description=DESCRIPTION`` changes the description of this function.
 
-- ``-e`` or ``--erase`` causes the specified functions to be erased.
+- ``-e`` or ``--erase`` causes the specified functions to be erased. This also means that it is prevented from autoloading.
 
 - ``-D`` or ``--details`` reports the path name where each function is defined or could be autoloaded, ``stdin`` if the function was defined interactively or on the command line or by reading stdin, and ``n/a`` if the function isn't available. If the ``--verbose`` option is also specified then five lines are written:
 

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -245,10 +245,9 @@ bool function_set_t::remove(const wcstring &name) {
 
 void function_remove(const wcstring &name) {
     auto funcset = function_set.acquire();
-    if (funcset->remove(name)) {
-        // Prevent re-autoloading this function.
-        funcset->autoload_tombstones.insert(name);
-    }
+    funcset->remove(name);
+    // Prevent (re-)autoloading this function.
+    funcset->autoload_tombstones.insert(name);
 }
 
 bool function_get_definition(const wcstring &name, wcstring &out_definition) {


### PR DESCRIPTION
Today, `functions --erase $function` does nothing if the function
hasn't been autoloaded yet.

E.g. run, in an interactive session

    > functions --erase ls
    > type ls

and be amazed that it still shows our default `ls --color=auto`
wrapper function.

This seems counter-intuitive - removing a function ought to remove it,
whether it had been executed before or not.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
