### PR TITLE
scp completions: inappropriate opt '-q' in `string match -eq` cmd

### DIFF
--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -52,7 +52,7 @@ complete -c scp -d "Local Path" -n "not string match @ -- (commandline -ct)"
 # Remote path
 #
 # Get the list of remote files from the scp target.
-complete -c scp -d "Remote Path" -f -n "commandline -ct | string match -eq ':'" -a "
+complete -c scp -d "Remote Path" -f -n "commandline -ct | string match -e ':'" -a "
 (__scp_remote_target):( \
         command ssh (__scp2ssh_port_number) -o 'BatchMode yes' (__scp_remote_target) /bin/ls\ -dp\ (__scp_remote_path_prefix)\* 2>/dev/null
 )


### PR DESCRIPTION
A recent commit 66938d206a0a801ecee87e21863badef7d0d5587 revealed a previously overseen instance of `string match` being executed with the invalid `-eq` combination of parameters. Given the context, my assumption is that the original intent was to go with `-e` (`--entire`) option only.