### PR TITLE
chore: Rename functions to match others

### DIFF
--- a/share/completions/clang++.fish
+++ b/share/completions/clang++.fish
@@ -2,6 +2,6 @@
 # They won't be autoloaded, but once clang++ is used once, they'll gain completions too.
 # This could potentially be moved to __fish_config_interactive.fish in the future.
 
-complete -p '*clang++*' -n '__fish_should_complete_switches' -xa '(__fish_clang_complete)'
+complete -p '*clang++*' -n '__fish_should_complete_switches' -xa '(__fish_complete_clang)'
 complete -p '*clang++*' -n 'not __fish_should_complete_switches' \
     -xa "(__fish_complete_suffix .o; __fish_complete_suffix .out; __fish_complete_suffix .c; __fish_complete_suffix .cpp; __fish_complete_suffix .so; __fish_complete_suffix .dylib)"

--- a/share/completions/clang.fish
+++ b/share/completions/clang.fish
@@ -3,7 +3,7 @@
 # This could potentially be moved to __fish_config_interactive.fish in the future.
 
 # This pattern unfortunately matches clang-format, etc. as well.
-complete -p '*clang*' -n '__fish_should_complete_switches' -xa '(__fish_clang_complete)'
+complete -p '*clang*' -n '__fish_should_complete_switches' -xa '(__fish_complete_clang)'
 complete -c 'clang' -n 'not __fish_should_complete_switches' \
     -xa "(__fish_complete_suffix .o; __fish_complete_suffix .out; __fish_complete_suffix .c; __fish_complete_suffix .cpp; __fish_complete_suffix .so; __fish_complete_suffix .dylib)"
 

--- a/share/completions/emaint.fish
+++ b/share/completions/emaint.fish
@@ -1,4 +1,4 @@
-function __fish_portage_print_repository_names --description 'Print the names of all configured repositories'
+function __fish_print_portage_repository_names --description 'Print the names of all configured repositories'
     # repos.conf may be a file or a directory
     find /etc/portage/repos.conf -type f -exec cat '{}' + | string replace -r --filter '^\s*\[([[:alnum:]_][[:alnum:]_-]*)\]' '$1' | string match -v -e DEFAULT
 end
@@ -32,6 +32,6 @@ complete -c emaint -n '__fish_seen_subcommand_from logs' -s C -l clean -d "Clean
 complete -c emaint -n '__fish_seen_subcommand_from sync' -s a -l auto -d "Sync auto-sync enabled repos only"
 complete -c emaint -n '__fish_seen_subcommand_from sync' -s A -l allrepos -d "Sync all repos that have a sync-url defined"
 complete -c emaint -n '__fish_seen_subcommand_from sync' -s r -l repo -d "Sync the specified repo" \
-    -xa "(__fish_portage_print_repository_names)"
+    -xa "(__fish_print_portage_repository_names)"
 complete -c emaint -n '__fish_seen_subcommand_from sync' -l sync-submodule -d "Restrict sync to the specified submodule(s)" \
     -xa "glsa news profiles"

--- a/share/completions/emerge.fish
+++ b/share/completions/emerge.fish
@@ -41,11 +41,11 @@ function __fish_emerge_possible_args
         # TODO deselect=y
     else if __fish_contains_opt config -s c depclean info -s P prune -s C unmerge
         __fish_emerge_print_sets
-        __fish_portage_print_installed_pkgs
+        __fish_print_portage_installed_pkgs
         # TODO deselect=n
     else
         __fish_emerge_print_sets
-        __fish_portage_print_available_pkgs
+        __fish_print_portage_available_pkgs
     end
 end
 

--- a/share/completions/epkginfo.fish
+++ b/share/completions/epkginfo.fish
@@ -1,4 +1,4 @@
-complete -c epkginfo -xa "(__fish_portage_print_available_pkgs)"
+complete -c epkginfo -xa "(__fish_print_portage_available_pkgs)"
 ## Opts
 complete -c epkginfo -s h -l help -d "display help"
 complete -c epkginfo -s d -l description -d "extended pkg description"

--- a/share/completions/equery.fish
+++ b/share/completions/equery.fish
@@ -40,9 +40,9 @@ complete -c equery -n '__fish_use_subcommand' -xa 'which' -d "Print full path to
 
 ## Arguments
 complete -c equery -n '__fish_seen_subcommand_from c changes d depends g depgraph y keywords m meta u uses w which' \
-    -xa '(__fish_portage_print_available_pkgs)'
+    -xa '(__fish_print_portage_available_pkgs)'
 complete -c equery -n '__fish_seen_subcommand_from k check f files s size' \
-    -xa '(__fish_portage_print_installed_pkgs)'
+    -xa '(__fish_print_portage_installed_pkgs)'
 
 ## Local opts
 # belongs
@@ -106,9 +106,9 @@ complete -c equery -n '__fish_seen_subcommand_from l list' -s o -l overlay-tree 
 complete -c equery -n '__fish_seen_subcommand_from l list' -s p -l portage-tree -d "List pkgs in the main portage tree"
 #complete -c equery -n '__fish_seen_subcommand_from l list' -s F -l format=TMPL       -d "Specify a custom output format"
 complete -c equery -n '__fish_seen_subcommand_from l list; and not __fish_contains_opt -s p portage-tree' \
