### PR TITLE
doc: mention history prefix search binds in binds.rst

### DIFF
--- a/sphinx_doc_src/cmds/bind.rst
+++ b/sphinx_doc_src/cmds/bind.rst
@@ -122,6 +122,10 @@ The following special input functions are available:
 
 - ``history-search-forward``, search the history for the next match
 
+- ``history-prefix-search-backward``, search the history for the previous prefix match
+
+- ``history-prefix-search-forward``, search the history for the next prefix match
+
 - ``history-token-search-backward``, search the history for the previous matching argument
 
 - ``history-token-search-forward``, search the history for the next matching argument


### PR DESCRIPTION


## Description

Mention history-prefix-search-forward and history-prefix-search-backward in
binds.rst

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
