### PR TITLE
Fix error messages for "and" and "or" after pipe

### DIFF
--- a/src/parse_constants.h
+++ b/src/parse_constants.h
@@ -178,6 +178,7 @@ enum parse_error_code_t {
     parse_error_unbalancing_else,          // else outside of if
     parse_error_unbalancing_case,          // case outside of switch
     parse_error_bare_variable_assignment,  // a=b without command
+    parse_error_andor_in_pipeline,         // "and" or "or" after a pipe
 };
 
 enum { PARSER_TEST_ERROR = 1, PARSER_TEST_INCOMPLETE = 2 };

--- a/src/parse_tree.h
+++ b/src/parse_tree.h
@@ -238,4 +238,7 @@ parsed_source_ref_t parse_source(wcstring src, parse_tree_flags_t flags, parse_e
 /// The position of the equal sign in a variable assignment like foo=bar.
 maybe_t<size_t> variable_assignment_equals_pos(const wcstring &txt);
 
+/// Error message for improper use of the exec builtin.
+#define EXEC_ERR_MSG _(L"The '%ls' command can not be used in a pipeline")
+
 #endif

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -28,9 +28,6 @@
 #include "wildcard.h"
 #include "wutil.h"  // IWYU pragma: keep
 
-/// Error message for improper use of the exec builtin.
-#define EXEC_ERR_MSG _(L"The '%ls' command can not be used in a pipeline")
-
 /// Error message for use of backgrounded commands before and/or.
 #define BOOL_AFTER_BACKGROUND_ERROR_MSG \
     _(L"The '%ls' command can not be used immediately after a backgrounded job")

--- a/tests/checks/andor.fish
+++ b/tests/checks/andor.fish
@@ -1,0 +1,9 @@
+#RUN: %fish %s
+
+set -xl LANG C # uniform quotes
+
+eval 'true | and'
+# CHECKERR: {{.*}}: The 'and' command can not be used in a pipeline
+
+eval 'true | or'
+# CHECKERR: {{.*}}: The 'or' command can not be used in a pipeline


### PR DESCRIPTION
Based on #6349, so only the second commit is interesting

Fixes #6347

## TODOs:
- [x] Tests have been added for regressions fixed
