### PR TITLE
Don't override exit status when stderr is closed by `2>&-`

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -292,7 +292,7 @@ static bool run_internal_process(process_t *p, std::string outdata, std::string 
     // If we have nothing to write we can elide the thread.
     // TODO: support eliding output to /dev/null.
     if (f->skip_out() && f->skip_err()) {
-        f->internal_proc->mark_exited(proc_status_t::from_exit_code(EXIT_SUCCESS));
+        f->internal_proc->mark_exited(p->status);
         return true;
     }
 

--- a/tests/checks/exit-status-with-closing-stderr.fish
+++ b/tests/checks/exit-status-with-closing-stderr.fish
@@ -1,0 +1,5 @@
+# RUN: %fish %s
+argparse r-require= -- --require 2>/dev/null ; echo $status
+# CHECK: 2
+argparse r-require= -- --require 2>&- ; echo $status
+# CHECK: 2


### PR DESCRIPTION
## Description

Fixes issue #6470

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
