### PR TITLE
Remove translations for non-existent files/functions

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3514,43 +3514,6 @@ msgstr ""
 msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:1
-#, fuzzy
-msgid "%s: invalid option -- %s\\n"
-msgstr "%s: Ungültige Prozesskennung -- %ls\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:2
-msgid "%s: %s cannot be specified along with %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:3
-#, fuzzy
-msgid "%s: option requires an argument -- %s\\n"
-msgstr "%s: Erwartete ein Argument, erhielt %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:4
-#, fuzzy
-msgid "%s: Unexpected argument -- %s\\n"
-msgstr "%s: Argument erwartet -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:5
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:8
-msgid "%s: abbreviation cannot have spaces in the key\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:6
-msgid "%s: abbreviation must have a value\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:7
-msgid "%s: abbreviation '%s' already exists, cannot rename\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:9
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:10
-msgid "%s: no such abbreviation '%s'\\n"
-msgstr ""
-
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 #, fuzzy
 msgid "%s: Name cannot be empty\\n"
@@ -4528,7 +4491,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/echo.fish:5
 #: /tmp/fish/implicit/share/completions/entr.fish:3
 #: /tmp/fish/implicit/share/completions/env.fish:5
-#: /tmp/fish/implicit/share/completions/eval.fish:1
 #: /tmp/fish/implicit/share/completions/exec.fish:1
 #: /tmp/fish/implicit/share/completions/exit.fish:1
 #: /tmp/fish/implicit/share/completions/fg.fish:1
@@ -5158,7 +5120,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mkvextract.fish:2
 #: /tmp/fish/implicit/share/completions/mocha.fish:1
 #: /tmp/fish/implicit/share/completions/modinfo.fish:11
-#: /tmp/fish/implicit/share/completions/netcat.fish:7
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:1
 #: /tmp/fish/implicit/share/completions/poweroff.fish:1
 #: /tmp/fish/implicit/share/completions/terraform.fish:2
@@ -13561,98 +13522,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mogrify.fish:100
 msgid "Enhance or reduce the image contrast"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:1
-#, fuzzy
-msgid "Show output in a more script friendly format"
-msgstr "Profilierungsinformation in angegebene Datei ausgeben"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:2
-#, fuzzy
-msgid "Download [twice to fetch dependencies]"
-msgstr "Status der Abhängigkeiten anzeigen"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:3
-msgid "Show info for target [twice for more details]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:4
-#, fuzzy
-msgid "Search for packages by maintainer"
-msgstr "Paket entsprechend Muster suchen"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:5
-#, fuzzy
-msgid "Search for packages by name"
-msgstr "Vollständigen Paketnamen suchen"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:6
-#, fuzzy
-msgid "Check AUR packages for updates"
-msgstr "Komprimierte Patche erstellen"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:7
-#, fuzzy
-msgid "Use colored output"
-msgstr "Farben benutzen"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:8
-#, fuzzy
-msgid "Show debug output"
-msgstr "Debug-Ausgabe aktivieren"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:9
-#, fuzzy
-msgid "Overwrite existing files when downloading"
-msgstr "Jede einzelne heruntergeladene Datei löschen"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:10
-#, fuzzy
-msgid "Print formatted"
-msgstr "Befehlstyp ausgeben"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:11
-#, fuzzy
-msgid "Display help and quit"
-msgstr "Hilfe anzeigen und beenden"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:12
-#, fuzzy
-msgid "Ignore a package upgrade"
-msgstr "Gehaltene Pakete ignorieren"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:13
-#, fuzzy
-msgid "Ignore a binary repo when checking for updates"
-msgstr "Benutzername für Zeitberechnungen ignorieren"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:14
-#, fuzzy
-msgid "Specify a delimiter for list formatters"
-msgstr "Verzeichnis für rpm-Datenbank angeben"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:15
-#, fuzzy
-msgid "Output less"
-msgstr "Ausgabeverfolgung"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:16
-msgid "Download targets to DIR"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:17
-msgid "Limit the number of threads created [10]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:18
-#, fuzzy
-msgid "Curl timeout in seconds"
-msgstr "Minimalintervall in Sekunden"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:19
-#, fuzzy
-msgid "Output more"
-msgstr "Ausgabeverfolgung"
 
 #: /tmp/fish/implicit/share/completions/cowsay.fish:1
 #: /tmp/fish/implicit/share/completions/cowthink.fish:1
@@ -46128,97 +45997,6 @@ msgstr "Alle Dateisysteme anzeigen"
 msgid "Exclude files that match any pattern in file"
 msgstr "Den Mustern in der Datei entsprechende Dateien ausschliessen"
 
-#: /tmp/fish/implicit/share/completions/netcat.fish:1
-#, fuzzy
-msgid "Remote hostname"
-msgstr "Eintrag für Hostname entfernen"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:2
-msgid "Same as -e, but use /bin/sh"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:3
-msgid "Program to execute after connection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:4
-#, fuzzy
-msgid "Allow broadcasts"
-msgstr "Ping an eine Broadcast-Adresse erlauben"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:5
-msgid "Source-routing hop points"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:6
-msgid "Source-routing pointer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:8
-msgid "Delay interval for lines sent, ports scaned"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:9
-#, fuzzy
-msgid "Set keepalive option"
-msgstr "Konfigurationsoption festlegen"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:10
-msgid "Listen mode, acts as a server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:11
-#, fuzzy
-msgid "Numeric-only IP addresses, no DNS"
-msgstr "Numerische Adresse"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:12
-msgid "Hex dump of traffic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:13
-#, fuzzy
-msgid "Local port number"
-msgstr "Satznummer anzeigen"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:14
-msgid "Randomize local and remote ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:15
-msgid "Quit after EOF on stdin and delay of secs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:16
-#, fuzzy
-msgid "Local source address"
-msgstr "Ursprung des Quellbaumes"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:17
-msgid "Answer Telnet negotiation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:18
-msgid "UDP Mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:19
-msgid "Verbose, use twice to be more verbose"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:20
-msgid "Timeout for connects and final net reads"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:21
-#, fuzzy
-msgid "Set Type of Service"
-msgstr "Dienst anhalten"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:22
-msgid "No I/O - used for scanning"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:3
 #, fuzzy
 msgid "List all available profiles for automatic selection"
@@ -52256,24 +52034,6 @@ msgstr "fish mit diesem Befehl ausführen"
 #: /tmp/fish/implicit/share/completions/rbenv.fish:12
 msgid "Show the full path for the given Ruby command"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:1
-#, fuzzy
-msgid "Filter started daemons"
-msgstr "Alle Namen ausgeben"
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:2
-msgid "Filter stopped daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:3
-msgid "Filter auto started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:4
-#, fuzzy
-msgid "Filter manually started daemons"
-msgstr "Alle installierten Pakete abfragen"
 
 #: /tmp/fish/implicit/share/completions/rc-service.fish:1
 msgid "Tests if the service exists or not"
@@ -66695,10 +66455,6 @@ msgstr ""
 msgid "Manage abbreviations using new fish 3.0 scheme."
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/abbr_old.fish:1
-msgid "Manage abbreviations using old fish 2.x scheme."
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/alias.fish:1
 msgid "Creates a function wrapping a command"
 msgstr ""
@@ -66731,10 +66487,6 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/eval.fish:1
-msgid "Evaluate parameters as a command"
-msgstr "Parameter als Befehl auswerten"
-
 #: /tmp/fish/implicit/share/functions/_.fish:1
 msgid "Alias for the gettext command"
 msgstr ""
@@ -66749,15 +66501,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_commandline_is_singlequoted.fish:1
 msgid "Return 0 if the current token has an open single-quote"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_abook_formats.fish:1
-#, fuzzy
-msgid "Complete abook formats"
-msgstr "Vergleiche FILE1 mit allen Operanden"
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_ant_targets.fish:1
-msgid "Print list of targets from build.xml and imported files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
@@ -67138,11 +66881,6 @@ msgstr "Saloppe Einhäng-Optionen tolerieren"
 msgid "Complete by list of running processes"
 msgstr "Liste laufender screen-Sitzungen ausgeben"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_setxkbmap.fish:1
-#, fuzzy
-msgid "Complete setxkb options"
-msgstr "Saloppe Einhäng-Optionen tolerieren"
-
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 #, fuzzy
 msgid "common completions for ssh commands"
@@ -67186,12 +66924,6 @@ msgstr "Optionen"
 #, fuzzy
 msgid "Complete subcommand"
 msgstr "Vergleiche FILE1 mit allen Operanden"
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_subcommand_root.fish:1
-msgid ""
-"Run the __fish_complete_subcommand function using a PATH containing /sbin "
-"and /usr/sbin"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_suffix.fish:1
 #, fuzzy
@@ -67283,7 +67015,6 @@ msgid "Checks if a specific option has been given in the current commandline"
 msgstr "Test, ob an apt noch ein Unterbefehl gegeben werden muss"
 
 #: /tmp/fish/implicit/share/functions/__fish_crux_packages.fish:1
-#: /tmp/fish/implicit/share/functions/__fish_prt_packages.fish:1
 #, fuzzy
 msgid "Obtain a list of installed packages"
 msgstr "Ein installiertes Paket neu erstellen und installieren"
@@ -67314,16 +67045,6 @@ msgstr "Zeigt Änderungsinformationen zu dem Paket an"
 #, fuzzy
 msgid "Command used to find descriptions for commands"
 msgstr "Funktionstasten für Befehle nutzen"
-
-#: /tmp/fish/implicit/share/functions/fish_fallback_prompt.fish:1
-msgid ""
-"A simple fallback prompt without too much color or special characters for "
-"linux VTs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_filter_ant_targets.fish:1
-msgid "Display targets within an ant build.xml file"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
 msgid "Helper function for __fish_git_prompt"
@@ -67445,30 +67166,15 @@ msgstr ""
 msgid "Paginate the current command using the users default pager"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_ports_dirs.fish:1
-#, fuzzy
-msgid "Obtain a list of ports local collections"
-msgstr "Liste laufender screen-Sitzungen ausgeben"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 #, fuzzy
 msgid "Print a list of known network addresses"
 msgstr "Liste laufender screen-Sitzungen ausgeben"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_arch_daemons.fish:1
-#, fuzzy
-msgid "Print arch daemons"
-msgstr "Alle Namen ausgeben"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 #, fuzzy
 msgid "Print a list of documented fish commands"
 msgstr "Liste laufender screen-Sitzungen ausgeben"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_debian_services.fish:1
-#, fuzzy
-msgid "Prints services installed"
-msgstr "Dienststatus ausgeben"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
 msgid "Complete using available character encodings"
@@ -67478,12 +67184,6 @@ msgstr ""
 #, fuzzy
 msgid "Print a list of all known filesystem types"
 msgstr "Liste laufender screen-Sitzungen ausgeben"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_function_prototypes.fish:1
-msgid ""
-"Prints the names of all function prototypes found in the headers in the "
-"current directory"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
 #, fuzzy
@@ -67514,11 +67214,6 @@ msgstr "Alle Versionen ausgeben"
 msgid "Print lpr printers"
 msgstr "Vollständige Datensätze ausgeben"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_lsblk_columns.fish:1
-#, fuzzy
-msgid "Print available lsblk columns"
-msgstr "Verfügbare Liste ausgeben"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 #, fuzzy
 msgid "Print mounted devices"
@@ -67548,75 +67243,24 @@ msgstr "Liste laufender screen-Sitzungen ausgeben"
 msgid "Print directories where desktop files are stored"
 msgstr "Verzeichnisse, aber nicht deren Inhalt auflisten"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xdg_desktop_file_ids.fish:1
-#, fuzzy
-msgid "Print all available xdg desktop file IDs"
-msgstr "Namen der verfügbaren Signale auflisten"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 #, fuzzy
 msgid "Print XDG mime types"
 msgstr "Befehlstyp ausgeben"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_modes.fish:1
