### PR TITLE
Fix typo in mplayer completions

### DIFF
--- a/share/completions/mplayer.fish
+++ b/share/completions/mplayer.fish
@@ -21,7 +21,7 @@ set mplayer_lang "
 	hu\tHungarian
 	pl\tPolish
 	pt\tPortugese
-	se\Swedish
+	se\tSwedish
 "
 
 complete -c mplayer -o autoq -d "Dynamically change postprocessing" -x


### PR DESCRIPTION
Swedish one was missing a tab.

![image](https://user-images.githubusercontent.com/20397027/73117661-92dab700-3f8c-11ea-8773-b4c02401ac09.png)
