### PR TITLE
Fix keyid completion function in gpg.fish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `switch` now allows arguments that expand to nothing, like empty variables (#5677).
 - The null command (:) now always exits successfully, rather than echoing last return code.
 - Cursor configuration instructions for vi-mode have been added to the fish documentation.
+- Context-based keyid completions are now formatted correctly
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, so things like `git reset HEAD@{0}` now work (#5869).

--- a/share/completions/gpg.fish
+++ b/share/completions/gpg.fish
@@ -27,17 +27,19 @@ function __fish_complete_gpg_user_id -d "Complete using gpg user ids"
     gpg --list-keys --with-colon | cut -d : -f 10 | sed -ne 's/\\\x3a/:/g' -e 's/\(.*\) <\(.*\)>/\1'\t'\2/p'
 end
 
-function __fish_complete_gpg_key_id -d 'Complete using gpg key ids'
-    # Use user_id as the description
-    set -l lastid
+function __fish_complete_gpg_key_id --description 'Complete using gpg key ids'
+    # Use user id as description
+    set -l keyid
     gpg --list-keys --with-colons | while read garbage
         switch $garbage
+            # Extract user ids
             case "uid*"
-                echo $garbage | cut -d ":" -f 10 | sed -e "s/\\\x3a/:/g" | read lastid
-            case "*"
-                echo $garbage | cut -d ":" -f 5 | read fingerprint
+                echo $garbage | cut -d ":" -f 10 | sed -e "s/\\\x3a/:/g" | read uid
+                printf "%s\t%s\n" $keyid $uid
+            # Extract key fingerprints
+            case "pub*"
+                echo $garbage | cut -d ":" -f 5 | read keyid
         end
-        printf "%s\t%s\n" $fingerprint $lastid
     end
 end
 

--- a/share/completions/gpg.fish
+++ b/share/completions/gpg.fish
@@ -21,13 +21,13 @@
 
 function __fish_complete_gpg_user_id -d "Complete using gpg user ids"
     # gpg doesn't seem to like it when you use the whole key name as a
-    # completion, so we skip the <EMAIL> part and use it a s a
+    # completion, so we skip the <EMAIL> part and use it as a
     # description.
     # It also replaces colons with \x3a
     gpg --list-keys --with-colon | cut -d : -f 10 | sed -ne 's/\\\x3a/:/g' -e 's/\(.*\) <\(.*\)>/\1'\t'\2/p'
 end
 
-function __fish_complete_gpg_key_id --description 'Complete using gpg key ids'
+function __fish_complete_gpg_key_id -d 'Complete using gpg key ids'
     # Use user id as description
     set -l keyid
     gpg --list-keys --with-colons | while read garbage
@@ -36,7 +36,7 @@ function __fish_complete_gpg_key_id --description 'Complete using gpg key ids'
             case "uid*"
                 echo $garbage | cut -d ":" -f 10 | sed -e "s/\\\x3a/:/g" | read uid
                 printf "%s\t%s\n" $keyid $uid
-            # Extract key fingerprints
+            # Extract key fingerprints (no subkeys)
             case "pub*"
                 echo $garbage | cut -d ":" -f 5 | read keyid
         end


### PR DESCRIPTION
## Description

Implements @zanchey's changes to `__fish_complete_gpg2_key_id` from #6062. Correctly formats completion output and excludes subkey fingerprints.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.md
