### PR TITLE
doc: add interlinks between `true` ←→ `false` and `and` ←→ `or` cmds

### DIFF
--- a/doc_src/cmds/and.rst
+++ b/doc_src/cmds/and.rst
@@ -10,7 +10,6 @@ Synopsis
 
     COMMAND1; and COMMAND2
 
-
 Description
 -----------
 
@@ -25,10 +24,11 @@ Example
 
 The following code runs the ``make`` command to build a program. If the build succeeds, ``make``'s exit status is 0, and the program is installed. If either step fails, the exit status is 1, and ``make clean`` is run, which removes the files created by the build process.
 
-
-
 ::
 
     make; and make install; or make clean
 
+See Also
+--------
 
+- :ref:`or <cmd-or>` command

--- a/doc_src/cmds/false.rst
+++ b/doc_src/cmds/false.rst
@@ -14,3 +14,9 @@ Description
 -----------
 
 ``false`` sets the exit status to 1.
+
+See Also
+--------
+
+- :ref:`true <cmd-true>` command
+- :ref:`$status <variables-status>` variable

--- a/doc_src/cmds/or.rst
+++ b/doc_src/cmds/or.rst
@@ -15,8 +15,7 @@ Description
 
 ``or`` is used to execute a command if the previous command was not successful (returned a status of something other than 0).
 
-``or`` statements may be used as part of the condition in an :ref:`and <cmd-if>` or :ref:`while <cmd-while>` block. See the documentation
-for :ref:`if <cmd-if>` and :ref:`while <cmd-while>` for examples.
+``or`` statements may be used as part of the condition in an :ref:`and <cmd-if>` or :ref:`while <cmd-while>` block.
 
 ``or`` does not change the current exit status itself, but the command it runs most likely will. The exit status of the last foreground command to exit can always be accessed using the :ref:`$status <variables-status>` variable.
 
@@ -25,9 +24,11 @@ Example
 
 The following code runs the ``make`` command to build a program. If the build succeeds, the program is installed. If either step fails, ``make clean`` is run, which removes the files created by the build process.
 
-
-
 ::
 
     make; and make install; or make clean
 
+See Also
+--------
+
+- :ref:`and <cmd-and>` command

--- a/doc_src/cmds/true.rst
+++ b/doc_src/cmds/true.rst
@@ -10,8 +10,13 @@ Synopsis
 
     true
 
-
 Description
 -----------
 
 ``true`` sets the exit status to 0.
+
+See Also
+--------
+
+- :ref:`false <cmd-false>` command
+- :ref:`$status <variables-status>` variable


### PR DESCRIPTION
Hi

These new links offer a convenient way to jump back and forth between tightly related commands.

`See Also` sections already exist for a few other commands like `cdh`.

(a few blank lines were removed to keep format consistent between tandem commands)