### PR TITLE
Make "time" a job prefix

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -44,6 +44,7 @@
 #include "reader.h"
 #include "redirection.h"
 #include "signal.h"
+#include "timer.h"
 #include "trace.h"
 #include "wutil.h"  // IWYU pragma: keep
 
@@ -1078,6 +1079,7 @@ bool exec_job(parser_t &parser, shared_ptr<job_t> j, const job_lineage_t &lineag
         parser.set_last_statuses(statuses_t::just(status));
         return false;
     }
+    cleanup_t timer = push_timer(j->flags().has_time_prefix);
 
     // Get the deferred process, if any. We will have to remember its pipes.
     autoclose_pipes_t deferred_pipes;

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -1211,6 +1211,10 @@ highlighter_t::color_array_t highlighter_t::highlight() {
                 this->color_node(node, highlight_role_t::statement_terminator);
                 break;
             }
+            case symbol_optional_time: {
+                this->color_node(node, highlight_role_t::operat);
+                break;
+            }
             case symbol_plain_statement: {
                 tnode_t<g::plain_statement> stmt(&parse_tree, &node);
                 // Get the decoration from the parent.

--- a/src/parse_constants.h
+++ b/src/parse_constants.h
@@ -52,6 +52,7 @@ enum parse_token_type_t : uint8_t {
     symbol_redirection,
     symbol_optional_background,
     symbol_optional_newlines,
+    symbol_optional_time,
     symbol_end_command,
     // Terminal types.
     parse_token_type_string,
@@ -157,11 +158,13 @@ enum parse_job_decoration_t {
     parse_job_decoration_none,
     parse_job_decoration_and,
     parse_job_decoration_or,
-    parse_job_decoration_time,
 };
 
 // Whether a statement is backgrounded.
 enum parse_optional_background_t { parse_no_background, parse_background };
+
+// Whether a job is prefixed with "time".
+enum parse_optional_time_t { parse_optional_time_no_time, parse_optional_time_time };
 
 // Parse error code list.
 enum parse_error_code_t {

--- a/src/parse_constants.h
+++ b/src/parse_constants.h
@@ -295,4 +295,8 @@ void parse_error_offset_source_start(parse_error_list_t *errors, size_t amt);
 #define ERROR_BAD_COMMAND_ASSIGN_ERR_MSG \
     _(L"Unsupported use of '='. In fish, please use 'set %ls %ls'.")
 
+/// Error message for a command like `time foo &`.
+#define ERROR_TIME_BACKGROUND \
+    _(L"'time' is not supported for background jobs. Consider using 'command time'.")
+
 #endif

--- a/src/parse_grammar.h
+++ b/src/parse_grammar.h
@@ -210,7 +210,6 @@ DEF_ALT(job_list) {
 DEF_ALT(job_decorator) {
     using ands = single<keyword<parse_keyword_and>>;
     using ors = single<keyword<parse_keyword_or>>;
-    using times = single<keyword<parse_keyword_time>>;
     using empty = grammar::empty;
     ALT_BODY(job_decorator, ands, ors, empty);
 };
@@ -225,13 +224,20 @@ DEF_ALT(job_conjunction_continuation) {
     ALT_BODY(job_conjunction_continuation, andands, orors, empty);
 };
 
+/// The time builtin.
+DEF_ALT(optional_time) {
+    using empty = grammar::empty;
+    using time = single<keyword<parse_keyword_time>>;
+    ALT_BODY(optional_time, empty, time);
+};
+
 // A job is a non-empty list of statements, separated by pipes. (Non-empty is useful for cases
 // like if statements, where we require a command). To represent "non-empty", we require a
 // statement, followed by a possibly empty job_continuation, and then optionally a background
 // specifier '&'
 DEF(job)
-produces_sequence<variable_assignments, statement, job_continuation, optional_background>{
-    BODY(job)};
+produces_sequence<optional_time, variable_assignments, statement, job_continuation,
+                  optional_background>{BODY(job)};
 
 DEF_ALT(job_continuation) {
     using piped =
@@ -322,8 +328,9 @@ produces_sequence<keyword<parse_keyword_function>, argument, argument_list, tok_
     BODY(function_header)};
 
 DEF_ALT(not_statement) {
-    using nots = seq<keyword<parse_keyword_not>, variable_assignments, statement>;
-    using exclams = seq<keyword<parse_keyword_exclam>, variable_assignments, statement>;
+    using nots = seq<keyword<parse_keyword_not>, variable_assignments, optional_time, statement>;
+    using exclams =
+        seq<keyword<parse_keyword_exclam>, variable_assignments, optional_time, statement>;
     ALT_BODY(not_statement, nots, exclams);
 };
 

--- a/src/parse_grammar_elements.inc
+++ b/src/parse_grammar_elements.inc
@@ -31,6 +31,7 @@ ELEM(argument)
 ELEM(redirection)
 ELEM(optional_background)
 ELEM(optional_newlines)
+ELEM(optional_time)
 ELEM(end_command)
 ELEM(freestanding_argument_list)
 #undef ELEM

--- a/src/parse_productions.cpp
+++ b/src/parse_productions.cpp
@@ -82,10 +82,6 @@ RESOLVE(job_decorator) {
             *out_tag = parse_job_decoration_or;
             return production_for<ors>();
         }
-        case parse_keyword_time: {
-            *out_tag = parse_job_decoration_time;
-            return production_for<times>();
-        }
         default: {
             *out_tag = parse_job_decoration_none;
             return production_for<empty>();
@@ -397,6 +393,19 @@ RESOLVE(optional_background) {
             *out_tag = parse_no_background;
             return production_for<empty>();
         }
+    }
+}
+
+RESOLVE(optional_time) {
+    UNUSED(token2);
+
+    switch (token1.keyword) {
+        case parse_keyword_time:
+            *out_tag = parse_optional_time_time;
+            return production_for<time>();
+        default:
+            *out_tag = parse_optional_time_no_time;
+            return production_for<empty>();
     }
 }
 

--- a/src/parse_tree.cpp
+++ b/src/parse_tree.cpp
@@ -955,7 +955,7 @@ void parse_ll_t::accept_tokens(parse_token_t token1, parse_token_t token2) {
                     case symbol_job:
                         variable_assignments =
                             tnode_t<grammar::job>(&nodes, parent)
-                                .try_get_child<grammar::variable_assignments, 0>();
+                                .try_get_child<grammar::variable_assignments, 1>();
                         break;
                     case symbol_job_continuation:
                         variable_assignments =

--- a/src/proc.h
+++ b/src/proc.h
@@ -410,6 +410,9 @@ class job_t {
 
         /// This job is disowned, and should be removed from the active jobs list.
         bool disown_requested{false};
+
+        /// Whether to print timing for this job.
+        bool has_time_prefix{false};
     } job_flags{};
 
     /// Access the job flags.

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -190,3 +190,22 @@ timer_snapshot_t::print_delta(timer_snapshot_t t1, timer_snapshot_t t2, bool ver
 
     return output;
 };
+
+static std::vector<timer_snapshot_t> active_timers;
+
+static void pop_timer() {
+    auto t1 = std::move(active_timers.back());
+    active_timers.pop_back();
+    auto t2 = timer_snapshot_t::take();
+
+    // Well, this is awkward. By defining `time` as a decorator and not a built-in, there's
+    // no associated stream for its output!
+    auto output = timer_snapshot_t::print_delta(std::move(t1), std::move(t2), true);
+    std::fwprintf(stderr, L"%S\n", output.c_str());
+}
+
+cleanup_t push_timer(bool enabled) {
+    if (!enabled) return {[]() {}};
+    active_timers.emplace_back(timer_snapshot_t::take());
+    return {[]() { pop_timer(); }};
+}

--- a/src/timer.h
+++ b/src/timer.h
@@ -12,6 +12,8 @@
 class parser_t;
 struct io_streams_t;
 
+cleanup_t push_timer(bool enabled);
+
 struct timer_snapshot_t {
 public:
     struct rusage cpu_fish;

--- a/src/tnode.cpp
+++ b/src/tnode.cpp
@@ -114,7 +114,7 @@ arguments_node_list_t get_argument_nodes(tnode_t<grammar::arguments_or_redirecti
 }
 
 bool job_node_is_background(tnode_t<grammar::job> job) {
-    tnode_t<grammar::optional_background> bg = job.child<3>();
+    tnode_t<grammar::optional_background> bg = job.child<4>();
     return bg.tag() == parse_background;
 }
 
@@ -144,7 +144,7 @@ pipeline_position_t get_pipeline_position(tnode_t<grammar::statement> st) {
 
     // Check if we're the beginning of a job, and if so, whether that job
     // has a non-empty continuation.
-    tnode_t<job_continuation> jc = st.try_get_parent<job>().child<2>();
+    tnode_t<job_continuation> jc = st.try_get_parent<job>().child<3>();
     if (jc.try_get_child<statement, 3>()) {
         return pipeline_position_t::first;
     }

--- a/tests/checks/time.fish
+++ b/tests/checks/time.fish
@@ -1,5 +1,5 @@
-#RUN: %fish %s
-time sleep 1s
+#RUN: %fish -C 'set -l fish %fish' %s
+time sleep 0s
 
 # These are a tad awkward because it picks the correct unit and adapts whitespace.
 # The idea is that it's a table.
@@ -43,3 +43,13 @@ not time true
 #CHECKERR: {{.*}}
 #CHECKERR: {{.*}}
 #CHECKERR: {{.*}}
+
+$fish -c 'time true&'
+#CHECKERR: fish: {{.*}}
+#CHECKERR: time true&
+#CHECKERR: ^
+
+$fish -c 'not time true&'
+#CHECKERR: fish: {{.*}}
+#CHECKERR: not time true&
+#CHECKERR: ^

--- a/tests/checks/time.fish
+++ b/tests/checks/time.fish
@@ -25,3 +25,21 @@ time echo 'foo -s   bar'
 #CHECKERR: Executed in {{[\d,.\s]*}} {{millis|micros|secs}} {{\s*}}fish {{\s*}}external
 #CHECKERR: usr time {{[\d,.\s]*}} {{millis|micros|secs}} {{[\d,.\s]*}} {{millis|micros|secs}} {{[\d,.\s]*}} {{millis|micros|secs}}
 #CHECKERR: sys time {{[\d,.\s]*}} {{millis|micros|secs}} {{[\d,.\s]*}} {{millis|micros|secs}} {{[\d,.\s]*}} {{millis|micros|secs}}
+
+true && time a=b not builtin true | true
+#CHECKERR: ___{{.*}}
+#CHECKERR: {{.*}}
+#CHECKERR: {{.*}}
+#CHECKERR: {{.*}}
+
+PATH= time true
+#CHECKERR: fish: Unknown command: time
+#CHECKERR: {{.*}}
+#CHECKERR: PATH= time true
+#CHECKERR:       ^
+
+not time true
+#CHECKERR: ___{{.*}}
+#CHECKERR: {{.*}}
+#CHECKERR: {{.*}}
+#CHECKERR: {{.*}}


### PR DESCRIPTION
In particular, this allows `true && time true`, or `true; and time true`.

time is valid only as job prefix, so `true | time true` could call `/bin/time`.
(I think this could be changed if anyone cares)

See discussion in #6442

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