-    -xa "(__fish_portage_print_installed_pkgs)"
+    -xa "(__fish_print_portage_installed_pkgs)"
 complete -c equery -n '__fish_seen_subcommand_from l list; and     __fish_contains_opt -s p portage-tree' \
-    -xa "(__fish_portage_print_available_pkgs)"
+    -xa "(__fish_print_portage_available_pkgs)"
 
 # meta
 complete -c equery -n '__fish_seen_subcommand_from m meta' -s d -l description -d "Show extended pkg description"

--- a/share/completions/systemctl.fish
+++ b/share/completions/systemctl.fish
@@ -38,7 +38,7 @@ complete -f -c systemctl -n "not __fish_seen_subcommand_from $commands" -a set-d
 complete -f -c systemctl -n "not __fish_seen_subcommand_from $commands" -a set-property -d 'Sets one or more properties of a unit'
 
 # Command completion done via argparse.
-complete -c systemctl -a '(_fish_systemctl)' -f
+complete -c systemctl -a '(__fish_systemctl)' -f
 
 # These "--x=help" outputs always have lines like "Available unit types:". We use the fact that they end in a ":" to filter them out.
 complete -f -c systemctl -s t -l type -d 'List of unit types' -xa '(systemctl --type=help --no-legend --no-pager | string match -v "*:")'

--- a/share/functions/__fish_complete_clang.fish
+++ b/share/functions/__fish_complete_clang.fish
@@ -1,7 +1,7 @@
 # This function is compatible with clang, clang++, and variations thereof, and is shared
 # by clang.fish and clang++.fish.
 # We dynamically query the head at `(commandline -o)[1]` to get the correct completions.
-function __fish_clang_complete
+function __fish_complete_clang
     # If the result is for a value, clang only prints the value, so completions
     # for `-std=` print `c++11` and not `-std=c++11` like we need. See #4174.
     set -l prefix (commandline -ct | string replace -fr -- '^(.*=)[^=]*' '$1')

--- a/share/functions/__fish_portage_print_available_pkgs.fish
+++ b/share/functions/__fish_portage_print_available_pkgs.fish
@@ -1,3 +1,0 @@
-function __fish_portage_print_available_pkgs --description 'Print all available packages'
-    find (__fish_portage_print_repository_paths) -mindepth 2 -maxdepth 2 -type d ! '(' '(' -path '*/eclass/*' -o -path '*/metadata/*' -o -path '*/profiles/*' -o -path '*/.*/*' ')' -prune ')' -printf '%P\n'
-end

--- a/share/functions/__fish_print_portage_available_pkgs.fish
+++ b/share/functions/__fish_print_portage_available_pkgs.fish
@@ -1,0 +1,3 @@
+function __fish_print_portage_available_pkgs --description 'Print all available packages'
+    find (__fish_print_portage_repository_paths) -mindepth 2 -maxdepth 2 -type d ! '(' '(' -path '*/eclass/*' -o -path '*/metadata/*' -o -path '*/profiles/*' -o -path '*/.*/*' ')' -prune ')' -printf '%P\n'
+end

--- a/share/functions/__fish_print_portage_installed_pkgs.fish
+++ b/share/functions/__fish_print_portage_installed_pkgs.fish
@@ -1,3 +1,3 @@
-function __fish_portage_print_installed_pkgs --description 'Print all installed packages (non-deduplicated)'
+function __fish_print_portage_installed_pkgs --description 'Print all installed packages (non-deduplicated)'
     find /var/db/pkg -mindepth 2 -maxdepth 2 -type d -printf '%P\n' | string replace -r -- '-[0-9][0-9.]*.*$' ''
 end

--- a/share/functions/__fish_print_portage_repository_paths.fish
+++ b/share/functions/__fish_print_portage_repository_paths.fish
@@ -1,4 +1,4 @@
-function __fish_portage_print_repository_paths --description 'Print the paths of all configured repositories'
+function __fish_print_portage_repository_paths --description 'Print the paths of all configured repositories'
     # repos.conf may be a file or a directory
     find /etc/portage/repos.conf -type f -exec cat '{}' + | string replace -r --filter '^\s*location\s*=\s*(\S+)' '$1'
 end

--- a/share/functions/__fish_systemctl.fish
+++ b/share/functions/__fish_systemctl.fish
@@ -1,4 +1,4 @@
-function _fish_systemctl --description 'Call systemctl with some options from the current commandline'
+function __fish_systemctl --description 'Call systemctl with some options from the current commandline'
     # These options are all global - before or after subcommand/arguments.
     # There's a bunch of long-only options in here, so we need to be creative with the mandatory short version.
     set -l opts t/type= s-state= p/property= a/all


### PR DESCRIPTION
## Description

Fixes:
- systemctl function only had one underscore
- portage print functions were the odd one out regarding the word order

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
