### PR TITLE
Document alternates for common arrow key usage.

### DIFF
--- a/sphinx_doc_src/faq.rst
+++ b/sphinx_doc_src/faq.rst
@@ -31,7 +31,7 @@ You can also use the Web configuration tool, :ref:`fish_config <cmd-fish_config>
 
 How do I run a command from history?
 ------------------------------------
-Type some part of the command, and then hit the :kbd:`↑` (up) or :kbd:`↓` (down) arrow keys to navigate through history matches.
+Type some part of the command, and then hit the :kbd:`↑` (up) or :kbd:`↓` (down) arrow keys to navigate through history matches. Additional default key bindings include :kbd:`Control+P` (up) and :kbd:`Control+N` (down).
 
 
 How do I run a subcommand? The backtick doesn't work!
@@ -231,7 +231,7 @@ Fish history recall is very simple yet effective:
 
   - If the line you want is far back in the history, type any part of the line and then press Up one or more times.  This will constrain the recall to lines that include this text, and you will get to the line you want much faster.  This replaces "!vi", "!?bar.c" and the like.
 
-- :kbd:`Alt+↑,Up` recalls individual arguments, starting from the last argument in the last line executed.  A single press replaces "!$", later presses replace "!!:4" and the like.
+- :kbd:`Alt+↑,Up` recalls individual arguments, starting from the last argument in the last line executed.  A single press replaces "!$", later presses replace "!!:4" and the like. An alternate key binding is :kbd:`Alt+.`.
 
   - If the argument you want is far back in history (e.g. 2 lines back - that's a lot of words!), type any part of it and then press :kbd:`Alt+↑,Up`.  This will show only arguments containing that part and you will get what you want much faster.  Try it out, this is very convenient!
 


### PR DESCRIPTION
## Description

Arrow keys are often not conveniently located on keyboards, so the use of arrow keys for common keyboard shortcuts can be a turn-off for some.

I found that fish supports alternate keybindings for these cases but I didn't seem them documented in these places where the arrow keys versions are highlighted.
