### PR TITLE
add a pacman completion for zstd support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
   - `tsc` (#6016)
   - `vbc` (#6016)
 - Lots of improvements to completions.
+  - `pacman` (#6212)
 
 ## Deprecations
 - The vcs-prompt functions have been promoted to names without double-underscore, so __fish_git_prompt is now fish_git_prompt, __fish_vcs_prompt is now fish_vcs_prompt, __fish_hg_prompt is now fish_hg_prompt and __fish_svn_prompt is now fish_svn_prompt. Shims at the old names have been added, and the variables have kept their old names (#5586).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - The default read limit has been increased to 100MiB (#5267).
 - `math` now also understands `x` for multiplication, provided it is followed by whitespace (#5906).
 - `functions --erase` now also prevents fish from autoloading a function for the first time (#5951).
+- `pacman -U` now also supports the completion of zstd compressed packages (#6212).
 
 ### Interactive improvements
 - fish only parses `/etc/paths` on macOS in login shells, matching the bash implementation (#5637) and avoiding changes to path ordering in child shells (#5456).
@@ -98,7 +99,6 @@
   - `tsc` (#6016)
   - `vbc` (#6016)
 - Lots of improvements to completions.
-  - `pacman` (#6212)
 
 ## Deprecations
 - The vcs-prompt functions have been promoted to names without double-underscore, so __fish_git_prompt is now fish_git_prompt, __fish_vcs_prompt is now fish_vcs_prompt, __fish_hg_prompt is now fish_hg_prompt and __fish_svn_prompt is now fish_svn_prompt. Shims at the old names have been added, and the variables have kept their old names (#5586).

--- a/share/completions/pacman.fish
+++ b/share/completions/pacman.fish
@@ -132,6 +132,6 @@ complete -c $progname -n "$files" -l machinereadable -d 'Show in machine readabl
 
 # Upgrade options
 # Theoretically, pacman reads packages in all formats that libarchive supports
-# In practice, it's going to be tar.xz or tar.gz
+# In practice, it's going to be tar.xz, tar.gz or tar.zst
 # Using "pkg.tar.*" here would change __fish_complete_suffix's descriptions to "unknown"
-complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix .pkg.tar\{,.xz,.gz\})' -d 'Package file'
+complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix .pkg.tar\{,.xz,.gz,.zst\})' -d 'Package file'


### PR DESCRIPTION
An update has been released by Arch Linux official to support the packages for zstd compression.

> https://www.archlinux.org/news/required-update-to-recent-libarchive/

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
