### PR TITLE
Clean up typos across codebase

### DIFF
--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -41,7 +41,7 @@ The pattern below is a basic pattern:
     COMMAND [OPTIONS] ARGUMENTS
 
 
-- **COMMAND**: the name of the executeable
+- **COMMAND**: the name of the executable
 
 - **[OPTIONS]**: options can change the behaviour of a command
 
@@ -59,11 +59,11 @@ Example:
 
 ::
 
-    >echo -s Hallo World!
-    HalloWorld!
+    >echo -s Hello World!
+    HelloWorld!
 
 
--  both ``Hallo`` and ``World!`` are arguments to the echo command
+-  both ``Hello`` and ``World!`` are arguments to the echo command
 - ``-s`` is an option that suppresses spaces in the output of the command
 
 Commands versus Programs
@@ -87,7 +87,7 @@ There are two ways to combine shell commands:
 
 Example::
 
-    # Every line of the ``ls`` command is immediatelly passed on to the ``grep`` command
+    # Every line of the ``ls`` command is immediately passed on to the ``grep`` command
     >ls -l | grep "my topic"
 
 
@@ -829,7 +829,7 @@ In these cases, the expansion eliminates the string, as a result of the implicit
 
 If, in the example above, $WORD is undefined or an empty list, the "s" is not printed. However, it is printed, if $WORD is the empty string.
 
