### PR TITLE
Handle recursive calls to complete

### DIFF
--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -336,7 +336,10 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         parser.libdata().transient_commandlines.push_back(do_complete_param);
         cleanup_t remove_transient([&] { parser.libdata().transient_commandlines.pop_back(); });
 
-        if (parser.libdata().builtin_complete_recursion_level < 1) {
+        // Allow a limited number of recursive calls to complete (#3474).
+        if (parser.libdata().builtin_complete_recursion_level >= 1) {
+            streams.err.append_format(L"%ls: maximum recursive depth reached\n", cmd);
+        } else {
             parser.libdata().builtin_complete_recursion_level++;
 
             std::vector<completion_t> comp;

--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -337,7 +337,7 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
         cleanup_t remove_transient([&] { parser.libdata().transient_commandlines.pop_back(); });
 
         // Allow a limited number of recursive calls to complete (#3474).
-        if (parser.libdata().builtin_complete_recursion_level >= 1) {
+        if (parser.libdata().builtin_complete_recursion_level >= 24) {
             streams.err.append_format(L"%ls: maximum recursive depth reached\n", cmd);
         } else {
             parser.libdata().builtin_complete_recursion_level++;

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -64,4 +64,27 @@ complete
 complete -c complete_test_recurse1 -xa '(echo recursing 1>&2; complete -C"complete_test_recurse1 ")'
 complete -C'complete_test_recurse1 '
 # CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
+# CHECKERR: recursing
 # CHECKERR: complete: maximum recursive depth reached

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -59,3 +59,9 @@ complete
 # CHECK: complete {{.*}}
 # CHECK: complete {{.*}}
 # CHECK: complete {{.*}}
+
+# Recursive calls to complete (see #3474)
+complete -c complete_test_recurse1 -xa '(echo recursing 1>&2; complete -C"complete_test_recurse1 ")'
+complete -C'complete_test_recurse1 '
+# CHECKERR: recursing
+# CHECKERR: complete: maximum recursive depth reached

--- a/tests/checks/wraps.fish
+++ b/tests/checks/wraps.fish
@@ -26,4 +26,6 @@ complete -c testcommand2 -x -a "(testcommand2_complete)"
 complete -c testcommand2 --wraps "testcommand2 from_wraps "
 complete -C'testcommand2 explicit '
 # CHECKERR: explicit
+# CHECKERR: complete: maximum recursive depth reached
 # CHECKERR: from_wraps explicit
+# CHECKERR: complete: maximum recursive depth reached

--- a/tests/checks/wraps.fish
+++ b/tests/checks/wraps.fish
@@ -19,13 +19,10 @@ function testcommand2_complete
     set -l tokens (commandline -opc) (commandline -ct)
     set -e tokens[1]
     echo $tokens 1>&2
-    complete -C"$tokens"
 end
 
 complete -c testcommand2 -x -a "(testcommand2_complete)"
 complete -c testcommand2 --wraps "testcommand2 from_wraps "
 complete -C'testcommand2 explicit '
 # CHECKERR: explicit
-# CHECKERR: complete: maximum recursive depth reached
 # CHECKERR: from_wraps explicit
-# CHECKERR: complete: maximum recursive depth reached


### PR DESCRIPTION
---

The first commit prints an error when the recursion limit is exceeded,
to make sure the user notices.

The second commit raises the limit to 2, to support cases like in #3474.
Not sure whether it is a good idea to do that but it seems to work.

----

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md