-#, fuzzy
-msgid "Print xrandr modes"
-msgstr "Roheinträge ausgeben"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_outputs.fish:1
-#, fuzzy
-msgid "Print xrandr outputs"
-msgstr "Wortzählung ausgeben"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 #, fuzzy
 msgid "Print X windows"
 msgstr "APM-Informationen ausgeben"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
-msgid "Lists ZFS bookmarks, if the feature is enabled"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
-#, fuzzy
-msgid "Lists ZFS filesystems"
-msgstr "Alle Dateisysteme anzeigen"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 #, fuzzy
 msgid "Lists ZFS snapshots"
 msgstr "Vertraute Schlüssel auflisten"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
-#, fuzzy
-msgid "Lists ZFS volumes"
-msgstr "Nach Spalten auflisten"
-
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
 msgstr "Prompt ausgeben"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_no_subcommand.fish:1
-#, fuzzy
-msgid "Test if prt-get has yet to be given the command"
-msgstr "Test, ob an apt noch ein Unterbefehl gegeben werden muss"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_ports.fish:1
-#, fuzzy
-msgid "Obtain a list of ports"
-msgstr "Liste laufender screen-Sitzungen ausgeben"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_package.fish:1
-#, fuzzy
-msgid "Test if prt-get should have packages as potential completion"
-msgstr ""
-"Testen, ob der apt-Befehl Pakete zur möglichen Fertigstellung haben sollte"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_port.fish:1
-#, fuzzy
-msgid "Test if prt-get should have ports as potential completion"
-msgstr ""
-"Testen, ob der apt-Befehl Pakete zur möglichen Fertigstellung haben sollte"
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:2
@@ -67649,10 +67293,6 @@ msgstr "Aktuelle Funktionen sind: "
 #, fuzzy
 msgid "Call systemctl with some options from the current commandline"
 msgstr "Test, ob an apt noch ein Unterbefehl gegeben werden muss"
-
-#: /tmp/fish/implicit/share/functions/__fish_test_arg.fish:1
-msgid "Test if the token under the cursor matches the specified wildcard"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_toggle_comment_commandline.fish:1
 msgid "Comment/uncomment the current command"

--- a/po/en.po
+++ b/po/en.po
@@ -3357,41 +3357,6 @@ msgstr "%s %s: Abbreviation %s already exists, cannot rename %s\\n"
 msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr "%s %s: Unexpected argument -- '%s'\\n"
 
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:1
-msgid "%s: invalid option -- %s\\n"
-msgstr "%s: invalid option -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:2
-msgid "%s: %s cannot be specified along with %s\\n"
-msgstr "%s: %s cannot be specified along with %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:3
-msgid "%s: option requires an argument -- %s\\n"
-msgstr "%s: option requires an argument -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:4
-msgid "%s: Unexpected argument -- %s\\n"
-msgstr "%s: Unexpected argument -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:5
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:8
-#, fuzzy
-msgid "%s: abbreviation cannot have spaces in the key\\n"
-msgstr "%s: abbreviation must have a non-empty key\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:6
-msgid "%s: abbreviation must have a value\\n"
-msgstr "%s: abbreviation must have a value\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:7
-msgid "%s: abbreviation '%s' already exists, cannot rename\\n"
-msgstr "%s: abbreviation '%s' already exists, cannot rename\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:9
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:10
-msgid "%s: no such abbreviation '%s'\\n"
-msgstr "%s: no such abbreviation “%s”\\n"
-
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 msgid "%s: Name cannot be empty\\n"
 msgstr "%s: Name cannot be empty\\n"
@@ -4981,7 +4946,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mkvextract.fish:2
 #: /tmp/fish/implicit/share/completions/mocha.fish:1
 #: /tmp/fish/implicit/share/completions/modinfo.fish:11
-#: /tmp/fish/implicit/share/completions/netcat.fish:7
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:1
 #: /tmp/fish/implicit/share/completions/poweroff.fish:1
 #: /tmp/fish/implicit/share/completions/terraform.fish:2
@@ -13376,100 +13340,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mogrify.fish:100
 msgid "Enhance or reduce the image contrast"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:1
-#, fuzzy
-msgid "Show output in a more script friendly format"
-msgstr "Output filenames using the specified format"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:2
-#, fuzzy
-msgid "Download [twice to fetch dependencies]"
-msgstr "Show state of dependencies"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:3
-msgid "Show info for target [twice for more details]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:4
-#, fuzzy
-msgid "Search for packages by maintainer"
-msgstr "Search for packages matching a pattern"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:5
-#, fuzzy
-msgid "Search for packages by name"
-msgstr "Search full package name"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:6
-#, fuzzy
-msgid "Check AUR packages for updates"
-msgstr "Check for patches"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:7
-#, fuzzy
-msgid "Use colored output"
-msgstr "Use colors in output"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:8
-#, fuzzy
-msgid "Show debug output"
-msgstr "Turn on debug output"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:9
-#, fuzzy
-msgid "Overwrite existing files when downloading"
-msgstr "Overwrite existing binstubs if they exist"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:10
-#, fuzzy
-msgid "Print formatted"
-msgstr "Prints formatted text"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:11
-#, fuzzy
-msgid "Display help and quit"
-msgstr "Display help and exit"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:12
-#, fuzzy
-msgid "Ignore a package upgrade"
-msgstr "Ignore package Holds"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:13
-#, fuzzy
-msgid "Ignore a binary repo when checking for updates"
-msgstr "Ignore ancestry when calculating merges"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:14
-#, fuzzy
-msgid "Specify a delimiter for list formatters"
-msgstr "Specify directory for rpm database"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:15
-#, fuzzy
-msgid "Output less"
-msgstr "Output file"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:16
-#, fuzzy
-msgid "Download targets to DIR"
-msgstr "Don't unlock targets"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:17
-#, fuzzy
-msgid "Limit the number of threads created [10]"
-msgstr "Only print number of matches"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:18
-#, fuzzy
-msgid "Curl timeout in seconds"
-msgstr "Minimum interval in seconds"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:19
-#, fuzzy
-msgid "Output more"
-msgstr "Output trace"
 
 #: /tmp/fish/implicit/share/completions/cowsay.fish:1
 #: /tmp/fish/implicit/share/completions/cowthink.fish:1
@@ -45835,97 +45705,6 @@ msgstr "Show all filesystems"
 msgid "Exclude files that match any pattern in file"
 msgstr "Exclude files that match pattern in file"
 
-#: /tmp/fish/implicit/share/completions/netcat.fish:1
-#, fuzzy
-msgid "Remote hostname"
-msgstr "Remove an entry for hostname"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:2
-msgid "Same as -e, but use /bin/sh"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:3
-msgid "Program to execute after connection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:4
-#, fuzzy
-msgid "Allow broadcasts"
-msgstr "Allow pinging a broadcast address"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:5
-msgid "Source-routing hop points"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:6
-msgid "Source-routing pointer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:8
-msgid "Delay interval for lines sent, ports scaned"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:9
-#, fuzzy
-msgid "Set keepalive option"
-msgstr "Set a config option"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:10
-msgid "Listen mode, acts as a server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:11
-#, fuzzy
-msgid "Numeric-only IP addresses, no DNS"
-msgstr "Numerical address"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:12
-msgid "Hex dump of traffic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:13
-#, fuzzy
-msgid "Local port number"
-msgstr "Show record number"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:14
-msgid "Randomize local and remote ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:15
-msgid "Quit after EOF on stdin and delay of secs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:16
-#, fuzzy
-msgid "Local source address"
-msgstr "Root source tree"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:17
-msgid "Answer Telnet negotiation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:18
-msgid "UDP Mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:19
-msgid "Verbose, use twice to be more verbose"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:20
-msgid "Timeout for connects and final net reads"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:21
-#, fuzzy
-msgid "Set Type of Service"
-msgstr "Stop service"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:22
-msgid "No I/O - used for scanning"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:3
 #, fuzzy
 msgid "List all available profiles for automatic selection"
@@ -51930,24 +51709,6 @@ msgstr "Run fish with this command"
 #: /tmp/fish/implicit/share/completions/rbenv.fish:12
 msgid "Show the full path for the given Ruby command"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:1
-#, fuzzy
-msgid "Filter started daemons"
-msgstr "Print arch daemons"
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:2
-msgid "Filter stopped daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:3
-msgid "Filter auto started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:4
-#, fuzzy
-msgid "Filter manually started daemons"
-msgstr "Show manually installed packages"
 
 #: /tmp/fish/implicit/share/completions/rc-service.fish:1
 msgid "Tests if the service exists or not"
@@ -66060,10 +65821,6 @@ msgstr ""
 msgid "Manage abbreviations using new fish 3.0 scheme."
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/abbr_old.fish:1
-msgid "Manage abbreviations using old fish 2.x scheme."
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/alias.fish:1
 msgid "Creates a function wrapping a command"
 msgstr ""
@@ -66097,10 +65854,6 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr "Edit a property with an external editor."
 
-#: /tmp/fish/implicit/share/functions/eval.fish:1
-msgid "Evaluate parameters as a command"
-msgstr "Evaluate parameters as a command"
-
 #: /tmp/fish/implicit/share/functions/_.fish:1
 msgid "Alias for the gettext command"
 msgstr "Alias for the gettext command"
@@ -66116,14 +65869,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_commandline_is_singlequoted.fish:1
 msgid "Return 0 if the current token has an open single-quote"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_abook_formats.fish:1
-msgid "Complete abook formats"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_ant_targets.fish:1
-msgid "Print list of targets from build.xml and imported files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
@@ -66492,10 +66237,6 @@ msgstr ""
 msgid "Complete by list of running processes"
 msgstr "Complete by list of running processes"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_setxkbmap.fish:1
-msgid "Complete setxkb options"
-msgstr "Complete setxkb options"
-
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 #, fuzzy
 msgid "common completions for ssh commands"
@@ -66537,12 +66278,6 @@ msgstr "Options"
 #, fuzzy
 msgid "Complete subcommand"
 msgstr "Complete dd operands"
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_subcommand_root.fish:1
-msgid ""
-"Run the __fish_complete_subcommand function using a PATH containing /sbin "
-"and /usr/sbin"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_suffix.fish:1
 #, fuzzy
@@ -66632,7 +66367,6 @@ msgid "Checks if a specific option has been given in the current commandline"
 msgstr "Test if adb has yet to be given the subcommand"
 
 #: /tmp/fish/implicit/share/functions/__fish_crux_packages.fish:1
-#: /tmp/fish/implicit/share/functions/__fish_prt_packages.fish:1
 #, fuzzy
 msgid "Obtain a list of installed packages"
 msgstr "Rebuild and install an installed package"
@@ -66663,16 +66397,6 @@ msgstr "Display change information for the package"
 #, fuzzy
 msgid "Command used to find descriptions for commands"
 msgstr "Use function keys for commands"
-
-#: /tmp/fish/implicit/share/functions/fish_fallback_prompt.fish:1
-msgid ""
-"A simple fallback prompt without too much color or special characters for "
-"linux VTs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_filter_ant_targets.fish:1
-msgid "Display targets within an ant build.xml file"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
 msgid "Helper function for __fish_git_prompt"
@@ -66795,26 +66519,13 @@ msgstr ""
 msgid "Paginate the current command using the users default pager"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_ports_dirs.fish:1
-#, fuzzy
-msgid "Obtain a list of ports local collections"
-msgstr "Print a list of local users"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr "Print a list of known network addresses"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_arch_daemons.fish:1
-msgid "Print arch daemons"
-msgstr "Print arch daemons"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 msgid "Print a list of documented fish commands"
 msgstr "Print a list of documented fish commands"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_debian_services.fish:1
