### PR TITLE
Deal with git version strings

### DIFF
--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -153,7 +153,7 @@ function help --description 'Show help for the fish shell'
         end
     else
         # Go to the web. Only include one dot in the version string
-        set -l version_string (echo $version| cut -d . -f 1,2)
+        set -l version_string (string cut --length 3 $version)
         set page_url https://fishshell.com/docs/$version_string/$fish_help_page
         # We don't need a trampoline for a remote URL.
         set need_trampoline


### PR DESCRIPTION
Using fish built from git master gives a version string like this:

echo $version
3.1b1-88-gc6f85238b

This breaks the link to the online docs generated by the help function.
Granted, the 3.1 docs don't seem to be up yet so even with the correct link (https://fishshell.com/docs/3.1/index.html), fixing this now still ends up with a 404. However after 3.1 is released it will work.

#6526 mentioned `cut` is not necessary to be replaced but it doesn't seem like we can deal with this situation using `cut` so I switched to the fish string built in. Also, there was a comment about the regex not being impenetrable so I tried to avoid it this time using `string sub`, assuming the fish version number stays single digits...