### PR TITLE
Let's fix the fish history file format, and maybe extend it to configuration

### DIFF
--- a/src/SimpleJSON/json.hpp
+++ b/src/SimpleJSON/json.hpp
@@ -1,0 +1,649 @@
+
+#pragma once
+
+#include <cstdint>
+#include <cmath>
+#include <cctype>
+#include <string>
+#include <deque>
+#include <map>
+#include <type_traits>
+#include <initializer_list>
+#include <ostream>
+#include <iostream>
+
+namespace json {
+
+using std::map;
+using std::deque;
+using std::string;
+using std::enable_if;
+using std::initializer_list;
+using std::is_same;
+using std::is_convertible;
+using std::is_integral;
+using std::is_floating_point;
+
+namespace {
+    string json_escape( const string &str ) {
+        string output;
+        for( unsigned i = 0; i < str.length(); ++i )
+            switch( str[i] ) {
+                case '\"': output += "\\\""; break;
+                case '\\': output += "\\\\"; break;
+                case '\b': output += "\\b";  break;
+                case '\f': output += "\\f";  break;
+                case '\n': output += "\\n";  break;
+                case '\r': output += "\\r";  break;
+                case '\t': output += "\\t";  break;
+                default  : output += str[i]; break;
+            }
+        return std::move( output );
+    }
+}
+
+class JSON
+{
+    union BackingData {
+        BackingData( double d ) : Float( d ){}
+        BackingData( long   l ) : Int( l ){}
+        BackingData( bool   b ) : Bool( b ){}
+        BackingData( string s ) : String( new string( s ) ){}
+        BackingData()           : Int( 0 ){}
+
+        deque<JSON>        *List;
+        map<string,JSON>   *Map;
+        string             *String;
+        double              Float;
+        long                Int;
+        bool                Bool;
+    } Internal;
+
+    public:
+        enum class Class {
+            Null,
+            Object,
+            Array,
+            String,
+            Floating,
+            Integral,
+            Boolean
+        };
+
+        template <typename Container>
+        class JSONWrapper {
+            Container *object;
+
+            public:
+                JSONWrapper( Container *val ) : object( val ) {}
+                JSONWrapper( std::nullptr_t )  : object( nullptr ) {}
+
+                typename Container::iterator begin() { return object ? object->begin() : typename Container::iterator(); }
+                typename Container::iterator end() { return object ? object->end() : typename Container::iterator(); }
+                typename Container::const_iterator begin() const { return object ? object->begin() : typename Container::iterator(); }
+                typename Container::const_iterator end() const { return object ? object->end() : typename Container::iterator(); }
+        };
+
+        template <typename Container>
+        class JSONConstWrapper {
+            const Container *object;
+
+            public:
+                JSONConstWrapper( const Container *val ) : object( val ) {}
+                JSONConstWrapper( std::nullptr_t )  : object( nullptr ) {}
+
+                typename Container::const_iterator begin() const { return object ? object->begin() : typename Container::const_iterator(); }
+                typename Container::const_iterator end() const { return object ? object->end() : typename Container::const_iterator(); }
+        };
+
+        JSON() : Internal(), Type( Class::Null ){}
+
+        JSON( initializer_list<JSON> list ) 
+            : JSON() 
+        {
+            SetType( Class::Object );
+            for( auto i = list.begin(), e = list.end(); i != e; ++i, ++i )
+                operator[]( i->ToString() ) = *std::next( i );
+        }
+
+        JSON( JSON&& other )
+            : Internal( other.Internal )
+            , Type( other.Type )
+        { other.Type = Class::Null; other.Internal.Map = nullptr; }
+
+        JSON& operator=( JSON&& other ) {
+            ClearInternal();
+            Internal = other.Internal;
+            Type = other.Type;
+            other.Internal.Map = nullptr;
+            other.Type = Class::Null;
+            return *this;
+        }
+
+        JSON( const JSON &other ) {
+            switch( other.Type ) {
+            case Class::Object:
+                Internal.Map = 
+                    new map<string,JSON>( other.Internal.Map->begin(),
+                                          other.Internal.Map->end() );
+                break;
+            case Class::Array:
+                Internal.List = 
+                    new deque<JSON>( other.Internal.List->begin(),
+                                      other.Internal.List->end() );
+                break;
+            case Class::String:
+                Internal.String = 
+                    new string( *other.Internal.String );
+                break;
+            default:
+                Internal = other.Internal;
+            }
+            Type = other.Type;
+        }
+
+        JSON& operator=( const JSON &other ) {
+            ClearInternal();
+            switch( other.Type ) {
+            case Class::Object:
+                Internal.Map = 
+                    new map<string,JSON>( other.Internal.Map->begin(),
+                                          other.Internal.Map->end() );
+                break;
+            case Class::Array:
+                Internal.List = 
+                    new deque<JSON>( other.Internal.List->begin(),
+                                      other.Internal.List->end() );
+                break;
+            case Class::String:
+                Internal.String = 
+                    new string( *other.Internal.String );
+                break;
+            default:
+                Internal = other.Internal;
+            }
+            Type = other.Type;
+            return *this;
+        }
+
+        ~JSON() {
+            switch( Type ) {
+            case Class::Array:
+                delete Internal.List;
+                break;
+            case Class::Object:
+                delete Internal.Map;
+                break;
+            case Class::String:
+                delete Internal.String;
+                break;
+            default:;
+            }
+        }
+
+        template <typename T>
+        JSON( T b, typename enable_if<is_same<T,bool>::value>::type* = 0 ) : Internal( b ), Type( Class::Boolean ){}
+
+        template <typename T>
+        JSON( T i, typename enable_if<is_integral<T>::value && !is_same<T,bool>::value>::type* = 0 ) : Internal( (long)i ), Type( Class::Integral ){}
+
+        template <typename T>
+        JSON( T f, typename enable_if<is_floating_point<T>::value>::type* = 0 ) : Internal( (double)f ), Type( Class::Floating ){}
+
+        template <typename T>
+        JSON( T s, typename enable_if<is_convertible<T,string>::value>::type* = 0 ) : Internal( string( s ) ), Type( Class::String ){}
+
+        JSON( std::nullptr_t ) : Internal(), Type( Class::Null ){}
+
+        static JSON Make( Class type ) {
+            JSON ret; ret.SetType( type );
+            return ret;
+        }
+
+        static JSON Load( const string & );
+
+        template <typename T>
+        void append( T arg ) {
+            SetType( Class::Array ); Internal.List->emplace_back( arg );
+        }
+
+        template <typename T, typename... U>
+        void append( T arg, U... args ) {
+            append( arg ); append( args... );
+        }
+
+        template <typename T>
+            typename enable_if<is_same<T,bool>::value, JSON&>::type operator=( T b ) {
+                SetType( Class::Boolean ); Internal.Bool = b; return *this;
+            }
+
+        template <typename T>
+            typename enable_if<is_integral<T>::value && !is_same<T,bool>::value, JSON&>::type operator=( T i ) {
+                SetType( Class::Integral ); Internal.Int = i; return *this;
+            }
+
+        template <typename T>
+            typename enable_if<is_floating_point<T>::value, JSON&>::type operator=( T f ) {
+                SetType( Class::Floating ); Internal.Float = f; return *this;
+            }
+
+        template <typename T>
+            typename enable_if<is_convertible<T,string>::value, JSON&>::type operator=( T s ) {
+                SetType( Class::String ); *Internal.String = string( s ); return *this;
+            }
+
+        JSON& operator[]( const string &key ) {
+            SetType( Class::Object ); return Internal.Map->operator[]( key );
+        }
+
+        JSON& operator[]( unsigned index ) {
+            SetType( Class::Array );
+            if( index >= Internal.List->size() ) Internal.List->resize( index + 1 );
+            return Internal.List->operator[]( index );
+        }
+
+        JSON &at( const string &key ) {
+            return operator[]( key );
+        }
+
+        const JSON &at( const string &key ) const {
+            return Internal.Map->at( key );
+        }
+
+        JSON &at( unsigned index ) {
+            return operator[]( index );
+        }
+
+        const JSON &at( unsigned index ) const {
+            return Internal.List->at( index );
+        }
+
+        int length() const {
+            if( Type == Class::Array )
+                return Internal.List->size();
+            else
+                return -1;
+        }
+
+        bool hasKey( const string &key ) const {
+            if( Type == Class::Object )
+                return Internal.Map->find( key ) != Internal.Map->end();
+            return false;
+        }
+
+        int size() const {
+            if( Type == Class::Object )
+                return Internal.Map->size();
+            else if( Type == Class::Array )
+                return Internal.List->size();
+            else
+                return -1;
+        }
+
+        Class JSONType() const { return Type; }
+
+        /// Functions for getting primitives from the JSON object.
+        bool IsNull() const { return Type == Class::Null; }
+
+        string ToString() const { bool b; return std::move( ToString( b ) ); }
+        string ToString( bool &ok ) const {
+            ok = (Type == Class::String);
+            return ok ? std::move( json_escape( *Internal.String ) ): string("");
+        }
+
+        double ToFloat() const { bool b; return ToFloat( b ); }
+        double ToFloat( bool &ok ) const {
+            ok = (Type == Class::Floating);
+            return ok ? Internal.Float : 0.0;
+        }
+
+        long ToInt() const { bool b; return ToInt( b ); }
+        long ToInt( bool &ok ) const {
+            ok = (Type == Class::Integral);
+            return ok ? Internal.Int : 0;
+        }
+
+        bool ToBool() const { bool b; return ToBool( b ); }
+        bool ToBool( bool &ok ) const {
+            ok = (Type == Class::Boolean);
+            return ok ? Internal.Bool : false;
+        }
+
+        JSONWrapper<map<string,JSON>> ObjectRange() {
+            if( Type == Class::Object )
+                return JSONWrapper<map<string,JSON>>( Internal.Map );
+            return JSONWrapper<map<string,JSON>>( nullptr );
+        }
+
+        JSONWrapper<deque<JSON>> ArrayRange() {
+            if( Type == Class::Array )
+                return JSONWrapper<deque<JSON>>( Internal.List );
+            return JSONWrapper<deque<JSON>>( nullptr );
+        }
+
+        JSONConstWrapper<map<string,JSON>> ObjectRange() const {
+            if( Type == Class::Object )
+                return JSONConstWrapper<map<string,JSON>>( Internal.Map );
+            return JSONConstWrapper<map<string,JSON>>( nullptr );
+        }
+
+
+        JSONConstWrapper<deque<JSON>> ArrayRange() const { 
+            if( Type == Class::Array )
+                return JSONConstWrapper<deque<JSON>>( Internal.List );
+            return JSONConstWrapper<deque<JSON>>( nullptr );
+        }
+
+        string dump( int depth = 1, string tab = "  ") const {
+            string pad = "";
+            for( int i = 0; i < depth; ++i, pad += tab );
+
+            switch( Type ) {
+                case Class::Null:
+                    return "null";
+                case Class::Object: {
+                    string s = "{\n";
+                    bool skip = true;
+                    for( auto &p : *Internal.Map ) {
+                        if( !skip ) s += ",\n";
+                        s += ( pad + "\"" + p.first + "\" : " + p.second.dump( depth + 1, tab ) );
+                        skip = false;
+                    }
+                    s += ( "\n" + pad.erase( 0, 2 ) + "}" ) ;
+                    return s;
+                }
+                case Class::Array: {
+                    string s = "[";
+                    bool skip = true;
+                    for( auto &p : *Internal.List ) {
+                        if( !skip ) s += ", ";
+                        s += p.dump( depth + 1, tab );
+                        skip = false;
+                    }
+                    s += "]";
+                    return s;
+                }
+                case Class::String:
+                    return "\"" + json_escape( *Internal.String ) + "\"";
+                case Class::Floating:
+                    return std::to_string( Internal.Float );
+                case Class::Integral:
+                    return std::to_string( Internal.Int );
+                case Class::Boolean:
+                    return Internal.Bool ? "true" : "false";
+                default:
+                    return "";
+            }
+            return "";
+        }
+
+        friend std::ostream& operator<<( std::ostream&, const JSON & );
+
+    private:
+        void SetType( Class type ) {
+            if( type == Type )
+                return;
+
+            ClearInternal();
+          
+            switch( type ) {
+            case Class::Null:      Internal.Map    = nullptr;                break;
+            case Class::Object:    Internal.Map    = new map<string,JSON>(); break;
+            case Class::Array:     Internal.List   = new deque<JSON>();     break;
+            case Class::String:    Internal.String = new string();           break;
+            case Class::Floating:  Internal.Float  = 0.0;                    break;
+            case Class::Integral:  Internal.Int    = 0;                      break;
+            case Class::Boolean:   Internal.Bool   = false;                  break;
+            }
+
+            Type = type;
+        }
+
+    private:
+      /* beware: only call if YOU know that Internal is allocated. No checks performed here. 
+         This function should be called in a constructed JSON just before you are going to 
+        overwrite Internal... 
+      */
+      void ClearInternal() {
+        switch( Type ) {
+          case Class::Object: delete Internal.Map;    break;
+          case Class::Array:  delete Internal.List;   break;
+          case Class::String: delete Internal.String; break;
+          default:;
+        }
+      }
+
+    private:
+
+        Class Type = Class::Null;
+};
+
+JSON Array() {
+    return std::move( JSON::Make( JSON::Class::Array ) );
+}
+
+template <typename... T>
+JSON Array( T... args ) {
+    JSON arr = JSON::Make( JSON::Class::Array );
+    arr.append( args... );
+    return std::move( arr );
+}
+
+JSON Object() {
+    return std::move( JSON::Make( JSON::Class::Object ) );
+}
+
+std::ostream& operator<<( std::ostream &os, const JSON &json ) {
+    os << json.dump();
+    return os;
+}
+
+namespace {
+    JSON parse_next( const string &, size_t & );
+
+    void consume_ws( const string &str, size_t &offset ) {
+        while( isspace( str[offset] ) ) ++offset;
+    }
+
+    JSON parse_object( const string &str, size_t &offset ) {
+        JSON Object = JSON::Make( JSON::Class::Object );
+
+        ++offset;
+        consume_ws( str, offset );
+        if( str[offset] == '}' ) {
+            ++offset; return std::move( Object );
+        }
+
+        while( true ) {
+            JSON Key = parse_next( str, offset );
+            consume_ws( str, offset );
+            if( str[offset] != ':' ) {
+                std::cerr << "Error: Object: Expected colon, found '" << str[offset] << "'\n";
+                break;
+            }
+            consume_ws( str, ++offset );
+            JSON Value = parse_next( str, offset );
+            Object[Key.ToString()] = Value;
+            
+            consume_ws( str, offset );
+            if( str[offset] == ',' ) {
+                ++offset; continue;
+            }
+            else if( str[offset] == '}' ) {
+                ++offset; break;
+            }
+            else {
+                std::cerr << "ERROR: Object: Expected comma, found '" << str[offset] << "'\n";
+                break;
+            }
+        }
+
+        return std::move( Object );
+    }
+
+    JSON parse_array( const string &str, size_t &offset ) {
+        JSON Array = JSON::Make( JSON::Class::Array );
+        unsigned index = 0;
+        
+        ++offset;
+        consume_ws( str, offset );
+        if( str[offset] == ']' ) {
+            ++offset; return std::move( Array );
+        }
+
+        while( true ) {
+            Array[index++] = parse_next( str, offset );
+            consume_ws( str, offset );
+
+            if( str[offset] == ',' ) {
+                ++offset; continue;
+            }
+            else if( str[offset] == ']' ) {
+                ++offset; break;
+            }
+            else {
+                std::cerr << "ERROR: Array: Expected ',' or ']', found '" << str[offset] << "'\n";
+                return std::move( JSON::Make( JSON::Class::Array ) );
+            }
+        }
+
+        return std::move( Array );
+    }
+
+    JSON parse_string( const string &str, size_t &offset ) {
+        JSON String;
+        string val;
+        for( char c = str[++offset]; c != '\"' ; c = str[++offset] ) {
+            if( c == '\\' ) {
+                switch( str[ ++offset ] ) {
+                case '\"': val += '\"'; break;
+                case '\\': val += '\\'; break;
+                case '/' : val += '/' ; break;
+                case 'b' : val += '\b'; break;
+                case 'f' : val += '\f'; break;
+                case 'n' : val += '\n'; break;
+                case 'r' : val += '\r'; break;
+                case 't' : val += '\t'; break;
+                case 'u' : {
+                    val += "\\u" ;
+                    for( unsigned i = 1; i <= 4; ++i ) {
+                        c = str[offset+i];
+                        if( (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') )
+                            val += c;
+                        else {
+                            std::cerr << "ERROR: String: Expected hex character in unicode escape, found '" << c << "'\n";
+                            return std::move( JSON::Make( JSON::Class::String ) );
+                        }
+                    }
+                    offset += 4;
+                } break;
+                default  : val += '\\'; break;
+                }
+            }
+            else
+                val += c;
+        }
+        ++offset;
+        String = val;
+        return std::move( String );
+    }
+
+    JSON parse_number( const string &str, size_t &offset ) {
+        JSON Number;
+        string val, exp_str;
+        char c;
+        bool isDouble = false;
+        long exp = 0;
+        while( true ) {
+            c = str[offset++];
+            if( (c == '-') || (c >= '0' && c <= '9') )
+                val += c;
+            else if( c == '.' ) {
+                val += c; 
+                isDouble = true;
+            }
+            else
+                break;
+        }
+        if( c == 'E' || c == 'e' ) {
+            c = str[ offset++ ];
+            if( c == '-' ){ ++offset; exp_str += '-';}
+            while( true ) {
+                c = str[ offset++ ];
+                if( c >= '0' && c <= '9' )
+                    exp_str += c;
+                else if( !isspace( c ) && c != ',' && c != ']' && c != '}' ) {
+                    std::cerr << "ERROR: Number: Expected a number for exponent, found '" << c << "'\n";
+                    return std::move( JSON::Make( JSON::Class::Null ) );
+                }
+                else
+                    break;
+            }
+            exp = std::stol( exp_str );
+        }
+        else if( !isspace( c ) && c != ',' && c != ']' && c != '}' ) {
+            std::cerr << "ERROR: Number: unexpected character '" << c << "'\n";
+            return std::move( JSON::Make( JSON::Class::Null ) );
+        }
+        --offset;
+        
+        if( isDouble )
+            Number = std::stod( val ) * std::pow( 10, exp );
+        else {
+            if( !exp_str.empty() )
+                Number = std::stol( val ) * std::pow( 10, exp );
+            else
+                Number = std::stol( val );
+        }
+        return std::move( Number );
+    }
+
+    JSON parse_bool( const string &str, size_t &offset ) {
+        JSON Bool;
+        if( str.substr( offset, 4 ) == "true" )
+            Bool = true;
+        else if( str.substr( offset, 5 ) == "false" )
+            Bool = false;
+        else {
+            std::cerr << "ERROR: Bool: Expected 'true' or 'false', found '" << str.substr( offset, 5 ) << "'\n";
+            return std::move( JSON::Make( JSON::Class::Null ) );
+        }
+        offset += (Bool.ToBool() ? 4 : 5);
+        return std::move( Bool );
+    }
+
+    JSON parse_null( const string &str, size_t &offset ) {
+        JSON Null;
+        if( str.substr( offset, 4 ) != "null" ) {
+            std::cerr << "ERROR: Null: Expected 'null', found '" << str.substr( offset, 4 ) << "'\n";
+            return std::move( JSON::Make( JSON::Class::Null ) );
+        }
+        offset += 4;
+        return std::move( Null );
+    }
+
+    JSON parse_next( const string &str, size_t &offset ) {
+        char value;
+        consume_ws( str, offset );
+        value = str[offset];
+        switch( value ) {
+            case '[' : return std::move( parse_array( str, offset ) );
+            case '{' : return std::move( parse_object( str, offset ) );
+            case '\"': return std::move( parse_string( str, offset ) );
+            case 't' :
+            case 'f' : return std::move( parse_bool( str, offset ) );
+            case 'n' : return std::move( parse_null( str, offset ) );
+            default  : if( ( value <= '9' && value >= '0' ) || value == '-' )
+                           return std::move( parse_number( str, offset ) );
+        }
+        std::cerr << "ERROR: Parse: Unknown starting character '" << value << "'\n";
+        return JSON();
+    }
+}
+
+JSON JSON::Load( const string &str ) {
+    size_t offset = 0;
+    return std::move( parse_next( str, offset ) );
+}
+
+} // End Namespace json

--- a/src/SimpleJSON/json.hpp
+++ b/src/SimpleJSON/json.hpp
@@ -53,7 +53,7 @@ string json_escape(const string &str) {
                 output += str[i];
                 break;
         }
-    return std::move(output);
+    return output;
 }
 }  // namespace
 
