### PR TITLE
doc: add link to feature flags in fish command

### DIFF
--- a/sphinx_doc_src/cmds/fish.rst
+++ b/sphinx_doc_src/cmds/fish.rst
@@ -43,6 +43,6 @@ The following options are available:
 
 - ``-D`` or ``--debug-stack-frames=DEBUG_LEVEL`` specify how many stack frames to display when debug messages are written. The default is zero. A value of 3 or 4 is usually sufficient to gain insight into how a given debug call was reached but you can specify a value up to 128.
 
-- ``-f`` or ``--features=FEATURES`` enables one or more feature flags (separated by a comma). These are how fish stages changes that might break scripts.
+- ``-f`` or ``--features=FEATURES`` enables one or more :ref:`feature flags <featureflags>` (separated by a comma). These are how fish stages changes that might break scripts.
 
 The fish exit status is generally the exit status of the last foreground command. If fish is exiting because of a parse error, the exit status is 127.


### PR DESCRIPTION
Hi

Following this link the user can learn more about which features flags are available and the `status features` command.
