### PR TITLE
Use $PWD to retrieve the current directory in __fish_move_last.

### DIFF
--- a/share/functions/__fish_move_last.fish
+++ b/share/functions/__fish_move_last.fish
@@ -12,7 +12,7 @@ function __fish_move_last -d "Move the last element of a directory history from 
     end
 
     # Append current dir to the end of the destination
-    set -g (echo $dest) $$dest (command pwd)
+    set -g (echo $dest) $$dest $PWD
 
     set ssrc $$src
 

--- a/tests/cd.in
+++ b/tests/cd.in
@@ -9,6 +9,8 @@ set real (mktemp -d)
 set link $base/link
 ln -s $real $link
 cd $link
+prevd
+nextd
 test "$PWD" = "$link" || echo "\$PWD != \$link:"\n   "\$PWD: $PWD"\n   "\$link: $link"\n
 test (pwd) = "$link" || echo "(pwd) != \$link:"\n   "\$PWD: "(pwd)\n   "\$link: $link"\n
 test (pwd -P) = "$real" || echo "(pwd -P) != \$real:"\n   "\$PWD: $PWD"\n   "\$real: $real"\n


### PR DESCRIPTION
## Description

(command pwd) uses the system's implementation of pwd. At least the GNU
coreutils implementation defaults to -P, which resulted in symlinks being
expanded when switching between directories with nextd/prevd.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
