### PR TITLE
improve documentation for fish_git_prompt

### DIFF
--- a/sphinx_doc_src/cmds/fish_git_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_git_prompt.rst
@@ -20,8 +20,8 @@ There are numerous customization options, which can be controlled with git optio
 
 - ``$__fish_git_prompt_showupstream`` can be set to a number of values to determine how changes between HEAD and upstream are shown:
 
-  ``auto``
-  summarize the difference between HEAD and its upstream
+     ``auto``
+          summarize the difference between HEAD and its upstream
      ``verbose``
           show number of commits ahead/behind (+/-) upstream
      ``name``

--- a/sphinx_doc_src/cmds/fish_git_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_git_prompt.rst
@@ -18,7 +18,7 @@ There are numerous customization options, which can be controlled with git optio
 
 - ``$__fish_git_prompt_showuntrackedfiles`` or the git option ``bash.showUntrackedFiles`` can be set to show if the repository has untracked files (that aren't ignored).
 
-- ``$__fish_git_prompt_showupstream`` can be set to a number of values to determine how changes between HEAD and upstream are shown:
+- ``$__fish_git_prompt_showupstream`` can be set to a space-delimited list of values to determine how changes between HEAD and upstream are shown:
 
      ``auto``
           summarize the difference between HEAD and its upstream

--- a/sphinx_doc_src/cmds/fish_git_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_git_prompt.rst
@@ -20,6 +20,8 @@ There are numerous customization options, which can be controlled with git optio
 
 - ``$__fish_git_prompt_showupstream`` can be set to a number of values to determine how changes between HEAD and upstream are shown:
 
+  ``auto``
+  summarize the difference between HEAD and its upstream
      ``verbose``
           show number of commits ahead/behind (+/-) upstream
      ``name``
@@ -112,5 +114,3 @@ A simple prompt that displays git info::
         set -g __fish_git_prompt_showupstream auto
         printf '%s %s$' $PWD (fish_git_prompt)
     end
-
-

--- a/sphinx_doc_src/cmds/fish_git_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_git_prompt.rst
@@ -39,7 +39,7 @@ There are numerous customization options, which can be controlled with git optio
 
 - ``$__fish_git_prompt_shorten_branch_len`` can be set to the number of characters that the branch name will be shortened to.
 
-- ``$__fish_git_prompt_describe_style`` can be set to a number of styles that describe the current HEAD:
+- ``$__fish_git_prompt_describe_style`` can be set to one of the following styles to describe the current HEAD:
 
      ``contains``
          relative to newer annotated tag, such as ``(v1.6.3.2~35)``


### PR DESCRIPTION
## Description

#5633 renamed fish's vcs prompt functions and documented them. One of the possible git prompt options, documented in `share/functions/fish_git_prompt.fish`, was not fully copied to `sphinx_doc_src/cmds/fish_git_prompt.rst`. These changes document it and make the wording around git prompt options less ambiguous.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
