### PR TITLE
doc: mention $fish_function_path in the Autoloading Functions section - fix #3371

### DIFF
--- a/sphinx_doc_src/tutorial.rst
+++ b/sphinx_doc_src/tutorial.rst
@@ -663,7 +663,7 @@ This is the preferred way to define your prompt as well::
     end
 
 
-See the documentation for :ref:`funced <cmd-funced>` and :ref:`funcsave <cmd-funcsave>` for ways to create these files automatically.
+See the documentation for :ref:`funced <cmd-funced>` and :ref:`funcsave <cmd-funcsave>` for ways to create these files automatically, and :ref:`$fish_function_path <syntax-function-autoloading>` to control their location.
 
 .. _tut-universal:
 


### PR DESCRIPTION
Hi

This ref-link allow the reader to easily jump to the more detailed explanation about autoloading functions.
Should fix https://github.com/fish-shell/fish-shell/issues/3371