### PR TITLE
completions/pacman.fish: Update for pacman 5.2

### DIFF
--- a/share/completions/pacman.fish
+++ b/share/completions/pacman.fish
@@ -88,8 +88,8 @@ end
 for condition in sync upgrade
     complete -c $progname -n "$$condition" -l asdeps -d 'Install packages as non-explicitly installed' -f
     complete -c $progname -n "$$condition" -l asexplicit -d 'Install packages as explicitly installed' -f
-    complete -c $progname -n "$$condition" -l ignore -d 'Ignore a package upgrade (can be used more than once)' -f
-    complete -c $progname -n "$$condition" -l ignoregroup -d 'Ignore a group upgrade (can be used more than once)' -f
+    complete -c $progname -n "$$condition" -l ignore -d 'Ignore a package upgrade (can be used more than once)' -xa "$listall"
+    complete -c $progname -n "$$condition" -l ignoregroup -d 'Ignore a group upgrade (can be used more than once)' -xa "$listgroups"
     complete -c $progname -n "$$condition" -l needed -d 'Do not reinstall up to date packages' -f
     complete -c $progname -n "$$condition" -l overwrite -d 'Overwrite conflicting files (can be used more than once)' -rF
 end

--- a/share/completions/pacman.fish
+++ b/share/completions/pacman.fish
@@ -1,6 +1,6 @@
 # Completions for pacman
 # Author: Giorgio Lando <patroclo7@gmail.com>
-# Updated by maxfl, SanskritFritz, faho, f1u77y
+# Updated by maxfl, SanskritFritz, faho, f1u77y, akiirui
 
 set -l progname pacman
 
@@ -18,86 +18,86 @@ set -l sync '__fish_contains_opt -s S sync'
 set -l upgrade '__fish_contains_opt -s U upgrade'
 set -l files '__fish_contains_opt -s F files'
 
-complete -c pacman -e
-complete -c pacman -f
+complete -c $progname -e
+complete -c $progname -f
 # HACK: We only need these two to coerce fish to stop file completion and complete options
-complete -c $progname -n $noopt -a "-D" -d "Modify the package database"
-complete -c $progname -n $noopt -a "-Q" -d "Query the package database"
+complete -c $progname -n "$noopt" -a "-D" -d "Modify the package database"
+complete -c $progname -n "$noopt" -a "-Q" -d "Query the package database"
 
 # Primary operations
-complete -c $progname -s D -f -l database -n $noopt -d 'Modify the package database'
-complete -c $progname -s Q -f -l query -n $noopt -d 'Query the package database'
-complete -c $progname -s R -f -l remove -n $noopt -d 'Remove packages from the system'
-complete -c $progname -s S -f -l sync -n $noopt -d 'Synchronize packages'
-complete -c $progname -s T -f -l deptest -n $noopt -d 'Check dependencies'
-complete -c $progname -s U -f -l upgrade -n $noopt -d 'Upgrade or add a local package'
-complete -c $progname -s F -f -l files -n $noopt -d 'Query the files database'
+complete -c $progname -s D -f -l database -n "$noopt" -d 'Modify the package database'
+complete -c $progname -s Q -f -l query -n "$noopt" -d 'Query the package database'
+complete -c $progname -s R -f -l remove -n "$noopt" -d 'Remove packages from the system'
+complete -c $progname -s S -f -l sync -n "$noopt" -d 'Synchronize packages'
+complete -c $progname -s T -f -l deptest -n "$noopt" -d 'Check dependencies'
+complete -c $progname -s U -f -l upgrade -n "$noopt" -d 'Upgrade or add a local package'
+complete -c $progname -s F -f -l files -n "$noopt" -d 'Query the files database'
 complete -c $progname -s V -f -l version -d 'Display version and exit'
 complete -c $progname -s h -f -l help -d 'Display help'
 
 # General options
 # Only offer these once a command has been given so they get prominent display
-complete -c $progname -n "not $noopt" -s b -l dbpath -d 'Alternate database location' -xa '(__fish_complete_directories)'
-complete -c $progname -n "not $noopt" -s r -l root -d 'Alternate installation root' -xa '(__fish_complete_directories)'
+complete -c $progname -n "not $noopt" -s b -l dbpath -d 'Alternate database location' -xa "(__fish_complete_directories)"
+complete -c $progname -n "not $noopt" -s r -l root -d 'Alternate installation root' -xa "(__fish_complete_directories)"
 complete -c $progname -n "not $noopt" -s v -l verbose -d 'Output more status messages' -f
 complete -c $progname -n "not $noopt" -l arch -d 'Alternate architecture' -f
