### PR TITLE
Fix Windows path support for WSL/Cygwin

### DIFF
--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -143,6 +143,7 @@ function help --description 'Show help for the fish shell'
         if type -q cygpath
             set page_url file://(cygpath -m $__fish_help_dir)/$fish_help_page
         else if type -q wslpath
+        and string match -qr '.exe' $fish_browser
             set page_url file://(wslpath -w $__fish_help_dir)/$fish_help_page
         end
     else

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -94,9 +94,11 @@ function help --description 'Show help for the fish shell'
         return 1
     end
 
-    # In Cygwin, start the user-specified browser using cygstart
+    # In Cygwin, start the user-specified browser using cygstart,
+    # only if a Windows browser is to be used.
     if type -q cygstart
         if test $fish_browser != "cygstart"
+        and not command -sq $fish_browser[1]
             # Escaped quotes are necessary to work with spaces in the path
             # when the command is finally eval'd.
             set fish_browser cygstart \"$fish_browser\"
@@ -140,10 +142,12 @@ function help --description 'Show help for the fish shell'
         set page_url file://$__fish_help_dir/$fish_help_page
 
         # For Windows (Cygwin and WSL), we need to convert the base help dir to a Windows path before converting it to a file URL
+        # but only if a Windows browser is being used
         if type -q cygpath
+        and string match -qr "cygstart" $fish_browser[1]
             set page_url file://(cygpath -m $__fish_help_dir)/$fish_help_page
         else if type -q wslpath
-        and string match -qr '.exe' $fish_browser
+        and string match -qr '.exe' $fish_browser[1]
             set page_url file://(wslpath -w $__fish_help_dir)/$fish_help_page
         end
     else


### PR DESCRIPTION
## Description

Using fish 3.0.2 and WSL1 on Win10 v1909, running `help` attempts to open the fish help page with a WSL-local path (/usr/...) which is unable to be accessed by cmd.exe which runs outside of WSL.

Also likely fixes issue #6338 
