### PR TITLE
functions/fish_clipboard_paste.fish: fix unknown command

### DIFF
--- a/share/functions/fish_clipboard_paste.fish
+++ b/share/functions/fish_clipboard_paste.fish
@@ -18,6 +18,11 @@ else if type -q xclip
 end
 
 function fish_clipboard_paste
+    # If not find any clipboard handler, Do not anything.
+    if not type -q __fish_clipboard_paste
+        return 1
+    end
+
     set -l data (__fish_clipboard_paste)
 
     # Issue 6254: Handle zero-length clipboard content


### PR DESCRIPTION
## Description

fish output error "Unknown command: __fish_clipboard_paste" at no clipboard handler system.

So, if not find clipboard handler, do not anything.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
