### PR TITLE
Doc: "source" to identify itself as a "block" first, "eval" example to use $cmd as an array

### DIFF
--- a/sphinx_doc_src/cmds/eval.rst
+++ b/sphinx_doc_src/cmds/eval.rst
@@ -17,7 +17,7 @@ Description
 
 If your command does not need access to stdin, consider using ``source`` instead.
 
-If no piping or other compound shell constructs are required, variable-expansion-as-command, as in  ``set cmd ls; $cmd``, is also an option.
+If no piping or other compound shell constructs are required, variable-expansion-as-command, as in  ``set cmd ls -la; $cmd``, is also an option.
 
 
 Example

--- a/sphinx_doc_src/cmds/source.rst
+++ b/sphinx_doc_src/cmds/source.rst
@@ -15,7 +15,7 @@ Synopsis
 Description
 -----------
 
-``source`` evaluates the commands of the specified file in the current shell. This is different from starting a new process to perform the commands (i.e. ``fish < FILENAME``) since the commands will be evaluated by the current shell, which means that changes in shell variables will affect the current shell. If additional arguments are specified after the file name, they will be inserted into the ``$argv`` variable. The ``$argv`` variable will not include the name of the sourced file.
+``source`` evaluates the commands of the specified file in the current shell as a new block of code. This is different from starting a new process to perform the commands (i.e. ``fish < FILENAME``) since the commands will be evaluated by the current shell, which means that changes in shell variables will affect the current shell. If additional arguments are specified after the file name, they will be inserted into the ``$argv`` variable. The ``$argv`` variable will not include the name of the sourced file.
 
 fish will search the working directory to resolve relative paths but will not search ``$PATH``.
 


### PR DESCRIPTION
## Description

This is updated and cleaned pull request for PR #6308 for documentation clarification

* "source" to identify itself as a "block" first
* "eval" example to use $cmd as an array

I think mentioning "block" early for "source" helps people to understand following long explanation.
