### PR TITLE
Add `fish_transient_right_prompt`

### DIFF
--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -1234,6 +1234,8 @@ The user can change the settings of ``fish`` by changing the values of certain v
 
 - ``fish_trace``, if set and not empty, will cause fish to print commands before they execute, similar to `set -x` in bash. The trace is printed to the path given by the :ref:`--debug-output <cmd-fish>` option to fish (stderr by default).
 
+- ``fish_transient_right_prompt``, if set, remove any right prompt from display when accepting a command line.  This may be useful with terminals with other cut/paste methods. Corresponds to ``TRANSIENT_RPROMPT`` in ``zsh``.
+
 - ``fish_user_paths``, a list of directories that are prepended to ``PATH``. This can be a universal variable.
 
 - ``umask``, the current file creation mask. The preferred way to change the umask variable is through the :ref:`umask <cmd-umask>` function. An attempt to set umask to an invalid value will always fail.

--- a/src/env.h
+++ b/src/env.h
@@ -313,6 +313,8 @@ class env_stack_t final : public environment_t {
 
 extern bool g_use_posix_spawn;
 
+extern bool g_transient_right_prompt;
+
 extern bool term_has_xn;  // does the terminal have the "eat_newline_glitch"
 
 /// Synchronizes all universal variable changes: writes everything out, reads stuff in.

--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -284,6 +284,11 @@ static void handle_read_limit_change(const environment_t &vars) {
     }
 }
 
+static void handle_fish_transient_right_prompt_change(const environment_t &vars) {
+    auto transient_right_prompt = vars.get(L"fish_transient_right_prompt");
+    g_transient_right_prompt = transient_right_prompt.has_value();
+}
+
 /// Populate the dispatch table used by `env_dispatch_var_change()` to efficiently call the
 /// appropriate function to handle a change to a variable.
 /// Note this returns a new-allocated value that we expect to leak.
@@ -310,6 +315,7 @@ static std::unique_ptr<const var_dispatch_table_t> create_dispatch_table() {
     var_dispatch_table->add(L"fish_history", handle_fish_history_change);
     var_dispatch_table->add(L"TZ", handle_tz_change);
     var_dispatch_table->add(L"fish_use_posix_spawn", handle_fish_use_posix_spawn_change);
+    var_dispatch_table->add(L"fish_transient_right_prompt", handle_fish_transient_right_prompt_change);
 
     // This std::move is required to avoid a build error on old versions of libc++ (#5801)
     return std::move(var_dispatch_table);
@@ -525,3 +531,6 @@ bool g_use_posix_spawn = false;
 // Limit `read` to 100 MiB (bytes not wide chars) by default. This can be overridden by the
 // fish_read_limit variable.
 size_t read_byte_limit = 100 * 1024 * 1024;
+
+/// Transient Right Prompt.
+bool g_transient_right_prompt = false;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -441,7 +441,7 @@ class reader_data_t : public std::enable_shared_from_this<reader_data_t> {
         : parser_ref(std::move(parser)), inputter(*parser_ref), history(hist) {}
 
     void update_buff_pos(editable_line_t *el, size_t buff_pos);
-    void repaint();
+    void repaint(bool no_right_prompt = false);
     void kill(editable_line_t *el, size_t begin_idx, size_t length, int mode, int newv);
     bool insert_string(editable_line_t *el, const wcstring &str);
 
@@ -604,7 +604,7 @@ void reader_data_t::update_buff_pos(editable_line_t *el, size_t buff_pos) {
 
 /// Repaint the entire commandline. This means reset and clear the commandline, write the prompt,
 /// perform syntax highlighting, write the commandline and move the cursor.
-void reader_data_t::repaint() {
+void reader_data_t::repaint(bool no_right_prompt) {
     editable_line_t *cmd_line = &command_line;
     // Update the indentation.
     indents = parse_util_compute_indents(cmd_line->text);
@@ -645,7 +645,7 @@ void reader_data_t::repaint() {
     size_t cursor_position = focused_on_pager ? pager.cursor_position() : cmd_line->position;
 
     // Prepend the mode prompt to the left prompt.
-    s_write(&screen, mode_prompt_buff + left_prompt_buff, right_prompt_buff, full_line,
+    s_write(&screen, mode_prompt_buff + left_prompt_buff, no_right_prompt ? L"" : right_prompt_buff, full_line,
             cmd_line->size(), colors, indents, cursor_position, current_page_rendering,
             focused_on_pager);
 
@@ -2774,7 +2774,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 }
                 rls.finished = true;
                 update_buff_pos(&command_line, command_line.size());
-                repaint();
+                repaint(g_transient_right_prompt);
             } else if (command_test_result == PARSER_TEST_INCOMPLETE) {
                 // We are incomplete, continue editing.
                 insert_char(el, L'\n');


### PR DESCRIPTION
## Description
- `fish_transient_right_prompt`, if set, remove any right prompt from display when accepting a command line.  This may be useful with terminals with other cut/paste methods. Corresponds to `TRANSIENT_RPROMPT` in zsh.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
