### PR TITLE
[WIP] Add completions for redirection and pipe operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - The locale is now reloaded when the `LOCPATH` variable is changed (#5815).
 - `read` no longer keeps a history, making it suitable for operations that shouldn't end up there, like password entry (#5904).
 - Completion of subcommands to builtins like `and` or `not` has been fixed (#6249).
+- Tab completion can now suggest commonly used redirections, pipes and logical operators (#6233).
 
 #### New or improved bindings
 - Pasting strips leading spaces to avoid pasted commands being omitted from the history (#4327).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - The locale is now reloaded when the `LOCPATH` variable is changed (#5815).
 - `read` no longer keeps a history, making it suitable for operations that shouldn't end up there, like password entry (#5904).
 - Completion of subcommands to builtins like `and` or `not` has been fixed (#6249).
-- Tab completion can now suggest commonly used redirections, pipes and logical operators (#6233).
+- Tab completion can now suggest redirections, pipes and logical operators (#6233).
 
 #### New or improved bindings
 - Pasting strips leading spaces to avoid pasted commands being omitted from the history (#4327).

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -398,7 +398,8 @@ int builtin_commandline(parser_t &parser, io_streams_t &streams, wchar_t **argv)
             break;
         }
         case PROCESS_MODE: {
-            parse_util_process_extent(current_buffer, current_cursor_pos, &begin, &end, nullptr);
+            parse_util_process_extent(current_buffer, current_cursor_pos, &begin, &end, nullptr,
+                                      nullptr);
             break;
         }
         case JOB_MODE: {

--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -326,10 +326,6 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
             }
             do_complete_param = cmd;
         }
-        const wchar_t *token;
-
-        parse_util_token_extent(do_complete_param.c_str(), do_complete_param.size(), &token, 0, 0,
-                                0);
 
         // Create a scoped transient command line, so that builtin_commandline will see our
         // argument, not the reader buffer.
@@ -347,7 +343,7 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 	    if (!have_do_complete_param)
                 parser.libdata().builtin_complete_current_commandline = true;
 
-            std::vector<completion_t> comp;
+            completion_result_t comp;
             complete(do_complete_param, &comp, completion_request_t::fuzzy_match, parser.vars(),
                      parser.shared());
 
@@ -355,10 +351,11 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 const completion_t &next = comp.choices.at(i);
 
                 // Make a fake commandline, and then apply the completion to it.
-                const wcstring faux_cmdline = token;
+                const wcstring faux_cmdline = do_complete_param.substr(comp.dest.start);
                 size_t tmp_cursor = faux_cmdline.size();
+                source_range_t dest{0, comp.dest.length};
                 wcstring faux_cmdline_with_completion = completion_apply_to_command_line(
-                    next.completion, next.flags, faux_cmdline, &tmp_cursor, false);
+                    next.completion, next.flags, faux_cmdline, &tmp_cursor, dest, false);
 
                 // completion_apply_to_command_line will append a space unless COMPLETE_NO_SPACE
                 // is set. We don't want to set COMPLETE_NO_SPACE because that won't close

--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -351,8 +351,8 @@ int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
             complete(do_complete_param, &comp, completion_request_t::fuzzy_match, parser.vars(),
                      parser.shared());
 
-            for (size_t i = 0; i < comp.size(); i++) {
-                const completion_t &next = comp.at(i);
+            for (size_t i = 0; i < comp.choices.size(); i++) {
+                const completion_t &next = comp.choices.at(i);
 
                 // Make a fake commandline, and then apply the completion to it.
                 const wcstring faux_cmdline = token;

--- a/src/complete.h
+++ b/src/complete.h
@@ -12,6 +12,7 @@
 
 #include "common.h"
 #include "enum_set.h"
+#include "tnode.h"
 
 struct completion_mode_t {
     /// If set, skip file completions.
@@ -169,11 +170,21 @@ void complete_remove(const wcstring &cmd, bool cmd_is_path, const wcstring &opti
 /// Removes all completions for a given command.
 void complete_remove_all(const wcstring &cmd, bool cmd_is_path);
 
-/// Find all completions of the command cmd, insert them into out.
+typedef std::vector<completion_t> completion_list_t;
+/// The result of a completion request.
+struct completion_result_t {
+    /// The list of matching complete_t entries.
+    completion_list_t choices;
+    /// The limits of the token for which the completion was computed
+    /// (relative to the commandline). A completion will either append
+    /// at the end of this range, or replace it entirely.
+    source_range_t dest;
+};
+
+/// Find all completions at the given cursor of the command cmd, insert them into out.
 class parser_t;
-void complete(const wcstring &cmd, std::vector<completion_t> *out_comps,
-              completion_request_flags_t flags, const environment_t &vars,
-              const std::shared_ptr<parser_t> &parser);
+void complete(const wcstring &cmd, completion_result_t *out_comps, completion_request_flags_t flags,
+              const environment_t &vars, const std::shared_ptr<parser_t> &parser);
 
 /// Return a list of all current completions.
 wcstring complete_print();

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2625,36 +2625,36 @@ static void test_complete() {
 
     auto parser = parser_t::principal_parser().shared();
 
-    completion_list_t completions;
+    completion_result_t completions;
     complete(L"$", &completions, {}, vars, parser);
-    completions_sort_and_prioritize(&completions);
-    do_test(completions.size() == 6);
-    do_test(completions.at(0).completion == L"Bar1");
-    do_test(completions.at(1).completion == L"Bar2");
-    do_test(completions.at(2).completion == L"Bar3");
-    do_test(completions.at(3).completion == L"Foo1");
-    do_test(completions.at(4).completion == L"Foo2");
-    do_test(completions.at(5).completion == L"Foo3");
+    completions_sort_and_prioritize(&completions.choices);
+    do_test(completions.choices.size() == 6);
+    do_test(completions.choices.at(0).completion == L"Bar1");
+    do_test(completions.choices.at(1).completion == L"Bar2");
+    do_test(completions.choices.at(2).completion == L"Bar3");
+    do_test(completions.choices.at(3).completion == L"Foo1");
+    do_test(completions.choices.at(4).completion == L"Foo2");
+    do_test(completions.choices.at(5).completion == L"Foo3");
 
-    completions.clear();
+    completions.choices.clear();
     complete(L"$F", &completions, {}, vars, parser);
-    completions_sort_and_prioritize(&completions);
-    do_test(completions.size() == 3);
-    do_test(completions.at(0).completion == L"oo1");
-    do_test(completions.at(1).completion == L"oo2");
-    do_test(completions.at(2).completion == L"oo3");
+    completions_sort_and_prioritize(&completions.choices);
+    do_test(completions.choices.size() == 3);
+    do_test(completions.choices.at(0).completion == L"oo1");
+    do_test(completions.choices.at(1).completion == L"oo2");
+    do_test(completions.choices.at(2).completion == L"oo3");
 
-    completions.clear();
+    completions.choices.clear();
     complete(L"$1", &completions, {}, vars, parser);
-    completions_sort_and_prioritize(&completions);
-    do_test(completions.empty());
+    completions_sort_and_prioritize(&completions.choices);
+    do_test(completions.choices.empty());
 
-    completions.clear();
+    completions.choices.clear();
     complete(L"$1", &completions, completion_request_t::fuzzy_match, vars, parser);
-    completions_sort_and_prioritize(&completions);
-    do_test(completions.size() == 2);
-    do_test(completions.at(0).completion == L"$Bar1");
-    do_test(completions.at(1).completion == L"$Foo1");
+    completions_sort_and_prioritize(&completions.choices);
+    do_test(completions.choices.size() == 2);
+    do_test(completions.choices.at(0).completion == L"$Bar1");
+    do_test(completions.choices.at(1).completion == L"$Foo1");
 
     if (system("mkdir -p 'test/complete_test'")) err(L"mkdir failed");
     if (system("touch 'test/complete_test/has space'")) err(L"touch failed");
@@ -2663,51 +2663,53 @@ static void test_complete() {
     if (system("touch 'test/complete_test/testfile'")) err(L"touch failed");
     if (system("chmod 700 'test/complete_test/testfile'")) err(L"chmod failed");
 
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo (test/complete_test/testfil", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"e");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"e");
 
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo (ls test/complete_test/testfil", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"e");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"e");
 
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo (command ls test/complete_test/testfil", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"e");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"e");
 
     // Completing after spaces - see #2447
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo (ls test/complete_test/has\\ ", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"space");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"space");
 
     // Brackets - see #5831
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo (ls test/complete_test/bracket[", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"test/complete_test/bracket[abc]");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"test/complete_test/bracket[abc]");
 
     wcstring cmdline = L"touch test/complete_test/bracket[";
-    completions.clear();
+    completions.choices.clear();
     complete(cmdline, &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.front().completion == L"test/complete_test/bracket[abc]");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.front().completion == L"test/complete_test/bracket[abc]");
     size_t where = cmdline.size();
     wcstring newcmdline = completion_apply_to_command_line(
-        completions.front().completion, completions.front().flags, cmdline, &where, false);
+        completions.choices.front().completion, completions.choices.front().flags, cmdline, &where,
+        completions.dest, false);
     do_test(newcmdline == L"touch test/complete_test/bracket\\[abc\\] ");
 
-    completions.clear();
+    completions.choices.clear();
     cmdline = LR"(touch test/complete_test/gnarlybracket\\[)";
     complete(cmdline, &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.front().completion == LR"(test/complete_test/gnarlybracket\[abc])");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.front().completion == LR"(test/complete_test/gnarlybracket\[abc])");
     where = cmdline.size();
-    newcmdline = completion_apply_to_command_line(
-        completions.front().completion, completions.front().flags, cmdline, &where, false);
+    newcmdline = completion_apply_to_command_line(completions.choices.front().completion,
+                                                  completions.choices.front().flags, cmdline,
+                                                  &where, completions.dest, false);
     do_test(newcmdline == LR"(touch test/complete_test/gnarlybracket\\\[abc\] )");
 
     // Add a function and test completing it in various ways.
@@ -2718,112 +2720,112 @@ static void test_complete() {
     function_add(func_data, parser_t::principal_parser());
 
     // Complete a function name.
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo (scuttlebut", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"t");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"t");
 
     // But not with the command prefix.
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo (command scuttlebut", &completions, {}, vars, parser);
-    do_test(completions.size() == 0);
+    do_test(completions.choices.size() == 0);
 
     // Not with the builtin prefix.
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo (builtin scuttlebut", &completions, {}, vars, parser);
-    do_test(completions.size() == 0);
+    do_test(completions.choices.size() == 0);
 
     // Not after a redirection.
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo hi > scuttlebut", &completions, {}, vars, parser);
-    do_test(completions.size() == 0);
+    do_test(completions.choices.size() == 0);
 
     // Trailing spaces (#1261).
     completion_mode_t no_files{};
     no_files.no_files = true;
     complete_add(L"foobarbaz", false, wcstring(), option_type_args_only, no_files, NULL, L"qux",
                  NULL, COMPLETE_AUTO_SPACE);
-    completions.clear();
+    completions.choices.clear();
     complete(L"foobarbaz ", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"qux");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"qux");
 
     // Don't complete variable names in single quotes (#1023).
-    completions.clear();
+    completions.choices.clear();
     complete(L"echo '$Foo", &completions, {}, vars, parser);
-    do_test(completions.empty());
-    completions.clear();
+    do_test(completions.choices.empty());
+    completions.choices.clear();
     complete(L"echo \\$Foo", &completions, {}, vars, parser);
-    do_test(completions.empty());
+    do_test(completions.choices.empty());
 
     // File completions.
-    completions.clear();
+    completions.choices.clear();
     complete(L"cat test/complete_test/te", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"stfile");
-    completions.clear();
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"stfile");
+    completions.choices.clear();
     complete(L"echo sup > test/complete_test/te", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"stfile");
-    completions.clear();
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"stfile");
+    completions.choices.clear();
     complete(L"echo sup > test/complete_test/te", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"stfile");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"stfile");
 
     if (!pushd("test/complete_test")) return;
     complete(L"cat te", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"stfile");
-    do_test(!(completions.at(0).flags & COMPLETE_REPLACES_TOKEN));
-    do_test(!(completions.at(0).flags & COMPLETE_DUPLICATES_ARGUMENT));
-    completions.clear();
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"stfile");
+    do_test(!(completions.choices.at(0).flags & COMPLETE_REPLACES_TOKEN));
+    do_test(!(completions.choices.at(0).flags & COMPLETE_DUPLICATES_ARGUMENT));
+    completions.choices.clear();
     complete(L"cat testfile te", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"stfile");
-    do_test(completions.at(0).flags & COMPLETE_DUPLICATES_ARGUMENT);
-    completions.clear();
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"stfile");
+    do_test(completions.choices.at(0).flags & COMPLETE_DUPLICATES_ARGUMENT);
+    completions.choices.clear();
     complete(L"cat testfile TE", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"testfile");
-    do_test(completions.at(0).flags & COMPLETE_REPLACES_TOKEN);
-    do_test(completions.at(0).flags & COMPLETE_DUPLICATES_ARGUMENT);
-    completions.clear();
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"testfile");
+    do_test(completions.choices.at(0).flags & COMPLETE_REPLACES_TOKEN);
+    do_test(completions.choices.at(0).flags & COMPLETE_DUPLICATES_ARGUMENT);
+    completions.choices.clear();
     complete(L"something --abc=te", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"stfile");
-    completions.clear();
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"stfile");
+    completions.choices.clear();
     complete(L"something -abc=te", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"stfile");
-    completions.clear();
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"stfile");
+    completions.choices.clear();
     complete(L"something abc=te", &completions, {}, vars, parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"stfile");
-    completions.clear();
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"stfile");
+    completions.choices.clear();
     complete(L"something abc=stfile", &completions, {}, vars, parser);
-    do_test(completions.size() == 0);
-    completions.clear();
+    do_test(completions.choices.size() == 0);
+    completions.choices.clear();
     complete(L"something abc=stfile", &completions, completion_request_t::fuzzy_match, vars,
              parser);
-    do_test(completions.size() == 1);
-    do_test(completions.at(0).completion == L"abc=testfile");
+    do_test(completions.choices.size() == 1);
+    do_test(completions.choices.at(0).completion == L"abc=testfile");
 
     // Zero escapes can cause problems. See issue #1631.
-    completions.clear();
+    completions.choices.clear();
     complete(L"cat foo\\0", &completions, {}, vars, parser);
-    do_test(completions.empty());
-    completions.clear();
+    do_test(completions.choices.empty());
+    completions.choices.clear();
     complete(L"cat foo\\0bar", &completions, {}, vars, parser);
-    do_test(completions.empty());
-    completions.clear();
+    do_test(completions.choices.empty());
+    completions.choices.clear();
     complete(L"cat \\0", &completions, {}, vars, parser);
-    do_test(completions.empty());
-    completions.clear();
+    do_test(completions.choices.empty());
+    completions.choices.clear();
     complete(L"cat te\\0", &completions, {}, vars, parser);
-    do_test(completions.empty());
+    do_test(completions.choices.empty());
 
     popd();
-    completions.clear();
+    completions.choices.clear();
 
     // Test abbreviations.
     auto &pvars = parser_t::principal_parser().vars();
@@ -2833,12 +2835,12 @@ static void test_complete() {
     int ret = pvars.set_one(L"_fish_abbr_testabbrsonetwothreezero", ENV_LOCAL, L"expansion");
     complete(L"testabbrsonetwothree", &completions, {}, pvars, parser);
     do_test(ret == 0);
-    do_test(completions.size() == 2);
-    do_test(completions.at(0).completion == L"four");
-    do_test((completions.at(0).flags & COMPLETE_NO_SPACE) == 0);
+    do_test(completions.choices.size() == 2);
+    do_test(completions.choices.at(0).completion == L"four");
+    do_test((completions.choices.at(0).flags & COMPLETE_NO_SPACE) == 0);
     // Abbreviations should not have a space after them.
-    do_test(completions.at(1).completion == L"zero");
-    do_test((completions.at(1).flags & COMPLETE_NO_SPACE) != 0);
+    do_test(completions.choices.at(1).completion == L"zero");
+    do_test((completions.choices.at(1).flags & COMPLETE_NO_SPACE) != 0);
 
     // Test wraps.
     do_test(comma_join(complete_get_wrap_targets(L"wrapper1")).empty());
@@ -2920,22 +2922,22 @@ static void perform_one_autosuggestion_cd_test(const wcstring &command, const wc
 
     bool expects_error = (expected == L"<error>");
 
-    if (comps.empty() && !expects_error) {
+    if (comps.choices.empty() && !expects_error) {
         std::fwprintf(stderr, L"line %ld: autosuggest_suggest_special() failed for command %ls\n",
                       line, command.c_str());
-        do_test_from(!comps.empty(), line);
+        do_test_from(!comps.choices.empty(), line);
         return;
-    } else if (!comps.empty() && expects_error) {
+    } else if (!comps.choices.empty() && expects_error) {
         std::fwprintf(stderr,
                       L"line %ld: autosuggest_suggest_special() was expected to fail but did not, "
                       L"for command %ls\n",
                       line, command.c_str());
-        do_test_from(comps.empty(), line);
+        do_test_from(comps.choices.empty(), line);
     }
 
-    if (!comps.empty()) {
-        completions_sort_and_prioritize(&comps);
-        const completion_t &suggestion = comps.at(0);
+    if (!comps.choices.empty()) {
+        completions_sort_and_prioritize(&comps.choices);
+        const completion_t &suggestion = comps.choices.at(0);
 
         if (suggestion.completion != expected) {
             std::fwprintf(
@@ -2951,27 +2953,27 @@ static void perform_one_autosuggestion_cd_test(const wcstring &command, const wc
 
 static void perform_one_completion_cd_test(const wcstring &command, const wcstring &expected,
                                            const environment_t &vars, long line) {
-    std::vector<completion_t> comps;
+    completion_result_t comps;
     complete(command, &comps, {}, vars, nullptr);
 
     bool expects_error = (expected == L"<error>");
 
-    if (comps.empty() && !expects_error) {
+    if (comps.choices.empty() && !expects_error) {
         std::fwprintf(stderr, L"line %ld: autosuggest_suggest_special() failed for command %ls\n",
                       line, command.c_str());
-        do_test_from(!comps.empty(), line);
+        do_test_from(!comps.choices.empty(), line);
         return;
-    } else if (!comps.empty() && expects_error) {
+    } else if (!comps.choices.empty() && expects_error) {
         std::fwprintf(stderr,
                       L"line %ld: autosuggest_suggest_special() was expected to fail but did not, "
                       L"for command %ls\n",
                       line, command.c_str());
-        do_test_from(comps.empty(), line);
+        do_test_from(comps.choices.empty(), line);
     }
 
-    if (!comps.empty()) {
-        completions_sort_and_prioritize(&comps);
-        const completion_t &suggestion = comps.at(0);
+    if (!comps.choices.empty()) {
+        completions_sort_and_prioritize(&comps.choices);
+        const completion_t &suggestion = comps.choices.at(0);
 
         if (suggestion.completion != expected) {
             std::fwprintf(stderr,
@@ -3091,11 +3093,11 @@ static void test_autosuggest_suggest_special() {
 }
 
 static void perform_one_autosuggestion_should_ignore_test(const wcstring &command, long line) {
-    completion_list_t comps;
+    completion_result_t comps;
     complete(command, &comps, completion_request_t::autosuggestion, null_environment_t{}, nullptr);
-    do_test(comps.empty());
-    if (!comps.empty()) {
-        const wcstring &suggestion = comps.front().completion;
+    do_test(comps.choices.empty());
+    if (!comps.choices.empty()) {
+        const wcstring &suggestion = comps.choices.front().completion;
         std::fwprintf(stderr, L"line %ld: complete() expected to return nothing for %ls\n", line,
                       command.c_str());
         std::fwprintf(stderr, L"  instead got: %ls\n", suggestion.c_str());

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -21,7 +21,6 @@
 #include "wutil.h"  // IWYU pragma: keep
 
 typedef pager_t::comp_t comp_t;
-typedef std::vector<completion_t> completion_list_t;
 typedef std::vector<comp_t> comp_info_list_t;
 
 /// The minimum width (in characters) the terminal must to show completions at all.

--- a/src/pager.h
+++ b/src/pager.h
@@ -60,8 +60,6 @@ enum class selection_motion_t {
 // How many rows we will show in the "initial" pager.
 #define PAGER_UNDISCLOSED_MAX_ROWS 4
 
-typedef std::vector<completion_t> completion_list_t;
-
 class pager_t {
     size_t available_term_width;
     size_t available_term_height;

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -289,8 +289,8 @@ void parse_util_cmdsubst_extent(const wchar_t *buff, size_t cursor_pos, const wc
 
 /// Get the beginning and end of the job or process definition under the cursor.
 static void job_or_process_extent(bool process, const wchar_t *buff, size_t cursor_pos,
-                                  const wchar_t **a, const wchar_t **b,
-                                  std::vector<tok_t> *tokens) {
+                                  const wchar_t **a, const wchar_t **b, std::vector<tok_t> *tokens,
+                                  tok_t *token_at_cursor) {
     assert(buff && "Null buffer");
     const wchar_t *begin = nullptr, *end = nullptr;
     int finished = 0;
@@ -314,6 +314,9 @@ static void job_or_process_extent(bool process, const wchar_t *buff, size_t curs
     while ((token = tok.next()) && !finished) {
         size_t tok_begin = token->offset;
 
+        if (token_at_cursor && token->location_in_or_at_end_of_source_range(pos)) {
+            *token_at_cursor = *token;
+        }
         switch (token->type) {
             case token_type_t::pipe: {
                 if (!process) {
@@ -345,12 +348,13 @@ static void job_or_process_extent(bool process, const wchar_t *buff, size_t curs
 }
 
 void parse_util_process_extent(const wchar_t *buff, size_t pos, const wchar_t **a,
-                               const wchar_t **b, std::vector<tok_t> *tokens) {
-    job_or_process_extent(true, buff, pos, a, b, tokens);
+                               const wchar_t **b, std::vector<tok_t> *tokens,
+                               tok_t *token_at_cursor) {
+    job_or_process_extent(true, buff, pos, a, b, tokens, token_at_cursor);
 }
 
 void parse_util_job_extent(const wchar_t *buff, size_t pos, const wchar_t **a, const wchar_t **b) {
-    job_or_process_extent(false, buff, pos, a, b, nullptr);
+    job_or_process_extent(false, buff, pos, a, b, nullptr, nullptr);
 }
 
 void parse_util_token_extent(const wchar_t *buff, size_t cursor_pos, const wchar_t **tok_begin,

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -58,8 +58,10 @@ void parse_util_cmdsubst_extent(const wchar_t *buff, size_t cursor_pos, const wc
 /// \param a the start of the process
 /// \param b the end of the process
 /// \param tokens the tokens in the process
+/// \param tokens the token at or directly left of the cursor
 void parse_util_process_extent(const wchar_t *buff, size_t cursor_pos, const wchar_t **a,
-                               const wchar_t **b, std::vector<tok_t> *tokens);
+                               const wchar_t **b, std::vector<tok_t> *tokens,
+                               tok_t *token_at_cursor);
 
 /// Find the beginning and end of the job definition under the cursor
 ///

--- a/src/reader.h
+++ b/src/reader.h
@@ -147,7 +147,7 @@ void reader_push(parser_t &parser, const wcstring &name);
 void reader_pop();
 
 /// Specify function to use for finding possible tab completions.
-typedef void (*complete_function_t)(const wcstring &, std::vector<completion_t> *,
+typedef void (*complete_function_t)(const wcstring &, completion_result_t *,
                                     completion_request_flags_t, const environment_t &,
                                     const std::shared_ptr<parser_t> &parser);
 void reader_set_complete_function(complete_function_t);
@@ -217,10 +217,11 @@ wcstring combine_command_and_autosuggestion(const wcstring &cmdline,
 maybe_t<wcstring> reader_expand_abbreviation_in_command(const wcstring &cmdline, size_t cursor_pos,
                                                         const environment_t &vars);
 
+struct source_range_t;
 /// Apply a completion string. Exposed for testing only.
 wcstring completion_apply_to_command_line(const wcstring &val_str, complete_flags_t flags,
                                           const wcstring &command_line, size_t *inout_cursor_pos,
-                                          bool append_only);
+                                          source_range_t dest, bool append_only);
 
 /// Print warning with list of backgrounded jobs
 void reader_bg_job_warning(const parser_t &parser);

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -150,3 +150,29 @@ complete -C'for _ in ' | string collect >&- && echo completed some files
 # function; #5415
 complete -C'function : --arg'
 # CHECK: --argument-names	{{.*}}
+
+# Redirections and pipes
+complete -C'complete_test_pipe |'
+# CHECK: |	pipe stdout
+# CHECK: 2>|	pipe stderr
+# CHECK: &|	pipe stdout/stderr
+# CHECK: ||	"or" - run on failure
+complete -C'complete_test_redir1 >'
+# CHECK: >	write stdout to file
+# CHECK: >>	append stdout to file
+# CHECK: &>	write stdout/stderr to file
+# CHECK: &>>	append stdout/stderr to file
+# CHECK: >&2	redirect stdout to stderr
+# CHECK: 2>&1	redirect stderr to stdout
+# CHECK: 2>|	pipe stderr
+complete -C'complete_test_redir2 >>'
+# CHECK: >>	append stdout to file
+# CHECK: &>>	append stdout/stderr to file
+complete -C'complete_test_redir3 &'
+# CHECK: &	run job in background
+# CHECK: &&	"and" - run on success
+# CHECK: &>	write stdout/stderr to file
+# CHECK: &>>	append stdout/stderr to file
+# CHECK: >&2	redirect stdout to stderr
+# CHECK: 2>&1	redirect stderr to stdout
+# CHECK: &|	pipe stdout/stderr

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -160,19 +160,16 @@ complete -C'complete_test_pipe |'
 complete -C'complete_test_redir1 >'
 # CHECK: >	write stdout to file
 # CHECK: >>	append stdout to file
+# CHECK: >?	write stdout to file - noclobber
+# CHECK: 2>	write stderr to file
 # CHECK: &>	write stdout/stderr to file
-# CHECK: &>>	append stdout/stderr to file
 # CHECK: >&2	redirect stdout to stderr
 # CHECK: 2>&1	redirect stderr to stdout
 # CHECK: 2>|	pipe stderr
-complete -C'complete_test_redir2 >>'
-# CHECK: >>	append stdout to file
-# CHECK: &>>	append stdout/stderr to file
 complete -C'complete_test_redir3 &'
 # CHECK: &	run job in background
 # CHECK: &&	"and" - run on success
 # CHECK: &>	write stdout/stderr to file
-# CHECK: &>>	append stdout/stderr to file
 # CHECK: >&2	redirect stdout to stderr
 # CHECK: 2>&1	redirect stderr to stdout
 # CHECK: &|	pipe stdout/stderr


### PR DESCRIPTION
## Description

(This is now based on #6249)

Since we now have many different kinds of special tokens available that act as redirections, pipes, and statement separators, it can be difficult to remember all of them. This adds tab completion for some of them, it looks like this:

![](http://cloud.ristl.it/s/nKQicRNqppnDgZq/preview)

If we want this, I'd like to hear opinions how we it should work and which operators to include.
I picked [some that should be useful](https://github.com/krobelus/fish-shell/blob/complete-redirections/src/complete.cpp#L1458) but maybe we can improve on that.

This currently only completes the part between the cursor and the first space left of the cursor, the implementation is a bit basic. Yet it already requires some changes to how completion work which cannot handle operators in general. The changes mean that the result of a completion includes the location where the completion can be inserted (which might make it easier to support completion of quoted subcommands like `fish -c 'some command<TAB>`).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md

