### PR TITLE
document vi mode cursor configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `string split` had a bug where empty strings would be dropped if the output was only empty strings; this has been fixed (#5987).
 - `switch` now allows arguments that expand to nothing, like empty variables (#5677).
 - The null command (:) now always exits successfully, rather than echoing last return code.
+- Cursor configuration instructions for vi-mode have been added to the fish documentation.
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, so things like `git reset HEAD@{0}` now work (#5869).

--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -1511,9 +1511,19 @@ It is also possible to add all emacs-mode bindings to vi-mode by using something
     end
 
 
-When in vi-mode, the :ref:`fish_mode_prompt <cmd-fish_mode_prompt>` function will display a mode indicator to the left of the prompt. The ``fish_vi_cursor`` function will be used to change the cursor's shape depending on the mode in supported terminals. To disable this feature, override it with an empty function. To display the mode elsewhere (like in your right prompt), use the output of the ``fish_default_mode_prompt`` function.
+When in vi-mode, the :ref:`fish_mode_prompt <cmd-fish_mode_prompt>` function will display a mode indicator to the left of the prompt. To disable this feature, override it with an empty function. To display the mode elsewhere (like in your right prompt), use the output of the ``fish_default_mode_prompt`` function.
 
 When a binding switches the mode, it will repaint the mode-prompt if it exists, and the rest of the prompt only if it doesn't. So if you want a mode-indicator in your ``fish_prompt``, you need to erase ``fish_mode_prompt`` e.g. by adding an empty file at `~/.config/fish/functions/fish_mode_prompt.fish`. (Bindings that change the mode are supposed to call the `repaint-mode` bind function, see :ref:`bind <cmd-bind>`)
+
+The ``fish_vi_cursor`` function will be used to change the cursor's shape depending on the mode in supported terminals. The following snippet can be used to manually configure cursors after enabling vi-mode::
+
+   # Emulates vim's cursor shape behavior
+   # Set the normal and visual mode cursors to a block
+   set fish_cursor_default block
+   # Set the insert mode cursor to a line
+   set fish_cursor_insert line
+   # Set the replace mode cursor to an underscore
+   set fish_cursor_replace_one underscore
 
 .. _vi-mode-command:
 

--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -1524,12 +1524,11 @@ The ``fish_vi_cursor`` function will be used to change the cursor's shape depend
    set fish_cursor_insert line
    # Set the replace mode cursor to an underscore
    set fish_cursor_replace_one underscore
-   # The following variable can be used to configure cursor
-   # shape in visual mode, but due to fish_cursor_default, is
-   # redundant here
+   # The following variable can be used to configure cursor shape in
+   # visual mode, but due to fish_cursor_default, is redundant here
    set fish_cursor_visual block
 
-Additionally, `blink` can be added after each of the cursor shape parameters to set a blinking cursor in the specified shape.
+Additionally, ``blink`` can be added after each of the cursor shape parameters to set a blinking cursor in the specified shape.
 
 .. _vi-mode-command:
 

--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -1524,6 +1524,12 @@ The ``fish_vi_cursor`` function will be used to change the cursor's shape depend
    set fish_cursor_insert line
    # Set the replace mode cursor to an underscore
    set fish_cursor_replace_one underscore
+   # The following variable can be used to configure cursor
+   # shape in visual mode, but due to fish_cursor_default, is
+   # redundant here
+   set fish_cursor_visual block
+
+Additionally, `blink` can be added after each of the cursor shape parameters to set a blinking cursor in the specified shape.
 
 .. _vi-mode-command:
 


### PR DESCRIPTION
## Description

The fish documentation has very little information on vi mode cursor configuration. This documents the settings someone configuring fish might want to use.

Fixes issue #4723

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] User-visible changes noted in CHANGELOG.md
- [ ] Tests have been added for regressions fixed
