### PR TITLE
added uncompressed pkg.tar files for completion

### DIFF
--- a/share/completions/pacman.fish
+++ b/share/completions/pacman.fish
@@ -140,5 +140,5 @@ complete -c $progname -n "$sync" -xa "$listall $listgroups"
 
 # Upgrade options
 # Theoretically, pacman reads packages in all formats that libarchive supports
-# In practice, it's going to be tar.xz, tar.gz or tar.zst
-complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar.zst; __fish_complete_suffix pkg.tar.xz; __fish_complete_suffix pkg.tar.gz)' -d 'Package file'
+# In practice, it's going to be tar.xz, tar.gz, tar.zst, or just pkg.tar (uncompressed pkg)
+complete -c $progname -n "$upgrade" -xa '(__fish_complete_suffix pkg.tar.zst; __fish_complete_suffix pkg.tar.xz; __fish_complete_suffix pkg.tar.gz; __fish_complete_suffix pkg.tar;)' -d 'Package file'


### PR DESCRIPTION
## Description
something like:
pacman -U name-of-package.pkg.tar
should auto-complete, as pkg.tar files can be files users quickly package without compression.
Fixes issue #
with changes brought forth in 3.1.0 to pacman.fish, uncompressed *.pkg.tar files did not tab-complete as expected, while compressed packages completed as expected.