### PR TITLE
doc: document relative path support for `source`.

### DIFF
--- a/sphinx_doc_src/cmds/source.rst
+++ b/sphinx_doc_src/cmds/source.rst
@@ -17,6 +17,8 @@ Description
 
 ``source`` evaluates the commands of the specified file in the current shell. This is different from starting a new process to perform the commands (i.e. ``fish < FILENAME``) since the commands will be evaluated by the current shell, which means that changes in shell variables will affect the current shell. If additional arguments are specified after the file name, they will be inserted into the ``$argv`` variable. The ``$argv`` variable will not include the name of the sourced file.
 
+fish will search the working directory to resolve relative paths but will not search ``$PATH``.
+
 If no file is specified and stdin is not the terminal, or if the file name '``-``' is used, stdin will be read.
 
 The exit status of ``source`` is the exit status of the last job to execute. If something goes wrong while opening or reading the file, ``source`` exits with a non-zero status.


### PR DESCRIPTION
## Description

Documents relative path handling of `source`. See #6193 for context.

Fixes issue #6193