### PR TITLE
Revert "Move __fish_systemd_machines into machinectl completion script"

### DIFF
--- a/share/completions/machinectl.fish
+++ b/share/completions/machinectl.fish
@@ -1,11 +1,3 @@
-function __fish_systemd_machine_images
-    # Like for running machines, I'm assuming machinectl doesn't allow spaces in image names
-    # This does not include the special image ".host" since it isn't valid for most operations
-    machinectl --no-legend --no-pager list-images | while read -l a b
-        echo $a
-    end
-end
-
 complete -f -e -c machinectl
 
 set -l commands list status show start login enable disable poweroff reboot \

--- a/share/functions/__fish_systemd_machines.fish
+++ b/share/functions/__fish_systemd_machines.fish
@@ -1,0 +1,6 @@
+# It seems machinectl will eliminate spaces from machine names so we don't need to handle that
+function __fish_systemd_machines
+    machinectl --no-legend --no-pager list --all | while read -l a b
+        echo $a
+    end
+end


### PR DESCRIPTION
## Description

This reverts commit 9c15b5b7a4008488f1a0e4e786db42a6cea397ca.

Because other complete are using `__fish_systemd_machines`:

```
completions/busctl.fish
completions/machinectl.fish
completions/systemd-analyze.fish
completions/systemctl.fish
```

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
