### PR TITLE
Avoid recursion in complete -C calls

### DIFF
--- a/share/completions/doas.fish
+++ b/share/completions/doas.fish
@@ -23,7 +23,7 @@ end
 
 function __fish_complete_doas_subcommand
     set -l args (__fish_doas_print_remaining_args)
-    complete -C"$args"
+    complete -C "$args"
 end
 
 complete -c doas -n "not __fish_doas_print_remaining_args" -s a -d "Choose auth method on systems using /etc/login.conf"

--- a/share/completions/env.fish
+++ b/share/completions/env.fish
@@ -16,7 +16,7 @@ function __fish_complete_env_subcommand
 
     # Then complete the rest as if it was given as a command.
     if set -q argv[1]
-        complete -C"$argv"
+        complete -C "$argv"
         return 0
     end
     return 1

--- a/share/completions/su.fish
+++ b/share/completions/su.fish
@@ -2,7 +2,7 @@
 
 complete -x -c su -a "(__fish_complete_users)"
 complete -c su -s l -l login -d "Make login shell"
-complete -r -c su -s c -l command -d "Pass command to shell" -xa "(complete -C(commandline -ct))"
+complete -c su -s c -l command -d "Pass command to shell" -xa "(__fish_complete_command)"
 complete -c su -s f -l fast -d "Pass -f to the shell"
 complete -c su -s m -l preserve_environment -d "Preserve environment"
 complete -c su -s p -d "Preserve environment"

--- a/share/completions/sudo.fish
+++ b/share/completions/sudo.fish
@@ -33,7 +33,7 @@ end
 
 function __fish_complete_sudo_subcommand
     set -l args (__fish_sudo_print_remaining_args)
-    complete -C"$args"
+    complete -C "$args"
 end
 
 # All these options should be valid for GNU and OSX sudo

--- a/share/completions/svn.fish
+++ b/share/completions/svn.fish
@@ -172,7 +172,7 @@ for cmd in $blame $diff $log $merge
 end
 
 for cmd in $cleanup $merge $switch $update
-    _svn_cmpl_ $cmd -l diff3-cmd -d 'Use as merge command' -xa "(complete -C(commandline -ct))"
+    _svn_cmpl_ $cmd -l diff3-cmd -d 'Use as merge command' -xa "(__fish_complete_command)"
 end
 
 for cmd in $blame $info $list $log $stat
@@ -193,7 +193,7 @@ end
 
 for cmd in $diff $log
     _svn_cmpl_ $cmd -l internal-diff -d 'Override diff-cmd specified in config file'
-    _svn_cmpl_ $cmd -l diff-cmd -d 'Use external diff command' -xa "(complete -C(commandline -ct))"
+    _svn_cmpl_ $cmd -l diff-cmd -d 'Use external diff command' -xa "(__fish_complete_command)"
 end
 
 for cmd in $add $import

--- a/share/completions/type.fish
+++ b/share/completions/type.fish
@@ -10,4 +10,4 @@ complete -c type -s q -l quiet -d "Suppress output"
 complete -c type -a "(builtin -n)" -d "Builtin"
 complete -c type -a "(functions -n)" -d "Function"
 
-complete -c type -a "(complete -C(commandline -ct))" -x
+complete -c type -a "(__fish_complete_command)" -x

--- a/share/completions/which.fish
+++ b/share/completions/which.fish
@@ -16,4 +16,4 @@ else # OSX
     complete -c which -s s -d "Print no output, only return 0 if found"
 end
 
-complete -c which -a "(complete -C(commandline -ct))" -x
+complete -c which -a "(__fish_complete_command)" -x

--- a/share/completions/xterm.fish
+++ b/share/completions/xterm.fish
@@ -98,7 +98,7 @@ complete -c xterm -o wc -d 'Use wide characters'
 complete -c xterm -o wf -d 'Wait the first time for the window to be mapped'
 complete -c xterm -o Sccn -d 'Use as input/output channel for an existing program'
 
-complete -c xterm -s e -a "(complete -C(commandline -ct))" -x -d 'Run program in xterm'
+complete -c xterm -s e -a "(__fish_complete_command)" -x -d 'Run program in xterm'
 
 complete -r -c xterm -o bcf -d 'Blinking cursor will be off for that many milliseconds'
 complete -r -c xterm -o bcn -d 'Blinking cursor will be on for that many milliseconds'

--- a/share/functions/__fish_complete_command.fish
+++ b/share/functions/__fish_complete_command.fish
@@ -4,6 +4,8 @@ function __fish_complete_command --description 'Complete using all available com
         case '*=*'
             set ctoken (string split "=" -- $ctoken)
             printf '%s\n' $ctoken[1]=(complete -C "$ctoken[2]")
+        case '-*' # For `su -c` do not complete "-c" as command.
+            return
         case '*'
             complete -C "$ctoken"
     end

--- a/share/functions/__fish_complete_command.fish
+++ b/share/functions/__fish_complete_command.fish
@@ -3,8 +3,8 @@ function __fish_complete_command --description 'Complete using all available com
     switch $ctoken
         case '*=*'
             set ctoken (string split "=" -- $ctoken)
-            printf '%s\n' $ctoken[1]=(complete -C$ctoken[2])
+            printf '%s\n' $ctoken[1]=(complete -C "$ctoken[2]")
         case '*'
-            complete -C$ctoken
+            complete -C "$ctoken"
     end
 end

--- a/share/functions/__fish_complete_subcommand.fish
+++ b/share/functions/__fish_complete_subcommand.fish
@@ -39,7 +39,7 @@ function __fish_complete_subcommand -d "Complete subcommand" --no-scope-shadowin
         end
     end
 
-    printf "%s\n" (complete -C$res)
+    printf "%s\n" (complete -C "$res")
 
 end
 

--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -338,7 +338,7 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 
         // Allow a limited number of recursive calls to complete (#3474).
         if (parser.libdata().builtin_complete_recursion_level >= 24) {
-            streams.err.append_format(L"%ls: maximum recursive depth reached\n", cmd);
+            streams.err.append_format(L"%ls: maximum recursion depth reached\n", cmd);
         } else {
             parser.libdata().builtin_complete_recursion_level++;
 

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -87,4 +87,4 @@ complete -C'complete_test_recurse1 '
 # CHECKERR: recursing
 # CHECKERR: recursing
 # CHECKERR: recursing
-# CHECKERR: complete: maximum recursive depth reached
+# CHECKERR: complete: maximum recursion depth reached


### PR DESCRIPTION
In completions that do not use the current commandline but $arg:
when $arg might be empty, we need to call

`complete -C "$arg"`

Both the space and the quotes are needed because if "$arg" is an empty string or has zero elements,
both `complete -C"$arg"` and `complete -C $arg` can be equivalent to `complete -C` which uses the
current commandline instead of `$arg`.


----

## Description

Reproduce on current master with `sudo <TAB>` - this calls complete until it hits the limit.

Otherwise, if we don't want to change the behavior, we should revert
https://github.com/fish-shell/fish-shell/pull/6161

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md