### PR TITLE
Make `type -p` and `type -P` behave as documented

### DIFF
--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -55,8 +55,9 @@ function type --description 'Print the type of a command'
                     case path
                         set -l func_path (functions --details $i)
                         switch $func_path
-                            case "n/a"
                             case "-"
+                            case "n/a"
+                            case "stdin"
                                 break
                             case "*"
                                 echo $func_path

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -56,7 +56,7 @@ function type --description 'Print the type of a command'
                         set -l func_path (functions --details $i)
                         switch $func_path
                             case "n/a"
-                            case "stdin"
+                            case "-"
                                 break
                             case "*"
                                 echo $func_path
@@ -107,6 +107,7 @@ function type --description 'Print the type of a command'
 
         if test $found = 0
             and test $mode != quiet
+            and test $mode != path
             printf (_ "%s: Could not find '%s'\n") type $i >&2
         end
     end


### PR DESCRIPTION
## Description

These changes bring the behavior of `type -p` and `type -P` into line with their documentation. Specifically:

`type -p`, invoked upon an interactively-defined function , now emits nothing, rather than a single `-`.
`type -p`, invoked upon a nonexistent command, now emits nothing, rather than `type: Could not find '<command>'`

`type -P`, invoked upon a name that does not correspond to an executable in its path, now emits nothing rather than `type: Could not find '<command>'`

**Please note**: This fix assumes that `functions --details` will and should emit `-`, rather than `stdin`, when invoked upon an interactively-defined function. See also issue #6407.

Fixes issue #6411 

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
