### PR TITLE
Fix variable leaking in completion `kill`

### DIFF
--- a/share/completions/kill.fish
+++ b/share/completions/kill.fish
@@ -1,8 +1,8 @@
 __fish_make_completion_signals
 
 for sig in $__kill_signals[-1..1]
-    set number (string split ' ' $sig)[1]
-    set name (string split ' ' $sig)[2]
+    set -l number (string split ' ' $sig)[1]
+    set -l name (string split ' ' $sig)[2]
     complete -c kill -o $number -d $name
     complete -c kill -o $name -d $number
     complete -c kill -k -s s -x -a "$name\t$number"


### PR DESCRIPTION
## Description

If we type `kill <tab>`, then global variables `number` and `name` will be set accidentally. This PR fix it.