### PR TITLE
Fix completions for `abbr --erase`

### DIFF
--- a/share/completions/abbr.fish
+++ b/share/completions/abbr.fish
@@ -1,7 +1,7 @@
 complete -c abbr -f -s a -l add -d 'Add abbreviation'
 # Abbr keys can't contain spaces, so we can safely replace the first space with a tab
 # `abbr -s` won't work here because that already escapes
-complete -c abbr -s e -l erase -d 'Erase abbreviation' -xa '(string replace " " \t -- $fish_user_abbreviations)'
+complete -c abbr -s e -l erase -d 'Erase abbreviation' -xa '(abbr --list)'
 complete -c abbr -f -s s -l show -d 'Print all abbreviations'
 complete -c abbr -f -s l -l list -d 'Print all abbreviation names'
 complete -c abbr -f -s h -l help -d 'Help'


### PR DESCRIPTION
## Description

The completions for `abbr --erase` weren't working. Looks like it was relying on `$fish_user_abbreviations` which is no longer used.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
