### PR TITLE
docs/bind: Mention history-token-search-backward and history-token-search-forward

### DIFF
--- a/sphinx_doc_src/cmds/bind.rst
+++ b/sphinx_doc_src/cmds/bind.rst
@@ -126,6 +126,10 @@ The following special input functions are available:
 
 - ``history-search-forward``, search the history for the next match
 
+- ``history-token-search-backward``, search the history for the previous matching argument
+
+- ``history-token-search-forward``, search the history for the next matching argument
+
 - ``kill-bigword``, move the next whitespace-delimited word to the killring
 
 - ``kill-line``, move everything from the cursor to the end of the line to the killring


### PR DESCRIPTION
As discussed in #6009. 

I struggled a bit with finding the right words to describe the functions. Is *history* what we're searching here? Is *command argument* correct? Let me know if you have any suggestions.

Added `[ci skip]` to the commit because I saw it was done in the history of that file.