### PR TITLE
Get the list of vmctl VMs in a less fragile way.

### DIFF
--- a/share/completions/vmctl.fish
+++ b/share/completions/vmctl.fish
@@ -1,4 +1,11 @@
 
+function __fish_get_vmctl_vms
+	for line in (vmctl status | string match -e -v "MAXMEM");
+		set a (string split " " $line)
+		and printf "%s " $a[-1]
+	end
+end
+
 complete -c vmctl -xa 'console create load log reload reset start status stop pause unpause send receive' -n 'not __fish_seen_subcommand_from list console create load log reload reset start status stop pause unpause send receive'
-complete -c vmctl -n '__fish_seen_subcommand_from console reload reset start status stop pause unpause send receive' -xa '(vmctl status | string match -e -v "MAXMEM" | string replace -r "^(\s+\S+\s+){7}" "")'
+complete -c vmctl -n '__fish_seen_subcommand_from console reload reset start status stop pause unpause send receive' -xa (__fish_get_vmctl_vms)
 


### PR DESCRIPTION
## Description

Currently the code that parses the list of VMs gets things a bit incorrect as a column was added.

This makes the vmctl completion always grab the last column for each vm line.
