### PR TITLE
Emulate path_helper more faithfully when constructing paths on macOS

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -173,10 +173,9 @@ if status --is-login
         # executable for fish; see
         # https://opensource.apple.com/source/shell_cmds/shell_cmds-203/path_helper/path_helper.c.auto.html .
         function __fish_macos_set_env -d "set an environment variable like path_helper does (macOS only)"
-            # The first argument is the variable name, the others are the files.
-            # Keep the components already there so we don't change the order
-            set -l result $$argv[1]
+            set -l result
 
+            # Populate path according to config files
             for path_file in $argv[2] $argv[3]/*
                 if [ -f $path_file ]
                     while read -l entry
@@ -185,6 +184,13 @@ if status --is-login
                             and set -a result $entry
                         end
                     end <$path_file
+                end
+            end
+
+            # Merge in any existing path elements
+            for existing_entry in $$argv[1]
+                if not contains -- $existing_entry $result
+                    set -a result $existing_entry
                 end
             end
 


### PR DESCRIPTION
## Description

Hello folks! 👋

A few weeks ago over in https://github.com/fish-shell/fish-shell/pull/5767#issuecomment-498529778 I noted that the adjusted PATH/MANTPATH initialization for macOS wasn't quite right, and would lead to actual problem with binaries in `/usr/local/bin` being hidden by same-named binaries in `/usr/bin`, because `/usr/bin` was incorrectly being left at the start of `PATH`.

I thought I could just go ahead and create a PR to fix the issue by more faithfully following path_helper's approach to building these paths.

I wanted to get this done now, because it'd be great to have a fix like this in place before your next release, if it's something you can see fitting in.

Full detail below:

---

Previously, elements already existing in the path variable would keep their position when the path was being constructed from the config files. This caused issues given that $PATH typically already contains "/usr/bin:/bin" when fish initializes within a macOS terminal app. In this case, these would keep their position at the front of the $PATH, even though the system path_helper configs explicitly place them _after_ other paths, like "/usr/local/bin". This would render binaries in "/usr/local/bin" as effectively "invisible" if they also happen to live in "/usr/bin" as well. This is not the intended macOS shell behaviour.

This change makes the __fish_macos_set_env config function emulate the macOS standard path_helper behavior more faithfully, with:

1. The path list being constructed *from scratch* based on the paths specified in the config files
2. Any distinct entries in the exist path environment variable being appended to this list
3. And then this list being used to *replace* the existing path environment variable

The result, for a vanilla fish shell on macOS, is that the $PATH is now set to:

    /usr/local/bin /usr/bin /bin /usr/sbin /sbin

Where previously it was set to:

    /usr/bin /bin /usr/local/bin /usr/sbin /sbin

This new $PATH exactly matches the order of paths specified in `/etc/paths`.

## TODOs:

This is my first contribution to fish-shell, and I'm not 100% if any of these apply here, since the change in #5767 (which I'm adjusting) didn't have any of them either. Would appreciate your help here!

I've tested this new config on my own installation of fish and it's working fine (in particular, it's allowed me to remove some hacks in my personal config I had to put in place to work around the previous behaviour).

<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md