### PR TITLE
Prevent prompt barfing errors when cwd has disappeared

### DIFF
--- a/share/functions/fish_print_hg_root.fish
+++ b/share/functions/fish_print_hg_root.fish
@@ -7,7 +7,9 @@ function fish_print_hg_root
     # Find an hg directory above $PWD
     # without calling `hg root` because that's too slow
     set -l root
-    set -l dir (pwd -P)
+    set -l dir (pwd -P 2>/dev/null)
+    or return 1
+
     while test $dir != "/"
         if test -f $dir'/.hg/dirstate'
             echo $dir/.hg


### PR DESCRIPTION
In terminal one: cwd is "a"
In terminal two: removed dir "a"

Tried to run a command in terminal one and:
```
[1]>ls                                                                                               0ms|20:58:04
pwd: realpath failed:test: Missing argument at index 2

/usr/share/fish/functions/fish_print_hg_root.fish (line 11): 
    while test $dir != "/"
          ^
in function 'fish_print_hg_root'
	called on line 1 of file /usr/share/fish/functions/fish_hg_prompt.fish
in command substitution
	called on line 30 of file /usr/share/fish/functions/fish_hg_prompt.fish
in function 'fish_hg_prompt'
	called on line 5 of file /usr/share/fish/functions/fish_vcs_prompt.fish
in function 'fish_vcs_prompt'
	called on line 1 of file ~/.config/fish/functions/fish_right_prompt.fish
in command substitution
	called on line 1 of file ~/.config/fish/functions/fish_right_prompt.fish
in command substitution
	called on line 8 of file ~/.config/fish/functions/fish_right_prompt.fish
in function 'fish_right_prompt'
in command substitution

(Type 'help test' for related documentation)
```