### PR TITLE
treewide: replace deprecated C headers

### DIFF
--- a/src/builtin_function.cpp
+++ b/src/builtin_function.cpp
@@ -22,7 +22,7 @@
 #include "parser.h"
 #include "parser_keywords.h"
 #include "proc.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "wgetopt.h"
 #include "wutil.h"  // IWYU pragma: keep
 

--- a/src/builtin_functions.cpp
+++ b/src/builtin_functions.cpp
@@ -26,7 +26,7 @@
 #include "parser.h"
 #include "parser_keywords.h"
 #include "proc.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "wcstringutil.h"
 #include "wgetopt.h"
 #include "wutil.h"  // IWYU pragma: keep

--- a/src/builtin_wait.cpp
+++ b/src/builtin_wait.cpp
@@ -10,7 +10,7 @@
 #include "common.h"
 #include "parser.h"
 #include "proc.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "wgetopt.h"
 #include "wutil.h"
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -5,23 +5,23 @@
 #include <cxxabi.h>
 #endif
 
-#include <ctype.h>
+#include <cctype>
 #include <dlfcn.h>
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
-#include <limits.h>
+#include <climits>
 #include <paths.h>
 #include <pthread.h>
-#include <stdarg.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <termios.h>
 #include <unistd.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <cstring>
 #include <cwchar>
@@ -61,7 +61,7 @@
 #include "iothread.h"
 #include "parser.h"
 #include "proc.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "wcstringutil.h"
 #include "wildcard.h"
 #include "wutil.h"  // IWYU pragma: keep

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -9,8 +9,8 @@
 
 #include <pthread.h>
 #include <pwd.h>
-#include <stddef.h>
-#include <wctype.h>
+#include <cstddef>
+#include <cwctype>
 
 #include <algorithm>
 #include <atomic>

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -3,11 +3,11 @@
 
 #include "env.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <pwd.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <sys/stat.h>
 #include <unistd.h>
 

--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -1,12 +1,12 @@
 // Support for dispatching on environment changes.
 #include "config.h"  // IWYU pragma: keep
 
-#include <errno.h>
-#include <limits.h>
-#include <locale.h>
-#include <stddef.h>
-#include <stdlib.h>
-#include <time.h>
+#include <cerrno>
+#include <climits>
+#include <clocale>
+#include <cstddef>
+#include <cstdlib>
+#include <ctime>
 #include <unistd.h>
 
 #include <cstring>
@@ -25,7 +25,7 @@
 #include <ncurses/term.h>
 #endif
 
-#include <assert.h>
+#include <cassert>
 
 #include <algorithm>
 #include <functional>

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -2,21 +2,21 @@
 #include "config.h"  // IWYU pragma: keep
 
 #include <arpa/inet.h>  // IWYU pragma: keep
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 // We need the sys/file.h for the flock() declaration on Linux but not OS X.
 #include <sys/file.h>  // IWYU pragma: keep
 // We need the ioctl.h header so we can check if SIOCGIFHWADDR is defined by it so we know if we're
 // on a Linux system.
-#include <limits.h>
+#include <climits>
 #include <netinet/in.h>  // IWYU pragma: keep
 #include <sys/ioctl.h>   // IWYU pragma: keep
 #if !defined(__APPLE__) && !defined(__CYGWIN__)
 #include <pwd.h>
 #endif
-#include <stddef.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
 
 #include <cstring>
 #ifdef __CYGWIN__

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -3,8 +3,8 @@
 
 #include "event.h"
 
-#include <signal.h>
-#include <stddef.h>
+#include <csignal>
+#include <cstddef>
 #include <unistd.h>
 
 #include <algorithm>
