### PR TITLE
Cd to dir starting with hyphen

### DIFF
--- a/share/functions/cd.fish
+++ b/share/functions/cd.fish
@@ -4,7 +4,7 @@
 function cd --description "Change directory"
     set -l MAX_DIR_HIST 25
 
-    if test (count $argv) -gt 1
+    if test (count $argv) -gt (test "$argv[1]" = "--" && echo 2 || echo 1)
         printf "%s\n" (_ "Too many args for cd command")
         return 1
     end

--- a/tests/cd.in
+++ b/tests/cd.in
@@ -76,6 +76,12 @@ set -g CDPATH ./
 cd $base
 test $PWD = $base; and echo No crash with ./ CDPATH
 
+# test for directories beginning with a hyphen
+mkdir $base/-testdir
+cd $base
+cd -- -testdir
+test $PWD = $base/-testdir
+
 # cd back before removing the test directory again.
 cd $oldpwd
 rm -Rf $base


### PR DESCRIPTION
## Description

currently, `cd`ing into a directory starting with a `-` gives the error `Too many args for cd command`
I've fixed this and wrote a test for this case.

Fixes issue #6071

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
