### PR TITLE
Fix expand.cpp compile failed with old SDK version

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -18,6 +18,7 @@
 #endif
 #if __APPLE__
 #include <sys/time.h>  // Required to build with old SDK versions
+// proc.h needs to be included *after* time.h, this comment stops clang-format from reordering.
 #include <sys/proc.h>
 #else
 #include <dirent.h>

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -17,8 +17,8 @@
 #include <procfs.h>
 #endif
 #if __APPLE__
-#include <sys/proc.h>
 #include <sys/time.h>  // Required to build with old SDK versions
+#include <sys/proc.h>
 #else
 #include <dirent.h>
 #include <sys/stat.h>


### PR DESCRIPTION
## Description

Workaround method to fix compile issue on old OSX SDK (10.11.6)
<sys/time.h> should be included ahead of <sys/proc.h>

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
