### PR TITLE
Support `TRANSIENT_RPROMPT` keyword in output of `fish_right_prompt`

### DIFF
--- a/sphinx_doc_src/cmds/fish_right_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_right_prompt.rst
@@ -20,6 +20,9 @@ Description
 
 Multiple lines are not supported in ``fish_right_prompt``.
 
+If ``fish_right_prompt`` returns a line containing only ``TRANSIENT_RPROMPT``, right prompt will be removed from display when accepting a command line.
+This may be useful with terminals with other cut/paste methods.
+Corresponds to setting ``TRANSIENT_RPROMPT`` in zsh.
 
 Example
 -------
@@ -34,4 +37,13 @@ A simple right prompt:
         date '+%m/%d/%y'
     end
 
+A transient right prompt:
 
+
+
+::
+
+    function fish_right_prompt -d "Write out the transient right prompt"
+        echo TRANSIENT_RPROMPT
+        date '+%m/%d/%y'
+    end


### PR DESCRIPTION
## Description

If ``fish_right_prompt`` returns a line containing only ``TRANSIENT_RPROMPT``, right prompt will be removed from display when accepting a command line.
This may be useful with terminals with other cut/paste methods.
Corresponds to setting ``TRANSIENT_RPROMPT`` in zsh.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

ref: #6405 #6414 
/cc: @faho Perhaps this is the last idea to implement `TRANSIENT_RPROMPT`.