### PR TITLE
Fix broken links to index.html in cmd docs

### DIFF
--- a/sphinx_doc_src/cmds/and.rst
+++ b/sphinx_doc_src/cmds/and.rst
@@ -18,7 +18,7 @@ Description
 
 ``and`` statements may be used as part of the condition in an :ref:`while <cmd-while>` or :ref:`if <cmd-if>` block.
 
-``and`` does not change the current exit status itself, but the command it runs most likely will. The exit status of the last foreground command to exit can always be accessed using the `$status <index.html#variables-status>`__ variable.
+``and`` does not change the current exit status itself, but the command it runs most likely will. The exit status of the last foreground command to exit can always be accessed using the :ref:`$status <variables-status>` variable.
 
 Example
 -------

--- a/sphinx_doc_src/cmds/bg.rst
+++ b/sphinx_doc_src/cmds/bg.rst
@@ -13,7 +13,7 @@ Synopsis
 Description
 -----------
 
-``bg`` sends `jobs <index.html#syntax-job-control>`__ to the background, resuming them if they are stopped.
+``bg`` sends :ref:`jobs <syntax-job-control>` to the background, resuming them if they are stopped.
 
 A background job is executed simultaneously with fish, and does not have access to the keyboard. If no job is specified, the last job to be used is put in the background. If PID is specified, the jobs with the specified process group IDs are put in the background.
 

--- a/sphinx_doc_src/cmds/bind.rst
+++ b/sphinx_doc_src/cmds/bind.rst
@@ -20,7 +20,7 @@ Description
 
 ``bind`` adds a binding for the specified key sequence to the specified command.
 
-SEQUENCE is the character sequence to bind to. These should be written as `fish escape sequences <index.html#escapes>`__. For example, because pressing the Alt key and another character sends that character prefixed with an escape character, Alt-based key bindings can be written using the ``\e`` escape. For example, :kbd:`Alt+w` can be written as ``\ew``. The control character can be written in much the same way using the ``\c`` escape, for example :kbd:`Control+X` (^X) can be written as ``\cx``. Note that Alt-based key bindings are case sensitive and Control-based key bindings are not. This is a constraint of text-based terminals, not ``fish``.
+SEQUENCE is the character sequence to bind to. These should be written as :ref:`fish escape sequences <escapes>`. For example, because pressing the Alt key and another character sends that character prefixed with an escape character, Alt-based key bindings can be written using the ``\e`` escape. For example, :kbd:`Alt+w` can be written as ``\ew``. The control character can be written in much the same way using the ``\c`` escape, for example :kbd:`Control+X` (^X) can be written as ``\cx``. Note that Alt-based key bindings are case sensitive and Control-based key bindings are not. This is a constraint of text-based terminals, not ``fish``.
 
 The default key binding can be set by specifying a ``SEQUENCE`` of the empty string (that is, ``''`` ). It will be used whenever no other binding matches. For most key bindings, it makes sense to use the ``self-insert`` function (i.e. ``bind '' self-insert``) as the default keybinding. This will insert any keystrokes not specifically bound to into the editor. Non- printable characters are ignored by the editor, so this will not result in control sequences being printable.
 
@@ -36,7 +36,7 @@ When multiple ``COMMAND``\s are provided, they are all run in the specified orde
 
 If no ``SEQUENCE`` is provided, all bindings (or just the bindings in the specified ``MODE``) are printed. If ``SEQUENCE`` is provided without ``COMMAND``, just the binding matching that sequence is printed.
 
-To save custom keybindings, put the ``bind`` statements into `config.fish <index.html#initialization>`__. Alternatively, fish also automatically executes a function called ``fish_user_key_bindings`` if it exists.
+To save custom keybindings, put the ``bind`` statements into :ref:`config.fish <initialization>`. Alternatively, fish also automatically executes a function called ``fish_user_key_bindings`` if it exists.
 
 Key bindings may use "modes", which mimics Vi's modal input behavior. The default mode is "default", and every bind applies to a single mode. The mode can be viewed/changed with the ``$fish_bind_mode`` variable.
 

--- a/sphinx_doc_src/cmds/breakpoint.rst
+++ b/sphinx_doc_src/cmds/breakpoint.rst
@@ -16,6 +16,6 @@ Description
 
 ``breakpoint`` is used to halt a running script and launch an interactive debugging prompt.
 
-For more details, see `Debugging fish scripts <index.html#debugging>`__ in the ``fish`` manual.
+For more details, see :ref:`Debugging fish scripts <debugging>` in the ``fish`` manual.
 
 There are no parameters for ``breakpoint``.

--- a/sphinx_doc_src/cmds/disown.rst
+++ b/sphinx_doc_src/cmds/disown.rst
@@ -13,7 +13,7 @@ Synopsis
 Description
 -----------
 
-``disown`` removes the specified `job <index.html#syntax-job-control>`__ from the list of jobs. The job itself continues to exist, but fish does not keep track of it any longer.
+``disown`` removes the specified :ref:`job <syntax-job-control>` from the list of jobs. The job itself continues to exist, but fish does not keep track of it any longer.
 
 Jobs in the list of jobs are sent a hang-up signal when fish terminates, which usually causes the job to terminate; ``disown`` allows these processes to continue regardless.
 

--- a/sphinx_doc_src/cmds/fg.rst
+++ b/sphinx_doc_src/cmds/fg.rst
@@ -13,7 +13,7 @@ Synopsis
 Description
 -----------
 
