### PR TITLE
Restore Swedish translations that were accidentally deleted

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -1,18 +1,17 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# fish - the friendly interactive shell
+# Copyright © 2006
+# This file is distributed under the same license as the fish package.
+# Axel Liljencrantz <liljencrantz@gmail.com>, 2006
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: fish 1.22.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-08 16:50+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2015-04-13 22:15+0800\n"
+"PO-Revision-Date: 2006-03-13 18:06+0100\n"
+"Last-Translator: Axel Liljencrantz <liljencrantz@gmail.com>\n"
+"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -90,22 +89,24 @@ msgstr ""
 msgid "%ls: Invalid --max-args value '%ls'\n"
 msgstr ""
 
-#: src/builtin_bg.cpp:23
+#: builtin.cpp:3639
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to background because it is not under job "
 "control\n"
 msgstr ""
+"Kan inte skicka jobb %d, '%ls' till bakgrunden eftersom det inte använder "
+"jobbkontrol\n"
 
-#: src/builtin_bg.cpp:29
+#: builtin.cpp:3649
 #, c-format
 msgid "Send job %d '%ls' to background\n"
-msgstr ""
+msgstr "Skicka jobb %d '%ls' till bakgrunden\n"
 
-#: src/builtin_bg.cpp:63 src/builtin_disown.cpp:69 src/builtin_fg.cpp:49
+#: builtin.cpp:3503 builtin.cpp:3682
 #, c-format
 msgid "%ls: There are no suitable jobs\n"
-msgstr ""
+msgstr "%ls: Det finns inga lämpliga jobb\n"
 
 #: src/builtin_bg.cpp:80 src/builtin_disown.cpp:82 src/builtin_wait.cpp:147
 #, c-format
@@ -117,80 +118,84 @@ msgstr ""
 msgid "%ls: Could not find job '%d'\n"
 msgstr ""
 
-#: src/builtin_bind.cpp:141
+#: builtin.cpp:531
 #, c-format
 msgid "%ls: No key with name '%ls' found\n"
-msgstr ""
+msgstr "%ls: Ingen tangent med namn '%ls' kunde hittas\n"
 
-#: src/builtin_bind.cpp:143
+#: builtin.cpp:537
 #, c-format
 msgid "%ls: Key with name '%ls' does not have any mapping\n"
-msgstr ""
+msgstr "%ls: Tangent med namn '%ls' har ingen mappning\n"
 
-#: src/builtin_bind.cpp:146
+#: builtin.cpp:543
 #, c-format
 msgid "%ls: Unknown error trying to bind to key named '%ls'\n"
 msgstr ""
+"%ls: Okänt fel inträffade vid försök att binda till tangent med namn '%ls'\n"
 
-#: src/builtin_bind.cpp:239
-#, c-format
+#: src/builtin_bind.cpp:239 builtin.cpp:794
+#, fuzzy, c-format
 msgid "%ls: No binding found for key '%ls'\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: Beskrivning saknas för typ '%ls'\n"
 
-#: src/builtin_bind.cpp:242
+#: builtin.cpp:798
 #, c-format
 msgid "%ls: No binding found for sequence '%ls'\n"
-msgstr ""
+msgstr "%ls: Ingen bindning funnen för sekvens '%ls'\n"
 
-#: src/builtin_bind.cpp:406
+#: builtin.cpp:834
 #, c-format
 msgid "%ls: Invalid state\n"
-msgstr ""
+msgstr "%ls: Ogiltigt tillstånd\n"
 
-#: src/builtin_block.cpp:89
+#: builtin.cpp:939
 #, c-format
 msgid "%ls: Can not specify scope when removing block\n"
-msgstr ""
+msgstr "%ls: Kan inte ange definitionsområde vid blockradering\n"
 
-#: src/builtin_block.cpp:94
+#: builtin.cpp:945
 #, c-format
 msgid "%ls: No blocks defined\n"
-msgstr ""
+msgstr "%ls: Inga block definerade\n"
 
-#: src/builtin_cd.cpp:44
+#: builtin.cpp:3192
 #, c-format
 msgid "%ls: Could not find home directory\n"
-msgstr ""
+msgstr "%ls: Kunde inte hitta hemkatalogen\n"
 
-#: src/builtin_cd.cpp:52 src/builtin_cd.cpp:79
+#: builtin.cpp:3212 builtin.cpp:3266
 #, c-format
 msgid "%ls: '%ls' is not a directory\n"
-msgstr ""
+msgstr "%ls: '%ls' är inte en katalog\n"
 
-#: src/builtin_cd.cpp:55
+#: builtin.cpp:3219
 #, c-format
 msgid "%ls: The directory '%ls' does not exist\n"
-msgstr ""
+msgstr "%ls: Katalogen '%ls' existerar inte\n"
 
-#: src/builtin_cd.cpp:58
+#: builtin.cpp:3226
 #, c-format
 msgid "%ls: '%ls' is a rotten symlink\n"
-msgstr ""
+msgstr "%ls: '%ls' är en rutten symbolisk länk\n"
 
-#: src/builtin_cd.cpp:61
+#: builtin.cpp:3234
 #, c-format
 msgid "%ls: Unknown error trying to locate directory '%ls'\n"
-msgstr ""
+msgstr "%ls: Okänd fel inträffade under lokalisering av katalogen '%ls'\n"
 
-#: src/builtin_cd.cpp:76
+#: builtin.cpp:3257
 #, c-format
 msgid "%ls: Permission denied: '%ls'\n"
-msgstr ""
+msgstr "%ls: Åtkomst nekad till katalogen '%ls'\n"
 
-#: src/builtin_cd.cpp:90
+#: builtin.cpp:3281
 #, c-format
 msgid "%ls: Could not set PWD variable\n"
-msgstr ""
+msgstr "%ls: Kunde inte sätta variableln PWD\n"
 
 #: src/builtin_commandline.cpp:344
 #, c-format
@@ -217,269 +222,293 @@ msgstr ""
 msgid "%ls: -o requires a non-empty string\n"
 msgstr ""
 
-#: src/builtin_contains.cpp:75
+#: builtin.cpp:3368
 #, c-format
 msgid "%ls: Key not specified\n"
-msgstr ""
+msgstr "%ls: Ingen nyckel angiven\n"
 
-#: src/builtin.cpp:262
+#: builtin.cpp:352
 #, c-format
 msgid ""
 "%ls: Type 'help %ls' for related documentation\n"
 "\n"
 msgstr ""
+"%ls: Skriv 'help %ls' för relaterad dokumnetation\n"
+"\n"
 
-#: src/builtin.cpp:338
+#: builtin.cpp:3760
 #, c-format
 msgid "%ls: Not inside of loop\n"
-msgstr ""
+msgstr "%ls: Inte i en loop\n"
 
 #: src/builtin.cpp:372
 #, c-format
 msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr ""
 
-#: src/builtin.cpp:410 src/builtin.cpp:460
+#: src/builtin.cpp:410 src/builtin.cpp:460 builtin.cpp:4069 builtin.cpp:4113
+#, fuzzy
 msgid "Test a condition"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa ett villkor"
 
-#: src/builtin.cpp:411
+#: builtin.cpp:4071
 msgid "Execute command if previous command suceeded"
-msgstr ""
+msgstr "Kör ett kommand om föregående kommando lyckades"
 
 #: src/builtin.cpp:412
 msgid "Parse options in fish script"
 msgstr ""
 
-#: src/builtin.cpp:413
+#: builtin.cpp:4072
 msgid "Create a block of code"
-msgstr ""
+msgstr "Skapa ett kodblock"
 
-#: src/builtin.cpp:414
+#: builtin.cpp:4073
 msgid "Send job to background"
-msgstr ""
+msgstr "Skicka jobb till bakgrunden"
 
-#: src/builtin.cpp:415
+#: builtin.cpp:4074
 msgid "Handle fish key bindings"
-msgstr ""
+msgstr "Hantera tangentbordsgenvägar för fish"
 
-#: src/builtin.cpp:416
+#: builtin.cpp:4075
 msgid "Temporarily block delivery of events"
-msgstr ""
+msgstr "Blockera tillfälligt leverans av händelser"
 
-#: src/builtin.cpp:417
+#: builtin.cpp:4076
 msgid "Stop the innermost loop"
-msgstr ""
+msgstr "Avbryt den innersta loopen"
 
-#: src/builtin.cpp:419
+#: builtin.cpp:4077
 msgid ""
 "Temporarily halt execution of a script and launch an interactive debug prompt"
-msgstr ""
+msgstr "Avbryt tillfälligt exekvering och starta en interaktiv debugprompt"
 
-#: src/builtin.cpp:420
+#: builtin.cpp:4078
 msgid "Run a builtin command instead of a function"
-msgstr ""
+msgstr "Kör ett inbyggt kommando istället för en funktion"
 
-#: src/builtin.cpp:421 src/builtin.cpp:459
+#: builtin.cpp:4079 builtin.cpp:4112
 msgid "Conditionally execute a block of commands"
-msgstr ""
+msgstr "Kör ett kommando om ett villkor är uppfyllt"
 
-#: src/builtin.cpp:422
+#: builtin.cpp:4080
 msgid "Change working directory"
-msgstr ""
+msgstr "Ändra arbetskatalog"
 
-#: src/builtin.cpp:423
+#: builtin.cpp:4081
 msgid "Run a program instead of a function or builtin"
-msgstr ""
+msgstr "Kör ett program istället för en funktion eller ett inbuggt kommando"
 
-#: src/builtin.cpp:424
+#: builtin.cpp:4082
 msgid "Set or get the commandline"
-msgstr ""
+msgstr "Ändra eller visa kommandoraden"
 
-#: src/builtin.cpp:425
+#: builtin.cpp:4083
 msgid "Edit command specific completions"
-msgstr ""
+msgstr "Redigera kommando-specifika kompletteringar"
 
-#: src/builtin.cpp:426
+#: builtin.cpp:4084
 msgid "Search for a specified string in a list"
-msgstr ""
+msgstr "Sök efter en angiven sträng i en lista"
 
-#: src/builtin.cpp:428
+#: builtin.cpp:4085
 msgid "Skip the rest of the current lap of the innermost loop"
-msgstr ""
+msgstr "Avbryt nuvarande varv i den innersta loopen"
 
-#: src/builtin.cpp:429
+#: builtin.cpp:4086
 msgid "Count the number of arguments"
-msgstr ""
+msgstr "Räkna antalet argument"
 
 #: src/builtin.cpp:430
 msgid "Remove job from job list"
 msgstr ""
 
-#: src/builtin.cpp:431
+#: src/builtin.cpp:431 builtin.cpp:4087
+#, fuzzy
 msgid "Print arguments"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa antal ord"
 
-#: src/builtin.cpp:432
+#: builtin.cpp:4088
 msgid "Evaluate block if condition is false"
-msgstr ""
+msgstr "Kör ett block om ett villkor inte är uppfyllt"
 
-#: src/builtin.cpp:433
+#: builtin.cpp:4089
 msgid "Emit an event"
-msgstr ""
+msgstr "Sänd en händelse"
 
-#: src/builtin.cpp:434
+#: builtin.cpp:4090
 msgid "End a block of commands"
-msgstr ""
+msgstr "Avsluta ett block av kommandon"
 
-#: src/builtin.cpp:435
+#: builtin.cpp:4091
 msgid "Run command in current process"
-msgstr ""
+msgstr "Kör ett kommando i den nuvarande processen"
 
-#: src/builtin.cpp:436
+#: builtin.cpp:4092
 msgid "Exit the shell"
-msgstr ""
+msgstr "Avsluta fish"
 
-#: src/builtin.cpp:437
+#: builtin.cpp:4093
 msgid "Return an unsuccessful result"
-msgstr ""
+msgstr "Returnera ett misslyckat resultat"
 
-#: src/builtin.cpp:438
+#: builtin.cpp:4094
 msgid "Send job to foreground"
-msgstr ""
+msgstr "Skick jobb till förgrunden"
 
-#: src/builtin.cpp:439
+#: builtin.cpp:4095
 msgid "Perform a set of commands multiple times"
-msgstr ""
+msgstr "Kör ett block flera gånger"
 
-#: src/builtin.cpp:440
+#: builtin.cpp:4096
 msgid "Define a new function"
-msgstr ""
+msgstr "Definera en ny funktion"
 
-#: src/builtin.cpp:441
+#: builtin.cpp:4097
 msgid "List or remove functions"
-msgstr ""
+msgstr "Visa eller ta bort funktioner"
 
-#: src/builtin.cpp:442
+#: builtin.cpp:4098
 msgid "History of commands executed by user"
-msgstr ""
+msgstr "Historik över användarens körda kommandon"
 
-#: src/builtin.cpp:443
+#: builtin.cpp:4099
 msgid "Evaluate block if condition is true"
-msgstr ""
+msgstr "Kör ett block om ett villkor är uppfyllt"
 
-#: src/builtin.cpp:444
+#: builtin.cpp:4100
 msgid "Print currently running jobs"
-msgstr ""
+msgstr "Visa nuvarande jobb"
 
 #: src/builtin.cpp:445
 msgid "Evaluate math expressions"
 msgstr ""
 
-#: src/builtin.cpp:446
+#: builtin.cpp:4101
 msgid "Negate exit status of job"
-msgstr ""
+msgstr "Negera resultatet av ett kommando"
 
-#: src/builtin.cpp:447
+#: builtin.cpp:4102
 msgid "Execute command if previous command failed"
-msgstr ""
+msgstr "Kör ett kommando om föregående kommando misslyckades"
 
-#: src/builtin.cpp:448
+#: src/builtin.cpp:448 builtin.cpp:4103
+#, fuzzy
 msgid "Prints formatted text"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriver ut formatterad text"
 
-#: src/builtin.cpp:449
+#: src/builtin.cpp:449 builtin.cpp:4104
+#, fuzzy
 msgid "Print the working directory"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa nuvarande katalog"
 
-#: src/builtin.cpp:450
+#: builtin.cpp:4105
 msgid "Generate random number"
-msgstr ""
+msgstr "Generera ett slumptal"
 
-#: src/builtin.cpp:451
+#: builtin.cpp:4106
 msgid "Read a line of input into variables"
-msgstr ""
+msgstr "Läs in en rad till variabler"
 
 #: src/builtin.cpp:452
 msgid "Convert path to absolute path without symlinks"
 msgstr ""
 
-#: src/builtin.cpp:453
+#: builtin.cpp:4107
 msgid "Stop the currently evaluated function"
-msgstr ""
+msgstr "Avbryt den nuvarande funktionen"
 
-#: src/builtin.cpp:454
+#: builtin.cpp:4108
 msgid "Handle environment variables"
-msgstr ""
+msgstr "Redigera miljövariabler"
 
-#: src/builtin.cpp:455
+#: src/builtin.cpp:455 builtin.cpp:4109
+#, fuzzy
 msgid "Set the terminal color"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Sätt terminalens färg"
 
-#: src/builtin.cpp:456
+#: builtin.cpp:4110
 msgid "Evaluate contents of file"
-msgstr ""
+msgstr "Kör filinnehåll som kommandon"
 
-#: src/builtin.cpp:457
+#: builtin.cpp:4111
 msgid "Return status information about fish"
-msgstr ""
+msgstr "Visa statusinformation om fish"
 
 #: src/builtin.cpp:458
 msgid "Manipulate strings"
 msgstr ""
 
-#: src/builtin.cpp:461
+#: builtin.cpp:4114
 msgid "Return a successful result"
-msgstr ""
+msgstr "Returenra ett lyckat resultat"
 
-#: src/builtin.cpp:462
+#: builtin.cpp:4115
 msgid "Set or get the shells resource usage limits"
-msgstr ""
+msgstr "Redigera eller visa skalets resursanvändningsgränser"
 
 #: src/builtin.cpp:463
 msgid "Wait for background processes completed"
 msgstr ""
 
-#: src/builtin.cpp:464
+#: builtin.cpp:4116
 msgid "Perform a command multiple times"
-msgstr ""
+msgstr "Kör ett kommando upprepade gånger"
 
-#: src/builtin_disown.cpp:21
+#: builtin.cpp:3630
 #, c-format
 msgid "%ls: Unknown job '%ls'\n"
-msgstr ""
+msgstr "%ls: Okänt jobb '%ls'\n"
 
 #: src/builtin_disown.cpp:30
 #, c-format
 msgid "%ls: job %d ('%ls') was stopped and has been signalled to continue.\n"
 msgstr ""
 
-#: src/builtin_exit.cpp:85 src/builtin_read.cpp:138 src/builtin_return.cpp:85
+#: builtin.cpp:2601 builtin.cpp:3150 builtin.cpp:3817
 #, c-format
 msgid "%ls: Argument '%ls' must be an integer\n"
-msgstr ""
+msgstr "%ls: Argumentet '%ls' måste vara ett heltal\n"
 
-#: src/builtin_fg.cpp:65
+#: builtin.cpp:3531
 #, c-format
 msgid "%ls: Ambiguous job\n"
-msgstr ""
+msgstr "%ls: Mer än ett jobb matchar\n"
 
-#: src/builtin_fg.cpp:67 src/builtin_jobs.cpp:181
+#: builtin.cpp:3537 builtin.cpp:3705 builtin_jobs.cpp:301
 #, c-format
 msgid "%ls: '%ls' is not a job\n"
-msgstr ""
+msgstr "%ls: '%ls' är inte ett jobb\n"
 
-#: src/builtin_fg.cpp:81 src/builtin_jobs.cpp:191
+#: builtin.cpp:3568 builtin_jobs.cpp:316
 #, c-format
 msgid "%ls: No suitable job: %d\n"
-msgstr ""
+msgstr "%ls: Inget passande jobb: %d\n"
 
-#: src/builtin_fg.cpp:84
+#: builtin.cpp:3577
 #, c-format
 msgid ""
 "%ls: Can't put job %d, '%ls' to foreground because it is not under job "
 "control\n"
 msgstr ""
+"Kan inte skicka jobb %d, '%ls' till förgrunden eftersom det inte använder "
+"jobbkontroll\n"
 
 #: src/builtin_function.cpp:68
 #, c-format
@@ -518,42 +547,49 @@ msgstr ""
 msgid "%ls: Unexpected positional argument '%ls'"
 msgstr ""
 
-#: src/builtin_functions.cpp:275 src/builtin.h:38
+#: builtin.cpp:1556 builtin.h:32
 #, c-format
 msgid "%ls: Invalid combination of options\n"
-msgstr ""
+msgstr "%ls: Ogiltig kombination av flaggor\n"
 
-#: src/builtin_functions.cpp:289
+#: builtin.cpp:1578
 #, c-format
 msgid "%ls: Expected exactly one function name\n"
-msgstr ""
+msgstr "%ls: Förväntade exakt ett funktionsnamn\n"
 
-#: src/builtin_functions.cpp:296 src/builtin_functions.cpp:352
+#: builtin.cpp:1588 builtin.cpp:1650
 #, c-format
 msgid "%ls: Function '%ls' does not exist\n"
-msgstr ""
+msgstr "%ls: Funktionen '%ls' existerar inte\n"
 
 #: src/builtin_functions.cpp:307
 #, c-format
 msgid "%ls: Expected exactly one function name for --details\n"
 msgstr ""
 
-#: src/builtin_functions.cpp:342
-#, c-format
+#: src/builtin_functions.cpp:342 builtin.cpp:1638
+#, fuzzy, c-format
 msgid ""
 "%ls: Expected exactly two names (current function name, and new function "
 "name)\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: Förväntade exakt två namn (nuvarande funktionsnamn, och nytt "
+"funktionsnamn)\n"
 
-#: src/builtin_functions.cpp:359
+#: builtin.cpp:1661 builtin.cpp:2230
 #, c-format
 msgid "%ls: Illegal function name '%ls'\n"
-msgstr ""
+msgstr "%ls: Ogiltigt funktionsnamn '%ls'\n"
 
-#: src/builtin_functions.cpp:368
-#, c-format
+#: src/builtin_functions.cpp:368 builtin.cpp:1672
+#, fuzzy, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy '%ls'\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: Funktionen '%ls' existerar inte. Kan inte skapa kopia '%ls'\n"
 
 #: src/builtin_history.cpp:71 src/builtin_status.cpp:117
 #, c-format
@@ -578,42 +614,46 @@ msgstr ""
 msgid "builtin history delete only supports --case-sensitive\n"
 msgstr ""
 
-#: src/builtin_jobs.cpp:55
+#: builtin_jobs.cpp:87
 msgid "Job\tGroup\t"
-msgstr ""
+msgstr "Jobb\tGrupp\t"
 
-#: src/builtin_jobs.cpp:57
+#: builtin_jobs.cpp:89
 msgid "CPU\t"
-msgstr ""
+msgstr "CPU\t"
 
-#: src/builtin_jobs.cpp:59
+#: builtin_jobs.cpp:91
 msgid "State\tCommand\n"
-msgstr ""
+msgstr "Status\tKommando\n"
 
-#: src/builtin_jobs.cpp:67
+#: builtin_jobs.cpp:99 proc.cpp:843
 msgid "stopped"
-msgstr ""
+msgstr "stannat"
 
-#: src/builtin_jobs.cpp:67
+#: builtin_jobs.cpp:99
 msgid "running"
-msgstr ""
+msgstr "körande"
 
-#: src/builtin_jobs.cpp:76
+#: builtin_jobs.cpp:113
 msgid "Group\n"
-msgstr ""
+msgstr "Grupp\n"
 
-#: src/builtin_jobs.cpp:84
+#: src/builtin_jobs.cpp:84 builtin_jobs.cpp:126
+#, fuzzy
 msgid "Process\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Process\n"
 
-#: src/builtin_jobs.cpp:95
+#: builtin_jobs.cpp:143
 msgid "Command\n"
-msgstr ""
+msgstr "Kommando\n"
 
-#: src/builtin_jobs.cpp:211
+#: builtin_jobs.cpp:344
 #, c-format
 msgid "%ls: There are no jobs\n"
-msgstr ""
+msgstr "%ls: Det finns inga jobb\n"
 
 #: src/builtin_math.cpp:44
 #, c-format
@@ -639,43 +679,52 @@ msgstr ""
 msgid "Number out of range"
 msgstr ""
 
-#: src/builtin_printf.cpp:249
-#, c-format
+#: src/builtin_printf.cpp:249 builtin_printf.cpp:256
+#, fuzzy, c-format
 msgid "%ls: expected a numeric value"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: förväntade ett numeriskt värde"
 
-#: src/builtin_printf.cpp:251
+#: builtin_printf.cpp:258
 #, c-format
 msgid "%ls: value not completely converted"
-msgstr ""
+msgstr "%ls: värdet konverterades inte helt"
 
-#: src/builtin_printf.cpp:363
+#: builtin_printf.cpp:359
 msgid "missing hexadecimal number in escape"
-msgstr ""
+msgstr "saknad hexadecimalt nummer i escapesekvens"
 
-#: src/builtin_printf.cpp:383
+#: builtin_printf.cpp:388
 msgid "Missing hexadecimal number in Unicode escape"
-msgstr ""
+msgstr "Saknad hexadecimalt nummer i Unicodeescapesekvens"
 
-#: src/builtin_printf.cpp:400
+#: builtin_printf.cpp:402
 #, c-format
 msgid "Unicode character out of range: \\%c%0*x"
-msgstr ""
+msgstr "Unicodetecken utanför giltigt spann: \\%c%0+x"
 
-#: src/builtin_printf.cpp:647
+#: builtin_printf.cpp:670
 #, c-format
 msgid "invalid field width: %ls"
-msgstr ""
+msgstr "oglitig fältvidd: %ls"
 
-#: src/builtin_printf.cpp:674
-#, c-format
+#: src/builtin_printf.cpp:674 builtin_printf.cpp:708
+#, fuzzy, c-format
 msgid "invalid precision: %ls"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"ogiltig precision %ls"
 
-#: src/builtin_printf.cpp:699
-#, c-format
+#: src/builtin_printf.cpp:699 builtin_printf.cpp:739
+#, fuzzy, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%.*ls: Ogiltig kombination av flaggor"
 
 #: src/builtin_read.cpp:123
 #, c-format
@@ -683,10 +732,13 @@ msgid ""
 "%ls: flags '--mode-name' / '-m' are now ignored. Set fish_history instead.\n"
 msgstr ""
 
-#: src/builtin_read.cpp:132
-#, c-format
+#: src/builtin_read.cpp:132 builtin.cpp:2593
+#, fuzzy, c-format
 msgid "%ls: Argument '%ls' is out of range\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: Argumentet '%ls' är utanför spannet\n"
 
 #: src/builtin_read.cpp:344
 #, c-format
@@ -698,20 +750,27 @@ msgstr ""
 msgid "%ls: Invalid path: %ls\n"
 msgstr ""
 
-#: src/builtin_return.cpp:100
+#: builtin.cpp:3845
 #, c-format
 msgid "%ls: Not inside of function\n"
-msgstr ""
+msgstr "%ls: Inte i en funktion\n"
 
 #: src/builtin_set_color.cpp:159 src/builtin_set_color.cpp:178
-#, c-format
+#: builtin_set_color.cpp:144 builtin_set_color.cpp:166
+#, fuzzy, c-format
 msgid "%ls: Unknown color '%ls'\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%s: Okänd färg '%s'\n"
 
-#: src/builtin_set_color.cpp:167
-#, c-format
+#: src/builtin_set_color.cpp:167 builtin_set_color.cpp:153
+#, fuzzy, c-format
 msgid "%ls: Expected an argument\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%s: Förväntade ett argument\n"
 
 #: src/builtin_set.cpp:62
 #, c-format
@@ -728,10 +787,13 @@ msgstr ""
 msgid "%ls: You provided %d indexes but %d values\n"
 msgstr ""
 
-#: src/builtin_set.cpp:66
-#, c-format
+#: src/builtin_set.cpp:66 builtin_set.cpp:647
+#, fuzzy, c-format
 msgid "%ls: Erase needs a variable name\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: Radering kräver ett variabelnamn\n"
 
 #: src/builtin_set.cpp:67
 #, c-format
@@ -745,25 +807,31 @@ msgid ""
 "name.\n"
 msgstr ""
 
-#: src/builtin_set.cpp:303
+#: builtin_set.cpp:155
 #, c-format
 msgid "%ls: Tried to change the read-only variable '%ls'\n"
-msgstr ""
+msgstr "%ls: Försökte ändra den skrivskyddade variablen '%ls'\n"
 
-#: src/builtin_set.cpp:310
-#, c-format
+#: src/builtin_set.cpp:310 builtin_set.cpp:162
+#, fuzzy, c-format
 msgid "%ls: Tried to set the special variable '%ls' with the wrong scope\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: Försökte ändra den speciella variablen '%ls' med fel definitionsområde\n"
 
-#: src/builtin_set.cpp:317
-#, c-format
+#: src/builtin_set.cpp:317 builtin_set.cpp:169
+#, fuzzy, c-format
 msgid "%ls: Tried to set the special variable '%ls' to an invalid value\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: Försökte ändra den speciella variablen '%ls' till ett ogiltigt värde\n"
 
-#: src/builtin_set.cpp:355
+#: builtin_set.cpp:248
 #, c-format
 msgid "%ls: Invalid index starting at '%ls'\n"
-msgstr ""
+msgstr "%ls: Ogiltigt index vid '%ls'\n"
 
 #: src/builtin_set.cpp:537
 #, c-format
@@ -798,63 +866,63 @@ msgstr ""
 msgid "%ls: `set --show` does not allow slices with the var names\n"
 msgstr ""
 
-#: src/builtin_source.cpp:49 src/builtin_source.cpp:57
+#: builtin.cpp:3412 builtin.cpp:3420
 #, c-format
 msgid "%ls: Error encountered while sourcing file '%ls':\n"
-msgstr ""
+msgstr "%ls: Ett fel uppstod medan filen '%ls' lästes in\n"
 
-#: src/builtin_source.cpp:65
+#: builtin.cpp:3428
 #, c-format
 msgid "%ls: '%ls' is not a file\n"
-msgstr ""
+msgstr "%ls: '%ls' är inte en fil\n"
 
-#: src/builtin_source.cpp:84
+#: builtin.cpp:3447
 #, c-format
 msgid "%ls: Error while reading file '%ls'\n"
-msgstr ""
+msgstr "%ls: Ett fel uppstod medan filen '%ls' lästes\n"
 
 #: src/builtin_status.cpp:155
 #, c-format
 msgid "%ls: Invalid level value '%ls'\n"
 msgstr ""
 
-#: src/builtin_status.cpp:276
+#: builtin.cpp:3108
 msgid "This is a login shell\n"
-msgstr ""
+msgstr "Detta är ett login-skal\n"
 
-#: src/builtin_status.cpp:278
+#: builtin.cpp:3110
 msgid "This is not a login shell\n"
-msgstr ""
+msgstr "Detta är inte ett login-skal\n"
 
-#: src/builtin_status.cpp:282
+#: builtin.cpp:3112
 #, c-format
 msgid "Job control: %ls\n"
-msgstr ""
+msgstr "Jobkontroll: %ls\n"
 
-#: src/builtin_status.cpp:284
+#: builtin.cpp:3113
 msgid "Only on interactive jobs"
-msgstr ""
+msgstr "Bara för interaktiva jobb"
 
-#: src/builtin_status.cpp:285
+#: builtin.cpp:3114
 msgid "Never"
-msgstr ""
+msgstr "Aldrig"
 
-#: src/builtin_status.cpp:285
+#: builtin.cpp:3114
 msgid "Always"
-msgstr ""
+msgstr "Alltid"
 
-#: src/builtin_status.cpp:312 src/fish.cpp:433 src/parser.cpp:552
+#: builtin.cpp:3065 fish.cpp:620 parser.cpp:764
 msgid "Standard input"
-msgstr ""
+msgstr "Standard in"
 
 #: src/builtin_status.cpp:320
 msgid "Not a function"
 msgstr ""
 
-#: src/builtin_string.cpp:39
+#: builtin.h:27
 #, c-format
 msgid "%ls: Expected argument\n"
-msgstr ""
+msgstr "%ls: Förväntade argument\n"
 
 #: src/builtin_string.cpp:160
 #, c-format
@@ -937,32 +1005,30 @@ msgstr ""
 msgid "Defaulting terminal size to 80x24."
 msgstr ""
 
-#: src/common.cpp:1781
+#: common.cpp:1917
 msgid "This is a bug. Break on bugreport to debug."
-msgstr ""
+msgstr "Detta är en bug. För att avlusa, sätt brytpunkten på bugreport."
 
-#: src/common.cpp:1782
-#, c-format
-msgid "If you can reproduce it, please send a bug report to %s."
-msgstr ""
-
-#: src/common.cpp:1792
+#: common.cpp:1936
 msgid "empty"
-msgstr ""
+msgstr "tom"
 
-#: src/complete.cpp:53
-#, c-format
+#: src/complete.cpp:53 complete.cpp:61
+#, fuzzy, c-format
 msgid "Home for %ls"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Hemkatalog för %s"
 
-#: src/complete.cpp:56
+#: complete.cpp:66
 #, c-format
 msgid "Variable: %ls"
-msgstr ""
+msgstr "Variabel: %ls"
 
-#: src/env.cpp:242
+#: env.cpp:1180
 msgid "Tried to pop empty environment stack."
-msgstr ""
+msgstr "Försökte ta bort element från tom variabelstack"
 
 #: src/env.cpp:537
 #, c-format
@@ -1051,107 +1117,117 @@ msgstr ""
 msgid "Unable to open a pipe for universal variables using '%ls': %s"
 msgstr ""
 
-#: src/event.cpp:119
+#: event.cpp:178
 #, c-format
 msgid "signal handler for %ls (%ls)"
-msgstr ""
+msgstr "signalhanterare för %ls (%ls)"
 
-#: src/event.cpp:124
+#: event.cpp:182
 #, c-format
 msgid "handler for variable '%ls'"
-msgstr ""
+msgstr "hanterare för variabel '%ls'"
 
-#: src/event.cpp:129
+#: event.cpp:188
 #, c-format
 msgid "exit handler for process %d"
-msgstr ""
+msgstr "avslutshanterare för process %d"
 
-#: src/event.cpp:134 src/event.cpp:145
+#: event.cpp:194 event.cpp:205
 #, c-format
 msgid "exit handler for job %d, '%ls'"
-msgstr ""
+msgstr "avslutshanterare för jobb %d, '%ls'"
 
-#: src/event.cpp:137
+#: event.cpp:196
 #, c-format
 msgid "exit handler for job with process group %d"
-msgstr ""
+msgstr "avslutshanterare för jobb med processgrupp %d"
 
-#: src/event.cpp:148
+#: event.cpp:207
 #, c-format
 msgid "exit handler for job with job id %d"
-msgstr ""
+msgstr "avslutshanterare för jobb med jobid %d"
 
-#: src/event.cpp:153
+#: event.cpp:213
 #, c-format
 msgid "handler for generic event '%ls'"
-msgstr ""
+msgstr "hanterare för generisk händelse '%ls'"
 
-#: src/event.cpp:157
-#, c-format
+#: src/event.cpp:157 event.cpp:217
+#, fuzzy, c-format
 msgid "Unknown event type '0x%x'"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Okänd händelsetyp '0x%x'"
 
-#: src/event.cpp:403
+#: event.cpp:613
 msgid "Signal list overflow. Signals have been ignored."
-msgstr ""
+msgstr "Signallistan är full. Signaler har ignorerats."
 
-#: src/exec.cpp:45
+#: exec.cpp:57
 #, c-format
 msgid "An error occurred while redirecting file descriptor %d"
-msgstr ""
+msgstr "Ett fel inträffade vid IO dirigering av filidentifierare %d"
 
-#: src/exec.cpp:48
+#: src/exec.cpp:48 exec.cpp:62
+#, fuzzy
 msgid "An error occurred while writing output"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ett fel inträffade under skrivandet av utdata"
 
-#: src/exec.cpp:51
-#, c-format
+#: src/exec.cpp:51 exec.cpp:67
+#, fuzzy, c-format
 msgid "An error occurred while redirecting file '%s'"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ett fel inträffade vid IO dirigering av filen '%ls'"
 
-#: src/exec.cpp:714
+#: exec.cpp:795
 #, c-format
 msgid "Unknown function '%ls'"
-msgstr ""
+msgstr "Okänd funktion '%ls'"
 
-#: src/exec.cpp:801
+#: exec.cpp:943
 #, c-format
 msgid "Unknown input redirection type %d"
-msgstr ""
+msgstr "Okänd dirigering av standard in av typ %d"
 
-#: src/expand.cpp:55
+#: expand.cpp:59
 msgid "Child process"
-msgstr ""
+msgstr "Barnprocess"
 
-#: src/expand.cpp:58
+#: expand.cpp:64
 msgid "Process"
-msgstr ""
+msgstr "Process"
 
-#: src/expand.cpp:61
+#: expand.cpp:69
 msgid "Job"
-msgstr ""
+msgstr "Jobb"
 
-#: src/expand.cpp:64
+#: expand.cpp:74
 #, c-format
 msgid "Job: %ls"
-msgstr ""
+msgstr "Jobb: %ls"
 
-#: src/expand.cpp:67
+#: expand.cpp:79
 msgid "Shell process"
-msgstr ""
+msgstr "Skalprocess"
 
-#: src/expand.cpp:70
+#: expand.cpp:84
 msgid "Last background job"
-msgstr ""
+msgstr "Senaste bakgrundsjobb"
 
 #: src/expand.cpp:398
 #, c-format
 msgid "Unexpected failure to convert pid '%ls' to integer\n"
 msgstr ""
 
-#: src/expand.cpp:984
+#: expand.cpp:1419
 msgid "Mismatched brackets"
-msgstr ""
+msgstr "Klammerparanteser matchar inte varandra"
 
 #: src/expand.cpp:1063
 msgid "Too much data emitted by command substitution so it was discarded\n"
@@ -1162,29 +1238,29 @@ msgstr ""
 msgid "Invalid value '%s' for debug-level flag"
 msgstr ""
 
-#: src/fish.cpp:302
+#: fish.cpp:461 mimedb.cpp:1343
 #, c-format
 msgid "%s, version %s\n"
-msgstr ""
+msgstr "%s, version %s\n"
 
 #: src/fish.cpp:316 src/fish_indent.cpp:434
 #, c-format
 msgid "Invalid value '%s' for debug-stack-frames flag"
 msgstr ""
 
-#: src/fish.cpp:366
+#: fish.cpp:516
 msgid "Can not use the no-execute mode when running an interactive session"
-msgstr ""
+msgstr "no-execute läget kan inte användas i en interaktiv session"
 
-#: src/fish.cpp:431
+#: fish.cpp:619
 #, c-format
 msgid "Error while reading file %ls\n"
-msgstr ""
+msgstr "Ett fel uppstod medan filen '%ls' lästes\n"
 
-#: src/fish_indent.cpp:389
+#: fish_indent.cpp:332
 #, c-format
 msgid "%ls, version %s\n"
-msgstr ""
+msgstr "%ls, version %s\n"
 
 #: src/fish_indent.cpp:453
 #, c-format
@@ -1234,35 +1310,53 @@ msgstr ""
 msgid "An error occured while reading output from code block on fd %d"
 msgstr ""
 
-#: src/output.cpp:559
-#, c-format
+#: src/output.cpp:559 output.cpp:608
+#, fuzzy, c-format
 msgid ""
 "Tried to use terminfo string %s on line %ld of %s, which is undefined in "
 "terminal of type \"%ls\". Please report this error to %s"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Försökte använda terminfosträng %s på rad %d av %s, vilken är odefinerad i "
+"terminaler av typen '%ls'. Vänligen rapportera detta fel till %s"
 
-#: src/pager.cpp:40
+#: src/pager.cpp:40 pager.cpp:24
+#, fuzzy
 msgid "search: "
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"sök: "
 
-#: src/pager.cpp:493
+#: pager.cpp:566
 #, c-format
 msgid "%lsand %lu more rows"
-msgstr ""
+msgstr "%lsoch %lu rader till"
 
-#: src/pager.cpp:500
-#, c-format
+#: src/pager.cpp:500 pager.cpp:571
+#, fuzzy, c-format
 msgid "rows %lu to %lu of %lu"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"rader %d till %d av %d"
 
-#: src/pager.cpp:503
+#: src/pager.cpp:503 pager.cpp:576
+#, fuzzy
 msgid "(no matches)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"(inga matchningar)"
 
-#: src/parse_execution.cpp:556
-#, c-format
+#: src/parse_execution.cpp:556 parse_execution.cpp:555
+#, fuzzy, c-format
 msgid "switch: Expected exactly one argument, got %lu\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"switch: Förväntade exakt ett argument, fick %lu\n"
 
 #: src/parse_execution.cpp:791
 #, c-format
@@ -1271,165 +1365,204 @@ msgid ""
 "use 'eval %ls'."
 msgstr ""
 
-#: src/parse_execution.cpp:796
-#, c-format
+#: src/parse_execution.cpp:796 parse_execution.cpp:848
+#, fuzzy, c-format
 msgid "The file '%ls' is not executable by this user"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Filen '%ls' existerar redan"
 
-#: src/parse_execution.cpp:1007
-#, c-format
+#: src/parse_execution.cpp:1007 parse_execution.cpp:1057
+#, fuzzy, c-format
 msgid "Invalid redirection target: %ls"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ogiltig IO omdirigering"
 
-#: src/parse_execution.cpp:1021
-#, c-format
+#: src/parse_execution.cpp:1021 parse_execution.cpp:1081
+#, fuzzy, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"IO dirigering till någonting som inte är en filidentifierare"
 
-#: src/parser.cpp:30
+#: parser.cpp:57
 #, c-format
 msgid "Tried to evaluate commands using invalid block type '%ls'"
-msgstr ""
+msgstr "Försökte utföra kommandon i ogiltig blocktyp '%ls'"
 
-#: src/parser.cpp:33
+#: parser.cpp:67 parse_constants.h:255
 msgid "'while' block"
-msgstr ""
+msgstr "'while' block"
 
-#: src/parser.cpp:36
+#: parser.cpp:72 parse_constants.h:260
 msgid "'for' block"
-msgstr ""
+msgstr "'for' block"
 
-#: src/parser.cpp:39
+#: parser.cpp:77 parse_constants.h:265
 msgid "block created by breakpoint"
-msgstr ""
+msgstr "block skapat av det inbuggde kommandot breakpoint"
 
-#: src/parser.cpp:42
+#: parser.cpp:82 parse_constants.h:272
 msgid "'if' conditional block"
-msgstr ""
+msgstr "'if' villkorligt block"
 
-#: src/parser.cpp:45
+#: parser.cpp:92 parse_constants.h:284
 msgid "function invocation block"
-msgstr ""
+msgstr "funktionsanropp-block"
 
-#: src/parser.cpp:48
+#: parser.cpp:97 parse_constants.h:289
 msgid "function invocation block with no variable shadowing"
-msgstr ""
+msgstr "funktionsanroppsblock utan variabelskuggning"
 
-#: src/parser.cpp:51
+#: parser.cpp:102 parse_constants.h:295
 msgid "'switch' block"
-msgstr ""
+msgstr "'switch' block"
 
-#: src/parser.cpp:54
+#: parser.cpp:112 parse_constants.h:307
 msgid "global root block"
-msgstr ""
+msgstr "globalt rot-block"
 
-#: src/parser.cpp:57
+#: parser.cpp:117 parse_constants.h:313
 msgid "command substitution block"
-msgstr ""
+msgstr "kommandosubstitution-block"
 
-#: src/parser.cpp:60
+#: parser.cpp:122 parse_constants.h:319
 msgid "'begin' unconditional block"
-msgstr ""
+msgstr "'begin' ovillkorligen exekverat block"
 
-#: src/parser.cpp:63
+#: parser.cpp:127 parse_constants.h:325
 msgid "block created by the . builtin"
-msgstr ""
+msgstr "block skapat av det inbyggda kommandot '.'"
 
-#: src/parser.cpp:66
+#: parser.cpp:132 parse_constants.h:330
 msgid "event handler block"
-msgstr ""
+msgstr "händelsehanterarblock"
 
-#: src/parser.cpp:69
+#: parser.cpp:137 parse_constants.h:336
 msgid "unknown/invalid block"
-msgstr ""
+msgstr "okänt/ogiltigt block"
 
-#: src/parser.cpp:306
+#: parser.cpp:474
 #, c-format
 msgid "Could not write profiling information to file '%s'"
-msgstr ""
+msgstr "Kunde inte skriva profileringsinformation till filen '%s'"
 
-#: src/parser.cpp:308
+#: parser.cpp:480
 msgid "Time\tSum\tCommand\n"
-msgstr ""
+msgstr "Tid\tSumma\tKommando\n"
 
-#: src/parser.cpp:366
+#: parser.cpp:562
 #, c-format
 msgid "in event handler: %ls\n"
-msgstr ""
+msgstr "i händelsehanterare: %ls\n"
 
-#: src/parser.cpp:385
-#, c-format
+#: src/parser.cpp:385 parser.cpp:590
+#, fuzzy, c-format
 msgid "from sourcing file %ls\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ett fel uppstod medan filen '%ls' lästes\n"
 
-#: src/parser.cpp:392
-#, c-format
+#: src/parser.cpp:392 parser.cpp:597
+#, fuzzy, c-format
 msgid "in function '%ls'\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"i funktion '%ls',\n"
 
-#: src/parser.cpp:396
+#: parser.cpp:602
 msgid "in command substitution\n"
-msgstr ""
+msgstr "i kommandosubstitution\n"
 
-#: src/parser.cpp:407
-#, c-format
+#: src/parser.cpp:407 parser.cpp:615
+#, fuzzy, c-format
 msgid "\tcalled on line %d of file %ls\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"\tanropad på rad %d i fil '%ls',\n"
 
-#: src/parser.cpp:410
+#: src/parser.cpp:410 parser.cpp:621
+#, fuzzy
 msgid "\tcalled during startup\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"\tanropad från standard in,\n"
 
-#: src/parser.cpp:412
+#: src/parser.cpp:412 parser.cpp:625
+#, fuzzy
 msgid "\tcalled on standard input\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"\tanropad från standard in,\n"
 
-#: src/parser.cpp:425
+#: parser.cpp:642
 #, c-format
 msgid "\twith parameter list '%ls'\n"
-msgstr ""
+msgstr "\tmed parameterlista '%ls'\n"
 
-#: src/parser.cpp:547
+#: parser.cpp:756
 #, c-format
 msgid "%ls (line %d): "
-msgstr ""
+msgstr "%ls (rad %d): "
 
-#: src/parser.cpp:550
+#: src/parser.cpp:550 parser.cpp:760
 msgid "Startup"
 msgstr ""
 
-#: src/parser.cpp:588
+#: parser.cpp:803
 msgid "Job inconsistency"
-msgstr ""
+msgstr "Jobb i ogiltigt tillstånd"
 
-#: src/parser.cpp:797
-#, c-format
+#: src/parser.cpp:797 parser.cpp:1047
+#, fuzzy, c-format
 msgid "%ls (line %lu): "
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls (rad %d): "
 
-#: src/parser.cpp:800
+#: src/parser.cpp:800 parser.cpp:1051
 #, c-format
 msgid "%ls: "
 msgstr ""
 
-#: src/parse_util.cpp:28
-#, c-format
+#: src/parse_util.cpp:28 parse_util.cpp:46
+#, fuzzy, c-format
 msgid "The '%ls' command can not be used in a pipeline"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Detta kommando kan ej användas i ett rör"
 
-#: src/parse_util.cpp:32
-#, c-format
+#: src/parse_util.cpp:32 parse_util.cpp:49
+#, fuzzy, c-format
 msgid "The '%ls' command can not be used immediately after a backgrounded job"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Detta kommando kan ej användas i ett rör"
 
-#: src/parse_util.cpp:36
+#: src/parse_util.cpp:36 parse_util.cpp:52
+#, fuzzy
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Detta kommando kan ej användas i ett rör"
 
-#: src/path.cpp:25
+#: path.cpp:24
 #, c-format
 msgid "Error while searching for command '%ls'"
-msgstr ""
+msgstr "Ett fel uppstod under sökning efter kommandot '%ls'"
 
 #: src/path.cpp:276
 #, c-format
@@ -1469,78 +1602,84 @@ msgstr ""
 msgid "Job %d, "
 msgstr ""
 
-#: src/proc.cpp:587
-#, c-format
+#: src/proc.cpp:587 proc.cpp:786
+#, fuzzy, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: Jobb %d, '%ls' avslutat av signal %ls (%ls)"
 
-#: src/proc.cpp:595
-#, c-format
+#: src/proc.cpp:595 proc.cpp:797
+#, fuzzy, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%ls: Process %d, '%ls', från jobb %d, '%ls' avslutat av signal %ls (%ls)"
 
-#: src/proc.cpp:779
+#: proc.cpp:1065
 msgid "An error occured while reading output from code block"
-msgstr ""
+msgstr "Ett fel inträffade under läsandet av utdata från kodblock"
 
 #: src/proc.cpp:856
 #, c-format
 msgid "Could not send job %d ('%ls') with pgid %d to foreground"
 msgstr ""
 
-#: src/proc.cpp:885
+#: proc.cpp:1094 proc.cpp:1106
 #, c-format
 msgid "Could not send job %d ('%ls') to foreground"
-msgstr ""
+msgstr "Kunde inte skicka jobb %d ('%ls') till förgrunden"
 
-#: src/proc.cpp:909 src/proc.cpp:918 src/proc.cpp:932
+#: proc.cpp:1126 proc.cpp:1136 proc.cpp:1151
 msgid "Could not return shell to foreground"
-msgstr ""
+msgstr "Kunde inte återställa skalet till förgrunden"
 
-#: src/proc.cpp:1065
+#: proc.cpp:1365
 #, c-format
 msgid "More than one job in foreground: job 1: '%ls' job 2: '%ls'"
-msgstr ""
+msgstr "Mer än ett jobb i förgrunden: job 1: '%ls', jobb 2 '%ls'"
 
-#: src/proc.cpp:1075
+#: proc.cpp:1378
 msgid "Process argument list"
-msgstr ""
+msgstr "Processargumentlista"
 
-#: src/proc.cpp:1076
+#: proc.cpp:1379
 msgid "Process name"
-msgstr ""
+msgstr "Processnamn"
 
-#: src/proc.cpp:1079
+#: proc.cpp:1385
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'stopped'=%d"
-msgstr ""
+msgstr "Jobb '%ls', process '%ls' har ogiltigt tillstånd 'stopped'=%d"
 
-#: src/proc.cpp:1085
+#: proc.cpp:1395
 #, c-format
 msgid "Job '%ls', process '%ls' has inconsistent state 'completed'=%d"
-msgstr ""
+msgstr "Jobb '%ls', process '%ls' har ogiltigt tillstånd 'completed'=%d"
 
-#: src/reader.cpp:333
+#: reader.cpp:478
 msgid "Could not set terminal mode for new job"
-msgstr ""
+msgstr "Kunde inte återställa terminalen för nytt jobb"
 
-#: src/reader.cpp:362
+#: reader.cpp:525
 msgid "Could not set terminal mode for shell"
-msgstr ""
+msgstr "Kunde inte återställa terminalen till skalet"
 
-#: src/reader.cpp:1601
+#: src/reader.cpp:1601 reader.cpp:2059
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr ""
 
-#: src/reader.cpp:1611
+#: src/reader.cpp:1611 reader.cpp:2074
 #, c-format
 msgid ""
 "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr ""
 
-#: src/reader.cpp:1994
+#: reader.cpp:2616
 msgid "Pop null reader block"
-msgstr ""
+msgstr "Ta bort element från tomt läsarblock"
 
 #: src/reader.cpp:2160
 msgid "There are still jobs active:\n"
@@ -1564,305 +1703,310 @@ msgid ""
 "Use 'disown PID' to remove jobs from the list without terminating them.\n"
 msgstr ""
 
-#: src/reader.cpp:3205
+#: reader.cpp:4115
 #, c-format
 msgid "Unknown key binding 0x%X"
-msgstr ""
+msgstr "Okänd tangentbords binding 0x%X"
 
-#: src/reader.cpp:3294
+#: reader.cpp:4226
 msgid "Error while reading from file descriptor"
-msgstr ""
+msgstr "Ett fel uppstod under inläsning från filidentifierare"
 
-#: src/reader.cpp:3308
+#: reader.cpp:4243
 msgid "Error while closing input stream"
-msgstr ""
+msgstr "Ett fel inträffade medan indataström stängdes"
 
-#: src/reader.cpp:3329
+#: reader.cpp:4270
 msgid "Error while opening input stream"
-msgstr ""
+msgstr "Ett fel inträffade medan indataström öppnades"
 
-#: src/sanity.cpp:18
+#: src/sanity.cpp:18 sanity.cpp:37
+#, fuzzy
 msgid "Errors detected, shutting down. Break on sanity_lose() to debug."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fel har upptäckts, avslutar programmet"
 
-#: src/sanity.cpp:33
+#: sanity.cpp:65
 #, c-format
 msgid "The pointer '%ls' is invalid"
-msgstr ""
+msgstr "Pekaren '%ls' är ogiltig"
 
-#: src/sanity.cpp:38
+#: sanity.cpp:71
 #, c-format
 msgid "The pointer '%ls' is null"
-msgstr ""
+msgstr "Pekaren '%ls' är noll"
 
-#: src/signal.cpp:36
+#: signal.cpp:69
 msgid "Terminal hung up"
-msgstr ""
+msgstr "Terminalen bröt uppkopplingen"
 
-#: src/signal.cpp:39
+#: signal.cpp:77
 msgid "Quit request from job control (^C)"
-msgstr ""
+msgstr "Avslutning via jobbkontroll (^C)"
 
-#: src/signal.cpp:42
+#: signal.cpp:85
 msgid "Quit request from job control with core dump (^\\)"
-msgstr ""
+msgstr "Avslutning via jobbkontroll med minnesdump (^\\)"
 
-#: src/signal.cpp:45
+#: signal.cpp:93
 msgid "Illegal instruction"
-msgstr ""
+msgstr "Ogiltig instruktion"
 
-#: src/signal.cpp:48
+#: signal.cpp:101
 msgid "Trace or breakpoint trap"
-msgstr ""
+msgstr "Spårnings eller brytpunktsfälla utlöstes"
 
-#: src/signal.cpp:51
+#: signal.cpp:109
 msgid "Abort"
-msgstr ""
+msgstr "Avbrott"
 
-#: src/signal.cpp:54
+#: signal.cpp:117
 msgid "Misaligned address error"
-msgstr ""
+msgstr "Bussfel (Ogiltigt justerad minnesadress)"
 
-#: src/signal.cpp:57
+#: signal.cpp:125
 msgid "Floating point exception"
-msgstr ""
+msgstr "Flyttalsundantag"
 
-#: src/signal.cpp:60
+#: signal.cpp:133
 msgid "Forced quit"
-msgstr ""
+msgstr "Tvingad avslutning"
 
-#: src/signal.cpp:63
+#: signal.cpp:141
 msgid "User defined signal 1"
-msgstr ""
+msgstr "Användardefinerad signal 1"
 
-#: src/signal.cpp:66
+#: signal.cpp:148
 msgid "User defined signal 2"
-msgstr ""
+msgstr "Användardefinerad signal 2"
 
-#: src/signal.cpp:69
+#: signal.cpp:156
 msgid "Address boundary error"
-msgstr ""
+msgstr "Minnesadress korsar segmentgräns"
 
-#: src/signal.cpp:72
+#: signal.cpp:164
 msgid "Broken pipe"
-msgstr ""
+msgstr "Avbrutet rör"
 
-#: src/signal.cpp:75
+#: signal.cpp:172
 msgid "Timer expired"
-msgstr ""
+msgstr "Timer utlöstes"
 
-#: src/signal.cpp:78
+#: signal.cpp:180
 msgid "Polite quit request"
-msgstr ""
+msgstr "Artig avslutning"
 
-#: src/signal.cpp:81
+#: signal.cpp:188
 msgid "Child process status changed"
-msgstr ""
+msgstr "Barnprocess fick ändrad status"
 
-#: src/signal.cpp:84
+#: signal.cpp:196
 msgid "Continue previously stopped process"
-msgstr ""
+msgstr "Fortsätt tidigare stannad process"
 
-#: src/signal.cpp:87
+#: signal.cpp:204
 msgid "Forced stop"
-msgstr ""
+msgstr "Tvingad att stoppa"
 
-#: src/signal.cpp:90
+#: signal.cpp:212
 msgid "Stop request from job control (^Z)"
-msgstr ""
+msgstr "Stoppad genom jobbkontroll (^Z)"
 
-#: src/signal.cpp:93
+#: signal.cpp:220
 msgid "Stop from terminal input"
-msgstr ""
+msgstr "Stoppad från terminalläsning"
 
-#: src/signal.cpp:96
+#: signal.cpp:228
 msgid "Stop from terminal output"
-msgstr ""
+msgstr "Stoppad från terminalskrivning"
 
-#: src/signal.cpp:99
+#: signal.cpp:236
 msgid "Urgent socket condition"
-msgstr ""
+msgstr "Viktig socket-situation"
 
-#: src/signal.cpp:102
+#: signal.cpp:244
 msgid "CPU time limit exceeded"
-msgstr ""
+msgstr "Slut på processortid"
 
-#: src/signal.cpp:105
+#: signal.cpp:252
 msgid "File size limit exceeded"
-msgstr ""
+msgstr "Maximal filstorlek överskriden"
 
-#: src/signal.cpp:108
+#: signal.cpp:260
 msgid "Virtual timer expired"
-msgstr ""
+msgstr "Virtuell timer utlöst"
 
-#: src/signal.cpp:111
+#: signal.cpp:268
 msgid "Profiling timer expired"
-msgstr ""
+msgstr "Profileringstimer utlöst"
 
-#: src/signal.cpp:114 src/signal.cpp:117
+#: signal.cpp:276 signal.cpp:284
 msgid "Window size change"
-msgstr ""
+msgstr "Terminalfönstret ändrade storlek"
 
-#: src/signal.cpp:120
+#: signal.cpp:292
 msgid "I/O on asynchronous file descriptor is possible"
-msgstr ""
+msgstr "Läsning/skrivning på asynkron filidentifierare möjligt"
 
-#: src/signal.cpp:123
+#: signal.cpp:300
 msgid "Power failure"
-msgstr ""
+msgstr "Strömavbrott"
 
-#: src/signal.cpp:126
+#: signal.cpp:308
 msgid "Bad system call"
-msgstr ""
+msgstr "Felaktigt systemanrop"
 
-#: src/signal.cpp:129
+#: signal.cpp:316
 msgid "Information request"
-msgstr ""
+msgstr "Informationsbegäran"
 
-#: src/signal.cpp:132
+#: signal.cpp:324
 msgid "Stack fault"
-msgstr ""
+msgstr "Stackfel"
 
-#: src/signal.cpp:135
+#: signal.cpp:332
 msgid "Emulator trap"
-msgstr ""
+msgstr "Emulatorfälla"
 
-#: src/signal.cpp:138
+#: signal.cpp:340
 msgid "Abort (Alias for SIGABRT)"
-msgstr ""
+msgstr "Avbrott (Alias för SIGABRT)"
 
-#: src/signal.cpp:141
+#: signal.cpp:348
 msgid "Unused signal"
-msgstr ""
+msgstr "Oanvänd signal"
 
-#: src/signal.cpp:173 src/signal.cpp:185
+#: mimedb.cpp:1402 signal.cpp:407 signal.cpp:422
 msgid "Unknown"
-msgstr ""
+msgstr "Okänd"
 
-#: src/signal.cpp:413
+#: signal.cpp:684
 msgid "Signal block mismatch"
-msgstr ""
+msgstr "Signalblockeringar matchar inte varandra"
 
-#: src/tokenizer.cpp:26
+#: tokenizer.cpp:32
 msgid "Unexpected end of string, quotes are not balanced"
-msgstr ""
+msgstr "Oväntat slut på textsträng, citationstecknen är inte balanserade"
 
-#: src/tokenizer.cpp:29
+#: tokenizer.cpp:37
 msgid "Unexpected end of string, parenthesis do not match"
-msgstr ""
+msgstr "Oväntat slut på textsträng, paranteserna är inte balanserade"
 
-#: src/tokenizer.cpp:32
+#: src/tokenizer.cpp:32 tokenizer.cpp:42
+#, fuzzy
 msgid "Unexpected end of string, square brackets do not match"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Oväntat slut på textsträng, paranteserna är inte balanserade"
 
 #: src/tokenizer.cpp:35
 msgid "Unexpected end of string, incomplete escape sequence"
 msgstr ""
 
-#: src/tokenizer.cpp:38
+#: tokenizer.cpp:48
 msgid "Invalid input/output redirection"
-msgstr ""
+msgstr "Ogiltig IO dirigering"
 
-#: src/tokenizer.cpp:41
+#: src/tokenizer.cpp:41 tokenizer.cpp:53
+#, fuzzy
 msgid "Cannot use stdin (fd 0) as pipe output"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Kan inte skicka rördata till filidentifierare 0"
 
-#: src/wgetopt.cpp:246
+#: wgetopt.cpp:638
 #, c-format
 msgid "%ls: Invalid option -- %lc\n"
-msgstr ""
+msgstr "%ls: Ogiltigt flagga -- %lc\n"
 
-#: src/wgetopt.cpp:277
+#: wgetopt.cpp:676
 #, c-format
 msgid "%ls: Option requires an argument -- %lc\n"
-msgstr ""
+msgstr "%ls: Flaggan kräver ett argument -- %lc\n"
 
-#: src/wgetopt.cpp:304
+#: wgetopt.cpp:560
 #, c-format
 msgid "%ls: Option '--%ls' doesn't allow an argument\n"
-msgstr ""
+msgstr "%ls: Flaggan '--%ls' tar inget argument\n"
 
-#: src/wgetopt.cpp:308
+#: wgetopt.cpp:565
 #, c-format
 msgid "%ls: Option '%lc%ls' doesn't allow an argument\n"
-msgstr ""
+msgstr "%ls: Flaggan '%lc%ls' tar inget argument\n"
 
-#: src/wgetopt.cpp:320
+#: wgetopt.cpp:579
 #, c-format
 msgid "%ls: Option '%ls' requires an argument\n"
-msgstr ""
+msgstr "%ls: Flaggan '%ls' kräver ett argument\n"
 
-#: src/wgetopt.cpp:383
+#: wgetopt.cpp:536
 #, c-format
 msgid "%ls: Option '%ls' is ambiguous\n"
-msgstr ""
+msgstr "%ls: Flaggan '%ls' är tvetydig\n"
 
-#: src/wgetopt.cpp:402
+#: wgetopt.cpp:607
 #, c-format
 msgid "%ls: Unrecognized option '--%ls'\n"
-msgstr ""
+msgstr "%ls: Okänd flagga '--%ls'\n"
 
-#: src/wgetopt.cpp:405
+#: wgetopt.cpp:611
 #, c-format
 msgid "%ls: Unrecognized option '%lc%ls'\n"
-msgstr ""
+msgstr "%ls: Okänd flagga '%lc%ls'\n"
 
-#: src/wildcard.cpp:27 /tmp/fish/implicit/share/completions/journalctl.fish:2
+#: wildcard.cpp:58
 msgid "Executable"
-msgstr ""
+msgstr "Program"
 
-#: src/wildcard.cpp:29
+#: wildcard.cpp:62
 msgid "Executable link"
-msgstr ""
+msgstr "Länk till program"
 
-#: src/wildcard.cpp:31 /tmp/fish/implicit/share/completions/fossil.fish:6
-#: /tmp/fish/implicit/share/completions/fossil.fish:90
-#: /tmp/fish/implicit/share/completions/git.fish:87
-#: /tmp/fish/implicit/share/completions/git.fish:133
-#: /tmp/fish/implicit/share/completions/git.fish:137
-#: /tmp/fish/implicit/share/completions/git.fish:208
-#: /tmp/fish/implicit/share/completions/git.fish:268
-#: /tmp/fish/implicit/share/completions/git.fish:269
+#: wildcard.cpp:67 share/completions/git.fish:178
 msgid "File"
-msgstr ""
+msgstr "Fil"
 
-#: src/wildcard.cpp:33
+#: wildcard.cpp:71
 msgid "Character device"
-msgstr ""
+msgstr "Teckenenhet"
 
-#: src/wildcard.cpp:35
+#: wildcard.cpp:75
 msgid "Block device"
-msgstr ""
+msgstr "Blockenhet"
 
-#: src/wildcard.cpp:37
+#: wildcard.cpp:79
 msgid "Fifo"
-msgstr ""
+msgstr "Fifo"
 
-#: src/wildcard.cpp:39
+#: wildcard.cpp:83
 msgid "Symbolic link"
-msgstr ""
+msgstr "Symbolisk länk"
 
-#: src/wildcard.cpp:41
+#
+#: wildcard.cpp:87
 msgid "Symbolic link to directory"
-msgstr ""
+msgstr "Symboliska länk till katalog"
 
-#: src/wildcard.cpp:43
+#: wildcard.cpp:91
 msgid "Rotten symbolic link"
-msgstr ""
+msgstr "Rutten symbolisk länk"
 
-#: src/wildcard.cpp:45
+#: wildcard.cpp:95
 msgid "Symbolic link loop"
-msgstr ""
+msgstr "Slinga av symboliska länkar"
 
-#: src/wildcard.cpp:47
+#: wildcard.cpp:99
 msgid "Socket"
-msgstr ""
+msgstr "Uttag (socket)"
 
-#: src/wildcard.cpp:49
-#: /tmp/fish/explicit/share/functions/__fish_complete_directories.fish:1
-#: /tmp/fish/implicit/share/completions/ruby.fish:22
+#: wildcard.cpp:103 share/completions/ruby.fish:23
+#: share/functions/__fish_complete_directories.fish:8
 msgid "Directory"
-msgstr ""
+msgstr "Katalog"
 
 #: src/wutil.cpp:146
 #, c-format
@@ -1874,27 +2018,31 @@ msgstr ""
 msgid "%ls: Expected argument for option %ls\n"
 msgstr ""
 
-#: src/builtin.h:41
+#: builtin.h:37
 #, c-format
 msgid ""
 "%ls: Invalid combination of options,\n"
 "%ls\n"
 msgstr ""
+"%ls: Ogiltig kombination av flaggor,\n"
+"%ls\n"
 
-#: src/builtin.h:45
+#: builtin.h:42
 #, c-format
 msgid "%ls: Variable scope can only be one of universal, global and local\n"
 msgstr ""
+"%ls: En variabels definitionsområde kan bara vara en av universal, global "
+"och lokal\n"
 
-#: src/builtin.h:48
+#: builtin.h:47
 #, c-format
 msgid "%ls: Variable can't be both exported and unexported\n"
-msgstr ""
+msgstr "%ls: Variabel kan inte vara både exporterad och oexporterad\n"
 
-#: src/builtin.h:51
+#: builtin.h:52
 #, c-format
 msgid "%ls: Unknown option '%ls'\n"
-msgstr ""
+msgstr "%ls: Okänd flagga '%ls'\n"
 
 #: src/builtin.h:54
 #, c-format
@@ -1926,15 +2074,15 @@ msgstr ""
 msgid "%ls: mode name '%ls' is not valid. See `help identifiers`.\n"
 msgstr ""
 
-#: src/builtin.h:66
+#: builtin.cpp:3827 builtin_complete.cpp:551 builtin.h:83
 #, c-format
 msgid "%ls: Too many arguments\n"
-msgstr ""
+msgstr "%ls: För många argument\n"
 
-#: src/builtin.h:69
+#: builtin.h:95
 #, c-format
 msgid "%ls: Argument '%ls' is not a number\n"
-msgstr ""
+msgstr "%ls: Argumentet '%ls' är inte ett nummer\n"
 
 #: src/builtin.h:72
 #, c-format
@@ -1946,57 +2094,66 @@ msgstr ""
 msgid "%ls: Subcommand '%ls' is not valid\n"
 msgstr ""
 
-#: src/builtin.h:76
+#: builtin.cpp:84
 #, c-format
 msgid "Send job %d, '%ls' to foreground\n"
-msgstr ""
+msgstr "Skicka job %d, '%ls' till förgrunden\n"
 
-#: src/exec.h:12
+#: exec.h:21
 msgid "An error occurred while setting up pipe"
-msgstr ""
+msgstr "Ett fel inträffade under skapandet av ett rör"
 
-#: src/parse_constants.h:225
+#: src/parse_constants.h:225 parse_constants.h:185
 #, c-format
 msgid ""
 "The function '%ls' calls itself immediately, which would result in an "
 "infinite loop."
 msgstr ""
 
-#: src/parse_constants.h:229
+#: src/parse_constants.h:229 parse_constants.h:189
 msgid ""
 "The function call stack limit has been exceeded. Do you have an accidental "
 "infinite loop?"
 msgstr ""
 
-#: src/parse_constants.h:233
+#: parse_constants.h:198
 #, c-format
 msgid "Illegal command name '%ls'"
-msgstr ""
+msgstr "Ogiltigt kommandonamn '%ls'"
 
-#: src/parse_constants.h:236
+#: parse_constants.h:201
 #, c-format
 msgid "Unknown builtin '%ls'"
-msgstr ""
+msgstr "Okänt inbyggt kommando '%ls'"
 
-#: src/parse_constants.h:239
-#, c-format
+#: src/parse_constants.h:239 parse_constants.h:204
+#, fuzzy, c-format
 msgid "Unable to expand variable name '%ls'"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ogiltigt variabelnamn '%ls'"
 
-#: src/parse_constants.h:242
-#, c-format
+#: src/parse_constants.h:242 parse_constants.h:207
+#, fuzzy, c-format
 msgid "Unable to find a process '%ls'"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Misslyckades med att exekvera processen '%ls'"
 
-#: src/parse_constants.h:245
-#, c-format
+#: src/parse_constants.h:245 parse_constants.h:210
+#, fuzzy, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ogiltig filidentifierare '%ls'"
 
-#: src/parse_constants.h:248
+#: parse_constants.h:213
 #, c-format
 msgid "No matches for wildcard '%ls'. See `help expand`."
-msgstr ""
+msgstr "Ingen träff för jokerteckenmönster '%ls' Se `help expand`."
 
 #: src/parse_constants.h:251
 msgid "'break' while not inside of loop"
@@ -2075,29 +2232,6 @@ msgstr ""
 msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
 msgstr ""
 
-#: /tmp/fish/explicit/share/completions/emerge.fish:1
-#: /tmp/fish/explicit/share/completions/emerge.fish:4
-msgid "All base system packages"
-msgstr ""
-
-#: /tmp/fish/explicit/share/completions/emerge.fish:2
-#: /tmp/fish/explicit/share/completions/emerge.fish:5
-#: /tmp/fish/explicit/share/completions/emerge.fish:6
-msgid "All packages in world"
-msgstr ""
-
-#: /tmp/fish/explicit/share/completions/emerge.fish:3
-#: /tmp/fish/implicit/share/completions/aura.fish:90
-#: /tmp/fish/implicit/share/completions/aura.fish:95
-#: /tmp/fish/implicit/share/completions/pacaur.fish:72
-#: /tmp/fish/implicit/share/completions/pacaur.fish:77
-#: /tmp/fish/implicit/share/completions/pacman.fish:50
-#: /tmp/fish/implicit/share/completions/pacman.fish:55
-#: /tmp/fish/implicit/share/completions/yaourt.fish:69
-#: /tmp/fish/implicit/share/completions/yaourt.fish:76
-msgid "Installed package"
-msgstr ""
-
 #: /tmp/fish/explicit/share/completions/emerge.fish:7
 msgid "Packages that are linked to preserved libs"
 msgstr ""
@@ -2106,151 +2240,247 @@ msgstr ""
 msgid "Packages that contain kernel modules"
 msgstr ""
 
-#: /tmp/fish/explicit/share/completions/emerge.fish:9
-msgid "Usage overview of emerge"
-msgstr ""
-
-#: /tmp/fish/explicit/share/completions/emerge.fish:10
-msgid "Help on subject system"
-msgstr ""
-
-#: /tmp/fish/explicit/share/completions/emerge.fish:11
-msgid "Help on subject config"
-msgstr ""
-
-#: /tmp/fish/explicit/share/completions/emerge.fish:12
-msgid "Help on subject sync"
-msgstr ""
-
-#: /tmp/fish/explicit/share/completions/emerge.fish:13
-msgid "Use colors in output"
-msgstr ""
-
-#: /tmp/fish/explicit/share/completions/emerge.fish:14
-msgid "Don't use colors in output"
-msgstr ""
-
 #: /tmp/fish/explicit/share/completions/emerge.fish:15
+#, fuzzy
 msgid "Pull in build time dependencies"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa byggberoenden"
 
 #: /tmp/fish/explicit/share/completions/emerge.fish:16
+#, fuzzy
 msgid "Don't pull in build time dependencies"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga efter extra beroenden"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:1
+#: share/completions/equery.fish:38
+#, fuzzy
 msgid "list all packages owning file(s)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa alla paket som äger filer"
 
-#: /tmp/fish/explicit/share/completions/equery.fish:2
+#: share/completions/equery.fish:39
 msgid "check MD5sums and timestamps of package"
-msgstr ""
+msgstr "Kontrollera MD5-summor och tidsstämplar på paket"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:3
+#: share/completions/equery.fish:40
+#, fuzzy
 msgid "list all packages depending on specified package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa paket som beror på"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:4
+#: share/completions/equery.fish:41
+#, fuzzy
 msgid "display a dependency tree for package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa beroenden för paket"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:5
+#: share/completions/equery.fish:42
+#, fuzzy
 msgid "list files owned by package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa filer i paket"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:6
+#: share/completions/equery.fish:43
+#, fuzzy
 msgid "list all packages with specified useflag"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga ett (oinstallerat) paket i angiven fil"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:7
+#: share/completions/equery.fish:44
+#, fuzzy
 msgid "list all packages matching pattern"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lista innehåll av paket som matchar mönster"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:8
+#: share/completions/equery.fish:45
+#, fuzzy
 msgid "print size of files contained in package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa paketets triggerskript"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:9
+#: share/completions/equery.fish:46
+#, fuzzy
 msgid "display USE flags for package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa ändringsinformation för paket"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:10
+#: share/completions/equery.fish:47
+#, fuzzy
 msgid "print full path to ebuild for package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa full sökväg till källkod"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:1
+#: share/completions/gem.fish:12
 msgid "Build a gem from a gemspec"
 msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:2
+#: share/completions/gem.fish:13
 msgid "Adjust RubyGems certificate settings"
 msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:3
+#: share/completions/gem.fish:14
+#, fuzzy
 msgid "Check installed gems"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga installerat paket"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:4
+#: share/completions/gem.fish:15
+#, fuzzy
 msgid "Cleanup old versions of installed gems in the local repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:5
+#: share/completions/gem.fish:16
+#, fuzzy
 msgid "Display the contents of the installed gems"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa låtsasinstallationsutdata i tabellform"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:6
+#: share/completions/gem.fish:17
+#, fuzzy
 msgid "Show the dependencies of an installed gem"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Verifiera inte beroenden före paketen avinstalleras"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:7
+#: share/completions/gem.fish:18
+#, fuzzy
 msgid "Display RubyGems environmental information"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa uppdateringsinformation"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:8
+#: share/completions/gem.fish:19
+#, fuzzy
 msgid "Provide help on the 'gem' command"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Hjälp för det angivna kommandot"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:9
+#: share/completions/gem.fish:20
+#, fuzzy
 msgid "Install a gem into the local repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Checka in filer till förråd"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:10
+#: share/completions/gem.fish:21
 msgid "Display all gems whose name starts with STRING"
 msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:11
+#: share/completions/gem.fish:22
+#, fuzzy
 msgid "Query gem information in local or remote repositories"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa information om lokal eller fjärrelement"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:12
+#: share/completions/gem.fish:23
 msgid "Generates RDoc for pre-installed gems"
 msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:13
+#: share/completions/gem.fish:24
 msgid "Display all gems whose name contains STRING"
 msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:14
+#: share/completions/gem.fish:25
+#, fuzzy
 msgid "Display gem specification (in yaml)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa senaste ändringsdatum för fil"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:15
+#: share/completions/gem.fish:26
+#, fuzzy
 msgid "Uninstall a gem from the local repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ta bort ett inlägg från förråd"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:16
+#: share/completions/gem.fish:27
+#, fuzzy
 msgid "Unpack an installed gem to the current directory"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:17
+#: share/completions/gem.fish:28
 msgid "Update the named gem (or all installed gems) in the local repository"
 msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:18
+#: share/completions/gem.fish:87
+#, fuzzy
 msgid "display the remote gem servers"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fil att hämta servrar från"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:19
+#: share/completions/gem.fish:92
 msgid "show some examples of usage"
 msgstr ""
 
@@ -2644,72 +2874,73 @@ msgstr ""
 msgid "Check, then resync"
 msgstr ""
 
-#: /tmp/fish/explicit/share/completions/set.fish:1
+#: share/completions/set.fish:79
 msgid "Locale"
-msgstr ""
+msgstr "Lokal"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:1
-#: /tmp/fish/explicit/share/completions/telnet.fish:6
+#: share/completions/telnet.fish:9 share/completions/telnet.fish:14
 msgid "Specifies an 8-bit data path"
-msgstr ""
+msgstr "Anger en 8-bitars dataväg"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:2
+#: share/completions/telnet.fish:10
 msgid "Do not try to negotiate TELNET BINARY option"
-msgstr ""
+msgstr "Försök inte förhandla TELNET BINARY-flaggan"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:3
+#: share/completions/telnet.fish:11
 msgid "Stops any character from being recognized as an escape character"
-msgstr ""
+msgstr "Hindra alla tecken från att kännas igen som specialsekvens"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:4
+#: share/completions/telnet.fish:12
 msgid "Use local Kerberos authentication, if possible"
-msgstr ""
+msgstr "Använd lokal kerberosautentisering, om möjligt"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:5
+#: share/completions/telnet.fish:13
 msgid "Specifies no automatic login to remote system"
-msgstr ""
+msgstr "Försök inte logga in automatiskt på fjärrsystem"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:7
+#: share/completions/telnet.fish:15
 msgid "Attempt automatic login"
-msgstr ""
+msgstr "Försök logga in automatiskt på fjärrsystem"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:8
+#: share/completions/telnet.fish:16
 msgid "Disables reading user's .telnetrc"
-msgstr ""
+msgstr "Inaktivera inläsning av användarens .telnetrc"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:9
+#: share/completions/telnet.fish:17
 msgid "Sets debug mode"
-msgstr ""
+msgstr "Väljer debugnivå"
 
 #: /tmp/fish/explicit/share/completions/telnet.fish:10
+#: share/completions/telnet.fish:18
 msgid "Sets IP TOS"
 msgstr ""
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:11
+#: share/completions/telnet.fish:19
 msgid "Disables specified type of authentication"
-msgstr ""
+msgstr "Inaktivera angivna autentiseringstypen"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:12
+#: share/completions/telnet.fish:20
 msgid "User login"
-msgstr ""
+msgstr "Användarinloggning"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:13
+#: share/completions/telnet.fish:21
 msgid "Log to tracefile"
-msgstr ""
+msgstr "Logga till spårfil"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:14
+#: share/completions/telnet.fish:22
 msgid "Turn on encryption"
-msgstr ""
+msgstr "Slå på kryptering"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:15
+#: share/completions/telnet.fish:23
 msgid "User interface similar to rlogin"
-msgstr ""
+msgstr "Användargränssnitt liknande rlogin"
 
-#: /tmp/fish/explicit/share/completions/telnet.fish:16
+#: share/completions/telnet.fish:24
 msgid "Use Kerberos realm for authentication"
-msgstr ""
+msgstr "Använd Kerberos-realm för autentisering"
 
 #: /tmp/fish/explicit/share/completions/update-eix-remote.fish:1
+#: share/completions/update-eix-remote.fish:16
 msgid "Remove all temporarily added virtual overlays from the eix database"
 msgstr ""
 
@@ -3299,10 +3530,16 @@ msgid "%s %s: Unexpected argument -- '%s'\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/alias.fish:1
+#: share/functions/alias.fish:42
+#, fuzzy
 msgid "%s: Name cannot be empty\\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%s: Den tomma strängen är inte ett tillåtet variabelnamn\\n"
 
 #: /tmp/fish/explicit/share/functions/alias.fish:2
+#: share/functions/alias.fish:45
 msgid "%s: Body cannot be empty\\n"
 msgstr ""
 
@@ -3476,9 +3713,10 @@ msgstr ""
 msgid "SELinux context for the root inode of the filesystem"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/__fish_config_interactive.fish:1
+#
+#: share/functions/__fish_config_interactive.fish:34
 msgid "Welcome to fish, the friendly interactive shell"
-msgstr ""
+msgstr "Välkommen till fish, det vänliga interaktiva skalet"
 
 #: /tmp/fish/explicit/share/functions/fish_md5.fish:1
 #: /tmp/fish/explicit/share/functions/fish_md5.fish:2
@@ -3493,27 +3731,16 @@ msgstr ""
 msgid "%s: The --short flag is required and must be a single character\\n"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/__fish_print_packages.fish:1
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:31
-#: /tmp/fish/implicit/share/completions/apt.fish:4
-#: /tmp/fish/implicit/share/completions/apt-get.fish:3
-#: /tmp/fish/implicit/share/completions/aptitude.fish:3
-#: /tmp/fish/implicit/share/completions/apt-mark.fish:3
-#: /tmp/fish/implicit/share/completions/dpkg-reconfigure.fish:1
-#: /tmp/fish/implicit/share/completions/pkg_delete.fish:1
-#: /tmp/fish/implicit/share/completions/pkg_info.fish:1
-#: /tmp/fish/implicit/share/completions/prt-get.fish:1
-#: /tmp/fish/implicit/share/completions/prt-get.fish:63
-#: /tmp/fish/implicit/share/completions/wajig.fish:3
-#: /tmp/fish/implicit/share/completions/zypper.fish:1
+#: share/functions/__fish_print_packages.fish:13
 msgid "Package"
-msgstr ""
+msgstr "Paket"
 
 #: /tmp/fish/explicit/share/functions/fish_update_completions.fish:1
 msgid "python executable not found"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/funced.fish:2
+#: share/functions/funced.fish:96
 msgid "Editing failed or was cancelled"
 msgstr ""
 
@@ -3522,32 +3749,46 @@ msgid "Editor exited but the function was not modified"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/funced.fish:4
+#: share/functions/funced.fish:103
 msgid "Edit the file again\\? [Y/n]"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/funced.fish:5
+#: share/functions/funced.fish:110
+#, fuzzy
 msgid "Cancelled function editing"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"funktionsdefinition-block"
 
-#: /tmp/fish/explicit/share/functions/funcsave.fish:1
+#: share/functions/funcsave.fish:26
 msgid "%s: Could not create configuration directory\\n"
-msgstr ""
+msgstr "%s: Kunde inte skapa konfigurationskatalogen\\n"
 
-#: /tmp/fish/explicit/share/functions/funcsave.fish:2
+#: share/functions/funcsave.fish:36
 msgid "%s: Unknown function '%s'\\n"
-msgstr ""
+msgstr "%s: Okänd funktion '%s'\\n"
 
-#: /tmp/fish/explicit/share/functions/help.fish:1
+#: share/functions/help.fish:76
 msgid "%s: Could not find a web browser.\\n"
-msgstr ""
+msgstr "%s: Kunde inte hitta en webbrowser\\n"
 
-#: /tmp/fish/explicit/share/functions/help.fish:3
+#: /tmp/fish/explicit/share/functions/help.fish:3 share/functions/help.fish:129
+#, fuzzy
 msgid "help: Help is being displayed in your default browser.\\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"help: Hjälp visas i ditt standardsurfprogram"
 
-#: /tmp/fish/explicit/share/functions/help.fish:4
+#: /tmp/fish/explicit/share/functions/help.fish:4 share/functions/help.fish:132
+#, fuzzy
 msgid "help: Help is being displayed in %s.\\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"help: Hjälp visas i %s\\n"
 
 #: /tmp/fish/explicit/share/functions/history.fish:1
 msgid "%ls: you cannot use any options with the %ls command\\n"
@@ -3578,10 +3819,10 @@ msgstr ""
 msgid "%s: Too many arguments"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/nextd.fish:1
-#: /tmp/fish/explicit/share/functions/prevd.fish:1
+#: share/functions/nextd.fish:28
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
 msgstr ""
+"%s: Antalet positioner att hoppa över måste vara ett positivt heltal\\n"
 
 #: /tmp/fish/explicit/share/functions/open.fish:1
 msgid "No open utility found. Try installing \"xdg-open\" or \"xdg-utils\"."
@@ -3599,55 +3840,66 @@ msgstr ""
 msgid "%s: These flags are not allowed by fish realpath: '%s'"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/seq.fish:1
+#: share/functions/seq.fish:31
 msgid "%s: Expected 1, 2 or 3 arguments, got %d\\n"
-msgstr ""
+msgstr "%s: Förväntade 1, 2 eller 3 argument, fick %d\\n"
 
-#: /tmp/fish/explicit/share/functions/seq.fish:2
+#: share/functions/seq.fish:38
 msgid "%s: '%s' is not a number\\n"
-msgstr ""
+msgstr "%s: '%s' är inte ett nummer\\n"
 
-#: /tmp/fish/explicit/share/functions/setenv.fish:1
-#: /tmp/fish/explicit/share/functions/umask.fish:3
+#: share/functions/umask.fish:212
 msgid "%s: Too many arguments\\n"
-msgstr ""
+msgstr "%s: För många argument\\n"
 
 #: /tmp/fish/explicit/share/functions/setenv.fish:2
 msgid "%s: Variable name must contain alphanumeric characters\\n"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/type.fish:1
+#: share/functions/type.fish:90
 msgid "%s is a function with definition\\n"
-msgstr ""
+msgstr "%s är en funktion med definitionen\\n"
 
-#: /tmp/fish/explicit/share/functions/type.fish:2
+#: /tmp/fish/explicit/share/functions/type.fish:2 share/functions/type.fish:94
+#, fuzzy
 msgid "function"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"funktion\\n"
 
-#: /tmp/fish/explicit/share/functions/type.fish:3
+#: share/functions/type.fish:107
 msgid "%s is a builtin\\n"
-msgstr ""
+msgstr "%s är ett inbyggt kommando\\n"
 
-#: /tmp/fish/explicit/share/functions/type.fish:4
+#: /tmp/fish/explicit/share/functions/type.fish:4 share/functions/type.fish:110
+#, fuzzy
 msgid "builtin"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"inbyggt kommando\\n"
 
-#: /tmp/fish/explicit/share/functions/type.fish:5
+#: share/functions/type.fish:130
 msgid "%s is %s\\n"
-msgstr ""
+msgstr "%s är %s\\n"
 
-#: /tmp/fish/explicit/share/functions/type.fish:6
+#: /tmp/fish/explicit/share/functions/type.fish:6 share/functions/type.fish:133
+#, fuzzy
 msgid "file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"fil\\n"
 
-#: /tmp/fish/explicit/share/functions/type.fish:7
+#: share/functions/type.fish:144
 msgid "%s: Could not find '%s'\\n"
-msgstr ""
+msgstr "%s: Kunde inte hitta '%s'\\n"
 
-#: /tmp/fish/explicit/share/functions/umask.fish:1
-#: /tmp/fish/explicit/share/functions/umask.fish:2
+#: share/functions/umask.fish:11 share/functions/umask.fish:69
+#: share/functions/umask.fish:76
 msgid "%s: Invalid mask '%s'\\n"
-msgstr ""
+msgstr "%s: Ogiltigt mask '%s'\\n"
 
 #: /tmp/fish/explicit/share/functions/_validate_int.fish:1
 msgid "%s: Value '%s' for flag '%s' is not an integer\\n"
@@ -3661,21 +3913,30 @@ msgstr ""
 msgid "%s: Value '%s' for flag '%s' greater than max allowed of '%s'\\n"
 msgstr ""
 
-#: /tmp/fish/explicit/share/functions/vared.fish:1
+#: share/functions/funced.fish:24 share/functions/nextd.fish:22
+#: share/functions/prevd.fish:22 share/functions/vared.fish:15
 msgid "%s: Unknown option %s\\n"
-msgstr ""
+msgstr "%s: Okänd flagga '%s'\\n"
 
 #: /tmp/fish/explicit/share/functions/vared.fish:2
+#: share/functions/vared.fish:40
+#, fuzzy
 msgid ""
 "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element "
 "of %s\\n"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"%s: %s är en arrayvariabel. Använd %svared%s %s[n] för att redigera det n:te "
+"elementet av %s\\n"
 
-#: /tmp/fish/explicit/share/functions/vared.fish:3
+#: share/functions/vared.fish:44
 msgid ""
 "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s "
 "VARIABLE\\n"
 msgstr ""
+"%s: Förväntade exakt ett argument, fick %s\\n\\nSynopsis:\\n\\t%svared%s "
+"VARIABEL\\n"
 
 #: /tmp/fish/implicit/share/config.fish:1
 msgid "Update PATH when fish_user_paths changes"
@@ -3783,11 +4044,9 @@ msgstr ""
 msgid "Accept reason"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ack.fish:1
-#: /tmp/fish/implicit/share/completions/grep.fish:23
-#: /tmp/fish/implicit/share/completions/sort.fish:3
+#: share/functions/__fish_complete_grep.fish:24
 msgid "Ignore case"
-msgstr ""
+msgstr "Ignorera skiftläge"
 
 #: /tmp/fish/implicit/share/completions/ack.fish:2
 msgid "Ignore case when pattern contains no uppercase"
@@ -3865,20 +4124,17 @@ msgstr ""
 msgid "Don't show column number of first match"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ack.fish:21
-#: /tmp/fish/implicit/share/completions/grep.fish:1
+#: share/functions/__fish_complete_grep.fish:2
 msgid "Print NUM lines of trailing context"
-msgstr ""
+msgstr "Visa NUM rader av följande sammanhang"
 
-#: /tmp/fish/implicit/share/completions/ack.fish:22
-#: /tmp/fish/implicit/share/completions/grep.fish:3
+#: share/functions/__fish_complete_grep.fish:4
 msgid "Print NUM lines of leading context"
-msgstr ""
+msgstr "Visa NUM rader av inledande sammanhang"
 
-#: /tmp/fish/implicit/share/completions/ack.fish:23
-#: /tmp/fish/implicit/share/completions/grep.fish:4
+#: share/functions/__fish_complete_grep.fish:5
 msgid "Print NUM lines of context"
-msgstr ""
+msgstr "Visa NUM rader av sammanhang"
 
 #: /tmp/fish/implicit/share/completions/ack.fish:24
 msgid "Print null byte as separator between filenames"
@@ -3988,21 +4244,14 @@ msgstr ""
 msgid "No descending into subdirectories"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ack.fish:51
-#: /tmp/fish/implicit/share/completions/file.fish:7
-#: /tmp/fish/implicit/share/completions/find.fish:2
-#: /tmp/fish/implicit/share/completions/ls.fish:16
-#: /tmp/fish/implicit/share/completions/ls.fish:17
-#: /tmp/fish/implicit/share/completions/ls.fish:71
-#: /tmp/fish/implicit/share/completions/ls.fish:72
-#: /tmp/fish/implicit/share/completions/s3cmd.fish:129
+#: share/functions/__fish_complete_ls.fish:19
+#: share/functions/__fish_complete_ls.fish:20
 msgid "Follow symlinks"
-msgstr ""
+msgstr "Följ symboliska länkar"
 
-#: /tmp/fish/implicit/share/completions/ack.fish:52
-#: /tmp/fish/implicit/share/completions/ls.fish:62
+#: share/functions/__fish_complete_ls.fish:105
 msgid "Don't follow symlinks"
-msgstr ""
+msgstr "Följ inte symboliska länkar"
 
 #: /tmp/fish/implicit/share/completions/ack.fish:53
 msgid "Include only recognized files"
@@ -4130,133 +4379,13 @@ msgstr ""
 msgid "<dir> path to ACPI info (/proc/acpi)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/acpi.fish:14
-#: /tmp/fish/implicit/share/completions/and.fish:1
-#: /tmp/fish/implicit/share/completions/apropos.fish:2
-#: /tmp/fish/implicit/share/completions/apt-build.fish:1
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:1
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:1
-#: /tmp/fish/implicit/share/completions/apt-config.fish:1
-#: /tmp/fish/implicit/share/completions/apt-extracttemplates.fish:1
-#: /tmp/fish/implicit/share/completions/apt-file.fish:1
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:1
-#: /tmp/fish/implicit/share/completions/apt-get.fish:4
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:1
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:1
-#: /tmp/fish/implicit/share/completions/apt-mark.fish:4
-#: /tmp/fish/implicit/share/completions/apt-proxy-import.fish:1
-#: /tmp/fish/implicit/share/completions/apt-rdepends.fish:1
-#: /tmp/fish/implicit/share/completions/apt-show-source.fish:1
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:1
-#: /tmp/fish/implicit/share/completions/apt-sortpkgs.fish:1
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:1
-#: /tmp/fish/implicit/share/completions/apt-src.fish:1
-#: /tmp/fish/implicit/share/completions/apt-zip-inst.fish:1
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:1
-#: /tmp/fish/implicit/share/completions/asp.fish:6
-#: /tmp/fish/implicit/share/completions/bc.fish:7
-#: /tmp/fish/implicit/share/completions/bd.fish:4
-#: /tmp/fish/implicit/share/completions/bg.fish:1
-#: /tmp/fish/implicit/share/completions/bind.fish:4
-#: /tmp/fish/implicit/share/completions/block.fish:1
-#: /tmp/fish/implicit/share/completions/break.fish:1
-#: /tmp/fish/implicit/share/completions/builtin.fish:1
-#: /tmp/fish/implicit/share/completions/cd.fish:1
-#: /tmp/fish/implicit/share/completions/chgrp.fish:9
-#: /tmp/fish/implicit/share/completions/chmod.fish:8
-#: /tmp/fish/implicit/share/completions/chown.fish:9
-#: /tmp/fish/implicit/share/completions/command.fish:1
-#: /tmp/fish/implicit/share/completions/commandline.fish:1
-#: /tmp/fish/implicit/share/completions/complete.fish:13
-#: /tmp/fish/implicit/share/completions/configure.fish:1
-#: /tmp/fish/implicit/share/completions/continue.fish:1
-#: /tmp/fish/implicit/share/completions/cowsay.fish:3
-#: /tmp/fish/implicit/share/completions/cowthink.fish:3
-#: /tmp/fish/implicit/share/completions/cut.fish:8
-#: /tmp/fish/implicit/share/completions/dconf.fish:10
-#: /tmp/fish/implicit/share/completions/diff.fish:25
-#: /tmp/fish/implicit/share/completions/du.fish:18
-#: /tmp/fish/implicit/share/completions/echo.fish:5
-#: /tmp/fish/implicit/share/completions/entr.fish:3
-#: /tmp/fish/implicit/share/completions/env.fish:5
-#: /tmp/fish/implicit/share/completions/exec.fish:1
-#: /tmp/fish/implicit/share/completions/exit.fish:1
-#: /tmp/fish/implicit/share/completions/fg.fish:1
-#: /tmp/fish/implicit/share/completions/find.fish:6
-#: /tmp/fish/implicit/share/completions/fish.fish:2
-#: /tmp/fish/implicit/share/completions/fish_indent.fish:1
-#: /tmp/fish/implicit/share/completions/functions.fish:4
-#: /tmp/fish/implicit/share/completions/fusermount.fish:2
-#: /tmp/fish/implicit/share/completions/gpg.fish:50
-#: /tmp/fish/implicit/share/completions/gprof.fish:30
-#: /tmp/fish/implicit/share/completions/grep.fish:21
-#: /tmp/fish/implicit/share/completions/grub-file.fish:31
-#: /tmp/fish/implicit/share/completions/gunzip.fish:3
-#: /tmp/fish/implicit/share/completions/gzip.fish:3
-#: /tmp/fish/implicit/share/completions/i3-msg.fish:3
-#: /tmp/fish/implicit/share/completions/iconv.fish:7
-#: /tmp/fish/implicit/share/completions/id.fish:6
-#: /tmp/fish/implicit/share/completions/jobs.fish:1
-#: /tmp/fish/implicit/share/completions/less.fish:1
-#: /tmp/fish/implicit/share/completions/ln.fish:14
-#: /tmp/fish/implicit/share/completions/ls.fish:57
-#: /tmp/fish/implicit/share/completions/man.fish:24
-#: /tmp/fish/implicit/share/completions/mount.fish:2
-#: /tmp/fish/implicit/share/completions/mplayer.fish:4
-#: /tmp/fish/implicit/share/completions/mplayer.fish:8
-#: /tmp/fish/implicit/share/completions/mplayer.fish:34
-#: /tmp/fish/implicit/share/completions/msgfmt.fish:24
-#: /tmp/fish/implicit/share/completions/mv.fish:10
-#: /tmp/fish/implicit/share/completions/nice.fish:3
-#: /tmp/fish/implicit/share/completions/not.fish:1
-#: /tmp/fish/implicit/share/completions/or.fish:1
-#: /tmp/fish/implicit/share/completions/patch.fish:15
-#: /tmp/fish/implicit/share/completions/pine.fish:3
-#: /tmp/fish/implicit/share/completions/ps.fish:39
-#: /tmp/fish/implicit/share/completions/psub.fish:1
-#: /tmp/fish/implicit/share/completions/python2.fish:5
-#: /tmp/fish/implicit/share/completions/python3.fish:5
-#: /tmp/fish/implicit/share/completions/python.fish:5
-#: /tmp/fish/implicit/share/completions/random.fish:1
-#: /tmp/fish/implicit/share/completions/read.fish:1
-#: /tmp/fish/implicit/share/completions/return.fish:1
-#: /tmp/fish/implicit/share/completions/rmdir.fish:4
-#: /tmp/fish/implicit/share/completions/rpm.fish:1
-#: /tmp/fish/implicit/share/completions/rsync.fish:104
-#: /tmp/fish/implicit/share/completions/ruby.fish:7
-#: /tmp/fish/implicit/share/completions/scrot.fish:1
-#: /tmp/fish/implicit/share/completions/set_color.fish:8
-#: /tmp/fish/implicit/share/completions/set.fish:10
-#: /tmp/fish/implicit/share/completions/setsid.fish:5
-#: /tmp/fish/implicit/share/completions/sort.fish:22
-#: /tmp/fish/implicit/share/completions/sshfs.fish:9
-#: /tmp/fish/implicit/share/completions/status.fish:1
-#: /tmp/fish/implicit/share/completions/sudo.fish:11
-#: /tmp/fish/implicit/share/completions/su.fish:6
-#: /tmp/fish/implicit/share/completions/sylpheed.fish:3
-#: /tmp/fish/implicit/share/completions/test.fish:1
-#: /tmp/fish/implicit/share/completions/tex.fish:1
-#: /tmp/fish/implicit/share/completions/time.fish:7
-#: /tmp/fish/implicit/share/completions/top.fish:4
-#: /tmp/fish/implicit/share/completions/trap.fish:3
-#: /tmp/fish/implicit/share/completions/type.fish:1
-#: /tmp/fish/implicit/share/completions/ulimit.fish:14
-#: /tmp/fish/implicit/share/completions/umount.fish:3
-#: /tmp/fish/implicit/share/completions/uname.fish:17
-#: /tmp/fish/implicit/share/completions/valgrind.fish:2
-#: /tmp/fish/implicit/share/completions/vared.fish:1
-#: /tmp/fish/implicit/share/completions/wc.fish:6
-#: /tmp/fish/implicit/share/completions/wget.fish:2
-#: /tmp/fish/implicit/share/completions/which.fish:12
-#: /tmp/fish/implicit/share/completions/who.fish:18
-#: /tmp/fish/implicit/share/completions/xargs.fish:4
-#: /tmp/fish/implicit/share/completions/xprop.fish:1
-#: /tmp/fish/implicit/share/completions/xsel.fish:16
-#: /tmp/fish/implicit/share/completions/yum.fish:11
-#: /tmp/fish/implicit/share/completions/zcat.fish:2
-#: /tmp/fish/implicit/share/completions/zip.fish:30
+#: share/completions/configure.fish:1
+#: share/functions/__fish_complete_diff.fish:27
+#: share/functions/__fish_complete_grep.fish:22
+#: share/functions/__fish_complete_ls.fish:95
+#: share/functions/__fish_complete_tex.fish:4
 msgid "Display help and exit"
-msgstr ""
+msgstr "Visa hjälp och avsluta"
 
 #: /tmp/fish/implicit/share/completions/acpi.fish:15
 #: /tmp/fish/implicit/share/completions/dmesg.fish:17
@@ -4271,15 +4400,21 @@ msgstr ""
 msgid "Output version information and exit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/adb.fish:1
+#: /tmp/fish/implicit/share/completions/adb.fish:1 share/completions/adb.fish:3
+#, fuzzy
 msgid "Test if adb has yet to be given the subcommand"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/adb.fish:2
+#: share/completions/adb.fish:12
 msgid "Run adb devices and parse output"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/adb.fish:3
+#: share/completions/adb.fish:24
 msgid "Runs adb with any -s parameters already given on the command line"
 msgstr ""
 
@@ -4528,12 +4663,10 @@ msgstr ""
 msgid "Kick current connection from device side and make it reconnect."
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/adduser.fish:1
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:28
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:11
-#: /tmp/fish/implicit/share/completions/apt-config.fish:5
+#: share/completions/apt-cache.fish:29 share/completions/apt-cdrom.fish:12
+#: share/completions/apt-config.fish:6
 msgid "Specify config file"
-msgstr ""
+msgstr "Välj konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/adduser.fish:2
 msgid "Do not run passwd to set the password"
@@ -5752,531 +5885,373 @@ msgstr ""
 msgid "Unstar given packages on https://atom.io"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apm.fish:84
-#: /tmp/fish/implicit/share/completions/apropos.fish:11
-#: /tmp/fish/implicit/share/completions/apt-build.fish:27
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:27
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:10
-#: /tmp/fish/implicit/share/completions/apt-config.fish:4
-#: /tmp/fish/implicit/share/completions/apt-file.fish:11
-#: /tmp/fish/implicit/share/completions/apt.fish:6
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:14
-#: /tmp/fish/implicit/share/completions/apt-get.fish:46
-#: /tmp/fish/implicit/share/completions/apt-mark.fish:12
-#: /tmp/fish/implicit/share/completions/apt-proxy-import.fish:2
-#: /tmp/fish/implicit/share/completions/apt-rdepends.fish:11
-#: /tmp/fish/implicit/share/completions/apt-show-source.fish:7
-#: /tmp/fish/implicit/share/completions/apt-sortpkgs.fish:3
-#: /tmp/fish/implicit/share/completions/apt-zip-inst.fish:2
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:2
-#: /tmp/fish/implicit/share/completions/at.fish:1
-#: /tmp/fish/implicit/share/completions/atq.fish:1
-#: /tmp/fish/implicit/share/completions/atrm.fish:1
-#: /tmp/fish/implicit/share/completions/aura.fish:17
-#: /tmp/fish/implicit/share/completions/bc.fish:6
-#: /tmp/fish/implicit/share/completions/bunzip2.fish:7
-#: /tmp/fish/implicit/share/completions/bzip2.fish:10
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:1
-#: /tmp/fish/implicit/share/completions/chgrp.fish:10
-#: /tmp/fish/implicit/share/completions/chmod.fish:9
-#: /tmp/fish/implicit/share/completions/chown.fish:10
-#: /tmp/fish/implicit/share/completions/chsh.fish:3
-#: /tmp/fish/implicit/share/completions/configure.fish:2
-#: /tmp/fish/implicit/share/completions/cut.fish:9
-#: /tmp/fish/implicit/share/completions/diff.fish:24
-#: /tmp/fish/implicit/share/completions/du.fish:19
-#: /tmp/fish/implicit/share/completions/env.fish:6
-#: /tmp/fish/implicit/share/completions/find.fish:14
-#: /tmp/fish/implicit/share/completions/fish.fish:3
-#: /tmp/fish/implicit/share/completions/fish_indent.fish:2
-#: /tmp/fish/implicit/share/completions/fusermount.fish:3
-#: /tmp/fish/implicit/share/completions/gphoto2.fish:17
-#: /tmp/fish/implicit/share/completions/gprof.fish:31
-#: /tmp/fish/implicit/share/completions/grep.fish:43
-#: /tmp/fish/implicit/share/completions/gunzip.fish:13
-#: /tmp/fish/implicit/share/completions/gzip.fish:13
-#: /tmp/fish/implicit/share/completions/iconv.fish:6
-#: /tmp/fish/implicit/share/completions/id.fish:7
-#: /tmp/fish/implicit/share/completions/less.fish:41
-#: /tmp/fish/implicit/share/completions/ls.fish:58
-#: /tmp/fish/implicit/share/completions/make.fish:19
-#: /tmp/fish/implicit/share/completions/modprobe.fish:9
-#: /tmp/fish/implicit/share/completions/mount.fish:1
-#: /tmp/fish/implicit/share/completions/mplayer.fish:35
-#: /tmp/fish/implicit/share/completions/msgfmt.fish:25
-#: /tmp/fish/implicit/share/completions/mv.fish:11
-#: /tmp/fish/implicit/share/completions/nice.fish:4
-#: /tmp/fish/implicit/share/completions/pacaur.fish:11
-#: /tmp/fish/implicit/share/completions/pacman.fish:10
-#: /tmp/fish/implicit/share/completions/patch.fish:30
-#: /tmp/fish/implicit/share/completions/perl.fish:36
-#: /tmp/fish/implicit/share/completions/ping.fish:26
-#: /tmp/fish/implicit/share/completions/pkg.fish:1
-#: /tmp/fish/implicit/share/completions/ps.fish:38
-#: /tmp/fish/implicit/share/completions/python2.fish:13
-#: /tmp/fish/implicit/share/completions/python3.fish:13
-#: /tmp/fish/implicit/share/completions/python.fish:14
-#: /tmp/fish/implicit/share/completions/rmdir.fish:5
-#: /tmp/fish/implicit/share/completions/rpm.fish:2
-#: /tmp/fish/implicit/share/completions/rsync.fish:103
-#: /tmp/fish/implicit/share/completions/ruby.fish:20
-#: /tmp/fish/implicit/share/completions/screen.fish:34
-#: /tmp/fish/implicit/share/completions/setsid.fish:4
-#: /tmp/fish/implicit/share/completions/sort.fish:23
-#: /tmp/fish/implicit/share/completions/sshfs.fish:1
-#: /tmp/fish/implicit/share/completions/su.fish:7
-#: /tmp/fish/implicit/share/completions/tar.fish:53
-#: /tmp/fish/implicit/share/completions/tex.fish:2
-#: /tmp/fish/implicit/share/completions/time.fish:8
-#: /tmp/fish/implicit/share/completions/top.fish:12
-#: /tmp/fish/implicit/share/completions/umount.fish:2
-#: /tmp/fish/implicit/share/completions/uname.fish:18
-#: /tmp/fish/implicit/share/completions/valgrind.fish:4
-#: /tmp/fish/implicit/share/completions/wc.fish:7
-#: /tmp/fish/implicit/share/completions/w.fish:5
-#: /tmp/fish/implicit/share/completions/wget.fish:1
-#: /tmp/fish/implicit/share/completions/which.fish:11
-#: /tmp/fish/implicit/share/completions/who.fish:19
-#: /tmp/fish/implicit/share/completions/xargs.fish:14
-#: /tmp/fish/implicit/share/completions/xsel.fish:18
-#: /tmp/fish/implicit/share/completions/yaourt.fish:11
-#: /tmp/fish/implicit/share/completions/yum.fish:19
-#: /tmp/fish/implicit/share/completions/zcat.fish:4
+#: share/completions/apm.fish:2 share/completions/apropos.fish:20
+#: share/completions/apt-build.fish:29 share/completions/apt-cache.fish:28
+#: share/completions/apt-cdrom.fish:11 share/completions/apt-config.fish:5
+#: share/completions/apt-file.fish:12 share/completions/apt-ftparchive.fish:15
+#: share/completions/apt-proxy-import.fish:3
+#: share/completions/apt-rdepends.fish:12
+#: share/completions/apt-show-source.fish:8
+#: share/completions/apt-sortpkgs.fish:4 share/completions/apt-zip-inst.fish:3
+#: share/completions/apt-zip-list.fish:3 share/completions/at.fish:2
+#: share/completions/atq.fish:2 share/completions/atrm.fish:2
+#: share/completions/perl.fish:41 share/functions/__fish_complete_diff.fish:26
+#: share/functions/__fish_complete_grep.fish:44
+#: share/functions/__fish_complete_ls.fish:96
+#: share/functions/__fish_complete_python.fish:15
+#: share/functions/__fish_complete_tex.fish:5
 msgid "Display version and exit"
-msgstr ""
+msgstr "Visa version och avsluta"
 
-#: /tmp/fish/implicit/share/completions/apm.fish:85
+#: share/completions/apm.fish:3
 msgid "Print APM info"
-msgstr ""
+msgstr "Visa APM-information"
 
-#: /tmp/fish/implicit/share/completions/apm.fish:86
+#: share/completions/apm.fish:4
 msgid "Print time remaining"
-msgstr ""
+msgstr "Visa kvarvarande tid"
 
-#: /tmp/fish/implicit/share/completions/apm.fish:87
+#: share/completions/apm.fish:5
 msgid "Monitor status info"
-msgstr ""
+msgstr "Bevaka statusinformation"
 
-#: /tmp/fish/implicit/share/completions/apm.fish:88
+#: share/completions/apm.fish:6
 msgid "Request APM standby mode"
-msgstr ""
+msgstr "Begär APM-standbyläge"
 
-#: /tmp/fish/implicit/share/completions/apm.fish:89
+#: share/completions/apm.fish:7
 msgid "Request APM suspend mode"
-msgstr ""
+msgstr "Begär APM-suspendläge"
 
-#: /tmp/fish/implicit/share/completions/apm.fish:90
+#: share/completions/apm.fish:8
 msgid "APM status debugging info"
-msgstr ""
+msgstr "APM-status debuginformation"
 
-#: /tmp/fish/implicit/share/completions/apropos.fish:1
-msgid "whatis entry"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apropos.fish:3
+#: share/completions/apropos.fish:12
 msgid "Print debugging info"
-msgstr ""
+msgstr "Visa debuginformation"
 
-#: /tmp/fish/implicit/share/completions/apropos.fish:4
-#: /tmp/fish/implicit/share/completions/apt-file.fish:7
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:3
-#: /tmp/fish/implicit/share/completions/apt-proxy-import.fish:3
-#: /tmp/fish/implicit/share/completions/apt-show-source.fish:9
-#: /tmp/fish/implicit/share/completions/arp.fish:1
-#: /tmp/fish/implicit/share/completions/badblocks.fish:10
-#: /tmp/fish/implicit/share/completions/feh.fish:54
-#: /tmp/fish/implicit/share/completions/fuser.fish:11
-#: /tmp/fish/implicit/share/completions/gcc.fish:452
-#: /tmp/fish/implicit/share/completions/godoc.fish:22
-#: /tmp/fish/implicit/share/completions/grub-install.fish:10
-#: /tmp/fish/implicit/share/completions/makedepend.fish:11
-#: /tmp/fish/implicit/share/completions/mkdosfs.fish:20
-#: /tmp/fish/implicit/share/completions/mount.fish:3
-#: /tmp/fish/implicit/share/completions/mv.fish:9
-#: /tmp/fish/implicit/share/completions/ping.fish:25
-#: /tmp/fish/implicit/share/completions/python2.fish:12
-#: /tmp/fish/implicit/share/completions/python3.fish:12
-#: /tmp/fish/implicit/share/completions/python.fish:13
-#: /tmp/fish/implicit/share/completions/rmdir.fish:3
-#: /tmp/fish/implicit/share/completions/rpm.fish:4
-#: /tmp/fish/implicit/share/completions/ruby.fish:18
-#: /tmp/fish/implicit/share/completions/tar.fish:51
-#: /tmp/fish/implicit/share/completions/time.fish:6
-#: /tmp/fish/implicit/share/completions/umount.fish:4
-#: /tmp/fish/implicit/share/completions/valgrind.fish:6
-#: /tmp/fish/implicit/share/completions/vi.fish:8
-#: /tmp/fish/implicit/share/completions/wget.fish:9
-#: /tmp/fish/implicit/share/completions/zfs.fish:42
-#: /tmp/fish/implicit/share/completions/zfs.fish:87
-#: /tmp/fish/implicit/share/completions/zip.fish:13
-#: /tmp/fish/implicit/share/completions/zpool.fish:140
-#: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:11
+#: share/completions/apropos.fish:13 share/completions/apt-file.fish:8
+#: share/completions/apt-listchanges.fish:4
+#: share/completions/apt-proxy-import.fish:4
+#: share/completions/apt-show-source.fish:10
+#: share/functions/__fish_complete_python.fish:14
+#: share/functions/__fish_complete_ssh.fish:59
+#: share/functions/__fish_complete_vi.fish:98
 msgid "Verbose mode"
-msgstr ""
+msgstr "Utförligt läge"
 
-#: /tmp/fish/implicit/share/completions/apropos.fish:5
+#: share/completions/apropos.fish:14
 msgid "Keyword as regex"
-msgstr ""
+msgstr "Nyckelord är ett reguljärt uttryck"
 
-#: /tmp/fish/implicit/share/completions/apropos.fish:6
+#: share/completions/apropos.fish:15
 msgid "Keyword as wildcards"
-msgstr ""
+msgstr "Nyckelord har jokertecken"
 
-#: /tmp/fish/implicit/share/completions/apropos.fish:7
+#: share/completions/apropos.fish:16
 msgid "Keyword as exactly match"
-msgstr ""
+msgstr "Nyckelord är en exakt matchning"
 
-#: /tmp/fish/implicit/share/completions/apropos.fish:8
+#: share/completions/apropos.fish:17
 msgid "Search for other system"
-msgstr ""
+msgstr "Sök efter annat system"
 
-#: /tmp/fish/implicit/share/completions/apropos.fish:9
+#: share/completions/apropos.fish:18
 msgid "Specify man path"
-msgstr ""
+msgstr "Välj manualsökväg"
 
-#: /tmp/fish/implicit/share/completions/apropos.fish:10
+#: share/completions/apropos.fish:19
 msgid "Specify a configuration file"
-msgstr ""
+msgstr "Välj en konfigurationsfil"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:2
+#: share/completions/apt-build.fish:4
 msgid "Update list of packages"
-msgstr ""
+msgstr "Updatera paketlista"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:3
-#: /tmp/fish/implicit/share/completions/pkg.fish:42
+#: share/completions/apt-build.fish:5
 msgid "Upgrade packages"
-msgstr ""
+msgstr "Upgradera paket"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:4
+#: share/completions/apt-build.fish:6
 msgid "Rebuild your system"
-msgstr ""
+msgstr "Återbygg systemet"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:5
+#: share/completions/apt-build.fish:7
 msgid "Build and install a new package"
-msgstr ""
+msgstr "Bygg och installera nytt paket"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:6
+#: share/completions/apt-build.fish:8
 msgid "Download and extract a source"
-msgstr ""
+msgstr "Nedladda och extrahera källkod"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:7
+#: share/completions/apt-build.fish:9
 msgid "Info on a package"
-msgstr ""
+msgstr "Visa info om paket"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:8
-#: /tmp/fish/implicit/share/completions/zypper.fish:19
+#: share/completions/apt-build.fish:10 share/completions/zypper.fish:45
 msgid "Remove packages"
-msgstr ""
+msgstr "Radera paket"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:9
+#: share/completions/apt-build.fish:11
 msgid "Erase built packages"
-msgstr ""
+msgstr "Radera byggda paket"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:10
+#: share/completions/apt-build.fish:12
 msgid "Build source without install"
-msgstr ""
+msgstr "Bygg källkod utan att installera"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:11
+#: share/completions/apt-build.fish:13
 msgid "Clean source directories"
-msgstr ""
+msgstr "Rengör källkodskataloger"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:12
+#: share/completions/apt-build.fish:14
 msgid "Update source and rebuild"
-msgstr ""
+msgstr "Uppdatera källkod och bygg om dem"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:13
+#: share/completions/apt-build.fish:15
 msgid "Update the repository"
-msgstr ""
+msgstr "Uppdatera förråd"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:14
+#: share/completions/apt-build.fish:16
 msgid "Do not use gcc wrapper"
-msgstr ""
+msgstr "Använd inte omslag (wrapper) kring gcc"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:15
+#: share/completions/apt-build.fish:17
 msgid "Remove build-dep"
-msgstr ""
+msgstr "Ta bort bygg-beroenden"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:16
+#: share/completions/apt-build.fish:18
 msgid "Do not download source"
-msgstr ""
+msgstr "Ladda inte ner källkod"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:17
+#: share/completions/apt-build.fish:19
 msgid "Specify build-dir"
-msgstr ""
+msgstr "Välj bygg-katalog"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:18
-#: /tmp/fish/implicit/share/completions/npm.fish:56
+#: share/completions/apt-build.fish:20
 msgid "Rebuild a package"
-msgstr ""
+msgstr "Bygg om paket"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:19
+#: share/completions/apt-build.fish:21
 msgid "Rebuild and install an installed package"
-msgstr ""
+msgstr "Bygg och installera ett installerat paket"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:20
-msgid "Use <command> to build"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-build.fish:21
+#: share/completions/apt-build.fish:23
 msgid "Apply <file> patch"
-msgstr ""
+msgstr "Applicera <fil> som fix"
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:22
-msgid "Prefix to strip on patch"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-build.fish:23
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:20
-#: /tmp/fish/implicit/share/completions/yum.fish:12
+#: share/completions/apt-listbugs.fish:21
 msgid "Assume yes to all questions"
-msgstr ""
+msgstr "Anta ja på alla frågor"
 
 #: /tmp/fish/implicit/share/completions/apt-build.fish:24
 #: /tmp/fish/implicit/share/completions/apt-get.fish:35
 msgid "Use purge instead of remove"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-build.fish:25
-msgid "Do not run update"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-build.fish:26
+#: share/completions/apt-build.fish:28
 msgid "Specify sources.list file"
-msgstr ""
+msgstr "Välj sources.list fil"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:2
+#: share/completions/apt-cache.fish:3
 msgid "Build apt cache"
-msgstr ""
+msgstr "Bygg aptcache"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:3
+#: share/completions/apt-cache.fish:4
 msgid "Show package info"
-msgstr ""
+msgstr "Visa paketinfo"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:4
+#: share/completions/apt-cache.fish:5
 msgid "Show cache statistics"
-msgstr ""
+msgstr "Visa cachestatistik"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:5
+#: share/completions/apt-cache.fish:6
 msgid "Show source package"
-msgstr ""
+msgstr "Visa alla källkodspaket"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:6
+#: share/completions/apt-cache.fish:7
 msgid "Show packages in cache"
-msgstr ""
+msgstr "Visa paket i cache"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:7
+#: share/completions/apt-cache.fish:8
 msgid "Print available list"
-msgstr ""
+msgstr "Visa tillgängliga paket"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:8
+#: share/completions/apt-cache.fish:9
 msgid "List unmet dependencies in cache"
-msgstr ""
+msgstr "Visa ouppklarade beroenden i cache"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:9
+#: share/completions/apt-cache.fish:10
 msgid "Display package record"
-msgstr ""
+msgstr "Visa paketpost"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:10
+#: share/completions/apt-cache.fish:11
 msgid "Search packagename by REGEX"
-msgstr ""
+msgstr "Sök paketnamn som matchar reguljärt uttryck"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:11
-msgid "Search full package name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:12
+#: share/completions/apt-cache.fish:13
 msgid "Search packagename only"
-msgstr ""
+msgstr "Sök enbart paketnamn"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:13
+#: share/completions/apt-cache.fish:14
 msgid "List dependencies for the package"
-msgstr ""
+msgstr "Visa beroenden för paket"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:14
+#: share/completions/apt-cache.fish:15
 msgid "List reverse dependencies for the package"
-msgstr ""
+msgstr "Visa paket som beror på det givna paketet"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:15
+#: share/completions/apt-cache.fish:16
 msgid "Print package name by prefix"
-msgstr ""
+msgstr "Visa paket som matchar det givna prefixet"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:16
+#: share/completions/apt-cache.fish:17
 msgid "Generate dotty output for packages"
-msgstr ""
+msgstr "Generera utdata för dotty"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:17
+#: share/completions/apt-cache.fish:18
 msgid "Debug preferences file"
-msgstr ""
+msgstr "Fil för debuginställningar"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:18
+#: share/completions/apt-cache.fish:19
 msgid "Select file to store package cache"
-msgstr ""
+msgstr "Välj paketcache"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:19
+#: share/completions/apt-cache.fish:20
 msgid "Select file to store source cache"
-msgstr ""
+msgstr "Välj fil för källkodscache"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:20
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:9
-#: /tmp/fish/implicit/share/completions/apt-get.fish:24
-#: /tmp/fish/implicit/share/completions/configure.fish:3
-#: /tmp/fish/implicit/share/completions/gpg.fish:62
-#: /tmp/fish/implicit/share/completions/hugo.fish:5
-#: /tmp/fish/implicit/share/completions/make.fish:16
-#: /tmp/fish/implicit/share/completions/ping.fish:16
-#: /tmp/fish/implicit/share/completions/rpm.fish:3
-#: /tmp/fish/implicit/share/completions/screen.fish:29
-#: /tmp/fish/implicit/share/completions/ssh.fish:15
-#: /tmp/fish/implicit/share/completions/valgrind.fish:5
-#: /tmp/fish/implicit/share/completions/wget.fish:8
-#: /tmp/fish/implicit/share/completions/zip.fish:12
+#: share/completions/apt-cache.fish:21 share/completions/apt-ftparchive.fish:10
 msgid "Quiet mode"
-msgstr ""
+msgstr "Tyst läge"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:21
+#: share/completions/apt-cache.fish:22
 msgid "Print important dependencies"
-msgstr ""
+msgstr "Visa viktiga beroenden"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:22
+#: share/completions/apt-cache.fish:23
 msgid "Print full records"
-msgstr ""
+msgstr "Visa fulla poster"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:23
+#: share/completions/apt-cache.fish:24
 msgid "Auto-gen package cache"
-msgstr ""
+msgstr "Autogenerera paketcache"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:24
+#: share/completions/apt-cache.fish:25
 msgid "Print all names"
-msgstr ""
+msgstr "Visa alla namn"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:25
+#: share/completions/apt-cache.fish:26
 msgid "Dep and rdep recursive"
-msgstr ""
+msgstr "Rekursiva beroendeberäkningar"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:26
+#: share/completions/apt-cache.fish:27
 msgid "Limit to installed"
-msgstr ""
+msgstr "Bara installerade paket"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:29
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:12
-#: /tmp/fish/implicit/share/completions/apt-config.fish:6
-#: /tmp/fish/implicit/share/completions/apt-extracttemplates.fish:4
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:9
+#: share/completions/apt-cache.fish:30 share/completions/apt-cdrom.fish:13
+#: share/completions/apt-config.fish:7
+#: share/completions/apt-extracttemplates.fish:6
 msgid "Specify options"
-msgstr ""
+msgstr "Välj inställningar"
 
-#: /tmp/fish/implicit/share/completions/apt-cache.fish:30
-#: /tmp/fish/implicit/share/completions/apt.fish:2
-#: /tmp/fish/implicit/share/completions/apt-get.fish:2
-#: /tmp/fish/implicit/share/completions/apt-mark.fish:2
+#: share/completions/apt-cache.fish:32 share/completions/apt-get.fish:12
+#: share/completions/apt-mark.fish:12
 msgid "Test if apt command should have packages as potential completion"
-msgstr ""
+msgstr "Testa om aptkommando borde ha paket som potentiell komplettering"
 
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:2
+#: share/completions/apt-cdrom.fish:3
 msgid "Add new disc to source list"
-msgstr ""
+msgstr "Lägg till skiva till källlista"
 
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:3
+#: share/completions/apt-cdrom.fish:4
 msgid "Report identity of disc"
-msgstr ""
+msgstr "Visa skivas identitet"
 
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:4
-#: /tmp/fish/implicit/share/completions/fusermount.fish:1
-#: /tmp/fish/implicit/share/completions/udisksctl.fish:21
-#: /tmp/fish/implicit/share/completions/umount.fish:1
+#: share/completions/apt-cdrom.fish:5 share/completions/mount.fish:7
 msgid "Mount point"
-msgstr ""
+msgstr "Monteringskatalog"
 
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:5
+#: share/completions/apt-cdrom.fish:6
 msgid "Rename a disc"
-msgstr ""
+msgstr "Byt namn på skiva"
 
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:6
+#: share/completions/apt-cdrom.fish:7
 msgid "No mounting"
-msgstr ""
+msgstr "Montera inte"
 
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:7
+#: share/completions/apt-cdrom.fish:8
 msgid "Fast copy"
-msgstr ""
+msgstr "Snabb kopiering"
 
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:8
+#: share/completions/apt-cdrom.fish:9
 msgid "Thorough package scan"
-msgstr ""
+msgstr "Nogrann paketskanning"
 
-#: /tmp/fish/implicit/share/completions/apt-cdrom.fish:9
+#: share/completions/apt-cdrom.fish:10
 msgid "No changes"
-msgstr ""
+msgstr "Inga förändringar"
 
-#: /tmp/fish/implicit/share/completions/apt-config.fish:2
-msgid "Access config file from shell"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-config.fish:3
+#: share/completions/apt-config.fish:4
 msgid "Dump contents of config file"
-msgstr ""
+msgstr "Skriv ut innehåll av konfigureringsfil"
 
-#: /tmp/fish/implicit/share/completions/apt-extracttemplates.fish:2
+#: share/completions/apt-extracttemplates.fish:4
 msgid "Set temp dir"
-msgstr ""
+msgstr "Välj temporär katalog"
 
-#: /tmp/fish/implicit/share/completions/apt-extracttemplates.fish:3
+#: share/completions/apt-extracttemplates.fish:5
 msgid "Specifiy config file"
-msgstr ""
+msgstr "Välj konfigurationsfil"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:2
+#: share/completions/apt-file.fish:3
 msgid "Resync package contents from source"
-msgstr ""
+msgstr "Återsynkronisera paketinnehåll från källkod"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:3
+#: share/completions/apt-file.fish:4
 msgid "Search package containing pattern"
-msgstr ""
+msgstr "Sök paket innehållande mönster"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:4
+#: share/completions/apt-file.fish:5
 msgid "List contents of a package matching pattern"
-msgstr ""
+msgstr "Lista innehåll av paket som matchar mönster"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:5
+#: share/completions/apt-file.fish:6
 msgid "Remove all gz files from cache"
-msgstr ""
+msgstr "Ta bort alla gz-filer från cache"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:6
+#: share/completions/apt-file.fish:7
 msgid "Set cache dir"
-msgstr ""
+msgstr "Välj cache katalog"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:8
-msgid "Use cdrom-mount-point"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-file.fish:9
-#: /tmp/fish/implicit/share/completions/apt-file.fish:15
+#: share/completions/apt-file.fish:10 share/completions/apt-file.fish:16
 msgid "Do not expand pattern"
-msgstr ""
+msgstr "Expandera inte mönster"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:10
+#: share/completions/apt-file.fish:11
 msgid "Pattern is regexp"
-msgstr ""
+msgstr "Mönster är ett reguljärt uttryck"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:12
+#: share/completions/apt-file.fish:13
 msgid "Set arch"
-msgstr ""
+msgstr "Välj arkitektur"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:13
+#: share/completions/apt-file.fish:14
 msgid "Set sources.list file"
-msgstr ""
+msgstr "Välj sources.list fil"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:14
+#: share/completions/apt-file.fish:15
 msgid "Only display package name"
-msgstr ""
+msgstr "Visa bara paketnamn"
 
-#: /tmp/fish/implicit/share/completions/apt-file.fish:16
+#: share/completions/apt-file.fish:17
 msgid "Run in dummy mode"
-msgstr ""
+msgstr "Kör i dummyläge"
 
-#: /tmp/fish/implicit/share/completions/apt.fish:1
-#: /tmp/fish/implicit/share/completions/apt-get.fish:1
-#: /tmp/fish/implicit/share/completions/apt-mark.fish:1
+#: share/completions/apt-get.fish:3 share/completions/apt-mark.fish:3
 msgid "Test if apt has yet to be given the subcommand"
-msgstr ""
+msgstr "Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/apt.fish:3
 #: /tmp/fish/implicit/share/completions/snap.fish:2
@@ -6288,157 +6263,134 @@ msgstr ""
 msgid "Set a configuration option"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt.fish:8
-#: /tmp/fish/implicit/share/completions/hugo.fish:1
-#: /tmp/fish/implicit/share/completions/man.fish:14
-#: /tmp/fish/implicit/share/completions/modprobe.fish:2
-#: /tmp/fish/implicit/share/completions/yum.fish:13
-#: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:8
+#: share/functions/__fish_complete_ssh.fish:10
 msgid "Configuration file"
-msgstr ""
+msgstr "Konfigureringsfil"
 
 #: /tmp/fish/implicit/share/completions/apt.fish:9
 msgid "Target release"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:2
+#: share/completions/apt-ftparchive.fish:3
 msgid "Generate package from source"
-msgstr ""
+msgstr "Generera paket från källkod"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:3
+#: share/completions/apt-ftparchive.fish:4
 msgid "Generate source index file"
-msgstr ""
+msgstr "Generera källindexfil"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:4
+#: share/completions/apt-ftparchive.fish:5
 msgid "Generate contents file"
-msgstr ""
+msgstr "Generera filinnehåll"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:5
+#: share/completions/apt-ftparchive.fish:6
 msgid "Generate release file"
-msgstr ""
+msgstr "Skapa release-fil"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:6
+#: share/completions/apt-ftparchive.fish:7
 msgid "Remove records"
-msgstr ""
+msgstr "Ta bort poster"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:7
+#: share/completions/apt-ftparchive.fish:8
 msgid "Generate MD5 sums"
-msgstr ""
+msgstr "Generera MD5-summa"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:8
+#: share/completions/apt-ftparchive.fish:9
 msgid "Use a binary db"
-msgstr ""
+msgstr "Använd binär databas"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:10
+#: share/completions/apt-ftparchive.fish:11
 msgid "Perform delinking"
-msgstr ""
+msgstr "Utför avlinkning"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:11
+#: share/completions/apt-ftparchive.fish:12
 msgid "Perform contents generation"
-msgstr ""
+msgstr "Utför innehållsgenerering"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:12
-msgid "Use source override"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:13
+#: share/completions/apt-ftparchive.fish:14
 msgid "Make caching db readonly"
-msgstr ""
+msgstr "Gör cache skrivskyddad"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:15
+#: share/completions/apt-ftparchive.fish:16
 msgid "Use config file"
-msgstr ""
+msgstr "Välj konfigurationsfil"
 
-#: /tmp/fish/implicit/share/completions/apt-ftparchive.fish:16
-#: /tmp/fish/implicit/share/completions/apt-sortpkgs.fish:5
-#: /tmp/fish/implicit/share/completions/composer.fish:7
+#: share/completions/apt-ftparchive.fish:17
 msgid "Set config options"
-msgstr ""
+msgstr "Välj konfigurationsinställningar"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:5
+#: share/completions/apt-get.fish:24
 msgid "Update sources"
-msgstr ""
+msgstr "Uppdatera källor"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:6
+#: share/completions/apt-get.fish:25
 msgid "Upgrade or install newest packages"
-msgstr ""
+msgstr "Bygg och installera nyaste paket"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:7
+#: share/completions/apt-get.fish:26
 msgid "Use with dselect front-end"
-msgstr ""
+msgstr "Använd med dselect-gränssnitt"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:8
+#: share/completions/apt-get.fish:27
 msgid "Distro upgrade"
-msgstr ""
+msgstr "Distibutionsuppgradering"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:9
+#: share/completions/apt-get.fish:28
 msgid "Install one or more packages"
-msgstr ""
+msgstr "Installera ett eller flera paket"
 
 #: /tmp/fish/implicit/share/completions/apt-get.fish:10
 msgid "Display changelog of one or more packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt-get.fish:11
+#: share/completions/apt-get.fish:29
+#, fuzzy
 msgid "Remove and purge one or more packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera ett eller flera paket"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:12
+#: share/completions/apt-get.fish:30
 msgid "Remove one or more packages"
-msgstr ""
+msgstr "Radera ett eller flera paket"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:13
+#: share/completions/apt-get.fish:31
 msgid "Fetch source packages"
-msgstr ""
+msgstr "Hämta källkodspaket"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:14
+#: share/completions/apt-get.fish:32
 msgid "Install/remove packages for dependencies"
-msgstr ""
+msgstr "Installera/ta bort paket för beroenden"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:15
+#: share/completions/apt-get.fish:33
 msgid "Update cache and check dependencies"
-msgstr ""
+msgstr "Uppdatera källkod och verifiera beroenden"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:16
+#: share/completions/apt-get.fish:34
 msgid "Clean local caches and packages"
-msgstr ""
+msgstr "Rengör lokala cachear och paket"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:17
+#: share/completions/apt-get.fish:35
 msgid "Clean packages no longer be downloaded"
-msgstr ""
+msgstr "Rengör paket som inte längre skall nedladdas"
 
 #: /tmp/fish/implicit/share/completions/apt-get.fish:18
+#: share/completions/apt-get.fish:36
+#, fuzzy
 msgid "Remove automatically installed packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga alla installerade paket"
 
 #: /tmp/fish/implicit/share/completions/apt-get.fish:19
 msgid "Do not install recommended packages"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:20
-#: /tmp/fish/implicit/share/completions/aptitude.fish:28
-msgid "Download Only"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:21
-#: /tmp/fish/implicit/share/completions/aptitude.fish:29
-msgid "Correct broken dependencies"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:22
-msgid "Ignore missing packages"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:23
-msgid "Disable downloading packages"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/apt-get.fish:25
 msgid "Perform a simulation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:26
-msgid "Automatic yes to prompts"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt-get.fish:27
@@ -6449,24 +6401,8 @@ msgstr ""
 msgid "Show full versions for packages"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:29
-msgid "Compile source packages"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/apt-get.fish:30
 msgid "Install recommended packages"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:31
-msgid "Ignore package Holds"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:32
-msgid "Do not upgrade packages"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:33
-msgid "Force yes"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt-get.fish:34
@@ -6477,69 +6413,42 @@ msgstr ""
 msgid "Reinstall packages"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:37
-msgid "Erase obsolete files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:38
-msgid "Control default input to the policy engine"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:39
-msgid "Only perform operations that are trivial"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:40
-msgid "Abort if any packages are to be removed"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:41
-msgid "Only accept source packages"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:42
-msgid "Download only diff file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:43
-msgid "Download only tar file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:44
-msgid "Only process arch-dependant build-dependencies"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:45
-msgid "Ignore non-authenticated packages"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-get.fish:47
-#: /tmp/fish/implicit/share/completions/apt-mark.fish:13
+#: share/completions/apt-get.fish:65 share/completions/apt-mark.fish:32
 msgid "Specify a config file"
-msgstr ""
+msgstr "Välj en konfigurationsfil"
 
-#: /tmp/fish/implicit/share/completions/apt-get.fish:48
-#: /tmp/fish/implicit/share/completions/apt-mark.fish:14
+#: share/completions/apt-get.fish:66 share/completions/apt-mark.fish:33
 msgid "Set a config option"
-msgstr ""
+msgstr "Välj en konfigurationsinställning"
 
-#: /tmp/fish/implicit/share/completions/aptitude.fish:1
+#: share/completions/aptitude.fish:3
 msgid "Test if aptitude has yet to be given the subcommand"
-msgstr ""
+msgstr "Testa om aptitude har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:2
+#: share/completions/aptitude.fish:12
+#, fuzzy
 msgid "Test if aptitude command should have packages as potential completion"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om aptkommando borde ha paket som potentiell komplettering"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:4
 msgid "Display a brief help message. Identical to the help action"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:5
+#: share/completions/aptitude.fish:24
+#, fuzzy
 msgid "Remove any cached packages which can no longer be downloaded"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Rengör paket som inte längre skall nedladdas"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:6
+#: share/completions/aptitude.fish:25
 msgid "Remove all downloaded .deb files from the package cache directory"
 msgstr ""
 
@@ -6548,78 +6457,149 @@ msgid "Forget all internal information about what packages are 'new'"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:8
+#: share/completions/aptitude.fish:27
 msgid "Cancel all scheduled actions on all packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:9
+#: share/completions/aptitude.fish:28
+#, fuzzy
 msgid "Update the list of available packages from the apt sources"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Updatera källkodpaketlista"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:10
+#: share/completions/aptitude.fish:29
+#, fuzzy
 msgid "Upgrade installed packages to their most recent version"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa alla källkodspaket med version"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:11
+#: share/completions/aptitude.fish:30
+#, fuzzy
 msgid "Download and displays the Debian changelog for the packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa ändringsinformation för paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:12
+#: share/completions/aptitude.fish:31
+#, fuzzy
 msgid "Upgrade, removing or installing packages as necessary"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Bygg och installera nyaste paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:13
+#: share/completions/aptitude.fish:32
+#, fuzzy
 msgid "Download the packages to the current directory"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:14
+#: share/completions/aptitude.fish:33
 msgid "Forbid the upgrade to a particular version"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:15
+#: share/completions/aptitude.fish:34
 msgid "Ignore the packages by future upgrade commands"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:16
+#: share/completions/aptitude.fish:35
+#, fuzzy
 msgid "Install the packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installera nytt paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:17
+#: share/completions/aptitude.fish:36
+#, fuzzy
 msgid "Cancel any scheduled actions on the packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa ändringsinformation för paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:18
+#: share/completions/aptitude.fish:37
+#, fuzzy
 msgid "Mark packages as automatically installed"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:19
+#: share/completions/aptitude.fish:38
 msgid "Remove and delete all associated configuration and data files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:20
+#: share/completions/aptitude.fish:39
+#, fuzzy
 msgid "Reinstall the packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ominstallera paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:21
+#: share/completions/aptitude.fish:40
+#, fuzzy
 msgid "Remove the packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:22
+#: share/completions/aptitude.fish:41
+#, fuzzy
 msgid "Display detailed information about the packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa ändringsinformation för paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:23
+#: share/completions/aptitude.fish:42
 msgid "Consider the packages by future upgrade commands"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:24
+#: share/completions/aptitude.fish:43
+#, fuzzy
 msgid "Mark packages as manually installed"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:25
+#: share/completions/aptitude.fish:44
+#, fuzzy
 msgid "Search for packages matching one of the patterns"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Sök paket innehållande mönster"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:26
+#: share/completions/aptitude.fish:45
 msgid "Display brief summary of the available commands and options"
 msgstr ""
 
@@ -6699,296 +6679,305 @@ msgstr ""
 msgid "Specify the display width for the output from the search command"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-key.fish:1
+#: share/completions/apt-key.fish:2
 msgid "Add a new key"
-msgstr ""
+msgstr "Lägg till ny nyckel"
 
-#: /tmp/fish/implicit/share/completions/apt-key.fish:2
+#: share/completions/apt-key.fish:3
 msgid "Remove a key"
-msgstr ""
+msgstr "Ta bort en nyckel"
 
-#: /tmp/fish/implicit/share/completions/apt-key.fish:3
+#: share/completions/apt-key.fish:4
 msgid "List trusted keys"
-msgstr ""
+msgstr "Visa pålitliga nycklar"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:2
+#: share/completions/apt-listbugs.fish:3
 msgid "Set severity"
-msgstr ""
+msgstr "Välj allvarlighetgrad"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:3
+#: share/completions/apt-listbugs.fish:4
 msgid "Tags you want to see"
-msgstr ""
+msgstr "Välj taggar du vill se"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:4
+#: share/completions/apt-listbugs.fish:5
 msgid "Bug-status you want to see"
-msgstr ""
+msgstr "Bugg-status du vill se"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:5
+#: share/completions/apt-listbugs.fish:6
 msgid "Ignore bugs in your system"
-msgstr ""
+msgstr "Ignorera buggar i ditt system"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:6
+#: share/completions/apt-listbugs.fish:7
 msgid "Ignore newer bugs than upgrade packages"
-msgstr ""
+msgstr "Ignorera nyare buggar än uppgraderade paket"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:7
+#: share/completions/apt-listbugs.fish:8
 msgid "Bugs for downgrade packages"
-msgstr ""
+msgstr "Buggar för nedgraderade paket"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:8
+#: share/completions/apt-listbugs.fish:9
 msgid "Bug Tracking system"
-msgstr ""
+msgstr "Buggtrackingsystem"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:9
+#: share/completions/apt-listbugs.fish:10
 msgid "Specify port for web interface"
-msgstr ""
+msgstr "Välj port för webbinterface"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:10
+#: share/completions/apt-listbugs.fish:11
 msgid "Use daily bug report"
-msgstr ""
+msgstr "Använd daglig buggrapport"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:11
+#: share/completions/apt-listbugs.fish:12
 msgid "Use the raw index.db"
-msgstr ""
+msgstr "Använd bar index.db"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:12
+#: share/completions/apt-listbugs.fish:13
 msgid "Specify index dir"
-msgstr ""
+msgstr "Välj indexkatalog"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:13
+#: share/completions/apt-listbugs.fish:14
 msgid "Specify Pin-Priority value"
-msgstr ""
+msgstr "Välj Pin-prioritetsvärde"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:14
+#: share/completions/apt-listbugs.fish:15
 msgid "Specify the title of rss"
-msgstr ""
+msgstr "Välj rss-titel"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:15
+#: share/completions/apt-listbugs.fish:16
 msgid "Retrieve fresh bugs"
-msgstr ""
+msgstr "Hämta färska buggar"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:16
-#: /tmp/fish/implicit/share/completions/aura.fish:31
-#: /tmp/fish/implicit/share/completions/pacaur.fish:47
-#: /tmp/fish/implicit/share/completions/pacman.fish:25
-#: /tmp/fish/implicit/share/completions/scp.fish:7
-#: /tmp/fish/implicit/share/completions/yaourt.fish:39
+#: share/completions/apt-listbugs.fish:17
 msgid "Do not display progress bar"
-msgstr ""
+msgstr "Visa inte förloppsindikator"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:17
+#: share/completions/apt-listbugs.fish:18
 msgid "Specify local cache dir"
-msgstr ""
+msgstr "Välj lokal cachekatalog"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:18
+#: share/completions/apt-listbugs.fish:19
 msgid "Specify the expire cache timer"
-msgstr ""
+msgstr "Välj cacheexpireringstimer"
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:19
-msgid "Specify apt config file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:21
+#: share/completions/apt-listbugs.fish:22
 msgid "Assume no to all questions"
-msgstr ""
+msgstr "Anta nej på alla frågor"
 
 #: /tmp/fish/implicit/share/completions/apt-listbugs.fish:22
 msgid "List bugs from packages"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-listbugs.fish:23
-msgid "List bugs in rss format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:2
-msgid "Read filenames from pipe"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:4
+#: share/completions/apt-listchanges.fish:5
 msgid "Select frontend interface"
-msgstr ""
+msgstr "Välj gränssnitt"
 
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:5
-#: /tmp/fish/implicit/share/completions/darcs.fish:749
+#: share/completions/darcs.fish:915
 msgid "Specify email address"
-msgstr ""
+msgstr "Välj e-postkatalog"
 
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:6
+#: share/completions/apt-listchanges.fish:7
 msgid "Ask confirmation"
-msgstr ""
+msgstr "Bekräfta val"
 
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:7
+#: share/completions/apt-listchanges.fish:8
 msgid "Display all changelogs"
-msgstr ""
+msgstr "Visa alla händelseloggar"
 
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:8
+#: share/completions/apt-listchanges.fish:9
 msgid "Avoid changelogs from db in named file"
-msgstr ""
+msgstr "Undvik händelseloggar från databas i fil"
 
 #: /tmp/fish/implicit/share/completions/apt-listchanges.fish:9
 msgid "Select display"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:10
+#: share/completions/apt-listchanges.fish:11
 msgid "Insert header"
-msgstr ""
+msgstr "Lägg till huvud"
 
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:11
-#: /tmp/fish/implicit/share/completions/ps.fish:40
+#: share/completions/apt-listchanges.fish:12
 msgid "Display debug info"
-msgstr ""
+msgstr "Visa debuginformation"
 
-#: /tmp/fish/implicit/share/completions/apt-listchanges.fish:12
+#: share/completions/apt-listchanges.fish:13
 msgid "Select an option profile"
-msgstr ""
+msgstr "Välj än inställningsprofil"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:5
+#: share/completions/apt-mark.fish:24
+#, fuzzy
 msgid "Mark a package as automatically installed"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:6
+#: share/completions/apt-mark.fish:25
+#, fuzzy
 msgid "Mark a package as manually installed"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:7
+#: share/completions/apt-mark.fish:26
 msgid "Hold a package, prevent automatic installation or removal"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:8
+#: share/completions/apt-mark.fish:27
+#, fuzzy
 msgid "Cancel a hold on a package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa info om paket"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:9
+#: share/completions/apt-mark.fish:28
+#, fuzzy
 msgid "Show automatically installed packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga alla installerade paket"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:10
+#: share/completions/apt-mark.fish:29
+#, fuzzy
 msgid "Show manually installed packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga alla installerade paket"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:11
+#: share/completions/apt-mark.fish:30
+#, fuzzy
 msgid "Show held packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa uppgraderade paket"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:15
+#: share/completions/apt-mark.fish:34
+#, fuzzy
 msgid "Write package statistics to a file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv prototyper till fil"
 
 #: /tmp/fish/implicit/share/completions/apt-move.fish:1
 msgid "Generate master file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:2
-msgid "Alias for 'get'"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-move.fish:3
+#: share/completions/apt-move.fish:4
 msgid "Move packages to local tree"
-msgstr ""
+msgstr "Flytta paket till lokalt träd"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:4
+#: share/completions/apt-move.fish:5
 msgid "Delete obsolete package files"
-msgstr ""
+msgstr "Radera obsoleta paketfiler"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:5
+#: share/completions/apt-move.fish:6
 msgid "Build new local files"
-msgstr ""
+msgstr "Bygg nya lokala filer"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:6
+#: share/completions/apt-move.fish:7
 msgid "Rebuild index files"
-msgstr ""
+msgstr "Bygg om indexfiler"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:7
+#: share/completions/apt-move.fish:8
 msgid "Move packages from cache to local mirror"
-msgstr ""
+msgstr "Flytta paket från cache till lokal spegel"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:8
+#: share/completions/apt-move.fish:9
 msgid "Alias for 'move delete packages'"
-msgstr ""
+msgstr "Alias för 'move delete packages'"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:9
+#: share/completions/apt-move.fish:10
 msgid "Alias for 'update'"
-msgstr ""
+msgstr "Alias för 'update'"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:10
+#: share/completions/apt-move.fish:11
 msgid "Download package missing from mirror"
-msgstr ""
+msgstr "Ladde ner paket som saknas från spegel"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:11
+#: share/completions/apt-move.fish:12
 msgid "Sync packages installed"
-msgstr ""
+msgstr "Synkronisera installerade paket"
 
 #: /tmp/fish/implicit/share/completions/apt-move.fish:13
 msgid "Move file specified on commandline"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:14
+#: share/completions/apt-move.fish:15
 msgid "List packages that may serve as input to mirrorbin or mirrorsource"
-msgstr ""
+msgstr "Visa paket som kan användas som input till mirrorbin eller mirrorsrc"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:15
+#: share/completions/apt-move.fish:16
 msgid "Fetch package from STDIN"
-msgstr ""
+msgstr "Hämta paket från standard in"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:16
+#: share/completions/apt-move.fish:17
 msgid "Fetch source package from STDIN"
-msgstr ""
+msgstr "Hämta källkodspaket från standard in"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:17
+#: share/completions/apt-move.fish:18
 msgid "Process all packages"
-msgstr ""
+msgstr "Behandla alla paket"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:18
-msgid "Use specific conffile"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-move.fish:19
+#: share/completions/apt-move.fish:20
 msgid "Force deletion"
-msgstr ""
+msgstr "Tvinga radering"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:20
+#: share/completions/apt-move.fish:21
 msgid "Suppresses normal output"
-msgstr ""
+msgstr "Tyst läge"
 
-#: /tmp/fish/implicit/share/completions/apt-move.fish:21
+#: share/completions/apt-move.fish:22
 msgid "Test run"
-msgstr ""
+msgstr "Testkörning"
 
-#: /tmp/fish/implicit/share/completions/apt-proxy-import.fish:4
+#: share/completions/apt-proxy-import.fish:5
 msgid "No message to STDOUT"
-msgstr ""
+msgstr "Inga meddelanden till standard ut"
 
-#: /tmp/fish/implicit/share/completions/apt-proxy-import.fish:5
+#: share/completions/apt-proxy-import.fish:6
 msgid "Recurse into subdir"
-msgstr ""
+msgstr "Rekursera till underkataloger"
 
-#: /tmp/fish/implicit/share/completions/apt-proxy-import.fish:6
+#: share/completions/apt-proxy-import.fish:7
 msgid "Dir to import"
-msgstr ""
+msgstr "Katalog att importera"
 
-#: /tmp/fish/implicit/share/completions/apt-proxy-import.fish:7
+#: share/completions/apt-proxy-import.fish:8
 msgid "Change to user"
-msgstr ""
+msgstr "Ändra till användare"
 
-#: /tmp/fish/implicit/share/completions/apt-proxy-import.fish:8
+#: share/completions/apt-proxy-import.fish:9
 msgid "Debug level[default 0]"
-msgstr ""
+msgstr "Debugnivå [Standard är 0]"
 
-#: /tmp/fish/implicit/share/completions/apt-rdepends.fish:2
+#: share/completions/apt-rdepends.fish:3
 msgid "Show build dependencies"
-msgstr ""
+msgstr "Visa byggberoenden"
 
-#: /tmp/fish/implicit/share/completions/apt-rdepends.fish:3
+#: share/completions/apt-rdepends.fish:4
 msgid "Generate a dotty graph"
-msgstr ""
+msgstr "Generera en dottygraf"
 
-#: /tmp/fish/implicit/share/completions/apt-rdepends.fish:4
+#: share/completions/apt-rdepends.fish:5
 msgid "Show state of dependencies"
-msgstr ""
+msgstr "Visa beroendens tillstånd"
 
-#: /tmp/fish/implicit/share/completions/apt-rdepends.fish:5
+#: share/completions/apt-rdepends.fish:6
 msgid "List packages depending on"
-msgstr ""
+msgstr "Visa paket som beror på"
 
 #: /tmp/fish/implicit/share/completions/apt-rdepends.fish:6
 msgid "Comma-separated list of dependency types to follow recursively"
@@ -6998,270 +6987,203 @@ msgstr ""
 msgid "Comma-separated list of dependency types to show"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-rdepends.fish:8
-msgid ""
-"Comma-separated list of package installation states to follow recursively"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-rdepends.fish:9
-msgid "Comma-separated list of package installation states to show"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-rdepends.fish:10
+#: share/completions/apt-rdepends.fish:11
 msgid "Display man page"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-setup.fish:1
-msgid "Probe a CD"
-msgstr ""
+msgstr "Visa manualsida"
 
 #: /tmp/fish/implicit/share/completions/apt-setup.fish:2
 msgid "Run in non-interactive mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-show-source.fish:2
-#: /tmp/fish/implicit/share/completions/apt-show-source.fish:3
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:9
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:10
+#: share/completions/apt-show-source.fish:3
+#: share/completions/apt-show-source.fish:4
+#: share/completions/apt-show-versions.fish:10
+#: share/completions/apt-show-versions.fish:11
 msgid "Read package from file"
-msgstr ""
+msgstr "Läs paket från fil"
 
-#: /tmp/fish/implicit/share/completions/apt-show-source.fish:4
-#: /tmp/fish/implicit/share/completions/apt-show-source.fish:5
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:11
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:12
+#: share/completions/apt-show-source.fish:5
+#: share/completions/apt-show-source.fish:6
+#: share/completions/apt-show-versions.fish:12
+#: share/completions/apt-show-versions.fish:13
 msgid "Specify APT list dir"
-msgstr ""
+msgstr "Välj APT listningskatalog"
 
-#: /tmp/fish/implicit/share/completions/apt-show-source.fish:6
+#: share/completions/apt-show-source.fish:7
 msgid "List PKG info"
-msgstr ""
+msgstr "Lista paketinformation"
 
-#: /tmp/fish/implicit/share/completions/apt-show-source.fish:8
+#: share/completions/apt-show-source.fish:9
 msgid "Print all source packages with version"
-msgstr ""
+msgstr "Visa alla källkodspaket med version"
 
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:2
+#: share/completions/apt-show-versions.fish:3
 msgid "Print PKG versions"
-msgstr ""
+msgstr "Visa paketversioner"
 
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:3
+#: share/completions/apt-show-versions.fish:4
 msgid "Using regex"
-msgstr ""
+msgstr "Använd reguljära uttryck"
 
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:4
+#: share/completions/apt-show-versions.fish:5
 msgid "Print only upgradeable packages"
-msgstr ""
+msgstr "Visa bara paket som kan uppgraderas"
 
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:5
+#: share/completions/apt-show-versions.fish:6
 msgid "Print all versions"
-msgstr ""
+msgstr "Visa alla versioner"
 
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:6
+#: share/completions/apt-show-versions.fish:7
 msgid "Print package name/distro"
-msgstr ""
+msgstr "Visa paketnamn/distribution"
 
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:7
+#: share/completions/apt-show-versions.fish:8
 msgid "Print verbose info"
-msgstr ""
+msgstr "Visa utförlig information"
 
-#: /tmp/fish/implicit/share/completions/apt-show-versions.fish:8
+#: share/completions/apt-show-versions.fish:9
 msgid "Init or update cache only"
-msgstr ""
+msgstr "Bara initiera eller uppdatera cachen"
 
-#: /tmp/fish/implicit/share/completions/apt-sortpkgs.fish:2
+#: share/completions/apt-sortpkgs.fish:3
 msgid "Use source index field"
-msgstr ""
+msgstr "Använd köllindexfält"
 
-#: /tmp/fish/implicit/share/completions/apt-sortpkgs.fish:4
+#: share/completions/apt-sortpkgs.fish:5
 msgid "Specify conffile"
-msgstr ""
+msgstr "Välj konfigurationsfil"
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:2
+#: share/completions/apt-spy.fish:3
 msgid "Debian distribution"
-msgstr ""
+msgstr "Debiandistribution"
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:3
+#: share/completions/apt-spy.fish:4
 msgid "Servers in the areas"
-msgstr ""
+msgstr "Servrar i områden"
 
 #: /tmp/fish/implicit/share/completions/apt-spy.fish:4
 msgid "Conf file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:5
+#: share/completions/apt-spy.fish:6
 msgid "Finish after number of servers"
-msgstr ""
+msgstr "Avsluta efter antal servrar"
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:6
-msgid "File to grab servers"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:7
-msgid "File as input"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:8
-msgid "Mirror-list file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:9
-msgid "Output sources.list file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:10
+#: share/completions/apt-spy.fish:11
 msgid "Use proxy server"
-msgstr ""
+msgstr "Använd proxyserver"
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:11
+#: share/completions/apt-spy.fish:12
 msgid "Comma separated country list"
-msgstr ""
+msgstr "Kommasepararad landslista"
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:12
+#: share/completions/apt-spy.fish:13
 msgid "How long in sec to download"
-msgstr ""
+msgstr "Hur länga i sekunder som nedladdning får ske"
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:13
+#: share/completions/apt-spy.fish:14
 msgid "Custom URL to get mirror list"
-msgstr ""
+msgstr "Egen URL för att hämta lista av speglar"
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:14
-msgid "Write top servers to file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:15
+#: share/completions/apt-spy.fish:16
 msgid "Number of top servers"
-msgstr ""
+msgstr "Antal toppservrar"
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:16
+#: share/completions/apt-spy.fish:17
 msgid "Update mirror list"
-msgstr ""
+msgstr "Uppdatera spegellista"
 
-#: /tmp/fish/implicit/share/completions/apt-spy.fish:17
+#: share/completions/apt-spy.fish:18
 msgid "Version number"
-msgstr ""
+msgstr "Visa versionsnummer"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:2
+#: share/completions/apt-src.fish:3
 msgid "Update list of source packages"
-msgstr ""
+msgstr "Updatera källkodpaketlista"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:3
+#: share/completions/apt-src.fish:4
 msgid "Install source packages"
-msgstr ""
+msgstr "Installera källkodpaket"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:4
+#: share/completions/apt-src.fish:5
 msgid "Upgrade source packages"
-msgstr ""
+msgstr "Upgradera källkodpaket"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:5
+#: share/completions/apt-src.fish:6
 msgid "Remove source packages"
-msgstr ""
+msgstr "Radera källkodpaket"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:6
-#: /tmp/fish/implicit/share/completions/apt-src.fish:13
+#: share/completions/apt-src.fish:7 share/completions/apt-src.fish:14
 msgid "Build source packages"
-msgstr ""
+msgstr "Bygg källkodpaket"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:7
+#: share/completions/apt-src.fish:8
 msgid "Clean source packages"
-msgstr ""
+msgstr "Rengör källkodpaket"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:8
+#: share/completions/apt-src.fish:9
 msgid "Detect known source tree"
-msgstr ""
+msgstr "Detektera känt källkodsträd"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:9
+#: share/completions/apt-src.fish:10
 msgid "List installed source package\\(s\\)"
-msgstr ""
+msgstr "Lista installerade källkodpaket"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:10
+#: share/completions/apt-src.fish:11
 msgid "Root source tree"
-msgstr ""
+msgstr "Rotkällträd"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:11
+#: share/completions/apt-src.fish:12
 msgid "Version of source package"
-msgstr ""
+msgstr "Version på källkodpaket"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:12
+#: share/completions/apt-src.fish:13
 msgid "Name of the source package"
-msgstr ""
+msgstr "Namn på källkodpaket"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:14
+#: share/completions/apt-src.fish:15
 msgid "Install after build"
-msgstr ""
+msgstr "Installera efter byggande"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:15
+#: share/completions/apt-src.fish:16
 msgid "Patch local changes"
-msgstr ""
+msgstr "Utför fixar för lokala ändringar"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:16
+#: share/completions/apt-src.fish:17
 msgid "Specify a dir"
-msgstr ""
+msgstr "Ange katalog"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:17
-msgid "Run on current dir"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-src.fish:18
+#: share/completions/apt-src.fish:19
 msgid "Omit debian version"
-msgstr ""
+msgstr "Ange inte Debian-version"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:19
+#: share/completions/apt-src.fish:20
 msgid "Do not del built files"
-msgstr ""
+msgstr "Radera inte byggda filer"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:20
+#: share/completions/apt-src.fish:21
 msgid "Do not del source files"
-msgstr ""
+msgstr "Radera inte källfiler"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:21
+#: share/completions/apt-src.fish:22
 msgid "Source tree version"
-msgstr ""
+msgstr "Källkodsträdsversion"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:22
+#: share/completions/apt-src.fish:23
 msgid "Output to /dev/null"
-msgstr ""
+msgstr "Skriv utdata till /dev/null"
 
-#: /tmp/fish/implicit/share/completions/apt-src.fish:23
+#: share/completions/apt-src.fish:24
 msgid "Output trace"
-msgstr ""
+msgstr "Utdataspår"
 
-#: /tmp/fish/implicit/share/completions/apt-zip-inst.fish:3
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:3
-msgid "Removable medium"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-zip-inst.fish:4
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:4
+#: share/completions/apt-zip-inst.fish:5 share/completions/apt-zip-list.fish:5
 msgid "Select an action"
-msgstr ""
+msgstr "Välj en handling"
 
-#: /tmp/fish/implicit/share/completions/apt-zip-inst.fish:5
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:5
-msgid "List of packages to install"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-zip-inst.fish:6
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:6
+#: share/completions/apt-zip-inst.fish:7 share/completions/apt-zip-list.fish:7
 msgid "Fix broken option"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-zip-inst.fish:7
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:7
-msgid "Specify a non-mountpoint dir"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:8
-msgid "Select a method"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:10
-msgid "Accept protocols"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/apt-zip-list.fish:11
-msgid "Reject protocols"
-msgstr ""
+msgstr "Fixa trasig flagga"
 
 #: /tmp/fish/implicit/share/completions/arc.fish:1
 msgid "Debugging command"
@@ -8001,37 +7923,29 @@ msgstr ""
 msgid "Shows the current version of arcanist"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/arp.fish:2
-msgid "Numerical address"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/arp.fish:3
+#: share/completions/arp.fish:4
 msgid "Class of hw type"
-msgstr ""
+msgstr "Klass av hårdvara"
 
-#: /tmp/fish/implicit/share/completions/arp.fish:4
+#: share/completions/arp.fish:5
 msgid "Show arp entries"
-msgstr ""
+msgstr "Visa ARP-inlägg"
 
-#: /tmp/fish/implicit/share/completions/arp.fish:5
+#: share/completions/arp.fish:6
 msgid "Remove an entry for hostname"
-msgstr ""
+msgstr "Ta bort hostname-inlägg"
 
-#: /tmp/fish/implicit/share/completions/arp.fish:6
-msgid "Use hardware address"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/arp.fish:7
+#: share/completions/arp.fish:8
 msgid "Select interface"
-msgstr ""
+msgstr "Välj gränssnitt"
 
-#: /tmp/fish/implicit/share/completions/arp.fish:8
+#: share/completions/arp.fish:9
 msgid "Manually create ARP address"
-msgstr ""
+msgstr "Skapa ARP adress manuellt"
 
-#: /tmp/fish/implicit/share/completions/arp.fish:9
+#: share/completions/arp.fish:10
 msgid "Take addr from filename, default /etc/ethers"
-msgstr ""
+msgstr "Hämta adress från filnamn, standard är /etc/ethers"
 
 #: /tmp/fish/implicit/share/completions/as.fish:1
 msgid "Omit false conditionals"
@@ -8379,53 +8293,49 @@ msgstr ""
 msgid "Remove target from local repository"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/atd.fish:1
+#: share/completions/atd.fish:2
 msgid "Limiting load factor"
-msgstr ""
+msgstr "Begränsande lastfaktor"
 
-#: /tmp/fish/implicit/share/completions/atd.fish:2
+#: share/completions/atd.fish:3
 msgid "Minimum interval in seconds"
-msgstr ""
+msgstr "Minimalt intervall i sekunder"
 
-#: /tmp/fish/implicit/share/completions/atd.fish:3
-#: /tmp/fish/implicit/share/completions/make.fish:4
-#: /tmp/fish/implicit/share/completions/sylpheed.fish:2
+#: share/completions/atd.fish:4
 msgid "Debug mode"
-msgstr ""
+msgstr "Debugläge"
 
-#: /tmp/fish/implicit/share/completions/atd.fish:4
+#: share/completions/atd.fish:5
 msgid "Process at queue only once"
-msgstr ""
+msgstr "Processa 'at'-kö bara en gång"
 
-#: /tmp/fish/implicit/share/completions/at.fish:2
-#: /tmp/fish/implicit/share/completions/atq.fish:2
+#: share/completions/at.fish:3 share/completions/atq.fish:3
 msgid "Use specified queue"
-msgstr ""
+msgstr "Använd angiven kö"
 
-#: /tmp/fish/implicit/share/completions/at.fish:3
+#: share/completions/at.fish:4
 msgid "Send mail to user"
-msgstr ""
+msgstr "Skicka e-post till användare"
 
-#: /tmp/fish/implicit/share/completions/at.fish:4
+#: share/completions/at.fish:5
 msgid "Read job from file"
-msgstr ""
+msgstr "Läs in jobb från fil"
 
-#: /tmp/fish/implicit/share/completions/at.fish:5
+#: share/completions/at.fish:6
 msgid "Alias for atq"
-msgstr ""
+msgstr "Alias för atq"
 
-#: /tmp/fish/implicit/share/completions/at.fish:6
+#: share/completions/at.fish:7
 msgid "Alias for atrm"
-msgstr ""
+msgstr "Alias för atrm"
 
-#: /tmp/fish/implicit/share/completions/at.fish:7
-#: /tmp/fish/implicit/share/completions/climate.fish:11
+#: share/completions/at.fish:8
 msgid "Show the time"
-msgstr ""
+msgstr "Visa tid"
 
-#: /tmp/fish/implicit/share/completions/at.fish:8
+#: share/completions/at.fish:9
 msgid "Print the jobs listed"
-msgstr ""
+msgstr "Visa listade jobb"
 
 #: /tmp/fish/implicit/share/completions/atom.fish:1
 msgid "Run in development mode."
@@ -9228,22 +9138,6 @@ msgstr ""
 msgid "Force interactive mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/bc.fish:2
-msgid "Define math library"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bc.fish:3
-msgid "Give warnings for extensions to POSIX bc"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bc.fish:4
-msgid "Process exactly POSIX bc"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bc.fish:5
-msgid "Do not print the GNU welcome"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/bd.fish:1
 msgid "Classic mode: goes back to the first directory named as the string"
 msgstr ""
@@ -9362,10 +9256,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bison.fish:15
 msgid "Equivalent to -o y.tab.c"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/block.fish:2
-msgid "Remove the topmost global event block"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/block.fish:3
@@ -9854,17 +9744,23 @@ msgstr ""
 msgid "Display formula's install path in Cellar"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/builtin.fish:2
-msgid "Print names of all existing builtins"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/bundle.fish:1
+#: share/completions/bundle.fish:3
+#, fuzzy
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om aptitude har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:2
+#: share/completions/bundle.fish:11
+#, fuzzy
 msgid "Test if bundle has been given a specific subcommand"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om aptitude har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:3
 msgid "Specify the number of times you wish to attempt network commands"
@@ -9879,8 +9775,13 @@ msgid "Enable verbose output mode"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:6
+#: share/completions/bundle.fish:31
+#, fuzzy
 msgid "Display a help page"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa manualsida"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:7
 msgid "Prints version information"
@@ -9888,208 +9789,327 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:8
 #: /tmp/fish/implicit/share/completions/bundle.fish:40
+#: share/completions/bundle.fish:39 share/completions/bundle.fish:83
 msgid "Install the gems specified by the Gemfile or Gemfile.lock"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:9
 #: /tmp/fish/implicit/share/completions/bundle.fish:57
+#: share/completions/bundle.fish:40 share/completions/bundle.fish:106
+#, fuzzy
 msgid "The location of the Gemfile bundler should use"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:10
+#: share/completions/bundle.fish:41
+#, fuzzy
 msgid "The location to install the gems in the bundle to"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:11
+#: share/completions/bundle.fish:42
+#, fuzzy
 msgid "Installs the gems in the bundle to the system location"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:12
+#: share/completions/bundle.fish:43
 msgid "A space-separated list of groups to skip installing"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:13
+#: share/completions/bundle.fish:44
 msgid "Use cached gems instead of connecting to rubygems.org"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:14
+#: share/completions/bundle.fish:45
 msgid "Switches bundler's defaults into deployment mode."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:15
+#: share/completions/bundle.fish:46
 msgid ""
 "Create a directory containing executabes that run in the context of the "
 "bundle"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:16
+#: share/completions/bundle.fish:47
 msgid "Specify a ruby executable to use with generated binstubs"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:17
+#: share/completions/bundle.fish:48
 msgid "Make a bundle that can work without RubyGems or Bundler at run-time"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:18
+#: share/completions/bundle.fish:49
 msgid "Apply a RubyGems security policy: {High,Medium,Low,No}Security"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:19
+#: share/completions/bundle.fish:50
 msgid "Install  gems parallely by starting size number of parallel workers"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:20
+#: share/completions/bundle.fish:51
 msgid "Do not update the cache in vendor/cache with the newly bundled gems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:21
+#: share/completions/bundle.fish:52
+#, fuzzy
 msgid "Do not print progress information to stdout"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa all information"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:22
+#: share/completions/bundle.fish:53
+#, fuzzy
 msgid "Run bundle clean automatically after install"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:23
 #: /tmp/fish/implicit/share/completions/bundle.fish:30
+#: share/completions/bundle.fish:54 share/completions/bundle.fish:63
 msgid "Use the rubygems modern index instead of the API endpoint"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:24
 #: /tmp/fish/implicit/share/completions/bundle.fish:89
+#: share/completions/bundle.fish:55 share/completions/bundle.fish:164
+#, fuzzy
 msgid "Do not remove stale gems from the cache"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ta bort alla gz-filer från cache"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:25
+#: share/completions/bundle.fish:56
 msgid "Do not allow the Gemfile.lock to be updated after this install"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:26
 #: /tmp/fish/implicit/share/completions/bundle.fish:41
+#: share/completions/bundle.fish:59 share/completions/bundle.fish:84
+#, fuzzy
 msgid "Update dependencies to their latest versions"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa alla källkodspaket med version"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:27
+#: share/completions/bundle.fish:60
 msgid "The name of a :git or :path source used in the Gemfile"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:28
+#: share/completions/bundle.fish:61
 msgid "Do not attempt to fetch gems remotely and use the gem cache instead"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:29
+#: share/completions/bundle.fish:62
 msgid "Only output warnings and errors"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:31
+#: share/completions/bundle.fish:64
+#, fuzzy
 msgid "Specify the number of jobs to run in parallel"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange antalet bytes av data att sicka"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:32
+#: share/completions/bundle.fish:65
+#, fuzzy
 msgid "Update a specific group"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Använd angiven tagg"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:33
+#: share/completions/bundle.fish:69
 msgid ""
 "Package the .gem files required by your application into the vendor/cache "
 "directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:34
+#: share/completions/bundle.fish:72
+#, fuzzy
 msgid "Install the binstubs of the listed gem"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa låtsasinstallationsutdata i tabellform"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:35
+#: share/completions/bundle.fish:73
+#, fuzzy
 msgid "Binstub destination directory (default bin)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installera dokumentation (standard)"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:36
+#: share/completions/bundle.fish:74
 msgid "Overwrite existing binstubs if they exist"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:37
 #: /tmp/fish/implicit/share/completions/bundle.fish:43
+#: share/completions/bundle.fish:78 share/completions/bundle.fish:86
 msgid "Execute a script in the context of the current bundle"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:38
+#: share/completions/bundle.fish:79
 msgid "Exec runs a command, providing it access to the gems in the bundle"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:39
+#: share/completions/bundle.fish:82
 msgid "Describe available tasks or one specific task"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:42
+#: share/completions/bundle.fish:85
+#, fuzzy
 msgid "Package .gem files into the vendor/cache directory"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ändra arbetskatalog"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:44
+#: share/completions/bundle.fish:87
+#, fuzzy
 msgid "Specify and read configuration options for bundler"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj en konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:45
+#: share/completions/bundle.fish:88
 msgid "Check bundler requirements for your application"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:46
+#: share/completions/bundle.fish:89
+#, fuzzy
 msgid "Show all of the gems in the current bundle"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:47
+#: share/completions/bundle.fish:90
+#, fuzzy
 msgid "Show the source location of a particular gem in the bundle"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa process-id för varje process i jobbet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:48
 #: /tmp/fish/implicit/share/completions/bundle.fish:64
+#: share/completions/bundle.fish:91 share/completions/bundle.fish:121
 msgid "Show all of the outdated gems in the current bundle"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:49
 #: /tmp/fish/implicit/share/completions/bundle.fish:69
+#: share/completions/bundle.fish:92 share/completions/bundle.fish:129
 msgid "Start an IRB session in the context of the current bundle"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:51
 #: /tmp/fish/implicit/share/completions/bundle.fish:71
+#: share/completions/bundle.fish:94 share/completions/bundle.fish:136
 msgid "Generate a visual representation of your dependencies"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:52
+#: share/completions/bundle.fish:95
+#, fuzzy
 msgid "Generate a simple Gemfile"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Generera huvudfil"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:53
 #: /tmp/fish/implicit/share/completions/bundle.fish:78
+#: share/completions/bundle.fish:96 share/completions/bundle.fish:147
 msgid "Create a simple gem, suitable for development with bundler"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:54
 #: /tmp/fish/implicit/share/completions/bundle.fish:83
+#: share/completions/bundle.fish:97 share/completions/bundle.fish:154
+#, fuzzy
 msgid "Displays platform compatibility information"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa uppdateringsinformation"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:55
 #: /tmp/fish/implicit/share/completions/bundle.fish:85
+#: share/completions/bundle.fish:98 share/completions/bundle.fish:158
 msgid "Cleans up unused gems in your bundler directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:56
+#: share/completions/bundle.fish:105
 msgid ""
 "Determine whether the requirements for your application are installed and "
 "available to bundler"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:58
+#: share/completions/bundle.fish:107
 msgid "Specify a path other than the system default (BUNDLE_PATH or GEM_HOME)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:59
+#: share/completions/bundle.fish:108
+#, fuzzy
 msgid "Lock the Gemfile"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Logga till spårfil"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:60
 #: /tmp/fish/implicit/share/completions/bundle.fish:62
+#: share/completions/bundle.fish:111 share/completions/bundle.fish:116
 msgid ""
 "Show lists the names and versions of all gems that are required by your "
 "Gemfile"
@@ -10097,34 +10117,50 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:61
 #: /tmp/fish/implicit/share/completions/bundle.fish:63
+#: share/completions/bundle.fish:112 share/completions/bundle.fish:117
 msgid "List the paths of all gems required by your Gemfile"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:65
+#: share/completions/bundle.fish:122
+#, fuzzy
 msgid "Check for newer pre-release gems"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Kontrollera förekomst av minnesläckor"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:66
+#: share/completions/bundle.fish:123
 msgid "Check against a specific source"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:67
+#: share/completions/bundle.fish:124
 msgid "Use cached gems instead of attempting to fetch gems remotely"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:68
+#: share/completions/bundle.fish:125
 msgid "Only list newer versions allowed by your Gemfile requirements"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:72
+#: share/completions/bundle.fish:137
 msgid "The name to use for the generated file (see format option)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:73
+#: share/completions/bundle.fish:138
+#, fuzzy
 msgid "Show each gem version"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Källkodsträdsversion"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:74
+#: share/completions/bundle.fish:139
 msgid "Show the version of each required dependency"
 msgstr ""
 
@@ -10133,91 +10169,93 @@ msgid "Output a specific format (png, jpg, svg, dot, …)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:76
+#: share/completions/bundle.fish:143
+#, fuzzy
 msgid "Generate a simple Gemfile, placed in the current directory"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:77
+#: share/completions/bundle.fish:144
 msgid "Use a specified .gemspec to create the Gemfile"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:79
+#: share/completions/bundle.fish:148
 msgid "Generate a binary for your library"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:80
+#: share/completions/bundle.fish:149
 msgid "Generate a test directory for your library (rspec or minitest)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:81
+#: share/completions/bundle.fish:150
+#, fuzzy
 msgid "Path to your editor"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj källkatalog"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:82
+#: share/completions/bundle.fish:151
 msgid "Generate the boilerplate for C extension code"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:84
+#: share/completions/bundle.fish:155
+#, fuzzy
 msgid "Only display Ruby directive information"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa uppdateringsinformation"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:86
+#: share/completions/bundle.fish:159
 msgid "Only print out changes, do not actually clean gems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:87
+#: share/completions/bundle.fish:160
 msgid "Forces clean even if --path is not set"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:88
+#: share/completions/bundle.fish:163
 msgid "Cache all the gems to vendor/cache"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:90
+#: share/completions/bundle.fish:165
 msgid "Include all sources (including path and git)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:91
+#: share/completions/bundle.fish:168
+#, fuzzy
 msgid "Prints the license of all gems in the bundle"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:92
+#: share/completions/bundle.fish:171
+#, fuzzy
 msgid "Print information about the environment Bundler is running under"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bunzip2.fish:1
-msgid "Decompress to stdout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bunzip2.fish:2
-#: /tmp/fish/implicit/share/completions/bzip2.fish:4
-#: /tmp/fish/implicit/share/completions/gunzip.fish:2
-#: /tmp/fish/implicit/share/completions/gzip.fish:2
-#: /tmp/fish/implicit/share/completions/zcat.fish:1
-msgid "Overwrite"
-msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Hämta ändringar från förrådet till arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/bunzip2.fish:3
 #: /tmp/fish/implicit/share/completions/bzip2.fish:5
 msgid "Do not overwrite"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bunzip2.fish:4
-#: /tmp/fish/implicit/share/completions/bzcat.fish:1
-#: /tmp/fish/implicit/share/completions/bzip2.fish:6
-msgid "Reduce memory usage"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bunzip2.fish:5
-#: /tmp/fish/implicit/share/completions/bzip2.fish:8
-msgid "Print compression ratios"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bunzip2.fish:6
-#: /tmp/fish/implicit/share/completions/bzip2.fish:9
-#: /tmp/fish/implicit/share/completions/gunzip.fish:5
-#: /tmp/fish/implicit/share/completions/gzip.fish:5
-#: /tmp/fish/implicit/share/completions/zcat.fish:3
-msgid "Print license"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/busctl.fish:1
@@ -10252,28 +10290,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gunzip.fish:1
 #: /tmp/fish/implicit/share/completions/gzip.fish:1
 msgid "Compress to stdout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bzip2.fish:2
-msgid "Compress file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bzip2.fish:3
-#: /tmp/fish/implicit/share/completions/gunzip.fish:11
-#: /tmp/fish/implicit/share/completions/gzip.fish:11
-msgid "Check integrity"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bzip2.fish:7
-msgid "Supress errors"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bzip2.fish:11
-msgid "Small block size"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/bzip2.fish:12
-msgid "Large block size"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bzr.fish:2
@@ -10893,11 +10909,6 @@ msgstr ""
 msgid "Loop over playlist, or file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/castnow.fish:14
-#: /tmp/fish/implicit/share/completions/mplayer.fish:7
-msgid "Play in random order"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/castnow.fish:15
 msgid "List all files in directories recursively"
 msgstr ""
@@ -10930,297 +10941,8 @@ msgstr ""
 msgid "Exit when playback begins or --command completes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:2
-msgid "Increment the level of general verbosity by one"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:3
-msgid "Increment the verbose level in respect of SCSI command transport by one"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:4
-msgid "Set the misc debug value to #"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:5
-msgid "Increment the misc debug level by one"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:6
-msgid "Do not print out a status report for failed SCSI commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:7
-msgid "Force to continue on some errors"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:8
-msgid "Tell cdrecord to set the SCSI IMMED flag in certain commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:9
-msgid ""
-"Defines the minimum drive buffer fill ratio for the experimental ATAPI wait "
-"mode intended to free the IDE bus to allow hard disk and CD/DVD writer on "
-"the same IDE cable"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:10
-msgid "Complete CD/DVD-Recorder recording process with the laser turned off"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:11
-msgid "Tells cdrecord to handle images created by readcd -clone"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:12
-msgid "Set SAO (Session At Once) mode, usually called Disk At Once mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:13
-msgid "Set TAO (Track At Once) writing mode"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/cdrecord.fish:14
 msgid "Set RAW writing mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:15
-msgid "Select Set RAW writing, the preferred raw writing mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:16
-msgid "Select Set RAW writing, the less preferred raw writing mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:17
-msgid ""
-"Select Set RAW writing, the preferred raw writing mode if raw96r is not "
-"supported"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:18
-msgid "Allow multi session CDs to be made"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:19
-msgid ""
-"Retrieve multi session info in a form suitable for mkisofs-1.10 or later"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:20
-msgid "Retrieve and print out the table of content or PMA of a CD"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:21
-msgid "Retrieve and print out the ATIP (absolute Time in Pre-groove) info"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:22
-msgid "The disk will only be fixated"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:23
-msgid "Do not fixate the disk after writing the tracks"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:24
-msgid ""
-"Wait for input to become available on standard input before trying to open "
-"the SCSI driver"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:25
-msgid "Load the media and exit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:26
-msgid "Load the media, lock the door and exit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:27
-msgid "Eject disk after doing the work"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:28
-msgid "Set the speed factor of the writing process to #"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:29
-msgid "Blank a CD-RW and exit or blank a CD-RW before writing"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:30
-msgid "Format a CD-RW/DVD-RW/DVD+RW disc"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:31
-msgid "Set the FIFO (ring buffer) size to #"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:32
-msgid "Set the maximum transfer size for a single SCSI command to #"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:33
-msgid "Sets the SCSI target for the CD/DVD-Recorder"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:34
-msgid "Set the grace time before starting to write to ># seconds"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:35
-msgid "Set the default SCSI command timeout value to # seconds"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:36
-msgid "Allows the user to manually select a driver for the device"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:37
-msgid "Set driver specific options"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:38
-msgid ""
-"Set the driveropts specified by driveropts=option list, the speed of the "
-"drive and the dummy flag and exit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:39
-msgid "Checks if a driver for the current drive is present and exit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:40
-msgid ""
-"Print the drive capabilities for SCSI-3/mmc compliant drives as obtained "
-"from mode page 0x2A"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:41
-msgid "Do an inquiry for the drive, print the inquiry info and exit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:42
-msgid "Scan all SCSI devices on all SCSI busses and print the inquiry strings"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:43
-msgid "Try to reset the SCSI bus where the CD recorder is located"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:44
-msgid "Try to send an abort sequence to the drive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:45
-msgid "Allow cdrecord to write more than the official size of a medium"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:46
-msgid "Ignore the known size of the medium, use for debugging only"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:47
-msgid "Use *.inf files to overwrite audio options"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:48
-msgid "Set the default pre-gap size for all tracks except track nr 1"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:49
-msgid "Set Packet writing mode (experimental interface)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:50
-msgid "Set the packet size to #, forces fixed packet mode (experimental)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:51
-msgid ""
-"Do not close the current track, only when in packet writing mode "
-"(experimental)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:52
-msgid "Set the Media Catalog Number of the CD"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:53
-msgid ""
-"Write CD-Text info based on info taken from a file that contains ascii info "
-"for the text strings"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:54
-msgid "Write CD-Text based on info found in the binary file filename"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:55
-msgid "Take all recording related info from a CDRWIN compliant CUE sheet file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:56
-msgid "Set the International Standard Recording Number for the next track"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:57
-msgid "Sets an index list for the next track"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:58
-msgid "All subsequent tracks are written in CD-DA audio format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:59
-msgid "Audio data is assumed to be in byte-swapped (little-endian) order"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:60
-msgid "All subsequent tracks are written in CD-ROM mode 1 (Yellow Book) format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:61
-msgid "All subsequent tracks are written in CD-ROM mode 2 format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:62
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:63
-msgid "All subsequent tracks are written in CD-ROM XA mode 2 form 1 format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:64
-msgid "All subsequent tracks are written in CD-ROM XA mode 2 form 2 format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:65
-msgid ""
-"All subsequent tracks are written in a way that allows a mix of CD-ROM XA "
-"mode 2 form 1/2 format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:66
-msgid "The TOC type for the disk is set to CDI, with XA only"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:67
-msgid "Use the ISO-9660 file system size as the size of the next track"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:68
-msgid ""
-"15 sectors of zeroed data will be added to the end of this and each "
-"subsequent data track"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:69
-msgid "Set the amount of data to be appended as padding to the next track"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cdrecord.fish:70
-msgid "Do not pad the following tracks - the default"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cdrecord.fish:71
@@ -11274,45 +10996,14 @@ msgid ""
 "this option to specify the valid amount of data on this disk"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/chgrp.fish:1
-#: /tmp/fish/implicit/share/completions/chown.fish:1
-msgid "Output diagnostic for changed files"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/chgrp.fish:2
 #: /tmp/fish/implicit/share/completions/chown.fish:2
 msgid "Dereference symbolic links"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/chgrp.fish:3
-#: /tmp/fish/implicit/share/completions/chown.fish:3
-msgid "Do not dereference symbolic links"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/chgrp.fish:4
-#: /tmp/fish/implicit/share/completions/chown.fish:4
-msgid "Change from owner/group"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/chgrp.fish:5
 #: /tmp/fish/implicit/share/completions/chown.fish:5
 msgid "Suppress errors"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/chgrp.fish:6
-#: /tmp/fish/implicit/share/completions/chown.fish:6
-msgid "Use same owner/group as file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/chgrp.fish:7
-#: /tmp/fish/implicit/share/completions/chown.fish:7
-#: /tmp/fish/implicit/share/completions/zip.fish:5
-msgid "Operate recursively"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/chgrp.fish:8
-#: /tmp/fish/implicit/share/completions/chown.fish:8
-msgid "Output diagnostic for every file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/chmod.fish:1
@@ -11344,11 +11035,9 @@ msgstr ""
 msgid "Change files and directories recursively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/chown.fish:11
-#: /tmp/fish/implicit/share/completions/chown.fish:12
-#: /tmp/fish/implicit/share/completions/w.fish:6
+#: share/completions/w.fish:6
 msgid "Username"
-msgstr ""
+msgstr "Användarnamn"
 
 #: /tmp/fish/implicit/share/completions/chsh.fish:1
 msgid "Specify your login shell"
@@ -11583,60 +11272,12 @@ msgstr ""
 msgid "Print the file that would be executed"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/command.fish:3
-#: /tmp/fish/implicit/share/completions/mosh.fish:1
-#: /tmp/fish/implicit/share/completions/setsid.fish:1
-#: /tmp/fish/implicit/share/completions/ssh.fish:1
-#: /tmp/fish/implicit/share/completions/sudo.fish:20
-msgid "Command to run"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:2
-msgid "Add text to the end of the selected area"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:3
-msgid "Add text at cursor"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:4
-msgid "Replace selected part"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:5
-msgid "Select job under cursor"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:6
-msgid "Select process under cursor"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:7
-msgid "Select token under cursor"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:8
-msgid "Select entire command line (default)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:9
-msgid "Only return that part of the command line before the cursor"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:10
-msgid "Inject readline functions to reader"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/commandline.fish:11
 msgid "Print each token on a separate line"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/commandline.fish:12
 msgid "Specify command to operate on"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/commandline.fish:13
-msgid "Set/get cursor position, not buffer contents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/commandline.fish:14
@@ -11762,62 +11403,12 @@ msgstr ""
 msgid "Declare the image as modified"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/complete.fish:1
-msgid "Command to add completion to"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:2
-msgid "Path to add completion to"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:3
-msgid "Posix-style option to complete"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:4
-msgid "GNU-style option to complete"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:5
-msgid "Old style long option to complete"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:6
-msgid "Do not use file completion"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:7
-msgid "Require parameter"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:8
-msgid "Require parameter and do not use file completion"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:9
-msgid "A list of possible arguments"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:10
-msgid "Description of this completions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:11
-msgid "Option list is not complete"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/complete.fish:12
 msgid "Remove completion"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/complete.fish:14
 msgid "Print all completions for the specified commandline"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/complete.fish:15
-msgid ""
-"The completion should only be used if the specified command has a zero exit "
-"status"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/complete.fish:16
@@ -12176,40 +11767,12 @@ msgstr ""
 msgid "Swap two images in the image sequence [indexes]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/configure.fish:4
+#: share/completions/configure.fish:4
 msgid "Cache test results in specified file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/configure.fish:5
-msgid "Cache test results in file config.cache"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/configure.fish:6
-msgid "Do not create output files"
-msgstr ""
+msgstr "Cache:a resultat i angiven fil"
 
 #: /tmp/fish/implicit/share/completions/configure.fish:7
 msgid "Set source directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/configure.fish:8
-msgid "Architecture-independent install directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/configure.fish:9
-msgid "Architecture-dependent install directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/configure.fish:10
-msgid "Configure for building on BUILD"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/configure.fish:11
-msgid "Cross-compile to build programs to run on HOST"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/configure.fish:12
-msgid "Configure for building compilers for TARGET"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/connmanctl.fish:1
@@ -12652,21 +12215,21 @@ msgstr ""
 msgid "Reject reason"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/cut.fish:1
+#: share/completions/cut.fish:2
 msgid "Output byte range"
-msgstr ""
+msgstr "Välj bytsekvens"
 
-#: /tmp/fish/implicit/share/completions/cut.fish:2
+#: share/completions/cut.fish:3
 msgid "Output character range"
-msgstr ""
+msgstr "Välj teckensekvens"
 
-#: /tmp/fish/implicit/share/completions/cut.fish:3
+#: share/completions/cut.fish:4
 msgid "Select field delimiter"
-msgstr ""
+msgstr "Välj fältavgränsare"
 
-#: /tmp/fish/implicit/share/completions/cut.fish:4
+#: share/completions/cut.fish:5
 msgid "Select fields"
-msgstr ""
+msgstr "Välj fält"
 
 #: /tmp/fish/implicit/share/completions/cut.fish:5
 msgid "Don't split multi byte characters"
@@ -12674,10 +12237,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cut.fish:6
 msgid "Do not print lines without delimiter"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cut.fish:7
-msgid "Select output delimiter"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:1
@@ -12749,67 +12308,60 @@ msgid "Use IPv6 addresses only."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:19
+#: share/completions/cvs.fish:35
+#, fuzzy
 msgid "Set CVS user variable."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj CVS-användare"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:20
+#: share/completions/cvs.fish:41
 msgid "Add a new file/directory to the repository"
-msgstr ""
+msgstr "Lägg till fil/katalog till förråd"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:21
+#: share/completions/cvs.fish:42
 msgid "Administration front end for rcs"
-msgstr ""
+msgstr "Administrationsfrontend för rcs"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:22
+#: share/completions/cvs.fish:43
 msgid "Show last revision where each line was modified"
-msgstr ""
+msgstr "Visa senaste revision vid vilken vare rad ändrades"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:23
+#: share/completions/cvs.fish:44
 msgid "Checkout sources for editing"
-msgstr ""
+msgstr "Checka ut källkod för redigering"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:24
+#: share/completions/cvs.fish:45
 msgid "Check files into the repository"
-msgstr ""
+msgstr "Checka in filer till förråd"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:25
+#: share/completions/cvs.fish:46
 msgid "Show differences between revisions"
-msgstr ""
+msgstr "Visa skillnader mellan revisioner"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:26
+#: share/completions/cvs.fish:47
 msgid "Get ready to edit a watched file"
-msgstr ""
+msgstr "Förbered redigering av övervakad fil"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:27
+#: share/completions/cvs.fish:48
 msgid "See who is editing a watched file"
-msgstr ""
+msgstr "Se vem som redigerar övervakad fil"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:28
+#: share/completions/cvs.fish:49
 msgid "Export sources from CVS, similar to checkout"
-msgstr ""
+msgstr "Exportera källkod från CSV"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:29
+#: share/completions/cvs.fish:50
 msgid "Show repository access history"
-msgstr ""
+msgstr "Visa förrådets åtkomsthistorik"
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:30
+#: share/completions/cvs.fish:51
 msgid "Import sources into CVS, using vendor branches"
-msgstr ""
+msgstr "Importera källor till CVS"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:31
 msgid "Create a CVS repository if it doesn't exist"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:32
-msgid "Kerberos server mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:33
-msgid "Print out history information for files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:34
-msgid "Prompt for password for authenticating server"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:35
@@ -12820,56 +12372,20 @@ msgstr ""
 msgid "List files available from CVS"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:37
-msgid "Password server mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:38
-msgid "Show last revision where each line of module was modified"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/cvs.fish:39
 msgid "Create 'patch' format diffs between releases"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:40
-msgid "Indicate that a Module is no longer in use"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:41
 msgid "Remove an entry from the repository"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:42
-msgid "Print out history information for a module"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/cvs.fish:43
 msgid "List files in a module"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/cvs.fish:44
-msgid "Add a symbolic tag to a module"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:45
-msgid "Server mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:46
-msgid "Display status information on checked out files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:47
-msgid "Add a symbolic tag to checked out version of files"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/cvs.fish:48
 msgid "Undo an edit command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:49
-msgid "Bring work tree in sync with repository"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:50
@@ -12878,10 +12394,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:51
 msgid "Set watches"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/cvs.fish:52
-msgid "See who is watching a file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:53
@@ -12905,6 +12417,7 @@ msgid "[rev]    Set default branch (highest branch on trunk if omitted)."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:58
+#: share/completions/cvs.fish:91
 msgid "Set comment leader."
 msgstr ""
 
@@ -12917,8 +12430,13 @@ msgid "Run interactively."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:61
+#: share/completions/cvs.fish:94
+#, fuzzy
 msgid "Set keyword substitution mode:"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange standardnyckelordssubstitution"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:62
 msgid "[rev]    Lock revision (latest revision on branch,"
@@ -13061,24 +12579,29 @@ msgid "Like -c, but include module status."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:90
+#: share/completions/cvs.fish:135
 msgid "Check out revision or tag. (implies -P) (is sticky)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:91
+#: share/completions/cvs.fish:136
 msgid "Check out revisions as of date. (implies -P) (is sticky)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:92
+#: share/completions/cvs.fish:137
 msgid "Check out into dir instead of module name."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:93
 #: /tmp/fish/implicit/share/completions/cvs.fish:280
+#: share/completions/cvs.fish:138
 msgid "Use RCS kopt -k option on checkout. (is sticky)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:94
 #: /tmp/fish/implicit/share/completions/cvs.fish:283
+#: share/completions/cvs.fish:139
 msgid "Merge in changes made between current revision and rev."
 msgstr ""
 
@@ -13095,36 +12618,56 @@ msgid "Force the file to be committed; disables recursion."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:99
+#: share/completions/cvs.fish:150
+#, fuzzy
 msgid "Read the log message from file."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Läs loggmeddelande från fil"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:100
 #: /tmp/fish/implicit/share/completions/cvs.fish:180
+#: share/completions/cvs.fish:151
+#, fuzzy
 msgid "Log message."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ersätt ett loggmeddelande"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:101
+#: share/completions/cvs.fish:152
 msgid "Commit to this branch or trunk revision."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:104
 #: /tmp/fish/implicit/share/completions/cvs.fish:218
+#: share/completions/cvs.fish:161
+#, fuzzy
 msgid "Specify keyword expansion mode."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj kärnversion"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:105
+#: share/completions/cvs.fish:162
 msgid "Diff revision for date against working file."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:106
+#: share/completions/cvs.fish:163
 msgid "Diff rev1/date1 against date2."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:107
+#: share/completions/cvs.fish:164
 msgid "Diff revision for rev1 against working file."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:108
+#: share/completions/cvs.fish:165
 msgid "Diff rev1/date1 against rev2."
 msgstr ""
 
@@ -13145,8 +12688,13 @@ msgid "--ignore-blank-lines  Ignore changes whose lines are all blank."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:113
+#: share/completions/cvs.fish:170
+#, fuzzy
 msgid "--ignore-matching-lines=RE  Ignore changes whose lines all match RE."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ignorera ändringar som matchar REGEX"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:114
 msgid "Binary  Read and write data in binary mode."
@@ -13171,6 +12719,7 @@ msgid "UM  Use NUM context lines."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:119
+#: share/completions/cvs.fish:176
 msgid "--label LABEL  Use LABEL instead of file name."
 msgstr ""
 
@@ -13179,6 +12728,7 @@ msgid "--show-c-function  Show which C function each change is in."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:121
+#: share/completions/cvs.fish:178
 msgid "--show-function-line=RE  Show the most recent line matching RE."
 msgstr ""
 
@@ -13203,6 +12753,7 @@ msgid "--side-by-side  Output in two columns."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:127
+#: share/completions/cvs.fish:184
 msgid "--width=NUM  Output at most NUM (default 130) characters per line."
 msgstr ""
 
@@ -13292,18 +12843,26 @@ msgid "Process this directory only (not recursive)."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:153
+#: share/completions/cvs.fish:228
+#, fuzzy
 msgid "Export tagged revisions."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Slå ihop revisioner"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:154
+#: share/completions/cvs.fish:229
 msgid "Export revisions as of date."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:155
+#: share/completions/cvs.fish:230
 msgid "Export into dir instead of module name."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:156
+#: share/completions/cvs.fish:231
 msgid "Use RCS kopt -k option on checkout."
 msgstr ""
 
@@ -13320,12 +12879,18 @@ msgid "Checked out modules"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:160
+#: share/completions/cvs.fish:241
 msgid "Look for specified module (repeatable)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:161
+#: share/completions/cvs.fish:242
+#, fuzzy
 msgid "Extract by record type"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange posttyp"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:162
 msgid "Everything (same as -x, but all record types)"
@@ -13344,38 +12909,51 @@ msgid "Working directory must match"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:166
+#: share/completions/cvs.fish:247
+#, fuzzy
 msgid "Since date (Many formats)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Format för profileringsdata"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:167
+#: share/completions/cvs.fish:248
 msgid "Back to record with str in module/file/repos field"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:168
+#: share/completions/cvs.fish:249
 msgid "Specified file (same as command line) (repeatable)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:169
+#: share/completions/cvs.fish:250
 msgid "In module (repeatable)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:170
+#: share/completions/cvs.fish:251
 msgid "In repository (repeatable)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:171
+#: share/completions/cvs.fish:252
 msgid "Since rev or tag (looks inside RCS files!)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:172
+#: share/completions/cvs.fish:253
 msgid "Since tag record placed in history file (by anyone)."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:173
+#: share/completions/cvs.fish:254
 msgid "For user name (repeatable)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:174
+#: share/completions/cvs.fish:255
 msgid "Output for time zone <tz> (e.g. -z -0700)"
 msgstr ""
 
@@ -13715,104 +13293,165 @@ msgid "Set the specified option"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:3
+#: share/completions/darcs.fish:19
+#, fuzzy
 msgid "Display help about darcs and darcs commands"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa användningsinformation för kommando"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:4
+#: share/completions/darcs.fish:20
 msgid "Add one or more new files or directories"
-msgstr ""
+msgstr "Lägg till filer eller kataloger till lagret"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:5
+#: share/completions/darcs.fish:21
+#, fuzzy
 msgid "Remove files from version control"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Placera filer och kataloger under versionskontroll"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:6
+#: share/completions/darcs.fish:22
+#, fuzzy
 msgid "Move or rename files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skapa inte fil"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:7
+#: share/completions/darcs.fish:23
 msgid "Substitute one word for another"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:8
+#: share/completions/darcs.fish:24
+#, fuzzy
 msgid "Discard unrecorded changes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa olagrade ändringar i arbetskopian"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:9
+#: share/completions/darcs.fish:25
 msgid "Undo the last revert (may fail if changes after the revert)"
 msgstr ""
+"Ångra senaste revert-operation (kan misslyckas om ändringar har utförts "
+"efter revert-operationen)"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:10
+#: share/completions/darcs.fish:26
+#, fuzzy
 msgid "List unrecorded changes in the working tree"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa olagrade ändringar i arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:11
+#: share/completions/darcs.fish:27
+#, fuzzy
 msgid "Create a patch from unrecorded changes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skapa komprimerade fixar"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:12
+#: share/completions/darcs.fish:28
 msgid "Remove recorded patches without changing the working copy"
-msgstr ""
+msgstr "Ta bort lagrade fixar utan att ändra arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:13
+#: share/completions/darcs.fish:29
+#, fuzzy
 msgid "Improve a patch before it leaves your repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ersätt den lagrade fixen med en bättre version"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:14
+#: share/completions/darcs.fish:30
+#, fuzzy
 msgid "Mark unresolved conflicts in working tree, for manual resolution"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Markera konflikter mot arketskopian för manuell lösning"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:15
+#: share/completions/darcs.fish:31
 msgid "Name the current repository state for future reference"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:16
+#: share/completions/darcs.fish:32
+#, fuzzy
 msgid "Set a preference (test, predist, boringfile or binariesfile)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj ett värde för en preferens (test, predisk, ...)"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:17
+#: share/completions/darcs.fish:33
 msgid "Create a diff between two versions of the repository"
-msgstr ""
+msgstr "Skappa en diff mellan två versioner i lagret"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:18
+#: share/completions/darcs.fish:34
+#, fuzzy
 msgid "List patches in the repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Uppdatera förråd"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:19
+#: share/completions/darcs.fish:35
 msgid "Display which patch last modified something"
-msgstr ""
+msgstr "Visa vilken fix som senast ändrade någonting"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:20
+#: share/completions/darcs.fish:36
 msgid "Create a distribution tarball"
-msgstr ""
+msgstr "Skapa distribuerbar tar-fil"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:21
+#: share/completions/darcs.fish:37
 msgid "Locate the most recent version lacking an error"
-msgstr ""
+msgstr "Hitta senaste version utan ett givet fel"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:22
+#: share/completions/darcs.fish:38
 msgid "Show information which is stored by darcs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:23
+#: share/completions/darcs.fish:39
 msgid "Copy and apply patches from another repository to this one"
-msgstr ""
+msgstr "Kopiera och applicera fixar från ett annat förråd till detta"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:24
+#: share/completions/darcs.fish:40
+#, fuzzy
 msgid "Delete selected patches from the repository. (UNSAFE!)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ordna om fixarna i förrådet"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:25
+#: share/completions/darcs.fish:41
 msgid "Record a new patch reversing some recorded changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:26
+#: share/completions/darcs.fish:42
 msgid "Copy and apply patches from this repository to another one"
-msgstr ""
+msgstr "Kopiera och applicera fixar från detta förråd till ett annat"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:27
+#: share/completions/darcs.fish:43
 msgid "Send by email a bundle of one or more patches"
-msgstr ""
+msgstr "Skicka e-postpaket av en eller flera fixar"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:403
 msgid "Path to a version-controlled boring file"
@@ -13822,69 +13461,69 @@ msgstr ""
 msgid "Path to a version-controlled binaries file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:405
-#: /tmp/fish/implicit/share/completions/darcs.fish:439
-#: /tmp/fish/implicit/share/completions/darcs.fish:847
-#: /tmp/fish/implicit/share/completions/darcs.fish:880
+#: share/completions/darcs.fish:551 share/completions/darcs.fish:1025
 msgid "Select changes up to a patch matching PATTERN"
-msgstr ""
+msgstr "Välj ändringar fram till fix som matchar MÖNSTER"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:406
-#: /tmp/fish/implicit/share/completions/darcs.fish:440
-#: /tmp/fish/implicit/share/completions/darcs.fish:848
-#: /tmp/fish/implicit/share/completions/darcs.fish:881
+#: share/completions/darcs.fish:552 share/completions/darcs.fish:1026
 msgid "Select changes up to a patch matching REGEXP"
-msgstr ""
+msgstr "Välj ändringar fram till fix som matchar REGEXP"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:407
-#: /tmp/fish/implicit/share/completions/darcs.fish:441
+#: share/completions/darcs.fish:553
 msgid "Select changes up to a tag matching REGEXP"
-msgstr ""
+msgstr "Välj ändringar fram till tag som matchar REGEXP"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:408
-#: /tmp/fish/implicit/share/completions/darcs.fish:442
-#: /tmp/fish/implicit/share/completions/darcs.fish:619
-#: /tmp/fish/implicit/share/completions/darcs.fish:657
+#: share/completions/darcs.fish:340 share/completions/darcs.fish:554
+#: share/completions/darcs.fish:767
 msgid "Select changes starting with a patch matching PATTERN"
-msgstr ""
+msgstr "Välj ändringar som börjar med fix som matchar MÖNSTER"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:409
-#: /tmp/fish/implicit/share/completions/darcs.fish:443
-#: /tmp/fish/implicit/share/completions/darcs.fish:620
-#: /tmp/fish/implicit/share/completions/darcs.fish:658
+#: share/completions/darcs.fish:341 share/completions/darcs.fish:555
+#: share/completions/darcs.fish:768
 msgid "Select changes starting with a patch matching REGEXP"
-msgstr ""
+msgstr "Välj ändringar som börjar med fix som matchar REGEXP"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:410
-#: /tmp/fish/implicit/share/completions/darcs.fish:444
-#: /tmp/fish/implicit/share/completions/darcs.fish:621
-#: /tmp/fish/implicit/share/completions/darcs.fish:659
+#: share/completions/darcs.fish:342 share/completions/darcs.fish:556
+#: share/completions/darcs.fish:769
 msgid "Select changes starting with a tag matching REGEXP"
-msgstr ""
+msgstr "Välj ändringar som börjar med tagg som matchar REGEXP"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:411
 #: /tmp/fish/implicit/share/completions/darcs.fish:495
 #: /tmp/fish/implicit/share/completions/darcs.fish:520
+#: share/completions/darcs.fish:378
+#, fuzzy
 msgid "Select a single patch matching PATTERN"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj fix som matchar MÖNSTER"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:412
 #: /tmp/fish/implicit/share/completions/darcs.fish:496
 #: /tmp/fish/implicit/share/completions/darcs.fish:521
+#: share/completions/darcs.fish:379
+#, fuzzy
 msgid "Select a single patch matching REGEXP"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj fix som matchar REGEXP"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:413
-#: /tmp/fish/implicit/share/completions/darcs.fish:445
-#: /tmp/fish/implicit/share/completions/darcs.fish:622
-#: /tmp/fish/implicit/share/completions/darcs.fish:660
+#: share/completions/darcs.fish:343 share/completions/darcs.fish:557
+#: share/completions/darcs.fish:770
 msgid "Select the last NUMBER patches"
-msgstr ""
+msgstr "Välj angivet antal fixar av de senaste fixarna"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:414
 #: /tmp/fish/implicit/share/completions/darcs.fish:446
+#: share/completions/darcs.fish:558
+#, fuzzy
 msgid "Select a range of patches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj angivet antal fixar av de senaste fixarna"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:415
 msgid "Specify diff command (ignores --diff-opts)"
@@ -13902,24 +13541,16 @@ msgstr ""
 msgid "Output patch in diff's dumb format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:419
-#: /tmp/fish/implicit/share/completions/darcs.fish:463
-#: /tmp/fish/implicit/share/completions/darcs.fish:500
-#: /tmp/fish/implicit/share/completions/darcs.fish:519
-#: /tmp/fish/implicit/share/completions/darcs.fish:543
-#: /tmp/fish/implicit/share/completions/darcs.fish:583
-#: /tmp/fish/implicit/share/completions/darcs.fish:631
-#: /tmp/fish/implicit/share/completions/darcs.fish:675
-#: /tmp/fish/implicit/share/completions/darcs.fish:710
-#: /tmp/fish/implicit/share/completions/darcs.fish:766
-#: /tmp/fish/implicit/share/completions/darcs.fish:813
-#: /tmp/fish/implicit/share/completions/darcs.fish:889
-#: /tmp/fish/implicit/share/completions/darcs.fish:918
-#: /tmp/fish/implicit/share/completions/darcs.fish:936
-#: /tmp/fish/implicit/share/completions/darcs.fish:969
-#: /tmp/fish/implicit/share/completions/darcs.fish:989
+#: share/completions/darcs.fish:116 share/completions/darcs.fish:146
+#: share/completions/darcs.fish:203 share/completions/darcs.fish:234
+#: share/completions/darcs.fish:264 share/completions/darcs.fish:352
+#: share/completions/darcs.fish:456 share/completions/darcs.fish:482
+#: share/completions/darcs.fish:525 share/completions/darcs.fish:725
+#: share/completions/darcs.fish:779 share/completions/darcs.fish:829
+#: share/completions/darcs.fish:870 share/completions/darcs.fish:985
+#: share/completions/darcs.fish:1073 share/completions/darcs.fish:1197
 msgid "Specify the repository directory in which to run"
-msgstr ""
+msgstr "Välj vilket förråd som skall användas"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:420
 #: /tmp/fish/implicit/share/completions/darcs.fish:524
@@ -13929,49 +13560,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/darcs.fish:421
 #: /tmp/fish/implicit/share/completions/darcs.fish:525
 msgid "Do patch application on disk [DEFAULT]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:422
-#: /tmp/fish/implicit/share/completions/darcs.fish:466
-#: /tmp/fish/implicit/share/completions/darcs.fish:501
-#: /tmp/fish/implicit/share/completions/darcs.fish:526
-#: /tmp/fish/implicit/share/completions/darcs.fish:544
-#: /tmp/fish/implicit/share/completions/darcs.fish:585
-#: /tmp/fish/implicit/share/completions/darcs.fish:636
-#: /tmp/fish/implicit/share/completions/darcs.fish:676
-#: /tmp/fish/implicit/share/completions/darcs.fish:714
-#: /tmp/fish/implicit/share/completions/darcs.fish:769
-#: /tmp/fish/implicit/share/completions/darcs.fish:814
-#: /tmp/fish/implicit/share/completions/darcs.fish:857
-#: /tmp/fish/implicit/share/completions/darcs.fish:890
-#: /tmp/fish/implicit/share/completions/darcs.fish:919
-#: /tmp/fish/implicit/share/completions/darcs.fish:943
-#: /tmp/fish/implicit/share/completions/darcs.fish:972
-#: /tmp/fish/implicit/share/completions/darcs.fish:990
-#: /tmp/fish/implicit/share/completions/darcs.fish:1010
-msgid "Disable this command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:423
-#: /tmp/fish/implicit/share/completions/darcs.fish:467
-#: /tmp/fish/implicit/share/completions/darcs.fish:502
-#: /tmp/fish/implicit/share/completions/darcs.fish:527
-#: /tmp/fish/implicit/share/completions/darcs.fish:545
-#: /tmp/fish/implicit/share/completions/darcs.fish:562
-#: /tmp/fish/implicit/share/completions/darcs.fish:586
-#: /tmp/fish/implicit/share/completions/darcs.fish:637
-#: /tmp/fish/implicit/share/completions/darcs.fish:677
-#: /tmp/fish/implicit/share/completions/darcs.fish:715
-#: /tmp/fish/implicit/share/completions/darcs.fish:770
-#: /tmp/fish/implicit/share/completions/darcs.fish:815
-#: /tmp/fish/implicit/share/completions/darcs.fish:858
-#: /tmp/fish/implicit/share/completions/darcs.fish:891
-#: /tmp/fish/implicit/share/completions/darcs.fish:920
-#: /tmp/fish/implicit/share/completions/darcs.fish:944
-#: /tmp/fish/implicit/share/completions/darcs.fish:973
-#: /tmp/fish/implicit/share/completions/darcs.fish:991
-#: /tmp/fish/implicit/share/completions/darcs.fish:1011
-msgid "Shows brief description of command and its arguments"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:424
@@ -14058,48 +13646,6 @@ msgstr ""
 msgid "Give verbose output"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:428
-#: /tmp/fish/implicit/share/completions/darcs.fish:472
-#: /tmp/fish/implicit/share/completions/darcs.fish:507
-#: /tmp/fish/implicit/share/completions/darcs.fish:532
-#: /tmp/fish/implicit/share/completions/darcs.fish:550
-#: /tmp/fish/implicit/share/completions/darcs.fish:591
-#: /tmp/fish/implicit/share/completions/darcs.fish:642
-#: /tmp/fish/implicit/share/completions/darcs.fish:682
-#: /tmp/fish/implicit/share/completions/darcs.fish:720
-#: /tmp/fish/implicit/share/completions/darcs.fish:775
-#: /tmp/fish/implicit/share/completions/darcs.fish:820
-#: /tmp/fish/implicit/share/completions/darcs.fish:863
-#: /tmp/fish/implicit/share/completions/darcs.fish:896
-#: /tmp/fish/implicit/share/completions/darcs.fish:925
-#: /tmp/fish/implicit/share/completions/darcs.fish:949
-#: /tmp/fish/implicit/share/completions/darcs.fish:978
-#: /tmp/fish/implicit/share/completions/darcs.fish:996
-#: /tmp/fish/implicit/share/completions/darcs.fish:1016
-msgid "Suppress informational output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:429
-#: /tmp/fish/implicit/share/completions/darcs.fish:473
-#: /tmp/fish/implicit/share/completions/darcs.fish:508
-#: /tmp/fish/implicit/share/completions/darcs.fish:533
-#: /tmp/fish/implicit/share/completions/darcs.fish:551
-#: /tmp/fish/implicit/share/completions/darcs.fish:592
-#: /tmp/fish/implicit/share/completions/darcs.fish:643
-#: /tmp/fish/implicit/share/completions/darcs.fish:683
-#: /tmp/fish/implicit/share/completions/darcs.fish:721
-#: /tmp/fish/implicit/share/completions/darcs.fish:776
-#: /tmp/fish/implicit/share/completions/darcs.fish:821
-#: /tmp/fish/implicit/share/completions/darcs.fish:864
-#: /tmp/fish/implicit/share/completions/darcs.fish:897
-#: /tmp/fish/implicit/share/completions/darcs.fish:926
-#: /tmp/fish/implicit/share/completions/darcs.fish:950
-#: /tmp/fish/implicit/share/completions/darcs.fish:979
-#: /tmp/fish/implicit/share/completions/darcs.fish:997
-#: /tmp/fish/implicit/share/completions/darcs.fish:1017
-msgid "Neither verbose nor quiet output"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/darcs.fish:430
 #: /tmp/fish/implicit/share/completions/darcs.fish:474
 #: /tmp/fish/implicit/share/completions/darcs.fish:509
@@ -14139,8 +13685,21 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/darcs.fish:981
 #: /tmp/fish/implicit/share/completions/darcs.fish:1000
 #: /tmp/fish/implicit/share/completions/darcs.fish:1025
+#: share/completions/darcs.fish:102 share/completions/darcs.fish:128
+#: share/completions/darcs.fish:157 share/completions/darcs.fish:187
+#: share/completions/darcs.fish:245 share/completions/darcs.fish:326
+#: share/completions/darcs.fish:364 share/completions/darcs.fish:408
+#: share/completions/darcs.fish:468 share/completions/darcs.fish:493
+#: share/completions/darcs.fish:537 share/completions/darcs.fish:753
+#: share/completions/darcs.fish:841 share/completions/darcs.fish:893
+#: share/completions/darcs.fish:1183 share/completions/darcs.fish:1208
+#: share/completions/darcs.fish:1239
+#, fuzzy
 msgid "Specify command to run after this darcs command"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange kommando att köra efter detta darcs-kommando"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:432
 #: /tmp/fish/implicit/share/completions/darcs.fish:482
@@ -14223,8 +13782,20 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/darcs.fish:985
 #: /tmp/fish/implicit/share/completions/darcs.fish:1004
 #: /tmp/fish/implicit/share/completions/darcs.fish:1029
+#: share/completions/darcs.fish:71 share/completions/darcs.fish:220
+#: share/completions/darcs.fish:283 share/completions/darcs.fish:439
+#: share/completions/darcs.fish:597 share/completions/darcs.fish:632
+#: share/completions/darcs.fish:663 share/completions/darcs.fish:688
+#: share/completions/darcs.fish:801 share/completions/darcs.fish:959
+#: share/completions/darcs.fish:1010 share/completions/darcs.fish:1054
+#: share/completions/darcs.fish:1095 share/completions/darcs.fish:1122
+#: share/completions/darcs.fish:1155
+#, fuzzy
 msgid "Specify command to run before this darcs command"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange kommando att köra efter detta darcs-kommando"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:436
 #: /tmp/fish/implicit/share/completions/darcs.fish:486
@@ -14289,34 +13860,26 @@ msgstr ""
 msgid "Run prehook command without prompting"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:447
-#: /tmp/fish/implicit/share/completions/darcs.fish:563
-#: /tmp/fish/implicit/share/completions/darcs.fish:623
-#: /tmp/fish/implicit/share/completions/darcs.fish:661
-#: /tmp/fish/implicit/share/completions/darcs.fish:695
-#: /tmp/fish/implicit/share/completions/darcs.fish:741
+#: share/completions/darcs.fish:344 share/completions/darcs.fish:559
+#: share/completions/darcs.fish:771 share/completions/darcs.fish:855
+#: share/completions/darcs.fish:907
 msgid "Select patches matching PATTERN"
-msgstr ""
+msgstr "Välj fixar som matchar MÖNSTER"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:448
-#: /tmp/fish/implicit/share/completions/darcs.fish:564
-#: /tmp/fish/implicit/share/completions/darcs.fish:624
-#: /tmp/fish/implicit/share/completions/darcs.fish:662
-#: /tmp/fish/implicit/share/completions/darcs.fish:696
-#: /tmp/fish/implicit/share/completions/darcs.fish:742
+#: share/completions/darcs.fish:345 share/completions/darcs.fish:560
+#: share/completions/darcs.fish:772 share/completions/darcs.fish:856
+#: share/completions/darcs.fish:908
 msgid "Select patches matching REGEXP"
-msgstr ""
+msgstr "Välj fixar som matchar REGEXP"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:449
-#: /tmp/fish/implicit/share/completions/darcs.fish:565
-#: /tmp/fish/implicit/share/completions/darcs.fish:625
-#: /tmp/fish/implicit/share/completions/darcs.fish:663
-#: /tmp/fish/implicit/share/completions/darcs.fish:697
-#: /tmp/fish/implicit/share/completions/darcs.fish:743
+#: share/completions/darcs.fish:346 share/completions/darcs.fish:561
+#: share/completions/darcs.fish:773 share/completions/darcs.fish:857
+#: share/completions/darcs.fish:909
 msgid "Select tags matching REGEXP"
-msgstr ""
+msgstr "Välj taggar som matchar REGEXP"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:450
+#: share/completions/darcs.fish:562
 msgid "Return only NUMBER results"
 msgstr ""
 
@@ -14326,25 +13889,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:452
 msgid "Show changes to all files [DEFAULT]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:453
-msgid "Give output suitable for get --context"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:454
-#: /tmp/fish/implicit/share/completions/darcs.fish:494
-#: /tmp/fish/implicit/share/completions/darcs.fish:575
-#: /tmp/fish/implicit/share/completions/darcs.fish:635
-#: /tmp/fish/implicit/share/completions/darcs.fish:707
-#: /tmp/fish/implicit/share/completions/darcs.fish:760
-#: /tmp/fish/implicit/share/completions/darcs.fish:803
-msgid "Generate XML formatted output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:455
-#: /tmp/fish/implicit/share/completions/darcs.fish:493
-msgid "Give human-readable output"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:456
@@ -14364,15 +13908,6 @@ msgstr ""
 msgid "Summarize changes"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:459
-#: /tmp/fish/implicit/share/completions/darcs.fish:490
-#: /tmp/fish/implicit/share/completions/darcs.fish:577
-#: /tmp/fish/implicit/share/completions/darcs.fish:633
-#: /tmp/fish/implicit/share/completions/darcs.fish:709
-#: /tmp/fish/implicit/share/completions/darcs.fish:762
-msgid "Don't summarize changes"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/darcs.fish:460
 msgid "Show changes in reverse order"
 msgstr ""
@@ -14383,26 +13918,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:462
 msgid "Specify the repository URL"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:464
-#: /tmp/fish/implicit/share/completions/darcs.fish:566
-#: /tmp/fish/implicit/share/completions/darcs.fish:629
-#: /tmp/fish/implicit/share/completions/darcs.fish:664
-#: /tmp/fish/implicit/share/completions/darcs.fish:701
-#: /tmp/fish/implicit/share/completions/darcs.fish:747
-#: /tmp/fish/implicit/share/completions/darcs.fish:800
-msgid "Answer yes to all patches"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:465
-#: /tmp/fish/implicit/share/completions/darcs.fish:567
-#: /tmp/fish/implicit/share/completions/darcs.fish:630
-#: /tmp/fish/implicit/share/completions/darcs.fish:665
-#: /tmp/fish/implicit/share/completions/darcs.fish:702
-#: /tmp/fish/implicit/share/completions/darcs.fish:748
-#: /tmp/fish/implicit/share/completions/darcs.fish:801
-msgid "Prompt user interactively"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:475
@@ -14462,53 +13977,35 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/darcs.fish:871
 #: /tmp/fish/implicit/share/completions/darcs.fish:906
 #: /tmp/fish/implicit/share/completions/darcs.fish:1024
+#: share/completions/darcs.fish:752 share/completions/darcs.fish:892
+#: share/completions/darcs.fish:1238
 msgid "Name of the darcs executable on the remote server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:491
-msgid "Output patch in a darcs-specific format similar to diff -u"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:492
 msgid "Output patch in darcs' usual format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:497
-#: /tmp/fish/implicit/share/completions/darcs.fish:522
-#: /tmp/fish/implicit/share/completions/darcs.fish:849
-#: /tmp/fish/implicit/share/completions/darcs.fish:882
+#: share/completions/darcs.fish:1027
 msgid "Select tag matching REGEXP"
-msgstr ""
+msgstr "Välj tagg som matchar REGEXP"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:498
 #: /tmp/fish/implicit/share/completions/darcs.fish:523
+#: share/completions/darcs.fish:380
+#, fuzzy
 msgid "Select one patch"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:499
-msgid "Specify hash of creator patch (see docs)"
-msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj en handling"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:518
 msgid "Name of version"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:553
-#: /tmp/fish/implicit/share/completions/darcs.fish:602
-#: /tmp/fish/implicit/share/completions/darcs.fish:831
-#: /tmp/fish/implicit/share/completions/darcs.fish:853
-#: /tmp/fish/implicit/share/completions/darcs.fish:884
-#: /tmp/fish/implicit/share/completions/darcs.fish:1009
-msgid "Make scripts executable"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/darcs.fish:568
 msgid "Mark conflicts [DEFAULT]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:569
-#: /tmp/fish/implicit/share/completions/darcs.fish:805
-msgid "Allow conflicts, but don't mark them"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:570
@@ -14516,39 +14013,9 @@ msgstr ""
 msgid "Filter out any patches that would create conflicts"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:571
-#: /tmp/fish/implicit/share/completions/darcs.fish:808
+#: share/completions/darcs.fish:713 share/completions/darcs.fish:980
 msgid "Use external tool to merge conflicts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:572
-#: /tmp/fish/implicit/share/completions/darcs.fish:672
-#: /tmp/fish/implicit/share/completions/darcs.fish:810
-#: /tmp/fish/implicit/share/completions/darcs.fish:966
-msgid "Run the test script"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:573
-#: /tmp/fish/implicit/share/completions/darcs.fish:671
-#: /tmp/fish/implicit/share/completions/darcs.fish:809
-#: /tmp/fish/implicit/share/completions/darcs.fish:965
-msgid "Don't run the test script"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:574
-#: /tmp/fish/implicit/share/completions/darcs.fish:634
-#: /tmp/fish/implicit/share/completions/darcs.fish:706
-#: /tmp/fish/implicit/share/completions/darcs.fish:759
-#: /tmp/fish/implicit/share/completions/darcs.fish:802
-msgid "Don't actually take the action"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:578
-#: /tmp/fish/implicit/share/completions/darcs.fish:626
-#: /tmp/fish/implicit/share/completions/darcs.fish:698
-#: /tmp/fish/implicit/share/completions/darcs.fish:744
-msgid "Don't automatically fulfill dependencies"
-msgstr ""
+msgstr "Använd externt verktyg för att hantera sammanslagningskonflikter"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:579
 #: /tmp/fish/implicit/share/completions/darcs.fish:627
@@ -14564,22 +14031,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/darcs.fish:700
 #: /tmp/fish/implicit/share/completions/darcs.fish:746
 msgid "Prompt about patches that are depended on by matched patches [DEFAULT]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:581
-#: /tmp/fish/implicit/share/completions/darcs.fish:711
-#: /tmp/fish/implicit/share/completions/darcs.fish:764
-#: /tmp/fish/implicit/share/completions/darcs.fish:851
-#: /tmp/fish/implicit/share/completions/darcs.fish:887
-msgid "Set default repository [DEFAULT]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:582
-#: /tmp/fish/implicit/share/completions/darcs.fish:712
-#: /tmp/fish/implicit/share/completions/darcs.fish:765
-#: /tmp/fish/implicit/share/completions/darcs.fish:852
-#: /tmp/fish/implicit/share/completions/darcs.fish:888
-msgid "Don't set default repository"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:584
@@ -14631,8 +14082,13 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/darcs.fish:601
 #: /tmp/fish/implicit/share/completions/darcs.fish:726
 #: /tmp/fish/implicit/share/completions/darcs.fish:781
+#: share/completions/darcs.fish:886
+#, fuzzy
 msgid "Specify the remote repository URL to work with"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange förråd-URL"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:603
 #: /tmp/fish/implicit/share/completions/darcs.fish:648
@@ -14640,6 +14096,13 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/darcs.fish:832
 #: /tmp/fish/implicit/share/completions/darcs.fish:954
 #: /tmp/fish/implicit/share/completions/darcs.fish:999
+#: share/completions/darcs.fish:101 share/completions/darcs.fish:127
+#: share/completions/darcs.fish:156 share/completions/darcs.fish:186
+#: share/completions/darcs.fish:244 share/completions/darcs.fish:324
+#: share/completions/darcs.fish:363 share/completions/darcs.fish:406
+#: share/completions/darcs.fish:467 share/completions/darcs.fish:492
+#: share/completions/darcs.fish:840 share/completions/darcs.fish:1004
+#: share/completions/darcs.fish:1207
 msgid "Specify umask to use when writing"
 msgstr ""
 
@@ -14648,56 +14111,25 @@ msgstr ""
 msgid "Don't allow darcs to touch external files or repo metadata"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:666
-#: /tmp/fish/implicit/share/completions/darcs.fish:750
+#: share/completions/darcs.fish:387 share/completions/darcs.fish:916
 msgid "Specify author id"
-msgstr ""
+msgstr "Ange författar-id"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:667
+#: share/completions/darcs.fish:388
 msgid "Name of patch"
-msgstr ""
+msgstr "Namn på fix"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:668
-msgid "Edit the long comment by default"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:669
-msgid "Don't give a long comment"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:670
-msgid "Prompt for whether to edit the long comment"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:673
-#: /tmp/fish/implicit/share/completions/darcs.fish:811
-#: /tmp/fish/implicit/share/completions/darcs.fish:967
-msgid "Don't remove the test directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:674
-#: /tmp/fish/implicit/share/completions/darcs.fish:812
-#: /tmp/fish/implicit/share/completions/darcs.fish:968
-msgid "Remove the test directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:703
-#: /tmp/fish/implicit/share/completions/darcs.fish:756
-msgid "Sign the patch with your gpg key"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:704
-#: /tmp/fish/implicit/share/completions/darcs.fish:757
+#: share/completions/darcs.fish:864 share/completions/darcs.fish:923
 msgid "Sign the patch with a given keyid"
-msgstr ""
+msgstr "Signera fix med givet nyckelid"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:705
-#: /tmp/fish/implicit/share/completions/darcs.fish:758
+#: share/completions/darcs.fish:865 share/completions/darcs.fish:924
 msgid "Sign the patch using openssl with a given private key"
-msgstr ""
+msgstr "Signera fix via openssl med en given hemlig nyckel"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:723
 #: /tmp/fish/implicit/share/completions/darcs.fish:899
+#: share/completions/darcs.fish:1083
 msgid "Apply patch as another user using sudo"
 msgstr ""
 
@@ -14706,37 +14138,43 @@ msgstr ""
 msgid "Don't use sudo to apply as another user [DEFAULT]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:751
+#: share/completions/darcs.fish:917
 msgid "Specify destination email"
-msgstr ""
+msgstr "Välj destinationsadress"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:752
+#: share/completions/darcs.fish:918
+#, fuzzy
 msgid "Mail results to additional EMAIL(s)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Posta resultat till extra adresser. (Kräver --reply)"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:753
+#: share/completions/darcs.fish:919
+#, fuzzy
 msgid "Specify mail subject"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange makefil"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:754
+#: share/completions/darcs.fish:920
+#, fuzzy
 msgid "Specify in-reply-to header"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj indexkatalog"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:755
+#: share/completions/darcs.fish:921
 msgid "Specify output filename"
-msgstr ""
+msgstr "Välj utfil"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:763
 msgid "Edit the patch bundle description"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:767
-#: /tmp/fish/implicit/share/completions/darcs.fish:827
-msgid "Specify sendmail command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:778
-msgid "Give patch name and comment in file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:779
@@ -14747,41 +14185,25 @@ msgstr ""
 msgid "Keep the logfile when done [DEFAULT]"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:782
-msgid "Send to context stored in FILENAME"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:797
-msgid "Verify that the patch was signed by a key in PUBRING"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/darcs.fish:798
+#, fuzzy
 msgid "Verify using openSSL with authorized keys from file KEYS"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:799
-msgid "Don't verify patch signature"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:804
-msgid "Mark conflicts"
-msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Verifiera med openSSL med auktoriserade nycklar från angiven fil"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:806
 msgid "Equivalent to --dont-allow-conflicts, for backwards compatibility"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:823
+#: share/completions/darcs.fish:995
 msgid "Reply to email-based patch using FROM address"
-msgstr ""
+msgstr "Svara på e-postbaserad fix från adress"
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:824
+#: share/completions/darcs.fish:996
 msgid "Mail results to additional EMAIL(s). Requires --reply"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:825
-msgid "Forward unsigned messages without extra header"
-msgstr ""
+msgstr "Posta resultat till extra adresser. (Kräver --reply)"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:826
 msgid "Don't forward unsigned messages without extra header [DEFAULT]"
@@ -14789,6 +14211,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:842
 #: /tmp/fish/implicit/share/completions/darcs.fish:1008
+#: share/completions/darcs.fish:1222
 msgid "--repodir=DIRECTORY"
 msgstr ""
 
@@ -14812,8 +14235,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:850
 #: /tmp/fish/implicit/share/completions/darcs.fish:883
+#: share/completions/darcs.fish:1028
+#, fuzzy
 msgid "Version specified by the context in FILENAME"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skicka till sammanhang lagrat i FILNAMN"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:855
 #: /tmp/fish/implicit/share/completions/darcs.fish:885
@@ -14841,16 +14269,8 @@ msgstr ""
 msgid "Reorder the patches in the repository"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/darcs.fish:938
-msgid "Specify a sibling directory"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/darcs.fish:939
 msgid "Relink random internal data to a sibling"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/darcs.fish:940
-msgid "Relink pristine tree (not recommended)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:941
@@ -14907,9 +14327,13 @@ msgstr ""
 msgid "display help and exit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/dd.fish:3
+#: /tmp/fish/implicit/share/completions/dd.fish:3 share/completions/dd.fish:5
+#, fuzzy
 msgid "Complete dd operands"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Jämför FIL1 med alla operander"
 
 #: /tmp/fish/implicit/share/completions/defaults.fish:1
 msgid "Restricts preferences operations to the current logged-in host"
@@ -15144,99 +14568,77 @@ msgstr ""
 msgid "Allow reboot after secs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/diff.fish:1
+#: share/functions/__fish_complete_diff.fish:3
 msgid "Ignore case differences"
-msgstr ""
+msgstr "Ignorera skiftläge"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:2
+#: share/functions/__fish_complete_diff.fish:4
 msgid "Ignore case when comparing file names"
-msgstr ""
+msgstr "Ignorera skiftläge på filnamn"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:3
+#: share/functions/__fish_complete_diff.fish:5
 msgid "Consider case when comparing file names"
-msgstr ""
+msgstr "Skilj på skiftläge på filnamn"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:4
+#: share/functions/__fish_complete_diff.fish:6
 msgid "Ignore changes due to tab expansion"
-msgstr ""
+msgstr "Ignorera ändringar på grund av tabbexpansion"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:5
+#: share/functions/__fish_complete_diff.fish:7
 msgid "Ignore changes in the amount of white space"
-msgstr ""
+msgstr "Ignorera skillnader i blanka tecken"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:6
+#: share/functions/__fish_complete_diff.fish:8
 msgid "Ignore all white space"
-msgstr ""
+msgstr "Ignorera blanka tecken"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:7
-#: /tmp/fish/implicit/share/completions/git.fish:327
+#: share/functions/__fish_complete_diff.fish:9
 msgid "Ignore changes whose lines are all blank"
-msgstr ""
+msgstr "Ignorera ändringar vars rader enbart består av blana tecken"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:8
-msgid "Ignore changes whose lines match the REGEX"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/diff.fish:9
-#: /tmp/fish/implicit/share/completions/git.fish:323
+#: share/functions/__fish_complete_diff.fish:11
 msgid "Treat all files as text"
-msgstr ""
+msgstr "Behandla alla filer som text"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:10
+#: share/functions/__fish_complete_diff.fish:12
 msgid "Recursively compare subdirectories"
-msgstr ""
+msgstr "Rekursera till underkataloger"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:11
+#: share/functions/__fish_complete_diff.fish:13
 msgid "Treat absent files as empty"
-msgstr ""
+msgstr "Behandla saknade filer som om de vore tomma"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:12
-msgid "Output NUM lines of copied context"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/diff.fish:13
+#: share/functions/__fish_complete_diff.fish:15
 msgid "Output 3 lines of copied context"
-msgstr ""
+msgstr "Skriv ut 3 rader av kopierad sammanhang"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:14
-msgid "Output NUM lines of unified context"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/diff.fish:15
+#: share/functions/__fish_complete_diff.fish:17
 msgid "Output 3 lines of unified context"
-msgstr ""
+msgstr "Skriv ut 3 rader av unifierat sammanhang"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:16
+#: share/functions/__fish_complete_diff.fish:18
 msgid "Output only whether the files differ"
-msgstr ""
+msgstr "Skriv bara ut huruvida filerna skiljer sig"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:17
+#: share/functions/__fish_complete_diff.fish:19
 msgid "Output a normal diff"
-msgstr ""
+msgstr "Skriv ut en vanlig diff"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:18
+#: share/functions/__fish_complete_diff.fish:20
 msgid "Output in two columns"
-msgstr ""
+msgstr "Skriv ut i två kolumner"
 
-#: /tmp/fish/implicit/share/completions/diff.fish:19
-msgid "Output at most NUM print columns"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/diff.fish:20
+#: share/functions/__fish_complete_diff.fish:22
 msgid "Try to find a smaller set of changes"
-msgstr ""
+msgstr "Försök hitta en mindre uppsättning ändringar"
 
 #: /tmp/fish/implicit/share/completions/diff.fish:21
 msgid "Compare FILE1 to all operands"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/diff.fish:22
-msgid "Compare FILE2 to all operands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/diff.fish:23
+#: share/functions/__fish_complete_diff.fish:25
 msgid "Pass the output through 'pr'"
-msgstr ""
+msgstr "Skicka utdata genom 'pr'"
 
 #: /tmp/fish/implicit/share/completions/dig.fish:1
 msgid "Use IPv4 query transport only"
@@ -15918,156 +15320,154 @@ msgstr ""
 msgid "Removes one or more directories from the exclusion list"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/du.fish:1
-msgid "Write size for all files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:2
-msgid "Print file size, not disk usage"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:3
-#: /tmp/fish/implicit/share/completions/tar.fish:13
+#: share/completions/df.fish:22
 msgid "Block size"
-msgstr ""
+msgstr "Blockstorlek"
 
-#: /tmp/fish/implicit/share/completions/du.fish:4
-msgid "Use 1B block size"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:5
-msgid "Produce grand total"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:6
-msgid "Dereference file symlinks"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:7
-#: /tmp/fish/implicit/share/completions/ls.fish:21
-#: /tmp/fish/implicit/share/completions/ls.fish:76
+#: share/functions/__fish_complete_ls.fish:24
 msgid "Human readable sizes"
-msgstr ""
+msgstr "Människoanpassade storleksangivelser, bas 1024"
 
-#: /tmp/fish/implicit/share/completions/du.fish:8
-#: /tmp/fish/implicit/share/completions/ls.fish:41
+#: share/functions/__fish_complete_ls.fish:62
 msgid "Human readable sizes, powers of 1000"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:9
-msgid "Use 1kB block size"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:10
-msgid "Count hard links multiple times"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:11
-msgid "Dereference all symlinks"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:12
-msgid "Do not include subdirectory size"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/du.fish:13
-msgid "Display only a total for each argument"
-msgstr ""
+msgstr "Människoanpassade storleksangivelser, bas 1000"
 
 #: /tmp/fish/implicit/share/completions/du.fish:14
 msgid "Skip other file systems"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/du.fish:15
+#: /tmp/fish/implicit/share/completions/du.fish:15 share/completions/du.fish:15
+#, fuzzy
 msgid "Exclude files that match pattern in file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Exkludera filer som matchar mönster från fil"
 
-#: /tmp/fish/implicit/share/completions/du.fish:16
-#: /tmp/fish/implicit/share/completions/ncdu.fish:5
+#: share/completions/du.fish:16
 msgid "Exclude files that match pattern"
-msgstr ""
+msgstr "Exkludera filer som matchar mönster"
 
-#: /tmp/fish/implicit/share/completions/du.fish:17
+#: share/completions/du.fish:17
 msgid "Recursion limit"
-msgstr ""
+msgstr "Rekursionsgräns"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:1
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:13
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:14
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:15
 #: /tmp/fish/implicit/share/completions/netctl.fish:17
+#: share/completions/duply.fish:3
+#, fuzzy
 msgid "Profile"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:2
+#: share/completions/duply.fish:4
 msgid "Get usage help text"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:3
+#: share/completions/duply.fish:7
+#, fuzzy
 msgid "Creates a configuration profile"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:4
+#: share/completions/duply.fish:8
 msgid "Backup with pre/post script execution"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:5
+#: share/completions/duply.fish:9
+#, fuzzy
 msgid "Backup without executing pre/post scripts"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Kör inte post-skript"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:6
+#: share/completions/duply.fish:10
+#, fuzzy
 msgid "Execute <profile>/pre script"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Kör inte pre-skript"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:7
+#: share/completions/duply.fish:11
+#, fuzzy
 msgid "Execute <profile>/post script"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Kör inte post-skript"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:8
+#: share/completions/duply.fish:12
 msgid "Force full backup"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:9
+#: share/completions/duply.fish:13
 msgid "Force incremental backup"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:10
+#: share/completions/duply.fish:14
 msgid "List all files in backup (as it was at <age>, default: now)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:11
+#: share/completions/duply.fish:15
 msgid "Prints backup sets and chains currently in repository"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:12
+#: share/completions/duply.fish:16
 msgid "List files changed since latest backup"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:13
+#: share/completions/duply.fish:17
 msgid "Shows outdated backup archives [--force, delete these files]"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:14
+#: share/completions/duply.fish:18
 msgid "Shows outdated backups [--force, delete these files]"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:15
+#: share/completions/duply.fish:19
 msgid "Shows broken backup archives [--force, delete these files]"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:16
+#: share/completions/duply.fish:20
 msgid "Restore the backup to <target_path> [as it was at <age>]"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:17
+#: share/completions/duply.fish:21
 msgid "Restore single file/folder from backup [as it was at <age>]"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:18
+#: share/completions/duply.fish:24
 msgid "Really execute the commands: purge, purge-full, cleanup"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:19
+#: share/completions/duply.fish:25
 msgid "Do nothing but print out generated duplicity command lines"
 msgstr ""
 
@@ -16082,8 +15482,13 @@ msgid "Don"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:22
+#: share/completions/duply.fish:28
+#, fuzzy
 msgid "Output verbosity level"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Återställ felrapporteringsnivå till 0"
 
 #: /tmp/fish/implicit/share/completions/echo.fish:1
 msgid "Do not output a newline"
@@ -16588,29 +15993,37 @@ msgstr ""
 msgid "set parent window"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/emerge.fish:1
-#: /tmp/fish/implicit/share/completions/equery.fish:1
+#: share/completions/emerge.fish:5 share/completions/equery.fish:5
 msgid ""
 "Prints completions for installed packages on the system from /var/db/pkg"
 msgstr ""
+"Visa kompletteringar för installerade packet på systemet från /var/db/pkg"
 
-#: /tmp/fish/implicit/share/completions/emerge.fish:2
-#: /tmp/fish/implicit/share/completions/equery.fish:2
+#: share/completions/emerge.fish:13 share/completions/equery.fish:12
 msgid ""
 "Prints completions for all available packages on the system from /usr/portage"
 msgstr ""
+"Visa kompletteringar för alla tillgängliga packet på systemet från /usr/"
+"portage"
 
-#: /tmp/fish/implicit/share/completions/emerge.fish:3
+#: share/completions/emerge.fish:22
 msgid ""
 "Tests if emerge command should have an installed package as potential "
 "completion"
 msgstr ""
+"Testa om emergekommando borde ha ett installerat paket som potentiell "
+"komplettering"
 
 #: /tmp/fish/implicit/share/completions/emerge.fish:4
+#: share/completions/emerge.fish:32
+#, fuzzy
 msgid ""
 "Print completions for all packages including the version compare if that is "
 "already typed"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa kompletteringar för installerade packet på systemet från /var/db/pkg"
 
 #: /tmp/fish/implicit/share/completions/emerge.fish:5
 msgid "Synchronize the portage tree"
@@ -16867,29 +16280,20 @@ msgstr ""
 msgid "Output version information"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/env.fish:1
+#: share/completions/env.fish:2
 msgid "Redefine variable"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/env.fish:2
-#: /tmp/fish/implicit/share/completions/nice.fish:1
-#: /tmp/fish/implicit/share/completions/time.fish:1
-msgid "Command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/env.fish:3
-msgid "Start with an empty environment"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/env.fish:4
-msgid "Remove variable from the environment"
-msgstr ""
+msgstr "Omdefinera variabel"
 
 #: /tmp/fish/implicit/share/completions/equery.fish:3
+#: share/completions/equery.fish:19
+#, fuzzy
 msgid ""
 "Prints completions for all available categories on the system from /usr/"
 "portage"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa kompletteringar för installerade packet på systemet från /var/db/pkg"
 
 #: /tmp/fish/implicit/share/completions/equery.fish:4
 msgid "causes minimal output to be emitted"
@@ -17548,11 +16952,9 @@ msgstr ""
 msgid "Reload filelist after given time in second"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/feh.fish:44
-#: /tmp/fish/implicit/share/completions/ls.fish:26
-#: /tmp/fish/implicit/share/completions/ls.fish:81
+#: share/functions/__fish_complete_ls.fish:29
 msgid "Reverse sort order"
-msgstr ""
+msgstr "Omvänd sorteringsordning"
 
 #: /tmp/fish/implicit/share/completions/feh.fish:45
 msgid "Scale image to fit window geometry"
@@ -17818,8 +17220,12 @@ msgid "Alternate list of files containing magic numbers"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:1
+#, fuzzy
 msgid "Never follow symlinks"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Följ aldrig symboliska länkar"
 
 #: /tmp/fish/implicit/share/completions/find.fish:3
 msgid ""
@@ -17832,8 +17238,12 @@ msgid "Measure from the beginning of today rather than  from  24  hours ago"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:5
+#, fuzzy
 msgid "Process subdirectories before the directory itself"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Processa underkataloger rekursivt"
 
 #: /tmp/fish/implicit/share/completions/find.fish:7
 msgid ""
@@ -17843,8 +17253,12 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/find.fish:8
 #: /tmp/fish/implicit/share/completions/zfs.fish:66
 #: /tmp/fish/implicit/share/completions/zfs.fish:76
+#, fuzzy
 msgid "Maximum recursion depth"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Maximal 'resident set size'"
 
 #: /tmp/fish/implicit/share/completions/find.fish:9
 msgid "Do not apply any tests or actions at levels less than specified level"
@@ -17869,20 +17283,32 @@ msgid "Specify regular expression type"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:15
+#, fuzzy
 msgid "Turn warnings on"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa inte varningar"
 
 #: /tmp/fish/implicit/share/completions/find.fish:16
+#, fuzzy
 msgid "Turn warnings off"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa inte varningar"
 
 #: /tmp/fish/implicit/share/completions/find.fish:17
 msgid "File last accessed specified number of minutes ago"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:18
+#, fuzzy
 msgid "File last accessed more recently than file was modified"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa senaste revision vid vilken vare rad ändrades"
 
 #: /tmp/fish/implicit/share/completions/find.fish:19
 msgid "File last accessed specified number of days ago"
@@ -17904,26 +17330,37 @@ msgstr ""
 msgid "File is empty and is either a regular file or a directory"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/find.fish:24
-#: /tmp/fish/implicit/share/completions/test.fish:31
-msgid "File is executable"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/find.fish:25
+#, fuzzy
 msgid "Always false"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Formatera alltid om"
 
 #: /tmp/fish/implicit/share/completions/find.fish:26
+#, fuzzy
 msgid "File is on filesystem of specified type"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa filsystem av angiven typ"
 
 #: /tmp/fish/implicit/share/completions/find.fish:27
+#, fuzzy
 msgid "Numeric group id of file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Bara numerisk utdata"
 
 #: /tmp/fish/implicit/share/completions/find.fish:28
+#, fuzzy
 msgid "Group name of file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa inod för filer"
 
 #: /tmp/fish/implicit/share/completions/find.fish:29
 msgid "File is symlink matching specified case insensitive pattern"
@@ -17934,8 +17371,12 @@ msgid "File name matches case insensitive pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:31
+#, fuzzy
 msgid "File has specified inode number"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Filtrera genom angivet program"
 
 #: /tmp/fish/implicit/share/completions/find.fish:32
 msgid "File path matches case insensitive pattern"
@@ -17946,8 +17387,12 @@ msgid "File name matches case insensetive regex"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:34
+#, fuzzy
 msgid "File has specified number of links"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Jämför bara angivet antal tecken"
 
 #: /tmp/fish/implicit/share/completions/find.fish:35
 msgid "File is symlink matching specified pattern"
@@ -17958,8 +17403,12 @@ msgid "File last modified specified number of minutes ago"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:37
+#, fuzzy
 msgid "File last modified more recently than file was modified"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa senaste revision vid vilken vare rad ändrades"
 
 #: /tmp/fish/implicit/share/completions/find.fish:38
 msgid "File last modified specified number of days ago"
@@ -17978,36 +17427,64 @@ msgid "No group corresponds to file's numeric group ID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:42
+#, fuzzy
 msgid "File path matches pattern"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Exkludera filer som matchar mönster"
 
 #: /tmp/fish/implicit/share/completions/find.fish:43
+#, fuzzy
 msgid "Files has specified permissions set"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Använd angiven kompressionsalgoritm"
 
 #: /tmp/fish/implicit/share/completions/find.fish:44
+#, fuzzy
 msgid "File name matches regex"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ignorera ändringar som matchar reguljärt uttryck"
 
 #: /tmp/fish/implicit/share/completions/find.fish:45
+#, fuzzy
 msgid "File refers to the same inode as specified file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Exklidera filer listade i angiven fil"
 
 #: /tmp/fish/implicit/share/completions/find.fish:46
 msgid "File uses specified units of space"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:47
+#, fuzzy
 msgid "Always true"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Alltid"
 
 #: /tmp/fish/implicit/share/completions/find.fish:48
+#, fuzzy
 msgid "File is of specified type"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa filsystem av angiven typ"
 
 #: /tmp/fish/implicit/share/completions/find.fish:49
+#, fuzzy
 msgid "File's owner has specified numeric user ID"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fil ägd av effektiv användar-id"
 
 #: /tmp/fish/implicit/share/completions/find.fish:50
 msgid ""
@@ -18016,8 +17493,12 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:51
+#, fuzzy
 msgid "File's owner"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fil är uttag (socket)"
 
 #: /tmp/fish/implicit/share/completions/find.fish:52
 msgid ""
@@ -18034,16 +17515,24 @@ msgid "Delete selected files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:55
+#, fuzzy
 msgid "Execute specified command for each located file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Utför  kommando om föregående kommando misslyckades"
 
 #: /tmp/fish/implicit/share/completions/find.fish:56
 msgid "Execute specified command for each located file, in the files directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:57
+#, fuzzy
 msgid "List file in ls -dils format, write to specified file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv profileringsinformation till angiven fil"
 
 #: /tmp/fish/implicit/share/completions/find.fish:58
 msgid "Print full file names into specified file"
@@ -18054,16 +17543,24 @@ msgid "Print null separated full file names into specified file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:60
+#, fuzzy
 msgid "Print formated data into specified file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv utdata till angiven fil"
 
 #: /tmp/fish/implicit/share/completions/find.fish:61
 msgid "Execute specified command for each located file after asking user"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:62
+#, fuzzy
 msgid "Print full file names"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa filnamn"
 
 #: /tmp/fish/implicit/share/completions/find.fish:63
 msgid ""
@@ -18072,8 +17569,12 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:64
+#, fuzzy
 msgid "Print null separated full file names"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv bara RCS-filnamn"
 
 #: /tmp/fish/implicit/share/completions/find.fish:65
 msgid "Print formated data"
@@ -18084,16 +17585,28 @@ msgid "Do not recurse unless -depth is specified"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:67
+#, fuzzy
 msgid "Exit at once"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Förklara vad som utförs"
 
 #: /tmp/fish/implicit/share/completions/find.fish:68
+#, fuzzy
 msgid "List file in ls -dils format"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lista information om inoder"
 
 #: /tmp/fish/implicit/share/completions/find.fish:69
+#, fuzzy
 msgid "Negate result of action"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Negera uttryck"
 
 #: /tmp/fish/implicit/share/completions/find.fish:70
 msgid "Result is only true if both previous and next action are true"
@@ -18101,22 +17614,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:71
 msgid "Result is true if either previous or next action are true"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/fish.fish:1
-msgid "Run fish with this command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/fish.fish:4
-msgid "Only parse input, do not execute"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/fish.fish:5
-msgid "Run in interactive mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/fish.fish:6
-msgid "Run in login mode"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/fish.fish:7
@@ -18139,10 +17636,9 @@ msgstr ""
 msgid "Output in HTML format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/fish_indent.fish:6
-#: /tmp/fish/implicit/share/completions/sort.fish:15
+#: share/completions/sort.fish:16
 msgid "Write to file"
-msgstr ""
+msgstr "Skriv till fil"
 
 #: /tmp/fish/implicit/share/completions/fish_indent.fish:7
 msgid "Enable debug at specified verbosity level"
@@ -19093,8 +18589,13 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:246
 #: /tmp/fish/implicit/share/completions/git.fish:295
 #: /tmp/fish/implicit/share/completions/git.fish:296
+#: share/completions/git.fish:177
+#, fuzzy
 msgid "Tag"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Mål"
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:160
 msgid "Show commit time"
@@ -19597,8 +19098,13 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/rejmerge.fish:3
 #: /tmp/fish/implicit/share/completions/root.fish:6
 #: /tmp/fish/implicit/share/completions/zypper.fish:4
+#: share/completions/zypper.fish:30
+#, fuzzy
 msgid "Print help"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa URIer"
 
 #: /tmp/fish/implicit/share/completions/funced.fish:1
 #: /tmp/fish/implicit/share/completions/funcsave.fish:1
@@ -19611,38 +19117,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/funced.fish:3
 msgid "Edit in interactive mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/function.fish:1
-#: /tmp/fish/implicit/share/completions/functions.fish:5
-msgid "Set function description"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/function.fish:2
-#: /tmp/fish/implicit/share/completions/functions.fish:2
-#: /tmp/fish/implicit/share/completions/type.fish:9
-msgid "Function"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/function.fish:3
-#: /tmp/fish/implicit/share/completions/type.fish:8
-msgid "Builtin"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/function.fish:4
-msgid "Make the function a job exit event handler"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/function.fish:5
-msgid "Make the function a process exit event handler"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/function.fish:6
-msgid "Make the function a signal event handler"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/function.fish:7
-msgid "Make the function a variable update event handler"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/function.fish:8
@@ -19661,17 +19135,17 @@ msgstr ""
 msgid "Inherit completions from the given command"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/functions.fish:1
-msgid "Erase function"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/functions.fish:3
 msgid "Show hidden functions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/functions.fish:6
+#, fuzzy
 msgid "Test if function is defined"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om variabeln är definerad"
 
 #: /tmp/fish/implicit/share/completions/functions.fish:7
 msgid "List the names of the functions, but not their definition"
@@ -19737,25 +19211,9 @@ msgstr ""
 msgid "Search only for IPv6 sockets"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/fusermount.fish:4
-#: /tmp/fish/implicit/share/completions/sshfs.fish:4
-#: /tmp/fish/implicit/share/completions/sshfs.fish:8
-#: /tmp/fish/implicit/share/completions/udisksctl.fish:19
+#: share/completions/fusermount.fish:15 share/completions/sshfs.fish:27
 msgid "Mount options"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/fusermount.fish:5
-msgid "Unmount"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/fusermount.fish:6
-#: /tmp/fish/implicit/share/completions/gdb.fish:10
-msgid "Quiet"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/fusermount.fish:7
-msgid "Lazy unmount"
-msgstr ""
+msgstr "Monteringsflagga"
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:1
 msgid "Standard mode"
@@ -19778,6 +19236,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:5
 #: /tmp/fish/implicit/share/completions/gcc.fish:481
+#: share/completions/gcc.fish:31 share/completions/gcc.fish:513
 msgid "Use dir as the logical root directory for headers and libraries"
 msgstr ""
 
@@ -20012,10 +19471,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gcc.fish:54
 msgid ""
 "Downgrade some diagnostics about nonconformant code from errors to warnings"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gcc.fish:55
-msgid "Enable automatic template instantiation at link time"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:56
@@ -22069,6 +21524,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:480
+#: share/completions/gcc.fish:512
 msgid ""
 "Process file after the compiler reads in the standard specs file, in order "
 "to override the defaults that the gcc driver program uses when determining "
@@ -22194,12 +21650,15 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gcc.fish:507
 #: /tmp/fish/implicit/share/completions/gcc.fish:508
 #: /tmp/fish/implicit/share/completions/gcc.fish:509
+#: share/completions/gcc.fish:539 share/completions/gcc.fish:540
+#: share/completions/gcc.fish:541
 msgid ""
 "This specifies what floating point hardware (or hardware emulation) is "
 "available on the target"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:510
+#: share/completions/gcc.fish:542
 msgid ""
 "The size of all structures and unions will be rounded up to a multiple of "
 "the number of bits set by this option"
@@ -22232,6 +21691,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:516
+#: share/completions/gcc.fish:548
 msgid "Specify the register to be used for PIC addressing"
 msgstr ""
 
@@ -22278,10 +21738,12 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:524
+#: share/completions/gcc.fish:556
 msgid "Specify the access model for the thread local storage pointer"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:525
+#: share/completions/gcc.fish:557
 msgid "Specify ATMEL AVR instruction set or MCU type"
 msgstr ""
 
@@ -22290,6 +21752,7 @@ msgid "Output instruction sizes to the asm file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:527
+#: share/completions/gcc.fish:559
 msgid ""
 "Specify the initial stack address, which may be a symbol or numeric value, "
 "__stack is the default"
@@ -22365,6 +21828,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gcc.fish:542
+#: share/completions/gcc.fish:574
 msgid ""
 "Specified the identification number of the ID based shared library being "
 "compiled"
@@ -25318,127 +24782,227 @@ msgid "Print the version and quit"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:3
+#: share/completions/gem.fish:35
 msgid "Use URL as the remote source for gems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:4
+#: share/completions/gem.fish:36
 msgid "Use the given HTTP proxy for remote operations"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:5
+#: share/completions/gem.fish:37
+#, fuzzy
 msgid "Use no HTTP proxy for remote operations"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj rot-katalog för rpm-operationer"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:6
+#: share/completions/gem.fish:38
+#, fuzzy
 msgid "Get help on this command"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj promptkommando"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:7
+#: share/completions/gem.fish:39
+#, fuzzy
 msgid "Set the verbose level of output"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Återställ felrapporteringsnivå till 0"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:8
+#: share/completions/gem.fish:40
+#, fuzzy
 msgid "Use this config file instead of default"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Använd angiven fil istället för standard-förtroendedatabasen"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:9
+#: share/completions/gem.fish:41
 msgid "Show stack backtrace on errors"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:10
+#: share/completions/gem.fish:42
+#, fuzzy
 msgid "Turn on Ruby debugging"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Slå av avmangling"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:11
+#: share/completions/gem.fish:47
 msgid "Add a trusted certificate"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:12
+#: share/completions/gem.fish:48
+#, fuzzy
 msgid "List trusted certificates"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa pålitliga nycklar"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:13
+#: share/completions/gem.fish:49
 msgid "Remove trusted certificates containing STRING"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:14
+#: share/completions/gem.fish:50
 msgid "Build private key and self-signed certificate for EMAIL_ADDR"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:15
+#: share/completions/gem.fish:51
 msgid "Certificate for --sign command"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:16
+#: share/completions/gem.fish:52
+#, fuzzy
 msgid "Private key for --sign command"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa typ av kommando"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:17
+#: share/completions/gem.fish:53
 msgid "Sign a certificate with my key and certificate"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:18
+#: share/completions/gem.fish:58
 msgid "Verify gem file against its internal checksum"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:19
+#: share/completions/gem.fish:59
+#, fuzzy
 msgid "Report 'unmanaged' or rogue files in the gem repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ta bort filer eller kataloger från lagret"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:20
+#: share/completions/gem.fish:60
 msgid "Run unit tests for gem"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:21
+#: share/completions/gem.fish:61
+#, fuzzy
 msgid "Specify version for which to run unit tests"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj vilket förråd som skall användas"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:22
+#: share/completions/gem.fish:66
+#, fuzzy
 msgid "Don't really cleanup"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Avinstallera ingenting på riktigt"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:23
+#: share/completions/gem.fish:71
+#, fuzzy
 msgid "List the files inside a Gem"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa filer i paket"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:24
+#: share/completions/gem.fish:72
+#, fuzzy
 msgid "Specify version for gem to view"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange användare för fråga"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:25
+#: share/completions/gem.fish:73
+#, fuzzy
 msgid "Search for gems under specific paths"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj drivrutinsspecifika inställningar"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:26
+#: share/completions/gem.fish:74
 msgid "Be verbose when showing status"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:27
 #: /tmp/fish/implicit/share/completions/gem.fish:82
+#: share/completions/gem.fish:79 share/completions/gem.fish:172
+#, fuzzy
 msgid "Specify version of gem to uninstall"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lista av paket att installera"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:28
+#: share/completions/gem.fish:80
+#, fuzzy
 msgid "Include reverse dependencies in the output"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa paket som beror på det givna paketet"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:29
+#: share/completions/gem.fish:81
+#, fuzzy
 msgid "Don't include reverse dependencies in the output"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa paket som beror på det givna paketet"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:30
+#: share/completions/gem.fish:82
 msgid "Pipe Format (name --version ver)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:31
+#: share/completions/gem.fish:97
+#, fuzzy
 msgid "Specify version of gem to install"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lista av paket att installera"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:32
 #: /tmp/fish/implicit/share/completions/gem.fish:51
 #: /tmp/fish/implicit/share/completions/gem.fish:57
 #: /tmp/fish/implicit/share/completions/gem.fish:68
 #: /tmp/fish/implicit/share/completions/gem.fish:72
+#: share/completions/gem.fish:98 share/completions/gem.fish:121
+#: share/completions/gem.fish:131 share/completions/gem.fish:150
+#: share/completions/gem.fish:158
 msgid "Restrict operations to the LOCAL domain (default)"
 msgstr ""
 
@@ -25447,6 +25011,9 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gem.fish:58
 #: /tmp/fish/implicit/share/completions/gem.fish:69
 #: /tmp/fish/implicit/share/completions/gem.fish:73
+#: share/completions/gem.fish:99 share/completions/gem.fish:122
+#: share/completions/gem.fish:132 share/completions/gem.fish:151
+#: share/completions/gem.fish:159
 msgid "Restrict operations to the REMOTE domain"
 msgstr ""
 
@@ -25455,156 +25022,242 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gem.fish:59
 #: /tmp/fish/implicit/share/completions/gem.fish:70
 #: /tmp/fish/implicit/share/completions/gem.fish:74
+#: share/completions/gem.fish:100 share/completions/gem.fish:123
+#: share/completions/gem.fish:133 share/completions/gem.fish:152
+#: share/completions/gem.fish:160
 msgid "Allow LOCAL and REMOTE operations"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:35
 #: /tmp/fish/implicit/share/completions/gem.fish:84
+#: share/completions/gem.fish:101 share/completions/gem.fish:182
 msgid "Gem repository directory to get installed gems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:36
 #: /tmp/fish/implicit/share/completions/gem.fish:85
+#: share/completions/gem.fish:102 share/completions/gem.fish:183
 msgid "Generate RDoc documentation for the gem on install"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:37
 #: /tmp/fish/implicit/share/completions/gem.fish:86
+#: share/completions/gem.fish:103 share/completions/gem.fish:184
 msgid "Don't generate RDoc documentation for the gem on install"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:38
 #: /tmp/fish/implicit/share/completions/gem.fish:87
+#: share/completions/gem.fish:104 share/completions/gem.fish:185
 msgid "Generate RI documentation for the gem on install"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:39
 #: /tmp/fish/implicit/share/completions/gem.fish:88
+#: share/completions/gem.fish:105 share/completions/gem.fish:186
 msgid "Don't generate RI documentation for the gem on install"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:40
 #: /tmp/fish/implicit/share/completions/gem.fish:89
+#: share/completions/gem.fish:106 share/completions/gem.fish:187
 msgid "Force gem to install, bypassing dependency checks"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:41
 #: /tmp/fish/implicit/share/completions/gem.fish:90
+#: share/completions/gem.fish:107 share/completions/gem.fish:188
+#, fuzzy
 msgid "Don't force gem to install, bypassing dependency checks"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Utför inte beroendeverifiering"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:42
 #: /tmp/fish/implicit/share/completions/gem.fish:91
+#: share/completions/gem.fish:108 share/completions/gem.fish:189
 msgid "Run unit tests prior to installation"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:43
 #: /tmp/fish/implicit/share/completions/gem.fish:92
+#: share/completions/gem.fish:109 share/completions/gem.fish:190
+#, fuzzy
 msgid "Don't run unit tests prior to installation"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Kontrollera inte diskutrymme före installation"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:44
 #: /tmp/fish/implicit/share/completions/gem.fish:93
+#: share/completions/gem.fish:110 share/completions/gem.fish:191
+#, fuzzy
 msgid "Use bin wrappers for executables"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fil är program"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:45
 #: /tmp/fish/implicit/share/completions/gem.fish:94
+#: share/completions/gem.fish:111 share/completions/gem.fish:192
+#, fuzzy
 msgid "Don't use bin wrappers for executables"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Gör inte skript exekverbara"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:46
 #: /tmp/fish/implicit/share/completions/gem.fish:95
+#: share/completions/gem.fish:112 share/completions/gem.fish:193
+#, fuzzy
 msgid "Specify gem trust policy"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange förtroendemodell"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:47
 #: /tmp/fish/implicit/share/completions/gem.fish:96
+#: share/completions/gem.fish:113 share/completions/gem.fish:194
 msgid "Do not install any required dependent gems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:48
 #: /tmp/fish/implicit/share/completions/gem.fish:97
+#: share/completions/gem.fish:114 share/completions/gem.fish:195
 msgid "Unconditionally install the required dependent gems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:49
 #: /tmp/fish/implicit/share/completions/gem.fish:55
 #: /tmp/fish/implicit/share/completions/gem.fish:66
+#: share/completions/gem.fish:119 share/completions/gem.fish:129
+#: share/completions/gem.fish:148
+#, fuzzy
 msgid "Display detailed information of gem(s)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa uppdateringsinformation"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:50
 #: /tmp/fish/implicit/share/completions/gem.fish:56
 #: /tmp/fish/implicit/share/completions/gem.fish:67
+#: share/completions/gem.fish:120 share/completions/gem.fish:130
+#: share/completions/gem.fish:149
+#, fuzzy
 msgid "Don't display detailed information of gem(s)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa uppdateringsinformation"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:54
+#: share/completions/gem.fish:128
 msgid "Name of gem(s) to query on matches the provided REGEXP"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:60
+#: share/completions/gem.fish:138
 msgid "Generate RDoc/RI documentation for all installed gems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:61
+#: share/completions/gem.fish:139
 msgid "Include RDoc generated documents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:62
+#: share/completions/gem.fish:140
 msgid "Don't include RDoc generated documents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:63
+#: share/completions/gem.fish:141
 msgid "Include RI generated documents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:64
+#: share/completions/gem.fish:142
 msgid "Don't include RI generated documents"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:65
+#: share/completions/gem.fish:143
+#, fuzzy
 msgid "Specify version of gem to rdoc"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange extern editor"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:71
+#: share/completions/gem.fish:157
+#, fuzzy
 msgid "Specify version of gem to examine"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj destinationsadress"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:75
+#: share/completions/gem.fish:161
 msgid "Output specifications for all versions of the gem"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:76
+#: share/completions/gem.fish:166
+#, fuzzy
 msgid "Uninstall all matching versions"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa alla versioner"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:77
+#: share/completions/gem.fish:167
+#, fuzzy
 msgid "Don't uninstall all matching versions"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Avinstallera ingenting på riktigt"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:78
+#: share/completions/gem.fish:168
 msgid "Ignore dependency requirements while uninstalling"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:79
+#: share/completions/gem.fish:169
+#, fuzzy
 msgid "Don't ignore dependency requirements while uninstalling"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Verifiera inte beroenden före paketen avinstalleras"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:80
+#: share/completions/gem.fish:170
 msgid "Uninstall applicable executables without confirmation"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:81
+#: share/completions/gem.fish:171
 msgid "Don't uninstall applicable executables without confirmation"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:83
+#: share/completions/gem.fish:177
 msgid "Specify version of gem to unpack"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:98
+#: share/completions/gem.fish:196
 msgid "Update the RubyGems system software"
 msgstr ""
 
@@ -25704,6 +25357,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:267
 #: /tmp/fish/implicit/share/completions/git.fish:287
 #: /tmp/fish/implicit/share/completions/git.fish:309
+#: share/completions/git.fish:153 share/completions/git.fish:176
 msgid "Branch"
 msgstr ""
 
@@ -25940,12 +25594,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:78
 msgid "Don't add the file(s), but only refresh their stat"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/git.fish:79
-#: /tmp/fish/implicit/share/completions/ipset.fish:8
-#: /tmp/fish/implicit/share/completions/make.fish:6
-msgid "Ignore errors"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/git.fish:80
@@ -27440,77 +27088,8 @@ msgid ""
 "gpg. argv[1] is a regexp"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:4
-msgid "Make a signature"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:5
-msgid "Make a clear text signature"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:6
-msgid "Make a detached signature"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:7
-msgid "Encrypt data"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:8
-msgid "Encrypt with a symmetric cipher using a passphrase"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:9
-msgid "Store only (make a simple RFC1991 packet)"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/gpg.fish:10
 msgid "Decrypt specified file or stdin"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:11
-msgid "Assume specified file or stdin is sigfile and verify it"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:12
-msgid "Modify certain other commands to accept multiple files for processing"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:13
-msgid "Identical to '--multifile --verify'"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:14
-msgid "Identical to '--multifile --encrypt'"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:15
-msgid "Identical to --multifile --decrypt"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:16
-#: /tmp/fish/implicit/share/completions/gpg.fish:17
-msgid ""
-"List all keys from the public keyrings, or just the ones given on the "
-"command line"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:18
-msgid ""
-"List all keys from the secret keyrings, or just the ones given on the "
-"command line"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:19
-msgid "Same as --list-keys, but the signatures are listed too"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:20
-msgid "Same as --list-keys, but the signatures are listed and verified"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:21
-msgid "List all keys with their fingerprints"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:22
@@ -27518,731 +27097,147 @@ msgstr ""
 msgid "Generate a new key pair"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:23
-msgid "Present a menu which enables you to do all key related tasks"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:24
-msgid "Sign a public key with your secret key"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:25
-msgid "Sign a public key with your secret key but mark it as non exportable"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:26
-msgid "Remove key from the public keyring"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:27
-msgid "Remove key from the secret and public keyring"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:28
-msgid ""
-"Same as --delete-key, but if a secret key exists, it will be removed first"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:29
-msgid "Generate a revocation certificate for the complete key"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:30
-msgid "Generate a designated revocation certificate for a key"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:31
-msgid "Export all or the given keys from all keyrings"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:32
-msgid "Same as --export but sends the keys to a keyserver"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:33
-#: /tmp/fish/implicit/share/completions/gpg.fish:34
-msgid "Same as --export, but exports the secret keys instead"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:35
-#: /tmp/fish/implicit/share/completions/gpg.fish:36
-msgid "Import/merge keys"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:37
-msgid "Import the keys with the given key IDs from a keyserver"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:38
-msgid ""
-"Request updates from a keyserver for keys that already exist on the local "
-"keyring"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:39
-msgid "Search the keyserver for the given names"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:40
-msgid "Do trust database maintenance"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:41
-msgid "Do trust database maintenance without user interaction"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:42
-msgid "Send the ownertrust values to stdout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:43
-msgid ""
-"Update the trustdb with the ownertrust values stored in specified files or "
-"stdin"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:44
-msgid "Create signature caches in the keyring"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:45
-msgid ""
-"Print message digest of specified algorithm for all given files or stdin"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:46
-msgid "Print message digest of all algorithms for all given files or stdin"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:47
-msgid "Emit specified number of random bytes of the given quality level"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:48
-msgid "Display version and supported algorithms, and exit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:49
-msgid "Display warranty and exit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:51
-msgid "Create ASCII armored output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:52
-#: /tmp/fish/implicit/share/completions/msgfmt.fish:8
-#: /tmp/fish/implicit/share/completions/xgettext.fish:4
+#: share/completions/gpg.fish:116
 msgid "Write output to specified file"
-msgstr ""
+msgstr "Skriv utdata till angiven fil"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:53
-msgid ""
-"Sets a limit on the number of bytes that will be generated when processing a "
-"file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:54
-msgid "Use specified key as the key to sign with"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:55
-msgid "Use specified key as the default key to sign with"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:56
-msgid "Encrypt for specified user id"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:57
-msgid "Encrypt for specified user id, but hide the keyid of the key"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:58
-msgid "Use specified user id as default recipient"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:59
-msgid "Use the default key as default recipient"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:60
-msgid "Reset --default-recipient and --default-recipient-self"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:61
-msgid "Give more information during processing"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:63
-#: /tmp/fish/implicit/share/completions/gpg.fish:64
-#: /tmp/fish/implicit/share/completions/gpg.fish:65
-msgid "Compression level"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:66
-msgid "Use a different decompression method for BZIP2 compressed files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:67
-msgid ""
-"Treat input files as text and store them in the OpenPGP canonical text form "
-"with standard 'CRLF' line endings"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:68
-msgid ""
-"Don't treat input files as text and store them in the OpenPGP canonical text "
-"form with standard 'CRLF' line endings"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:69
-msgid "Don't make any changes (this is not completely implemented)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:70
-#: /tmp/fish/implicit/share/completions/mv.fish:3
-msgid "Prompt before overwrite"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:71
-#: /tmp/fish/implicit/share/completions/scp.fish:3
-#: /tmp/fish/implicit/share/completions/top.fish:1
-msgid "Batch mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:72
-msgid "Don't use batch mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:73
-msgid "Never write output to terminal"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:74
-msgid "Assume yes on most questions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:75
-msgid "Assume no on most questions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:76
-msgid "Prompt for a certification level when making a key signature"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:77
-msgid "Don't prompt for a certification level when making a key signature"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:78
-msgid ""
-"The default certification level to use for the level check when signing a key"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:79
-msgid ""
-"Disregard any signatures with a certification level below specified level "
-"when building the trust database"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:80
-msgid ""
-"Assume that the specified key is as trustworthy as one of your own secret "
-"keys"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:81
-msgid "Specify trust model"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:82
-msgid "Select how to display key IDs"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:83
+#: share/completions/gpg.fish:161
 msgid "Use specified keyserver"
-msgstr ""
+msgstr "Använd angiven nyckelserver"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:84
-msgid "Options for the keyserver"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:85
-msgid "Options for importing keys"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:86
-msgid "Options for exporting keys"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:87
-msgid "Options for listing keys and signatures"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:88
-msgid "Options for verifying signatures"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:89
+#: share/completions/gpg.fish:169
 msgid "The command line that should be run to view a photo ID"
-msgstr ""
+msgstr "Kommandoraden som skall köras för att visa ett fotoid"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:90
+#: share/completions/gpg.fish:170
 msgid ""
 "Sets a list of directories to search for photo viewers and keyserver helpers"
 msgstr ""
+"Sätt en lista av kataloger att söka efter fotovisare och nyckelserverhjälpare"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:91
-msgid ""
-"Display the keyring name at the head of key listings to show which keyring a "
-"given key resides on"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:92
+#: share/completions/gpg.fish:173
 msgid "Add specified file to the current list of keyrings"
-msgstr ""
+msgstr "Lägg till angiven fil fill den nuvarande listan av nyckelringar"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:93
+#: share/completions/gpg.fish:175
 msgid "Add specified file to the current list of secret keyrings"
 msgstr ""
+"Lägg till angiven fil fill den nuvarande listan av hemliga nyckelringar"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:94
+#: share/completions/gpg.fish:176
 msgid "Designate specified file as the primary public keyring"
-msgstr ""
+msgstr "Välj den angivna filen som den primära öppna nyckelring"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:95
+#: share/completions/gpg.fish:178
 msgid "Use specified file instead of the default trustdb"
-msgstr ""
+msgstr "Använd angiven fil istället för standard-förtroendedatabasen"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:96
-msgid "Set the home directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:97
-msgid "Set the native character set"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:98
-msgid "Assume that following command line arguments are given in UTF8"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:99
-msgid ""
-"Assume that following arguments are encoded in the character set specified "
-"by --display-charset"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:100
+#: share/completions/gpg.fish:184
 msgid "Read options from specified file, do not read the default options file"
-msgstr ""
+msgstr "Läs inställningar från angivan fil, läs inte standardinställningsfil"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:101
-msgid "Shortcut for '--options /dev/null'"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:102
+#: share/completions/gpg.fish:186
 msgid "Load an extension module"
-msgstr ""
+msgstr "Ladda en förlängningsmodul"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:103
+#: share/completions/gpg.fish:188
 msgid "Write special status strings to the specified file descriptor"
-msgstr ""
+msgstr "Skriv speciella statussträngar till den angivna filidentifieraren"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:104
+#: share/completions/gpg.fish:189
 msgid "Write log output to the specified file descriptor"
-msgstr ""
+msgstr "Skriv loggdata till angiven filidentifierare"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:105
-msgid "Write attribute subpackets to the specified file descriptor"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:106
-msgid "Include secret key comment packets when exporting secret keys"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:107
-msgid "Don't include secret key comment packets when exporting secret keys"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:108
+#: share/completions/gpg.fish:195
 msgid "Use specified string as comment string"
-msgstr ""
+msgstr "Använd angiven sträng som kommentarsträng"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:109
-msgid "Don't use a comment string"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:110
-msgid "Include the version string in ASCII armored output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:111
-msgid "Don't include the version string in ASCII armored output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:112
+#: share/completions/gpg.fish:204
 msgid "Put the specified name value pair into the signature as notation data"
-msgstr ""
+msgstr "Lägg angivet namn/värde-par i signaturen som notationsdata"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:113
+#: share/completions/gpg.fish:205
 msgid "Set signature policy"
-msgstr ""
+msgstr "Välj signaturpolicy"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:114
+#: share/completions/gpg.fish:206
 msgid "Set certificate policy"
-msgstr ""
+msgstr "Välj certifikatpolicy"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:115
+#: share/completions/gpg.fish:207
 msgid "Set signature and certificate policy"
-msgstr ""
+msgstr "Välj signatur- och certifikatpolicy"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:116
+#: share/completions/gpg.fish:208
 msgid "Use specified URL as a preferred keyserver for data signatures"
-msgstr ""
+msgstr "Använd angiven URL som preferrerad nyckelserver för datasignaturer"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:117
+#: share/completions/gpg.fish:210
 msgid "Use specified string as the filename which is stored inside messages"
-msgstr ""
+msgstr "Använd angiven sträng som filnamn att lagra i meddelande"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:118
-msgid "Set the 'for your eyes only' flag in the message"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:119
-msgid "Clear the 'for your eyes only' flag in the message"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:120
-msgid "Create file with name as given in data"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:121
-msgid "Don't create file with name as given in data"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:122
+#: share/completions/gpg.fish:218
 msgid ""
 "Number of completely trusted users to introduce a new key signer (defaults "
 "to 1)"
 msgstr ""
+"Antal användare med fullt förtroende för att introducera nya "
+"nyckelunderskrivare (standard är 1)"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:123
+#: share/completions/gpg.fish:219
 msgid ""
 "Number of marginally trusted users to introduce a new key signer (defaults "
 "to 3)"
 msgstr ""
+"Antal användare med marginellt förtroende för att introducera nya "
+"nyckelunderskrivare (standard är 3)"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:124
+#: share/completions/gpg.fish:221
 msgid "Maximum depth of a certification chain (default is 5)"
-msgstr ""
+msgstr "MAximalt djup i certifieringskedjan (standard är 5)"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:125
-msgid "Use specified cipher algorithm"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:126
-msgid "Use specified message digest algorithm"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:127
-msgid "Use specified compression algorithm"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:128
-msgid "Use specified message digest algorithm when signing a key"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:129
-msgid "Use specified cipher algorithm to protect secret keys"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:130
-msgid "Use specified digest algorithm to mangle the passphrases"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:131
-msgid "Selects how passphrases are mangled"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:132
-msgid "Integrity protect secret keys by using a SHA-1 checksum"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:133
-msgid "Never allow the use of specified cipher algorithm"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:134
-msgid "Never allow the use of specified public key algorithm"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:135
-msgid "Do not cache the verification status of key signatures"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:136
-msgid "Do not verify each signature right after creation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:137
-msgid "Automatically run the --check-trustdb command internally when needed"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:138
-msgid "Never automatically run the --check-trustdb"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:139
-msgid "Do not put the recipient keyid into encrypted packets"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:140
-msgid "Put the recipient keyid into encrypted packets"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:141
-msgid ""
-"Change the behavior of cleartext signatures so that they can be used for "
-"patch files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:142
-msgid "Mangle From-field of email headers (default)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:143
-msgid "Do not mangle From-field of email headers"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:144
+#: share/completions/gpg.fish:249
 msgid "Read passphrase from specified file descriptor"
-msgstr ""
+msgstr "Läss passfras från angiven filidentifierare"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:145
+#: share/completions/gpg.fish:250
 msgid "Read user input from specified file descriptor"
-msgstr ""
+msgstr "Läs användarindata från angiven filidentifierare"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:146
-msgid "Try to use the GnuPG-Agent"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:147
-msgid "Do not try to use the GnuPG-Agent"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:148
+#: share/completions/gpg.fish:254
 msgid "Override value of GPG_AGENT_INFO environment variable"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:149
-msgid "Force v3 signatures for signatures on data"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:150
-msgid "Do not force v3 signatures for signatures on data"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:151
-msgid "Always use v4 key signatures even on v3 keys"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:152
-msgid "Don't use v4 key signatures on v3 keys"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:153
-msgid "Force the use of encryption with a modification detection code"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:154
-msgid "Disable the use of the modification detection code"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:155
-msgid ""
-"Allow the import and use of keys with user IDs which are not self-signed"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:156
-msgid ""
-"Do not allow the import and use of keys with user IDs which are not self-"
-"signed"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:157
-msgid ""
-"Disable all checks on the form of the user ID while generating a new one"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:158
-msgid "Do not fail if signature is older than key"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:159
-msgid "Allow subkeys that have a timestamp from the future"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:160
-msgid "Ignore CRC errors"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:161
-msgid "Do not fail on MDC integrity protection failure"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:162
-msgid ""
-"Lock the databases the first time a lock is requested and do not release the "
-"lock until the process terminates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:163
-msgid "Release the locks every time a lock is no longer needed"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:164
-msgid ""
-"Do not create an internal pool file for quicker generation of random numbers"
-msgstr ""
+msgstr "Åsidosätt värdet på GPG_AGENT_INFO-miljövariablen"
 
 #: /tmp/fish/implicit/share/completions/gpg.fish:165
 msgid "Reset verbose level to 0"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:166
-msgid "Suppress the initial copyright message"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:167
-msgid "Suppress the warning about 'using insecure memory'"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:168
-msgid ""
-"Suppress the warning about unsafe file and home directory (--homedir) "
-"permissions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:169
-msgid "Suppress the warning about missing MDC integrity protection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:170
-msgid "Refuse to run if GnuPG cannot get secure memory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:171
-msgid "Do not refuse to run if GnuPG cannot get secure memory (default)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:172
-msgid "Assume the input data is not in ASCII armored format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:173
-msgid "Do not add the default keyrings to the list of keyrings"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:174
-msgid "Skip the signature verification step"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:175
-msgid "Print key listings delimited by colons"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:176
-msgid ""
-"Print key listings delimited by colons (like --with-colons) and print the "
-"public key data"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:177
-msgid ""
-"Same as the command --fingerprint but changes only the format of the output "
-"and may be used together with another command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:178
-msgid "Changes the output of the list commands to work faster"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:179
-msgid ""
-"Do not merge primary user ID and primary key in --with-colon listing mode "
-"and print all timestamps as UNIX timestamps"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:180
-msgid ""
-"Changes the behaviour of some commands. This is like --dry-run but different"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:181
-msgid "Display the session key used for one message"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:182
+#: share/completions/gpg.fish:304
 msgid "Don't use the public key but the specified session key"
-msgstr ""
+msgstr "Använd inte den öppna nyckel utan den angivna sessionsnyckeln"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:183
-#: /tmp/fish/implicit/share/completions/gpg.fish:185
-msgid "Prompt for an expiration time"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:184
-#: /tmp/fish/implicit/share/completions/gpg.fish:186
-msgid "Do not prompt for an expiration time"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:187
-msgid ""
-"Don't look at the key ID as stored in the message but try all secret keys in "
-"turn to find the right decryption key"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:188
-msgid ""
-"Enable a mode in which filenames of the form -&n, where n is a non-negative "
-"decimal number, refer to the file descriptor n and not to a file with that "
-"name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:189
+#: share/completions/gpg.fish:315
 msgid "Sets up a named group, which is similar to aliases in email programs"
-msgstr ""
+msgstr "Skapa en namngiven grupp, liknande alias i e-postprogram"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:190
-msgid "Remove a given entry from the --group list"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:191
-msgid "Remove all entries from the --group list"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:192
-msgid ""
-"Don't change the permissions of a secret keyring back to user read/write only"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gpg.fish:193
+#: share/completions/gpg.fish:321
 msgid "Set the list of personal cipher preferences to the specified string"
-msgstr ""
+msgstr "Sätt listan på personliga chifferpreferenser till den angivna strängen"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:194
+#: share/completions/gpg.fish:322
 msgid "Set the list of personal digest preferences to the specified string"
 msgstr ""
+"Sätt listan på personliga digestinställningar till den angivna strängen"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:195
+#: share/completions/gpg.fish:323
 msgid ""
 "Set the list of personal compression preferences to the specified string"
 msgstr ""
+"Sätt listan på personliga kompressionsinställningar till den angivna strängen"
 
-#: /tmp/fish/implicit/share/completions/gpg.fish:196
+#: share/completions/gpg.fish:324
 msgid "Set the list of default preferences to the specified string"
-msgstr ""
+msgstr "Sätt listan på standardinställningar till den angivna strängen"
 
 #: /tmp/fish/implicit/share/completions/gphoto2.fish:1
 msgid "Print complete help message on program usage"
@@ -28508,129 +27503,25 @@ msgstr ""
 msgid "Overwrite files without asking"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/gprof.fish:1
-msgid "Print annotated source"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:2
-msgid "Do not print explanations"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:3
-msgid "Print tally"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:4
-msgid "Display summary"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/gprof.fish:5
 msgid "Search directories for source"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:6
-msgid "No annotated source"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:7
-msgid "Print full path of source"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gprof.fish:8
 msgid "Print flat profile"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/gprof.fish:9
-msgid "No flat profile"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:10
-msgid "Print call graph"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:11
-msgid "No call graph"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:12
-msgid "Annotate to file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:13
-msgid "No tally"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:14
-msgid "Suggest function ordering"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:15
-msgid "Suggest file ordering"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:16
-msgid "Traditional mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:17
-msgid "Set width of output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:18
-msgid "Annotate every line"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:19
-msgid "Set demangling style"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:20
-msgid "Turn of demangling"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:21
-msgid "Supress static functions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:22
-msgid "Ignore symbols not known to be functions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:23
+#: share/completions/gprof.fish:24
 msgid "Delete arcs from callgraph"
-msgstr ""
+msgstr "Radera arker från anropsgraf"
 
-#: /tmp/fish/implicit/share/completions/gprof.fish:24
-msgid "Line by line profiling"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:25
+#: share/completions/gprof.fish:26
 msgid "Supress output when executed less than specified times"
-msgstr ""
+msgstr "Visa inte utdata för kod som exekverats färre gånger än angivet antal"
 
-#: /tmp/fish/implicit/share/completions/gprof.fish:26
-msgid "Only propagate times for matching symbols"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:27
-msgid "Do not propagate times for matching symbols"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:28
-msgid "Mention unused functions in flat profile"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:29
-msgid "Specify debugging options"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:32
+#: share/completions/gprof.fish:33
 msgid "Profile data format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gprof.fish:33
-msgid "Print summary"
-msgstr ""
+msgstr "Format för profileringsdata"
 
 #: /tmp/fish/implicit/share/completions/gradle.fish:2
 msgid "Don't rebuild dependencies"
@@ -28783,17 +27674,22 @@ msgstr ""
 msgid "Specify task to be excluded from execution"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/grep.fish:2
+#: share/functions/__fish_complete_grep.fish:3
 msgid "Process binary file as text"
-msgstr ""
+msgstr "Processa binär fil som text"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:5
+#: share/functions/__fish_complete_grep.fish:6
+#, fuzzy
 msgid "Print byte offset of matches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv bara ut angivet antal matchningar"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:6
+#: share/functions/__fish_complete_grep.fish:7
 msgid "Assume data type for binary files"
-msgstr ""
+msgstr "Antag följande datatyp för binära filer"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:7
 msgid "Colour output"
@@ -28805,138 +27701,173 @@ msgid "Color output"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/grep.fish:9
+#: share/functions/__fish_complete_grep.fish:10
+#, fuzzy
 msgid "Only print number of matches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv bara ut angivet antal matchningar"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:10
-msgid "Action for devices"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/grep.fish:11
-msgid "Action for directories"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/grep.fish:12
+#: share/functions/__fish_complete_grep.fish:13
 msgid "Pattern is extended regexp"
-msgstr ""
+msgstr "Mönster är ett förlängt reguljärt uttryck"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:13
+#: share/functions/__fish_complete_grep.fish:14
 msgid "Pattern is a regexp"
-msgstr ""
+msgstr "Mönster är ett reguljärt uttryck"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:14
+#: share/functions/__fish_complete_grep.fish:15
 msgid "Read pattern list from file. Skip files whose base name matches list"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/grep.fish:15
+#: share/functions/__fish_complete_grep.fish:16
+#, fuzzy
 msgid "Exclude matching directories from recursive searches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Sök i angivna kataloger efter källkod"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:16
+#: share/functions/__fish_complete_grep.fish:17
 msgid "Pattern is a fixed string"
-msgstr ""
+msgstr "Mönster är en fixsträng"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:17
 msgid "Use patterns from a file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/grep.fish:18
+#: share/functions/__fish_complete_grep.fish:19
 msgid "Pattern is basic regex"
-msgstr ""
+msgstr "Mönster är ett grundläggande reguljärt uttryck"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:19
+#: share/functions/__fish_complete_grep.fish:20
 msgid "Print filename"
-msgstr ""
+msgstr "Visa filnamn"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:20
+#: share/functions/__fish_complete_grep.fish:21
+#, fuzzy
 msgid "Suppress printing filename"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa inte filnamn"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:22
+#: share/functions/__fish_complete_grep.fish:23
 msgid "Skip binary files"
-msgstr ""
+msgstr "Skippa binära filer"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:24
+#: share/functions/__fish_complete_grep.fish:25
 msgid "Print first non-matching file"
-msgstr ""
+msgstr "Visa första icke-matchande fil"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:25
+#: share/functions/__fish_complete_grep.fish:26
 msgid "Print first matching file"
-msgstr ""
+msgstr "Visa första matchande fil"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:26
+#: share/functions/__fish_complete_grep.fish:27
 msgid "Stop reading after NUM matches"
-msgstr ""
+msgstr "Sluta läsa efter NUM matchningar"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:27
+#: share/functions/__fish_complete_grep.fish:28
 msgid "Use the mmap system call to read input"
-msgstr ""
+msgstr "Använd systemanroppet mmap för inläsning"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:28
+#: share/functions/__fish_complete_grep.fish:29
+#, fuzzy
 msgid "Print line number"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa radnummer"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:29
+#: share/functions/__fish_complete_grep.fish:30
 msgid "Show only matching part"
-msgstr ""
+msgstr "Visa bara matchande del"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:30
+#: share/functions/__fish_complete_grep.fish:31
 msgid "Rename stdin"
-msgstr ""
+msgstr "Byt namn på standard in"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:31
+#: share/functions/__fish_complete_grep.fish:32
 msgid "Use line buffering"
-msgstr ""
+msgstr "Använd radbuffring"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:32
+#: share/functions/__fish_complete_grep.fish:33
+#, fuzzy
 msgid "Pattern is a Perl regexp (PCRE) string"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Mönster är ett reguljärt uttryck"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:33
-#: /tmp/fish/implicit/share/completions/grep.fish:34
+#: share/functions/__fish_complete_grep.fish:34
+#: share/functions/__fish_complete_grep.fish:35
 msgid "Do not write anything"
-msgstr ""
+msgstr "Skriv ingenting"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:35
 #: /tmp/fish/implicit/share/completions/grep.fish:36
+#: share/functions/__fish_complete_grep.fish:36
+#: share/functions/__fish_complete_grep.fish:37
+#, fuzzy
 msgid "Read files under each directory, recursively"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Läs filer i varje katalog"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:37
+#: share/functions/__fish_complete_grep.fish:38
+#, fuzzy
 msgid "Search only files matching PATTERN"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Rekursera, sök i filer som matchar mönster"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:38
+#: share/functions/__fish_complete_grep.fish:39
+#, fuzzy
 msgid "Skip files matching PATTERN"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Rekursera, skippa filer som matchar mönster"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:39
+#: share/functions/__fish_complete_grep.fish:40
 msgid "Suppress error messages"
-msgstr ""
+msgstr "Visa inte felmeddelanden"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:40
+#: share/functions/__fish_complete_grep.fish:41
 msgid "Ensure first character of actual line content lies on a tab stop"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/grep.fish:41
+#: share/functions/__fish_complete_grep.fish:42
 msgid "Treat files as binary"
-msgstr ""
+msgstr "Behandla filer som om de vore binära"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:42
+#: share/functions/__fish_complete_grep.fish:43
 msgid "Report Unix-style byte offsets"
-msgstr ""
+msgstr "Visa Unix-typ av byteavstånd"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:44
+#: share/functions/__fish_complete_grep.fish:45
 msgid "Invert the sense of matching"
-msgstr ""
+msgstr "Invertera matchning"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:45
+#: share/functions/__fish_complete_grep.fish:46
 msgid "Only whole matching words"
-msgstr ""
+msgstr "Matcha bara hela ord"
 
-#: /tmp/fish/implicit/share/completions/grep.fish:46
+#: share/functions/__fish_complete_grep.fish:47
 msgid "Only whole matching lines"
-msgstr ""
+msgstr "Matcha bara hela rader"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:47
 msgid "Ignore case (deprecated: use -i instead)"
@@ -28946,9 +27877,9 @@ msgstr ""
 msgid "Treat input as a set of zero-terminated lines"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/grep.fish:49
+#: share/functions/__fish_complete_grep.fish:50
 msgid "Output a zero byte after filename"
-msgstr ""
+msgstr "Skriv en nollad byte efter filnamn"
 
 #: /tmp/fish/implicit/share/completions/groupadd.fish:1
 msgid "Exit with success status if the specified group already exists"
@@ -29273,35 +28204,14 @@ msgstr ""
 msgid "List keys and values, recursively"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/gunzip.fish:4
-#: /tmp/fish/implicit/share/completions/gzip.fish:4
-msgid "List compression information"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gunzip.fish:6
-#: /tmp/fish/implicit/share/completions/gzip.fish:6
-msgid "Do not save/restore filename"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gunzip.fish:7
-#: /tmp/fish/implicit/share/completions/gzip.fish:7
-msgid "Save/restore filename"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/gunzip.fish:9
 #: /tmp/fish/implicit/share/completions/gzip.fish:9
 msgid "Recurse directories"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/gunzip.fish:10
-#: /tmp/fish/implicit/share/completions/gzip.fish:10
+#: share/completions/gunzip.fish:15 share/completions/gzip.fish:17
 msgid "Suffix"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gunzip.fish:12
-#: /tmp/fish/implicit/share/completions/gzip.fish:12
-msgid "Display compression ratios"
-msgstr ""
+msgstr "Suffix"
 
 #: /tmp/fish/implicit/share/completions/gv.fish:1
 msgid "Display document using only black and white"
@@ -29481,14 +28391,6 @@ msgstr ""
 msgid "Show gv version and exit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/gzip.fish:14
-msgid "Use fast setting"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/gzip.fish:15
-msgid "Use high compression setting"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/helm.fish:1
 msgid "Enable verbose output"
 msgstr ""
@@ -29585,8 +28487,12 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/helm.fish:24
 #: /tmp/fish/implicit/share/completions/helm.fish:68
 #: /tmp/fish/implicit/share/completions/helm.fish:76
+#, fuzzy
 msgid "Revision"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Slå ihop revisioner"
 
 #: /tmp/fish/implicit/share/completions/helm.fish:25
 msgid "Dump all (computed) values"
@@ -29875,6 +28781,7 @@ msgid "Configurable greeting"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/help.fish:27
+#: share/completions/help.fish:12
 msgid "Help on how to reuse previously entered commands"
 msgstr ""
 
@@ -29939,6 +28846,7 @@ msgid "Shared bindings"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/help.fish:43
+#: share/completions/help.fish:9
 msgid "Introduction to the fish syntax"
 msgstr ""
 
@@ -31730,8 +30638,12 @@ msgid "use IPv6 in addition to IPv4"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/hg.fish:480
+#, fuzzy
 msgid "SSL certificate file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj certifikatpolicy"
 
 #: /tmp/fish/implicit/share/completions/hg.fish:482
 msgid "show status of all files"
@@ -31863,11 +30775,6 @@ msgstr ""
 msgid "Highlight style"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/htop.fish:1
-#: /tmp/fish/implicit/share/completions/top.fish:3
-msgid "Update interval"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/htop.fish:2
 #: /tmp/fish/implicit/share/completions/htop.fish:3
 msgid "Start htop in monochrome mode"
@@ -31879,8 +30786,13 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/pv.fish:32
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:41
 #: /tmp/fish/implicit/share/completions/subl.fish:8
+#: share/completions/perl.fish:27
+#, fuzzy
 msgid "Show help and exit"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa hjälp och avsluta"
 
 #: /tmp/fish/implicit/share/completions/htop.fish:5
 msgid "Show only given PIDs"
@@ -32394,12 +31306,12 @@ msgid "Convert to specified encoding"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/iconv.fish:3
+#, fuzzy
 msgid "List known coded character sets"
 msgstr ""
-
-#: /tmp/fish/implicit/share/completions/iconv.fish:4
-msgid "Output file"
-msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj den interna teckenuppsättningen"
 
 #: /tmp/fish/implicit/share/completions/iconv.fish:5
 msgid "Print progress information"
@@ -32431,24 +31343,8 @@ msgstr ""
 msgid "Replace each pixel with its complementary color"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/id.fish:1
-msgid "Print effective group id"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/id.fish:2
-msgid "Print all group ids"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/id.fish:3
 msgid "Print name, not number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/id.fish:4
-msgid "Print real ID, not effective"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/id.fish:5
-msgid "Print effective user ID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/iex.fish:15
@@ -32461,19 +31357,18 @@ msgid ""
 "no file will be loaded"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ifconfig.fish:1
+#: share/completions/ifconfig.fish:1
 msgid "Stop interface"
-msgstr ""
+msgstr "Stanna gränssnitt"
 
-#: /tmp/fish/implicit/share/completions/ifconfig.fish:2
+#: share/completions/ifconfig.fish:2
 msgid "Start interface"
-msgstr ""
+msgstr "Starta gränssnitt"
 
-#: /tmp/fish/implicit/share/completions/ifconfig.fish:3
-#: /tmp/fish/implicit/share/completions/ifdown.fish:1
-#: /tmp/fish/implicit/share/completions/ifup.fish:1
+#: share/completions/ifconfig.fish:25 share/completions/ifdown.fish:1
+#: share/completions/ifup.fish:1
 msgid "Network interface"
-msgstr ""
+msgstr "Nätverkgränssnitt"
 
 #: /tmp/fish/implicit/share/completions/ifdata.fish:1
 msgid "Reports interface existence via return code"
@@ -33322,18 +32217,6 @@ msgstr ""
 msgid "Show the process id of each process in the job"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/jobs.fish:3
-msgid "Show group id of job"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/jobs.fish:4
-msgid "Show commandname of each job"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/jobs.fish:5
-msgid "Only show status for last job to be started"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/journalctl.fish:1
 msgid "Journal field"
 msgstr ""
@@ -33735,8 +32618,13 @@ msgid "Do not skip zombies"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/kitchen.fish:1
+#: share/completions/kitchen.fish:3
+#, fuzzy
 msgid "Test if kitchen has yet to be given the main command"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/kitchen.fish:2
 #: /tmp/fish/implicit/share/completions/kitchen.fish:3
@@ -34132,73 +33020,9 @@ msgstr ""
 msgid "Apply the given task with the profile(s) specified."
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/less.fish:2
-msgid "Search after end of screen"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:3
+#: share/completions/less.fish:3
 msgid "Buffer space"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:4
-msgid "Disable automtic buffer allocation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:5
-msgid "Repaint from top"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:6
-msgid "Clear and repaint from top"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:7
-msgid "Supress error for lacking terminal capability"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:8
-msgid "Exit on second EOF"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:9
-msgid "Exit on EOF"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:10
-msgid "Open non-regular files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:11
-msgid "Quit if file shorter than one screen"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:12
-msgid "Hilight one search target"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:13
-msgid "No search highlighting"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:14
-msgid "Maximum backward scroll"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:15
-msgid "Search ignores lowercase case"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:16
-msgid "Search ignores all case"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:17
-msgid "Target line"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:18
-msgid "Display status column"
-msgstr ""
+msgstr "Buffert-utrymme"
 
 #: /tmp/fish/implicit/share/completions/less.fish:19
 msgid "Specify key bindings file"
@@ -34208,114 +33032,8 @@ msgstr ""
 msgid "Prompt with percentage"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/less.fish:22
-msgid "Verbose prompt"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:23
-msgid "Display line number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:24
-msgid "Display line number for each line"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:25
-msgid "Log input to file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:26
-msgid "Log to file, overwrite"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:27
-msgid "Start at first occurrence of pattern"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:28
-msgid "Prompt string"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:29
-#: /tmp/fish/implicit/share/completions/less.fish:30
-msgid "Silent mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:31
-#: /tmp/fish/implicit/share/completions/less.fish:32
-msgid "Completly silent mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:33
-msgid "Display control chars"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:34
-msgid "Display control chars, guess screen appearance"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:35
-msgid "Multiple blank lines sqeezed"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/less.fish:36
 msgid "Do not fold long lines"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:37
-msgid "Edit tag"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:38
-msgid "Set tag file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:39
-msgid "Allow backspace and carriage return"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:40
-msgid "Allow backspace, tab and carriage return"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:42
-msgid "Highlight first unread line on new page"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:43
-msgid "Highlight first unread line on any movement"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:44
-msgid "Set tab stops"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:45
-msgid "No termcap init"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:46
-msgid "No keypad init"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:47
-msgid "Maximum forward scroll"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:48
-msgid "Max scroll window"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:49
-msgid "Set quote char"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:50
-msgid "Lines after EOF are blank"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/less.fish:51
-msgid "Characters to scroll on left/right arrows"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/light.fish:3
@@ -34958,239 +33676,198 @@ msgstr ""
 msgid "Print hexadecimal masks rather thans lists of CPUs"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ls.fish:1
+#: share/functions/__fish_complete_ls.fish:32
 msgid "List by columns"
-msgstr ""
+msgstr "Visa kolumnvis"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:2
+#: share/functions/__fish_complete_ls.fish:33
 msgid "Sort by size"
-msgstr ""
+msgstr "Sortera på storlek"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:3
+#: share/functions/__fish_complete_ls.fish:34
 msgid "Show and sort by ctime"
-msgstr ""
+msgstr "Visa och sortera på skapelsetidpunkt"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:4
+#: share/functions/__fish_complete_ls.fish:35
 msgid "Don't sort"
-msgstr ""
+msgstr "Sortera ej filer"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:5
+#: share/functions/__fish_complete_ls.fish:36
 msgid "Long format without owner"
-msgstr ""
+msgstr "Långt format utan ägare"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:6
+#: share/functions/__fish_complete_ls.fish:37
 msgid "Set blocksize to 1kB"
-msgstr ""
+msgstr "Välj blockstorlek 1kB"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:7
-#: /tmp/fish/implicit/share/completions/ps.fish:22
+#: share/functions/__fish_complete_ls.fish:38
 msgid "Long format"
-msgstr ""
+msgstr "Långt format"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:8
+#: share/functions/__fish_complete_ls.fish:39
 msgid "Comma separated format"
-msgstr ""
+msgstr "Kommaseparerat format"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:9
+#: share/functions/__fish_complete_ls.fish:40
 msgid "Sort by modification time"
-msgstr ""
+msgstr "Sortera på ändringstid"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:10
+#: share/functions/__fish_complete_ls.fish:41
 msgid "Show access time"
-msgstr ""
+msgstr "Visa senaste åtkomsttid"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:11
+#: share/functions/__fish_complete_ls.fish:42
 msgid "List entries by lines"
-msgstr ""
+msgstr "Visa radvis"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:12
+#: share/functions/__fish_complete_ls.fish:43
 msgid "List one file per line"
-msgstr ""
+msgstr "Visa en fil per rad"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:13
-#: /tmp/fish/implicit/share/completions/ls.fish:68
+#: share/functions/__fish_complete_ls.fish:16
 msgid "Show hidden"
-msgstr ""
+msgstr "Visa dolda filer"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:14
-#: /tmp/fish/implicit/share/completions/ls.fish:69
+#: share/functions/__fish_complete_ls.fish:17
 msgid "Show hidden except . and .."
-msgstr ""
+msgstr "Visa dolda filer utom . och .."
 
-#: /tmp/fish/implicit/share/completions/ls.fish:15
-#: /tmp/fish/implicit/share/completions/ls.fish:24
-#: /tmp/fish/implicit/share/completions/ls.fish:42
-#: /tmp/fish/implicit/share/completions/ls.fish:70
-#: /tmp/fish/implicit/share/completions/ls.fish:79
+#: share/functions/__fish_complete_ls.fish:18
+#: share/functions/__fish_complete_ls.fish:27
 msgid "Append filetype indicator"
-msgstr ""
+msgstr "Lägg till filtypsindikator"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:18
-#: /tmp/fish/implicit/share/completions/ls.fish:73
+#: share/functions/__fish_complete_ls.fish:21
 msgid "List subdirectory recursively"
-msgstr ""
+msgstr "Visa underkataloger rekursivt"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:19
-#: /tmp/fish/implicit/share/completions/ls.fish:59
-#: /tmp/fish/implicit/share/completions/ls.fish:74
+#: share/functions/__fish_complete_ls.fish:22
+#: share/functions/__fish_complete_ls.fish:102
 msgid "Octal escapes for non graphic characters"
-msgstr ""
+msgstr "Använd oktala specialsekvenser för ickegrafiska tecken"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:20
-#: /tmp/fish/implicit/share/completions/ls.fish:75
+#: share/functions/__fish_complete_ls.fish:23
 msgid "List directories, not their content"
-msgstr ""
+msgstr "Visa kataloger, inte deras innehåll"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:22
-#: /tmp/fish/implicit/share/completions/ls.fish:77
+#: share/functions/__fish_complete_ls.fish:25
 msgid "Print inode number of files"
-msgstr ""
+msgstr "Visa inod för filer"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:23
-#: /tmp/fish/implicit/share/completions/ls.fish:78
+#: share/functions/__fish_complete_ls.fish:26
 msgid "Long format, numeric IDs"
-msgstr ""
+msgstr "Långt format, numeriska IDn"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:25
-#: /tmp/fish/implicit/share/completions/ls.fish:80
+#: share/functions/__fish_complete_ls.fish:28
 msgid "Replace non-graphic characters with '?'"
-msgstr ""
+msgstr "Ersätt ickegrafiska tecken med '?'"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:27
-#: /tmp/fish/implicit/share/completions/ls.fish:82
+#: share/functions/__fish_complete_ls.fish:30
 msgid "Print size of files"
-msgstr ""
+msgstr "Visa filstorlek"
 
 #: /tmp/fish/implicit/share/completions/ls.fish:28
 msgid "Group directories before files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ls.fish:29
+#: share/functions/__fish_complete_ls.fish:49
 msgid "Do not list implied entries matching specified shell pattern"
-msgstr ""
+msgstr "Visa inte filer som matchar mönster"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:30
+#: share/functions/__fish_complete_ls.fish:50
 msgid "Display security context"
-msgstr ""
+msgstr "Visa säkerhetskontext"
 
 #: /tmp/fish/implicit/share/completions/ls.fish:31
+#: share/functions/__fish_complete_ls.fish:51
 msgid "Display  security  context  so  it fits on most displays"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/ls.fish:32
+#: share/functions/__fish_complete_ls.fish:52
 msgid "Display only security context and file name"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ls.fish:33
+#: share/functions/__fish_complete_ls.fish:54
 msgid "Print author"
-msgstr ""
+msgstr "Visa författare"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:34
-#: /tmp/fish/implicit/share/completions/xz.fish:19
-msgid "Set block size"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ls.fish:35
+#: share/functions/__fish_complete_ls.fish:56
 msgid "Ignore files ending with ~"
-msgstr ""
+msgstr "Ignorera filer som slutar på ~"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:36
-#: /tmp/fish/implicit/share/completions/ls.fish:60
+#: share/functions/__fish_complete_ls.fish:103
 msgid "Use colors"
-msgstr ""
+msgstr "Använd färger"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:37
+#: share/functions/__fish_complete_ls.fish:58
 msgid "Generate dired output"
-msgstr ""
+msgstr "Generera utdata för dired"
 
 #: /tmp/fish/implicit/share/completions/ls.fish:38
 msgid "List format"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ls.fish:39
+#: share/functions/__fish_complete_ls.fish:60
 msgid "Long format, full-iso time"
-msgstr ""
+msgstr "Långt format, full-iso-tid"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:40
+#: share/functions/__fish_complete_ls.fish:61
 msgid "Don't print group information"
-msgstr ""
+msgstr "Visa inte information om grupp"
 
 #: /tmp/fish/implicit/share/completions/ls.fish:43
 msgid "Skip entries matching pattern"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ls.fish:44
-#: /tmp/fish/implicit/share/completions/ls.fish:67
+#: share/functions/__fish_complete_ls.fish:66
+#: share/functions/__fish_complete_ls.fish:110
 msgid "Print raw entry names"
-msgstr ""
+msgstr "Skriv obehandlade filnamn"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:45
+#: share/functions/__fish_complete_ls.fish:67
 msgid "Long format without groups"
-msgstr ""
+msgstr "Långt fromat utan grupper"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:46
+#: share/functions/__fish_complete_ls.fish:68
 msgid "Non graphic as-is"
-msgstr ""
+msgstr "Ersätt inte icke-grafiska tecken"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:47
+#: share/functions/__fish_complete_ls.fish:69
 msgid "Enclose entry in quotes"
-msgstr ""
+msgstr "Omgärda namn med citattecken"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:48
-msgid "Select quoting style"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ls.fish:49
-msgid "Sort criteria"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ls.fish:50
-msgid "Show time type"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ls.fish:51
-msgid "Select time style"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ls.fish:52
-msgid "Assume tab stops at each COLS"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ls.fish:53
+#: share/functions/__fish_complete_ls.fish:91
 msgid "Do not sort"
-msgstr ""
+msgstr "Sortera ej filer"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:54
+#: share/functions/__fish_complete_ls.fish:92
 msgid "Sort by version"
-msgstr ""
+msgstr "Sortera på version"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:55
-msgid "Assume screen width"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ls.fish:56
+#: share/functions/__fish_complete_ls.fish:94
 msgid "Sort by extension"
-msgstr ""
+msgstr "Sortera på filändelse"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:61
+#: share/functions/__fish_complete_ls.fish:104
 msgid "Prevent -A from being automatically set for root"
-msgstr ""
+msgstr "Hindra -A från att automatiskt sättas för root"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:63
+#: share/functions/__fish_complete_ls.fish:106
 msgid "Show modification time"
-msgstr ""
+msgstr "Visa ändringstid"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:64
+#: share/functions/__fish_complete_ls.fish:107
 msgid "Show whiteouts when scanning directories"
-msgstr ""
+msgstr "Visa korrigeringstecken vid katalogskanning"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:65
+#: share/functions/__fish_complete_ls.fish:108
 msgid "Display each file's MAC label"
-msgstr ""
+msgstr "Visa varje file MAC-etikett"
 
-#: /tmp/fish/implicit/share/completions/ls.fish:66
+#: share/functions/__fish_complete_ls.fish:109
 msgid "Include the file flags in a long (-l) output"
-msgstr ""
+msgstr "Visa filflaggor vid långt (-l) formay"
 
 #: /tmp/fish/implicit/share/completions/lsof.fish:2
 msgid "Causes list selections to be ANDed"
@@ -35253,6 +33930,7 @@ msgid "Increase verbosity (show descriptors)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/lsusb.fish:2
+#: share/completions/lsusb.fish:2
 msgid "Show only devices with specified device and/or bus numbers (in decimal)"
 msgstr ""
 
@@ -35856,119 +34534,73 @@ msgstr ""
 msgid "Don't ask any interactive question"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:1
+#: share/completions/makedepend.fish:1
 msgid "Define"
-msgstr ""
+msgstr "Definering"
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:2
+#: share/completions/makedepend.fish:2
 msgid "Include directory"
-msgstr ""
+msgstr "Inkluderingskatalog"
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:3
+#: share/completions/makedepend.fish:3
 msgid "Replace include directories"
-msgstr ""
+msgstr "Ersätt inkluderingskataloger"
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:4
-msgid "Append dependencies to makefile"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/makedepend.fish:5
+#: share/completions/makedepend.fish:5
 msgid "Specify makefile"
-msgstr ""
+msgstr "Ange makefil"
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:6
+#: share/completions/makedepend.fish:6
 msgid "Prepend file to input"
-msgstr ""
+msgstr "Lägg till fil före indata"
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:7
+#: share/completions/makedepend.fish:7
 msgid "Object file suffix"
-msgstr ""
+msgstr "Objektfilsuffix"
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:8
+#: share/completions/makedepend.fish:8
 msgid "Object file prefix"
-msgstr ""
+msgstr "Objektfilprefix"
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:9
+#: share/completions/makedepend.fish:9
 msgid "Starting string delimiter"
-msgstr ""
+msgstr "Avdelare för start av sträng"
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:10
+#: share/completions/makedepend.fish:10
 msgid "Line width"
-msgstr ""
+msgstr "Radbredd"
 
-#: /tmp/fish/implicit/share/completions/makedepend.fish:12
-msgid "Warn about multiple inclusion"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:1
+#: share/completions/make.fish:12
 msgid "Target"
-msgstr ""
+msgstr "Mål"
 
-#: /tmp/fish/implicit/share/completions/make.fish:2
+#: share/completions/make.fish:13
 msgid "Use file as makefile"
-msgstr ""
+msgstr "Använd som make-fil"
 
-#: /tmp/fish/implicit/share/completions/make.fish:3
-#: /tmp/fish/implicit/share/completions/tar.fish:15
-#: /tmp/fish/implicit/share/functions/cd.fish:1
+#: share/completions/tar.fish:19 share/functions/cd.fish:5
 msgid "Change directory"
-msgstr ""
+msgstr "Ändra katalog"
 
-#: /tmp/fish/implicit/share/completions/make.fish:5
-msgid "Environment before makefile"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:7
+#: share/completions/make.fish:18
 msgid "Search directory for makefile"
-msgstr ""
+msgstr "Sökkatalog för make-fil"
 
-#: /tmp/fish/implicit/share/completions/make.fish:8
+#: share/completions/make.fish:19
 msgid "Number of concurrent jobs"
-msgstr ""
+msgstr "Antal simultana jobb"
 
-#: /tmp/fish/implicit/share/completions/make.fish:9
-msgid "Continue after an error"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:10
-msgid "Start when load drops"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:11
-msgid "Do not execute commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:12
+#: share/completions/make.fish:23
 msgid "Ignore specified file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:13
-msgid "Print database"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:14
-msgid "Question mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:15
-msgid "Eliminate implicit rules"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:17
-msgid "Don't continue after an error"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/make.fish:18
-msgid "Touch files, don't run commands"
-msgstr ""
+msgstr "Ignorera angiven fil"
 
 #: /tmp/fish/implicit/share/completions/make.fish:20
 msgid "Print working directory"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/make.fish:21
+#: share/completions/make.fish:32
 msgid "Pretend file is modified"
-msgstr ""
+msgstr "Låtsas att fil modifierats"
 
 #: /tmp/fish/implicit/share/completions/makepkg.fish:1
 msgid "Ignore missing or incomplete arch field"
@@ -36122,117 +34754,12 @@ msgstr ""
 msgid "Print SRCINFO to stdout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/man.fish:1
-msgid "Program section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:2
-msgid "Syscall section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:3
-msgid "Library section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:4
-msgid "Device section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:5
-msgid "File format section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:6
-msgid "Games section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:7
-msgid "Misc section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:8
-msgid "Admin section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:9
-msgid "Kernel section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:10
-msgid "Tcl section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:11
-msgid "New section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:12
-msgid "Local section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:13
-msgid "Old section"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:15
-msgid "Manpath"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:16
-msgid "Pager"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/man.fish:17
 msgid "Manual sections"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/man.fish:18
 msgid "Display all matches"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:19
-msgid "Always reformat"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:20
-msgid "Debug"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:21
-msgid "Debug and run"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:22
-msgid "Show whatis information"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:23
-msgid "Format only"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:25
-msgid "Show apropos information"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:26
-msgid "Search in all man pages"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:27
-msgid "Set system"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:28
-msgid "Preprocessors"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:29
-msgid "Format for printing"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/man.fish:30
-#: /tmp/fish/implicit/share/completions/man.fish:31
-msgid "Only print locations"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mc.fish:1
@@ -36390,6 +34917,7 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/mdadm.fish:11
 #: /tmp/fish/implicit/share/completions/obnam.fish:47
 #: /tmp/fish/implicit/share/completions/xrandr.fish:1
+#: share/completions/obnam.fish:52
 msgid "Be more verbose"
 msgstr ""
 
@@ -38006,73 +36534,12 @@ msgstr ""
 msgid "Use DIR as filesystem root for /lib/modules"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/modprobe.fish:1
-msgid "Print messages about what the program is doing"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:3
-msgid "Dump configuration file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:4
-msgid "Do not actually insert/remove module"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:5
-#: /tmp/fish/implicit/share/completions/modprobe.fish:6
-msgid "Ignore install and remove commands in configuration file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:7
-msgid "Ignore bogus module names"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:8
-msgid "Remove modules"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:10
-msgid "Ignore all version information"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/modprobe.fish:11
 msgid "Ignore version magic information"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/modprobe.fish:12
-msgid "Ignore module interface version"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/modprobe.fish:13
 msgid "List all modules matching the given wildcard"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:14
-msgid "Insert modules matching the given wildcard"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:15
-msgid "Restrict wildcards to specified directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:16
-msgid "Send error messages through syslog"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:17
-msgid "Specify kernel version"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:18
-msgid "List dependencies of module"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:19
-msgid "Rename module"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/modprobe.fish:20
-msgid "Fail if inserting already loaded module"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mogrify.fish:35
@@ -38198,6 +36665,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mosh.fish:5
+#: share/completions/mosh.fish:20
 msgid "Controls use of speculative local echo"
 msgstr ""
 
@@ -38217,22 +36685,6 @@ msgstr ""
 msgid "Mount file systems in fstab"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/mount.fish:5
-msgid "Fork process for each mount"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mount.fish:6
-msgid "Fake mounting"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mount.fish:7
-msgid "Add label to output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mount.fish:8
-msgid "Do not write mtab"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/mount.fish:9
 msgid "Tolerate sloppy mount options"
 msgstr ""
@@ -38245,188 +36697,144 @@ msgstr ""
 msgid "Read/Write mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/mount.fish:12
+#: share/completions/mount.fish:19
 msgid "Mount partition with specified label"
-msgstr ""
+msgstr "Montera partitioner med angiven etikett"
 
-#: /tmp/fish/implicit/share/completions/mount.fish:13
+#: share/completions/mount.fish:20
 msgid "Mount partition with specified UID"
-msgstr ""
+msgstr "Montera partition med angivet UID"
 
 #: /tmp/fish/implicit/share/completions/mount.fish:14
+#: share/completions/mount.fish:21
+#, fuzzy
 msgid "Exclude file systems"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Exkludera filsystem"
 
-#: /tmp/fish/implicit/share/completions/mount.fish:15
+#: share/completions/mount.fish:22
 msgid "Remount a subtree to a second position"
-msgstr ""
+msgstr "Montera om ett subträd till en andra plats"
 
-#: /tmp/fish/implicit/share/completions/mount.fish:16
+#: share/completions/mount.fish:23
 msgid "Move a subtree to a new position"
-msgstr ""
+msgstr "Flytta ett subträd till en ny plats"
 
 #: /tmp/fish/implicit/share/completions/mount.fish:17
+#: share/completions/mount.fish:24
+#, fuzzy
 msgid "File system"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Filsystem"
 
-#: /tmp/fish/implicit/share/completions/mount.fish:18
+#: share/completions/mount.fish:26
 msgid "Mount option"
-msgstr ""
+msgstr "Monteringsflagga"
 
-#: /tmp/fish/implicit/share/completions/mplayer.fish:1
-msgid "Dynamically change postprocessing"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:2
+#: share/completions/mplayer.fish:28
 msgid "A/V sync speed"
-msgstr ""
+msgstr "Ljud/bild synkroniseringshastighet"
 
-#: /tmp/fish/implicit/share/completions/mplayer.fish:3
-#: /tmp/fish/implicit/share/completions/mplayer.fish:5
-msgid "Skip frames to maintain A/V sync"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:6
+#: share/completions/mplayer.fish:32
 msgid "Loop playback"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:9
-msgid "Full screen"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:10
-msgid "Set playlist"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:11
-msgid "Audio language"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:12
-msgid "Play audio from file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:13
-msgid "Set default CD-ROM drive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:14
-msgid "Set number of audio channels"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:15
-msgid "Set start chapter"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:16
-msgid "Set default DVD-ROM drive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:17
-msgid "Set dvd viewing angle"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:18
-msgid "Force rebuilding index"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:19
-msgid "Override framerate"
-msgstr ""
+msgstr "Upprepa uppspelning"
 
 #: /tmp/fish/implicit/share/completions/mplayer.fish:20
 msgid "Build index if unavailable"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/mplayer.fish:21
-msgid "Load index from file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:22
-msgid "Force non-interleaved AVI parser"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:23
-msgid "Rebuild index and save to file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:24
-msgid "Seek to given time position"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:25
-msgid "TV capture mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:26
-msgid "Subtitle language"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:27
-msgid "Subtitle file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:28
-msgid "Handle subtitlefile as unicode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:29
-msgid "Handle subtitlefile as utf8"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mplayer.fish:30
-#: /tmp/fish/implicit/share/completions/mplayer.fish:33
+#: share/completions/mplayer.fish:58 share/completions/mplayer.fish:76
 msgid "Video output"
-msgstr ""
+msgstr "Bildutdata"
 
-#: /tmp/fish/implicit/share/completions/mplayer.fish:31
-#: /tmp/fish/implicit/share/completions/mplayer.fish:32
+#: share/completions/mplayer.fish:64 share/completions/mplayer.fish:70
 msgid "Audio output"
-msgstr ""
+msgstr "Ljudutdata"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:1
 msgid "Add specified directory to list for input files search"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:2
+#: share/completions/msgfmt.fish:5
+#, fuzzy
 msgid "Generate a Java ResourceBundle class"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Generera källindexfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:3
+#: share/completions/msgfmt.fish:6
 msgid "Like --java, and assume Java2 (JDK 1.2 or higher)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:4
+#: share/completions/msgfmt.fish:7
+#, fuzzy
 msgid "Generate a .NET .dll file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Generera huvudfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:5
+#: share/completions/msgfmt.fish:8
+#, fuzzy
 msgid "Generate a .NET .resources file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Generera källindexfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:6
+#: share/completions/msgfmt.fish:9
+#, fuzzy
 msgid "Generate a tcl/msgcat .msg file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Generera huvudfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:7
+#: share/completions/msgfmt.fish:10
+#, fuzzy
 msgid "Generate a Qt .qm file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Generera huvudfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:9
 msgid "Enable strict Uniforum mode"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:10
+#: share/completions/msgfmt.fish:17
+#, fuzzy
 msgid "Resource name"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj volymnamn"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:11
+#: share/completions/msgfmt.fish:18
 msgid "Locale name, either language or language_COUNTRY"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:12
+#: share/completions/msgfmt.fish:19
+#, fuzzy
 msgid "Base directory for output"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Filidentifierare för indata"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:13
 msgid "Input files are in Java .properties syntax"
@@ -38485,11 +36893,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:1
 #: /tmp/fish/implicit/share/completions/mutt.fish:16
+#: share/completions/mutt.fish:21
 msgid "Specify a carbon-copy (CC) recipient"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:2
 #: /tmp/fish/implicit/share/completions/mutt.fish:15
+#: share/completions/mutt.fish:20
 msgid "Specify a blind-carbon-copy (BCC) recipient"
 msgstr ""
 
@@ -38530,72 +36940,82 @@ msgid "Open the first mailbox which contains new mail"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:13
+#: share/completions/mutt.fish:18
 msgid "An expanded version of the given alias is passed to stdout"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:14
+#: share/completions/mutt.fish:19
 msgid "Attach a file to your message using MIME"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:17
+#: share/completions/mutt.fish:22
 msgid "Run command after processing of initialization files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:18
+#: share/completions/mutt.fish:23
+#, fuzzy
 msgid "Specify which mailbox to load"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange sendmailkommando"
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:19
+#: share/completions/mutt.fish:24
+#, fuzzy
 msgid "Specify an initialization file to read instead of ~/.muttrc"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange logmeddelande istället för att anropa editor"
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:20
+#: share/completions/mutt.fish:25
 msgid "Specify a draft file containing header and body for the message"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:21
+#: share/completions/mutt.fish:26
 msgid "Specify a file to include into the body of a message"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:22
+#: share/completions/mutt.fish:27
+#, fuzzy
 msgid "Specify a default mailbox type"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj kärnversion"
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:23
+#: share/completions/mutt.fish:28
+#, fuzzy
 msgid "Query a configuration variables value"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj en konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:24
+#: share/completions/mutt.fish:29
+#, fuzzy
 msgid "Specify the subject of the message"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange meddelande för tillägg"
 
-#: /tmp/fish/implicit/share/completions/mv.fish:1
-msgid "Make backup of each existing destination file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mv.fish:2
-msgid "Do not prompt before overwriting"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mv.fish:4
+#: share/completions/mv.fish:4
 msgid "Answer for overwrite questions"
-msgstr ""
+msgstr "Svar till överskrivningsfrågor"
 
-#: /tmp/fish/implicit/share/completions/mv.fish:5
-msgid "Remove trailing slashes from source"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mv.fish:6
+#: share/completions/cp.fish:11 share/completions/mv.fish:6
 msgid "Backup suffix"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mv.fish:7
-msgid "Target directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/mv.fish:8
-msgid "Do not overwrite newer files"
-msgstr ""
+msgstr "Backup-ändelse"
 
 #: /tmp/fish/implicit/share/completions/mvn.fish:1
 msgid "If project list is specified, also build projects required by the list"
@@ -42845,11 +41265,6 @@ msgstr ""
 msgid "Open the specified profile in an editor"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/nextd.fish:1
-#: /tmp/fish/implicit/share/completions/prevd.fish:1
-msgid "Also print directory history"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/nice.fish:2
 msgid "Add specified amount to niceness value"
 msgstr ""
@@ -43069,16 +41484,31 @@ msgid "Display this program's version number"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/node.fish:1
+#: share/completions/node.fish:9
+#, fuzzy
 msgid "Print node's version"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa kärnversion"
 
 #: /tmp/fish/implicit/share/completions/node.fish:2
+#: share/completions/node.fish:10
+#, fuzzy
 msgid "Evaluate script"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Extrahera skript"
 
 #: /tmp/fish/implicit/share/completions/node.fish:3
+#: share/completions/node.fish:11
+#, fuzzy
 msgid "Print result of --eval"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa platt profil"
 
 #: /tmp/fish/implicit/share/completions/node.fish:4
 msgid "Always enter the REPL even if stdin does not appear to be a terminal"
@@ -44485,10 +42915,12 @@ msgid "Verify that live data and backed up data match"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:26
+#: share/completions/obnam.fish:30
 msgid "Restore setuid/setgid bits in restored files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:27
+#: share/completions/obnam.fish:31
 msgid "Do not restore setuid/setgid bits in restored files"
 msgstr ""
 
@@ -44497,42 +42929,72 @@ msgid "Use CHECKSUM algorithm"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:29
+#: share/completions/obnam.fish:32
+#, fuzzy
 msgid "Name of client"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"NAmn på version at använda som kontrollpunkt"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:30
+#: share/completions/obnam.fish:33
+#, fuzzy
 msgid "Compress repository with"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Komprimera till standard ut"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:31
+#: share/completions/obnam.fish:34
 msgid "For --nagios-last-backup-age: maximum age"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:32
+#: share/completions/obnam.fish:35
 msgid "Dump metadata about files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:33
+#: share/completions/obnam.fish:36
+#, fuzzy
 msgid "Do not dump metadata about files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera inte byggda filer"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:34
+#: share/completions/obnam.fish:37
+#, fuzzy
 msgid "Generate man page"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Generera ett nytt nyckelpar"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:35
+#: share/completions/obnam.fish:38
 msgid "Which generation to restore"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:36
+#: share/completions/obnam.fish:39
+#, fuzzy
 msgid "Show this help message and exit"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:37
+#: share/completions/obnam.fish:40
 msgid "Policy for what generations to keep when forgetting."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:38
+#: share/completions/obnam.fish:41
 msgid "Wait TIMEOUT seconds for an existing lock"
 msgstr ""
 
@@ -44541,18 +43003,30 @@ msgid "Write output to FILE instead of STDOUT"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:40
+#: share/completions/obnam.fish:43
+#, fuzzy
 msgid "Do not actually change anything"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv ingenting"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:41
+#: share/completions/obnam.fish:44
+#, fuzzy
 msgid "Actually commit changes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Summera ändringar"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:42
+#: share/completions/obnam.fish:45
 msgid "Show only errors, no progress updates"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:43
+#: share/completions/obnam.fish:46
 msgid "Show errors and progress updates"
 msgstr ""
 
@@ -44569,41 +43043,68 @@ msgid "Where to restore / mount to"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:48
+#: share/completions/obnam.fish:53
+#, fuzzy
 msgid "Do not be verbose"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv inte över"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:49
+#: share/completions/obnam.fish:54
 msgid "Verify N files randomly from the backup"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:50
 #: /tmp/fish/implicit/share/completions/transmission-remote.fish:72
+#: share/completions/obnam.fish:55
+#, fuzzy
 msgid "Show version number and exit"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:51
 msgid "For nagios-last-backup-age: maximum age"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:52
+#: share/completions/obnam.fish:57
 msgid "Make a checkpoint after a given SIZE"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:53
+#: share/completions/obnam.fish:58
+#, fuzzy
 msgid "Deduplicate mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Läs ock skrivbart läge"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:54
 msgid "REGEXP for pathnames to exclude"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:55
+#: share/completions/obnam.fish:60
+#, fuzzy
 msgid "Exclude directories tagged as cache"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Sök i angivna kataloger efter källkod"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:56
+#: share/completions/obnam.fish:61
+#, fuzzy
 msgid "Include directories tagged as cache"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Inkluderingskatalog"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:57
 #: /tmp/fish/implicit/share/completions/rsync.fish:77
@@ -44615,30 +43116,44 @@ msgid "REGEXP for pathnames to include, even if matches --exclude"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:59
+#: share/completions/obnam.fish:63
 msgid "Leave checkpoint generations at the end of backup"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:60
+#: share/completions/obnam.fish:64
 msgid "Omit checkpoint generations at the end of backup"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:61
+#: share/completions/obnam.fish:65
+#, fuzzy
 msgid "Do not follow mount points"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radbryt inte långa rader"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:62
+#: share/completions/obnam.fish:66
+#, fuzzy
 msgid "Follow mount points"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Monteringskatalog"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:63
 msgid "What to backup"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:64
+#: share/completions/obnam.fish:67
 msgid "Put small files directly into the B-tree"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:65
+#: share/completions/obnam.fish:68
 msgid "No not put small files into the B-tree"
 msgstr ""
 
@@ -44647,24 +43162,49 @@ msgid "Add FILE to config files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:67
+#: share/completions/obnam.fish:70
+#, fuzzy
 msgid "Write out the current configuration"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ladda om konfiguration för tjänst"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:68
+#: share/completions/obnam.fish:71
+#, fuzzy
 msgid "Write out setting names"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv prompten"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:69
+#: share/completions/obnam.fish:72
+#, fuzzy
 msgid "Show all options"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa hjälp om flaggor"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:70
+#: share/completions/obnam.fish:73
+#, fuzzy
 msgid "List config files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:71
+#: share/completions/obnam.fish:74
+#, fuzzy
 msgid "Clear list of configuration files to read"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa rpmkonfigurationsfiler"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:72
 msgid "Artificially crash the program after COUNTER files"
@@ -44675,14 +43215,20 @@ msgid "Pretend it is TIMESTAMP"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:74
+#: share/completions/obnam.fish:49
+#, fuzzy
 msgid "Simulate failures for files that match REGEXP"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj fix som matchar REGEXP"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:75
 msgid "FILENAME pattern for trace debugging"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:76
+#: share/completions/obnam.fish:75
 msgid "PGP key with which to encrypt"
 msgstr ""
 
@@ -44691,42 +43237,68 @@ msgid "Home directory for GPG"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:78
+#: share/completions/obnam.fish:76
+#, fuzzy
 msgid "Show additional user IDs"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa historik för alla användare"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:79
+#: share/completions/obnam.fish:77
+#, fuzzy
 msgid "Do not show additional user IDs"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lagra inte katalognamn"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:80
+#: share/completions/obnam.fish:78
 msgid "PGP key id"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:81
+#: share/completions/obnam.fish:79
 msgid "Size of symmetric key"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:82
+#: share/completions/obnam.fish:80
+#, fuzzy
 msgid "Use /dev/urandom instead of /dev/random"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Använd rensning istället för radering"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:83
+#: share/completions/obnam.fish:81
 msgid "Use default /dev/random"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:84
+#: share/completions/obnam.fish:83
 msgid "fsck should try to fix problems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:85
+#: share/completions/obnam.fish:84
 msgid "fsck should not try to fix problems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:86
+#: share/completions/obnam.fish:85
+#, fuzzy
 msgid "Ignore chunks when checking integrity"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ignorera skiftläge på filnamn"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:87
+#: share/completions/obnam.fish:86
 msgid "Check chunks when checking integrity"
 msgstr ""
 
@@ -44735,13 +43307,23 @@ msgid "Do not check data for cient NAME"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:89
+#: share/completions/obnam.fish:88
+#, fuzzy
 msgid "Check only the last generation"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Återupta senaste installationsoperation"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:90
 #: /tmp/fish/implicit/share/completions/obnam.fish:100
+#: share/completions/obnam.fish:89 share/completions/obnam.fish:95
+#, fuzzy
 msgid "Check all generations"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga installerat paket"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:91
 #: /tmp/fish/implicit/share/completions/obnam.fish:92
@@ -44757,102 +43339,166 @@ msgid "Check checksums of files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:95
+#: share/completions/obnam.fish:90
+#, fuzzy
 msgid "Do not check directories"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lagra inte katalognamn"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:96
+#: share/completions/obnam.fish:91
+#, fuzzy
 msgid "Check directories"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Rekursera till underkataloger"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:97
+#: share/completions/obnam.fish:92
+#, fuzzy
 msgid "Do not check files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ändra inga filer"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:98
+#: share/completions/obnam.fish:93
+#, fuzzy
 msgid "Check files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga installerat paket"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:99
+#: share/completions/obnam.fish:94
+#, fuzzy
 msgid "Do not check any generations"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ändra inga filer"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:101
+#: share/completions/obnam.fish:96
+#, fuzzy
 msgid "Do not check per-client B-trees"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv inte ut taggar"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:102
+#: share/completions/obnam.fish:97
 msgid "Check per-client B-trees"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:103
+#: share/completions/obnam.fish:98
+#, fuzzy
 msgid "Do not check shared B-trees"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ändra inga filer"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:104
+#: share/completions/obnam.fish:99
+#, fuzzy
 msgid "Check shared B-trees"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga installerat paket"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:105
 msgid "Write log to FILE or syslog"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:106
+#: share/completions/obnam.fish:102
 msgid "Keep last N logs (10)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:107
+#: share/completions/obnam.fish:103
 msgid "Log at LEVEL"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:108
+#: share/completions/obnam.fish:104
 msgid "Rotate logs larger than SIZE"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:109
+#: share/completions/obnam.fish:105
 msgid "Set permissions of logfiles to MODE"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:110
+#: share/completions/obnam.fish:106
 msgid "Options to pass to FUSE"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:111
+#: share/completions/obnam.fish:107
 msgid "Make memory profiling dumps using METHOD"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:112
+#: share/completions/obnam.fish:108
 msgid "Make memory profiling dumps at SECONDS"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:113
+#: share/completions/obnam.fish:109
 msgid "Size of chunks of file data"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:114
+#: share/completions/obnam.fish:110
 msgid "Encode NUM chunk ids per group"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:115
+#: share/completions/obnam.fish:111
 msgid "Chunk id level size"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:116
+#: share/completions/obnam.fish:112
+#, fuzzy
 msgid "Depth of chunk id mapping"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Djup i anroppskedjan"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:117
+#: share/completions/obnam.fish:113
 msgid "Chunk id mapping lowest bits skip"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:118
+#: share/completions/obnam.fish:114
 msgid "Size of LRU cache for B-tree nodes"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:119
+#: share/completions/obnam.fish:115
+#, fuzzy
 msgid "Size of B-tree nodes on disk"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa ändringar i omvänd ordning"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:120
+#: share/completions/obnam.fish:116
 msgid "Length of upload queue for B-tree nodes"
 msgstr ""
 
@@ -44873,18 +43519,25 @@ msgid "In-memory cache SIZE for dir objects"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:125
+#: share/completions/obnam.fish:117
 msgid "Use only paramiko, no openssh"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:126
+#: share/completions/obnam.fish:118
+#, fuzzy
 msgid "Use openssh if available"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Bygg index om inte tillgängligt"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:127
 msgid "Executable to be used instead of \"ssh\""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:128
+#: share/completions/obnam.fish:120
 msgid "ssh host key check"
 msgstr ""
 
@@ -45726,20 +44379,6 @@ msgstr ""
 msgid "Set an alternate configuration file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/patch.fish:1
-msgid ""
-"Make backup files, when patching a file, rename or copy the original instead "
-"of removing it"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/patch.fish:2
-msgid "Back up a file if the patch does not match the file exactly"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/patch.fish:3
-msgid "Do not back up a file if the patch does not match the file exactly"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/patch.fish:4
 msgid "Prefix pref to a file name when generating its simple backup file name"
 msgstr ""
@@ -45765,10 +44404,6 @@ msgid ""
 "Print the results of applying the patches without actually changing any files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/patch.fish:10
-msgid "Interpret the patch file as an ed script"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/patch.fish:11
 msgid "Remove output files that are empty after the patches have been applied"
 msgstr ""
@@ -45777,10 +44412,6 @@ msgstr ""
 msgid ""
 "Assume that the user knows exactly what he/she is doing, and do not ask "
 "questions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/patch.fish:13
-msgid "Set the maximum fuzz factor"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/patch.fish:14
@@ -45821,22 +44452,6 @@ msgstr ""
 msgid "Conform more strictly to the POSIX standard"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/patch.fish:23
-msgid "Use style word to quote output names"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/patch.fish:24
-msgid "Put rejects into rejectfile instead of the default .rej file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/patch.fish:25
-msgid "Assume that this patch was created with the old and new files swapped"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/patch.fish:26
-msgid "Work silently, unless an error occurs"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/patch.fish:27
 msgid "Suppress questions like -f, but make some different assumptions"
 msgstr ""
@@ -45845,10 +44460,6 @@ msgstr ""
 msgid ""
 "Set the modification and access times of patched files from time stamps "
 "given in context diff headers, local time"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/patch.fish:29
-msgid "Interpret the patch file as a unified context diff"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/patch.fish:31
@@ -45985,8 +44596,12 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pdftotext.fish:19
 #: /tmp/fish/implicit/share/completions/xpdf.fish:28
+#, fuzzy
 msgid "Don't print any messages or errors"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Kör inga taggningsprogram"
 
 #: /tmp/fish/implicit/share/completions/pdftotext.fish:20
 msgid "Print copyright and version"
@@ -45997,110 +44612,101 @@ msgstr ""
 msgid "Print usage information"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/perl.fish:1
-#: /tmp/fish/implicit/share/completions/ruby.fish:1
+#: share/completions/perl.fish:6
 msgid "Specify record separator"
-msgstr ""
+msgstr "Ange postavdelare"
 
-#: /tmp/fish/implicit/share/completions/perl.fish:2
-#: /tmp/fish/implicit/share/completions/ruby.fish:2
+#: share/completions/perl.fish:7
 msgid "Turn on autosplit mode"
-msgstr ""
+msgstr "Slå på autosplitläge"
 
-#: /tmp/fish/implicit/share/completions/perl.fish:3
-#: /tmp/fish/implicit/share/completions/ruby.fish:3
+#: share/completions/perl.fish:8
 msgid "Check syntax"
-msgstr ""
+msgstr "Kontrollera syntax"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:4
+#: share/completions/perl.fish:9
 msgid "Control Unicode features"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:5
+#: share/completions/perl.fish:10
 msgid "Debug UTF-8 cache"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:6
+#: share/completions/perl.fish:11
 msgid "ARGV uses UTF-8"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:7
+#: share/completions/perl.fish:12
 msgid "Opened filehandles are UTF-8"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:8
+#: share/completions/perl.fish:13
 msgid "STDERR is UTF-8"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:9
+#: share/completions/perl.fish:14
 msgid "Filehandles that are read are UTF-8"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:10
+#: share/completions/perl.fish:15
 msgid "STDIN is UTF-8"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:11
+#: share/completions/perl.fish:16
 msgid "Enable Unicode conditionally"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:12
+#: share/completions/perl.fish:17
 msgid "Filehandles written to are UTF-8"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:13
+#: share/completions/perl.fish:18
 msgid "STDOUT is UTF-8"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:14
+#: share/completions/perl.fish:19
 msgid "STDOUT, STDIN, and STDERR are UTF-8"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/perl.fish:15
-#: /tmp/fish/implicit/share/completions/ruby.fish:5
+#: share/completions/perl.fish:20
 msgid "Debugger"
-msgstr ""
+msgstr "Debugger"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:16
 msgid "Debugger, with threads"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/perl.fish:17
-msgid "Debug option"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/perl.fish:18
-#: /tmp/fish/implicit/share/completions/ruby.fish:6
+#: share/completions/ruby.fish:7
 msgid "Execute command"
-msgstr ""
+msgstr "Utför kommando"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:19
 msgid "Execute command, enable optional features"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:20
+#: share/completions/perl.fish:25
+#, fuzzy
 msgid "Disable sitecustomize.pl"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Inaktivera användandet av kakor"
 
-#: /tmp/fish/implicit/share/completions/perl.fish:21
-#: /tmp/fish/implicit/share/completions/ruby.fish:8
-msgid "Set regexp used to split input"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/perl.fish:23
-#: /tmp/fish/implicit/share/completions/ruby.fish:9
-msgid "Edit files in-place"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/perl.fish:24
-#: /tmp/fish/implicit/share/completions/ruby.fish:10
-msgid "Include path"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/perl.fish:25
-#: /tmp/fish/implicit/share/completions/ruby.fish:11
+#: share/completions/perl.fish:30
 msgid "Automatic line ending processing"
-msgstr ""
+msgstr "Automatisk radslutprocessning"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:26
 msgid "Require module"
@@ -46110,48 +44716,67 @@ msgstr ""
 msgid "Use module"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/perl.fish:28
-#: /tmp/fish/implicit/share/completions/ruby.fish:12
+#: share/completions/perl.fish:33
 msgid "Loop script"
-msgstr ""
+msgstr "Upprepa skript"
 
-#: /tmp/fish/implicit/share/completions/perl.fish:30
-#: /tmp/fish/implicit/share/completions/ruby.fish:15
+#: share/completions/perl.fish:35
 msgid "Define custom switches"
-msgstr ""
+msgstr "Definera egna flaggor"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:32
+#: share/completions/perl.fish:37
 msgid "Taint checking, but only with warnings"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/perl.fish:33
-#: /tmp/fish/implicit/share/completions/ruby.fish:17
+#: share/completions/perl.fish:38
 msgid "Taint checking"
-msgstr ""
+msgstr "'taint'-verifiering"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:34
+#: share/completions/perl.fish:39
 msgid "Dump core"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/perl.fish:35
+#: share/completions/perl.fish:40
 msgid "Unsafe mode"
-msgstr ""
+msgstr "Osäkert läge"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:37
+#: share/completions/perl.fish:42
+#, fuzzy
 msgid "Display configuration and exit"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:38
+#: share/completions/perl.fish:43
+#, fuzzy
 msgid "Show warnings"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa inte varningar"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:39
+#: share/completions/perl.fish:44
+#, fuzzy
 msgid "Force warnings"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa inte varningar"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:40
+#: share/completions/perl.fish:45
+#, fuzzy
 msgid "Disable warnings"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa inte varningar om MFC"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:41
 #: /tmp/fish/implicit/share/completions/ruby.fish:21
@@ -46178,168 +44803,16 @@ msgstr ""
 msgid "List the process name as well as the process ID"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/pine.fish:1
-msgid "Open folder"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:2
-msgid "Open file"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/pine.fish:4
 msgid "Start in folder index"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:5
-msgid "Initial set of keystrokes"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:6
-msgid "Use function keys for commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:7
-msgid "Expand collections in FOLDER LIST display"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:8
-msgid "Start with specified current message number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:9
-msgid "Open folder read-only"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:11
-msgid "Set global configuration file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pine.fish:12
 msgid "Restricted mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/pine.fish:13
-msgid "Enable suspension support"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:14
-msgid "Produce a sample global configuration file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:15
-msgid "Produce sample configuration file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:16
-msgid "Set mail sort order"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/pine.fish:17
-msgid "Config option"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:1
-msgid "Audible ping"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:2
-msgid "Adaptive ping"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:3
-msgid "Allow pinging a broadcast address"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:4
-msgid "Do not allow ping to change source address of probes"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:5
-msgid "Stop after specified number of ECHO_REQUEST packets"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:6
-msgid "Set the SO_DEBUG option on the socket being used"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:7
-msgid "Allocate and set 20 bit flow label on ECHO_REQUEST packets"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:8
-msgid "Flood ping"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:9
-msgid "Wait specified interval of seconds between sending each packet"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:10
-msgid "Set source address to specified interface address"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:11
-msgid "Send the specified number of packets without waiting for reply"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:12
-msgid "Suppress loopback of multicast packets"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:13
-msgid "Numeric output only"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:14
-msgid "Pad packet with empty bytes"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:15
-msgid "Set Quality of Service -related bits in ICMP datagrams"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:17
-msgid "Record route"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:18
-msgid ""
-"Bypass the normal routing tables and send directly to a host on an attached "
-"interface"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/ping.fish:19
 msgid "Specifies the number of data bytes to be sent"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:20
-msgid "Set socket buffer size"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:21
-msgid "Set the IP Time to Live"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:22
-msgid "Set special IP timestamp options"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:23
-msgid "Select Path MTU Discovery strategy"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:24
-msgid "Print full user-to-user latency"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:27
-msgid ""
-"Specify  a timeout, in seconds, before ping exits regardless of how many "
-"packets have been sent or received"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ping.fish:28
-msgid "Time to wait for a response, in seconds"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pinky.fish:1
@@ -46645,8 +45118,13 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/pkg.fish:26
 #: /tmp/fish/implicit/share/completions/zypper.fish:3
 #: /tmp/fish/implicit/share/completions/zypper.fish:18
+#: share/completions/zypper.fish:44
+#, fuzzy
 msgid "Install packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installerade paket"
 
 #: /tmp/fish/implicit/share/completions/pkg.fish:27
 msgid "Prevent package modification"
@@ -46656,10 +45134,9 @@ msgstr ""
 msgid "List package manager plugins"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/pkg.fish:29
-#: /tmp/fish/implicit/share/completions/rpm.fish:95
+#: share/completions/rpm.fish:126
 msgid "Query installed packages"
-msgstr ""
+msgstr "Fråga installerat paket"
 
 #: /tmp/fish/implicit/share/completions/pkg.fish:30
 msgid "Register a package in a database"
@@ -47097,12 +45574,22 @@ msgid "display the version number El ENVIRONMENT The d… [See Man Page]"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/portmaster.fish:44
+#: share/completions/portmaster.fish:49
+#, fuzzy
 msgid "Ports Directory"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Katalog"
 
 #: /tmp/fish/implicit/share/completions/portmaster.fish:45
+#: share/completions/portmaster.fish:55
+#, fuzzy
 msgid "Installed Package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installerade paket"
 
 #: /tmp/fish/implicit/share/completions/ports.fish:1
 msgid "Update ports"
@@ -47144,13 +45631,10 @@ msgstr ""
 msgid "Don't send wall message"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/prt-get.fish:2
-#: /tmp/fish/implicit/share/completions/prt-get.fish:62
-#: /tmp/fish/implicit/share/completions/scp.fish:5
-#: /tmp/fish/implicit/share/completions/ssh.fish:14
-#: /tmp/fish/implicit/share/completions/sshfs.fish:2
+#: share/completions/scp.fish:41 share/completions/ssh.fish:39
+#: share/completions/sshfs.fish:25
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 #: /tmp/fish/implicit/share/completions/prt-get.fish:3
 #: /tmp/fish/implicit/share/completions/prt-get.fish:64
@@ -47399,100 +45883,8 @@ msgstr ""
 msgid "Write output to log file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ps.fish:1
-#: /tmp/fish/implicit/share/completions/ps.fish:5
-msgid "Select all"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:2
-msgid "Invert selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:3
-msgid "Select all processes except session leaders and terminal-less"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:4
-msgid "Select all processes except session leaders"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:6
-msgid "Deselect all processes that do not fulfill conditions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:7
-msgid "Select by command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:8
-msgid "Select by group"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:9
-#: /tmp/fish/implicit/share/completions/ps.fish:10
-msgid "Select by user"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:11
-msgid "Select by group/session"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:12
-msgid "Select by PID"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:13
-msgid "Select by parent PID"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:14
-msgid "Select by session ID"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:15
-msgid "Select by tty"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:16
-msgid "Extra full format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:17
-#: /tmp/fish/implicit/share/completions/ps.fish:23
-msgid "User defined format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:18
-#: /tmp/fish/implicit/share/completions/ps.fish:25
-msgid "Add column for security data"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/ps.fish:19
 msgid "Show different scheduler information for the -l option"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:20
-msgid "Full format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:21
-msgid "Jobs format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:24
-msgid "Do not show flags"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:26
-msgid "Show hierarchy"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:27
-msgid "Set namelist file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ps.fish:28
-msgid "Wide output"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/ps.fish:29
@@ -47540,8 +45932,13 @@ msgid "run only single command (SQL or internal) and exit"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/psql.fish:3
+#: share/completions/psql.fish:19
+#, fuzzy
 msgid "execute commands from file, then exit"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Utför kommando som om get vore en del av .wgetrc"
 
 #: /tmp/fish/implicit/share/completions/psql.fish:4
 msgid "list available databases, then exit"
@@ -47636,6 +46033,7 @@ msgid "database server host or socket directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/psql.fish:27
+#: share/completions/psql.fish:63
 msgid "database server port"
 msgstr ""
 
@@ -47902,36 +46300,6 @@ msgstr ""
 msgid "Don't write .py[co] files on import"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/python2.fish:2
-#: /tmp/fish/implicit/share/completions/python3.fish:2
-#: /tmp/fish/implicit/share/completions/python.fish:2
-msgid "Execute argument as command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/python2.fish:3
-#: /tmp/fish/implicit/share/completions/python3.fish:3
-#: /tmp/fish/implicit/share/completions/python.fish:3
-msgid "Debug on"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/python2.fish:4
-#: /tmp/fish/implicit/share/completions/python3.fish:4
-#: /tmp/fish/implicit/share/completions/python.fish:4
-msgid "Ignore environment variables"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/python2.fish:6
-#: /tmp/fish/implicit/share/completions/python3.fish:6
-#: /tmp/fish/implicit/share/completions/python.fish:6
-msgid "Interactive mode after executing commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/python2.fish:7
-#: /tmp/fish/implicit/share/completions/python3.fish:7
-#: /tmp/fish/implicit/share/completions/python.fish:8
-msgid "Enable optimizations"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/python2.fish:8
 #: /tmp/fish/implicit/share/completions/python3.fish:8
 #: /tmp/fish/implicit/share/completions/python.fish:9
@@ -47944,23 +46312,13 @@ msgstr ""
 msgid "Don't add user site directory to sys.path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/python2.fish:10
-#: /tmp/fish/implicit/share/completions/python3.fish:10
-#: /tmp/fish/implicit/share/completions/python.fish:11
+#: share/functions/__fish_complete_python.fish:12
 msgid "Disable import of site module"
-msgstr ""
+msgstr "Slå av importering av platsmodul"
 
-#: /tmp/fish/implicit/share/completions/python2.fish:11
-#: /tmp/fish/implicit/share/completions/python3.fish:11
-#: /tmp/fish/implicit/share/completions/python.fish:12
+#: share/functions/__fish_complete_python.fish:13
 msgid "Unbuffered input and output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/python2.fish:14
-#: /tmp/fish/implicit/share/completions/python3.fish:14
-#: /tmp/fish/implicit/share/completions/python.fish:15
-msgid "Warning control"
-msgstr ""
+msgstr "Buffra inte indata och utdata"
 
 #: /tmp/fish/implicit/share/completions/python2.fish:15
 #: /tmp/fish/implicit/share/completions/python3.fish:15
@@ -47979,15 +46337,9 @@ msgstr ""
 msgid "Warn about Python 3.x incompatibilities that 2to3 cannot trivially fix"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/python2.fish:18
-#: /tmp/fish/implicit/share/completions/python.fish:19
+#: share/functions/__fish_complete_python.fish:24
 msgid "Warn on mixed tabs and spaces"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/python2.fish:19
-#: /tmp/fish/implicit/share/completions/python.fish:20
-msgid "Division control"
-msgstr ""
+msgstr "Varna vid blandad användning av tabbar och mellanslag"
 
 #: /tmp/fish/implicit/share/completions/python2.fish:20
 #: /tmp/fish/implicit/share/completions/python3.fish:21
@@ -48276,36 +46628,6 @@ msgstr ""
 msgid "Run quietly (Does not affect errors)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/read.fish:2
-msgid "Set prompt command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/read.fish:3
-#: /tmp/fish/implicit/share/completions/set.fish:4
-msgid "Export variable to subprocess"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/read.fish:4
-#: /tmp/fish/implicit/share/completions/set.fish:6
-msgid "Make variable scope global"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/read.fish:5
-#: /tmp/fish/implicit/share/completions/set.fish:7
-msgid "Make variable scope local"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/read.fish:6
-msgid ""
-"Make variable scope universal, i.e. share variable with all the users fish "
-"processes on this computer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/read.fish:7
-#: /tmp/fish/implicit/share/completions/set.fish:5
-msgid "Do not export variable to subprocess"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/read.fish:8
 msgid "Name to load/save history under"
 msgstr ""
@@ -48392,18 +46714,6 @@ msgstr ""
 msgid "Alternative root"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/renice.fish:1
-msgid "Force following parameters to be process ID's (The default)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/renice.fish:2
-msgid "Force following parameters to be interpreted as process group ID's"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/renice.fish:3
-msgid "Force following parameters to be interpreted as user names"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/return.fish:2
 msgid "Return from function with normal exit status"
 msgstr ""
@@ -48414,14 +46724,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rfkill.fish:1
 msgid "device group"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rmdir.fish:1
-msgid "Ignore errors from non-empty directories"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rmdir.fish:2
-msgid "Remove each component of path"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rmmod.fish:1
@@ -48474,378 +46776,378 @@ msgstr ""
 msgid "List of rpm configuration files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:6
-msgid "Pipe output through specified command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rpm.fish:7
-msgid "Specify directory for rpm database"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rpm.fish:8
-msgid "Specify root directory for rpm operations"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rpm.fish:9
+#: share/completions/rpm.fish:22
 msgid "Add suggested packages to the transaction set when needed"
-msgstr ""
+msgstr "Lägg till föreslagna paket till transkation vid behov"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:10
+#: share/completions/rpm.fish:23
 msgid ""
 "Installs or upgrades all the files in the package, even if they aren't "
 "needed (missingok) and don't exist"
 msgstr ""
+"Installerar eller uppgraderar alla saknade filer i paketet, även om de inte "
+"behövs (missingok) och inte existerar"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:11
+#: share/completions/rpm.fish:24
 msgid ""
 "Used with --relocate, permit relocations on all file paths, not just those "
 "OLD-PATH's included in the binary package relocation hint(s)"
 msgstr ""
+"Använd tillsammans med --relocate, tillåter flyttning på alla fökvägar, inte "
+"bara de OLD_PATH inkluderade i de binära paketflyttningshintarna"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:12
+#: share/completions/rpm.fish:25
 msgid "Don't install files whose name begins with specified path"
-msgstr ""
+msgstr "Installera inte filer vars namn börjar med angiven sökväg"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:13
+#: share/completions/rpm.fish:26
 msgid "Don't install any files which are marked as documentation"
-msgstr ""
+msgstr "Installera inte filer som markerats som dokumentation"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:14
+#: share/completions/rpm.fish:27
 msgid "Same as using --replacepkgs, --replacefiles, and --oldpackage"
-msgstr ""
+msgstr "Samma sak som --replacepkgs, --replacefiles, och --oldpackage"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:15
+#: share/completions/rpm.fish:28
 msgid "Print 50 hash marks as the package archive is unpacked"
-msgstr ""
+msgstr "Visa 50 brädgårdstecken medan arkivet packas upp"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:16
+#: share/completions/rpm.fish:29
 msgid "Don't check for sufficient disk space before installation"
-msgstr ""
+msgstr "Kontrollera inte diskutrymme före installation"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:17
+#: share/completions/rpm.fish:30
 msgid ""
 "Allow installation or upgrading even if the architectures of the binary "
 "package and host don't match"
 msgstr ""
+"Tillåt installation eller uppgradering även om binärt pakets arkitetkur inte "
+"matchar värddatorns"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:18
+#: share/completions/rpm.fish:31
 msgid ""
 "Allow installation or upgrading even if the operating systems of the binary "
 "package and host don't match"
 msgstr ""
+"Tillåt installation eller uppgradering även om binärt pakets operativsystem "
+"inte matchar värddatorns"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:19
+#: share/completions/rpm.fish:32
 msgid "Install documentation files (default)"
-msgstr ""
+msgstr "Installera dokumentation (standard)"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:20
+#: share/completions/rpm.fish:33
 msgid "Update only the database, not the filesystem"
-msgstr ""
+msgstr "Uppdatera bara databasen, inte filsystemet"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:21
-#: /tmp/fish/implicit/share/completions/rpm.fish:70
+#: share/completions/rpm.fish:34 share/completions/rpm.fish:94
 msgid "Don't verify package or header digests when reading"
-msgstr ""
+msgstr "Kontrollera inte paket- eller huvudsammanfattningar vid inläsning"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:22
-#: /tmp/fish/implicit/share/completions/rpm.fish:73
+#: share/completions/rpm.fish:35 share/completions/rpm.fish:97
 msgid "Don't verify package or header signatures when reading"
-msgstr ""
+msgstr "Kontrollera inte paket- eller huvudsignatur vid inläsning"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:23
+#: share/completions/rpm.fish:36
 msgid "Don't do a dependency check"
-msgstr ""
+msgstr "Utför inte beroendeverifiering"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:24
+#: share/completions/rpm.fish:37
 msgid "Don't suggest package(s) that provide a missing dependency"
-msgstr ""
+msgstr "Föreslå inte paket som upfyller ett ouppfyllt beroende"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:25
+#: share/completions/rpm.fish:38
 msgid "Don't change the package installation order"
-msgstr ""
+msgstr "Byt inte paketinstallationsordning "
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:26
+#: share/completions/rpm.fish:39
 msgid "Don't execute scripts"
-msgstr ""
+msgstr "Kör inte skript"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:27
+#: share/completions/rpm.fish:40
 msgid "Don't execute pre scripts"
-msgstr ""
+msgstr "Kör inte pre-skript"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:28
+#: share/completions/rpm.fish:41
 msgid "Don't execute post scripts"
-msgstr ""
+msgstr "Kör inte post-skript"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:29
+#: share/completions/rpm.fish:42
 msgid "Don't execute preun scripts"
-msgstr ""
+msgstr "Kör inte preun-skript"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:30
+#: share/completions/rpm.fish:43
 msgid "Don't execute postun scripts"
-msgstr ""
+msgstr "Kör inte postun-skript"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:31
-#: /tmp/fish/implicit/share/completions/rpm.fish:87
+#: share/completions/rpm.fish:44 share/completions/rpm.fish:115
 msgid "Don't execute trigger scriptlets"
-msgstr ""
+msgstr "Kör inte trigger-skriptlets"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:32
+#: share/completions/rpm.fish:45
 msgid "Don't execute triggerin scriptlets"
-msgstr ""
+msgstr "Kör inte triggerin-skriptlets"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:33
-#: /tmp/fish/implicit/share/completions/rpm.fish:88
+#: share/completions/rpm.fish:46 share/completions/rpm.fish:116
 msgid "Don't execute triggerun scriptlets"
-msgstr ""
+msgstr "Kör inte triggerun-skriptlets"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:34
-#: /tmp/fish/implicit/share/completions/rpm.fish:89
+#: share/completions/rpm.fish:47 share/completions/rpm.fish:117
 msgid "Don't execute triggerpostun scriptlets"
-msgstr ""
+msgstr "Kör inte triggerpostun-skriptlets"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:35
+#: share/completions/rpm.fish:48
 msgid "Allow an upgrade to replace a newer package with an older one"
-msgstr ""
+msgstr "Tillåt en uppgradering att ersätta ett nyare paket med ett äldre"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:36
+#: share/completions/rpm.fish:49
 msgid ""
 "Print percentages as files are unpacked from the package archive. This is "
 "intended to make rpm easy to run from other tools"
 msgstr ""
+"Visa procentandel medan filer packas upp från paketarkiv. Detta är tänkt att "
+"användas för att göra rpm lättare att köra från andra verktyg"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:37
+#: share/completions/rpm.fish:50
 msgid ""
 "For relocatable binary packages, translate all file paths that start with "
 "the installation prefix in the package relocation hint(s) to NEWPATH"
 msgstr ""
+"För flyttbara binära paket, översätt alla sökvägar som startar med "
+"installationsprefixet i paketets flytthintar till den angivna sökvägen"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:38
-msgid ""
-"Translate all paths that start with first half of following parameter to "
-"second half of following parameter"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/rpm.fish:39
-#: /tmp/fish/implicit/share/completions/rpm.fish:90
+#: share/completions/rpm.fish:52 share/completions/rpm.fish:118
 msgid "Re-package the files before erasing"
-msgstr ""
+msgstr "Ompaketera paket inan radering"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:40
+#: share/completions/rpm.fish:53
 msgid ""
 "Install the packages even if they replace files from other, already "
 "installed, packages"
 msgstr ""
+"Installera paket även om de ersätter filer från andra, redan installerade "
+"paket"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:41
+#: share/completions/rpm.fish:54
 msgid ""
 "Install the packages even if some of them are already installed on this "
 "system"
-msgstr ""
+msgstr "Installera paket även om somliga redan är installerade"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:42
+#: share/completions/rpm.fish:55
 msgid ""
 "Don't install the package, simply check for and report potential conflicts"
 msgstr ""
+"Installera inte paket, kontrollera och rapportera potentiella konflikter"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:43
+#: share/completions/rpm.fish:59
 msgid "Display change information for the package"
-msgstr ""
+msgstr "Visa ändringsinformation för paket"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:44
+#: share/completions/rpm.fish:60
 msgid "List only configuration files (implies -l)"
-msgstr ""
+msgstr "Visa bara konfigurationsfiler (implicerar -l)"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:45
+#: share/completions/rpm.fish:61
 msgid "List only documentation files (implies -l)"
-msgstr ""
+msgstr "Visa bara dokumentationsfiler (implicerar -l)"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:46
+#: share/completions/rpm.fish:62
 msgid "Dump file information. Must be used with at least one of -l, -c, -d"
-msgstr ""
+msgstr "Dumpa filinformation. Kräver minst en av -l, -c, -d"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:47
+#: share/completions/rpm.fish:63
 msgid "List all the files in each selected package"
-msgstr ""
+msgstr "Visa alla filer i varje valt paket"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:48
+#: share/completions/rpm.fish:64
 msgid ""
 "Display package information, including name, version, and description. Uses "
 "--queryformat if specified"
 msgstr ""
+"Visa paketinformation, inklusive namn, version och beskrivning. Använder --"
+"queryfromet om angivet"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:49
+#: share/completions/rpm.fish:65
 msgid "Orders the package listing by install time"
-msgstr ""
+msgstr "Sortera paketlistning efter installationstid"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:50
+#: share/completions/rpm.fish:66
 msgid "List files in package"
-msgstr ""
+msgstr "Visa filer i paket"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:51
+#: share/completions/rpm.fish:67
 msgid "List capabilities this package provides"
-msgstr ""
+msgstr "Visa förmågor som detta paket tillhandahåller"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:52
+#: share/completions/rpm.fish:68
 msgid "List packages on which this package depends"
-msgstr ""
+msgstr "Visa paket som detta paket beror på"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:53
+#: share/completions/rpm.fish:69
 msgid "List the package specific scriptlets"
-msgstr ""
+msgstr "Visa paket-specifika skriptlets"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:54
+#: share/completions/rpm.fish:70
 msgid ""
 "Display the states of files in the package. The state of each file is one of "
 "normal, not installed, or replaced"
 msgstr ""
+"Visa tillstånd för paketets filer. Tillståndet är en av normal, inte "
+"installerad och ersatt"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:55
-#: /tmp/fish/implicit/share/completions/rpm.fish:56
+#: share/completions/rpm.fish:71 share/completions/rpm.fish:72
 msgid "Display the trigger scripts contained in the package"
-msgstr ""
+msgstr "Visa paketets triggerskript"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:57
+#: share/completions/rpm.fish:78
 msgid "Query all installed packages"
-msgstr ""
+msgstr "Fråga alla installerade paket"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:58
+#: share/completions/rpm.fish:79
 msgid "Query package owning specified file"
-msgstr ""
+msgstr "Fråga paket som äger angiven fil"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:59
+#: share/completions/rpm.fish:80
 msgid ""
 "Query package that contains a given file identifier, i.e. the MD5 digest of "
 "the file contents"
 msgstr ""
+"Fråga paket som innehåller en given filidentitet, dvs. MD5-summa av "
+"filinnehåll"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:60
+#: share/completions/rpm.fish:81
 msgid "Query packages with the specified group"
-msgstr ""
+msgstr "Fråga paket med angiven grupp"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:61
+#: share/completions/rpm.fish:82
 msgid ""
 "Query package that contains a given header identifier, i.e. the SHA1 digest "
 "of the immutable header region"
 msgstr ""
+"Fråga paket som innehåller en given huvudidentitet, dvs. SHA1-summa av den "
+"konstanta huvud-regionen"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:62
+#: share/completions/rpm.fish:83
 msgid "Query an (uninstalled) package in specified file"
-msgstr ""
+msgstr "Fråga ett (oinstallerat) paket i angiven fil"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:63
+#: share/completions/rpm.fish:84
 msgid ""
 "Query package that contains a given package identifier, i.e. the MD5 digest "
 "of the combined header and payload contents"
 msgstr ""
+"Fråga paket som innehåller en given paketidentitet, dvs. MD5-summa av den "
+"kombinerade huvud- och filinnehållet"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:64
+#: share/completions/rpm.fish:85
 msgid "Parse and query specified spec-file as if it were a package"
-msgstr ""
+msgstr "Tolka och fråga angiven spec-fil som om det vore ett paket"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:65
+#: share/completions/rpm.fish:86
 msgid "Query package(s) that have the specified TID (transaction identifier)"
-msgstr ""
+msgstr "Fråga paket med angiven TID (transaktions-id)"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:66
+#: share/completions/rpm.fish:87
 msgid "Query packages that are triggered by the specified packages"
-msgstr ""
+msgstr "Fråga paket som triggas av angivna paket"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:67
+#: share/completions/rpm.fish:88
 msgid "Query all packages that provide the specified capability"
-msgstr ""
+msgstr "Fråga alla paket som tillhandahåller den angivna förmågan"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:68
+#: share/completions/rpm.fish:89
 msgid ""
 "Query all packages that requires the specified capability for functioning"
-msgstr ""
+msgstr "Fråga alla paket som kräver den angivna förmågan för att fungera"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:69
+#: share/completions/rpm.fish:93
 msgid "Don't verify dependencies of packages"
-msgstr ""
+msgstr "Verifiera inte paketens beroenden"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:71
+#: share/completions/rpm.fish:95
 msgid "Don't verify any attributes of package files"
-msgstr ""
+msgstr "Verifiera inga attribut i paketfiler"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:72
+#: share/completions/rpm.fish:96
 msgid "Don't execute the %verifyscript scriptlet"
-msgstr ""
+msgstr "Utför inte %verifyskriptlet"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:74
+#: share/completions/rpm.fish:98
 msgid "Don't verify linkto attribute"
-msgstr ""
+msgstr "Verifiera inte linkto-attribut"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:75
+#: share/completions/rpm.fish:99
 msgid "Don't verify md5 attribute"
-msgstr ""
+msgstr "Verifiera inte md5-attribut"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:76
+#: share/completions/rpm.fish:100
 msgid "Don't verify size attribute"
-msgstr ""
+msgstr "Verifiera inte storleksattribut"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:77
+#: share/completions/rpm.fish:101
 msgid "Don't verify user attribute"
-msgstr ""
+msgstr "Verifiera inte användarattribut"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:78
+#: share/completions/rpm.fish:102
 msgid "Don't verify group attribute"
-msgstr ""
+msgstr "Verifiera inte gruppattribut"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:79
+#: share/completions/rpm.fish:103
 msgid "Don't verify time attribute"
-msgstr ""
+msgstr "Verifiera inte tidsattribut"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:80
+#: share/completions/rpm.fish:104
 msgid "Don't verify mode attribute"
-msgstr ""
+msgstr "Verifiera inte filrättighetsattribut"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:81
+#: share/completions/rpm.fish:105
 msgid "Don't verify dev attribute"
-msgstr ""
+msgstr "Verifiera inte enhetsattribut"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:82
+#: share/completions/rpm.fish:110
 msgid "Remove all versions of the package which match specified string"
-msgstr ""
+msgstr "Ta bort alla version av paketet som matchar angiven sträng"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:83
+#: share/completions/rpm.fish:111
 msgid "Don't check dependencies before uninstalling the packages"
-msgstr ""
+msgstr "Verifiera inte beroenden före paketen avinstalleras"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:84
+#: share/completions/rpm.fish:112
 msgid "Don't execute scriplets"
-msgstr ""
+msgstr "Kör inte skriptlets"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:85
+#: share/completions/rpm.fish:113
 msgid "Don't execute preun scriptlet"
-msgstr ""
+msgstr "Kör inte preun-skriptlet"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:86
+#: share/completions/rpm.fish:114
 msgid "Don't execute postun scriptlet"
-msgstr ""
+msgstr "Kör inte postun-skriptlet"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:91
+#: share/completions/rpm.fish:119
 msgid "Don't really uninstall anything"
-msgstr ""
+msgstr "Avinstallera ingenting på riktigt"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:92
+#: share/completions/rpm.fish:123
 msgid "Install new package"
-msgstr ""
+msgstr "Installera nytt paket"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:93
+#: share/completions/rpm.fish:124
 msgid "Upgrade existing package"
-msgstr ""
+msgstr "Upgradera existerande paket"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:94
+#: share/completions/rpm.fish:125
 msgid "Upgrade package if already installed"
-msgstr ""
+msgstr "Upgradera paket om det är installerat"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:96
+#: share/completions/rpm.fish:127
 msgid "Verify package integrity"
-msgstr ""
+msgstr "Verifiera paketintegritet"
 
-#: /tmp/fish/implicit/share/completions/rpm.fish:97
+#: share/completions/rpm.fish:128
 msgid "Erase package"
-msgstr ""
+msgstr "Ta bort paket"
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:2
 msgid "Suppress non-error messages"
@@ -49000,16 +47302,27 @@ msgid "Don’t cross filesystem boundaries"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:40
+#: share/completions/rsync.fish:41
 msgid "Force a fixed checksum block-size"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:41
+#: share/completions/rsync.fish:42
+#, fuzzy
 msgid "Specify the remote shell to use"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange förråd-URL"
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:42
+#: share/completions/rsync.fish:43
+#, fuzzy
 msgid "Specify the rsync to run on remote machine"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj destinationsadress"
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:43
 msgid "Ignore non-existing files on receiving side"
@@ -49112,10 +47425,12 @@ msgid "Find similar file for basis if no dest file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:68
+#: share/completions/rsync.fish:69
 msgid "Also compare received files relative to DIR"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:69
+#: share/completions/rsync.fish:70
 msgid ""
 "Also compare received files relative to DIR and include copies of unchanged "
 "files"
@@ -49208,10 +47523,16 @@ msgid "Output a change-summary for all updates"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:92
+#: share/completions/rsync.fish:93
+#, fuzzy
 msgid "Output filenames using the specified format"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Exklidera filer listade i angiven fil"
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:93
+#: share/completions/rsync.fish:94
 msgid "Read password from FILE"
 msgstr ""
 
@@ -49220,10 +47541,12 @@ msgid "List the files instead of copying them"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:95
+#: share/completions/rsync.fish:96
 msgid "Limit I/O bandwidth; KBytes per second"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:96
+#: share/completions/rsync.fish:97
 msgid "Write a batched update to FILE"
 msgstr ""
 
@@ -49232,14 +47555,21 @@ msgid "Like --write-batch but w/o updating dest"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:98
+#: share/completions/rsync.fish:99
+#, fuzzy
 msgid "Read a batched update from FILE"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Läs fix från patchfil"
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:99
+#: share/completions/rsync.fish:100
 msgid "Force an older protocol version to be used"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:100
+#: share/completions/rsync.fish:101
 msgid "Set block/file checksum seed (advanced)"
 msgstr ""
 
@@ -49271,21 +47601,9 @@ msgstr ""
 msgid "List all built-in definitions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ruby.fish:4
-msgid "Kanji code-set"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ruby.fish:14
+#: share/completions/ruby.fish:15
 msgid "Require file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ruby.fish:19
-msgid "Verbose mode without message"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ruby.fish:23
-msgid "Compiler debug mode"
-msgstr ""
+msgstr "Kräv fil"
 
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:1
 msgid "Make bucket"
@@ -50438,18 +48756,9 @@ msgstr ""
 msgid "Remote Path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/scp.fish:4
+#: share/completions/scp.fish:40
 msgid "Bandwidth limit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/scp.fish:6
-msgid ""
-"Preserves modification times, access times, and modes from the original file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/scp.fish:8
-msgid "Recursively copy"
-msgstr ""
+msgstr "Bandbreddsgräns"
 
 #: /tmp/fish/implicit/share/completions/scp.fish:9
 msgid "Encryption program"
@@ -50475,9 +48784,9 @@ msgstr ""
 msgid "Print a list of attached screen sessions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/screen.fish:6
+#: share/completions/screen.fish:1
 msgid "Print a list of running screen sessions"
-msgstr ""
+msgstr "Visa lista på alla körande screen-sessioner"
 
 #: /tmp/fish/implicit/share/completions/screen.fish:7
 msgid "Include all capabilitys"
@@ -50508,10 +48817,9 @@ msgstr ""
 msgid "Reattach/create any session"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/screen.fish:15
-#: /tmp/fish/implicit/share/completions/ssh.fish:5
+#: share/completions/ssh.fish:30
 msgid "Escape character"
-msgstr ""
+msgstr "Avbrottstecken"
 
 #: /tmp/fish/implicit/share/completions/screen.fish:16
 msgid "Flow control on"
@@ -50646,19 +48954,13 @@ msgstr ""
 msgid "Service name"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/set_color.fish:1
+#: share/completions/set.fish:73 share/completions/set_color.fish:1
 msgid "Color"
-msgstr ""
+msgstr "Färg"
 
-#: /tmp/fish/implicit/share/completions/set_color.fish:2
-#: /tmp/fish/implicit/share/completions/set.fish:12
+#: share/completions/set.fish:74 share/completions/set_color.fish:2
 msgid "Change background color"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/set_color.fish:3
-#: /tmp/fish/implicit/share/completions/set.fish:13
-msgid "Make font bold"
-msgstr ""
+msgstr "Byt bakgrundsfärg"
 
 #: /tmp/fish/implicit/share/completions/set_color.fish:4
 msgid "Italicise"
@@ -50708,21 +49010,17 @@ msgstr ""
 msgid "Test if We are specifying a locale value for the prompt"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/set.fish:3
-msgid "Erase variable"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/set.fish:8
 msgid "Share variable persistently across sessions"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/set.fish:9
-msgid "Test if variable is defined"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/set.fish:11
+#, fuzzy
 msgid "List the names of the variables, but not their value"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/set.fish:14
 msgid "Locale variable"
@@ -50885,32 +49183,8 @@ msgstr ""
 msgid "Snap"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/sort.fish:1
-msgid "Ignore leading blanks"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:2
-msgid "Consider only blanks and alphanumerics"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:4
-msgid "Compare general numeric value"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:5
-msgid "Consider only printable"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/sort.fish:6
 msgid "Compare human readable numbers [2K 1G]"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:7
-msgid "Compare month names"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:8
-msgid "Compare string numerical value"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sort.fish:9
@@ -50921,137 +49195,25 @@ msgstr ""
 msgid "Get random bytes from FILE"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/sort.fish:11
-msgid "Reverse results"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:12
-msgid "Only check if sorted"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:13
-msgid "Define key"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/sort.fish:14
 msgid "Merge sorted files"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/sort.fish:16
-msgid "Stabilize sort"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:17
+#: share/completions/sort.fish:18
 msgid "Set memory buffer size"
-msgstr ""
+msgstr "Välj minnesbuffertstorlek"
 
-#: /tmp/fish/implicit/share/completions/sort.fish:18
-msgid "Field separator"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:19
+#: share/completions/sort.fish:20
 msgid "Set temporary directory"
-msgstr ""
+msgstr "Välj katalog för tillfälligt lagringsutrymme"
 
-#: /tmp/fish/implicit/share/completions/sort.fish:20
-msgid "Output only first of equal lines"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sort.fish:21
-msgid "Lines end with 0 byte"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:2
-msgid "Disables forwarding of the authentication agent"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:3
-msgid "Enables forwarding of the authentication agent"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:4
+#: share/completions/ssh.fish:24
 msgid "Interface to transmit from"
-msgstr ""
+msgstr "Gränssnitt att skicka från"
 
-#: /tmp/fish/implicit/share/completions/ssh.fish:6
-msgid "Go to background"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:7
-msgid "Allow remote host to connect to local forwarded ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:8
-msgid "Smartcard device"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:9
-msgid "Disable forwarding of Kerberos tickets"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:10
+#: share/completions/ssh.fish:35
 msgid "User"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:11
-msgid "MAC algorithm"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:12
-msgid "Prevent reading from stdin"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:13
-msgid "Do not execute remote command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:16
-msgid "Subsystem"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:17
-msgid "Force pseudo-tty allocation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:18
-msgid "Disable pseudo-tty allocation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:19
-msgid "Disable X11 forwarding"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:20
-msgid "Enable X11 forwarding"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:21
-msgid "Locally forwarded ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:22
-msgid "Remotely forwarded ports"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ssh.fish:23
-msgid "Dynamic port forwarding"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sshfs.fish:3
-msgid "Compression"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sshfs.fish:5
-msgid "Enable debug"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sshfs.fish:6
-msgid "Foreground operation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sshfs.fish:7
-msgid "Disable multi-threaded operation"
-msgstr ""
+msgstr "Användare"
 
 #: /tmp/fish/implicit/share/completions/stack.fish:1
 msgid "Show this help text"
@@ -51318,36 +49480,8 @@ msgstr ""
 msgid "Subcommands specific to package signatures (experimental)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/status.fish:2
-msgid "Test if this is a login shell"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/status.fish:3
-msgid "Test if this is an interactive shell"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/status.fish:4
-msgid "Test if a command substitution is currently evaluated"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/status.fish:5
-msgid "Test if a code block is currently evaluated"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/status.fish:6
 msgid "Test if a breakpoint is currently in effect"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/status.fish:7
-msgid "Test if new jobs are never put under job control"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/status.fish:8
-msgid "Test if only interactive new jobs are put under job control"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/status.fish:9
-msgid "Test if all new jobs are put under job control"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/status.fish:10
@@ -51356,11 +49490,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/status.fish:11
 msgid "Print the line number of the currently running script"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/status.fish:12
-msgid ""
-"Print a list of all function calls leading up to running the current command"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/status.fish:13
@@ -51427,10 +49556,6 @@ msgstr ""
 msgid "Report all matches per line/string"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/string.fish:11
-msgid "Case insensitive"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/string.fish:12
 msgid "Use regex instead of globs"
 msgstr ""
@@ -51477,12 +49602,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sudo.fish:2
 msgid "Close all file descriptors greater or equal to the given number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/sudo.fish:3
-#: /tmp/fish/implicit/share/completions/su.fish:4
-#: /tmp/fish/implicit/share/completions/su.fish:5
-msgid "Preserve environment"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sudo.fish:4
@@ -51547,23 +49666,16 @@ msgstr ""
 msgid "Validate the credentials, extending timeout"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/su.fish:1
-msgid "Make login shell"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/su.fish:2
+#: share/completions/su.fish:5
 msgid "Pass command to shell"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/su.fish:3
-msgid "Pass -f to the shell"
-msgstr ""
+msgstr "Skicka kommando till skalet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:1
 msgid "Make a completion for a subcommand"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:2
+#: share/functions/__fish_complete_svn.fish:48
 msgid ""
 "Put files and directories under version control, scheduling them for "
 "addition to repository.  They will be added in next commit."
@@ -51571,172 +49683,344 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:3
 #: /tmp/fish/implicit/share/completions/svn.fish:5
+#: share/functions/__fish_complete_svn.fish:49
+#: share/functions/__fish_complete_svn.fish:51
+#, fuzzy
 msgid ""
 "Output the content of specified files or URLs with revision and author "
 "information in-line."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa filer/URL:er med revisions- och författarinformation inbakat"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:4
+#: share/functions/__fish_complete_svn.fish:50
+#, fuzzy
 msgid "Output the content of specified files or URLs."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa innehåll av filer/URL:er"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:6
+#: share/functions/__fish_complete_svn.fish:52
+#, fuzzy
 msgid "Check out a working copy from a repository."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Hämta ut en arbetskopia från förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:7
+#: share/functions/__fish_complete_svn.fish:53
 msgid ""
 "Recursively clean up the working copy, removing locks, resuming unfinished "
 "operations, etc."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:8
+#: share/functions/__fish_complete_svn.fish:54
+#, fuzzy
 msgid "Send changes from your working copy to the repository."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skicka ändringar i arbetskopian till lagret"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:9
+#: share/functions/__fish_complete_svn.fish:55
+#, fuzzy
 msgid "Duplicate something in working copy or repository, remembering history."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Flytta och/eller byt namn på någonting i arbetskopian eller förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:10
+#: share/functions/__fish_complete_svn.fish:56
+#, fuzzy
 msgid "Display the differences between two revisions or paths."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Applicera differensen mellan två källor till en arbetskopiesökväg"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:11
+#: share/functions/__fish_complete_svn.fish:57
 msgid "Create an unversioned copy of a tree."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:12
+#: share/functions/__fish_complete_svn.fish:58
+#, fuzzy
 msgid "Describe the usage of this program or its subcommands."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Beskriv användandet av detta program eller dess underkommandon"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:13
+#: share/functions/__fish_complete_svn.fish:59
+#, fuzzy
 msgid "Commit an unversioned file or tree into the repository."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:14
+#: share/functions/__fish_complete_svn.fish:60
+#, fuzzy
 msgid "Display information about a local or remote item."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa information om lokal eller fjärrelement"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:15
+#: share/functions/__fish_complete_svn.fish:61
+#, fuzzy
 msgid "List directory entries in the repository."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lista kataloger i förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:16
+#: share/functions/__fish_complete_svn.fish:62
+#, fuzzy
 msgid ""
 "Lock working copy paths or URLs in the repository, so that no other user can "
 "commit changes to them."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Läs arbetskopiwsökvägar eller URL:er i förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:17
+#: share/functions/__fish_complete_svn.fish:63
+#, fuzzy
 msgid "Show the log messages for a set of revision(s) and/or file(s)."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:18
+#: share/functions/__fish_complete_svn.fish:64
+#, fuzzy
 msgid "Apply the differences between two sources to a working copy path."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Applicera differensen mellan två källor till en arbetskopiesökväg"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:19
+#: share/functions/__fish_complete_svn.fish:65
+#, fuzzy
 msgid "Display information related to merges"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa ändringsinformation för paket"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:20
+#: share/functions/__fish_complete_svn.fish:66
+#, fuzzy
 msgid "Create a new directory under version control."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skapa ny katalog under revisionskontroll"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:21
+#: share/functions/__fish_complete_svn.fish:67
+#, fuzzy
 msgid "Move and/or rename something in working copy or repository."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Flytta och/eller byt namn på någonting i arbetskopian eller förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:22
+#: share/functions/__fish_complete_svn.fish:68
+#, fuzzy
 msgid "Apply a unidiff patch to the working copy"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa olagrade ändringar i arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:23
+#: share/functions/__fish_complete_svn.fish:69
+#, fuzzy
 msgid "Remove a property from files, dirs, or revisions."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ta bort en egenskap från filer, kataloger eller revisioner"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:24
+#: share/functions/__fish_complete_svn.fish:70
+#, fuzzy
 msgid "Edit a property with an external editor."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Redigera en egenskap med extern edito för mål"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:25
+#: share/functions/__fish_complete_svn.fish:71
+#, fuzzy
 msgid "Print the value of a property on files, dirs, or revisions."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv ut värde för en egenskap hos filer, kataloger eller revisioner"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:26
+#: share/functions/__fish_complete_svn.fish:72
+#, fuzzy
 msgid "List all properties on files, dirs, or revisions."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa alla engenskaper hos filer, kataloger eller revisioner"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:27
+#: share/functions/__fish_complete_svn.fish:73
+#, fuzzy
 msgid "Set the value of a property on files, dirs, or revisions."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv ut värde för en egenskap hos filer, kataloger eller revisioner"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:28
+#: share/functions/__fish_complete_svn.fish:74
+#, fuzzy
 msgid "Rewrite working copy url metadata"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera arbetskopia om släppning lyckas"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:29
+#: share/functions/__fish_complete_svn.fish:75
+#, fuzzy
 msgid "Remove files and directories from version control."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Placera filer och kataloger under versionskontroll"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:30
+#: share/functions/__fish_complete_svn.fish:76
+#, fuzzy
 msgid "Remove conflicts on working copy files or directories."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ta bort konflikttillstånd hos arbetskopiefiler eller kataloger"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:31
 msgid "Remove 'conflicted' state on working copy files or directories."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:32
+#: share/functions/__fish_complete_svn.fish:78
+#, fuzzy
 msgid "Restore pristine working copy file (undo most local edits)."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Återställ rensad arbetskopiefil"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:33
+#: share/functions/__fish_complete_svn.fish:79
+#, fuzzy
 msgid "Print the status of working copy files and directories."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa status för arbetskopians filer och kataloger"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:34
+#: share/functions/__fish_complete_svn.fish:80
+#, fuzzy
 msgid "Update the working copy to a different URL."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Uppdatera arbetskopian till en annan URL"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:35
+#: share/functions/__fish_complete_svn.fish:81
+#, fuzzy
 msgid "Unlock working copy paths or URLs."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lås upp arbetskopians sökvägar eller URL:er"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:36
+#: share/functions/__fish_complete_svn.fish:82
+#, fuzzy
 msgid "Bring changes from the repository into the working copy."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Hämta ändringar från förrådet till arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:37
+#: share/functions/__fish_complete_svn.fish:83
 msgid "Upgrade the metadata storage format for a working copy."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:38
+#, fuzzy
 msgid "Specify a username ARG"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj användarnamn"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:39
+#, fuzzy
 msgid "Specify a password ARG"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj lösenord"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:40
+#: share/functions/__fish_complete_svn.fish:90
+#, fuzzy
 msgid "Do not cache authentication tokens"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Cacha inte autentiseringssymboler"
 
-#: /tmp/fish/implicit/share/completions/svn.fish:41
+#: share/functions/__fish_complete_svn.fish:91
 msgid "Do no interactive prompting"
-msgstr ""
+msgstr "Ställ inga interaktiva frågor"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:42
+#: share/functions/__fish_complete_svn.fish:92
 msgid ""
 "Accept SSL server certificates from unknown authorities (ony with --non-"
 "interactive)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:43
+#, fuzzy
 msgid "Read user configuration files from directory ARG"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Läs användarkonfigurationsfiler från angiven katalog"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:44
 msgid ""
@@ -51748,36 +50032,52 @@ msgid "Exit sylpheed"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:5
+#: share/completions/sylpheed.fish:8
 msgid "Open composition window with address"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:6
+#: share/completions/sylpheed.fish:9
 msgid "Open composition window with attached files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:7
+#: share/completions/sylpheed.fish:10
+#, fuzzy
 msgid "Receive new messages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ersätt ett loggmeddelande"
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:8
+#: share/completions/sylpheed.fish:11
 msgid "Receive new messages of all accounts"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:9
+#: share/completions/sylpheed.fish:12
 msgid "Send all queued messages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:10
+#: share/completions/sylpheed.fish:13
 msgid "Show the total number of messages for folder"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:11
+#: share/completions/sylpheed.fish:14
 msgid "Show the total number of messages for each folder"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:12
+#: share/completions/sylpheed.fish:15
+#, fuzzy
 msgid "Specify directory with configuration files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj en konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/sysbench.fish:1
 msgid "The total number of worker threads to create (default: 1)"
@@ -52414,209 +50714,50 @@ msgid ""
 "output the last K lines, instead of the last 10 - or only K lines with -r"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/tar.fish:1
-#: /tmp/fish/implicit/share/completions/tar.fish:2
-msgid "Append archive to archive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:3
-msgid "Create archive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:4
-#: /tmp/fish/implicit/share/completions/tar.fish:5
-msgid "Compare archive and filesystem"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:6
-msgid "Delete from archive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:7
-msgid "Append files to archive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:8
-#: /tmp/fish/implicit/share/completions/unrar.fish:2
+#: share/completions/unrar.fish:6
 msgid "List archive"
-msgstr ""
+msgstr "Visa arkivinnehåll"
 
-#: /tmp/fish/implicit/share/completions/tar.fish:9
-msgid "Append new files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:10
-#: /tmp/fish/implicit/share/completions/tar.fish:11
-msgid "Extract from archive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:12
-msgid "Keep access time"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:14
-msgid "Reblock while reading"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:16
-msgid "Print directory names"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:17
+#: share/completions/tar.fish:21
 msgid "Archive file"
-msgstr ""
+msgstr "Arkivfil"
 
-#: /tmp/fish/implicit/share/completions/tar.fish:18
-msgid "Archive is local"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:19
-msgid "Run script at end of tape"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:20
-msgid "Use old incremental GNU format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:21
-msgid "Use new incremental GNU format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:22
-msgid "Dereference symlinks"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:23
-msgid "Ignore zero block in archive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:24
-msgid "Filter through bzip2"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:25
-msgid "Don't exit on unreadable files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:26
-msgid "Don't overwrite"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:27
+#: share/completions/tar.fish:31
 msgid "Starting file in archive"
-msgstr ""
+msgstr "Startfil i arkiv"
 
-#: /tmp/fish/implicit/share/completions/tar.fish:28
-msgid "Stay in local filesystem"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:29
+#: share/completions/tar.fish:33
 msgid "Tape length"
-msgstr ""
+msgstr "Bandlängd"
 
-#: /tmp/fish/implicit/share/completions/tar.fish:30
-#: /tmp/fish/implicit/share/completions/tar.fish:31
-msgid "Don't extract modification time"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:32
-msgid "Multi volume archive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:33
-#: /tmp/fish/implicit/share/completions/tar.fish:34
+#: share/completions/tar.fish:36
 msgid "Only store newer files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:35
-#: /tmp/fish/implicit/share/completions/tar.fish:36
-msgid "Use V7 format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:37
-msgid "Extract to stdout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:38
-#: /tmp/fish/implicit/share/completions/tar.fish:39
-msgid "Extract all permissions"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:40
-msgid "Don't strip leading /"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:41
-msgid "Preserve all permissions and do not sort file arguments"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:42
-msgid "Show record number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:43
-msgid "Remove files after adding to archive"
-msgstr ""
+msgstr "Lagra bara nyare filer"
 
 #: /tmp/fish/implicit/share/completions/tar.fish:44
 #: /tmp/fish/implicit/share/completions/tar.fish:45
 msgid "Do not sort file arguments"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/tar.fish:46
-msgid "Preserve file ownership"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:47
-msgid "Handle sparse files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:48
+#: share/completions/tar.fish:50
 msgid "Extract file from file"
-msgstr ""
+msgstr "Axtrahera fil från fil"
 
-#: /tmp/fish/implicit/share/completions/tar.fish:49
-msgid "-T has null-terminated names"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:50
-msgid "Print total bytes written"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:52
+#: share/completions/tar.fish:54
 msgid "Set volume name"
-msgstr ""
+msgstr "Välj volymnamn"
 
-#: /tmp/fish/implicit/share/completions/tar.fish:54
-#: /tmp/fish/implicit/share/completions/tar.fish:55
-msgid "Ask for confirmation"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:56
-msgid "Verify archive"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:57
+#: share/completions/tar.fish:59
 msgid "Exclude file"
-msgstr ""
+msgstr "Exkludera fil"
 
-#: /tmp/fish/implicit/share/completions/tar.fish:58
+#: share/completions/tar.fish:60
 msgid "Exclude files listed in specified file"
-msgstr ""
+msgstr "Exklidera filer listade i angiven fil"
 
-#: /tmp/fish/implicit/share/completions/tar.fish:59
-#: /tmp/fish/implicit/share/completions/tar.fish:60
-msgid "Filter through compress"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:61
-#: /tmp/fish/implicit/share/completions/tar.fish:62
-msgid "Filter through gzip"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/tar.fish:63
+#: share/completions/tar.fish:65
 msgid "Filter through specified program"
-msgstr ""
+msgstr "Filtrera genom angivet program"
 
 #: /tmp/fish/implicit/share/completions/tar.fish:64
 msgid "Filter through xz"
@@ -52995,80 +51136,12 @@ msgstr ""
 msgid "Print the Terraform version"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/test.fish:2
-msgid "Negate expression"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/test.fish:3
 msgid "Logical AND"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/test.fish:4
 msgid "Logical OR"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:5
-msgid "String length is non-zero"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:6
-msgid "String length is zero"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:7
-msgid "Strings are equal"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:8
-msgid "Strings are not equal"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:9
-msgid "Integers are equal"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:10
-msgid "Left integer larger than or equal to right integer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:11
-msgid "Left integer larger than right integer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:12
-msgid "Left integer less than or equal to right integer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:13
-msgid "Left integer less than right integer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:14
-msgid "Left integer not equal to right integer"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:15
-msgid "File is block device"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:16
-msgid "File is character device"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:17
-msgid "File is directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:18
-msgid "File exists"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:19
-msgid "File is regular"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:20
-msgid "File is set-group-ID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/test.fish:21
@@ -53087,28 +51160,12 @@ msgstr ""
 msgid "File is a named pipe"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/test.fish:25
-msgid "File is readable"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:26
-msgid "File size is non-zero"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/test.fish:27
 msgid "File is a socket"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/test.fish:28
 msgid "FD is a terminal"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:29
-msgid "File set-user-ID bit is set"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/test.fish:30
-msgid "File is writable"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/tex.fish:3
@@ -53156,22 +51213,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/timedatectl.fish:6
 msgid "Execute operation on a local container"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/time.fish:2
-msgid "Specify output format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/time.fish:3
-msgid "Use the portable output format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/time.fish:4
-msgid "Do not send the results to stderr, but overwrite the specified file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/time.fish:5
-msgid "(Used together with -o) Do not overwrite but append"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/timeout.fish:1
@@ -53386,16 +51427,27 @@ msgid "Print as XML"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/tmux.fish:1
+#: share/completions/tmux.fish:1
+#, fuzzy
 msgid "available sessions"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Utför argument som kommandon"
 
 #: /tmp/fish/implicit/share/completions/tmux.fish:2
+#: share/completions/tmux.fish:5
 msgid "connected clients"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/tmux.fish:3
+#: share/completions/tmux.fish:9
+#, fuzzy
 msgid "window panes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Terminalfönstret ändrade storlek"
 
 #: /tmp/fish/implicit/share/completions/tmux.fish:4
 msgid "Force tmux to assume the terminal supports 256 colours"
@@ -53686,36 +51738,8 @@ msgstr ""
 msgid "target-pane"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/top.fish:2
-msgid "Toggle command line/program name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/top.fish:5
-msgid "Toggle idle processes"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/top.fish:6
 msgid "Maximum iterations"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/top.fish:7
-msgid "Monitor effective UID"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/top.fish:8
-msgid "Monitor user"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/top.fish:9
-msgid "Monitor PID"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/top.fish:10
-msgid "Secure mode"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/top.fish:11
-msgid "Cumulative mode"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/totem.fish:1
@@ -53775,10 +51799,12 @@ msgid "Tell any running totem instance: Quit"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/totem.fish:15
+#: share/completions/totem.fish:18
 msgid "Tell any running totem instance: Add to playlist"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/totem.fish:16
+#: share/completions/totem.fish:19
 msgid "Tell any running totem instance: Play from playlist"
 msgstr ""
 
@@ -54084,14 +52110,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/transmission-remote.fish:78
 msgid "List the current torrent's connected peers"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/trap.fish:1
-msgid "Display names of all signals"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/trap.fish:2
-msgid "Display all currently defined trap handlers"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/trap.fish:4
@@ -54591,24 +52609,12 @@ msgstr ""
 msgid "hexadecimal characters"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/type.fish:2
-msgid "Print all possible definitions of the specified name"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/type.fish:3
 msgid "Suppress function and builtin lookup"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/type.fish:4
 msgid "Print command type"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/type.fish:5
-msgid "Print path to command, or nothing if name is not a command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/type.fish:6
-msgid "Print path to command"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/type.fish:7
@@ -54745,93 +52751,8 @@ msgstr ""
 msgid "Set or get hard limit"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/ulimit.fish:3
-msgid "Set or get all current limits"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:4
-msgid "Maximum size of core files created"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:5
-msgid "Maximum size of a process's data segment"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:6
-msgid "Maximum size of files created by the shell"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:7
-msgid "Maximum size that may be locked into memory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:8
-msgid "Maximum resident set size"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:9
-msgid "Maximum number of open file descriptors"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:10
-msgid "Maximum stack size"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:11
-msgid "Maximum amount of cpu time in seconds"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:12
-msgid "Maximum number of processes available to a single user"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/ulimit.fish:13
-msgid "Maximum amount of virtual memory available to the shell"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/ulimit.fish:15
 msgid "New resource limit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/umount.fish:5
-msgid "Unmount without writing in /etc/mtab"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/umount.fish:6
-msgid "In case unmounting fails, try to remount read-only"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/umount.fish:7
-msgid ""
-"In case the unmounted device was a loop device, also free this loop device"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/umount.fish:8
-msgid "Don't call the /sbin/umount.<filesystem> helper even if it exists"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/umount.fish:9
-msgid "Unmount all of the file systems described in /etc/mtab"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/umount.fish:10
-msgid "Actions should only be taken on file systems of the specified type"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/umount.fish:11
-msgid ""
-"Actions should only be taken on file systems with the specified options in /"
-"etc/fstab"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/umount.fish:12
-msgid "Force unmount (in case of an unreachable NFS system)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/umount.fish:13
-msgid ""
-"Detach the filesystem from the filesystem hierarchy now, and cleanup all "
-"references to the filesystem as soon as it is not busy"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/uname.fish:1
@@ -54866,32 +52787,8 @@ msgstr ""
 msgid "Print all information"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/uname.fish:9
-msgid "Print kernel name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/uname.fish:10
-msgid "Print network node hostname"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/uname.fish:11
-msgid "Print kernel release"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/uname.fish:12
 msgid "Print kernel version"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/uname.fish:13
-msgid "Print machine name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/uname.fish:14
-msgid "Print processor"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/uname.fish:15
-msgid "Print hardware platform"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/uname.fish:16
@@ -54915,40 +52812,77 @@ msgid "use comma separated LIST of tab positions (enables -a)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:1
+#: share/completions/unrar.fish:5
+#, fuzzy
 msgid "Extract files to current directory"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Läs filer i varje katalog"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:3
+#: share/completions/unrar.fish:7
+#, fuzzy
 msgid "List archive (technical)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa arkivinnehåll"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:4
+#: share/completions/unrar.fish:8
+#, fuzzy
 msgid "List archive (bare)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa arkivinnehåll"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:5
+#: share/completions/unrar.fish:9
+#, fuzzy
 msgid "Print file to stdout"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skicka filer till standard ut"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:6
+#: share/completions/unrar.fish:10
+#, fuzzy
 msgid "Test archive files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Arkivfil"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:7
+#: share/completions/unrar.fish:11
+#, fuzzy
 msgid "Verbosely list archive"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Verifiera arkiv"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:8
+#: share/completions/unrar.fish:12
 msgid "Verbosely list archive (technical)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:9
+#: share/completions/unrar.fish:13
 msgid "Verbosely list archive (bare)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:10
+#: share/completions/unrar.fish:14
+#, fuzzy
 msgid "Extract files with full path"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Axtrahera fil från fil"
 
 #: /tmp/fish/implicit/share/completions/update-eix.fish:1
 msgid "Show a short help screen"
@@ -55136,12 +53070,22 @@ msgid "The new SELinux user for the user's login"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vagrant.fish:1
+#: share/completions/vagrant.fish:3
+#, fuzzy
 msgid "Test if vagrant has yet to be given the main command"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/vagrant.fish:2
+#: share/completions/vagrant.fish:23
+#, fuzzy
 msgid "Lists all available Vagrant boxes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/vagrant.fish:4
 msgid "Print the help and exit"
@@ -55380,60 +53324,16 @@ msgstr ""
 msgid "Enable only certain provisioners, by type"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/valgrind.fish:1
+#: share/completions/valgrind.fish:12
 msgid "Skin"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:3
-msgid "Display help and debug options"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:7
-msgid "Valgrind-ise children"
-msgstr ""
+msgstr "Verktyg"
 
 #: /tmp/fish/implicit/share/completions/valgrind.fish:8
 msgid "Track file descriptors"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/valgrind.fish:9
-msgid "Log to file descriptor"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/valgrind.fish:10
 msgid "Log to file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:11
-msgid "Log to socket"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:12
-msgid "Callers in stack trace"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:13
-msgid "Stop showing errors if too many"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:14
-msgid "Continue trace below main()"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:15
-msgid "Supress errors from file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:16
-msgid "Print suppressions for detected errors"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:17
-msgid "Start debugger on error"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:18
-msgid "Debugger command"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/valgrind.fish:19
@@ -55443,22 +53343,6 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/valgrind.fish:20
 #: /tmp/fish/implicit/share/completions/valgrind.fish:26
 msgid "Check for memory leaks"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:21
-#: /tmp/fish/implicit/share/completions/valgrind.fish:27
-msgid "Show reachable leaked memory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:22
-msgid ""
-"Determines how willing Memcheck is to consider different backtraces to be "
-"the same"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:23
-#: /tmp/fish/implicit/share/completions/valgrind.fish:29
-msgid "Set size of freed memory pool"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/valgrind.fish:24
@@ -55471,47 +53355,25 @@ msgstr ""
 msgid "Whether to skip error reporting for the strlen function"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/valgrind.fish:28
-msgid ""
-"Determines how willing Addrcheck is to consider different backtraces to be "
-"the same"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:32
-msgid "Type of L1 instruction cache"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:33
-msgid "Type of L1 data cache"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:34
-msgid "Type of L2 cache"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/valgrind.fish:35
-msgid "Specify a function that allocates memory"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/valgrind.fish:36
 msgid "Profile heap usage"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/valgrind.fish:37
+#: share/completions/valgrind.fish:78
 msgid "The number of bytes of heap overhead per allocation"
-msgstr ""
+msgstr "Antalet bytes av extra heap-utrymme som används per allokering"
 
-#: /tmp/fish/implicit/share/completions/valgrind.fish:38
+#: share/completions/valgrind.fish:79
 msgid "Profile stack usage"
-msgstr ""
+msgstr "Profilera stackanvändning"
 
-#: /tmp/fish/implicit/share/completions/valgrind.fish:39
+#: share/completions/valgrind.fish:80
 msgid "Depth of call chain"
-msgstr ""
+msgstr "Djup i anroppskedjan"
 
-#: /tmp/fish/implicit/share/completions/valgrind.fish:40
+#: share/completions/valgrind.fish:81
 msgid "Profiling output format"
-msgstr ""
+msgstr "Utdataformat för profilering"
 
 #: /tmp/fish/implicit/share/completions/VBoxHeadless.fish:1
 msgid "Start given VM"
@@ -55685,31 +53547,43 @@ msgid "Deny usage of VT-x/AMD-V"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vi.fish:1
+#: share/functions/__fish_complete_vi.fish:91
 msgid "Suppress all interactive user feedback"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vi.fish:2
 #: /tmp/fish/implicit/share/completions/vi.fish:9
+#: share/functions/__fish_complete_vi.fish:92
+#: share/functions/__fish_complete_vi.fish:99
 msgid "Encrypt/decrypt text"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vi.fish:3
+#: share/functions/__fish_complete_vi.fish:93
 msgid "Set up for editing LISP programs"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vi.fish:4
+#: share/functions/__fish_complete_vi.fish:94
 msgid "List saved file names after crash"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vi.fish:5
+#: share/functions/__fish_complete_vi.fish:95
+#, fuzzy
 msgid "Read-only mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skrivskyddad"
 
 #: /tmp/fish/implicit/share/completions/vi.fish:6
+#: share/functions/__fish_complete_vi.fish:96
 msgid "Use linear search for tags if tag file not sorted"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vi.fish:7
+#: share/functions/__fish_complete_vi.fish:97
 msgid "Start in display editing state"
 msgstr ""
 
@@ -55726,8 +53600,13 @@ msgid "Begin editing by executing the specified  editor command"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim-addons.fish:1
+#: share/completions/vim-addons.fish:8
+#, fuzzy
 msgid "Test if vim-addons has yet to be given the subcommand"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/vim-addons.fish:2
 msgid "list the names of the addons available in the system"
@@ -55862,73 +53741,152 @@ msgid "Record all typed characters (overwrite file)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:18
+#: share/functions/__fish_complete_vi.fish:37
+#, fuzzy
 msgid "Start in Arabic mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Starta gränssnitt"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:19
+#: share/functions/__fish_complete_vi.fish:38
+#, fuzzy
 msgid "Start in binary mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Standardläge"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:20
+#: share/functions/__fish_complete_vi.fish:39
 msgid "Behave mostly like vi"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:21
+#: share/functions/__fish_complete_vi.fish:40
+#, fuzzy
 msgid "Start in diff mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:22
+#: share/functions/__fish_complete_vi.fish:41
+#, fuzzy
 msgid "Debugging mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Debugläge"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:23
+#: share/functions/__fish_complete_vi.fish:42
+#, fuzzy
 msgid "Start in Ex mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:24
+#: share/functions/__fish_complete_vi.fish:43
+#, fuzzy
 msgid "Start in improved Ex mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:25
 #: /tmp/fish/implicit/share/completions/vim.fish:46
+#: share/functions/__fish_complete_vi.fish:44
+#: share/functions/__fish_complete_vi.fish:67
+#, fuzzy
 msgid "Start in foreground mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:26
+#: share/functions/__fish_complete_vi.fish:45
+#, fuzzy
 msgid "Start in Farsi mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Standardläge"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:27
+#: share/functions/__fish_complete_vi.fish:46
+#, fuzzy
 msgid "Start in GUI mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:28
 #: /tmp/fish/implicit/share/completions/vim.fish:48
+#: share/functions/__fish_complete_vi.fish:47
+#: share/functions/__fish_complete_vi.fish:69
+#, fuzzy
 msgid "Print help message and exit"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:29
+#: share/functions/__fish_complete_vi.fish:48
+#, fuzzy
 msgid "Start in Hebrew mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:30
 #: /tmp/fish/implicit/share/completions/vim.fish:37
+#: share/functions/__fish_complete_vi.fish:49
+#, fuzzy
 msgid "List swap files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Arkivfil"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:31
+#: share/functions/__fish_complete_vi.fish:50
+#, fuzzy
 msgid "Start in lisp mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:32
+#: share/functions/__fish_complete_vi.fish:51
+#, fuzzy
 msgid "Disable file modification"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lita inte på filändringstid"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:33
+#: share/functions/__fish_complete_vi.fish:52
+#, fuzzy
 msgid "Disallow file modification"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa bara senaste modifiering"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:34
+#: share/functions/__fish_complete_vi.fish:53
 msgid "Reset compatibility mode"
 msgstr ""
 
@@ -55961,26 +53919,44 @@ msgid "Don't connect to X server"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:43
+#: share/functions/__fish_complete_vi.fish:62
+#, fuzzy
 msgid "Start in easy mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Starta gränssnitt"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:44
+#: share/functions/__fish_complete_vi.fish:63
+#, fuzzy
 msgid "Start in restricted mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Inskränkt läge"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:45
+#: share/functions/__fish_complete_vi.fish:65
 msgid "Become an editor server for NetBeans"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:47
+#: share/functions/__fish_complete_vi.fish:68
 msgid "Echo the Window ID on stdout (GTK GUI only)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:49
+#: share/functions/__fish_complete_vi.fish:70
+#, fuzzy
 msgid "Do not expand wildcards"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Expandera inte mönster"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:50
+#: share/functions/__fish_complete_vi.fish:71
 msgid "Skip loading plugins"
 msgstr ""
 
@@ -55988,40 +53964,79 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/vim.fish:54
 #: /tmp/fish/implicit/share/completions/vim.fish:55
 #: /tmp/fish/implicit/share/completions/vim.fish:56
+#: share/functions/__fish_complete_vi.fish:72
+#: share/functions/__fish_complete_vi.fish:75
+#: share/functions/__fish_complete_vi.fish:76
+#: share/functions/__fish_complete_vi.fish:77
+#, fuzzy
 msgid "Edit files on Vim server"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Redigera filer på plats"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:52
+#: share/functions/__fish_complete_vi.fish:73
+#, fuzzy
 msgid "Evaluate expr on Vim server"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Utför argument som kommandon"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:53
+#: share/functions/__fish_complete_vi.fish:74
+#, fuzzy
 msgid "Send keys to Vim server"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skicka e-post till användare"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:57
+#: share/functions/__fish_complete_vi.fish:78
 msgid "List all Vim servers that can be found"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:58
+#: share/functions/__fish_complete_vi.fish:79
+#, fuzzy
 msgid "Set server name"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Namn på tjänst"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:59
+#: share/functions/__fish_complete_vi.fish:80
+#, fuzzy
 msgid "Print version information and exit"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:60
 msgid "Run gvim in another window (GTK GUI only)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:1
+#: share/completions/wajig.fish:1
+#, fuzzy
 msgid "Test if wajig has yet to be given the subcommand"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:2
+#: share/completions/wajig.fish:10
+#, fuzzy
 msgid "Test if wajig command should have packages as potential completion"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Testa om aptkommando borde ha paket som potentiell komplettering"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:4
 msgid "Do system commands everything quietly."
@@ -56146,6 +54161,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:34
 #: /tmp/fish/implicit/share/completions/wajig.fish:115
+#: share/completions/wajig.fish:131
 msgid "Search for an unofficial Debian package at apt-get.org"
 msgstr ""
 
@@ -56175,6 +54191,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:41
 #: /tmp/fish/implicit/share/completions/wajig.fish:90
+#: share/completions/wajig.fish:106
 msgid "Initialise or reset the JIG archive files"
 msgstr ""
 
@@ -56184,6 +54201,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:43
 #: /tmp/fish/implicit/share/completions/wajig.fish:82
+#: share/completions/wajig.fish:98
 msgid "Install package and associated recommended packages"
 msgstr ""
 
@@ -56193,6 +54211,7 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:45
 #: /tmp/fish/implicit/share/completions/wajig.fish:111
+#: share/completions/wajig.fish:127
 msgid "Install package and associated suggested packages"
 msgstr ""
 
@@ -56307,8 +54326,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:75
 #: /tmp/fish/implicit/share/completions/wajig.fish:89
+#: share/completions/wajig.fish:105
+#, fuzzy
 msgid "Generate a .deb file for an installed package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Bygg och installera ett installerat paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:76
 msgid "From preferences file show priorities/policy (available)"
@@ -56331,148 +54355,228 @@ msgid "Display the package's README file from /usr/share/doc"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:81
+#: share/completions/wajig.fish:97
+#, fuzzy
 msgid "Download package and any packages it depends on"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa paket som detta paket beror på"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:83
+#: share/completions/wajig.fish:99
 msgid "Reconfigure the named installed packages or run gkdebconf"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:84
+#: share/completions/wajig.fish:100
+#, fuzzy
 msgid "Reinstall each of the named packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installera ett eller flera paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:85
+#: share/completions/wajig.fish:101
 msgid "Reload daemon configs, e.g., gdm, apache (see list-daemons)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:86
+#: share/completions/wajig.fish:102
+#, fuzzy
 msgid "Remove one or more packages (see also purge)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera ett eller flera paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:87
+#: share/completions/wajig.fish:103
 msgid "Remove package and its dependees not required by others"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:88
+#: share/completions/wajig.fish:104
 msgid "Remove orphaned libraries (not required by installed packages)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:91
+#: share/completions/wajig.fish:107
 msgid "Stop then start a daemon, e.g., gdm, apache (see list-daemons)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:92
+#: share/completions/wajig.fish:108
+#, fuzzy
 msgid "Install a RedHat .rpm package"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installera nytt paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:93
+#: share/completions/wajig.fish:109
 msgid "Convert a RedHat .rpm file to a Debian .deb file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:94
+#: share/completions/wajig.fish:110
+#, fuzzy
 msgid "Search for packages containing listed words"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Sök paket innehållande mönster"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:95
+#: share/completions/wajig.fish:111
 msgid "Find local Debian archives suitable for sources.list"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:96
+#: share/completions/wajig.fish:112
 msgid "Configure the sources.list file which locates Debian archives"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:97
+#: share/completions/wajig.fish:113
 msgid "Provide a detailed description of package [same as detail]"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:98
+#: share/completions/wajig.fish:114
 msgid "Trace the steps that a dist-upgrade would perform"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:99
+#: share/completions/wajig.fish:115
 msgid "Trace the steps that an install would perform"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:100
+#: share/completions/wajig.fish:116
 msgid "Trace the steps that a remove would perform"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:101
+#: share/completions/wajig.fish:117
 msgid "Trace the steps that an upgrade would perform"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:102
 #: /tmp/fish/implicit/share/completions/wajig.fish:103
+#: share/completions/wajig.fish:118 share/completions/wajig.fish:119
 msgid "Print out the size (in K) of all, or listed, installed packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:104
+#: share/completions/wajig.fish:120
 msgid "Generates list of package=version for all installed packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:105
+#: share/completions/wajig.fish:121
+#, fuzzy
 msgid "Retrieve and unpack sources for the named packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa paket som beror på det givna paketet"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:106
+#: share/completions/wajig.fish:122
 msgid "Start a daemon, e.g., gdm, apache (see list-daemons)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:107
+#: share/completions/wajig.fish:123
+#, fuzzy
 msgid "Show the version and available version of packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa fulla versioner för paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:108
 #: /tmp/fish/implicit/share/completions/wajig.fish:109
+#: share/completions/wajig.fish:124 share/completions/wajig.fish:125
 msgid "Show the version and available version of matching packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:110
+#: share/completions/wajig.fish:126
 msgid "Stop a daemon, e.g., gdm, apache (see list-daemons)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:112
+#: share/completions/wajig.fish:128
 msgid "Run the Gnome task selector to install groups of packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:113
+#: share/completions/wajig.fish:129
+#, fuzzy
 msgid "List packages with newer versions available for upgrading"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Uppdaterar till den bästa tillgängliga versionen"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:114
+#: share/completions/wajig.fish:130
 msgid "Remove listed packages from hold so they are again upgraded"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:116
+#: share/completions/wajig.fish:132
+#, fuzzy
 msgid "Update the list of down-loadable packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Updatera källkodpaketlista"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:117
+#: share/completions/wajig.fish:133
 msgid "Update default alternative for things like x-window-manager"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:118
+#: share/completions/wajig.fish:134
 msgid "Updates the local list of PCI ids from the internet master list"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:119
+#: share/completions/wajig.fish:135
 msgid "Updates the local list of USB ids from the internet master list"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:120
+#: share/completions/wajig.fish:136
 msgid "Upgrade all of the installed packages or just those listed"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:121
+#: share/completions/wajig.fish:137
+#, fuzzy
 msgid "List version and distribution of (all) packages."
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Verifiera inga attribut i paketfiler"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:122
+#: share/completions/wajig.fish:138
+#, fuzzy
 msgid "A synonym for describe"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Synonym för -i"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:123
+#: share/completions/wajig.fish:139
 msgid "Find the package that supplies the given command or file"
 msgstr ""
 
@@ -56511,22 +54615,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/watch.fish:10
 msgid "Pass command to exec instead of \"sh -c\""
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wc.fish:1
-msgid "Print byte counts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wc.fish:2
-msgid "Print character counts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wc.fish:3
-msgid "Print newline counts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wc.fish:4
-msgid "Print length of longest line"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wc.fish:5
@@ -56655,240 +54743,12 @@ msgstr ""
 msgid "Sets the number of turns for the chosen scenario"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/w.fish:1
-msgid "Dont print header"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/w.fish:2
-msgid "Ignore username for time calculations"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/w.fish:3
-msgid "Short format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/w.fish:4
-msgid "Toggle printing of remote hostname"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:3
-msgid "Go to background immediately after startup"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/wget.fish:4
 msgid "Execute command as if part of .wgetrc"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/wget.fish:5
-msgid "Log all messages to logfile"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:6
-msgid "Append all messages to logfile"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:7
-msgid "Turn on debug output"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:10
-#: /tmp/fish/implicit/share/completions/wget.fish:11
-msgid "Turn off verbose without being completely quiet"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:12
-msgid "Read URLs from file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:13
-msgid "Force input to be treated as HTML"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:14
-msgid "Prepend string to relative links"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:15
-msgid "Bind address on local machine"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:16
-msgid "Set number of retries to number"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:17
-msgid "Concatenate output to file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:18
-#: /tmp/fish/implicit/share/completions/wget.fish:19
-msgid "Never overwrite files with same name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:20
-msgid "Continue getting a partially-downloaded file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:21
-msgid "Select progress meter type"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:22
-msgid "Turn on time-stamping"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:23
-msgid "Print the headers/responses sent by servers"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:24
-msgid "Do not download the pages, just check that they are there"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:25
-msgid "Set the network timeout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:26
-msgid "Set the DNS lookup timeout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:27
-msgid "Set the connect timeout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:28
-msgid "Set the read (and write) timeout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:29
-msgid "Limit the download speed"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:30
-msgid "Wait the specified number of seconds between the retrievals"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:31
-msgid "Wait time between retries"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:32
-msgid "Wait random amount of time between retrievals"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:33
-msgid "Toggle proxy support"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:34
-msgid "Specify download quota for automatic retrievals"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:35
-msgid "Turn off caching of DNS lookups"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:36
-msgid ""
-"Change which characters found in remote URLs may show up in local file names"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:37
-#: /tmp/fish/implicit/share/completions/wget.fish:38
-msgid "Do not create a hierarchy of directories"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:39
-msgid "Force creation of a hierarchy of directories"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:40
-#: /tmp/fish/implicit/share/completions/wget.fish:41
-msgid "Disable generation of host-prefixed directories"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:42
-msgid "Use the protocol name as a directory component"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:43
-msgid "Ignore specified number of directory components"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:44
-msgid "Set directory prefix"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:45
-msgid "Force html files to have html extension"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:46
-msgid "Specify the http username"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:47
-msgid "Specify the http password"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:48
-msgid "Disable server-side cache"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/wget.fish:49
 msgid "Disable the use of cookies"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:50
-msgid "Load cookies from file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:51
-msgid "Save cookies to file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:52
-msgid "Save session cookies"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:53
-msgid "Ignore 'Content-Length' header"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:54
-msgid "Define an additional-header to be passed to the HTTP servers"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:55
-msgid "Specify the proxy username"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:56
-msgid "Specify the proxy password"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:57
-msgid "Set referer URL"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:58
-msgid "Save the headers sent by the HTTP server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:59
-msgid "Identify as agent-string"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:60
-#: /tmp/fish/implicit/share/completions/wget.fish:61
-msgid ""
-"Use POST as the method for all HTTP requests and send the specified data in "
-"the request body"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:62
-msgid "Turn off keep-alive for http downloads"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wget.fish:63
@@ -56947,216 +54807,17 @@ msgstr ""
 msgid "Path of HSTS database"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/wget.fish:77
-msgid "Don't remove the temporary .listing files generated"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:78
-msgid "Turn off FTP globbing"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:79
-msgid "Use the passive FTP retrieval scheme"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:80
-msgid "Traverse symlinks and retrieve pointed-to files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:81
-msgid "Turn on recursive retrieving"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:82
-msgid "Specify recursion maximum depth"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:83
-msgid "Delete every single file downloaded"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:84
-msgid ""
-"Convert the links in the document to make them suitable for local viewing"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:85
-msgid "Back up the original version"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:86
-msgid "Turn on options suitable for mirroring"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:87
-msgid ""
-"Download all the files that are necessary to properly display a given HTML "
-"page"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:88
-msgid "Turn on strict parsing of HTML comments"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:89
-msgid "Comma-separated lists of file name suffixes or patterns to accept"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:90
-msgid "Comma-separated lists of file name suffixes or patterns to reject"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:91
-msgid "Set domains to be followed"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:92
-msgid "Specify the domains that are not to be followed"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:93
-msgid "Follow FTP links from HTML documents"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:94
-msgid "HTML tags to follow"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:95
-msgid "HTML tags to ignore"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:96
-msgid "Enable spanning across hosts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:97
-msgid "Follow relative links only"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:98
-msgid "Specify a comma-separated list of directories you wish to follow"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/wget.fish:99
-msgid "Specify a comma-separated list of directories you wish to exclude"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/wget.fish:100
 #: /tmp/fish/implicit/share/completions/wget.fish:101
 msgid "Do not ever ascend to the parent directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:1
-#: /tmp/fish/implicit/share/completions/which.fish:13
-msgid "Print all matching executables in PATH, not just the first"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:2
-msgid "Read aliases from stdin, reporting matching ones on stdout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:3
-msgid "Ignore option '--read-alias'"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:4
-msgid ""
-"Read shell function definitions from stdin, reporting matching ones on stdout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:5
-msgid "Ignore option '--read-functions'"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:6
-msgid "Skip directories in PATH that start with a dot"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:7
-msgid ""
-"Skip directories in PATH that start with a tilde and executables which "
-"reside in the HOME directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:8
-msgid ""
-"If a directory in PATH starts with a dot and a matching executable was found "
-"for that path, then print './programname'"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:9
-msgid "Output a tilde when a directory matches the HOME directory"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/which.fish:10
-msgid "Stop processing options on the right if not on tty"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/which.fish:14
 msgid "Print no output, only return 0 if found"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/who.fish:1
-msgid "Same as -b -d --login -p -r -t -T -u"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:2
-msgid "Print time of last boot"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/who.fish:3
 msgid "Print dead processes"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:4
-msgid "Print line of headings"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:5
-msgid "Print idle time"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:6
-msgid "Print login process"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:7
-msgid "Canonicalize hostnames via DNS"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:8
-msgid "Print hostname and user for stdin"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:9
-msgid "Print active processes spawned by init"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:10
-msgid "Print all login names and number of users logged on"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:11
-msgid "Print current runlevel"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:12
-msgid "Print name, line, and time"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:13
-msgid "Print last system clock change"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:14
-#: /tmp/fish/implicit/share/completions/who.fish:15
-#: /tmp/fish/implicit/share/completions/who.fish:16
-msgid "Print users message status as +, - or ?"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/who.fish:17
-msgid "List users logged in"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wicd-client.fish:1
@@ -57241,150 +54902,239 @@ msgid "Set the network"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:1
+#: share/completions/wpa_cli.fish:3
 msgid "get current WPA/EAPOL/EAP status"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:2
+#: share/completions/wpa_cli.fish:4
 msgid "get MIB variables (dot1x, dot11)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:3
+#: share/completions/wpa_cli.fish:5
 msgid "show this usage help"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:4
+#: share/completions/wpa_cli.fish:6
+#, fuzzy
 msgid "show interfaces/select interface"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj gränssnitt"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:5
+#: share/completions/wpa_cli.fish:7
+#, fuzzy
 msgid "change debug level"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj debugnivå"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:6
+#: share/completions/wpa_cli.fish:8
 msgid "show full wpa_cli license"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:7
+#: share/completions/wpa_cli.fish:9
 msgid "IEEE 802.1X EAPOL state machine logoff"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:8
+#: share/completions/wpa_cli.fish:10
 msgid "IEEE 802.1X EAPOL state machine logon"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:9
+#: share/completions/wpa_cli.fish:11
+#, fuzzy
 msgid "set/list variables"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera variabel"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:10
+#: share/completions/wpa_cli.fish:12
 msgid "show PMKSA cache"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:11
+#: share/completions/wpa_cli.fish:13
+#, fuzzy
 msgid "force reassociation"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Tvinga namn/revision-association"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:12
+#: share/completions/wpa_cli.fish:14
 msgid "force wpa_supplicant to re-read its config file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:13
+#: share/completions/wpa_cli.fish:15
+#, fuzzy
 msgid "force preauthentication"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Tvinga pseudo-tty-allokering"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:14
+#: share/completions/wpa_cli.fish:16
 msgid "configure identity for an SSID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:15
+#: share/completions/wpa_cli.fish:17
 msgid "configure password for an SSID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:16
+#: share/completions/wpa_cli.fish:18
 msgid "change password for an SSID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:17
+#: share/completions/wpa_cli.fish:19
+#, fuzzy
 msgid "configure pin for an SSID"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Konfiurera för att bygga på given målarkitektur"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:18
+#: share/completions/wpa_cli.fish:20
 msgid "configure one-time-password for an SSID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:19
+#: share/completions/wpa_cli.fish:21
 msgid "configure private key passphrase for an SSID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:20
+#: share/completions/wpa_cli.fish:22
 msgid "set preferred BSSID for an SSID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:21
+#: share/completions/wpa_cli.fish:23
 msgid "list configured networks"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:22
+#: share/completions/wpa_cli.fish:24
 msgid "select a network (disable others)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:23
+#: share/completions/wpa_cli.fish:25
+#, fuzzy
 msgid "enable a network"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Aktivera förråd"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:24
+#: share/completions/wpa_cli.fish:26
+#, fuzzy
 msgid "disable a network"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Inaktivera förråd"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:25
+#: share/completions/wpa_cli.fish:27
+#, fuzzy
 msgid "add a network"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lägg till ny nyckel"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:26
+#: share/completions/wpa_cli.fish:28
+#, fuzzy
 msgid "remove a network"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ta bort en nyckel"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:27
+#: share/completions/wpa_cli.fish:29
 msgid "set/list network variables"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:28
+#: share/completions/wpa_cli.fish:30
+#, fuzzy
 msgid "get network variables"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj CVS-användare"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:29
+#: share/completions/wpa_cli.fish:31
+#, fuzzy
 msgid "save the current configuration"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ladda om konfiguration för tjänst"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:30
+#: share/completions/wpa_cli.fish:32
 msgid "disconnect and wait for reassociate command before connecting"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:31
+#: share/completions/wpa_cli.fish:33
 msgid "request new BSS scan"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:32
+#: share/completions/wpa_cli.fish:34
 msgid "get latest scan results"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:33
+#: share/completions/wpa_cli.fish:35
+#, fuzzy
 msgid "get capabilies"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj spellista"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:34
+#: share/completions/wpa_cli.fish:36
 msgid "request STAKey negotiation with <addr>"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:35
+#: share/completions/wpa_cli.fish:37
 msgid "set ap_scan parameter"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:36
+#: share/completions/wpa_cli.fish:38
 msgid "request STK negotiation with <addr>"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:37
+#: share/completions/wpa_cli.fish:39
 msgid "terminate wpa_supplicant"
 msgstr ""
 
@@ -57402,59 +55152,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wvdial.fish:4
 msgid "Don't output debug information"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:1
-msgid ""
-"Input filenames are terminated by a null character instead of by whitespace, "
-"and the quotes and backslash are not special"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:2
-#: /tmp/fish/implicit/share/completions/xargs.fish:3
-msgid "Set the end of file string to eof-str"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:5
-#: /tmp/fish/implicit/share/completions/xargs.fish:6
-msgid ""
-"Replace replace-str in the initial arguments with names from standard input"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:7
-#: /tmp/fish/implicit/share/completions/xargs.fish:8
-msgid "Use at most max-lines nonblank input lines per command line"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:9
-msgid "Use at most max-args arguments per command line"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:10
-msgid ""
-"Prompt the user about whether to run each command line and read a line from "
-"the terminal"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:11
-msgid ""
-"If the standard input does not contain any nonblanks, do not run the command"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:12
-msgid "Use at most max-chars characters per command line"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:13
-msgid "Print the command line on the standard error output before executing it"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:15
-msgid "Exit if the size is exceeded"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xargs.fish:16
-msgid "Run up to max-procs processes at a time"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xdg-mime.fish:1
@@ -57660,16 +55357,24 @@ msgid "Show summary of options"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:2
+#, fuzzy
 msgid "Select XMMS session (Default: 0)"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj via sessions-id"
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:3
 msgid "Skip backwards in playlist"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:4
+#, fuzzy
 msgid "Start playing current playlist"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa eller redigera alla resursanvändningsgränser"
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:5
 msgid "Pause current song"
@@ -57688,8 +55393,12 @@ msgid "Skip forward in playlist"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:9
+#, fuzzy
 msgid "Don't clear the playlist"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj spellista"
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:10
 msgid "Show the main window"
@@ -57700,8 +55409,12 @@ msgid "Set the initial window geometry"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:2
+#, fuzzy
 msgid "Set the window title"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj nätverkstimeout"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:3
 msgid "Install a private colormap"
@@ -57712,12 +55425,20 @@ msgid "Set the size of the largest RGB cube xpdf will try to allocate"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:5
+#, fuzzy
 msgid "Set reverse video mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Serverläge"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:6
+#, fuzzy
 msgid "Set the background of the page display"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skapa fönster på angiven skärm"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:7
 msgid "Set the color for background outside the page area"
@@ -57744,12 +55465,20 @@ msgid "Enable or disable font anti-aliasing (Default: yes)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:13
+#, fuzzy
 msgid "Set the default file name for PostScript output"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange standardnyckelordssubstitution"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:14
+#, fuzzy
 msgid "Set the paper size"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj uttags (socket) buffertstorlek"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:15
 msgid "Set the paper width, in points"
@@ -57760,24 +55489,44 @@ msgid "Set the paper height, in points"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:17
+#, fuzzy
 msgid "Generate Level 1 PostScript"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Generera utdata för dired"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:18
+#, fuzzy
 msgid "Sets the encoding to use for text output"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Varken tyst eller utförligt läge"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:19
+#, fuzzy
 msgid "Sets the end-of-line convention to use"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Sätt slut-på-fil-strängen till angiven sträng"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:20
+#, fuzzy
 msgid "Specify the owner password for the PDF file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj proxylösenord"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:21
+#, fuzzy
 msgid "Specify the user password for the PDF file"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj proxylösenord"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:22
 msgid "Open xpdf in full-screen mode"
@@ -57800,75 +55549,43 @@ msgid "Kill xpdf remote server"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:27
+#, fuzzy
 msgid "Print commands as they're executed"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv kommandon till standard fel"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:29
 msgid "Specify config file to use instead of ~/.xpdfrc"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:30
+#, fuzzy
 msgid "Print copyright and version information"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ignorera all versionsinformation"
 
-#: /tmp/fish/implicit/share/completions/xprop.fish:2
-msgid "Display grammar and exit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xprop.fish:3
+#: share/completions/xprop.fish:4
 msgid "Select window by id"
-msgstr ""
+msgstr "Välj fönster via id"
 
-#: /tmp/fish/implicit/share/completions/xprop.fish:4
-msgid "Select window by name"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xprop.fish:5
+#: share/completions/xprop.fish:6
 msgid "Display font properties"
-msgstr ""
+msgstr "Visa fontegenskaper"
 
-#: /tmp/fish/implicit/share/completions/xprop.fish:6
-msgid "Select root window"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xprop.fish:7
-msgid "Specify X server"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xprop.fish:8
+#: share/completions/xprop.fish:9
 msgid "Maximum display length"
-msgstr ""
+msgstr "Maximal displaylängd"
 
-#: /tmp/fish/implicit/share/completions/xprop.fish:9
-msgid "Do not show property type"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xprop.fish:10
+#: share/completions/xprop.fish:11
 msgid "Set format file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xprop.fish:11
-msgid "Select a window by clicking on its frame"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xprop.fish:12
-msgid "Remove property"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xprop.fish:13
-msgid "Set property"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xprop.fish:14
-msgid "Examine property updates forever"
-msgstr ""
+msgstr "Välj formatfil"
 
 #: /tmp/fish/implicit/share/completions/xprop.fish:15
 msgid "Set format"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xrandr.fish:2
-msgid "Make no changes"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xrandr.fish:3
@@ -58117,69 +55834,13 @@ msgstr ""
 msgid "don't warn about duplicates"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/xsel.fish:1
-msgid "Append input to selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:2
-msgid "Append to selection as input grows"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:3
-msgid "Read into selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:4
-msgid "Write selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:5
-msgid "Clear selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:6
-msgid "Delete selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:7
-msgid "Use primary selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:8
-msgid "Use secondary selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:9
-msgid "Use clipboard selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:10
-msgid "Make current selections persistent after program exit"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:11
-msgid "Exchange primary and secondary selections"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:12
+#: share/completions/xsel.fish:12
 msgid "X server display"
-msgstr ""
+msgstr "X-serverdisplay"
 
-#: /tmp/fish/implicit/share/completions/xsel.fish:13
-msgid "Timeout for retrieving selection"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:14
+#: share/completions/xsel.fish:14
 msgid "Error log"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:15
-msgid "Do not detach from the controlling terminal"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/xsel.fish:17
-msgid "Print informative messages"
-msgstr ""
+msgstr "Fellogg"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:1
 msgid "Never highlight the text cursor"
@@ -58562,108 +56223,170 @@ msgid "Use as input/output channel for an existing program"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:96
+#: share/completions/xterm.fish:101
 msgid "Run program in xterm"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:97
+#: share/completions/xterm.fish:103
 msgid "Blinking cursor will be off for that many milliseconds"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:98
+#: share/completions/xterm.fish:104
 msgid "Blinking cursor will be on for that many milliseconds"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:99
+#: share/completions/xterm.fish:105
 msgid "Override xterm resource class"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:100
+#: share/completions/xterm.fish:106
 msgid "Color for the text cursor"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:101
+#: share/completions/xterm.fish:107
+#, fuzzy
 msgid "xterm encoding"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Tvinga kodning"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:102
+#: share/completions/xterm.fish:108
 msgid "Bold font"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:103
+#: share/completions/xterm.fish:109
 msgid "FreeType font pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:104
+#: share/completions/xterm.fish:110
 msgid "FreeType double-width font pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:105
+#: share/completions/xterm.fish:111
+#, fuzzy
 msgid "Font for active icons"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Tvinga interaktivt läge"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:106
+#: share/completions/xterm.fish:112
 msgid "Font size for FreeType font"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:107
+#: share/completions/xterm.fish:113
 msgid "Font for displaying wide text"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:108
+#: share/completions/xterm.fish:114
 msgid "Font for displaying bold wide text"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:109
+#: share/completions/xterm.fish:115
 msgid "Font for the preedit string in \"OverTheSpot\""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:110
+#: share/completions/xterm.fish:116
 msgid "Color for highlighted text"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:111
+#: share/completions/xterm.fish:117
+#, fuzzy
 msgid "Embed xterm into window"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa trådar"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:112
+#: share/completions/xterm.fish:118
+#, fuzzy
 msgid "Set keyboard type"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange posttyp"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:113
+#: share/completions/xterm.fish:119
 msgid "File name for the encoding converter"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:114
+#: share/completions/xterm.fish:120
+#, fuzzy
 msgid "Log filename"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Logga till fil"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:115
+#: share/completions/xterm.fish:121
 msgid "Maximum time in milliseconds between multi-click selections"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:116
+#: share/completions/xterm.fish:122
 msgid "Color for the pointer cursor"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:117
+#: share/completions/xterm.fish:123
 msgid "Distance from the right end for ringing the margin bell"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:118
+#: share/completions/xterm.fish:124
+#, fuzzy
 msgid "Number of scrolled off lines"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Numrera alla rader"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:119
+#: share/completions/xterm.fish:125
+#, fuzzy
 msgid "Terminal identification"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa all information"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:121
+#: share/completions/xterm.fish:127
+#, fuzzy
 msgid "zIconBeep percentage"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa filposition i procent i prompten"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:122
+#: share/completions/xterm.fish:129
+#, fuzzy
 msgid "Size of the inner border"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa ändringar i omvänd ordning"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:123
 msgid "Use jump scrolling"
@@ -59093,48 +56816,12 @@ msgstr ""
 msgid "Generate rss changelog"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/yum.fish:14
-msgid "Set debug level"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/yum.fish:15
-msgid "Set error level"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/yum.fish:16
-msgid "Be tolerant of errors in commandline"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/yum.fish:17
-msgid "Set maximum delay between commands"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/yum.fish:18
-msgid "Run commands from cache"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/yum.fish:20
-msgid "Specify installroot"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/yum.fish:21
 msgid "Enable repository"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/yum.fish:22
 msgid "Disable repository"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/yum.fish:23
-msgid "Enables obsolets processing logic"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/yum.fish:24
-msgid "Output rss-data to file"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/yum.fish:25
-msgid "Exclude specified package from updates"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/yum.fish:26
@@ -59158,16 +56845,31 @@ msgid "List packages that are obsoleted by packages in repositories"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/yum.fish:32
+#: share/completions/yum.fish:53
+#, fuzzy
 msgid "Delete cached package files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera obsoleta paketfiler"
 
 #: /tmp/fish/implicit/share/completions/yum.fish:33
+#: share/completions/yum.fish:54
+#, fuzzy
 msgid "Delete cached header files"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera urval"
 
 #: /tmp/fish/implicit/share/completions/yum.fish:34
+#: share/completions/yum.fish:55
+#, fuzzy
 msgid "Delete all cache contents"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera logfil"
 
 #: /tmp/fish/implicit/share/completions/zfs.fish:1
 msgid ""
@@ -59767,109 +57469,21 @@ msgstr ""
 msgid "Pool which program will be executed on"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/zip.fish:1
-msgid "Freshen: only changed files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:2
-msgid "Delete entries in zipfile"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:3
-msgid "Update: only changed or newer files"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:4
-msgid "Move into zipfile (delete files)"
-msgstr ""
-
 #: /tmp/fish/implicit/share/completions/zip.fish:6
 msgid "Do not store directory names"
 msgstr ""
 
-#: /tmp/fish/implicit/share/completions/zip.fish:7
-msgid "Do not compress at all"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:8
-msgid "Convert LF to CR LF"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:9
-msgid "Convert CR LF to LF"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:10
-msgid "Compress faster"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:11
-msgid "Compress better"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:14
-msgid "Add one-line comments"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:15
-msgid "Add zipfile comments"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:16
-msgid "Read names from stdin"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:17
-msgid "Make zipfile as old as the latest entry"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:18
+#: share/completions/zip.fish:19
 msgid "Exclude the following names"
-msgstr ""
+msgstr "Exkludera följande namn"
 
-#: /tmp/fish/implicit/share/completions/zip.fish:19
+#: share/completions/zip.fish:20
 msgid "Include only the following names"
-msgstr ""
+msgstr "Inkludera bara följande namn"
 
-#: /tmp/fish/implicit/share/completions/zip.fish:20
-msgid "Fix zipfile"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:21
-msgid "Fix zipfile (try harder)"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:22
-msgid "Adjust offsets to suit self-extracting exe"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:23
-msgid "Strip prepended data"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:24
-msgid "Test zipfile integrity"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:25
-msgid "Exclude extra file attributes"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:26
-msgid "Store symbolic links as links"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:27
-msgid "PKZIP recursion"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:28
-msgid "Encrypt"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/zip.fish:29
+#: share/completions/zip.fish:30
 msgid "Don't compress files with these suffixes"
-msgstr ""
+msgstr "Komprimera inte filer med dessa ändelser"
 
 #: /tmp/fish/implicit/share/completions/zpool.fish:1
 msgid ""
@@ -60339,164 +57953,341 @@ msgid "Repo"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:5
+#: share/completions/zypper.fish:31
 msgid "Accept multiple commands at once"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:6
+#: share/completions/zypper.fish:32
 msgid "List all defined repositories"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:7
+#: share/completions/zypper.fish:33
+#, fuzzy
 msgid "Add a new repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Uppdatera förråd"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:8
+#: share/completions/zypper.fish:34
+#, fuzzy
 msgid "Remove specified repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange förråd-URL"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:9
+#: share/completions/zypper.fish:35
+#, fuzzy
 msgid "Rename specified repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Reparera trasigt förråd"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:10
+#: share/completions/zypper.fish:36
+#, fuzzy
 msgid "Modify specified repository"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ange förråd-URL"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:11
+#: share/completions/zypper.fish:37
+#, fuzzy
 msgid "Refresh all repositories"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skrivskyddat förråd-läge"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:12
+#: share/completions/zypper.fish:38
+#, fuzzy
 msgid "Clean local caches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Rengör lokala cachear och paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:13
+#: share/completions/zypper.fish:39
 msgid "List all defined services"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:14
+#: share/completions/zypper.fish:40
+#, fuzzy
 msgid "Add a new service"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lägg till ny nyckel"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:15
+#: share/completions/zypper.fish:41
+#, fuzzy
 msgid "Modify specified service"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Använd angiven nyckelserver"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:16
+#: share/completions/zypper.fish:42
+#, fuzzy
 msgid "Remove specified service"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Använd angiven nyckelserver"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:17
+#: share/completions/zypper.fish:43
 msgid "Refresh all services"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:20
+#: share/completions/zypper.fish:46
+#, fuzzy
 msgid "Verify integrity of package dependencies"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installera/ta bort paket för beroenden"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:21
+#: share/completions/zypper.fish:47
+#, fuzzy
 msgid "Install source packages and their build dependencies"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installera/ta bort paket för beroenden"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:22
+#: share/completions/zypper.fish:48
+#, fuzzy
 msgid "Install newly added packages recommended by installed packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installera paket även om de ersätter filer från andra, redan installerade "
+"paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:23
+#: share/completions/zypper.fish:49
+#, fuzzy
 msgid "Update installed packages with newer versions"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa alla källkodspaket med version"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:24
+#: share/completions/zypper.fish:50
+#, fuzzy
 msgid "List available updates"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa tillgängliga paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:25
+#: share/completions/zypper.fish:51
+#, fuzzy
 msgid "Install needed patches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Installera nytt paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:26
+#: share/completions/zypper.fish:52
+#, fuzzy
 msgid "List needed patches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa byteavstånd för matchningar"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:27
+#: share/completions/zypper.fish:53
+#, fuzzy
 msgid "Perform a distribution upgrade"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Utför en simulering"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:28
+#: share/completions/zypper.fish:54
+#, fuzzy
 msgid "Check for patches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Dekomprimera fixar"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:29
+#: share/completions/zypper.fish:55
+#, fuzzy
 msgid "Search for packages matching a pattern"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Sök paket innehållande mönster"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:30
+#: share/completions/zypper.fish:56
+#, fuzzy
 msgid "Show full information for specified packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa fulla versioner för paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:31
+#: share/completions/zypper.fish:57
+#, fuzzy
 msgid "Show full information for specified patches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv profileringsinformation till angiven fil"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:32
+#: share/completions/zypper.fish:58
+#, fuzzy
 msgid "Show full information for specified patterns"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa inte filer som matchar mönster"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:33
+#: share/completions/zypper.fish:59
+#, fuzzy
 msgid "Show full information for specified products"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv profileringsinformation till angiven fil"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:34
+#: share/completions/zypper.fish:60
+#, fuzzy
 msgid "List all available patches"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:35
+#: share/completions/zypper.fish:61
+#, fuzzy
 msgid "List all available packages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Ominstallera paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:36
+#: share/completions/zypper.fish:62
+#, fuzzy
 msgid "List all available patterns"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:37
+#: share/completions/zypper.fish:63
+#, fuzzy
 msgid "List all available products"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:38
+#: share/completions/zypper.fish:64
+#, fuzzy
 msgid "List packages providing specified capability"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Fråga alla paket som tillhandahåller den angivna förmågan"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:39
+#: share/completions/zypper.fish:65
+#, fuzzy
 msgid "Add a package lock"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Bygg om paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:40
+#: share/completions/zypper.fish:66
+#, fuzzy
 msgid "Remove a package lock"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:41
+#: share/completions/zypper.fish:67
+#, fuzzy
 msgid "List current package locks"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Lista buggar från paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:42
+#: share/completions/zypper.fish:68
+#, fuzzy
 msgid "Remove unused locks"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Radera källkodpaket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:43
+#: share/completions/zypper.fish:69
 msgid "Compare two version strings"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:44
+#: share/completions/zypper.fish:70
+#, fuzzy
 msgid "Print the target operating system ID string"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa operativsystem"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:45
+#: share/completions/zypper.fish:71
 msgid "Print report about licenses and EULAs of installed packages"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:46
+#: share/completions/zypper.fish:72
+#, fuzzy
 msgid "Download source rpms for all installed packages to a local directory"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:48
 msgid "Output the version number"
@@ -61324,6 +59115,7 @@ msgid "Menu based cd command"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/contains_seq.fish:1
+#: share/functions/contains_seq.fish:1
 msgid "Return true if array contains a sequence"
 msgstr ""
 
@@ -61331,9 +59123,9 @@ msgstr ""
 msgid "Print the current directory history (the prev and next lists)"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/dirs.fish:1
+#: share/functions/dirs.fish:1
 msgid "Print directory stack"
-msgstr ""
+msgstr "Visa katalogstack"
 
 #: /tmp/fish/implicit/share/functions/down-or-search.fish:1
 msgid ""
@@ -61345,9 +59137,14 @@ msgstr ""
 msgid "Edit the command buffer in an external editor"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/_.fish:1
+#: /tmp/fish/implicit/share/functions/_.fish:1 share/functions/_.fish:8
+#: share/functions/_.fish:12
+#, fuzzy
 msgid "Alias for the gettext command"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Hjälp för det angivna kommandot"
 
 #: /tmp/fish/implicit/share/functions/_.fish:2
 msgid "Fallback alias for the gettext command"
@@ -61362,136 +59159,43 @@ msgid "Return 0 if the current token has an open single-quote"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
+#: share/functions/__fish_complete_atool_archive_contents.fish:1
+#, fuzzy
 msgid "List archive contents"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa arkivinnehåll"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:1
-msgid "Maximum uploads at once"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:2
-msgid "Number of seconds between keepalives"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:3
-msgid "Bytes per request"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:4
-msgid "Requests per pipe"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:5
-msgid "Maximum length prefix encoding"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:6
+#: share/functions/__fish_complete_bittorrent.fish:9
 msgid "IP to report to the tracker"
-msgstr ""
+msgstr "IP adress att rapportera till tracker"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:7
+#: share/functions/__fish_complete_bittorrent.fish:10
 msgid "Minimum port to listen to"
-msgstr ""
+msgstr "Lägsta portnummer att lyssna på"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:8
+#: share/functions/__fish_complete_bittorrent.fish:11
 msgid "Maximum port to listen to"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:9
-msgid "File for server response"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:10
-msgid "URL to get file from"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:11
-msgid "Local file target"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:12
-msgid "Time to close inactive socket"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:13
-msgid "Time between checking timeouts"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:14
-msgid "Maximum outgoing slice length"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:15
-msgid "Maximum time to guess rate"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:16
-msgid "IP to bind to locally"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:17
-msgid "Time between screen updates"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:18
-msgid "Time to wait between requesting more peers"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:19
-msgid "Minimum number of peers to not do requesting"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:20
-msgid "Number of seconds before assuming http timeout"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:21
-msgid "Number of peers at which to stop initiating new connections"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:22
-msgid "Maximum number of connections to allow"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:23
-msgid "Whether to check hashes on disk"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:24
-msgid "Maximum kB/s to upload at"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:25
-msgid "Seconds to wait for data to come in before assuming choking"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:26
-msgid "Whether to display diagnostic info"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:27
-msgid "Number of downloads at which to switch from random to rarest first"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:28
-msgid "Number of uploads to fill out to with optimistic unchokes"
-msgstr ""
-
-#: /tmp/fish/implicit/share/functions/__fish_complete_bittorrent.fish:29
-msgid "Whether to inform the user that hash failures occur"
-msgstr ""
+msgstr "Högsta portnummer att lyssna på"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_cd.fish:1
 msgid "Completions for the cd command"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_command.fish:1
+#: share/functions/__fish_complete_command.fish:1
 msgid "Complete using all available commands"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_convert_options.fish:1
+#: share/functions/__fish_complete_convert_options.fish:1
+#, fuzzy
 msgid "Complete Convert options"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Tolerera slarviga monteringsflaggor"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_directories.fish:1
 msgid "Complete directory prefixes"
@@ -61550,6 +59254,7 @@ msgid "Enable debugging"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_groups.fish:1
+#: share/functions/__fish_complete_groups.fish:2
 msgid "Print a list of local groups, with group members as the description"
 msgstr ""
 
@@ -61630,12 +59335,22 @@ msgid "Set the page margins when printing text files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_lpr_option.fish:1
+#: share/functions/__fish_complete_lpr_option.fish:1
+#, fuzzy
 msgid "Complete lpr option"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Tolerera slarviga monteringsflaggor"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_path.fish:1
+#: share/functions/__fish_complete_path.fish:1
+#, fuzzy
 msgid "Complete using path"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Tolerera slarviga monteringsflaggor"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_pgrep.fish:1
 msgid "Complete pgrep/pkill"
@@ -61702,48 +59417,64 @@ msgid "Print a list of process identifiers along with brief descriptions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_ppp_peer.fish:1
+#: share/functions/__fish_complete_ppp_peer.fish:1
 msgid "Complete isp name for pon/poff"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_proc.fish:1
+#: share/functions/__fish_complete_proc.fish:1
+#, fuzzy
 msgid "Complete by list of running processes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa lista på alla körande screen-sessioner"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 msgid "common completions for ssh commands"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:2
+#: share/functions/__fish_complete_ssh.fish:4
+#, fuzzy
 msgid "Protocol version 1 only"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Bara protokoll version 1"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:3
+#: share/functions/__fish_complete_ssh.fish:5
+#, fuzzy
 msgid "Protocol version 2 only"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Bara protokoll version 2"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:4
+#: share/functions/__fish_complete_ssh.fish:6
 msgid "IPv4 addresses only"
-msgstr ""
+msgstr "Bara IPv4-adresser"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:5
+#: share/functions/__fish_complete_ssh.fish:7
 msgid "IPv6 addresses only"
-msgstr ""
+msgstr "Bara IPv6-adresser"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:6
+#: share/functions/__fish_complete_ssh.fish:8
 msgid "Compress all data"
-msgstr ""
+msgstr "Komprimera all data"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:7
+#: share/functions/__fish_complete_ssh.fish:9
 msgid "Encryption algorithm"
-msgstr ""
+msgstr "Krypteringsalgoritm"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:9
+#: share/functions/__fish_complete_ssh.fish:11
 msgid "Identity file"
-msgstr ""
+msgstr "Identitetsfil"
 
-#: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:10
+#: share/functions/__fish_complete_ssh.fish:12
 msgid "Options"
-msgstr ""
+msgstr "Flaggor"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_subcommand.fish:1
 msgid "Complete subcommand"
@@ -61758,6 +59489,7 @@ msgid "Print list host-names with user@"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_users.fish:1
+#: share/functions/__fish_complete_users.fish:2
 msgid "Print a list of local users, with the real user name as a description"
 msgstr ""
 
@@ -61784,6 +59516,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_config.fish:1
+#: share/functions/fish_config.fish:1
 msgid "Launch fish's web based configuration"
 msgstr ""
 
@@ -61791,33 +59524,38 @@ msgstr ""
 msgid "Initializations that should be performed when entering interactive mode"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_config_interactive.fish:2
+#: share/functions/__fish_config_interactive.fish:130
 msgid "Event handler, repaints the prompt when fish_color_cwd changes"
-msgstr ""
+msgstr "Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
 #: /tmp/fish/implicit/share/functions/__fish_config_interactive.fish:3
+#: share/functions/__fish_config_interactive.fish:137
+#, fuzzy
 msgid "Event handler, repaints the prompt when fish_color_cwd_root changes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
-#: /tmp/fish/implicit/share/functions/__fish_config_interactive.fish:4
+#: share/functions/__fish_config_interactive.fish:149
 msgid "Start service"
-msgstr ""
+msgstr "Starta tjänst"
 
-#: /tmp/fish/implicit/share/functions/__fish_config_interactive.fish:5
+#: share/functions/__fish_config_interactive.fish:150
 msgid "Stop service"
-msgstr ""
+msgstr "Stanna tjänst"
 
-#: /tmp/fish/implicit/share/functions/__fish_config_interactive.fish:6
+#: share/functions/__fish_config_interactive.fish:151
 msgid "Print service status"
-msgstr ""
+msgstr "Visa status för tjänst"
 
-#: /tmp/fish/implicit/share/functions/__fish_config_interactive.fish:7
+#: share/functions/__fish_config_interactive.fish:152
 msgid "Stop and then start service"
-msgstr ""
+msgstr "Stanna och starta tjänst"
 
-#: /tmp/fish/implicit/share/functions/__fish_config_interactive.fish:8
+#: share/functions/__fish_config_interactive.fish:153
 msgid "Reload service configuration"
-msgstr ""
+msgstr "Ladda om konfiguration för tjänst"
 
 #: /tmp/fish/implicit/share/functions/__fish_config_interactive.fish:9
 msgid "Reload key bindings when binding variable change"
@@ -61860,48 +59598,74 @@ msgid "Command used to find descriptions for commands"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:1
+#: share/functions/__fish_git_prompt.fish:173
 msgid "Helper function for __fish_git_prompt"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:2
+#: share/functions/__fish_git_prompt.fish:348
+#, fuzzy
 msgid "Prompt function for Git"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Nuvarande funktioner är: "
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:3
+#: share/functions/__fish_git_prompt.fish:458
 msgid ""
 "__fish_git_prompt helper, tells whether or not the current branch has staged "
 "files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:4
+#: share/functions/__fish_git_prompt.fish:471
 msgid ""
 "__fish_git_prompt helper, tells whether or not the current branch has "
 "tracked, modified files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:5
+#: share/functions/__fish_git_prompt.fish:526
 msgid "__fish_git_prompt helper, returns the current Git operation and branch"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:6
+#: share/functions/__fish_git_prompt.fish:639
 msgid "__fish_git_prompt helper, checks char variables"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:7
+#: share/functions/__fish_git_prompt.fish:690
 msgid "__fish_git_prompt helper, checks color variables"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:8
+#: share/functions/__fish_git_prompt.fish:730
+#, fuzzy
 msgid "Event handler, repaints prompt when functionality changes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:9
+#: share/functions/__fish_git_prompt.fish:748
+#, fuzzy
 msgid "Event handler, repaints prompt when any color changes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:10
+#: share/functions/__fish_git_prompt.fish:768
+#, fuzzy
 msgid "Event handler, repaints prompt when any char changes"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
 #: /tmp/fish/implicit/share/functions/__fish_gnu_complete.fish:1
 msgid ""
@@ -61910,8 +59674,13 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_hg_prompt.fish:1
+#: share/functions/__fish_hg_prompt.fish:23
+#, fuzzy
 msgid "Write out the hg prompt"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv prompten"
 
 #: /tmp/fish/implicit/share/functions/fish_hybrid_key_bindings.fish:1
 msgid "Vi-style bindings that inherit emacs-style bindings in all modes"
@@ -61926,6 +59695,7 @@ msgid "Check if the current directory is a git repository"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_is_token_n.fish:1
+#: share/functions/__fish_is_token_n.fish:1
 msgid "Test if current token is on Nth place"
 msgstr ""
 
@@ -61942,6 +59712,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_make_completion_signals.fish:1
+#: share/functions/__fish_make_completion_signals.fish:1
 msgid "Make list of kill signals for completion"
 msgstr ""
 
@@ -61950,12 +59721,21 @@ msgid "List names of available signals"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_make_completion_signals.fish:3
+#, fuzzy
 msgid "List codes and names of available signals"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/functions/fish_mode_prompt.fish:1
+#: share/functions/fish_vi_prompt.fish:1
+#, fuzzy
 msgid "Displays the current mode"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa säkerhetskontext"
 
 #: /tmp/fish/implicit/share/functions/__fish_move_last.fish:1
 msgid "Move the last element of a directory history from src to dest"
@@ -61974,12 +59754,22 @@ msgid "Paginate the current command using the users default pager"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
+#: share/functions/__fish_print_addresses.fish:1
+#, fuzzy
 msgid "Print a list of known network addresses"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa lista på alla körande screen-sessioner"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
+#: share/functions/__fish_print_commands.fish:1
+#, fuzzy
 msgid "Print a list of documented fish commands"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa en lista på alla tillåtna färgnamn"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
 msgid "Complete using available character encodings"
@@ -61993,29 +59783,50 @@ msgstr ""
 msgid "Print a list of local groups"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_print_help.fish:1
+#: share/functions/__fish_print_help.fish:1
 msgid "Print help message for the specified fish function or builtin"
 msgstr ""
+"Visa hjälpmeddelande för specificerad fish-funktion eller inbyggt kommando"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_hostnames.fish:1
 msgid "Print a list of known hostnames"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_interfaces.fish:1
+#: share/functions/__fish_print_interfaces.fish:1
+#, fuzzy
 msgid "Print a list of known network interfaces"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa en lista på alla tillåtna färgnamn"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_lpr_options.fish:1
+#: share/functions/__fish_print_lpr_options.fish:1
+#, fuzzy
 msgid "Print lpr options"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa alla versioner"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_lpr_printers.fish:1
+#: share/functions/__fish_print_lpr_printers.fish:1
+#, fuzzy
 msgid "Print lpr printers"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa fulla poster"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
+#: share/functions/__fish_print_mounted.fish:1
+#, fuzzy
 msgid "Print mounted devices"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa viktiga beroenden"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_pacman_repos.fish:1
 msgid "Print the repositories configured for arch's pacman package manager"
@@ -62026,37 +59837,62 @@ msgid "All services known to the system"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_svn_rev.fish:1
+#: share/functions/__fish_print_svn_rev.fish:1
+#, fuzzy
 msgid "Print svn revisions"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv bara ut angiven revision"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_users.fish:1
+#: share/functions/__fish_print_users.fish:2
+#, fuzzy
 msgid "Print a list of local users"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa en lista på alla tillåtna färgnamn"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_applications_directories.fish:1
 msgid "Print directories where desktop files are stored"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
+#: share/functions/__fish_print_xdg_mimetypes.fish:1
+#, fuzzy
 msgid "Print XDG mime types"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv ut kommandotyp"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
+#: share/functions/__fish_print_xwindows.fish:1
+#, fuzzy
 msgid "Print X windows"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa APM-information"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 msgid "Lists ZFS snapshots"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/fish_prompt.fish:1
+#: share/functions/fish_prompt.fish:5
 msgid "Write out the prompt"
-msgstr ""
+msgstr "Skriv prompten"
 
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:2
+#: share/functions/__fish_pwd.fish:3 share/functions/__fish_pwd.fish:7
+#, fuzzy
 msgid "Show current path"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa alla källkodspaket"
 
 #: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
 msgid "Call grep without honoring GREP_OPTIONS settings"
@@ -62087,8 +59923,13 @@ msgid "Comment/uncomment the current command"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_update_completions.fish:1
+#: share/functions/fish_update_completions.fish:1
+#, fuzzy
 msgid "Update man-page based completions"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Redigera kommando-specifika kompletteringar"
 
 #: /tmp/fish/implicit/share/functions/__fish_use_subcommand.fish:1
 msgid "Test if a non-switch argument has been given in the current commandline"
@@ -62103,20 +59944,31 @@ msgid "Set cursor shape for different vi modes"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_vi_key_bindings.fish:1
+#: share/functions/fish_vi_key_bindings.fish:1
+#, fuzzy
 msgid "vi-like key bindings for fish"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Välj fil med tangentbordsgenvägar"
 
 #: /tmp/fish/implicit/share/functions/funced.fish:1
+#: share/functions/funced.fish:1
+#, fuzzy
 msgid "Edit function definition"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"funktionsdefinition-block"
 
 #: /tmp/fish/implicit/share/functions/funcsave.fish:1
+#: share/functions/funcsave.fish:2
 msgid "Save the current definition of all specified functions to file"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/help.fish:1
+#: share/functions/help.fish:1
 msgid "Show help for the fish shell"
-msgstr ""
+msgstr "Visa hjälp för fish-skalet"
 
 #: /tmp/fish/implicit/share/functions/history.fish:1
 msgid "display or manipulate interactive command history"
@@ -62130,59 +59982,68 @@ msgstr ""
 msgid "Tests if a file descriptor is a tty"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/la.fish:1
+#: share/functions/la.fish:4
 msgid ""
 "List contents of directory, including hidden files in directory using long "
 "format"
-msgstr ""
+msgstr "Visa kataloginnehåll, inklusive dolda filer i långt format"
 
-#: /tmp/fish/implicit/share/functions/ll.fish:1
+#: share/functions/ll.fish:4
 msgid "List contents of directory using long format"
-msgstr ""
+msgstr "Visa kataloginnehåll i långt format"
 
-#: /tmp/fish/implicit/share/functions/ls.fish:1
-#: /tmp/fish/implicit/share/functions/ls.fish:2
-#: /tmp/fish/implicit/share/functions/ls.fish:3
+#: share/functions/ls.fish:7 share/functions/ls.fish:32
 msgid "List contents of directory"
-msgstr ""
+msgstr "Visa kataloginnehåll"
 
-#: /tmp/fish/implicit/share/functions/man.fish:1
+#: /tmp/fish/implicit/share/functions/man.fish:1 share/functions/man.fish:1
+#, fuzzy
 msgid "Format and display the on-line manual pages"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa ändringsinformation för paket"
 
-#: /tmp/fish/implicit/share/functions/nextd.fish:1
+#: share/functions/nextd.fish:2
 msgid "Move forward in the directory history"
-msgstr ""
+msgstr "Gå frammåt i kataloghistorik"
 
-#: /tmp/fish/implicit/share/functions/N_.fish:1
+#: /tmp/fish/implicit/share/functions/N_.fish:1 share/functions/N_.fish:3
 msgid "No-op"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/open.fish:1
+#: share/functions/open.fish:8
 msgid "Open file in default application"
-msgstr ""
+msgstr "Öppna fil i standardprogram"
 
 #: /tmp/fish/implicit/share/functions/popd.fish:1
 msgid "Pop directory from the stack and cd to it"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/prevd.fish:1
+#: share/functions/prevd.fish:2
 msgid "Move back in the directory history"
-msgstr ""
+msgstr "Gå bakåt i kataloghistorik"
 
 #: /tmp/fish/implicit/share/functions/prompt_pwd.fish:1
+#: share/functions/prompt_pwd.fish:11
+#, fuzzy
 msgid "Print the current working directory, shortened to fit the prompt"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa aktuell arbetskatalog, förkortad till att passa i kommandoraden"
 
-#: /tmp/fish/implicit/share/functions/psub.fish:1
+#: share/functions/psub.fish:3
 msgid ""
 "Read from stdin into a file and output the filename. Remove the file when "
 "the command that called psub exits."
 msgstr ""
+"Läs från standard in och skriv till fil. Skriv filnamnet på standard ut. "
+"Radera filen när det anropande programmet avslutar."
 
-#: /tmp/fish/implicit/share/functions/pushd.fish:1
+#: share/functions/pushd.fish:3
 msgid "Push directory to stack"
-msgstr ""
+msgstr "Lägg till katalog till stack"
 
 #: /tmp/fish/implicit/share/functions/realpath.fish:1
 msgid "print the resolved path [command realpath]"
@@ -62196,13 +60057,21 @@ msgstr ""
 msgid "return an absolute path without symlinks"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/seq.fish:1
+#: /tmp/fish/implicit/share/functions/seq.fish:1 share/functions/seq.fish:7
+#, fuzzy
 msgid "Print sequences of numbers"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa namn, inte nummer"
 
-#: /tmp/fish/implicit/share/functions/seq.fish:2
+#: /tmp/fish/implicit/share/functions/seq.fish:2 share/functions/seq.fish:11
+#, fuzzy
 msgid "Fallback implementation of the seq command"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Visa alla möjliga kompletteringar för det angivna commandot"
 
 #: /tmp/fish/implicit/share/functions/setenv.fish:1
 msgid "Set an env var for csh compatibility."
@@ -62213,20 +60082,25 @@ msgid "Suspend the current shell."
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__terlar_git_prompt.fish:1
+#: share/functions/__terlar_git_prompt.fish:23
+#, fuzzy
 msgid "Write out the git prompt"
 msgstr ""
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
+"Skriv prompten"
 
 #: /tmp/fish/implicit/share/functions/trap.fish:1
 msgid "Perform an action when the shell receives a signal"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/type.fish:1
+#: share/functions/type.fish:2
 msgid "Print the type of a command"
-msgstr ""
+msgstr "Visa typ av kommando"
 
-#: /tmp/fish/implicit/share/functions/umask.fish:1
+#: share/functions/umask.fish:137
 msgid "Set default file permission mask"
-msgstr ""
+msgstr "Välj standardfilrättighetsmask"
 
 #: /tmp/fish/implicit/share/functions/up-or-search.fish:1
 msgid ""
@@ -62234,6 +60108,6514 @@ msgid ""
 "move up one line"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/vared.fish:1
+#: share/functions/vared.fish:6
 msgid "Edit variable value"
+msgstr "Redigera variabelvärde"
+
+#: autoload.cpp:113
+#, c-format
+msgid "Could not autoload item '%ls', it is already being autoloaded. "
 msgstr ""
+"Kunde inte automatiskt ladda elementet '%ls', det laddas automatiskt redan. "
+
+#: builtin.cpp:2070
+#, c-format
+msgid "%ls: Unknown signal '%ls'\n"
+msgstr "%ls: Okänd signal '%ls'\n"
+
+#: builtin.cpp:2085 builtin.cpp:2195 builtin.cpp:2263
+#, c-format
+msgid "%ls: Invalid variable name '%ls'\n"
+msgstr "%ls: Ogiltigt variabelnamn '%ls'\n"
+
+#: builtin.cpp:2138
+#, c-format
+msgid "%ls: Cannot find calling job for event handler\n"
+msgstr "%ls: Kan inte hitta anropande job för händelsehanterare\n"
+
+#: builtin.cpp:2156
+#, c-format
+msgid "%ls: Invalid process id %ls\n"
+msgstr "%ls: Ogiltigt processid %ls\n"
+
+#: builtin.cpp:2223
+#, c-format
+msgid "%ls: Expected function name\n"
+msgstr "%ls: Förväntade ett funktionsnamn\n"
+
+#: builtin.cpp:2240
+#, c-format
+msgid ""
+"%ls: The name '%ls' is reserved,\n"
+"and can not be used as a function name\n"
+msgstr ""
+"%ls: Namnet '%ls' är reserverat,\n"
+"och kan inte användas som funktionsnamn\n"
+
+#: builtin.cpp:2248
+#, fuzzy, c-format
+msgid "%ls: No function name given\n"
+msgstr "%ls: Inget funktionsnamn givet\n"
+
+#: builtin.cpp:2276
+#, c-format
+msgid "%ls: Expected one argument, got %d\n"
+msgstr "%ls: Förväntade ett argument, fick %d\n"
+
+#: builtin.cpp:2412
+#, c-format
+msgid "%ls: Seed value '%ls' is not a valid number\n"
+msgstr "%ls: Slumpfröet '%ls' är inte ett giltigt nummer\n"
+
+#: builtin.cpp:2426
+#, c-format
+msgid "%ls: Expected zero or one argument, got %d\n"
+msgstr "%ls: Förväntade noll eller ett argument, fick %d\n"
+
+#: builtin.cpp:2656
+#, fuzzy, c-format
+msgid "%ls: --array option requires a single variable name.\n"
+msgstr "%ls: --array flaggan kräver ett enskilt variablenamn.\n"
+
+#: builtin.cpp:3688
+msgid "(default)"
+msgstr "(standard)"
+
+#: builtin.cpp:4070
+msgid "Try out the new parser"
+msgstr "Testa den nya parsern"
+
+#: builtin_commandline.cpp:466
+#, c-format
+msgid "%ls: Unknown input function '%ls'\n"
+msgstr "%ls: Okänd inläsnings-funktion '%ls'\n"
+
+#: builtin_printf.cpp:175
+#, c-format
+msgid ""
+"warning: %ls: character(s) following character constant have been ignored"
+msgstr "varning: %ls: tecken(s) efterföljande teckenskonstant ignorerades"
+
+#: builtin_printf.cpp:771
+msgid "printf: not enough arguments"
+msgstr "printf: inte tillräckligt med argument"
+
+#: builtin_set.cpp:221
+#, c-format
+msgid "%ls: Multiple variable names specified in single call (%ls and %.*ls)\n"
+msgstr "%ls: Flera variabelnamn angivna i ett anrop (%ls och %.*ls)\n"
+
+#: builtin_set.cpp:791
+#, c-format
+msgid "%ls: Values cannot be specfied with erase\n"
+msgstr "%ls: Värden kan inte anges vid radering\n"
+
+#: builtin_set.cpp:817
+#, c-format
+msgid ""
+"%ls: Warning: universal scope selected, but a global variable '%ls' exists.\n"
+msgstr ""
+"Varning: universellt definitionsområde valt, men global variable "
+"'%ls'existerar readn.\n"
+
+#: builtin_set_color.cpp:173
+#, fuzzy, c-format
+msgid "%ls: Could not set up terminal\n"
+msgstr "%ls: Kunde inte initiera terminalen\n"
+
+#: complete.cpp:901 complete.cpp:919
+msgid "Unknown option: "
+msgstr "Okänd flagga: "
+
+#: complete.cpp:923
+msgid "Multiple matches for option: "
+msgstr "Mer än en flagga matchar: "
+
+#: env.cpp:315
+msgid "Changing language to English"
+msgstr "Byter språk till svenska"
+
+#: env_universal_common.cpp:617 path.cpp:279
+msgid ""
+"Unable to create a configuration directory for fish. Your personal settings "
+"will not be saved. Please set the $XDG_CONFIG_HOME variable to a directory "
+"where the current user has write access."
+msgstr ""
+"Kunde inte skapa en konfigurationskatalog för fish. Dina personliga "
+"inställningar kommer inte sparas. Var vänlig sätt variabeln $XDH_CONFIG_HOME "
+"till en katalog där den nuvarande användaren har skrivrättigheter."
+
+#: fish.cpp:330
+msgid ""
+"Old versions of fish appear to be running. You will not be able to share "
+"variable values between old and new fish sessions. For best results, restart "
+"all running instances of fish."
+msgstr ""
+"Gammal version av fish verkar köra. Du kommer inte kunna dela variabler "
+"mellanden gammla och den nya fish sessionen. För bästa resultat, starta om "
+"allakörande instanser av fish."
+
+#: fish.cpp:420
+#, c-format
+msgid "Invalid value '%s' for debug level switch"
+msgstr "Ogiltigt värde '%s' för debugnivåflagga"
+
+#: input.cpp:483 input.cpp:493
+msgid "Could not set up terminal"
+msgstr "Kunde inte initiera terminalen"
+
+#: input.cpp:486
+#, c-format
+msgid "Check that your terminal type, '%ls', is supported on this system"
+msgstr "Säkerställa att din terminaltyp, '%ls', stöds av det här systemet"
+
+#: input.cpp:488
+#, c-format
+msgid "Attempting to use '%ls' instead"
+msgstr "Försöker använda '%ls' istället"
+
+#: input.cpp:535
+msgid "Error while closing terminfo"
+msgstr "Ett fel inträffade medan terminfo stängdes"
+
+#: io.cpp:112
+#, c-format
+msgid ""
+"An error occured while reading output from code block on file descriptor %d"
+msgstr ""
+"Ett fel inträffade under inläsning av utdata från kodblock på "
+"filidentifierare %d"
+
+#: mimedb.cpp:174 mimedb.cpp:188 mimedb.cpp:1179
+#, c-format
+msgid "%s: Out of memory\n"
+msgstr "%s: Slut på minne\n"
+
+#: mimedb.cpp:463
+#, c-format
+msgid "%s: Unknown error in munge()\n"
+msgstr "%s: Okänt fel i munge()\n"
+
+#: mimedb.cpp:481
+#, c-format
+msgid "%s: Locale string too long\n"
+msgstr "%s: Lokalsträng för lång\n"
+
+#: mimedb.cpp:551 mimedb.cpp:559
+#, c-format
+msgid "%s: Could not compile regular expressions %s with error %s\n"
+msgstr "%s: Kunde inte kompilera reguljärt uttryck %s med fel %s\n"
+
+#: mimedb.cpp:676
+#, c-format
+msgid "%s: No description for type %s\n"
+msgstr "%s: Beskrivning saknas för typ %s\n"
+
+#: mimedb.cpp:744
+#, c-format
+msgid "%s: Could not parse launcher string '%s'\n"
+msgstr "%s: Kunde inte tolka körsträng '%ls'\n"
+
+#: mimedb.cpp:780
+#, c-format
+msgid "%s: Default launcher '%s' does not specify how to start\n"
+msgstr "%s: Standardkörsträng '%s' anger inte hur programmet ska startas\n"
+
+#: mimedb.cpp:1158
+#, c-format
+msgid "%s: Unsupported switch '%c' in launch string '%s'\n"
+msgstr "%s: Flaggan '%c' i körsträng '%s' stöds inte\n"
+
+#: mimedb.cpp:1354
+#, c-format
+msgid "%s: Can not launch a mimetype\n"
+msgstr "%s: Kan inte köra en mimetyp\n"
+
+#: mimedb.cpp:1382
+#, c-format
+msgid "%s: Could not parse mimetype from argument '%s'\n"
+msgstr "%s: Kunde inte tolka mimetyp från argument '%s'\n"
+
+#: pager.cpp:562
+#, c-format
+msgid "%lsand 1 more row"
+msgstr "%lsoch 1 rad till"
+
+#: parse_execution.cpp:799
+#, fuzzy, c-format
+msgid ""
+"Unknown command '%ls'. Did you mean to run %ls with a modified environment? "
+"Try 'env %ls=%ls %ls%ls'. See the help section on the set command by typing "
+"'help set'."
+msgstr ""
+"Okänt kommando '%ls'. Menade du 'set %ls %ls'? För mer information om hur "
+"man tilldelar variabler, se hjälpsektionen om det inbyggda kommandot 'set' "
+"genom att skriva 'help set'."
+
+#: parse_execution.cpp:824
+#, fuzzy, c-format
+msgid ""
+"Variables may not be used as commands. Instead, define a function like "
+"'function %ls; %ls $argv; end' or use the eval builtin instead, like 'eval "
+"%ls'. See the help section for the function command by typing 'help "
+"function'."
+msgstr ""
+"Variabler får inte användas som kommandon. Definera istället en funktion, t."
+"ex. 'function %ls; %ls $argv; end'. Se hjälpsektionen för function-kommandot "
+"genom att skriva 'help function'"
+
+#: parse_execution.cpp:833
+#, fuzzy, c-format
+msgid ""
+"Variables may not be used as commands. Instead, define a function or use the "
+"eval builtin instead, like 'eval %ls'. See the help section for the function "
+"command by typing 'help function'."
+msgstr ""
+"Variabler får inte användas som kommandon. Definera istället en funktion. Se "
+"hjälpsektionen för function-kommandot genom att skriva 'help function'"
+
+#: parse_execution.cpp:841
+#, c-format
+msgid ""
+"Commands may not contain variables. Use the eval builtin instead, like 'eval "
+"%ls'. See the help section for the eval command by typing 'help eval'."
+msgstr ""
+"Okänt kommando '%ls'. Menade du 'set VARIABEL VÄRDE'? Se hjälpsektionen om "
+"det inbyggda kommandot 'set' genom att skriva 'help set'."
+
+#: parser.cpp:52
+#, c-format
+msgid "Tokenizer error: '%ls'"
+msgstr "Ett fel inträffade vid symboluppdelning: '%ls'"
+
+#: parser.cpp:62
+#, c-format
+msgid "Unexpected token of type '%ls'"
+msgstr "Oväntad symbol av typ '%ls'"
+
+#: parser.cpp:87 parse_constants.h:278
+msgid "function definition block"
+msgstr "funktionsdefinition-block"
+
+#: parser.cpp:107 parse_constants.h:301
+msgid "unexecutable block"
+msgstr "oexekverbart block"
+
+#: parser.cpp:956
+msgid "End of block mismatch. Program terminating."
+msgstr "Blockslut matchar inte. Programmet avslutas."
+
+#: proc.cpp:690
+#, fuzzy, c-format
+msgid "'%ls' has %ls"
+msgstr "Jobb %d, '%ls' har %ls"
+
+#: proc.cpp:694
+#, c-format
+msgid "Job %d, '%ls' has %ls"
+msgstr "Jobb %d, '%ls' har %ls"
+
+#: proc.cpp:828
+msgid "ended"
+msgstr "avslutat"
+
+#: proc.cpp:1354 proc.cpp:1380
+msgid "Process list pointer"
+msgstr "Processlistepekare"
+
+#: reader.cpp:2105
+msgid "Couldn't put the shell in its own process group"
+msgstr "Kunde inte skicka skalet till sin egen processgrupp"
+
+#: reader.cpp:2115
+msgid "Couldn't grab control of terminal"
+msgstr "Kunde inte ta kontroll över terminalen"
+
+#: reader.cpp:2882
+msgid ""
+"There are stopped jobs. A second attempt to exit will enforce their "
+"termination.\n"
+msgstr ""
+
+#: tokenizer.cpp:65
+msgid "Tokenizer not yet initialized"
+msgstr "Symbolavdelaren inte initierad"
+
+#: tokenizer.cpp:66
+msgid "Tokenizer error"
+msgstr "Symbolavdelarfel"
+
+#: tokenizer.cpp:67
+msgid "String"
+msgstr "Textsträng"
+
+#: tokenizer.cpp:68
+msgid "Pipe"
+msgstr "Rör"
+
+#: tokenizer.cpp:69
+msgid "End of command"
+msgstr "Slut av kommando"
+
+#: tokenizer.cpp:70
+msgid "Redirect output to file"
+msgstr "IO dirigering av utdata till fil"
+
+#: tokenizer.cpp:71
+msgid "Append output to file"
+msgstr "IO dirigering av utdata till slutet av fil"
+
+#: tokenizer.cpp:72
+msgid "Redirect input to file"
+msgstr "IO dirigering av indata till fil"
+
+#: tokenizer.cpp:73
+msgid "Redirect to file descriptor"
+msgstr "IO dirigering till filidentifierare"
+
+#: tokenizer.cpp:74
+msgid "Redirect output to file if file does not exist"
+msgstr "IO dirigering av utdata till fil om filen inte existerar"
+
+#: tokenizer.cpp:75
+msgid "Run job in background"
+msgstr "Kör jobb i bakgrunden"
+
+#: tokenizer.cpp:76
+msgid "Comment"
+msgstr "Kommentar"
+
+#: tokenizer.cpp:561
+msgid "Invalid token type"
+msgstr "Ogiltig symboltyp"
+
+#: wgetopt.cpp:636
+#, c-format
+msgid "%ls: Illegal option -- %lc\n"
+msgstr "%ls: Ogiltig flagga -- '%lc'\n"
+
+#: builtin.h:57
+#, c-format
+msgid ""
+"%ls: Invalid character '%lc' in variable name. Only alphanumerical "
+"characters and underscores are valid in a variable name.\n"
+msgstr ""
+"%ls: Ogiltigt tecken '%lc' i variabelnamn. Bara alfanumeriska tecken och "
+"understreck är tillåtna i variabelnamn.\n"
+
+#: builtin.h:62
+#, c-format
+msgid "%ls: Variable name can not be the empty string\n"
+msgstr "%ls: Den tomma strängen är inte ett tillåtet variabelnamn\n"
+
+#: builtin.h:67
+#, c-format
+msgid "%ls: Second argument must be 'in'\n"
+msgstr "%ls: Andra argumentet måste vara 'in'\n"
+
+#: builtin.h:72
+#, c-format
+msgid "%ls: Expected at least two arguments, got %d\n"
+msgstr "%ls: Förväntade minst två argument, fick %d\n"
+
+#: builtin.h:74
+#, c-format
+msgid "%ls: '%ls' is not a valid variable name\n"
+msgstr "%ls: '%ls' är ett ogiltigt variabelnamn\n"
+
+#: builtin.h:77
+#, c-format
+msgid "%ls: can only take 'if' and then another command as an argument\n"
+msgstr ""
+
+#: builtin.h:78
+#, fuzzy, c-format
+msgid "%ls: any second argument must be 'if'\n"
+msgstr "%ls: Andra argumentet måste vara 'in'\n"
+
+#: builtin.h:88
+#, c-format
+msgid "%ls: Block mismatch: '%ls' vs. '%ls'\n"
+msgstr "%ls: Blockmismatchning: '%ls' mot '%ls'\n"
+
+#: builtin.h:93
+#, c-format
+msgid "%ls: Unknown block type '%ls'\n"
+msgstr "%ls: Okänd blocktyp '%ls'\n"
+
+#: expand.h:135
+msgid "Array index out of bounds"
+msgstr "Arrayindexet är otållåtet"
+
+#: parse_constants.h:192
+#, fuzzy
+msgid ""
+"Expected a command, but instead found a pipe. Did you mean 'COMMAND; or "
+"COMMAND'? See the help section for the 'or' builtin command by typing 'help "
+"or'."
+msgstr ""
+"Förväntade att hitta ett kommandonamn, hittade en symbol av typen '%ls'. "
+"Menade du 'KOMMANDO; or KOMMANDO'? Se hjälpsektionen om 'or' genom att "
+"skriva 'help or'."
+
+#: parse_constants.h:195
+#, fuzzy
+msgid ""
+"Expected a command, but instead found an '&'. Did you mean 'COMMAND; and "
+"COMMAND'? See the help section for the 'and' builtin command by typing 'help "
+"and'."
+msgstr ""
+"Förväntade att hitta ett kommandonamn, hittade en symbol av typen '%ls'. "
+"Menade du 'KOMMANDO; and KOMMANDO'? Se hjälpsektionen om 'and' genom att "
+"skriva 'help and'."
+
+#: parse_constants.h:216
+#, fuzzy
+msgid "break command while not inside of loop"
+msgstr "Loopstyrningskommandon får bara användas i loopar."
+
+#: parse_constants.h:219
+#, fuzzy
+msgid "continue command while not inside of loop"
+msgstr "Loopstyrningskommandon får bara användas i loopar."
+
+#: parse_constants.h:222
+msgid "'return' builtin command outside of function definition"
+msgstr ""
+"Det inbyggda kommandot 'return' påträffades utanför en funktionsdefinition"
+
+#: parse_constants.h:225
+#, fuzzy, c-format
+msgid ""
+"Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
+"the set command by typing 'help set'."
+msgstr ""
+"Okänt kommando '%ls'. Menade du 'set %ls %ls'? För mer information om hur "
+"man tilldelar variabler, se hjälpsektionen om det inbyggda kommandot 'set' "
+"genom att skriva 'help set'."
+
+#: parse_constants.h:230
+#, c-format
+msgid ""
+"The '$' character begins a variable name. The character '%lc', which "
+"directly followed a '$', is not allowed as a part of a variable name, and "
+"variable names may not be zero characters long. To learn more about variable "
+"expansion in fish, type 'help expand-variable'."
+msgstr ""
+"Tecknet '$' börjar ett variabelnamn. Tecknet '%lc', som direkt följde ett "
+"'$', är inte tillåtet som del av ett variabelnamn, och variabelnamn får inte "
+"vara noll tecken långa. För mer information om variabelexpansion i fish, "
+"skriv 'help expand-variable'."
+
+#: parse_constants.h:235
+msgid ""
+"$? is not a valid variable in fish. If you want the exit status of the last "
+"command, try $status."
+msgstr ""
+
+#: parse_constants.h:240
+msgid ""
+"The '$' begins a variable name. It was given at the end of an argument. "
+"Variable names may not be zero characters long. To learn more about variable "
+"expansion in fish, type 'help expand-variable'."
+msgstr ""
+"Tecknet '$' börjar ett variabelnamn. Det påträffades som det sista tecknet i "
+"ett argument. Variabelnamn får inte vara noll tecken långa. För mer "
+"information om variabelexpansion i fish, skriv 'help expand-variable'."
+
+#: parse_constants.h:245
+#, c-format
+msgid ""
+"Did you mean %ls{$%ls}%ls? The '$' character begins a variable name. A "
+"bracket, which directly followed a '$', is not allowed as a part of a "
+"variable name, and variable names may not be zero characters long. To learn "
+"more about variable expansion in fish, type 'help expand-variable'."
+msgstr ""
+"Menade du %ls{$%ls}%ls? Tecknet '$' börjar ett variabelnamn. En "
+"klammerparantes, som direkt följde ett '$', är inte tillåtet som del av ett "
+"variabelnamn, och variabelnamn får inte vara noll tecken långa. För mer "
+"information om variabelexpansion i fish, skriv 'help expand-variable'."
+
+#: parse_constants.h:250
+msgid ""
+"Did you mean (COMMAND)? In fish, the '$' character is only used for "
+"accessing variables. To learn more about command substitution in fish, type "
+"'help expand-command-substitution'."
+msgstr ""
+"Menade du (KOMMANDO)? I fish används tecknet '$' bara för att komma åt "
+"variabler. För att lära dig mer om kommandosubstitutionm skriv 'help expand-"
+"command-substitution'."
+
+#: share/completions/aptitude.fish:26
+msgid "Forget all internal information about what packages are \\new"
+msgstr ""
+
+#: share/completions/bundle.fish:93 share/completions/bundle.fish:132
+#, sh-format
+msgid "Open an installed gem in your $EDITOR"
+msgstr ""
+
+#: share/completions/bundle.fish:140
+msgid "Output a specific format (png, jpg, svg, dot, ...)"
+msgstr ""
+
+#: share/completions/cp.fish:20
+msgid "Preserve ATTRIBUTES if possible"
+msgstr ""
+
+#: share/completions/cp.fish:29
+msgid "Set security context of copy to CONTEXT"
+msgstr "Ange säkerhetskontext för kopia"
+
+#: share/completions/cvs.fish:26
+#, fuzzy
+msgid "Use \\tmpdir for temporary files."
+msgstr "Välj temporär katalog"
+
+#: share/completions/cvs.fish:27
+#, fuzzy
+msgid "Use \\editor for editing log information."
+msgstr "Välj editor för loginformationsredigering"
+
+#: share/completions/cvs.fish:28
+#, sh-format
+msgid "Overrides $CVSROOT as the root of the CVS tree."
+msgstr ""
+
+#: share/completions/cvs.fish:30
+#, fuzzy
+msgid "Request compression level \\# for net traffic."
+msgstr "Kompressionsnivå för nätverkstrafik"
+
+#: share/completions/cvs.fish:52
+#, fuzzy
+msgid "Create a CVS repository if it doesn\\t"
+msgstr "Skapa förråd om det inte redan existerar"
+
+#: share/completions/cvs.fish:97
+#, fuzzy
+msgid "Replace revision\\s"
+msgstr "Slå ihop revisioner"
+
+#: share/completions/darcs.fish:44
+msgid ""
+"Apply a patch bundle created by `darcs send\\\n"
+"complete -c darcs -n __fish_use_subcommand -x -a get --description Create"
+msgstr ""
+
+#: share/completions/darcs.fish:171
+#, fuzzy
+msgid "Define token to contain these characters"
+msgstr "Dela inte multibytesekvenser"
+
+#: share/completions/darcs.fish:501
+msgid "Shell command that runs regression tests"
+msgstr ""
+
+#: share/completions/darcs.fish:502
+msgid ""
+"Shell command to run before `darcs dist\\\n"
+"complete -c darcs -n contains"
+msgstr ""
+
+#: share/completions/dcop.fish:34
+msgid "Show help about options"
+msgstr "Visa hjälp om flaggor"
+
+#: share/completions/dcop.fish:35
+msgid "Connect to the given user's DCOP server"
+msgstr "Koppla till den angivna användarens DCOP-server"
+
+#: share/completions/dcop.fish:36
+msgid "Send the same DCOP call to all users with a running DCOP server"
+msgstr ""
+"Skicka samma DCOP-signal till alla användare med en körande DCOP-server"
+
+#: share/completions/dcop.fish:37
+msgid "List all active KDE session for a user or all users"
+msgstr "Visa alla aktiva KDE-sessioner för en användare eller alla användare"
+
+#: share/completions/dcop.fish:38
+msgid "Send to the given KDE session"
+msgstr "Skicka till den angivna KDE-sessionen"
+
+#: share/completions/dcop.fish:39
+msgid "Don't update the user activity timestamp in the called application"
+msgstr ""
+"Uppdatera inte tidsstämpeln för användaraktivitet i det anropade programmet"
+
+#: share/completions/dcop.fish:40
+msgid "Call DCOP for each line read from stdin"
+msgstr "Anropa DCOP för varje rad läst från standard in"
+
+#: share/completions/df.fish:17
+#, fuzzy
+msgid "Show file systems of specified type"
+msgstr "Visa filsystem av angiven typ"
+
+#: share/completions/docker.fish:19
+#, fuzzy
+msgid "Show all containers"
+msgstr "Visa ARP-inlägg"
+
+#: share/completions/docker.fish:24
+#, fuzzy
+msgid "Show the running containers"
+msgstr "Visa dolda funktioner"
+
+#: share/completions/docker.fish:28
+#, fuzzy
+msgid "Show the exited containers"
+msgstr "Visa tid"
+
+#: share/completions/docker.fish:70 share/completions/docker.fish:92
+msgid "Docker container"
+msgstr ""
+
+#: share/completions/docker.fish:82
+msgid "Stopped container"
+msgstr ""
+
+#: share/completions/docker.fish:87
+msgid "Container running"
+msgstr ""
+
+#: share/completions/duply.fish:26
+msgid "Calculate what would be done, but dont perform any actions"
+msgstr ""
+
+#: share/completions/duply.fish:27
+msgid "Dont abort when backup different dirs to the same backend"
+msgstr ""
+
+#: share/completions/gcc.fish:25
+msgid "Set maximum template depth"
+msgstr "Sätt maximalt malldjup"
+
+#: share/completions/gcc.fish:261
+msgid ""
+"Print the full absolute name of the library file library that would be used "
+"when linking---and don\\t"
+msgstr ""
+
+#: share/completions/gem.fish:87
+#, fuzzy
+msgid "display the package version"
+msgstr "Visa paketpost"
+
+#: share/completions/gem.fish:87
+msgid "display the path where gems are installed"
+msgstr ""
+
+#: share/completions/gem.fish:87
+#, fuzzy
+msgid "display path used to search for gems"
+msgstr "Visa sessionsnyckel som används för ett meddelande"
+
+#: share/completions/gem.fish:87
+#, fuzzy
+msgid "display the gem format version"
+msgstr "Visa uppdateringsinformation"
+
+#: share/completions/gem.fish:92
+#, fuzzy
+msgid "list all 'gem' commands"
+msgstr "Inaktivera kommando"
+
+#: share/completions/git.fish:98
+#, fuzzy
+msgid "name"
+msgstr "Användarnamn"
+
+#: share/completions/help.fish:6
+#, fuzzy
+msgid "Help for this command"
+msgstr "Välj promptkommando"
+
+#: share/completions/help.fish:10
+msgid "Incomplete aspects of fish"
+msgstr ""
+
+#: share/completions/help.fish:11
+msgid "Known fish bugs"
+msgstr ""
+
+#: share/completions/help.fish:14
+msgid "Help on how tab-completion works"
+msgstr "Hjälp om hur tabbkomplettering fungerar"
+
+#: share/completions/help.fish:15
+msgid "Help on how job control works"
+msgstr "Hjälp om hur jobbkontroll fungerar"
+
+#: share/completions/help.fish:16
+msgid "Summary on how fish differs from other shells"
+msgstr "Summera hur fish skiljer sig från andra skal"
+
+#: share/completions/help.fish:18
+msgid "Help on how to set the prompt"
+msgstr "Hjälp om hur man ändrar prompten"
+
+#: share/completions/help.fish:19
+msgid "Help on how to set the titlebar message"
+msgstr "Hjälp om hur man ändrar titelradsmeddelandet"
+
+#: share/completions/help.fish:20
+msgid "Help on how to copy and paste"
+msgstr "Hjälp om hur man kopierar och klistrar in"
+
+#: share/completions/help.fish:21
+msgid "Help on editor shortcuts"
+msgstr "Hjälp om tangentbordsgenvägar"
+
+#: share/completions/help.fish:22
+msgid "Help on environment variables"
+msgstr "Hjälp om miljövariabler"
+
+#: share/completions/help.fish:23
+msgid "Help on setting syntax highlighting colors"
+msgstr "Hjälp om syntaxfärgläggningsfärger"
+
+#: share/completions/help.fish:25 share/completions/help.fish:26
+msgid "Help on parameter expansion (Globbing)"
+msgstr "Hjälp om parameterexpansion (Globbing)"
+
+#: share/completions/help.fish:27
+#, sh-format
+msgid "Help on variable expansion $VARNAME"
+msgstr "Hjälp om variabelexpansion $VARIABEL"
+
+#: share/completions/help.fish:28
+msgid "Help on home directory expansion ~USER"
+msgstr "Hjälp om hemkatalogexpansion ~ANVÄNDARE"
+
+#: share/completions/help.fish:29
+msgid "Help on brace expansion {a,b,c}"
+msgstr "Hjälp om klammerparantesexpansion {a,b,c}"
+
+#: share/completions/help.fish:30
+msgid "Help on wildcard expansion *.*"
+msgstr "Hjälp om jokertecken *.*"
+
+#: share/completions/help.fish:31
+msgid "Help on command substitution (SUBCOMMAND)"
+msgstr "Hjälp om kommandosubstitution (UNDERKOMMANDO)"
+
+#: share/completions/help.fish:32
+msgid "Help on process expansion %JOB"
+msgstr "Hjälp om processexpansion %JOB"
+
+#: share/completions/history.fish:1
+msgid "Match history items that start with the given prefix"
+msgstr ""
+
+#: share/completions/history.fish:2
+msgid "Match history items that contain the given string"
+msgstr ""
+
+#: share/completions/obnam.fish:9
+#, fuzzy
+msgid "Adds an encryption key to the repository"
+msgstr "Lägg till fil/katalog till förråd"
+
+#: share/completions/obnam.fish:11
+msgid "Lists the keys associated with each client"
+msgstr ""
+
+#: share/completions/obnam.fish:12
+#, fuzzy
+msgid "Lists the clients in the repository"
+msgstr "Uppdatera förråd"
+
+#: share/completions/obnam.fish:13
+#, fuzzy
+msgid "Compares two generations"
+msgstr "Tolerera slarviga monteringsflaggor"
+
+#: share/completions/obnam.fish:14
+#, fuzzy
+msgid "Dumps the repository"
+msgstr "Uppdatera förråd"
+
+#: share/completions/obnam.fish:15
+#, fuzzy
+msgid "Removes a lock file for a client"
+msgstr "Ta bort alla gz-filer från cache"
+
+#: share/completions/obnam.fish:16
+#, fuzzy
+msgid "Removes backup generations"
+msgstr "Ta bort komplettering"
+
+#: share/completions/obnam.fish:17
+#, fuzzy
+msgid "Checks the consistency of the repository"
+msgstr "Kontrollera hela lagret"
+
+#: share/completions/obnam.fish:18
+msgid "Lists every backup generation"
+msgstr ""
+
+#: share/completions/obnam.fish:19
+msgid "Lists the identifier for every generation"
+msgstr ""
+
+#: share/completions/obnam.fish:20
+#, fuzzy
+msgid "Lists the keys"
+msgstr "Visa pålitliga nycklar"
+
+#: share/completions/obnam.fish:21
+#, fuzzy
+msgid "Lists the toplevel keys"
+msgstr "Visa pålitliga nycklar"
+
+#: share/completions/obnam.fish:22
+#, fuzzy
+msgid "Lists the contents of a given generation"
+msgstr "Visa kataloginnehåll"
+
+#: share/completions/obnam.fish:23
+#, fuzzy
+msgid "Makes the repository available via FUSE"
+msgstr "Uppdatera förråd"
+
+#: share/completions/obnam.fish:24
+msgid "Check if a backup age exceeds a threshold"
+msgstr ""
+
+#: share/completions/obnam.fish:25
+#, fuzzy
+msgid "Removes a client from the repository"
+msgstr "Ange förråd-URL"
+
+#: share/completions/obnam.fish:26
+#, fuzzy
+msgid "Removes a key from the repository"
+msgstr "Skapa lokal kopia av förråd"
+
+#: share/completions/obnam.fish:27
+#, fuzzy
+msgid "Restore files from the repository"
+msgstr "Checka in filer till förråd"
+
+#: share/completions/obnam.fish:28
+#, fuzzy
+msgid "Verifies files in the repository"
+msgstr "Checka in filer till förråd"
+
+#: share/completions/obnam.fish:87
+msgid "Do not check data for cient NAME."
+msgstr ""
+
+#: share/completions/perl.fish:34
+#, sh-format
+msgid "Loop script, print $_"
+msgstr "Upprepa skript, skriv $_"
+
+#: share/completions/perl.fish:36
+#, sh-format
+msgid "Search $PATH for script"
+msgstr "Genomsök $PATH efter skript"
+
+#: share/completions/sed.fish:13
+msgid "Evaluate expression"
+msgstr "Utför argument som kommandon"
+
+#: share/completions/sed.fish:14
+msgid "Evalute file"
+msgstr "Utför filinnehåll som kommandon"
+
+#: share/completions/sed.fish:22
+msgid "Specify line-length"
+msgstr "Välj radlängd"
+
+#: share/completions/touch.fish:2
+msgid "Set date back"
+msgstr "Sätt tillbaka datum"
+
+#: share/completions/touch.fish:4
+msgid "Set date"
+msgstr "Välj datum"
+
+#: share/completions/touch.fish:5
+msgid "Set date forward"
+msgstr "Sätt fram datum"
+
+#: share/completions/touch.fish:9
+msgid "Set time"
+msgstr "Välj tid"
+
+#: share/completions/update-eix-remote.fish:16
+msgid ""
+"Fetch the eix-caches of some layman overlays into a temporary file resp. "
+"into FILE and add them to the eix database"
+msgstr ""
+
+#: share/completions/update-eix-remote.fish:16
+msgid "Only fetch the overlays into FILE"
+msgstr ""
+
+#: share/completions/update-eix-remote.fish:16
+msgid "Only add the overlays from FILE to the eix database"
+msgstr ""
+
+#: share/completions/xterm.fish:126
+#, sh-format
+msgid "Terminal name for $TERM"
+msgstr ""
+
+#: share/functions/_.fish:9
+msgid "fish"
+msgstr ""
+
+#: share/functions/__fish_complete_abook_formats.fish:1
+msgid "Complete abook formats"
+msgstr ""
+
+#: share/functions/__fish_complete_atool.fish:1
+msgid "Complete atool"
+msgstr ""
+
+#: share/functions/__fish_complete_grep.fish:48
+#, fuzzy
+msgid "Obsolete synonym for -i"
+msgstr "Synonym för -i"
+
+#: share/functions/__fish_complete_grep.fish:49
+msgid "treat input as a set of lines each terminated by a zero byte"
+msgstr ""
+
+#: share/functions/__fish_complete_python.fish:2
+#: share/functions/__fish_complete_python.fish:28
+#: share/functions/__fish_complete_vi.fish:54
+msgid "Don\\t"
+msgstr ""
+
+#: share/functions/__fish_complete_setxkbmap.fish:1
+#, fuzzy
+msgid "Complete setxkb options"
+msgstr "Tolerera slarviga monteringsflaggor"
+
+#: share/functions/__fish_complete_svn.fish:77
+#, fuzzy
+msgid "Remove \\conflicted state on working copy files or directories."
+msgstr "Ta bort konflikttillstånd hos arbetskopiefiler eller kataloger"
+
+#: share/functions/__fish_complete_svn.fish:103
+#, fuzzy
+msgid "Specify log message"
+msgstr "Välj e-postkatalog"
+
+#: share/functions/__fish_complete_svn.fish:105
+#, fuzzy
+msgid "Read log message from file"
+msgstr "Läs loggmeddelande från fil"
+
+#: share/functions/__fish_complete_svn.fish:106
+#, fuzzy
+msgid "Force validity of log message source"
+msgstr "Tvinga validitet av loggmeddelandes källa"
+
+#: share/functions/__fish_complete_svn.fish:118
+#, fuzzy
+msgid "Print nothing, or only summary information"
+msgstr "Visa all information"
+
+#: share/functions/__fish_complete_svn.fish:122
+msgid "Force operation to run"
+msgstr "Tvinga operationen att utföras"
+
+#: share/functions/__fish_complete_svn.fish:126
+#, fuzzy
+msgid "Process contents of file ARG as additional args"
+msgstr "Skicka filinnehåll som extra argument"
+
+#: share/functions/__fish_complete_svn.fish:130
+msgid "Operate only on members of changelist"
+msgstr ""
+
+#: share/functions/__fish_complete_svn.fish:134
+#, fuzzy
+msgid "Output in xml"
+msgstr "Utadata i XML-format"
+
+#: share/functions/__fish_complete_svn.fish:138
+#, fuzzy
+msgid "Retrieve revision property"
+msgstr "Utför på revisionsegenskap"
+
+#: share/functions/__fish_complete_svn.fish:150
+msgid "Ignore externals definitions"
+msgstr "Ignorera definitioner av externals"
+
+#: share/functions/__fish_complete_svn.fish:154
+#, fuzzy
+msgid "Print extra information"
+msgstr "Visa all information"
+
+#: share/functions/__fish_complete_svn.fish:158
+#, fuzzy
+msgid "Operate on a revision property (use with -r)"
+msgstr "Utför på revisionsegenskap"
+
+#: share/functions/__fish_complete_svn.fish:162
+msgid "Add intermediate parents"
+msgstr ""
+
+#: share/functions/__fish_complete_svn.fish:189
+#, fuzzy
+msgid "Try operation but make no changes"
+msgstr "Försök hitta en mindre uppsättning ändringar"
+
+#: share/functions/__fish_complete_svn.fish:193
+#, fuzzy
+msgid "Ignore ancestry when calculating merges"
+msgstr "Ignorera ursprung vid beräknandet av sammanslagning"
+
+#: share/functions/__fish_complete_svn.fish:197
+#, fuzzy
+msgid "Override diff-cmd specified in config file"
+msgstr "Flytta filen angiven på kommandoraden"
+
+#: share/functions/__fish_complete_svn.fish:198
+#, fuzzy
+msgid "Use external diff command"
+msgstr "Ångra ett redigeringskommando"
+
+#: share/functions/__fish_complete_svn.fish:202
+msgid "Disable automatic properties"
+msgstr "Inaktivera automatiska egenskaper"
+
+#: share/functions/__fish_complete_svn.fish:206
+#, fuzzy
+msgid "Set new working copy depth"
+msgstr "Välj RAW-skrivläge"
+
+#: share/functions/__fish_complete_svn.fish:230
+msgid "don\\t"
+msgstr ""
+
+#: share/functions/__fish_complete_svn.fish:241
+msgid "Use ARG as the older target"
+msgstr ""
+
+#: share/functions/__fish_complete_svn.fish:242
+msgid "Use ARG as the newer target"
+msgstr ""
+
+#: share/functions/__fish_complete_svn.fish:243
+#, fuzzy
+msgid "Do not print differences for deleted files"
+msgstr "Skriv inte ut rader utan fältavgränsare"
+
+#: share/functions/__fish_complete_svn.fish:244
+#, fuzzy
+msgid "Notice ancestry when calculating differences"
+msgstr "Ignorera ursprung vid beräknandet av sammanslagning"
+
+#: share/functions/__fish_complete_svn.fish:245
+#, fuzzy
+msgid "Show a summary of the results"
+msgstr "Välj en konfigurationsinställning"
+
+#: share/functions/__fish_complete_svn.fish:257
+#, fuzzy
+msgid "Do not cross copies while traversing history"
+msgstr "Korsa inte kopior"
+
+#: share/functions/__fish_complete_svn.fish:259
+#, fuzzy
+msgid "Produce diff output"
+msgstr "Ljudutdata"
+
+#: share/functions/__fish_complete_svn.fish:279
+msgid "Use strict semantics"
+msgstr "Använd strikt semantik"
+
+#: share/functions/__fish_complete_svn.fish:306
+#, fuzzy
+msgid "Relocate via URL-rewriting"
+msgstr "Relokera via URL-omskrivning"
+
+#: share/functions/__fish_complete_svn_diff.fish:1
+#, fuzzy
+msgid "Complete \"svn diff\" arguments"
+msgstr "Räkna antalet argument"
+
+#: share/functions/__fish_complete_tar.fish:14
+#: share/functions/__fish_complete_tar.fish:21
+#: share/functions/__fish_complete_tar.fish:28
+#: share/functions/__fish_complete_unrar.fish:14
+msgid "%s\\tArchived file\\n"
+msgstr "%s\\tArkivfil\\n"
+
+#: share/functions/__fish_complete_wvdial_peers.fish:1
+msgid "Complete wvdial peers"
+msgstr ""
+
+#: share/functions/__fish_complete_xsum.fish:1
+msgid "Complete md5sum sha1 etc"
+msgstr ""
+
+#
+#: share/functions/__fish_config_interactive.fish:35
+msgid "Type %shelp%s for instructions on how to use fish"
+msgstr "Skriv %shelp%s för instruktioner om hur man använder fish"
+
+#: share/functions/__fish_config_interactive.fish:193
+#, sh-format
+msgid "Notify VTE of change to $PWD"
+msgstr ""
+
+#: share/functions/__fish_move_last.fish:9
+msgid "Hit end of history...\\n"
+msgstr "Slut på kataloghistorik...\\n"
+
+#: share/functions/__fish_print_abook_emails.fish:1
+#, fuzzy
+msgid "Print email addresses (abook)"
+msgstr "Visa döda processer"
+
+#: share/functions/__fish_print_arch_daemons.fish:1
+#, fuzzy
+msgid "Print arch daemons"
+msgstr "Visa alla namn"
+
+#: share/functions/__fish_print_debian_services.fish:1
+#, fuzzy
+msgid "Prints services installed"
+msgstr "Visa status för tjänst"
+
+#: share/functions/__fish_print_lsblk_columns.fish:1
+#, fuzzy
+msgid "Print available lsblk columns"
+msgstr "Visa tillgängliga paket"
+
+#: share/functions/__fish_print_xdg_mimeapps.fish:1
+#, fuzzy
+msgid "Print xdg mime applications"
+msgstr "Visa all information"
+
+#: share/functions/__fish_print_xrandr_modes.fish:1
+#, fuzzy
+msgid "Print xrandr modes"
+msgstr "Skriv obehandlade filnamn"
+
+#: share/functions/__fish_print_xrandr_outputs.fish:1
+#, fuzzy
+msgid "Print xrandr outputs"
+msgstr "Visa antal ord"
+
+#: share/functions/__fish_test_arg.fish:2
+msgid "Test if the token under the cursor matches the specified wildcard"
+msgstr ""
+
+#: share/functions/__fish_urlencode.fish:1
+#, fuzzy
+msgid "URL-encode stdin"
+msgstr "Byt namn på standard in"
+
+#: share/functions/abbr.fish:1
+#, fuzzy
+msgid "Manage abbreviations"
+msgstr "Manualsektion"
+
+#: share/functions/abbr.fish:40
+#, fuzzy
+msgid "%s: invalid option -- %s\\n"
+msgstr "%s: Ogiltigt flagga -- %s\\n"
+
+#: share/functions/abbr.fish:47
+#, fuzzy
+msgid "%s: %s cannot be specified along with %s\\n"
+msgstr "%s: Värden kan inte anges vid radering %s\\n"
+
+#: share/functions/abbr.fish:56
+#, fuzzy
+msgid "%s: option requires an argument -- %s\\n"
+msgstr "%s: Flaggan kräver ett argument -- %s\\n"
+
+#: share/functions/abbr.fish:62
+#, fuzzy
+msgid "%s: Unexpected argument -- %s\\n"
+msgstr "%ls: Förväntade argument\\n"
+
+#: share/functions/abbr.fish:75
+msgid "%s: abbreviation must have a non-empty key\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:79
+msgid "%s: abbreviation must have a value\\n"
+msgstr ""
+
+#: share/functions/abbr.fish:101
+#, fuzzy
+msgid "%s: no such abbreviation '%s'\\n"
+msgstr "%s: Okänd funktion '%s'\\n"
+
+#: share/functions/alias.fish:2
+msgid ""
+"Legacy function for creating shellscript functions using an alias-like syntax"
+msgstr ""
+"Bakåtkompatibilitetsfunktion för att skapa skalfunktioner med en alias-"
+"liknande syntax"
+
+#: share/functions/alias.fish:36
+#, fuzzy
+msgid "%s: Expected one or two arguments, got %d\\n"
+msgstr "%ls: Förväntade ett eller två argument, fick %d"
+
+#: share/functions/dirh.fish:2
+msgid "Print the current directory history (the back- and fwd- lists)"
+msgstr "Visa arbetskatalogshistorik (bakåt och frammåt)"
+
+#: share/functions/export.fish:1
+msgid "Set global variable. Alias for set -g, made for bash compatibility"
+msgstr ""
+
+#: share/functions/fish_indent.fish:1
+msgid "Indenter and prettifier for fish code"
+msgstr ""
+
+#: share/functions/fish_vi_prompt.fish:17
+msgid "Simple vi prompt"
+msgstr ""
+
+#: share/functions/funced.fish:36
+#, fuzzy
+msgid "funced: You must specify one function name\n"
+msgstr "%ls: Förväntade exakt ett funktionsnamn\n"
+
+#: share/functions/funcsave.fish:11
+#, fuzzy
+msgid "%s: Expected function name\\n"
+msgstr "%s: Förväntade ett funktionsnamn\\n"
+
+#: share/functions/help.fish:77
+#, fuzzy, sh-format
+msgid ""
+"Please set the variable $BROWSER to a suitable browser and try again.\\n\\n"
+msgstr ""
+"Var vänlig sätt variablen $BROWSER så den anger en lämplig browser och "
+"försök igen\\n\\n"
+
+#: share/functions/history.fish:5
+msgid "Deletes an item from history"
+msgstr ""
+
+#: share/functions/hostname.fish:7
+msgid "Show or set the system's host name"
+msgstr ""
+
+#: share/functions/math.fish:2
+msgid "Perform math calculations in bc"
+msgstr "Utför matematiska beräkningar i bc"
+
+#: share/functions/mimedb.fish:8
+msgid "Look up file information via the mimedb database"
+msgstr ""
+
+#: share/functions/popd.fish:2
+msgid "Pop dir from stack"
+msgstr "Ta bort katalog från stack"
+
+#
+#: share/functions/popd.fish:14
+msgid "%s: Directory stack is empty...\\n"
+msgstr "%s: Katalogstacken är tom...\\n"
+
+#: share/functions/prevd.fish:28
+msgid "The number of positions to skip must be a non-negative integer\\n"
+msgstr "Antalet positioner att hoppa över måste vara ett positivt heltal"
+
+#: share/functions/setenv.fish:2
+msgid "Set global variable. Alias for set -g, made for csh compatibility"
+msgstr ""
+
+#~ msgid "If you can reproduce it, please send a bug report to %s."
+#~ msgstr ""
+#~ "Om du kan reproducera det, var vänlig skicka en buggrapport till %s."
+
+#~ msgid "All base system packages"
+#~ msgstr "Alla bassystempaket"
+
+#~ msgid "All packages in world"
+#~ msgstr "Alla paket i världen"
+
+#~ msgid "Installed package"
+#~ msgstr "Installerade paket"
+
+#~ msgid "Usage overview of emerge"
+#~ msgstr "Användningsöversikt av emerge"
+
+#~ msgid "Help on subject system"
+#~ msgstr "Hjälp för ämnet system"
+
+#~ msgid "Help on subject config"
+#~ msgstr "Hjäl för ämnet konfiguration"
+
+#~ msgid "Help on subject sync"
+#~ msgstr "Hjälp för ämnet sync"
+
+#~ msgid "Use colors in output"
+#~ msgstr "Använd färger"
+
+#~ msgid "Don't use colors in output"
+#~ msgstr "Använd inte färger"
+
+#~ msgid "whatis entry"
+#~ msgstr "'whatis'-inlägg"
+
+#~ msgid "Use <command> to build"
+#~ msgstr "Använd <kommando> för att bygga"
+
+#~ msgid "Prefix to strip on patch"
+#~ msgstr "Ta bort <prefix> på fix"
+
+#~ msgid "Do not run update"
+#~ msgstr "Kör inte uppdatering"
+
+#~ msgid "Search full package name"
+#~ msgstr "Sök fullt paketnamn"
+
+#~ msgid "Access config file from shell"
+#~ msgstr "Hitta konfigurationsfil via skalet"
+
+#~ msgid "Use cdrom-mount-point"
+#~ msgstr "Välj cdrom-monteringsplats"
+
+#~ msgid "Use source override"
+#~ msgstr "Använd källkodsåsidosättning"
+
+#~ msgid "Download Only"
+#~ msgstr "Bara nedladdning"
+
+#~ msgid "Correct broken dependencies"
+#~ msgstr "Korrigera trasiga beroenden"
+
+#~ msgid "Ignore missing packages"
+#~ msgstr "Ignorera saknade paket"
+
+#~ msgid "Disable downloading packages"
+#~ msgstr "Inaktivera paketnedladdning"
+
+#~ msgid "Automatic yes to prompts"
+#~ msgstr "Svara automatiskt ja på alla frågor"
+
+#~ msgid "Compile source packages"
+#~ msgstr "Kompilera källkodspaket"
+
+#~ msgid "Ignore package Holds"
+#~ msgstr "Ignorera paketblockar"
+
+#~ msgid "Do not upgrade packages"
+#~ msgstr "Upgradera inte paket"
+
+#~ msgid "Force yes"
+#~ msgstr "Tvinga ja"
+
+#~ msgid "Erase obsolete files"
+#~ msgstr "Radera förlegade filer"
+
+#~ msgid "Control default input to the policy engine"
+#~ msgstr "Kontrollera standardindata till policymotorn"
+
+#~ msgid "Only perform operations that are trivial"
+#~ msgstr "Utför bara triviala operationer"
+
+#~ msgid "Abort if any packages are to be removed"
+#~ msgstr "Avbryt om paket ska tas bort"
+
+#~ msgid "Only accept source packages"
+#~ msgstr "Acceptera bara källkodpaket"
+
+#~ msgid "Download only diff file"
+#~ msgstr "Ladda bara ner difffiler"
+
+#~ msgid "Download only tar file"
+#~ msgstr "Ladda bara tar-fil"
+
+#~ msgid "Only process arch-dependant build-dependencies"
+#~ msgstr "Processa bara arkitekturberoende byggberoenden"
+
+#~ msgid "Ignore non-authenticated packages"
+#~ msgstr "Ignorera oautentiserande paket"
+
+#~ msgid "Specify apt config file"
+#~ msgstr "Välj apt-konfigurationsfil"
+
+#~ msgid "List bugs in rss format"
+#~ msgstr "Lista information om inoder"
+
+#~ msgid "Read filenames from pipe"
+#~ msgstr "Läs filnamn från rör"
+
+#~ msgid "Alias for 'get'"
+#~ msgstr "Alias för 'get'"
+
+#~ msgid "Use specific conffile"
+#~ msgstr "Välj konfigurationsfil"
+
+#~ msgid ""
+#~ "Comma-separated list of package installation states to follow recursively"
+#~ msgstr ""
+#~ "Komma-separarad lista av paketinstallationstillstånd att följa rekursivt"
+
+#~ msgid "Comma-separated list of package installation states to show"
+#~ msgstr "Komma-separarad lista av paketinstallationstillstånd att visa"
+
+#~ msgid "Probe a CD"
+#~ msgstr "Sondera en CD"
+
+#~ msgid "File to grab servers"
+#~ msgstr "Fil att hämta servrar från"
+
+#~ msgid "File as input"
+#~ msgstr "Fil som indata"
+
+#~ msgid "Mirror-list file"
+#~ msgstr "Spegel-listefil"
+
+#~ msgid "Output sources.list file"
+#~ msgstr "Skriv en sources.list fil"
+
+#~ msgid "Write top servers to file"
+#~ msgstr "Skriv top-servrar till fil"
+
+#~ msgid "Run on current dir"
+#~ msgstr "Kör i den nuvarande katalogen"
+
+#~ msgid "Removable medium"
+#~ msgstr "Löstagbart medium"
+
+#~ msgid "List of packages to install"
+#~ msgstr "Lista av paket att installera"
+
+#~ msgid "Specify a non-mountpoint dir"
+#~ msgstr "Välj katalog som inte är monteringsplats"
+
+#~ msgid "Select a method"
+#~ msgstr "Välj metod"
+
+#~ msgid "Accept protocols"
+#~ msgstr "Acceptera angivna protokoll"
+
+#~ msgid "Reject protocols"
+#~ msgstr "Vägra använda angivna protokoll"
+
+#~ msgid "Numerical address"
+#~ msgstr "Numerisk adress"
+
+#~ msgid "Use hardware address"
+#~ msgstr "Använd hårdvaruadress"
+
+#~ msgid "Define math library"
+#~ msgstr "Definera matematikbibliotek"
+
+#~ msgid "Give warnings for extensions to POSIX bc"
+#~ msgstr "Varna vid användning av Posix-förlängningar"
+
+#~ msgid "Process exactly POSIX bc"
+#~ msgstr "Använd exakt Posix bc"
+
+#~ msgid "Do not print the GNU welcome"
+#~ msgstr "Visa inte GNUs välkomstmeddelande"
+
+#~ msgid "Remove the topmost global event block"
+#~ msgstr "Ta bort den översta globala händelseblockeraren"
+
+#~ msgid "Print names of all existing builtins"
+#~ msgstr "Visa namnen på alla tillgängliga inbbyggda kommandon"
+
+#~ msgid "Decompress to stdout"
+#~ msgstr "Dekomprimera till standard ut"
+
+#~ msgid "Overwrite"
+#~ msgstr "Skiv över"
+
+#~ msgid "Reduce memory usage"
+#~ msgstr "Minska minnesanvändning"
+
+#~ msgid "Print compression ratios"
+#~ msgstr "Skriv ut kompressionsfaktor"
+
+#~ msgid "Print license"
+#~ msgstr "Skriv ut licens"
+
+#~ msgid "Compress file"
+#~ msgstr "Komprimera fil"
+
+#~ msgid "Check integrity"
+#~ msgstr "Verifiera integritet"
+
+#~ msgid "Supress errors"
+#~ msgstr "Visa inte fel"
+
+#~ msgid "Small block size"
+#~ msgstr "Liten blockstorlek"
+
+#~ msgid "Large block size"
+#~ msgstr "Stor blockstorlek"
+
+#~ msgid "Play in random order"
+#~ msgstr "Spela i slumpmässig ordning"
+
+#~ msgid "Increment the level of general verbosity by one"
+#~ msgstr "Öka pratigheten ett steg"
+
+#~ msgid ""
+#~ "Increment the verbose level in respect of SCSI command transport by one"
+#~ msgstr "Öka pratighet om SCSI-kommandotransporten ett steg"
+
+#~ msgid "Set the misc debug value to #"
+#~ msgstr "Välj den allmänna debugnivån"
+
+#~ msgid "Increment the misc debug level by one"
+#~ msgstr "Öka den allmänna debugnivån ett steg"
+
+#~ msgid "Do not print out a status report for failed SCSI commands"
+#~ msgstr "Skriv inte ut en statusrapport för misslyckade SCSI-kommandon"
+
+#~ msgid "Force to continue on some errors"
+#~ msgstr "Tvinga att fortsätt vid fel"
+
+#~ msgid "Tell cdrecord to set the SCSI IMMED flag in certain commands"
+#~ msgstr "Instruera cdrecord att sätta SCSI IMMED-flaggan i vissa kommandon"
+
+#~ msgid ""
+#~ "Defines the minimum drive buffer fill ratio for the experimental ATAPI "
+#~ "wait mode intended to free the IDE bus to allow hard disk and CD/DVD "
+#~ "writer on the same IDE cable"
+#~ msgstr ""
+#~ "Definerar den minsta enhetsbufferfyllnadshastigheten för det "
+#~ "experimentella ATAPI-vänteläget som är menat att underlätta för IDE-"
+#~ "bussen att låta hårddisk och CD/DVD-skrivare befinna sig på samma IDE-"
+#~ "kabel"
+
+#~ msgid "Complete CD/DVD-Recorder recording process with the laser turned off"
+#~ msgstr "Fullfölj CD/DVD-brännarens inspelningsprocess med lasern avstängd"
+
+#~ msgid "Tells cdrecord to handle images created by readcd -clone"
+#~ msgstr "Ange att cdrecord ska hantera bilder skapade av readcd -clone"
+
+#~ msgid "Set SAO (Session At Once) mode, usually called Disk At Once mode"
+#~ msgstr ""
+#~ "Välj SAO- (Session At Once) skrivläge, vanligtvis kallat Disk At Once-"
+#~ "skrivläge"
+
+#~ msgid "Set TAO (Track At Once) writing mode"
+#~ msgstr "Välj TAO- (Track At Once) skrivläge"
+
+#~ msgid "Select Set RAW writing, the preferred raw writing mode"
+#~ msgstr "Välj det bättre RAW-skrivläget"
+
+#~ msgid "Select Set RAW writing, the less preferred raw writing mode"
+#~ msgstr "Välj det mindre bra RAW-skrivläget"
+
+#~ msgid ""
+#~ "Select Set RAW writing, the preferred raw writing mode if raw96r is not "
+#~ "supported"
+#~ msgstr "Välj det RAW-skrivläget som är bäst om stöd saknas för raw96r"
+
+#~ msgid "Allow multi session CDs to be made"
+#~ msgstr "Tillåt skapandet av multisessions-CD"
+
+#~ msgid ""
+#~ "Retrieve multi session info in a form suitable for mkisofs-1.10 or later"
+#~ msgstr ""
+#~ "Hämta multisessionsinfo i ett format lämpligt för mkisofs-1.10 och senare"
+
+#~ msgid "Retrieve and print out the table of content or PMA of a CD"
+#~ msgstr "Hämta och skriv ut innehållsförteckningen eller PMA för en CD"
+
+#~ msgid "Retrieve and print out the ATIP (absolute Time in Pre-groove) info"
+#~ msgstr "Hämta och skriv ut ATIP (absolute Time in Pre-groove) info"
+
+#~ msgid "The disk will only be fixated"
+#~ msgstr "Fixera endast skivan"
+
+#~ msgid "Do not fixate the disk after writing the tracks"
+#~ msgstr "Fixera inte skivan efter stt spåren skrivits"
+
+#~ msgid ""
+#~ "Wait for input to become available on standard input before trying to "
+#~ "open the SCSI driver"
+#~ msgstr ""
+#~ "Vänta på att indata ska bli tillgängligt från standard in innan försök "
+#~ "rill att öppna SCSI-enheten"
+
+#~ msgid "Load the media and exit"
+#~ msgstr "Ladda mediet och avsluta"
+
+#~ msgid "Load the media, lock the door and exit"
+#~ msgstr "Ladda mediet, lås luckan och avsluta"
+
+#~ msgid "Eject disk after doing the work"
+#~ msgstr "Skicka ut skivan efter arbetets utförande"
+
+#~ msgid "Set the speed factor of the writing process to #"
+#~ msgstr "Sätt hastighetsfaktorn för skrivprocessen"
+
+#~ msgid "Blank a CD-RW and exit or blank a CD-RW before writing"
+#~ msgstr "Töm en CD-RW och avsluta eller töm en CD-RW för skrivning"
+
+#~ msgid "Format a CD-RW/DVD-RW/DVD+RW disc"
+#~ msgstr "Formatera en CD-RW/DVD-RW/DVD+RW-skiva"
+
+#~ msgid "Set the FIFO (ring buffer) size to #"
+#~ msgstr "Välj FIFO- (ringbuffert) storlek"
+
+#~ msgid "Set the maximum transfer size for a single SCSI command to #"
+#~ msgstr "Välj maximal överföringshastighet för ett enkilt SCSI-kommando"
+
+#~ msgid "Sets the SCSI target for the CD/DVD-Recorder"
+#~ msgstr "Välj SCSI-målet för CD/DVD-brännaren"
+
+#~ msgid "Set the grace time before starting to write to ># seconds"
+#~ msgstr "Välj väntetiden i sekunder innan skrivning till skivan påbörjas"
+
+#~ msgid "Set the default SCSI command timeout value to # seconds"
+#~ msgstr "Välj standard-SCSI-timeoutvärdet i sekunder"
+
+#~ msgid "Allows the user to manually select a driver for the device"
+#~ msgstr "Låter användaren manuellt välja en drivrutin för enheten"
+
+#~ msgid "Set driver specific options"
+#~ msgstr "Välj drivrutinsspecifika inställningar"
+
+#~ msgid ""
+#~ "Set the driveropts specified by driveropts=option list, the speed of the "
+#~ "drive and the dummy flag and exit"
+#~ msgstr ""
+#~ "Välj drivrutinsinställningar angivna av listandriveropt=inställning, "
+#~ "hastigheten på enheten och dunny-flaggan och avsluta"
+
+#~ msgid "Checks if a driver for the current drive is present and exit"
+#~ msgstr ""
+#~ "Kontrollerar om en drivrutin för den nuvarande enheten finns tillgänglig "
+#~ "och avsluta"
+
+#~ msgid ""
+#~ "Print the drive capabilities for SCSI-3/mmc compliant drives as obtained "
+#~ "from mode page 0x2A"
+#~ msgstr ""
+#~ "Visa enhetsförmågor för SCSI-3/mmc-anpassade enheter hämtade från "
+#~ "lägessida 0x2A"
+
+#~ msgid "Do an inquiry for the drive, print the inquiry info and exit"
+#~ msgstr ""
+#~ "Utför en föffrågan på enheten, visa förfrågningsinformationen och avsluta"
+
+#~ msgid ""
+#~ "Scan all SCSI devices on all SCSI busses and print the inquiry strings"
+#~ msgstr ""
+#~ "Genomsök alla SCSI-enheter på alla SCSI-bussar och skriv ut "
+#~ "förfrågningssträngarna"
+
+#~ msgid "Try to reset the SCSI bus where the CD recorder is located"
+#~ msgstr "Försök att återställa SCSI-bussen som CD-brännaren befinner sig på"
+
+#~ msgid "Try to send an abort sequence to the drive"
+#~ msgstr "Försök skicka en avbrottssekvens till enheten"
+
+#~ msgid "Allow cdrecord to write more than the official size of a medium"
+#~ msgstr ""
+#~ "Tillåt cdrecord att skriva mer än den officiella storleken på ett medium"
+
+#~ msgid "Ignore the known size of the medium, use for debugging only"
+#~ msgstr ""
+#~ "Ignorera den kända storleken på ett medium, använd endast vid debuggning"
+
+#~ msgid "Use *.inf files to overwrite audio options"
+#~ msgstr "Använd *.inf-filer för att skriva över ljudinställningar"
+
+#~ msgid "Set the default pre-gap size for all tracks except track nr 1"
+#~ msgstr "Välj standard-pre-gap-storlek för alla spår utom spår 1"
+
+#~ msgid "Set Packet writing mode (experimental interface)"
+#~ msgstr "Välj paketskrivningsläge (experimentellt gränssnitt)"
+
+#~ msgid "Set the packet size to #, forces fixed packet mode (experimental)"
+#~ msgstr "Ange paketstorlek, tvingar fast paket-läge (experimentell)"
+
+#~ msgid ""
+#~ "Do not close the current track, only when in packet writing mode "
+#~ "(experimental)"
+#~ msgstr ""
+#~ "Avsluta inte det nuvarande spåret, bara i paketskrivningsläge "
+#~ "(experimentell)"
+
+#~ msgid "Set the Media Catalog Number of the CD"
+#~ msgstr "Välj Mediakatalog-nummer för CD:n"
+
+#~ msgid ""
+#~ "Write CD-Text info based on info taken from a file that contains ascii "
+#~ "info for the text strings"
+#~ msgstr ""
+#~ "Skriv CD-Text-infromation baserat på information tagen från fil i ascii-"
+#~ "format"
+
+#~ msgid "Write CD-Text based on info found in the binary file filename"
+#~ msgstr ""
+#~ "Skriv CD-Text-infromation baserat på information tagen från fil i binärt "
+#~ "format"
+
+#~ msgid ""
+#~ "Take all recording related info from a CDRWIN compliant CUE sheet file"
+#~ msgstr ""
+#~ "Ta all inspelningrelaterad information från en CDRWIN-anpassad CUE-"
+#~ "bladsfil"
+
+#~ msgid "Set the International Standard Recording Number for the next track"
+#~ msgstr "Ange det internationella standardinspelningsnumret för nästa spår"
+
+#~ msgid "Sets an index list for the next track"
+#~ msgstr "Ange en indexlista för nästa spår"
+
+#~ msgid "All subsequent tracks are written in CD-DA audio format"
+#~ msgstr "Alla följande spår är skrivna i CD-DA-ljudformatet"
+
+#~ msgid "Audio data is assumed to be in byte-swapped (little-endian) order"
+#~ msgstr "Ljuddata antas vara i omvänd byteordning"
+
+#~ msgid ""
+#~ "All subsequent tracks are written in CD-ROM mode 1 (Yellow Book) format"
+#~ msgstr ""
+#~ "Alla följande spår är skrivna i CD-ROM läge 1 (Yellow book) formatet"
+
+#~ msgid "All subsequent tracks are written in CD-ROM mode 2 format"
+#~ msgstr "Alla följande spår är skrivna i CD-ROM läge 2 formatet"
+
+#~ msgid "All subsequent tracks are written in CD-ROM XA mode 2 form 1 format"
+#~ msgstr "Alla följande spår är skrivna i CD-ROM XA läge 2 form 1 formatet"
+
+#~ msgid "All subsequent tracks are written in CD-ROM XA mode 2 form 2 format"
+#~ msgstr "Alla följande spår är skrivna i CD-ROM XA läge 2 form 2 formatet"
+
+#~ msgid ""
+#~ "All subsequent tracks are written in a way that allows a mix of CD-ROM XA "
+#~ "mode 2 form 1/2 format"
+#~ msgstr ""
+#~ "Alla följande spår är skrivna på ett sätt som fillåter en blandning av CD-"
+#~ "ROM XA läge 2 form 1/2 formaten"
+
+#~ msgid "The TOC type for the disk is set to CDI, with XA only"
+#~ msgstr "Innehållsförteckningen är satt till CDI, med enbart XA"
+
+#~ msgid "Use the ISO-9660 file system size as the size of the next track"
+#~ msgstr "Använd ISO-9660-filsystemets storlek som storlek på nästa spår"
+
+#~ msgid ""
+#~ "15 sectors of zeroed data will be added to the end of this and each "
+#~ "subsequent data track"
+#~ msgstr ""
+#~ "Lägg till 15 sektorer av nolldata till slutet av varje efterföljande "
+#~ "dataspår"
+
+#~ msgid "Set the amount of data to be appended as padding to the next track"
+#~ msgstr ""
+#~ "Ange mängden data som skall läggas till som paddning till nästa spår"
+
+#~ msgid "Do not pad the following tracks - the default"
+#~ msgstr "Lägg inte till paddning till de följande spåren - standard"
+
+#~ msgid "Output diagnostic for changed files"
+#~ msgstr "Visa information om ändrade filer"
+
+#~ msgid "Do not dereference symbolic links"
+#~ msgstr "Följ ej symboliska länkar"
+
+#~ msgid "Change from owner/group"
+#~ msgstr "Byt från ägare/grupp"
+
+#~ msgid "Use same owner/group as file"
+#~ msgstr "Använd samma ägargrupp som angiven fil"
+
+#~ msgid "Operate recursively"
+#~ msgstr "Rekurivt läge"
+
+#~ msgid "Output diagnostic for every file"
+#~ msgstr "Visa information om alla filer"
+
+#~ msgid "Command to run"
+#~ msgstr "Kommando att utföra"
+
+#~ msgid "Add text to the end of the selected area"
+#~ msgstr "Lägg till text till slutet av valt område"
+
+#~ msgid "Add text at cursor"
+#~ msgstr "Lägg till text vid markören"
+
+#~ msgid "Replace selected part"
+#~ msgstr "Ersätt valt område"
+
+#~ msgid "Select job under cursor"
+#~ msgstr "Välj jobb under markören"
+
+#~ msgid "Select process under cursor"
+#~ msgstr "Välj process under markören"
+
+#~ msgid "Select token under cursor"
+#~ msgstr "Välj symbol under markören"
+
+#~ msgid "Select entire command line (default)"
+#~ msgstr "Välj hela kommandoraden (standard)"
+
+#~ msgid "Only return that part of the command line before the cursor"
+#~ msgstr "Visa bara den del av kommandoraden som är före markören"
+
+#~ msgid "Inject readline functions to reader"
+#~ msgstr "Skicka readline-funktion till läsaren"
+
+#~ msgid "Set/get cursor position, not buffer contents"
+#~ msgstr "Sätt/hämta markörposition, inte bufferinnehåll"
+
+#~ msgid "Command to add completion to"
+#~ msgstr "Kommando att komplettera"
+
+#~ msgid "Path to add completion to"
+#~ msgstr "Sökväg att komplettera"
+
+#~ msgid "Posix-style option to complete"
+#~ msgstr "Posix-typ av flagga att komplettera"
+
+#~ msgid "GNU-style option to complete"
+#~ msgstr "GNU-typ av flagga att komplettera"
+
+#~ msgid "Old style long option to complete"
+#~ msgstr "Gammal typ av lång flagga att komplettera"
+
+#~ msgid "Do not use file completion"
+#~ msgstr "Använd inte fil-komplettering"
+
+#~ msgid "Require parameter"
+#~ msgstr "Kräv parameter"
+
+#~ msgid "Require parameter and do not use file completion"
+#~ msgstr "Kräv parameter, använd inte filkomplettering"
+
+#~ msgid "A list of possible arguments"
+#~ msgstr "Parametrar specifikt för denna flagga för flagga"
+
+#~ msgid "Description of this completions"
+#~ msgstr "Beskrivning av denna komplettering"
+
+#~ msgid "Option list is not complete"
+#~ msgstr "Detta kommando accepterar andra flaggor än de här angivna"
+
+#~ msgid ""
+#~ "The completion should only be used if the specified command has a zero "
+#~ "exit status"
+#~ msgstr ""
+#~ "Completteringen skall bara användas om det angivna kommandot har "
+#~ "nollskild avslutningstatus"
+
+#~ msgid "Cache test results in file config.cache"
+#~ msgstr "Cachea test resultat i filen config.cache"
+
+#~ msgid "Do not create output files"
+#~ msgstr "Skapa inte utfiler"
+
+#~ msgid "Architecture-independent install directory"
+#~ msgstr "Arkitekturoberoende installationskatalog"
+
+#~ msgid "Architecture-dependent install directory"
+#~ msgstr "Arkitekturberoende installationskatalog"
+
+#~ msgid "Configure for building on BUILD"
+#~ msgstr "Konfiurera för att bygga på given målarkitektur"
+
+#~ msgid "Cross-compile to build programs to run on HOST"
+#~ msgstr "Korskompilera för angiven värd"
+
+#~ msgid "Configure for building compilers for TARGET"
+#~ msgstr "Konfigurera för att bygga kompilator för angivet mål"
+
+#~ msgid "Select output delimiter"
+#~ msgstr "Välj utdataavgränsare"
+
+#~ msgid "Kerberos server mode"
+#~ msgstr "Kerberosserverläge"
+
+#~ msgid "Print out history information for files"
+#~ msgstr "Visa historikinformation för filer"
+
+#~ msgid "Prompt for password for authenticating server"
+#~ msgstr "Be om lösenord för autentisering"
+
+#~ msgid "Password server mode"
+#~ msgstr "Serverlösenordsläge"
+
+#~ msgid "Show last revision where each line of module was modified"
+#~ msgstr "Visa senaste revision vid vilken vare rad i modul ändrades"
+
+#~ msgid "Indicate that a Module is no longer in use"
+#~ msgstr "Indikera att modul inte längre används"
+
+#~ msgid "Print out history information for a module"
+#~ msgstr "Skriv ut historik för modul"
+
+#~ msgid "Add a symbolic tag to a module"
+#~ msgstr "Lägg till symbolisk tagg till modul"
+
+#~ msgid "Server mode"
+#~ msgstr "Serverläge"
+
+#~ msgid "Display status information on checked out files"
+#~ msgstr "Visa status för utcheckade files"
+
+#~ msgid "Add a symbolic tag to checked out version of files"
+#~ msgstr "Lägg till symbolisk tagg till utcheckad version av filer"
+
+#~ msgid "Bring work tree in sync with repository"
+#~ msgstr "Synkronisera arbetsträd med förråd"
+
+#~ msgid "See who is watching a file"
+#~ msgstr "Visa övervakningar på fil"
+
+#~ msgid "Disable this command"
+#~ msgstr "Inaktivera kommando"
+
+#~ msgid "Shows brief description of command and its arguments"
+#~ msgstr "Visa kort beskrivning av underkommandon"
+
+#~ msgid "Suppress informational output"
+#~ msgstr "Tyst läge"
+
+#~ msgid "Neither verbose nor quiet output"
+#~ msgstr "Varken tyst eller utförligt läge"
+
+#~ msgid "Give output suitable for get --context"
+#~ msgstr "Formatera utdata lämpligt för get --context"
+
+#~ msgid "Generate XML formatted output"
+#~ msgstr "Generera XML-formaterad utdata"
+
+#~ msgid "Give human-readable output"
+#~ msgstr "Människoanpassad formatering av utdata"
+
+#~ msgid "Don't summarize changes"
+#~ msgstr "Summera inte ändringar"
+
+#~ msgid "Answer yes to all patches"
+#~ msgstr "Svara ja på alla fixar"
+
+#~ msgid "Prompt user interactively"
+#~ msgstr "Fråga användaren interaktivt"
+
+#~ msgid "Output patch in a darcs-specific format similar to diff -u"
+#~ msgstr "Skriv fix i darcs-specifikt format som liknar diff -u"
+
+#~ msgid "Specify hash of creator patch (see docs)"
+#~ msgstr "Ange hash av skaparfix (se dokumentationen)"
+
+#~ msgid "Make scripts executable"
+#~ msgstr "Gör skript exekverbara"
+
+#~ msgid "Allow conflicts, but don't mark them"
+#~ msgstr "Tillåt konflikter, men markera dem inte"
+
+#~ msgid "Run the test script"
+#~ msgstr "Kör testskript"
+
+#~ msgid "Don't run the test script"
+#~ msgstr "Kör inte testskript"
+
+#~ msgid "Don't actually take the action"
+#~ msgstr "Gör ingenting"
+
+#~ msgid "Don't automatically fulfill dependencies"
+#~ msgstr "Fråga efter extra beroenden"
+
+#~ msgid "Set default repository [DEFAULT]"
+#~ msgstr "Välj standardförråd"
+
+#~ msgid "Don't set default repository"
+#~ msgstr "Välj inte standardförråd"
+
+#~ msgid "Edit the long comment by default"
+#~ msgstr "Redigera långa kommentarer som standard"
+
+#~ msgid "Don't give a long comment"
+#~ msgstr "Redigera inte lång kommentar"
+
+#~ msgid "Prompt for whether to edit the long comment"
+#~ msgstr "Fråga om den långa kommentaren skall redigeras"
+
+#~ msgid "Don't remove the test directory"
+#~ msgstr "Ta inte bort testkatalog"
+
+#~ msgid "Remove the test directory"
+#~ msgstr "Ta bort testkatalog"
+
+#~ msgid "Sign the patch with your gpg key"
+#~ msgstr "Signera fix med din gpg-nyckel"
+
+#~ msgid "Specify sendmail command"
+#~ msgstr "Ange sendmailkommando"
+
+#~ msgid "Give patch name and comment in file"
+#~ msgstr "Välj fixnamn och kommentar via fil"
+
+#~ msgid "Send to context stored in FILENAME"
+#~ msgstr "Skicka till sammanhang lagrat i FILNAMN"
+
+#~ msgid "Verify that the patch was signed by a key in PUBRING"
+#~ msgstr "Verifiera att fix är signerad från nyckel i angiven nyckelring"
+
+#~ msgid "Don't verify patch signature"
+#~ msgstr "Verifiera inte fix-signaturer"
+
+#~ msgid "Mark conflicts"
+#~ msgstr "Markera konflikter"
+
+#~ msgid "Forward unsigned messages without extra header"
+#~ msgstr "Skicka vidare osignerade meddelanden utan extra huvud"
+
+#~ msgid "Specify a sibling directory"
+#~ msgstr "Ange en syskonkatalog"
+
+#~ msgid "Relink pristine tree (not recommended)"
+#~ msgstr "Linka om till det orörda trädet (inte rekommenderat)"
+
+#~ msgid "Ignore changes whose lines match the REGEX"
+#~ msgstr "Ignorera ändringar som matchar REGEX"
+
+#~ msgid "Output NUM lines of copied context"
+#~ msgstr "Skriv ut NUM rader av kopierad sammanhang"
+
+#~ msgid "Output NUM lines of unified context"
+#~ msgstr "Skriv ut NUM rader av unifieradt sammanhang"
+
+#~ msgid "Output at most NUM print columns"
+#~ msgstr "Skriv ut som mest NUM kolumner"
+
+#~ msgid "Compare FILE2 to all operands"
+#~ msgstr "Jämför FIL2 med alla operander"
+
+#~ msgid "Write size for all files"
+#~ msgstr "Skriv ut storlek för alla filer"
+
+#~ msgid "Print file size, not disk usage"
+#~ msgstr "Skriv ut filstorlek, inte använt diskutrymme"
+
+#~ msgid "Use 1B block size"
+#~ msgstr "Använd 1B som blockstorlek"
+
+#~ msgid "Produce grand total"
+#~ msgstr "Visa totalsumma"
+
+#~ msgid "Dereference file symlinks"
+#~ msgstr "Följ symboliska länkar till filer"
+
+#~ msgid "Use 1kB block size"
+#~ msgstr "Använd 1kB blockstorlek"
+
+#~ msgid "Count hard links multiple times"
+#~ msgstr "Räkna hårda länkar alla gånger de förekommer"
+
+#~ msgid "Dereference all symlinks"
+#~ msgstr "Följ alla symboliska länkar"
+
+#~ msgid "Do not include subdirectory size"
+#~ msgstr "Inkludera inte underkatalogers storlek"
+
+#~ msgid "Display only a total for each argument"
+#~ msgstr "Visa bara en totalsumma för varje argument"
+
+#~ msgid "Command"
+#~ msgstr "Kommando"
+
+#~ msgid "Start with an empty environment"
+#~ msgstr "Starta med tom miljö"
+
+#~ msgid "Remove variable from the environment"
+#~ msgstr "Ta bort variabel från variablestacken"
+
+#~ msgid "File is executable"
+#~ msgstr "Fil är program"
+
+#~ msgid "Run fish with this command"
+#~ msgstr "Utför detta kommando i fish"
+
+#~ msgid "Only parse input, do not execute"
+#~ msgstr "Verifiera bara kommandon, utför dem inte"
+
+#~ msgid "Run in interactive mode"
+#~ msgstr "Kör i interaktivt läge"
+
+#~ msgid "Run in login mode"
+#~ msgstr "Kör i loginläge"
+
+#~ msgid "Set function description"
+#~ msgstr "Välj funktionsbeskrivning"
+
+#~ msgid "Function"
+#~ msgstr "Funktion"
+
+#~ msgid "Builtin"
+#~ msgstr "Inbyggt kommando"
+
+#~ msgid "Make the function a job exit event handler"
+#~ msgstr "Gör funktionen till en händelsehanterare för avslutade jobb"
+
+#~ msgid "Make the function a process exit event handler"
+#~ msgstr "Gör funktionen till en händelsehanterare för avslutade processer"
+
+#~ msgid "Make the function a signal event handler"
+#~ msgstr "Gör funktionen till en händelsehanterare för signaler"
+
+#~ msgid "Make the function a variable update event handler"
+#~ msgstr "Gör funktionen till en händelsehanterare för variabeluppdateringar"
+
+#~ msgid "Erase function"
+#~ msgstr "Radera funktion"
+
+#~ msgid "Unmount"
+#~ msgstr "Avmontera"
+
+#~ msgid "Quiet"
+#~ msgstr "Tyst läge"
+
+#~ msgid "Lazy unmount"
+#~ msgstr "Lat avmontering"
+
+#~ msgid "Enable automatic template instantiation at link time"
+#~ msgstr "Slå på automatisk templateinstantiering vid länktillfälle"
+
+#~ msgid "Ignore errors"
+#~ msgstr "Ignorera fel"
+
+#~ msgid "Make a signature"
+#~ msgstr "Skapa signatur"
+
+#~ msgid "Make a clear text signature"
+#~ msgstr "Skapa klartextsignatur"
+
+#~ msgid "Make a detached signature"
+#~ msgstr "Skapa bortkopplad signatur"
+
+#~ msgid "Encrypt data"
+#~ msgstr "Kryptera data"
+
+#~ msgid "Encrypt with a symmetric cipher using a passphrase"
+#~ msgstr "Kryptera med symmetriskt chiffer och passfras"
+
+#~ msgid "Store only (make a simple RFC1991 packet)"
+#~ msgstr "Endast lagring (skapa ett enkelt RFC1991-paket)"
+
+#~ msgid "Assume specified file or stdin is sigfile and verify it"
+#~ msgstr ""
+#~ "Antag att angiven fil eller standard in är signatur och verifiera den"
+
+#~ msgid ""
+#~ "Modify certain other commands to accept multiple files for processing"
+#~ msgstr "Ändra vissa andra kommandon so de behandlar multipla filer"
+
+#~ msgid "Identical to '--multifile --verify'"
+#~ msgstr "Identiskt med '--multifile --verify'"
+
+#~ msgid "Identical to '--multifile --encrypt'"
+#~ msgstr "Identiskt med '--multifile --encrypt'"
+
+#~ msgid "Identical to --multifile --decrypt"
+#~ msgstr "Identiskt med --multifile --decrypt"
+
+#~ msgid ""
+#~ "List all keys from the public keyrings, or just the ones given on the "
+#~ "command line"
+#~ msgstr ""
+#~ "Visa alla nycklar från den öppna nyckelringen, eller de angivna på "
+#~ "kommandoraden"
+
+#~ msgid ""
+#~ "List all keys from the secret keyrings, or just the ones given on the "
+#~ "command line"
+#~ msgstr ""
+#~ "Visa alla nycklar från den hemliga nyckelringen, eller de angivna på "
+#~ "kommandoraden"
+
+#~ msgid "Same as --list-keys, but the signatures are listed too"
+#~ msgstr "Samma som --list-keys, men visa även signaturer"
+
+#~ msgid "Same as --list-keys, but the signatures are listed and verified"
+#~ msgstr "Samma som --list-keys, men visa och verifiera även signaturer"
+
+#~ msgid "List all keys with their fingerprints"
+#~ msgstr "Visa alla nycklar och deras fingeravtryck"
+
+#~ msgid "Present a menu which enables you to do all key related tasks"
+#~ msgstr "Visa en meny som låter dig utföra alla nyckelrelaterade aktiviteter"
+
+#~ msgid "Sign a public key with your secret key"
+#~ msgstr "Signera en öppen nyckel med din hemliga nyckel"
+
+#~ msgid "Sign a public key with your secret key but mark it as non exportable"
+#~ msgstr ""
+#~ "Signera en öppen nyckel med din hemliga nyckel men markera den som icke-"
+#~ "exporterbar"
+
+#~ msgid "Remove key from the public keyring"
+#~ msgstr "Ta bort en nyckel från den öppna nyckelringen"
+
+#~ msgid "Remove key from the secret and public keyring"
+#~ msgstr "Ta bort en nyckel från den öppna och den hemliga nyckelringen"
+
+#~ msgid ""
+#~ "Same as --delete-key, but if a secret key exists, it will be removed first"
+#~ msgstr ""
+#~ "Samma som --delete-key, men om en hemlig nyckel existerar, ta bort den "
+#~ "först"
+
+#~ msgid "Generate a revocation certificate for the complete key"
+#~ msgstr "Generera ett återkallelsecertifikat för hela nyckeln"
+
+#~ msgid "Generate a designated revocation certificate for a key"
+#~ msgstr "Generera ett utsett återkallelsecertifikat för en nyckel"
+
+#~ msgid "Export all or the given keys from all keyrings"
+#~ msgstr "Exportera alla eller alla angivna nycklar från alla nyckelringar"
+
+#~ msgid "Same as --export but sends the keys to a keyserver"
+#~ msgstr "Samma som --export, men skicka nycklar till en nyckelserver"
+
+#~ msgid "Same as --export, but exports the secret keys instead"
+#~ msgstr "Samma som --export, men exportera hemliga nycklar istället"
+
+#~ msgid "Import/merge keys"
+#~ msgstr "Importera/sammanslå mycklar"
+
+#~ msgid "Import the keys with the given key IDs from a keyserver"
+#~ msgstr "Importera nycklarna med givet nyckel-id från nyckelserver"
+
+#~ msgid ""
+#~ "Request updates from a keyserver for keys that already exist on the local "
+#~ "keyring"
+#~ msgstr ""
+#~ "Begär uppdateringar från en nyckelserver för nycklar som redan existerar "
+#~ "i den lokala nyckelringen"
+
+#~ msgid "Search the keyserver for the given names"
+#~ msgstr "Sök nyckelservern efter de angivna namnen"
+
+#~ msgid "Do trust database maintenance"
+#~ msgstr "Utför underhåll på förtroendedatabasen"
+
+#~ msgid "Do trust database maintenance without user interaction"
+#~ msgstr "Utför underhåll på förtroendedatabasen utan användarinteraktion"
+
+#~ msgid "Send the ownertrust values to stdout"
+#~ msgstr "Visa ögarförtroendevärdena på standard ut"
+
+#~ msgid ""
+#~ "Update the trustdb with the ownertrust values stored in specified files "
+#~ "or stdin"
+#~ msgstr ""
+#~ "Uppdatera förtroendedatabasen med ägarförtroendevärdena lagrade i den "
+#~ "angivna filen eller standard in"
+
+#~ msgid "Create signature caches in the keyring"
+#~ msgstr "Skapa signarurcache i nyckelringen"
+
+#~ msgid ""
+#~ "Print message digest of specified algorithm for all given files or stdin"
+#~ msgstr ""
+#~ "Visa meddelandedigest med given algoritm för alla angivna filer eller "
+#~ "standard in"
+
+#~ msgid "Print message digest of all algorithms for all given files or stdin"
+#~ msgstr ""
+#~ "Visa meddelandedigest med given algoritm för alla angivna filer eller "
+#~ "standard in"
+
+#~ msgid "Emit specified number of random bytes of the given quality level"
+#~ msgstr ""
+#~ "Skapa det angivna antalet slumpmässiga bytes med den angivna kvaliteten"
+
+#~ msgid "Display version and supported algorithms, and exit"
+#~ msgstr "Visa version och stödda algoritmer och avsluta"
+
+#~ msgid "Display warranty and exit"
+#~ msgstr "Visa garanti och avsluta"
+
+#~ msgid "Create ASCII armored output"
+#~ msgstr "Skapa ASCII-skyddad utdata"
+
+#~ msgid ""
+#~ "Sets a limit on the number of bytes that will be generated when "
+#~ "processing a file"
+#~ msgstr ""
+#~ "Sätt gräns på antal bytes som kommer genereras vid behandlande av en fil"
+
+#~ msgid "Use specified key as the key to sign with"
+#~ msgstr "Använd angiven nyckel som nyckel för signering"
+
+#~ msgid "Use specified key as the default key to sign with"
+#~ msgstr "Använd angiven nyckel som standardnyckel för signering"
+
+#~ msgid "Encrypt for specified user id"
+#~ msgstr "Kryptera för angivet användarid"
+
+#~ msgid "Encrypt for specified user id, but hide the keyid of the key"
+#~ msgstr "Kryptera för angivet användarid, men dölj nyckelid hos nyckel"
+
+#~ msgid "Use specified user id as default recipient"
+#~ msgstr "Använd angiven användarid som standardmottagare"
+
+#~ msgid "Use the default key as default recipient"
+#~ msgstr "Använd standardnyckel som standardmottagare"
+
+#~ msgid "Reset --default-recipient and --default-recipient-self"
+#~ msgstr "Återställ --default-recipient och --default-recipient-self"
+
+#~ msgid "Give more information during processing"
+#~ msgstr "Ge mer information under behandling"
+
+#~ msgid "Compression level"
+#~ msgstr "Kompressionsnivå"
+
+#~ msgid "Use a different decompression method for BZIP2 compressed files"
+#~ msgstr "Använd alternativ dekompressionsmetod för BZIP2-komprimerade filer"
+
+#~ msgid ""
+#~ "Treat input files as text and store them in the OpenPGP canonical text "
+#~ "form with standard 'CRLF' line endings"
+#~ msgstr ""
+#~ "Behandla indatafiler som text och lagra dem i det kanoniska OpenPGP-"
+#~ "textformatet med standard 'CRLF' radavslut"
+
+#~ msgid ""
+#~ "Don't treat input files as text and store them in the OpenPGP canonical "
+#~ "text form with standard 'CRLF' line endings"
+#~ msgstr ""
+#~ "Behandla inte indatafiler som text och lagra dem inte i det kanoniska "
+#~ "OpenPGP-textformatet med standard 'CRLF' radavslut"
+
+#~ msgid "Don't make any changes (this is not completely implemented)"
+#~ msgstr "Gör inga ändringar (inte helt implementerat)"
+
+#~ msgid "Prompt before overwrite"
+#~ msgstr "Fråga före överskrivning"
+
+#~ msgid "Batch mode"
+#~ msgstr "Satsvis-läge"
+
+#~ msgid "Don't use batch mode"
+#~ msgstr "Använd inte satsvis-läge"
+
+#~ msgid "Never write output to terminal"
+#~ msgstr "Skriv aldrig utdata till terminalen"
+
+#~ msgid "Assume yes on most questions"
+#~ msgstr "Anta ja på de flesta frågor"
+
+#~ msgid "Assume no on most questions"
+#~ msgstr "Anta nej på de flesta frågor"
+
+#~ msgid "Prompt for a certification level when making a key signature"
+#~ msgstr "Fråga efter certifieringsnivå vid nyckelsignaturskapande"
+
+#~ msgid "Don't prompt for a certification level when making a key signature"
+#~ msgstr "Fråga inte efter certifieringsnivå vid nyckelsignaturskapande"
+
+#~ msgid ""
+#~ "The default certification level to use for the level check when signing a "
+#~ "key"
+#~ msgstr ""
+#~ "Standardcertifieringsnivå att använda för nivåkontroll vid nyckelsignering"
+
+#~ msgid ""
+#~ "Disregard any signatures with a certification level below specified level "
+#~ "when building the trust database"
+#~ msgstr ""
+#~ "Ignorera alla signaturer med signaturnivå under angiven nivå vid "
+#~ "byggandet av förtroendedatabasen"
+
+#~ msgid ""
+#~ "Assume that the specified key is as trustworthy as one of your own secret "
+#~ "keys"
+#~ msgstr ""
+#~ "Anta att den angivna nyckeln är lika pålitlig som en av dina egna hemliga "
+#~ "nycklar"
+
+#~ msgid "Specify trust model"
+#~ msgstr "Ange förtroendemodell"
+
+#~ msgid "Select how to display key IDs"
+#~ msgstr "Välj hur nyckelid ska visas"
+
+#~ msgid "Options for the keyserver"
+#~ msgstr "Inställningar till nyckelservern"
+
+#~ msgid "Options for importing keys"
+#~ msgstr "Inställningar för att importera nycklar"
+
+#~ msgid "Options for exporting keys"
+#~ msgstr "Inställningar för att exportera nycklar"
+
+#~ msgid "Options for listing keys and signatures"
+#~ msgstr "Inställningar för visning av nycklar och signaturer"
+
+#~ msgid "Options for verifying signatures"
+#~ msgstr "Inställningar för verifiering av signaturer"
+
+#~ msgid ""
+#~ "Display the keyring name at the head of key listings to show which "
+#~ "keyring a given key resides on"
+#~ msgstr ""
+#~ "Visa nyckelringnamnet vid toppen av nyckellistan för att visa vilken "
+#~ "nyckelring en given nyckel ligger i"
+
+#~ msgid "Set the home directory"
+#~ msgstr "Välj hemkatalog"
+
+#~ msgid "Set the native character set"
+#~ msgstr "Välj den interna teckenuppsättningen"
+
+#~ msgid "Assume that following command line arguments are given in UTF8"
+#~ msgstr "Antag att efterföljande argument är lagrade i UTF8"
+
+#~ msgid ""
+#~ "Assume that following arguments are encoded in the character set "
+#~ "specified by --display-charset"
+#~ msgstr ""
+#~ "Antag att efterföljande argument är lagrade i teckenuppsättningen angiven "
+#~ "av --display-charset"
+
+#~ msgid "Shortcut for '--options /dev/null'"
+#~ msgstr "Genväg för '--options /dev/null'"
+
+#~ msgid "Write attribute subpackets to the specified file descriptor"
+#~ msgstr "Skriv attributunderpaket till angiven filidentifierare"
+
+#~ msgid "Include secret key comment packets when exporting secret keys"
+#~ msgstr ""
+#~ "Inkludera hemliga nyckel-kommentarpaket vid exportering av hemliga nycklar"
+
+#~ msgid "Don't include secret key comment packets when exporting secret keys"
+#~ msgstr ""
+#~ "Inkludera inte hemliga nyckel-kommentarpaket vid exportering av hemliga "
+#~ "nycklar (standard)"
+
+#~ msgid "Don't use a comment string"
+#~ msgstr "Använd inte en kommentarsträng"
+
+#~ msgid "Include the version string in ASCII armored output"
+#~ msgstr "Inkludera versionssträng i ASCII-skyddat utdata"
+
+#~ msgid "Don't include the version string in ASCII armored output"
+#~ msgstr "Inkludera inte versionssträng i ASCII-skyddat utdata (standard)"
+
+#~ msgid "Set the 'for your eyes only' flag in the message"
+#~ msgstr "Sätt 'for your eyes only'-flaggan i meddelandet"
+
+#~ msgid "Clear the 'for your eyes only' flag in the message"
+#~ msgstr "Töm 'for your eyes only'-flaggan i meddelandet"
+
+#~ msgid "Create file with name as given in data"
+#~ msgstr "Skapa fil med namn angivet i data"
+
+#~ msgid "Don't create file with name as given in data"
+#~ msgstr "Skapa inte fil med namn angivet i data"
+
+#~ msgid "Use specified cipher algorithm"
+#~ msgstr "Använd angiven chiffer-algoritm"
+
+#~ msgid "Use specified message digest algorithm"
+#~ msgstr "Använd angiven meddelandedigestalgoritm"
+
+#~ msgid "Use specified compression algorithm"
+#~ msgstr "Använd angiven kompressionsalgoritm"
+
+#~ msgid "Use specified message digest algorithm when signing a key"
+#~ msgstr "Använd angiven meddelandedigestalgoritm vid nyckelsignering"
+
+#~ msgid "Use specified cipher algorithm to protect secret keys"
+#~ msgstr "Använd angiven chifferalgoritm för att skydda hemliga nycklar"
+
+#~ msgid "Use specified digest algorithm to mangle the passphrases"
+#~ msgstr "Använd angiven digestalgoritm för passfrasmangling"
+
+#~ msgid "Selects how passphrases are mangled"
+#~ msgstr "Välj hur passfrasmangling"
+
+#~ msgid "Integrity protect secret keys by using a SHA-1 checksum"
+#~ msgstr ""
+#~ "Sködda hemliga nycklars integritet genom att använda en SHA-1-"
+#~ "kontrollsumma"
+
+#~ msgid "Never allow the use of specified cipher algorithm"
+#~ msgstr "Tilåt aldrig användandet av angiven chifferalgoritm"
+
+#~ msgid "Never allow the use of specified public key algorithm"
+#~ msgstr "Tillåt aldrig användandet av angiven öppen nyckel-algoritm"
+
+#~ msgid "Do not cache the verification status of key signatures"
+#~ msgstr "Cache:a inte verifieringsstatus av nyckelsignaturer"
+
+#~ msgid "Do not verify each signature right after creation"
+#~ msgstr "Kontrollera inte varje signatur direkt efter skapande"
+
+#~ msgid "Automatically run the --check-trustdb command internally when needed"
+#~ msgstr "Utför automatiskt '--check-trustdb'-kommandot internt vid behov"
+
+#~ msgid "Never automatically run the --check-trustdb"
+#~ msgstr "Utför aldrig automatiskt '--check-trustdb'-kommandot"
+
+#~ msgid "Do not put the recipient keyid into encrypted packets"
+#~ msgstr "Lägg inte in mottagarens nyckelid i krypterade paket"
+
+#~ msgid "Put the recipient keyid into encrypted packets"
+#~ msgstr "Lägg in mottagarens nyckelid i krypterade paket"
+
+#~ msgid ""
+#~ "Change the behavior of cleartext signatures so that they can be used for "
+#~ "patch files"
+#~ msgstr ""
+#~ "Ändra beteendet av klartextsignaturer så att de kan användas för fix-filer"
+
+#~ msgid "Mangle From-field of email headers (default)"
+#~ msgstr "Mangla 'From'-fält i e-posthuvuden (standard)"
+
+#~ msgid "Do not mangle From-field of email headers"
+#~ msgstr "Mangla inte 'From'-fält i e-posthuvuden (standard)"
+
+#~ msgid "Try to use the GnuPG-Agent"
+#~ msgstr "Försök använda GnuPG-Agent"
+
+#~ msgid "Do not try to use the GnuPG-Agent"
+#~ msgstr "Försök inte använda GnuPG-Agent"
+
+#~ msgid "Force v3 signatures for signatures on data"
+#~ msgstr "Tvinga v3-signaturer för signering av data"
+
+#~ msgid "Do not force v3 signatures for signatures on data"
+#~ msgstr "Tvinga inte v3-signaturer för signering av data"
+
+#~ msgid "Always use v4 key signatures even on v3 keys"
+#~ msgstr "Använd alltid v4-nyckelsignaturer även på v3-nycklar"
+
+#~ msgid "Don't use v4 key signatures on v3 keys"
+#~ msgstr "Använd inte v4-nyckelsignaturer på v3-nycklar"
+
+#~ msgid "Force the use of encryption with a modification detection code"
+#~ msgstr "Tvinga användandet av kryptering med en modifieringsdetekteringskod"
+
+#~ msgid "Disable the use of the modification detection code"
+#~ msgstr "Avaktivera användandet av ändringsdetekteringskod"
+
+#~ msgid ""
+#~ "Allow the import and use of keys with user IDs which are not self-signed"
+#~ msgstr ""
+#~ "Tillåt importering och användning av nycklar med användarid som inte är "
+#~ "självsignerade"
+
+#~ msgid ""
+#~ "Do not allow the import and use of keys with user IDs which are not self-"
+#~ "signed"
+#~ msgstr ""
+#~ "Tillåt inte importering och användning av nycklar med användarid som inte "
+#~ "är självsignerade"
+
+#~ msgid ""
+#~ "Disable all checks on the form of the user ID while generating a new one"
+#~ msgstr ""
+#~ "Avaktivera alla kontroller på formatet av användarid vid generering av "
+#~ "nya användarid"
+
+#~ msgid "Do not fail if signature is older than key"
+#~ msgstr "Misslyckas inte om signatur är äldre än nyckel"
+
+#~ msgid "Allow subkeys that have a timestamp from the future"
+#~ msgstr "Tillåt undernycklar som har tidsstämpel från framtiden"
+
+#~ msgid "Ignore CRC errors"
+#~ msgstr "Ignorera CRC-fel"
+
+#~ msgid "Do not fail on MDC integrity protection failure"
+#~ msgstr "Misslyckas inte vid MDC-integritetsskyddsmisslyckande"
+
+#~ msgid ""
+#~ "Lock the databases the first time a lock is requested and do not release "
+#~ "the lock until the process terminates"
+#~ msgstr ""
+#~ "Lås databaser vid första läsförfrågan och släpp inte låset före processen "
+#~ "avslutar"
+
+#~ msgid "Release the locks every time a lock is no longer needed"
+#~ msgstr "Släpp lås varje gång det inte längre behövs"
+
+#~ msgid ""
+#~ "Do not create an internal pool file for quicker generation of random "
+#~ "numbers"
+#~ msgstr "Skapa inte en intern pool-fil för snabbare generering av slumptal"
+
+#~ msgid "Suppress the initial copyright message"
+#~ msgstr "Visa inte initialt copyrightmeddelande"
+
+#~ msgid "Suppress the warning about 'using insecure memory'"
+#~ msgstr "Undertryck varningen om 'använder osäkert minne'"
+
+#~ msgid ""
+#~ "Suppress the warning about unsafe file and home directory (--homedir) "
+#~ "permissions"
+#~ msgstr ""
+#~ "Undertryck varningen om osäkra fil- och hemkatalogrättigheter (--homedir) "
+
+#~ msgid "Suppress the warning about missing MDC integrity protection"
+#~ msgstr "Undertryck varningen om saknat MDCintegritetsskydd"
+
+#~ msgid "Refuse to run if GnuPG cannot get secure memory"
+#~ msgstr "Vägra köra om GnuPG inte kan få säkert minne"
+
+#~ msgid "Do not refuse to run if GnuPG cannot get secure memory (default)"
+#~ msgstr "Vägra inte köra om GnuPG inte kan få säkert minne"
+
+#~ msgid "Assume the input data is not in ASCII armored format"
+#~ msgstr "Antag att indata inte är i ASCII-skyddat format"
+
+#~ msgid "Do not add the default keyrings to the list of keyrings"
+#~ msgstr "Lägg inte standardnyckelringar till listan på nyckelringar"
+
+#~ msgid "Skip the signature verification step"
+#~ msgstr "Skippa signaturverifieringssteg"
+
+#~ msgid "Print key listings delimited by colons"
+#~ msgstr "Visa nyckellistning separerad av kolon"
+
+#~ msgid ""
+#~ "Print key listings delimited by colons (like --with-colons) and print the "
+#~ "public key data"
+#~ msgstr ""
+#~ "Visa nyckellistning separerad av kolon (som --with-colons) och visa öppen "
+#~ "nyckel data"
+
+#~ msgid ""
+#~ "Same as the command --fingerprint but changes only the format of the "
+#~ "output and may be used together with another command"
+#~ msgstr ""
+#~ "Samma som kommandot --fingerprint men byter bara formatet på utdata och "
+#~ "kan användas med andra kommandon"
+
+#~ msgid "Changes the output of the list commands to work faster"
+#~ msgstr "Ändrar utdata av listningskommandon så det fungerar snabbare"
+
+#~ msgid ""
+#~ "Do not merge primary user ID and primary key in --with-colon listing mode "
+#~ "and print all timestamps as UNIX timestamps"
+#~ msgstr ""
+#~ "Sammanställ inte primära användarid i '--with-colon'-listningsläge och "
+#~ "skriv alla tidsstämplar som UNIX-tidsstämplar"
+
+#~ msgid ""
+#~ "Changes the behaviour of some commands. This is like --dry-run but "
+#~ "different"
+#~ msgstr "Ändrar beteendet av vissa kommandon. Som --dry-run men annorlunda"
+
+#~ msgid "Display the session key used for one message"
+#~ msgstr "Visa sessionsnyckel som används för ett meddelande"
+
+#~ msgid "Prompt for an expiration time"
+#~ msgstr "Fråga efter utgångsdatum"
+
+#~ msgid "Do not prompt for an expiration time"
+#~ msgstr "Fråga inte efter utgångsdatum"
+
+#~ msgid ""
+#~ "Don't look at the key ID as stored in the message but try all secret keys "
+#~ "in turn to find the right decryption key"
+#~ msgstr ""
+#~ "Undersök inte nyckelid lagrat i meddelande, försök alla hemliga nycklar i "
+#~ "turordningför att hitta rätt dekrypteringsnyckel"
+
+#~ msgid ""
+#~ "Enable a mode in which filenames of the form -&n, where n is a non-"
+#~ "negative decimal number, refer to the file descriptor n and not to a file "
+#~ "with that name"
+#~ msgstr ""
+#~ "Aktivera ett läge i vilket filnamn på formen -&n, där n är ett positivt "
+#~ "heltal, refererar  till filidentifierare n, och inte till filen med det "
+#~ "angivna namnet"
+
+#~ msgid "Remove a given entry from the --group list"
+#~ msgstr "Ta bort ett inlägg från ---group'-listan"
+
+#~ msgid "Remove all entries from the --group list"
+#~ msgstr "Ta bort alla inlägg från förråd från '--group'-listan"
+
+#~ msgid ""
+#~ "Don't change the permissions of a secret keyring back to user read/write "
+#~ "only"
+#~ msgstr ""
+#~ "Ändra inte rättigheterna på en hemlig nyckel tillbaka till läs/skriv "
+#~ "endast för användaren"
+
+#~ msgid "Print annotated source"
+#~ msgstr "Skriv ut kommenterad källkod"
+
+#~ msgid "Do not print explanations"
+#~ msgstr "Skriv inte ut förklaringar"
+
+#~ msgid "Print tally"
+#~ msgstr "Visa sammanställning av antal funktionanrop"
+
+#~ msgid "Display summary"
+#~ msgstr "Visa sammanställning"
+
+#~ msgid "No annotated source"
+#~ msgstr "Visa inte kommenterad källkod"
+
+#~ msgid "Print full path of source"
+#~ msgstr "Visa full sökväg till källkod"
+
+#~ msgid "No flat profile"
+#~ msgstr "Visa inte platt profil"
+
+#~ msgid "Print call graph"
+#~ msgstr "Visa anropsgraf"
+
+#~ msgid "No call graph"
+#~ msgstr "Visa inte anropsgraf"
+
+#~ msgid "Annotate to file"
+#~ msgstr "Skriv kommentarer till fil"
+
+#~ msgid "No tally"
+#~ msgstr "Visa inte sammanställning av antal funktionanrop"
+
+#~ msgid "Suggest function ordering"
+#~ msgstr "Föreslå funktionsordning"
+
+#~ msgid "Suggest file ordering"
+#~ msgstr "Föreslå filordning"
+
+#~ msgid "Traditional mode"
+#~ msgstr "Traditionellt läge"
+
+#~ msgid "Set width of output"
+#~ msgstr "Välj bredd på utdata"
+
+#~ msgid "Annotate every line"
+#~ msgstr "Kommentera varje rad"
+
+#~ msgid "Set demangling style"
+#~ msgstr "Välj avmanglingsstil"
+
+#~ msgid "Turn of demangling"
+#~ msgstr "Slå av avmangling"
+
+#~ msgid "Supress static functions"
+#~ msgstr "Visa inte statiska funktioner"
+
+#~ msgid "Ignore symbols not known to be functions"
+#~ msgstr "Ignorera symboler som inte är kända funktioner"
+
+#~ msgid "Line by line profiling"
+#~ msgstr "Profilera radvis"
+
+#~ msgid "Only propagate times for matching symbols"
+#~ msgstr "Propagera bara tider för matchande symboler"
+
+#~ msgid "Do not propagate times for matching symbols"
+#~ msgstr "Skicka inte vidare tider för matchande symboler"
+
+#~ msgid "Mention unused functions in flat profile"
+#~ msgstr "Nämn oanvända funktioner i platt profil"
+
+#~ msgid "Specify debugging options"
+#~ msgstr "Välj debuginställningar"
+
+#~ msgid "Print summary"
+#~ msgstr "Visa sammanfattning"
+
+#~ msgid "Action for devices"
+#~ msgstr "Handling för enheter"
+
+#~ msgid "Action for directories"
+#~ msgstr "Handling för kataloger"
+
+#~ msgid "List compression information"
+#~ msgstr "Visa kompressionsinformation"
+
+#~ msgid "Do not save/restore filename"
+#~ msgstr "Spara/återställ inte filnamn"
+
+#~ msgid "Save/restore filename"
+#~ msgstr "Spara/återställ filnamn"
+
+#~ msgid "Display compression ratios"
+#~ msgstr "Visa kompressionsgrad"
+
+#~ msgid "Use fast setting"
+#~ msgstr "Använd inställningar för hög fart"
+
+#~ msgid "Use high compression setting"
+#~ msgstr "Använd inställningar för hög kompressionsnivå"
+
+#~ msgid "Update interval"
+#~ msgstr "Uppdateringsintervall"
+
+#~ msgid "Output file"
+#~ msgstr "Utdatafil"
+
+#~ msgid "Print effective group id"
+#~ msgstr "Visa effektivt grupp-id"
+
+#~ msgid "Print all group ids"
+#~ msgstr "Visa alla grupp-id"
+
+#~ msgid "Print real ID, not effective"
+#~ msgstr "Visa verkligt id, inte effektivt"
+
+#~ msgid "Print effective user ID"
+#~ msgstr "Visa effektivt användar-id"
+
+#~ msgid "Show group id of job"
+#~ msgstr "Visa grupp-id för jobb"
+
+#~ msgid "Show commandname of each job"
+#~ msgstr "Visa kommandonamn för varje jobb"
+
+#~ msgid "Only show status for last job to be started"
+#~ msgstr "Visa bara status för det senast startade jobbet"
+
+#~ msgid "Search after end of screen"
+#~ msgstr "Sök förbi slut på skärmen"
+
+#~ msgid "Disable automtic buffer allocation"
+#~ msgstr "Inaktivera automatisk buffert-allokering"
+
+#~ msgid "Repaint from top"
+#~ msgstr "Rita om från toppen"
+
+#~ msgid "Clear and repaint from top"
+#~ msgstr "Töm och rita om från toppen"
+
+#~ msgid "Supress error for lacking terminal capability"
+#~ msgstr "Visa inte felmeddelanden för saknade terminalförmågor"
+
+#~ msgid "Exit on second EOF"
+#~ msgstr "Avsluta andra gången filslut påträffas"
+
+#~ msgid "Exit on EOF"
+#~ msgstr "Avsluta vid filslut"
+
+#~ msgid "Open non-regular files"
+#~ msgstr "Öppna icke-reguljär fil"
+
+#~ msgid "Quit if file shorter than one screen"
+#~ msgstr "Avsluta om filen är kortare än en skärmfull"
+
+#~ msgid "Hilight one search target"
+#~ msgstr "Markera ett sökmål"
+
+#~ msgid "No search highlighting"
+#~ msgstr "Markera inte sökmål"
+
+#~ msgid "Maximum backward scroll"
+#~ msgstr "MAximal bakåtrullning"
+
+#~ msgid "Search ignores lowercase case"
+#~ msgstr "Sökning ignorerar gemener"
+
+#~ msgid "Search ignores all case"
+#~ msgstr "Sökning ignorerar skiftläge"
+
+#~ msgid "Target line"
+#~ msgstr "Målrad"
+
+#~ msgid "Display status column"
+#~ msgstr "Visa statuskolumn"
+
+#~ msgid "Verbose prompt"
+#~ msgstr "Utförlig prompt"
+
+#~ msgid "Display line number"
+#~ msgstr "Visa radnummer"
+
+#~ msgid "Display line number for each line"
+#~ msgstr "Visa radnummer för varje rad"
+
+#~ msgid "Log input to file"
+#~ msgstr "Logga indata till fil"
+
+#~ msgid "Log to file, overwrite"
+#~ msgstr "Logga til fil, skriv över tidigare information"
+
+#~ msgid "Start at first occurrence of pattern"
+#~ msgstr "Starta vid första matchningen av angivet mönster"
+
+#~ msgid "Prompt string"
+#~ msgstr "Promptsträng"
+
+#~ msgid "Silent mode"
+#~ msgstr "Tyst läge"
+
+#~ msgid "Completly silent mode"
+#~ msgstr "Fullständigt tyst läge"
+
+#~ msgid "Display control chars"
+#~ msgstr "Visa kontrolltecken"
+
+#~ msgid "Display control chars, guess screen appearance"
+#~ msgstr "Visa kontrolltecken, försök gissa skärmutseende"
+
+#~ msgid "Multiple blank lines sqeezed"
+#~ msgstr "Slå ihop multipla tomma rader"
+
+#~ msgid "Edit tag"
+#~ msgstr "Redigera markering"
+
+#~ msgid "Set tag file"
+#~ msgstr "Välj markeringsfil"
+
+#~ msgid "Allow backspace and carriage return"
+#~ msgstr "Tillåt backsteg och vagnretur"
+
+#~ msgid "Allow backspace, tab and carriage return"
+#~ msgstr "Tillåt backsteg, tabb och vagnretur"
+
+#~ msgid "Highlight first unread line on new page"
+#~ msgstr "Markera den första olästa raden på ny sida"
+
+#~ msgid "Highlight first unread line on any movement"
+#~ msgstr "Markera den första olästa radenvid alla rörelser"
+
+#~ msgid "Set tab stops"
+#~ msgstr "Välj tabbstorlek"
+
+#~ msgid "No termcap init"
+#~ msgstr "Initiera inte med termcap"
+
+#~ msgid "No keypad init"
+#~ msgstr "Initiera inte numeriskt tangentbord"
+
+#~ msgid "Maximum forward scroll"
+#~ msgstr "Maximal framrullning"
+
+#~ msgid "Max scroll window"
+#~ msgstr "Maximalt rullningsfönster"
+
+#~ msgid "Set quote char"
+#~ msgstr "Välj citat-tecken"
+
+#~ msgid "Lines after EOF are blank"
+#~ msgstr "Gör rader efter filslut tomma"
+
+#~ msgid "Characters to scroll on left/right arrows"
+#~ msgstr "Tecken att rulla på vänster/högerpil"
+
+#~ msgid "Set block size"
+#~ msgstr "Välj blockstorlek"
+
+#~ msgid "Select quoting style"
+#~ msgstr "Välj citatstil"
+
+#~ msgid "Sort criteria"
+#~ msgstr "Sorteringskriterium"
+
+#~ msgid "Show time type"
+#~ msgstr "Visa tidtyp"
+
+#~ msgid "Select time style"
+#~ msgstr "Välj tidformat"
+
+#~ msgid "Assume tab stops at each COLS"
+#~ msgstr "Antag tabbavstånd"
+
+#~ msgid "Assume screen width"
+#~ msgstr "Antag skärmbredd"
+
+#~ msgid "Append dependencies to makefile"
+#~ msgstr "Lägg till beroenden till makefil"
+
+#~ msgid "Warn about multiple inclusion"
+#~ msgstr "Varna vid upprapad inkudering"
+
+#~ msgid "Environment before makefile"
+#~ msgstr "Använd värden från miljövariabler före värden från make-fil"
+
+#~ msgid "Continue after an error"
+#~ msgstr "Fortsätt vid fel"
+
+#~ msgid "Start when load drops"
+#~ msgstr "Starta när belastningen minstar"
+
+#~ msgid "Do not execute commands"
+#~ msgstr "Utför inte kommandon"
+
+#~ msgid "Print database"
+#~ msgstr "Visa databas"
+
+#~ msgid "Question mode"
+#~ msgstr "Frågeläge"
+
+#~ msgid "Eliminate implicit rules"
+#~ msgstr "Ta bort implicita regler"
+
+#~ msgid "Don't continue after an error"
+#~ msgstr "Fortsätt inte vid fel"
+
+#~ msgid "Touch files, don't run commands"
+#~ msgstr "Ändra ändringstid på filer, utför inte kommandon"
+
+#~ msgid "Program section"
+#~ msgstr "Programsektion"
+
+#~ msgid "Syscall section"
+#~ msgstr "Systemanroppssektion"
+
+#~ msgid "Library section"
+#~ msgstr "Bibliotekssektion"
+
+#~ msgid "Device section"
+#~ msgstr "Enhetssektion"
+
+#~ msgid "File format section"
+#~ msgstr "Filformatssektion"
+
+#~ msgid "Games section"
+#~ msgstr "Spelsektion"
+
+#~ msgid "Misc section"
+#~ msgstr "Övrig sektion"
+
+#~ msgid "Admin section"
+#~ msgstr "Administartionssektion"
+
+#~ msgid "Kernel section"
+#~ msgstr "Kärnsektion"
+
+#~ msgid "Tcl section"
+#~ msgstr "Tclsektion"
+
+#~ msgid "New section"
+#~ msgstr "Ny sektion"
+
+#~ msgid "Local section"
+#~ msgstr "Lokal sektion"
+
+#~ msgid "Old section"
+#~ msgstr "Gammal sektion"
+
+#~ msgid "Manpath"
+#~ msgstr "Manualsökväg"
+
+#~ msgid "Pager"
+#~ msgstr "Visare"
+
+#~ msgid "Always reformat"
+#~ msgstr "Formatera alltid om"
+
+#~ msgid "Debug"
+#~ msgstr "Debug-läge"
+
+#~ msgid "Debug and run"
+#~ msgstr "Debugga och kör"
+
+#~ msgid "Show whatis information"
+#~ msgstr "Visa whatis-information"
+
+#~ msgid "Format only"
+#~ msgstr "Formatera bara, visa inte"
+
+#~ msgid "Show apropos information"
+#~ msgstr "Visa apropos-information"
+
+#~ msgid "Search in all man pages"
+#~ msgstr "Sök i alla manualsidor"
+
+#~ msgid "Set system"
+#~ msgstr "Välj system"
+
+#~ msgid "Preprocessors"
+#~ msgstr "Förprocessorer"
+
+#~ msgid "Format for printing"
+#~ msgstr "Formatera för utskrift"
+
+#~ msgid "Only print locations"
+#~ msgstr "Visa bara platser"
+
+#~ msgid "Print messages about what the program is doing"
+#~ msgstr "Visa meddelanden om vad programmet gör"
+
+#~ msgid "Dump configuration file"
+#~ msgstr "Dumpa konfigurationsfil"
+
+#~ msgid "Do not actually insert/remove module"
+#~ msgstr "Utför inte insättning/borttagning av modul"
+
+#~ msgid "Ignore install and remove commands in configuration file"
+#~ msgstr ""
+#~ "Ignorera installations- och borttagningskommandon i konfigurationsfil"
+
+#~ msgid "Ignore bogus module names"
+#~ msgstr "Ignorera felaktiga modulnamn"
+
+#~ msgid "Remove modules"
+#~ msgstr "Ta bort moduler"
+
+#~ msgid "Ignore all version information"
+#~ msgstr "Ignorera all versionsinformation"
+
+#~ msgid "Ignore module interface version"
+#~ msgstr "Ignorera modulinterfaceversion"
+
+#~ msgid "Insert modules matching the given wildcard"
+#~ msgstr "Ligg till alla moduler som matchar parameter med jokertecken"
+
+#~ msgid "Restrict wildcards to specified directory"
+#~ msgstr "Begränsa jokertecken till den angivna katalogen"
+
+#~ msgid "Send error messages through syslog"
+#~ msgstr "Skicka felmeddelanden genom syslog"
+
+#~ msgid "Specify kernel version"
+#~ msgstr "Välj kärnversion"
+
+#~ msgid "List dependencies of module"
+#~ msgstr "Visa beroenden för modul"
+
+#~ msgid "Rename module"
+#~ msgstr "Byt namn på modul"
+
+#~ msgid "Fail if inserting already loaded module"
+#~ msgstr "Misslyckas vid insättning av redan laddad modul"
+
+#~ msgid "Fork process for each mount"
+#~ msgstr "Starta underprocess för varje montering"
+
+#~ msgid "Fake mounting"
+#~ msgstr "Falsk montering"
+
+#~ msgid "Add label to output"
+#~ msgstr "Lägg till etikett till utdata"
+
+#~ msgid "Do not write mtab"
+#~ msgstr "Skriv inte till mtab"
+
+#~ msgid "Dynamically change postprocessing"
+#~ msgstr "Ändra efterbehyandling dynamiskt"
+
+#~ msgid "Skip frames to maintain A/V sync"
+#~ msgstr "Hoppa över bilder för att behålla ljud/bild synkronisering"
+
+#~ msgid "Full screen"
+#~ msgstr "Fullskärmsläge"
+
+#~ msgid "Set playlist"
+#~ msgstr "Välj spellista"
+
+#~ msgid "Audio language"
+#~ msgstr "Ljudspråk"
+
+#~ msgid "Play audio from file"
+#~ msgstr "Spela ljud från fil"
+
+#~ msgid "Set default CD-ROM drive"
+#~ msgstr "Välj normal CD-ROM-enhet"
+
+#~ msgid "Set number of audio channels"
+#~ msgstr "Välj antal ljudkanaler"
+
+#~ msgid "Set start chapter"
+#~ msgstr "Välj startkapitel"
+
+#~ msgid "Set default DVD-ROM drive"
+#~ msgstr "Välj normal DVD-ROM-enhet"
+
+#~ msgid "Set dvd viewing angle"
+#~ msgstr "Välj dvd-betraktningsvinkel"
+
+#~ msgid "Force rebuilding index"
+#~ msgstr "Tvinga ombyggning av index"
+
+#~ msgid "Override framerate"
+#~ msgstr "Åsidosätt bildfrekvens"
+
+#~ msgid "Load index from file"
+#~ msgstr "Ladda index från fil"
+
+#~ msgid "Force non-interleaved AVI parser"
+#~ msgstr "Tvinga icke-sammanflätat AVI-tolk"
+
+#~ msgid "Rebuild index and save to file"
+#~ msgstr "Bygg om index och spara till fil"
+
+#~ msgid "Seek to given time position"
+#~ msgstr "Sök till angiven tidsposition"
+
+#~ msgid "TV capture mode"
+#~ msgstr "TV-inspelningsläge"
+
+#~ msgid "Subtitle language"
+#~ msgstr "Textningsspråk"
+
+#~ msgid "Subtitle file"
+#~ msgstr "Textningsfil"
+
+#~ msgid "Handle subtitlefile as unicode"
+#~ msgstr "Hantera textningsfil som unicode"
+
+#~ msgid "Handle subtitlefile as utf8"
+#~ msgstr "Hantera textningsfil som utf8"
+
+#~ msgid "Make backup of each existing destination file"
+#~ msgstr "Gör backup av varje existerande destinationsfil"
+
+#~ msgid "Do not prompt before overwriting"
+#~ msgstr "Fråga inte före överskrivning"
+
+#~ msgid "Remove trailing slashes from source"
+#~ msgstr "Ta bort snedstreck i slutet på källangivelser"
+
+#~ msgid "Target directory"
+#~ msgstr "Målkatalog"
+
+#~ msgid "Do not overwrite newer files"
+#~ msgstr "Skriv inte över nyare filer"
+
+#~ msgid "Also print directory history"
+#~ msgstr "Skriv även ut kataloghistorik"
+
+#~ msgid ""
+#~ "Make backup files, when patching a file, rename or copy the original "
+#~ "instead of removing it"
+#~ msgstr ""
+#~ "Skapa backupfiler, vid fixning av fil, byt namn eller kopiera orginalet "
+#~ "istället för att ta bort det"
+
+#~ msgid "Back up a file if the patch does not match the file exactly"
+#~ msgstr "Skapa backup av fil om fix inte matchar filen exakt"
+
+#~ msgid "Do not back up a file if the patch does not match the file exactly"
+#~ msgstr "Skapa inte backup av fil om fix inte matchar filen exakt"
+
+#~ msgid "Interpret the patch file as an ed script"
+#~ msgstr "Tolka fixfil som ett ed-skript"
+
+#~ msgid "Set the maximum fuzz factor"
+#~ msgstr "Sätt maximal fuzzfaktor"
+
+#~ msgid "Use style word to quote output names"
+#~ msgstr "Använd angiven stil vid citering av utdatanamn"
+
+#~ msgid "Put rejects into rejectfile instead of the default .rej file"
+#~ msgstr ""
+#~ "Lägg till misslyckade fixar till angiven fil istället för standard-.rej-"
+#~ "fil"
+
+#~ msgid ""
+#~ "Assume that this patch was created with the old and new files swapped"
+#~ msgstr "Antag att denna fix skapades med ombytta gamla och nya filer"
+
+#~ msgid "Work silently, unless an error occurs"
+#~ msgstr "Arbeta tyst, om inte ett fel uppstår"
+
+#~ msgid "Interpret the patch file as a unified context diff"
+#~ msgstr "Tolka fixfil som unifierad kontextdiff"
+
+#~ msgid "Debug option"
+#~ msgstr "Debugflagga"
+
+#~ msgid "Set regexp used to split input"
+#~ msgstr "Välj reguljärt uttryck för att avdela indata"
+
+#~ msgid "Edit files in-place"
+#~ msgstr "Redigera filer på plats"
+
+#~ msgid "Include path"
+#~ msgstr "Inkluderingssökväg"
+
+#~ msgid "Open folder"
+#~ msgstr "Öppna katalog"
+
+#~ msgid "Open file"
+#~ msgstr "Öppna fil"
+
+#~ msgid "Initial set of keystrokes"
+#~ msgstr "Initiala tangenttryckningar"
+
+#~ msgid "Use function keys for commands"
+#~ msgstr "Använd funktionstangenter för kommandon"
+
+#~ msgid "Expand collections in FOLDER LIST display"
+#~ msgstr "Expandera samlingar i sidan 'FOLDER LIST'"
+
+#~ msgid "Start with specified current message number"
+#~ msgstr "Starta vid angivet meddelandenummer"
+
+#~ msgid "Open folder read-only"
+#~ msgstr "Öppna folder i skrivskyddat läge"
+
+#~ msgid "Set global configuration file"
+#~ msgstr "Välj global konfigurationsfil"
+
+#~ msgid "Enable suspension support"
+#~ msgstr "Aktivera stöd för programpausning (^Z)"
+
+#~ msgid "Produce a sample global configuration file"
+#~ msgstr "Skapa global exempelkonfigurationsfil"
+
+#~ msgid "Produce sample configuration file"
+#~ msgstr "Skapa exempelkonfigurationsfil"
+
+#~ msgid "Set mail sort order"
+#~ msgstr "Välj brevsorteringsordning"
+
+#~ msgid "Config option"
+#~ msgstr "Konfigurationsinställning"
+
+#~ msgid "Audible ping"
+#~ msgstr "Hörbart ping"
+
+#~ msgid "Adaptive ping"
+#~ msgstr "Adaptiv ping"
+
+#~ msgid "Allow pinging a broadcast address"
+#~ msgstr "Tillåt pingning till broadcast-adress"
+
+#~ msgid "Do not allow ping to change source address of probes"
+#~ msgstr "Tillåt inte ping att ändra källadress på sonder"
+
+#~ msgid "Stop after specified number of ECHO_REQUEST packets"
+#~ msgstr "Stoppa efter angivet antal ECHO_REQUEST-paket"
+
+#~ msgid "Set the SO_DEBUG option on the socket being used"
+#~ msgstr "Sätt SO_DEBUG-flaggan på uttaget (socket) som används"
+
+#~ msgid "Allocate and set 20 bit flow label on ECHO_REQUEST packets"
+#~ msgstr "Allokera och sätt 20 bitars flödesetikett på ECHO_REQUEST-paket"
+
+#~ msgid "Flood ping"
+#~ msgstr "Översvämmningsping"
+
+#~ msgid "Wait specified interval of seconds between sending each packet"
+#~ msgstr "Vänta angivet antal sekunder mellan skickande av paket"
+
+#~ msgid "Set source address to specified interface address"
+#~ msgstr "Välj källadress till angiven gränssnittsadress"
+
+#~ msgid "Send the specified number of packets without waiting for reply"
+#~ msgstr "Skicka angivet antal paket utan att vänta på svar"
+
+#~ msgid "Suppress loopback of multicast packets"
+#~ msgstr "Undertryck vändslinga (loopback) för multicastpaket"
+
+#~ msgid "Numeric output only"
+#~ msgstr "Bara numerisk utdata"
+
+#~ msgid "Pad packet with empty bytes"
+#~ msgstr "Lägg till tomma bytes till paket"
+
+#~ msgid "Set Quality of Service -related bits in ICMP datagrams"
+#~ msgstr "Sätt Tjänstekvalitets-relaterade bitar i ICMP-datagram"
+
+#~ msgid "Record route"
+#~ msgstr "Spela in rutt"
+
+#~ msgid ""
+#~ "Bypass the normal routing tables and send directly to a host on an "
+#~ "attached interface"
+#~ msgstr ""
+#~ "Gå förbi de vanliga rutt-tabellerna och skicka direkt till en värd på ett "
+#~ "inkopplat gränssnitt"
+
+#~ msgid "Set socket buffer size"
+#~ msgstr "Välj uttags (socket) buffertstorlek"
+
+#~ msgid "Set the IP Time to Live"
+#~ msgstr "Välj paketlivstid på IP-protokollnivå"
+
+#~ msgid "Set special IP timestamp options"
+#~ msgstr "Välj särskilda inställningar för IP-protokoll-tidsstämpel"
+
+#~ msgid "Select Path MTU Discovery strategy"
+#~ msgstr "Välj MTU-väghittarstrategi"
+
+#~ msgid "Print full user-to-user latency"
+#~ msgstr "Visa full användare-tilöl-användare-latens"
+
+#~ msgid ""
+#~ "Specify  a timeout, in seconds, before ping exits regardless of how many "
+#~ "packets have been sent or received"
+#~ msgstr ""
+#~ "Ange en timeout, i sekunder, innan ping avslutar oavsett hur många paket "
+#~ "som skickats eller tagits emot"
+
+#~ msgid "Time to wait for a response, in seconds"
+#~ msgstr "Tid att vänta på ett svar, i sekunder"
+
+#~ msgid "Select all"
+#~ msgstr "Välj alla"
+
+#~ msgid "Invert selection"
+#~ msgstr "Invertera val"
+
+#~ msgid "Select all processes except session leaders and terminal-less"
+#~ msgstr "Välj alla processer utom sessionsledare och terminal-lösa"
+
+#~ msgid "Select all processes except session leaders"
+#~ msgstr "Välj alla processer utom sessionsledare"
+
+#~ msgid "Deselect all processes that do not fulfill conditions"
+#~ msgstr "Avmarkera alla processer som inte uppfyller villkor"
+
+#~ msgid "Select by command"
+#~ msgstr "Välj via kommando"
+
+#~ msgid "Select by group"
+#~ msgstr "Välj via grupp"
+
+#~ msgid "Select by user"
+#~ msgstr "Välj via användare"
+
+#~ msgid "Select by group/session"
+#~ msgstr "Väljvia användare/session"
+
+#~ msgid "Select by PID"
+#~ msgstr "Välj via process-id"
+
+#~ msgid "Select by parent PID"
+#~ msgstr "Välj via förälders process-id"
+
+#~ msgid "Select by session ID"
+#~ msgstr "Välj via sessions-id"
+
+#~ msgid "Select by tty"
+#~ msgstr "Välj via tty"
+
+#~ msgid "Extra full format"
+#~ msgstr "Extra utförligt format"
+
+#~ msgid "User defined format"
+#~ msgstr "Användardefinerat format"
+
+#~ msgid "Add column for security data"
+#~ msgstr "Lägg till kolumn med säkerhetsinformation"
+
+#~ msgid "Full format"
+#~ msgstr "Fullt format"
+
+#~ msgid "Jobs format"
+#~ msgstr "Jobbformat"
+
+#~ msgid "Do not show flags"
+#~ msgstr "Visa inte flaggor"
+
+#~ msgid "Show hierarchy"
+#~ msgstr "Visa hierarki"
+
+#~ msgid "Set namelist file"
+#~ msgstr "Visa namnlistfil"
+
+#~ msgid "Wide output"
+#~ msgstr "Bred utdata"
+
+#~ msgid "Execute argument as command"
+#~ msgstr "Utför parameter som kommando"
+
+#~ msgid "Debug on"
+#~ msgstr "Debugläge på"
+
+#~ msgid "Ignore environment variables"
+#~ msgstr "Ignorera miljövariabler"
+
+#~ msgid "Interactive mode after executing commands"
+#~ msgstr "Interaktivt läge efter att komandon utförts"
+
+#~ msgid "Enable optimizations"
+#~ msgstr "Slå på optimeringar"
+
+#~ msgid "Warning control"
+#~ msgstr "Varningsläge"
+
+#~ msgid "Division control"
+#~ msgstr "Divisionskontroll"
+
+#~ msgid "Set prompt command"
+#~ msgstr "Välj promptkommando"
+
+#~ msgid "Export variable to subprocess"
+#~ msgstr "Exportera variabel till underprocess"
+
+#~ msgid "Make variable scope global"
+#~ msgstr "Globalt definitionsområde"
+
+#~ msgid "Make variable scope local"
+#~ msgstr "Lokalt defintionsområde"
+
+#~ msgid ""
+#~ "Make variable scope universal, i.e. share variable with all the users "
+#~ "fish processes on this computer"
+#~ msgstr ""
+#~ "Gör variabelns definitionsområde universellt, dvs. dela variabel med alla "
+#~ "användarens fish-processer på denna dator"
+
+#~ msgid "Do not export variable to subprocess"
+#~ msgstr "Exportera inte variabel till barnprocesser"
+
+#~ msgid "Force following parameters to be process ID's (The default)"
+#~ msgstr ""
+#~ "Tvinga efterföljande parametrar att tolkas som process-id (standard)"
+
+#~ msgid "Force following parameters to be interpreted as process group ID's"
+#~ msgstr "Tvinga efterföljande parametrar att tolkas som grupp-id"
+
+#~ msgid "Force following parameters to be interpreted as user names"
+#~ msgstr "Tvinga efterföljande parametrar att tolkas som användarnamn"
+
+#~ msgid "Ignore errors from non-empty directories"
+#~ msgstr "Ignorera fel från icke-tomma kataloger"
+
+#~ msgid "Remove each component of path"
+#~ msgstr "Ta bort alla sökvägskomponenter"
+
+#~ msgid "Pipe output through specified command"
+#~ msgstr "Filtrera utdata genom angivet kommando"
+
+#~ msgid "Specify directory for rpm database"
+#~ msgstr "Välj katalog för rpm-databas"
+
+#~ msgid "Specify root directory for rpm operations"
+#~ msgstr "Välj rot-katalog för rpm-operationer"
+
+#~ msgid ""
+#~ "Translate all paths that start with first half of following parameter to "
+#~ "second half of following parameter"
+#~ msgstr ""
+#~ "Översätt alla sökvägar som börjar med första halvan av följande parameter "
+#~ "till sista halvan av följande parameter"
+
+#~ msgid "Kanji code-set"
+#~ msgstr "Använd Kanji-tecken"
+
+#~ msgid "Verbose mode without message"
+#~ msgstr "Utförligt läge utan meddelande"
+
+#~ msgid "Compiler debug mode"
+#~ msgstr "Kompliatordebugläge"
+
+#~ msgid ""
+#~ "Preserves modification times, access times, and modes from the original "
+#~ "file"
+#~ msgstr "Bevara ändringstid, åtkomsttid och rättigheter från orginalfil"
+
+#~ msgid "Recursively copy"
+#~ msgstr "Rekursiv kopiering"
+
+#~ msgid "Make font bold"
+#~ msgstr "Använd fetstil"
+
+#~ msgid "Erase variable"
+#~ msgstr "Radera variabel"
+
+#~ msgid "Test if variable is defined"
+#~ msgstr "Testa om variabeln är definerad"
+
+#~ msgid "Ignore leading blanks"
+#~ msgstr "Ignorera inledande mellanslag"
+
+#~ msgid "Consider only blanks and alphanumerics"
+#~ msgstr "Ta endast hänsyn till mellanslag och alfanumeriska tecken"
+
+#~ msgid "Compare general numeric value"
+#~ msgstr "Jämför generellt numeriskt värde"
+
+#~ msgid "Consider only printable"
+#~ msgstr "Ta endast hänsyn till skrivbara tecken"
+
+#~ msgid "Compare month names"
+#~ msgstr "Jämför månadsnamn"
+
+#~ msgid "Compare string numerical value"
+#~ msgstr "Jämför strängars numeriska värde"
+
+#~ msgid "Reverse results"
+#~ msgstr "Omvända resultat"
+
+#~ msgid "Only check if sorted"
+#~ msgstr "Verifiera bara sortering"
+
+#~ msgid "Define key"
+#~ msgstr "Definera nyckel"
+
+#~ msgid "Stabilize sort"
+#~ msgstr "Stabilisera sortering"
+
+#~ msgid "Field separator"
+#~ msgstr "Fältavdelare"
+
+#~ msgid "Output only first of equal lines"
+#~ msgstr "Visa bara först raden vid dubletter"
+
+#~ msgid "Lines end with 0 byte"
+#~ msgstr "Rader slutar ned nolltecken"
+
+#~ msgid "Disables forwarding of the authentication agent"
+#~ msgstr "Inaktivera vidareskickning av autentiseringsagent"
+
+#~ msgid "Enables forwarding of the authentication agent"
+#~ msgstr "Aktivera vidareskickning av autentiseringsagent"
+
+#~ msgid "Go to background"
+#~ msgstr "Gå till bakgrunden"
+
+#~ msgid "Allow remote host to connect to local forwarded ports"
+#~ msgstr "Tillåt fjärrvärd att koppla in sig på lokala vidareskickade portar"
+
+#~ msgid "Smartcard device"
+#~ msgstr "Smartcardenhet"
+
+#~ msgid "Disable forwarding of Kerberos tickets"
+#~ msgstr "Inaktivera vidareskickning av Kerberosbiljetter"
+
+#~ msgid "MAC algorithm"
+#~ msgstr "MAC-algoritm"
+
+#~ msgid "Prevent reading from stdin"
+#~ msgstr "Förhindra läsning från standard in"
+
+#~ msgid "Do not execute remote command"
+#~ msgstr "Utför inte fjärrkommando"
+
+#~ msgid "Subsystem"
+#~ msgstr "Subsystem"
+
+#~ msgid "Force pseudo-tty allocation"
+#~ msgstr "Tvinga pseudo-tty-allokering"
+
+#~ msgid "Disable pseudo-tty allocation"
+#~ msgstr "Inaktivera pseudo-tty-allokering"
+
+#~ msgid "Disable X11 forwarding"
+#~ msgstr "Inaktivera X11-vidareskickning"
+
+#~ msgid "Enable X11 forwarding"
+#~ msgstr "Aktivera X11-vidareskickning"
+
+#~ msgid "Locally forwarded ports"
+#~ msgstr "Lokalt vidareskickade portar"
+
+#~ msgid "Remotely forwarded ports"
+#~ msgstr "Vidareskickade portar på fjärrdatorn"
+
+#~ msgid "Dynamic port forwarding"
+#~ msgstr "Dynamisk portvidareskickning"
+
+#~ msgid "Compression"
+#~ msgstr "Kompression"
+
+#~ msgid "Enable debug"
+#~ msgstr "Slå på debugning"
+
+#~ msgid "Foreground operation"
+#~ msgstr "Förgrundsoperation"
+
+#~ msgid "Disable multi-threaded operation"
+#~ msgstr "Inaktivera flertrådat läge"
+
+#~ msgid "Test if this is a login shell"
+#~ msgstr "Testa om detta är ett login-skal"
+
+#~ msgid "Test if this is an interactive shell"
+#~ msgstr "Testa om detta är ett interaktivt skal"
+
+#~ msgid "Test if a command substitution is currently evaluated"
+#~ msgstr "Testa om en kommandosubstitution utförs för tillfället"
+
+#~ msgid "Test if a code block is currently evaluated"
+#~ msgstr "Testa om ett kodblock utförs för tillfället"
+
+#~ msgid "Test if new jobs are never put under job control"
+#~ msgstr "Testa om inga nya job ställs unde jobbkontroll"
+
+#~ msgid "Test if only interactive new jobs are put under job control"
+#~ msgstr "Testa om bara interaktiva nya job ställs unde jobbkontroll"
+
+#~ msgid "Test if all new jobs are put under job control"
+#~ msgstr "Testa om alla nya job ställs unde jobbkontroll"
+
+#~ msgid ""
+#~ "Print a list of all function calls leading up to running the current "
+#~ "command"
+#~ msgstr ""
+#~ "Visa en lista av alla funktionsanropp som lett fram till anropet på det "
+#~ "nu körande kommandot"
+
+#~ msgid "Case insensitive"
+#~ msgstr "Ignorera skiftläge"
+
+#~ msgid "Preserve environment"
+#~ msgstr "Bevara miljövariabler"
+
+#~ msgid "Make login shell"
+#~ msgstr "Skapa login-skal"
+
+#~ msgid "Pass -f to the shell"
+#~ msgstr "Skicka -f till skalet"
+
+#~ msgid "Append archive to archive"
+#~ msgstr "Lägg till arkiv till annat arkiv"
+
+#~ msgid "Create archive"
+#~ msgstr "Skapa arkiv"
+
+#~ msgid "Compare archive and filesystem"
+#~ msgstr "Jämför arkiv med filsystem"
+
+#~ msgid "Delete from archive"
+#~ msgstr "Radera från arkiv"
+
+#~ msgid "Append files to archive"
+#~ msgstr "Lägg till filer till arkiv"
+
+#~ msgid "Append new files"
+#~ msgstr "Lägg till nya filer"
+
+#~ msgid "Extract from archive"
+#~ msgstr "Hämta från arkiv"
+
+#~ msgid "Keep access time"
+#~ msgstr "Behåll åtkomsttid"
+
+#~ msgid "Reblock while reading"
+#~ msgstr "Gör om block-indelning under inläsning"
+
+#~ msgid "Print directory names"
+#~ msgstr "Visa katalognamn"
+
+#~ msgid "Archive is local"
+#~ msgstr "Arkiv är lokalt"
+
+#~ msgid "Run script at end of tape"
+#~ msgstr "Utför skript vid slut på band"
+
+#~ msgid "Use old incremental GNU format"
+#~ msgstr "Använd gammalt inkrementellt GNU-format"
+
+#~ msgid "Use new incremental GNU format"
+#~ msgstr "Använd nytt inkrementellt GNU-format"
+
+#~ msgid "Dereference symlinks"
+#~ msgstr "Följ symboliska länkar"
+
+#~ msgid "Ignore zero block in archive"
+#~ msgstr "Ignorera nollblock i arkiv"
+
+#~ msgid "Filter through bzip2"
+#~ msgstr "Filtrera genom bzip2"
+
+#~ msgid "Don't exit on unreadable files"
+#~ msgstr "Avsluta inte vid oläsbara filer"
+
+#~ msgid "Don't overwrite"
+#~ msgstr "Skriv inte över"
+
+#~ msgid "Stay in local filesystem"
+#~ msgstr "Stanna på lokala filsystem"
+
+#~ msgid "Don't extract modification time"
+#~ msgstr "Hämta inte ändringstider"
+
+#~ msgid "Multi volume archive"
+#~ msgstr "Flervolymsarkiv"
+
+#~ msgid "Use V7 format"
+#~ msgstr "Använd V7-format"
+
+#~ msgid "Extract to stdout"
+#~ msgstr "Hämta till standard ut"
+
+#~ msgid "Extract all permissions"
+#~ msgstr "Hämta alla rättigheter"
+
+#~ msgid "Don't strip leading /"
+#~ msgstr "Ta inte bort inledande /"
+
+#~ msgid "Preserve all permissions and do not sort file arguments"
+#~ msgstr "Bevara alla rättigheter, och sortera inte filargument"
+
+#~ msgid "Show record number"
+#~ msgstr "Visa paketnummer"
+
+#~ msgid "Remove files after adding to archive"
+#~ msgstr "Ta bort filer efter att de lagts till arkivet"
+
+#~ msgid "Preserve file ownership"
+#~ msgstr "Bevara filägare"
+
+#~ msgid "Handle sparse files"
+#~ msgstr "Hantera glesa filer"
+
+#~ msgid "-T has null-terminated names"
+#~ msgstr "-T har noll-terminerade namn"
+
+#~ msgid "Print total bytes written"
+#~ msgstr "Visa totalt anta skrivna bytes"
+
+#~ msgid "Ask for confirmation"
+#~ msgstr "Be om bekräftelse"
+
+#~ msgid "Verify archive"
+#~ msgstr "Verifiera arkiv"
+
+#~ msgid "Filter through compress"
+#~ msgstr "Filtrera genom compress"
+
+#~ msgid "Filter through gzip"
+#~ msgstr "Filtrera genom gzip"
+
+#~ msgid "Negate expression"
+#~ msgstr "Negera uttryck"
+
+#~ msgid "String length is non-zero"
+#~ msgstr "Strängens längd är nollskild"
+
+#~ msgid "String length is zero"
+#~ msgstr "Strängens längd är noll"
+
+#~ msgid "Strings are equal"
+#~ msgstr "Strängar är identiska"
+
+#~ msgid "Strings are not equal"
+#~ msgstr "Strängar skiljer sig"
+
+#~ msgid "Integers are equal"
+#~ msgstr "Heltal är identiska"
+
+#~ msgid "Left integer larger than or equal to right integer"
+#~ msgstr "Vänster tal är större än eller lika med höger tal"
+
+#~ msgid "Left integer larger than right integer"
+#~ msgstr "Vänster tal är större än höger tal"
+
+#~ msgid "Left integer less than or equal to right integer"
+#~ msgstr "Vänster tal är mindre än eller lika med höger tal"
+
+#~ msgid "Left integer less than right integer"
+#~ msgstr "Vänster tal är mindre än höger tal"
+
+#~ msgid "Left integer not equal to right integer"
+#~ msgstr "Vänster tal skilt från höger tal"
+
+#~ msgid "File is block device"
+#~ msgstr "Fil är blockenhet"
+
+#~ msgid "File is character device"
+#~ msgstr "Fil är teckenenhet"
+
+#~ msgid "File is directory"
+#~ msgstr "Fil är katalog"
+
+#~ msgid "File exists"
+#~ msgstr "Fil existerar"
+
+#~ msgid "File is regular"
+#~ msgstr "Fil är vanlig fil"
+
+#~ msgid "File is set-group-ID"
+#~ msgstr "Fil har kör-som-grupp-bit satt"
+
+#~ msgid "File is readable"
+#~ msgstr "Fil är läsbar"
+
+#~ msgid "File size is non-zero"
+#~ msgstr "Filstorlek är nollskild"
+
+#~ msgid "File set-user-ID bit is set"
+#~ msgstr "Fil har hör-som-användare-bit satt"
+
+#~ msgid "File is writable"
+#~ msgstr "Fil är skrivbar"
+
+#~ msgid "Specify output format"
+#~ msgstr "Välj utdataformat"
+
+#~ msgid "Use the portable output format"
+#~ msgstr "Använd portabelt utdataformat"
+
+#~ msgid "Do not send the results to stderr, but overwrite the specified file"
+#~ msgstr ""
+#~ "Skicka inte utdata till standard fel, skriv istället över angiven fil"
+
+#~ msgid "(Used together with -o) Do not overwrite but append"
+#~ msgstr "(Används tillsamans med -o) Skriv inte över utan lägg till"
+
+#~ msgid "Toggle command line/program name"
+#~ msgstr "Växla visning av kommandorad/programnamn"
+
+#~ msgid "Toggle idle processes"
+#~ msgstr "Växla visning av overksamma processer"
+
+#~ msgid "Monitor effective UID"
+#~ msgstr "Bevaka effektivt användarid"
+
+#~ msgid "Monitor user"
+#~ msgstr "Bevaka användare"
+
+#~ msgid "Monitor PID"
+#~ msgstr "Bevaka process-id"
+
+#~ msgid "Secure mode"
+#~ msgstr "Säkert läge"
+
+#~ msgid "Cumulative mode"
+#~ msgstr "Ackumulerande läge"
+
+#~ msgid "Display names of all signals"
+#~ msgstr "Visa namn på alla signaler"
+
+#~ msgid "Display all currently defined trap handlers"
+#~ msgstr "Visa all för tillfället definerade trap-hanterare"
+
+#~ msgid "Print all possible definitions of the specified name"
+#~ msgstr "Visa alla möjliga definitioner av det angivna namnet"
+
+#~ msgid "Print path to command, or nothing if name is not a command"
+#~ msgstr ""
+#~ "Visa sökväg till kommando, eller ingenting om namn inte är ett kommando"
+
+#~ msgid "Print path to command"
+#~ msgstr "Visa sökväg till kommando"
+
+#~ msgid "Set or get all current limits"
+#~ msgstr "Visa eller redigera alla resursanvändningsgränser"
+
+#~ msgid "Maximum size of core files created"
+#~ msgstr "Maximal storlek på skapade corefiler"
+
+#~ msgid "Maximum size of a process's data segment"
+#~ msgstr "Maximal storlek på på en process datasegment"
+
+#~ msgid "Maximum size of files created by the shell"
+#~ msgstr "Maximal storlek på filer skapade av skalet"
+
+#~ msgid "Maximum size that may be locked into memory"
+#~ msgstr "Maximal  storlek som kan låsas i minnet"
+
+#~ msgid "Maximum resident set size"
+#~ msgstr "Maximal 'resident set size'"
+
+#~ msgid "Maximum number of open file descriptors"
+#~ msgstr "Maximalt antal öppna filidentifierare"
+
+#~ msgid "Maximum stack size"
+#~ msgstr "Maximal stackstorlek"
+
+#~ msgid "Maximum amount of cpu time in seconds"
+#~ msgstr "Maximal cpu-tid i sekunder"
+
+#~ msgid "Maximum number of processes available to a single user"
+#~ msgstr "Maximalt antal processer tillgängliga för en enskild användare"
+
+#~ msgid "Maximum amount of virtual memory available to the shell"
+#~ msgstr "Maximal mängd virtuellt minne tillgängligt för skalet"
+
+#~ msgid "Unmount without writing in /etc/mtab"
+#~ msgstr "Avmontera utan stt skriva till /etc/mtab"
+
+#~ msgid "In case unmounting fails, try to remount read-only"
+#~ msgstr "Om avmontering misslyckas, försök att ommontera i skrivskyddat läge"
+
+#~ msgid ""
+#~ "In case the unmounted device was a loop device, also free this loop device"
+#~ msgstr ""
+#~ "Om den avmonterade enheten var en vändslinga, återlämna också denna enhet"
+
+#~ msgid "Don't call the /sbin/umount.<filesystem> helper even if it exists"
+#~ msgstr ""
+#~ "Anropa inte /sbin/umount.<filsystem>-hjälparen, även om den existerar"
+
+#~ msgid "Unmount all of the file systems described in /etc/mtab"
+#~ msgstr "Avmontera all a filsystem i /etc/mtab"
+
+#~ msgid "Actions should only be taken on file systems of the specified type"
+#~ msgstr "Utför bara handlingar på filsystem av angiven typ"
+
+#~ msgid ""
+#~ "Actions should only be taken on file systems with the specified options "
+#~ "in /etc/fstab"
+#~ msgstr ""
+#~ "Utför bara handlingar på filsystem med de angivna flaggorna i /etc/fstab"
+
+#~ msgid "Force unmount (in case of an unreachable NFS system)"
+#~ msgstr "Tvinga avmontering (vid onåbart NFS-filsystem)"
+
+#~ msgid ""
+#~ "Detach the filesystem from the filesystem hierarchy now, and cleanup all "
+#~ "references to the filesystem as soon as it is not busy"
+#~ msgstr ""
+#~ "Koppla bort filsystemet från hierarkin nu, och rensa upp alla referenser "
+#~ "till filsystemet så fort som det inte är upptaget"
+
+#~ msgid "Print kernel name"
+#~ msgstr "Visa kärnnamn"
+
+#~ msgid "Print network node hostname"
+#~ msgstr "Visa värdnamn på nätverksnod"
+
+#~ msgid "Print kernel release"
+#~ msgstr "Visa kärnrelese"
+
+#~ msgid "Print machine name"
+#~ msgstr "Visa maskinnamn"
+
+#~ msgid "Print processor"
+#~ msgstr "Visa processor"
+
+#~ msgid "Print hardware platform"
+#~ msgstr "Visa hårdvaruplattoform"
+
+#~ msgid "Display help and debug options"
+#~ msgstr "Visa hjälp och debug-val"
+
+#~ msgid "Valgrind-ise children"
+#~ msgstr "Kör barnprocesser i valgrind"
+
+#~ msgid "Log to file descriptor"
+#~ msgstr "Logga fill filidentifierare"
+
+#~ msgid "Log to socket"
+#~ msgstr "Logga till uttag (socket)"
+
+#~ msgid "Callers in stack trace"
+#~ msgstr "Antal visade anrop i stack-spår"
+
+#~ msgid "Stop showing errors if too many"
+#~ msgstr "Sluta visa fel om för många"
+
+#~ msgid "Continue trace below main()"
+#~ msgstr "Fortsätt spåra under main()-anroppet"
+
+#~ msgid "Supress errors from file"
+#~ msgstr "Undertryck fel från fil"
+
+#~ msgid "Print suppressions for detected errors"
+#~ msgstr "Visa undertryckningar för detekterade fel"
+
+#~ msgid "Start debugger on error"
+#~ msgstr "Starta debugger vid fel"
+
+#~ msgid "Debugger command"
+#~ msgstr "Debuggerkommando"
+
+#~ msgid "Show reachable leaked memory"
+#~ msgstr "Visa nåbart läckt minne"
+
+#~ msgid ""
+#~ "Determines how willing Memcheck is to consider different backtraces to be "
+#~ "the same"
+#~ msgstr ""
+#~ "Bestämmer hur villig Memcheck är att betrakta olika stack-spår som lika"
+
+#~ msgid "Set size of freed memory pool"
+#~ msgstr "Välj storlek på pool av återlämnat minne"
+
+#~ msgid ""
+#~ "Determines how willing Addrcheck is to consider different backtraces to "
+#~ "be the same"
+#~ msgstr ""
+#~ "Bestämmer hur villig Addrcheck är att betrakta olika stack-spår som lika"
+
+#~ msgid "Type of L1 instruction cache"
+#~ msgstr "Typ av L1-instruktionscache"
+
+#~ msgid "Type of L1 data cache"
+#~ msgstr "Typ av L1-datacache"
+
+#~ msgid "Type of L2 cache"
+#~ msgstr "Typ av L2-cache"
+
+#~ msgid "Specify a function that allocates memory"
+#~ msgstr "Ange en minnesallokeringsfunktion"
+
+#~ msgid "Print byte counts"
+#~ msgstr "Visa antal bytes"
+
+#~ msgid "Print character counts"
+#~ msgstr "Visa antal tecken"
+
+#~ msgid "Print newline counts"
+#~ msgstr "Visa antal radbrytningar"
+
+#~ msgid "Print length of longest line"
+#~ msgstr "Visa längd av längsta rad"
+
+#~ msgid "Dont print header"
+#~ msgstr "Visa inte huvud"
+
+#~ msgid "Ignore username for time calculations"
+#~ msgstr "Ignorera användarnamn vid tidsberäkningar"
+
+#~ msgid "Short format"
+#~ msgstr "Kort format"
+
+#~ msgid "Toggle printing of remote hostname"
+#~ msgstr "Växla utskrift av värdnamn för andra datorer"
+
+#~ msgid "Go to background immediately after startup"
+#~ msgstr "Gå till bakgrunden omedelbart efter uppstart"
+
+#~ msgid "Log all messages to logfile"
+#~ msgstr "Logga alla meddelanden till loggfil"
+
+#~ msgid "Append all messages to logfile"
+#~ msgstr "Lägg till alla meddelanden till loggfil"
+
+#~ msgid "Turn on debug output"
+#~ msgstr "Slå på visning av debuginformation"
+
+#~ msgid "Turn off verbose without being completely quiet"
+#~ msgstr "Slå av utförligt läge utan att vara helt tyst"
+
+#~ msgid "Read URLs from file"
+#~ msgstr "Läs URLer från fil"
+
+#~ msgid "Force input to be treated as HTML"
+#~ msgstr "Tvinga indata att behandlas som HTML"
+
+#~ msgid "Prepend string to relative links"
+#~ msgstr "Lägg till sträng före relativa länkar"
+
+#~ msgid "Bind address on local machine"
+#~ msgstr "Bind till adress på lokal maskin"
+
+#~ msgid "Set number of retries to number"
+#~ msgstr "Välj antal gånger att försöka igen"
+
+#~ msgid "Concatenate output to file"
+#~ msgstr "Sammanlägg utdata till fil"
+
+#~ msgid "Never overwrite files with same name"
+#~ msgstr "Skriv aldrig över filer med samma namn"
+
+#~ msgid "Continue getting a partially-downloaded file"
+#~ msgstr "Fortsätt hämta partiellt nedladdad fil"
+
+#~ msgid "Select progress meter type"
+#~ msgstr "Välj förloppsindikatortyp"
+
+#~ msgid "Turn on time-stamping"
+#~ msgstr "Slå på tidsstämpling"
+
+#~ msgid "Print the headers/responses sent by servers"
+#~ msgstr "Visa huvuden/svar skickade från servrar"
+
+#~ msgid "Do not download the pages, just check that they are there"
+#~ msgstr "Ladda inte ner sidorna, kontrollera bara att de är där"
+
+#~ msgid "Set the network timeout"
+#~ msgstr "Välj nätverkstimeout"
+
+#~ msgid "Set the DNS lookup timeout"
+#~ msgstr "Välj DNS-lookuptimeout"
+
+#~ msgid "Set the connect timeout"
+#~ msgstr "Välj uppkopplingstimeout"
+
+#~ msgid "Set the read (and write) timeout"
+#~ msgstr "Välj läs (och skriv) timeout"
+
+#~ msgid "Limit the download speed"
+#~ msgstr "Begränsa nedladdningshastigheten"
+
+#~ msgid "Wait the specified number of seconds between the retrievals"
+#~ msgstr "Vänta det angivna antalet sekunder mellan hämtningar"
+
+#~ msgid "Wait time between retries"
+#~ msgstr "Vänta tid mellan nytt hämtförsök"
+
+#~ msgid "Wait random amount of time between retrievals"
+#~ msgstr "Vänta en slumpvald tid mellan hämtningar"
+
+#~ msgid "Toggle proxy support"
+#~ msgstr "Slå på proxystöd"
+
+#~ msgid "Specify download quota for automatic retrievals"
+#~ msgstr "Ange nedladdningskvot för automatiska hämtningar"
+
+#~ msgid "Turn off caching of DNS lookups"
+#~ msgstr "Slå av cachning av DNS-frågor"
+
+#~ msgid ""
+#~ "Change which characters found in remote URLs may show up in local file "
+#~ "names"
+#~ msgstr "Ändra vilka tecken i fjärr-URL som får förekomma i lokala filnamn"
+
+#~ msgid "Do not create a hierarchy of directories"
+#~ msgstr "Skapa inte en kataloghierarki"
+
+#~ msgid "Force creation of a hierarchy of directories"
+#~ msgstr "Tvinga skapande av kataloghierarki"
+
+#~ msgid "Disable generation of host-prefixed directories"
+#~ msgstr "Inaktivera generering av värd-prefixkatalogkomponenter"
+
+#~ msgid "Use the protocol name as a directory component"
+#~ msgstr "Använd protokollnamn som katalogkomponent"
+
+#~ msgid "Ignore specified number of directory components"
+#~ msgstr "Ignorera angivet antal katalogkomponenter"
+
+#~ msgid "Set directory prefix"
+#~ msgstr "Välj katalogprefix"
+
+#~ msgid "Force html files to have html extension"
+#~ msgstr "Tvinga html-filer att få html-suffix"
+
+#~ msgid "Specify the http username"
+#~ msgstr "Välj httpanvändarnamn"
+
+#~ msgid "Specify the http password"
+#~ msgstr "Välj httplösenord"
+
+#~ msgid "Disable server-side cache"
+#~ msgstr "Inaktivera cache på serversidan"
+
+#~ msgid "Load cookies from file"
+#~ msgstr "Ladda kakor från fil"
+
+#~ msgid "Save cookies to file"
+#~ msgstr "Spara kakor till fil"
+
+#~ msgid "Save session cookies"
+#~ msgstr "Spara sessionskakor"
+
+#~ msgid "Ignore 'Content-Length' header"
+#~ msgstr "Ignorera 'Content-Length' huvud"
+
+#~ msgid "Define an additional-header to be passed to the HTTP servers"
+#~ msgstr "Definera ett extra huvud att skicka till HTTP-servern"
+
+#~ msgid "Specify the proxy username"
+#~ msgstr "Välj proxyanvändarnamn"
+
+#~ msgid "Specify the proxy password"
+#~ msgstr "Välj proxylösenord"
+
+#~ msgid "Set referer URL"
+#~ msgstr "Välj referens-URL"
+
+#~ msgid "Save the headers sent by the HTTP server"
+#~ msgstr "Spara headers skickade av HTTP-servern"
+
+#~ msgid "Identify as agent-string"
+#~ msgstr "Identifiera som följande agent"
+
+#~ msgid ""
+#~ "Use POST as the method for all HTTP requests and send the specified data "
+#~ "in the request body"
+#~ msgstr ""
+#~ "Använd POST som metod för atta HTTP-anropp och skicka den angivna datan i "
+#~ "anroppskroppen"
+
+#~ msgid "Turn off keep-alive for http downloads"
+#~ msgstr "Slå av keep-alive för http-nedladdningar"
+
+#~ msgid "Don't remove the temporary .listing files generated"
+#~ msgstr "Radera inte de tillfälliga .listing filerna som genererats"
+
+#~ msgid "Turn off FTP globbing"
+#~ msgstr "Använd inte filmatchning i FTP"
+
+#~ msgid "Use the passive FTP retrieval scheme"
+#~ msgstr "Använd passiv FTP"
+
+#~ msgid "Traverse symlinks and retrieve pointed-to files"
+#~ msgstr "Följ symboliska länkar och hämta pekade filer"
+
+#~ msgid "Turn on recursive retrieving"
+#~ msgstr "Använd rekursiv hämtning"
+
+#~ msgid "Specify recursion maximum depth"
+#~ msgstr "Maximalt rekursionsdjup"
+
+#~ msgid "Delete every single file downloaded"
+#~ msgstr "Radera alla nedladdade filer"
+
+#~ msgid ""
+#~ "Convert the links in the document to make them suitable for local viewing"
+#~ msgstr ""
+#~ "Konvertera länkarna i dokumentet så att de passar för att titta på lokalt"
+
+#~ msgid "Back up the original version"
+#~ msgstr "Backa upp orginalversionen"
+
+#~ msgid "Turn on options suitable for mirroring"
+#~ msgstr "Slå på passande flaggor för spegling"
+
+#~ msgid ""
+#~ "Download all the files that are necessary to properly display a given "
+#~ "HTML page"
+#~ msgstr ""
+#~ "Ladda ner alla filer som behövs för att visa en given HTML-sida korrekt"
+
+#~ msgid "Turn on strict parsing of HTML comments"
+#~ msgstr "Slå på strikt tolkning av HTML-kommentarer"
+
+#~ msgid "Comma-separated lists of file name suffixes or patterns to accept"
+#~ msgstr "Kommaseparerad lista av filnamns-suffix eller mönster att ladda ner"
+
+#~ msgid "Comma-separated lists of file name suffixes or patterns to reject"
+#~ msgstr ""
+#~ "Kommaseparerad lista av filnamns-suffix eller mönster att inte ladda ner"
+
+#~ msgid "Set domains to be followed"
+#~ msgstr "Välj domäner att följa"
+
+#~ msgid "Specify the domains that are not to be followed"
+#~ msgstr "Välj domäner som inte skall följas"
+
+#~ msgid "Follow FTP links from HTML documents"
+#~ msgstr "Följ FTP-länkar från HTML-dokument"
+
+#~ msgid "HTML tags to follow"
+#~ msgstr "Följ angivna HTML-taggar"
+
+#~ msgid "HTML tags to ignore"
+#~ msgstr "Ignorera angivna HTML-taggar"
+
+#~ msgid "Enable spanning across hosts"
+#~ msgstr "Följ länkar mellan olika värdar"
+
+#~ msgid "Follow relative links only"
+#~ msgstr "Följ bara relativa länkar"
+
+#~ msgid "Specify a comma-separated list of directories you wish to follow"
+#~ msgstr "Välj en kommaseparerad lista av kataloger som skall följas"
+
+#~ msgid "Specify a comma-separated list of directories you wish to exclude"
+#~ msgstr "Välj en kommaseparerad lista av kataloger som skall exkluderas"
+
+#~ msgid "Print all matching executables in PATH, not just the first"
+#~ msgstr "Visa alla matchande program i PATH, inte bara den första"
+
+#~ msgid "Read aliases from stdin, reporting matching ones on stdout"
+#~ msgstr "Läs alias från standard in, raportera matchningar på standard ut"
+
+#~ msgid "Ignore option '--read-alias'"
+#~ msgstr "Ignorera flaggan '--read-alias'"
+
+#~ msgid ""
+#~ "Read shell function definitions from stdin, reporting matching ones on "
+#~ "stdout"
+#~ msgstr ""
+#~ "Läs funktionsdefinitioner från standard in, raportera matchningar på "
+#~ "standard ut"
+
+#~ msgid "Ignore option '--read-functions'"
+#~ msgstr "Ignorera flaggan '--read-functions'"
+
+#~ msgid "Skip directories in PATH that start with a dot"
+#~ msgstr "Hoppa över kataloger i PATH som börjar med en punkt"
+
+#~ msgid ""
+#~ "Skip directories in PATH that start with a tilde and executables which "
+#~ "reside in the HOME directory"
+#~ msgstr ""
+#~ "Hoppa över kataloger i PATH som börjar med ett tilde och program som "
+#~ "ligger i HOME-katalogen"
+
+#~ msgid ""
+#~ "If a directory in PATH starts with a dot and a matching executable was "
+#~ "found for that path, then print './programname'"
+#~ msgstr ""
+#~ "Om en katalog i PATH börjar med en punkt och ett matchande program hittas "
+#~ "i den katalogen, skriv ut './programnamn'"
+
+#~ msgid "Output a tilde when a directory matches the HOME directory"
+#~ msgstr "Skriv ut ett tilde när en katalog matcher HOME-katalogen"
+
+#~ msgid "Stop processing options on the right if not on tty"
+#~ msgstr "Sluta processa flaggor till höger om inte på en tty"
+
+#~ msgid "Same as -b -d --login -p -r -t -T -u"
+#~ msgstr "Synonymt med -b -d --login -p -r -t -T -u"
+
+#~ msgid "Print time of last boot"
+#~ msgstr "Visa tidpunkt för senaste uppstart"
+
+#~ msgid "Print line of headings"
+#~ msgstr "Skriv ut rad av överskrifter"
+
+#~ msgid "Print idle time"
+#~ msgstr "Visa overksam tid"
+
+#~ msgid "Print login process"
+#~ msgstr "Visa inloggningsprocess"
+
+#~ msgid "Canonicalize hostnames via DNS"
+#~ msgstr "Gör värdnamn kanoniska via DNS"
+
+#~ msgid "Print hostname and user for stdin"
+#~ msgstr "Visa värdnamn och användare för standard in"
+
+#~ msgid "Print active processes spawned by init"
+#~ msgstr "Visa aktiva processer skapade av init"
+
+#~ msgid "Print all login names and number of users logged on"
+#~ msgstr "Skriv ut alla inloggningsnamn och antal inloggade användare"
+
+#~ msgid "Print current runlevel"
+#~ msgstr "Skriv ut nuvarande körnivå"
+
+#~ msgid "Print name, line, and time"
+#~ msgstr "Visa namn, rad och tid"
+
+#~ msgid "Print last system clock change"
+#~ msgstr "Visa senaste systemklockändring"
+
+#~ msgid "Print users message status as +, - or ?"
+#~ msgstr "Visa användarstatus som +, - eller ?"
+
+#~ msgid "List users logged in"
+#~ msgstr "Visa inloggade användare"
+
+#~ msgid ""
+#~ "Input filenames are terminated by a null character instead of by "
+#~ "whitespace, and the quotes and backslash are not special"
+#~ msgstr ""
+#~ "Indatafilnamn avslutas av ett nulltecken istället för ett blanktecken, "
+#~ "och citationstecken samt omvänt snedstreck är inte speciella"
+
+#~ msgid "Set the end of file string to eof-str"
+#~ msgstr "Sätt slut-på-fil-strängen till angiven sträng"
+
+#~ msgid ""
+#~ "Replace replace-str in the initial arguments with names from standard "
+#~ "input"
+#~ msgstr ""
+#~ "Ersätt angiven sträng i ursprungsargumenten med namn från standard in"
+
+#~ msgid "Use at most max-lines nonblank input lines per command line"
+#~ msgstr "Använd som mest angivet antal icke-tomma indatarader per kommando"
+
+#~ msgid "Use at most max-args arguments per command line"
+#~ msgstr "Använd som mest angivet antal argument per kommando"
+
+#~ msgid ""
+#~ "Prompt the user about whether to run each command line and read a line "
+#~ "from the terminal"
+#~ msgstr ""
+#~ "Fråga användaren om varje kommando ska utföras och läs en rad från "
+#~ "terminalen"
+
+#~ msgid ""
+#~ "If the standard input does not contain any nonblanks, do not run the "
+#~ "command"
+#~ msgstr ""
+#~ "Om inte standard in innehåller icke-tomma tecken, utför inte kommandot"
+
+#~ msgid "Use at most max-chars characters per command line"
+#~ msgstr "Använd som mest angivet antal tecken per kommandorad"
+
+#~ msgid ""
+#~ "Print the command line on the standard error output before executing it"
+#~ msgstr "Skriv ut kommandoraden på standard fel före exekvering"
+
+#~ msgid "Exit if the size is exceeded"
+#~ msgstr "Avsluta om storleken överskrids"
+
+#~ msgid "Run up to max-procs processes at a time"
+#~ msgstr "Kör upp till angivet antal processer i taget"
+
+#~ msgid "Display grammar and exit"
+#~ msgstr "Visa grammatik och avsluta"
+
+#~ msgid "Select window by name"
+#~ msgstr "Välj fönster via namn"
+
+#~ msgid "Select root window"
+#~ msgstr "Välj rotfönster"
+
+#~ msgid "Specify X server"
+#~ msgstr "Välj X-server"
+
+#~ msgid "Do not show property type"
+#~ msgstr "Visa inte egenskapstyp"
+
+#~ msgid "Select a window by clicking on its frame"
+#~ msgstr "Välj ett fönster genom att klicka på dess ram"
+
+#~ msgid "Remove property"
+#~ msgstr "Ta bort egenskap"
+
+#~ msgid "Set property"
+#~ msgstr "Sätt egenskap"
+
+#~ msgid "Examine property updates forever"
+#~ msgstr "Lyssna efter uppdateringar för alltid"
+
+#~ msgid "Make no changes"
+#~ msgstr "Gör inga förändringar"
+
+#~ msgid "Append input to selection"
+#~ msgstr "Lägg till indata till slutet at urval"
+
+#~ msgid "Append to selection as input grows"
+#~ msgstr "Lägg till till urval när indata växer"
+
+#~ msgid "Read into selection"
+#~ msgstr "Läs in i urval"
+
+#~ msgid "Write selection"
+#~ msgstr "Visa urval"
+
+#~ msgid "Clear selection"
+#~ msgstr "Töm urval"
+
+#~ msgid "Delete selection"
+#~ msgstr "Radera urval"
+
+#~ msgid "Use primary selection"
+#~ msgstr "Använd primärt urval"
+
+#~ msgid "Use secondary selection"
+#~ msgstr "Använd sekundärt urval"
+
+#~ msgid "Use clipboard selection"
+#~ msgstr "Använd urklipp (clipboard) istället för urval"
+
+#~ msgid "Make current selections persistent after program exit"
+#~ msgstr "Gör så nuvarande urval finns kvar efter programavslut"
+
+#~ msgid "Exchange primary and secondary selections"
+#~ msgstr "Växla primärt och sekundärt urval"
+
+#~ msgid "Timeout for retrieving selection"
+#~ msgstr "Timeout under hämtning"
+
+#~ msgid "Do not detach from the controlling terminal"
+#~ msgstr "Frikoppla inte från terminalen"
+
+#~ msgid "Print informative messages"
+#~ msgstr "Visa informativa meddelanden"
+
+#~ msgid "Set debug level"
+#~ msgstr "Välj debugnivå"
+
+#~ msgid "Set error level"
+#~ msgstr "Välj felrapporteringsnivå"
+
+#~ msgid "Be tolerant of errors in commandline"
+#~ msgstr "Tolerera fel i kommandoraden"
+
+#~ msgid "Set maximum delay between commands"
+#~ msgstr "Välj maximal fördröjning mellan kommandon"
+
+#~ msgid "Run commands from cache"
+#~ msgstr "Kör ett kommando från cache"
+
+#~ msgid "Specify installroot"
+#~ msgstr "Välj installationsrot"
+
+#~ msgid "Enables obsolets processing logic"
+#~ msgstr "Slå på hantering av obsoleta paket"
+
+#~ msgid "Output rss-data to file"
+#~ msgstr "Skriv rss-data till fil"
+
+#~ msgid "Exclude specified package from updates"
+#~ msgstr "Exkludera angivna paket från uppdateringar"
+
+#~ msgid "Freshen: only changed files"
+#~ msgstr "Uppdatera: Lägg till ändrade filer"
+
+#~ msgid "Delete entries in zipfile"
+#~ msgstr "Radera filer från zipfil"
+
+#~ msgid "Update: only changed or newer files"
+#~ msgstr "Uppdatera: Lägg bara till ändrade och nya filer"
+
+#~ msgid "Move into zipfile (delete files)"
+#~ msgstr "Radera de filer som läggs till arkivet"
+
+#~ msgid "Do not compress at all"
+#~ msgstr "Komprimera inte alls"
+
+#~ msgid "Convert LF to CR LF"
+#~ msgstr "Konvertera LF (Unixradbrytning) till CR LF (Windowsradbrytning)"
+
+#~ msgid "Convert CR LF to LF"
+#~ msgstr "Konvertera CR LF (Windowsradbrytning) till LF (Unixradbrytning)"
+
+#~ msgid "Compress faster"
+#~ msgstr "Snabb komprimering"
+
+#~ msgid "Compress better"
+#~ msgstr "Högre kompressionsgrad"
+
+#~ msgid "Add one-line comments"
+#~ msgstr "Lägg till enradskommentar"
+
+#~ msgid "Add zipfile comments"
+#~ msgstr "Lägg till kommentar till zipfil"
+
+#~ msgid "Read names from stdin"
+#~ msgstr "Läs namn från standard in"
+
+#~ msgid "Make zipfile as old as the latest entry"
+#~ msgstr "Sätt filens ändringsdatum till ändringsdatum av senaste fil"
+
+#~ msgid "Fix zipfile"
+#~ msgstr "Reparera zip-fil"
+
+#~ msgid "Fix zipfile (try harder)"
+#~ msgstr "Reparera zip-fil (försök mer)"
+
+#~ msgid "Adjust offsets to suit self-extracting exe"
+#~ msgstr ""
+#~ "Justera förskjutningar för att lämna plats för att skapa ett "
+#~ "självextraherande arkiv"
+
+#~ msgid "Strip prepended data"
+#~ msgstr "Ta bort datablock före arkivet"
+
+#~ msgid "Test zipfile integrity"
+#~ msgstr "Testa zipfilintegritet"
+
+#~ msgid "Exclude extra file attributes"
+#~ msgstr "Exkludera extra filattribut"
+
+#~ msgid "Store symbolic links as links"
+#~ msgstr "Lagra symboliska länkar som länkar"
+
+#~ msgid "PKZIP recursion"
+#~ msgstr "PKZIP-rekursion"
+
+#~ msgid "Encrypt"
+#~ msgstr "Kryptera"
+
+#~ msgid "Maximum uploads at once"
+#~ msgstr "Maximalt antal samtidiga uppladningar"
+
+#~ msgid "Number of seconds between keepalives"
+#~ msgstr "Sekunder mellan keepalives"
+
+#~ msgid "Bytes per request"
+#~ msgstr "Bytes per förfrågan"
+
+#~ msgid "Requests per pipe"
+#~ msgstr "Förfrågningar per rör"
+
+#~ msgid "Maximum length prefix encoding"
+#~ msgstr "Maximal längd på prefixkod"
+
+#~ msgid "File for server response"
+#~ msgstr "Fil att lagra serversvar i"
+
+#~ msgid "URL to get file from"
+#~ msgstr "URL att hämta fil från"
+
+#~ msgid "Local file target"
+#~ msgstr "Lokal fil att hämta till"
+
+#~ msgid "Time to close inactive socket"
+#~ msgstr "Fördröjning innan inaktivt uttag (socket) stängs"
+
+#~ msgid "Time between checking timeouts"
+#~ msgstr "Intervall mellan kontroller av timeouts"
+
+#~ msgid "Maximum outgoing slice length"
+#~ msgstr "Längsta slice-storlek"
+
+#~ msgid "Maximum time to guess rate"
+#~ msgstr "Maximalt tid att gissa kvot"
+
+#~ msgid "IP to bind to locally"
+#~ msgstr "Lokal IP-adress att binda till"
+
+#~ msgid "Time between screen updates"
+#~ msgstr "Tid mellan skärmuppdateringar"
+
+#~ msgid "Time to wait between requesting more peers"
+#~ msgstr "Tidsintevall mellan förfrågningar efter nya fränder"
+
+#~ msgid "Minimum number of peers to not do requesting"
+#~ msgstr "Minimalt antal fränder för att inte skicka förfrågan"
+
+#~ msgid "Number of seconds before assuming http timeout"
+#~ msgstr "Sekunder innan http-timeout"
+
+#~ msgid "Number of peers at which to stop initiating new connections"
+#~ msgstr "Antal fränder för att inte skapa nya uppkopplingar"
+
+#~ msgid "Maximum number of connections to allow"
+#~ msgstr "Maximalt antal tillåtna uppkopplingar"
+
+#~ msgid "Whether to check hashes on disk"
+#~ msgstr "Om disk-hashar skall verifieras"
+
+#~ msgid "Maximum kB/s to upload at"
+#~ msgstr "Maximal uppladdningstakt i kB/s"
+
+#~ msgid "Seconds to wait for data to come in before assuming choking"
+#~ msgstr "Antal sekunder att vänta innan antagande om strypning"
+
+#~ msgid "Whether to display diagnostic info"
+#~ msgstr "Visa debuginfo"
+
+#~ msgid "Number of downloads at which to switch from random to rarest first"
+#~ msgstr ""
+#~ "Antal nedladdningar för att byta från slumpmässig slice till ovanligaste "
+#~ "slice först"
+
+#~ msgid "Number of uploads to fill out to with optimistic unchokes"
+#~ msgstr "Antalet uppladningar att fylla med optimistisk avstrypning"
+
+#~ msgid "Whether to inform the user that hash failures occur"
+#~ msgstr "Om användaren skall informeras om hashfel"
+
+#, fuzzy
+#~ msgid "%ls: Expected zero or two parameters, got %d\n"
+#~ msgstr "%ls: Förväntade noll eller två argument, fick %d"
+
+#~ msgid "Current functions are: "
+#~ msgstr "Nuvarande funktioner är: "
+
+#~ msgid "%ls: Not inside of block\n"
+#~ msgstr "%ls: Inte i ett block\n"
+
+#~ msgid "%ls: Not inside of 'if' block\n"
+#~ msgstr "%ls: Inte i ett 'if' block\n"
+
+#~ msgid "%ls: Expected exactly one argument, got %d\n"
+#~ msgstr "%ls: Förväntade exakt ett argument, fick %d\n"
+
+#~ msgid "%ls: 'case' command while not in switch block\n"
+#~ msgstr "%ls: 'case' kommandot kan bara användas i ett 'switch'-block\n"
+
+#~ msgid "%ls: Unknown error"
+#~ msgstr "%ls: Okänt fel"
+
+#~ msgid "%ls: Can not specify scope when erasing array slice\n"
+#~ msgstr "%ls: Kan inte ange definitionsområde vid radering av arraydel\n"
+
+#~ msgid "Could not get user information"
+#~ msgstr "Kunde inte hitta information om användare"
+
+#~ msgid "Could not convert message '%s' to wide character string"
+#~ msgstr "Kunde inte konvertera meddelandet '%s' till en bred teckensträng"
+
+#~ msgid "%ls: Argument '%s' is not a valid file descriptor\n"
+#~ msgstr "%ls: Argumentet '%s' är inte en giltig filidentifierare\n"
+
+#~ msgid "Could not set up output file descriptors for pager"
+#~ msgstr "Kunde inte initiera utdata-filidentifierare för visare"
+
+#~ msgid "Could not set up input file descriptors for pager"
+#~ msgstr "Kunde inte initiera indata-filidentifierare för visare"
+
+#~ msgid "Could not open tty for pager"
+#~ msgstr "Kunde inte öppna tty för visare"
+
+#~ msgid "Could not initialize result pipe"
+#~ msgstr "Kunde inte initiera rör för utskrift av resultat"
+
+#
+#~ msgid "Unspecified file descriptors"
+#~ msgstr "Ospecificerad filidentifierare"
+
+#
+#~ msgid "Could not read completions"
+#~ msgstr "Kunde inte läsa kompletteringar"
+
+#~ msgid "Could not expand string '%ls'"
+#~ msgstr "Kunde inte expandera strängen '%ls'"
+
+#~ msgid "An additional command is required"
+#~ msgstr "Ett till kommand krävs"
+
+#~ msgid ""
+#~ "Could not locate end of block. The 'end' command is missing, misspelled "
+#~ "or a ';' is missing."
+#~ msgstr ""
+#~ "Kunde inte hitta slutet på kodblock. Kommandot 'end' saknas, är felstavat "
+#~ "eller ett ';' saknas."
+
+#~ msgid "Expected a command name, got token of type '%ls'"
+#~ msgstr ""
+#~ "Förväntade att hitta ett kommandonamn, hittade en symbol av typen '%ls'"
+
+#~ msgid "'case' builtin not inside of switch block"
+#~ msgstr ""
+#~ "Det inbyggda kommandot 'case' får bara användas i ett 'switch'-block."
+
+#~ msgid "Loop control command while not inside of loop"
+#~ msgstr "Loopstyrningskommandon får bara användas i loopar."
+
+#, fuzzy
+#~ msgid "'%ls' builtin not inside of if block"
+#~ msgstr "Det inbyggda kommandot 'else' får bara användas i ett if-block"
+
+#~ msgid "'end' command outside of block"
+#~ msgstr "Det inbyggda kommandot 'end' får bara användas i ett block"
+
+#~ msgid "Expected redirection specification, got token of type '%ls'"
+#~ msgstr "Förväntade en IO dirigering, hittade en symbol av typen '%ls'"
+
+#~ msgid ""
+#~ "Encountered redirection when expecting a command name. Fish does not "
+#~ "allow a redirection operation before a command."
+#~ msgstr ""
+#~ "Förväntade ett kommandonamn, hittade en IO dirigering. Fish tillåter into "
+#~ "IO dirigeringar före kommandonamn"
+
+#~ msgid "Invalid IO redirection"
+#~ msgstr "Ogiltig IO omdirigering"
+
+#~ msgid "Requested redirection to something that is not a file descriptor %ls"
+#~ msgstr "IO dirigering till någonting som inte är en filidentifierare"
+
+#~ msgid "Don't preserve the specified attributes"
+#~ msgstr "Behåll inte de angivna attributen"
+
+#~ msgid "Control creation of sparse files"
+#~ msgstr "Kontrollera skapandet av glesa filer"
+
+#, fuzzy
+#~ msgid "add the specified files on the next commit"
+#~ msgstr "Lägg till angiven fil fill den nuvarande listan av nyckelringar"
+
+#, fuzzy
+#~ msgid "show changeset information by line for each file"
+#~ msgstr "Visa ändringsinformation för paket"
+
+#, fuzzy
+#~ msgid "create an unversioned archive of a repository revision"
+#~ msgstr "Lägg till fil eller träd utan version till förrådet"
+
+#, fuzzy
+#~ msgid "list repository named branches"
+#~ msgstr "Inaktivera förråd"
+
+#, fuzzy
+#~ msgid "create a changegroup file"
+#~ msgstr "Skapa en kontrollpunktfil"
+
+#, fuzzy
+#~ msgid "output the current or given revision of files"
+#~ msgstr "Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
+
+#, fuzzy
+#~ msgid "make a copy of an existing repository"
+#~ msgstr "Skapa lokal kopia av förråd"
+
+#, fuzzy
+#~ msgid "commit the specified files or all outstanding changes"
+#~ msgstr "Dekryptera angiven fil eller standard in"
+
+#, fuzzy
+#~ msgid "diff repository (or selected files)"
+#~ msgstr "Radera urval"
+
+#, fuzzy
+#~ msgid "forget the specified files on the next commit"
+#~ msgstr "Flytta filen angiven på kommandoraden"
+
+#, fuzzy
+#~ msgid "copy changes from other branches onto the current branch"
+#~ msgstr "Hämta ändringar från förrådet till arbetskopian"
+
+#, fuzzy
+#~ msgid "identify the working copy or specified revision"
+#~ msgstr "Uppdatera arbetskopian till en annan URL"
+
+#, fuzzy
+#~ msgid "import an ordered set of patches"
+#~ msgstr "Visa byteavstånd för matchningar"
+
+#, fuzzy
+#~ msgid "create a new repository in the given directory"
+#~ msgstr "Skapa förråd om det inte redan existerar"
+
+#, fuzzy
+#~ msgid "locate files matching specific patterns"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "output the current or given revision of the project manifest"
+#~ msgstr "Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
+
+#, fuzzy
+#~ msgid "show changesets not found in the destination"
+#~ msgstr "Fråga paket med angiven grupp"
+
+#, fuzzy
+#~ msgid "show the parents of the working directory or revision"
+#~ msgstr "Ändra arbetskatalog"
+
+#, fuzzy
+#~ msgid "show aliases for remote repositories"
+#~ msgstr "Ta bort inlägg i .cvspass för fjärrförråd"
+
+#, fuzzy
+#~ msgid "pull changes from the specified source"
+#~ msgstr "Fråga paket med angiven grupp"
+
+#, fuzzy
+#~ msgid "push changes to the specified destination"
+#~ msgstr "Fråga paket med angiven grupp"
+
+#, fuzzy
+#~ msgid "remove the specified files on the next commit"
+#~ msgstr "Flytta filen angiven på kommandoraden"
+
+#, fuzzy
+#~ msgid "roll back the last transaction (dangerous)"
+#~ msgstr "Ordna om fixarna i förrådet"
+
+#, fuzzy
+#~ msgid "print the root (top) of the current working directory"
+#~ msgstr "Ändra arbetskatalog"
+
+#, fuzzy
+#~ msgid "show changed files in the working directory"
+#~ msgstr "Ändra arbetskatalog"
+
+#, fuzzy
+#~ msgid "summarize working directory state"
+#~ msgstr "Visa nuvarande katalog"
+
+#, fuzzy
+#~ msgid "list repository tags"
+#~ msgstr "Inaktivera förråd"
+
+#, fuzzy
+#~ msgid "show the tip revision"
+#~ msgstr "Visa tid"
+
+#, fuzzy
+#~ msgid "apply one or more changegroup files"
+#~ msgstr "Läs paket från fil"
+
+#, fuzzy
+#~ msgid "update working directory (or switch revisions)"
+#~ msgstr "Ändra arbetskatalog"
+
+#, fuzzy
+#~ msgid "verify the integrity of the repository"
+#~ msgstr "Ta bort ett inlägg från förråd"
+
+#, fuzzy
+#~ msgid "output version and copyright information"
+#~ msgstr "Ignorera versionsmagiinformation"
+
+#, fuzzy
+#~ msgid "Configuration Files"
+#~ msgstr "Konfigureringsfil"
+
+#, fuzzy
+#~ msgid "Date Formats"
+#~ msgstr "Välj format"
+
+#, fuzzy
+#~ msgid "Diff Formats"
+#~ msgstr "Listformat"
+
+#, fuzzy
+#~ msgid "Environment Variables"
+#~ msgstr "Redigera miljövariabler"
+
+#, fuzzy
+#~ msgid "Specifying File Sets"
+#~ msgstr "Välj konfigurationsfil"
+
+#, fuzzy
+#~ msgid "Configuring hgweb"
+#~ msgstr "Konfigureringsfil"
+
+#, fuzzy
+#~ msgid "Merge Tools"
+#~ msgstr "Sammanslå sorterade filer"
+
+#, fuzzy
+#~ msgid "Specifying Multiple Revisions"
+#~ msgstr "Ange revision"
+
+#, fuzzy
+#~ msgid "File Name Patterns"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "Specifying Single Revisions"
+#~ msgstr "Ange revision"
+
+#, fuzzy
+#~ msgid "Specifying Revision Sets"
+#~ msgstr "Ange revisionstiollstånd"
+
+#, fuzzy
+#~ msgid "Subrepositories"
+#~ msgstr "Aktivera förråd"
+
+#, fuzzy
+#~ msgid "[+] include names matching the given patterns"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "[+] exclude names matching the given patterns"
+#~ msgstr "Lista alla moduler som matchar parameter med jokertecken"
+
+#, fuzzy
+#~ msgid "[+]   include names matching the given patterns"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "[+]   exclude names matching the given patterns"
+#~ msgstr "Lista alla moduler som matchar parameter med jokertecken"
+
+#, fuzzy
+#~ msgid "Annotate the specified revision"
+#~ msgstr "Hjälp för det angivna inbyggda kommandot"
+
+#, fuzzy
+#~ msgid "Use text as commit message"
+#~ msgstr "Läs meddelande för tillägg från fil"
+
+#~ msgid "Read commit message from file"
+#~ msgstr "Läs meddelande för tillägg från fil"
+
+#, fuzzy
+#~ msgid "Record the specified date as commit date"
+#~ msgstr "Hjälp för det angivna kommandot"
+
+#, fuzzy
+#~ msgid "Record the specified user as committer"
+#~ msgstr "Använd angiven sträng som kommentarsträng"
+
+#, fuzzy
+#~ msgid "File to store the bundles into"
+#~ msgstr "Redigera fix-paketbeskrivning"
+
+#, fuzzy
+#~ msgid "Limit number of changes displayed"
+#~ msgstr "Skriv bara ut angivet antal matchningar"
+
+#, fuzzy
+#~ msgid "Display with template"
+#~ msgstr "Visa alla matchningar"
+
+#, fuzzy
+#~ msgid "Specify ssh command to use"
+#~ msgstr "Ange kommando att operera på"
+
+#, fuzzy
+#~ msgid "Specify hg command to run on the remote side"
+#~ msgstr "Välj destinationsadress"
+
+#, fuzzy
+#~ msgid "Search the repository as it is in REV"
+#~ msgstr "Ange förråd-URL"
+
+#, fuzzy
+#~ msgid "Show revisions matching date spec"
+#~ msgstr "Visa bara matchande del"
+
+#, fuzzy
+#~ msgid "Revision to display"
+#~ msgstr "Välj display"
+
+#, fuzzy
+#~ msgid "Specify merge tool"
+#~ msgstr "Ange förtroendemodell"
+
+#, fuzzy
+#~ msgid "Show parents of the specified revision"
+#~ msgstr "Fråga paket med angiven grupp"
+
+#, fuzzy
+#~ msgid "[+] target revision"
+#~ msgstr "Slå ihop revisioner"
+
+#, fuzzy
+#~ msgid "Tipmost revision matching date"
+#~ msgstr "Visa inte filer som matchar mönster"
+
+#, fuzzy
+#~ msgid "Revert to the specified revision"
+#~ msgstr "Flytta filen angiven på kommandoraden"
+
+#, fuzzy
+#~ msgid "For remote clients"
+#~ msgstr "Visa eller ta bort funktioner"
+
+#, fuzzy
+#~ msgid "Untrusted configuration options"
+#~ msgstr "Välj konfigurationsinställningar"
+
+#, fuzzy
+#~ msgid "List the changed files of a revision"
+#~ msgstr "Visa alla engenskaper hos filer, kataloger eller revisioner"
+
+#~ msgid ""
+#~ "\\nWARNING\\n\\nThe location for fish configuration files has changed to "
+#~ "%s.\\nYour old files have been moved to this location.\\nYou can change "
+#~ "to a different location by changing the value of the variable "
+#~ "$XDG_CONFIG_HOME.\\n\\n"
+#~ msgstr ""
+#~ "\\nVARNING\\n\\nLagringsplatsen för fish-konfigureringsfiler har ändrats "
+#~ "till %s. Dina gamla filer har flyttats till denna plats.\\nDu kan ändra "
+#~ "denna plats genom att byta värde på variabeln $XDG_CONFIG_HOME.\\n\\n"
+
+#~ msgid "%ls: Missing function definition information."
+#~ msgstr "%ls: Funktionsdefinition saknas."
+
+#~ msgid "%ls: Command only available in interactive sessions"
+#~ msgstr "%ls: Kommandot finns bara tillgängligt under interaktiva sessioner"
+
+#~ msgid "Procces\n"
+#~ msgstr "Process\n"
+
+#~ msgid "This is a bug. "
+#~ msgstr "Detta är en bug. "
+
+#~ msgid "Could not create child process - exiting"
+#~ msgstr "Kunde inte skapa barnprocess - avslutar programmet"
+
+#~ msgid "Failed to close file descriptor %d"
+#~ msgstr "Misslyckades med att stänga filidentifierare %d"
+
+#~ msgid ""
+#~ "Could not send process %d, '%ls' in job %d, '%ls' from group %d to group "
+#~ "%d"
+#~ msgstr ""
+#~ "Kunde inte skicka process %d, '%ls', i jobb %d, '%ls' från grupp %d till "
+#~ "grupp %d"
+
+#~ msgid "%s: Unknown error\n"
+#~ msgstr "%s: Okänt fel\n"
+
+#~ msgid "Maximum recursion depth reached. Accidental infinite loop?"
+#~ msgstr "Maximalt rekursionsdjup uppnått. Oavsiktlig oändlig upprepning?"
+
+#~ msgid "Maximum number of nested blocks reached."
+#~ msgstr "Maximalt antal nästade block har uppnåtts."
+
+#~ msgid ""
+#~ "Warning: No match for wildcard '%ls'. The command will not be executed."
+#~ msgstr ""
+#~ "Varning: Inga matchningar för jokertecknen i '%ls'. Kommandot kommer inte "
+#~ "utföras."
+
+#~ msgid "Tried to evaluate null pointer."
+#~ msgstr "Försökte evaluera nollpekare."
+
+#~ msgid "in . (source) call of file '%ls',\n"
+#~ msgstr "i '.'-anrop av fil '%ls',\n"
+
+#~ msgid "Unknown command '%ls'"
+#~ msgstr "Okänt kommando '%ls'"
+
+#~ msgid "Job command"
+#~ msgstr "Jobb kommando"
+
+#~ msgid "Job list pointer"
+#~ msgstr "Jobblistepekare"
+
+#~ msgid "Process command"
+#~ msgstr "Processkommando"
+
+#~ msgid "There are stopped jobs\n"
+#~ msgstr "Det finns stannade jobb\n"
+
+#~ msgid "Could not convert input. Read %d bytes."
+#~ msgstr "Kunde inte konvertera indata. Läste %d bytes."
+
+#~ msgid "Could not read input stream"
+#~ msgstr "Kunde inte läsa från indataström"
+
+#~ msgid "%s: Too many arguments\n"
+#~ msgstr "%s: För många argument\n"
+
+#~ msgid "Invalid token"
+#~ msgstr "Ogiltig symbol"
+
+#~ msgid "function %s called with null value for argument %s. "
+#~ msgstr "funktionen %s anropades med nollvärde som argument %s. "
+
+#~ msgid "function %s called while blocking signals. "
+#~ msgstr "funktionen %s anropades medan signaler var blockerade. "
+
+#~ msgid "Remove one or more files or directories from the repository"
+#~ msgstr "Ta bort filer eller kataloger från lagret"
+
+#~ msgid "Move/rename one or more files or directories"
+#~ msgstr "Flytta/byt namn på en eller flera filer eller kataloger"
+
+#~ msgid "Replace a token with a new value for that token"
+#~ msgstr "Ersätt en symbol med ett nytt värde för den symbolen"
+
+#~ msgid "Revert to the recorded version (safe the first time only)"
+#~ msgstr "Backa till senaste lagrade version (Är bara säkert en gång)"
+
+#~ msgid "Save changes in the working copy to the repository as a patch"
+#~ msgstr "Spara ändringar i arbetskopian till lagret som en fix"
+
+#~ msgid "Tag the contents of the repository with a version name"
+#~ msgstr "Tagga innehållet i lagret med ett versionsnummer"
+
+#, fuzzy
+#~ msgid "Record an inverse patch without changing the working directory"
+#~ msgstr "Lagra en omvänd fix utan att ändra arbetskopian"
+
+#, fuzzy
+#~ msgid "Gives a changelog-style summary of the repository history"
+#~ msgstr "Ge en changelog-formaterad summering av förrådhistorik"
+
+#, fuzzy
+#~ msgid "Opposite of pull; unsafe if patch is not in remote repository"
+#~ msgstr "Motsatsen till pull, osäker om fixen inte finns i fjärrlagret"
+
+#~ msgid "Apply patches (from an email bundle) to the repository"
+#~ msgstr "Applicera fixar (från e-postpaket) till lagret"
+
+#~ msgid "Create a local copy of another repository"
+#~ msgstr "Skapa lokal kopia av förråd"
+
+#, fuzzy
+#~ msgid "Initialize a new source tree as a darcs repository"
+#~ msgstr "Checka in filer till förråd"
+
+#~ msgid "Optimize the repository"
+#~ msgstr "Optimera förråd"
+
+#~ msgid "Check the repository for consistency"
+#~ msgstr "Kontrollera lagrets konsistens"
+
+#~ msgid "Name of version to checkpoint"
+#~ msgstr "NAmn på version at använda som kontrollpunkt"
+
+#~ msgid "Use pattern from file"
+#~ msgstr "Använd mönster från fil"
+
+#, fuzzy
+#~ msgid "Use ARG as merge command"
+#~ msgstr "Ange sammanslagningskommando"
+
+#, fuzzy
+#~ msgid "Use ARG as external editor"
+#~ msgstr "Ange extern editor"
+
+#~ msgid "Maximum number of log entries"
+#~ msgstr "Maximalt antal logginlägg"
+
+#~ msgid "Commands to execute when fish exits"
+#~ msgstr "Kommandon som utförs när fish avslutas"
+
+#~ msgid "Good bye\\n"
+#~ msgstr "Hej då\\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%sfunced%s "
+#~ "FUNCTION\\n"
+#~ msgstr ""
+#~ "%s: Förväntade exakt ett argument, fick %s\\n\\nSynopsis:\\n\\t%svared%s "
+#~ "VARIABEL\\n"
+
+#~ msgid ""
+#~ "%ls: '%ls' is not a directory or you do not have permission to enter it\n"
+#~ msgstr ""
+#~ "%ls: '%ls' är inte en katalog eller så har du inte rättigheter att läsa "
+#~ "denna katalog\n"
+
+#~ msgid "%ls: Expected at least one argument, got %d\n"
+#~ msgstr "%ls: Förväntade minst ett argument, fick %d\n"
+
+#~ msgid "Evaluate parameters as a command"
+#~ msgstr "Utför argument som kommando"
+
+#~ msgid "User home"
+#~ msgstr "Hemkatalog"
+
+#~ msgid "Invalid Control sequence"
+#~ msgstr "Ogiltig kontroll-sekvens"
+
+#~ msgid "Could not parse sequence '%ls'"
+#~ msgstr "Kunde inte tolka sekvens '%ls'"
+
+#~ msgid "Invalid sequence - no dash after control\n"
+#~ msgstr "Ogiltig sekvens - inget bindestreck efter 'control'\n"
+
+#~ msgid "Invalid sequence - Control-nothing?\n"
+#~ msgstr "Ogiltig sekvens - Kontroll-ingenting?\n"
+
+#~ msgid "Invalid sequence - no dash after meta\n"
+#~ msgstr "Ogiltig sekvens - inget bindestreck efter 'meta'\n"
+
+#~ msgid "Invalid sequence - Meta-nothing?"
+#~ msgstr "Ogiltig sekvens - Meta-ingenting?"
+
+#~ msgid "Invalid sequence - '%ls' expanded to zero characters"
+#~ msgstr "Ogiltig sekvens - '%ls' expanderades till en tom sträng"
+
+#~ msgid "Mismatched $endif in inputrc file"
+#~ msgstr "$endif matchade inte i inputrc-fil"
+
+#~ msgid "Mismatched quote"
+#~ msgstr "Citat-tecknen matchar inte varandra"
+
+#~ msgid "Expected a ':'"
+#~ msgstr "Förväntade ett ':'"
+
+#~ msgid "I don't know what '%ls' means"
+#~ msgstr "Vet inte vad '%ls' betyder"
+
+#~ msgid "Expected end of line, got '%ls'"
+#~ msgstr "Förväntade radslut, fick '%ls'"
+
+#~ msgid "Syntax: set KEY VALUE"
+#~ msgstr "Syntax: set NAMN VÄRDE"
+
+#~ msgid "Unable to parse key binding"
+#~ msgstr "Kunde inte tolka tangentbordsgenväg"
+
+#~ msgid "I don't know what %ls means"
+#~ msgstr "Vet inte vad '%ls' betyder"
+
+#~ msgid "Error while reading input information from file '%ls'"
+#~ msgstr "Ett fel uppstod under inläsning av filen '%ls'"
+
+#~ msgid ""
+#~ "This is a circular dependency in the autoloading scripts, please remove "
+#~ "it."
+#~ msgstr ""
+#~ "Detta är ett cirkulärt beroende i de automatiskt laddade filerna, var "
+#~ "vänlig ta bort det."
+
+#~ msgid "Error while reading commands"
+#~ msgstr "Ett fel inträffade medan kommandon lästes in"
+
+#~ msgid ""
+#~ "%s: Warning: The directory %s has been removed from your PATH because it "
+#~ "does not exist\\n"
+#~ msgstr ""
+#~ "%s: Varning: Katalogen %s har tagits bort från din PATH eftersom den inte "
+#~ "existerar\\n"
+
+#~ msgid "Comma-separated list of dependancy types to follow recursively"
+#~ msgstr "Komma-separarad lista av beroendetyper att följa rekursivt"
+
+#~ msgid "Comma-separated list of dependancy types to show"
+#~ msgstr "Komma-separarad lista av beroendetyper att visa"
+
+#~ msgid "Run in noninteractive mode"
+#~ msgstr "Kör i icke-interaktivt läge"
+
+#
+#~ msgid "Change input mode"
+#~ msgstr "Ändra inmatningsläge"
+
+#~ msgid "Escape all non-printing characters"
+#~ msgstr "Ersätt oskrivbara tecken med specialsekvenser"
+
+#~ msgid "Number nonblank lines"
+#~ msgstr "Numrera icke-tomma rader"
+
+#~ msgid "Escape non-printing characters except tab"
+#~ msgstr "Erätt oskrivbarta tecken utom tab med specialsekvenser"
+
+#~ msgid "Display $ at end of line"
+#~ msgstr "Visa $ vid radslut"
+
+#~ msgid "Never more than single blank line"
+#~ msgstr "Visa maximalt en tom rad i följd"
+
+#~ msgid "Escape non-printing characters except newline"
+#~ msgstr "Erätt oskrivbarta tecken utom radbrytning med specialsekvenser"
+
+#~ msgid "Escape tab"
+#~ msgstr "Ersätt tab med specialsekvens"
+
+#~ msgid "Escape non-printing except newline and tab"
+#~ msgstr ""
+#~ "Erätt oskrivbarta tecken utom tab och radbrytning med specialsekvenser"
+
+#~ msgid "Dereferense symbolic links"
+#~ msgstr "Följ symboliska länkar"
+
+#~ msgid "Same as -dpR"
+#~ msgstr "Samma sak som -dpR"
+
+#~ msgid "Copy contents of special files when recursive"
+#~ msgstr "Kopiera innehåll i specialla filer i rekursivt läge"
+
+#~ msgid "Same as --no-dereference --preserve=link"
+#~ msgstr "Samma sak som --no-dereference --preserve=link"
+
+#~ msgid "Follow command-line symbolic links"
+#~ msgstr "Följ symboliska länkar från kommandoraden"
+
+#~ msgid "Link files instead of copying"
+#~ msgstr "Länka filer istället för att kopiera dem"
+
+#~ msgid "Always follow symbolic links"
+#~ msgstr "Följ alltid symboliska länkar"
+
+#~ msgid "Never follow symbolic links"
+#~ msgstr "Följ aldrig symboliska länkar"
+
+#~ msgid "Use full source file name under DIRECTORY"
+#~ msgstr "Använd fullt källfilsnamn under KATALOG"
+
+#~ msgid "Copy directories recursively"
+#~ msgstr "Kopiera kataloger rekursivt"
+
+#~ msgid ""
+#~ "Remove each existing destination file before attempting to open it "
+#~ "(contrast with --force)"
+#~ msgstr ""
+#~ "Ta bort varje existerande målfil innan försök att öppna den (jämför med --"
+#~ "force)"
+
+#~ msgid "Make symbolic links instead of copying"
+#~ msgstr "Skapa symboliska länkar istället för att kopiera"
+
+#~ msgid "Treat DEST as a normal file"
+#~ msgstr "Behandla DEST som en vanlig fil"
+
+#~ msgid "Stay on this file system"
+#~ msgstr "Stanna på detta filsystem"
+
+#~ msgid "Create patch format diffs between releases"
+#~ msgstr "Skapa differens mellan versioner i \"patch\"-format"
+
+#~ msgid "Specify legal cvsroot directory."
+#~ msgstr "Välj laglig cvsroot-katalog"
+
+#~ msgid "Authenticate all net traffic"
+#~ msgstr "Autentisera all nätverkstrafik"
+
+#~ msgid "Do not use the ~/.cvsrc file"
+#~ msgstr "Ignorera ~/.cvsrc"
+
+#~ msgid "Cause CVS to be really quiet"
+#~ msgstr "Gör CVS mycket tyst läge"
+
+#~ msgid "Cause CVS to be somewhat quiet"
+#~ msgstr "Gör CVS något tystare"
+
+#~ msgid "Make checked-out files read-only"
+#~ msgstr "Gör utcheckade filer skrivskyddade"
+
+#~ msgid "Show trace of program execution -- try with -n"
+#~ msgstr "Visa spår av programexekvering -- använd med -n"
+
+#~ msgid "Make checked-out files read-write (default)"
+#~ msgstr "Gör utcheckade filer läs och skrivbara"
+
+#~ msgid "Encrypt all net traffic"
+#~ msgstr "Kryptera all nätverkstrafik"
+
+#~ msgid "Use the most recent revision no later than date"
+#~ msgstr "Använd den senaste revisionen som ej är nyare än angivet datum"
+
+#~ msgid "Retrieve files even when no match for tag/date"
+#~ msgstr "Hämta filer även när ingen matchning finns för tagg/datum"
+
+#~ msgid "Alter default keyword processing"
+#~ msgstr "Ändra standardnyckelordsprocessning"
+
+#~ msgid "Don't recurse"
+#~ msgstr "Rekursera inte"
+
+#~ msgid "Specify log message instead of invoking editor"
+#~ msgstr "Ange logmeddelande istället för att anropa editor"
+
+#~ msgid "Don't run any tag programs"
+#~ msgstr "Kör inga taggningsprogram"
+
+#~ msgid "Prune empty directories"
+#~ msgstr "Rensa bort tomma kataloger"
+
+#~ msgid "Pipe files to stdout"
+#~ msgstr "Skicka filer till standard ut"
+
+#~ msgid "Process directories recursively"
+#~ msgstr "Processa underkataloger rekursivt"
+
+#~ msgid "Specify filenames to be filtered"
+#~ msgstr "Ange filnamn att filtrera"
+
+#~ msgid "Lock a revision"
+#~ msgstr "Lås en revision"
+
+#~ msgid "Force name/rev association"
+#~ msgstr "Tvinga namn/revision-association"
+
+#~ msgid "Make a name/rev association"
+#~ msgstr "Skapa namn/revision-association"
+
+#~ msgid "Run quietly"
+#~ msgstr "Tyst läge"
+
+#~ msgid "Set a state attribute for a revision"
+#~ msgstr "Välj ett tillståndsattribut för en revision"
+
+#~ msgid "Write descriptive text from a file into RCS"
+#~ msgstr "Skriv beskrivande text från en fil till RCS"
+
+#~ msgid "Write descriptive text into RCS"
+#~ msgstr "Skriv beskrivande text till RCS"
+
+#~ msgid "Unlock a revision"
+#~ msgstr "Lås upp revision"
+
+#~ msgid "Annotate binary files"
+#~ msgstr "Annotera binära filer"
+
+#~ msgid "Reset sticky tags/dates/k-opts"
+#~ msgstr "Återställ fasta tagg/datum/k-opts"
+
+#~ msgid "Copy module file to stdout"
+#~ msgstr "Kopiera modulfil till standard ut"
+
+#~ msgid "Name directory for working files"
+#~ msgstr "Ange katalog för arbetsfiler"
+
+#~ msgid "For -d. Don't shorten paths"
+#~ msgstr "För -d. Förkorta inte sökvägar"
+
+#~ msgid "Force new revision"
+#~ msgstr "Tvinga ny revision"
+
+#~ msgid "Treat all whitespace as one space"
+#~ msgstr "Behandla alla blanktecken som ett mellanslag"
+
+#~ msgid "Ignore blank line only changes"
+#~ msgstr "Ignorera ändringar som bara består av ändringar i tomma rader"
+
+#~ msgid "Binary mode"
+#~ msgstr "Binärt läge"
+
+#~ msgid "Report only whether files differ"
+#~ msgstr "Skriv bara ut huruvida filerna skiljer sig"
+
+#~ msgid "Use context format"
+#~ msgstr "Använd kontext-format"
+
+#~ msgid "Set context size"
+#~ msgstr "Välj kontextstorlek"
+
+#~ msgid "Set context format and, optionally, size"
+#~ msgstr "Välj kontextformat och eventuellt storlek"
+
+#~ msgid "Set line group format"
+#~ msgstr "Välj radgruppsformat"
+
+#~ msgid "Make output a valid ed script"
+#~ msgstr "Gör utdata till ett giltigt ed-skript"
+
+#~ msgid "Expand tabs to spaces"
+#~ msgstr "Expandera tabbar till mellanslag"
+
+#~ msgid "Output that looks like an ed script"
+#~ msgstr "Utdata ser ut som ett ed-skript"
+
+#~ msgid "Set regexp for context, unified formats"
+#~ msgstr "Välj reguljärt uttryck för kontext, unifierade format"
+
+#~ msgid "Speed handling of large files with small changes"
+#~ msgstr "Snabb hantering av stora filer med små ändringar"
+
+#~ msgid "Set horizon lines"
+#~ msgstr "Välj horisontlinjer"
+
+#~ msgid "Ignore changes in case"
+#~ msgstr "Ignorera ändringar i skiftläge"
+
+#~ msgid "Ignore changes matching regexp"
+#~ msgstr "Ignorera ändringar som matchar reguljärt uttryck"
+
+#~ msgid "Make ifdef from diff"
+#~ msgstr "Skapa ifdef från differens"
+
+#~ msgid "Ignore whitespace"
+#~ msgstr "Ignorera blanktecken"
+
+#~ msgid "Start lines with a tab"
+#~ msgstr "Starta rader med en tabb"
+
+#~ msgid "Use label instead of filename in output"
+#~ msgstr "Använd etikett istället för filnamn i utdata"
+
+#~ msgid "Print only left column"
+#~ msgstr "Visa bara vänster kolumn"
+
+#~ msgid "Use format to produce if-then-else output"
+#~ msgstr "Använd format för att producera if-then-else utdata"
+
+#~ msgid "Produce RCS-style diffs"
+#~ msgstr "Producera differenser i RCS-stil"
+
+#~ msgid "Treat files absent from one dir as empty"
+#~ msgstr "Behandla saknade filer från katalog som om de vore tomma"
+
+#~ msgid "Specifies line formatting"
+#~ msgstr "Ange radformatering"
+
+#~ msgid "Identify the C function each change is in"
+#~ msgstr "Identifiera vilken C-funktion varje ändring är i"
+
+#~ msgid "Report identical files"
+#~ msgstr "Rapportera identiska filer"
+
+#~ msgid "Use side-by-side format"
+#~ msgstr "Använd sida-vid-sida-format"
+
+#~ msgid "Suppress common lines in side-by-side"
+#~ msgstr "Undertryck vanliga rader i sida-vid-sida"
+
+#~ msgid "Use unified format"
+#~ msgstr "Använd unifierat format"
+
+#~ msgid "Set context size in unified"
+#~ msgstr "Välj kontextstorlek i unifierat format"
+
+#~ msgid "Set column width for side-by-side format"
+#~ msgstr "Välj kolumnbredd för sida-vis-sida-format"
+
+#~ msgid "Report on each commit"
+#~ msgstr "Rapport för varje tillägg"
+
+#~ msgid "Report on everything"
+#~ msgstr "Rapport för allt"
+
+#~ msgid "Report on a module"
+#~ msgstr "Rapport för modul"
+
+#~ msgid "Report on checked-out modules"
+#~ msgstr "Rapport för ut-checkade moduler"
+
+#~ msgid "Report on all tags"
+#~ msgstr "Rapport för alla taggar"
+
+#~ msgid "Show only records for this directory"
+#~ msgstr "Visa bara poster för angiven katalog"
+
+#~ msgid "Multiple vendor branch"
+#~ msgstr "Multipel distributör-gren"
+
+#~ msgid "Files to ignore during import"
+#~ msgstr "Filer att ignorera vid import"
+
+#~ msgid "Print info about revision on default branch"
+#~ msgstr "Visa information om revision i standardgren"
+
+#~ msgid "Specify date range for query"
+#~ msgstr "Ange dataspann för fråga"
+
+#~ msgid "Print only file info"
+#~ msgstr "Visa utförlig information"
+
+#~ msgid "Print only rcs filename"
+#~ msgstr "Skriv bara RCS-filnamn"
+
+#~ msgid "Suppress header if no revisions found"
+#~ msgstr "Visa inte huvud om inga revisioner hittas"
+
+#~ msgid "Same as -h, plus descriptive text"
+#~ msgstr "Samma som -h, men med beskrivande text"
+
+#~ msgid "Specify users for query"
+#~ msgstr "Ange användare för fråga"
+
+#~ msgid "Use context diff format"
+#~ msgstr "Användar kontextdifferensformat"
+
+#~ msgid "Create summary change report"
+#~ msgstr "Skapa översiktilig ändringsrapport"
+
+#~ msgid "diff top two revisions"
+#~ msgstr "Visa differens mellan två senaste revisioner"
+
+#~ msgid "Use unidiff format"
+#~ msgstr "Använd unidiff-format"
+
+#~ msgid "Reset sticky tags, dates, and k-opts"
+#~ msgstr "Återställ fasta taggar, datum och k-opts"
+
+#~ msgid "Overwrite modified files with clean copies"
+#~ msgstr "Skriv över ändrade filer med rena kopior"
+
+#~ msgid "Create any missing directories"
+#~ msgstr "Skapa saknade kataloger"
+
+#~ msgid "Specify files to ignore"
+#~ msgstr "Ange filer att ignorera"
+
+#~ msgid "Create new project"
+#~ msgstr "Skapa nytt projekt"
+
+#~ msgid ""
+#~ "In addition to modifications, look for files that are not boring, and "
+#~ "thus are potentially pending addition"
+#~ msgstr ""
+#~ "Förutom att lägga till ändringar, sök efter interessanta filer att lägga "
+#~ "till lagret"
+
+#~ msgid "Don't create compressed patches"
+#~ msgstr "Skapa inte komprimerade fixar"
+
+#~ msgid "Expect to receive input from a pipe"
+#~ msgstr "Förvänta indata från rör"
+
+#~ msgid "Ask for extra dependencies"
+#~ msgstr "Fråga efter extra beroenden"
+
+#~ msgid "Don't ask for extra dependencies"
+#~ msgstr "Fråga inte efter extra beroenden"
+
+#~ msgid ""
+#~ "Don't look for any files or directories that could be added, and don't "
+#~ "add them automatically"
+#~ msgstr ""
+#~ "Leta inte efter filer eller kataloger att lägga till, och lägg inte till "
+#~ "dem automatiskt"
+
+#~ msgid "Don't make scripts executable"
+#~ msgstr "Gör inte skript exekverbara"
+
+#~ msgid "Fail on patches that create conflicts [DEFAULT]"
+#~ msgstr "Misslyckas på fixar som skapar konflikter [STANDARD]"
+
+#~ msgid "Check patches since latest checkpoint"
+#~ msgstr "Kontrollera fixar sedan senaste kontrollpunkt"
+
+#~ msgid "Don't refuse to add files differing only in case"
+#~ msgstr "Vägra inte lägga till filer som bara skiljer i skiftläge"
+
+#~ msgid "Do not sign the patch"
+#~ msgstr "Signera inte fixen"
+
+#~ msgid "Use a plain pristine tree [DEFAULT]"
+#~ msgstr "Använd enkelt pristint träd [DEFAULT]"
+
+#~ msgid "Use no pristine tree"
+#~ msgstr "Använd inte pristint träd"
+
+#~ msgid "Give human readable output"
+#~ msgstr "Människoanpassad formatering av utdata"
+
+#~ msgid "Don't skip boring files"
+#~ msgstr "Skippa inte tråkiga filer"
+
+#~ msgid "Add contents of subdirectories"
+#~ msgstr "Lägg till innehåll i underkataloger"
+
+#~ msgid "Don't add contents of subdirectories"
+#~ msgstr "Lägg inte till innehåll i underkataloger"
+
+#~ msgid "Add files with date appended to avoid conflict. [EXPERIMENTAL]"
+#~ msgstr ""
+#~ "Lägg till filer med datum efter för att undvika konflikter. "
+#~ "[EEXPERIMENTELLT]"
+
+#~ msgid "Don't use experimental date appending trick. [DEFAULT]"
+#~ msgstr "Använd inte experimentellt datum-tillläggningstrick. [STANDARD]"
+
+#~ msgid "Rewrite all patches in current darcs format"
+#~ msgstr "Skriv om alla fixar till nuvarande darcs-format"
+
+#~ msgid "Do not run posthook command."
+#~ msgstr "Utför inte posthook-kommando"
+
+#~ msgid "Display date described by string"
+#~ msgstr "Visa datum angivet i textsträng"
+
+#~ msgid "Display date for each line in file"
+#~ msgstr "Visa datum för varje rad i fil"
+
+#~ msgid "Output in ISO 8601 format"
+#~ msgstr "Visa datum i ISO 8601-format"
+
+#~ msgid "Output RFC-2822 compliant date string"
+#~ msgstr "Visa datum i RFC-2822-format"
+
+#~ msgid "Display the last modification time of file"
+#~ msgstr "Visa senaste ändringsdatum för fil"
+
+#~ msgid "Print or set Coordinated Universal Time"
+#~ msgstr "Visa eller välj Koordinerad universaltid (UCT)"
+
+#~ msgid "List inode information"
+#~ msgstr "Lista information om inoder"
+
+#~ msgid "List only local filesystems"
+#~ msgstr "Lista bara lokala filsystem"
+
+#~ msgid "Use Posix format"
+#~ msgstr "Använd Posix-format"
+
+#~ msgid "Include empty filesystems"
+#~ msgstr "Inkludera tomma filsystem"
+
+#~ msgid "Do not sync before getting usage info"
+#~ msgstr "Synkronisera inte filsystem innan användningsinformation hämtas"
+
+#~ msgid "Sync before getting usage info"
+#~ msgstr "Synkronisera filsystem innan användningsinformation hämtas"
+
+#~ msgid "Print filesystem type"
+#~ msgstr "Visa filsystemtyp"
+
+#~ msgid "Excluded filesystem type"
+#~ msgstr "Exkludera filsystemtyp"
+
+#~ msgid "Show all filesystems"
+#~ msgstr "Visa alla filsystem"
+
+#~ msgid "Show sizes in gigabytes"
+#~ msgstr "Visa storlekar i gigabyte"
+
+#~ msgid "Show sizes in megabytes"
+#~ msgstr "Visa storlekar i megabyte"
+
+#~ msgid "Print out the previously obtained statistics from the file systems"
+#~ msgstr "Visa tidigare hämtad statistik från filsystemet"
+
+#~ msgid "Skip other filesystems"
+#~ msgstr "Skippa andra filsystem"
+
+#~ msgid "No newline"
+#~ msgstr "Skriv ingen radbrytning"
+
+#~ msgid "Use backslash escaped characters"
+#~ msgstr "Använd omvänt snedstreck-specialsekvenser"
+
+#~ msgid "Do not use backslash escaped characters"
+#~ msgstr "Använd inte omvänt snedstreck-specialsekvenser"
+
+#~ msgid "Do not load init files"
+#~ msgstr "Ladda inte initieringsfiler"
+
+#~ msgid "Load users init file"
+#~ msgstr "Ladda användarens initieringsfiler"
+
+#~ msgid "Use file as terminal"
+#~ msgstr "Användard fil som terminal"
+
+#~ msgid "Execute Lisp function"
+#~ msgstr "Utför lispfunktion"
+
+#~ msgid "Load Lisp code from file"
+#~ msgstr "Ladda lispfunktion från fil"
+
+#~ msgid "Do not use X interface"
+#~ msgstr "Använd inte X-användargränssnittet"
+
+#~ msgid "Create window on the specified display"
+#~ msgstr "Skapa fönster på angiven skärm"
+
+#~ msgid "Allow dash (-) in function name"
+#~ msgstr "Tillåt bindestreck (-) i funktionsnamn"
+
+#~ msgid "Language"
+#~ msgstr "Språk"
+
+#~ msgid "Pass program exit codes"
+#~ msgstr "Skicka vidare slutstatus"
+
+#~ msgid "Stop after assembler"
+#~ msgstr "Stanna efter assembler"
+
+#~ msgid "Stop after compile"
+#~ msgstr "Stanna efter kompilering"
+
+#~ msgid "Stop after preprocessor"
+#~ msgstr "Stanna efter förprocessor"
+
+#~ msgid "Print commands to stderr"
+#~ msgstr "Skriv kommandon till standard fel"
+
+#~ msgid "Print quoted commands to stderr, do not run"
+#~ msgstr "Skriv citerade kommandon till standard fel, utför dem inte"
+
+#~ msgid "Use pipes"
+#~ msgstr "Använd rör"
+
+#~ msgid "Use ansi mode"
+#~ msgstr "Använd ansiläge"
+
+#~ msgid "Do not recognize asm, inline or typeof keywords"
+#~ msgstr "Känn inte igen asm, inline och typeof nyckelorden"
+
+#~ msgid "Do not use builtin functions"
+#~ msgstr "Använd inte inbyggda funktioner"
+
+#~ msgid "Assert hosted environment"
+#~ msgstr "Försäkra värdmiljö"
+
+#~ msgid "Assert freestanding environment"
+#~ msgstr "Försäkra självständig miljö"
+
+#~ msgid "Use Microsoft extensions"
+#~ msgstr "Använd Microsoftförlängningar"
+
+#~ msgid "Use ANSI trigraphs"
+#~ msgstr "Använd ANSI-trigrafer"
+
+#~ msgid "Do not use integrated preprocessor"
+#~ msgstr "Använd inte inbyggd förprocessor"
+
+#~ msgid "char is unsigned"
+#~ msgstr "char har inte tecken"
+
+#~ msgid "char is signed"
+#~ msgstr "char har tecken"
+
+#~ msgid "bitfield is unsigned"
+#~ msgstr "bitfield har inte tecken"
+
+#~ msgid "bitfield is signed"
+#~ msgstr "bitfield har tecken"
+
+#~ msgid "All bitfields are signed"
+#~ msgstr "Alla bitfield har tecken"
+
+#~ msgid "All bitfields are unsigned"
+#~ msgstr "Inga bitfield har tecken"
+
+#~ msgid "String constants are not const"
+#~ msgstr "Strängkonstanter är inte konstanta"
+
+#~ msgid "C++ ABI version"
+#~ msgstr "C++ ABI-version"
+
+#~ msgid "Turn off access checking"
+#~ msgstr "Slå av rättighetskontroll"
+
+#~ msgid "Check pointer returned by new"
+#~ msgstr "Kontrollera pekare från 'new'"
+
+#~ msgid "Put globals in the common segment"
+#~ msgstr "Lägg globaler i det gemensamma segmentet"
+
+#~ msgid "Accept $ in identifiers"
+#~ msgstr "Acceptera $ i identifierare"
+
+#~ msgid "Reject $ in identifiers"
+#~ msgstr "Acceptera inte $ i identifierare"
+
+#~ msgid "Do not omit unneeded temporarys"
+#~ msgstr "Ta into bort onödiga tillfälliga variabler"
+
+#~ msgid "Allow exception violations"
+#~ msgstr "Tillåt brott mot undantag"
+
+#~ msgid "Do not extend for-loop scope"
+#~ msgstr "Utöka inte definitionsområde för for-loop"
+
+#~ msgid "Extend for-loop scope"
+#~ msgstr "Utöka definitionsområde för for-loop"
+
+#~ msgid "Do not recognize typeof as keyword"
+#~ msgstr "Känn inte igen typeof som nyckelord"
+
+#~ msgid "Do not emit code for implicit templates"
+#~ msgstr "Skapa inte kod for implicita mallar"
+
+#~ msgid "Do not emit code for implicit inline templates"
+#~ msgstr "Skapa inte kod för implicita inlinemallar"
+
+#~ msgid "Do not emit out-of-line code for inline functions"
+#~ msgstr "Skapa inte icke-inlinekod for inline-funktioner"
+
+#~ msgid "Disable some built-in functions"
+#~ msgstr "Inaktivera somliga inbyggda funktioner"
+
+#~ msgid "Disable operator keywords"
+#~ msgstr "Inaktivera operator-nyckelord"
+
+#~ msgid "Disable optional diagnostics"
+#~ msgstr "Inaktivera frivillig diagnostik"
+
+#~ msgid "Downgrade some errors to warnings"
+#~ msgstr "Nedgradera vissa fel till varningar"
+
+#~ msgid "Disable generation of C++ runtime type information"
+#~ msgstr ""
+#~ "Inaktivera generering av C++-typinformation under körning av program"
+
+#~ msgid "Do not emit code for thread-safe initialization of local statics"
+#~ msgstr ""
+#~ "Skapa inte kod för tråd-säker initiering av lokala statiska variabler"
+
+#~ msgid "Use __cxa_atexit for destructors"
+#~ msgstr "Använd __cxa_atexit för destruktorer"
+
+#~ msgid "Hides inline methods from export table"
+#~ msgstr "Dölj inline-metoder från exporttabeller"
+
+#~ msgid "Do not use weak symbol support"
+#~ msgstr "Stöd inte svaga symboler"
+
+#, fuzzy
+#~ msgid "Match only the base name against the specified patterns"
+#~ msgstr "Installera inte filer vars namn börjar med angiven sökväg"
+
+#, fuzzy
+#~ msgid "Ignore case distinctions when matching patterns"
+#~ msgstr "Ignorera skiftläge på filnamn"
+
+#, fuzzy
+#~ msgid "Ignored"
+#~ msgstr "Ignorera skiftläge"
+
+#, fuzzy
+#~ msgid "Write no messages about errors encountered"
+#~ msgstr "Visa meddelanden om vad programmet gör"
+
+#, fuzzy
+#~ msgid "Interpret all patterns as extended regexps"
+#~ msgstr "Mönster är ett förlängt reguljärt uttryck"
+
+#, fuzzy
+#~ msgid "Match only the whole path name against the specified patterns"
+#~ msgstr "Installera inte filer vars namn börjar med angiven sökväg"
+
+#~ msgid "Input is a file, use name and contents to determine mimetype"
+#~ msgstr ""
+#~ "Indata är en fil, använd namn och innehåll för att bestämma mime-typ"
+
+#~ msgid "Input is a file, use name to determine mimetype"
+#~ msgstr "Indata är en fil, använd namn för att bestämma mime-typ"
+
+#~ msgid "Input is a mimetype"
+#~ msgstr "Indata är en mime-typ"
+
+#~ msgid "Output mimetype"
+#~ msgstr "Utdata är mimetyp"
+
+#~ msgid "Output description of mimetype"
+#~ msgstr "Utdata är beskrivning av mimetyp"
+
+#~ msgid "Output default action for mimetype"
+#~ msgstr "Utdata är standardkommando för filtyp"
+
+#~ msgid "Launch default action for each file"
+#~ msgstr "Utför standardkommando för varje fil"
+
+#~ msgid "Mount filesystems in fstab"
+#~ msgstr "Montera filsystemen i fstab"
+
+#~ msgid "Invoke CPP"
+#~ msgstr "Kör C-förprocessorn"
+
+#~ msgid "Show threads"
+#~ msgstr "Visa trådar"
+
+#~ msgid "Ignore first line of input"
+#~ msgstr "Ignorera första raden indata"
+
+#~ msgid "Unlink directory (Only by superuser)"
+#~ msgstr "Avlänka katalog (Kan bara utföras av administratör)"
+
+#~ msgid "Never prompt before removal"
+#~ msgstr "Fråga inte före borttagning"
+
+#~ msgid "Prompt before removal"
+#~ msgstr "Fråga före borttagning"
+
+#~ msgid "Recursively remove subdirectories"
+#~ msgstr "Ta bort underkataloger rekursivt"
+
+#~ msgid "Explain what is done"
+#~ msgstr "Förklara vad som utförs"
+
+#~ msgid "Encyption program"
+#~ msgstr "Krypteringsprogram"
+
+#~ msgid "Disable all GNU extensions"
+#~ msgstr "Inaktivera alla GNU-förlängningar"
+
+#~ msgid "Use extended regexp"
+#~ msgstr "Använd utökade reguljära uttryck"
+
+#~ msgid "Consider files as separate"
+#~ msgstr "Betrakta filer separat"
+
+#~ msgid "Use minimal IO buffers"
+#~ msgstr "Minimera användning av IO-buffrar"
+
+#~ msgid ""
+#~ "Delay opening files until a command containing the related 'w' function "
+#~ "is applied"
+#~ msgstr ""
+#~ "Fördröj filöppnande till ett kommando inehållande den relaterade 'w' "
+#~ "functionen appliceras"
+
+#~ msgid "Set which jobs are out under job control"
+#~ msgstr "Välj vilka jobb som ställs under jobbkontroll"
+
+#~ msgid "Validate"
+#~ msgstr "Verifiera"
+
+#~ msgid "Place files or directories under version control"
+#~ msgstr "Placera filer och kataloger under versionskontroll"
+
+#~ msgid "Recursively clean up the working copy"
+#~ msgstr "Rensa arbetskopian rekursivt"
+
+#~ msgid "Pass contents of file as additional args"
+#~ msgstr "Skicka filinnehåll som extra argument"
+
+#~ msgid "Print as little as possible"
+#~ msgstr "Skriv ut så lite som möjligt"
+
+#~ msgid "Enable automatic properties"
+#~ msgstr "Aktivera automatiska egenskaper"
+
+#~ msgid "Print extra info"
+#~ msgstr "Visa utförlig information"
+
+#~ msgid "Don't unlock targets"
+#~ msgstr "Lås inte upp mål"
+
+#~ msgid "Descend recursively"
+#~ msgstr "Rekurivt läge"
+
+#~ msgid "Give output suitable for concatenation"
+#~ msgstr "Formatera utdata lämpligt för sammanslagning"
+
+#~ msgid "Disregard ignores"
+#~ msgstr "Strunta i ignores"
+
+#~ msgid "Print client version info"
+#~ msgstr "Visa klientversion"
+
+#, fuzzy
+#~ msgid "force operation to run"
+#~ msgstr "Tvinga operationen att utföras"
+
+#, fuzzy
+#~ msgid "print as little as possible"
+#~ msgstr "Skriv ut så lite som möjligt"
+
+#~ msgid "Logical and"
+#~ msgstr "Logisk 'och'"
+
+#~ msgid "Logical or"
+#~ msgstr "Logisk 'eller'"
+
+#~ msgid "Left file equal to right file"
+#~ msgstr "Vänster fil identisk med höger fil"
+
+#~ msgid "Left file newer than right file"
+#~ msgstr "Vänster fil nyare än höger fil"
+
+#~ msgid "Left file older than right file"
+#~ msgstr "Vänster fil är äldre än höger fil"
+
+#~ msgid "File is symlink"
+#~ msgstr "Fil är symbolisk länk"
+
+#~ msgid "File owned by effective group ID"
+#~ msgstr "Fil ägs av effektiv grupp-id"
+
+#~ msgid "File has sticky bit set"
+#~ msgstr "Fils fastbit är satt"
+
+#~ msgid "File owned by effective user ID"
+#~ msgstr "Fil ägd av effektiv användar-id"
+
+#~ msgid "File is named pipe"
+#~ msgstr "Fil är namngivet rör"
+
+#~ msgid "File is socket"
+#~ msgstr "Fil är uttag (socket)"
+
+#~ msgid "FD is terminal"
+#~ msgstr "Filidentifierare är terminal"
+
+#~ msgid "Maximium iterations"
+#~ msgstr "Maximalt antal step"
+
+#~ msgid "Change access time"
+#~ msgstr "Visa åtkomsttid"
+
+#~ msgid "Change modification time"
+#~ msgstr "Ändra ändringstid"
+
+#~ msgid "Use this files times"
+#~ msgstr "Använd denna fils tider"
+
+#~ msgid "Supress function and builtin lookup"
+#~ msgstr "Undertryck kontroll av funktioner och inbyggda kommandon"
+
+#~ msgid "Print number of occurences"
+#~ msgstr "Visa antal händelser"
+
+#~ msgid "Only print duplicates"
+#~ msgstr "Visa bara dubletter"
+
+#~ msgid "Remove non-duplicate lines"
+#~ msgstr "Ta bort rader som saknar dubletter"
+
+#~ msgid "Avoid comparing first N fields"
+#~ msgstr "Jämför inte första N fält"
+
+#~ msgid "Avoid comparing first N characters"
+#~ msgstr "Jämför inte de första N tecken"
+
+#~ msgid "Only print unique lines"
+#~ msgstr "Visa bara unika rader"
+
+#~ msgid "Compare only specified number of characters"
+#~ msgstr "Jämför bara angivet antal tecken"
+
+#~ msgid "Test if a key is contained in a set of values"
+#~ msgstr "Testa om en nyckel finns med i en uppsättning av värden"
+
+#~ msgid "%s: Unknown option '%s'\\n"
+#~ msgstr "%s: Okänd flagga '%s'\\n"
+
+#~ msgid "%s: Unknown argument '%s'\\n"
+#~ msgstr "%s: Okänt argument '%s'\\n"
+
+#~ msgid ""
+#~ "Current function definitions are:\n"
+#~ "\n"
+#~ msgstr ""
+#~ "Nuvarande funktionsdefinitioner är:\n"
+#~ "\n"
+
+#~ msgid ""
+#~ "Sent null command to subshell. This is a fish bug. If it can be "
+#~ "reproduced, please send a bug report to %s."
+#~ msgstr ""
+#~ "Skickade noll-kommando till subskal. Detta är en fish-bug. Om den kan "
+#~ "reproduceras, skicka en rapport till %s."
+
+#~ msgid "Parenthesis mismatch"
+#~ msgstr "Paranteser matchar inte varandra"
+
+#~ msgid "Invalid input"
+#~ msgstr "Ogiltig indata"
+
+#~ msgid ""
+#~ "Tests if emerge command should have package as potential completion for "
+#~ "removal"
+#~ msgstr ""
+#~ "Testa om emergekommando borde ha paket som potentiell komplettering för "
+#~ "borttagning"
+
+#~ msgid "Cleans the system by removing outdated packages"
+#~ msgstr "Rensa systemet genom att ta bort inaktuella paket"
+
+#~ msgid ""
+#~ "Cleans the system by removing packages that are not associated with "
+#~ "explicitly merged packages"
+#~ msgstr ""
+#~ "Rensa systemet genom att ta bort paket som int är associerade med "
+#~ "explicit installerade paket"
+
+#~ msgid ""
+#~ "Displays important portage variables that will be exported to ebuild.sh "
+#~ "when performing merges"
+#~ msgstr ""
+#~ "Visa viktiga portage-variabler som kommer esporteras till ebuild.sh vid "
+#~ "installationer"
+
+#~ msgid ""
+#~ "Causes portage to process all the metacache files as is normally done on "
+#~ "the tail end of an rsync update using emerge --sync"
+#~ msgstr ""
+#~ "Får portage att behandla alla metacache-filer som vanligtvis görs vid "
+#~ "slutet av en rsync-uppdatering vid användande av emerge --sync"
+
+#~ msgid ""
+#~ "Removes all but the most recently installed version of a package from "
+#~ "your system"
+#~ msgstr ""
+#~ "Tar bort alla utom den senast installerade versionen av ett paket från "
+#~ "ditt system"
+
+#~ msgid ""
+#~ "Causes portage to check and update the dependency cache of all ebuilds in "
+#~ "the portage tree"
+#~ msgstr ""
+#~ "Får portage att kontrollera och uppdatera beroendecachen av alla abuilds "
+#~ "i partageträdet"
+
+#~ msgid ""
+#~ "Searches for matches of the supplied string in the current local portage "
+#~ "tree"
+#~ msgstr ""
+#~ "Söker efter matchar till den angivna strängen i det nuvarande lokala "
+#~ "portageträdet"
+
+#~ msgid "Removes all matching packages completely from your system"
+#~ msgstr "Ta bort alla matchande paket helt från ditt system"
+
+#~ msgid ""
+#~ "Before performing the merge, display what ebuilds and tbz2s will be "
+#~ "installed, in the same format as when using --pretend"
+#~ msgstr ""
+#~ "Före installationen utförs, visa vilka ebuilds och tbz2:or som kommer "
+#~ "installeras, i samma format som vid --pretend"
+
+#~ msgid ""
+#~ "Tell emerge to build binary packages for all ebuilds processed in "
+#~ "addition to actually merging the packages"
+#~ msgstr ""
+#~ "Bygg binära paket för alla ebuilds som behandlats förutom att installera "
+#~ "paketen"
+
+#~ msgid "Creates a binary package, but does not merge it to the system"
+#~ msgstr "Skapa ett binärt paket, men installera dem inte"
+
+#~ msgid ""
+#~ "When pretending, also display the ChangeLog entries for packages that "
+#~ "will be upgraded"
+#~ msgstr ""
+#~ "Vid låtsasinstallation, visa också ChangeLog-filen för paketet som kommer "
+#~ "uppgraderas"
+
+#~ msgid "Tell emerge to run the ebuild command in --debug mode"
+#~ msgstr "Utför ebuild-kmmandot i '--debug'-läge"
+
+#~ msgid ""
+#~ "When used in conjunction with --update, this flag forces emerge to "
+#~ "consider the entire dependency tree of packages, instead of checking only "
+#~ "the immediate dependencies of the packages"
+#~ msgstr ""
+#~ "Vid användning med --update tvingar denna flagga emerge att betrakta hela "
+#~ "beroendeträdet av paket, istället för att bara kontrollera omedelbara "
+#~ "beroenden"
+
+#~ msgid "Virtually tweaks the tree of installed packages to contain nothing"
+#~ msgstr "Ändrar virtuellt trädet av installerade paket till att vara tomt"
+
+#~ msgid ""
+#~ "Instead of doing any package building, just perform fetches for all "
+#~ "packages (main package as well as all dependencies)"
+#~ msgstr ""
+#~ "Istället för att bygga paket, utför bara hämtning för alla paket "
+#~ "(huvudpaket och alla beroenden)"
+
+#~ msgid ""
+#~ "Same as --fetchonly except that all package files, including those not "
+#~ "required to build the package, will be processed"
+#~ msgstr ""
+#~ "Samma som --fetchonly utom att alla paketfiler, inklusive de som inte "
+#~ "krävs för att bygga paketet, processas"
+
+#~ msgid ""
+#~ "Using the server and location defined in PORTAGE_BINHOST, portage will "
+#~ "download the information from each binary file there and it will use that "
+#~ "information to help build the dependency list"
+#~ msgstr ""
+#~ "Portage laddar ner informationen från varje binär fil från servern och "
+#~ "platsen angivna i PORTAGE_BINHOST, och använder den informationen vid "
+#~ "konstruktionen av beroendeträdet"
+
+#~ msgid ""
+#~ "This option is identical to -g, except it will not use ANY information "
+#~ "from the local machine"
+#~ msgstr ""
+#~ "Samma sak som -g, utom at det kommer inte använda NÅGON information från "
+#~ "den lokala maskinen"
+
+#~ msgid ""
+#~ "Tells emerge to include installed packages where USE flags have changed "
+#~ "since installation"
+#~ msgstr ""
+#~ "Instruera emerge att inkludera installerade paket där USE-flaggor har "
+#~ "ändrats sedan senaste installation"
+
+#~ msgid ""
+#~ "Merge files in CONFIG_PROTECT to the live fs instead of silently dropping "
+#~ "them"
+#~ msgstr ""
+#~ "Installera filer i CONFIG_PROTECT till filsystemet istället för att tyst "
+#~ "ignorera dem"
+
+#~ msgid "Merge specified packages, but don't merge any dependencies"
+#~ msgstr "Installera angivna paket, men installera inga beroenden"
+
+#~ msgid ""
+#~ "Skip the packages specified on the command-line that have already been "
+#~ "installed"
+#~ msgstr "Skippa angivna paket som redan har installerats"
+
+#~ msgid "Disables the spinner regardless of terminal type"
+#~ msgstr "Avaktivera statusuppdateraren, oavsett terminaltyp"
+
+#~ msgid "Emerge as normal, but don't add packages to the world profile"
+#~ msgstr ""
+#~ "Kör emerge som vanligt, men lägg inte till paket till världsprofilen"
+
+#~ msgid ""
+#~ "Only merge (or pretend to merge) the dependencies of the specified "
+#~ "packages, not the packages themselves"
+#~ msgstr ""
+#~ "Installera (eller låtsas installera) bara beroendena till de angivna "
+#~ "paketen, inte själva paketen"
+
+#~ msgid ""
+#~ "Do not merge, display what ebuilds and tbz2s would have been installed"
+#~ msgstr ""
+#~ "Installera inte, visa vilka ebuilds och tbz2:or som skulle ha installerats"
+
+#~ msgid "Reduced output from portage's displays"
+#~ msgstr "Reducerad utdata från portage"
+
+#~ msgid ""
+#~ "Matches the search string against the description field as well the "
+#~ "package's name"
+#~ msgstr "Matchar söksträngen mot beskrivningsfältet samt paketets namn"
+
+#~ msgid ""
+#~ "Remove the first package in the resume list so that a merge may continue "
+#~ "in the presence of an uncorrectable or inconsequential error"
+#~ msgstr ""
+#~ "Ta bort det första paketet i resume-listan så att en installation kan "
+#~ "fortsätta vid irreparabelt eller oviktigt fel"
+
+#~ msgid "Shows the dependency tree using indentation for dependencies"
+#~ msgstr "Visa beroendeträdet med indentering för beroenden"
+
+#~ msgid ""
+#~ "Like --usepkg, except this only allows the use of binary packages, and it "
+#~ "will abort the emerge if the package is not available at the time of "
+#~ "dependency calculation"
+#~ msgstr ""
+#~ "Som --usepkg, men tillåter bara binära paket, och avbryter installationen "
+#~ "om paketet inte finns tillgängligt vid beroendeberäkningarna"
+
+#~ msgid "Increased or expanded display of content in portage's displays"
+#~ msgstr "Utökat utdata från portage"
+
+#~ msgid ""
+#~ "Displays the currently installed version of portage along with other "
+#~ "information useful for quick reference on a system"
+#~ msgstr ""
+#~ "Visar den för tillfället installerade versionen av portage och annan "
+#~ "information som är användbar som en snabbreferens för systemet"
+
+#~ msgid "A short summary of all builtin commands"
+#~ msgstr "En kort sammanfattning om alla inbyggda kommandon"
+
+#~ msgid "Increment priority by specified number first"
+#~ msgstr "Öka prioritet med angivet nummer först"
+
+#~ msgid "Pipe or short circuit command requires additional command"
+#~ msgstr "Pipa eller kortslutningkommando kräver ett efterföljande kommandon"
+
+#, fuzzy
+#~ msgid "%ls: Argument must be a number: %ls\n"
+#~ msgstr "%ls: Argumentet '%ls' måste vara ett heltal\n"
+
+#~ msgid "Could not set exit function"
+#~ msgstr "Kunde inte sätta avslutningsfunktionen"
+
+#~ msgid "No history item at index %d\n"
+#~ msgstr "Ingen historieinformation vid index %d\n"
+
+#~ msgid "%ls: Expected at least two arguments\n"
+#~ msgstr "%ls: Förväntade minst två argument\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,4 +1,3 @@
-# fish - the friendly interactive shell
 # Copyright © 2006
 # This file is distributed under the same license as the fish package.
 # Axel Liljencrantz <liljencrantz@gmail.com>, 2006
@@ -135,12 +134,9 @@ msgstr ""
 "%ls: Okänt fel inträffade vid försök att binda till tangent med namn '%ls'\n"
 
 #: src/builtin_bind.cpp:239 builtin.cpp:794
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: No binding found for key '%ls'\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: Beskrivning saknas för typ '%ls'\n"
 
 #: builtin.cpp:798
 #, c-format
@@ -247,12 +243,8 @@ msgid "%ls: Command not valid at an interactive prompt\n"
 msgstr ""
 
 #: src/builtin.cpp:410 src/builtin.cpp:460 builtin.cpp:4069 builtin.cpp:4113
-#, fuzzy
 msgid "Test a condition"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa ett villkor"
 
 #: builtin.cpp:4071
 msgid "Execute command if previous command suceeded"
@@ -328,12 +320,8 @@ msgid "Remove job from job list"
 msgstr ""
 
 #: src/builtin.cpp:431 builtin.cpp:4087
-#, fuzzy
 msgid "Print arguments"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa antal ord"
 
 #: builtin.cpp:4088
 msgid "Evaluate block if condition is false"
@@ -400,20 +388,12 @@ msgid "Execute command if previous command failed"
 msgstr "Kör ett kommando om föregående kommando misslyckades"
 
 #: src/builtin.cpp:448 builtin.cpp:4103
-#, fuzzy
 msgid "Prints formatted text"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriver ut formatterad text"
 
 #: src/builtin.cpp:449 builtin.cpp:4104
-#, fuzzy
 msgid "Print the working directory"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa nuvarande katalog"
 
 #: builtin.cpp:4105
 msgid "Generate random number"
@@ -436,12 +416,8 @@ msgid "Handle environment variables"
 msgstr "Redigera miljövariabler"
 
 #: src/builtin.cpp:455 builtin.cpp:4109
-#, fuzzy
 msgid "Set the terminal color"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Sätt terminalens färg"
 
 #: builtin.cpp:4110
 msgid "Evaluate contents of file"
@@ -568,15 +544,11 @@ msgid "%ls: Expected exactly one function name for --details\n"
 msgstr ""
 
 #: src/builtin_functions.cpp:342 builtin.cpp:1638
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "%ls: Expected exactly two names (current function name, and new function "
 "name)\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: Förväntade exakt två namn (nuvarande funktionsnamn, och nytt "
-"funktionsnamn)\n"
 
 #: builtin.cpp:1661 builtin.cpp:2230
 #, c-format
@@ -584,12 +556,9 @@ msgid "%ls: Illegal function name '%ls'\n"
 msgstr "%ls: Ogiltigt funktionsnamn '%ls'\n"
 
 #: src/builtin_functions.cpp:368 builtin.cpp:1672
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy '%ls'\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: Funktionen '%ls' existerar inte. Kan inte skapa kopia '%ls'\n"
 
 #: src/builtin_history.cpp:71 src/builtin_status.cpp:117
 #, c-format
@@ -639,12 +608,8 @@ msgid "Group\n"
 msgstr "Grupp\n"
 
 #: src/builtin_jobs.cpp:84 builtin_jobs.cpp:126
-#, fuzzy
 msgid "Process\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Process\n"
 
 #: builtin_jobs.cpp:143
 msgid "Command\n"
@@ -680,12 +645,9 @@ msgid "Number out of range"
 msgstr ""
 
 #: src/builtin_printf.cpp:249 builtin_printf.cpp:256
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: förväntade ett numeriskt värde"
 
 #: builtin_printf.cpp:258
 #, c-format
@@ -711,20 +673,14 @@ msgid "invalid field width: %ls"
 msgstr "oglitig fältvidd: %ls"
 
 #: src/builtin_printf.cpp:674 builtin_printf.cpp:708
-#, fuzzy, c-format
+#, c-format
 msgid "invalid precision: %ls"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"ogiltig precision %ls"
 
 #: src/builtin_printf.cpp:699 builtin_printf.cpp:739
-#, fuzzy, c-format
+#, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%.*ls: Ogiltig kombination av flaggor"
 
 #: src/builtin_read.cpp:123
 #, c-format
@@ -733,12 +689,9 @@ msgid ""
 msgstr ""
 
 #: src/builtin_read.cpp:132 builtin.cpp:2593
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: Argument '%ls' is out of range\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: Argumentet '%ls' är utanför spannet\n"
 
 #: src/builtin_read.cpp:344
 #, c-format
@@ -757,20 +710,14 @@ msgstr "%ls: Inte i en funktion\n"
 
 #: src/builtin_set_color.cpp:159 src/builtin_set_color.cpp:178
 #: builtin_set_color.cpp:144 builtin_set_color.cpp:166
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: Unknown color '%ls'\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%s: Okänd färg '%s'\n"
 
 #: src/builtin_set_color.cpp:167 builtin_set_color.cpp:153
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: Expected an argument\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%s: Förväntade ett argument\n"
 
 #: src/builtin_set.cpp:62
 #, c-format
@@ -788,12 +735,9 @@ msgid "%ls: You provided %d indexes but %d values\n"
 msgstr ""
 
 #: src/builtin_set.cpp:66 builtin_set.cpp:647
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: Erase needs a variable name\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: Radering kräver ett variabelnamn\n"
 
 #: src/builtin_set.cpp:67
 #, c-format
@@ -813,20 +757,14 @@ msgid "%ls: Tried to change the read-only variable '%ls'\n"
 msgstr "%ls: Försökte ändra den skrivskyddade variablen '%ls'\n"
 
 #: src/builtin_set.cpp:310 builtin_set.cpp:162
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: Tried to set the special variable '%ls' with the wrong scope\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: Försökte ändra den speciella variablen '%ls' med fel definitionsområde\n"
 
 #: src/builtin_set.cpp:317 builtin_set.cpp:169
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: Tried to set the special variable '%ls' to an invalid value\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: Försökte ändra den speciella variablen '%ls' till ett ogiltigt värde\n"
 
 #: builtin_set.cpp:248
 #, c-format
@@ -1014,12 +952,9 @@ msgid "empty"
 msgstr "tom"
 
 #: src/complete.cpp:53 complete.cpp:61
-#, fuzzy, c-format
+#, c-format
 msgid "Home for %ls"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Hemkatalog för %s"
 
 #: complete.cpp:66
 #, c-format
@@ -1153,12 +1088,9 @@ msgid "handler for generic event '%ls'"
 msgstr "hanterare för generisk händelse '%ls'"
 
 #: src/event.cpp:157 event.cpp:217
-#, fuzzy, c-format
+#, c-format
 msgid "Unknown event type '0x%x'"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Okänd händelsetyp '0x%x'"
 
 #: event.cpp:613
 msgid "Signal list overflow. Signals have been ignored."
@@ -1170,20 +1102,13 @@ msgid "An error occurred while redirecting file descriptor %d"
 msgstr "Ett fel inträffade vid IO dirigering av filidentifierare %d"
 
 #: src/exec.cpp:48 exec.cpp:62
-#, fuzzy
 msgid "An error occurred while writing output"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ett fel inträffade under skrivandet av utdata"
 
 #: src/exec.cpp:51 exec.cpp:67
-#, fuzzy, c-format
+#, c-format
 msgid "An error occurred while redirecting file '%s'"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ett fel inträffade vid IO dirigering av filen '%ls'"
 
 #: exec.cpp:795
 #, c-format
@@ -1311,23 +1236,15 @@ msgid "An error occured while reading output from code block on fd %d"
 msgstr ""
 
 #: src/output.cpp:559 output.cpp:608
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Tried to use terminfo string %s on line %ld of %s, which is undefined in "
 "terminal of type \"%ls\". Please report this error to %s"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Försökte använda terminfosträng %s på rad %d av %s, vilken är odefinerad i "
-"terminaler av typen '%ls'. Vänligen rapportera detta fel till %s"
 
 #: src/pager.cpp:40 pager.cpp:24
-#, fuzzy
 msgid "search: "
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"sök: "
 
 #: pager.cpp:566
 #, c-format
@@ -1335,28 +1252,18 @@ msgid "%lsand %lu more rows"
 msgstr "%lsoch %lu rader till"
 
 #: src/pager.cpp:500 pager.cpp:571
-#, fuzzy, c-format
+#, c-format
 msgid "rows %lu to %lu of %lu"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"rader %d till %d av %d"
 
 #: src/pager.cpp:503 pager.cpp:576
-#, fuzzy
 msgid "(no matches)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"(inga matchningar)"
 
 #: src/parse_execution.cpp:556 parse_execution.cpp:555
-#, fuzzy, c-format
+#, c-format
 msgid "switch: Expected exactly one argument, got %lu\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"switch: Förväntade exakt ett argument, fick %lu\n"
 
 #: src/parse_execution.cpp:791
 #, c-format
@@ -1366,28 +1273,19 @@ msgid ""
 msgstr ""
 
 #: src/parse_execution.cpp:796 parse_execution.cpp:848
-#, fuzzy, c-format
+#, c-format
 msgid "The file '%ls' is not executable by this user"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Filen '%ls' existerar redan"
 
 #: src/parse_execution.cpp:1007 parse_execution.cpp:1057
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid redirection target: %ls"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ogiltig IO omdirigering"
 
 #: src/parse_execution.cpp:1021 parse_execution.cpp:1081
-#, fuzzy, c-format
+#, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"IO dirigering till någonting som inte är en filidentifierare"
 
 #: parser.cpp:57
 #, c-format
@@ -1461,48 +1359,31 @@ msgid "in event handler: %ls\n"
 msgstr "i händelsehanterare: %ls\n"
 
 #: src/parser.cpp:385 parser.cpp:590
-#, fuzzy, c-format
+#, c-format
 msgid "from sourcing file %ls\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ett fel uppstod medan filen '%ls' lästes\n"
 
 #: src/parser.cpp:392 parser.cpp:597
-#, fuzzy, c-format
+#, c-format
 msgid "in function '%ls'\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"i funktion '%ls',\n"
 
 #: parser.cpp:602
 msgid "in command substitution\n"
 msgstr "i kommandosubstitution\n"
 
 #: src/parser.cpp:407 parser.cpp:615
-#, fuzzy, c-format
+#, c-format
 msgid "\tcalled on line %d of file %ls\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"\tanropad på rad %d i fil '%ls',\n"
 
 #: src/parser.cpp:410 parser.cpp:621
-#, fuzzy
 msgid "\tcalled during startup\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"\tanropad från standard in,\n"
 
 #: src/parser.cpp:412 parser.cpp:625
-#, fuzzy
 msgid "\tcalled on standard input\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"\tanropad från standard in,\n"
 
 #: parser.cpp:642
 #, c-format
@@ -1523,12 +1404,9 @@ msgid "Job inconsistency"
 msgstr "Jobb i ogiltigt tillstånd"
 
 #: src/parser.cpp:797 parser.cpp:1047
-#, fuzzy, c-format
+#, c-format
 msgid "%ls (line %lu): "
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls (rad %d): "
 
 #: src/parser.cpp:800 parser.cpp:1051
 #, c-format
@@ -1536,28 +1414,18 @@ msgid "%ls: "
 msgstr ""
 
 #: src/parse_util.cpp:28 parse_util.cpp:46
-#, fuzzy, c-format
+#, c-format
 msgid "The '%ls' command can not be used in a pipeline"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Detta kommando kan ej användas i ett rör"
 
 #: src/parse_util.cpp:32 parse_util.cpp:49
-#, fuzzy, c-format
+#, c-format
 msgid "The '%ls' command can not be used immediately after a backgrounded job"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Detta kommando kan ej användas i ett rör"
 
 #: src/parse_util.cpp:36 parse_util.cpp:52
-#, fuzzy
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Detta kommando kan ej användas i ett rör"
 
 #: path.cpp:24
 #, c-format
@@ -1603,20 +1471,14 @@ msgid "Job %d, "
 msgstr ""
 
 #: src/proc.cpp:587 proc.cpp:786
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: Jobb %d, '%ls' avslutat av signal %ls (%ls)"
 
 #: src/proc.cpp:595 proc.cpp:797
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: Process %d, '%ls' %ls'%ls' terminated by signal %ls (%ls)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%ls: Process %d, '%ls', från jobb %d, '%ls' avslutat av signal %ls (%ls)"
 
 #: proc.cpp:1065
 msgid "An error occured while reading output from code block"
@@ -1686,13 +1548,10 @@ msgid "There are still jobs active:\n"
 msgstr ""
 
 #: src/reader.cpp:2161
-#, fuzzy
 msgid ""
 "\n"
 "   PID  Command\n"
 msgstr ""
-"\n"
-"   PID  Command\n"
 
 #: src/reader.cpp:2170
 msgid "A second attempt to exit will terminate them.\n"
@@ -1721,12 +1580,8 @@ msgid "Error while opening input stream"
 msgstr "Ett fel inträffade medan indataström öppnades"
 
 #: src/sanity.cpp:18 sanity.cpp:37
-#, fuzzy
 msgid "Errors detected, shutting down. Break on sanity_lose() to debug."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fel har upptäckts, avslutar programmet"
 
 #: sanity.cpp:65
 #, c-format
@@ -1895,12 +1750,8 @@ msgid "Unexpected end of string, parenthesis do not match"
 msgstr "Oväntat slut på textsträng, paranteserna är inte balanserade"
 
 #: src/tokenizer.cpp:32 tokenizer.cpp:42
-#, fuzzy
 msgid "Unexpected end of string, square brackets do not match"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Oväntat slut på textsträng, paranteserna är inte balanserade"
 
 #: src/tokenizer.cpp:35
 msgid "Unexpected end of string, incomplete escape sequence"
@@ -1911,12 +1762,8 @@ msgid "Invalid input/output redirection"
 msgstr "Ogiltig IO dirigering"
 
 #: src/tokenizer.cpp:41 tokenizer.cpp:53
-#, fuzzy
 msgid "Cannot use stdin (fd 0) as pipe output"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Kan inte skicka rördata till filidentifierare 0"
 
 #: wgetopt.cpp:638
 #, c-format
@@ -2127,28 +1974,19 @@ msgid "Unknown builtin '%ls'"
 msgstr "Okänt inbyggt kommando '%ls'"
 
 #: src/parse_constants.h:239 parse_constants.h:204
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to expand variable name '%ls'"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ogiltigt variabelnamn '%ls'"
 
 #: src/parse_constants.h:242 parse_constants.h:207
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to find a process '%ls'"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Misslyckades med att exekvera processen '%ls'"
 
 #: src/parse_constants.h:245 parse_constants.h:210
-#, fuzzy, c-format
+#, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ogiltig filidentifierare '%ls'"
 
 #: parse_constants.h:213
 #, c-format
@@ -2241,29 +2079,17 @@ msgid "Packages that contain kernel modules"
 msgstr ""
 
 #: /tmp/fish/explicit/share/completions/emerge.fish:15
-#, fuzzy
 msgid "Pull in build time dependencies"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa byggberoenden"
 
 #: /tmp/fish/explicit/share/completions/emerge.fish:16
-#, fuzzy
 msgid "Don't pull in build time dependencies"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga efter extra beroenden"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:1
 #: share/completions/equery.fish:38
-#, fuzzy
 msgid "list all packages owning file(s)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa alla paket som äger filer"
 
 #: share/completions/equery.fish:39
 msgid "check MD5sums and timestamps of package"
@@ -2271,75 +2097,43 @@ msgstr "Kontrollera MD5-summor och tidsstämplar på paket"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:3
 #: share/completions/equery.fish:40
-#, fuzzy
 msgid "list all packages depending on specified package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa paket som beror på"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:4
 #: share/completions/equery.fish:41
-#, fuzzy
 msgid "display a dependency tree for package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa beroenden för paket"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:5
 #: share/completions/equery.fish:42
-#, fuzzy
 msgid "list files owned by package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa filer i paket"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:6
 #: share/completions/equery.fish:43
-#, fuzzy
 msgid "list all packages with specified useflag"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga ett (oinstallerat) paket i angiven fil"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:7
 #: share/completions/equery.fish:44
-#, fuzzy
 msgid "list all packages matching pattern"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lista innehåll av paket som matchar mönster"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:8
 #: share/completions/equery.fish:45
-#, fuzzy
 msgid "print size of files contained in package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa paketets triggerskript"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:9
 #: share/completions/equery.fish:46
-#, fuzzy
 msgid "display USE flags for package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa ändringsinformation för paket"
 
 #: /tmp/fish/explicit/share/completions/equery.fish:10
 #: share/completions/equery.fish:47
-#, fuzzy
 msgid "print full path to ebuild for package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa full sökväg till källkod"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:1
 #: share/completions/gem.fish:12
@@ -2353,66 +2147,38 @@ msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:3
 #: share/completions/gem.fish:14
-#, fuzzy
 msgid "Check installed gems"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga installerat paket"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:4
 #: share/completions/gem.fish:15
-#, fuzzy
 msgid "Cleanup old versions of installed gems in the local repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:5
 #: share/completions/gem.fish:16
-#, fuzzy
 msgid "Display the contents of the installed gems"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa låtsasinstallationsutdata i tabellform"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:6
 #: share/completions/gem.fish:17
-#, fuzzy
 msgid "Show the dependencies of an installed gem"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Verifiera inte beroenden före paketen avinstalleras"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:7
 #: share/completions/gem.fish:18
-#, fuzzy
 msgid "Display RubyGems environmental information"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa uppdateringsinformation"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:8
 #: share/completions/gem.fish:19
-#, fuzzy
 msgid "Provide help on the 'gem' command"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Hjälp för det angivna kommandot"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:9
 #: share/completions/gem.fish:20
-#, fuzzy
 msgid "Install a gem into the local repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Checka in filer till förråd"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:10
 #: share/completions/gem.fish:21
@@ -2421,12 +2187,8 @@ msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:11
 #: share/completions/gem.fish:22
-#, fuzzy
 msgid "Query gem information in local or remote repositories"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa information om lokal eller fjärrelement"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:12
 #: share/completions/gem.fish:23
@@ -2440,30 +2202,18 @@ msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:14
 #: share/completions/gem.fish:25
-#, fuzzy
 msgid "Display gem specification (in yaml)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa senaste ändringsdatum för fil"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:15
 #: share/completions/gem.fish:26
-#, fuzzy
 msgid "Uninstall a gem from the local repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ta bort ett inlägg från förråd"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:16
 #: share/completions/gem.fish:27
-#, fuzzy
 msgid "Unpack an installed gem to the current directory"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:17
 #: share/completions/gem.fish:28
@@ -2472,12 +2222,8 @@ msgstr ""
 
 #: /tmp/fish/explicit/share/completions/gem.fish:18
 #: share/completions/gem.fish:87
-#, fuzzy
 msgid "display the remote gem servers"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fil att hämta servrar från"
 
 #: /tmp/fish/explicit/share/completions/gem.fish:19
 #: share/completions/gem.fish:92
@@ -3507,9 +3253,8 @@ msgid "%s %s: Abbreviation %s cannot have spaces in the word\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/abbr.fish:4
-#, fuzzy
 msgid "%s %s: Expected one argument\\n"
-msgstr "%s %s: Expected one argument\\n"
+msgstr ""
 
 #: /tmp/fish/explicit/share/functions/abbr.fish:6
 #: /tmp/fish/explicit/share/functions/abbr.fish:10
@@ -3531,12 +3276,8 @@ msgstr ""
 
 #: /tmp/fish/explicit/share/functions/alias.fish:1
 #: share/functions/alias.fish:42
-#, fuzzy
 msgid "%s: Name cannot be empty\\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%s: Den tomma strängen är inte ett tillåtet variabelnamn\\n"
 
 #: /tmp/fish/explicit/share/functions/alias.fish:2
 #: share/functions/alias.fish:45
@@ -3755,12 +3496,8 @@ msgstr ""
 
 #: /tmp/fish/explicit/share/functions/funced.fish:5
 #: share/functions/funced.fish:110
-#, fuzzy
 msgid "Cancelled function editing"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"funktionsdefinition-block"
 
 #: share/functions/funcsave.fish:26
 msgid "%s: Could not create configuration directory\\n"
@@ -3775,20 +3512,12 @@ msgid "%s: Could not find a web browser.\\n"
 msgstr "%s: Kunde inte hitta en webbrowser\\n"
 
 #: /tmp/fish/explicit/share/functions/help.fish:3 share/functions/help.fish:129
-#, fuzzy
 msgid "help: Help is being displayed in your default browser.\\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"help: Hjälp visas i ditt standardsurfprogram"
 
 #: /tmp/fish/explicit/share/functions/help.fish:4 share/functions/help.fish:132
-#, fuzzy
 msgid "help: Help is being displayed in %s.\\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"help: Hjälp visas i %s\\n"
 
 #: /tmp/fish/explicit/share/functions/history.fish:1
 msgid "%ls: you cannot use any options with the %ls command\\n"
@@ -3861,36 +3590,24 @@ msgid "%s is a function with definition\\n"
 msgstr "%s är en funktion med definitionen\\n"
 
 #: /tmp/fish/explicit/share/functions/type.fish:2 share/functions/type.fish:94
-#, fuzzy
 msgid "function"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"funktion\\n"
 
 #: share/functions/type.fish:107
 msgid "%s is a builtin\\n"
 msgstr "%s är ett inbyggt kommando\\n"
 
 #: /tmp/fish/explicit/share/functions/type.fish:4 share/functions/type.fish:110
-#, fuzzy
 msgid "builtin"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"inbyggt kommando\\n"
 
 #: share/functions/type.fish:130
 msgid "%s is %s\\n"
 msgstr "%s är %s\\n"
 
 #: /tmp/fish/explicit/share/functions/type.fish:6 share/functions/type.fish:133
-#, fuzzy
 msgid "file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"fil\\n"
 
 #: share/functions/type.fish:144
 msgid "%s: Could not find '%s'\\n"
@@ -3920,15 +3637,10 @@ msgstr "%s: Okänd flagga '%s'\\n"
 
 #: /tmp/fish/explicit/share/functions/vared.fish:2
 #: share/functions/vared.fish:40
-#, fuzzy
 msgid ""
 "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element "
 "of %s\\n"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"%s: %s är en arrayvariabel. Använd %svared%s %s[n] för att redigera det n:te "
-"elementet av %s\\n"
 
 #: share/functions/vared.fish:44
 msgid ""
@@ -4401,12 +4113,8 @@ msgid "Output version information and exit"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/adb.fish:1 share/completions/adb.fish:3
-#, fuzzy
 msgid "Test if adb has yet to be given the subcommand"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/adb.fish:2
 #: share/completions/adb.fish:12
@@ -6345,12 +6053,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt-get.fish:11
 #: share/completions/apt-get.fish:29
-#, fuzzy
 msgid "Remove and purge one or more packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera ett eller flera paket"
 
 #: share/completions/apt-get.fish:30
 msgid "Remove one or more packages"
@@ -6378,12 +6082,8 @@ msgstr "Rengör paket som inte längre skall nedladdas"
 
 #: /tmp/fish/implicit/share/completions/apt-get.fish:18
 #: share/completions/apt-get.fish:36
-#, fuzzy
 msgid "Remove automatically installed packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga alla installerade paket"
 
 #: /tmp/fish/implicit/share/completions/apt-get.fish:19
 msgid "Do not install recommended packages"
@@ -6427,12 +6127,8 @@ msgstr "Testa om aptitude har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:2
 #: share/completions/aptitude.fish:12
-#, fuzzy
 msgid "Test if aptitude command should have packages as potential completion"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om aptkommando borde ha paket som potentiell komplettering"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:4
 msgid "Display a brief help message. Identical to the help action"
@@ -6440,12 +6136,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:5
 #: share/completions/aptitude.fish:24
-#, fuzzy
 msgid "Remove any cached packages which can no longer be downloaded"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Rengör paket som inte längre skall nedladdas"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:6
 #: share/completions/aptitude.fish:25
@@ -6463,48 +6155,28 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:9
 #: share/completions/aptitude.fish:28
-#, fuzzy
 msgid "Update the list of available packages from the apt sources"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Updatera källkodpaketlista"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:10
 #: share/completions/aptitude.fish:29
-#, fuzzy
 msgid "Upgrade installed packages to their most recent version"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa alla källkodspaket med version"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:11
 #: share/completions/aptitude.fish:30
-#, fuzzy
 msgid "Download and displays the Debian changelog for the packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa ändringsinformation för paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:12
 #: share/completions/aptitude.fish:31
-#, fuzzy
 msgid "Upgrade, removing or installing packages as necessary"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Bygg och installera nyaste paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:13
 #: share/completions/aptitude.fish:32
-#, fuzzy
 msgid "Download the packages to the current directory"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:14
 #: share/completions/aptitude.fish:33
@@ -6518,30 +6190,18 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:16
 #: share/completions/aptitude.fish:35
-#, fuzzy
 msgid "Install the packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installera nytt paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:17
 #: share/completions/aptitude.fish:36
-#, fuzzy
 msgid "Cancel any scheduled actions on the packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa ändringsinformation för paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:18
 #: share/completions/aptitude.fish:37
-#, fuzzy
 msgid "Mark packages as automatically installed"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:19
 #: share/completions/aptitude.fish:38
@@ -6550,30 +6210,18 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:20
 #: share/completions/aptitude.fish:39
-#, fuzzy
 msgid "Reinstall the packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ominstallera paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:21
 #: share/completions/aptitude.fish:40
-#, fuzzy
 msgid "Remove the packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:22
 #: share/completions/aptitude.fish:41
-#, fuzzy
 msgid "Display detailed information about the packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa ändringsinformation för paket"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:23
 #: share/completions/aptitude.fish:42
@@ -6582,21 +6230,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:24
 #: share/completions/aptitude.fish:43
-#, fuzzy
 msgid "Mark packages as manually installed"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:25
 #: share/completions/aptitude.fish:44
-#, fuzzy
 msgid "Search for packages matching one of the patterns"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Sök paket innehållande mönster"
 
 #: /tmp/fish/implicit/share/completions/aptitude.fish:26
 #: share/completions/aptitude.fish:45
@@ -6805,21 +6445,13 @@ msgstr "Välj än inställningsprofil"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:5
 #: share/completions/apt-mark.fish:24
-#, fuzzy
 msgid "Mark a package as automatically installed"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:6
 #: share/completions/apt-mark.fish:25
-#, fuzzy
 msgid "Mark a package as manually installed"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:7
 #: share/completions/apt-mark.fish:26
@@ -6828,48 +6460,28 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:8
 #: share/completions/apt-mark.fish:27
-#, fuzzy
 msgid "Cancel a hold on a package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa info om paket"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:9
 #: share/completions/apt-mark.fish:28
-#, fuzzy
 msgid "Show automatically installed packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga alla installerade paket"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:10
 #: share/completions/apt-mark.fish:29
-#, fuzzy
 msgid "Show manually installed packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga alla installerade paket"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:11
 #: share/completions/apt-mark.fish:30
-#, fuzzy
 msgid "Show held packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa uppgraderade paket"
 
 #: /tmp/fish/implicit/share/completions/apt-mark.fish:15
 #: share/completions/apt-mark.fish:34
-#, fuzzy
 msgid "Write package statistics to a file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv prototyper till fil"
 
 #: /tmp/fish/implicit/share/completions/apt-move.fish:1
 msgid "Generate master file"
@@ -9746,21 +9358,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:1
 #: share/completions/bundle.fish:3
-#, fuzzy
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om aptitude har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:2
 #: share/completions/bundle.fish:11
-#, fuzzy
 msgid "Test if bundle has been given a specific subcommand"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om aptitude har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:3
 msgid "Specify the number of times you wish to attempt network commands"
@@ -9776,12 +9380,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:6
 #: share/completions/bundle.fish:31
-#, fuzzy
 msgid "Display a help page"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa manualsida"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:7
 msgid "Prints version information"
@@ -9796,30 +9396,18 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bundle.fish:9
 #: /tmp/fish/implicit/share/completions/bundle.fish:57
 #: share/completions/bundle.fish:40 share/completions/bundle.fish:106
-#, fuzzy
 msgid "The location of the Gemfile bundler should use"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:10
 #: share/completions/bundle.fish:41
-#, fuzzy
 msgid "The location to install the gems in the bundle to"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:11
 #: share/completions/bundle.fish:42
-#, fuzzy
 msgid "Installs the gems in the bundle to the system location"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:12
 #: share/completions/bundle.fish:43
@@ -9870,21 +9458,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:21
 #: share/completions/bundle.fish:52
-#, fuzzy
 msgid "Do not print progress information to stdout"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa all information"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:22
 #: share/completions/bundle.fish:53
-#, fuzzy
 msgid "Run bundle clean automatically after install"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Upgradera paket om det är installerat"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:23
 #: /tmp/fish/implicit/share/completions/bundle.fish:30
@@ -9895,12 +9475,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bundle.fish:24
 #: /tmp/fish/implicit/share/completions/bundle.fish:89
 #: share/completions/bundle.fish:55 share/completions/bundle.fish:164
-#, fuzzy
 msgid "Do not remove stale gems from the cache"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ta bort alla gz-filer från cache"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:25
 #: share/completions/bundle.fish:56
@@ -9910,12 +9486,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bundle.fish:26
 #: /tmp/fish/implicit/share/completions/bundle.fish:41
 #: share/completions/bundle.fish:59 share/completions/bundle.fish:84
-#, fuzzy
 msgid "Update dependencies to their latest versions"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa alla källkodspaket med version"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:27
 #: share/completions/bundle.fish:60
@@ -9934,21 +9506,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:31
 #: share/completions/bundle.fish:64
-#, fuzzy
 msgid "Specify the number of jobs to run in parallel"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange antalet bytes av data att sicka"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:32
 #: share/completions/bundle.fish:65
-#, fuzzy
 msgid "Update a specific group"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Använd angiven tagg"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:33
 #: share/completions/bundle.fish:69
@@ -9959,21 +9523,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:34
 #: share/completions/bundle.fish:72
-#, fuzzy
 msgid "Install the binstubs of the listed gem"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa låtsasinstallationsutdata i tabellform"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:35
 #: share/completions/bundle.fish:73
-#, fuzzy
 msgid "Binstub destination directory (default bin)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installera dokumentation (standard)"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:36
 #: share/completions/bundle.fish:74
@@ -9998,21 +9554,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:42
 #: share/completions/bundle.fish:85
-#, fuzzy
 msgid "Package .gem files into the vendor/cache directory"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ändra arbetskatalog"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:44
 #: share/completions/bundle.fish:87
-#, fuzzy
 msgid "Specify and read configuration options for bundler"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj en konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:45
 #: share/completions/bundle.fish:88
@@ -10021,21 +9569,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:46
 #: share/completions/bundle.fish:89
-#, fuzzy
 msgid "Show all of the gems in the current bundle"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:47
 #: share/completions/bundle.fish:90
-#, fuzzy
 msgid "Show the source location of a particular gem in the bundle"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa process-id för varje process i jobbet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:48
 #: /tmp/fish/implicit/share/completions/bundle.fish:64
@@ -10057,12 +9597,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:52
 #: share/completions/bundle.fish:95
-#, fuzzy
 msgid "Generate a simple Gemfile"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Generera huvudfil"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:53
 #: /tmp/fish/implicit/share/completions/bundle.fish:78
@@ -10073,12 +9609,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/bundle.fish:54
 #: /tmp/fish/implicit/share/completions/bundle.fish:83
 #: share/completions/bundle.fish:97 share/completions/bundle.fish:154
-#, fuzzy
 msgid "Displays platform compatibility information"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa uppdateringsinformation"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:55
 #: /tmp/fish/implicit/share/completions/bundle.fish:85
@@ -10100,12 +9632,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:59
 #: share/completions/bundle.fish:108
-#, fuzzy
 msgid "Lock the Gemfile"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Logga till spårfil"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:60
 #: /tmp/fish/implicit/share/completions/bundle.fish:62
@@ -10123,12 +9651,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:65
 #: share/completions/bundle.fish:122
-#, fuzzy
 msgid "Check for newer pre-release gems"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Kontrollera förekomst av minnesläckor"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:66
 #: share/completions/bundle.fish:123
@@ -10152,12 +9676,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:73
 #: share/completions/bundle.fish:138
-#, fuzzy
 msgid "Show each gem version"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Källkodsträdsversion"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:74
 #: share/completions/bundle.fish:139
@@ -10170,12 +9690,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:76
 #: share/completions/bundle.fish:143
-#, fuzzy
 msgid "Generate a simple Gemfile, placed in the current directory"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:77
 #: share/completions/bundle.fish:144
@@ -10194,12 +9710,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:81
 #: share/completions/bundle.fish:150
-#, fuzzy
 msgid "Path to your editor"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj källkatalog"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:82
 #: share/completions/bundle.fish:151
@@ -10208,12 +9720,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:84
 #: share/completions/bundle.fish:155
-#, fuzzy
 msgid "Only display Ruby directive information"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa uppdateringsinformation"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:86
 #: share/completions/bundle.fish:159
@@ -10237,21 +9745,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:91
 #: share/completions/bundle.fish:168
-#, fuzzy
 msgid "Prints the license of all gems in the bundle"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/bundle.fish:92
 #: share/completions/bundle.fish:171
-#, fuzzy
 msgid "Print information about the environment Bundler is running under"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Hämta ändringar från förrådet till arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/bunzip2.fish:3
 #: /tmp/fish/implicit/share/completions/bzip2.fish:5
@@ -12309,12 +11809,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:19
 #: share/completions/cvs.fish:35
-#, fuzzy
 msgid "Set CVS user variable."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj CVS-användare"
 
 #: share/completions/cvs.fish:41
 msgid "Add a new file/directory to the repository"
@@ -12431,12 +11927,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:61
 #: share/completions/cvs.fish:94
-#, fuzzy
 msgid "Set keyword substitution mode:"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange standardnyckelordssubstitution"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:62
 msgid "[rev]    Lock revision (latest revision on branch,"
@@ -12619,22 +12111,14 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:99
 #: share/completions/cvs.fish:150
-#, fuzzy
 msgid "Read the log message from file."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Läs loggmeddelande från fil"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:100
 #: /tmp/fish/implicit/share/completions/cvs.fish:180
 #: share/completions/cvs.fish:151
-#, fuzzy
 msgid "Log message."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ersätt ett loggmeddelande"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:101
 #: share/completions/cvs.fish:152
@@ -12644,12 +12128,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/cvs.fish:104
 #: /tmp/fish/implicit/share/completions/cvs.fish:218
 #: share/completions/cvs.fish:161
-#, fuzzy
 msgid "Specify keyword expansion mode."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj kärnversion"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:105
 #: share/completions/cvs.fish:162
@@ -12689,12 +12169,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:113
 #: share/completions/cvs.fish:170
-#, fuzzy
 msgid "--ignore-matching-lines=RE  Ignore changes whose lines all match RE."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ignorera ändringar som matchar REGEX"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:114
 msgid "Binary  Read and write data in binary mode."
@@ -12844,12 +12320,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:153
 #: share/completions/cvs.fish:228
-#, fuzzy
 msgid "Export tagged revisions."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Slå ihop revisioner"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:154
 #: share/completions/cvs.fish:229
@@ -12885,12 +12357,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:161
 #: share/completions/cvs.fish:242
-#, fuzzy
 msgid "Extract by record type"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange posttyp"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:162
 msgid "Everything (same as -x, but all record types)"
@@ -12910,12 +12378,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:166
 #: share/completions/cvs.fish:247
-#, fuzzy
 msgid "Since date (Many formats)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Format för profileringsdata"
 
 #: /tmp/fish/implicit/share/completions/cvs.fish:167
 #: share/completions/cvs.fish:248
@@ -13294,12 +12758,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:3
 #: share/completions/darcs.fish:19
-#, fuzzy
 msgid "Display help about darcs and darcs commands"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa användningsinformation för kommando"
 
 #: share/completions/darcs.fish:20
 msgid "Add one or more new files or directories"
@@ -13307,21 +12767,13 @@ msgstr "Lägg till filer eller kataloger till lagret"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:5
 #: share/completions/darcs.fish:21
-#, fuzzy
 msgid "Remove files from version control"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Placera filer och kataloger under versionskontroll"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:6
 #: share/completions/darcs.fish:22
-#, fuzzy
 msgid "Move or rename files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skapa inte fil"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:7
 #: share/completions/darcs.fish:23
@@ -13330,12 +12782,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:8
 #: share/completions/darcs.fish:24
-#, fuzzy
 msgid "Discard unrecorded changes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa olagrade ändringar i arbetskopian"
 
 #: share/completions/darcs.fish:25
 msgid "Undo the last revert (may fail if changes after the revert)"
@@ -13345,21 +12793,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:10
 #: share/completions/darcs.fish:26
-#, fuzzy
 msgid "List unrecorded changes in the working tree"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa olagrade ändringar i arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:11
 #: share/completions/darcs.fish:27
-#, fuzzy
 msgid "Create a patch from unrecorded changes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skapa komprimerade fixar"
 
 #: share/completions/darcs.fish:28
 msgid "Remove recorded patches without changing the working copy"
@@ -13367,21 +12807,13 @@ msgstr "Ta bort lagrade fixar utan att ändra arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:13
 #: share/completions/darcs.fish:29
-#, fuzzy
 msgid "Improve a patch before it leaves your repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ersätt den lagrade fixen med en bättre version"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:14
 #: share/completions/darcs.fish:30
-#, fuzzy
 msgid "Mark unresolved conflicts in working tree, for manual resolution"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Markera konflikter mot arketskopian för manuell lösning"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:15
 #: share/completions/darcs.fish:31
@@ -13390,12 +12822,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:16
 #: share/completions/darcs.fish:32
-#, fuzzy
 msgid "Set a preference (test, predist, boringfile or binariesfile)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj ett värde för en preferens (test, predisk, ...)"
 
 #: share/completions/darcs.fish:33
 msgid "Create a diff between two versions of the repository"
@@ -13403,12 +12831,8 @@ msgstr "Skappa en diff mellan två versioner i lagret"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:18
 #: share/completions/darcs.fish:34
-#, fuzzy
 msgid "List patches in the repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Uppdatera förråd"
 
 #: share/completions/darcs.fish:35
 msgid "Display which patch last modified something"
@@ -13433,12 +12857,8 @@ msgstr "Kopiera och applicera fixar från ett annat förråd till detta"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:24
 #: share/completions/darcs.fish:40
-#, fuzzy
 msgid "Delete selected patches from the repository. (UNSAFE!)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ordna om fixarna i förrådet"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:25
 #: share/completions/darcs.fish:41
@@ -13492,23 +12912,15 @@ msgstr "Välj ändringar som börjar med tagg som matchar REGEXP"
 #: /tmp/fish/implicit/share/completions/darcs.fish:495
 #: /tmp/fish/implicit/share/completions/darcs.fish:520
 #: share/completions/darcs.fish:378
-#, fuzzy
 msgid "Select a single patch matching PATTERN"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj fix som matchar MÖNSTER"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:412
 #: /tmp/fish/implicit/share/completions/darcs.fish:496
 #: /tmp/fish/implicit/share/completions/darcs.fish:521
 #: share/completions/darcs.fish:379
-#, fuzzy
 msgid "Select a single patch matching REGEXP"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj fix som matchar REGEXP"
 
 #: share/completions/darcs.fish:343 share/completions/darcs.fish:557
 #: share/completions/darcs.fish:770
@@ -13518,12 +12930,8 @@ msgstr "Välj angivet antal fixar av de senaste fixarna"
 #: /tmp/fish/implicit/share/completions/darcs.fish:414
 #: /tmp/fish/implicit/share/completions/darcs.fish:446
 #: share/completions/darcs.fish:558
-#, fuzzy
 msgid "Select a range of patches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj angivet antal fixar av de senaste fixarna"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:415
 msgid "Specify diff command (ignores --diff-opts)"
@@ -13694,12 +13102,8 @@ msgstr ""
 #: share/completions/darcs.fish:841 share/completions/darcs.fish:893
 #: share/completions/darcs.fish:1183 share/completions/darcs.fish:1208
 #: share/completions/darcs.fish:1239
-#, fuzzy
 msgid "Specify command to run after this darcs command"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange kommando att köra efter detta darcs-kommando"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:432
 #: /tmp/fish/implicit/share/completions/darcs.fish:482
@@ -13790,12 +13194,8 @@ msgstr ""
 #: share/completions/darcs.fish:1010 share/completions/darcs.fish:1054
 #: share/completions/darcs.fish:1095 share/completions/darcs.fish:1122
 #: share/completions/darcs.fish:1155
-#, fuzzy
 msgid "Specify command to run before this darcs command"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange kommando att köra efter detta darcs-kommando"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:436
 #: /tmp/fish/implicit/share/completions/darcs.fish:486
@@ -13993,12 +13393,8 @@ msgstr "Välj tagg som matchar REGEXP"
 #: /tmp/fish/implicit/share/completions/darcs.fish:498
 #: /tmp/fish/implicit/share/completions/darcs.fish:523
 #: share/completions/darcs.fish:380
-#, fuzzy
 msgid "Select one patch"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj en handling"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:518
 msgid "Name of version"
@@ -14083,12 +13479,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/darcs.fish:726
 #: /tmp/fish/implicit/share/completions/darcs.fish:781
 #: share/completions/darcs.fish:886
-#, fuzzy
 msgid "Specify the remote repository URL to work with"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange förråd-URL"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:603
 #: /tmp/fish/implicit/share/completions/darcs.fish:648
@@ -14144,30 +13536,18 @@ msgstr "Välj destinationsadress"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:752
 #: share/completions/darcs.fish:918
-#, fuzzy
 msgid "Mail results to additional EMAIL(s)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Posta resultat till extra adresser. (Kräver --reply)"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:753
 #: share/completions/darcs.fish:919
-#, fuzzy
 msgid "Specify mail subject"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange makefil"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:754
 #: share/completions/darcs.fish:920
-#, fuzzy
 msgid "Specify in-reply-to header"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj indexkatalog"
 
 #: share/completions/darcs.fish:921
 msgid "Specify output filename"
@@ -14186,12 +13566,8 @@ msgid "Keep the logfile when done [DEFAULT]"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:798
-#, fuzzy
 msgid "Verify using openSSL with authorized keys from file KEYS"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Verifiera med openSSL med auktoriserade nycklar från angiven fil"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:806
 msgid "Equivalent to --dont-allow-conflicts, for backwards compatibility"
@@ -14236,12 +13612,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/darcs.fish:850
 #: /tmp/fish/implicit/share/completions/darcs.fish:883
 #: share/completions/darcs.fish:1028
-#, fuzzy
 msgid "Version specified by the context in FILENAME"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skicka till sammanhang lagrat i FILNAMN"
 
 #: /tmp/fish/implicit/share/completions/darcs.fish:855
 #: /tmp/fish/implicit/share/completions/darcs.fish:885
@@ -14328,12 +13700,8 @@ msgid "display help and exit"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/dd.fish:3 share/completions/dd.fish:5
-#, fuzzy
 msgid "Complete dd operands"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Jämför FIL1 med alla operander"
 
 #: /tmp/fish/implicit/share/completions/defaults.fish:1
 msgid "Restricts preferences operations to the current logged-in host"
@@ -15337,12 +14705,8 @@ msgid "Skip other file systems"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/du.fish:15 share/completions/du.fish:15
-#, fuzzy
 msgid "Exclude files that match pattern in file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Exkludera filer som matchar mönster från fil"
 
 #: share/completions/du.fish:16
 msgid "Exclude files that match pattern"
@@ -15358,12 +14722,8 @@ msgstr "Rekursionsgräns"
 #: /tmp/fish/implicit/share/completions/netctl-auto.fish:15
 #: /tmp/fish/implicit/share/completions/netctl.fish:17
 #: share/completions/duply.fish:3
-#, fuzzy
 msgid "Profile"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:2
 #: share/completions/duply.fish:4
@@ -15372,12 +14732,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:3
 #: share/completions/duply.fish:7
-#, fuzzy
 msgid "Creates a configuration profile"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:4
 #: share/completions/duply.fish:8
@@ -15386,30 +14742,18 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:5
 #: share/completions/duply.fish:9
-#, fuzzy
 msgid "Backup without executing pre/post scripts"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Kör inte post-skript"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:6
 #: share/completions/duply.fish:10
-#, fuzzy
 msgid "Execute <profile>/pre script"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Kör inte pre-skript"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:7
 #: share/completions/duply.fish:11
-#, fuzzy
 msgid "Execute <profile>/post script"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Kör inte post-skript"
 
 #: /tmp/fish/implicit/share/completions/duply.fish:8
 #: share/completions/duply.fish:12
@@ -15483,12 +14827,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/duply.fish:22
 #: share/completions/duply.fish:28
-#, fuzzy
 msgid "Output verbosity level"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Återställ felrapporteringsnivå till 0"
 
 #: /tmp/fish/implicit/share/completions/echo.fish:1
 msgid "Do not output a newline"
@@ -16016,14 +15356,10 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/emerge.fish:4
 #: share/completions/emerge.fish:32
-#, fuzzy
 msgid ""
 "Print completions for all packages including the version compare if that is "
 "already typed"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa kompletteringar för installerade packet på systemet från /var/db/pkg"
 
 #: /tmp/fish/implicit/share/completions/emerge.fish:5
 msgid "Synchronize the portage tree"
@@ -16286,14 +15622,10 @@ msgstr "Omdefinera variabel"
 
 #: /tmp/fish/implicit/share/completions/equery.fish:3
 #: share/completions/equery.fish:19
-#, fuzzy
 msgid ""
 "Prints completions for all available categories on the system from /usr/"
 "portage"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa kompletteringar för installerade packet på systemet från /var/db/pkg"
 
 #: /tmp/fish/implicit/share/completions/equery.fish:4
 msgid "causes minimal output to be emitted"
@@ -17220,12 +16552,8 @@ msgid "Alternate list of files containing magic numbers"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:1
-#, fuzzy
 msgid "Never follow symlinks"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Följ aldrig symboliska länkar"
 
 #: /tmp/fish/implicit/share/completions/find.fish:3
 msgid ""
@@ -17238,12 +16566,8 @@ msgid "Measure from the beginning of today rather than  from  24  hours ago"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:5
-#, fuzzy
 msgid "Process subdirectories before the directory itself"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Processa underkataloger rekursivt"
 
 #: /tmp/fish/implicit/share/completions/find.fish:7
 msgid ""
@@ -17253,12 +16577,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/find.fish:8
 #: /tmp/fish/implicit/share/completions/zfs.fish:66
 #: /tmp/fish/implicit/share/completions/zfs.fish:76
-#, fuzzy
 msgid "Maximum recursion depth"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Maximal 'resident set size'"
 
 #: /tmp/fish/implicit/share/completions/find.fish:9
 msgid "Do not apply any tests or actions at levels less than specified level"
@@ -17283,32 +16603,20 @@ msgid "Specify regular expression type"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:15
-#, fuzzy
 msgid "Turn warnings on"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa inte varningar"
 
 #: /tmp/fish/implicit/share/completions/find.fish:16
-#, fuzzy
 msgid "Turn warnings off"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa inte varningar"
 
 #: /tmp/fish/implicit/share/completions/find.fish:17
 msgid "File last accessed specified number of minutes ago"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:18
-#, fuzzy
 msgid "File last accessed more recently than file was modified"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa senaste revision vid vilken vare rad ändrades"
 
 #: /tmp/fish/implicit/share/completions/find.fish:19
 msgid "File last accessed specified number of days ago"
@@ -17331,36 +16639,20 @@ msgid "File is empty and is either a regular file or a directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:25
-#, fuzzy
 msgid "Always false"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Formatera alltid om"
 
 #: /tmp/fish/implicit/share/completions/find.fish:26
-#, fuzzy
 msgid "File is on filesystem of specified type"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa filsystem av angiven typ"
 
 #: /tmp/fish/implicit/share/completions/find.fish:27
-#, fuzzy
 msgid "Numeric group id of file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Bara numerisk utdata"
 
 #: /tmp/fish/implicit/share/completions/find.fish:28
-#, fuzzy
 msgid "Group name of file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa inod för filer"
 
 #: /tmp/fish/implicit/share/completions/find.fish:29
 msgid "File is symlink matching specified case insensitive pattern"
@@ -17371,12 +16663,8 @@ msgid "File name matches case insensitive pattern"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:31
-#, fuzzy
 msgid "File has specified inode number"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Filtrera genom angivet program"
 
 #: /tmp/fish/implicit/share/completions/find.fish:32
 msgid "File path matches case insensitive pattern"
@@ -17387,12 +16675,8 @@ msgid "File name matches case insensetive regex"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:34
-#, fuzzy
 msgid "File has specified number of links"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Jämför bara angivet antal tecken"
 
 #: /tmp/fish/implicit/share/completions/find.fish:35
 msgid "File is symlink matching specified pattern"
@@ -17403,12 +16687,8 @@ msgid "File last modified specified number of minutes ago"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:37
-#, fuzzy
 msgid "File last modified more recently than file was modified"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa senaste revision vid vilken vare rad ändrades"
 
 #: /tmp/fish/implicit/share/completions/find.fish:38
 msgid "File last modified specified number of days ago"
@@ -17427,64 +16707,36 @@ msgid "No group corresponds to file's numeric group ID"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:42
-#, fuzzy
 msgid "File path matches pattern"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Exkludera filer som matchar mönster"
 
 #: /tmp/fish/implicit/share/completions/find.fish:43
-#, fuzzy
 msgid "Files has specified permissions set"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Använd angiven kompressionsalgoritm"
 
 #: /tmp/fish/implicit/share/completions/find.fish:44
-#, fuzzy
 msgid "File name matches regex"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ignorera ändringar som matchar reguljärt uttryck"
 
 #: /tmp/fish/implicit/share/completions/find.fish:45
-#, fuzzy
 msgid "File refers to the same inode as specified file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Exklidera filer listade i angiven fil"
 
 #: /tmp/fish/implicit/share/completions/find.fish:46
 msgid "File uses specified units of space"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:47
-#, fuzzy
 msgid "Always true"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Alltid"
 
 #: /tmp/fish/implicit/share/completions/find.fish:48
-#, fuzzy
 msgid "File is of specified type"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa filsystem av angiven typ"
 
 #: /tmp/fish/implicit/share/completions/find.fish:49
-#, fuzzy
 msgid "File's owner has specified numeric user ID"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fil ägd av effektiv användar-id"
 
 #: /tmp/fish/implicit/share/completions/find.fish:50
 msgid ""
@@ -17493,12 +16745,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:51
-#, fuzzy
 msgid "File's owner"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fil är uttag (socket)"
 
 #: /tmp/fish/implicit/share/completions/find.fish:52
 msgid ""
@@ -17515,24 +16763,16 @@ msgid "Delete selected files"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:55
-#, fuzzy
 msgid "Execute specified command for each located file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Utför  kommando om föregående kommando misslyckades"
 
 #: /tmp/fish/implicit/share/completions/find.fish:56
 msgid "Execute specified command for each located file, in the files directory"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:57
-#, fuzzy
 msgid "List file in ls -dils format, write to specified file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv profileringsinformation till angiven fil"
 
 #: /tmp/fish/implicit/share/completions/find.fish:58
 msgid "Print full file names into specified file"
@@ -17543,24 +16783,16 @@ msgid "Print null separated full file names into specified file"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:60
-#, fuzzy
 msgid "Print formated data into specified file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv utdata till angiven fil"
 
 #: /tmp/fish/implicit/share/completions/find.fish:61
 msgid "Execute specified command for each located file after asking user"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:62
-#, fuzzy
 msgid "Print full file names"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa filnamn"
 
 #: /tmp/fish/implicit/share/completions/find.fish:63
 msgid ""
@@ -17569,12 +16801,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:64
-#, fuzzy
 msgid "Print null separated full file names"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv bara RCS-filnamn"
 
 #: /tmp/fish/implicit/share/completions/find.fish:65
 msgid "Print formated data"
@@ -17585,28 +16813,16 @@ msgid "Do not recurse unless -depth is specified"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/find.fish:67
-#, fuzzy
 msgid "Exit at once"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Förklara vad som utförs"
 
 #: /tmp/fish/implicit/share/completions/find.fish:68
-#, fuzzy
 msgid "List file in ls -dils format"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lista information om inoder"
 
 #: /tmp/fish/implicit/share/completions/find.fish:69
-#, fuzzy
 msgid "Negate result of action"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Negera uttryck"
 
 #: /tmp/fish/implicit/share/completions/find.fish:70
 msgid "Result is only true if both previous and next action are true"
@@ -18590,12 +17806,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/git.fish:295
 #: /tmp/fish/implicit/share/completions/git.fish:296
 #: share/completions/git.fish:177
-#, fuzzy
 msgid "Tag"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Mål"
 
 #: /tmp/fish/implicit/share/completions/fossil.fish:160
 msgid "Show commit time"
@@ -19099,12 +18311,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/root.fish:6
 #: /tmp/fish/implicit/share/completions/zypper.fish:4
 #: share/completions/zypper.fish:30
-#, fuzzy
 msgid "Print help"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa URIer"
 
 #: /tmp/fish/implicit/share/completions/funced.fish:1
 #: /tmp/fish/implicit/share/completions/funcsave.fish:1
@@ -19140,12 +18348,8 @@ msgid "Show hidden functions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/functions.fish:6
-#, fuzzy
 msgid "Test if function is defined"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om variabeln är definerad"
 
 #: /tmp/fish/implicit/share/completions/functions.fish:7
 msgid "List the names of the functions, but not their definition"
@@ -24793,39 +23997,23 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:5
 #: share/completions/gem.fish:37
-#, fuzzy
 msgid "Use no HTTP proxy for remote operations"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj rot-katalog för rpm-operationer"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:6
 #: share/completions/gem.fish:38
-#, fuzzy
 msgid "Get help on this command"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj promptkommando"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:7
 #: share/completions/gem.fish:39
-#, fuzzy
 msgid "Set the verbose level of output"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Återställ felrapporteringsnivå till 0"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:8
 #: share/completions/gem.fish:40
-#, fuzzy
 msgid "Use this config file instead of default"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Använd angiven fil istället för standard-förtroendedatabasen"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:9
 #: share/completions/gem.fish:41
@@ -24834,12 +24022,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:10
 #: share/completions/gem.fish:42
-#, fuzzy
 msgid "Turn on Ruby debugging"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Slå av avmangling"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:11
 #: share/completions/gem.fish:47
@@ -24848,12 +24032,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:12
 #: share/completions/gem.fish:48
-#, fuzzy
 msgid "List trusted certificates"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa pålitliga nycklar"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:13
 #: share/completions/gem.fish:49
@@ -24872,12 +24052,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:16
 #: share/completions/gem.fish:52
-#, fuzzy
 msgid "Private key for --sign command"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa typ av kommando"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:17
 #: share/completions/gem.fish:53
@@ -24891,12 +24067,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:19
 #: share/completions/gem.fish:59
-#, fuzzy
 msgid "Report 'unmanaged' or rogue files in the gem repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ta bort filer eller kataloger från lagret"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:20
 #: share/completions/gem.fish:60
@@ -24905,48 +24077,28 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:21
 #: share/completions/gem.fish:61
-#, fuzzy
 msgid "Specify version for which to run unit tests"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj vilket förråd som skall användas"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:22
 #: share/completions/gem.fish:66
-#, fuzzy
 msgid "Don't really cleanup"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Avinstallera ingenting på riktigt"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:23
 #: share/completions/gem.fish:71
-#, fuzzy
 msgid "List the files inside a Gem"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa filer i paket"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:24
 #: share/completions/gem.fish:72
-#, fuzzy
 msgid "Specify version for gem to view"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange användare för fråga"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:25
 #: share/completions/gem.fish:73
-#, fuzzy
 msgid "Search for gems under specific paths"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj drivrutinsspecifika inställningar"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:26
 #: share/completions/gem.fish:74
@@ -24956,30 +24108,18 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gem.fish:27
 #: /tmp/fish/implicit/share/completions/gem.fish:82
 #: share/completions/gem.fish:79 share/completions/gem.fish:172
-#, fuzzy
 msgid "Specify version of gem to uninstall"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lista av paket att installera"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:28
 #: share/completions/gem.fish:80
-#, fuzzy
 msgid "Include reverse dependencies in the output"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa paket som beror på det givna paketet"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:29
 #: share/completions/gem.fish:81
-#, fuzzy
 msgid "Don't include reverse dependencies in the output"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa paket som beror på det givna paketet"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:30
 #: share/completions/gem.fish:82
@@ -24988,12 +24128,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:31
 #: share/completions/gem.fish:97
-#, fuzzy
 msgid "Specify version of gem to install"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lista av paket att installera"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:32
 #: /tmp/fish/implicit/share/completions/gem.fish:51
@@ -25067,12 +24203,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gem.fish:41
 #: /tmp/fish/implicit/share/completions/gem.fish:90
 #: share/completions/gem.fish:107 share/completions/gem.fish:188
-#, fuzzy
 msgid "Don't force gem to install, bypassing dependency checks"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Utför inte beroendeverifiering"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:42
 #: /tmp/fish/implicit/share/completions/gem.fish:91
@@ -25083,42 +24215,26 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gem.fish:43
 #: /tmp/fish/implicit/share/completions/gem.fish:92
 #: share/completions/gem.fish:109 share/completions/gem.fish:190
-#, fuzzy
 msgid "Don't run unit tests prior to installation"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Kontrollera inte diskutrymme före installation"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:44
 #: /tmp/fish/implicit/share/completions/gem.fish:93
 #: share/completions/gem.fish:110 share/completions/gem.fish:191
-#, fuzzy
 msgid "Use bin wrappers for executables"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fil är program"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:45
 #: /tmp/fish/implicit/share/completions/gem.fish:94
 #: share/completions/gem.fish:111 share/completions/gem.fish:192
-#, fuzzy
 msgid "Don't use bin wrappers for executables"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Gör inte skript exekverbara"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:46
 #: /tmp/fish/implicit/share/completions/gem.fish:95
 #: share/completions/gem.fish:112 share/completions/gem.fish:193
-#, fuzzy
 msgid "Specify gem trust policy"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange förtroendemodell"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:47
 #: /tmp/fish/implicit/share/completions/gem.fish:96
@@ -25137,24 +24253,16 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/gem.fish:66
 #: share/completions/gem.fish:119 share/completions/gem.fish:129
 #: share/completions/gem.fish:148
-#, fuzzy
 msgid "Display detailed information of gem(s)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa uppdateringsinformation"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:50
 #: /tmp/fish/implicit/share/completions/gem.fish:56
 #: /tmp/fish/implicit/share/completions/gem.fish:67
 #: share/completions/gem.fish:120 share/completions/gem.fish:130
 #: share/completions/gem.fish:149
-#, fuzzy
 msgid "Don't display detailed information of gem(s)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa uppdateringsinformation"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:54
 #: share/completions/gem.fish:128
@@ -25188,21 +24296,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:65
 #: share/completions/gem.fish:143
-#, fuzzy
 msgid "Specify version of gem to rdoc"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange extern editor"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:71
 #: share/completions/gem.fish:157
-#, fuzzy
 msgid "Specify version of gem to examine"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj destinationsadress"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:75
 #: share/completions/gem.fish:161
@@ -25211,21 +24311,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:76
 #: share/completions/gem.fish:166
-#, fuzzy
 msgid "Uninstall all matching versions"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa alla versioner"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:77
 #: share/completions/gem.fish:167
-#, fuzzy
 msgid "Don't uninstall all matching versions"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Avinstallera ingenting på riktigt"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:78
 #: share/completions/gem.fish:168
@@ -25234,12 +24326,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/gem.fish:79
 #: share/completions/gem.fish:169
-#, fuzzy
 msgid "Don't ignore dependency requirements while uninstalling"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Verifiera inte beroenden före paketen avinstalleras"
 
 #: /tmp/fish/implicit/share/completions/gem.fish:80
 #: share/completions/gem.fish:170
@@ -27680,12 +26768,8 @@ msgstr "Processa binär fil som text"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:5
 #: share/functions/__fish_complete_grep.fish:6
-#, fuzzy
 msgid "Print byte offset of matches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv bara ut angivet antal matchningar"
 
 #: share/functions/__fish_complete_grep.fish:7
 msgid "Assume data type for binary files"
@@ -27702,12 +26786,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/grep.fish:9
 #: share/functions/__fish_complete_grep.fish:10
-#, fuzzy
 msgid "Only print number of matches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv bara ut angivet antal matchningar"
 
 #: share/functions/__fish_complete_grep.fish:13
 msgid "Pattern is extended regexp"
@@ -27724,12 +26804,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/grep.fish:15
 #: share/functions/__fish_complete_grep.fish:16
-#, fuzzy
 msgid "Exclude matching directories from recursive searches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Sök i angivna kataloger efter källkod"
 
 #: share/functions/__fish_complete_grep.fish:17
 msgid "Pattern is a fixed string"
@@ -27749,12 +26825,8 @@ msgstr "Visa filnamn"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:20
 #: share/functions/__fish_complete_grep.fish:21
-#, fuzzy
 msgid "Suppress printing filename"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa inte filnamn"
 
 #: share/functions/__fish_complete_grep.fish:23
 msgid "Skip binary files"
@@ -27778,12 +26850,8 @@ msgstr "Använd systemanroppet mmap för inläsning"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:28
 #: share/functions/__fish_complete_grep.fish:29
-#, fuzzy
 msgid "Print line number"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa radnummer"
 
 #: share/functions/__fish_complete_grep.fish:30
 msgid "Show only matching part"
@@ -27799,12 +26867,8 @@ msgstr "Använd radbuffring"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:32
 #: share/functions/__fish_complete_grep.fish:33
-#, fuzzy
 msgid "Pattern is a Perl regexp (PCRE) string"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Mönster är ett reguljärt uttryck"
 
 #: share/functions/__fish_complete_grep.fish:34
 #: share/functions/__fish_complete_grep.fish:35
@@ -27815,30 +26879,18 @@ msgstr "Skriv ingenting"
 #: /tmp/fish/implicit/share/completions/grep.fish:36
 #: share/functions/__fish_complete_grep.fish:36
 #: share/functions/__fish_complete_grep.fish:37
-#, fuzzy
 msgid "Read files under each directory, recursively"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Läs filer i varje katalog"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:37
 #: share/functions/__fish_complete_grep.fish:38
-#, fuzzy
 msgid "Search only files matching PATTERN"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Rekursera, sök i filer som matchar mönster"
 
 #: /tmp/fish/implicit/share/completions/grep.fish:38
 #: share/functions/__fish_complete_grep.fish:39
-#, fuzzy
 msgid "Skip files matching PATTERN"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Rekursera, skippa filer som matchar mönster"
 
 #: share/functions/__fish_complete_grep.fish:40
 msgid "Suppress error messages"
@@ -28487,12 +27539,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/helm.fish:24
 #: /tmp/fish/implicit/share/completions/helm.fish:68
 #: /tmp/fish/implicit/share/completions/helm.fish:76
-#, fuzzy
 msgid "Revision"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Slå ihop revisioner"
 
 #: /tmp/fish/implicit/share/completions/helm.fish:25
 msgid "Dump all (computed) values"
@@ -30638,12 +29686,8 @@ msgid "use IPv6 in addition to IPv4"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/hg.fish:480
-#, fuzzy
 msgid "SSL certificate file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj certifikatpolicy"
 
 #: /tmp/fish/implicit/share/completions/hg.fish:482
 msgid "show status of all files"
@@ -30787,12 +29831,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/s3cmd.fish:41
 #: /tmp/fish/implicit/share/completions/subl.fish:8
 #: share/completions/perl.fish:27
-#, fuzzy
 msgid "Show help and exit"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa hjälp och avsluta"
 
 #: /tmp/fish/implicit/share/completions/htop.fish:5
 msgid "Show only given PIDs"
@@ -31306,12 +30346,8 @@ msgid "Convert to specified encoding"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/iconv.fish:3
-#, fuzzy
 msgid "List known coded character sets"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj den interna teckenuppsättningen"
 
 #: /tmp/fish/implicit/share/completions/iconv.fish:5
 msgid "Print progress information"
@@ -32619,12 +31655,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/kitchen.fish:1
 #: share/completions/kitchen.fish:3
-#, fuzzy
 msgid "Test if kitchen has yet to be given the main command"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/kitchen.fish:2
 #: /tmp/fish/implicit/share/completions/kitchen.fish:3
@@ -36707,12 +35739,8 @@ msgstr "Montera partition med angivet UID"
 
 #: /tmp/fish/implicit/share/completions/mount.fish:14
 #: share/completions/mount.fish:21
-#, fuzzy
 msgid "Exclude file systems"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Exkludera filsystem"
 
 #: share/completions/mount.fish:22
 msgid "Remount a subtree to a second position"
@@ -36724,12 +35752,8 @@ msgstr "Flytta ett subträd till en ny plats"
 
 #: /tmp/fish/implicit/share/completions/mount.fish:17
 #: share/completions/mount.fish:24
-#, fuzzy
 msgid "File system"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Filsystem"
 
 #: share/completions/mount.fish:26
 msgid "Mount option"
@@ -36761,12 +35785,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:2
 #: share/completions/msgfmt.fish:5
-#, fuzzy
 msgid "Generate a Java ResourceBundle class"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Generera källindexfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:3
 #: share/completions/msgfmt.fish:6
@@ -36775,39 +35795,23 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:4
 #: share/completions/msgfmt.fish:7
-#, fuzzy
 msgid "Generate a .NET .dll file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Generera huvudfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:5
 #: share/completions/msgfmt.fish:8
-#, fuzzy
 msgid "Generate a .NET .resources file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Generera källindexfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:6
 #: share/completions/msgfmt.fish:9
-#, fuzzy
 msgid "Generate a tcl/msgcat .msg file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Generera huvudfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:7
 #: share/completions/msgfmt.fish:10
-#, fuzzy
 msgid "Generate a Qt .qm file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Generera huvudfil"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:9
 msgid "Enable strict Uniforum mode"
@@ -36815,12 +35819,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:10
 #: share/completions/msgfmt.fish:17
-#, fuzzy
 msgid "Resource name"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj volymnamn"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:11
 #: share/completions/msgfmt.fish:18
@@ -36829,12 +35829,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:12
 #: share/completions/msgfmt.fish:19
-#, fuzzy
 msgid "Base directory for output"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Filidentifierare för indata"
 
 #: /tmp/fish/implicit/share/completions/msgfmt.fish:13
 msgid "Input files are in Java .properties syntax"
@@ -36956,21 +35952,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:18
 #: share/completions/mutt.fish:23
-#, fuzzy
 msgid "Specify which mailbox to load"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange sendmailkommando"
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:19
 #: share/completions/mutt.fish:24
-#, fuzzy
 msgid "Specify an initialization file to read instead of ~/.muttrc"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange logmeddelande istället för att anropa editor"
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:20
 #: share/completions/mutt.fish:25
@@ -36984,30 +35972,18 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:22
 #: share/completions/mutt.fish:27
-#, fuzzy
 msgid "Specify a default mailbox type"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj kärnversion"
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:23
 #: share/completions/mutt.fish:28
-#, fuzzy
 msgid "Query a configuration variables value"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj en konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/mutt.fish:24
 #: share/completions/mutt.fish:29
-#, fuzzy
 msgid "Specify the subject of the message"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange meddelande för tillägg"
 
 #: share/completions/mv.fish:4
 msgid "Answer for overwrite questions"
@@ -41485,30 +40461,18 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/node.fish:1
 #: share/completions/node.fish:9
-#, fuzzy
 msgid "Print node's version"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa kärnversion"
 
 #: /tmp/fish/implicit/share/completions/node.fish:2
 #: share/completions/node.fish:10
-#, fuzzy
 msgid "Evaluate script"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Extrahera skript"
 
 #: /tmp/fish/implicit/share/completions/node.fish:3
 #: share/completions/node.fish:11
-#, fuzzy
 msgid "Print result of --eval"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa platt profil"
 
 #: /tmp/fish/implicit/share/completions/node.fish:4
 msgid "Always enter the REPL even if stdin does not appear to be a terminal"
@@ -42930,21 +41894,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:29
 #: share/completions/obnam.fish:32
-#, fuzzy
 msgid "Name of client"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"NAmn på version at använda som kontrollpunkt"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:30
 #: share/completions/obnam.fish:33
-#, fuzzy
 msgid "Compress repository with"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Komprimera till standard ut"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:31
 #: share/completions/obnam.fish:34
@@ -42958,21 +41914,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:33
 #: share/completions/obnam.fish:36
-#, fuzzy
 msgid "Do not dump metadata about files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera inte byggda filer"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:34
 #: share/completions/obnam.fish:37
-#, fuzzy
 msgid "Generate man page"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Generera ett nytt nyckelpar"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:35
 #: share/completions/obnam.fish:38
@@ -42981,12 +41929,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:36
 #: share/completions/obnam.fish:39
-#, fuzzy
 msgid "Show this help message and exit"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:37
 #: share/completions/obnam.fish:40
@@ -43004,21 +41948,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:40
 #: share/completions/obnam.fish:43
-#, fuzzy
 msgid "Do not actually change anything"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv ingenting"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:41
 #: share/completions/obnam.fish:44
-#, fuzzy
 msgid "Actually commit changes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Summera ändringar"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:42
 #: share/completions/obnam.fish:45
@@ -43044,12 +41980,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:48
 #: share/completions/obnam.fish:53
-#, fuzzy
 msgid "Do not be verbose"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv inte över"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:49
 #: share/completions/obnam.fish:54
@@ -43059,12 +41991,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/obnam.fish:50
 #: /tmp/fish/implicit/share/completions/transmission-remote.fish:72
 #: share/completions/obnam.fish:55
-#, fuzzy
 msgid "Show version number and exit"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:51
 msgid "For nagios-last-backup-age: maximum age"
@@ -43077,12 +42005,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:53
 #: share/completions/obnam.fish:58
-#, fuzzy
 msgid "Deduplicate mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Läs ock skrivbart läge"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:54
 msgid "REGEXP for pathnames to exclude"
@@ -43090,21 +42014,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:55
 #: share/completions/obnam.fish:60
-#, fuzzy
 msgid "Exclude directories tagged as cache"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Sök i angivna kataloger efter källkod"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:56
 #: share/completions/obnam.fish:61
-#, fuzzy
 msgid "Include directories tagged as cache"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Inkluderingskatalog"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:57
 #: /tmp/fish/implicit/share/completions/rsync.fish:77
@@ -43127,21 +42043,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:61
 #: share/completions/obnam.fish:65
-#, fuzzy
 msgid "Do not follow mount points"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radbryt inte långa rader"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:62
 #: share/completions/obnam.fish:66
-#, fuzzy
 msgid "Follow mount points"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Monteringskatalog"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:63
 msgid "What to backup"
@@ -43163,48 +42071,28 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:67
 #: share/completions/obnam.fish:70
-#, fuzzy
 msgid "Write out the current configuration"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ladda om konfiguration för tjänst"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:68
 #: share/completions/obnam.fish:71
-#, fuzzy
 msgid "Write out setting names"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv prompten"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:69
 #: share/completions/obnam.fish:72
-#, fuzzy
 msgid "Show all options"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa hjälp om flaggor"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:70
 #: share/completions/obnam.fish:73
-#, fuzzy
 msgid "List config files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:71
 #: share/completions/obnam.fish:74
-#, fuzzy
 msgid "Clear list of configuration files to read"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa rpmkonfigurationsfiler"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:72
 msgid "Artificially crash the program after COUNTER files"
@@ -43216,12 +42104,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:74
 #: share/completions/obnam.fish:49
-#, fuzzy
 msgid "Simulate failures for files that match REGEXP"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj fix som matchar REGEXP"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:75
 msgid "FILENAME pattern for trace debugging"
@@ -43238,21 +42122,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:78
 #: share/completions/obnam.fish:76
-#, fuzzy
 msgid "Show additional user IDs"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa historik för alla användare"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:79
 #: share/completions/obnam.fish:77
-#, fuzzy
 msgid "Do not show additional user IDs"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lagra inte katalognamn"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:80
 #: share/completions/obnam.fish:78
@@ -43266,12 +42142,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:82
 #: share/completions/obnam.fish:80
-#, fuzzy
 msgid "Use /dev/urandom instead of /dev/random"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Använd rensning istället för radering"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:83
 #: share/completions/obnam.fish:81
@@ -43290,12 +42162,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:86
 #: share/completions/obnam.fish:85
-#, fuzzy
 msgid "Ignore chunks when checking integrity"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ignorera skiftläge på filnamn"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:87
 #: share/completions/obnam.fish:86
@@ -43308,22 +42176,14 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:89
 #: share/completions/obnam.fish:88
-#, fuzzy
 msgid "Check only the last generation"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Återupta senaste installationsoperation"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:90
 #: /tmp/fish/implicit/share/completions/obnam.fish:100
 #: share/completions/obnam.fish:89 share/completions/obnam.fish:95
-#, fuzzy
 msgid "Check all generations"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga installerat paket"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:91
 #: /tmp/fish/implicit/share/completions/obnam.fish:92
@@ -43340,57 +42200,33 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:95
 #: share/completions/obnam.fish:90
-#, fuzzy
 msgid "Do not check directories"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lagra inte katalognamn"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:96
 #: share/completions/obnam.fish:91
-#, fuzzy
 msgid "Check directories"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Rekursera till underkataloger"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:97
 #: share/completions/obnam.fish:92
-#, fuzzy
 msgid "Do not check files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ändra inga filer"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:98
 #: share/completions/obnam.fish:93
-#, fuzzy
 msgid "Check files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga installerat paket"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:99
 #: share/completions/obnam.fish:94
-#, fuzzy
 msgid "Do not check any generations"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ändra inga filer"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:101
 #: share/completions/obnam.fish:96
-#, fuzzy
 msgid "Do not check per-client B-trees"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv inte ut taggar"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:102
 #: share/completions/obnam.fish:97
@@ -43399,21 +42235,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:103
 #: share/completions/obnam.fish:98
-#, fuzzy
 msgid "Do not check shared B-trees"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ändra inga filer"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:104
 #: share/completions/obnam.fish:99
-#, fuzzy
 msgid "Check shared B-trees"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga installerat paket"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:105
 msgid "Write log to FILE or syslog"
@@ -43471,12 +42299,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:116
 #: share/completions/obnam.fish:112
-#, fuzzy
 msgid "Depth of chunk id mapping"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Djup i anroppskedjan"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:117
 #: share/completions/obnam.fish:113
@@ -43490,12 +42314,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:119
 #: share/completions/obnam.fish:115
-#, fuzzy
 msgid "Size of B-tree nodes on disk"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa ändringar i omvänd ordning"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:120
 #: share/completions/obnam.fish:116
@@ -43525,12 +42345,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:126
 #: share/completions/obnam.fish:118
-#, fuzzy
 msgid "Use openssh if available"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Bygg index om inte tillgängligt"
 
 #: /tmp/fish/implicit/share/completions/obnam.fish:127
 msgid "Executable to be used instead of \"ssh\""
@@ -44596,12 +43412,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/pdftotext.fish:19
 #: /tmp/fish/implicit/share/completions/xpdf.fish:28
-#, fuzzy
 msgid "Don't print any messages or errors"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Kör inga taggningsprogram"
 
 #: /tmp/fish/implicit/share/completions/pdftotext.fish:20
 msgid "Print copyright and version"
@@ -44697,12 +43509,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/perl.fish:20
 #: share/completions/perl.fish:25
-#, fuzzy
 msgid "Disable sitecustomize.pl"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Inaktivera användandet av kakor"
 
 #: share/completions/perl.fish:30
 msgid "Automatic line ending processing"
@@ -44744,39 +43552,23 @@ msgstr "Osäkert läge"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:37
 #: share/completions/perl.fish:42
-#, fuzzy
 msgid "Display configuration and exit"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:38
 #: share/completions/perl.fish:43
-#, fuzzy
 msgid "Show warnings"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa inte varningar"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:39
 #: share/completions/perl.fish:44
-#, fuzzy
 msgid "Force warnings"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa inte varningar"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:40
 #: share/completions/perl.fish:45
-#, fuzzy
 msgid "Disable warnings"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa inte varningar om MFC"
 
 #: /tmp/fish/implicit/share/completions/perl.fish:41
 #: /tmp/fish/implicit/share/completions/ruby.fish:21
@@ -45119,12 +43911,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/zypper.fish:3
 #: /tmp/fish/implicit/share/completions/zypper.fish:18
 #: share/completions/zypper.fish:44
-#, fuzzy
 msgid "Install packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installerade paket"
 
 #: /tmp/fish/implicit/share/completions/pkg.fish:27
 msgid "Prevent package modification"
@@ -45575,21 +44363,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/portmaster.fish:44
 #: share/completions/portmaster.fish:49
-#, fuzzy
 msgid "Ports Directory"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Katalog"
 
 #: /tmp/fish/implicit/share/completions/portmaster.fish:45
 #: share/completions/portmaster.fish:55
-#, fuzzy
 msgid "Installed Package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installerade paket"
 
 #: /tmp/fish/implicit/share/completions/ports.fish:1
 msgid "Update ports"
@@ -45933,12 +44713,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/psql.fish:3
 #: share/completions/psql.fish:19
-#, fuzzy
 msgid "execute commands from file, then exit"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Utför kommando som om get vore en del av .wgetrc"
 
 #: /tmp/fish/implicit/share/completions/psql.fish:4
 msgid "list available databases, then exit"
@@ -47308,21 +46084,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:41
 #: share/completions/rsync.fish:42
-#, fuzzy
 msgid "Specify the remote shell to use"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange förråd-URL"
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:42
 #: share/completions/rsync.fish:43
-#, fuzzy
 msgid "Specify the rsync to run on remote machine"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj destinationsadress"
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:43
 msgid "Ignore non-existing files on receiving side"
@@ -47524,12 +46292,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:92
 #: share/completions/rsync.fish:93
-#, fuzzy
 msgid "Output filenames using the specified format"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Exklidera filer listade i angiven fil"
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:93
 #: share/completions/rsync.fish:94
@@ -47556,12 +46320,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:98
 #: share/completions/rsync.fish:99
-#, fuzzy
 msgid "Read a batched update from FILE"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Läs fix från patchfil"
 
 #: /tmp/fish/implicit/share/completions/rsync.fish:99
 #: share/completions/rsync.fish:100
@@ -49015,12 +47775,8 @@ msgid "Share variable persistently across sessions"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/set.fish:11
-#, fuzzy
 msgid "List the names of the variables, but not their value"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/set.fish:14
 msgid "Locale variable"
@@ -49685,32 +48441,20 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/svn.fish:5
 #: share/functions/__fish_complete_svn.fish:49
 #: share/functions/__fish_complete_svn.fish:51
-#, fuzzy
 msgid ""
 "Output the content of specified files or URLs with revision and author "
 "information in-line."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa filer/URL:er med revisions- och författarinformation inbakat"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:4
 #: share/functions/__fish_complete_svn.fish:50
-#, fuzzy
 msgid "Output the content of specified files or URLs."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa innehåll av filer/URL:er"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:6
 #: share/functions/__fish_complete_svn.fish:52
-#, fuzzy
 msgid "Check out a working copy from a repository."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Hämta ut en arbetskopia från förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:7
 #: share/functions/__fish_complete_svn.fish:53
@@ -49721,30 +48465,18 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:8
 #: share/functions/__fish_complete_svn.fish:54
-#, fuzzy
 msgid "Send changes from your working copy to the repository."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skicka ändringar i arbetskopian till lagret"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:9
 #: share/functions/__fish_complete_svn.fish:55
-#, fuzzy
 msgid "Duplicate something in working copy or repository, remembering history."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Flytta och/eller byt namn på någonting i arbetskopian eller förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:10
 #: share/functions/__fish_complete_svn.fish:56
-#, fuzzy
 msgid "Display the differences between two revisions or paths."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Applicera differensen mellan två källor till en arbetskopiesökväg"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:11
 #: share/functions/__fish_complete_svn.fish:57
@@ -49753,176 +48485,100 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:12
 #: share/functions/__fish_complete_svn.fish:58
-#, fuzzy
 msgid "Describe the usage of this program or its subcommands."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Beskriv användandet av detta program eller dess underkommandon"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:13
 #: share/functions/__fish_complete_svn.fish:59
-#, fuzzy
 msgid "Commit an unversioned file or tree into the repository."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lägg till fil eller träd utan version till förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:14
 #: share/functions/__fish_complete_svn.fish:60
-#, fuzzy
 msgid "Display information about a local or remote item."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa information om lokal eller fjärrelement"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:15
 #: share/functions/__fish_complete_svn.fish:61
-#, fuzzy
 msgid "List directory entries in the repository."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lista kataloger i förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:16
 #: share/functions/__fish_complete_svn.fish:62
-#, fuzzy
 msgid ""
 "Lock working copy paths or URLs in the repository, so that no other user can "
 "commit changes to them."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Läs arbetskopiwsökvägar eller URL:er i förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:17
 #: share/functions/__fish_complete_svn.fish:63
-#, fuzzy
 msgid "Show the log messages for a set of revision(s) and/or file(s)."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:18
 #: share/functions/__fish_complete_svn.fish:64
-#, fuzzy
 msgid "Apply the differences between two sources to a working copy path."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Applicera differensen mellan två källor till en arbetskopiesökväg"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:19
 #: share/functions/__fish_complete_svn.fish:65
-#, fuzzy
 msgid "Display information related to merges"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa ändringsinformation för paket"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:20
 #: share/functions/__fish_complete_svn.fish:66
-#, fuzzy
 msgid "Create a new directory under version control."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skapa ny katalog under revisionskontroll"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:21
 #: share/functions/__fish_complete_svn.fish:67
-#, fuzzy
 msgid "Move and/or rename something in working copy or repository."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Flytta och/eller byt namn på någonting i arbetskopian eller förrådet"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:22
 #: share/functions/__fish_complete_svn.fish:68
-#, fuzzy
 msgid "Apply a unidiff patch to the working copy"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa olagrade ändringar i arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:23
 #: share/functions/__fish_complete_svn.fish:69
-#, fuzzy
 msgid "Remove a property from files, dirs, or revisions."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ta bort en egenskap från filer, kataloger eller revisioner"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:24
 #: share/functions/__fish_complete_svn.fish:70
-#, fuzzy
 msgid "Edit a property with an external editor."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Redigera en egenskap med extern edito för mål"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:25
 #: share/functions/__fish_complete_svn.fish:71
-#, fuzzy
 msgid "Print the value of a property on files, dirs, or revisions."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv ut värde för en egenskap hos filer, kataloger eller revisioner"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:26
 #: share/functions/__fish_complete_svn.fish:72
-#, fuzzy
 msgid "List all properties on files, dirs, or revisions."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa alla engenskaper hos filer, kataloger eller revisioner"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:27
 #: share/functions/__fish_complete_svn.fish:73
-#, fuzzy
 msgid "Set the value of a property on files, dirs, or revisions."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv ut värde för en egenskap hos filer, kataloger eller revisioner"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:28
 #: share/functions/__fish_complete_svn.fish:74
-#, fuzzy
 msgid "Rewrite working copy url metadata"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera arbetskopia om släppning lyckas"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:29
 #: share/functions/__fish_complete_svn.fish:75
-#, fuzzy
 msgid "Remove files and directories from version control."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Placera filer och kataloger under versionskontroll"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:30
 #: share/functions/__fish_complete_svn.fish:76
-#, fuzzy
 msgid "Remove conflicts on working copy files or directories."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ta bort konflikttillstånd hos arbetskopiefiler eller kataloger"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:31
 msgid "Remove 'conflicted' state on working copy files or directories."
@@ -49930,48 +48586,28 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:32
 #: share/functions/__fish_complete_svn.fish:78
-#, fuzzy
 msgid "Restore pristine working copy file (undo most local edits)."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Återställ rensad arbetskopiefil"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:33
 #: share/functions/__fish_complete_svn.fish:79
-#, fuzzy
 msgid "Print the status of working copy files and directories."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa status för arbetskopians filer och kataloger"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:34
 #: share/functions/__fish_complete_svn.fish:80
-#, fuzzy
 msgid "Update the working copy to a different URL."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Uppdatera arbetskopian till en annan URL"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:35
 #: share/functions/__fish_complete_svn.fish:81
-#, fuzzy
 msgid "Unlock working copy paths or URLs."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lås upp arbetskopians sökvägar eller URL:er"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:36
 #: share/functions/__fish_complete_svn.fish:82
-#, fuzzy
 msgid "Bring changes from the repository into the working copy."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Hämta ändringar från förrådet till arbetskopian"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:37
 #: share/functions/__fish_complete_svn.fish:83
@@ -49979,29 +48615,17 @@ msgid "Upgrade the metadata storage format for a working copy."
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:38
-#, fuzzy
 msgid "Specify a username ARG"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj användarnamn"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:39
-#, fuzzy
 msgid "Specify a password ARG"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj lösenord"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:40
 #: share/functions/__fish_complete_svn.fish:90
-#, fuzzy
 msgid "Do not cache authentication tokens"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Cacha inte autentiseringssymboler"
 
 #: share/functions/__fish_complete_svn.fish:91
 msgid "Do no interactive prompting"
@@ -50015,12 +48639,8 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/svn.fish:43
-#, fuzzy
 msgid "Read user configuration files from directory ARG"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Läs användarkonfigurationsfiler från angiven katalog"
 
 #: /tmp/fish/implicit/share/completions/svn.fish:44
 msgid ""
@@ -50043,12 +48663,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:7
 #: share/completions/sylpheed.fish:10
-#, fuzzy
 msgid "Receive new messages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ersätt ett loggmeddelande"
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:8
 #: share/completions/sylpheed.fish:11
@@ -50072,12 +48688,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/sylpheed.fish:12
 #: share/completions/sylpheed.fish:15
-#, fuzzy
 msgid "Specify directory with configuration files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj en konfigurationsfil"
 
 #: /tmp/fish/implicit/share/completions/sysbench.fish:1
 msgid "The total number of worker threads to create (default: 1)"
@@ -51428,12 +50040,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/tmux.fish:1
 #: share/completions/tmux.fish:1
-#, fuzzy
 msgid "available sessions"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Utför argument som kommandon"
 
 #: /tmp/fish/implicit/share/completions/tmux.fish:2
 #: share/completions/tmux.fish:5
@@ -51442,12 +50050,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/tmux.fish:3
 #: share/completions/tmux.fish:9
-#, fuzzy
 msgid "window panes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Terminalfönstret ändrade storlek"
 
 #: /tmp/fish/implicit/share/completions/tmux.fish:4
 msgid "Force tmux to assume the terminal supports 256 colours"
@@ -52813,57 +51417,33 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:1
 #: share/completions/unrar.fish:5
-#, fuzzy
 msgid "Extract files to current directory"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Läs filer i varje katalog"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:3
 #: share/completions/unrar.fish:7
-#, fuzzy
 msgid "List archive (technical)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa arkivinnehåll"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:4
 #: share/completions/unrar.fish:8
-#, fuzzy
 msgid "List archive (bare)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa arkivinnehåll"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:5
 #: share/completions/unrar.fish:9
-#, fuzzy
 msgid "Print file to stdout"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skicka filer till standard ut"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:6
 #: share/completions/unrar.fish:10
-#, fuzzy
 msgid "Test archive files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Arkivfil"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:7
 #: share/completions/unrar.fish:11
-#, fuzzy
 msgid "Verbosely list archive"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Verifiera arkiv"
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:8
 #: share/completions/unrar.fish:12
@@ -52877,12 +51457,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/unrar.fish:10
 #: share/completions/unrar.fish:14
-#, fuzzy
 msgid "Extract files with full path"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Axtrahera fil från fil"
 
 #: /tmp/fish/implicit/share/completions/update-eix.fish:1
 msgid "Show a short help screen"
@@ -53071,21 +51647,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vagrant.fish:1
 #: share/completions/vagrant.fish:3
-#, fuzzy
 msgid "Test if vagrant has yet to be given the main command"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/vagrant.fish:2
 #: share/completions/vagrant.fish:23
-#, fuzzy
 msgid "Lists all available Vagrant boxes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/vagrant.fish:4
 msgid "Print the help and exit"
@@ -53570,12 +52138,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vi.fish:5
 #: share/functions/__fish_complete_vi.fish:95
-#, fuzzy
 msgid "Read-only mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skrivskyddad"
 
 #: /tmp/fish/implicit/share/completions/vi.fish:6
 #: share/functions/__fish_complete_vi.fish:96
@@ -53601,12 +52165,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim-addons.fish:1
 #: share/completions/vim-addons.fish:8
-#, fuzzy
 msgid "Test if vim-addons has yet to be given the subcommand"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/vim-addons.fish:2
 msgid "list the names of the addons available in the system"
@@ -53742,21 +52302,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:18
 #: share/functions/__fish_complete_vi.fish:37
-#, fuzzy
 msgid "Start in Arabic mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Starta gränssnitt"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:19
 #: share/functions/__fish_complete_vi.fish:38
-#, fuzzy
 msgid "Start in binary mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Standardläge"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:20
 #: share/functions/__fish_complete_vi.fish:39
@@ -53765,125 +52317,73 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:21
 #: share/functions/__fish_complete_vi.fish:40
-#, fuzzy
 msgid "Start in diff mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:22
 #: share/functions/__fish_complete_vi.fish:41
-#, fuzzy
 msgid "Debugging mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Debugläge"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:23
 #: share/functions/__fish_complete_vi.fish:42
-#, fuzzy
 msgid "Start in Ex mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:24
 #: share/functions/__fish_complete_vi.fish:43
-#, fuzzy
 msgid "Start in improved Ex mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:25
 #: /tmp/fish/implicit/share/completions/vim.fish:46
 #: share/functions/__fish_complete_vi.fish:44
 #: share/functions/__fish_complete_vi.fish:67
-#, fuzzy
 msgid "Start in foreground mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:26
 #: share/functions/__fish_complete_vi.fish:45
-#, fuzzy
 msgid "Start in Farsi mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Standardläge"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:27
 #: share/functions/__fish_complete_vi.fish:46
-#, fuzzy
 msgid "Start in GUI mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:28
 #: /tmp/fish/implicit/share/completions/vim.fish:48
 #: share/functions/__fish_complete_vi.fish:47
 #: share/functions/__fish_complete_vi.fish:69
-#, fuzzy
 msgid "Print help message and exit"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:29
 #: share/functions/__fish_complete_vi.fish:48
-#, fuzzy
 msgid "Start in Hebrew mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:30
 #: /tmp/fish/implicit/share/completions/vim.fish:37
 #: share/functions/__fish_complete_vi.fish:49
-#, fuzzy
 msgid "List swap files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Arkivfil"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:31
 #: share/functions/__fish_complete_vi.fish:50
-#, fuzzy
 msgid "Start in lisp mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Börja i folderindex"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:32
 #: share/functions/__fish_complete_vi.fish:51
-#, fuzzy
 msgid "Disable file modification"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lita inte på filändringstid"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:33
 #: share/functions/__fish_complete_vi.fish:52
-#, fuzzy
 msgid "Disallow file modification"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa bara senaste modifiering"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:34
 #: share/functions/__fish_complete_vi.fish:53
@@ -53920,21 +52420,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:43
 #: share/functions/__fish_complete_vi.fish:62
-#, fuzzy
 msgid "Start in easy mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Starta gränssnitt"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:44
 #: share/functions/__fish_complete_vi.fish:63
-#, fuzzy
 msgid "Start in restricted mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Inskränkt läge"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:45
 #: share/functions/__fish_complete_vi.fish:65
@@ -53948,12 +52440,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:49
 #: share/functions/__fish_complete_vi.fish:70
-#, fuzzy
 msgid "Do not expand wildcards"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Expandera inte mönster"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:50
 #: share/functions/__fish_complete_vi.fish:71
@@ -53968,30 +52456,18 @@ msgstr ""
 #: share/functions/__fish_complete_vi.fish:75
 #: share/functions/__fish_complete_vi.fish:76
 #: share/functions/__fish_complete_vi.fish:77
-#, fuzzy
 msgid "Edit files on Vim server"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Redigera filer på plats"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:52
 #: share/functions/__fish_complete_vi.fish:73
-#, fuzzy
 msgid "Evaluate expr on Vim server"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Utför argument som kommandon"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:53
 #: share/functions/__fish_complete_vi.fish:74
-#, fuzzy
 msgid "Send keys to Vim server"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skicka e-post till användare"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:57
 #: share/functions/__fish_complete_vi.fish:78
@@ -54000,21 +52476,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/vim.fish:58
 #: share/functions/__fish_complete_vi.fish:79
-#, fuzzy
 msgid "Set server name"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Namn på tjänst"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:59
 #: share/functions/__fish_complete_vi.fish:80
-#, fuzzy
 msgid "Print version information and exit"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa version och avsluta"
 
 #: /tmp/fish/implicit/share/completions/vim.fish:60
 msgid "Run gvim in another window (GTK GUI only)"
@@ -54022,21 +52490,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:1
 #: share/completions/wajig.fish:1
-#, fuzzy
 msgid "Test if wajig has yet to be given the subcommand"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om apt har tagit emot ett underkommando"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:2
 #: share/completions/wajig.fish:10
-#, fuzzy
 msgid "Test if wajig command should have packages as potential completion"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Testa om aptkommando borde ha paket som potentiell komplettering"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:4
 msgid "Do system commands everything quietly."
@@ -54327,12 +52787,8 @@ msgstr ""
 #: /tmp/fish/implicit/share/completions/wajig.fish:75
 #: /tmp/fish/implicit/share/completions/wajig.fish:89
 #: share/completions/wajig.fish:105
-#, fuzzy
 msgid "Generate a .deb file for an installed package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Bygg och installera ett installerat paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:76
 msgid "From preferences file show priorities/policy (available)"
@@ -54356,12 +52812,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:81
 #: share/completions/wajig.fish:97
-#, fuzzy
 msgid "Download package and any packages it depends on"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa paket som detta paket beror på"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:83
 #: share/completions/wajig.fish:99
@@ -54370,12 +52822,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:84
 #: share/completions/wajig.fish:100
-#, fuzzy
 msgid "Reinstall each of the named packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installera ett eller flera paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:85
 #: share/completions/wajig.fish:101
@@ -54384,12 +52832,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:86
 #: share/completions/wajig.fish:102
-#, fuzzy
 msgid "Remove one or more packages (see also purge)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera ett eller flera paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:87
 #: share/completions/wajig.fish:103
@@ -54408,12 +52852,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:92
 #: share/completions/wajig.fish:108
-#, fuzzy
 msgid "Install a RedHat .rpm package"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installera nytt paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:93
 #: share/completions/wajig.fish:109
@@ -54422,12 +52862,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:94
 #: share/completions/wajig.fish:110
-#, fuzzy
 msgid "Search for packages containing listed words"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Sök paket innehållande mönster"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:95
 #: share/completions/wajig.fish:111
@@ -54477,12 +52913,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:105
 #: share/completions/wajig.fish:121
-#, fuzzy
 msgid "Retrieve and unpack sources for the named packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa paket som beror på det givna paketet"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:106
 #: share/completions/wajig.fish:122
@@ -54491,12 +52923,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:107
 #: share/completions/wajig.fish:123
-#, fuzzy
 msgid "Show the version and available version of packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa fulla versioner för paket"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:108
 #: /tmp/fish/implicit/share/completions/wajig.fish:109
@@ -54516,12 +52944,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:113
 #: share/completions/wajig.fish:129
-#, fuzzy
 msgid "List packages with newer versions available for upgrading"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Uppdaterar till den bästa tillgängliga versionen"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:114
 #: share/completions/wajig.fish:130
@@ -54530,12 +52954,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:116
 #: share/completions/wajig.fish:132
-#, fuzzy
 msgid "Update the list of down-loadable packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Updatera källkodpaketlista"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:117
 #: share/completions/wajig.fish:133
@@ -54559,21 +52979,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:121
 #: share/completions/wajig.fish:137
-#, fuzzy
 msgid "List version and distribution of (all) packages."
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Verifiera inga attribut i paketfiler"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:122
 #: share/completions/wajig.fish:138
-#, fuzzy
 msgid "A synonym for describe"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Synonym för -i"
 
 #: /tmp/fish/implicit/share/completions/wajig.fish:123
 #: share/completions/wajig.fish:139
@@ -54918,21 +53330,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:4
 #: share/completions/wpa_cli.fish:6
-#, fuzzy
 msgid "show interfaces/select interface"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj gränssnitt"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:5
 #: share/completions/wpa_cli.fish:7
-#, fuzzy
 msgid "change debug level"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj debugnivå"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:6
 #: share/completions/wpa_cli.fish:8
@@ -54951,12 +53355,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:9
 #: share/completions/wpa_cli.fish:11
-#, fuzzy
 msgid "set/list variables"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera variabel"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:10
 #: share/completions/wpa_cli.fish:12
@@ -54965,12 +53365,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:11
 #: share/completions/wpa_cli.fish:13
-#, fuzzy
 msgid "force reassociation"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Tvinga namn/revision-association"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:12
 #: share/completions/wpa_cli.fish:14
@@ -54979,12 +53375,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:13
 #: share/completions/wpa_cli.fish:15
-#, fuzzy
 msgid "force preauthentication"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Tvinga pseudo-tty-allokering"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:14
 #: share/completions/wpa_cli.fish:16
@@ -55003,12 +53395,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:17
 #: share/completions/wpa_cli.fish:19
-#, fuzzy
 msgid "configure pin for an SSID"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Konfiurera för att bygga på given målarkitektur"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:18
 #: share/completions/wpa_cli.fish:20
@@ -55037,39 +53425,23 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:23
 #: share/completions/wpa_cli.fish:25
-#, fuzzy
 msgid "enable a network"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Aktivera förråd"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:24
 #: share/completions/wpa_cli.fish:26
-#, fuzzy
 msgid "disable a network"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Inaktivera förråd"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:25
 #: share/completions/wpa_cli.fish:27
-#, fuzzy
 msgid "add a network"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lägg till ny nyckel"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:26
 #: share/completions/wpa_cli.fish:28
-#, fuzzy
 msgid "remove a network"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ta bort en nyckel"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:27
 #: share/completions/wpa_cli.fish:29
@@ -55078,21 +53450,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:28
 #: share/completions/wpa_cli.fish:30
-#, fuzzy
 msgid "get network variables"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj CVS-användare"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:29
 #: share/completions/wpa_cli.fish:31
-#, fuzzy
 msgid "save the current configuration"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ladda om konfiguration för tjänst"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:30
 #: share/completions/wpa_cli.fish:32
@@ -55111,12 +53475,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:33
 #: share/completions/wpa_cli.fish:35
-#, fuzzy
 msgid "get capabilies"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj spellista"
 
 #: /tmp/fish/implicit/share/completions/wpa_cli.fish:34
 #: share/completions/wpa_cli.fish:36
@@ -55357,24 +53717,16 @@ msgid "Show summary of options"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:2
-#, fuzzy
 msgid "Select XMMS session (Default: 0)"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj via sessions-id"
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:3
 msgid "Skip backwards in playlist"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:4
-#, fuzzy
 msgid "Start playing current playlist"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa eller redigera alla resursanvändningsgränser"
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:5
 msgid "Pause current song"
@@ -55393,12 +53745,8 @@ msgid "Skip forward in playlist"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:9
-#, fuzzy
 msgid "Don't clear the playlist"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj spellista"
 
 #: /tmp/fish/implicit/share/completions/xmms.fish:10
 msgid "Show the main window"
@@ -55409,12 +53757,8 @@ msgid "Set the initial window geometry"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:2
-#, fuzzy
 msgid "Set the window title"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj nätverkstimeout"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:3
 msgid "Install a private colormap"
@@ -55425,20 +53769,12 @@ msgid "Set the size of the largest RGB cube xpdf will try to allocate"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:5
-#, fuzzy
 msgid "Set reverse video mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Serverläge"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:6
-#, fuzzy
 msgid "Set the background of the page display"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skapa fönster på angiven skärm"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:7
 msgid "Set the color for background outside the page area"
@@ -55465,20 +53801,12 @@ msgid "Enable or disable font anti-aliasing (Default: yes)"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:13
-#, fuzzy
 msgid "Set the default file name for PostScript output"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange standardnyckelordssubstitution"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:14
-#, fuzzy
 msgid "Set the paper size"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj uttags (socket) buffertstorlek"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:15
 msgid "Set the paper width, in points"
@@ -55489,44 +53817,24 @@ msgid "Set the paper height, in points"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:17
-#, fuzzy
 msgid "Generate Level 1 PostScript"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Generera utdata för dired"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:18
-#, fuzzy
 msgid "Sets the encoding to use for text output"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Varken tyst eller utförligt läge"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:19
-#, fuzzy
 msgid "Sets the end-of-line convention to use"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Sätt slut-på-fil-strängen till angiven sträng"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:20
-#, fuzzy
 msgid "Specify the owner password for the PDF file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj proxylösenord"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:21
-#, fuzzy
 msgid "Specify the user password for the PDF file"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj proxylösenord"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:22
 msgid "Open xpdf in full-screen mode"
@@ -55549,24 +53857,16 @@ msgid "Kill xpdf remote server"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:27
-#, fuzzy
 msgid "Print commands as they're executed"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv kommandon till standard fel"
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:29
 msgid "Specify config file to use instead of ~/.xpdfrc"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xpdf.fish:30
-#, fuzzy
 msgid "Print copyright and version information"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ignorera all versionsinformation"
 
 #: share/completions/xprop.fish:4
 msgid "Select window by id"
@@ -56249,12 +54549,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:101
 #: share/completions/xterm.fish:107
-#, fuzzy
 msgid "xterm encoding"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Tvinga kodning"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:102
 #: share/completions/xterm.fish:108
@@ -56273,12 +54569,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:105
 #: share/completions/xterm.fish:111
-#, fuzzy
 msgid "Font for active icons"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Tvinga interaktivt läge"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:106
 #: share/completions/xterm.fish:112
@@ -56307,21 +54599,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:111
 #: share/completions/xterm.fish:117
-#, fuzzy
 msgid "Embed xterm into window"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa trådar"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:112
 #: share/completions/xterm.fish:118
-#, fuzzy
 msgid "Set keyboard type"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange posttyp"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:113
 #: share/completions/xterm.fish:119
@@ -56330,12 +54614,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:114
 #: share/completions/xterm.fish:120
-#, fuzzy
 msgid "Log filename"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Logga till fil"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:115
 #: share/completions/xterm.fish:121
@@ -56354,39 +54634,23 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:118
 #: share/completions/xterm.fish:124
-#, fuzzy
 msgid "Number of scrolled off lines"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Numrera alla rader"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:119
 #: share/completions/xterm.fish:125
-#, fuzzy
 msgid "Terminal identification"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa all information"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:121
 #: share/completions/xterm.fish:127
-#, fuzzy
 msgid "zIconBeep percentage"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa filposition i procent i prompten"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:122
 #: share/completions/xterm.fish:129
-#, fuzzy
 msgid "Size of the inner border"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa ändringar i omvänd ordning"
 
 #: /tmp/fish/implicit/share/completions/xterm.fish:123
 msgid "Use jump scrolling"
@@ -56846,30 +55110,18 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/yum.fish:32
 #: share/completions/yum.fish:53
-#, fuzzy
 msgid "Delete cached package files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera obsoleta paketfiler"
 
 #: /tmp/fish/implicit/share/completions/yum.fish:33
 #: share/completions/yum.fish:54
-#, fuzzy
 msgid "Delete cached header files"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera urval"
 
 #: /tmp/fish/implicit/share/completions/yum.fish:34
 #: share/completions/yum.fish:55
-#, fuzzy
 msgid "Delete all cache contents"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera logfil"
 
 #: /tmp/fish/implicit/share/completions/zfs.fish:1
 msgid ""
@@ -57964,57 +56216,33 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:7
 #: share/completions/zypper.fish:33
-#, fuzzy
 msgid "Add a new repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Uppdatera förråd"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:8
 #: share/completions/zypper.fish:34
-#, fuzzy
 msgid "Remove specified repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange förråd-URL"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:9
 #: share/completions/zypper.fish:35
-#, fuzzy
 msgid "Rename specified repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Reparera trasigt förråd"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:10
 #: share/completions/zypper.fish:36
-#, fuzzy
 msgid "Modify specified repository"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ange förråd-URL"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:11
 #: share/completions/zypper.fish:37
-#, fuzzy
 msgid "Refresh all repositories"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skrivskyddat förråd-läge"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:12
 #: share/completions/zypper.fish:38
-#, fuzzy
 msgid "Clean local caches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Rengör lokala cachear och paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:13
 #: share/completions/zypper.fish:39
@@ -58023,30 +56251,18 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:14
 #: share/completions/zypper.fish:40
-#, fuzzy
 msgid "Add a new service"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lägg till ny nyckel"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:15
 #: share/completions/zypper.fish:41
-#, fuzzy
 msgid "Modify specified service"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Använd angiven nyckelserver"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:16
 #: share/completions/zypper.fish:42
-#, fuzzy
 msgid "Remove specified service"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Använd angiven nyckelserver"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:17
 #: share/completions/zypper.fish:43
@@ -58055,211 +56271,118 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:20
 #: share/completions/zypper.fish:46
-#, fuzzy
 msgid "Verify integrity of package dependencies"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installera/ta bort paket för beroenden"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:21
 #: share/completions/zypper.fish:47
-#, fuzzy
 msgid "Install source packages and their build dependencies"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installera/ta bort paket för beroenden"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:22
 #: share/completions/zypper.fish:48
-#, fuzzy
 msgid "Install newly added packages recommended by installed packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installera paket även om de ersätter filer från andra, redan installerade "
-"paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:23
 #: share/completions/zypper.fish:49
-#, fuzzy
 msgid "Update installed packages with newer versions"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa alla källkodspaket med version"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:24
 #: share/completions/zypper.fish:50
-#, fuzzy
 msgid "List available updates"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa tillgängliga paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:25
 #: share/completions/zypper.fish:51
-#, fuzzy
 msgid "Install needed patches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Installera nytt paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:26
 #: share/completions/zypper.fish:52
-#, fuzzy
 msgid "List needed patches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa byteavstånd för matchningar"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:27
 #: share/completions/zypper.fish:53
-#, fuzzy
 msgid "Perform a distribution upgrade"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Utför en simulering"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:28
 #: share/completions/zypper.fish:54
-#, fuzzy
 msgid "Check for patches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Dekomprimera fixar"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:29
 #: share/completions/zypper.fish:55
-#, fuzzy
 msgid "Search for packages matching a pattern"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Sök paket innehållande mönster"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:30
 #: share/completions/zypper.fish:56
-#, fuzzy
 msgid "Show full information for specified packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa fulla versioner för paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:31
 #: share/completions/zypper.fish:57
-#, fuzzy
 msgid "Show full information for specified patches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv profileringsinformation till angiven fil"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:32
 #: share/completions/zypper.fish:58
-#, fuzzy
 msgid "Show full information for specified patterns"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa inte filer som matchar mönster"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:33
 #: share/completions/zypper.fish:59
-#, fuzzy
 msgid "Show full information for specified products"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv profileringsinformation till angiven fil"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:34
 #: share/completions/zypper.fish:60
-#, fuzzy
 msgid "List all available patches"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:35
 #: share/completions/zypper.fish:61
-#, fuzzy
 msgid "List all available packages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Ominstallera paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:36
 #: share/completions/zypper.fish:62
-#, fuzzy
 msgid "List all available patterns"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:37
 #: share/completions/zypper.fish:63
-#, fuzzy
 msgid "List all available products"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:38
 #: share/completions/zypper.fish:64
-#, fuzzy
 msgid "List packages providing specified capability"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Fråga alla paket som tillhandahåller den angivna förmågan"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:39
 #: share/completions/zypper.fish:65
-#, fuzzy
 msgid "Add a package lock"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Bygg om paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:40
 #: share/completions/zypper.fish:66
-#, fuzzy
 msgid "Remove a package lock"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:41
 #: share/completions/zypper.fish:67
-#, fuzzy
 msgid "List current package locks"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Lista buggar från paket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:42
 #: share/completions/zypper.fish:68
-#, fuzzy
 msgid "Remove unused locks"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Radera källkodpaket"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:43
 #: share/completions/zypper.fish:69
@@ -58268,12 +56391,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:44
 #: share/completions/zypper.fish:70
-#, fuzzy
 msgid "Print the target operating system ID string"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa operativsystem"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:45
 #: share/completions/zypper.fish:71
@@ -58282,12 +56401,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:46
 #: share/completions/zypper.fish:72
-#, fuzzy
 msgid "Download source rpms for all installed packages to a local directory"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Nedstig aldrig i föräldrakatalog"
 
 #: /tmp/fish/implicit/share/completions/zypper.fish:48
 msgid "Output the version number"
@@ -59139,12 +57254,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/_.fish:1 share/functions/_.fish:8
 #: share/functions/_.fish:12
-#, fuzzy
 msgid "Alias for the gettext command"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Hjälp för det angivna kommandot"
 
 #: /tmp/fish/implicit/share/functions/_.fish:2
 msgid "Fallback alias for the gettext command"
@@ -59160,12 +57271,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_atool_archive_contents.fish:1
 #: share/functions/__fish_complete_atool_archive_contents.fish:1
-#, fuzzy
 msgid "List archive contents"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa arkivinnehåll"
 
 #: share/functions/__fish_complete_bittorrent.fish:9
 msgid "IP to report to the tracker"
@@ -59190,12 +57297,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_convert_options.fish:1
 #: share/functions/__fish_complete_convert_options.fish:1
-#, fuzzy
 msgid "Complete Convert options"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Tolerera slarviga monteringsflaggor"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_directories.fish:1
 msgid "Complete directory prefixes"
@@ -59336,21 +57439,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_lpr_option.fish:1
 #: share/functions/__fish_complete_lpr_option.fish:1
-#, fuzzy
 msgid "Complete lpr option"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Tolerera slarviga monteringsflaggor"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_path.fish:1
 #: share/functions/__fish_complete_path.fish:1
-#, fuzzy
 msgid "Complete using path"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Tolerera slarviga monteringsflaggor"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_pgrep.fish:1
 msgid "Complete pgrep/pkill"
@@ -59423,12 +57518,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_proc.fish:1
 #: share/functions/__fish_complete_proc.fish:1
-#, fuzzy
 msgid "Complete by list of running processes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa lista på alla körande screen-sessioner"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:1
 msgid "common completions for ssh commands"
@@ -59436,21 +57527,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:2
 #: share/functions/__fish_complete_ssh.fish:4
-#, fuzzy
 msgid "Protocol version 1 only"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Bara protokoll version 1"
 
 #: /tmp/fish/implicit/share/functions/__fish_complete_ssh.fish:3
 #: share/functions/__fish_complete_ssh.fish:5
-#, fuzzy
 msgid "Protocol version 2 only"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Bara protokoll version 2"
 
 #: share/functions/__fish_complete_ssh.fish:6
 msgid "IPv4 addresses only"
@@ -59530,12 +57613,8 @@ msgstr "Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
 #: /tmp/fish/implicit/share/functions/__fish_config_interactive.fish:3
 #: share/functions/__fish_config_interactive.fish:137
-#, fuzzy
 msgid "Event handler, repaints the prompt when fish_color_cwd_root changes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
 #: share/functions/__fish_config_interactive.fish:149
 msgid "Start service"
@@ -59604,12 +57683,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:2
 #: share/functions/__fish_git_prompt.fish:348
-#, fuzzy
 msgid "Prompt function for Git"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Nuvarande funktioner är: "
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:3
 #: share/functions/__fish_git_prompt.fish:458
@@ -59642,30 +57717,18 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:8
 #: share/functions/__fish_git_prompt.fish:730
-#, fuzzy
 msgid "Event handler, repaints prompt when functionality changes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:9
 #: share/functions/__fish_git_prompt.fish:748
-#, fuzzy
 msgid "Event handler, repaints prompt when any color changes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
 #: /tmp/fish/implicit/share/functions/__fish_git_prompt.fish:10
 #: share/functions/__fish_git_prompt.fish:768
-#, fuzzy
 msgid "Event handler, repaints prompt when any char changes"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Händelsehanterare, ritar om prompten när fish_color_cwd ändras"
 
 #: /tmp/fish/implicit/share/functions/__fish_gnu_complete.fish:1
 msgid ""
@@ -59675,12 +57738,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_hg_prompt.fish:1
 #: share/functions/__fish_hg_prompt.fish:23
-#, fuzzy
 msgid "Write out the hg prompt"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv prompten"
 
 #: /tmp/fish/implicit/share/functions/fish_hybrid_key_bindings.fish:1
 msgid "Vi-style bindings that inherit emacs-style bindings in all modes"
@@ -59721,21 +57780,13 @@ msgid "List names of available signals"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_make_completion_signals.fish:3
-#, fuzzy
 msgid "List codes and names of available signals"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa namnen på alla tillgängliga signaler"
 
 #: /tmp/fish/implicit/share/functions/fish_mode_prompt.fish:1
 #: share/functions/fish_vi_prompt.fish:1
-#, fuzzy
 msgid "Displays the current mode"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa säkerhetskontext"
 
 #: /tmp/fish/implicit/share/functions/__fish_move_last.fish:1
 msgid "Move the last element of a directory history from src to dest"
@@ -59755,21 +57806,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_addresses.fish:1
 #: share/functions/__fish_print_addresses.fish:1
-#, fuzzy
 msgid "Print a list of known network addresses"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa lista på alla körande screen-sessioner"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_commands.fish:1
 #: share/functions/__fish_print_commands.fish:1
-#, fuzzy
 msgid "Print a list of documented fish commands"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa en lista på alla tillåtna färgnamn"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_encodings.fish:1
 msgid "Complete using available character encodings"
@@ -59794,39 +57837,23 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_interfaces.fish:1
 #: share/functions/__fish_print_interfaces.fish:1
-#, fuzzy
 msgid "Print a list of known network interfaces"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa en lista på alla tillåtna färgnamn"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_lpr_options.fish:1
 #: share/functions/__fish_print_lpr_options.fish:1
-#, fuzzy
 msgid "Print lpr options"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa alla versioner"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_lpr_printers.fish:1
 #: share/functions/__fish_print_lpr_printers.fish:1
-#, fuzzy
 msgid "Print lpr printers"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa fulla poster"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_mounted.fish:1
 #: share/functions/__fish_print_mounted.fish:1
-#, fuzzy
 msgid "Print mounted devices"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa viktiga beroenden"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_pacman_repos.fish:1
 msgid "Print the repositories configured for arch's pacman package manager"
@@ -59838,21 +57865,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_svn_rev.fish:1
 #: share/functions/__fish_print_svn_rev.fish:1
-#, fuzzy
 msgid "Print svn revisions"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv bara ut angiven revision"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_users.fish:1
 #: share/functions/__fish_print_users.fish:2
-#, fuzzy
 msgid "Print a list of local users"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa en lista på alla tillåtna färgnamn"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_applications_directories.fish:1
 msgid "Print directories where desktop files are stored"
@@ -59860,21 +57879,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xdg_mimetypes.fish:1
 #: share/functions/__fish_print_xdg_mimetypes.fish:1
-#, fuzzy
 msgid "Print XDG mime types"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv ut kommandotyp"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_xwindows.fish:1
 #: share/functions/__fish_print_xwindows.fish:1
-#, fuzzy
 msgid "Print X windows"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa APM-information"
 
 #: /tmp/fish/implicit/share/functions/__fish_print_zfs_snapshots.fish:1
 msgid "Lists ZFS snapshots"
@@ -59887,12 +57898,8 @@ msgstr "Skriv prompten"
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:1
 #: /tmp/fish/implicit/share/functions/__fish_pwd.fish:2
 #: share/functions/__fish_pwd.fish:3 share/functions/__fish_pwd.fish:7
-#, fuzzy
 msgid "Show current path"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa alla källkodspaket"
 
 #: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
 msgid "Call grep without honoring GREP_OPTIONS settings"
@@ -59924,12 +57931,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_update_completions.fish:1
 #: share/functions/fish_update_completions.fish:1
-#, fuzzy
 msgid "Update man-page based completions"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Redigera kommando-specifika kompletteringar"
 
 #: /tmp/fish/implicit/share/functions/__fish_use_subcommand.fish:1
 msgid "Test if a non-switch argument has been given in the current commandline"
@@ -59945,21 +57948,13 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/fish_vi_key_bindings.fish:1
 #: share/functions/fish_vi_key_bindings.fish:1
-#, fuzzy
 msgid "vi-like key bindings for fish"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Välj fil med tangentbordsgenvägar"
 
 #: /tmp/fish/implicit/share/functions/funced.fish:1
 #: share/functions/funced.fish:1
-#, fuzzy
 msgid "Edit function definition"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"funktionsdefinition-block"
 
 #: /tmp/fish/implicit/share/functions/funcsave.fish:1
 #: share/functions/funcsave.fish:2
@@ -59997,12 +57992,8 @@ msgid "List contents of directory"
 msgstr "Visa kataloginnehåll"
 
 #: /tmp/fish/implicit/share/functions/man.fish:1 share/functions/man.fish:1
-#, fuzzy
 msgid "Format and display the on-line manual pages"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa ändringsinformation för paket"
 
 #: share/functions/nextd.fish:2
 msgid "Move forward in the directory history"
@@ -60026,12 +58017,8 @@ msgstr "Gå bakåt i kataloghistorik"
 
 #: /tmp/fish/implicit/share/functions/prompt_pwd.fish:1
 #: share/functions/prompt_pwd.fish:11
-#, fuzzy
 msgid "Print the current working directory, shortened to fit the prompt"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa aktuell arbetskatalog, förkortad till att passa i kommandoraden"
 
 #: share/functions/psub.fish:3
 msgid ""
@@ -60058,20 +58045,12 @@ msgid "return an absolute path without symlinks"
 msgstr ""
 
 #: /tmp/fish/implicit/share/functions/seq.fish:1 share/functions/seq.fish:7
-#, fuzzy
 msgid "Print sequences of numbers"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa namn, inte nummer"
 
 #: /tmp/fish/implicit/share/functions/seq.fish:2 share/functions/seq.fish:11
-#, fuzzy
 msgid "Fallback implementation of the seq command"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Visa alla möjliga kompletteringar för det angivna commandot"
 
 #: /tmp/fish/implicit/share/functions/setenv.fish:1
 msgid "Set an env var for csh compatibility."
@@ -60083,12 +58062,8 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/functions/__terlar_git_prompt.fish:1
 #: share/functions/__terlar_git_prompt.fish:23
-#, fuzzy
 msgid "Write out the git prompt"
 msgstr ""
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"#-#-#-#-#  sv.po (fish 1.22.3)  #-#-#-#-#\n"
-"Skriv prompten"
 
 #: /tmp/fish/implicit/share/functions/trap.fish:1
 msgid "Perform an action when the shell receives a signal"
@@ -60153,9 +58128,9 @@ msgstr ""
 "och kan inte användas som funktionsnamn\n"
 
 #: builtin.cpp:2248
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: No function name given\n"
-msgstr "%ls: Inget funktionsnamn givet\n"
+msgstr ""
 
 #: builtin.cpp:2276
 #, c-format
@@ -60173,9 +58148,9 @@ msgid "%ls: Expected zero or one argument, got %d\n"
 msgstr "%ls: Förväntade noll eller ett argument, fick %d\n"
 
 #: builtin.cpp:2656
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: --array option requires a single variable name.\n"
-msgstr "%ls: --array flaggan kräver ett enskilt variablenamn.\n"
+msgstr ""
 
 #: builtin.cpp:3688
 msgid "(default)"
@@ -60219,9 +58194,9 @@ msgstr ""
 "'%ls'existerar readn.\n"
 
 #: builtin_set_color.cpp:173
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: Could not set up terminal\n"
-msgstr "%ls: Kunde inte initiera terminalen\n"
+msgstr ""
 
 #: complete.cpp:901 complete.cpp:919
 msgid "Unknown option: "
@@ -60342,37 +58317,29 @@ msgid "%lsand 1 more row"
 msgstr "%lsoch 1 rad till"
 
 #: parse_execution.cpp:799
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Unknown command '%ls'. Did you mean to run %ls with a modified environment? "
 "Try 'env %ls=%ls %ls%ls'. See the help section on the set command by typing "
 "'help set'."
 msgstr ""
-"Okänt kommando '%ls'. Menade du 'set %ls %ls'? För mer information om hur "
-"man tilldelar variabler, se hjälpsektionen om det inbyggda kommandot 'set' "
-"genom att skriva 'help set'."
 
 #: parse_execution.cpp:824
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function like "
 "'function %ls; %ls $argv; end' or use the eval builtin instead, like 'eval "
 "%ls'. See the help section for the function command by typing 'help "
 "function'."
 msgstr ""
-"Variabler får inte användas som kommandon. Definera istället en funktion, t."
-"ex. 'function %ls; %ls $argv; end'. Se hjälpsektionen för function-kommandot "
-"genom att skriva 'help function'"
 
 #: parse_execution.cpp:833
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Variables may not be used as commands. Instead, define a function or use the "
 "eval builtin instead, like 'eval %ls'. See the help section for the function "
 "command by typing 'help function'."
 msgstr ""
-"Variabler får inte användas som kommandon. Definera istället en funktion. Se "
-"hjälpsektionen för function-kommandot genom att skriva 'help function'"
 
 #: parse_execution.cpp:841
 #, c-format
@@ -60406,9 +58373,9 @@ msgid "End of block mismatch. Program terminating."
 msgstr "Blockslut matchar inte. Programmet avslutas."
 
 #: proc.cpp:690
-#, fuzzy, c-format
+#, c-format
 msgid "'%ls' has %ls"
-msgstr "Jobb %d, '%ls' har %ls"
+msgstr ""
 
 #: proc.cpp:694
 #, c-format
@@ -60529,9 +58496,9 @@ msgid "%ls: can only take 'if' and then another command as an argument\n"
 msgstr ""
 
 #: builtin.h:78
-#, fuzzy, c-format
+#, c-format
 msgid "%ls: any second argument must be 'if'\n"
-msgstr "%ls: Andra argumentet måste vara 'in'\n"
+msgstr ""
 
 #: builtin.h:88
 #, c-format
@@ -60548,36 +58515,26 @@ msgid "Array index out of bounds"
 msgstr "Arrayindexet är otållåtet"
 
 #: parse_constants.h:192
-#, fuzzy
 msgid ""
 "Expected a command, but instead found a pipe. Did you mean 'COMMAND; or "
 "COMMAND'? See the help section for the 'or' builtin command by typing 'help "
 "or'."
 msgstr ""
-"Förväntade att hitta ett kommandonamn, hittade en symbol av typen '%ls'. "
-"Menade du 'KOMMANDO; or KOMMANDO'? Se hjälpsektionen om 'or' genom att "
-"skriva 'help or'."
 
 #: parse_constants.h:195
-#, fuzzy
 msgid ""
 "Expected a command, but instead found an '&'. Did you mean 'COMMAND; and "
 "COMMAND'? See the help section for the 'and' builtin command by typing 'help "
 "and'."
 msgstr ""
-"Förväntade att hitta ett kommandonamn, hittade en symbol av typen '%ls'. "
-"Menade du 'KOMMANDO; and KOMMANDO'? Se hjälpsektionen om 'and' genom att "
-"skriva 'help and'."
 
 #: parse_constants.h:216
-#, fuzzy
 msgid "break command while not inside of loop"
-msgstr "Loopstyrningskommandon får bara användas i loopar."
+msgstr ""
 
 #: parse_constants.h:219
-#, fuzzy
 msgid "continue command while not inside of loop"
-msgstr "Loopstyrningskommandon får bara användas i loopar."
+msgstr ""
 
 #: parse_constants.h:222
 msgid "'return' builtin command outside of function definition"
@@ -60585,14 +58542,11 @@ msgstr ""
 "Det inbyggda kommandot 'return' påträffades utanför en funktionsdefinition"
 
 #: parse_constants.h:225
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Unknown command '%ls'. Did you mean 'set %ls %ls'? See the help section on "
 "the set command by typing 'help set'."
 msgstr ""
-"Okänt kommando '%ls'. Menade du 'set %ls %ls'? För mer information om hur "
-"man tilldelar variabler, se hjälpsektionen om det inbyggda kommandot 'set' "
-"genom att skriva 'help set'."
 
 #: parse_constants.h:230
 #, c-format
@@ -60668,14 +58622,12 @@ msgid "Set security context of copy to CONTEXT"
 msgstr "Ange säkerhetskontext för kopia"
 
 #: share/completions/cvs.fish:26
-#, fuzzy
 msgid "Use \\tmpdir for temporary files."
-msgstr "Välj temporär katalog"
+msgstr ""
 
 #: share/completions/cvs.fish:27
-#, fuzzy
 msgid "Use \\editor for editing log information."
-msgstr "Välj editor för loginformationsredigering"
+msgstr ""
 
 #: share/completions/cvs.fish:28
 #, sh-format
@@ -60683,19 +58635,16 @@ msgid "Overrides $CVSROOT as the root of the CVS tree."
 msgstr ""
 
 #: share/completions/cvs.fish:30
-#, fuzzy
 msgid "Request compression level \\# for net traffic."
-msgstr "Kompressionsnivå för nätverkstrafik"
+msgstr ""
 
 #: share/completions/cvs.fish:52
-#, fuzzy
 msgid "Create a CVS repository if it doesn\\t"
-msgstr "Skapa förråd om det inte redan existerar"
+msgstr ""
 
 #: share/completions/cvs.fish:97
-#, fuzzy
 msgid "Replace revision\\s"
-msgstr "Slå ihop revisioner"
+msgstr ""
 
 #: share/completions/darcs.fish:44
 msgid ""
@@ -60704,9 +58653,8 @@ msgid ""
 msgstr ""
 
 #: share/completions/darcs.fish:171
-#, fuzzy
 msgid "Define token to contain these characters"
-msgstr "Dela inte multibytesekvenser"
+msgstr ""
 
 #: share/completions/darcs.fish:501
 msgid "Shell command that runs regression tests"
@@ -60749,24 +58697,20 @@ msgid "Call DCOP for each line read from stdin"
 msgstr "Anropa DCOP för varje rad läst från standard in"
 
 #: share/completions/df.fish:17
-#, fuzzy
 msgid "Show file systems of specified type"
-msgstr "Visa filsystem av angiven typ"
+msgstr ""
 
 #: share/completions/docker.fish:19
-#, fuzzy
 msgid "Show all containers"
-msgstr "Visa ARP-inlägg"
+msgstr ""
 
 #: share/completions/docker.fish:24
-#, fuzzy
 msgid "Show the running containers"
-msgstr "Visa dolda funktioner"
+msgstr ""
 
 #: share/completions/docker.fish:28
-#, fuzzy
 msgid "Show the exited containers"
-msgstr "Visa tid"
+msgstr ""
 
 #: share/completions/docker.fish:70 share/completions/docker.fish:92
 msgid "Docker container"
@@ -60799,38 +58743,32 @@ msgid ""
 msgstr ""
 
 #: share/completions/gem.fish:87
-#, fuzzy
 msgid "display the package version"
-msgstr "Visa paketpost"
+msgstr ""
 
 #: share/completions/gem.fish:87
 msgid "display the path where gems are installed"
 msgstr ""
 
 #: share/completions/gem.fish:87
-#, fuzzy
 msgid "display path used to search for gems"
-msgstr "Visa sessionsnyckel som används för ett meddelande"
+msgstr ""
 
 #: share/completions/gem.fish:87
-#, fuzzy
 msgid "display the gem format version"
-msgstr "Visa uppdateringsinformation"
+msgstr ""
 
 #: share/completions/gem.fish:92
-#, fuzzy
 msgid "list all 'gem' commands"
-msgstr "Inaktivera kommando"
+msgstr ""
 
 #: share/completions/git.fish:98
-#, fuzzy
 msgid "name"
-msgstr "Användarnamn"
+msgstr ""
 
 #: share/completions/help.fish:6
-#, fuzzy
 msgid "Help for this command"
-msgstr "Välj promptkommando"
+msgstr ""
 
 #: share/completions/help.fish:10
 msgid "Incomplete aspects of fish"
@@ -60914,43 +58852,36 @@ msgid "Match history items that contain the given string"
 msgstr ""
 
 #: share/completions/obnam.fish:9
-#, fuzzy
 msgid "Adds an encryption key to the repository"
-msgstr "Lägg till fil/katalog till förråd"
+msgstr ""
 
 #: share/completions/obnam.fish:11
 msgid "Lists the keys associated with each client"
 msgstr ""
 
 #: share/completions/obnam.fish:12
-#, fuzzy
 msgid "Lists the clients in the repository"
-msgstr "Uppdatera förråd"
+msgstr ""
 
 #: share/completions/obnam.fish:13
-#, fuzzy
 msgid "Compares two generations"
-msgstr "Tolerera slarviga monteringsflaggor"
+msgstr ""
 
 #: share/completions/obnam.fish:14
-#, fuzzy
 msgid "Dumps the repository"
-msgstr "Uppdatera förråd"
+msgstr ""
 
 #: share/completions/obnam.fish:15
-#, fuzzy
 msgid "Removes a lock file for a client"
-msgstr "Ta bort alla gz-filer från cache"
+msgstr ""
 
 #: share/completions/obnam.fish:16
-#, fuzzy
 msgid "Removes backup generations"
-msgstr "Ta bort komplettering"
+msgstr ""
 
 #: share/completions/obnam.fish:17
-#, fuzzy
 msgid "Checks the consistency of the repository"
-msgstr "Kontrollera hela lagret"
+msgstr ""
 
 #: share/completions/obnam.fish:18
 msgid "Lists every backup generation"
@@ -60961,48 +58892,40 @@ msgid "Lists the identifier for every generation"
 msgstr ""
 
 #: share/completions/obnam.fish:20
-#, fuzzy
 msgid "Lists the keys"
-msgstr "Visa pålitliga nycklar"
+msgstr ""
 
 #: share/completions/obnam.fish:21
-#, fuzzy
 msgid "Lists the toplevel keys"
-msgstr "Visa pålitliga nycklar"
+msgstr ""
 
 #: share/completions/obnam.fish:22
-#, fuzzy
 msgid "Lists the contents of a given generation"
-msgstr "Visa kataloginnehåll"
+msgstr ""
 
 #: share/completions/obnam.fish:23
-#, fuzzy
 msgid "Makes the repository available via FUSE"
-msgstr "Uppdatera förråd"
+msgstr ""
 
 #: share/completions/obnam.fish:24
 msgid "Check if a backup age exceeds a threshold"
 msgstr ""
 
 #: share/completions/obnam.fish:25
-#, fuzzy
 msgid "Removes a client from the repository"
-msgstr "Ange förråd-URL"
+msgstr ""
 
 #: share/completions/obnam.fish:26
-#, fuzzy
 msgid "Removes a key from the repository"
-msgstr "Skapa lokal kopia av förråd"
+msgstr ""
 
 #: share/completions/obnam.fish:27
-#, fuzzy
 msgid "Restore files from the repository"
-msgstr "Checka in filer till förråd"
+msgstr ""
 
 #: share/completions/obnam.fish:28
-#, fuzzy
 msgid "Verifies files in the repository"
-msgstr "Checka in filer till förråd"
+msgstr ""
 
 #: share/completions/obnam.fish:87
 msgid "Do not check data for cient NAME."
@@ -61078,9 +59001,8 @@ msgid "Complete atool"
 msgstr ""
 
 #: share/functions/__fish_complete_grep.fish:48
-#, fuzzy
 msgid "Obsolete synonym for -i"
-msgstr "Synonym för -i"
+msgstr ""
 
 #: share/functions/__fish_complete_grep.fish:49
 msgid "treat input as a set of lines each terminated by a zero byte"
@@ -61093,104 +59015,88 @@ msgid "Don\\t"
 msgstr ""
 
 #: share/functions/__fish_complete_setxkbmap.fish:1
-#, fuzzy
 msgid "Complete setxkb options"
-msgstr "Tolerera slarviga monteringsflaggor"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:77
-#, fuzzy
 msgid "Remove \\conflicted state on working copy files or directories."
-msgstr "Ta bort konflikttillstånd hos arbetskopiefiler eller kataloger"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:103
-#, fuzzy
 msgid "Specify log message"
-msgstr "Välj e-postkatalog"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:105
-#, fuzzy
 msgid "Read log message from file"
-msgstr "Läs loggmeddelande från fil"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:106
-#, fuzzy
 msgid "Force validity of log message source"
-msgstr "Tvinga validitet av loggmeddelandes källa"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:118
-#, fuzzy
 msgid "Print nothing, or only summary information"
-msgstr "Visa all information"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:122
 msgid "Force operation to run"
 msgstr "Tvinga operationen att utföras"
 
 #: share/functions/__fish_complete_svn.fish:126
-#, fuzzy
 msgid "Process contents of file ARG as additional args"
-msgstr "Skicka filinnehåll som extra argument"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:130
 msgid "Operate only on members of changelist"
 msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:134
-#, fuzzy
 msgid "Output in xml"
-msgstr "Utadata i XML-format"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:138
-#, fuzzy
 msgid "Retrieve revision property"
-msgstr "Utför på revisionsegenskap"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:150
 msgid "Ignore externals definitions"
 msgstr "Ignorera definitioner av externals"
 
 #: share/functions/__fish_complete_svn.fish:154
-#, fuzzy
 msgid "Print extra information"
-msgstr "Visa all information"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:158
-#, fuzzy
 msgid "Operate on a revision property (use with -r)"
-msgstr "Utför på revisionsegenskap"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:162
 msgid "Add intermediate parents"
 msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:189
-#, fuzzy
 msgid "Try operation but make no changes"
-msgstr "Försök hitta en mindre uppsättning ändringar"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:193
-#, fuzzy
 msgid "Ignore ancestry when calculating merges"
-msgstr "Ignorera ursprung vid beräknandet av sammanslagning"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:197
-#, fuzzy
 msgid "Override diff-cmd specified in config file"
-msgstr "Flytta filen angiven på kommandoraden"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:198
-#, fuzzy
 msgid "Use external diff command"
-msgstr "Ångra ett redigeringskommando"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:202
 msgid "Disable automatic properties"
 msgstr "Inaktivera automatiska egenskaper"
 
 #: share/functions/__fish_complete_svn.fish:206
-#, fuzzy
 msgid "Set new working copy depth"
-msgstr "Välj RAW-skrivläge"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:230
 msgid "don\\t"
@@ -61205,43 +59111,36 @@ msgid "Use ARG as the newer target"
 msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:243
-#, fuzzy
 msgid "Do not print differences for deleted files"
-msgstr "Skriv inte ut rader utan fältavgränsare"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:244
-#, fuzzy
 msgid "Notice ancestry when calculating differences"
-msgstr "Ignorera ursprung vid beräknandet av sammanslagning"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:245
-#, fuzzy
 msgid "Show a summary of the results"
-msgstr "Välj en konfigurationsinställning"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:257
-#, fuzzy
 msgid "Do not cross copies while traversing history"
-msgstr "Korsa inte kopior"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:259
-#, fuzzy
 msgid "Produce diff output"
-msgstr "Ljudutdata"
+msgstr ""
 
 #: share/functions/__fish_complete_svn.fish:279
 msgid "Use strict semantics"
 msgstr "Använd strikt semantik"
 
 #: share/functions/__fish_complete_svn.fish:306
-#, fuzzy
 msgid "Relocate via URL-rewriting"
-msgstr "Relokera via URL-omskrivning"
+msgstr ""
 
 #: share/functions/__fish_complete_svn_diff.fish:1
-#, fuzzy
 msgid "Complete \"svn diff\" arguments"
-msgstr "Räkna antalet argument"
+msgstr ""
 
 #: share/functions/__fish_complete_tar.fish:14
 #: share/functions/__fish_complete_tar.fish:21
@@ -61273,73 +59172,60 @@ msgid "Hit end of history...\\n"
 msgstr "Slut på kataloghistorik...\\n"
 
 #: share/functions/__fish_print_abook_emails.fish:1
-#, fuzzy
 msgid "Print email addresses (abook)"
-msgstr "Visa döda processer"
+msgstr ""
 
 #: share/functions/__fish_print_arch_daemons.fish:1
-#, fuzzy
 msgid "Print arch daemons"
-msgstr "Visa alla namn"
+msgstr ""
 
 #: share/functions/__fish_print_debian_services.fish:1
-#, fuzzy
 msgid "Prints services installed"
-msgstr "Visa status för tjänst"
+msgstr ""
 
 #: share/functions/__fish_print_lsblk_columns.fish:1
-#, fuzzy
 msgid "Print available lsblk columns"
-msgstr "Visa tillgängliga paket"
+msgstr ""
 
 #: share/functions/__fish_print_xdg_mimeapps.fish:1
-#, fuzzy
 msgid "Print xdg mime applications"
-msgstr "Visa all information"
+msgstr ""
 
 #: share/functions/__fish_print_xrandr_modes.fish:1
-#, fuzzy
 msgid "Print xrandr modes"
-msgstr "Skriv obehandlade filnamn"
+msgstr ""
 
 #: share/functions/__fish_print_xrandr_outputs.fish:1
-#, fuzzy
 msgid "Print xrandr outputs"
-msgstr "Visa antal ord"
+msgstr ""
 
 #: share/functions/__fish_test_arg.fish:2
 msgid "Test if the token under the cursor matches the specified wildcard"
 msgstr ""
 
 #: share/functions/__fish_urlencode.fish:1
-#, fuzzy
 msgid "URL-encode stdin"
-msgstr "Byt namn på standard in"
+msgstr ""
 
 #: share/functions/abbr.fish:1
-#, fuzzy
 msgid "Manage abbreviations"
-msgstr "Manualsektion"
+msgstr ""
 
 #: share/functions/abbr.fish:40
-#, fuzzy
 msgid "%s: invalid option -- %s\\n"
-msgstr "%s: Ogiltigt flagga -- %s\\n"
+msgstr ""
 
 #: share/functions/abbr.fish:47
-#, fuzzy
 msgid "%s: %s cannot be specified along with %s\\n"
-msgstr "%s: Värden kan inte anges vid radering %s\\n"
+msgstr ""
 
 #: share/functions/abbr.fish:56
-#, fuzzy
 msgid "%s: option requires an argument -- %s\\n"
-msgstr "%s: Flaggan kräver ett argument -- %s\\n"
+msgstr ""
 
 #: share/functions/abbr.fish:62
-#, fuzzy
 msgid "%s: Unexpected argument -- %s\\n"
-msgstr "%ls: Förväntade argument\\n"
+msgstr ""
 
 #: share/functions/abbr.fish:75
 msgid "%s: abbreviation must have a non-empty key\\n"
@@ -61350,9 +59236,8 @@ msgid "%s: abbreviation must have a value\\n"
 msgstr ""
 
 #: share/functions/abbr.fish:101
-#, fuzzy
 msgid "%s: no such abbreviation '%s'\\n"
-msgstr "%s: Okänd funktion '%s'\\n"
+msgstr ""
 
 #: share/functions/alias.fish:2
 msgid ""
@@ -61362,9 +59247,8 @@ msgstr ""
 "liknande syntax"
 
 #: share/functions/alias.fish:36
-#, fuzzy
 msgid "%s: Expected one or two arguments, got %d\\n"
-msgstr "%ls: Förväntade ett eller två argument, fick %d"
+msgstr ""
 
 #: share/functions/dirh.fish:2
 msgid "Print the current directory history (the back- and fwd- lists)"
@@ -61383,29 +59267,21 @@ msgid "Simple vi prompt"
 msgstr ""
 
 #: share/functions/funced.fish:36
-#, fuzzy
 msgid "funced: You must specify one function name\n"
-msgstr "%ls: Förväntade exakt ett funktionsnamn\n"
+msgstr ""
 
 #: share/functions/funcsave.fish:11
-#, fuzzy
 msgid "%s: Expected function name\\n"
-msgstr "%s: Förväntade ett funktionsnamn\\n"
+msgstr ""
 
 #: share/functions/help.fish:77
-#, fuzzy, sh-format
+#, sh-format
 msgid ""
 "Please set the variable $BROWSER to a suitable browser and try again.\\n\\n"
 msgstr ""
-"Var vänlig sätt variablen $BROWSER så den anger en lämplig browser och "
-"försök igen\\n\\n"
 
 #: share/functions/history.fish:5
 msgid "Deletes an item from history"
-msgstr ""
-
-#: share/functions/hostname.fish:7
-msgid "Show or set the system's host name"
 msgstr ""
 
 #: share/functions/math.fish:2
@@ -64869,7 +62745,6 @@ msgstr ""
 #~ msgid "Whether to inform the user that hash failures occur"
 #~ msgstr "Om användaren skall informeras om hashfel"
 
-#, fuzzy
 #~ msgid "%ls: Expected zero or two parameters, got %d\n"
 #~ msgstr "%ls: Förväntade noll eller två argument, fick %d"
 
@@ -64947,7 +62822,6 @@ msgstr ""
 #~ msgid "Loop control command while not inside of loop"
 #~ msgstr "Loopstyrningskommandon får bara användas i loopar."
 
-#, fuzzy
 #~ msgid "'%ls' builtin not inside of if block"
 #~ msgstr "Det inbyggda kommandot 'else' får bara användas i ett if-block"
 
@@ -64976,278 +62850,210 @@ msgstr ""
 #~ msgid "Control creation of sparse files"
 #~ msgstr "Kontrollera skapandet av glesa filer"
 
-#, fuzzy
 #~ msgid "add the specified files on the next commit"
 #~ msgstr "Lägg till angiven fil fill den nuvarande listan av nyckelringar"
 
-#, fuzzy
 #~ msgid "show changeset information by line for each file"
 #~ msgstr "Visa ändringsinformation för paket"
 
-#, fuzzy
 #~ msgid "create an unversioned archive of a repository revision"
 #~ msgstr "Lägg till fil eller träd utan version till förrådet"
 
-#, fuzzy
 #~ msgid "list repository named branches"
 #~ msgstr "Inaktivera förråd"
 
-#, fuzzy
 #~ msgid "create a changegroup file"
 #~ msgstr "Skapa en kontrollpunktfil"
 
-#, fuzzy
 #~ msgid "output the current or given revision of files"
 #~ msgstr "Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
 
-#, fuzzy
 #~ msgid "make a copy of an existing repository"
 #~ msgstr "Skapa lokal kopia av förråd"
 
-#, fuzzy
 #~ msgid "commit the specified files or all outstanding changes"
 #~ msgstr "Dekryptera angiven fil eller standard in"
 
-#, fuzzy
 #~ msgid "diff repository (or selected files)"
 #~ msgstr "Radera urval"
 
-#, fuzzy
 #~ msgid "forget the specified files on the next commit"
 #~ msgstr "Flytta filen angiven på kommandoraden"
 
-#, fuzzy
 #~ msgid "copy changes from other branches onto the current branch"
 #~ msgstr "Hämta ändringar från förrådet till arbetskopian"
 
-#, fuzzy
 #~ msgid "identify the working copy or specified revision"
 #~ msgstr "Uppdatera arbetskopian till en annan URL"
 
-#, fuzzy
 #~ msgid "import an ordered set of patches"
 #~ msgstr "Visa byteavstånd för matchningar"
 
-#, fuzzy
 #~ msgid "create a new repository in the given directory"
 #~ msgstr "Skapa förråd om det inte redan existerar"
 
-#, fuzzy
 #~ msgid "locate files matching specific patterns"
 #~ msgstr "Visa inte filer som matchar mönster"
 
-#, fuzzy
 #~ msgid "output the current or given revision of the project manifest"
 #~ msgstr "Visa loggmeddelanden för en uppsättning revisioner och/eller filer"
 
-#, fuzzy
 #~ msgid "show changesets not found in the destination"
 #~ msgstr "Fråga paket med angiven grupp"
 
-#, fuzzy
 #~ msgid "show the parents of the working directory or revision"
 #~ msgstr "Ändra arbetskatalog"
 
-#, fuzzy
 #~ msgid "show aliases for remote repositories"
 #~ msgstr "Ta bort inlägg i .cvspass för fjärrförråd"
 
-#, fuzzy
 #~ msgid "pull changes from the specified source"
 #~ msgstr "Fråga paket med angiven grupp"
 
-#, fuzzy
 #~ msgid "push changes to the specified destination"
 #~ msgstr "Fråga paket med angiven grupp"
 
-#, fuzzy
 #~ msgid "remove the specified files on the next commit"
 #~ msgstr "Flytta filen angiven på kommandoraden"
 
-#, fuzzy
 #~ msgid "roll back the last transaction (dangerous)"
 #~ msgstr "Ordna om fixarna i förrådet"
 
-#, fuzzy
 #~ msgid "print the root (top) of the current working directory"
 #~ msgstr "Ändra arbetskatalog"
 
-#, fuzzy
 #~ msgid "show changed files in the working directory"
 #~ msgstr "Ändra arbetskatalog"
 
-#, fuzzy
 #~ msgid "summarize working directory state"
 #~ msgstr "Visa nuvarande katalog"
 
-#, fuzzy
 #~ msgid "list repository tags"
 #~ msgstr "Inaktivera förråd"
 
-#, fuzzy
 #~ msgid "show the tip revision"
 #~ msgstr "Visa tid"
 
-#, fuzzy
 #~ msgid "apply one or more changegroup files"
 #~ msgstr "Läs paket från fil"
 
-#, fuzzy
 #~ msgid "update working directory (or switch revisions)"
 #~ msgstr "Ändra arbetskatalog"
 
-#, fuzzy
 #~ msgid "verify the integrity of the repository"
 #~ msgstr "Ta bort ett inlägg från förråd"
 
-#, fuzzy
 #~ msgid "output version and copyright information"
 #~ msgstr "Ignorera versionsmagiinformation"
 
-#, fuzzy
 #~ msgid "Configuration Files"
 #~ msgstr "Konfigureringsfil"
 
-#, fuzzy
 #~ msgid "Date Formats"
 #~ msgstr "Välj format"
 
-#, fuzzy
 #~ msgid "Diff Formats"
 #~ msgstr "Listformat"
 
-#, fuzzy
 #~ msgid "Environment Variables"
 #~ msgstr "Redigera miljövariabler"
 
-#, fuzzy
 #~ msgid "Specifying File Sets"
 #~ msgstr "Välj konfigurationsfil"
 
-#, fuzzy
 #~ msgid "Configuring hgweb"
 #~ msgstr "Konfigureringsfil"
 
-#, fuzzy
 #~ msgid "Merge Tools"
 #~ msgstr "Sammanslå sorterade filer"
 
-#, fuzzy
 #~ msgid "Specifying Multiple Revisions"
 #~ msgstr "Ange revision"
 
-#, fuzzy
 #~ msgid "File Name Patterns"
 #~ msgstr "Visa inte filer som matchar mönster"
 
-#, fuzzy
 #~ msgid "Specifying Single Revisions"
 #~ msgstr "Ange revision"
 
-#, fuzzy
 #~ msgid "Specifying Revision Sets"
 #~ msgstr "Ange revisionstiollstånd"
 
-#, fuzzy
 #~ msgid "Subrepositories"
 #~ msgstr "Aktivera förråd"
 
-#, fuzzy
 #~ msgid "[+] include names matching the given patterns"
 #~ msgstr "Visa inte filer som matchar mönster"
 
-#, fuzzy
 #~ msgid "[+] exclude names matching the given patterns"
 #~ msgstr "Lista alla moduler som matchar parameter med jokertecken"
 
-#, fuzzy
 #~ msgid "[+]   include names matching the given patterns"
 #~ msgstr "Visa inte filer som matchar mönster"
 
-#, fuzzy
 #~ msgid "[+]   exclude names matching the given patterns"
 #~ msgstr "Lista alla moduler som matchar parameter med jokertecken"
 
-#, fuzzy
 #~ msgid "Annotate the specified revision"
 #~ msgstr "Hjälp för det angivna inbyggda kommandot"
 
-#, fuzzy
 #~ msgid "Use text as commit message"
 #~ msgstr "Läs meddelande för tillägg från fil"
 
 #~ msgid "Read commit message from file"
 #~ msgstr "Läs meddelande för tillägg från fil"
 
-#, fuzzy
 #~ msgid "Record the specified date as commit date"
 #~ msgstr "Hjälp för det angivna kommandot"
 
-#, fuzzy
 #~ msgid "Record the specified user as committer"
 #~ msgstr "Använd angiven sträng som kommentarsträng"
 
-#, fuzzy
 #~ msgid "File to store the bundles into"
 #~ msgstr "Redigera fix-paketbeskrivning"
 
-#, fuzzy
 #~ msgid "Limit number of changes displayed"
 #~ msgstr "Skriv bara ut angivet antal matchningar"
 
-#, fuzzy
 #~ msgid "Display with template"
 #~ msgstr "Visa alla matchningar"
 
-#, fuzzy
 #~ msgid "Specify ssh command to use"
 #~ msgstr "Ange kommando att operera på"
 
-#, fuzzy
 #~ msgid "Specify hg command to run on the remote side"
 #~ msgstr "Välj destinationsadress"
 
-#, fuzzy
 #~ msgid "Search the repository as it is in REV"
 #~ msgstr "Ange förråd-URL"
 
-#, fuzzy
 #~ msgid "Show revisions matching date spec"
 #~ msgstr "Visa bara matchande del"
 
-#, fuzzy
 #~ msgid "Revision to display"
 #~ msgstr "Välj display"
 
-#, fuzzy
 #~ msgid "Specify merge tool"
 #~ msgstr "Ange förtroendemodell"
 
-#, fuzzy
 #~ msgid "Show parents of the specified revision"
 #~ msgstr "Fråga paket med angiven grupp"
 
-#, fuzzy
 #~ msgid "[+] target revision"
 #~ msgstr "Slå ihop revisioner"
 
-#, fuzzy
 #~ msgid "Tipmost revision matching date"
 #~ msgstr "Visa inte filer som matchar mönster"
 
-#, fuzzy
 #~ msgid "Revert to the specified revision"
 #~ msgstr "Flytta filen angiven på kommandoraden"
 
-#, fuzzy
 #~ msgid "For remote clients"
 #~ msgstr "Visa eller ta bort funktioner"
 
-#, fuzzy
 #~ msgid "Untrusted configuration options"
 #~ msgstr "Välj konfigurationsinställningar"
 
-#, fuzzy
 #~ msgid "List the changed files of a revision"
 #~ msgstr "Visa alla engenskaper hos filer, kataloger eller revisioner"
 
@@ -65358,15 +63164,12 @@ msgstr ""
 #~ msgid "Tag the contents of the repository with a version name"
 #~ msgstr "Tagga innehållet i lagret med ett versionsnummer"
 
-#, fuzzy
 #~ msgid "Record an inverse patch without changing the working directory"
 #~ msgstr "Lagra en omvänd fix utan att ändra arbetskopian"
 
-#, fuzzy
 #~ msgid "Gives a changelog-style summary of the repository history"
 #~ msgstr "Ge en changelog-formaterad summering av förrådhistorik"
 
-#, fuzzy
 #~ msgid "Opposite of pull; unsafe if patch is not in remote repository"
 #~ msgstr "Motsatsen till pull, osäker om fixen inte finns i fjärrlagret"
 
@@ -65376,7 +63179,6 @@ msgstr ""
 #~ msgid "Create a local copy of another repository"
 #~ msgstr "Skapa lokal kopia av förråd"
 
-#, fuzzy
 #~ msgid "Initialize a new source tree as a darcs repository"
 #~ msgstr "Checka in filer till förråd"
 
@@ -65392,11 +63194,9 @@ msgstr ""
 #~ msgid "Use pattern from file"
 #~ msgstr "Använd mönster från fil"
 
-#, fuzzy
 #~ msgid "Use ARG as merge command"
 #~ msgstr "Ange sammanslagningskommando"
 
-#, fuzzy
 #~ msgid "Use ARG as external editor"
 #~ msgstr "Ange extern editor"
 
@@ -65409,7 +63209,6 @@ msgstr ""
 #~ msgid "Good bye\\n"
 #~ msgstr "Hej då\\n"
 
-#, fuzzy
 #~ msgid ""
 #~ "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%sfunced%s "
 #~ "FUNCTION\\n"
@@ -66154,27 +63953,21 @@ msgstr ""
 #~ msgid "Do not use weak symbol support"
 #~ msgstr "Stöd inte svaga symboler"
 
-#, fuzzy
 #~ msgid "Match only the base name against the specified patterns"
 #~ msgstr "Installera inte filer vars namn börjar med angiven sökväg"
 
-#, fuzzy
 #~ msgid "Ignore case distinctions when matching patterns"
 #~ msgstr "Ignorera skiftläge på filnamn"
 
-#, fuzzy
 #~ msgid "Ignored"
 #~ msgstr "Ignorera skiftläge"
 
-#, fuzzy
 #~ msgid "Write no messages about errors encountered"
 #~ msgstr "Visa meddelanden om vad programmet gör"
 
-#, fuzzy
 #~ msgid "Interpret all patterns as extended regexps"
 #~ msgstr "Mönster är ett förlängt reguljärt uttryck"
 
-#, fuzzy
 #~ msgid "Match only the whole path name against the specified patterns"
 #~ msgstr "Installera inte filer vars namn börjar med angiven sökväg"
 
@@ -66288,11 +64081,9 @@ msgstr ""
 #~ msgid "Print client version info"
 #~ msgstr "Visa klientversion"
 
-#, fuzzy
 #~ msgid "force operation to run"
 #~ msgstr "Tvinga operationen att utföras"
 
-#, fuzzy
 #~ msgid "print as little as possible"
 #~ msgstr "Skriv ut så lite som möjligt"
 
@@ -66607,7 +64398,6 @@ msgstr ""
 #~ msgid "Pipe or short circuit command requires additional command"
 #~ msgstr "Pipa eller kortslutningkommando kräver ett efterföljande kommandon"
 
-#, fuzzy
 #~ msgid "%ls: Argument must be a number: %ls\n"
 #~ msgstr "%ls: Argumentet '%ls' måste vara ett heltal\n"
 


### PR DESCRIPTION
## Description

 Running `msgattrib --translated po/sv.po -o po/sv.po` returns basically an empty file containing no translations:
<details><summary>sv.po contents</summary>

```
# SOME DESCRIPTIVE TITLE.
# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
# This file is distributed under the same license as the PACKAGE package.
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
#
#, fuzzy
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2017-12-08 16:50+0100\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: LANGUAGE <LL@li.org>\n"
"Language: \n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"

#: src/reader.cpp:2161
#, fuzzy
msgid ""
"\n"
"   PID  Command\n"
msgstr ""
"\n"
"   PID  Command\n"

#: /tmp/fish/explicit/share/functions/abbr.fish:4
#, fuzzy
msgid "%s %s: Expected one argument\\n"
msgstr "%s %s: Expected one argument\\n"
```
</details>

Swedish translations existed at some point but looks like they were wiped out (by accident?) in f854d4a737ccb24ddb9893cc7d20b1feba62fabd more than 2 years ago.

Just to be sure the other files are OK, I ran a little Python script that detects the language used in each translated sentence and returns the most frequent detect language for our current PO files:
<details><summary>Python script</summary>

```
import re
from pathlib import Path
from langdetect import detect

p = Path("/path/to/fish-shell/po/")
pattern = re.compile('^msgstr\s*"(.{10,})"')
for pofile in list(p.glob('*.po')):
    language = []
    with open(pofile) as f:
        po_data = f.readlines()
    for line in po_data:
        if m := pattern.match(line):
            language.append(detect(m.group(1)))
    if language:
        result = max(set(language), key=language.count) 
    else:
        result = "No translations or languages detected!" 
    print(f"{pofile}: {result}")
```
</details>

Which returned the below showing `sv.po` is the odd one out.
```
po/zh_CN.po: zh-cn
po/sv.po: No translations or languages detected!
po/pt_BR.po: en (checked manually and file was in Portuguese so it's OK)
po/pl.po: pl
po/nn.po: no
po/nb.po: da
po/fr.po: fr
po/en.po: en
po/de.po: de
```

I opted to just delete the whole file rather then try and restore and maintain the old file. Let me know if you want to try restoring it instead.