### PR TITLE
Fix completion for subcommands of builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - fish only parses `/etc/paths` on macOS in login shells, matching the bash implementation (#5637) and avoiding changes to path ordering in child shells (#5456).
 - The locale is now reloaded when the `LOCPATH` variable is changed (#5815).
 - `read` no longer keeps a history, making it suitable for operations that shouldn't end up there, like password entry (#5904).
+- Completion of subcommands to builtins like `and` or `not` has been fixed (#6249).
 
 #### New or improved bindings
 - Pasting strips leading spaces to avoid pasted commands being omitted from the history (#4327).

--- a/share/completions/begin.fish
+++ b/share/completions/begin.fish
@@ -1,0 +1,2 @@
+complete -c begin -s h -l help -d 'Display help and exit'
+complete -c begin -xa '(__fish_complete_subcommand)'

--- a/share/completions/builtin.fish
+++ b/share/completions/builtin.fish
@@ -1,5 +1,4 @@
-
-complete -c builtin -s h -l help -d 'Display help and exit'
-complete -c builtin -s n -l names -d 'Print names of all existing builtins'
-complete -c builtin -xa '(builtin -n)'
-complete -c builtin -n '__fish_use_subcommand' -xa '(__fish_complete_subcommand)'
+complete -c builtin -n 'test (count (commandline -opc)) -eq 1' -s h -l help -d 'Display help and exit'
+complete -c builtin -n 'test (count (commandline -opc)) -eq 1' -s n -l names -d 'Print names of all existing builtins'
+complete -c builtin -n 'test (count (commandline -opc)) -eq 1' -xa '(builtin -n)'
+complete -c builtin -n 'test (count (commandline -opc)) -ge 2' -xa '(__fish_complete_subcommand)'

--- a/share/completions/command.fish
+++ b/share/completions/command.fish
@@ -1,4 +1,7 @@
-
-complete -c command -s h -l help -d 'Display help and exit'
-complete -c command -s s -l search -d 'Print the file that would be executed'
-complete -c command -d "Command to run" -xa "(__fish_complete_subcommand)"
+complete -c command -n 'test (count (commandline -opc)) -eq 1' -s h -l help -d 'Display help and exit'
+complete -c command -n 'test (count (commandline -opc)) -eq 1' -s a -l all -d 'Print all external commands by the given name'
+complete -c command -n 'test (count (commandline -opc)) -eq 1' -s q -l quiet -d 'Do not print anything, only set exit status'
+complete -c command -n 'test (count (commandline -opc)) -eq 1' -s s -l search -d 'Print the file that would be executed'
+complete -c command -n 'test (count (commandline -opc)) -eq 1' -s s -l search -d 'Print the file that would be executed'
+complete -c command -n 'test (count (commandline -opc)) -eq 1' -xa "(__fish_complete_external_command)"
+complete -c command -n 'test (count (commandline -opc)) -ge 2' -xa "(__fish_complete_subcommand)"

--- a/share/completions/exec.fish
+++ b/share/completions/exec.fish
@@ -1,2 +1,3 @@
-complete -c exec -s h -l help -d 'Display help and exit'
-complete -c exec -r -a '(__fish_complete_subcommand)'
+complete -c exec -n 'test (count (commandline -opc)) -eq 1' -s h -l help -d 'Display help and exit'
+complete -c exec -n 'test (count (commandline -opc)) -eq 1' -xa "(__fish_complete_external_command)"
+complete -c exec -n 'test (count (commandline -opc)) -ge 2' -xa "(__fish_complete_subcommand)"

--- a/share/completions/for.fish
+++ b/share/completions/for.fish
@@ -1,0 +1,3 @@
+complete -c for -n 'test (count (commandline -opc)) -eq 1' -s h -l help -d 'Display help and exit'
+complete -c for -n 'test (count (commandline -opc)) -eq 1' -f
+complete -c for -n 'test (count (commandline -opc)) -eq 2' -xa in

--- a/share/completions/if.fish
+++ b/share/completions/if.fish
@@ -1,0 +1,2 @@
+complete -c if -s h -l help -d 'Display help and exit'
+complete -c if -xa '(__fish_complete_subcommand)'

--- a/share/completions/while.fish
+++ b/share/completions/while.fish
@@ -1,0 +1,2 @@
+complete -c while -s h -l help -d 'Display help and exit'
+complete -c while -xa '(__fish_complete_subcommand)'

--- a/share/functions/__fish_complete_external_command.fish
+++ b/share/functions/__fish_complete_external_command.fish
@@ -1,0 +1,3 @@
+function __fish_complete_external_command
+    command find $PATH/ -maxdepth 1 -perm +u+x 2>&- | string match -r '[^/]*$'
+end

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -163,11 +163,12 @@ function __fish_config_interactive -d "Initializations that should be performed 
     # the user tries [ interactively.
     #
     complete -c [ --wraps test
+    complete -c ! --wraps not
 
     #
     # Only a few builtins take filenames; initialize the rest with no file completions
     #
-    complete -c(builtin -n | string match -rv 'source|cd|exec|realpath|set|\[|test') --no-files
+    complete -c(builtin -n | string match -rv '(source|cd|exec|realpath|set|\\[|test|for)') --no-files
 
     # Reload key bindings when binding variable change
     function __fish_reload_key_bindings -d "Reload key bindings when binding variable change" --on-variable fish_key_bindings

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -398,7 +398,7 @@ int builtin_commandline(parser_t &parser, io_streams_t &streams, wchar_t **argv)
             break;
         }
         case PROCESS_MODE: {
-            parse_util_process_extent(current_buffer, current_cursor_pos, &begin, &end);
+            parse_util_process_extent(current_buffer, current_cursor_pos, &begin, &end, nullptr);
             break;
         }
         case JOB_MODE: {

--- a/src/parse_tree.h
+++ b/src/parse_tree.h
@@ -25,6 +25,11 @@ typedef uint32_t source_offset_t;
 
 constexpr source_offset_t SOURCE_OFFSET_INVALID = static_cast<source_offset_t>(-1);
 
+struct source_range_t {
+    uint32_t start;
+    uint32_t length;
+};
+
 /// A struct representing the token type that we use internally.
 struct parse_token_t {
     enum parse_token_type_t type;  // The type of the token as represented by the parser
@@ -135,6 +140,11 @@ class parse_node_t {
     /// Indicates if we have a preceding escaped newline.
     bool has_preceding_escaped_newline() const {
         return this->flags & parse_node_flag_preceding_escaped_nl;
+    }
+
+    source_range_t source_range() const {
+        assert(has_source());
+        return {source_start, source_length};
     }
 
     /// Gets source for the node, or the empty string if it has no source.

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -55,10 +55,11 @@ void parse_util_cmdsubst_extent(const wchar_t *buff, size_t cursor_pos, const wc
 ///
 /// \param buff the string to search for subshells
 /// \param cursor_pos the position of the cursor
-/// \param a the start of the searched string
-/// \param b the end of the searched string
+/// \param a the start of the process
+/// \param b the end of the process
+/// \param tokens the tokens in the process
 void parse_util_process_extent(const wchar_t *buff, size_t cursor_pos, const wchar_t **a,
-                               const wchar_t **b);
+                               const wchar_t **b, std::vector<tok_t> *tokens);
 
 /// Find the beginning and end of the job definition under the cursor
 ///

--- a/src/tnode.h
+++ b/src/tnode.h
@@ -5,11 +5,6 @@
 #include "parse_grammar.h"
 #include "parse_tree.h"
 
-struct source_range_t {
-    uint32_t start;
-    uint32_t length;
-};
-
 // Check if a child type is possible for a parent type at a given index.
 template <typename Parent, typename Child, size_t Index>
 constexpr bool child_type_possible_at_index() {

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -87,6 +87,13 @@ struct tok_t {
 
     // Construct from a token type.
     explicit tok_t(token_type_t type);
+
+    /// Returns whether the given location is within the source range or at its end.
+    bool location_in_or_at_end_of_source_range(size_t loc) const {
+        return offset <= loc && loc - offset <= length;
+    }
+    /// Gets source for the token, or the empty string if it has no source.
+    wcstring get_source(const wcstring &str) const { return {str, offset, length}; }
 };
 
 /// The tokenizer struct.

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -124,3 +124,29 @@ complete -C'foo -y' | string match -- -y-single-long
 # CHECK: -zARGZ
 complete -C'foo -z'
 
+
+# Builtins (with subcommands; #2705)
+complete -c complete_test_subcommand -n 'test (commandline -op)[1] = complete_test_subcommand' -xa 'ok'
+complete -C'not complete_test_subcommand '
+# CHECK: ok
+complete -C'echo; and complete_test_subcommand '
+# CHECK: ok
+complete -C'or complete_test_subcommand '
+# CHECK: ok
+complete -C'echo && command complete_test_subcommand '
+# CHECK: ok
+complete -C'echo || exec complete_test_subcommand '
+# CHECK: ok
+complete -C'echo | builtin complete_test_subcommand '
+# CHECK: ok
+complete -C'echo & complete_test_subcommand '
+# CHECK: ok
+complete -C'if while begin begin complete_test_subcommand '
+# CHECK: ok
+
+complete -C'for _ in ' | string collect >&- && echo completed some files
+# CHECK: completed some files
+
+# function; #5415
+complete -C'function : --arg'
+# CHECK: --argument-names	{{.*}}


### PR DESCRIPTION
This fixes #2705 - broken subcommand completion for builtins, and #5415 - completions for `function`.

Back when the complete builtin [was introduced](521d09b6d0264aaac17b9359ebcb1a0cb6ca8906), builtins like
`builtin`, `exec`, `command`, `not`, `if`, `while`, `or` and `and` could
be handled by the completion engine just like any other command.
Much has changed, now we are using a grammar that contains dedicated
AST nodes for those commands.

The completion engine works on plain_statement nodes and has some
special handling for builtins like exec and builtin.  However,
__fish_complete_subcommand passes subcommand tokens to the completion
engine that are based on `commandline -op`, which includes the
builtins.

Example: type "command git " and hit tab. Git completion does not work.
What happens is that the completion scripts assume that the first
token on the commandline ("command") is the git executable, and the next
token ("git") is the subcommand. Since "command" is ignored, the git completion is called
with garbage input.

This change uses the information provided by the AST to make completion treat the builtins like any other command. In above example the completions for "command" will be called first.
They will remove the "command" token and then call into "git" completions.

<details>
<summary>Previous approach </summary>

https://github.com/fish-shell/fish-shell/commit/6e733d90a66f2bb07091051a9c7a759ef3d45caa

This changes `commandline -p` to only return the plain_statement,
without any decorators to make examples like the above one work.  If
anyone needs them to return decorators, then it may be preferable to
maintain compatibility instead. However, I think it makes sense to not
print decorators, consider for example:
```
false; and builtin A || B     # B is not executed!
       ^
```
commandline -p would print `and builtin A`, but in fish's grammar,
`and` applies to the entire expression `builtin A || B`.
With this change, it only prints `A`.

If needed I can make it so it does print the simple decorators
"exec", "command", "builtin" and "not".

Note that we keep completions like share/completions/builtin.fish
around, even though they are handled in C++, because a commandline
like "builtin " is parsed as plain statement
(while "builtin a" is recognised as decorated statement).
</details>

----

## TODOs:
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md