### PR TITLE
Reduce number of communication channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,6 @@ See the [Guide for Developers](CONTRIBUTING.md).
 
 ## Contact Us
 
-Questions, comments, rants and raves can be posted to the official fish mailing list at <https://lists.sourceforge.net/lists/listinfo/fish-users> or join us on our [gitter.im channel](https://gitter.im/fish-shell/fish-shell) or IRC channel [#fish at irc.oftc.net](https://webchat.oftc.net/?channels=fish). Or use the [fish tag on Stackoverflow](https://stackoverflow.com/questions/tagged/fish) for questions related to fish script and the [fish tag on Superuser](https://superuser.com/questions/tagged/fish) for all other questions (e.g., customizing colors, changing key bindings).
+Questions, comments, rants and raves can be posted to the official fish mailing list at <https://lists.sourceforge.net/lists/listinfo/fish-users> or join us on our [gitter.im channel](https://gitter.im/fish-shell/fish-shell). Or use the [fish tag on Stackoverflow](https://stackoverflow.com/questions/tagged/fish) for questions related to fish script and the [fish tag on Superuser](https://superuser.com/questions/tagged/fish) for all other questions (e.g., customizing colors, changing key bindings).
 
 Found a bug? Have an awesome idea? Please [open an issue](https://github.com/fish-shell/fish-shell/issues/new).

--- a/sphinx_doc_src/tutorial.rst
+++ b/sphinx_doc_src/tutorial.rst
@@ -711,4 +711,4 @@ with ``/bin/bash``, ``/bin/tcsh`` or ``/bin/zsh`` as appropriate in the steps ab
 Ready for more?
 ---------------
 
-If you want to learn more about fish, there is :ref:`lots of detailed documentation <intro>`, the `official gitter channel <https://gitter.im/fish-shell/fish-shell>`__, an `official mailing list <https://lists.sourceforge.net/lists/listinfo/fish-users>`__, the IRC channel \#fish on ``irc.oftc.net``, and the `github page <https://github.com/fish-shell/fish-shell/>`__.
+If you want to learn more about fish, there is :ref:`lots of detailed documentation <intro>`, the `official gitter channel <https://gitter.im/fish-shell/fish-shell>`__, an `official mailing list <https://lists.sourceforge.net/lists/listinfo/fish-users>`__, and the `github page <https://github.com/fish-shell/fish-shell/>`__.


### PR DESCRIPTION
We have, in our documentation, a rather large number of "official" communication channels.

Among them:

- github (issues)
- gitter (general questions)
- the mailing list
- stackoverflow
- superuser
- IRC

Having that many channels to talk about fish is confusing, and some of these are apparently not monitored.

In #6331 someone asked on IRC and didn't get an answer. I didn't answer because I'm not on IRC, and even if I was it's very possible that I would not have seen it because IRC doesn't really have missed notifications like e.g. gitter has.

So this PR for now removes IRC from our documentation (it's possible we'd have to add some in fish-site as well). Personally I'd also remove the mailing list as it's barely used and I'm not subscribed, but AFAIK @zanchey is still on there. Also the stackoverflow/superuser division is a bit crappy (but imposed by those sites).