### PR TITLE
Emit omitted-newline string before fish_prompt event

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2250,7 +2250,6 @@ static int read_i(parser_t &parser) {
     data->prev_end_loop = 0;
 
     while (!shell_is_exiting()) {
-        event_fire_generic(parser, L"fish_prompt");
         run_count++;
 
         if (parser.libdata().is_breakpoint && function_exists(DEBUG_PROMPT_FUNCTION_NAME, parser)) {
@@ -3189,10 +3188,11 @@ maybe_t<wcstring> reader_data_t::readline(int nchars_or_0) {
 
     history_search.reset();
 
+    s_reset(&screen, screen_reset_abandon_line);
+    event_fire_generic(parser(), L"fish_prompt");
     exec_prompt();
 
     super_highlight_me_plenty();
-    s_reset(&screen, screen_reset_abandon_line);
     repaint();
 
     // Get the current terminal modes. These will be restored when the function returns.


### PR DESCRIPTION
See issue #6118 "omitted-newline string emitted after fish_prompt event"

## Description

Fixes issue #6118 - which provides an explanation.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
