### PR TITLE
doc: add interlinks between `echo` ←→ `printf` commands

### DIFF
--- a/doc_src/cmds/echo.rst
+++ b/doc_src/cmds/echo.rst
@@ -57,18 +57,19 @@ If ``-e`` is used, the following sequences are recognized:
 Example
 -------
 
-
-
 ::
 
     echo 'Hello World'
 
 Print hello world to stdout
 
-
-
 ::
 
     echo -e 'Top\\nBottom'
 
 Print Top and Bottom on separate lines, using an escape sequence
+
+See Also
+--------
+
+- the :ref:`printf <cmd-printf>` command, for more control over output formatting

--- a/doc_src/cmds/printf.rst
+++ b/doc_src/cmds/printf.rst
@@ -66,18 +66,19 @@ This file has been imported from the printf in GNU Coreutils version 6.9. If you
 Example
 -------
 
-
-
 ::
 
     printf '%s\\t%s\\n' flounder fish
 
 Will print "flounder	fish" (separated with a tab character), followed by a newline character. This is useful for writing completions, as fish expects completion scripts to output the option followed by the description, separated with a tab character.
 
-
-
 ::
 
     printf '%s: %d' "Number of bananas in my pocket" 42
 
 Will print "Number of bananas in my pocket: 42", _without_ a newline.
+
+See Also
+--------
+
+- the :ref:`echo <cmd-echo>` command, for simpler output


### PR DESCRIPTION
Hello

`echo` and `printf` are related functions which could benefit for more obvious links to navigate between them.
