### PR TITLE
__fish_prepend_sudo: Don't move the relative position of the cursor

### DIFF
--- a/share/functions/__fish_prepend_sudo.fish
+++ b/share/functions/__fish_prepend_sudo.fish
@@ -1,8 +1,9 @@
 function __fish_prepend_sudo -d "Prepend 'sudo ' to the beginning of the current commandline"
     set -l cmd (commandline -poc)
     if test "$cmd[1]" != "sudo"
+        set -l cursor (commandline -C)
         commandline -C 0
         commandline -i "sudo "
-        commandline -f end-of-line
+        commandline -C (math $cursor + 5)
     end
 end


### PR DESCRIPTION
## Description

At the moment the "prepend sudo" (Alt-S) functionality always sets the cursor to the end of the line. This changes it to restore the relative position of the cursor.

The functionality was added in https://github.com/fish-shell/fish-shell/pull/6140 (0f802ea). The PR description says "This does not move the cursor", which suggests that the current behaviour is a mistake.

For example, let's say the user entered `ls /root` and then moved the cursor to, e.g.

    ls |/root

where | is the cursor position. Running the function currently turns it to

    sudo ls /root|

whereas after this change it is

    sudo ls |/root


## TODOs:

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md