### PR TITLE
Stringify j.fish

### DIFF
--- a/share/completions/j.fish
+++ b/share/completions/j.fish
@@ -1,5 +1,5 @@
 function __history_completions --argument limit
-    if echo $limit | string match -q ""
+    if string match -q "" -- "$limit"
         set limit 25
     end
 


### PR DESCRIPTION
## Description

String doesn't need to read from stdin. 

Fixes one of the tasks in issue #6520 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
