### PR TITLE
Clear `cancellation_signal` before firing `fish_postexec` event

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2441,6 +2441,7 @@ static int read_i(parser_t &parser) {
             wcstring_list_t argv(1, command);
             event_fire_generic(parser, L"fish_preexec", &argv);
             reader_run_command(parser, command);
+            parser.clear_cancel();
             event_fire_generic(parser, L"fish_postexec", &argv);
             // Allow any pending history items to be returned in the history array.
             if (data->history) {

--- a/tests/signals.expect
+++ b/tests/signals.expect
@@ -10,6 +10,14 @@ expect_prompt
 exec -- kill -INT $pid
 expect "SIGINT spotted"
 
+# Verify that the fish_postexec handler is called after SIGINT.
+send_line "function postexec --on-event fish_postexec; echo fish_postexec spotted; end"
+expect_prompt
+send_line read
+expect -re "\\r\\n?read> $"
+exec -- kill -INT $pid
+expect "fish_postexec spotted"
+
 # Verify that sending SIGHUP to the shell, such as will happen when the tty is
 # closed by the terminal, terminates the shell and the foreground command and
 # any background commands run from that shell.


### PR DESCRIPTION
## Description

Fixes issue #2356

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
