### PR TITLE
Move __fish_print_abook_emails into mutt completion script

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -67455,11 +67455,6 @@ msgstr ""
 msgid "Obtain a list of ports local collections"
 msgstr "Liste laufender screen-Sitzungen ausgeben"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_abook_emails.fish:1
-#, fuzzy
-msgid "Print email addresses (abook)"
-msgstr "Tote Prozesse ausgeben"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 #, fuzzy
 msgid "Print a list of known network addresses"

--- a/po/en.po
+++ b/po/en.po
@@ -66804,10 +66804,6 @@ msgstr ""
 msgid "Obtain a list of ports local collections"
 msgstr "Print a list of local users"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_abook_emails.fish:1
-msgid "Print email addresses (abook)"
-msgstr "Print email addresses (abook)"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr "Print a list of known network addresses"

--- a/po/fr.po
+++ b/po/fr.po
@@ -65773,10 +65773,6 @@ msgstr ""
 msgid "Obtain a list of ports local collections"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_abook_emails.fish:1
-msgid "Print email addresses (abook)"
-msgstr "Afficher les adresses email (abook)"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -62226,10 +62226,6 @@ msgstr ""
 msgid "Obtain a list of ports local collections"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_abook_emails.fish:1
-msgid "Print email addresses (abook)"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -62226,10 +62226,6 @@ msgstr ""
 msgid "Obtain a list of ports local collections"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_abook_emails.fish:1
-msgid "Print email addresses (abook)"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -62816,10 +62816,6 @@ msgstr ""
 msgid "Obtain a list of ports local collections"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_abook_emails.fish:1
-msgid "Print email addresses (abook)"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -67934,11 +67934,6 @@ msgstr ""
 msgid "Obtain a list of ports local collections"
 msgstr "Print a list of all accepted color names"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_abook_emails.fish:1
-#, fuzzy
-msgid "Print email addresses (abook)"
-msgstr "Print dead processes"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 #, fuzzy
 msgid "Print a list of known network addresses"

--- a/po/sv.po
+++ b/po/sv.po
@@ -62230,10 +62230,6 @@ msgstr ""
 msgid "Obtain a list of ports local collections"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_abook_emails.fish:1
-msgid "Print email addresses (abook)"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -62777,10 +62777,6 @@ msgstr ""
 msgid "Obtain a list of ports local collections"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_abook_emails.fish:1
-msgid "Print email addresses (abook)"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""

--- a/share/completions/mutt.fish
+++ b/share/completions/mutt.fish
@@ -1,3 +1,8 @@
+function __fish_print_abook_emails --description 'Print email addresses (abook)'
+    abook --mutt-query "" | string match -r -v '^\s*$'
+
+end
+
 if command -sq abook
     complete -c mutt -f -a '(__fish_print_abook_emails)'
     complete -c mutt -s c -x -d 'Specify a carbon-copy (CC) recipient' -a '(__fish_print_abook_emails)'
@@ -27,4 +32,3 @@ complete -r -c mutt -s i -d 'Specify a file to include into the body of a messag
 complete -r -c mutt -s m -d 'Specify a default mailbox type'
 complete -r -c mutt -s Q -d 'Query a configuration variables value'
 complete -r -c mutt -s s -d 'Specify the subject of the message'
-

--- a/share/functions/__fish_print_abook_emails.fish
+++ b/share/functions/__fish_print_abook_emails.fish
@@ -1,4 +1,0 @@
-function __fish_print_abook_emails --description 'Print email addresses (abook)'
-    abook --mutt-query "" | string match -r -v '^\s*$'
-
-end


### PR DESCRIPTION
## Description

One of the tasks from #5279.

Only place it was used was for the mutt completion script:
```
> rg -uu abook_emails share/.                                        
share/./functions/__fish_print_abook_emails.fish
1:function __fish_print_abook_emails --description 'Print email addresses (abook)'

share/./completions/mutt.fish
2:    complete -c mutt -f -a '(__fish_print_abook_emails)'
3:    complete -c mutt -s c -x -d 'Specify a carbon-copy (CC) recipient' -a '(__fish_print_abook_emails)'
4:    complete -c mutt -s b -x -d 'Specify a blind-carbon-copy (BCC) recipient' -a '(__fish_print_abook_emails)'
```
