### PR TITLE
Correct `list-language` to `list-languages` in bat completions

### DIFF
--- a/share/completions/bat.fish
+++ b/share/completions/bat.fish
@@ -56,7 +56,7 @@ set -l tabs_opts '
 '
 
 complete -c bat -n 'not __fish_seen_subcommand_from cache' -x -s l -l language -a '(__bat_complete_languages_and_extensions)' -d 'Set language for syntax highlighting'
-complete -c bat -n 'not __fish_seen_subcommand_from cache' -f -s L -l list-language -d 'List supported languages for syntax highlighting'
+complete -c bat -n 'not __fish_seen_subcommand_from cache' -f -s L -l list-languages -d 'List supported languages for syntax highlighting'
 complete -c bat -n 'not __fish_seen_subcommand_from cache' -x -s m -l map-syntax -d 'Map file name/extension to existing syntax'
 complete -c bat -n 'not __fish_seen_subcommand_from cache' -x -l theme -a '(__bat_complete_themes)' -d 'Set theme for syntax highlighting'
 complete -c bat -n 'not __fish_seen_subcommand_from cache' -f -l list-themes -d 'List syntax-highlighting themes'


### PR DESCRIPTION
## Description

This commit just fixes a minor typo where the wrong option was suggested (`list-language` instead of `list-languages`).

Source:
https://github.com/sharkdp/bat/blob/e98f34b1e8a420aad4eba313bd1604d640183413/src/bin/bat/clap_app.rs#L340-L347

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