-complete -c $progname -n "not $noopt" -l cachedir -d 'Alternate package cache location' -xa '(__fish_complete_directories)'
+complete -c $progname -n "not $noopt" -l cachedir -d 'Alternate package cache location' -xa "(__fish_complete_directories)"
 complete -c $progname -n "not $noopt" -l color -d 'Colorize the output' -fa '{auto,always,never}'
-complete -c $progname -n "not $noopt" -l config -d 'Alternate config file' -F
+complete -c $progname -n "not $noopt" -l config -d 'Alternate config file' -rF
 complete -c $progname -n "not $noopt" -l confirm -d 'Always ask for confirmation' -f
 complete -c $progname -n "not $noopt" -l debug -d 'Display debug messages' -f
 complete -c $progname -n "not $noopt" -l disable-download-timeout -d 'Use relaxed timeouts for download' -f
-complete -c $progname -n "not $noopt" -l gpgdir -d 'Alternate home directory for GnuPG' -xa '(__fish_complete_directories)'
-complete -c $progname -n "not $noopt" -l hookdir -d 'Alternate hook location' -xa '(__fish_complete_directories)'
+complete -c $progname -n "not $noopt" -l gpgdir -d 'Alternate home directory for GnuPG' -xa "(__fish_complete_directories)"
+complete -c $progname -n "not $noopt" -l hookdir -d 'Alternate hook location' -xa "(__fish_complete_directories)"
 complete -c $progname -n "not $noopt" -l logfile -d 'Alternate log file'
 complete -c $progname -n "not $noopt" -l noconfirm -d 'Bypass any confirmation' -f
-complete -c $progname -n "not $noopt" -l sysroot -d 'Operate on a mounted guest system (root-only)' -xa '(__fish_complete_directories)'
+complete -c $progname -n "not $noopt" -l sysroot -d 'Operate on a mounted guest system (root-only)' -xa "(__fish_complete_directories)"
 
-# File, query, sync options
+# File, query, sync options (files, query, sync)
 for condition in files query sync
-    complete -c $progname -n $$condition -s q -l quiet -d 'Show less information' -f
+    complete -c $progname -n "$$condition" -s q -l quiet -d 'Show less information' -f
 end
 
 # Transaction options (sync, remove, upgrade)
 for condition in sync remove upgrade
-    complete -c $progname -n $$condition -s d -l nodeps -d 'Skip [all] dependency checks' -f
-    complete -c $progname -n $$condition -s p -l print -d 'Dry run, only print targets' -f
-    complete -c $progname -n $$condition -l assume-installed -d 'Add a virtual package to satisfy dependencies' -f
-    complete -c $progname -n $$condition -l dbonly -d 'Modify database entry only' -f
-    complete -c $progname -n $$condition -l noprogressbar -d 'Do not display progress bar' -f
-    complete -c $progname -n $$condition -l noscriptlet -d 'Do not execute install script' -f
-    complete -c $progname -n $$condition -l print-format -d 'Specify printf-like format' -x
+    complete -c $progname -n "$$condition" -s d -l nodeps -d 'Skip [all] dependency checks' -f
+    complete -c $progname -n "$$condition" -s p -l print -d 'Dry run, only print targets' -f
+    complete -c $progname -n "$$condition" -l assume-installed -d 'Add a virtual package to satisfy dependencies' -f
+    complete -c $progname -n "$$condition" -l dbonly -d 'Modify database entry only' -f
+    complete -c $progname -n "$$condition" -l noprogressbar -d 'Do not display progress bar' -f
+    complete -c $progname -n "$$condition" -l noscriptlet -d 'Do not execute install script' -f
+    complete -c $progname -n "$$condition" -l print-format -d 'Specify printf-like format' -x
 end
 
-# File and query options
+# File and query options (files, query)
 for condition in files query
