### PR TITLE
Include special characters in conda env names

### DIFF
--- a/share/completions/conda.fish
+++ b/share/completions/conda.fish
@@ -31,7 +31,7 @@ function __fish_conda_config_keys
 end
 
 function __fish_conda_environments
-    conda env list | string match -rv '^#' | string match -r '^\w+'
+    conda env list | string match -rv '^#' | string match -r '^\S+'
 end
 
 # common options


### PR DESCRIPTION
## Description

Allows completion for environments with names containing special
characters. For example my-env, myenv.1, myenv+1

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
