### PR TITLE
functions/__fish_print_hostnames: Fix ssh_configs no values return

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -108,7 +108,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
             read -z -l contents <$file
 
             # Print hosts from system wide ssh configuration file
-            string replace -rfi '^\s*Host\s+(\S.*?)\s*$' '$1' -- $contents | string split ' ' | string match -v '*\**'
+            string split '\n' -- $contents | string replace -rfi '^\s*Host\s+(\S.*?)\s*$' '$1' | string match -v '*\**'
             # Also extract known_host paths.
             set known_hosts $known_hosts (string replace -rfi '.*KnownHostsFile\s*' '' -- $contents)
         end

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -105,10 +105,10 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
         if test -r $file
             # Don't read from $file twice. We could use `while read` instead, but that is extremely
             # slow.
-            read -z -l contents <$file
+            read -alz -d \n contents <$file
 
             # Print hosts from system wide ssh configuration file
-            string split \n -- $contents | string replace -rfi '^\s*Host\s+(\S.*?)\s*$' '$1' | string match -v '*\**'
+            string replace -rfi '^\s*Host\s+(\S.*?)\s*$' '$1' -- $contents | string match -v '*\**'
             # Also extract known_host paths.
             set known_hosts $known_hosts (string replace -rfi '.*KnownHostsFile\s*' '' -- $contents)
         end

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -108,7 +108,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
             read -z -l contents <$file
 
             # Print hosts from system wide ssh configuration file
-            string split '\n' -- $contents | string replace -rfi '^\s*Host\s+(\S.*?)\s*$' '$1' | string match -v '*\**'
+            string split \n -- $contents | string replace -rfi '^\s*Host\s+(\S.*?)\s*$' '$1' | string match -v '*\**'
             # Also extract known_host paths.
             set known_hosts $known_hosts (string replace -rfi '.*KnownHostsFile\s*' '' -- $contents)
         end


### PR DESCRIPTION
## Description

`string replace` not work fine with multiline string.
So split per line first.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
