### PR TITLE
Move __fish_print_debian_services into invoke-rc.d completion script

### DIFF
--- a/share/completions/invoke-rc.d.fish
+++ b/share/completions/invoke-rc.d.fish
@@ -1,3 +1,10 @@
+function __fish_print_debian_services --description 'Prints services installed'
+    for service in /etc/init.d/*
+        if [ -x $service ]
+            basename $service
+        end
+    end
+end
 
 function __fish_invoke_rcd_has_service
     set tokens (commandline -opc)
@@ -15,4 +22,3 @@ complete -f -c invoke-rc.d -n '__fish_invoke_rcd_has_service' -a 'restart' -d 'R
 complete -f -c invoke-rc.d -n '__fish_invoke_rcd_has_service' -a 'reload' -d 'Reload Configuration'
 complete -f -c invoke-rc.d -n '__fish_invoke_rcd_has_service' -a 'force-reload' -d 'Force reloading configuration'
 complete -f -c invoke-rc.d -n '__fish_invoke_rcd_has_service' -a 'status' -d 'Print the status of the service'
-

--- a/share/functions/__fish_print_debian_services.fish
+++ b/share/functions/__fish_print_debian_services.fish
@@ -1,7 +1,0 @@
-function __fish_print_debian_services --description 'Prints services installed'
-    for service in /etc/init.d/*
-        if [ -x $service ]
-            basename $service
-        end
-    end
-end


### PR DESCRIPTION
## Description

One of the tasks from #5279.

Only place it was used was for the invoke-rc.d completion script.