### PR TITLE
doc: add link to event handlers in emit

### DIFF
--- a/sphinx_doc_src/cmds/emit.rst
+++ b/sphinx_doc_src/cmds/emit.rst
@@ -13,7 +13,7 @@ Synopsis
 Description
 -----------
 
-``emit`` emits, or fires, an event. Events are delivered to, or caught by, special functions called event handlers. The arguments are passed to the event handlers as function arguments.
+``emit`` emits, or fires, an event. Events are delivered to, or caught by, special functions called :ref:`event handlers <event>`. The arguments are passed to the event handlers as function arguments.
 
 
 Example


### PR DESCRIPTION
Hi

With this link, someone interested in the `emit` function will be able to learn more details about `event handlers` in general.