### PR TITLE
Handle multiple arguments in $PAGER

### DIFF
--- a/share/functions/__fish_paginate.fish
+++ b/share/functions/__fish_paginate.fish
@@ -2,7 +2,7 @@ function __fish_paginate -d "Paginate the current command using the users defaul
 
     set -l cmd less
     if set -q PAGER
-        set cmd $PAGER
+        echo $PAGER | read -at cmd
     end
 
     if test -z (commandline -j | string join '')

--- a/share/functions/__fish_print_help.fish
+++ b/share/functions/__fish_print_help.fish
@@ -110,7 +110,7 @@ function __fish_print_help --description "Print help message for the specified f
     begin
         set -l pager less
         set -q PAGER
-        and set pager $PAGER
+        and echo $PAGER | read -at pager
         not isatty stdout
         and set pager cat # cannot use a builtin here
         # similar to man, but add -F to quit paging when the help output is brief (#6227)

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -86,7 +86,7 @@ function history --description "display or manipulate interactive command histor
             if isatty stdout
                 set -l pager less
                 set -q PAGER
-                and set pager $PAGER
+                and echo $PAGER | read -at pager
 
                 # If the user hasn't preconfigured less with the $LESS environment variable,
                 # we do so to have it behave like cat if output fits on one screen. Prevent the


### PR DESCRIPTION
## Description

`$PAGER` may contain arguments, and should thus be word-split before invocation.

On NixOS, `$PAGER` defaults to `less -R`, which breaks fish's history command:

    edef@vixen ~> history
    less -R: command not found
    /nix/store/2avc537xc3sibmw7a12nffnxrdvyc2y8-fish-3.0.2/share/fish/functions/history.fish (line 99):
                    builtin history search $search_mode $show_time $max_count $_flag_case_sensitive $_flag_reverse $_flag_null -- $argv | $pager
                                                                                                                                          ^
    in function “history”
    	called on standard input


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md