### PR TITLE
Add additional vi bindings

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -151,6 +151,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset dt begin-selection forward-jump backward-char kill-selection end-selection
     bind -s --preset dF begin-selection backward-jump kill-selection end-selection
     bind -s --preset dT begin-selection backward-jump forward-char kill-selection end-selection
+    bind -s --preset dh backward-char delete-char
+    bind -s --preset dl delete-char
 
     bind -s --preset -m insert s delete-char repaint-mode
     bind -s --preset -m insert S kill-whole-line repaint-mode
@@ -158,6 +160,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert C kill-line repaint-mode
     bind -s --preset -m insert c\$ kill-line repaint-mode
     bind -s --preset -m insert c\^ backward-kill-line repaint-mode
+    bind -s --preset -m insert c0 backward-kill-line repaint-mode
     bind -s --preset -m insert cw kill-word repaint-mode
     bind -s --preset -m insert cW kill-bigword repaint-mode
     bind -s --preset -m insert ciw forward-char forward-char backward-word kill-word repaint-mode
@@ -170,6 +173,12 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert cB backward-kill-bigword repaint-mode
     bind -s --preset -m insert cge backward-kill-word repaint-mode
     bind -s --preset -m insert cgE backward-kill-bigword repaint-mode
+    bind -s --preset -m insert cf begin-selection forward-jump kill-selection end-selection repaint-mode
+    bind -s --preset -m insert ct begin-selection forward-jump backward-char kill-selection end-selection repaint-mode
+    bind -s --preset -m insert cF begin-selection backward-jump kill-selection end-selection repaint-mode
+    bind -s --preset -m insert cT begin-selection backward-jump forward-char kill-selection end-selection repaint-mode
+    bind -s --preset -m insert ch backward-char begin-selection kill-selection end-selection repaint-mode
+    bind -s --preset -m insert cl begin-selection kill-selection end-selection repaint-mode
 
     bind -s --preset '~' capitalize-word
     bind -s --preset gu downcase-word
@@ -182,6 +191,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset Y kill-whole-line yank
     bind -s --preset y\$ kill-line yank
     bind -s --preset y\^ backward-kill-line yank
+    bind -s --preset y0 backward-kill-line yank
     bind -s --preset yw kill-word yank
     bind -s --preset yW kill-bigword yank
     bind -s --preset yiw forward-char forward-char backward-word kill-word yank


### PR DESCRIPTION
Adds `dh`, `dl`, `c0`, `cf`, `ct`, `cF`, `cT`, `ch`, `cl`, and `y0` bindings.

## Description

I added a couple of missing vim bindings. This is kind of related to #4019 even though the issues does not mention the missing bindings explicitly.
The `dh` and `ch` bindings delete the first character of the line when used at the beginning of the line. This is different from vim, but I did not find a clean way to fix this and I consider this a minor difference.
I also noticed that the `y0` binding pastes if used at the beginning of the line. This is the same for the already existing `y^` binding so I guess it is not a problem?

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
