### PR TITLE
Use a pager to view long outputs of builtin --help

### DIFF
--- a/share/functions/__fish_print_help.fish
+++ b/share/functions/__fish_print_help.fish
@@ -56,57 +56,57 @@ function __fish_print_help --description "Print help message for the specified f
     begin
         set -ql error
         and printf "%s\n" $error
-    for line in $help
-        # categorize the line
-        set -l line_type
-        switch $line
-            case ' *' \t\*
-                # starts with whitespace, check if it has non-whitespace
-                printf "%s\n" $line | read -l word __
-                if test -n $word
-                    set line_type normal
-                else
-                    # lines with just spaces probably shouldn't happen
-                    # but let's consider them to be blank
+        for line in $help
+            # categorize the line
+            set -l line_type
+            switch $line
+                case ' *' \t\*
+                    # starts with whitespace, check if it has non-whitespace
+                    printf "%s\n" $line | read -l word __
+                    if test -n $word
+                        set line_type normal
+                    else
+                        # lines with just spaces probably shouldn't happen
+                        # but let's consider them to be blank
+                        set line_type blank
+                    end
+                case ''
                     set line_type blank
-                end
-            case ''
-                set line_type blank
-            case '*'
-                # Remove man's bolding
-                set -l name (string replace -ra '(.)'\b'.' '$1' -- $line)
-                # We start after we have the name
-                contains -- $name NAME; and set have_name 1; and continue
-                # We ignore the SYNOPSIS header
-                contains -- $name SYNOPSIS; and continue
-                # Everything after COPYRIGHT is useless
-                contains -- $name COPYRIGHT; and break
+                case '*'
+                    # Remove man's bolding
+                    set -l name (string replace -ra '(.)'\b'.' '$1' -- $line)
+                    # We start after we have the name
+                    contains -- $name NAME; and set have_name 1; and continue
+                    # We ignore the SYNOPSIS header
+                    contains -- $name SYNOPSIS; and continue
+                    # Everything after COPYRIGHT is useless
+                    contains -- $name COPYRIGHT; and break
 
-                # not leading space, and not empty, so must contain a non-space
-                # in the first column. That makes it a header/footer.
-                set line_type meta
-        end
+                    # not leading space, and not empty, so must contain a non-space
+                    # in the first column. That makes it a header/footer.
+                    set line_type meta
+            end
 
-        set -q have_name[1]; or continue
-        switch $state
-            case normal
-                switch $line_type
-                    case normal meta
-                        printf "%s\n" $line
-                    case blank
-                        set state blank
-                end
-            case blank
-                switch $line_type
-                    case normal meta
-                        echo # print the blank line
-                        printf "%s\n" $line
-                        set state normal
-                    case blank meta
-                        # skip it
-                end
+            set -q have_name[1]; or continue
+            switch $state
+                case normal
+                    switch $line_type
+                        case normal meta
+                            printf "%s\n" $line
+                        case blank
+                            set state blank
+                    end
+                case blank
+                    switch $line_type
+                        case normal meta
+                            echo # print the blank line
+                            printf "%s\n" $line
+                            set state normal
+                        case blank meta
+                            # skip it
+                    end
+            end
         end
-    end
     end | string replace -ra '^       ' '' | ul | # post-process with `ul`, to interpret the old-style grotty escapes
     begin
         set -l pager less

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -206,14 +206,14 @@ static int builtin_generic(parser_t &parser, io_streams_t &streams, wchar_t **ar
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 
     // Hackish - if we have no arguments other than the command, we are a "naked invocation" and we
     // just print help.
     if (argc == 1) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_INVALID_ARGS;
     }
 
