### PR TITLE
Add the `--succinct` flag to `type`

### DIFF
--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -3,7 +3,7 @@ function type --description 'Print the type of a command'
     set -q argv[1]
     or return 1
 
-    set -l options 'h/help' 'a/all' 'f/no-functions' 't/type' 'p/path' 'P/force-path' 'q/quiet'
+    set -l options 'h/help' 'a/all' 's/succinct' 'f/no-functions' 't/type' 'p/path' 'P/force-path' 'q/quiet'
     argparse -n type -x t,p,P $options -- $argv
     or return
 
@@ -16,6 +16,7 @@ function type --description 'Print the type of a command'
     set -l mode normal
     set -l multi no
     set -l selection all
+    set -l succinct no
 
     # Technically all four of these flags are mutually exclusive. However, we allow -q to be used
     # with the other three because old versions of this function explicitly allowed it by making
@@ -34,6 +35,9 @@ function type --description 'Print the type of a command'
     set -q _flag_all
     and set multi yes
 
+    set -q _flag_succinct
+    and set succinct yes
+
     set -q _flag_no_functions
     and set selection files
 
@@ -48,8 +52,13 @@ function type --description 'Print the type of a command'
                 set found 1
                 switch $mode
                     case normal
-                        printf (_ '%s is a function with definition\n') $i
-                        functions $i
+                        printf (_ '%s is a function') $i
+                        if test $succinct != yes
+                            printf (_ ' with definition\n')
+                            functions $i
+                        else
+                            echo
+                        end
                     case type
                         echo (_ 'function')
                     case path

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -54,7 +54,7 @@ function type --description 'Print the type of a command'
                     case normal
                         printf (_ '%s is a function') $i
                         if test $succinct != yes
-                            printf (_ ' with definition\n')
+                            echo (_ ' with definition')
                             functions $i
                         else
                             echo

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -3,7 +3,7 @@ function type --description 'Print the type of a command'
     set -q argv[1]
     or return 1
 
-    set -l options 'h/help' 'a/all' 's/succinct' 'f/no-functions' 't/type' 'p/path' 'P/force-path' 'q/quiet'
+    set -l options 'h/help' 'a/all' 's/short' 'f/no-functions' 't/type' 'p/path' 'P/force-path' 'q/quiet'
     argparse -n type -x t,p,P $options -- $argv
     or return
 
@@ -16,7 +16,7 @@ function type --description 'Print the type of a command'
     set -l mode normal
     set -l multi no
     set -l selection all
-    set -l succinct no
+    set -l short no
 
     # Technically all four of these flags are mutually exclusive. However, we allow -q to be used
     # with the other three because old versions of this function explicitly allowed it by making
@@ -35,8 +35,8 @@ function type --description 'Print the type of a command'
     set -q _flag_all
     and set multi yes
 
-    set -q _flag_succinct
-    and set succinct yes
+    set -q _flag_short
+    and set short yes
 
     set -q _flag_no_functions
     and set selection files
@@ -53,12 +53,17 @@ function type --description 'Print the type of a command'
                 switch $mode
                     case normal
                         printf (_ '%s is a function') $i
-                        if test $succinct != yes
+                        if test $short != yes
                             echo (_ ' with definition')
                             functions $i
                         else
-                            echo
-                        end
+                            set -l func_path (functions --details $i)
+                            if test $func_path != -
+                                printf (_ ' (defined in %s)\n') $func_path
+                            else
+                                echo
+                            end
+                    end
                     case type
                         echo (_ 'function')
                     case path

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -59,11 +59,10 @@ function type --description 'Print the type of a command'
                         else
                             set -l func_path (functions --details $i)
                             if test $func_path != -
-                                printf (_ ' (defined in %s)\n') $func_path
-                            else
-                                echo
+                                printf (_ ' (defined in %s)') $func_path
                             end
-                    end
+                            echo
+                        end
                     case type
                         echo (_ 'function')
                     case path

--- a/sphinx_doc_src/cmds/type.rst
+++ b/sphinx_doc_src/cmds/type.rst
@@ -20,6 +20,8 @@ The following options are available:
 
 - ``-a`` or ``--all`` prints all of possible definitions of the specified names.
 
+- ``-s`` or ``--succinct`` suppresses function expansion when used with no options, or ``-a``/``--all``.
+
 - ``-f`` or ``--no-functions`` suppresses function and builtin lookup.
 
 - ``-t`` or ``--type`` prints ``function``, ``builtin``, or ``file`` if ``NAME`` is a shell function, builtin, or disk file, respectively.

--- a/sphinx_doc_src/cmds/type.rst
+++ b/sphinx_doc_src/cmds/type.rst
@@ -20,7 +20,7 @@ The following options are available:
 
 - ``-a`` or ``--all`` prints all of possible definitions of the specified names.
 
-- ``-s`` or ``--succinct`` suppresses function expansion when used with no options, or ``-a``/``--all``.
+- ``-s`` or ``--short`` suppresses function expansion when used with no options or with ``-a``/``--all``.
 
 - ``-f`` or ``--no-functions`` suppresses function and builtin lookup.
 


### PR DESCRIPTION
## Description

Add a new flag, `-s`/`--succinct`, to the `type` function: when used, it suppresses the expansion of function definitions normally performed by `type <name>` and `type -a <name>`.

Fixes issue #6402 

## TODOs:
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
