### PR TITLE
Change vi selection mode to be inclusive

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -594,10 +594,10 @@ void reader_data_t::update_buff_pos(editable_line_t *el, size_t buff_pos) {
     if (el == &command_line && sel_active) {
         if (sel_begin_pos <= buff_pos) {
             sel_start_pos = sel_begin_pos;
-            sel_stop_pos = buff_pos;
+            sel_stop_pos = buff_pos + 1;
         } else {
             sel_start_pos = buff_pos;
-            sel_stop_pos = sel_begin_pos;
+            sel_stop_pos = sel_begin_pos + 1;
         }
     }
 }
@@ -3095,11 +3095,12 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
         case rl::begin_selection:
         case rl::end_selection: {
             sel_start_pos = command_line.position;
-            sel_stop_pos = command_line.position;
             if (c == rl::begin_selection) {
+                sel_stop_pos = command_line.position + 1;
                 sel_active = true;
                 sel_begin_pos = command_line.position;
             } else {
+                sel_stop_pos = command_line.position;
                 sel_active = false;
             }
 


### PR DESCRIPTION
The current cursor position should be included in the selection to be
consistent with the behavior of vi.

Fixes #5770

## Description

The current cursor position should be included in the selection. Because it makes sense to keep sel_stop_pos as the exclusive upper-bound, it must be adjusted by 1 to make the selection inclusive.

As far as I can tell, emacs mode does not use these code paths, but I'd be happy for someone more familiar with the code base to correct me.

Fixes issue #5770

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
