### PR TITLE
Fix 256 color detection on xterm-like

### DIFF
--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -348,17 +348,17 @@ static void update_fish_color_support(const environment_t &vars) {
         // Assume that all 'xterm's can handle 256, except for Terminal.app from Snow Leopard
         wcstring term_program;
         if (auto tp = vars.get(L"TERM_PROGRAM")) term_program = tp->as_string();
-        if (auto tpv = vars.get(L"TERM_PROGRAM_VERSION")) {
-            if (term_program == L"Apple_Terminal" &&
-                fish_wcstod(tpv->as_string().c_str(), nullptr) > 299) {
+        if (term_program == L"Apple_Terminal") {
+            auto tpv = vars.get(L"TERM_PROGRAM_VERSION");
+            if (tpv && fish_wcstod(tpv->as_string().c_str(), nullptr) > 299) {
                 // OS X Lion is version 299+, it has 256 color support (see github Wiki)
                 support_term256 = true;
                 FLOGF(term_support, L"256 color support enabled for TERM=%ls on Terminal.app",
                       term.c_str());
-            } else {
-                support_term256 = true;
-                FLOGF(term_support, L"256 color support enabled for TERM=%ls", term.c_str());
             }
+        } else {
+            support_term256 = true;
+            debug(2, L"256 color support enabled for TERM=%ls", term.c_str());
         }
     } else if (cur_term != nullptr) {
         // See if terminfo happens to identify 256 colors


### PR DESCRIPTION
bbc3fecbe introduced a regression where support for 256 color was not
detected on xterm-like terminals that did not define the TERM_PROGRAM
env variable. Almost no terminal on linux define this variable.

## Description

The upgrade from fish 3.0 to 3.1 broke the color on my terminal (kitty). Its `TERM` environment variable is `xterm-kitty`, and it does not define a `TERM_PROGRAM` env variable (neither do xterm, or urxvt). I changed the logic of checking for Terminal.app back to what it was before bbc3fecbe and fixed the problem.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
