### PR TITLE
completions: speed up python startup time

### DIFF
--- a/share/completions/bower.fish
+++ b/share/completions/bower.fish
@@ -53,7 +53,7 @@ function __bower_list_installed
     if set -l python (__fish_anypython)
         # Warning: That weird indentation is necessary, because python.
         $python -S -c 'import json, sys; data = json.load(sys.stdin);
-for k,v in data["dependencies"].items(): print(k + "\t" + v[:18])' bower.json 2>/dev/null
+for k,v in data["dependencies"].items(): print(k + "\t" + v[:18])' <bower.json 2>/dev/null
         return
     end
 

--- a/share/completions/bower.fish
+++ b/share/completions/bower.fish
@@ -52,7 +52,7 @@ function __bower_list_installed
 
     if set -l python (__fish_anypython)
         # Warning: That weird indentation is necessary, because python.
-        $python -c 'import json, sys; data = json.load(sys.stdin);
+        $python -S -c 'import json, sys; data = json.load(sys.stdin);
 for k,v in data["dependencies"].items(): print(k + "\t" + v[:18])' bower.json 2>/dev/null
         return
     end

--- a/share/completions/composer.fish
+++ b/share/completions/composer.fish
@@ -31,7 +31,7 @@ data = json.load(json_data)
 json_data.close()
 packages = itertools.chain(data['require'].keys(), data['require-dev'].keys())
 print(\"\n\".join(packages))
-      " | $python
+      " | $python -S
 end
 
 function __fish_composer_installed_packages
@@ -48,7 +48,7 @@ for package in data['packages']:
 for package in data['packages-dev']:
     installed_packages.append(package['name'])
 print(\"\n\".join(installed_packages))
-" | $python
+" | $python -S
 end
 
 function __fish_composer_scripts
@@ -61,7 +61,7 @@ data = json.load(json_data)
 json_data.close()
 if 'scripts' in data and data['scripts']:
     print(\"\n\".join(data['scripts'].keys()))
-" | $python
+" | $python -S
 end
 
 # add cmds list

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -91,7 +91,7 @@ function __fish_npm_run
     # npm is dog-slow and might check for updates online!
     if test -e package.json; and set -l python (__fish_anypython)
         # Warning: That weird indentation is necessary, because python.
-        $python -c 'import json, sys; data = json.load(sys.stdin);
+        $python -S -c 'import json, sys; data = json.load(sys.stdin);
 for k,v in data["scripts"].items(): print(k + "\t" + v[:18])' <package.json 2>/dev/null
     else if command -sq jq; and test -e package.json
         jq -r '.scripts | to_entries | map("\(.key)\t\(.value | tostring | .[0:20])") | .[]' package.json

--- a/share/completions/yarn.fish
+++ b/share/completions/yarn.fish
@@ -73,7 +73,7 @@ complete -f -c yarn -n '__fish_use_subcommand' -a run
 function __fish_yarn_run
     if test -e package.json; and set -l python (__fish_anypython)
         # Warning: That weird indentation is necessary, because python.
-        $python -c 'import json, sys; data = json.load(sys.stdin);
+        $python -S -c 'import json, sys; data = json.load(sys.stdin);
 for k,v in data["scripts"].items(): print(k + "\t" + v[:18])' <package.json 2>/dev/null
     else if test -e package.json; and type -q jq
         jq -r '.scripts | to_entries | map("\(.key)\t\(.value | tostring | .[0:20])") | .[]' package.json

--- a/share/functions/fish_npm_helper.fish
+++ b/share/functions/fish_npm_helper.fish
@@ -58,7 +58,7 @@ function __yarn_installed_packages
     end
 
     if set -l python (__fish_anypython)
-        $python -c 'import json, sys; data = json.load(sys.stdin);
+        $python -S -c 'import json, sys; data = json.load(sys.stdin);
 print("\n".join(data["dependencies"])); print("\n".join(data["devDependencies"]))' <$package_json 2>/dev/null
     else if type -q jq
         jq -r '.dependencies as $a1 | .devDependencies as $a2 | ($a1 + $a2) | to_entries[] | .key' $package_json


### PR DESCRIPTION
We only use the standard library so it should be OK to use python's [-S](https://docs.python.org/3/using/cmdline.html#id3) flag.

Before and after:
```
>time for i in (seq 50); python -c pass; end
Executed in    1.00 secs   fish           external 
   usr time  816.77 millis    0.00 millis  816.77 millis 
   sys time  183.10 millis   39.58 millis  143.52 millis 

>time for i in (seq 50); python -S -c pass; end
Executed in  505.14 millis    fish           external 
   usr time  336.00 millis    1.10 millis  334.90 millis 
   sys time  169.42 millis   33.09 millis  136.33 millis 
```

Also: found a bug in the bower completions which was causing it to hang. Seems like it was broken from the start.