### PR TITLE
sphinx: honor changes in static html assets

### DIFF
--- a/cmake/Docs.cmake
+++ b/cmake/Docs.cmake
@@ -16,7 +16,9 @@ SET(SPHINX_MANPAGE_DIR "${SPHINX_ROOT_DIR}/man")
 # sphinx-docs uses fish_indent for highlighting.
 # Prepend the output dir of fish_indent to PATH.
 ADD_CUSTOM_TARGET(sphinx-docs
-    env PATH="$<TARGET_FILE_DIR:fish_indent>:$$PATH"
+    ${CMAKE_COMMAND} -E copy_if_different ${SPHINX_SRC_DIR}/_static/pygments.css ${SPHINX_HTML_DIR}/_static/
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SPHINX_SRC_DIR}/_static/custom.css ${SPHINX_HTML_DIR}/_static/
+    COMMAND env PATH="$<TARGET_FILE_DIR:fish_indent>:$$PATH"
         ${SPHINX_EXECUTABLE}
         -q -b html
         -c "${SPHINX_SRC_DIR}"

--- a/sphinx_doc_src/_static/custom.css
+++ b/sphinx_doc_src/_static/custom.css
@@ -1,1 +1,1 @@
-.sphinxsidebar > ul.current > li.current { font-weight: bold }
+.sphinxsidebar ul.current > li.current { font-weight: bold }


### PR DESCRIPTION
## Description

Sphinx does not do proper rebuild after changes like #6207.
One solution is to remove `build/user_docs/html`.
Using this we don't need to remove the entire html build when changing styles. I don't know whether that's worth the extra script. There will always be cases where a clean rebuild is necessary.