### PR TITLE
prompts: fix pipestatus for jobs prefixed with "not"

### DIFF
--- a/share/functions/__fish_print_pipestatus.fish
+++ b/share/functions/__fish_print_pipestatus.fish
@@ -1,4 +1,11 @@
 function __fish_print_pipestatus --description "Print pipestatus for prompt"
+    # take $status as optional argument to maintain compatibility
+    set -l last_status
+    if set last_status (string match -r -- '^\d+$' $argv[1])
+        set -e argv[1]
+    else
+        set last_status $argv[-1] # default to $pipestatus[-1]
+    end
     set -l left_brace $argv[1]
     set -l right_brace $argv[2]
     set -l separator $argv[3]
@@ -6,13 +13,16 @@ function __fish_print_pipestatus --description "Print pipestatus for prompt"
     set -l status_color $argv[5]
     set -e argv[1 2 3 4 5]
 
-    # only output status codes if some process in the pipe failed
-    # SIGPIPE (141 = 128 + 13) is usually not a failure, see #6375.
-    if string match -qvr '^(0|141)$' $argv
+    # Only print status codes if the job failed.
+    if test $last_status -ne 0
         set -l sep (set_color normal){$brace_sep_color}{$separator}(set_color normal){$status_color}
         set -l last_pipestatus_string (string join "$sep" (__fish_pipestatus_with_signal $argv))
-        printf "%s%s%s%s%s%s%s%s%s%s" (set_color normal )$brace_sep_color $left_brace \
+        set -l last_status_string ""
+        if test $last_status -ne $argv[-1]
+            set last_status_string " "$status_color$last_status
+        end
+        printf "%s%s%s%s%s%s%s%s%s%s%s" (set_color normal )$brace_sep_color $left_brace \
             (set_color normal) $status_color $last_pipestatus_string (set_color normal) \
-            $brace_sep_color $right_brace (set_color normal)
+            $brace_sep_color $right_brace $last_status_string (set_color normal)
     end
 end

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -3,6 +3,7 @@
 
 function fish_prompt --description 'Write out the prompt'
     set -l last_pipestatus $pipestatus
+    set -l last_status $status
     set -l normal (set_color normal)
 
     # Color the prompt differently when we're root
@@ -22,7 +23,7 @@ function fish_prompt --description 'Write out the prompt'
     end
 
     # Write pipestatus
-    set -l prompt_status (__fish_print_pipestatus " [" "]" "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus)
+    set -l prompt_status (__fish_print_pipestatus $last_status " [" "]" "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus)
 
     echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "
 end

--- a/share/tools/web_config/sample_prompts/classic_status.fish
+++ b/share/tools/web_config/sample_prompts/classic_status.fish
@@ -4,6 +4,7 @@
 function fish_prompt --description "Write out the prompt"
     # Save our status
     set -l last_pipestatus $pipestatus
+    set -l last_status $status
 
     set -l color_cwd
     set -l suffix
@@ -21,6 +22,6 @@ function fish_prompt --description "Write out the prompt"
     end
 
     echo -n -s "$USER" @ (prompt_hostname) ' ' (set_color $color_cwd) (prompt_pwd) \
-        (__fish_print_pipestatus " [" "]" "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus) \
+        (__fish_print_pipestatus $last_status " [" "]" "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus) \
         (set_color normal) "$suffix "
 end

--- a/share/tools/web_config/sample_prompts/classic_vcs.fish
+++ b/share/tools/web_config/sample_prompts/classic_vcs.fish
@@ -23,7 +23,7 @@ function fish_prompt --description 'Write out the prompt'
     end
 
     # Write pipestatus
-    set -l prompt_status (__fish_print_pipestatus " [" "]" "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus)
+    set -l prompt_status (__fish_print_pipestatus $last_status " [" "]" "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus)
 
     echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "
 end

--- a/share/tools/web_config/sample_prompts/informative.fish
+++ b/share/tools/web_config/sample_prompts/informative.fish
@@ -4,6 +4,7 @@
 function fish_prompt --description 'Informative prompt'
     #Save the return status of the previous command
     set -l last_pipestatus $pipestatus
+    set -l last_status $status
 
     switch "$USER"
         case root toor
@@ -12,7 +13,7 @@ function fish_prompt --description 'Informative prompt'
                                                              or set_color $fish_color_cwd) \
                 (prompt_pwd) (set_color normal)
         case '*'
-            set -l pipestatus_string (__fish_print_pipestatus "[" "] " "|" (set_color $fish_color_status) \
+            set -l pipestatus_string (__fish_print_pipestatus $last_status "[" "] " "|" (set_color $fish_color_status) \
                                       (set_color --bold $fish_color_status) $last_pipestatus)
 
             printf '[%s] %s%s@%s %s%s %s%s%s \f\r> ' (date "+%H:%M:%S") (set_color brblue) \

--- a/share/tools/web_config/sample_prompts/informative_vcs.fish
+++ b/share/tools/web_config/sample_prompts/informative_vcs.fish
@@ -3,6 +3,7 @@
 
 function fish_prompt --description 'Write out the prompt'
     set -l last_pipestatus $pipestatus
+    set -l last_status $status
 
     if not set -q __fish_git_prompt_show_informative_status
         set -g __fish_git_prompt_show_informative_status 1
@@ -78,7 +79,7 @@ function fish_prompt --description 'Write out the prompt'
 
     printf '%s ' (fish_vcs_prompt)
 
-    set -l pipestatus_string (__fish_print_pipestatus "[" "] " "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus)
+    set -l pipestatus_string (__fish_print_pipestatus $last_status "[" "] " "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus)
     echo -n $pipestatus_string
     set_color normal
 


### PR DESCRIPTION
6902459566b491e2debb136f43f815965910eeee was an attempt to not print
$status twice in the prompt. As a result we print $pipestatus but
not $status, which *usually* is the same as $pipestatus[-1] --- unless
the builtin "not" is used, which inverts the $status of a job (it does
not alter $pipestatus).

As a result, the default prompt prints unexpected status codes:

	~ > not false
	~ [1]> not true
	~ > not true | true
	~ > not false | false
	~ [1|1]>

This commit reintroduces printing of $status after $pipestatus, but only
if it is different from $pipestatus[-1].
Additionally, we only print anything at all if the $status is nonzero,
to avoid confusing output on `not false | false`

	~ > not false
	~ > not true
	~ [0] 1> not true | true
	~ [0|0] 1> not false | false
	~ >

I think this is closer to users' expectations for those cases; they should
not have to think about this implementation detail of the not-statement.