-msgid "Prints services installed"
-msgstr "Prints services installed"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
 msgid "Complete using available character encodings"
@@ -66824,14 +66535,6 @@ msgstr ""
 #, fuzzy
 msgid "Print a list of all known filesystem types"
 msgstr "Print a list of known network interfaces"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_function_prototypes.fish:1
-#, fuzzy
-msgid ""
-"Prints the names of all function prototypes found in the headers in the "
-"current directory"
-msgstr ""
-"Print a list of all function calls leading up to running the current command"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
 msgid "Print a list of local groups"
@@ -66858,10 +66561,6 @@ msgstr "Print lpr options"
 msgid "Print lpr printers"
 msgstr "Print lpr printers"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_lsblk_columns.fish:1
-msgid "Print available lsblk columns"
-msgstr "Print available lsblk columns"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 msgid "Print mounted devices"
 msgstr "Print mounted devices"
@@ -66887,66 +66586,21 @@ msgstr "Print a list of local users"
 msgid "Print directories where desktop files are stored"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xdg_desktop_file_ids.fish:1
-#, fuzzy
-msgid "Print all available xdg desktop file IDs"
-msgstr "Print available lsblk columns"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 msgid "Print XDG mime types"
 msgstr "Print XDG mime types"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_modes.fish:1
-msgid "Print xrandr modes"
-msgstr "Print xrandr modes"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_outputs.fish:1
-msgid "Print xrandr outputs"
-msgstr "Print xrandr outputs"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
 msgstr "Print X windows"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
-msgid "Lists ZFS bookmarks, if the feature is enabled"
-msgstr "Lists ZFS bookmarks, if the feature is enabled"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
-msgid "Lists ZFS filesystems"
-msgstr "Lists ZFS filesystems"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 msgid "Lists ZFS snapshots"
 msgstr "Lists ZFS snapshots"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
-msgid "Lists ZFS volumes"
-msgstr "Lists ZFS volumes"
-
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
 msgstr "Write out the prompt"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_no_subcommand.fish:1
-#, fuzzy
-msgid "Test if prt-get has yet to be given the command"
-msgstr "Test if apt has yet to be given the subcommand"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_ports.fish:1
-#, fuzzy
-msgid "Obtain a list of ports"
-msgstr "Print a list of local users"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_package.fish:1
-#, fuzzy
-msgid "Test if prt-get should have packages as potential completion"
-msgstr "Test if apt command should have packages as potential completion"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_port.fish:1
-#, fuzzy
-msgid "Test if prt-get should have ports as potential completion"
-msgstr "Test if apt command should have packages as potential completion"
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:2
@@ -66977,10 +66631,6 @@ msgstr "Prompt function for Git"
 #: /tmp/fish/implicit/share/functions/_fish_systemctl.fish:1
 msgid "Call systemctl with some options from the current commandline"
 msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_test_arg.fish:1
-msgid "Test if the token under the cursor matches the specified wildcard"
-msgstr "Test if the token under the cursor matches the specified wildcard"
 
 #: /tmp/fish/implicit/share/functions/__fish_toggle_comment_commandline.fish:1
 msgid "Comment/uncomment the current command"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3533,40 +3533,6 @@ msgstr "%s %s : L’abréviation %s existe, impossible de renommer %s\\n"
 msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr "%s %s : Argument inattendu -- '%s'\\n"
 
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:1
-msgid "%s: invalid option -- %s\\n"
-msgstr "%s : option invalide -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:2
-msgid "%s: %s cannot be specified along with %s\\n"
-msgstr "%s : %s ne peut être spécifié avec %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:3
-msgid "%s: option requires an argument -- %s\\n"
-msgstr "%s : l’option requiert un argument -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:4
-msgid "%s: Unexpected argument -- %s\\n"
-msgstr "%s : Argument inattendu -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:5
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:8
-msgid "%s: abbreviation cannot have spaces in the key\\n"
-msgstr "%s : l’abréviation ne peut comporter d’espaces dans la clé\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:6
-msgid "%s: abbreviation must have a value\\n"
-msgstr "%s : l’abréviation doit être dotée d’une valeur\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:7
-msgid "%s: abbreviation '%s' already exists, cannot rename\\n"
-msgstr "%s : l’abréviation '%s' existe, impossible de renommer\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:9
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:10
-msgid "%s: no such abbreviation '%s'\\n"
-msgstr "%s : aucune abréviation '%s'\\n"
-
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 msgid "%s: Name cannot be empty\\n"
 msgstr "%s : Le nom ne peut être une chaîne vide\\n"
@@ -4478,7 +4444,6 @@ msgstr "<dir> chemin vers les informations ACPI (/proc/acpi)"
 #: /tmp/fish/implicit/share/completions/echo.fish:5
 #: /tmp/fish/implicit/share/completions/entr.fish:3
 #: /tmp/fish/implicit/share/completions/env.fish:5
-#: /tmp/fish/implicit/share/completions/eval.fish:1
 #: /tmp/fish/implicit/share/completions/exec.fish:1
 #: /tmp/fish/implicit/share/completions/exit.fish:1
 #: /tmp/fish/implicit/share/completions/fg.fish:1
@@ -5098,7 +5063,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mkvextract.fish:2
 #: /tmp/fish/implicit/share/completions/mocha.fish:1
 #: /tmp/fish/implicit/share/completions/modinfo.fish:11
-#: /tmp/fish/implicit/share/completions/netcat.fish:7
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:1
 #: /tmp/fish/implicit/share/completions/poweroff.fish:1
 #: /tmp/fish/implicit/share/completions/terraform.fish:2
@@ -13194,83 +13158,6 @@ msgstr "Appliquer la correction de couleur à l’image [matrice]"
 #: /tmp/fish/implicit/share/completions/mogrify.fish:100
 msgid "Enhance or reduce the image contrast"
 msgstr "Augmenter ou réduire le contraste de l’image"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:1
-msgid "Show output in a more script friendly format"
-msgstr "Afficher la sortie dans un format utilisable par un programme"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:2
-msgid "Download [twice to fetch dependencies]"
-msgstr "Télécharger (deux fois pour récupérer également les dépendances)"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:3
-msgid "Show info for target [twice for more details]"
-msgstr ""
-"Afficher les informations sur la cible (deux fois pour plus de détails)"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:4
-msgid "Search for packages by maintainer"
-msgstr "Rechercher les paquets par mainteneur"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:5
-msgid "Search for packages by name"
-msgstr "Rechercher les paquets par nom"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:6
-msgid "Check AUR packages for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:7
-msgid "Use colored output"
-msgstr "Colorier la sortie"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:8
-msgid "Show debug output"
-msgstr "Afficher les informations de débogage"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:9
-msgid "Overwrite existing files when downloading"
-msgstr "Écraser les fichiers existants lors du téléchargement"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:10
-msgid "Print formatted"
-msgstr "Afficher de manière formatée"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:11
-msgid "Display help and quit"
-msgstr "Afficher l’aide et quitter"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:12
-msgid "Ignore a package upgrade"
-msgstr "Ignorer la mise à jour d’un paquet"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:13
-msgid "Ignore a binary repo when checking for updates"
-msgstr "Ignorer un dépôt binaire lors de la recherche de mises à jour"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:14
-msgid "Specify a delimiter for list formatters"
-msgstr "Spécifier un séparateur de liste"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:15
-msgid "Output less"
-msgstr "Afficher moins de choses"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:16
-msgid "Download targets to DIR"
-msgstr "Télécharger les cibles dans DOSSIER"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:17
-msgid "Limit the number of threads created [10]"
-msgstr "Limiter le nombre de processus légers créés (10 par défaut)"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:18
-msgid "Curl timeout in seconds"
-msgstr "Délai d’attente en secondes pour curl"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:19
-msgid "Output more"
-msgstr "Afficher plus de choses"
 
 #: /tmp/fish/implicit/share/completions/cowsay.fish:1
 #: /tmp/fish/implicit/share/completions/cowthink.fish:1
@@ -45808,90 +45695,6 @@ msgstr "Même système de fichiers"
 msgid "Exclude files that match any pattern in file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/netcat.fish:1
-msgid "Remote hostname"
-msgstr "Nom de l’hôte distant"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:2
-msgid "Same as -e, but use /bin/sh"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:3
-msgid "Program to execute after connection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:4
-msgid "Allow broadcasts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:5
-msgid "Source-routing hop points"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:6
-msgid "Source-routing pointer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:8
-msgid "Delay interval for lines sent, ports scaned"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:9
-msgid "Set keepalive option"
-msgstr "Paramétrer l’option keepalive"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:10
-msgid "Listen mode, acts as a server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:11
-msgid "Numeric-only IP addresses, no DNS"
-msgstr "Adresse IP numérique, sans résolution DNS"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:12
-msgid "Hex dump of traffic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:13
-msgid "Local port number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:14
-msgid "Randomize local and remote ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:15
-msgid "Quit after EOF on stdin and delay of secs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:16
-msgid "Local source address"
-msgstr "Adresse source locale"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:17
-msgid "Answer Telnet negotiation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:18
-msgid "UDP Mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:19
-msgid "Verbose, use twice to be more verbose"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:20
-msgid "Timeout for connects and final net reads"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:21
-msgid "Set Type of Service"
-msgstr "Paramétrer le Type de service"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:22
-msgid "No I/O - used for scanning"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:3
 msgid "List all available profiles for automatic selection"
 msgstr "Lister tous les profils disponibles pour la sélection automatique"
@@ -51594,23 +51397,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/rbenv.fish:12
 msgid "Show the full path for the given Ruby command"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:1
-msgid "Filter started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:2
-msgid "Filter stopped daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:3
-msgid "Filter auto started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:4
-#, fuzzy
-msgid "Filter manually started daemons"
-msgstr "Reconstruire et installer un paquet installé"
 
 #: /tmp/fish/implicit/share/completions/rc-service.fish:1
 msgid "Tests if the service exists or not"
@@ -65057,10 +64843,6 @@ msgstr ""
 msgid "Manage abbreviations using new fish 3.0 scheme."
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/abbr_old.fish:1
-msgid "Manage abbreviations using old fish 2.x scheme."
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/alias.fish:1
 msgid "Creates a function wrapping a command"
 msgstr ""
@@ -65092,10 +64874,6 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/eval.fish:1
-msgid "Evaluate parameters as a command"
-msgstr "Évaluer le paramètre comme une commande"
-
 #: /tmp/fish/implicit/share/functions/_.fish:1
 msgid "Alias for the gettext command"
 msgstr "Alias pour la commande gettext"
@@ -65110,14 +64888,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_commandline_is_singlequoted.fish:1
 msgid "Return 0 if the current token has an open single-quote"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_abook_formats.fish:1
-msgid "Complete abook formats"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_ant_targets.fish:1
-msgid "Print list of targets from build.xml and imported files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
@@ -65471,10 +65241,6 @@ msgstr ""
 msgid "Complete by list of running processes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_setxkbmap.fish:1
-msgid "Complete setxkb options"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 msgid "common completions for ssh commands"
 msgstr ""
@@ -65514,12 +65280,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/functions/__fish_complete_subcommand.fish:1
 msgid "Complete subcommand"
 msgstr "Compléter la sous-commande"
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_subcommand_root.fish:1
-msgid ""
-"Run the __fish_complete_subcommand function using a PATH containing /sbin "
-"and /usr/sbin"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_suffix.fish:1
 msgid "Complete using files"
@@ -65609,7 +65369,6 @@ msgstr ""
 "actuelle"
 
 #: /tmp/fish/implicit/share/functions/__fish_crux_packages.fish:1
-#: /tmp/fish/implicit/share/functions/__fish_prt_packages.fish:1
 msgid "Obtain a list of installed packages"
 msgstr "Obtenir une liste des paquets installés"
 
