### PR TITLE
Fixed invalid assignments in fish_print_git_action

### DIFF
--- a/share/functions/fish_print_git_action.fish
+++ b/share/functions/fish_print_git_action.fish
@@ -44,10 +44,8 @@ function fish_print_git_action --argument-names git_dir
 
     if test -f "$git_dir/CHERRY_PICK_HEAD"
         if test -d "$git_dir/sequencer"
-            cherry_pick_sequence_formatted='cherry-pick-sequence'
             echo -n 'cherry-pick-sequence'
         else
-            cherry_pick_formatted='cherry-pick'
             echo -n 'cherry-pick'
         end
         return 0


### PR DESCRIPTION
## Description

I don't always cherry-pick and get merge conflicts in my Git repos, but when I do I notice leftover ZSH code in my fish-shell. 😄
After merging this the sorin theme will also work during an cherry-pick-induced merge conflict and stop it from spamming errors into the terminal output. 🙂