### PR TITLE
Add prefix history search

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -91,6 +91,8 @@ static const input_function_metadata_t input_function_metadata[] = {
     {readline_cmd_t::backward_word, L"backward-word"},
     {readline_cmd_t::forward_bigword, L"forward-bigword"},
     {readline_cmd_t::backward_bigword, L"backward-bigword"},
+    {readline_cmd_t::history_prefix_search_backward, L"history-prefix-search-backward"},
+    {readline_cmd_t::history_prefix_search_forward, L"history-prefix-search-forward"},
     {readline_cmd_t::history_search_backward, L"history-search-backward"},
     {readline_cmd_t::history_search_forward, L"history-search-forward"},
     {readline_cmd_t::delete_char, L"delete-char"},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -19,6 +19,8 @@ enum class readline_cmd_t {
     backward_bigword,
     history_search_backward,
     history_search_forward,
+    history_prefix_search_backward,
+    history_prefix_search_forward,
     delete_char,
     backward_delete_char,
     kill_line,


### PR DESCRIPTION
## Description

This adds a `history-prefix-search-backward` and `history-prefix-search-forward` bind.

Fixes issue #992

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] User-visible changes noted in CHANGELOG.md
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
