### PR TITLE
Delete __fish_git_prompt.fish

### DIFF
--- a/share/functions/__fish_git_prompt.fish
+++ b/share/functions/__fish_git_prompt.fish
@@ -1,4 +1,0 @@
-function __fish_git_prompt
-    # TODO: This name is deprecated, figure out a way to tell users.
-    fish_git_prompt $argv
-end


### PR DESCRIPTION
## Description

Was deprecated about a year ago with a TODO remaining regarding announcing its deprecation. It does [come up a fair bit](https://github.com/search?q=__fish_git_prompt&type=Code) in repos on GitHub but if we will be cutting a release soon for 3.1 then it might be good timing to delete the function now and make the announcement via the changelog.

Fixes issue #

Not specifically mentioned in #5279, but it fits the bill.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] User-visible changes noted in CHANGELOG.md
