### PR TITLE
Support for &> and |& as convenience redirections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 - `switch` now allows arguments that expand to nothing, like empty variables (#5677).
 - The null command (`:`) now always exits successfully, rather than passing through the previous exit status (#6022).
 - `jobs --last` returns 0 to indicate success when a job is found (#6104).
-- `commandline -p` and `commandline -j` now split on `&&` and `||` in addition to `;` and `&` (#6214)
-- `fish` now correctly handles CDPATH entries that starts with `..` (#6220)
+- `commandline -p` and `commandline -j` now split on `&&` and `||` in addition to `;` and `&` (#6214).
+- `fish` now correctly handles CDPATH entries that starts with `..` (#6220).
+- New redirections `&>` and `&|` may be used to redirect or pipe stdout, and also redirect stderr to stdout (#6192).
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, meaning common commands such as `git reset HEAD@{0}` do not require escaping (#5869).

--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -337,8 +337,6 @@ Most programs use three input/output (IO) streams, each represented by a number 
 
 - Standard error, FD 2, for writing errors and warnings, defaults to writing to the screen.
 
-The reason for providing for two output file descriptors is to allow separation of errors and warnings from regular program output.
-
 Any file descriptor can be directed to a different output than its default through a simple mechanism called a redirection.
 
 An example of a file redirection is ``echo hello > output.txt``, which directs the output of the echo command to the file output.txt.
@@ -358,9 +356,11 @@ An example of a file redirection is ``echo hello > output.txt``, which directs t
 
 - An ampersand followed by a minus sign (``&-``). The file descriptor will be closed.
 
+As a convenience, the redirection ``&>`` can be used to direct both stdout and stderr to the same file.
+
 Example:
 
-To redirect both standard output and standard error to the file 'all_output.txt', you can write ``echo Hello > all_output.txt 2>&1``.
+To redirect both standard output and standard error to the file 'all_output.txt', you can write ``echo Hello &> all_output.txt``, which is a convenience for ``echo Hello > all_output.txt 2>&1``.
 
 Any file descriptor can be redirected in an arbitrary way by prefixing the redirection with the file descriptor.
 
@@ -388,6 +388,7 @@ Pipes usually connect file descriptor 1 (standard output) of the first process t
 
 will attempt to build the fish program, and any errors will be shown using the less pager.
 
+As a convenience, the pipe ``&|`` may be used to redirect both stdout and stderr to the same process. (Note this is different from bash, which uses ``|&``).
 
 .. _syntax-background:
 

--- a/src/proc.h
+++ b/src/proc.h
@@ -215,7 +215,7 @@ class process_t {
     /// IO chain getter and setter.
     const io_chain_t &io_chain() const { return process_io_chain; }
 
-    void set_io_chain(const io_chain_t &chain) { this->process_io_chain = chain; }
+    void set_io_chain(io_chain_t chain) { this->process_io_chain = std::move(chain); }
 
     /// Store the current topic generations. That is, right before the process is launched, record
     /// the generations of all topics; then we can tell which generation values have changed after

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -51,6 +51,7 @@ enum class tokenizer_error_t {
     unterminated_escape,
     invalid_redirect,
     invalid_pipe,
+    invalid_pipe_ampersand,
     closing_unopened_subshell,
     illegal_slice,
     closing_unopened_brace,

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -152,6 +152,10 @@ struct pipe_or_redir_t {
     // Ignored for pipes.
     redirection_mode_t mode{redirection_mode_t::overwrite};
 
+    // Whether, in addition to this redirection, stderr should also be dup'd to stdout
+    // For example &| or &>
+    bool stderr_merge{false};
+
     // Number of characters consumed when parsing the string.
     size_t consumed{0};
 

--- a/tests/checks/redirect.fish
+++ b/tests/checks/redirect.fish
@@ -1,0 +1,27 @@
+#RUN: %fish %s
+
+function outnerr
+    command echo out $argv
+    command echo err $argv 1>&2
+end
+
+outnerr 0 &| count
+#CHECK: 2
+
+set -l tmpdir (mktemp -d)
+outnerr overwrite &> $tmpdir/file.txt
+cat $tmpdir/file.txt
+#CHECK: out overwrite
+#CHECK: err overwrite
+
+outnerr append &>> $tmpdir/file.txt
+cat $tmpdir/file.txt
+#CHECK: out overwrite
+#CHECK: err overwrite
+#CHECK: out append
+#CHECK: err append
+
+echo noclobber &>>? $tmpdir/file.txt
+#CHECKERR: {{.*}} The file {{.*}} already exists
+
+rm -Rf $tmpdir

--- a/tests/checks/redirect.fish
+++ b/tests/checks/redirect.fish
@@ -24,4 +24,9 @@ cat $tmpdir/file.txt
 echo noclobber &>>? $tmpdir/file.txt
 #CHECKERR: {{.*}} The file {{.*}} already exists
 
+eval "echo foo |& false"
+#CHECKERR: {{.*}} |& is not valid. In fish, use &| to pipe both stdout and stderr.
+#CHECKERR: echo foo |& false
+#CHECKERR:          ^
+
 rm -Rf $tmpdir


### PR DESCRIPTION
This adds support for &> and |& syntax, which redirect stderr to stdout, and then redirect that merged stdout.  See #6192

     cmd &> file.txt
     cmd |& another_cmd

are shorthand for (respectively):

    cmd 2>&1 > file.txt
    cmd 2>&1 | another_cmd

`&>>` (append) and `&>?` (noclobber) are also supported.
 
This syntax matches bash - [pipelines](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Pipelines) and [redirection](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Redirecting-Standard-Output-and-Standard-Error). [Also zsh](http://zsh.sourceforge.net/Doc/Release/Redirection.html).

Note bash and zsh also support the syntax `>& abc`. fish should *not* support this because it collides with the syntax for fd redirection. bash "resolves" this by treating numbers specially:

    # bash not fish
    cmd >& path   # redirect stdout and stderr to file 'path'
    cmd >& 5      # redirect stdout to fd 5, leave stderr alone
    cmd >& $var   # either of the above, depending on expansion of $var

This is some good bash bananas, and probably why bash says to "prefer" `&>` over `>&`. In fish we can say that `>&` is always fd redirection and error if the argument is not a number.

That said, this syntax is asymmetric and we should probably add a warning for |& (or perhaps treat it the same as as &|).

Deferring updating docs and changelog until we get agreement.