-    complete -c $progname -n $$condition -s l -l list -d 'List the files owned by PACKAGE' -f
+    complete -c $progname -n "$$condition" -s l -l list -d 'List the files owned by PACKAGE' -f
 end
 
-# File and sync options
+# File and sync options (files, sync)
 for condition in files sync
-    complete -c $progname -n $$condition -s y -l refresh -d 'Download fresh package databases [force]' -f
+    complete -c $progname -n "$$condition" -s y -l refresh -d 'Download fresh package databases [force]' -f
 end
 
-# Query and sync options
+# Query and sync options (query, sync)
 for condition in query sync
-    complete -c $progname -n $$condition -s g -l groups -d 'Display members of [all] package GROUP' -xa "$listgroups"
+    complete -c $progname -n "$$condition" -s g -l groups -d 'Display members of [all] package GROUP' -xa "$listgroups"
 end
 
 # Sync and upgrade options (sync, upgrade)
 for condition in sync upgrade
-    complete -c $progname -n $$condition -l asdeps -d 'Install packages as non-explicitly installed' -f
-    complete -c $progname -n $$condition -l asexplicit -d 'Install packages as explicitly installed' -f
-    complete -c $progname -n $$condition -l ignore -d 'Ignore a package upgrade (can be used more than once)' -f
-    complete -c $progname -n $$condition -l ignoregroup -d 'Ignore a group upgrade (can be used more than once)' -f
-    complete -c $progname -n $$condition -l needed -d 'Do not reinstall up to date packages' -f
-    complete -c $progname -n $$condition -l overwrite -d 'Overwrite conflicting files (can be used more than once)' -F
+    complete -c $progname -n "$$condition" -l asdeps -d 'Install packages as non-explicitly installed' -f
+    complete -c $progname -n "$$condition" -l asexplicit -d 'Install packages as explicitly installed' -f
+    complete -c $progname -n "$$condition" -l ignore -d 'Ignore a package upgrade (can be used more than once)' -f
+    complete -c $progname -n "$$condition" -l ignoregroup -d 'Ignore a group upgrade (can be used more than once)' -f
+    complete -c $progname -n "$$condition" -l needed -d 'Do not reinstall up to date packages' -f
+    complete -c $progname -n "$$condition" -l overwrite -d 'Overwrite conflicting files (can be used more than once)' -rF
 end
 
 # Database options
 set -l has_db_opt '__fish_contains_opt asdeps asexplicit check -s k'
 complete -c $progname -n "$database; and not $has_db_opt" -s k -l check -d 'Check database validity'
-complete -c $progname -n $database -s q -l quite -d 'Suppress output of success messages' -f
+complete -c $progname -n "$database" -s q -l quite -d 'Suppress output of success messages' -f
 complete -c $progname -n "$database; and not $has_db_opt" -l asdeps -d 'Mark PACKAGE as dependency' -x
 complete -c $progname -n "$database; and not $has_db_opt" -l asexplicit -d 'Mark PACKAGE as explicitly installed' -x
 complete -c $progname -n "$has_db_opt; and $database" -xa "$listinstalled"
@@ -105,40 +105,41 @@ complete -c $progname -n "$has_db_opt; and $database" -xa "$listinstalled"
 # File options - since pacman 5
 complete -c $progname -n "$files" -s x -l regex -d 'Interpret each query as a regular expression' -f
 complete -c $progname -n "$files" -l machinereadable -d 'Print each match in a machine readable output format' -f
+complete -c $progname -n "$files" -d 'Package' -xa "$listall"
 
 # Query options
