### PR TITLE
clang-tidy 2

### DIFF
--- a/src/autoload.cpp
+++ b/src/autoload.cpp
@@ -141,7 +141,7 @@ maybe_t<autoloadable_file_t> autoload_file_cache_t::check(const wcstring &cmd, b
 autoload_t::autoload_t(wcstring env_var_name)
     : env_var_name_(std::move(env_var_name)), cache_(make_unique<autoload_file_cache_t>()) {}
 
-autoload_t::autoload_t(autoload_t &&) = default;
+autoload_t::autoload_t(autoload_t &&) noexcept = default;
 autoload_t::~autoload_t() = default;
 
 void autoload_t::invalidate_cache() {

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -222,7 +222,7 @@ static int builtin_generic(parser_t &parser, io_streams_t &streams, wchar_t **ar
 
 // How many bytes we read() at once.
 // Since this is just for counting, it can be massive.
-#define COUNT_CHUNK_SIZE 512 * 256
+#define COUNT_CHUNK_SIZE (512 * 256)
 /// Implementation of the builtin count command, used to count the number of arguments sent to it.
 static int builtin_count(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     UNUSED(parser);

--- a/src/builtin_eval.cpp
+++ b/src/builtin_eval.cpp
@@ -27,7 +27,7 @@ int builtin_eval(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const auto cached_exec_count = parser.libdata().exec_count;
     int status = STATUS_CMD_OK;
     if (argc > 1) {
-        if (parser.eval(std::move(new_cmd), *streams.io_chain, block_type_t::TOP) != 0) {
+        if (parser.eval(new_cmd, *streams.io_chain, block_type_t::TOP) != 0) {
             // This indicates a parse error; nothing actually got executed.
             status = STATUS_CMD_ERROR;
         } else if (cached_exec_count == parser.libdata().exec_count) {

--- a/src/builtin_functions.cpp
+++ b/src/builtin_functions.cpp
@@ -299,7 +299,7 @@ int builtin_functions(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     }
 
     // Erase, desc, query, copy and list are mutually exclusive.
-    bool describe = opts.description ? true : false;
+    bool describe = opts.description != nullptr;
     if (describe + opts.erase + opts.list + opts.query + opts.copy > 1) {
         streams.err.append_format(BUILTIN_ERR_COMBO, cmd);
         builtin_print_error_trailer(parser, streams.err, cmd);

--- a/src/builtin_functions.cpp
+++ b/src/builtin_functions.cpp
@@ -258,7 +258,7 @@ static int report_function_metadata(const wchar_t *funcname, bool verbose, io_st
     }
 
     if (metadata_as_comments) {
-        if (std::wcscmp(path, L"stdin")) {
+        if (std::wcscmp(path, L"stdin") != 0) {
             wcstring comment;
             append_format(comment, L"# Defined in %ls @ line %d\n", path, line_number);
             if (!streams.out_is_redirected && isatty(STDOUT_FILENO)) {

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1222,7 +1222,7 @@ static int string_sub(parser_t &parser, io_streams_t &streams, int argc, wchar_t
     int nsub = 0;
     arg_iterator_t aiter(argv, optind, streams);
     while (const wcstring *s = aiter.nextstr()) {
-        typedef wcstring::size_type size_type;
+        using size_type = wcstring::size_type;
         size_type pos = 0;
         size_type count = wcstring::npos;
         if (opts.start > 0) {

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -615,7 +615,7 @@ class string_matcher_t {
 
    public:
     string_matcher_t(options_t opts_, io_streams_t &streams_)
-        : opts(std::move(opts_)), streams(streams_), total_matched(0) {}
+        : opts(opts_), streams(streams_), total_matched(0) {}
 
     virtual ~string_matcher_t() = default;
     virtual bool report_matches(const wcstring &arg) = 0;
@@ -888,7 +888,7 @@ class string_replacer_t {
 
    public:
     string_replacer_t(const wchar_t *argv0_, options_t opts_, io_streams_t &streams_)
-        : argv0(argv0_), opts(std::move(opts_)), total_replaced(0), streams(streams_) {}
+        : argv0(argv0_), opts(opts_), total_replaced(0), streams(streams_) {}
 
     virtual ~string_replacer_t() = default;
     int replace_count() const { return total_replaced; }

--- a/src/builtin_test.cpp
+++ b/src/builtin_test.cpp
@@ -217,7 +217,7 @@ struct range_t {
 /// Base class for expressions.
 class expression {
    protected:
-    expression(token_t what, range_t where) : token(what), range(std::move(where)) {}
+    expression(token_t what, range_t where) : token(what), range(where) {}
 
    public:
     const token_t token;
@@ -267,7 +267,7 @@ class combining_expression : public expression {
 
     combining_expression(token_t tok, range_t where, std::vector<unique_ptr<expression>> exprs,
                          const std::vector<token_t> &combs)
-        : expression(tok, where), subjects(std::move(exprs)), combiners(std::move(combs)) {
+        : expression(tok, where), subjects(std::move(exprs)), combiners(combs) {
         // We should have one more subject than combiner.
         assert(subjects.size() == combiners.size() + 1);
     }

--- a/src/builtin_wait.cpp
+++ b/src/builtin_wait.cpp
@@ -60,10 +60,7 @@ static bool any_jobs_finished(size_t jobs_len, const parser_t &parser) {
             no_jobs_running = false;
         }
     }
-    if (no_jobs_running) {
-        return true;
-    }
-    return false;
+    return no_jobs_running;
 }
 
 static int wait_for_backgrounds(parser_t &parser, bool any_flag) {

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -174,7 +174,7 @@ wcstring_list_t rgb_color_t::named_color_names() {
     wcstring_list_t result;
     result.reserve(1 + count);
     for (size_t i = 0; i < count; i++) {
-        if (named_colors[i].hidden == false) {
+        if (!named_colors[i].hidden) {
             result.push_back(named_colors[i].name);
         }
     }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -252,7 +252,7 @@ int fgetws2(wcstring *s, FILE *f) {
     int i = 0;
     wint_t c;
 
-    while (1) {
+    while (true) {
         errno = 0;
 
         c = std::fgetwc(f);
@@ -556,7 +556,7 @@ void append_format(wcstring &str, const wchar_t *format, ...) {
 wchar_t *quote_end(const wchar_t *pos) {
     wchar_t c = *pos;
 
-    while (1) {
+    while (true) {
         pos++;
 
         if (!*pos) return nullptr;
@@ -816,7 +816,7 @@ wcstring reformat_for_screen(const wcstring &msg) {
     if (screen_width) {
         const wchar_t *start = msg.c_str();
         const wchar_t *pos = start;
-        while (1) {
+        while (true) {
             int overflow = 0;
 
             int tok_width = 0;

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -208,11 +208,11 @@ completion_t::completion_t(wcstring comp, wcstring desc, string_fuzzy_match_t ma
                            complete_flags_t flags_val)
     : completion(std::move(comp)),
       description(std::move(desc)),
-      match(std::move(mat)),
+      match(mat),
       flags(resolve_auto_space(completion, flags_val)) {}
 
 completion_t::completion_t(const completion_t &him) = default;
-completion_t::completion_t(completion_t &&him) = default;
+completion_t::completion_t(completion_t &&him) noexcept = default;
 completion_t &completion_t::operator=(const completion_t &him) = default;
 completion_t &completion_t::operator=(completion_t &&him) = default;
 completion_t::~completion_t() = default;
@@ -1647,16 +1647,16 @@ void complete(const wcstring &cmd_with_subcmds, std::vector<completion_t> *out_c
 
 /// Print the short switch \c opt, and the argument \c arg to the specified
 /// wcstring, but only if \c argument isn't an empty string.
-static void append_switch(wcstring &out, wchar_t opt, const wcstring arg) {
+static void append_switch(wcstring &out, wchar_t opt, const wcstring &arg) {
     if (arg.empty()) return;
     append_format(out, L" -%lc %ls", opt, escape_string(arg, ESCAPE_ALL).c_str());
 }
-static void append_switch(wcstring &out, const wcstring opt, const wcstring arg) {
+static void append_switch(wcstring &out, const wcstring &opt, const wcstring &arg) {
     if (arg.empty()) return;
     append_format(out, L" --%ls %ls", opt.c_str(), escape_string(arg, ESCAPE_ALL).c_str());
 }
 static void append_switch(wcstring &out, wchar_t opt) { append_format(out, L" -%lc", opt); }
-static void append_switch(wcstring &out, const wcstring opt) {
+static void append_switch(wcstring &out, const wcstring &opt) {
     append_format(out, L" --%ls", opt.c_str());
 }
 

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -586,7 +586,7 @@ void completer_t::complete_cmd_desc(const wcstring &str) {
     // least two characters if we don't know the location of the whatis-database.
     if (cmd.length() < 2) return;
 
-    if (wildcard_has(cmd, 0)) {
+    if (wildcard_has(cmd, false)) {
         return;
     }
 
@@ -939,7 +939,7 @@ bool completer_t::complete_param(const wcstring &cmd_orig, const wcstring &popt,
     for (const option_list_t &options : all_options) {
         size_t short_opt_pos = short_option_pos(str, options);
         bool last_option_requires_param = false;
-        use_common = 1;
+        use_common = true;
         if (use_switches) {
             if (str[0] == L'-') {
                 // Check if we are entering a combined option and argument (like --color=auto or

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -902,7 +902,7 @@ bool completer_t::complete_param(const wcstring &cmd_orig, const wcstring &popt,
     // FLOGF(error, L"\nThinking about looking up completions for %ls\n", cmd.c_str());
     bool head_exists = builtin_exists(cmd);
     // Only reload environment variables if builtin_exists returned false, as an optimization
-    if (head_exists == false) {
+    if (!head_exists) {
         head_exists = function_exists_no_autoload(cmd);
         // While it may seem like first testing `path_get_path` before resorting to an env lookup
         // may be faster, path_get_path can potentially do a lot of FS/IO access, so env.get() +

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -124,7 +124,7 @@ typedef struct complete_entry_opt {
 static std::atomic<unsigned int> k_complete_order{0};
 
 /// Struct describing a command completion.
-typedef std::list<complete_entry_opt_t> option_list_t;
+using option_list_t = std::list<complete_entry_opt_t>;
 class completion_entry_t {
    public:
     /// List of all options.
@@ -166,7 +166,7 @@ struct equal_to<completion_entry_t> {
     }
 };
 }  // namespace std
-typedef std::unordered_set<completion_entry_t> completion_entry_set_t;
+using completion_entry_set_t = std::unordered_set<completion_entry_t>;
 static owning_lock<completion_entry_set_t> s_completion_set;
 
 /// Completion "wrapper" support. The map goes from wrapping-command to wrapped-command-list.

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -878,7 +878,7 @@ class env_stack_impl_t final : public env_scoped_impl_t {
 
     /// Remove a variable from the chain \p node.
     /// \return true if the variable was found and removed.
-    bool remove_from_chain(env_node_ref_t node, const wcstring &key) const {
+    bool remove_from_chain(const env_node_ref_t &node, const wcstring &key) const {
         for (auto cursor = node; cursor; cursor = cursor->next) {
             auto iter = cursor->env.find(key);
             if (iter != cursor->env.end()) {
@@ -901,7 +901,7 @@ class env_stack_impl_t final : public env_scoped_impl_t {
     void set_universal(const wcstring &key, wcstring_list_t val, const query_t &query);
 
     /// Set a variable in a given node \p node.
-    void set_in_node(env_node_ref_t node, const wcstring &key, wcstring_list_t &&val,
+    void set_in_node(const env_node_ref_t &node, const wcstring &key, wcstring_list_t &&val,
                      const var_flags_t &flags);
 
     // Implement the default behavior of 'set' by finding the node for an unspecified scope.
@@ -970,8 +970,8 @@ static wcstring_list_t colon_split(const wcstring_list_t &val) {
     return split_val;
 }
 
-void env_stack_impl_t::set_in_node(env_node_ref_t node, const wcstring &key, wcstring_list_t &&val,
-                                   const var_flags_t &flags) {
+void env_stack_impl_t::set_in_node(const env_node_ref_t &node, const wcstring &key,
+                                   wcstring_list_t &&val, const var_flags_t &flags) {
     env_var_t &var = node->env[key];
 
     // Use an explicit exports, or inherit from the existing variable.

--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -507,7 +507,7 @@ static void init_locale(const environment_t &vars) {
     FLOGF(env_locale, L"old LC_MESSAGES locale: '%s'", old_msg_locale);
     FLOGF(env_locale, L"new LC_MESSAGES locale: '%s'", new_msg_locale);
 #ifdef HAVE__NL_MSG_CAT_CNTR
-    if (std::strcmp(old_msg_locale, new_msg_locale)) {
+    if (std::strcmp(old_msg_locale, new_msg_locale) != 0) {
         // Make change known to GNU gettext.
         extern int _nl_msg_cat_cntr;
         _nl_msg_cat_cntr++;

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -276,9 +276,9 @@ void env_universal_t::set_internal(const wcstring &key, const env_var_t &var) {
     }
 }
 
-void env_universal_t::set(const wcstring &key, env_var_t var) {
+void env_universal_t::set(const wcstring &key, const env_var_t &var) {
     scoped_lock locker(lock);
-    this->set_internal(key, std::move(var));
+    this->set_internal(key, var);
 }
 
 bool env_universal_t::remove_internal(const wcstring &key) {

--- a/src/env_universal_common.h
+++ b/src/env_universal_common.h
@@ -103,7 +103,7 @@ class env_universal_t {
     maybe_t<env_var_t::env_var_flags_t> get_flags(const wcstring &name) const;
 
     // Sets a variable.
-    void set(const wcstring &key, env_var_t var);
+    void set(const wcstring &key, const env_var_t &var);
 
     // Removes a variable. Returns true if it was found, false if not.
     bool remove(const wcstring &key);

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -315,7 +315,7 @@ void internal_exec(env_stack_t &vars, job_t *j, const io_chain_t &all_ios) {
         launch_process_nofork(vars, j->processes.front().get());
     } else {
         j->mut_flags().constructed = true;
-        j->processes.front()->completed = 1;
+        j->processes.front()->completed = true;
         return;
     }
 }
@@ -645,7 +645,7 @@ static bool handle_builtin_output(parser_t &parser, const std::shared_ptr<job_t>
     if (!must_use_process && outbuff.empty() && errbuff.empty()) {
         // We do not need to construct a background process.
         // TODO: factor this job-status-setting stuff into a single place.
-        p->completed = 1;
+        p->completed = true;
         if (p->is_last_in_job) {
             FLOGF(exec_job_status, L"Set status of job %d (%ls) to %d using short circuit",
                   j->job_id, j->preview().c_str(), p->status);
@@ -863,7 +863,7 @@ static bool exec_block_or_func_process(parser_t &parser, std::shared_ptr<job_t> 
     if (!block_output_bufferfill) {
         // No buffer, so we exit directly. This means we have to manually set the exit
         // status.
-        p->completed = 1;
+        p->completed = true;
         if (p->is_last_in_job) {
             parser.set_last_statuses(j->get_statuses());
         }
@@ -883,7 +883,7 @@ static bool exec_block_or_func_process(parser_t &parser, std::shared_ptr<job_t> 
         if (p->is_last_in_job) {
             parser.set_last_statuses(j->get_statuses());
         }
-        p->completed = 1;
+        p->completed = true;
     }
     return true;
 }
@@ -1128,7 +1128,7 @@ bool exec_job(parser_t &parser, shared_ptr<job_t> j) {
         internal_exec(parser.vars(), j.get(), all_ios);
         // internal_exec only returns if it failed to set up redirections.
         // In case of an successful exec, this code is not reached.
-        bool status = j->flags().negate ? 0 : 1;
+        bool status = j->flags().negate ? false : true;
         parser.set_last_statuses(statuses_t::just(status));
         return false;
     }

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -338,7 +338,7 @@ static void on_process_created(const std::shared_ptr<job_t> &j, pid_t child_pid)
 /// (stdout), and there is a dup2 3->1, then we need to write to fd 3. Then exit the internal
 /// process.
 static bool run_internal_process(process_t *p, std::string outdata, std::string errdata,
-                                 io_chain_t ios) {
+                                 const io_chain_t &ios) {
     p->check_generations_before_launch();
 
     // We want both the dup2s and the io_chain_ts to be kept alive by the background thread, because
@@ -818,9 +818,9 @@ static void function_restore_environment(parser_t &parser, const block_t *block)
 /// our pipes.
 /// \p allow_buffering if true, permit buffering the output.
 /// \return true on success, false on error.
-static bool exec_block_or_func_process(parser_t &parser, std::shared_ptr<job_t> j, process_t *p,
-                                       const io_chain_t &user_ios, io_chain_t io_chain,
-                                       bool allow_buffering) {
+static bool exec_block_or_func_process(parser_t &parser, const std::shared_ptr<job_t> &j,
+                                       process_t *p, const io_chain_t &user_ios,
+                                       io_chain_t io_chain, bool allow_buffering) {
     assert((p->type == process_type_t::function || p->type == process_type_t::block_node) &&
            "Unexpected process type");
 
@@ -893,7 +893,7 @@ static bool exec_block_or_func_process(parser_t &parser, std::shared_ptr<job_t> 
 /// \p deferred_pipes represents the pipes from our deferred process; if set ensure they get closed
 /// in any child. If \p is_deferred_run is true, then this is a deferred run; this affects how
 /// certain buffering works. \returns true on success, false on exec error.
-static bool exec_process_in_job(parser_t &parser, process_t *p, std::shared_ptr<job_t> j,
+static bool exec_process_in_job(parser_t &parser, process_t *p, const std::shared_ptr<job_t> &j,
                                 autoclose_pipes_t pipes, const io_chain_t &all_ios,
                                 const autoclose_pipes_t &deferred_pipes, size_t stdout_read_limit,
                                 bool is_deferred_run = false) {
@@ -1085,7 +1085,7 @@ static bool should_claim_process_group_for_job(const shared_ptr<job_t> &j) {
     DIE("unreachable");
 }
 
-bool exec_job(parser_t &parser, shared_ptr<job_t> j) {
+bool exec_job(parser_t &parser, const shared_ptr<job_t> &j) {
     assert(j && "null job_t passed to exec_job!");
 
     // Set to true if something goes wrong while executing the job, in which case the cleanup

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1128,7 +1128,7 @@ bool exec_job(parser_t &parser, shared_ptr<job_t> j) {
         internal_exec(parser.vars(), j.get(), all_ios);
         // internal_exec only returns if it failed to set up redirections.
         // In case of an successful exec, this code is not reached.
-        bool status = j->flags().negate ? false : true;
+        bool status = !j->flags().negate;
         parser.set_last_statuses(statuses_t::just(status));
         return false;
     }

--- a/src/exec.h
+++ b/src/exec.h
@@ -14,7 +14,7 @@
 /// Execute the processes specified by \p j in the parser \p.
 class job_t;
 class parser_t;
-bool exec_job(parser_t &parser, std::shared_ptr<job_t> j);
+bool exec_job(parser_t &parser, const std::shared_ptr<job_t> &j);
 
 /// Evaluate the expression cmd in a subshell, add the outputs into the list l. On return, the
 /// status flag as returned bu \c proc_gfet_last_status will not be changed.

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -671,8 +671,7 @@ static bool expand_cmdsubst(wcstring input, parser_t &parser, std::vector<comple
         }
     }
 
-    if (parser.get_last_status() == STATUS_READ_TOO_MUCH) return false;
-    return true;
+    return parser.get_last_status() != STATUS_READ_TOO_MUCH;
 }
 
 // Given that input[0] is HOME_DIRECTORY or tilde (ugh), return the user's name. Return the empty

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -156,7 +156,7 @@ static size_t parse_slice(const wchar_t *in, wchar_t **end_ptr, std::vector<long
     int zero_index = -1;
     bool literal_zero_index = true;
 
-    while (1) {
+    while (true) {
         while (iswspace(in[pos]) || (in[pos] == INTERNAL_SEPARATOR)) pos++;
         if (in[pos] == L']') {
             pos++;

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -47,7 +47,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #define SPACES_PER_INDENT 4
 
 // An indent_t represents an abstract indent depth. 2 means we are in a doubly-nested block, etc.
-typedef unsigned int indent_t;
+using indent_t = unsigned int;
 static bool dump_parse_tree = false;
 static int ret = 0;
 

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -54,7 +54,7 @@ static int ret = 0;
 // Read the entire contents of a file into the specified string.
 static wcstring read_file(FILE *f) {
     wcstring result;
-    while (1) {
+    while (true) {
         wint_t c = std::fgetwc(f);
 
         if (c == WEOF) {

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -137,7 +137,7 @@ struct prettifier_t {
 static void dump_node(indent_t node_indent, const parse_node_t &node, const wcstring &source) {
     wchar_t nextc = L' ';
     wchar_t prevc = L' ';
-    wcstring source_txt = L"";
+    wcstring source_txt;
     if (node.source_start != SOURCE_OFFSET_INVALID && node.source_length != SOURCE_OFFSET_INVALID) {
         int nextc_idx = node.source_start + node.source_length;
         if (static_cast<size_t>(nextc_idx) < source.size()) {

--- a/src/fish_test_helper.cpp
+++ b/src/fish_test_helper.cpp
@@ -3,17 +3,19 @@
 
 #include <unistd.h>
 
+#include <chrono>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <thread>
 
 static void become_foreground_then_print_stderr() {
     if (tcsetpgrp(STDOUT_FILENO, getpgrp()) < 0) {
         perror("tcsetgrp");
         exit(EXIT_FAILURE);
     }
-    usleep(1000000 / 4);  //.25 secs
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
     fprintf(stderr, "become_foreground_then_print_stderr done\n");
 }
 
@@ -28,14 +30,14 @@ static void report_foreground() {
                 return;
             }
         }
-        usleep(1000000 / 2);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 }
 
 static void sigint_parent() {
     // SIGINT the parent after 1 second, then exit
     int parent = getppid();
-    usleep(1000000 / 4);  //.25 secs
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
     kill(parent, SIGINT);
     fprintf(stderr, "Sent SIGINT to %d\n", parent);
 }

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -166,7 +166,8 @@ void function_add(wcstring name, wcstring description, function_properties_ref_t
 
     // Create and store a new function.
     auto ins = funcset->funcs.emplace(
-        std::move(name), function_info_t(props, std::move(description), filename, is_autoload));
+        std::move(name),
+        function_info_t(std::move(props), std::move(description), filename, is_autoload));
     assert(ins.second && "Function should not already be present in the table");
     (void)ins;
 }

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -774,7 +774,7 @@ class highlighter_t {
     // Working directory.
     const wcstring working_directory;
     // The resulting colors.
-    typedef std::vector<highlight_spec_t> color_array_t;
+    using color_array_t = std::vector<highlight_spec_t>;
     color_array_t color_array;
     // The parse tree of the buff.
     parse_node_tree_t parse_tree;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1239,10 +1239,7 @@ bool all_paths_are_valid(const path_list_t &paths, const wcstring &working_direc
 
 static bool string_could_be_path(const wcstring &potential_path) {
     // Assume that things with leading dashes aren't paths.
-    if (potential_path.empty() || potential_path.at(0) == L'-') {
-        return false;
-    }
-    return true;
+    return !(potential_path.empty() || potential_path.at(0) == L'-');
 }
 
 /// Very simple, just mark that we have no more pending items.

--- a/src/history_file.cpp
+++ b/src/history_file.cpp
@@ -480,7 +480,7 @@ static history_item_t decode_item_fish_1_x(const char *begin, size_t length) {
     bool timestamp_mode = false;
     time_t timestamp = 0;
 
-    while (1) {
+    while (true) {
         wchar_t c;
         size_t res;
         mbstate_t state = {};

--- a/src/history_file.cpp
+++ b/src/history_file.cpp
@@ -265,7 +265,7 @@ static history_item_t decode_item_fish_2_0(const char *base, size_t len) {
                 size_t advance = read_line(base, cursor, len, line);
                 if (trim_leading_spaces(line) <= indent) break;
 
-                if (std::strncmp(line.c_str(), "- ", 2)) break;
+                if (std::strncmp(line.c_str(), "- ", 2) != 0) break;
 
                 // We're going to consume this line.
                 cursor += advance;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -429,9 +429,9 @@ bool inputter_t::mapping_is_match(const input_mapping_t &m) {
     return true;
 }
 
-void inputter_t::queue_ch(char_event_t ch) { event_queue_.push_back(ch); }
+void inputter_t::queue_ch(const char_event_t &ch) { event_queue_.push_back(ch); }
 
-void inputter_t::push_front(char_event_t ch) { event_queue_.push_front(ch); }
+void inputter_t::push_front(const char_event_t &ch) { event_queue_.push_front(ch); }
 
 /// \return the first mapping that matches, walking first over the user's mapping list, then the
 /// preset list. \return null if nothing matches.

--- a/src/input.h
+++ b/src/input.h
@@ -57,10 +57,10 @@ class inputter_t {
 
     /// Enqueue a char event to the queue of unread characters that input_readch will return before
     /// actually reading from fd 0.
-    void queue_ch(char_event_t ch);
+    void queue_ch(const char_event_t &ch);
 
     /// Enqueue a char event to the front of the queue; this will be the next event returned.
-    void push_front(char_event_t ch);
+    void push_front(const char_event_t &ch);
 
     /// Sets the return status of the most recently executed input function.
     void function_set_status(bool status) { function_status_ = status; }

--- a/src/input_common.cpp
+++ b/src/input_common.cpp
@@ -171,7 +171,7 @@ char_event_t input_event_queue_t::readch() {
     }
     wchar_t res;
     mbstate_t state = {};
-    while (1) {
+    while (true) {
         auto evt = readb();
         if (!evt.is_char()) {
             return evt;

--- a/src/input_common.cpp
+++ b/src/input_common.cpp
@@ -225,6 +225,6 @@ char_event_t input_event_queue_t::readch_timed(bool dequeue_timeouts) {
     return result;
 }
 
-void input_event_queue_t::push_back(char_event_t ch) { queue_.push_back(ch); }
+void input_event_queue_t::push_back(const char_event_t &ch) { queue_.push_back(ch); }
 
-void input_event_queue_t::push_front(char_event_t ch) { queue_.push_front(ch); }
+void input_event_queue_t::push_front(const char_event_t &ch) { queue_.push_front(ch); }

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -188,11 +188,11 @@ class input_event_queue_t {
 
     /// Enqueue a character or a readline function to the queue of unread characters that
     /// readch will return before actually reading from fd 0.
-    void push_back(char_event_t ch);
+    void push_back(const char_event_t &ch);
 
     /// Add a character or a readline function to the front of the queue of unread characters.  This
     /// will be the next character returned by readch.
-    void push_front(char_event_t ch);
+    void push_front(const char_event_t &ch);
 };
 
 #endif

--- a/src/iothread.cpp
+++ b/src/iothread.cpp
@@ -41,7 +41,7 @@
 static void iothread_service_main_thread_requests();
 static void iothread_service_result_queue();
 
-typedef std::function<void(void)> void_function_t;
+using void_function_t = std::function<void()>;
 
 struct work_request_t {
     void_function_t handler;

--- a/src/kill.cpp
+++ b/src/kill.cpp
@@ -15,7 +15,7 @@
 #include "fallback.h"  // IWYU pragma: keep
 
 /** Kill ring */
-typedef std::list<wcstring> kill_list_t;
+using kill_list_t = std::list<wcstring>;
 static kill_list_t kill_list;
 
 void kill_add(wcstring str) {

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -20,9 +20,9 @@
 #include "screen.h"
 #include "wutil.h"  // IWYU pragma: keep
 
-typedef pager_t::comp_t comp_t;
-typedef std::vector<completion_t> completion_list_t;
-typedef std::vector<comp_t> comp_info_list_t;
+using comp_t = pager_t::comp_t;
+using completion_list_t = std::vector<completion_t>;
+using comp_info_list_t = std::vector<comp_t>;
 
 /// The minimum width (in characters) the terminal must to show completions at all.
 #define PAGER_MIN_WIDTH 16

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -1078,7 +1078,7 @@ parse_execution_result_t parse_execution_context_t::apply_variable_assignments(
             vals.emplace_back(std::move(completion.completion));
         }
         if (proc) proc->variable_assignments.push_back({variable_name, vals});
-        parser->vars().set(std::move(variable_name), ENV_LOCAL | ENV_EXPORT, std::move(vals));
+        parser->vars().set(variable_name, ENV_LOCAL | ENV_EXPORT, std::move(vals));
     }
     return parse_execution_success;
 }

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -460,7 +460,7 @@ static wchar_t get_quote(const wcstring &cmd_str, size_t len) {
     wchar_t res = 0;
     const wchar_t *const cmd = cmd_str.c_str();
 
-    while (1) {
+    while (true) {
         if (!cmd[i]) break;
 
         if (cmd[i] == L'\\') {

--- a/src/parser.h
+++ b/src/parser.h
@@ -256,17 +256,17 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     /// \param block_type The type of block to push on the block stack
     ///
     /// \return 0 on success, 1 on a parse error.
-    int eval(wcstring cmd, const io_chain_t &io, enum block_type_t block_type);
+    int eval(const wcstring &cmd, const io_chain_t &io, enum block_type_t block_type);
 
     /// Evaluate the parsed source ps.
     /// \return 0 on success, 1 on a parse error.
-    int eval(parsed_source_ref_t ps, const io_chain_t &io, enum block_type_t block_type);
+    int eval(const parsed_source_ref_t &ps, const io_chain_t &io, enum block_type_t block_type);
 
     /// Evaluates a node.
     /// The node type must be grammar::statement or grammar::job_list.
     template <typename T>
-    int eval_node(parsed_source_ref_t ps, tnode_t<T> node, const io_chain_t &io,
-                  block_type_t block_type, std::shared_ptr<job_t> parent_job);
+    int eval_node(const parsed_source_ref_t &ps, tnode_t<T> node, const io_chain_t &io,
+                  block_type_t block_type, const std::shared_ptr<job_t> &parent_job);
 
     /// Evaluate line as a list of parameters, i.e. tokenize it and perform parameter expansion and
     /// cmdsubst execution on the tokens. Errors are ignored. If a parser is provided, it is used

--- a/src/parser_keywords.cpp
+++ b/src/parser_keywords.cpp
@@ -9,7 +9,7 @@
 #include "common.h"
 #include "fallback.h"  // IWYU pragma: keep
 
-typedef std::unordered_set<wcstring> string_set_t;
+using string_set_t = std::unordered_set<wcstring>;
 
 static const wcstring skip_keywords[]{
     L"else",

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -290,7 +290,7 @@ io_chain_t job_t::all_io_redirections() const {
     return result;
 }
 
-typedef unsigned int process_generation_count_t;
+using process_generation_count_t = unsigned int;
 
 /// A list of pids/pgids that have been disowned. They are kept around until either they exit or
 /// we exit. Poll these from time-to-time to prevent zombie processes from happening (#5342).

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2240,9 +2240,7 @@ static bool selection_is_at_top() {
     if (row != 0 && row != PAGER_SELECTION_NONE) return false;
 
     size_t col = pager->get_selected_column(data->current_page_rendering);
-    if (col != 0 && col != PAGER_SELECTION_NONE) return false;
-
-    return true;
+    return !(col != 0 && col != PAGER_SELECTION_NONE);
 }
 
 static relaxed_atomic_t<uint64_t> run_count{0};

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -517,7 +517,7 @@ static bool should_exit() { return s_end_current_loop || s_exit_forced; }
 static void term_donate(outputter_t &outp) {
     outp.set_color(rgb_color_t::normal(), rgb_color_t::normal());
 
-    while (1) {
+    while (true) {
         if (tcsetattr(STDIN_FILENO, TCSANOW, &tty_modes_for_external_cmds) == -1) {
             if (errno == EIO) redirect_tty_output();
             if (errno != EINTR) {
@@ -532,7 +532,7 @@ static void term_donate(outputter_t &outp) {
 
 /// Grab control of terminal.
 static void term_steal() {
-    while (1) {
+    while (true) {
         if (tcsetattr(STDIN_FILENO, TCSANOW, &shell_modes) == -1) {
             if (errno == EIO) redirect_tty_output();
             if (errno != EINTR) {
@@ -2224,7 +2224,7 @@ static void handle_end_loop(const parser_t &parser) {
         if (!data->prev_end_loop && bg_jobs) {
             reader_bg_job_warning(parser);
             reader_set_end_loop(false);
-            data->prev_end_loop = 1;
+            data->prev_end_loop = true;
             return;
         }
     }
@@ -2261,7 +2261,7 @@ static int read_i(parser_t &parser) {
     reader_import_history_if_necessary();
 
     reader_data_t *data = current_data();
-    data->prev_end_loop = 0;
+    data->prev_end_loop = false;
 
     while (!shell_is_exiting()) {
         run_count++;
@@ -2302,7 +2302,7 @@ static int read_i(parser_t &parser) {
             if (shell_is_exiting()) {
                 handle_end_loop(parser);
             } else {
-                data->prev_end_loop = 0;
+                data->prev_end_loop = false;
             }
         }
     }
@@ -3254,7 +3254,7 @@ maybe_t<wcstring> reader_data_t::readline(int nchars_or_0) {
         }
 
         maybe_t<char_event_t> event_needing_handling{};
-        while (1) {
+        while (true) {
             event_needing_handling = read_normal_chars(rls);
             if (event_needing_handling.has_value()) break;
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1301,7 +1301,7 @@ static std::function<autosuggestion_result_t(void)> get_autosuggestion_performer
 
         history_search_t searcher(*history, search_string, history_search_type_t::prefix);
         while (!reader_test_should_cancel() && searcher.go_backwards()) {
-            history_item_t item = searcher.current_item();
+            const history_item_t &item = searcher.current_item();
 
             // Skip items with newlines because they make terrible autosuggestions.
             if (item.str().find(L'\n') != wcstring::npos) continue;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -278,7 +278,7 @@ maybe_t<prompt_layout_t> layout_cache_t::find_prompt_layout(const wcstring &inpu
 
 void layout_cache_t::add_prompt_layout(wcstring input, prompt_layout_t layout) {
     assert(!find_prompt_layout(input) && "Should not have a prompt layout for this input");
-    prompt_cache_.emplace_front(std::move(input), std::move(layout));
+    prompt_cache_.emplace_front(std::move(input), layout);
     if (prompt_cache_.size() > prompt_cache_max_size) {
         prompt_cache_.pop_back();
     }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -1226,9 +1226,6 @@ void screen_force_clear_to_end() {
 
 screen_t::screen_t()
     : outp_(outputter_t::stdoutput()),
-      desired(),
-      actual(),
-      actual_left_prompt(),
       last_right_prompt_width(),
       actual_width(SCREEN_WIDTH_UNINITIALIZED),
       soft_wrap_location(INVALID_LOCATION),

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -47,7 +47,7 @@
 #define INDENT_STEP 4u
 
 /// The initial screen width.
-#define SCREEN_WIDTH_UNINITIALIZED -1
+#define SCREEN_WIDTH_UNINITIALIZED (-1)
 
 /// A helper value for an invalid location.
 #define INVALID_LOCATION (screen_data_t::cursor_t(-1, -1))

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -38,9 +38,9 @@
 
 // TODO: It would be nice not to rely on a typedef for this, especially one that can only do
 // functions with two args.
-typedef double (*te_fun2)(double, double);
-typedef double (*te_fun1)(double);
-typedef double (*te_fun0)();
+using te_fun2 = double (*)(double, double);
+using te_fun1 = double (*)(double);
+using te_fun0 = double (*)();
 
 enum {
     TE_CONSTANT = 0,

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -33,10 +33,10 @@
 #define _BOM 0xfeff
 
 // We can tweak the following typedef to allow us to simulate Windows-style 16 bit wchar's on Unix.
-typedef wchar_t utf8_wchar_t;
+using utf8_wchar_t = wchar_t;
 #define UTF8_WCHAR_MAX (wchar_t) std::numeric_limits<utf8_wchar_t>::max()
 
-typedef std::basic_string<utf8_wchar_t> utf8_wstring_t;
+using utf8_wstring_t = std::basic_string<utf8_wchar_t>;
 
 static size_t utf8_to_wchar_internal(const char *in, size_t insize, utf8_wstring_t *out_string,
                                      int flags);

--- a/src/wcstringutil.cpp
+++ b/src/wcstringutil.cpp
@@ -7,7 +7,7 @@
 
 #include "common.h"
 
-typedef wcstring::size_type size_type;
+using size_type = wcstring::size_type;
 
 wcstring_range wcstring_tok(wcstring &str, const wcstring &needle, wcstring_range last) {
     size_type pos = last.second == wcstring::npos ? wcstring::npos : last.first;

--- a/src/wildcard.cpp
+++ b/src/wildcard.cpp
@@ -927,7 +927,7 @@ int wildcard_expand_string(const wcstring &wc, const wcstring &working_directory
     // Check for a leading slash. If we find one, we have an absolute path: the prefix is empty, the
     // base dir is /, and the wildcard is the remainder. If we don't find one, the prefix is the
     // working directory, the base dir is empty.
-    wcstring prefix = L"", base_dir = L"", effective_wc;
+    wcstring prefix, base_dir, effective_wc;
     if (string_prefixes_string(L"/", wc)) {
         base_dir = L"/";
         effective_wc = wc.substr(1);

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -127,8 +127,7 @@ bool wreaddir_for_dirs(DIR *dir, wcstring *out_name) {
     if (result && out_name) {
         *out_name = str2wcstring(result->d_name);
     }
-    if (!result) return false;
-    return true;
+    return result != nullptr;
 }
 
 const wcstring wgetcwd() {

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -31,7 +31,7 @@
 #include "flog.h"
 #include "wutil.h"  // IWYU pragma: keep
 
-typedef std::string cstring;
+using cstring = std::string;
 
 const file_id_t kInvalidFileID = {static_cast<dev_t>(-1LL),
                                   static_cast<ino_t>(-1LL),


### PR DESCRIPTION
First change is to fix deprecated usleep usage, which is optionally not available everywhere. Other changes are more clang-tidy ones.