### PR TITLE
Use `string length -q` over `test -n`

### DIFF
--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -24,7 +24,7 @@ function __fish_adb_run_command -d 'Runs adb with any -s parameters already give
     set -l cmd (commandline -poc)
     set -e cmd[1]
     for i in $cmd
-        if test -n "$sopt_is_next"
+        if string length -q "$sopt_is_next"
             set sopt -s $i
             break
         else

--- a/share/completions/dconf.fish
+++ b/share/completions/dconf.fish
@@ -11,7 +11,7 @@ function __fish_dconf_keys
         if string match -q "[*]" -- $line
             # New directory - just save it for the keys
             set dir /(string trim -c "[]" -- $line)
-        else if test -n "$line"
+        else if string length -q "$line"
             # New key - output with the dir prepended.
             echo $dir/(string replace -r '=.*' '' -- $line)
         end

--- a/share/completions/doas.fish
+++ b/share/completions/doas.fish
@@ -12,7 +12,7 @@ function __fish_doas_print_remaining_args
     argparse -s $opts -- $tokens 2>/dev/null
     # The remaining argv is the subcommand with all its options, which is what
     # we want.
-    if test -n "$argv"
+    if string length -q "$argv"
         and not string match -qr '^-' $argv[1]
         string join0 -- $argv
         return 0

--- a/share/completions/env.fish
+++ b/share/completions/env.fish
@@ -16,7 +16,7 @@ function __fish_complete_env_subcommand
     end
 
     # Then complete the rest as if it was given as a command.
-    if test -n "$argv"
+    if string length -q "$argv"
         __fish_complete_subcommand --commandline $argv
         return 0
     end

--- a/share/completions/p4.fish
+++ b/share/completions/p4.fish
@@ -25,7 +25,7 @@ end
 
 function __fish_print_p4_changelists -d "Reformat output from `p4 changes` to simple format. Specify 'detailed!' as first argument to use username@workspace prefix"
     set -l detailed
-    if test -n "$argv"
+    if string length -q "$argv"
         and test $argv[1] = "detailed!"
         set detailed true
         set -e argv[1]
@@ -46,13 +46,13 @@ function __fish_print_p4_changelists -d "Reformat output from `p4 changes` to si
         end
         # see output format ^^^
         set -l change_match (string match -ar '^Change ([0-9]+) on [0-9/]+ by (\S+).*$' $line)
-        if test -n "$change_match"
-            if test -n "$result"
+        if string length -q "$change_match"
+            if string length -q "$result"
                 echo $result
                 set result
             end
             set result $change_match[2]\t
-            if test -n "$detailed"
+            if string length -q "$detailed"
                 set result $result $change_match[3]:
             end
         else
@@ -60,7 +60,7 @@ function __fish_print_p4_changelists -d "Reformat output from `p4 changes` to si
         end
     end
 
-    if test -n "$result"
+    if string length -q "$result"
         echo $result
     end
 end
@@ -125,7 +125,7 @@ end
 
 function __fish_print_p4_workspace_changelists -d "Lists all changelists for current user"
     set -l client (__fish_print_p4_client_name)
-    if test -n "$client"
+    if string length -q "$client"
         __fish_print_p4_changelists -c $client $argv
     end
 end
@@ -235,17 +235,17 @@ end
 
 function __fish_print_p4_parallel_options -d "Values for --parallel option in various commands"
     set -l mode
-    if test -n "$argv"
+    if string length -q "$argv"
         set mode $argv[1]
     end
 
     # for now only looks that mode is set, later it will need to have a specific setting
     echo 'threads='\t"sends files concurrently using N independent network connections"
     echo 'batch='\t"specifies the number of files in a batch"
-    test -n "$mode"
+    string length -q "$mode"
     or echo 'batchsize='\t"specifies the number of bytes in a batch"
     echo 'min='\t"specifies the minimum number of files in a parallel sync"
-    test -n "$mode"
+    string length -q "$mode"
     or echo 'minsize='\t"specifies the minimum number of bytes in a parallel sync"
 end
 

