### PR TITLE
completions/canto.fish: s/cnato/canto/

### DIFF
--- a/share/completions/canto.fish
+++ b/share/completions/canto.fish
@@ -25,7 +25,7 @@ complete -f -c canto -s n -l checknew -d 'Show number of new items for feed'
 complete -f -c canto -n '__fish_canto_using_command -l --checknew' -d 'Feed' -a '(command canto -l)'
 
 complete -c canto -s o -l opml -d 'Print conf as OPML'
-complete -c cnato -s i -l import -d 'Import from OPML'
+complete -c canto -s i -l import -d 'Import from OPML'
 complete -f -c canto -s r -l url -d 'Add feed'
 
 complete -c canto -s D -l dir -d 'Set configuration directory'


### PR DESCRIPTION
## Description

I was flipping through the completions looking for style inspiration for my own completions. This typo jumped out at me even though I've never even heard of canto.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