@@ -439,7 +439,7 @@ proc_status_t builtin_run(parser_t &parser, int job_pgid, wchar_t **argv, io_str
     // follows the keyword by `-h` or `--help`. Since it isn't really a builtin command we need to
     // handle displaying help for it here.
     if (argv[1] && !argv[2] && parse_util_argument_is_help(argv[1]) && cmd_needs_help(argv[0])) {
-        builtin_print_help(parser, streams, argv[0], streams.out);
+        builtin_print_help(parser, streams, argv[0]);
         return proc_status_t::from_exit_code(STATUS_CMD_OK);
     }
 

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -257,9 +257,8 @@ static int builtin_break_continue(parser_t &parser, io_streams_t &streams, wchar
     int argc = builtin_count_args(argv);
 
     if (argc != 1) {
-        streams.err.append_format(BUILTIN_ERR_UNKNOWN, argv[0], argv[1]);
-
-        builtin_print_help(parser, streams, argv[0], streams.err);
+        wcstring error_message = format_string(BUILTIN_ERR_UNKNOWN, argv[0], argv[1]);
+        builtin_print_help(parser, streams, argv[0], &error_message);
         return STATUS_INVALID_ARGS;
     }
 
@@ -271,8 +270,8 @@ static int builtin_break_continue(parser_t &parser, io_streams_t &streams, wchar
         if (b->type() == FUNCTION_CALL) break;
     }
     if (!has_loop) {
-        streams.err.append_format(_(L"%ls: Not inside of loop\n"), argv[0]);
-        builtin_print_help(parser, streams, argv[0], streams.err);
+        wcstring error_message = format_string(_(L"%ls: Not inside of loop\n"), argv[0]);
+        builtin_print_help(parser, streams, argv[0], &error_message);
         return STATUS_CMD_ERROR;
     }
 

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -89,7 +89,7 @@ const wchar_t *builtin_get_desc(const wcstring &b);
 wcstring builtin_help_get(parser_t &parser, const wchar_t *cmd);
 
 void builtin_print_help(parser_t &parser, io_streams_t &streams, const wchar_t *cmd,
-                        output_stream_t &b);
+                        wcstring *error_message = nullptr);
 int builtin_count_args(const wchar_t *const *argv);
 
 void builtin_unknown_option(parser_t &parser, io_streams_t &streams, const wchar_t *cmd,

--- a/src/builtin_argparse.cpp
+++ b/src/builtin_argparse.cpp
@@ -699,7 +699,7 @@ int builtin_argparse(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_bg.cpp
+++ b/src/builtin_bg.cpp
@@ -21,10 +21,10 @@
 static int send_to_bg(parser_t &parser, io_streams_t &streams, job_t *j) {
     assert(j != NULL);
     if (!j->wants_job_control()) {
-        streams.err.append_format(
+        wcstring error_message = format_string(
             _(L"%ls: Can't put job %d, '%ls' to background because it is not under job control\n"),
             L"bg", j->job_id, j->command_wcstr());
-        builtin_print_help(parser, streams, L"bg", streams.err);
+        builtin_print_help(parser, streams, L"bg", &error_message);
         return STATUS_CMD_ERROR;
     }
 

--- a/src/builtin_bg.cpp
+++ b/src/builtin_bg.cpp
@@ -47,7 +47,7 @@ int builtin_bg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_bind.cpp
+++ b/src/builtin_bind.cpp
@@ -431,7 +431,7 @@ int builtin_bind_t::builtin_bind(parser_t &parser, io_streams_t &streams, wchar_
         return STATUS_CMD_OK;
     }
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_block.cpp
+++ b/src/builtin_block.cpp
@@ -81,7 +81,7 @@ int builtin_block(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_builtin.cpp
+++ b/src/builtin_builtin.cpp
@@ -77,7 +77,7 @@ int builtin_builtin(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_cd.cpp
+++ b/src/builtin_cd.cpp
@@ -31,7 +31,7 @@ int builtin_cd(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_command.cpp
+++ b/src/builtin_command.cpp
@@ -84,13 +84,13 @@ int builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 
     // Quiet implies find_path.
     if (!opts.find_path && !opts.all_paths && !opts.quiet) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_INVALID_ARGS;
     }
 

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -263,7 +263,7 @@ int builtin_commandline(parser_t &parser, io_streams_t &streams, wchar_t **argv)
                 break;
             }
             case 'h': {
-                builtin_print_help(parser, streams, cmd, streams.out);
+                builtin_print_help(parser, streams, cmd);
                 return STATUS_CMD_OK;
             }
             case ':': {

--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -247,7 +247,7 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 break;
             }
             case 'h': {
-                builtin_print_help(parser, streams, cmd, streams.out);
+                builtin_print_help(parser, streams, cmd);
                 return STATUS_CMD_OK;
             }
             case ':': {

--- a/src/builtin_contains.cpp
+++ b/src/builtin_contains.cpp
@@ -68,7 +68,7 @@ int builtin_contains(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_disown.cpp
+++ b/src/builtin_disown.cpp
@@ -52,7 +52,7 @@ int builtin_disown(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_emit.cpp
+++ b/src/builtin_emit.cpp
@@ -21,7 +21,7 @@ int builtin_emit(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_exit.cpp
+++ b/src/builtin_exit.cpp
@@ -69,7 +69,7 @@ int builtin_exit(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_fg.cpp
+++ b/src/builtin_fg.cpp
@@ -31,7 +31,7 @@ int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_functions.cpp
+++ b/src/builtin_functions.cpp
@@ -298,7 +298,7 @@ int builtin_functions(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_history.cpp
+++ b/src/builtin_history.cpp
@@ -212,7 +212,7 @@ int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_jobs.cpp
+++ b/src/builtin_jobs.cpp
@@ -151,7 +151,7 @@ int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 break;
             }
             case 'h': {
-                builtin_print_help(parser, streams, cmd, streams.out);
+                builtin_print_help(parser, streams, cmd);
                 return STATUS_CMD_OK;
             }
             case ':': {

--- a/src/builtin_math.cpp
+++ b/src/builtin_math.cpp
@@ -243,7 +243,7 @@ int builtin_math(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_printf.cpp
+++ b/src/builtin_printf.cpp
@@ -742,7 +742,7 @@ int builtin_printf(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_pwd.cpp
+++ b/src/builtin_pwd.cpp
@@ -33,7 +33,7 @@ int builtin_pwd(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 resolve_symlinks = true;
                 break;
             case 'h':
-                builtin_print_help(parser, streams, cmd, streams.out);
+                builtin_print_help(parser, streams, cmd);
                 return STATUS_CMD_OK;
             case '?': {
                 builtin_unknown_option(parser, streams, cmd, argv[w.woptind - 1]);

--- a/src/builtin_random.cpp
+++ b/src/builtin_random.cpp
@@ -38,7 +38,7 @@ int builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_read.cpp
+++ b/src/builtin_read.cpp
@@ -431,7 +431,7 @@ int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     }
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_realpath.cpp
+++ b/src/builtin_realpath.cpp
@@ -28,13 +28,13 @@ int builtin_realpath(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 
     if (optind + 1 != argc) {  // TODO: allow arbitrary args. `realpath *` should print many paths
         streams.err.append_format(BUILTIN_ERR_ARG_COUNT1, cmd, 1, argc - optind);
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_INVALID_ARGS;
     }
 

--- a/src/builtin_return.cpp
+++ b/src/builtin_return.cpp
@@ -68,7 +68,7 @@ int builtin_return(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -807,7 +807,7 @@ int builtin_set(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     argc -= optind;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_set_color.cpp
+++ b/src/builtin_set_color.cpp
@@ -109,7 +109,7 @@ int builtin_set_color(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 break;
             }
             case 'h': {
-                builtin_print_help(parser, streams, argv[0], streams.out);
+                builtin_print_help(parser, streams, argv[0]);
                 return STATUS_CMD_OK;
             }
             case 'o': {

--- a/src/builtin_source.cpp
+++ b/src/builtin_source.cpp
@@ -33,7 +33,7 @@ int builtin_source(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_status.cpp
+++ b/src/builtin_status.cpp
@@ -280,7 +280,7 @@ int builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     if (retval != STATUS_CMD_OK) return retval;
 
     if (opts.print_help) {
-        builtin_print_help(parser, streams, cmd, streams.out);
+        builtin_print_help(parser, streams, cmd);
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1352,7 +1352,7 @@ int builtin_string(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     }
 
     if (std::wcscmp(argv[1], L"-h") == 0 || std::wcscmp(argv[1], L"--help") == 0) {
-        builtin_print_help(parser, streams, L"string", streams.out);
+        builtin_print_help(parser, streams, L"string");
         return STATUS_CMD_OK;
     }
 

--- a/src/builtin_ulimit.cpp
+++ b/src/builtin_ulimit.cpp
@@ -239,7 +239,7 @@ int builtin_ulimit(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
             }
 #endif
             case 'h': {
-                builtin_print_help(parser, streams, cmd, streams.out);
+                builtin_print_help(parser, streams, cmd);
                 return STATUS_CMD_OK;
             }
             case ':': {


### PR DESCRIPTION
Every builtin or function shipped with fish supports flag -h or --help to
print a slightly condensed version of its manpage.
Some of those help messages are longer than a typical screen;
this commit pipes the help to a pager to make it easier to read.

As in other places in fish we assume that either $PAGER or "less" is a
valid pager and use that.

In three places (error messages for bg, break and continue) the help is
printed to stderr instead of stdout.  To make sure the error message is
visible in the pager, we pass it to builtin_print_help, every call of which
needs to be updated.

Fixes #6227

----

## TODOs:
- [ ] User-visible changes noted in CHANGELOG.md