### PR TITLE
Documentation: Initialization files paths

### DIFF
--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -1667,8 +1667,8 @@ Configuration files are evaluated in the following order:
 - Configuration snippets in files ending in ``.fish``, in the directories:
 
   - ``$__fish_config_dir/conf.d`` (by default, ``~/.config/fish/conf.d/``)
-  - ``$__fish_sysconf_dir/conf.d`` (by default, ``/etc/fish/conf.d``)
-  - ``/usr/share/fish/vendor_conf.d`` (set at compile time; by default, ``$__fish_data_dir/vendor_conf.d``)
+  - ``$__fish_sysconf_dir/conf.d`` (by default, ``/etc/fish/conf.d/``)
+  - ``/usr/share/fish/vendor_conf.d`` (set at compile time; by default, ``$__fish_data_dir/vendor_conf.d/``)
 
   If there are multiple files with the same name in these directories, only the first will be executed.
   They are executed in order of their filename, sorted (like globs) in a natural order (i.e. "01" sorts before "2").


### PR DESCRIPTION
Adds slash to end of example paths to align with that
~/.config/fish/conf.d/ had a slash at the end.

## Description

http://fishshell.com/docs/current/index.html#initialization has the first example director ending with a slash after conf.d to make it absolutely clear it is a directory. I added this to the other two examples. There might be another prefered way for this change to align all directory paths, if so please let me know.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
