### PR TITLE
docs: fix undefined label

### DIFF
--- a/doc_src/faq.rst
+++ b/doc_src/faq.rst
@@ -35,7 +35,7 @@ You can also use the Web configuration tool, :ref:`fish_config <cmd-fish_config>
 Why does my prompt show a `[I]`?
 --------------------------------
 
-That's the :ref:`fish_mode_prompt <cmd-fish_mode_prompt>`. It is displayed by default when you've activated :ref:`vi mode <cmd-fish_vi_key_bindings>`.
+That's the :ref:`fish_mode_prompt <cmd-fish_mode_prompt>`. It is displayed by default when you've activated vi mode using ``fish_vi_key_bindings``.
 
 If you haven't activated vi mode on purpose, you might have installed a third-party theme that does it.
 


### PR DESCRIPTION
Replaces the non-existing link with a named reference to the function.

```
[100%] Building HTML documentation with Sphinx
[100%] Building man pages with Sphinx
make[2]: Leaving directory '/home/ammgws/.cache/pikaur/build/fish-git/src/fish-shell/build'
[100%] Built target sphinx-docs
/home/ammgws/.cache/pikaur/build/fish-git/src/fish-shell/doc_src/faq.rst:38: WARNING: undefined label: cmd-fish_vi_key_bindings (if the link has no caption the label must precede a section header)
/home/ammgws/.cache/pikaur/build/fish-git/src/fish-shell/doc_src/faq.rst:38: WARNING: undefined label: cmd-fish_vi_key_bindings (if the link has no caption the label must precede a section header)
make[2]: Leaving directory '/home/ammgws/.cache/pikaur/build/fish-git/src/fish-shell/build'
[100%] Built target sphinx-manpages
```