### PR TITLE
Move __fish_portage_print_repository_names into emaint completion script

### DIFF
--- a/share/completions/emaint.fish
+++ b/share/completions/emaint.fish
@@ -1,3 +1,8 @@
+function __fish_portage_print_repository_names --description 'Print the names of all configured repositories'
+    # repos.conf may be a file or a directory
+    find /etc/portage/repos.conf -type f -exec cat '{}' + | string replace -r --filter '^\s*\[([[:alnum:]_][[:alnum:]_-]*)\]' '$1' | string match -v -e DEFAULT
+end
+
 ## Global Opts
 complete -c emaint -s h -l help -d "Show this help message and exit"
 complete -c emaint -s c -l check -d "Check for problems"

--- a/share/functions/__fish_portage_print_repository_names.fish
+++ b/share/functions/__fish_portage_print_repository_names.fish
@@ -1,4 +1,0 @@
-function __fish_portage_print_repository_names --description 'Print the names of all configured repositories'
-    # repos.conf may be a file or a directory
-    find /etc/portage/repos.conf -type f -exec cat '{}' + | string replace -r --filter '^\s*\[([[:alnum:]_][[:alnum:]_-]*)\]' '$1' | string match -v -e DEFAULT
-end


### PR DESCRIPTION
## Description

One of the tasks from #5279.

Only place it was used was for the emaint completion script:
```
> rg -uu __fish_portage_print_repository_names .
./share/functions/__fish_portage_print_repository_names.fish
1:function __fish_portage_print_repository_names --description 'Print the names of all configured repositories'

./share/completions/emaint.fish
30:    -xa "(__fish_portage_print_repository_names)"
```