### PR TITLE
Add `read --tokenize`

### DIFF
--- a/benchmarks/benchmarks/aliases.fish
+++ b/benchmarks/benchmarks/aliases.fish
@@ -44,22 +44,12 @@ function alias --description 'Creates a function wrapping a command'
         return 1
     end
 
-    # Extract the first command from the body. This is supposed to replace all non-escaped (i.e.
-    # preceded by an odd number of `\`) spaces with a newline so it splits on them. See issue #2220
-    # for why the following borderline incomprehensible code exists.
-    set -l tmp (string replace -ra -- "([^\\\ ])((\\\\\\\)*) " '$1\n' $body)
-    set first_word (string trim -- $tmp[1])
-    # If the user does something like `alias x 'foo; bar'` we need to strip the semicolon.
-    set base_command (string trim -c ';' -- $first_word)
-    if set -q tmp[2]
-        set body $tmp[2..-1]
-    else
-        set body
-    end
+    # Extract the first command from the body.
+    printf '%s\n' $body | read -lt first_word body
 
     # Prevent the alias from immediately running into an infinite recursion if
     # $body starts with the same command as $name.
-    if test $base_command = $name
+    if test $first_word = $name
         if contains $name (builtin --names)
             set prefix builtin
         else

--- a/share/functions/alias.fish
+++ b/share/functions/alias.fish
@@ -44,22 +44,12 @@ function alias --description 'Creates a function wrapping a command'
         return 1
     end
 
-    # Extract the first command from the body. This is supposed to replace all non-escaped (i.e.
-    # preceded by an odd number of `\`) spaces with a newline so it splits on them. See issue #2220
-    # for why the following borderline incomprehensible code exists.
-    set -l tmp (string replace -ra -- "([^\\\ ])((\\\\\\\)*) " '$1\n' $body)
-    set first_word (string trim -- $tmp[1])
-    # If the user does something like `alias x 'foo; bar'` we need to strip the semicolon.
-    set base_command (string trim -c ';' -- $first_word)
-    if set -q tmp[2]
-        set body $tmp[2..-1]
-    else
-        set body
-    end
+    # Extract the first command from the body.
+    printf '%s\n' $body | read -lt first_word body
 
     # Prevent the alias from immediately running into an infinite recursion if
     # $body starts with the same command as $name.
-    if test $base_command = $name
+    if test $first_word = $name
         if contains $name (builtin --names)
             set prefix builtin
         else

--- a/sphinx_doc_src/cmds/read.rst
+++ b/sphinx_doc_src/cmds/read.rst
@@ -38,6 +38,8 @@ The following options are available:
 
 - ``-S`` or ``--shell`` enables syntax highlighting, tab completions and command termination suitable for entering shellscript code in the interactive mode. NOTE: Prior to fish 3.0, the short opt for ``--shell`` was ``-s``, but it has been changed for compatibility with bash's ``-s`` short opt for ``--silent``.
 
+- ``-t`` -or ``--tokenize`` causes read to split the input into variables by the shell's tokenization rules. This means it will honor quotes and escaping. This option is of course incompatible with other options to control splitting like ``--delimiter`` and does not honor $IFS (like fish's tokenizer). It saves the tokens in the manner they'd be passed to commands on the commandline, so e.g. ``a\ b`` is stored as ``a b``. Note that currently it leaves command substitutions intact along with the parentheses.
+
 - ``-u`` or ``--unexport`` prevents the variables from being exported to child processes (default behaviour).
 
 - ``-U`` or ``--universal`` causes the specified shell variable to be made universal.
@@ -53,7 +55,7 @@ The following options are available:
 
 Without the ``--line`` option, ``read`` reads a single line of input from standard input, breaks it into tokens, and then assigns one token to each variable specified in ``VARIABLES``. If there are more tokens than variables, the complete remainder is assigned to the last variable.
 
-If the ``--delimiter`` argument is not given, the variable ``IFS`` is used as a list of characters to split on. Relying on the use of ``IFS`` is deprecated and this behaviour will be removed in future versions. The default value of ``IFS`` contains space, tab and newline characters. As a special case, if ``IFS`` is set to the empty string, each character of the input is considered a separate token.
+If no option to determine how to split like ``--delimiter``, ``--line`` or ``--tokenize`` is given, the variable ``IFS`` is used as a list of characters to split on. Relying on the use of ``IFS`` is deprecated and this behaviour will be removed in future versions. The default value of ``IFS`` contains space, tab and newline characters. As a special case, if ``IFS`` is set to the empty string, each character of the input is considered a separate token.
 
 With the ``--line`` option, ``read`` reads a line of input from standard input into each provided variable, stopping when each variable has been filled. The line is not tokenized.
 
@@ -101,3 +103,12 @@ The following code stores the value 'hello' in the shell variable ``$foo``.
     echo $a # a
     echo $b # b
     echo $c # c
+
+    # --tokenize honors quotes and escaping like the shell's argument passing:
+    echo 'a\ b' | read -t first second
+    echo $first # outputs "a b", $second is empty
+
+    echo 'a"foo bar"b (command echo wurst)*" "{a,b}' | read -lt -l a b c
+    echo $a # outputs 'afoo bar' (without the quotes)
+    echo $b # outputs '(command echo wurst)* {a,b}' (without the quotes)
+    echo $c # nothing

--- a/tests/checks/alias.fish
+++ b/tests/checks/alias.fish
@@ -10,9 +10,11 @@ my_alias
 
 alias a-2='echo "hello there"'
 
+alias foo '"a b" c d e'
 # Bare `alias` should list the aliases we have created and nothing else
 # We have to exclude two aliases because they're an artifact of the unit test
 # framework and we can't predict the definition.
 alias | grep -Ev '^alias (fish_indent|fish_key_reader) '
 # CHECK: alias a-2 'echo "hello there"'
+# CHECK: alias foo '"a b" c d e'
 # CHECK: alias my_alias 'foo; and echo foo ran'

--- a/tests/checks/read.fish
+++ b/tests/checks/read.fish
@@ -1,0 +1,14 @@
+# RUN: %fish %s
+echo 'a | b' | read -lt a b c
+
+set -l
+# CHECK: a a
+# CHECK: b '|'
+# CHECK: c b
+
+echo 'a"foo bar"b' | read -lt a b c
+
+set -l
+# CHECK: a 'afoo barb'
+# CHECK: b
+# CHECK: c


### PR DESCRIPTION
## Description

This adds a `--tokenize` option to `read` that splits the input into variables by tokenizing it. That means it'll obey quotes and escaping and such.

Because it uses the actual tokenizer, it doesn't descend into command substitutions, which is a tad weird.

Note that this unescapes the tokens so they appear as they'd be passed on (and you can basically do `echo "somecommandline"  | read -lat cmdline; $cmdline` to run it). I decided that that one was the more usable mode, otherwise you'd have to constantly `string unescape` tokens. It would be simple to add a "--tokenize-raw" mode that doesn't, which might be useful for bindings and such where you actually care about things *as they look*.

Fixes issue #3823. Note that issue asked for `string tokenize`. I chose `read` instead because that manipulates multiple variables (also it's the builtin you'd pick in POSIX).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added
- [ ] User-visible changes noted in CHANGELOG.md