@@ -65635,16 +65394,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_describe_command.fish:1
 msgid "Command used to find descriptions for commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/fish_fallback_prompt.fish:1
-msgid ""
-"A simple fallback prompt without too much color or special characters for "
-"linux VTs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_filter_ant_targets.fish:1
-msgid "Display targets within an ant build.xml file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
@@ -65765,26 +65514,13 @@ msgstr ""
 msgid "Paginate the current command using the users default pager"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_ports_dirs.fish:1
-msgid "Obtain a list of ports local collections"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_arch_daemons.fish:1
-#, fuzzy
-msgid "Print arch daemons"
-msgstr "Afficher les démons arch"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 msgid "Print a list of documented fish commands"
 msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_debian_services.fish:1
-msgid "Prints services installed"
-msgstr "Afficher les services installés"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
 msgid "Complete using available character encodings"
@@ -65792,12 +65528,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_filesystems.fish:1
 msgid "Print a list of all known filesystem types"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_function_prototypes.fish:1
-msgid ""
-"Prints the names of all function prototypes found in the headers in the "
-"current directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
@@ -65825,10 +65555,6 @@ msgstr "Afficher les options lpr"
 msgid "Print lpr printers"
 msgstr "Afficher les imprimantes lpr"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_lsblk_columns.fish:1
-msgid "Print available lsblk columns"
-msgstr "Afficher les colonnes lsblk disponibles"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 msgid "Print mounted devices"
 msgstr "Afficher les périphériques"
@@ -65854,65 +65580,21 @@ msgstr ""
 msgid "Print directories where desktop files are stored"
 msgstr "Omettre les dossiers pour la préservation des horodatages"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xdg_desktop_file_ids.fish:1
-#, fuzzy
-msgid "Print all available xdg desktop file IDs"
-msgstr "Lister tous les greffons disponibles"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 msgid "Print XDG mime types"
 msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_modes.fish:1
-#, fuzzy
-msgid "Print xrandr modes"
-msgstr "Afficher tous les noms"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_outputs.fish:1
-msgid "Print xrandr outputs"
-msgstr "Afficher les sorties xrandr"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
 msgstr "Afficher les fenêtres X"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
-msgid "Lists ZFS bookmarks, if the feature is enabled"
-msgstr "Liste les marque-pages ZFS, si la fonctionnalité est activée"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
-msgid "Lists ZFS filesystems"
-msgstr "Liste les systèmes de fichiers ZFS"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 msgid "Lists ZFS snapshots"
 msgstr "Liste les instantanés ZFS"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
-msgid "Lists ZFS volumes"
-msgstr "Liste les volumess ZFS"
-
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
 msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_no_subcommand.fish:1
-msgid "Test if prt-get has yet to be given the command"
-msgstr "Vérifier si prt-get doit encore se faire donner la commande"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_ports.fish:1
-msgid "Obtain a list of ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_package.fish:1
-msgid "Test if prt-get should have packages as potential completion"
-msgstr ""
-"Vérifier si prt-get doit avoir les paquets comme complétions potentielles"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_port.fish:1
-msgid "Test if prt-get should have ports as potential completion"
-msgstr ""
-"Vérifier si prt-get doit avoir les ports comme complétions potentielles"
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:2
@@ -65945,10 +65627,6 @@ msgid "Call systemctl with some options from the current commandline"
 msgstr ""
 "Vérifier si une option spécifique a été donnée sur la ligne de commande "
 "actuelle"
-
-#: /tmp/fish/implicit/share/functions/__fish_test_arg.fish:1
-msgid "Test if the token under the cursor matches the specified wildcard"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_toggle_comment_commandline.fish:1
 msgid "Comment/uncomment the current command"

--- a/po/nb.po
+++ b/po/nb.po
@@ -3294,40 +3294,6 @@ msgstr ""
 msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:1
-msgid "%s: invalid option -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:2
-msgid "%s: %s cannot be specified along with %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:3
-msgid "%s: option requires an argument -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:4
-msgid "%s: Unexpected argument -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:5
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:8
-msgid "%s: abbreviation cannot have spaces in the key\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:6
-msgid "%s: abbreviation must have a value\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:7
-msgid "%s: abbreviation '%s' already exists, cannot rename\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:9
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:10
-msgid "%s: no such abbreviation '%s'\\n"
-msgstr ""
-
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 msgid "%s: Name cannot be empty\\n"
 msgstr ""
@@ -4209,7 +4175,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/echo.fish:5
 #: /tmp/fish/implicit/share/completions/entr.fish:3
 #: /tmp/fish/implicit/share/completions/env.fish:5
-#: /tmp/fish/implicit/share/completions/eval.fish:1
 #: /tmp/fish/implicit/share/completions/exec.fish:1
 #: /tmp/fish/implicit/share/completions/exit.fish:1
 #: /tmp/fish/implicit/share/completions/fg.fish:1
@@ -4791,7 +4756,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mkvextract.fish:2
 #: /tmp/fish/implicit/share/completions/mocha.fish:1
 #: /tmp/fish/implicit/share/completions/modinfo.fish:11
-#: /tmp/fish/implicit/share/completions/netcat.fish:7
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:1
 #: /tmp/fish/implicit/share/completions/poweroff.fish:1
 #: /tmp/fish/implicit/share/completions/terraform.fish:2
@@ -12584,82 +12548,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/display.fish:59
 #: /tmp/fish/implicit/share/completions/mogrify.fish:100
 msgid "Enhance or reduce the image contrast"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:1
-msgid "Show output in a more script friendly format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:2
-msgid "Download [twice to fetch dependencies]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:3
-msgid "Show info for target [twice for more details]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:4
-msgid "Search for packages by maintainer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:5
-msgid "Search for packages by name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:6
-msgid "Check AUR packages for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:7
-msgid "Use colored output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:8
-msgid "Show debug output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:9
-msgid "Overwrite existing files when downloading"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:10
-msgid "Print formatted"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:11
-msgid "Display help and quit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:12
-msgid "Ignore a package upgrade"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:13
-msgid "Ignore a binary repo when checking for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:14
-msgid "Specify a delimiter for list formatters"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:15
-msgid "Output less"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:16
-msgid "Download targets to DIR"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:17
-msgid "Limit the number of threads created [10]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:18
-msgid "Curl timeout in seconds"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:19
-msgid "Output more"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cowsay.fish:1
@@ -42857,90 +42745,6 @@ msgstr ""
 msgid "Exclude files that match any pattern in file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/netcat.fish:1
-msgid "Remote hostname"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:2
-msgid "Same as -e, but use /bin/sh"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:3
-msgid "Program to execute after connection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:4
-msgid "Allow broadcasts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:5
-msgid "Source-routing hop points"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:6
-msgid "Source-routing pointer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:8
-msgid "Delay interval for lines sent, ports scaned"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:9
-msgid "Set keepalive option"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:10
-msgid "Listen mode, acts as a server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:11
-msgid "Numeric-only IP addresses, no DNS"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:12
-msgid "Hex dump of traffic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:13
-msgid "Local port number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:14
-msgid "Randomize local and remote ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:15
-msgid "Quit after EOF on stdin and delay of secs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:16
-msgid "Local source address"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:17
-msgid "Answer Telnet negotiation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:18
-msgid "UDP Mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:19
-msgid "Verbose, use twice to be more verbose"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:20
-msgid "Timeout for connects and final net reads"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:21
-msgid "Set Type of Service"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:22
-msgid "No I/O - used for scanning"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:3
 msgid "List all available profiles for automatic selection"
 msgstr ""
@@ -48442,22 +48246,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rbenv.fish:12
 msgid "Show the full path for the given Ruby command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:1
-msgid "Filter started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:2
-msgid "Filter stopped daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:3
-msgid "Filter auto started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:4
-msgid "Filter manually started daemons"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rc-service.fish:1
@@ -61523,10 +61311,6 @@ msgstr ""
 msgid "Manage abbreviations using new fish 3.0 scheme."
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/abbr_old.fish:1
-msgid "Manage abbreviations using old fish 2.x scheme."
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/alias.fish:1
 msgid "Creates a function wrapping a command"
 msgstr ""
@@ -61557,10 +61341,6 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/eval.fish:1
-msgid "Evaluate parameters as a command"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/_.fish:1
 msgid "Alias for the gettext command"
 msgstr ""
@@ -61575,14 +61355,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_commandline_is_singlequoted.fish:1
 msgid "Return 0 if the current token has an open single-quote"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_abook_formats.fish:1
-msgid "Complete abook formats"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_ant_targets.fish:1
-msgid "Print list of targets from build.xml and imported files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
@@ -61933,10 +61705,6 @@ msgstr ""
 msgid "Complete by list of running processes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_setxkbmap.fish:1
-msgid "Complete setxkb options"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 msgid "common completions for ssh commands"
 msgstr ""
@@ -61975,12 +61743,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_subcommand.fish:1
 msgid "Complete subcommand"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_subcommand_root.fish:1
-msgid ""
-"Run the __fish_complete_subcommand function using a PATH containing /sbin "
-"and /usr/sbin"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_suffix.fish:1
@@ -62066,7 +61828,6 @@ msgid "Checks if a specific option has been given in the current commandline"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_crux_packages.fish:1
-#: /tmp/fish/implicit/share/functions/__fish_prt_packages.fish:1
 msgid "Obtain a list of installed packages"
 msgstr ""
 
@@ -62092,16 +61853,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_describe_command.fish:1
 msgid "Command used to find descriptions for commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/fish_fallback_prompt.fish:1
-msgid ""
-"A simple fallback prompt without too much color or special characters for "
-"linux VTs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_filter_ant_targets.fish:1
-msgid "Display targets within an ant build.xml file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
@@ -62218,24 +61969,12 @@ msgstr ""
 msgid "Paginate the current command using the users default pager"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_ports_dirs.fish:1
-msgid "Obtain a list of ports local collections"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_arch_daemons.fish:1
-msgid "Print arch daemons"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 msgid "Print a list of documented fish commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_debian_services.fish:1
-msgid "Prints services installed"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
@@ -62244,12 +61983,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_filesystems.fish:1
 msgid "Print a list of all known filesystem types"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_function_prototypes.fish:1
-msgid ""
-"Prints the names of all function prototypes found in the headers in the "
-"current directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
@@ -62276,10 +62009,6 @@ msgstr ""
 msgid "Print lpr printers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_lsblk_columns.fish:1
-msgid "Print available lsblk columns"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 msgid "Print mounted devices"
 msgstr ""
@@ -62304,60 +62033,20 @@ msgstr ""
 msgid "Print directories where desktop files are stored"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xdg_desktop_file_ids.fish:1
-msgid "Print all available xdg desktop file IDs"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 msgid "Print XDG mime types"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_modes.fish:1
-msgid "Print xrandr modes"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_outputs.fish:1
-msgid "Print xrandr outputs"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
-msgid "Lists ZFS bookmarks, if the feature is enabled"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
-msgid "Lists ZFS filesystems"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 msgid "Lists ZFS snapshots"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
-msgid "Lists ZFS volumes"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_no_subcommand.fish:1
-msgid "Test if prt-get has yet to be given the command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_ports.fish:1
-msgid "Obtain a list of ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_package.fish:1
-msgid "Test if prt-get should have packages as potential completion"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_port.fish:1
-msgid "Test if prt-get should have ports as potential completion"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
@@ -62387,10 +62076,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/_fish_systemctl.fish:1
 msgid "Call systemctl with some options from the current commandline"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_test_arg.fish:1
-msgid "Test if the token under the cursor matches the specified wildcard"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_toggle_comment_commandline.fish:1

--- a/po/nn.po
+++ b/po/nn.po
@@ -3294,40 +3294,6 @@ msgstr ""
 msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:1
