### PR TITLE
fix(git_prompt): fix wrong untracked count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `switch` now allows arguments that expand to nothing, like empty variables (#5677).
 - The null command (`:`) now always exits successfully, rather than passing through the previous exit status (#6022).
 - `jobs --last` returns 0 to indicate success when a job is found (#6104).
+- Fix `fish_git_prompt` always returning 0 for the number of untracked files
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, meaning common commands such as `git reset HEAD@{0}` do not require escaping (#5869).

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -545,7 +545,7 @@ function __fish_git_prompt_informative_status
     set -l x (count $stagedFiles)
     set -l invalidstate (count (string match -r "U" -- $stagedFiles))
     set -l stagedstate (math $x - $invalidstate)
-    set -l untrackedfiles (command git ls-files --others --exclude-standard | count)
+    set -l untrackedfiles (count (command git ls-files --others --exclude-standard))
     set -l stashstate 0
     set -l stashfile "$argv[1]/logs/refs/stash"
     if set -q __fish_git_prompt_showstashstate; and test -e "$stashfile"


### PR DESCRIPTION
## Description

I was getting started with fish (first time user), and while setting up the git prompt I realized that the number of untracked files was always set to 0. After looking at the code I saw that the `count` method was not used properly:

Assuming this repo:
```
❯ git ls-files --others --exclude-standard
.DS_Store
images/.DS_Store
images/favicon/.DS_Store
``` 

Current behavior to count untracked files (see commit for the specific line in the script)
```
❯ git ls-files --others --exclude-standard | count
0
```

Fix
```
❯ count (git ls-files --others --exclude-standard)
3
```

## TODOs:
<!-- Just check off what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