--- a/share/completions/sed.fish
+++ b/share/completions/sed.fish
@@ -14,7 +14,7 @@ __fish_gnu_complete -c sed -s e -l expression -x -d "Evaluate expression" $is_gn
 __fish_gnu_complete -c sed -s f -l file -r -d "Evalute file" $is_gnu
 __fish_gnu_complete -c sed -s i -l in-place -d "Edit files in place" $is_gnu
 
-if test -n "$is_gnu"
+if string length -q "$is_gnu"
 
     # GNU specific features
 

--- a/share/completions/tar.fish
+++ b/share/completions/tar.fish
@@ -6,7 +6,7 @@ function __fish_complete_tar -d "Peek inside of archives and list all files"
                 set -e args[1]
                 if test -f $args[1]
                     set -l file_list (tar -atf $args[1] 2> /dev/null)
-                    if test -n "$file_list"
+                    if string length -q "$file_list"
                         printf (_ "%s\tArchived file\n") $file_list
                     end
                     return

--- a/share/functions/__fish_cancel_commandline.fish
+++ b/share/functions/__fish_cancel_commandline.fish
@@ -4,7 +4,7 @@ function __fish_cancel_commandline
     commandline -f cancel
 
     set -l cmd (commandline)
-    if test -n "$cmd"
+    if string length -q "$cmd"
         commandline -C 1000000
         if set -q fish_color_cancel
             echo -ns (set_color $fish_color_cancel) "^C" (set_color normal)

--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -29,7 +29,7 @@ function __fish_complete_man
         set token "."
     end
 
-    if test -n "$token"
+    if string length -q "$token"
         # Do the actual search
         apropos $token 2>/dev/null | awk '
                 BEGIN { FS="[\t ]- "; OFS="\t"; }

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -127,7 +127,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
         else
             # The greeting used to be skipped when fish_greeting was empty (not just undefined)
             # Keep it that way to not print superfluous newlines on old configuration
-            test -n "$fish_greeting"
+            string length -q "$fish_greeting"
             and echo $fish_greeting
         end
     end

--- a/share/functions/__fish_contains_opt.fish
+++ b/share/functions/__fish_contains_opt.fish
@@ -4,7 +4,7 @@ function __fish_contains_opt -d "Checks if a specific option has been given in t
     set -l long_opt
 
     for i in $argv
-        if test -n "$next_short"
+        if string length -q "$next_short"
             set next_short
             set -a short_opt $i
         else

--- a/share/functions/__fish_not_contain_opt.fish
+++ b/share/functions/__fish_not_contain_opt.fish
@@ -4,7 +4,7 @@ function __fish_not_contain_opt -d "Checks that a specific option is not in the 
     set -l long_opt
 
     for i in $argv
-        if test -n "$next_short"
+        if string length -q "$next_short"
             set next_short
             set short_opt $short_opt $i
         else

--- a/share/functions/__fish_print_help.fish
+++ b/share/functions/__fish_print_help.fish
@@ -12,7 +12,7 @@ function __fish_print_help --description "Print help message for the specified f
     set -l help
     set -l format
     set -l cols
-    if test -n "$COLUMNS"
+    if string length -q "$COLUMNS"
         set cols (math $COLUMNS - 4) # leave a bit of space on the right
     end
 
@@ -22,12 +22,12 @@ function __fish_print_help --description "Print help message for the specified f
         if test -e $__fish_data_dir/groff/fish.tmac
             set -a format -M$__fish_data_dir/groff -mfish
         end
-        if test -n "$cols"
+        if string length -q "$cols"
             set -a format -rLL={$cols}n
         end
     else if command -qs mandoc
         set format mandoc -c
-        if test -n "$cols"
+        if string length -q "$cols"
             set -a format -O width=$cols
         end
     else
@@ -62,7 +62,7 @@ function __fish_print_help --description "Print help message for the specified f
                 case ' *' \t\*
                     # starts with whitespace, check if it has non-whitespace
                     printf "%s\n" $line | read -l word __
-                    if test -n $word
+                    if string length -q $word
                         set line_type normal
                     else
                         # lines with just spaces probably shouldn't happen

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -93,7 +93,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
                 end
             end
 
-            if test -n "$new_paths"
+            if string length -q "$new_paths"
                 _recursive $new_paths
             end
         end

