### PR TITLE
Added the missing argument for -c|--configuration option of PHPUnit

### DIFF
--- a/share/completions/phpunit.fish
+++ b/share/completions/phpunit.fish
@@ -95,7 +95,7 @@ complete -f -c phpunit -l do-not-cache-result -d 'Do not write test results to c
 # Configuration Options:
 complete -x -c phpunit -l prepend -d 'A PHP script that is included as early as possible'
 complete -x -c phpunit -l bootstrap -d 'A PHP script that is included before the tests run'
-complete -x -c phpunit -s c -l configuration -d 'Read configuration from XML file'
+complete -x -c phpunit -s c -l configuration -a '(__fish_complete_suffix ".xml{,.dist}")' -d 'Read configuration from XML file'
 complete -f -c phpunit -l no-configuration -d 'Ignore default configuration file (phpunit.xml)'
 complete -f -c phpunit -l no-logging -d 'Ignore logging configuration'
 complete -f -c phpunit -l no-extensions -d 'Do not load PHPUnit extensions'


### PR DESCRIPTION
## Description

The `phpunit -c|--configuration` option is marked as `-x` without the specification of arguments which makes the shell not suggest anything. The proper suggestions are `*.xml` and `*.xml.dist` files.
