### PR TITLE
Load vendor configuration directories outside install prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@
 - mandoc can now be used to format the output from `--help` if `nroff` is not installed, reducing the number of external dependencies on systems with `mandoc` installed (#5489).
 - Some bugs preventing building on Solaris-derived systems such as Illumos were fixed (#5458, #5461, #5611).
 - Completions for `npm`, `bower` and `yarn` no longer require the `jq` utility for full functionality, but will use Python instead if it is available.
+- Third-party completions are sourced first from `$XDG_DATA_DIRS/share/fish/vendor_completions.d` in addition to `(pkg-config fish --variable completionsdir)` which defaults to `$PREFIX/share/fish/vendor_completions.d`. Same for vendor_functions.d and vendor_conf.d (#5029).
 
 ---
 

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -30,7 +30,7 @@ SET(extra_completionsdir
 
 SET(extra_functionsdir
     ${datadir}/fish/vendor_functions.d
-    CACHE STRING "Path for extra completions")
+    CACHE STRING "Path for extra functions")
 
 SET(extra_confdir
     ${datadir}/fish/vendor_conf.d


### PR DESCRIPTION
Vendor configuration provided by third party packages is sourced first
from `$EXTRA_VENDOR_PATH/vendor_*` and `$PREFIX/share/fish/vendor_*`
instead of only the latter.  The default for `$EXTRA_VENDOR_PATH` is
`/usr/local/share/fish:/usr/share/fish`, which enables fish to source
third party configuration from packages installed there, even if fish is
installed with a different prefix. The directories in `$EXTRA_VENDOR_PATH`
will not be created by (installing) fish.

In particular, with this change
`/usr/bin/fish` also uses `/usr/local/share/fish/vendor_completions.d`, and
`/usr/local/bin/fish` also uses `/usr/share/fish/vendor_completions.d`

Fixes #5029

## Description

Not sure if this is right, I haven't tested this on different systems.

But it does solve issues like missing upstreams completions for say `docker` when the user installs `docker` to `/usr` and fish to `usr/local`, or vice versa. Which seem like legitimate uses.
It also allows a fish install to a random `$PREFIX` to work just as well installing it to `/usr/local`, which is nice for development.

I guess distros like Arch that don't have `/usr/local/bin` in the default `$PATH` would want to set `EXTRA_VENDOR_PATH=""`, but I think the default of `/usr/local/share/fish:/usr/share/fish` is safe for most systems out there.

`$XDG_DATA_DIRS` could be added easily - but it is specified to fall back to `/usr/local/share:/usr/share` if undefined, so we might still want a configuration time switch to not use those default.
Looks like `zsh` always adds `/usr/local/share/zsh/site-functions` to `$fpath`, that works as well.

## TODOs:
- [x] User-visible changes noted in CHANGELOG.md
