### PR TITLE
Allow to omit indices in index range expansions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Syntax changes and new commands
 
 ### Scripting improvements
+- Range limits in index range expansions like `$x[$start..$end]` may be omitted: `$start` and `$end` default to 1 and -1 (the last item) respectively.
 
 ### Interactive improvements
 

--- a/sphinx_doc_src/index.rst
+++ b/sphinx_doc_src/index.rst
@@ -661,6 +661,8 @@ Sequences of elements can be written with the range operator '``..``'. A range '
 
 If the end is smaller than the start, or the start is larger than the end, range expansion will go in reverse. This is unless exactly one of the given indices is negative, so the direction doesn't change if the list has fewer elements than expected.
 
+A missing starting index in a range defaults to 1. This is allowed if the range is the first index expression of the sequence. Similarly, a missing ending index, defaulting to -1 is allowed for the last index range in the sequence.
+
 Some examples::
 
 
@@ -671,6 +673,9 @@ Some examples::
     echo (seq 10)[2..5]
     # Uses elements from 2 to 5
     # Output is: 2 3 4 5
+
+    echo (seq 10)[7..]
+    # Prints: 7 8 9 10
 
     # Use overlapping ranges:
     echo (seq 10)[2..5 1..3]

--- a/tests/checks/slices.fish
+++ b/tests/checks/slices.fish
@@ -3,6 +3,8 @@ set n 10
 set test (seq $n)
 echo $test[1..$n]      # normal range
 #CHECK: 1 2 3 4 5 6 7 8 9 10
+echo $test[1 .. 2]     # spaces are allowed
+#CHECK: 1 2
 echo $test[$n..1]      # inverted range
 #CHECK: 10 9 8 7 6 5 4 3 2 1
 echo $test[2..5 8..6]  # several ranges
@@ -31,3 +33,36 @@ echo $test[(count $test)..1]
 #CHECK: 10 9 8 7 6 5 4 3 2 1
 echo $test[1..(count $test)]
 #CHECK: 1 2 3 4 5 6 7 8 9 10
+
+echo $test[ .. ]
+#CHECK: 1 2 3 4 5 6 7 8 9 10
+echo $test[ ..3]
+#CHECK: 1 2 3
+echo $test[8.. ]
+#CHECK: 8 9 10
+echo $test[..2 5]
+# CHECK: 1 2 5
+echo $test[2 9..]
+# CHECK: 2 9 10
+
+# missing start, cannot use implied range
+echo $test[1..2..]
+#CHECKERR: {{.*}}: Invalid index value
+#CHECKERR: echo $test[1..2..]
+#CHECKERR:                ^
+echo $test[..1..2]
+#CHECKERR: {{.*}}: Invalid index value
+#CHECKERR: echo $test[..1..2]
+#CHECKERR:               ^
+
+set -l empty
+echo $test[ $empty..]
+#CHECK:
+echo $test[.."$empty"]
+#CHECK: 1 2 3 4 5 6 7 8 9 10
+echo $test["$empty"..]
+#CHECK: 1 2 3 4 5 6 7 8 9 10
+echo $test[ (true)..3]
+#CHECK:
+echo $test[ (string join \n 1 2 3)..3 ]
+#CHECK: 1 2 3 2 3 3


### PR DESCRIPTION
## Description

So omitted range limits in, say `$PATH[..]` default to the first/last element, just like Python/Go/Rust slices.
This is something I have had expected to work several times (coming from Python). It essentially saves typing the `1`/`-1` in a `..` range and I don't see any harm in defaulting to those values.
However, it's not super well thought out, and a language change so I'm asking if there are any concerns.

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
