### PR TITLE
Prefer using clr_eos to clear "remaining lines" - but reset color first

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -645,6 +645,8 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
     // Determine how many lines have stuff on them; we need to clear lines with stuff that we don't
     // want.
     const size_t lines_with_stuff = std::max(actual_lines_before_reset, scr->actual.line_count());
+    if (scr->desired.line_count() < lines_with_stuff)
+        need_clear_screen = true;
 
     if (left_prompt != scr->actual_left_prompt) {
         s_move(scr, 0, 0);
@@ -732,6 +734,7 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
             // wrapping.
             if (should_clear_screen_this_line && !has_cleared_screen &&
                 (done || j + 1 == (size_t)screen_width)) {
+                s_set_color(scr, vars, highlight_spec_t{});
                 s_move(scr, current_width, (int)i);
                 s_write_mbs(scr, clr_eos);
                 has_cleared_screen = true;
@@ -794,7 +797,7 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
     }
 
     // Clear remaining lines (if any) if we haven't cleared the screen.
-    if (!has_cleared_screen && scr->desired.line_count() < lines_with_stuff && clr_eol) {
+    if (!has_cleared_screen && need_clear_screen && clr_eol) {
         s_set_color(scr, vars, highlight_spec_t{});
         for (size_t i = scr->desired.line_count(); i < lines_with_stuff; i++) {
             s_move(scr, 0, (int)i);


### PR DESCRIPTION
This un-reverts pull request #6190, but adds a missing
reset of the color before doing the clr_eos.
