### PR TITLE
change href attribute to ng-href

### DIFF
--- a/share/tools/web_config/partials/colors.html
+++ b/share/tools/web_config/partials/colors.html
@@ -127,7 +127,7 @@ fish cannot change the background color of your terminal. Refer to your terminal
 				<div class="color_scheme_choice_label">
 					<!-- This click/clickBubble nonsense is so that we can have a separate URL inside a parent with an onClick handler -->
                                         {{colorScheme.name}}
-          <a data-ng-show="colorScheme.url" style="text-decoration: none; color: inherit;" href="{{colorScheme.url}}">&#10138;</a>
+          <a data-ng-show="colorScheme.url" style="text-decoration: none; color: inherit;" ng-href="{{colorScheme.url}}">&#10138;</a>
 				</div>
 				<div class="colorpicker_text_sample_tight" data-ng-style="{'background-color': colorScheme.preferred_background}">
 					<span data-ng-style="{'color': colorScheme.command}">/bright/vixens</span>


### PR DESCRIPTION
Since the url is inside a AngularJS markup {{hash}}, it's better to use **ng-href**.

## Description

From  [AngularJS Documentation](https://docs.angularjs.org/api/ng/directive/ngHref):

"Using AngularJS markup like {{hash}} in an href attribute will make the link go to the wrong URL if the user clicks it before AngularJS has a chance to replace the {{hash}} markup with its value. Until AngularJS replaces the markup the link will be broken and will most likely return a 404 error. The ngHref directive solves this problem."

