### PR TITLE
Fix typo in git clean completion

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1710,7 +1710,7 @@ complete -f -c git -n '__fish_git_needs_command' -a clean -d 'Remove untracked f
 complete -f -c git -n '__fish_git_using_command clean' -s f -l force -d 'Force run'
 complete -f -c git -n '__fish_git_using_command clean' -s i -l interactive -d 'Show what would be done and clean files interactively'
 complete -f -c git -n '__fish_git_using_command clean' -s n -l dry-run -d 'Don\'t actually remove anything, just show what would be done'
-complete -f -c git -n '__fish_git_using_command clean' -s q -l quite -d 'Be quiet, only report errors'
+complete -f -c git -n '__fish_git_using_command clean' -s q -l quiet -d 'Be quiet, only report errors'
 complete -f -c git -n '__fish_git_using_command clean' -s d -d 'Remove untracked directories in addition to untracked files'
 complete -f -c git -n '__fish_git_using_command clean' -s x -d 'Remove ignored files, as well'
 complete -f -c git -n '__fish_git_using_command clean' -s X -d 'Remove only ignored files'


### PR DESCRIPTION
## Description

This (hopefully) fixes a typo in the tab completion for git clean's arguments.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
