### PR TITLE
Have `type` deal with both flavors of fileless function

### DIFF
--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -58,7 +58,7 @@ function type --description 'Print the type of a command'
                             functions $i
                         else
                             set -l func_path (functions --details $i)
-                            if test $func_path != -
+                            if not contains $func_path - stdin
                                 printf (_ ' (defined in %s)') $func_path
                             end
                             echo

--- a/share/functions/type.fish
+++ b/share/functions/type.fish
@@ -58,7 +58,7 @@ function type --description 'Print the type of a command'
                             functions $i
                         else
                             set -l func_path (functions --details $i)
-                            if not contains $func_path - stdin
+                            if not contains -- $func_path - stdin
                                 printf (_ ' (defined in %s)') $func_path
                             end
                             echo


### PR DESCRIPTION
## Description

This is an update to a recent enhancement, the addition of the `--short` flag to `type`.

The update is prompted by the realization arising from issue #6407, to wit: that `functions --details` can emit _either_ `stdin` or `-`, depending upon whether the function in question was defined interactively or via an alias. This tweak ensures that `type` will deal gracefully with both.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
