### PR TITLE
Fix options after --argument-names to function

### DIFF
--- a/tests/checks/function.fish
+++ b/tests/checks/function.fish
@@ -2,13 +2,3 @@
 function t --argument-names a b c
     echo t
 end
-
-function t2 --argument-names a b c --no-scope-shadowing
-    echo t2
-end
-#CHECKERR: {{.*/?}}function.fish (line {{\d+}}): function: Variable name '--no-scope-shadowing' is not valid. See `help identifiers`.
-#CHECKERR: function t2 --argument-names a b c --no-scope-shadowing
-#CHECKERR: ^
-
-functions -q t2 && echo exists || echo does not exist
-#CHECK: does not exist


### PR DESCRIPTION
## Description

Allows for options to be passed after --argument-names, and handles them correctly as options instead of as additional argument names.

Fixes issue #6186

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
