### PR TITLE
Add support for -oldstyle switches in __fish_seen_argument

### DIFF
--- a/share/functions/__fish_seen_argument.fish
+++ b/share/functions/__fish_seen_argument.fish
@@ -1,11 +1,17 @@
 function __fish_seen_argument
-    argparse 's/short=+' 'l/long=+' -- $argv
+    argparse 's/short=+' 'o/old=+' 'l/long=+' -- $argv
 
     set cmd (commandline -co)
     set -e cmd[1]
     for t in $cmd
         for s in $_flag_s
             if string match -qr "^-[A-z0-9]*"$s"[A-z0-9]*\$" -- $t
+                return 0
+            end
+        end
+
+        for o in $_flag_o
+            if string match -qr "^-$s\$" -- $t
                 return 0
             end
         end


### PR DESCRIPTION
## Description

I was working on completions this morning and realized `__fish_seen_argument` only supported `-s/--short` and `-l/--long`, not `-o/--old`. This adds support for that.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
