### PR TITLE
completions: never escape separators supplied by complete scripts

### DIFF
--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -727,7 +727,8 @@ void completer_t::complete_abbr(const wcstring &cmd) {
         assert(iter != abbrs.end() && "Abbreviation not found");
         return format_string(ABBR_DESC, iter->second.c_str());
     };
-    this->complete_strings(cmd, desc_func, possible_comp, COMPLETE_NO_SPACE);
+    this->complete_strings(cmd, desc_func, possible_comp,
+                           COMPLETE_NO_SPACE | COMPLETE_SUPPLIED_BY_USER);
 }
 
 /// Evaluate the argument list (as supplied by complete -a) and insert any
@@ -768,7 +769,8 @@ void completer_t::complete_from_args(const wcstring &str, const wcstring &args,
         parser->libdata().is_interactive = saved_interactive;
     }
 
-    this->complete_strings(escape_string(str, ESCAPE_ALL), const_desc(desc), possible_comp, flags);
+    this->complete_strings(escape_string(str, ESCAPE_ALL), const_desc(desc), possible_comp,
+                           flags | COMPLETE_SUPPLIED_BY_USER);
 }
 
 static size_t leading_dash_count(const wchar_t *str) {

--- a/src/complete.h
+++ b/src/complete.h
@@ -44,7 +44,9 @@ enum {
     /// Do not sort supplied completions
     COMPLETE_DONT_SORT = 1 << 6,
     /// This completion looks to have the same string as an existing argument.
-    COMPLETE_DUPLICATES_ARGUMENT = 1 << 7
+    COMPLETE_DUPLICATES_ARGUMENT = 1 << 7,
+    /// If this completion is expanded from `complete` or `abbr`.
+    COMPLETE_SUPPLIED_BY_USER = 1 << 8,
 };
 typedef int complete_flags_t;
 

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -520,11 +520,12 @@ void parse_util_get_parameter_info(const wcstring &cmd, const size_t pos, wchar_
     free(cmd_tmp);
 }
 
-wcstring parse_util_escape_string_with_quote(const wcstring &cmd, wchar_t quote, bool no_tilde) {
+wcstring parse_util_escape_string_with_quote(const wcstring &cmd, wchar_t quote, bool no_tilde,
+                                             bool escape_separators) {
     wcstring result;
     if (quote == L'\0') {
-        escape_flags_t flags =
-            ESCAPE_ALL | ESCAPE_NO_QUOTED | (no_tilde ? ESCAPE_NO_TILDE : 0) | ESCAPE_SEPARATORS;
+        escape_flags_t flags = ESCAPE_ALL | ESCAPE_NO_QUOTED | (no_tilde ? ESCAPE_NO_TILDE : 0);
+        if (escape_separators) flags |= ESCAPE_SEPARATORS;
         result = escape_string(cmd, flags);
     } else {
         // Here we are going to escape a string with quotes.

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -116,7 +116,7 @@ void parse_util_get_parameter_info(const wcstring &cmd, const size_t pos, wchar_
 /// character. The quote can be a single quote or double quote, or L'\0' to indicate no quoting (and
 /// thus escaping should be with backslashes). Optionally do not escape tildes.
 wcstring parse_util_escape_string_with_quote(const wcstring &cmd, wchar_t quote,
-                                             bool no_tilde = false);
+                                             bool no_tilde = false, bool escape_separators = false);
 
 /// Given a string, parse it as fish code and then return the indents. The return value has the same
 /// size as the string.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1143,6 +1143,7 @@ wcstring completion_apply_to_command_line(const wcstring &val, complete_flags_t 
     bool do_replace = bool(flags & COMPLETE_REPLACES_TOKEN);
     bool do_escape = !bool(flags & COMPLETE_DONT_ESCAPE);
     bool no_tilde = bool(flags & COMPLETE_DONT_ESCAPE_TILDES);
+    bool escape_separators = !bool(flags & COMPLETE_SUPPLIED_BY_USER);
 
     const size_t cursor_pos = *inout_cursor_pos;
     bool back_into_trailing_quote = false;
@@ -1158,8 +1159,9 @@ wcstring completion_apply_to_command_line(const wcstring &val, complete_flags_t 
         wcstring sb(buff, begin - buff);
 
         if (do_escape) {
-            wcstring escaped = escape_string(
-                val, ESCAPE_ALL | ESCAPE_NO_QUOTED | (no_tilde ? ESCAPE_NO_TILDE : 0));
+            wcstring escaped = escape_string(val, ESCAPE_ALL | ESCAPE_NO_QUOTED |
+                                                      (no_tilde ? ESCAPE_NO_TILDE : 0) |
+                                                      (escape_separators ? ESCAPE_SEPARATORS : 0));
             sb.append(escaped);
             move_cursor = escaped.size();
         } else {
@@ -1196,7 +1198,7 @@ wcstring completion_apply_to_command_line(const wcstring &val, complete_flags_t 
             }
         }
 
-        replaced = parse_util_escape_string_with_quote(val, quote, no_tilde);
+        replaced = parse_util_escape_string_with_quote(val, quote, no_tilde, escape_separators);
     } else {
         replaced = val;
     }


### PR DESCRIPTION
Commit f7dac82ed introduced escaping separators = and : that have a special meaning for completion.

Unfortunately this caused a regression in some completions that use these separators. For example,
typing `dd bs<TAB>` results in `dd bs\=` while it should be `dd bs=`.

This commit disables escaping of separators in completions that were expanded from
a custom completion (based off `complete` or `abbr`) to fix above regression,
while still escaping separators that are parts of filenames.
Note that separators in filenames supplied by `complete` will not
be escaped. There is probably no easy way around that.