-``fg`` brings the specified `job <index.html#syntax-job-control>`__ to the foreground, resuming it if it is stopped. While a foreground job is executed, fish is suspended. If no job is specified, the last job to be used is put in the foreground. If PID is specified, the job with the specified group ID is put in the foreground.
+``fg`` brings the specified :ref:`job <syntax-job-control>` to the foreground, resuming it if it is stopped. While a foreground job is executed, fish is suspended. If no job is specified, the last job to be used is put in the foreground. If PID is specified, the job with the specified group ID is put in the foreground.
 
 
 Example

--- a/sphinx_doc_src/cmds/fish_breakpoint_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_breakpoint_prompt.rst
@@ -18,7 +18,7 @@ Description
 
 By defining the ``fish_breakpoint_prompt`` function, the user can choose a custom prompt when asking for input in response to a :ref:`breakpoint <cmd-breakpoint>` command. The ``fish_breakpoint_prompt`` function is executed when the prompt is to be shown, and the output is used as a prompt.
 
-The exit status of commands within ``fish_breakpoint_prompt`` will not modify the value of `$status <index.html#variables-status>`__ outside of the ``fish_breakpoint_prompt`` function.
+The exit status of commands within ``fish_breakpoint_prompt`` will not modify the value of :ref:`$status <variables-status>` outside of the ``fish_breakpoint_prompt`` function.
 
 ``fish`` ships with a default version of this function that displays the function name and line number of the current execution context.
 

--- a/sphinx_doc_src/cmds/fish_prompt.rst
+++ b/sphinx_doc_src/cmds/fish_prompt.rst
@@ -18,7 +18,7 @@ Description
 
 By defining the ``fish_prompt`` function, the user can choose a custom prompt. The ``fish_prompt`` function is executed when the prompt is to be shown, and the output is used as a prompt.
 
-The exit status of commands within ``fish_prompt`` will not modify the value of `$status <index.html#variables-status>`__ outside of the ``fish_prompt`` function.
+The exit status of commands within ``fish_prompt`` will not modify the value of :ref:`$status <variables-status>` outside of the ``fish_prompt`` function.
 
 ``fish`` ships with a number of example prompts that can be chosen with the ``fish_config`` command.
 

--- a/sphinx_doc_src/cmds/function.rst
+++ b/sphinx_doc_src/cmds/function.rst
@@ -44,7 +44,7 @@ The following options are available:
 
 - ``-V`` or ``--inherit-variable NAME`` snapshots the value of the variable ``NAME`` and defines a local variable with that same name and value when the function is defined. This is similar to a closure in other languages like Python but a bit different. Note the word "snapshot" in the first sentence. If you change the value of the variable after defining the function, even if you do so in the same scope (typically another function) the new value will not be used by the function you just created using this option. See the ``function notify`` example below for how this might be used.
 
-If the user enters any additional arguments after the function, they are inserted into the environment `variable list <index.html#variables-lists>`__ ``$argv``. If the ``--argument-names`` option is provided, the arguments are also assigned to names specified in that option.
+If the user enters any additional arguments after the function, they are inserted into the environment :ref:`variable list <variables-lists>` ``$argv``. If the ``--argument-names`` option is provided, the arguments are also assigned to names specified in that option.
 
 By using one of the event handler switches, a function can be made to run automatically at specific events. The user may generate new events using the :ref:`emit <cmd-emit>` builtin. Fish generates the following named events:
 

--- a/sphinx_doc_src/cmds/jobs.rst
+++ b/sphinx_doc_src/cmds/jobs.rst
@@ -14,7 +14,7 @@ Synopsis
 Description
 -----------
 
-``jobs`` prints a list of the currently running `jobs <index.html#syntax-job-control>`__ and their status.
+``jobs`` prints a list of the currently running :ref:`jobs <syntax-job-control>` and their status.
 
 jobs accepts the following switches:
 

--- a/sphinx_doc_src/faq.rst
+++ b/sphinx_doc_src/faq.rst
@@ -233,7 +233,7 @@ Fish history recall is very simple yet effective:
 
   - If you want to reuse several arguments from the same line ("!!:3*" and the like), consider recalling the whole line and removing what you don't need (:kbd:`Alt+D` and :kbd:`Alt+Backspace` are your friends).
 
-See `documentation <index.html#editor>`__ for more details about line editing in fish.
+See :ref:`documentation <editor>` for more details about line editing in fish.
 
 
 How can I use ``-`` as a shortcut for ``cd -``?

--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -77,7 +77,7 @@ You can make fish your default shell by adding fish's  executable in two places:
 - add ``/usr/local/bin/fish``  to  ``/etc/shells``
 - change your default shell with ``chsh -s`` to ``/usr/local/bin/fish``
 
-For for detailed instructions see `Switching to fish <tutorial.html#tut_switching_to_fish>`_.
+For for detailed instructions see :ref:`Switching to fish <tut_switching_to_fish>`.
 
 Uninstalling
 ------------


### PR DESCRIPTION
Everything linking back to index.html in the parent directory is broken because it gets resolved to cmds/index.html instead of just index.html.

Reproduced on master/3.1b on two different systems (Arch and WSL Ubuntu).

On phone so can't produce a better screenshot but here is an example of a broken link:
![Screenshot_20200131-113748](https://user-images.githubusercontent.com/20397027/73510988-5e9d4580-4427-11ea-8e7e-ea6a55b905f2.png)
