### PR TITLE
jobs: return success when a job is found via --last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `switch` now allows arguments that expand to nothing, like empty variables (#5677).
 - The null command (:) now always exits successfully, rather than echoing last return code.
 - Cursor configuration instructions for vi-mode have been added to the fish documentation.
+- `jobs --last` returns 0 to indicate success when a job is found (#6104).
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, so things like `git reset HEAD@{0}` now work (#5869).

--- a/src/builtin_jobs.cpp
+++ b/src/builtin_jobs.cpp
@@ -174,9 +174,10 @@ int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         for (const auto &j : parser.jobs()) {
             if (j->is_visible()) {
                 builtin_jobs_print(j.get(), mode, !streams.out_is_redirected, streams);
-                return STATUS_CMD_ERROR;
+                return STATUS_CMD_OK;
             }
         }
+        return STATUS_CMD_ERROR;
 
     } else {
         if (w.woptind < argc) {

--- a/tests/jobs.in
+++ b/tests/jobs.in
@@ -30,3 +30,9 @@ function sleep_done_$sleep_job --on-job-exit $sleep_job
     functions --erase sleep_done_$sleep_job
 end
 sleep 2
+
+# Verify `jobs -l` works and returns the right status codes
+# https://github.com/fish-shell/fish-shell/issues/6104
+jobs --last --command; echo $status
+sleep 0.2 &
+jobs -lc; echo $status

--- a/tests/jobs.out
+++ b/tests/jobs.out
@@ -9,3 +9,7 @@ sleep
 Command
 sleep
 sleep is done
+1
+Command
+sleep
+0


### PR DESCRIPTION
Closes #6104.

- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md