-complete -c $progname -n $query -s c -l changelog -d 'View the change log of PACKAGE' -f
-complete -c $progname -n $query -s d -l deps -d 'List only non-explicit packages (dependencies)' -f
-complete -c $progname -n $query -s e -l explicit -d 'List only explicitly installed packages' -f
-complete -c $progname -n $query -s i -l info -d 'View PACKAGE [backup files] information' -f
-complete -c $progname -n $query -s k -l check -d 'Check that PACKAGE files exist' -f
-complete -c $progname -n $query -s m -l foreign -d 'List installed packages not found in sync database' -f
-complete -c $progname -n $query -s n -l native -d 'list installed packages only found in sync database' -f
-complete -c $progname -n $query -s o -l owns -d 'Query the package that owns FILE' -rF
-complete -c $progname -n $query -s p -l file -d 'Query a package file instead of the database' -F
-complete -c $progname -n $query -s s -l search -d 'Search locally-installed packages for regexp' -f
-complete -c $progname -n $query -s t -l unrequired -d 'List only unrequired packages [and optdepends]' -f
-complete -c $progname -n $query -s u -l upgrades -d 'List only out-of-date packages' -f
-complete -c $progname -n $query -d 'Installed package' -xa $listinstalled
+complete -c $progname -n "$query" -s c -l changelog -d 'View the change log of PACKAGE' -f
+complete -c $progname -n "$query" -s d -l deps -d 'List only non-explicit packages (dependencies)' -f
+complete -c $progname -n "$query" -s e -l explicit -d 'List only explicitly installed packages' -f
+complete -c $progname -n "$query" -s i -l info -d 'View PACKAGE [backup files] information' -f
+complete -c $progname -n "$query" -s k -l check -d 'Check that PACKAGE files exist' -f
+complete -c $progname -n "$query" -s m -l foreign -d 'List installed packages not found in sync database' -f
+complete -c $progname -n "$query" -s n -l native -d 'list installed packages only found in sync database' -f
+complete -c $progname -n "$query" -s o -l owns -d 'Query the package that owns FILE' -rF
+complete -c $progname -n "$query" -s p -l file -d 'Query a package file instead of the database' -rF
+complete -c $progname -n "$query" -s s -l search -d 'Search locally-installed packages for regexp' -f
+complete -c $progname -n "$query" -s t -l unrequired -d 'List only unrequired packages [and optdepends]' -f
+complete -c $progname -n "$query" -s u -l upgrades -d 'List only out-of-date packages' -f
+complete -c $progname -n "$query" -d 'Installed package' -xa "$listinstalled"
 
 # Remove options
-complete -c $progname -n $remove -s c -l cascade -d 'Also remove packages depending on PACKAGE' -f
-complete -c $progname -n $remove -s n -l nosave -d 'Ignore file backup designations' -f
-complete -c $progname -n $remove -s s -l recursive -d 'Also remove dependencies of PACKAGE' -f
-complete -c $progname -n $remove -s u -l unneeded -d 'Only remove targets not required by PACKAGE' -f
-complete -c $progname -n "$remove" -d 'Installed package' -xa $listinstalled
+complete -c $progname -n "$remove" -s c -l cascade -d 'Also remove packages depending on PACKAGE' -f
+complete -c $progname -n "$remove" -s n -l nosave -d 'Ignore file backup designations' -f
+complete -c $progname -n "$remove" -s s -l recursive -d 'Also remove dependencies of PACKAGE' -f
+complete -c $progname -n "$remove" -s u -l unneeded -d 'Only remove targets not required by PACKAGE' -f
+complete -c $progname -n "$remove" -d 'Installed package' -xa "$listinstalled"
 
 # Sync options
-complete -c $progname -n $sync -s c -l clean -d 'Remove [all] packages from cache' -f
-complete -c $progname -n $sync -s i -l info -d 'View PACKAGE [extended] information' -f
-complete -c $progname -n $sync -s l -l list -d 'List all packages in REPOSITORY' -xa "$listrepos"
-complete -c $progname -n $sync -s s -l search -d 'Search remote repositories for regexp' -f
-complete -c $progname -n $sync -s u -l sysupgrade -d 'Upgrade all packages that are out of date'
-complete -c $progname -n $sync -s w -l downloadonly -d 'Only download the target packages'
+complete -c $progname -n "$sync" -s c -l clean -d 'Remove [all] packages from cache' -f
+complete -c $progname -n "$sync" -s i -l info -d 'View PACKAGE [extended] information' -f
+complete -c $progname -n "$sync" -s l -l list -d 'List all packages in REPOSITORY' -xa "$listrepos"
+complete -c $progname -n "$sync" -s s -l search -d 'Search remote repositories for regexp' -f
+complete -c $progname -n "$sync" -s u -l sysupgrade -d 'Upgrade all packages that are out of date'
+complete -c $progname -n "$sync" -s w -l downloadonly -d 'Only download the target packages'
 complete -c $progname -n "$sync" -xa "$listall $listgroups"
 
 # Upgrade options
 # Theoretically, pacman reads packages in all formats that libarchive supports
 # In practice, it's going to be tar.xz, tar.gz or tar.zst
 # Using "pkg.tar.*" here would change __fish_complete_suffix's descriptions to "unknown"
-complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix .pkg.tar\{,.xz,.gz,.zst\})' -d 'Package file'
+complete -c $progname -n "$upgrade" -d 'Package file' -xa "(__fish_complete_suffix .pkg.tar\{,.xz,.gz,.zst\})"

--- a/share/completions/pacman.fish
+++ b/share/completions/pacman.fish
@@ -23,6 +23,7 @@ complete -c pacman -f
 # HACK: We only need these two to coerce fish to stop file completion and complete options
 complete -c $progname -n $noopt -a "-D" -d "Modify the package database"
 complete -c $progname -n $noopt -a "-Q" -d "Query the package database"
+
 # Primary operations
 complete -c $progname -s D -f -l database -n $noopt -d 'Modify the package database'
 complete -c $progname -s Q -f -l query -n $noopt -d 'Query the package database'
@@ -36,96 +37,105 @@ complete -c $progname -s h -f -l help -d 'Display help'
 
 # General options
 # Only offer these once a command has been given so they get prominent display
-complete -c $progname -n "not $noopt" -s b -l dbpath -d 'Alternative database location' -xa '(__fish_complete_directories)'
-complete -c $progname -n "not $noopt" -s r -l root -d 'Alternative installation root'
-complete -c $progname -n "not $noopt" -s v -l verbose -d 'Output more status messages'
+complete -c $progname -n "not $noopt" -s b -l dbpath -d 'Alternate database location' -xa '(__fish_complete_directories)'
+complete -c $progname -n "not $noopt" -s r -l root -d 'Alternate installation root' -xa '(__fish_complete_directories)'
+complete -c $progname -n "not $noopt" -s v -l verbose -d 'Output more status messages' -f
 complete -c $progname -n "not $noopt" -l arch -d 'Alternate architecture' -f
-complete -c $progname -n "not $noopt" -l cachedir -d 'Alternative package cache location'
-complete -c $progname -n "not $noopt" -l config -d 'Alternate config file'
+complete -c $progname -n "not $noopt" -l cachedir -d 'Alternate package cache location' -xa '(__fish_complete_directories)'
+complete -c $progname -n "not $noopt" -l color -d 'Colorize the output' -fa '{auto,always,never}'
+complete -c $progname -n "not $noopt" -l config -d 'Alternate config file' -F
+complete -c $progname -n "not $noopt" -l confirm -d 'Always ask for confirmation' -f
 complete -c $progname -n "not $noopt" -l debug -d 'Display debug messages' -f
-complete -c $progname -n "not $noopt" -l gpgdir -d 'GPG directory to verify signatures'
-complete -c $progname -n "not $noopt" -l hookdir -d 'Hook file directory'
-complete -c $progname -n "not $noopt" -l logfile -d 'Specify alternative log file'
-complete -c $progname -n "not $noopt" -l noconfirm -d 'Bypass any question' -f
+complete -c $progname -n "not $noopt" -l disable-download-timeout -d 'Use relaxed timeouts for download' -f
+complete -c $progname -n "not $noopt" -l gpgdir -d 'Alternate home directory for GnuPG' -xa '(__fish_complete_directories)'
+complete -c $progname -n "not $noopt" -l hookdir -d 'Alternate hook location' -xa '(__fish_complete_directories)'
+complete -c $progname -n "not $noopt" -l logfile -d 'Alternate log file'
+complete -c $progname -n "not $noopt" -l noconfirm -d 'Bypass any confirmation' -f
+complete -c $progname -n "not $noopt" -l sysroot -d 'Operate on a mounted guest system (root-only)' -xa '(__fish_complete_directories)'
+
+# File, query, sync options
+for condition in files query sync
+    complete -c $progname -n $$condition -s q -l quiet -d 'Show less information' -f
+end
 
 # Transaction options (sync, remove, upgrade)
 for condition in sync remove upgrade
     complete -c $progname -n $$condition -s d -l nodeps -d 'Skip [all] dependency checks' -f
