### PR TITLE
Move __fish_print_function_prototypes into valgrind completion script

### DIFF
--- a/share/completions/valgrind.fish
+++ b/share/completions/valgrind.fish
@@ -72,6 +72,13 @@ complete -n "__fish_valgrind_skin cachegrind" -xc valgrind -l D1 -d "Type of L1 
 complete -n "__fish_valgrind_skin cachegrind" -xc valgrind -l L2 -d "Type of L2 cache"
 
 
+function __fish_print_function_prototypes -d "Prints the names of all function prototypes found in the headers in the current directory"
+    set -l headers *.h *.hh *.hpp *.hxx
+    if set -q headers[1]
+        sed -n "s/^\(.*[^[a-zA-Z_0-9]\|\)\([a-zA-Z_][a-zA-Z_0-9]*\) *(.*);.*\$/\2/p" $headers
+    end
+end
+
 # Massif-specific options
 complete -c valgrind -n "__fish_valgrind_skin massif" -l alloc-fn -d "Specify a function that allocates memory" -x -a "(__fish_print_function_prototypes)"
 complete -c valgrind -n "__fish_valgrind_skin massif" -x -l heap -d 'Profile heap usage' -a 'yes\t"Profile heap usage" no\t"Do not profile heap usage"'

--- a/share/functions/__fish_print_function_prototypes.fish
+++ b/share/functions/__fish_print_function_prototypes.fish
@@ -1,8 +1,0 @@
-
-function __fish_print_function_prototypes -d "Prints the names of all function prototypes found in the headers in the current directory"
-    set -l headers *.h *.hh *.hpp *.hxx
-    if set -q headers[1]
-        sed -n "s/^\(.*[^[a-zA-Z_0-9]\|\)\([a-zA-Z_][a-zA-Z_0-9]*\) *(.*);.*\$/\2/p" $headers
-    end
-end
-


### PR DESCRIPTION
## Description

One of the tasks from #5279.

Only place it was used was for the valgrind completion script:
```
> rg -uu __fish_print_function_prototypes .

./share/functions/__fish_print_function_prototypes.fish
2:function __fish_print_function_prototypes -d "Prints the names of all function prototypes found in the headers in the current directory"

./share/completions/valgrind.fish
76:complete -c valgrind -n "__fish_valgrind_skin massif" -l alloc-fn -d "Specify a function that allocates memory" -x -a "(__fish_print_function_prototypes)"
```
