### PR TITLE
Fix paginate binding (\ep) for multiline jobs

### DIFF
--- a/share/functions/__fish_paginate.fish
+++ b/share/functions/__fish_paginate.fish
@@ -5,7 +5,7 @@ function __fish_paginate -d "Paginate the current command using the users defaul
         set cmd $PAGER
     end
 
-    if test -z (commandline -j)
+    if test -z (commandline -j | string join '')
         commandline -a $history[1]
     end
 


### PR DESCRIPTION
Reproducer: type `: \<RET><M-p>`. This used to print an error due to builtin test receiving
too many arguments.

It looks like (commandline -j) can return multiple items, because a job can be broken up in multiple
lines terminated by backslashes.