@@ -305,11 +305,11 @@ class JSON {
 
     string ToString() const {
         bool b;
-        return std::move(ToString(b));
+        return ToString(b);
     }
     string ToString(bool &ok) const {
         ok = (Type == Class::String);
-        return ok ? std::move(json_escape(*Internal.String)) : string("");
+        return ok ? json_escape(*Internal.String) : string("");
     }
 
     double ToFloat() const {
@@ -462,16 +462,16 @@ class JSON {
     Class Type = Class::Null;
 };
 
-JSON Array() { return std::move(JSON::Make(JSON::Class::Array)); }
+JSON Array() { return JSON::Make(JSON::Class::Array); }
 
 template <typename... T>
 JSON Array(T... args) {
     JSON arr = JSON::Make(JSON::Class::Array);
     arr.append(args...);
-    return std::move(arr);
+    return arr;
 }
 
-JSON Object() { return std::move(JSON::Make(JSON::Class::Object)); }
+JSON Object() { return JSON::Make(JSON::Class::Object); }
 
 std::ostream &operator<<(std::ostream &os, const JSON &json) {
     os << json.dump();
@@ -492,7 +492,7 @@ JSON parse_object(const string &str, size_t &offset) {
     consume_ws(str, offset);
     if (str[offset] == '}') {
         ++offset;
-        return std::move(Object);
+        return Object;
     }
 
     while (true) {
@@ -519,7 +519,7 @@ JSON parse_object(const string &str, size_t &offset) {
         }
     }
 
-    return std::move(Object);
+    return Object;
 }
 
 JSON parse_array(const string &str, size_t &offset) {
@@ -530,7 +530,7 @@ JSON parse_array(const string &str, size_t &offset) {
     consume_ws(str, offset);
     if (str[offset] == ']') {
         ++offset;
-        return std::move(Array);
+        return Array;
     }
 
     while (true) {
@@ -545,11 +545,11 @@ JSON parse_array(const string &str, size_t &offset) {
             break;
         } else {
             std::cerr << "ERROR: Array: Expected ',' or ']', found '" << str[offset] << "'\n";
-            return std::move(JSON::Make(JSON::Class::Array));
+            return JSON::Make(JSON::Class::Array);
         }
     }
 
-    return std::move(Array);
+    return Array;
 }
 
 JSON parse_string(const string &str, size_t &offset) {
@@ -593,7 +593,7 @@ JSON parse_string(const string &str, size_t &offset) {
                             std::cerr << "ERROR: String: Expected hex character in unicode escape, "
                                          "found '"
                                       << c << "'\n";
-                            return std::move(JSON::Make(JSON::Class::String));
+                            return JSON::Make(JSON::Class::String);
                         }
                     }
                     offset += 4;
@@ -607,7 +607,7 @@ JSON parse_string(const string &str, size_t &offset) {
     }
     ++offset;
     String = val;
-    return std::move(String);
+    return String;
 }
 
 JSON parse_number(const string &str, size_t &offset) {
@@ -638,14 +638,14 @@ JSON parse_number(const string &str, size_t &offset) {
                 exp_str += c;
             else if (!isspace(c) && c != ',' && c != ']' && c != '}') {
                 std::cerr << "ERROR: Number: Expected a number for exponent, found '" << c << "'\n";
-                return std::move(JSON::Make(JSON::Class::Null));
+                return JSON::Make(JSON::Class::Null);
             } else
                 break;
         }
         exp = std::stol(exp_str);
     } else if (!isspace(c) && c != ',' && c != ']' && c != '}') {
         std::cerr << "ERROR: Number: unexpected character '" << c << "'\n";
-        return std::move(JSON::Make(JSON::Class::Null));
+        return JSON::Make(JSON::Class::Null);
     }
     --offset;
 
@@ -657,7 +657,7 @@ JSON parse_number(const string &str, size_t &offset) {
         else
             Number = std::stol(val);
     }
-    return std::move(Number);
+    return Number;
 }
 
 JSON parse_bool(const string &str, size_t &offset) {
@@ -669,20 +669,20 @@ JSON parse_bool(const string &str, size_t &offset) {
     else {
         std::cerr << "ERROR: Bool: Expected 'true' or 'false', found '" << str.substr(offset, 5)
                   << "'\n";
-        return std::move(JSON::Make(JSON::Class::Null));
+        return JSON::Make(JSON::Class::Null);
     }
     offset += (Bool.ToBool() ? 4 : 5);
-    return std::move(Bool);
+    return Bool;
 }
 
 JSON parse_null(const string &str, size_t &offset) {
     JSON Null;
     if (str.substr(offset, 4) != "null") {
         std::cerr << "ERROR: Null: Expected 'null', found '" << str.substr(offset, 4) << "'\n";
-        return std::move(JSON::Make(JSON::Class::Null));
+        return JSON::Make(JSON::Class::Null);
     }
     offset += 4;
-    return std::move(Null);
+    return Null;
 }
 
 JSON parse_next(const string &str, size_t &offset) {
@@ -691,19 +691,18 @@ JSON parse_next(const string &str, size_t &offset) {
     value = str[offset];
     switch (value) {
         case '[':
-            return std::move(parse_array(str, offset));
+            return parse_array(str, offset);
         case '{':
-            return std::move(parse_object(str, offset));
+            return parse_object(str, offset);
         case '\"':
-            return std::move(parse_string(str, offset));
+            return parse_string(str, offset);
         case 't':
         case 'f':
-            return std::move(parse_bool(str, offset));
+            return parse_bool(str, offset);
         case 'n':
-            return std::move(parse_null(str, offset));
+            return parse_null(str, offset);
         default:
-            if ((value <= '9' && value >= '0') || value == '-')
-                return std::move(parse_number(str, offset));
+            if ((value <= '9' && value >= '0') || value == '-') return parse_number(str, offset);
     }
     std::cerr << "ERROR: Parse: Unknown starting character '" << value << "'\n";
     return JSON();
@@ -712,7 +711,7 @@ JSON parse_next(const string &str, size_t &offset) {
 
 JSON JSON::Load(const string &str) {
     size_t offset = 0;
-    return std::move(parse_next(str, offset));
+    return parse_next(str, offset);
 }
 
 }  // End Namespace json

--- a/src/SimpleJSON/json.hpp
+++ b/src/SimpleJSON/json.hpp
@@ -359,7 +359,7 @@ class JSON {
         return JSONConstWrapper<deque<JSON>>(nullptr);
     }
 
-    string dump(int depth = 1, string tab = "  ") const {
+    string dump(int depth = 1, const string &tab = "  ", bool compact = false) const {
         string pad = "";
         for (int i = 0; i < depth; ++i, pad += tab)
             ;
@@ -368,14 +368,19 @@ class JSON {
             case Class::Null:
                 return "null";
             case Class::Object: {
-                string s = "{\n";
+                string s = compact ? "{" : "{\n";
                 bool skip = true;
                 for (auto &p : *Internal.Map) {
-                    if (!skip) s += ",\n";
-                    s += (pad + "\"" + p.first + "\" : " + p.second.dump(depth + 1, tab));
+                    if (!skip) s += compact ? "," : ",\n";
+                    s += pad;
+                    s += '"';
+                    s += p.first;
+                    s += '"';
+                    s += (compact ? ":" : " : ");
+                    s += p.second.dump(depth + 1, tab);
                     skip = false;
                 }
-                s += ("\n" + pad.erase(0, 2) + "}");
+                s += ((compact ? "" : "\n") + pad.erase(0, 2) + "}");
                 return s;
             }
             case Class::Array: {

--- a/src/SimpleJSON/json.hpp
+++ b/src/SimpleJSON/json.hpp
@@ -1,173 +1,183 @@
 
 #pragma once
 
-#include <cstdint>
-#include <cmath>
 #include <cctype>
-#include <string>
+#include <cmath>
+#include <cstdint>
 #include <deque>
-#include <map>
-#include <type_traits>
 #include <initializer_list>
-#include <ostream>
 #include <iostream>
+#include <map>
+#include <ostream>
+#include <string>
+#include <type_traits>
 
 namespace json {
 
-using std::map;
 using std::deque;
-using std::string;
 using std::enable_if;
 using std::initializer_list;
-using std::is_same;
 using std::is_convertible;
-using std::is_integral;
 using std::is_floating_point;
+using std::is_integral;
+using std::is_same;
+using std::map;
+using std::string;
 
 namespace {
-    string json_escape( const string &str ) {
-        string output;
-        for( unsigned i = 0; i < str.length(); ++i )
-            switch( str[i] ) {
-                case '\"': output += "\\\""; break;
-                case '\\': output += "\\\\"; break;
-                case '\b': output += "\\b";  break;
-                case '\f': output += "\\f";  break;
-                case '\n': output += "\\n";  break;
-                case '\r': output += "\\r";  break;
-                case '\t': output += "\\t";  break;
-                default  : output += str[i]; break;
-            }
-        return std::move( output );
-    }
+string json_escape(const string &str) {
+    string output;
+    for (unsigned i = 0; i < str.length(); ++i) switch (str[i]) {
+            case '\"':
+                output += "\\\"";
+                break;
+            case '\\':
+                output += "\\\\";
+                break;
+            case '\b':
+                output += "\\b";
+                break;
+            case '\f':
+                output += "\\f";
+                break;
+            case '\n':
+                output += "\\n";
+                break;
+            case '\r':
+                output += "\\r";
+                break;
+            case '\t':
+                output += "\\t";
+                break;
+            default:
+                output += str[i];
+                break;
+        }
+    return std::move(output);
 }
+}  // namespace
 
-class JSON
-{
+class JSON {
     union BackingData {
-        BackingData( double d ) : Float( d ){}
-        BackingData( long   l ) : Int( l ){}
-        BackingData( bool   b ) : Bool( b ){}
-        BackingData( string s ) : String( new string( s ) ){}
-        BackingData()           : Int( 0 ){}
+        BackingData(double d) : Float(d) {}
+        BackingData(long l) : Int(l) {}
+        BackingData(bool b) : Bool(b) {}
+        BackingData(string s) : String(new string(s)) {}
+        BackingData() : Int(0) {}
 
-        deque<JSON>        *List;
-        map<string,JSON>   *Map;
-        string             *String;
-        double              Float;
-        long                Int;
-        bool                Bool;
+        deque<JSON> *List;
+        map<string, JSON> *Map;
+        string *String;
+        double Float;
+        long Int;
+        bool Bool;
     } Internal;
 
-    public:
-        enum class Class {
-            Null,
-            Object,
-            Array,
-            String,
-            Floating,
-            Integral,
-            Boolean
-        };
+   public:
+    enum class Class { Null, Object, Array, String, Floating, Integral, Boolean };
 
-        template <typename Container>
-        class JSONWrapper {
-            Container *object;
+    template <typename Container>
+    class JSONWrapper {
+        Container *object;
 
-            public:
-                JSONWrapper( Container *val ) : object( val ) {}
-                JSONWrapper( std::nullptr_t )  : object( nullptr ) {}
+       public:
+        JSONWrapper(Container *val) : object(val) {}
+        JSONWrapper(std::nullptr_t) : object(nullptr) {}
 
-                typename Container::iterator begin() { return object ? object->begin() : typename Container::iterator(); }
-                typename Container::iterator end() { return object ? object->end() : typename Container::iterator(); }
-                typename Container::const_iterator begin() const { return object ? object->begin() : typename Container::iterator(); }
-                typename Container::const_iterator end() const { return object ? object->end() : typename Container::iterator(); }
-        };
-
-        template <typename Container>
-        class JSONConstWrapper {
-            const Container *object;
-
-            public:
-                JSONConstWrapper( const Container *val ) : object( val ) {}
-                JSONConstWrapper( std::nullptr_t )  : object( nullptr ) {}
-
-                typename Container::const_iterator begin() const { return object ? object->begin() : typename Container::const_iterator(); }
-                typename Container::const_iterator end() const { return object ? object->end() : typename Container::const_iterator(); }
-        };
-
-        JSON() : Internal(), Type( Class::Null ){}
-
-        JSON( initializer_list<JSON> list ) 
-            : JSON() 
-        {
-            SetType( Class::Object );
-            for( auto i = list.begin(), e = list.end(); i != e; ++i, ++i )
-                operator[]( i->ToString() ) = *std::next( i );
+        typename Container::iterator begin() {
+            return object ? object->begin() : typename Container::iterator();
         }
-
-        JSON( JSON&& other )
-            : Internal( other.Internal )
-            , Type( other.Type )
-        { other.Type = Class::Null; other.Internal.Map = nullptr; }
-
-        JSON& operator=( JSON&& other ) {
-            ClearInternal();
-            Internal = other.Internal;
-            Type = other.Type;
-            other.Internal.Map = nullptr;
-            other.Type = Class::Null;
-            return *this;
+        typename Container::iterator end() {
+            return object ? object->end() : typename Container::iterator();
         }
+        typename Container::const_iterator begin() const {
+            return object ? object->begin() : typename Container::iterator();
+        }
+        typename Container::const_iterator end() const {
+            return object ? object->end() : typename Container::iterator();
+        }
+    };
 
-        JSON( const JSON &other ) {
-            switch( other.Type ) {
+    template <typename Container>
+    class JSONConstWrapper {
+        const Container *object;
+
+       public:
+        JSONConstWrapper(const Container *val) : object(val) {}
+        JSONConstWrapper(std::nullptr_t) : object(nullptr) {}
+
+        typename Container::const_iterator begin() const {
+            return object ? object->begin() : typename Container::const_iterator();
+        }
+        typename Container::const_iterator end() const {
+            return object ? object->end() : typename Container::const_iterator();
+        }
+    };
+
+    JSON() : Internal(), Type(Class::Null) {}
+
+    JSON(initializer_list<JSON> list) : JSON() {
+        SetType(Class::Object);
+        for (auto i = list.begin(), e = list.end(); i != e; ++i, ++i)
+            operator[](i->ToString()) = *std::next(i);
+    }
+
+    JSON(JSON &&other) : Internal(other.Internal), Type(other.Type) {
+        other.Type = Class::Null;
+        other.Internal.Map = nullptr;
+    }
+
+    JSON &operator=(JSON &&other) {
+        ClearInternal();
+        Internal = other.Internal;
+        Type = other.Type;
+        other.Internal.Map = nullptr;
+        other.Type = Class::Null;
+        return *this;
+    }
+
+    JSON(const JSON &other) {
+        switch (other.Type) {
             case Class::Object:
-                Internal.Map = 
-                    new map<string,JSON>( other.Internal.Map->begin(),
-                                          other.Internal.Map->end() );
+                Internal.Map =
+                    new map<string, JSON>(other.Internal.Map->begin(), other.Internal.Map->end());
                 break;
             case Class::Array:
-                Internal.List = 
-                    new deque<JSON>( other.Internal.List->begin(),
-                                      other.Internal.List->end() );
+                Internal.List =
+                    new deque<JSON>(other.Internal.List->begin(), other.Internal.List->end());
                 break;
             case Class::String:
-                Internal.String = 
-                    new string( *other.Internal.String );
+                Internal.String = new string(*other.Internal.String);
                 break;
             default:
                 Internal = other.Internal;
-            }
-            Type = other.Type;
         }
+        Type = other.Type;
+    }
 
-        JSON& operator=( const JSON &other ) {
-            ClearInternal();
-            switch( other.Type ) {
+    JSON &operator=(const JSON &other) {
+        ClearInternal();
+        switch (other.Type) {
             case Class::Object:
-                Internal.Map = 
-                    new map<string,JSON>( other.Internal.Map->begin(),
-                                          other.Internal.Map->end() );
+                Internal.Map =
+                    new map<string, JSON>(other.Internal.Map->begin(), other.Internal.Map->end());
                 break;
             case Class::Array:
-                Internal.List = 
-                    new deque<JSON>( other.Internal.List->begin(),
-                                      other.Internal.List->end() );
+                Internal.List =
+                    new deque<JSON>(other.Internal.List->begin(), other.Internal.List->end());
                 break;
             case Class::String:
-                Internal.String = 
-                    new string( *other.Internal.String );
+                Internal.String = new string(*other.Internal.String);
                 break;
             default:
                 Internal = other.Internal;
-            }
-            Type = other.Type;
-            return *this;
         }
+        Type = other.Type;
+        return *this;
+    }
 
-        ~JSON() {
-            switch( Type ) {
+    ~JSON() {
+        switch (Type) {
             case Class::Array:
                 delete Internal.List;
                 break;
@@ -178,472 +188,531 @@ class JSON
                 delete Internal.String;
                 break;
             default:;
-            }
         }
+    }
 
-        template <typename T>
-        JSON( T b, typename enable_if<is_same<T,bool>::value>::type* = 0 ) : Internal( b ), Type( Class::Boolean ){}
+    template <typename T>
+    JSON(T b, typename enable_if<is_same<T, bool>::value>::type * = 0)
+        : Internal(b), Type(Class::Boolean) {}
 
-        template <typename T>
-        JSON( T i, typename enable_if<is_integral<T>::value && !is_same<T,bool>::value>::type* = 0 ) : Internal( (long)i ), Type( Class::Integral ){}
+    template <typename T>
+    JSON(T i, typename enable_if<is_integral<T>::value && !is_same<T, bool>::value>::type * = 0)
+        : Internal((long)i), Type(Class::Integral) {}
 
-        template <typename T>
-        JSON( T f, typename enable_if<is_floating_point<T>::value>::type* = 0 ) : Internal( (double)f ), Type( Class::Floating ){}
+    template <typename T>
+    JSON(T f, typename enable_if<is_floating_point<T>::value>::type * = 0)
+        : Internal((double)f), Type(Class::Floating) {}
 
-        template <typename T>
-        JSON( T s, typename enable_if<is_convertible<T,string>::value>::type* = 0 ) : Internal( string( s ) ), Type( Class::String ){}
+    template <typename T>
+    JSON(T s, typename enable_if<is_convertible<T, string>::value>::type * = 0)
+        : Internal(string(s)), Type(Class::String) {}
 
-        JSON( std::nullptr_t ) : Internal(), Type( Class::Null ){}
+    JSON(std::nullptr_t) : Internal(), Type(Class::Null) {}
 
-        static JSON Make( Class type ) {
-            JSON ret; ret.SetType( type );
-            return ret;
-        }
+    static JSON Make(Class type) {
+        JSON ret;
+        ret.SetType(type);
+        return ret;
+    }
 
-        static JSON Load( const string & );
+    static JSON Load(const string &);
 
-        template <typename T>
-        void append( T arg ) {
-            SetType( Class::Array ); Internal.List->emplace_back( arg );
-        }
+    template <typename T>
+    void append(T arg) {
+        SetType(Class::Array);
+        Internal.List->emplace_back(arg);
+    }
 
-        template <typename T, typename... U>
-        void append( T arg, U... args ) {
-            append( arg ); append( args... );
-        }
+    template <typename T, typename... U>
+    void append(T arg, U... args) {
+        append(arg);
+        append(args...);
+    }
 
-        template <typename T>
-            typename enable_if<is_same<T,bool>::value, JSON&>::type operator=( T b ) {
-                SetType( Class::Boolean ); Internal.Bool = b; return *this;
-            }
+    template <typename T>
+    typename enable_if<is_same<T, bool>::value, JSON &>::type operator=(T b) {
+        SetType(Class::Boolean);
+        Internal.Bool = b;
+        return *this;
+    }
 
-        template <typename T>
-            typename enable_if<is_integral<T>::value && !is_same<T,bool>::value, JSON&>::type operator=( T i ) {
-                SetType( Class::Integral ); Internal.Int = i; return *this;
-            }
+    template <typename T>
+    typename enable_if<is_integral<T>::value && !is_same<T, bool>::value, JSON &>::type operator=(
+        T i) {
+        SetType(Class::Integral);
+        Internal.Int = i;
+        return *this;
+    }
 
-        template <typename T>
-            typename enable_if<is_floating_point<T>::value, JSON&>::type operator=( T f ) {
-                SetType( Class::Floating ); Internal.Float = f; return *this;
-            }
+    template <typename T>
+    typename enable_if<is_floating_point<T>::value, JSON &>::type operator=(T f) {
+        SetType(Class::Floating);
+        Internal.Float = f;
+        return *this;
+    }
 
-        template <typename T>
-            typename enable_if<is_convertible<T,string>::value, JSON&>::type operator=( T s ) {
-                SetType( Class::String ); *Internal.String = string( s ); return *this;
-            }
+    template <typename T>
+    typename enable_if<is_convertible<T, string>::value, JSON &>::type operator=(T s) {
+        SetType(Class::String);
+        *Internal.String = string(s);
+        return *this;
+    }
 
-        JSON& operator[]( const string &key ) {
-            SetType( Class::Object ); return Internal.Map->operator[]( key );
-        }
+    JSON &operator[](const string &key) {
+        SetType(Class::Object);
+        return Internal.Map->operator[](key);
+    }
 
-        JSON& operator[]( unsigned index ) {
-            SetType( Class::Array );
-            if( index >= Internal.List->size() ) Internal.List->resize( index + 1 );
-            return Internal.List->operator[]( index );
-        }
+    JSON &operator[](unsigned index) {
+        SetType(Class::Array);
+        if (index >= Internal.List->size()) Internal.List->resize(index + 1);
+        return Internal.List->operator[](index);
+    }
 
-        JSON &at( const string &key ) {
-            return operator[]( key );
-        }
+    JSON &at(const string &key) { return operator[](key); }
 
-        const JSON &at( const string &key ) const {
-            return Internal.Map->at( key );
-        }
+    const JSON &at(const string &key) const { return Internal.Map->at(key); }
 
-        JSON &at( unsigned index ) {
-            return operator[]( index );
-        }
+    JSON &at(unsigned index) { return operator[](index); }
 
-        const JSON &at( unsigned index ) const {
-            return Internal.List->at( index );
-        }
+    const JSON &at(unsigned index) const { return Internal.List->at(index); }
 
-        int length() const {
-            if( Type == Class::Array )
-                return Internal.List->size();
-            else
-                return -1;
-        }
+    int length() const {
+        if (Type == Class::Array)
+            return Internal.List->size();
+        else
+            return -1;
+    }
 
-        bool hasKey( const string &key ) const {
-            if( Type == Class::Object )
-                return Internal.Map->find( key ) != Internal.Map->end();
-            return false;
-        }
+    bool hasKey(const string &key) const {
+        if (Type == Class::Object) return Internal.Map->find(key) != Internal.Map->end();
+        return false;
+    }
 
-        int size() const {
-            if( Type == Class::Object )
-                return Internal.Map->size();
-            else if( Type == Class::Array )
-                return Internal.List->size();
-            else
-                return -1;
-        }
+    int size() const {
+        if (Type == Class::Object)
+            return Internal.Map->size();
+        else if (Type == Class::Array)
+            return Internal.List->size();
+        else
+            return -1;
+    }
 
-        Class JSONType() const { return Type; }
+    Class JSONType() const { return Type; }
 
-        /// Functions for getting primitives from the JSON object.
-        bool IsNull() const { return Type == Class::Null; }
+    /// Functions for getting primitives from the JSON object.
+    bool IsNull() const { return Type == Class::Null; }
 
-        string ToString() const { bool b; return std::move( ToString( b ) ); }
-        string ToString( bool &ok ) const {
-            ok = (Type == Class::String);
-            return ok ? std::move( json_escape( *Internal.String ) ): string("");
-        }
+    string ToString() const {
+        bool b;
+        return std::move(ToString(b));
+    }
+    string ToString(bool &ok) const {
+        ok = (Type == Class::String);
+        return ok ? std::move(json_escape(*Internal.String)) : string("");
+    }
 
-        double ToFloat() const { bool b; return ToFloat( b ); }
-        double ToFloat( bool &ok ) const {
-            ok = (Type == Class::Floating);
-            return ok ? Internal.Float : 0.0;
-        }
+    double ToFloat() const {
+        bool b;
+        return ToFloat(b);
+    }
+    double ToFloat(bool &ok) const {
+        ok = (Type == Class::Floating);
+        return ok ? Internal.Float : 0.0;
+    }
 
-        long ToInt() const { bool b; return ToInt( b ); }
-        long ToInt( bool &ok ) const {
-            ok = (Type == Class::Integral);
-            return ok ? Internal.Int : 0;
-        }
+    long ToInt() const {
+        bool b;
+        return ToInt(b);
+    }
+    long ToInt(bool &ok) const {
+        ok = (Type == Class::Integral);
+        return ok ? Internal.Int : 0;
+    }
 
-        bool ToBool() const { bool b; return ToBool( b ); }
-        bool ToBool( bool &ok ) const {
-            ok = (Type == Class::Boolean);
-            return ok ? Internal.Bool : false;
-        }
+    bool ToBool() const {
+        bool b;
+        return ToBool(b);
+    }
+    bool ToBool(bool &ok) const {
+        ok = (Type == Class::Boolean);
+        return ok ? Internal.Bool : false;
+    }
 
-        JSONWrapper<map<string,JSON>> ObjectRange() {
-            if( Type == Class::Object )
-                return JSONWrapper<map<string,JSON>>( Internal.Map );
-            return JSONWrapper<map<string,JSON>>( nullptr );
-        }
+    JSONWrapper<map<string, JSON>> ObjectRange() {
+        if (Type == Class::Object) return JSONWrapper<map<string, JSON>>(Internal.Map);
+        return JSONWrapper<map<string, JSON>>(nullptr);
+    }
 
-        JSONWrapper<deque<JSON>> ArrayRange() {
-            if( Type == Class::Array )
-                return JSONWrapper<deque<JSON>>( Internal.List );
-            return JSONWrapper<deque<JSON>>( nullptr );
-        }
+    JSONWrapper<deque<JSON>> ArrayRange() {
+        if (Type == Class::Array) return JSONWrapper<deque<JSON>>(Internal.List);
+        return JSONWrapper<deque<JSON>>(nullptr);
+    }
 
-        JSONConstWrapper<map<string,JSON>> ObjectRange() const {
-            if( Type == Class::Object )
-                return JSONConstWrapper<map<string,JSON>>( Internal.Map );
-            return JSONConstWrapper<map<string,JSON>>( nullptr );
-        }
+    JSONConstWrapper<map<string, JSON>> ObjectRange() const {
+        if (Type == Class::Object) return JSONConstWrapper<map<string, JSON>>(Internal.Map);
+        return JSONConstWrapper<map<string, JSON>>(nullptr);
+    }
 
+    JSONConstWrapper<deque<JSON>> ArrayRange() const {
+        if (Type == Class::Array) return JSONConstWrapper<deque<JSON>>(Internal.List);
+        return JSONConstWrapper<deque<JSON>>(nullptr);
+    }
 
-        JSONConstWrapper<deque<JSON>> ArrayRange() const { 
-            if( Type == Class::Array )
-                return JSONConstWrapper<deque<JSON>>( Internal.List );
-            return JSONConstWrapper<deque<JSON>>( nullptr );
-        }
+    string dump(int depth = 1, string tab = "  ") const {
+        string pad = "";
+        for (int i = 0; i < depth; ++i, pad += tab)
+            ;
 
-        string dump( int depth = 1, string tab = "  ") const {
-            string pad = "";
-            for( int i = 0; i < depth; ++i, pad += tab );
-
-            switch( Type ) {
-                case Class::Null:
-                    return "null";
-                case Class::Object: {
-                    string s = "{\n";
-                    bool skip = true;
-                    for( auto &p : *Internal.Map ) {
-                        if( !skip ) s += ",\n";
-                        s += ( pad + "\"" + p.first + "\" : " + p.second.dump( depth + 1, tab ) );
-                        skip = false;
-                    }
-                    s += ( "\n" + pad.erase( 0, 2 ) + "}" ) ;
-                    return s;
+        switch (Type) {
+            case Class::Null:
+                return "null";
+            case Class::Object: {
+                string s = "{\n";
+                bool skip = true;
+                for (auto &p : *Internal.Map) {
+                    if (!skip) s += ",\n";
+                    s += (pad + "\"" + p.first + "\" : " + p.second.dump(depth + 1, tab));
+                    skip = false;
                 }
-                case Class::Array: {
-                    string s = "[";
-                    bool skip = true;
-                    for( auto &p : *Internal.List ) {
-                        if( !skip ) s += ", ";
-                        s += p.dump( depth + 1, tab );
-                        skip = false;
-                    }
-                    s += "]";
-                    return s;
+                s += ("\n" + pad.erase(0, 2) + "}");
+                return s;
+            }
+            case Class::Array: {
+                string s = "[";
+                bool skip = true;
+                for (auto &p : *Internal.List) {
+                    if (!skip) s += ", ";
+                    s += p.dump(depth + 1, tab);
+                    skip = false;
                 }
-                case Class::String:
-                    return "\"" + json_escape( *Internal.String ) + "\"";
-                case Class::Floating:
-                    return std::to_string( Internal.Float );
-                case Class::Integral:
-                    return std::to_string( Internal.Int );
-                case Class::Boolean:
-                    return Internal.Bool ? "true" : "false";
-                default:
-                    return "";
+                s += "]";
+                return s;
             }
-            return "";
+            case Class::String:
+                return "\"" + json_escape(*Internal.String) + "\"";
+            case Class::Floating:
+                return std::to_string(Internal.Float);
+            case Class::Integral:
+                return std::to_string(Internal.Int);
+            case Class::Boolean:
+                return Internal.Bool ? "true" : "false";
+            default:
+                return "";
+        }
+        return "";
+    }
+
+    friend std::ostream &operator<<(std::ostream &, const JSON &);
+
+   private:
+    void SetType(Class type) {
+        if (type == Type) return;
+
+        ClearInternal();
+
+        switch (type) {
+            case Class::Null:
+                Internal.Map = nullptr;
+                break;
+            case Class::Object:
+                Internal.Map = new map<string, JSON>();
+                break;
+            case Class::Array:
+                Internal.List = new deque<JSON>();
+                break;
+            case Class::String:
+                Internal.String = new string();
+                break;
+            case Class::Floating:
+                Internal.Float = 0.0;
+                break;
+            case Class::Integral:
+                Internal.Int = 0;
+                break;
+            case Class::Boolean:
+                Internal.Bool = false;
+                break;
         }
 
-        friend std::ostream& operator<<( std::ostream&, const JSON & );
+        Type = type;
+    }
 
-    private:
-        void SetType( Class type ) {
-            if( type == Type )
-                return;
-
-            ClearInternal();
-          
-            switch( type ) {
-            case Class::Null:      Internal.Map    = nullptr;                break;
-            case Class::Object:    Internal.Map    = new map<string,JSON>(); break;
-            case Class::Array:     Internal.List   = new deque<JSON>();     break;
-            case Class::String:    Internal.String = new string();           break;
-            case Class::Floating:  Internal.Float  = 0.0;                    break;
-            case Class::Integral:  Internal.Int    = 0;                      break;
-            case Class::Boolean:   Internal.Bool   = false;                  break;
-            }
-
-            Type = type;
+   private:
+    /* beware: only call if YOU know that Internal is allocated. No checks performed here.
+       This function should be called in a constructed JSON just before you are going to
+      overwrite Internal...
+    */
+    void ClearInternal() {
+        switch (Type) {
+            case Class::Object:
+                delete Internal.Map;
+                break;
+            case Class::Array:
+                delete Internal.List;
+                break;
+            case Class::String:
+                delete Internal.String;
+                break;
+            default:;
         }
+    }
 
-    private:
-      /* beware: only call if YOU know that Internal is allocated. No checks performed here. 
-         This function should be called in a constructed JSON just before you are going to 
-        overwrite Internal... 
-      */
-      void ClearInternal() {
-        switch( Type ) {
-          case Class::Object: delete Internal.Map;    break;
-          case Class::Array:  delete Internal.List;   break;
-          case Class::String: delete Internal.String; break;
-          default:;
-        }
-      }
-
-    private:
-
-        Class Type = Class::Null;
+   private:
+    Class Type = Class::Null;
 };
 
-JSON Array() {
-    return std::move( JSON::Make( JSON::Class::Array ) );
-}
+JSON Array() { return std::move(JSON::Make(JSON::Class::Array)); }
 
 template <typename... T>
-JSON Array( T... args ) {
-    JSON arr = JSON::Make( JSON::Class::Array );
-    arr.append( args... );
-    return std::move( arr );
+JSON Array(T... args) {
+    JSON arr = JSON::Make(JSON::Class::Array);
+    arr.append(args...);
+    return std::move(arr);
 }
 
-JSON Object() {
-    return std::move( JSON::Make( JSON::Class::Object ) );
-}
+JSON Object() { return std::move(JSON::Make(JSON::Class::Object)); }
 
-std::ostream& operator<<( std::ostream &os, const JSON &json ) {
+std::ostream &operator<<(std::ostream &os, const JSON &json) {
     os << json.dump();
     return os;
 }
 
 namespace {
-    JSON parse_next( const string &, size_t & );
+JSON parse_next(const string &, size_t &);
 
-    void consume_ws( const string &str, size_t &offset ) {
-        while( isspace( str[offset] ) ) ++offset;
-    }
+void consume_ws(const string &str, size_t &offset) {
+    while (isspace(str[offset])) ++offset;
+}
 
-    JSON parse_object( const string &str, size_t &offset ) {
-        JSON Object = JSON::Make( JSON::Class::Object );
+JSON parse_object(const string &str, size_t &offset) {
+    JSON Object = JSON::Make(JSON::Class::Object);
 
+    ++offset;
+    consume_ws(str, offset);
+    if (str[offset] == '}') {
         ++offset;
-        consume_ws( str, offset );
-        if( str[offset] == '}' ) {
-            ++offset; return std::move( Object );
-        }
-
-        while( true ) {
-            JSON Key = parse_next( str, offset );
-            consume_ws( str, offset );
-            if( str[offset] != ':' ) {
-                std::cerr << "Error: Object: Expected colon, found '" << str[offset] << "'\n";
-                break;
-            }
-            consume_ws( str, ++offset );
-            JSON Value = parse_next( str, offset );
-            Object[Key.ToString()] = Value;
-            
-            consume_ws( str, offset );
-            if( str[offset] == ',' ) {
-                ++offset; continue;
-            }
-            else if( str[offset] == '}' ) {
-                ++offset; break;
-            }
-            else {
-                std::cerr << "ERROR: Object: Expected comma, found '" << str[offset] << "'\n";
-                break;
-            }
-        }
-
-        return std::move( Object );
+        return std::move(Object);
     }
 
-    JSON parse_array( const string &str, size_t &offset ) {
-        JSON Array = JSON::Make( JSON::Class::Array );
-        unsigned index = 0;
-        
+    while (true) {
+        JSON Key = parse_next(str, offset);
+        consume_ws(str, offset);
+        if (str[offset] != ':') {
+            std::cerr << "Error: Object: Expected colon, found '" << str[offset] << "'\n";
+            break;
+        }
+        consume_ws(str, ++offset);
+        JSON Value = parse_next(str, offset);
+        Object[Key.ToString()] = Value;
+
+        consume_ws(str, offset);
+        if (str[offset] == ',') {
+            ++offset;
+            continue;
+        } else if (str[offset] == '}') {
+            ++offset;
+            break;
+        } else {
+            std::cerr << "ERROR: Object: Expected comma, found '" << str[offset] << "'\n";
+            break;
+        }
+    }
+
+    return std::move(Object);
+}
+
+JSON parse_array(const string &str, size_t &offset) {
+    JSON Array = JSON::Make(JSON::Class::Array);
+    unsigned index = 0;
+
+    ++offset;
+    consume_ws(str, offset);
+    if (str[offset] == ']') {
         ++offset;
-        consume_ws( str, offset );
-        if( str[offset] == ']' ) {
-            ++offset; return std::move( Array );
-        }
-
-        while( true ) {
-            Array[index++] = parse_next( str, offset );
-            consume_ws( str, offset );
-
-            if( str[offset] == ',' ) {
-                ++offset; continue;
-            }
-            else if( str[offset] == ']' ) {
-                ++offset; break;
-            }
-            else {
-                std::cerr << "ERROR: Array: Expected ',' or ']', found '" << str[offset] << "'\n";
-                return std::move( JSON::Make( JSON::Class::Array ) );
-            }
-        }
-
-        return std::move( Array );
+        return std::move(Array);
     }
 
-    JSON parse_string( const string &str, size_t &offset ) {
-        JSON String;
-        string val;
-        for( char c = str[++offset]; c != '\"' ; c = str[++offset] ) {
-            if( c == '\\' ) {
-                switch( str[ ++offset ] ) {
-                case '\"': val += '\"'; break;
-                case '\\': val += '\\'; break;
-                case '/' : val += '/' ; break;
-                case 'b' : val += '\b'; break;
-                case 'f' : val += '\f'; break;
-                case 'n' : val += '\n'; break;
-                case 'r' : val += '\r'; break;
-                case 't' : val += '\t'; break;
-                case 'u' : {
-                    val += "\\u" ;
-                    for( unsigned i = 1; i <= 4; ++i ) {
-                        c = str[offset+i];
-                        if( (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') )
+    while (true) {
+        Array[index++] = parse_next(str, offset);
+        consume_ws(str, offset);
+
+        if (str[offset] == ',') {
+            ++offset;
+            continue;
+        } else if (str[offset] == ']') {
+            ++offset;
+            break;
+        } else {
+            std::cerr << "ERROR: Array: Expected ',' or ']', found '" << str[offset] << "'\n";
+            return std::move(JSON::Make(JSON::Class::Array));
+        }
+    }
+
+    return std::move(Array);
+}
+
+JSON parse_string(const string &str, size_t &offset) {
+    JSON String;
+    string val;
+    for (char c = str[++offset]; c != '\"'; c = str[++offset]) {
+        if (c == '\\') {
+            switch (str[++offset]) {
+                case '\"':
+                    val += '\"';
+                    break;
+                case '\\':
+                    val += '\\';
+                    break;
+                case '/':
+                    val += '/';
+                    break;
+                case 'b':
+                    val += '\b';
+                    break;
+                case 'f':
+                    val += '\f';
+                    break;
+                case 'n':
+                    val += '\n';
+                    break;
+                case 'r':
+                    val += '\r';
+                    break;
+                case 't':
+                    val += '\t';
+                    break;
+                case 'u': {
+                    val += "\\u";
+                    for (unsigned i = 1; i <= 4; ++i) {
+                        c = str[offset + i];
+                        if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+                            (c >= 'A' && c <= 'F'))
                             val += c;
                         else {
-                            std::cerr << "ERROR: String: Expected hex character in unicode escape, found '" << c << "'\n";
-                            return std::move( JSON::Make( JSON::Class::String ) );
+                            std::cerr << "ERROR: String: Expected hex character in unicode escape, "
+                                         "found '"
+                                      << c << "'\n";
+                            return std::move(JSON::Make(JSON::Class::String));
                         }
                     }
                     offset += 4;
                 } break;
-                default  : val += '\\'; break;
-                }
-            }
-            else
-                val += c;
-        }
-        ++offset;
-        String = val;
-        return std::move( String );
-    }
-
-    JSON parse_number( const string &str, size_t &offset ) {
-        JSON Number;
-        string val, exp_str;
-        char c;
-        bool isDouble = false;
-        long exp = 0;
-        while( true ) {
-            c = str[offset++];
-            if( (c == '-') || (c >= '0' && c <= '9') )
-                val += c;
-            else if( c == '.' ) {
-                val += c; 
-                isDouble = true;
-            }
-            else
-                break;
-        }
-        if( c == 'E' || c == 'e' ) {
-            c = str[ offset++ ];
-            if( c == '-' ){ ++offset; exp_str += '-';}
-            while( true ) {
-                c = str[ offset++ ];
-                if( c >= '0' && c <= '9' )
-                    exp_str += c;
-                else if( !isspace( c ) && c != ',' && c != ']' && c != '}' ) {
-                    std::cerr << "ERROR: Number: Expected a number for exponent, found '" << c << "'\n";
-                    return std::move( JSON::Make( JSON::Class::Null ) );
-                }
-                else
+                default:
+                    val += '\\';
                     break;
             }
-            exp = std::stol( exp_str );
-        }
-        else if( !isspace( c ) && c != ',' && c != ']' && c != '}' ) {
-            std::cerr << "ERROR: Number: unexpected character '" << c << "'\n";
-            return std::move( JSON::Make( JSON::Class::Null ) );
-        }
-        --offset;
-        
-        if( isDouble )
-            Number = std::stod( val ) * std::pow( 10, exp );
-        else {
-            if( !exp_str.empty() )
-                Number = std::stol( val ) * std::pow( 10, exp );
-            else
-                Number = std::stol( val );
-        }
-        return std::move( Number );
+        } else
+            val += c;
     }
-
-    JSON parse_bool( const string &str, size_t &offset ) {
-        JSON Bool;
-        if( str.substr( offset, 4 ) == "true" )
-            Bool = true;
-        else if( str.substr( offset, 5 ) == "false" )
-            Bool = false;
-        else {
-            std::cerr << "ERROR: Bool: Expected 'true' or 'false', found '" << str.substr( offset, 5 ) << "'\n";
-            return std::move( JSON::Make( JSON::Class::Null ) );
-        }
-        offset += (Bool.ToBool() ? 4 : 5);
-        return std::move( Bool );
-    }
-
-    JSON parse_null( const string &str, size_t &offset ) {
-        JSON Null;
-        if( str.substr( offset, 4 ) != "null" ) {
-            std::cerr << "ERROR: Null: Expected 'null', found '" << str.substr( offset, 4 ) << "'\n";
-            return std::move( JSON::Make( JSON::Class::Null ) );
-        }
-        offset += 4;
-        return std::move( Null );
-    }
-
-    JSON parse_next( const string &str, size_t &offset ) {
-        char value;
-        consume_ws( str, offset );
-        value = str[offset];
-        switch( value ) {
-            case '[' : return std::move( parse_array( str, offset ) );
-            case '{' : return std::move( parse_object( str, offset ) );
-            case '\"': return std::move( parse_string( str, offset ) );
-            case 't' :
-            case 'f' : return std::move( parse_bool( str, offset ) );
-            case 'n' : return std::move( parse_null( str, offset ) );
-            default  : if( ( value <= '9' && value >= '0' ) || value == '-' )
-                           return std::move( parse_number( str, offset ) );
-        }
-        std::cerr << "ERROR: Parse: Unknown starting character '" << value << "'\n";
-        return JSON();
-    }
+    ++offset;
+    String = val;
+    return std::move(String);
 }
 
-JSON JSON::Load( const string &str ) {
+JSON parse_number(const string &str, size_t &offset) {
+    JSON Number;
+    string val, exp_str;
+    char c;
+    bool isDouble = false;
+    long exp = 0;
+    while (true) {
+        c = str[offset++];
+        if ((c == '-') || (c >= '0' && c <= '9'))
+            val += c;
+        else if (c == '.') {
+            val += c;
+            isDouble = true;
+        } else
+            break;
+    }
+    if (c == 'E' || c == 'e') {
+        c = str[offset++];
+        if (c == '-') {
+            ++offset;
+            exp_str += '-';
+        }
+        while (true) {
+            c = str[offset++];
+            if (c >= '0' && c <= '9')
+                exp_str += c;
+            else if (!isspace(c) && c != ',' && c != ']' && c != '}') {
+                std::cerr << "ERROR: Number: Expected a number for exponent, found '" << c << "'\n";
+                return std::move(JSON::Make(JSON::Class::Null));
+            } else
+                break;
+        }
+        exp = std::stol(exp_str);
+    } else if (!isspace(c) && c != ',' && c != ']' && c != '}') {
+        std::cerr << "ERROR: Number: unexpected character '" << c << "'\n";
+        return std::move(JSON::Make(JSON::Class::Null));
+    }
+    --offset;
+
+    if (isDouble)
+        Number = std::stod(val) * std::pow(10, exp);
+    else {
+        if (!exp_str.empty())
+            Number = std::stol(val) * std::pow(10, exp);
+        else
+            Number = std::stol(val);
+    }
+    return std::move(Number);
+}
+
+JSON parse_bool(const string &str, size_t &offset) {
+    JSON Bool;
+    if (str.substr(offset, 4) == "true")
+        Bool = true;
+    else if (str.substr(offset, 5) == "false")
+        Bool = false;
+    else {
+        std::cerr << "ERROR: Bool: Expected 'true' or 'false', found '" << str.substr(offset, 5)
+                  << "'\n";
+        return std::move(JSON::Make(JSON::Class::Null));
+    }
+    offset += (Bool.ToBool() ? 4 : 5);
+    return std::move(Bool);
+}
+
+JSON parse_null(const string &str, size_t &offset) {
+    JSON Null;
+    if (str.substr(offset, 4) != "null") {
+        std::cerr << "ERROR: Null: Expected 'null', found '" << str.substr(offset, 4) << "'\n";
+        return std::move(JSON::Make(JSON::Class::Null));
+    }
+    offset += 4;
+    return std::move(Null);
+}
+
+JSON parse_next(const string &str, size_t &offset) {
+    char value;
+    consume_ws(str, offset);
+    value = str[offset];
+    switch (value) {
+        case '[':
+            return std::move(parse_array(str, offset));
+        case '{':
+            return std::move(parse_object(str, offset));
+        case '\"':
+            return std::move(parse_string(str, offset));
+        case 't':
+        case 'f':
+            return std::move(parse_bool(str, offset));
+        case 'n':
+            return std::move(parse_null(str, offset));
+        default:
+            if ((value <= '9' && value >= '0') || value == '-')
+                return std::move(parse_number(str, offset));
+    }
+    std::cerr << "ERROR: Parse: Unknown starting character '" << value << "'\n";
+    return JSON();
+}
+}  // namespace
+
+JSON JSON::Load(const string &str) {
     size_t offset = 0;
-    return std::move( parse_next( str, offset ) );
+    return std::move(parse_next(str, offset));
 }
 
-} // End Namespace json
+}  // End Namespace json

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -116,7 +116,7 @@ static maybe_t<wcstring> history_filename(const wcstring &session_id, const wcst
 
     result.append(L"/");
     result.append(session_id);
-    result.append(L"_history");
+    result.append(L"_history.json");
     result.append(suffix);
     return result;
 }

--- a/src/history.h
+++ b/src/history.h
@@ -177,8 +177,10 @@ class history_t {
     // Irreversibly clears history.
     void clear();
 
-    // Populates from older location (in config path, rather than data path).
-    void populate_from_config_path();
+    // Populates from older locations:
+    // 1. The unsuffixed pre-JSON path.
+    // 2. In config path, rather than data path.
+    void populate_from_legacy_paths();
 
     // Populates from a bash history file.
     void populate_from_bash(FILE *f);

--- a/src/history_file.h
+++ b/src/history_file.h
@@ -25,12 +25,6 @@ class history_file_contents_t {
     /// Decode an item at a given offset.
     history_item_t decode_item(size_t offset) const;
 
-    /// Support for iterating item offsets.
-    /// The cursor should initially be 0.
-    /// If cutoff is nonzero, skip items whose timestamp is newer than cutoff.
-    /// \return the offset of the next item, or none() on end.
-    maybe_t<size_t> offset_of_next_item(size_t *cursor, time_t cutoff);
-
     /// Get the file type.
     history_file_type_t type() const { return type_; }
 
@@ -64,8 +58,36 @@ class history_file_contents_t {
     // Private constructor; use the static create() function.
     history_file_contents_t(const char *mmap_start, size_t mmap_length, history_file_type_t type);
 
+    /// Support for iterating item offsets.
+    /// The cursor should initially be 0.
+    /// If cutoff is nonzero, skip items whose timestamp is newer than cutoff.
+    /// \return the offset of the next item, or none() on end.
+    maybe_t<size_t> offset_of_next_item(size_t *cursor, time_t cutoff) const;
+
     history_file_contents_t(history_file_contents_t &&) = delete;
     void operator=(history_file_contents_t &&) = delete;
+
+    friend class history_file_reader_t;
+};
+
+/// A class which knows how to produce history items from a history file contents.
+class history_file_reader_t {
+   public:
+    /// \return the offset in the file contents of the next history item, or none() if exhausted.
+    /// If \p out is set, then return the item as well by reference.
+    maybe_t<size_t> next(history_item_t *out);
+
+    /// Construct from the file contents. The contents are held by reference.
+    /// If \p cutoff is not zero, then ignore items whose timestamp is larger than cutoff.
+    history_file_reader_t(const history_file_contents_t &contents, time_t cutoff);
+
+    ~history_file_reader_t();
+
+   private:
+    struct impl_t;
+    const history_file_contents_t &contents_;
+    time_t cutoff_;
+    std::unique_ptr<impl_t> impl_;
 };
 
 /// Append a history item to a buffer, in preparation for outputting it to the history file.

--- a/src/history_file.h
+++ b/src/history_file.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 
+#include <string.h>
 #include <sys/mman.h>
 
 #include <cassert>
@@ -14,7 +15,7 @@
 class history_item_t;
 
 // History file types.
-enum history_file_type_t { history_type_fish_2_0, history_type_fish_1_x };
+enum history_file_type_t { history_type_fish_json, history_type_fish_2_0, history_type_fish_1_x };
 
 /// history_file_contents_t holds the read-only contents of a file.
 class history_file_contents_t {
@@ -41,6 +42,14 @@ class history_file_contents_t {
     const char *address_at(size_t offset) const {
         assert(offset <= length_ && "Invalid offset");
         return start_ + offset;
+    }
+
+    /// Find the offset of a character, starting at a given index.
+    maybe_t<size_t> find_char(char c, size_t offset) const {
+        assert(offset <= length_ && "Invalid offset");
+        const char *where = static_cast<const char *>(memchr(start_ + offset, c, length_ - offset));
+        if (where == nullptr) return none();
+        return where - start_;
     }
 
     ~history_file_contents_t();

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2163,7 +2163,7 @@ void reader_import_history_if_necessary() {
     // Import history from older location (config path) if our current history is empty.
     reader_data_t *data = current_data();
     if (data->history && data->history->is_empty()) {
-        data->history->populate_from_config_path();
+        data->history->populate_from_legacy_paths();
     }
 
     // Import history from bash, etc. if our current history is still empty and is the default

--- a/tests/histfile.expect
+++ b/tests/histfile.expect
@@ -1,9 +1,9 @@
 # vim: set filetype=expect:
 # We're going to use three history files, including the default, to verify
 # that the fish_history variable works as expected.
-set default_histfile "../test/data/fish/fish_history"
-set my_histfile "../test/data/fish/my_history"
-set env_histfile "../test/data/fish/env_history"
+set default_histfile "../test/data/fish/fish_history.json"
+set my_histfile "../test/data/fish/my_history.json"
+set env_histfile "../test/data/fish/env_history.json"
 
 # =============
 # Verify that if we spawn fish with no fish_history env var it uses the
@@ -14,7 +14,7 @@ expect_prompt
 
 # Verify that a command is recorded in the default history file.
 set cmd1 "echo $fish_pid default histfile"
-set hist_line "- cmd: $cmd1"
+set hist_line "$cmd1"
 send "$cmd1\r"
 expect_prompt
 
@@ -23,8 +23,8 @@ expect_prompt
 send "history --save\r"
 expect_prompt
 
-send "grep '^$hist_line' $default_histfile\r"
-expect_prompt -re "\r\n$hist_line\r\n" {
+send "grep -q '$hist_line' $default_histfile; echo \$status\r"
+expect_prompt -re "\r\n0\r\n" {
     puts "cmd1 found in default histfile"
 } unmatched {
     puts stderr "cmd1 not found in default histfile"
@@ -33,30 +33,29 @@ expect_prompt -re "\r\n$hist_line\r\n" {
 # Switch to a new history file and verify it is written to and the default
 # history file is not written to.
 set cmd2 "echo $fish_pid my histfile"
-set hist_line "- cmd: $cmd2"
+set hist_line "$cmd2"
 send "set fish_history my\r"
 expect_prompt
 send "$cmd2\r"
 expect_prompt
 
-send "grep '^$hist_line' $my_histfile\r"
-expect_prompt -re "\r\n$hist_line\r\n" {
+send "grep -q '$hist_line' $my_histfile; echo \$status\r"
+expect_prompt -re "\r\n0\r\n" {
     puts "cmd2 found in my histfile"
 } unmatched {
     puts stderr "cmd2 not found in my histfile"
 }
-# We expect this grep to fail to find the pattern and thus the expect_prompt
-# block is inverted.
-send "grep '^$hist_line' $default_histfile\r"
-expect_prompt -re "\r\n$hist_line\r\n" {
-    puts stderr "cmd2 found in default histfile"
-} unmatched {
+# We expect this grep to fail to find the pattern.
+send "grep -q '$hist_line' $default_histfile; echo \$status\r"
+expect_prompt -re "\r\n1\r\n" {
     puts "cmd2 not found in default histfile"
+} unmatched {
+    puts stderr "cmd2 found in default histfile"
 }
 
 # Switch back to the default history file.
 set cmd3 "echo $fish_pid default histfile again"
-set hist_line "- cmd: $cmd3"
+set hist_line "$cmd3"
 send "set fish_history default\r"
 expect_prompt
 send "$cmd3\r"
@@ -67,15 +66,15 @@ expect_prompt
 send "history --save\r"
 expect_prompt
 
-send "grep '^$hist_line' $default_histfile\r"
-expect_prompt -re "\r\n$hist_line\r\n" {
+send "grep -q '$hist_line' $default_histfile; echo \$status\r"
+expect_prompt -re "\r\n0\r\n" {
     puts "cmd3 found in default histfile"
 } unmatched {
     puts stderr "cmd3 not found in default histfile"
 }
 # We expect this grep to fail to find the pattern and thus the expect_prompt
 # block is inverted.
-send "grep '^$hist_line' $my_histfile\r"
+send "grep -q '$hist_line' $my_histfile; echo \$status\r"
 expect_prompt -re "\r\n$hist_line\r\n" {
     puts stderr "cmd3 found in my histfile"
 } unmatched {
@@ -100,7 +99,7 @@ expect_prompt
 
 # Verify that the new fish shell is using the fish_history value for history.
 set cmd4 "echo $fish_pid env histfile"
-set hist_line "- cmd: $cmd4"
+set hist_line "$cmd4"
 send "$cmd4\r"
 expect_prompt
 
@@ -109,17 +108,16 @@ expect_prompt
 # send "history --save\r"
 # expect_prompt
 
-send "grep '^$hist_line' $env_histfile\r"
-expect_prompt -re "\r\n$hist_line\r\n" {
+send "grep -q '$hist_line' $env_histfile; echo \$status\r"
+expect_prompt -re "\r\n0\r\n" {
     puts "cmd4 found in env histfile"
 } unmatched {
     puts stderr "cmd4 not found in env histfile"
 }
-# We expect this grep to fail to find the pattern and thus the expect_prompt
-# block is inverted.
-send "grep '^$hist_line' $default_histfile\r"
-expect_prompt -re "\r\n$hist_line\r\n" {
-    puts stderr "cmd4 found in default histfile"
-} unmatched {
+# We expect this grep to fail to find the pattern.
+send "grep '$hist_line' $default_histfile; echo \$status\r"
+expect_prompt -re "\r\n1\r\n" {
     puts "cmd4 not found in default histfile"
+} unmatched {
+    puts stderr "cmd4 found in default histfile"
 }


### PR DESCRIPTION
Let's figure out what the fish history file format should be. There's some discussion in #3341 and also [here](https://news.ycombinator.com/item?id=20732197).

The goal is to settle on a fish history format, and then eventually re-use the format to persist configuration data, like universal variables and abbreviations. The user is never expected to look at or edit these files manually. But they may choose to.

## State of the world

fish history is currently a broken psuedo-YAML. Mea culpa: I added this about 8 years ago, without thinking hard enough. It is ad-hoc, underspecified and buggy (#6032). This complicates adding new fields while maintaining backwards compatibility, and it prevents the format from being successfully parsed by any other libraries.

The goal here is to settle on a widely-recognized, fully-specified format.

## Desirable Properties for fish

These are my opinions only and are totally fair game for discussion.

- **Textual**. Shells are built on text, which rules out binary formats like SQLite or protobuf. It should be obvious to the user how the history file is stored.


- **Self Describing**. fish history should be a sequence of key-value pairs, not a positional list, so that new fields may be added in the future. This rules out formats like CSV or zsh's [extended history](https://unix.stackexchange.com/questions/416309/what-does-extended-history-in-zsh-do).


- **Not Ad-Hoc**. The new history format should be a real and commonly understood format, not something that we just make up.


- **Trivial Appending**. The file must not require "closing." fish's normal history-saving is O\_APPEND writes with best-effort file locking. This rules out formats like XML (`</xml>`) or JSON (`}`) that require explicit closing.

- **Streamable Searching**. fish should be able to search the history without decoding the entire history file into memory. A SAX-style parser would satisfy this; so also is easily-identifiable record boundaries.

## Candidates

I know of two plausible options: JSON Lines and TOML. I don't have a strong opinion between them - I keep going back and forth, and am open to alternatives. IMO YAML is out because of the complexity of the spec, and to avoid ambiguity with the existing format.

### JSON Lines

[JSON Lines](http://jsonlines.org), also known as JSON Object Streams, is simply newline-delimited JSON objects. Of course JSON is ubiquitous, but newline-delimited JSON objects is itself a fairly common serialization format - it [is understood by `jq`](http://jsonlines.org/examples/), which is the JSON Swiss Army knife. `jq` can slice and dice, filter, query, etc.

fish history in JSON lines might look like:
  
    {"cmd":"git branch -D tmp_fchown","when":1457678810}
    {"cmd":"git checkout pr/2809","when":1457678814}
    {"cmd":"cat ~/file.txt","when":1457678820}
    {"cmd":"git diff src/fallback.h","paths":["src/fallback.h"],"when":1460230565}

__Advantages__

- Ubiquitous, including support in `jq`.
- Good library support for both reading and writing. This PR uses [SimpleJSON](https://github.com/nbsdx/SimpleJSON).
- Trivial record separators (just newlines) allows efficient streaming reads.

__Disadvantages__

- Ugly.
- Bad for human editing. If we used this to persist configuration data, like universal variables and abbreviations, they will be harder to edit by hand.

### TOML

[TOML](https://github.com/toml-lang/toml) is a configuration file format aimed at human-editability. It supports appending via the "list of tables" syntax. Here we might use its support for real dates: 

    [[item]]
    cmd = "git branch -D tmp_fchown"
    when = 2019-05-27T05:32:00
    
    [[item]]
    cmd = "git branch -D tmp_fchown"
    when = 2017-06-2T11:16:05
    
    [[item]]
    cmd = "git diff src/fallback.h"
    when = 2020-05-15T1:2:4
    paths = ["src/fallback.h"]

__Advantages__

- Visually nice
- Excellent for configuration due to its human editability support.

__Disadvantages__

- Existing libraries are not ideal for fish's use case:
    - We'll need some hacks to detect record boundaries.
    - Generating TOML is not a priority for most libraries, we might have to write our own.

## What Other Shells Do

AFAICT fish would be the only shell doing this:

- PowerShell stores commands as naive newline-delimited, with no metadata.

- ksh stores the commands with two nul bytes as delimiters. There is no metadata.

- zsh has a fixed list of [positional fields](http://zsh.sourceforge.net/Doc/Release/Options.html#History).

- elvish uses a binary database called [bolt](https://github.com/boltdb/bolt).


## Compatibility

The new format will be incompatible with the old format. For that reason, the filename should be different: it will be (for example) `fish_history.json` instead of merely `fish_history`. This avoids the problem where you test the new fish, then revert back, and now your history is mangled.

Ideally this is the last time we wholesale replace the fish history file format. Future changes will be adding new key/value pairs, which will be ignored by previous fish shells.
