### PR TITLE
disable virtualenv prompt update in nim prompt

### DIFF
--- a/share/tools/web_config/sample_prompts/nim.fish
+++ b/share/tools/web_config/sample_prompts/nim.fish
@@ -76,6 +76,8 @@ function fish_prompt
     _nim_prompt_wrapper $retc '' (date +%X)
 
     # Virtual Environment
+    set -q VIRTUAL_ENV_DISABLE_PROMPT
+    or set -g VIRTUAL_ENV_DISABLE_PROMPT true
     set -q VIRTUAL_ENV
     and _nim_prompt_wrapper $retc V (basename "$VIRTUAL_ENV")
 


### PR DESCRIPTION
As this information is already wrapped into a `_nim_prompt_wrapper`

In other words, fix
```
(dashboard-apps-qCpYW6-b-py3.8) ┬─[nim@Nausicaa:~/d/.c/fish]─[12:42:36]─[V:dashboard-apps-qCpYW6-b-py3.8]─[G:master↑3|✚1]
╰─>$
```

into 
```
┬─[nim@Nausicaa:~/d/.c/fish]─[12:43:23]─[V:dashboard-apps-qCpYW6-b-py3.8]─[G:master↑3|✚1]
╰─>$
```