### PR TITLE
Add the machine "type" to the default prompt

### DIFF
--- a/share/functions/fish_describe_machinetype.fish
+++ b/share/functions/fish_describe_machinetype.fish
@@ -1,0 +1,35 @@
+function fish_describe_machinetype
+    # Check what kind of "machine" we think fish is running on,
+    # whether that be remote via ssh or a container or vm (or multiple).
+    #
+    # This depends on tools to give us the info,
+    # and VMs can also just hide from us, so it isn't good enough
+    # to use to e.g. hide the user@host info in a prompt.
+
+    # We cache this because it doesn't change.
+    if not set -q __fish_machine_type
+        set -g __fish_machine_type
+
+        if set -q SSH_TTY
+            set -a __fish_machine_type ssh
+        end
+
+        if command -sq systemd-detect-virt
+            # This prints "none" on local bare metal, but it then also returns 1.
+            set -l sdv (systemd-detect-virt)
+            and set -a __fish_machine_type $sdv
+        end
+
+        if test -r /etc/debian_chroot
+            or begin command -sq ischroot
+                and ischroot 2>/dev/null
+            end
+            set -a __fish_machine_type chroot
+        end
+    end
+
+    string join \n $__fish_machine_type
+
+    # Return 0 if we have something
+    set -q __fish_machine_type[1]
+end

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -19,12 +19,15 @@ function fish_prompt --description 'Write out the prompt'
     # Write pipestatus
     set -l prompt_status (__fish_print_pipestatus " [" "]" "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus)
 
-    # The kind of machine we're on - ssh or a container or vm technology.
-    # This is empty if it's just a normal local terminal
+    set -q fish_color_host_ssh
+    or set -U fish_color_host_ssh yellow
+
+    # If we're connected via ssh, color the host differently.
+    set -l hostcolor $fish_color_host
     set -l machinetype (fish_describe_machinetype)
-    if set -q machinetype[1]
-        set machinetype "[$machinetype]"
+    if contains -- ssh $machinetype
+        set hostcolor $fish_color_host_ssh
     end
 
-    echo -n -s $machinetype (set_color $fish_color_user) "$USER" $normal @ (set_color $fish_color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "
+    echo -n -s $machinetype (set_color $fish_color_user) "$USER" $normal @ (set_color $hostcolor) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "
 end

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -19,5 +19,12 @@ function fish_prompt --description 'Write out the prompt'
     # Write pipestatus
     set -l prompt_status (__fish_print_pipestatus " [" "]" "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus)
 
-    echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $fish_color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "
+    # The kind of machine we're on - ssh or a container or vm technology.
+    # This is empty if it's just a normal local terminal
+    set -l machinetype (fish_describe_machinetype)
+    if set -q machinetype[1]
+        set machinetype "[$machinetype]"
+    end
+
+    echo -n -s $machinetype (set_color $fish_color_user) "$USER" $normal @ (set_color $fish_color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "
 end

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -29,5 +29,5 @@ function fish_prompt --description 'Write out the prompt'
         set hostcolor $fish_color_host_ssh
     end
 
-    echo -n -s $machinetype (set_color $fish_color_user) "$USER" $normal @ (set_color $hostcolor) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "
+    echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $hostcolor) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "
 end


### PR DESCRIPTION
This is a description of whether we're connected over ssh or in a
container or something.

It's used to signal to the user that this
particular terminal is "special", and not on the local machine, e.g.
to avoid mistakes like executing `poweroff` on a server instead of
your development laptop.

Unfortunately this (at least currently) isn't dependable enough
to *disable* display of the user@host part on "normal" machines, but
we can add something on ssh.

This is most useful to have if it is the default, because that means you don't have to set it up on every single remote machine you ever come into contact with.

See #6375.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
- [ ] Do we add this to classic+vcs, or make the default prompt yet another version of that?
- [ ] Are there more ways of detection to be added?
- [ ] Do we have to handle multiple stacked things? Ssh-on-container, is that important? Or is there some order of precedence here?
- [ ] Is there a better term than "machine type"?