### PR TITLE
Fix: equality vs identity

### DIFF
--- a/share/tools/deroff.py
+++ b/share/tools/deroff.py
@@ -800,7 +800,7 @@ class Deroffer:
         if self.str_at(0):
             # Split at whitespace
             comps = self.s.split(None, 2)
-            if len(comps) is 2:
+            if len(comps) == 2:
                 name, value = comps
                 value = value.rstrip()
                 self.reg_table[name] = value
@@ -998,7 +998,7 @@ class Deroffer:
             if self.str_at(0):
                 # Split at whitespace
                 comps = self.s.split(None, 2)
-                if len(comps) is 2:
+                if len(comps) == 2:
                     name, value = comps
                     value = value.rstrip()
                     self.reg_table[name] = value


### PR DESCRIPTION
Changes identity `is` for equality `==` check. To remove python warnings when updating auto complete

```
/usr/local/Cellar/fish/3.0.2/share/fish/tools/deroff.py:770: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(comps) is 2:
/usr/local/Cellar/fish/3.0.2/share/fish/tools/deroff.py:954: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(comps) is 2:
Parsing man pages and writing completions to /Users/james/.local/share/fish/generated_completions/
  6155 / 6155 : zic.8
```
