### PR TITLE
Restore error messages for bare variable assignment

### DIFF
--- a/src/parse_constants.h
+++ b/src/parse_constants.h
@@ -174,9 +174,10 @@ enum parse_error_code_t {
     parse_error_tokenizer_unterminated_escape,
     parse_error_tokenizer_other,
 
-    parse_error_unbalancing_end,   // end outside of block
-    parse_error_unbalancing_else,  // else outside of if
-    parse_error_unbalancing_case   // case outside of switch
+    parse_error_unbalancing_end,           // end outside of block
+    parse_error_unbalancing_else,          // else outside of if
+    parse_error_unbalancing_case,          // case outside of switch
+    parse_error_bare_variable_assignment,  // a=b without command
 };
 
 enum { PARSER_TEST_ERROR = 1, PARSER_TEST_INCOMPLETE = 2 };

--- a/tests/checks/variable-assignment.fish
+++ b/tests/checks/variable-assignment.fish
@@ -76,3 +76,11 @@ complete -C'a=b xalias '
 alias envxalias='a=b x'
 complete -C'a=b envxalias '
 # CHECK: arg
+
+# Eval invalid grammar to allow fish to parse this file
+eval 'a=(echo b)'
+# CHECKERR: {{.*}}: Unsupported use of '='. In fish, please use 'set a (echo b)'.
+eval ': | a=b'
+# CHECKERR: {{.*}}: Unsupported use of '='. In fish, please use 'set a b'.
+eval 'not a=b'
+# CHECKERR: {{.*}}: Unsupported use of '='. In fish, please use 'set a b'.


### PR DESCRIPTION
Since #6287, bare variable assignments do not parse, which broke
the "Unsupported use of '='" error message.

This commit catches parse errors that occur on bare variable assignments.
When a statement node fails to parse, then we check if there is at least one
prefixing variable assignment. If so, we emit the old error message.

See also #6347


## TODOs:
- [x] Tests have been added for regressions fixed
