### PR TITLE
builtin commandline: fix flags -p and -j not splitting on && and ||

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `switch` now allows arguments that expand to nothing, like empty variables (#5677).
 - The null command (`:`) now always exits successfully, rather than passing through the previous exit status (#6022).
 - `jobs --last` returns 0 to indicate success when a job is found (#6104).
+- `commandline -p` and `commandline -j` now split on `&&` and `||` in addition to `;` and `&` (#6214)
 
 ### Syntax changes and new commands
 - Brace expansion now only takes place if the braces include a "," or a variable expansion, meaning common commands such as `git reset HEAD@{0}` do not require escaping (#5869).

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -323,12 +323,14 @@ static void job_or_process_extent(const wchar_t *buff, size_t cursor_pos, const 
                 }
                 /* FALLTHROUGH */
                 case token_type_t::end:
-                case token_type_t::background: {
+                case token_type_t::background:
+                case token_type_t::andand:
+                case token_type_t::oror: {
                     if (tok_begin >= pos) {
                         finished = 1;
                         if (b) *b = (wchar_t *)begin + tok_begin;
                     } else {
-                        if (a) *a = (wchar_t *)begin + tok_begin + 1;
+                        if (a) *a = (wchar_t *)begin + tok_begin + token->length;
                     }
                     break;
                 }


### PR DESCRIPTION
Fixes #6214


----

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md