+    complete -c $progname -n $$condition -s p -l print -d 'Dry run, only print targets' -f
+    complete -c $progname -n $$condition -l assume-installed -d 'Add a virtual package to satisfy dependencies' -f
     complete -c $progname -n $$condition -l dbonly -d 'Modify database entry only' -f
     complete -c $progname -n $$condition -l noprogressbar -d 'Do not display progress bar' -f
     complete -c $progname -n $$condition -l noscriptlet -d 'Do not execute install script' -f
-    complete -c $progname -n $$condition -s p -l print -d 'Dry run, only print targets' -f
-    complete -c $progname -n $$condition -l print-format -x -d 'Specify printf-like format' -f
+    complete -c $progname -n $$condition -l print-format -d 'Specify printf-like format' -x
 end
 
-# Database and upgrade options (database, sync, upgrade)
-for condition in database sync upgrade
-    complete -c $progname -n $$condition -l asdeps -d 'Mark PACKAGE as dependency' -f
-    complete -c $progname -n $$condition -l asexplicit -d 'Mark PACKAGE as explicitly installed' -f
+# File and query options
+for condition in files query
+    complete -c $progname -n $$condition -s l -l list -d 'List the files owned by PACKAGE' -f
 end
 
-# Upgrade options (sync, upgrade)
-for condition in sync upgrade
-    complete -c $progname -n $$condition -l overwrite -d 'overwrite conflicting files (can be used more than once)'
-    complete -c $progname -n $$condition -l ignore -d 'Ignore upgrade of PACKAGE' -xa "$listinstalled" -f
-    complete -c $progname -n $$condition -l ignoregroup -d 'Ignore upgrade of GROUP' -xa "$listgroups" -f
-    complete -c $progname -n $$condition -l needed -d 'Do not reinstall up-to-date targets' -f
-    complete -c $progname -n $$condition -l recursive -d 'Recursively reinstall all dependencies' -f
+# File and sync options
+for condition in files sync
+    complete -c $progname -n $$condition -s y -l refresh -d 'Download fresh package databases [force]' -f
 end
 
 # Query and sync options
 for condition in query sync
-    complete -c $progname -n $$condition -s g -l groups -d 'Display all packages in GROUP' -xa "$listgroups" -f
-    complete -c $progname -n $$condition -s i -l info -d 'Display information on PACKAGE' -f
-    complete -c $progname -n $$condition -s q -l quiet -d 'Show less information' -f
-    complete -c $progname -n $$condition -s s -l search -r -d 'Search packages for regexp' -f
+    complete -c $progname -n $$condition -s g -l groups -d 'Display members of [all] package GROUP' -xa "$listgroups"
 end
+
+# Sync and upgrade options (sync, upgrade)
+for condition in sync upgrade
+    complete -c $progname -n $$condition -l asdeps -d 'Install packages as non-explicitly installed' -f
+    complete -c $progname -n $$condition -l asexplicit -d 'Install packages as explicitly installed' -f
+    complete -c $progname -n $$condition -l ignore -d 'Ignore a package upgrade (can be used more than once)' -f
+    complete -c $progname -n $$condition -l ignoregroup -d 'Ignore a group upgrade (can be used more than once)' -f
+    complete -c $progname -n $$condition -l needed -d 'Do not reinstall up to date packages' -f
+    complete -c $progname -n $$condition -l overwrite -d 'Overwrite conflicting files (can be used more than once)' -F
+end
+
+# Database options
+set -l has_db_opt '__fish_contains_opt asdeps asexplicit check -s k'
+complete -c $progname -n "$database; and not $has_db_opt" -s k -l check -d 'Check database validity'
+complete -c $progname -n $database -s q -l quite -d 'Suppress output of success messages' -f
+complete -c $progname -n "$database; and not $has_db_opt" -l asdeps -d 'Mark PACKAGE as dependency' -x
+complete -c $progname -n "$database; and not $has_db_opt" -l asexplicit -d 'Mark PACKAGE as explicitly installed' -x
+complete -c $progname -n "$has_db_opt; and $database" -xa "$listinstalled"
+
+# File options - since pacman 5
+complete -c $progname -n "$files" -s x -l regex -d 'Interpret each query as a regular expression' -f
+complete -c $progname -n "$files" -l machinereadable -d 'Print each match in a machine readable output format' -f
 
 # Query options
 complete -c $progname -n $query -s c -l changelog -d 'View the change log of PACKAGE' -f
 complete -c $progname -n $query -s d -l deps -d 'List only non-explicit packages (dependencies)' -f
 complete -c $progname -n $query -s e -l explicit -d 'List only explicitly installed packages' -f