--- a/share/functions/fish_clipboard_copy.fish
+++ b/share/functions/fish_clipboard_copy.fish
@@ -1,7 +1,7 @@
 function fish_clipboard_copy
     # Copy the current selection, or the entire commandline if that is empty.
     set -l cmdline (commandline --current-selection)
-    test -n "$cmdline"; or set cmdline (commandline)
+    string lenth -q "$cmdline"; or set cmdline (commandline)
     if type -q pbcopy
         printf '%s\n' $cmdline | pbcopy
     else if set -q WAYLAND_DISPLAY; and type -q wl-copy

--- a/share/functions/fish_clipboard_paste.fish
+++ b/share/functions/fish_clipboard_paste.fish
@@ -36,7 +36,7 @@ function fish_clipboard_paste
         # so we don't trigger ignoring history.
         set data[1] (string trim -l -- $data[1])
     end
-    if test -n "$data"
+    if string length -q "$data"
         commandline -i -- $data
     end
 end

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -198,12 +198,12 @@ function __fish_git_prompt_show_upstream --description "Helper function for fish
         switch $key
             case bash.showupstream
                 set show_upstream $value
-                test -n "$show_upstream"
+                string length -q "$show_upstream"
                 or return
             case svn-remote.'*'.url
                 set svn_remote $svn_remote $value
                 # Avoid adding \| to the beginning to avoid needing #?? later
-                if test -n "$svn_url_pattern"
+                if string length -q "$svn_url_pattern"
                     set svn_url_pattern $svn_url_pattern"|$value"
                 else
                     set svn_url_pattern $value
@@ -260,7 +260,7 @@ function __fish_git_prompt_show_upstream --description "Helper function for fish
 
                 if test -z "$svn_upstream"
                     # default branch name for checkouts with no layout:
-                    if test -n "$GIT_SVN_ID"
+                    if string length -q "$GIT_SVN_ID"
                         set upstream $GIT_SVN_ID
                     else
                         set upstream git-svn
@@ -270,7 +270,7 @@ function __fish_git_prompt_show_upstream --description "Helper function for fish
 
                     # Use fetch config to fix upstream
                     set -l fetch_val (command git config "$cur_prefix".fetch)
-                    if test -n "$fetch_val"
+                    if string length -q "$fetch_val"
                         string split -m1 : -- "$fetch_val" | read -l trunk pattern
                         set upstream (string replace -r -- "/$trunk\$" '' $pattern) /$upstream
                     end
@@ -284,7 +284,7 @@ function __fish_git_prompt_show_upstream --description "Helper function for fish
     set count (command git rev-list --count --left-right $upstream...HEAD 2>/dev/null | string replace \t " ")
 
     # calculate the result
-    if test -n "$verbose"
+    if string length -q "$verbose"
         # Verbose has a space by default
         set -l prefix "$___fish_git_prompt_char_upstream_prefix"
         # Using two underscore version to check if user explicitly set to nothing
@@ -307,7 +307,7 @@ function __fish_git_prompt_show_upstream --description "Helper function for fish
         if test -n "$count" -a -n "$name"
             echo " "(command git rev-parse --abbrev-ref "$upstream" 2>/dev/null)
         end
-    else if test -n "$informative"
+    else if string length -q "$informative"
         echo $count | read -l behind ahead
         switch "$count"
             case '' # no upstream
@@ -344,7 +344,7 @@ function fish_git_prompt --description "Prompt function for Git"
         return 1
     end
     set -l repo_info (command git rev-parse --git-dir --is-inside-git-dir --is-bare-repository --is-inside-work-tree HEAD 2>/dev/null)
-    test -n "$repo_info"
+    string length -q "$repo_info"
     or return
 
     set -l git_dir $repo_info[1]
@@ -438,16 +438,16 @@ function fish_git_prompt --description "Prompt function for Git"
         end
     end
 
-    if test -n "$w"
+    if string length -q "$w"
         set w "$___fish_git_prompt_color_dirtystate$w$___fish_git_prompt_color_dirtystate_done"
     end
-    if test -n "$i"
+    if string length -q "$i"
         set i "$___fish_git_prompt_color_stagedstate$i$___fish_git_prompt_color_stagedstate_done"
     end
-    if test -n "$s"
+    if string length -q "$s"
         set s "$___fish_git_prompt_color_stashstate$s$___fish_git_prompt_color_stashstate_done"
     end