-msgid "%s: invalid option -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:2
-msgid "%s: %s cannot be specified along with %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:3
-msgid "%s: option requires an argument -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:4
-msgid "%s: Unexpected argument -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:5
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:8
-msgid "%s: abbreviation cannot have spaces in the key\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:6
-msgid "%s: abbreviation must have a value\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:7
-msgid "%s: abbreviation '%s' already exists, cannot rename\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:9
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:10
-msgid "%s: no such abbreviation '%s'\\n"
-msgstr ""
-
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 msgid "%s: Name cannot be empty\\n"
 msgstr ""
@@ -4791,7 +4757,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mkvextract.fish:2
 #: /tmp/fish/implicit/share/completions/mocha.fish:1
 #: /tmp/fish/implicit/share/completions/modinfo.fish:11
-#: /tmp/fish/implicit/share/completions/netcat.fish:7
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:1
 #: /tmp/fish/implicit/share/completions/poweroff.fish:1
 #: /tmp/fish/implicit/share/completions/terraform.fish:2
@@ -12584,82 +12549,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/display.fish:59
 #: /tmp/fish/implicit/share/completions/mogrify.fish:100
 msgid "Enhance or reduce the image contrast"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:1
-msgid "Show output in a more script friendly format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:2
-msgid "Download [twice to fetch dependencies]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:3
-msgid "Show info for target [twice for more details]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:4
-msgid "Search for packages by maintainer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:5
-msgid "Search for packages by name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:6
-msgid "Check AUR packages for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:7
-msgid "Use colored output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:8
-msgid "Show debug output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:9
-msgid "Overwrite existing files when downloading"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:10
-msgid "Print formatted"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:11
-msgid "Display help and quit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:12
-msgid "Ignore a package upgrade"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:13
-msgid "Ignore a binary repo when checking for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:14
-msgid "Specify a delimiter for list formatters"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:15
-msgid "Output less"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:16
-msgid "Download targets to DIR"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:17
-msgid "Limit the number of threads created [10]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:18
-msgid "Curl timeout in seconds"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:19
-msgid "Output more"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cowsay.fish:1
@@ -42857,90 +42746,6 @@ msgstr ""
 msgid "Exclude files that match any pattern in file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/netcat.fish:1
-msgid "Remote hostname"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:2
-msgid "Same as -e, but use /bin/sh"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:3
-msgid "Program to execute after connection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:4
-msgid "Allow broadcasts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:5
-msgid "Source-routing hop points"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:6
-msgid "Source-routing pointer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:8
-msgid "Delay interval for lines sent, ports scaned"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:9
-msgid "Set keepalive option"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:10
-msgid "Listen mode, acts as a server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:11
-msgid "Numeric-only IP addresses, no DNS"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:12
-msgid "Hex dump of traffic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:13
-msgid "Local port number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:14
-msgid "Randomize local and remote ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:15
-msgid "Quit after EOF on stdin and delay of secs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:16
-msgid "Local source address"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:17
-msgid "Answer Telnet negotiation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:18
-msgid "UDP Mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:19
-msgid "Verbose, use twice to be more verbose"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:20
-msgid "Timeout for connects and final net reads"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:21
-msgid "Set Type of Service"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:22
-msgid "No I/O - used for scanning"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:3
 msgid "List all available profiles for automatic selection"
 msgstr ""
@@ -48442,22 +48247,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rbenv.fish:12
 msgid "Show the full path for the given Ruby command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:1
-msgid "Filter started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:2
-msgid "Filter stopped daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:3
-msgid "Filter auto started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:4
-msgid "Filter manually started daemons"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rc-service.fish:1
@@ -61523,10 +61312,6 @@ msgstr ""
 msgid "Manage abbreviations using new fish 3.0 scheme."
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/abbr_old.fish:1
-msgid "Manage abbreviations using old fish 2.x scheme."
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/alias.fish:1
 msgid "Creates a function wrapping a command"
 msgstr ""
@@ -61557,10 +61342,6 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/eval.fish:1
-msgid "Evaluate parameters as a command"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/_.fish:1
 msgid "Alias for the gettext command"
 msgstr ""
@@ -61575,14 +61356,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_commandline_is_singlequoted.fish:1
 msgid "Return 0 if the current token has an open single-quote"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_abook_formats.fish:1
-msgid "Complete abook formats"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_ant_targets.fish:1
-msgid "Print list of targets from build.xml and imported files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
@@ -61933,10 +61706,6 @@ msgstr ""
 msgid "Complete by list of running processes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_setxkbmap.fish:1
-msgid "Complete setxkb options"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 msgid "common completions for ssh commands"
 msgstr ""
@@ -61975,12 +61744,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_subcommand.fish:1
 msgid "Complete subcommand"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_subcommand_root.fish:1
-msgid ""
-"Run the __fish_complete_subcommand function using a PATH containing /sbin "
-"and /usr/sbin"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_suffix.fish:1
@@ -62066,7 +61829,6 @@ msgid "Checks if a specific option has been given in the current commandline"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_crux_packages.fish:1
-#: /tmp/fish/implicit/share/functions/__fish_prt_packages.fish:1
 msgid "Obtain a list of installed packages"
 msgstr ""
 
@@ -62092,16 +61854,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_describe_command.fish:1
 msgid "Command used to find descriptions for commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/fish_fallback_prompt.fish:1
-msgid ""
-"A simple fallback prompt without too much color or special characters for "
-"linux VTs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_filter_ant_targets.fish:1
-msgid "Display targets within an ant build.xml file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
@@ -62218,24 +61970,12 @@ msgstr ""
 msgid "Paginate the current command using the users default pager"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_ports_dirs.fish:1
-msgid "Obtain a list of ports local collections"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_arch_daemons.fish:1
-msgid "Print arch daemons"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 msgid "Print a list of documented fish commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_debian_services.fish:1
-msgid "Prints services installed"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
@@ -62244,12 +61984,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_filesystems.fish:1
 msgid "Print a list of all known filesystem types"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_function_prototypes.fish:1
-msgid ""
-"Prints the names of all function prototypes found in the headers in the "
-"current directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
@@ -62276,10 +62010,6 @@ msgstr ""
 msgid "Print lpr printers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_lsblk_columns.fish:1
-msgid "Print available lsblk columns"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 msgid "Print mounted devices"
 msgstr ""
@@ -62304,60 +62034,20 @@ msgstr ""
 msgid "Print directories where desktop files are stored"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xdg_desktop_file_ids.fish:1
-msgid "Print all available xdg desktop file IDs"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 msgid "Print XDG mime types"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_modes.fish:1
-msgid "Print xrandr modes"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_outputs.fish:1
-msgid "Print xrandr outputs"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
-msgid "Lists ZFS bookmarks, if the feature is enabled"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
-msgid "Lists ZFS filesystems"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 msgid "Lists ZFS snapshots"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
-msgid "Lists ZFS volumes"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_no_subcommand.fish:1
-msgid "Test if prt-get has yet to be given the command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_ports.fish:1
-msgid "Obtain a list of ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_package.fish:1
-msgid "Test if prt-get should have packages as potential completion"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_port.fish:1
-msgid "Test if prt-get should have ports as potential completion"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
@@ -62387,10 +62077,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/_fish_systemctl.fish:1
 msgid "Call systemctl with some options from the current commandline"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_test_arg.fish:1
-msgid "Test if the token under the cursor matches the specified wildcard"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_toggle_comment_commandline.fish:1

--- a/po/pl.po
+++ b/po/pl.po
@@ -3346,44 +3346,6 @@ msgstr ""
 msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr "%s %s: Oczekiwano argumentu -- '%s'\\n"
 
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:1
-#, fuzzy
-msgid "%s: invalid option -- %s\\n"
-msgstr "%s: Nieprawidłowa opcja -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:2
-msgid "%s: %s cannot be specified along with %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:3
-#, fuzzy
-msgid "%s: option requires an argument -- %s\\n"
-msgstr "%s: Opcja wymaga argumentu -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:4
-#, fuzzy
-msgid "%s: Unexpected argument -- %s\\n"
-msgstr "%s: Oczekiwano argumentu -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:5
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:8
-msgid "%s: abbreviation cannot have spaces in the key\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:6
-msgid "%s: abbreviation must have a value\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:7
-#, fuzzy
-msgid "%s: abbreviation '%s' already exists, cannot rename\\n"
-msgstr "%s: Funkcja '%ls' już istnieje. Nie można utworzyć kopii\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:9
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:10
-msgid "%s: no such abbreviation '%s'\\n"
-msgstr ""
-
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 #, fuzzy
 msgid "%s: Name cannot be empty\\n"
@@ -4281,7 +4243,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/echo.fish:5
 #: /tmp/fish/implicit/share/completions/entr.fish:3
 #: /tmp/fish/implicit/share/completions/env.fish:5
-#: /tmp/fish/implicit/share/completions/eval.fish:1
 #: /tmp/fish/implicit/share/completions/exec.fish:1
 #: /tmp/fish/implicit/share/completions/exit.fish:1
 #: /tmp/fish/implicit/share/completions/fg.fish:1
@@ -4868,7 +4829,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mkvextract.fish:2
 #: /tmp/fish/implicit/share/completions/mocha.fish:1
 #: /tmp/fish/implicit/share/completions/modinfo.fish:11
-#: /tmp/fish/implicit/share/completions/netcat.fish:7
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:1
 #: /tmp/fish/implicit/share/completions/poweroff.fish:1
 #: /tmp/fish/implicit/share/completions/terraform.fish:2
@@ -12734,83 +12694,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/display.fish:59
 #: /tmp/fish/implicit/share/completions/mogrify.fish:100
 msgid "Enhance or reduce the image contrast"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:1
-msgid "Show output in a more script friendly format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:2
-msgid "Download [twice to fetch dependencies]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:3
-msgid "Show info for target [twice for more details]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:4
-msgid "Search for packages by maintainer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:5
-msgid "Search for packages by name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:6
-msgid "Check AUR packages for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:7
-msgid "Use colored output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:8
-msgid "Show debug output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:9
-msgid "Overwrite existing files when downloading"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:10
-#, fuzzy
-msgid "Print formatted"
-msgstr "Zwraca sformatowany tekst"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:11
-msgid "Display help and quit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:12
-msgid "Ignore a package upgrade"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:13
-msgid "Ignore a binary repo when checking for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:14
-msgid "Specify a delimiter for list formatters"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:15
-msgid "Output less"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:16
-msgid "Download targets to DIR"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:17
-msgid "Limit the number of threads created [10]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:18
-msgid "Curl timeout in seconds"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:19
-msgid "Output more"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cowsay.fish:1
@@ -43260,90 +43143,6 @@ msgstr ""
 msgid "Exclude files that match any pattern in file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/netcat.fish:1
-msgid "Remote hostname"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:2
-msgid "Same as -e, but use /bin/sh"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:3
-msgid "Program to execute after connection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:4
-msgid "Allow broadcasts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:5
-msgid "Source-routing hop points"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:6
-msgid "Source-routing pointer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:8
-msgid "Delay interval for lines sent, ports scaned"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:9
-msgid "Set keepalive option"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:10
-msgid "Listen mode, acts as a server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:11
-msgid "Numeric-only IP addresses, no DNS"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:12
-msgid "Hex dump of traffic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:13
-msgid "Local port number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:14
-msgid "Randomize local and remote ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:15
-msgid "Quit after EOF on stdin and delay of secs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:16
-msgid "Local source address"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:17
-msgid "Answer Telnet negotiation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:18
-msgid "UDP Mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:19
-msgid "Verbose, use twice to be more verbose"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:20
-msgid "Timeout for connects and final net reads"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:21
-msgid "Set Type of Service"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:22
-msgid "No I/O - used for scanning"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:3
 msgid "List all available profiles for automatic selection"
 msgstr ""
