### PR TITLE
Suppress shell function lookup for ssh during scp completion

### DIFF
--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -54,7 +54,7 @@ complete -c scp -d "Local Path" -n "not string match @ -- (commandline -ct)"
 # Get the list of remote files from the scp target.
 complete -c scp -d "Remote Path" -f -n "commandline -ct | string match -eq ':'" -a "
 (__scp_remote_target):( \
-        ssh (__scp2ssh_port_number) -o 'BatchMode yes' (__scp_remote_target) /bin/ls\ -dp\ (__scp_remote_path_prefix)\* 2>/dev/null
+        command ssh (__scp2ssh_port_number) -o 'BatchMode yes' (__scp_remote_target) /bin/ls\ -dp\ (__scp_remote_path_prefix)\* 2>/dev/null
 )
 "
 complete -c scp -s B -d "Batch mode"


### PR DESCRIPTION
## Description

This prevents functions or aliases to run during tab completion of remote files for the `scp` command.

Fixes issue #

I'm currently running Kitty and my terminal emulator, and its terminfo is often missing on older systems I SSH into. This documented in the [FAQ](https://sw.kovidgoyal.net/kitty/faq.html#i-get-errors-about-the-terminal-being-unknown-or-opening-the-terminal-failing-when-sshing-into-a-different-computer), and can be worked around with the following command:

```sh
kitty +kitten ssh server1.example.com
```

Naturally I created my own function for this:

```fish
# ~/.config/fish/functions/ssh.fish
function ssh -d 'kitty compatible ssh command'
    switch $TERM
    case xterm-kitty
        kitty +kitten ssh $argv
    case "*"
        command ssh $argv
    end
end
```

However the problem is the "kitten" has some issues with globs (see https://github.com/kovidgoyal/kitty/issues/1787), and this breaks tab completion.

```sh
kitty +kitten ssh -o 'BatchMode yes' example.com /bin/ls -dp \*
/bin/ls: cannot access '*': No such file or directory
```

```sh
ssh -o 'BatchMode yes' example.com /bin/ls -dp \*
404.jpg
src/
temp/
```

And while this seems to mostly be an issue on the Kitty end, I figured running `command ssh` instead of `ssh` to ignore functions/aliases wouldn't hurt.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md