### PR TITLE
Add undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Interactive improvements
 
 #### New or improved bindings
+- New readline commands `undo` (Ctrl+_) and `redo` (Alt-/) can be used to revert changes to the command line or the pager search field (#6570).
 
 #### Improved prompts
 - The default and example prompts print the correct exit status for commands prefixed with `not` (#6566).

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -69,6 +69,8 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
     bind --preset $argv \cf forward-char
     bind --preset $argv \cb backward-char
     bind --preset $argv \ct transpose-chars
+    bind --preset $argv \c_ undo
+    bind --preset $argv \e/ redo
     bind --preset $argv \et transpose-words
     bind --preset $argv \eu upcase-word
 

--- a/sphinx_doc_src/cmds/bind.rst
+++ b/sphinx_doc_src/cmds/bind.rst
@@ -172,6 +172,8 @@ The following special input functions are available:
 
 - ``up-line``, move up one line
 
+- ``undo`` and ``redo``, revert or redo the most recent edits on the command line
+
 - ``upcase-word``, make the current word uppercase
 
 - ``yank``, insert the latest entry of the killring into the buffer

--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -1440,6 +1440,10 @@ Emacs mode commands
 
 - :kbd:`Alt+t` transposes the last two words
 
+- :kbd:`Control+_` (:kbd:`Control+/` on some terminals) undoes the most recent edit of the line
+
+- :kbd:`Alt+/` reverts the most recent undo
+
 
 You can change these key bindings using the :ref:`bind <cmd-bind>` builtin.
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -145,7 +145,10 @@ static const input_function_metadata_t input_function_metadata[] = {
     {readline_cmd_t::func_and, L"and"},
     {readline_cmd_t::expand_abbr, L"expand-abbr"},
     {readline_cmd_t::delete_or_exit, L"delete-or-exit"},
-    {readline_cmd_t::cancel, L"cancel"}};
+    {readline_cmd_t::cancel, L"cancel"},
+    {readline_cmd_t::undo, L"undo"},
+    {readline_cmd_t::redo, L"redo"},
+};
 
 static_assert(sizeof(input_function_metadata) / sizeof(input_function_metadata[0]) ==
                   input_function_count,

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -69,6 +69,8 @@ enum class readline_cmd_t {
     expand_abbr,
     delete_or_exit,
     cancel,
+    undo,
+    redo,
     repeat_jump,
     // NOTE: This one has to be last.
     reverse_repeat_jump


### PR DESCRIPTION
Add the readline function `undo` which is bound to `\c_` (control + / on
some terminals). Redoing the most recent chain of undos is supported,
`redo` is bound to `\e/` for now.

Closes #1367.
This approach should not have the issues discussed in #5897.

Every single modification to the commandline can be undone individually,
except for adjacent single-character inserts, which are coalesced,
so they can be reverted with a single undo. Coalescing is not done for
space characters, so each word can be undone separately.

When moving between history search entries, only the current history
search entry is reachable via the undo history. This allows to go back
to the original search string with a single undo, or by pressing the
escape key.
Similarly, when moving between pager entries, only the most recent
selection in the pager can be undone.

TODO: (I'm not sure about the first three)

- [ ] decide on the redo hotkey; `\e/` does not seem to work on xterm
      (it is tempting to add [emacs-style redo] but that would probably be less popular)
- [ ] vi mode: find some suitable bindings (`u` and `\cr` are taken)
- [ ] vi mode: find out how to bind in insert mode (which should then also work in the pager's search field)
- [x] update documentation
- [x] User-visible changes noted in CHANGELOG.md

These areas should be mostly alright based on what I tried but there may be room for improvement:

- make sure the undo grouping behavior works nicely in practise
- make sure the interaction with history search feels right
- make sure the interaction with the pager feels right
- add some tests (interactive tests are missing - expect-based tests are not very nice to write last time I tried)

I think this also allows us to get rid of `cycle_command_line` and `cycle_cursor_pos` because we can obtain those from the history.

[emacs-style redo]: <https://www.gnu.org/software/emacs/manual/html_node/emacs/Undo.html>