-Unlike all other expanions, variable expansion also happens in double quoted strings. Inside double quotes (``"these"``), variables will always expand to exactly one argument. If they are empty or undefined, it will result in an empty string. If they have one element, they'll expand to that element. If they have more than that, the elements will be joined with spaces.
+Unlike all other expansions, variable expansion also happens in double quoted strings. Inside double quotes (``"these"``), variables will always expand to exactly one argument. If they are empty or undefined, it will result in an empty string. If they have one element, they'll expand to that element. If they have more than that, the elements will be joined with spaces.
 
 Outside of double quotes, variables will expand to as many arguments as they have elements. That means an empty list will expand to nothing, a variable with one element will expand to that element, and a variable with multiple elements will expand to each of those elements separately.
 

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -18,7 +18,7 @@ struct io_streams_t;
 struct builtin_data_t {
     // Name of the builtin.
     const wchar_t *name;
-    // Function pointer tothe builtin implementation.
+    // Function pointer to the builtin implementation.
     int (*func)(parser_t &parser, io_streams_t &streams, wchar_t **argv);
     // Description of what the builtin does.
     const wchar_t *desc;

--- a/src/builtin_realpath.cpp
+++ b/src/builtin_realpath.cpp
@@ -15,7 +15,7 @@
 #include "io.h"
 #include "wutil.h"  // IWYU pragma: keep
 
-/// An implementation of the external realpath command. Desn't support any options.
+/// An implementation of the external realpath command. Doesn't support any options.
 /// In general scripts shouldn't invoke this directly. They should just use `realpath` which
 /// will fallback to this builtin if an external command cannot be found.
 int builtin_realpath(parser_t &parser, io_streams_t &streams, wchar_t **argv) {

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -106,7 +106,7 @@ static bool should_test_function(const char *func_name) {
 #define ESCAPE_TEST_COUNT 100000
 /// The average length of strings to unescape.
 #define ESCAPE_TEST_LENGTH 100
-/// The higest character number of character to try and escape.
+/// The highest character number of character to try and escape.
 #define ESCAPE_TEST_CHAR 4000
 
 /// Number of encountered errors.

--- a/src/highlight.h
+++ b/src/highlight.h
@@ -78,7 +78,7 @@ std::string colorize(const wcstring &text, const std::vector<highlight_spec_t> &
 /// array as a color_code from the HIGHLIGHT_ enum for each character in buff.
 ///
 /// \param buffstr The buffer on which to perform syntax highlighting
-/// \param color The array in wchich to store the color codes. The first 8 bits are used for fg
+/// \param color The array in which to store the color codes. The first 8 bits are used for fg
 /// color, the next 8 bits for bg color.
 /// \param pos the cursor position. Used for quote matching, etc.
 /// \param error a list in which a description of each error will be inserted. May be 0, in whcich
@@ -96,7 +96,7 @@ void highlight_shell_no_io(const wcstring &buffstr, std::vector<highlight_spec_t
 /// for each character in buff.
 ///
 /// \param buffstr The buffer on which to perform syntax highlighting
-/// \param color The array in wchich to store the color codes. The first 8 bits are used for fg
+/// \param color The array in which to store the color codes. The first 8 bits are used for fg
 /// color, the next 8 bits for bg color.
 /// \param pos the cursor position. Used for quote matching, etc.
 /// \param error a list in which a description of each error will be inserted. May be 0, in whcich

--- a/src/history_file.cpp
+++ b/src/history_file.cpp
@@ -121,7 +121,7 @@ std::unique_ptr<history_file_contents_t> history_file_contents_t::create(int fd)
     if (len <= 0 || static_cast<unsigned long>(len) >= SIZE_MAX) return nullptr;
     if (lseek(fd, 0, SEEK_SET) != 0) return nullptr;
 
-    // Read the file, possibly ussing mmap.
+    // Read the file, possibly using mmap.
     void *mmap_start = nullptr;
     if (should_mmap(fd)) {
         // We feel confident to map the file directly. Note this is still risky: if another

--- a/src/kill.h
+++ b/src/kill.h
@@ -1,6 +1,6 @@
 // Prototypes for the killring.
 //
-// Works like the killring in emacs and readline. The killring is cut and paste whith a memory of
+// Works like the killring in emacs and readline. The killring is cut and paste with a memory of
 // previous cuts.
 #ifndef FISH_KILL_H
 #define FISH_KILL_H

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -1307,7 +1307,7 @@ parse_execution_result_t parse_execution_context_t::run_1_job(tnode_t<g::job> jo
             remove_job(*this->parser, job.get());
         }
 
-        // Update universal vaiables on external conmmands.
+        // Update universal variables on external conmmands.
         // TODO: justify this, why not on every command?
         if (job_contained_external_command) {
             parser->vars().universal_barrier();

--- a/src/parser.h
+++ b/src/parser.h
@@ -121,7 +121,7 @@ class parse_execution_context_t;
 class completion_t;
 struct event_t;
 
-/// Miscelleneous data used to avoid recursion and others.
+/// Miscellaneous data used to avoid recursion and others.
 struct library_data_t {
     /// A counter incremented every time a command executes.
     uint64_t exec_count{0};

--- a/src/path.h
+++ b/src/path.h
@@ -53,7 +53,7 @@ wcstring_list_t path_get_paths(const wcstring &cmd, const environment_t &vars);
 /// directories for relative paths.
 ///
 /// If no valid path is found, false is returned and errno is set to ENOTDIR if at least one such
-/// path was found, but it did not point to a directory, EROTTEN if a arotten symbolic link was
+/// path was found, but it did not point to a directory, EROTTEN if a rotten symbolic link was
 /// found, or ENOENT if no file of the specified name was found. If both a rotten symlink and a file
 /// are found, it is undefined which error status will be returned.
 ///

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -285,7 +285,7 @@ void layout_cache_t::add_prompt_layout(wcstring input, prompt_layout_t layout) {
 }
 
 /// Calculate layout information for the given prompt. Does some clever magic to detect common
-/// escape sequences that may be embeded in a prompt, such as those to set visual attributes.
+/// escape sequences that may be embedded in a prompt, such as those to set visual attributes.
 static prompt_layout_t calc_prompt_layout(const wcstring &prompt, layout_cache_t &cache) {
     if (auto cached_layout = cache.find_prompt_layout(prompt)) {
         return *cached_layout;

--- a/src/wildcard.cpp
+++ b/src/wildcard.cpp
@@ -805,7 +805,7 @@ void wildcard_expander_t::expand_last_segment(const wcstring &base_dir, DIR *bas
 ///
 /// Args:
 /// base_dir: the "working directory" against which the wildcard is to be resolved
-/// wc: the wildcard string itself, e.g. foo*bar/baz (where * is acutally ANY_CHAR)
+/// wc: the wildcard string itself, e.g. foo*bar/baz (where * is actually ANY_CHAR)
 /// prefix: the string that should be prepended for completions that replace their token.
 //    This is usually the same thing as the original wildcard, but for fuzzy matching, we
 //    expand intermediate segments. effective_prefix is always either empty, or ends with a slash


### PR DESCRIPTION
## Description

Went through the codebase with `spell` and cleaned up a decent number of typos.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
