### PR TITLE
Add default \es keybinding for "prepend sudo"

### DIFF
--- a/share/functions/__fish_prepend_sudo.fish
+++ b/share/functions/__fish_prepend_sudo.fish
@@ -1,0 +1,8 @@
+function __fish_prepend_sudo -d "Prepend 'sudo ' to the beginning of the current commandline"
+    set -l cmd (commandline -boc)
+    if test "$cmd[1]" != "sudo"
+        commandline -C 0
+        commandline -i "sudo "
+        commandline -f end-of-line
+    end
+end

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -93,6 +93,9 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
     bind --preset $argv \cd delete-or-exit
 
+    # Prepend 'sudo ' to the current commandline
+    bind --preset $argv \es __fish_prepend_sudo
+
     # Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh).
     bind --preset $argv -k f1 __fish_man_page
     bind --preset $argv \eh __fish_man_page


### PR DESCRIPTION
## Description

This creates a new function `__fish_prepend_sudo` and a new default keybinding `Alt+S` that prepends `sudo ` to the beginning of your current commandline.

Example:
```fish
$ vim /etc/hosts
```
pressing `Alt+S` yields
```fish
$ sudo vim /etc/hosts
```

This does not move the cursor.

This was inspired by the comment [here](https://github.com/fish-shell/fish-shell/issues/288#issuecomment-16552504).

Personally, I think this might allay some of the agitation around the lack of the `!!` operator in fish, since `sudo !!` can now effectively be done with `Ctrl+p Alt+s`, which is even easier!
