### PR TITLE
Delete __fish_sgrep.fish

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -67268,10 +67268,6 @@ msgstr "Prompt ausgeben"
 msgid "Show current path"
 msgstr "Quellpaket anzeigen"
 
-#: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
-msgid "Call grep without honoring GREP_OPTIONS settings"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_shared_key_bindings.fish:1
 msgid "Bindings shared between emacs and vi mode"
 msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -66607,10 +66607,6 @@ msgstr "Write out the prompt"
 msgid "Show current path"
 msgstr "Show current path"
 
-#: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
-msgid "Call grep without honoring GREP_OPTIONS settings"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_shared_key_bindings.fish:1
 msgid "Bindings shared between emacs and vi mode"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -65601,10 +65601,6 @@ msgstr ""
 msgid "Show current path"
 msgstr "Afficher le chemin actuel"
 
-#: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
-msgid "Call grep without honoring GREP_OPTIONS settings"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_shared_key_bindings.fish:1
 msgid "Bindings shared between emacs and vi mode"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -62054,10 +62054,6 @@ msgstr ""
 msgid "Show current path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
-msgid "Call grep without honoring GREP_OPTIONS settings"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_shared_key_bindings.fish:1
 msgid "Bindings shared between emacs and vi mode"
 msgstr ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -62055,10 +62055,6 @@ msgstr ""
 msgid "Show current path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
-msgid "Call grep without honoring GREP_OPTIONS settings"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_shared_key_bindings.fish:1
 msgid "Bindings shared between emacs and vi mode"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -62641,10 +62641,6 @@ msgstr ""
 msgid "Show current path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
-msgid "Call grep without honoring GREP_OPTIONS settings"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_shared_key_bindings.fish:1
 msgid "Bindings shared between emacs and vi mode"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -67748,10 +67748,6 @@ msgstr "Write out the prompt"
 msgid "Show current path"
 msgstr "Show source package"
 
-#: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
-msgid "Call grep without honoring GREP_OPTIONS settings"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_shared_key_bindings.fish:1
 msgid "Bindings shared between emacs and vi mode"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -62602,10 +62602,6 @@ msgstr ""
 msgid "Show current path"
 msgstr ""
 
-#: /tmp/fish/implicit/share/functions/__fish_sgrep.fish:1
-msgid "Call grep without honoring GREP_OPTIONS settings"
-msgstr ""
-
 #: /tmp/fish/implicit/share/functions/__fish_shared_key_bindings.fish:1
 msgid "Bindings shared between emacs and vi mode"
 msgstr ""

--- a/share/functions/__fish_sgrep.fish
+++ b/share/functions/__fish_sgrep.fish
@@ -1,5 +1,0 @@
-# This function is deprecated. Do not introduce new uses. Use the `string` command instead.
-function __fish_sgrep -d "Call grep without honoring GREP_OPTIONS settings"
-    set -l GREP_OPTIONS
-    command grep $argv
-end


### PR DESCRIPTION
## Description

Was deprecated over 2 and a half years ago.

Fixes issue #

One of the last remaining tasks from #5279.

## TODOs (needed?):
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] User-visible changes noted in CHANGELOG.md