-complete -c $progname -n $query -s k -l check -d 'Check if all files owned by PACKAGE are present' -f
-complete -c $progname -n $query -s l -l list -d 'List all files owned by PACKAGE' -f
-complete -c $progname -n $query -s m -l foreign -d 'List all packages not in the database' -f
-complete -c $progname -n $query -s o -l owns -rF -d 'Search for the package that owns FILE'
-complete -c $progname -n $query -s p -l file -d 'Apply the query to a package file, not package'
-complete -c $progname -n $query -s t -l unrequired -d 'List only unrequired packages' -f
+complete -c $progname -n $query -s i -l info -d 'View PACKAGE [backup files] information' -f
+complete -c $progname -n $query -s k -l check -d 'Check that PACKAGE files exist' -f
+complete -c $progname -n $query -s m -l foreign -d 'List installed packages not found in sync database' -f
+complete -c $progname -n $query -s n -l native -d 'list installed packages only found in sync database' -f
+complete -c $progname -n $query -s o -l owns -d 'Query the package that owns FILE' -rF
+complete -c $progname -n $query -s p -l file -d 'Query a package file instead of the database' -F
+complete -c $progname -n $query -s s -l search -d 'Search locally-installed packages for regexp' -f
+complete -c $progname -n $query -s t -l unrequired -d 'List only unrequired packages [and optdepends]' -f
 complete -c $progname -n $query -s u -l upgrades -d 'List only out-of-date packages' -f
-complete -c $progname -n "$query" -d 'Installed package' -xa $listinstalled -f
+complete -c $progname -n $query -d 'Installed package' -xa $listinstalled
 
 # Remove options
 complete -c $progname -n $remove -s c -l cascade -d 'Also remove packages depending on PACKAGE' -f
 complete -c $progname -n $remove -s n -l nosave -d 'Ignore file backup designations' -f
 complete -c $progname -n $remove -s s -l recursive -d 'Also remove dependencies of PACKAGE' -f
 complete -c $progname -n $remove -s u -l unneeded -d 'Only remove targets not required by PACKAGE' -f
-complete -c $progname -n "$remove" -d 'Installed package' -xa $listinstalled -f
+complete -c $progname -n "$remove" -d 'Installed package' -xa $listinstalled
 
 # Sync options
-complete -c $progname -n $sync -s c -l clean -d 'Remove [all] packages from cache'
-complete -c $progname -n $sync -s l -l list -xa "$listrepos" -d 'List all packages in REPOSITORY'
-complete -c $progname -n "$sync; and not __fish_contains_opt -s u sysupgrade" -s u -l sysupgrade -d 'Upgrade all packages that are out of date'
-complete -c $progname -n "$sync; and __fish_contains_opt -s u sysupgrade" -s u -l sysupgrade -d 'Also downgrade packages'
+complete -c $progname -n $sync -s c -l clean -d 'Remove [all] packages from cache' -f
+complete -c $progname -n $sync -s i -l info -d 'View PACKAGE [extended] information' -f
+complete -c $progname -n $sync -s l -l list -d 'List all packages in REPOSITORY' -xa "$listrepos"
+complete -c $progname -n $sync -s s -l search -d 'Search remote repositories for regexp' -f
+complete -c $progname -n $sync -s u -l sysupgrade -d 'Upgrade all packages that are out of date'
 complete -c $progname -n $sync -s w -l downloadonly -d 'Only download the target packages'
-complete -c $progname -n $sync -s y -l refresh -d 'Download fresh copy of the package list'
 complete -c $progname -n "$sync" -xa "$listall $listgroups"
