### PR TITLE
Check all fish files

### DIFF
--- a/tests/checks/check-all-fish-files.fish
+++ b/tests/checks/check-all-fish-files.fish
@@ -1,0 +1,8 @@
+#RUN: %fish -C 'set -l fish %fish' %s
+# Test ALL THE FISH FILES
+# in share/, that is - the tests are exempt because they contain syntax errors, on purpose
+
+for file in $__fish_data_dir/**.fish
+    $fish -n $file
+end
+# No output is good output


### PR DESCRIPTION
## Description

This adds a check to run all fish files (except tests/) through the recently fixed `fish --no-execute` in order to find syntax errors.

It would have caught 63b4a891ff3559a14b13124ea3bbca19fae98b9d (but not #6617).

This is a nice idea, but it comes at a cost of ~4s per test run (on my machine).

So the question is: Are we willing to spend that?

Also there are a bunch of things that we could skip when we do --no-execute, like initializing the environment. Note that currently feature flags don't matter for no-execute because they don't change any syntax *errors* - nothing starts to be syntactically valid or stops being valid.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.md
