### PR TITLE
Fix `math` incorrect parenthesis error on missing term

### DIFF
--- a/src/builtin_math.cpp
+++ b/src/builtin_math.cpp
@@ -147,6 +147,8 @@ static const wchar_t *math_describe_error(te_error_t &error) {
             return _(L"Too many arguments");
         case TE_ERROR_MISSING_OPERATOR:
             return _(L"Missing operator");
+        case TE_ERROR_UNEXPECTED_TOKEN:
+            return _(L"Unexpected token");
         case TE_ERROR_UNKNOWN:
             return _(L"Expression is bogus");
         default:

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -367,7 +367,7 @@ static te_expr *base(state *s) {
                 }
                 if (s->type == TOK_CLOSE && i == arity - 1) {
                     next_token(s);
-                } else if (s->type != TOK_ERROR || s->error == TE_ERROR_UNKNOWN) {
+                } else if (s->type != TOK_ERROR || s->error == TE_ERROR_UNEXPECTED_TOKEN) {
                     s->type = TOK_ERROR;
                     s->error = i < arity ? TE_ERROR_TOO_FEW_ARGS : TE_ERROR_TOO_MANY_ARGS;
                 }
@@ -403,7 +403,7 @@ static te_expr *base(state *s) {
         default:
             ret = new_expr(0, 0);
             s->type = TOK_ERROR;
-            s->error = TE_ERROR_UNKNOWN;
+            s->error = TE_ERROR_UNEXPECTED_TOKEN;
             ret->value = NAN;
             break;
     }

--- a/src/tinyexpr.h
+++ b/src/tinyexpr.h
@@ -35,7 +35,8 @@ typedef enum {
     TE_ERROR_TOO_FEW_ARGS = 4,
     TE_ERROR_TOO_MANY_ARGS = 5,
     TE_ERROR_MISSING_OPERATOR = 6,
-    TE_ERROR_UNKNOWN = 7
+    TE_ERROR_UNEXPECTED_TOKEN = 7,
+    TE_ERROR_UNKNOWN = 8
 } te_error_type_t;
 
 typedef struct te_error_t {

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -91,7 +91,7 @@ not math 'ncr(1)'
 # CHECKERR: 'ncr(1)'
 # CHECKERR:       ^
 not math 'max()'
-# CHECKERR: math: Error: Expression is bogus
+# CHECKERR: math: Error: Unexpected token
 # CHECKERR: 'max()'
 # CHECKERR:    ^
 not math 'sin()'


### PR DESCRIPTION
## Description

Add unexpected token error

Fixes issue #6063 

### Backgrounds

The cause of the bug is below:
`math '()'` calls `base`, `base` eats `'('` and then calls `expr`,
`expr` returns `TE_ERROR_UNKNOWN`, and if error is unknown,
`base` overwrites it to `TE_ERROR_MISSING_CLOSING_PARENTHESIS`.
This is why `math '(42 -)'` and `math ()` throws missing closing parenthesis error.

That means `TE_ERROR_UNKNOWN` is used to represent unexpected token error in `src/tinyexpr.cpp` though this type of error is ignored when another error happened.
So I added a new error.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