-
-# Database options
-set -l has_db_opt '__fish_contains_opt asdeps asexplicit'
-complete -c $progname -n "$database; and not $has_db_opt" -xa --asdeps -d 'Mark PACKAGE as dependency'
-complete -c $progname -n "$database; and not $has_db_opt" -xa --asexplicit -d 'Mark PACKAGE as explicitly installed'
-complete -c $progname -n "$database; and not $has_db_opt" -s k -l check -d 'Check database validity'
-complete -c $progname -n "$has_db_opt; and $database" -xa "$listinstalled"
-
-# File options - since pacman 5
-set -l has_file_opt '__fish_contains_opt list search -s l -s s'
-complete -c $progname -n "$files; and not $has_file_opt" -xa --list -d 'List files owned by given packages'
-complete -c $progname -n "$files; and not $has_file_opt" -xa -l -d 'List files owned by given packages'
-complete -c $progname -n "$files" -s y -l refresh -d 'Refresh the files database' -f
-complete -c $progname -n "$files" -s l -l list -d 'List files owned by given packages' -xa $listall
-complete -c $progname -n "$files" -s x -l regex -d 'Interpret each query as a regular expression' -f
-complete -c $progname -n "$files" -s q -l quiet -d 'Show less information' -f
-complete -c $progname -n "$files" -l machinereadable -d 'Print each match in a machine readable output format' -f
 
 # Upgrade options
 # Theoretically, pacman reads packages in all formats that libarchive supports

--- a/share/completions/pacman.fish
+++ b/share/completions/pacman.fish
@@ -121,14 +121,11 @@ complete -c $progname -n "$has_db_opt; and $database" -xa "$listinstalled"
 set -l has_file_opt '__fish_contains_opt list search -s l -s s'
 complete -c $progname -n "$files; and not $has_file_opt" -xa --list -d 'List files owned by given packages'
 complete -c $progname -n "$files; and not $has_file_opt" -xa -l -d 'List files owned by given packages'
-complete -c $progname -n "$files; and not $has_file_opt" -xa --search -d 'Search packages for matching files'
-complete -c $progname -n "$files; and not $has_file_opt" -xa -s -d 'Search packages for matching files'
 complete -c $progname -n "$files" -s y -l refresh -d 'Refresh the files database' -f
 complete -c $progname -n "$files" -s l -l list -d 'List files owned by given packages' -xa $listall
-complete -c $progname -n "$files" -s s -l search -d 'Search packages for matching files'
-complete -c $progname -n "$files" -s o -l owns -d 'Search for packages that include the given files'
+complete -c $progname -n "$files" -s x -l regex -d 'Interpret each query as a regular expression' -f
 complete -c $progname -n "$files" -s q -l quiet -d 'Show less information' -f
-complete -c $progname -n "$files" -l machinereadable -d 'Show in machine readable format: repo\0pkgname\0pkgver\0path\n' -f
+complete -c $progname -n "$files" -l machinereadable -d 'Print each match in a machine readable output format' -f
 
 # Upgrade options
 # Theoretically, pacman reads packages in all formats that libarchive supports

--- a/share/completions/pacman.fish
+++ b/share/completions/pacman.fish
@@ -66,7 +66,7 @@ end
 
 # Upgrade options (sync, upgrade)
 for condition in sync upgrade
-    complete -c $progname -n $$condition -l force -d 'Bypass file conflict checks' -f
+    complete -c $progname -n $$condition -l overwrite -d 'overwrite conflicting files (can be used more than once)'
     complete -c $progname -n $$condition -l ignore -d 'Ignore upgrade of PACKAGE' -xa "$listinstalled" -f
     complete -c $progname -n $$condition -l ignoregroup -d 'Ignore upgrade of GROUP' -xa "$listgroups" -f
     complete -c $progname -n $$condition -l needed -d 'Do not reinstall up-to-date targets' -f

--- a/share/functions/__fish_print_pacman_repos.fish
+++ b/share/functions/__fish_print_pacman_repos.fish
@@ -1,3 +1,3 @@
 function __fish_print_pacman_repos --description "Print the repositories configured for arch's pacman package manager"
-    string replace -r -a "\[(.+)\]" "\1" </etc/pacman.conf | string match -r -v "^#|options"
+    string match -er "\[.*\]" </etc/pacman.conf | string match -r -v "^#|options" | string replace -ra "\[|\]" ""
 end


### PR DESCRIPTION
## Description

pacman 5.2 has remove File Options `-s --search` and `-o --owns`.
Ref: [pacman: rework the UI of -F](https://git.archlinux.org/pacman.git/commit/?id=ff1ae94c102cab487444bcdb0c76ee489c11dfe8)

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
