### PR TITLE
Remove deprecated fish_vi_mode function

### DIFF
--- a/share/functions/fish_vi_mode.fish
+++ b/share/functions/fish_vi_mode.fish
@@ -1,6 +1,0 @@
-function fish_vi_mode
-    echo 'The `fish_vi_mode` function is deprecated.' >&2
-    echo 'Please switch to calling `fish_vi_key_bindings`.' >&2
-    # Turn on vi keybindings
-    set -g fish_key_bindings fish_vi_key_bindings
-end


### PR DESCRIPTION
## Description

One of the tasks from #5279.
Should be OK for it to go with next release as no longer mentioned in docs either.