### PR TITLE
Fix __fish_complete_subcommand.fish some issues

### DIFF
--- a/share/completions/doas.fish
+++ b/share/completions/doas.fish
@@ -14,7 +14,7 @@ function __fish_doas_print_remaining_args
     # we want.
     if test -n "$argv"
         and not string match -qr '^-' $argv[1]
-        string escape -- $argv
+        string join0 -- $argv
         return 0
     else
         return 1
@@ -22,7 +22,7 @@ function __fish_doas_print_remaining_args
 end
 
 function __fish_complete_doas_subcommand
-    set -l args (__fish_doas_print_remaining_args)
+    set -l args (__fish_complete_doas_subcommand | string split0)
     set -lx -a PATH /usr/local/sbin /sbin /usr/sbin
     __fish_complete_subcommand --commandline $args
 end

--- a/share/completions/doas.fish
+++ b/share/completions/doas.fish
@@ -14,7 +14,7 @@ function __fish_doas_print_remaining_args
     # we want.
     if test -n "$argv"
         and not string match -qr '^-' $argv[1]
-        echo $argv
+        string escape -- $argv
         return 0
     else
         return 1

--- a/share/completions/env.fish
+++ b/share/completions/env.fish
@@ -23,7 +23,7 @@ function __fish_complete_env_subcommand
     return 1
 end
 
-complete -c env -xa "(__fish_complete_env_subcommand)"
+complete -c env -a "(__fish_complete_env_subcommand)"
 
 # complete VAR= only if the cursor is left of the =, otherwise complete the file right of the =
 complete -c env -n 'not __fish_complete_env_subcommand; and not string match -eq = -- (commandline -ct)' -a "(set -n)=" -f -d "Redefine variable"

--- a/share/completions/env.fish
+++ b/share/completions/env.fish
@@ -23,7 +23,7 @@ function __fish_complete_env_subcommand
     return 1
 end
 
-complete -c env -a "(__fish_complete_env_subcommand)"
+complete -c env -xa "(__fish_complete_env_subcommand)"
 
 # complete VAR= only if the cursor is left of the =, otherwise complete the file right of the =
 complete -c env -n 'not __fish_complete_env_subcommand; and not string match -eq = -- (commandline -ct)' -a "(set -n)=" -f -d "Redefine variable"

--- a/share/completions/sudo.fish
+++ b/share/completions/sudo.fish
@@ -20,7 +20,7 @@ function __fish_sudo_print_remaining_args
     # we want.
     if test -n "$argv"
         and not string match -qr '^-' $argv[1]
-        echo $argv
+        string escape -- $argv
         return 0
     else
         return 1

--- a/share/completions/sudo.fish
+++ b/share/completions/sudo.fish
@@ -20,7 +20,7 @@ function __fish_sudo_print_remaining_args
     # we want.
     if test -n "$argv"
         and not string match -qr '^-' $argv[1]
-        string escape -- $argv
+        string join0 -- $argv
         return 0
     else
         return 1
@@ -32,7 +32,7 @@ function __fish_sudo_no_subcommand
 end
 
 function __fish_complete_sudo_subcommand
-    set -l args (__fish_sudo_print_remaining_args)
+    set -l args (__fish_sudo_print_remaining_args | string split0)
     set -lx -a PATH /usr/local/sbin /sbin /usr/sbin
     __fish_complete_subcommand --commandline $args
 end

--- a/share/functions/__fish_complete_subcommand.fish
+++ b/share/functions/__fish_complete_subcommand.fish
@@ -17,14 +17,14 @@ function __fish_complete_subcommand -d "Complete subcommand" --no-scope-shadowin
             case '--allow-functions-and-builtins'
                 set allow_functions_and_builtins true
             case '--commandline'
-                set subcommand $argv
+                set subcommand (string split ' ' -- $argv)
                 set -e argv
                 break
         end
     end
     set -l options_with_param $argv
 
-    if not string length -q $subcommand
+    if not string length -q -- $subcommand
         set cmd (commandline -cop) (commandline -ct)
         while set -q cmd[1]
             set -l token $cmd[1]
@@ -55,4 +55,3 @@ function __fish_complete_subcommand -d "Complete subcommand" --no-scope-shadowin
     end
 
 end
-

--- a/share/functions/__fish_complete_subcommand.fish
+++ b/share/functions/__fish_complete_subcommand.fish
@@ -17,7 +17,7 @@ function __fish_complete_subcommand -d "Complete subcommand" --no-scope-shadowin
             case '--allow-functions-and-builtins'
                 set allow_functions_and_builtins true
             case '--commandline'
-                set subcommand (string split ' ' -- $argv)
+                set subcommand $argv
                 set -e argv
                 break
         end


### PR DESCRIPTION
## Description

1. Fix string length: Unknown option':
    Add `--` before $subcommand
2. Fix count $subcommand always = 1 with `sudo`:
    Because `completions/sudo.fish` give a single string $args, not string array of $args.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
