### PR TITLE
Avoid apropos on macOS 10.15 with man completion

### DIFF
--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -1,3 +1,20 @@
+# macOS 10.15 "Catalina" has some major issues.
+# The whatis database is non-existent, so apropos tries (and fails) to create it every time,
+# which takes about half a second.
+#
+# So we disable this entirely in that case.
+if test (uname) = Darwin
+    set -l darwin_version (uname -r | string split .)
+    # macOS 15 is Darwin 19, this is an issue at least up to 10.15.3.
+    # If this is fixed in later versions uncomment the second check.
+    if test "$darwin_version[1]" = 19 # -a "$darwin_version[2]" -le 3
+        function __fish_complete_man
+        end
+        # (remember: exit when `source`ing only exits the file, not the shell)
+        exit
+    end
+end
+
 function __fish_complete_man
     # Try to guess what section to search in. If we don't know, we
     # use [^)]*, which should match any section.


### PR DESCRIPTION
Same issue with `apropos` and `makewhatis` as described in #6270 occurs with man completions on macOS 10.15. I've just copied the workaround merged in 611a658 for `__fish_describe_command.fish` verbatim here for `__fish_complete_man.fish` (except for the function name, of course).
