### PR TITLE
Use dynamic path resolve for chsh command instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following optional features also have specific requirements:
 
 If you wish to use fish as your default shell, use the following command:
 
-	chsh -s /usr/local/bin/fish
+	chsh -s `which fish`
 
 `chsh` will prompt you for your password and change your default shell. (Substitute `/usr/local/bin/fish` with whatever path fish was installed to, if it differs.) Log out, then log in again for the changes to take effect.
 


### PR DESCRIPTION
## Description

After installing `fish`, the location of the executable was different from what the README.md stated (in `/usr/bin/fish`). Though this was *easy* to resolve, me from maybe even a year ago might have been very confused as to what is going on, and having this path get dynamically resolved seems a bit more user friendly.

Fixes issue #
N/A

## TODOs:
N/A
