### PR TITLE
builtin-math: Use normal C trunc

### DIFF
--- a/src/builtin_math.cpp
+++ b/src/builtin_math.cpp
@@ -163,7 +163,7 @@ static wcstring format_double(double v, const math_cmd_opts_t &opts) {
     // As a special-case, a scale of 0 means to truncate to an integer
     // instead of rounding.
     if (opts.scale == 0) {
-        v = std::trunc(v);
+        v = trunc(v);
         return format_string(L"%.*f", opts.scale, v);
     }
 


### PR DESCRIPTION
uClibc-ng does not expose C++11 math
functions to the std namespace, breaking
compilation. This is fine as the argument
type is double.
