### PR TITLE
Emit 'fish_cancel' at end of __fish_cancel_commandline.

### DIFF
--- a/share/functions/__fish_cancel_commandline.fish
+++ b/share/functions/__fish_cancel_commandline.fish
@@ -20,5 +20,6 @@ function __fish_cancel_commandline
         end
         commandline ""
         commandline -f repaint
+        emit fish_cancel
     end
 end


### PR DESCRIPTION
This helps with shell integration - see issue #5973
"shell-integration - how distringuish winch repaint from ctrl-c cancel".

This probably also should have a documentation update.