### PR TITLE
doc(end): mention the 'function' command and add links to all block starters

### DIFF
--- a/doc_src/cmds/end.rst
+++ b/doc_src/cmds/end.rst
@@ -9,17 +9,20 @@ Synopsis
 ::
 
     begin; [COMMANDS...] end
+    function NAME [OPTIONS]; COMMANDS...; end
     if CONDITION; COMMANDS_TRUE...; [else; COMMANDS_FALSE...;] end
+    switch VALUE; [case [WILDCARD...]; [COMMANDS...]; ...] end
     while CONDITION; COMMANDS...; end
     for VARNAME in [VALUES...]; COMMANDS...; end
-    switch VALUE; [case [WILDCARD...]; [COMMANDS...]; ...] end
 
 Description
 -----------
 
-``end`` ends a block of commands.
+``end`` ends a block of commands started by one of the following commands:
 
-For more information, read the
-documentation for the block constructs, such as ``if``, ``for`` and ``while``.
+- :ref:`begin <cmd-begin>` to start a block of commands
+- :ref:`function <cmd-function>` to define a function
+- :ref:`if <cmd-if>`, :ref:`switch <cmd-switch>` to conditionally execute commands
+- :ref:`while <cmd-while>`, :ref:`for <cmd-for>` to perform commands multiple times
 
 The ``end`` command does not change the current exit status. Instead, the status after it will be the status returned by the most recent command.


### PR DESCRIPTION
Hi

`function` was missing from the synopsis. Also convenient links have been added to all block constructs commands.