### PR TITLE
Make sure null command always exits successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Empty universal variables may now be exported (#5992).
 - `string split` had a bug where empty strings would be dropped if the output was only empty strings; this has been fixed (#5987).
 - `switch` now allows arguments that expand to nothing, like empty variables (#5677).
+- The null command (:) now always exits successfully, rather than echoing last return code.
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, so things like `git reset HEAD@{0}` now work (#5869).

--- a/share/config.fish
+++ b/share/config.fish
@@ -75,7 +75,9 @@ end
 function : -d "no-op function"
     # for compatibility with sh, bash, and others.
     # Often used to insert a comment into a chain of commands without having
-    # it eat up the remainder of the line, handy in Makefiles. 
+    # it eat up the remainder of the line, handy in Makefiles.
+    # This command always succeeds
+    true
 end
 
 #


### PR DESCRIPTION
## Description

The null command (‘:’) now always exits successfully (rather than echoing the last return code), mimicking the behaviour of the similar command in e.g. `bash`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.md
