### PR TITLE
Move logic to remove trailing spaces when pasting to C++

### DIFF
--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -159,9 +159,6 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     # into one literal token, to facilitate pasting non-code (e.g. markdown or git commitishes)
     bind --preset -M paste "'" "__fish_commandline_insert_escaped \' \$__fish_paste_quoted"
     bind --preset -M paste \\ "__fish_commandline_insert_escaped \\\ \$__fish_paste_quoted"
-    # Only insert spaces if we're either quoted or not at the beginning of the commandline
-    # - this strips leading spaces if they would trigger histignore.
-    bind --preset -M paste \  'if set -q __fish_paste_quoted[1]; or string length -q -- (commandline -c); commandline -i " "; end'
 end
 
 function __fish_commandline_insert_escaped --description 'Insert the first arg escaped if a second arg is given'


### PR DESCRIPTION
Fixes #6704

Removing trailing spaces can be quite useful, especially when `fish_clipboard_paste` is not available (ssh/container/vm). I'm trying to do the equivalent thing in C++, I hope this doesn't break anything.