### PR TITLE
Move __fish_systemd_machines into machinectl completion script

### DIFF
--- a/share/completions/machinectl.fish
+++ b/share/completions/machinectl.fish
@@ -1,3 +1,11 @@
+function __fish_systemd_machine_images
+    # Like for running machines, I'm assuming machinectl doesn't allow spaces in image names
+    # This does not include the special image ".host" since it isn't valid for most operations
+    machinectl --no-legend --no-pager list-images | while read -l a b
+        echo $a
+    end
+end
+
 complete -f -e -c machinectl
 
 set -l commands list status show start login enable disable poweroff reboot \

--- a/share/functions/__fish_systemd_machines.fish
+++ b/share/functions/__fish_systemd_machines.fish
@@ -1,6 +1,0 @@
-# It seems machinectl will eliminate spaces from machine names so we don't need to handle that
-function __fish_systemd_machines
-    machinectl --no-legend --no-pager list --all | while read -l a b
-        echo $a
-    end
-end


### PR DESCRIPTION
## Description

One of the tasks from #5279.

Only place it was used was for the machinectl completion script:
```
> rg -uu __fish_systemd_machine_images .
./share/functions/__fish_systemd_machine_images.fish
3:function __fish_systemd_machine_images

./share/completions/machinectl.fish
8:    set -l images (__fish_systemd_machine_images)
114:complete -f -c machinectl -n "__fish_seen_subcommand_from start clone rename image-status show-image remove enable disable" -a "(__fish_systemd_machine_images)"
125:complete -f -c machinectl -n "__fish_seen_subcommand_from read-only; and not __fish_systemd_has_machine_image" -a "(__fish_systemd_machine_images)"
```