-    if test -n "$u"
+    if string length -q "$u"
         set u "$___fish_git_prompt_color_untrackedfiles$u$___fish_git_prompt_color_untrackedfiles_done"
     end
 
@@ -457,23 +457,23 @@ function fish_git_prompt --description "Prompt function for Git"
     if string match -qr '^\d+$' "$__fish_git_prompt_shorten_branch_len"; and test (string length "$b") -gt $__fish_git_prompt_shorten_branch_len
         set b (string sub -l "$__fish_git_prompt_shorten_branch_len" "$b")"$__fish_git_prompt_shorten_branch_char_suffix"
     end
-    if test -n "$b"
+    if string length -q "$b"
         set b "$branch_color$b$branch_done"
     end
 
-    if test -n "$c"
+    if string length -q "$c"
         set c "$___fish_git_prompt_color_bare$c$___fish_git_prompt_color_bare_done"
     end
-    if test -n "$r"
+    if string length -q "$r"
         set r "$___fish_git_prompt_color_merging$r$___fish_git_prompt_color_merging_done"
     end
-    if test -n "$p"
+    if string length -q "$p"
         set p "$___fish_git_prompt_color_upstream$p$___fish_git_prompt_color_upstream_done"
     end
 
     # Formatting
     set -l f "$w$i$s$u"
-    if test -n "$f"
+    if string length -q "$f"
         set f "$space$f"
     end
     set -l format $argv[1]
@@ -491,7 +491,7 @@ function __fish_git_prompt_staged --description "fish_git_prompt helper, tells w
     set -l staged
     set -l ret 0
 
-    if test -n "$sha"
+    if string length -q "$sha"
         # The "diff" functions all return > 0 if there _is_ a diff,
         # but we want to return 0 if there are staged changes.
         # So we invert the status.
@@ -745,7 +745,7 @@ function __fish_git_prompt_set_color
     set -l variable_done "$variable"_done
 
     if not set -q $variable
-        if test -n "$user_variable"
+        if string length -q "$user_variable"
             set -g $variable (set_color $user_variable)
             set -g $variable_done (set_color normal)
         else

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -2,7 +2,7 @@
 # Wrap the builtin history command to provide additional functionality.
 #
 function __fish_unexpected_hist_args --no-scope-shadowing
-    if test -n "$search_mode"
+    if string length -q "$search_mode"
         or set -q show_time[1]
         printf (_ "%ls: you cannot use any options with the %ls command\n") $cmd $hist_cmd >&2
         return 0

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -61,7 +61,7 @@ function psub --description "Read from stdin into a file and output the filename
     # Make sure we erase file when caller exits
     function $funcname --on-job-exit caller --inherit-variable filename --inherit-variable dirname --inherit-variable funcname
         command rm $filename
-        if test -n "$dirname"
+        if string length -q "$dirname"
             command rmdir $dirname
         end
         functions -e $funcname

--- a/share/functions/trap.fish
+++ b/share/functions/trap.fish
@@ -54,7 +54,7 @@ function trap -d 'Perform an action when the shell receives a signal'
         case clear
             for i in $argv
                 set sig (__trap_translate_signal $i)
-                if test -n "$sig"
+                if string length -q "$sig"
                     functions -e __trap_handler_$sig
                 end
             end
@@ -67,7 +67,7 @@ function trap -d 'Perform an action when the shell receives a signal'
                 set -l sig (__trap_translate_signal $i)
                 set sw (__trap_switch $sig)
 
-                if test -n "$sig"
+                if string length -q "$sig"
                     echo "function __trap_handler_$sig $sw; $cmd; end" | source
                 else
                     return 1
@@ -85,7 +85,7 @@ function trap -d 'Perform an action when the shell receives a signal'
             for i in $names
                 set sig (__trap_translate_signal $i)
 
-                if test -n "$sig"
+                if string length -q "$sig"
                     functions __trap_handler_$i
                 else
                     return 1


### PR DESCRIPTION
## Description

Hopefully this isn't controversial.

Reason for changing:
- promote "fishy" ways by using it in our own code (assuming this change is more fishy than current)
- test -n $var returns true if $var is list-empty (or currently undefined)
- current docs for `string length` mention the commands are "equivalent"

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
