### PR TITLE
Restore `time` as a generic builtin

### DIFF
--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -394,6 +394,7 @@ static const builtin_data_t builtin_datas[] = {
     {L"string", &builtin_string, N_(L"Manipulate strings")},
     {L"switch", &builtin_generic, N_(L"Conditionally execute a block of commands")},
     {L"test", &builtin_test, N_(L"Test a condition")},
+    {L"time", &builtin_generic, N_(L"Time the execution of a job")},
     {L"true", &builtin_true, N_(L"Return a successful result")},
     {L"ulimit", &builtin_ulimit, N_(L"Set or get the shells resource usage limits")},
     {L"wait", &builtin_wait, N_(L"Wait for background processes completed")},


### PR DESCRIPTION
## Description

Resolves #6598.
