### PR TITLE
Fix compatibility with BSD sed in gpg.fish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `switch` now allows arguments that expand to nothing, like empty variables (#5677).
 - The null command (:) now always exits successfully, rather than echoing last return code.
 - Cursor configuration instructions for vi-mode have been added to the fish documentation.
+- The GPG completion script(s) now work with BSD sed
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, so things like `git reset HEAD@{0}` now work (#5869).

--- a/share/completions/gpg.fish
+++ b/share/completions/gpg.fish
@@ -59,7 +59,15 @@ function __fish_print_gpg_algo -d "Complete using all algorithms of the type spe
     # 	remove all blanks
     # 	transliterate ',' with '\n' (OSX apparently doesn't like '\n' on RHS of the s-command)
     # 	print result
-    gpg --version | sed -ne "/$argv:/"'{:loop; /,$/{N; y!\n! !; b loop}; s!^[^:]*:!!; s![ ]*!!g; y!,!\n!; p}'
+    gpg --version | sed -ne "/$argv:/"'{:loop
+    /,$/{N; y!\n! !
+    b loop
+    }
+    s!^[^:]*:!!
+    s![ ]*!!g
+    y!,!\n!
+    p
+    }'
 end
 
 


### PR DESCRIPTION
## Description

One of the sed scripts in `gpg.fish` is not compatible with BSD sed (for example, on macOS).

Fixes the bug mentioned by @zanchey in #6062.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.md
