### PR TITLE
Fix caret position of invalid expansion in command position

### DIFF
--- a/tests/checks/expansion.fish
+++ b/tests/checks/expansion.fish
@@ -1,0 +1,13 @@
+# RUN: %fish -C 'set -g fish %fish' %s
+
+# caret position (#5812)
+printf '<%s>\n' ($fish -c ' $f[a]' 2>&1)
+
+# CHECK: <fish: Invalid index value>
+# CHECK: < $f[a]>
+# CHECK: <    ^>
+ 
+printf '<%s>\n' ($fish -c 'if $f[a]; end' 2>&1)
+# CHECK: <fish: Invalid index value>
+# CHECK: <if $f[a]; end>
+# CHECK: <      ^>

--- a/tests/expansion.err
+++ b/tests/expansion.err
@@ -41,4 +41,4 @@ echo {}}
 
 fish: Command substitutions not allowed
 command (asd)
-^
+        ^

--- a/tests/expansion.in
+++ b/tests/expansion.in
@@ -153,6 +153,5 @@ logmsg Test fatal syntax errors
 ../test/root/bin/fish -c 'echo $,foo'
 ../test/root/bin/fish -c 'echo {'
 ../test/root/bin/fish -c 'echo {}}'
-# The output for this is wrong in non-interactive mode and will need fixing when #5812 is fixed
 ../test/root/bin/fish -c 'command (asd)'
 true


### PR DESCRIPTION
Fixes #5812


----

I haven't yet checked whether a similar change is necessary in other places.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