@@ -20,7 +20,7 @@
 #include "io.h"
 #include "parser.h"
 #include "proc.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "wutil.h"  // IWYU pragma: keep
 
 class pending_signals_t {

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -4,16 +4,16 @@
 // performed have been massive.
 #include "config.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #ifdef HAVE_SIGINFO_H
 #include <siginfo.h>
 #endif
-#include <signal.h>
+#include <csignal>
 #ifdef HAVE_SPAWN_H
 #include <spawn.h>
 #endif
-#include <stdio.h>
+#include <cstdio>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -44,7 +44,7 @@
 #include "proc.h"
 #include "reader.h"
 #include "redirection.h"
-#include "signal.h"
+#include <csignal>
 #include "timer.h"
 #include "trace.h"
 #include "wutil.h"  // IWYU pragma: keep

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -2,13 +2,13 @@
 // IWYU pragma: no_include <cstddef>
 #include "config.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <pwd.h>
-#include <stdarg.h>
-#include <stddef.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdlib>
 #include <unistd.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <cstring>
 #include <cwchar>

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -8,16 +8,16 @@
 // IWYU likes to recommend adding term.h when we want ncurses.h.
 // IWYU pragma: no_include term.h
 #include <dirent.h>  // IWYU pragma: keep
-#include <errno.h>   // IWYU pragma: keep
+#include <cerrno>   // IWYU pragma: keep
 #include <fcntl.h>   // IWYU pragma: keep
-#include <limits.h>  // IWYU pragma: keep
-#include <stdarg.h>  // IWYU pragma: keep
-#include <stdio.h>   // IWYU pragma: keep
-#include <stdlib.h>
+#include <climits>  // IWYU pragma: keep
+#include <cstdarg>  // IWYU pragma: keep
+#include <cstdio>   // IWYU pragma: keep
+#include <cstdlib>
 #include <sys/stat.h>   // IWYU pragma: keep
 #include <sys/types.h>  // IWYU pragma: keep
 #include <unistd.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <algorithm>
 #include <cstring>
@@ -37,7 +37,7 @@
 #elif HAVE_NCURSES_TERM_H
 #include <ncurses/term.h>
 #endif
-#include <signal.h>  // IWYU pragma: keep
+#include <csignal>  // IWYU pragma: keep
 
 #include <cwchar>  // IWYU pragma: keep
 

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -18,15 +18,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
 #include "config.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <getopt.h>
-#include <limits.h>
-#include <locale.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <climits>
+#include <clocale>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -54,7 +54,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "path.h"
 #include "proc.h"
 #include "reader.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "wcstringutil.h"
 #include "wutil.h"  // IWYU pragma: keep
 

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -17,13 +17,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
 #include "config.h"  // IWYU pragma: keep
 
-#include <errno.h>
+#include <cerrno>
 #include <getopt.h>
-#include <locale.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <wctype.h>
+#include <clocale>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cwctype>
 
 #include <cstring>
 #include <cwchar>

--- a/src/fish_key_reader.cpp
+++ b/src/fish_key_reader.cpp
@@ -8,12 +8,12 @@
 // Type "exit" or "quit" to terminate the program.
 #include "config.h"  // IWYU pragma: keep
 
-#include <errno.h>
+#include <cerrno>
 #include <getopt.h>
-#include <signal.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <csignal>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <termios.h>
 #include <unistd.h>
 
@@ -33,7 +33,7 @@
 #include "print_help.h"
 #include "proc.h"
 #include "reader.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "wutil.h"  // IWYU pragma: keep
 
 struct config_paths_t determine_config_directory_paths(const char *argv0);

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -7,7 +7,7 @@
 // IWYU pragma: no_include <type_traits>
 #include <dirent.h>
 #include <pthread.h>
-#include <stddef.h>
+#include <cstddef>
 
 #include <algorithm>
 #include <cwchar>

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -3,7 +3,7 @@
 
 // IWYU pragma: no_include <cstddef>
 #include <dirent.h>
-#include <errno.h>
+#include <cerrno>
 #include <sys/stat.h>
 #include <unistd.h>
 

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,22 +1,22 @@
 // History functions, part of the user interface.
 #include "config.h"  // IWYU pragma: keep
 
-#include <ctype.h>
-#include <errno.h>
+#include <cctype>
+#include <cerrno>
 #include <fcntl.h>
 #include <pthread.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 
 #include <cstdint>
 #include <cstring>
 // We need the sys/file.h for the flock() declaration on Linux but not OS X.
 #include <sys/file.h>  // IWYU pragma: keep
 #include <sys/stat.h>
-#include <time.h>
+#include <ctime>
 #include <unistd.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <algorithm>
 #include <atomic>

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1,8 +1,8 @@
 // Functions for reading a character of input from stdin.
 #include "config.h"
 
-#include <errno.h>
-#include <wctype.h>
+#include <cerrno>
+#include <cwctype>
 
 #include <cwchar>
 #if HAVE_TERM_H
@@ -31,7 +31,7 @@
 #include "parser.h"
 #include "proc.h"
 #include "reader.h"
-#include "signal.h"  // IWYU pragma: keep
+#include <csignal>  // IWYU pragma: keep
 #include "wutil.h"   // IWYU pragma: keep
 
 /// A name for our own key mapping for nul.

--- a/src/input_common.cpp
+++ b/src/input_common.cpp
@@ -1,15 +1,15 @@
 // Implementation file for the low level input library.
 #include "config.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <unistd.h>
 
 #include <cstring>
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <sys/time.h>
 #include <sys/types.h>
 

--- a/src/intern.cpp
+++ b/src/intern.cpp
@@ -3,7 +3,7 @@
 
 #include "intern.h"
 
-#include <stddef.h>
+#include <cstddef>
 
 #include <algorithm>
 #include <cwchar>

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -3,10 +3,10 @@
 
 #include "io.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
-#include <stddef.h>
-#include <stdio.h>
+#include <cstddef>
+#include <cstdio>
 #include <unistd.h>
 
 #include <cstring>

--- a/src/iothread.cpp
+++ b/src/iothread.cpp
@@ -2,11 +2,14 @@
 
 #include "iothread.h"
 
-#include <limits.h>
+#include <climits>
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
+#include <csignal>
+#include <cstdio>
+#include <cstring>
 #include <sys/select.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/src/kill.cpp
+++ b/src/kill.cpp
@@ -4,7 +4,7 @@
 // previous cuts.
 #include "config.h"  // IWYU pragma: keep
 
-#include <stddef.h>
+#include <cstddef>
 
 #include <algorithm>
 #include <list>

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1,8 +1,8 @@
 // Generic output functions.
 #include "config.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include <cstring>
 #if HAVE_CURSES_H
@@ -17,7 +17,7 @@
 #elif HAVE_NCURSES_TERM_H
 #include <ncurses/term.h>
 #endif
-#include <limits.h>
+#include <climits>
 
 #include <cwchar>
 #include <memory>

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -1,8 +1,8 @@
 #include "config.h"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <cstddef>
-#include <stddef.h>
-#include <wctype.h>
+#include <cstddef>
+#include <cwctype>
 
 #include <algorithm>
 #include <cwchar>

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -10,13 +10,13 @@
 
 #include "parse_execution.h"
 
-#include <errno.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cerrno>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
 #include <termios.h>
 #include <unistd.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <algorithm>
 #include <cwchar>

--- a/src/parse_productions.cpp
+++ b/src/parse_productions.cpp
@@ -2,7 +2,7 @@
 
 #include "parse_productions.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "common.h"
 #include "flog.h"

--- a/src/parse_tree.cpp
+++ b/src/parse_tree.cpp
@@ -3,9 +3,9 @@
 
 #include "parse_tree.h"
 
-#include <stdarg.h>
-#include <stddef.h>
-#include <stdio.h>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdio>
 
 #include <algorithm>
 #include <cwchar>

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -6,8 +6,8 @@
 
 #include "parse_util.h"
 
-#include <stdarg.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstdlib>
 
 #include <cwchar>
 #include <memory>

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -4,7 +4,7 @@
 #include "parser.h"
 
 #include <fcntl.h>
-#include <stdio.h>
+#include <cstdio>
 
 #include <algorithm>
 #include <cwchar>

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -5,7 +5,7 @@
 
 #include "path.h"
 
-#include <errno.h>
+#include <cerrno>
 #include <sys/stat.h>
 #include <unistd.h>
 

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -1,11 +1,11 @@
 // Functions that we may safely call after fork().
 #include "config.h"  // IWYU pragma: keep
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
-#include <signal.h>
-#include <stdio.h>
-#include <time.h>
+#include <csignal>
+#include <cstdio>
+#include <ctime>
 
 #include <cstring>
 #include <memory>
@@ -22,7 +22,7 @@
 #include "postfork.h"
 #include "proc.h"
 #include "redirection.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "wutil.h"  // IWYU pragma: keep
 
 #ifndef JOIN_THREADS_BEFORE_FORK

--- a/src/print_help.cpp
+++ b/src/print_help.cpp
@@ -3,9 +3,8 @@
 
 #include "print_help.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 #include "common.h"

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -6,12 +6,12 @@
 // IWYU pragma: no_include <__bit_reference>
 #include "config.h"
 
-#include <errno.h>
+#include <cerrno>
+#include <csignal>
+#include <cstdio>
 #include <fcntl.h>
-#include <signal.h>
-#include <stdio.h>
 #include <unistd.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <atomic>
 #include <cwchar>
@@ -49,7 +49,7 @@
 #include "proc.h"
 #include "reader.h"
 #include "sanity.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "wutil.h"  // IWYU pragma: keep
 
 /// The signals that signify crashes to us.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -14,15 +14,15 @@
 #include "config.h"
 
 // IWYU pragma: no_include <type_traits>
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <pthread.h>
 #ifdef HAVE_SIGINFO_H
 #include <siginfo.h>
 #endif
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
 
 #include <cstring>
 #ifdef HAVE_SYS_SELECT_H
@@ -31,9 +31,9 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <termios.h>
-#include <time.h>
+#include <ctime>
 #include <unistd.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <algorithm>
 #include <atomic>
@@ -73,7 +73,7 @@
 #include "reader.h"
 #include "sanity.h"
 #include "screen.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "tnode.h"
 #include "tokenizer.h"
 #include "wutil.h"  // IWYU pragma: keep

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -7,11 +7,11 @@
 // IWYU pragma: no_include <cstddef>
 #include "config.h"
 
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <termios.h>
-#include <time.h>
+#include <ctime>
 #include <unistd.h>
 
 #include <cstring>

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -1,9 +1,9 @@
 // The library for various signal related issues.
 #include "config.h"  // IWYU pragma: keep
 
-#include <errno.h>
-#include <signal.h>
-#include <stdio.h>
+#include <cerrno>
+#include <csignal>
+#include <cstdio>
 #ifdef HAVE_SIGINFO_H
 #include <siginfo.h>
 #endif
@@ -15,7 +15,7 @@
 #include "parser.h"
 #include "proc.h"
 #include "reader.h"
-#include "signal.h"
+#include "signal.h" // NOLINT
 #include "topic_monitor.h"
 #include "wutil.h"  // IWYU pragma: keep
 

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -3,7 +3,7 @@
 
 #include "timer.h"
 
-#include <string.h>
+#include <cstring>
 
 #include <algorithm>
 #include <cerrno>

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -25,11 +25,11 @@
 // This version has been altered and ported to C++ for inclusion in fish.
 #include "tinyexpr.h"
 
-#include <ctype.h>
-#include <limits.h>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cctype>
+#include <climits>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
 
 #include <algorithm>
 #include <cstring>

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -5,9 +5,9 @@
 #include "tokenizer.h"
 
 #include <fcntl.h>
-#include <limits.h>
+#include <climits>
 #include <unistd.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <cwchar>
 #include <string>

--- a/src/topic_monitor.cpp
+++ b/src/topic_monitor.cpp
@@ -2,7 +2,7 @@
 
 #include "topic_monitor.h"
 
-#include <limits.h>
+#include <climits>
 #include <unistd.h>
 
 #include "flog.h"

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -17,7 +17,7 @@
 
 #include "utf8.h"
 
-#include <stdint.h>  // IWYU pragma: keep
+#include <cstdint>  // IWYU pragma: keep
 #include <sys/types.h>
 
 #include <limits>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,10 +3,10 @@
 
 #include "util.h"
 
-#include <errno.h>
-#include <stddef.h>
+#include <cerrno>
+#include <cstddef>
 #include <sys/time.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <cwchar>
 

--- a/src/wcstringutil.cpp
+++ b/src/wcstringutil.cpp
@@ -3,7 +3,7 @@
 
 #include "wcstringutil.h"
 
-#include <wctype.h>
+#include <cwctype>
 
 #include <locale>
 

--- a/src/wgetopt.cpp
+++ b/src/wgetopt.cpp
@@ -38,7 +38,7 @@
 // Ave, Cambridge, MA 02139, USA.
 #include "config.h"  // IWYU pragma: keep
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <cstring>
 #include <cwchar>

--- a/src/wildcard.cpp
+++ b/src/wildcard.cpp
@@ -5,8 +5,8 @@
 #include "wildcard.h"
 
 #include <dirent.h>
-#include <errno.h>
-#include <stddef.h>
+#include <cerrno>
+#include <cstddef>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -3,12 +3,12 @@
 #include "config.h"
 
 #include <dirent.h>
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <libgen.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
 #include <sys/stat.h>
 
 #include <cstring>
@@ -19,7 +19,7 @@
 #include <sys/statvfs.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <wctype.h>
+#include <cwctype>
 
 #include <atomic>
 #include <cwchar>


### PR DESCRIPTION
Found with clang-tidy's modernize-deprecated-headers.

Signed-off-by: Rosen Penev <rosenp@gmail.com>