### PR TITLE
Move __fish_print_xdg_desktop_file_ids into xdg-mime completion script

### DIFF
--- a/share/completions/xdg-mime.fish
+++ b/share/completions/xdg-mime.fish
@@ -1,3 +1,6 @@
+function __fish_print_xdg_desktop_file_ids --description 'Print all available xdg desktop file IDs'
+    find (__fish_print_xdg_applications_directories) -name \*.desktop \( -type f -or -type l \) -printf '%P\n' | tr / - | sort -u
+end
 
 # main completion
 complete -c xdg-mime -n 'not __fish_seen_subcommand_from query default install uninstall' -xa 'query default install uninstall'

--- a/share/functions/__fish_print_xdg_desktop_file_ids.fish
+++ b/share/functions/__fish_print_xdg_desktop_file_ids.fish
@@ -1,3 +1,0 @@
-function __fish_print_xdg_desktop_file_ids --description 'Print all available xdg desktop file IDs'
-    find (__fish_print_xdg_applications_directories) -name \*.desktop \( -type f -or -type l \) -printf '%P\n' | tr / - | sort -u
-end


### PR DESCRIPTION
## Description

One of the tasks from #5279.

Only place it was used was for the xdg-mime completion script:
```
> rg -uu __fish_print_xdg_desktop_file_ids .
./share/completions/xdg-mime.fish
15:complete -c xdg-mime -d 'Choose application' -n '__fish_seen_subcommand_from default; and __fish_is_token_n 3' -xa '(__fish_print_xdg_desktop_file_ids)'

./share/functions/__fish_print_xdg_desktop_file_ids.fish
1:function __fish_print_xdg_desktop_file_ids --description 'Print all available xdg desktop file IDs'
```