@@ -48882,22 +48681,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rbenv.fish:12
 msgid "Show the full path for the given Ruby command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:1
-msgid "Filter started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:2
-msgid "Filter stopped daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:3
-msgid "Filter auto started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:4
-msgid "Filter manually started daemons"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rc-service.fish:1
@@ -62108,10 +61891,6 @@ msgstr ""
 msgid "Manage abbreviations using new fish 3.0 scheme."
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/abbr_old.fish:1
-msgid "Manage abbreviations using old fish 2.x scheme."
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/alias.fish:1
 msgid "Creates a function wrapping a command"
 msgstr ""
@@ -62144,10 +61923,6 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/eval.fish:1
-msgid "Evaluate parameters as a command"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/_.fish:1
 msgid "Alias for the gettext command"
 msgstr ""
@@ -62162,14 +61937,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_commandline_is_singlequoted.fish:1
 msgid "Return 0 if the current token has an open single-quote"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_abook_formats.fish:1
-msgid "Complete abook formats"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_ant_targets.fish:1
-msgid "Print list of targets from build.xml and imported files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
@@ -62522,10 +62289,6 @@ msgstr ""
 msgid "Complete by list of running processes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_setxkbmap.fish:1
-msgid "Complete setxkb options"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 msgid "common completions for ssh commands"
 msgstr ""
@@ -62564,12 +62327,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_subcommand.fish:1
 msgid "Complete subcommand"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_subcommand_root.fish:1
-msgid ""
-"Run the __fish_complete_subcommand function using a PATH containing /sbin "
-"and /usr/sbin"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_suffix.fish:1
@@ -62655,7 +62412,6 @@ msgid "Checks if a specific option has been given in the current commandline"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_crux_packages.fish:1
-#: /tmp/fish/implicit/share/functions/__fish_prt_packages.fish:1
 msgid "Obtain a list of installed packages"
 msgstr ""
 
@@ -62681,16 +62437,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_describe_command.fish:1
 msgid "Command used to find descriptions for commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/fish_fallback_prompt.fish:1
-msgid ""
-"A simple fallback prompt without too much color or special characters for "
-"linux VTs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_filter_ant_targets.fish:1
-msgid "Display targets within an ant build.xml file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
@@ -62808,25 +62554,12 @@ msgstr ""
 msgid "Paginate the current command using the users default pager"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_ports_dirs.fish:1
-msgid "Obtain a list of ports local collections"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_arch_daemons.fish:1
-#, fuzzy
-msgid "Print arch daemons"
-msgstr "Wypisz argumenty"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 msgid "Print a list of documented fish commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_debian_services.fish:1
-msgid "Prints services installed"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
@@ -62835,12 +62568,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_filesystems.fish:1
 msgid "Print a list of all known filesystem types"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_function_prototypes.fish:1
-msgid ""
-"Prints the names of all function prototypes found in the headers in the "
-"current directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
@@ -62869,10 +62596,6 @@ msgstr ""
 msgid "Print lpr printers"
 msgstr "Wypisz argumenty"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_lsblk_columns.fish:1
-msgid "Print available lsblk columns"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 msgid "Print mounted devices"
 msgstr ""
@@ -62897,62 +62620,20 @@ msgstr ""
 msgid "Print directories where desktop files are stored"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xdg_desktop_file_ids.fish:1
-msgid "Print all available xdg desktop file IDs"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 msgid "Print XDG mime types"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_modes.fish:1
-#, fuzzy
-msgid "Print xrandr modes"
-msgstr "Wypisz argumenty"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_outputs.fish:1
-#, fuzzy
-msgid "Print xrandr outputs"
-msgstr "Wypisz argumenty"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
-msgid "Lists ZFS bookmarks, if the feature is enabled"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
-msgid "Lists ZFS filesystems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 msgid "Lists ZFS snapshots"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
-msgid "Lists ZFS volumes"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_no_subcommand.fish:1
-msgid "Test if prt-get has yet to be given the command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_ports.fish:1
-msgid "Obtain a list of ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_package.fish:1
-msgid "Test if prt-get should have packages as potential completion"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_port.fish:1
-msgid "Test if prt-get should have ports as potential completion"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
@@ -62982,10 +62663,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/_fish_systemctl.fish:1
 msgid "Call systemctl with some options from the current commandline"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_test_arg.fish:1
-msgid "Test if the token under the cursor matches the specified wildcard"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_toggle_comment_commandline.fish:1

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3489,44 +3489,6 @@ msgstr "%s %s: Função “%s” já existe. Não é possivel criar cópia “%s
 msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr "%s %s: Esperava argumento -- '%s'\\n"
 
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:1
-#, fuzzy
-msgid "%s: invalid option -- %s\\n"
-msgstr "%s: Opção inválida -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:2
-msgid "%s: %s cannot be specified along with %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:3
-#, fuzzy
-msgid "%s: option requires an argument -- %s\\n"
-msgstr "%s: Opção requer argumento -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:4
-#, fuzzy
-msgid "%s: Unexpected argument -- %s\\n"
-msgstr "%s: Esperava argumento -- %s\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:5
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:8
-msgid "%s: abbreviation cannot have spaces in the key\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:6
-msgid "%s: abbreviation must have a value\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:7
-msgid "%s: abbreviation '%s' already exists, cannot rename\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:9
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:10
-#, fuzzy
-msgid "%s: no such abbreviation '%s'\\n"
-msgstr "%s: Unknown option “%s”\\n"
-
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 #, fuzzy
 msgid "%s: Name cannot be empty\\n"
@@ -5154,7 +5116,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mkvextract.fish:2
 #: /tmp/fish/implicit/share/completions/mocha.fish:1
 #: /tmp/fish/implicit/share/completions/modinfo.fish:11
-#: /tmp/fish/implicit/share/completions/netcat.fish:7
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:1
 #: /tmp/fish/implicit/share/completions/poweroff.fish:1
 #: /tmp/fish/implicit/share/completions/terraform.fish:2
@@ -13804,100 +13765,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mogrify.fish:100
 msgid "Enhance or reduce the image contrast"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:1
-#, fuzzy
-msgid "Show output in a more script friendly format"
-msgstr "Output profiling information to specified file"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:2
-#, fuzzy
-msgid "Download [twice to fetch dependencies]"
-msgstr "Show state of dependencies"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:3
-msgid "Show info for target [twice for more details]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:4
-#, fuzzy
-msgid "Search for packages by maintainer"
-msgstr "Search package containing pattern"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:5
-#, fuzzy
-msgid "Search for packages by name"
-msgstr "Search full package name"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:6
-#, fuzzy
-msgid "Check AUR packages for updates"
-msgstr "Create compressed patches"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:7
-#, fuzzy
-msgid "Use colored output"
-msgstr "Use colors"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:8
-#, fuzzy
-msgid "Show debug output"
-msgstr "Turn on debug output"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:9
-#, fuzzy
-msgid "Overwrite existing files when downloading"
-msgstr "Overwrite modified files with clean copies"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:10
-#, fuzzy
-msgid "Print formatted"
-msgstr "Imprime texto formatado"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:11
-#, fuzzy
-msgid "Display help and quit"
-msgstr "Display help and exit"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:12
-#, fuzzy
-msgid "Ignore a package upgrade"
-msgstr "Ignore package Holds"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:13
-#, fuzzy
-msgid "Ignore a binary repo when checking for updates"
-msgstr "Ignore ancestry when calculating merge"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:14
-#, fuzzy
-msgid "Specify a delimiter for list formatters"
-msgstr "Specify directory for rpm database"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:15
-#, fuzzy
-msgid "Output less"
-msgstr "Output file"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:16
-#, fuzzy
-msgid "Download targets to DIR"
-msgstr "Don't unlock targets"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:17
-#, fuzzy
-msgid "Limit the number of threads created [10]"
-msgstr "Only print number of matches"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:18
-#, fuzzy
-msgid "Curl timeout in seconds"
-msgstr "Minimum interval in seconds"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:19
-#, fuzzy
-msgid "Output more"
-msgstr "Output trace"
 
 #: /tmp/fish/implicit/share/completions/cowsay.fish:1
 #: /tmp/fish/implicit/share/completions/cowthink.fish:1
@@ -46505,97 +46372,6 @@ msgstr "Show all filesystems"
 msgid "Exclude files that match any pattern in file"
 msgstr "Exclude files thet match pattern in file"
 
-#: /tmp/fish/implicit/share/completions/netcat.fish:1
-#, fuzzy
-msgid "Remote hostname"
-msgstr "Remove an entry for hostname"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:2
-msgid "Same as -e, but use /bin/sh"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:3
-msgid "Program to execute after connection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:4
-#, fuzzy
-msgid "Allow broadcasts"
-msgstr "Allow pinging a broadcast address"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:5
-msgid "Source-routing hop points"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:6
-msgid "Source-routing pointer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:8
-msgid "Delay interval for lines sent, ports scaned"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:9
-#, fuzzy
-msgid "Set keepalive option"
-msgstr "Set a config option"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:10
-msgid "Listen mode, acts as a server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:11
-#, fuzzy
-msgid "Numeric-only IP addresses, no DNS"
-msgstr "Numerical address"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:12
-msgid "Hex dump of traffic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:13
-#, fuzzy
-msgid "Local port number"
-msgstr "Show record number"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:14
-msgid "Randomize local and remote ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:15
-msgid "Quit after EOF on stdin and delay of secs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:16
-#, fuzzy
-msgid "Local source address"
-msgstr "Root source tree"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:17
-msgid "Answer Telnet negotiation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:18
-msgid "UDP Mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:19
-msgid "Verbose, use twice to be more verbose"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:20
-msgid "Timeout for connects and final net reads"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:21
-#, fuzzy
-msgid "Set Type of Service"
-msgstr "Stop service"
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:22
-msgid "No I/O - used for scanning"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:3
 #, fuzzy
 msgid "List all available profiles for automatic selection"
@@ -52660,24 +52436,6 @@ msgstr "Run fish with this command"
 #: /tmp/fish/implicit/share/completions/rbenv.fish:12
 msgid "Show the full path for the given Ruby command"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:1
-#, fuzzy
-msgid "Filter started daemons"
-msgstr "Print all names"
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:2
-msgid "Filter stopped daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:3
-msgid "Filter auto started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:4
-#, fuzzy
-msgid "Filter manually started daemons"
-msgstr "Query all installed packages"
 
 #: /tmp/fish/implicit/share/completions/rc-service.fish:1
 msgid "Tests if the service exists or not"
@@ -67168,10 +66926,6 @@ msgstr ""
 msgid "Manage abbreviations using new fish 3.0 scheme."
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/abbr_old.fish:1
-msgid "Manage abbreviations using old fish 2.x scheme."
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/alias.fish:1
 msgid "Creates a function wrapping a command"
 msgstr ""
@@ -67206,10 +66960,6 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr "Edit a property with an external editor on targets"
 
-#: /tmp/fish/implicit/share/functions/eval.fish:1
-msgid "Evaluate parameters as a command"
-msgstr "Evaluate parameters as a command"
-
 #: /tmp/fish/implicit/share/functions/_.fish:1
 #, fuzzy
 msgid "Alias for the gettext command"
@@ -67226,14 +66976,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_commandline_is_singlequoted.fish:1
 msgid "Return 0 if the current token has an open single-quote"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_abook_formats.fish:1
-msgid "Complete abook formats"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_ant_targets.fish:1
-msgid "Print list of targets from build.xml and imported files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
@@ -67610,11 +67352,6 @@ msgstr ""
 msgid "Complete by list of running processes"
 msgstr "Print a list of running screen sessions"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_setxkbmap.fish:1
-#, fuzzy
-msgid "Complete setxkb options"
-msgstr "Tolerate sloppy mount options"
-
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 #, fuzzy
 msgid "common completions for ssh commands"
