### PR TITLE
Unify upgrades between fish versions with $__fish_initialized

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -8,6 +8,16 @@ set -g IFS \n\ \t
 set -qg __fish_added_user_paths
 or set -g __fish_added_user_paths
 
+# For one-off upgrades of the fish version, see __fish_config_interactive.fish
+if not set -q __fish_initialized
+    set -U __fish_initialized 0
+    if set -q __fish_init_2_39_8
+        set __fish_initialized 2398
+    else if set -q __fish_init_2_3_0
+        set __fish_initialized 2300
+    end
+end
+
 #
 # Create the default command_not_found handler
 #
@@ -154,7 +164,7 @@ end
 # Upgrade pre-existing abbreviations from the old "key=value" to the new "key value" syntax.
 # This needs to be in share/config.fish because __fish_config_interactive is called after sourcing
 # config.fish, which might contain abbr calls.
-if not set -q __fish_init_2_3_0
+if test $__fish_initialized -lt 2300
     if set -q fish_user_abbreviations
         set -l fab
         for abbr in $fish_user_abbreviations
@@ -162,7 +172,6 @@ if not set -q __fish_init_2_3_0
         end
         set fish_user_abbreviations $fab
     end
-    set -U __fish_init_2_3_0
 end
 
 #

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -4,13 +4,11 @@
 # This function is called by the __fish_on_interactive function, which is defined in config.fish.
 #
 function __fish_config_interactive -d "Initializations that should be performed when entering interactive mode"
-    if not set -q __fish_init_3_x
+    if test $__fish_initialized -lt 3000
         # Perform transitions relevant to going from fish 2.x to 3.x.
 
         # Migrate old universal abbreviations to the new scheme.
         __fish_abbr_old | source
-
-        set -U __fish_init_3_x
     end
 
     # Make sure this function is only run once.
@@ -24,7 +22,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
     if not set -q fish_greeting
         set -l line1 (_ 'Welcome to fish, the friendly interactive shell')
         set -l line2 ''
-        if not set -q __fish_init_2_3_0
+        if test $__fish_initialized -lt 2300
             set line2 \n(_ 'Type `help` for instructions on how to use fish')
         end
         set -U fish_greeting "$line1$line2"
@@ -44,7 +42,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
 
     #
     # If we are starting up for the first time, set various defaults.
-    if not set -q __fish_init_3_1_0
+    if test $__fish_initialized -lt 3100
 
         # Regular syntax highlighting colors
         __init_uvar fish_color_normal normal
@@ -89,9 +87,6 @@ function __fish_config_interactive -d "Initializations that should be performed 
         # Directory history colors
         #
         __init_uvar fish_color_history_current --bold
-
-        set -e __fish_init_2_39_8
-        set -U __fish_init_3_1_0
     end
 
     #
@@ -338,4 +333,8 @@ function __fish_config_interactive -d "Initializations that should be performed 
             end
         end
     end
+
+    # Bump this whenever some code below needs to run once when upgrading to a new version.
+    # The universal variable __fish_initialized is initialized in share/config.fish.
+    set __fish_initialized 3100
 end


### PR DESCRIPTION
This variable holds an integer that resembles the fish version up to
that initializations were performed. It should be incremented whenever
some new initialization is required after upgrading fish.  This should
not change the behavior for existing fish installations, except for a
minor message on installations that upgrade from fish<2.3.0.

## Description

See the discussion in
https://github.com/fish-shell/fish-shell/commit/2f1a5e65d8a8d639926517df0b8ece2613b1f04c#commitcomment-36379056
