### PR TITLE
Escape dollar sign in completions inside double quotes

### DIFF
--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -549,7 +549,7 @@ wcstring parse_util_escape_string_with_quote(const wcstring &cmd, wchar_t quote,
                     result.append({L'\\', L'\\'});
                     break;
                 default:
-                    if (c == quote) result.push_back(L'\\');
+                    if (c == quote || (c == L'$' && quote == L'"')) result.push_back(L'\\');
                     result.push_back(c);
                     break;
             }

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -548,8 +548,12 @@ wcstring parse_util_escape_string_with_quote(const wcstring &cmd, wchar_t quote,
                 case L'\\':
                     result.append({L'\\', L'\\'});
                     break;
+                case L'$':
+                    if (quote == L'"') result.push_back(L'\\');
+                    result.push_back(L'$');
+                    break;
                 default:
-                    if (c == quote || (c == L'$' && quote == L'"')) result.push_back(L'\\');
+                    if (c == quote) result.push_back(L'\\');
                     result.push_back(c);
                     break;
             }


### PR DESCRIPTION
Motivating example: Run `touch 'foo$'` and type `ls "foo<TAB>`

Current result: `ls "foo$"`
Result with this change: `ls "foo\$"`


----

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md