### PR TITLE
Minor tweak to silence warning

### DIFF
--- a/src/builtin_read.cpp
+++ b/src/builtin_read.cpp
@@ -533,7 +533,7 @@ int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 }
 
                 // If we still have tokens, set the last variable to them.
-                if (t = tok.next()) {
+                if ((t = tok.next())) {
                     wcstring rest = wcstring(buff, t->offset);
                     vars.set_one(*var_ptr++, opts.place, rest);
                 }


### PR DESCRIPTION
Silences a clang++ warning:

"using the result of an assignment as a condition without parentheses"

## Description

Silences a compiler warning about assignment. 



