### PR TITLE
Fix default Alt+W keybinding

### DIFF
--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -80,7 +80,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv \e. history-token-search-backward
 
     bind --preset $argv \el __fish_list_current_token
-    bind --preset $argv \ew 'set tok (commandline -pt); if test -n "$tok[1]"; echo; whatis $tok[1]; commandline -f repaint; end'
+    bind --preset $argv \ew __fish_whatis_current_token
     # ncurses > 6.0 sends a "delete scrollback" sequence along with clear.
     # This string replace removes it.
     bind --preset $argv \cl 'echo -n (clear | string replace \e\[3J ""); commandline -f repaint'

--- a/share/functions/__fish_whatis_current_token.fish
+++ b/share/functions/__fish_whatis_current_token.fish
@@ -1,17 +1,15 @@
 # This function is typically bound to Alt-W, it is used to list man page entries
 # for the command under the cursor.
 function __fish_whatis_current_token -d "Show man page entries related to the token under the cursor"
-    set tok (commandline -pt)
+    set -l tok (commandline -pt)
 
     if test $tok[1]
         printf "\n"
         whatis $tok[1]
 
         set -l line_count (count (fish_prompt))
-        if test $line_count -gt 1
-            for x in (seq 2 $line_count)
-                printf "\n"
-            end
+        for x in (seq 2 $line_count)
+            printf "\n"
         end
 
         commandline -f repaint

--- a/share/functions/__fish_whatis_current_token.fish
+++ b/share/functions/__fish_whatis_current_token.fish
@@ -1,0 +1,19 @@
+# This function is typically bound to Alt-W, it is used to list man page entries
+# for the command under the cursor.
+function __fish_whatis_current_token -d "Show man page entries related to the token under the cursor"
+    set tok (commandline -pt)
+
+    if test $tok[1]
+        printf "\n"
+        whatis $tok[1]
+
+        set -l line_count (count (fish_prompt))
+        if test $line_count -gt 1
+            for x in (seq 2 $line_count)
+                printf "\n"
+            end
+        end
+
+        commandline -f repaint
+    end
+end

--- a/share/functions/__fish_whatis_current_token.fish
+++ b/share/functions/__fish_whatis_current_token.fish
@@ -3,7 +3,7 @@
 function __fish_whatis_current_token -d "Show man page entries related to the token under the cursor"
     set -l tok (commandline -pt)
 
-    if test $tok[1]
+    if test -n "$tok[1]"
         printf "\n"
         whatis $tok[1]
 


### PR DESCRIPTION
## Description

The old keybinding would chop off the last line of the `whatis` output
when using a multi-line prompt. This fix corrects that.

### Before
In this example, I am using the [pure](https://github.com/rafaelrinaldi/pure) prompt, which is a multi-line prompt. Using `whatis vim` as an example, the _correct_ output should be
```
~
❯ whatis vim
evim(1)                  - easy Vim, edit a file with Vim and setup for modeless editing
vim(1)                   - Vi IMproved, a programmer's text editor
vimdiff(1)               - edit two, three or four versions of a file with Vim and show differences
vimtutor(1)              - the Vim tutor
```

However, using the Alt+W keybinding shows
```
~
❯ vim| (<- Press Alt+W here)
evim(1)                  - easy Vim, edit a file with Vim and setup for modeless editing
vim(1)                   - Vi IMproved, a programmer's text editor
vimdiff(1)               - edit two, three or four versions of a file with Vim and show differences
~
❯ vim|
```

As you can see, the last line of the `whatis` output (`vimtutor(1)`) is missing.

## After
```
~
❯ vim| (<- Press Alt+W here)
evim(1)                  - easy Vim, edit a file with Vim and setup for modeless editing
vim(1)                   - Vi IMproved, a programmer's text editor
vimdiff(1)               - edit two, three or four versions of a file with Vim and show differences
vimtutor(1)              - the Vim tutor
~
❯ vim|
```

This correctly shows the full output of `whatis`.