@@ -67656,12 +67393,6 @@ msgstr "Opções"
 #, fuzzy
 msgid "Complete subcommand"
 msgstr "Compare FILE1 to all operands"
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_subcommand_root.fish:1
-msgid ""
-"Run the __fish_complete_subcommand function using a PATH containing /sbin "
-"and /usr/sbin"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_suffix.fish:1
 #, fuzzy
@@ -67758,7 +67489,6 @@ msgid "Checks if a specific option has been given in the current commandline"
 msgstr "Test if apt has yet to be given the subcommand"
 
 #: /tmp/fish/implicit/share/functions/__fish_crux_packages.fish:1
-#: /tmp/fish/implicit/share/functions/__fish_prt_packages.fish:1
 #, fuzzy
 msgid "Obtain a list of installed packages"
 msgstr "Rebuild and install an installed package"
@@ -67789,16 +67519,6 @@ msgstr "Display change information for the package"
 #, fuzzy
 msgid "Command used to find descriptions for commands"
 msgstr "Use function keys for commands"
-
-#: /tmp/fish/implicit/share/functions/fish_fallback_prompt.fish:1
-msgid ""
-"A simple fallback prompt without too much color or special characters for "
-"linux VTs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_filter_ant_targets.fish:1
-msgid "Display targets within an ant build.xml file"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
 msgid "Helper function for __fish_git_prompt"
@@ -67924,30 +67644,15 @@ msgstr ""
 msgid "Paginate the current command using the users default pager"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_ports_dirs.fish:1
-#, fuzzy
-msgid "Obtain a list of ports local collections"
-msgstr "Print a list of all accepted color names"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 #, fuzzy
 msgid "Print a list of known network addresses"
 msgstr "Print a list of running screen sessions"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_arch_daemons.fish:1
-#, fuzzy
-msgid "Print arch daemons"
-msgstr "Print all names"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 #, fuzzy
 msgid "Print a list of documented fish commands"
 msgstr "Print a list of all accepted color names"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_debian_services.fish:1
-#, fuzzy
-msgid "Prints services installed"
-msgstr "Print service status"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
 msgid "Complete using available character encodings"
@@ -67957,14 +67662,6 @@ msgstr ""
 #, fuzzy
 msgid "Print a list of all known filesystem types"
 msgstr "Print a list of all accepted color names"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_function_prototypes.fish:1
-#, fuzzy
-msgid ""
-"Prints the names of all function prototypes found in the headers in the "
-"current directory"
-msgstr ""
-"Print a list of all function calls leading up to running the current command"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
 #, fuzzy
@@ -67996,11 +67693,6 @@ msgstr "Print all versions"
 msgid "Print lpr printers"
 msgstr "Print full records"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_lsblk_columns.fish:1
-#, fuzzy
-msgid "Print available lsblk columns"
-msgstr "Print available list"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 #, fuzzy
 msgid "Print mounted devices"
@@ -68030,74 +67722,25 @@ msgstr "Print a list of all accepted color names"
 msgid "Print directories where desktop files are stored"
 msgstr "Lista diretórios, não seu conteúdo"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xdg_desktop_file_ids.fish:1
-#, fuzzy
-msgid "Print all available xdg desktop file IDs"
-msgstr "List names of available signals"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 #, fuzzy
 msgid "Print XDG mime types"
 msgstr "Print command type"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_modes.fish:1
-#, fuzzy
-msgid "Print xrandr modes"
-msgstr "Print raw entry names"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_outputs.fish:1
-#, fuzzy
-msgid "Print xrandr outputs"
-msgstr "Print word counts"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 #, fuzzy
 msgid "Print X windows"
 msgstr "Print APM info"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
-msgid "Lists ZFS bookmarks, if the feature is enabled"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
-#, fuzzy
-msgid "Lists ZFS filesystems"
-msgstr "Show all filesystems"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 #, fuzzy
 msgid "Lists ZFS snapshots"
 msgstr "Lista as chaves"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
-#, fuzzy
-msgid "Lists ZFS volumes"
-msgstr "Lista por colunas"
-
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 #, fuzzy
 msgid "Write out the prompt"
 msgstr "Write out the prompt"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_no_subcommand.fish:1
-#, fuzzy
-msgid "Test if prt-get has yet to be given the command"
-msgstr "Test if apt has yet to be given the subcommand"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_ports.fish:1
-#, fuzzy
-msgid "Obtain a list of ports"
-msgstr "Print a list of all accepted color names"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_package.fish:1
-#, fuzzy
-msgid "Test if prt-get should have packages as potential completion"
-msgstr "Test if apt command should have packages as potential completion"
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_port.fish:1
-#, fuzzy
-msgid "Test if prt-get should have ports as potential completion"
-msgstr "Test if apt command should have packages as potential completion"
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:2
@@ -68130,10 +67773,6 @@ msgstr "Current functions are: "
 #, fuzzy
 msgid "Call systemctl with some options from the current commandline"
 msgstr "Test if apt has yet to be given the subcommand"
-
-#: /tmp/fish/implicit/share/functions/__fish_test_arg.fish:1
-msgid "Test if the token under the cursor matches the specified wildcard"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_toggle_comment_commandline.fish:1
 msgid "Comment/uncomment the current command"

--- a/po/sv.po
+++ b/po/sv.po
@@ -3298,40 +3298,6 @@ msgstr ""
 msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:1
-msgid "%s: invalid option -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:2
-msgid "%s: %s cannot be specified along with %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:3
-msgid "%s: option requires an argument -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:4
-msgid "%s: Unexpected argument -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:5
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:8
-msgid "%s: abbreviation cannot have spaces in the key\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:6
-msgid "%s: abbreviation must have a value\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:7
-msgid "%s: abbreviation '%s' already exists, cannot rename\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:9
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:10
-msgid "%s: no such abbreviation '%s'\\n"
-msgstr ""
-
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 msgid "%s: Name cannot be empty\\n"
 msgstr ""
@@ -4213,7 +4179,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/echo.fish:5
 #: /tmp/fish/implicit/share/completions/entr.fish:3
 #: /tmp/fish/implicit/share/completions/env.fish:5
-#: /tmp/fish/implicit/share/completions/eval.fish:1
 #: /tmp/fish/implicit/share/completions/exec.fish:1
 #: /tmp/fish/implicit/share/completions/exit.fish:1
 #: /tmp/fish/implicit/share/completions/fg.fish:1
@@ -4795,7 +4760,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mkvextract.fish:2
 #: /tmp/fish/implicit/share/completions/mocha.fish:1
 #: /tmp/fish/implicit/share/completions/modinfo.fish:11
-#: /tmp/fish/implicit/share/completions/netcat.fish:7
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:1
 #: /tmp/fish/implicit/share/completions/poweroff.fish:1
 #: /tmp/fish/implicit/share/completions/terraform.fish:2
@@ -12588,82 +12552,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/display.fish:59
 #: /tmp/fish/implicit/share/completions/mogrify.fish:100
 msgid "Enhance or reduce the image contrast"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:1
-msgid "Show output in a more script friendly format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:2
-msgid "Download [twice to fetch dependencies]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:3
-msgid "Show info for target [twice for more details]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:4
-msgid "Search for packages by maintainer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:5
-msgid "Search for packages by name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:6
-msgid "Check AUR packages for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:7
-msgid "Use colored output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:8
-msgid "Show debug output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:9
-msgid "Overwrite existing files when downloading"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:10
-msgid "Print formatted"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:11
-msgid "Display help and quit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:12
-msgid "Ignore a package upgrade"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:13
-msgid "Ignore a binary repo when checking for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:14
-msgid "Specify a delimiter for list formatters"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:15
-msgid "Output less"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:16
-msgid "Download targets to DIR"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:17
-msgid "Limit the number of threads created [10]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:18
-msgid "Curl timeout in seconds"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:19
-msgid "Output more"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cowsay.fish:1
@@ -42861,90 +42749,6 @@ msgstr ""
 msgid "Exclude files that match any pattern in file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/netcat.fish:1
-msgid "Remote hostname"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:2
-msgid "Same as -e, but use /bin/sh"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:3
-msgid "Program to execute after connection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:4
-msgid "Allow broadcasts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:5
-msgid "Source-routing hop points"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:6
-msgid "Source-routing pointer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:8
-msgid "Delay interval for lines sent, ports scaned"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:9
-msgid "Set keepalive option"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:10
-msgid "Listen mode, acts as a server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:11
-msgid "Numeric-only IP addresses, no DNS"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:12
-msgid "Hex dump of traffic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:13
-msgid "Local port number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:14
-msgid "Randomize local and remote ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:15
-msgid "Quit after EOF on stdin and delay of secs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:16
-msgid "Local source address"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:17
-msgid "Answer Telnet negotiation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:18
-msgid "UDP Mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:19
-msgid "Verbose, use twice to be more verbose"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:20
-msgid "Timeout for connects and final net reads"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:21
-msgid "Set Type of Service"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:22
-msgid "No I/O - used for scanning"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:3
 msgid "List all available profiles for automatic selection"
 msgstr ""
@@ -48446,22 +48250,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rbenv.fish:12
 msgid "Show the full path for the given Ruby command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:1
-msgid "Filter started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:2
-msgid "Filter stopped daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:3
-msgid "Filter auto started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:4
-msgid "Filter manually started daemons"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rc-service.fish:1
@@ -61527,10 +61315,6 @@ msgstr ""
 msgid "Manage abbreviations using new fish 3.0 scheme."
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/abbr_old.fish:1
-msgid "Manage abbreviations using old fish 2.x scheme."
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/alias.fish:1
 msgid "Creates a function wrapping a command"
 msgstr ""
@@ -61561,10 +61345,6 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/eval.fish:1
-msgid "Evaluate parameters as a command"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/_.fish:1
 msgid "Alias for the gettext command"
 msgstr ""
@@ -61579,14 +61359,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_commandline_is_singlequoted.fish:1
 msgid "Return 0 if the current token has an open single-quote"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_abook_formats.fish:1
-msgid "Complete abook formats"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_ant_targets.fish:1
-msgid "Print list of targets from build.xml and imported files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
@@ -61937,10 +61709,6 @@ msgstr ""
 msgid "Complete by list of running processes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_setxkbmap.fish:1
-msgid "Complete setxkb options"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 msgid "common completions for ssh commands"
 msgstr ""
@@ -61979,12 +61747,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_subcommand.fish:1
 msgid "Complete subcommand"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_subcommand_root.fish:1
-msgid ""
-"Run the __fish_complete_subcommand function using a PATH containing /sbin "
-"and /usr/sbin"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_suffix.fish:1
@@ -62070,7 +61832,6 @@ msgid "Checks if a specific option has been given in the current commandline"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_crux_packages.fish:1
-#: /tmp/fish/implicit/share/functions/__fish_prt_packages.fish:1
 msgid "Obtain a list of installed packages"
 msgstr ""
 
@@ -62096,16 +61857,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_describe_command.fish:1
 msgid "Command used to find descriptions for commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/fish_fallback_prompt.fish:1
-msgid ""
-"A simple fallback prompt without too much color or special characters for "
-"linux VTs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_filter_ant_targets.fish:1
-msgid "Display targets within an ant build.xml file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
@@ -62222,24 +61973,12 @@ msgstr ""
 msgid "Paginate the current command using the users default pager"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_ports_dirs.fish:1
-msgid "Obtain a list of ports local collections"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_arch_daemons.fish:1
-msgid "Print arch daemons"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 msgid "Print a list of documented fish commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_debian_services.fish:1
-msgid "Prints services installed"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
@@ -62248,12 +61987,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_filesystems.fish:1
 msgid "Print a list of all known filesystem types"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_function_prototypes.fish:1
