### PR TITLE
Mention how `functions --details` handles aliases

### DIFF
--- a/sphinx_doc_src/cmds/functions.rst
+++ b/sphinx_doc_src/cmds/functions.rst
@@ -29,7 +29,7 @@ The following options are available:
 
 - ``-e`` or ``--erase`` causes the specified functions to be erased. This also means that it is prevented from autoloading.
 
-- ``-D`` or ``--details`` reports the path name where each function is defined or could be autoloaded, ``stdin`` if the function was defined interactively or on the command line or by reading stdin, and ``n/a`` if the function isn't available. If the ``--verbose`` option is also specified then five lines are written:
+- ``-D`` or ``--details`` reports the path name where each function is defined or could be autoloaded, ``stdin`` if the function was defined interactively or on the command line or by reading stdin, ``-`` if the function was created via ``alias``, and ``n/a`` if the function isn't available. If the ``--verbose`` option is also specified then five lines are written:
 
     - the pathname as already described,
     - ``autoloaded``, ``not-autoloaded`` or ``n/a``,

--- a/sphinx_doc_src/cmds/functions.rst
+++ b/sphinx_doc_src/cmds/functions.rst
@@ -29,7 +29,7 @@ The following options are available:
 
 - ``-e`` or ``--erase`` causes the specified functions to be erased. This also means that it is prevented from autoloading.
 
-- ``-D`` or ``--details`` reports the path name where each function is defined or could be autoloaded, ``stdin`` if the function was defined interactively or on the command line or by reading stdin, ``-`` if the function was created via ``alias``, and ``n/a`` if the function isn't available. If the ``--verbose`` option is also specified then five lines are written:
+- ``-D`` or ``--details`` reports the path name where each function is defined or could be autoloaded, ``stdin`` if the function was defined interactively or on the command line or by reading stdin, ``-`` if the function was created via ``source``, and ``n/a`` if the function isn't available. (Functions created via ``alias`` will return ``-``, because ``alias`` uses ``source`` internally.) If the ``--verbose`` option is also specified then five lines are written:
 
     - the pathname as already described,
     - ``autoloaded``, ``not-autoloaded`` or ``n/a``,


### PR DESCRIPTION
## Description

As discovered in the course of discussing issue #6407, `functions --details` handles functions defined via alias differently from functions defined interactively, outputting `-` for the former. The documentation doesn't mention this, which has caused… some confusion. This patch adds mention of the alias case.

Fixes issue #6407

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
