### PR TITLE
Do not add a space after completion if one is already there

### DIFF
--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2844,8 +2844,10 @@ static void test_completion_insertions() {
 #define TEST_1_COMPLETION(a, b, c, d, e) test_1_completion(a, b, c, d, e, __LINE__)
     say(L"Testing completion insertions");
     TEST_1_COMPLETION(L"foo^", L"bar", 0, false, L"foobar ^");
-    // We really do want to insert two spaces here - otherwise it's hidden by the cursor.
-    TEST_1_COMPLETION(L"foo^ baz", L"bar", 0, false, L"foobar ^ baz");
+    // An unambiguous completion of a token that is already trailed by a space character.
+    // After completing, the cursor moves on to the next token, suggesting to the user that the
+    // current token is finished.
+    TEST_1_COMPLETION(L"foo^ baz", L"bar", 0, false, L"foobar ^baz");
     TEST_1_COMPLETION(L"'foo^", L"bar", 0, false, L"'foobar' ^");
     TEST_1_COMPLETION(L"'foo'^", L"bar", 0, false, L"'foobar' ^");
     TEST_1_COMPLETION(L"'foo\\'^", L"bar", 0, false, L"'foo\\'bar' ^");
@@ -2853,7 +2855,7 @@ static void test_completion_insertions() {
 
     // Test append only.
     TEST_1_COMPLETION(L"foo^", L"bar", 0, true, L"foobar ^");
-    TEST_1_COMPLETION(L"foo^ baz", L"bar", 0, true, L"foobar ^ baz");
+    TEST_1_COMPLETION(L"foo^ baz", L"bar", 0, true, L"foobar ^baz");
     TEST_1_COMPLETION(L"'foo^", L"bar", 0, true, L"'foobar' ^");
     TEST_1_COMPLETION(L"'foo'^", L"bar", 0, true, L"'foo'bar ^");
     TEST_1_COMPLETION(L"'foo\\'^", L"bar", 0, true, L"'foo\\'bar' ^");

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1146,6 +1146,7 @@ wcstring completion_apply_to_command_line(const wcstring &val, complete_flags_t 
 
     const size_t cursor_pos = *inout_cursor_pos;
     bool back_into_trailing_quote = false;
+    bool have_space_after_token = command_line[cursor_pos] == L' ';
 
     if (do_replace) {
         size_t move_cursor;
@@ -1168,7 +1169,7 @@ wcstring completion_apply_to_command_line(const wcstring &val, complete_flags_t 
         }
 
         if (add_space) {
-            sb.append(L" ");
+            if (!have_space_after_token) sb.append(L" ");
             move_cursor += 1;
         }
         sb.append(end);
@@ -1217,7 +1218,8 @@ wcstring completion_apply_to_command_line(const wcstring &val, complete_flags_t 
             // This is a quoted parameter, first print a quote.
             result.insert(new_cursor_pos++, wcstring(&quote, 1));
         }
-        result.insert(new_cursor_pos++, L" ");
+        if (!have_space_after_token) result.insert(new_cursor_pos, L" ");
+        new_cursor_pos++;
     }
     *inout_cursor_pos = new_cursor_pos;
     return result;


### PR DESCRIPTION
Example: type `cd --help --help`, move the cursor inside the first `--help` and press tab.
This used to add a redundant space.