-msgid ""
-"Prints the names of all function prototypes found in the headers in the "
-"current directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
@@ -62280,10 +62013,6 @@ msgstr ""
 msgid "Print lpr printers"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_lsblk_columns.fish:1
-msgid "Print available lsblk columns"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 msgid "Print mounted devices"
 msgstr ""
@@ -62308,60 +62037,20 @@ msgstr ""
 msgid "Print directories where desktop files are stored"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xdg_desktop_file_ids.fish:1
-msgid "Print all available xdg desktop file IDs"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 msgid "Print XDG mime types"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_modes.fish:1
-msgid "Print xrandr modes"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_outputs.fish:1
-msgid "Print xrandr outputs"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
-msgid "Lists ZFS bookmarks, if the feature is enabled"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
-msgid "Lists ZFS filesystems"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 msgid "Lists ZFS snapshots"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
-msgid "Lists ZFS volumes"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_no_subcommand.fish:1
-msgid "Test if prt-get has yet to be given the command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_ports.fish:1
-msgid "Obtain a list of ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_package.fish:1
-msgid "Test if prt-get should have packages as potential completion"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_port.fish:1
-msgid "Test if prt-get should have ports as potential completion"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
@@ -62391,10 +62080,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/_fish_systemctl.fish:1
 msgid "Call systemctl with some options from the current commandline"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_test_arg.fish:1
-msgid "Test if the token under the cursor matches the specified wildcard"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_toggle_comment_commandline.fish:1

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3332,43 +3332,6 @@ msgstr "%s %s：函数 “%s” 不存在 %s\\n"
 msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr "%s %s：应有一个参数，提供了 %s 个\\n"
 
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:1
-#, fuzzy
-msgid "%s: invalid option -- %s\\n"
-msgstr "%s：进程id %s 非法\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:2
-msgid "%s: %s cannot be specified along with %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:3
-msgid "%s: option requires an argument -- %s\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:4
-#, fuzzy
-msgid "%s: Unexpected argument -- %s\\n"
-msgstr "%s：应有一个参数，提供了 %s 个\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:5
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:8
-msgid "%s: abbreviation cannot have spaces in the key\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:6
-msgid "%s: abbreviation must have a value\\n"
-msgstr ""
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:7
-#, fuzzy
-msgid "%s: abbreviation '%s' already exists, cannot rename\\n"
-msgstr "%s：函数 “%s” 不存在\\n"
-
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:9
-#: /tmp/fish/explicit/share/functions/abbr_old.fish:10
-msgid "%s: no such abbreviation '%s'\\n"
-msgstr ""
-
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 msgid "%s: Name cannot be empty\\n"
 msgstr ""
@@ -4268,7 +4231,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/echo.fish:5
 #: /tmp/fish/implicit/share/completions/entr.fish:3
 #: /tmp/fish/implicit/share/completions/env.fish:5
-#: /tmp/fish/implicit/share/completions/eval.fish:1
 #: /tmp/fish/implicit/share/completions/exec.fish:1
 #: /tmp/fish/implicit/share/completions/exit.fish:1
 #: /tmp/fish/implicit/share/completions/fg.fish:1
@@ -4854,7 +4816,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mkvextract.fish:2
 #: /tmp/fish/implicit/share/completions/mocha.fish:1
 #: /tmp/fish/implicit/share/completions/modinfo.fish:11
-#: /tmp/fish/implicit/share/completions/netcat.fish:7
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:1
 #: /tmp/fish/implicit/share/completions/poweroff.fish:1
 #: /tmp/fish/implicit/share/completions/terraform.fish:2
@@ -12716,83 +12677,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/display.fish:59
 #: /tmp/fish/implicit/share/completions/mogrify.fish:100
 msgid "Enhance or reduce the image contrast"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:1
-msgid "Show output in a more script friendly format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:2
-msgid "Download [twice to fetch dependencies]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:3
-msgid "Show info for target [twice for more details]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:4
-msgid "Search for packages by maintainer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:5
-msgid "Search for packages by name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:6
-msgid "Check AUR packages for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:7
-msgid "Use colored output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:8
-msgid "Show debug output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:9
-msgid "Overwrite existing files when downloading"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:10
-#, fuzzy
-msgid "Print formatted"
-msgstr "显示命令类型"
-
-#: /tmp/fish/implicit/share/completions/cower.fish:11
-msgid "Display help and quit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:12
-msgid "Ignore a package upgrade"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:13
-msgid "Ignore a binary repo when checking for updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:14
-msgid "Specify a delimiter for list formatters"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:15
-msgid "Output less"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:16
-msgid "Download targets to DIR"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:17
-msgid "Limit the number of threads created [10]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:18
-msgid "Curl timeout in seconds"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cower.fish:19
-msgid "Output more"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cowsay.fish:1
@@ -43234,90 +43118,6 @@ msgstr ""
 msgid "Exclude files that match any pattern in file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/netcat.fish:1
-msgid "Remote hostname"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:2
-msgid "Same as -e, but use /bin/sh"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:3
-msgid "Program to execute after connection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:4
-msgid "Allow broadcasts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:5
-msgid "Source-routing hop points"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:6
-msgid "Source-routing pointer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:8
-msgid "Delay interval for lines sent, ports scaned"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:9
-msgid "Set keepalive option"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:10
-msgid "Listen mode, acts as a server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:11
-msgid "Numeric-only IP addresses, no DNS"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:12
-msgid "Hex dump of traffic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:13
-msgid "Local port number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:14
-msgid "Randomize local and remote ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:15
-msgid "Quit after EOF on stdin and delay of secs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:16
-msgid "Local source address"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:17
-msgid "Answer Telnet negotiation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:18
-msgid "UDP Mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:19
-msgid "Verbose, use twice to be more verbose"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:20
-msgid "Timeout for connects and final net reads"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:21
-msgid "Set Type of Service"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/netcat.fish:22
-msgid "No I/O - used for scanning"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:3
 msgid "List all available profiles for automatic selection"
 msgstr ""
@@ -48853,22 +48653,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rbenv.fish:12
 msgid "Show the full path for the given Ruby command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:1
-msgid "Filter started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:2
-msgid "Filter stopped daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:3
-msgid "Filter auto started daemons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rc.d.fish:4
-msgid "Filter manually started daemons"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rc-service.fish:1
@@ -62066,10 +61850,6 @@ msgstr ""
 msgid "Manage abbreviations using new fish 3.0 scheme."
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/abbr_old.fish:1
-msgid "Manage abbreviations using old fish 2.x scheme."
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/alias.fish:1
 msgid "Creates a function wrapping a command"
 msgstr ""
@@ -62102,10 +61882,6 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/eval.fish:1
-msgid "Evaluate parameters as a command"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/_.fish:1
 #, fuzzy
 msgid "Alias for the gettext command"
@@ -62121,14 +61897,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_commandline_is_singlequoted.fish:1
 msgid "Return 0 if the current token has an open single-quote"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_abook_formats.fish:1
-msgid "Complete abook formats"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_ant_targets.fish:1
-msgid "Print list of targets from build.xml and imported files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
@@ -62482,10 +62250,6 @@ msgstr ""
 msgid "Complete by list of running processes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_setxkbmap.fish:1
-msgid "Complete setxkb options"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 msgid "common completions for ssh commands"
 msgstr ""
@@ -62524,12 +62288,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_subcommand.fish:1
 msgid "Complete subcommand"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_subcommand_root.fish:1
-msgid ""
-"Run the __fish_complete_subcommand function using a PATH containing /sbin "
-"and /usr/sbin"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_suffix.fish:1
@@ -62615,7 +62373,6 @@ msgid "Checks if a specific option has been given in the current commandline"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_crux_packages.fish:1
-#: /tmp/fish/implicit/share/functions/__fish_prt_packages.fish:1
 msgid "Obtain a list of installed packages"
 msgstr ""
 
@@ -62641,16 +62398,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_describe_command.fish:1
 msgid "Command used to find descriptions for commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/fish_fallback_prompt.fish:1
-msgid ""
-"A simple fallback prompt without too much color or special characters for "
-"linux VTs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_filter_ant_targets.fish:1
-msgid "Display targets within an ant build.xml file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
@@ -62768,25 +62515,12 @@ msgstr ""
 msgid "Paginate the current command using the users default pager"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_ports_dirs.fish:1
-msgid "Obtain a list of ports local collections"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 msgid "Print a list of known network addresses"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_arch_daemons.fish:1
-#, fuzzy
-msgid "Print arch daemons"
-msgstr "打印单词计数"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 msgid "Print a list of documented fish commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_debian_services.fish:1
-msgid "Prints services installed"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
@@ -62795,12 +62529,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_filesystems.fish:1
 msgid "Print a list of all known filesystem types"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_function_prototypes.fish:1
-msgid ""
-"Prints the names of all function prototypes found in the headers in the "
-"current directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_groups.fish:1
@@ -62829,10 +62557,6 @@ msgstr ""
 msgid "Print lpr printers"
 msgstr "打印单词计数"
 
-#: /tmp/fish/implicit/share/functions/__fish_print_lsblk_columns.fish:1
-msgid "Print available lsblk columns"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 msgid "Print mounted devices"
 msgstr ""
@@ -62857,62 +62581,20 @@ msgstr ""
 msgid "Print directories where desktop files are stored"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xdg_desktop_file_ids.fish:1
-msgid "Print all available xdg desktop file IDs"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 msgid "Print XDG mime types"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_modes.fish:1
-#, fuzzy
-msgid "Print xrandr modes"
-msgstr "打印单词计数"
-
-#: /tmp/fish/implicit/share/functions/__fish_print_xrandr_outputs.fish:1
-#, fuzzy
-msgid "Print xrandr outputs"
-msgstr "打印单词计数"
-
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 msgid "Print X windows"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_bookmarks.fish:1
-msgid "Lists ZFS bookmarks, if the feature is enabled"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_filesystems.fish:1
-msgid "Lists ZFS filesystems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 msgid "Lists ZFS snapshots"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_zfs_volumes.fish:1
-msgid "Lists ZFS volumes"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
 msgid "Write out the prompt"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_no_subcommand.fish:1
-msgid "Test if prt-get has yet to be given the command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_ports.fish:1
-msgid "Obtain a list of ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_package.fish:1
-msgid "Test if prt-get should have packages as potential completion"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_prt_use_port.fish:1
-msgid "Test if prt-get should have ports as potential completion"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
@@ -62944,10 +62626,6 @@ msgstr ""
 #, fuzzy
 msgid "Call systemctl with some options from the current commandline"
 msgstr "设置或取得命令行"
-
-#: /tmp/fish/implicit/share/functions/__fish_test_arg.fish:1
-msgid "Test if the token under the cursor matches the specified wildcard"
-msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_toggle_comment_commandline.fish:1
 msgid "Comment/uncomment the current command"


### PR DESCRIPTION
## Description

Cleanup PO files after the work completed in #5279.

Files were found using this Python script which checks whether each entry in the PO file exists in the `fish` repo or not:
<details><summary>Code</summary>

```python
import re
from pathlib import Path

p = Path("/path/to/fish-shell/po/")
for pofile in list(p.glob('*.po')):
    print(f"=============================\n{pofile}\n=============================")
    with open(pofile) as f:
        po_data = f.readlines()

    del_these = set()
    pattern = re.compile("#: \/tmp\/fish\/implicit\/share\/(.+):\d+")
    for line in po_data:
        if m := pattern.match(line):
            testp = Path('/path/to/fish-shell/share') / m.group(1)
            if not testp.exists():
                del_these.add(str(testp))
    del_these = list(del_these)
    del_these.sort()
    for x in del_these:
        print(x)
```
</details>

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] en.po
- [x] de.po
- [x] fr.po
- [x] nb.po
- [x] nn.po
- [x] pl.po
- [x] pt_BR.po
- [x] sv.po
- [x] zh_CN.po
