### PR TITLE
Added `git restore` and `git switch` completions

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1424,6 +1424,13 @@ complete -f -c git -n '__fish_git_using_command reset; and contains -- -- (comma
 complete -f -c git -n '__fish_git_using_command reset; and not contains -- -- (commandline -op)' -a '(__fish_git_reflog)' -d 'Reflog'
 # TODO options
 
+### restore
+complete -f -c git -n '__fish_git_needs_command' -a restore -d 'Restore working tree files'
+complete -f -c git -n '__fish_git_using_command restore' -s s -l source -d 'Specify the source tree used to restore working tree'
+complete -f -c git -n '__fish_git_using_command restore' -s p -l patch -d 'Interactive mode'
+complete -f -c git -n '__fish_git_using_command restore' -s W -l worktree -d 'Restore working tree (default)'
+complete -f -c git -n '__fish_git_using_command restore' -s S -l staged -d 'Restore the index'
+
 ### revert
 complete -f -c git -n '__fish_git_needs_command' -a revert -d 'Revert an existing commit'
 complete -f -c git -n '__fish_git_using_command revert' -ka '(__fish_git_commits)'
@@ -1449,6 +1456,15 @@ complete -f -c git -n '__fish_git_using_command status' -s z -d 'Terminate entri
 complete -f -c git -n '__fish_git_using_command status' -s u -l untracked-files -x -a 'no normal all' -d 'The untracked files handling mode'
 complete -f -c git -n '__fish_git_using_command status' -l ignore-submodules -x -a 'none untracked dirty all' -d 'Ignore changes to submodules'
 # TODO options
+
+### switch
+complete -f -c git -n '__fish_git_needs_command' -a switch -d 'Switch to a branch'
+complete -k -f -c git -n '__fish_git_using_command switch; and not contains -- -- (commandline -op)' -a '(__fish_git_branches)'
+complete -f -c git -n '__fish_git_using_command switch' -s c -l create -d 'Create a new branch'
+complete -f -c git -n '__fish_git_using_command switch' -s C -l force-create -d 'Force create a new branch'
+complete -f -c git -n '__fish_git_using_command switch' -s d -l detach -d 'Switch to a commit for inspection and discardable experiment'
+complete -f -c git -n '__fish_git_using_command switch' -l no-guess -d 'Do not guess branch name from remote branch'
+complete -f -c git -n '__fish_git_using_command switch' -l orphan -d 'Create a new orphan branch'
 
 ### tag
 complete -f -c git -n '__fish_git_needs_command' -a tag -d 'Create, list, delete or verify a tag object signed with GPG'
@@ -1657,6 +1673,7 @@ complete -f -c git -n '__fish_git_using_command help' -a push -d 'Update remote 
 complete -f -c git -n '__fish_git_using_command help' -a rebase -d 'Forward-port local commits to the updated upstream head'
 complete -f -c git -n '__fish_git_using_command help' -a remote -d 'Manage set of tracked repositories'
 complete -f -c git -n '__fish_git_using_command help' -a reset -d 'Reset current HEAD to the specified state'
+complete -f -c git -n '__fish_git_using_command help' -a restore -d 'Restore working tree files'
 complete -f -c git -n '__fish_git_using_command help' -a revert -d 'Revert an existing commit'
 complete -f -c git -n '__fish_git_using_command help' -a rm -d 'Remove files from the working tree and from the index'
 complete -f -c git -n '__fish_git_using_command help' -a show -d 'Shows the last commit of a branch'
@@ -1664,6 +1681,7 @@ complete -f -c git -n '__fish_git_using_command help' -a show-branch -d 'Shows t
 complete -f -c git -n '__fish_git_using_command help' -a stash -d 'Stash away changes'
 complete -f -c git -n '__fish_git_using_command help' -a status -d 'Show the working tree status'
 complete -f -c git -n '__fish_git_using_command help' -a submodule -d 'Initialize, update or inspect submodules'
+complete -f -c git -n '__fish_git_using_command help' -a switch -d 'Switch to a branch'
 complete -f -c git -n '__fish_git_using_command help' -a tag -d 'Create, list, delete or verify a tag object signed with GPG'
 complete -f -c git -n '__fish_git_using_command help' -a whatchanged -d 'Show logs with difference each commit introduces'
 complete -f -c git -n '__fish_git_using_command help' -a worktree -d 'Manage multiple working trees'


### PR DESCRIPTION
## Description
See: Docs of [git-switch](https://git-scm.com/docs/git-switch) and [git-restore](https://git-scm.com/docs/git-restore).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
