### PR TITLE
Move __fish_ports_dirs into ports completion script

### DIFF
--- a/share/completions/ports.fish
+++ b/share/completions/ports.fish
@@ -1,8 +1,9 @@
-#completion for ports
+function __fish_ports_dirs -d 'Obtain a list of ports local collections'
+    ls /usr/ports
+end
 
 complete -f -c ports -s u -l update -a '(__fish_ports_dirs)' -d 'Update ports'
 complete -f -c ports -s l -l list -d 'List ports'
 complete -f -c ports -s d -l diff -d 'List version diffs between local and installed ports'
 complete -f -c ports -s v -l version -d 'Print version'
 complete -f -c ports -s h -l help -d 'Print help'
-

--- a/share/functions/__fish_ports_dirs.fish
+++ b/share/functions/__fish_ports_dirs.fish
@@ -1,5 +1,0 @@
-# a function to print a list of ports local collections
-
-function __fish_ports_dirs -d 'Obtain a list of ports local collections'
-    ls /usr/ports
-end


### PR DESCRIPTION
## Description

One of the tasks from #5279.

Only place it was used was for the ports completion script:
```
> rg -uu fish_ports_dirs .
./share/functions/__fish_ports_dirs.fish
3:function __fish_ports_dirs -d 'Obtain a list of ports local collections'

./share/completions/ports.fish
3:complete -f -c ports -s u -l update -a '(__fish_ports_dirs)' -d 'Update ports'
```