### PR TITLE
Work around compilation failure with old Apple SDKs

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -17,6 +17,7 @@
 #include <procfs.h>
 #endif
 #if __APPLE__
+#include <sys/time.h> // Required to build with old SDK versions
 #include <sys/proc.h>
 #else
 #include <dirent.h>


### PR DESCRIPTION
When building fish-shell with the macOS 10.12 SDK, `<sys/proc.h>` does not include `<sys/time.h>` but references `struct itimerval`. This causes a compilation failure if we don't import `<sys/time.h>` ourselves.

This was previously masked by an import of `<sys/sysctl.h>`, which was removed in fc0c39b6fdb6.

This fixes a build failure when building Fish using Nix, as Nix is currently on the macOS 10.12 SDK.
