### PR TITLE
doc: add ref to cmd-breakpoint

### DIFF
--- a/sphinx_doc_src/cmds/fish_breakpoint_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_breakpoint_prompt.rst
@@ -16,7 +16,7 @@ Synopsis
 Description
 -----------
 
-By defining the ``fish_breakpoint_prompt`` function, the user can choose a custom prompt when asking for input in response to a ``breakpoint`` command. The ``fish_breakpoint_prompt`` function is executed when the prompt is to be shown, and the output is used as a prompt.
+By defining the ``fish_breakpoint_prompt`` function, the user can choose a custom prompt when asking for input in response to a :ref:`breakpoint <cmd-breakpoint>` command. The ``fish_breakpoint_prompt`` function is executed when the prompt is to be shown, and the output is used as a prompt.
 
 The exit status of commands within ``fish_breakpoint_prompt`` will not modify the value of `$status <index.html#variables-status>`__ outside of the ``fish_breakpoint_prompt`` function.
 


### PR DESCRIPTION
Hi

This should create a link to the `breakpoint` command from the `fish_breakpoint command`
