### PR TITLE
doc: add links between dirs, pushd and popd

### DIFF
--- a/sphinx_doc_src/cmds/dirs.rst
+++ b/sphinx_doc_src/cmds/dirs.rst
@@ -14,7 +14,7 @@ Synopsis
 Description
 -----------
 
-``dirs`` prints the current directory stack, as created by the :ref:`pushd <cmd-pushd>` command.
+``dirs`` prints the current directory stack, as created by :ref:`pushd <cmd-pushd>` and modified by :ref:`popd <cmd-popd>`.
 
 With "-c", it clears the directory stack instead.
 

--- a/sphinx_doc_src/cmds/popd.rst
+++ b/sphinx_doc_src/cmds/popd.rst
@@ -14,7 +14,7 @@ Synopsis
 Description
 -----------
 
-``popd`` removes the top directory from the directory stack and changes the working directory to the new top directory. Use :ref:`pushd <cmd-pushd>` to add directories to the stack.
+``popd`` removes the top directory from the directory stack and changes the working directory to the new top directory. Use :ref:`pushd <cmd-pushd>` to add directories to the stack or :ref:`dirs <cmd-dirs>` to print it.
 
 You may be interested in the :ref:`cdh <cmd-cdh>` command which provides a more intuitive way to navigate to recently visited directories.
 

--- a/sphinx_doc_src/cmds/pushd.rst
+++ b/sphinx_doc_src/cmds/pushd.rst
@@ -21,7 +21,7 @@ Without arguments, it exchanges the top two directories in the stack.
 
 ``pushd -NUMBER`` rotates clockwise i.e. top to bottom.
 
-See also ``dirs`` and ``dirs -c``.
+See also :ref:`dirs <cmd-dirs>` to print the stack and ``dirs -c`` to clear it.
 
 You may be interested in the :ref:`cdh <cmd-cdh>` command which provides a more intuitive way to navigate to recently visited directories.
 


### PR DESCRIPTION
Hi

`dirs`, `pushd` and `popd` act as a trio of tightly connected commands dealing with the dirstack.

These reference links ensure that the reader can navigate to one another in one click.


