### PR TITLE
Add replace mode in vi-mode

### DIFF
--- a/share/functions/fish_default_mode_prompt.fish
+++ b/share/functions/fish_default_mode_prompt.fish
@@ -12,6 +12,9 @@ function fish_default_mode_prompt --description "Display the default mode for th
             case replace_one
                 set_color --bold --background green white
                 echo '[R]'
+            case replace
+                set_color --bold --background cyan white
+                echo '[R]'
             case visual
                 set_color --bold --background magenta white
                 echo '[V]'

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -219,6 +219,17 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M replace_one -m default \e cancel repaint-mode
 
     #
+    # Uppercase R, enters replace mode
+    #
+    bind -s --preset -m replace R repaint-mode
+    bind -s --preset -M replace '' delete-char self-insert
+    bind -s --preset -M replace -m insert \r execute repaint-mode
+    bind -s --preset -M replace -m default \e cancel repaint-mode
+    # in vim (and maybe in vi), <BS> deletes the changes
+    # but this binding just move cursor backward, not delete the changes
+    bind -s --preset -M replace -k backspace backward-char
+
+    #
     # visual mode
     #
     bind -s --preset -M visual h backward-char
@@ -263,6 +274,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # the commenting chars so the command can be further edited then executed.
     bind -s --preset -M default \# __fish_toggle_comment_commandline
     bind -s --preset -M visual \# __fish_toggle_comment_commandline
+    bind -s --preset -M replace \# __fish_toggle_comment_commandline
 
     # Set the cursor shape
     # After executing once, this will have defined functions listening for the variable.


### PR DESCRIPTION
## Description

Added replace mode.
Input 'R' in normal mode to enter replace mode.

In replace mode:
- esc key to exit to normal mode
- enter key to execute command and switch to insert mode
- backspace key to move cursor backward ( This behaviour is different from vim. If previous character is changed by current replace mode, vim reverts the change, but implemented one does not revert. )
- any other keys to replace character
- prompt background is different from replace_one mode. background color of replace mode is cyan.

Fixes issue #1417

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
