### PR TITLE
Add lz4 and zstd completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,11 +111,13 @@
   - `irb` (#6260)
   - `iw` (#6232)
   - `kak`
+  - `lz4`, `lz4c` and `lz4cat` (#6364)
   - `mariner` (#5718)
   - `nethack` (#6240)
   - `patool` (#6083)
   - `phpunit` (#6197)
   - `plutil` (#6301)
+  - `pzstd` (#6364)
   - `qubes-gpg-client` (#6067)
   - `rg`
   - `rustup`
@@ -124,8 +126,11 @@
   - `src` (#6026)
   - `tokei` (#6085)
   - `tsc` (#6016)
+  - `unlz4` (#6364)
+  - `unzstd` (#6364)
   - `vbc` (#6016)
   - `zpaq` (#6245)
+  - `zstd`, `zstdcat`, `zstdgrep`, `zstdless` and `zstdmt` (#6364)
 - Lots of improvements to completions.
 
 ### Deprecations

--- a/share/completions/lz4.fish
+++ b/share/completions/lz4.fish
@@ -1,0 +1,41 @@
+# Completions for lz4
+
+complete -c lz4 -s z -l compress -d "Compress (default)"
+complete -c lz4 -s d -l decompress -l uncompress -d "Decompress" -x -a "
+(
+    __fish_complete_suffix .lz4
+)
+"
+
+complete -c lz4 -s t -l test -d "Test the integrity"
+complete -c lz4 -l list -d "List information about .lz4 file(s)"
+
+for level in (seq 1 12)
+    complete -c lz4 -o $level -d "Set compression level"
+end
+
+complete -c lz4 -l fast -d "Ultra-fast compression"
+complete -c lz4 -l best -d "Highest compression, same as -12"
+complete -c lz4 -l favor-decSpeed -d "Generate file(s) optimized for decompression speed"
+complete -r -c lz4 -s D -d "Use specified file as dictionary"
+complete -c lz4 -s f -l force -d "Overwrite without prompting"
+complete -c lz4 -s c -l stdout -l to-stdout -d "Force write to stdout"
+complete -c lz4 -s m -l multiple -d "Multiple input files"
+complete -c lz4 -s r -d "Recurse directories"
+complete -c lz4 -o B4 -d "Set block size to 64KB"
+complete -c lz4 -o B5 -d "Set block size to 256KB"
+complete -c lz4 -o B6 -d "Set block size to 1MB"
+complete -c lz4 -o B7 -d "Set block size to 4MB"
+complete -c lz4 -o BI -d "Block independence (default)"
+complete -c lz4 -o BD -d "Block dependency"
+complete -c lz4 -l no-frame-crc -d "Disable frame checksum"
+complete -c lz4 -l content-size -d "Header includes original size"
+complete -c lz4 -l sparse -d "Enable sparse mode"
+complete -c lz4 -l no-sparse -d "Disable sparse mode"
+complete -c lz4 -s v -l verbose -d "Be verbose"
+complete -c lz4 -s q -l quiet -d "Suppress warnings"
+complete -c lz4 -s h -l help -d "Show help"
+complete -c lz4 -s H -d "Show long help"
+complete -c lz4 -s V -l version -d "Show version"
+complete -c lz4 -s k -l keep -d "Keep input file(s) (default)"
+complete -c lz4 -l rm -d "Remove input file(s) after de/compression"

--- a/share/completions/lz4c.fish
+++ b/share/completions/lz4c.fish
@@ -1,0 +1,3 @@
+# Completions for lz4c
+
+complete -c lz4c -w lz4

--- a/share/completions/lz4cat.fish
+++ b/share/completions/lz4cat.fish
@@ -1,0 +1,18 @@
+# Completions for lz4cat
+
+complete -c lz4cat -x -a "
+(
+    __fish_complete_suffix .lz4
+)
+"
+
+complete -c lz4cat -s t -l test -d "Test the integrity"
+complete -c lz4cat -l list -d "List information about .lz4 file(s)"
+complete -r -c lz4cat -s D -d "Use specified file as dictionary"
+complete -c lz4cat -l sparse -d "Enable sparse mode"
+complete -c lz4cat -l no-sparse -d "Disable sparse mode"
+complete -c lz4cat -s v -l verbose -d "Be verbose"
+complete -c lz4cat -s q -l quiet -d "Suppress warnings"
+complete -c lz4cat -s h -l help -d "Show help"
+complete -c lz4cat -s H -d "Show long help"
+complete -c lz4cat -s V -l version -d "Show version"

--- a/share/completions/pzstd.fish
+++ b/share/completions/pzstd.fish
@@ -14,8 +14,14 @@ end
 
 complete -c pzstd -l ultra -d "Enable compression level beyond 19"
 
-for threads in (seq 1 (count (cat /proc/cpuinfo | string match -r "processor")))
-    complete -x -c pzstd -s p -l processes -a "$threads" -d "De/compress using $threads working threads"
+## If Python 3.4 or later installed, the number of physical cores is assigned to a variable.
+set -l python (__fish_anypython)
+set -q python[1]; and set -l physical_cores ($python -c 'import os; os.cpu_count() is not None and print(os.cpu_count())' 2> /dev/null)
+
+if set -q physical_cores; and test -n "$physical_cores"
+    complete -x -c pzstd -s p -l processes -a "(seq 1 $physical_cores)" -d "De/compress using $threads working threads"
+else
+    complete -x -c pzstd -s p -l processes -a NUM -d "De/compress using NUM working threads"
 end
 
 complete -r -c pzstd -s o -d "Specify file to save"

--- a/share/completions/pzstd.fish
+++ b/share/completions/pzstd.fish
@@ -1,0 +1,32 @@
+# Completions for pzstd
+
+complete -c pzstd -s d -l decompress -d "Decompress" -x -a "
+(
+    __fish_complete_suffix .zst
+)
+"
+
+complete -c pzstd -s t -l test -d "Test the integrity"
+
+for level in (seq 1 19)
+    complete -c pzstd -o $level -d "Set compression level"
+end
+
+complete -c pzstd -l ultra -d "Enable compression level beyond 19"
+
+for threads in (seq 1 (count (cat /proc/cpuinfo | string match -r "processor")))
+    complete -x -c pzstd -s p -l processes -a "$threads" -d "De/compress using $threads working threads"
+end
+
+complete -r -c pzstd -s o -d "Specify file to save"
+complete -c pzstd -s f -l force -d "Overwrite without prompting"
+complete -c pzstd -s c -l stdout -d "Force write to stdout"
+complete -c pzstd -l rm -d "Remove input file(s) after de/compression"
+complete -c pzstd -s k -l keep -d "Keep input file(s) (default)"
+complete -c pzstd -s r -d "Recurse directories"
+complete -c pzstd -s h -l help -d "Show help"
+complete -c pzstd -s H -d "Show long help"
+complete -c pzstd -s V -l version -d "Show version"
+complete -c pzstd -s v -l verbose -d "Be verbose"
+complete -c pzstd -s q -l quiet -d "Suppress warnings"
+complete -c pzstd -l no-check -d "Disable integrity check"

--- a/share/completions/unlz4.fish
+++ b/share/completions/unlz4.fish
@@ -1,0 +1,23 @@
+# Completions for unlz4
+
+complete -c unlz4 -x -a "
+(
+    __fish_complete_suffix .lz4
+)
+"
+
+complete -c unlz4 -s t -l test -d "Test the integrity"
+complete -c unlz4 -l list -d "List information about .lz4 file(s)"
+complete -r -c unlz4 -s D -d "Use specified file as dictionary"
+complete -c unlz4 -s f -l force -d "Overwrite without prompting"
+complete -c unlz4 -s c -l stdout -l to-stdout -d "Force write to stdout"
+complete -c unlz4 -s m -l multiple -d "Multiple input files"
+complete -c unlz4 -l sparse -d "Enable sparse mode"
+complete -c unlz4 -l no-sparse -d "Disable sparse mode"
+complete -c unlz4 -s v -l verbose -d "Be verbose"
+complete -c unlz4 -s q -l quiet -d "Suppress warnings"
+complete -c unlz4 -s h -l help -d "Show help"
+complete -c unlz4 -s H -d "Show long help"
+complete -c unlz4 -s V -l version -d "Show version"
+complete -c unlz4 -s k -l keep -d "Keep input file(s) (default)"
+complete -c unlz4 -l rm -d "Remove input file(s) after decompression"

--- a/share/completions/unzstd.fish
+++ b/share/completions/unzstd.fish
@@ -1,0 +1,35 @@
+# Completions for unzstd
+
+complete -c unzstd -x -a "
+(
+    __fish_complete_suffix .zst
+)
+"
+
+complete -c unzstd -s t -l test -d "Test the integrity"
+complete -r -c unzstd -l train -d "Create a dictionary from specified file(s)"
+complete -c unzstd -s l -l list -d "List information about .zst file(s)"
+complete -c unzstd -l long -d "Enable long distance matching with specified windowLog"
+complete -c unzstd -l single-thread -d "Single-thread mode"
+complete -r -c unzstd -s D -d "Use specified file as dictionary"
+complete -r -c unzstd -s o -d "Specify file to save"
+complete -c unzstd -s f -l force -d "Overwrite without prompting"
+complete -c unzstd -s c -l stdout -d "Force write to stdout"
+complete -c unzstd -l sparse -d "Enable sparse mode"
+complete -c unzstd -l no-sparse -d "Disable sparse mode"
+complete -c unzstd -l rm -d "Remove input file(s) after decompression"
+complete -c unzstd -s k -l keep -d "Keep input file(s) (default)"
+complete -c unzstd -s r -d "Recurse directories"
+complete -c unzstd -l filelist -d "Read a list of files"
+complete -c unzstd -l output-dir-flat -d "Specify a directory to output all files"
+
+for format in zstd gzip xz lzma lz4
+    complete -c unzstd -l format="$format" -d "Specify the format to use for decompression"
+end
+
+complete -c unzstd -s h -l help -d "Show help"
+complete -c unzstd -s H -d "Show long help"
+complete -c unzstd -s V -l version -d "Show version"
+complete -c unzstd -s v -l verbose -d "Be verbose"
+complete -c unzstd -s q -l quiet -d "Suppress warnings"
+complete -c unzstd -l no-progress -d "Do not show the progress bar"

--- a/share/completions/zstd.fish
+++ b/share/completions/zstd.fish
@@ -1,0 +1,58 @@
+# Completions for zstd
+
+complete -c zstd -s z -l compress -d "Compress (default)"
+complete -c zstd -s d -l decompress -l uncompress -d "Decompress" -x -a "
+(
+    __fish_complete_suffix .zst
+)
+"
+
+complete -c zstd -s t -l test -d "Test the integrity"
+complete -r -c zstd -l train -d "Create a dictionary from specified file(s)"
+complete -c zstd -s l -l list -d "List information about .zst file(s)"
+
+for level in (seq 1 19)
+    complete -c zstd -o $level -d "Set compression level"
+end
+
+complete -c zstd -l fast -d "Ultra-fast compression"
+complete -c zstd -l ultra -d "Enable compression level beyond 19"
+complete -c zstd -l long -d "Enable long distance matching with specified windowLog"
+
+for threads in (seq 0 (count (cat /proc/cpuinfo | string match -r "processor")))
+    if test $threads -eq 0
+        complete -c zstd -o T"$threads" -l threads="$threads" -d "Compress using as many threads as there are CPU cores on the system"
+    else
+        complete -c zstd -o T"$threads" -l threads="$threads" -d "Compress using $threads working threads"
+    end
+end
+
+complete -c zstd -l single-thread -d "Single-thread mode"
+complete -c zstd -l adapt -d "Dynamically adapt compression level to I/O conditions"
+complete -c zstd -l stream-size -d "Optimize compression parameters for streaming input of specified bytes"
+complete -c zstd -l size-hint -d "Optimize compression parameters for streaming input of approximately this size"
+complete -c zstd -l rsyncable -d "Compress using a rsync-friendly method"
+complete -r -c zstd -s D -d "Use specified file as dictionary"
+complete -c zstd -l no-dictID -d "Do not write dictID into header"
+complete -r -c zstd -s o -d "Specify file to save"
+complete -c zstd -s f -l force -d "Overwrite without prompting"
+complete -c zstd -s c -l stdout -d "Force write to stdout"
+complete -c zstd -l sparse -d "Enable sparse mode"
+complete -c zstd -l no-sparse -d "Disable sparse mode"
+complete -c zstd -l rm -d "Remove input file(s) after de/compression"
+complete -c zstd -s k -l keep -d "Keep input file(s) (default)"
+complete -c zstd -s r -d "Recurse directories"
+complete -c zstd -l filelist -d "Read a list of files"
+complete -c zstd -l output-dir-flat -d "Specify a directory to output all files"
+
+for format in zstd gzip xz lzma lz4
+    complete -c zstd -l format="$format" -d "Specify the format to use for compression"
+end
+
+complete -c zstd -s h -l help -d "Show help"
+complete -c zstd -s H -d "Show long help"
+complete -c zstd -s V -l version -d "Show version"
+complete -c zstd -s v -l verbose -d "Be verbose"
+complete -c zstd -s q -l quiet -d "Suppress warnings"
+complete -c zstd -l no-progress -d "Do not show the progress bar"
+complete -c zstd -l no-check -d "Disable integrity check"

--- a/share/completions/zstd.fish
+++ b/share/completions/zstd.fish
@@ -19,12 +19,18 @@ complete -c zstd -l fast -d "Ultra-fast compression"
 complete -c zstd -l ultra -d "Enable compression level beyond 19"
 complete -c zstd -l long -d "Enable long distance matching with specified windowLog"
 
-for threads in (seq 0 (count (cat /proc/cpuinfo | string match -r "processor")))
-    if test $threads -eq 0
-        complete -c zstd -o T"$threads" -l threads="$threads" -d "Compress using as many threads as there are CPU cores on the system"
-    else
+## If Python 3.4 or later installed, the number of physical cores is assigned to a variable.
+set -l python (__fish_anypython)
+set -q python[1]; and set -l physical_cores ($python -c 'import os; os.cpu_count() is not None and print(os.cpu_count())' 2> /dev/null)
+## When using all physical cores.
+complete -c zstd -o T0 -l threads=0 -d "Compress using as many threads as there are CPU cores on the system"
+
+if set -q physical_cores; and test -n "$physical_cores"
+    for threads in (seq 1 $physical_cores)
         complete -c zstd -o T"$threads" -l threads="$threads" -d "Compress using $threads working threads"
     end
+else
+    complete -c zstd -o TNUM -l threads=NUM -d "Compress using NUM working threads"
 end
 
 complete -c zstd -l single-thread -d "Single-thread mode"

--- a/share/completions/zstdcat.fish
+++ b/share/completions/zstdcat.fish
@@ -1,0 +1,28 @@
+# Completions for zstdcat
+
+complete -c zstdcat -x -a "
+(
+    __fish_complete_suffix .zst
+)
+"
+
+complete -c zstdcat -s t -l test -d "Test the integrity"
+complete -c zstdcat -s l -l list -d "List information about .zst file(s)"
+complete -c zstdcat -l long -d "Enable long distance matching with specified windowLog"
+complete -c zstdcat -l single-thread -d "Single-thread mode"
+complete -r -c zstdcat -s D -d "Use specified file as dictionary"
+complete -c zstdcat -l sparse -d "Enable sparse mode"
+complete -c zstdcat -l no-sparse -d "Disable sparse mode"
+complete -c zstdcat -s r -d "Recurse directories"
+complete -c zstdcat -l filelist -d "Read a list of files"
+
+for format in zstd gzip xz lzma lz4
+    complete -c zstdcat -l format="$format" -d "Specify the format to use for decompression"
+end
+
+complete -c zstdcat -s h -l help -d "Show help"
+complete -c zstdcat -s H -d "Show long help"
+complete -c zstdcat -s V -l version -d "Show version"
+complete -c zstdcat -s v -l verbose -d "Be verbose"
+complete -c zstdcat -s q -l quiet -d "Suppress warnings"
+complete -c zstdcat -l no-progress -d "Do not show the progress bar"

--- a/share/completions/zstdgrep.fish
+++ b/share/completions/zstdgrep.fish
@@ -1,0 +1,3 @@
+# Completions for zstdgrep
+
+complete -c zstdgrep -w grep

--- a/share/completions/zstdless.fish
+++ b/share/completions/zstdless.fish
@@ -1,0 +1,3 @@
+# Completions for zstdless
+
+complete -c zstdless -w zstdcat

--- a/share/completions/zstdmt.fish
+++ b/share/completions/zstdmt.fish
@@ -1,0 +1,49 @@
+# Completions for zstdmt
+
+complete -c zstdmt -s z -l compress -d "Compress (default)"
+complete -c zstdmt -s d -l decompress -l uncompress -d "Decompress" -x -a "
+(
+    __fish_complete_suffix .zst
+)
+"
+
+complete -c zstdmt -s t -l test -d "Test the integrity"
+complete -r -c zstdmt -l train -d "Create a dictionary from specified file(s)"
+complete -c zstdmt -s l -l list -d "List information about .zst file(s)"
+
+for level in (seq 1 19)
+    complete -c zstdmt -o $level -d "Set compression level"
+end
+
+complete -c zstdmt -l fast -d "Ultra-fast compression"
+complete -c zstdmt -l ultra -d "Enable compression level beyond 19"
+complete -c zstdmt -l long -d "Enable long distance matching with specified windowLog"
+complete -c zstdmt -l single-thread -d "Single-thread mode"
+complete -c zstdmt -l adapt -d "Dynamically adapt compression level to I/O conditions"
+complete -c zstdmt -l stream-size -d "Optimize compression parameters for streaming input of specified bytes"
+complete -c zstdmt -l size-hint -d "Optimize compression parameters for streaming input of approximately this size"
+complete -c zstdmt -l rsyncable -d "Compress using a rsync-friendly method"
+complete -r -c zstdmt -s D -d "Use specified file as dictionary"
+complete -c zstdmt -l no-dictID -d "Do not write dictID into header"
+complete -r -c zstdmt -s o -d "Specify file to save"
+complete -c zstdmt -s f -l force -d "Overwrite without prompting"
+complete -c zstdmt -s c -l stdout -d "Force write to stdout"
+complete -c zstdmt -l sparse -d "Enable sparse mode"
+complete -c zstdmt -l no-sparse -d "Disable sparse mode"
+complete -c zstdmt -l rm -d "Remove input file(s) after de/compression"
+complete -c zstdmt -s k -l keep -d "Keep input file(s) (default)"
+complete -c zstdmt -s r -d "Recurse directories"
+complete -c zstdmt -l filelist -d "Read a list of files"
+complete -c zstdmt -l output-dir-flat -d "Specify a directory to output all files"
+
+for format in zstd gzip xz lzma lz4
+    complete -c zstdmt -l format="$format" -d "Specify the format to use for compression"
+end
+
+complete -c zstdmt -s h -l help -d "Show help"
+complete -c zstdmt -s H -d "Show long help"
+complete -c zstdmt -s V -l version -d "Show version"
+complete -c zstdmt -s v -l verbose -d "Be verbose"
+complete -c zstdmt -s q -l quiet -d "Suppress warnings"
+complete -c zstdmt -l no-progress -d "Do not show the progress bar"
+complete -c zstdmt -l no-check -d "Disable integrity check"


### PR DESCRIPTION
## Description
Added completions for lz4 and zstd.

In commands other than `pzstd`, syntax of options such as `-T 4` and `--format zstd` does not seem to work. These options work when changed to `-T4` and `--format=zstd`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
