### PR TITLE
Make the prompts customizable before and after entering the command line.

### DIFF
--- a/sphinx_doc_src/cmds/fish_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_prompt.rst
@@ -18,6 +18,8 @@ Description
 
 By defining the ``fish_prompt`` function, the user can choose a custom prompt. The ``fish_prompt`` function is executed when the prompt is to be shown, and the output is used as a prompt.
 
+``fish`` passes ``before_input`` or ``after_input`` as a parameter to ``fish_prompt`` depending on the timing of calling.
+
 The exit status of commands within ``fish_prompt`` will not modify the value of `$status <index.html#variables-status>`__ outside of the ``fish_prompt`` function.
 
 ``fish`` ships with a number of example prompts that can be chosen with the ``fish_config`` command.

--- a/sphinx_doc_src/cmds/fish_right_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_right_prompt.rst
@@ -18,11 +18,13 @@ Description
 
 ``fish_right_prompt`` is similar to ``fish_prompt``, except that it appears on the right side of the terminal window.
 
+``fish`` passes ``before_input`` or ``after_input`` as a parameter to ``fish_right_prompt`` depending on the timing of calling.
+
 Multiple lines are not supported in ``fish_right_prompt``.
 
 
-Example
--------
+Examples
+--------
 
 A simple right prompt:
 
@@ -35,3 +37,14 @@ A simple right prompt:
     end
 
 
+
+A simple transient right prompt:
+
+
+
+::
+
+    function fish_right_prompt -a input_phase -d "Write out the transient right prompt"
+        test $input_phase = "before_input"
+            and date '+%m/%d/%y'
+    end

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -928,7 +928,11 @@ void reader_data_t::exec_prompt(const wcstring &input_phase) {
         if (!left_prompt.empty()) {
             wcstring_list_t prompt_list;
             // Ignore return status.
-            exec_subshell(left_prompt + L" " + input_phase, parser(), prompt_list, apply_exit_status);
+            if (left_prompt.compare(LEFT_PROMPT_FUNCTION_NAME) == 0) {
+                exec_subshell(left_prompt + L" " + input_phase, parser(), prompt_list, apply_exit_status);
+            } else {
+                exec_subshell(left_prompt, parser(), prompt_list, apply_exit_status);
+            }
             for (size_t i = 0; i < prompt_list.size(); i++) {
                 if (i > 0) left_prompt_buff += L'\n';
                 left_prompt_buff += prompt_list.at(i);
@@ -938,7 +942,11 @@ void reader_data_t::exec_prompt(const wcstring &input_phase) {
         if (!right_prompt.empty()) {
             wcstring_list_t prompt_list;
             // Status is ignored.
-            exec_subshell(right_prompt + L" " + input_phase, parser(), prompt_list, apply_exit_status);
+            if (right_prompt.compare(RIGHT_PROMPT_FUNCTION_NAME) == 0) {
+                exec_subshell(right_prompt + L" " + input_phase, parser(), prompt_list, apply_exit_status);
+            } else {
+                exec_subshell(right_prompt, parser(), prompt_list, apply_exit_status);
+            }
             for (const auto &i : prompt_list) {
                 // Right prompt does not support multiple lines, so just concatenate all of them.
                 right_prompt_buff += i;


### PR DESCRIPTION
## Description

- Evaluate prompt functions after command line input
- Pass `before_input` or `after_input` as parameter to `fish_prompt` and `fish_right_prompt` functions

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

refs: #6405 #6414 #6419