### PR TITLE
Fix cargo completions

### DIFF
--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -9,8 +9,8 @@ complete -c cargo -s q -l quiet -d 'No output printed to stdout'
 
 set -l __fish_cargo_subcommands (cargo --list 2>&1 | string replace -rf '^\s+([^\s]+)\s+(.*)' '$1\t$2')
 
-complete -c cargo -f -c cargo -n '__fish_use_subcommand' -a "$__fish_cargo_subcommands"
-complete -c cargo -x -c cargo -n '__fish_seen_subcommand_from help' -a "$__fish_cargo_subcommands"
+complete -c cargo -f -c cargo -n '__fish_use_subcommand' -a '$__fish_cargo_subcommands'
+complete -c cargo -x -c cargo -n '__fish_seen_subcommand_from help' -a '$__fish_cargo_subcommands'
 
 for x in bench build clean doc fetch generate-lockfile \
     locate-project package pkgid publish \

--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -5,8 +5,7 @@ complete -c cargo -l list -d 'List installed commands'
 complete -c cargo -s v -l verbose -d 'Use verbose output'
 complete -c cargo -s q -l quiet -d 'No output printed to stdout'
 
-set -l __fish_cargo_subcommands (cargo --list 2>&1 | string replace -rf '^\s+([^\s]+)\s+(.*)' '$1\t$2')
-
+set -lx __fish_cargo_subcommands (cargo --list 2>&1 | string replace -rf '^\s+([^\s]+)\s+(.*)' '$1\t$2')
 complete -c cargo -f -c cargo -n '__fish_use_subcommand' -a '$__fish_cargo_subcommands'
 complete -c cargo -x -c cargo -n '__fish_seen_subcommand_from help' -a '$__fish_cargo_subcommands'
 

--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -1,6 +1,4 @@
 # Tab completion for cargo (https://github.com/rust-lang/cargo).
-complete -e -c cargo
-
 complete -c cargo -s h -l help
 complete -c cargo -s V -l version -d 'Print version info and exit'
 complete -c cargo -l list -d 'List installed commands'


### PR DESCRIPTION
fish, version 3.1.0-305-gf10ef4f94

Cargo completions spew all over the terminal when they attempt to use the following line from the output of `cargo --list`, due to the angle brackets: `new                  Create a new cargo package at <path>`

Fixed it by using single quotes.

Also, for some reason using `set -l` doesn't allow the variable to be passed through to the complete command, and trying to use `set -e` to cleanup afterwards results in the same thing. Or is it due to the single quotes?


<details close>
<summary>not working with `set -l` :</summary>
<br>

```
>cat ~/.config/fish/completions/cargo.fish
set -l __fish_cargo_subcommands (cargo --list 2>&1 | string replace -rf '^\s+([^\s]+)\s+(.*)' '$1\t$2')
complete -c cargo -f -c cargo -n '__fish_use_subcommand' -a '$__fish_cargo_subcommands'
>                                                                                                                                             
>set fish_trace 1
>complete -C"cargo "
+ complete '-Ccargo '
++ source /home/ammgws/.config/fish/completions/cargo.fish
+++++ cargo --list
+++++ string replace -rf \^\\s+\(\[\^\\s\]+\)\\s+\(.\*\) \$1\\t\$2
++++ set -l __fish_cargo_subcommands bench\tExecute\ all\ benchmarks\ of\ a\ local\ package build\tCompile\ a\ local\ package\ and\ all\ of\ its\ dependencies check\tCheck\ a\ local\ package\ and\ all\ of\ its\ dependencies\ for\ errors clean\tRemove\ artifacts\ that\ cargo\ has\ generated\ in\ the\ past clippy-preview\tChecks\ a\ package\ to\ catch\ common\ mistakes\ and\ improve\ your\ Rust\ code. doc\tBuild\ a\ package\'s\ documentation fetch\tFetch\ dependencies\ of\ a\ package\ from\ the\ network fix\tAutomatically\ fix\ lint\ warnings\ reported\ by\ rustc generate-lockfile\tGenerate\ the\ lockfile\ for\ a\ package git-checkout\tCheckout\ a\ copy\ of\ a\ Git\ repository init\tCreate\ a\ new\ cargo\ package\ in\ an\ existing\ directory install\tInstall\ a\ Rust\ binary.\ Default\ location\ is\ \$HOME/.cargo/bin locate-project\tPrint\ a\ JSON\ representation\ of\ a\ Cargo.toml\ file\'s\ location login\tSave\ an\ api\ token\ from\ the\ registry\ locally.\ If\ token\ is\ not\ specified,\ it\ will\ be\ read\ from\ stdin. metadata\tOutput\ the\ resolved\ dependencies\ of\ a\ package,\ the\ concrete\ used\ versions\ including\ overrides,\ in\ machine-readable\ format new\tCreate\ a\ new\ cargo\ package\ at\ \<path\> owner\tManage\ the\ owners\ of\ a\ crate\ on\ the\ registry package\tAssemble\ the\ local\ package\ into\ a\ distributable\ tarball pkgid\tPrint\ a\ fully\ qualified\ package\ specification publish\tUpload\ a\ package\ to\ the\ registry read-manifest\tPrint\ a\ JSON\ representation\ of\ a\ Cargo.toml\ manifest. run\tRun\ a\ binary\ or\ example\ of\ the\ local\ package rustc\tCompile\ a\ package\ and\ all\ of\ its\ dependencies rustdoc\tBuild\ a\ package\'s\ documentation,\ using\ specified\ custom\ flags. search\tSearch\ packages\ in\ crates.io test\tExecute\ all\ unit\ and\ integration\ tests\ and\ build\ examples\ of\ a\ local\ package uninstall\tRemove\ a\ Rust\ binary update\tUpdate\ dependencies\ as\ recorded\ in\ the\ local\ lock\ file vendor\tVendor\ all\ dependencies\ for\ a\ project\ locally verify-project\tCheck\ correctness\ of\ crate\ manifest version\tShow\ version\ information yank\tRemove\ a\ pushed\ crate\ from\ the\ index
++++ complete -c cargo -f -c cargo -n __fish_use_subcommand -a '$__fish_cargo_subcommands'
+++ source /usr/share/fish/functions/__fish_use_subcommand.fish
+++++ function __fish_use_subcommand -d 'Test if a non-switch argument has been given in the current commandline'
++ __fish_use_subcommand
+++++ commandline -poc
++++ set -l cmd cargo
++++ set -e 'cmd[1]'
++++ for
++++ end for
++++ return 0
```

</details>

<details close>
<summary>barf:</summary>
<br>

```
>set fish_trace 1
>complete -C"cargo "
+ complete '-Ccargo '
++ source /usr/share/fish/completions/cargo.fish
++++ complete -e -c cargo
++++ complete -c cargo -s h -l help
++++ complete -c cargo -s V -l version -d 'Print version info and exit'
++++ complete -c cargo -l list -d 'List installed commands'
++++ complete -c cargo -s v -l verbose -d 'Use verbose output'
++++ complete -c cargo -s q -l quiet -d 'No output printed to stdout'
+++++ cargo --list
+++++ string replace -rf \^\\s+\(\[\^\\s\]+\)\\s+\(.\*\) \$1\\t\$2
++++ set -l __fish_cargo_subcommands bench\tExecute\ all\ benchmarks\ of\ a\ local\ package build\tCompile\ a\ local\ package\ and\ all\ of\ its\ dependencies check\tCheck\ a\ local\ package\ and\ all\ of\ its\ dependencies\ for\ errors clean\tRemove\ artifacts\ that\ cargo\ has\ generated\ in\ the\ past clippy-preview\tChecks\ a\ package\ to\ catch\ common\ mistakes\ and\ improve\ your\ Rust\ code. doc\tBuild\ a\ package\'s\ documentation fetch\tFetch\ dependencies\ of\ a\ package\ from\ the\ network fix\tAutomatically\ fix\ lint\ warnings\ reported\ by\ rustc generate-lockfile\tGenerate\ the\ lockfile\ for\ a\ package git-checkout\tCheckout\ a\ copy\ of\ a\ Git\ repository init\tCreate\ a\ new\ cargo\ package\ in\ an\ existing\ directory install\tInstall\ a\ Rust\ binary.\ Default\ location\ is\ \$HOME/.cargo/bin locate-project\tPrint\ a\ JSON\ representation\ of\ a\ Cargo.toml\ file\'s\ location login\tSave\ an\ api\ token\ from\ the\ registry\ locally.\ If\ token\ is\ not\ specified,\ it\ will\ be\ read\ from\ stdin. metadata\tOutput\ the\ resolved\ dependencies\ of\ a\ package,\ the\ concrete\ used\ versions\ including\ overrides,\ in\ machine-readable\ format new\tCreate\ a\ new\ cargo\ package\ at\ \<path\> owner\tManage\ the\ owners\ of\ a\ crate\ on\ the\ registry package\tAssemble\ the\ local\ package\ into\ a\ distributable\ tarball pkgid\tPrint\ a\ fully\ qualified\ package\ specification publish\tUpload\ a\ package\ to\ the\ registry read-manifest\tPrint\ a\ JSON\ representation\ of\ a\ Cargo.toml\ manifest. run\tRun\ a\ binary\ or\ example\ of\ the\ local\ package rustc\tCompile\ a\ package\ and\ all\ of\ its\ dependencies rustdoc\tBuild\ a\ package\'s\ documentation,\ using\ specified\ custom\ flags. search\tSearch\ packages\ in\ crates.io test\tExecute\ all\ unit\ and\ integration\ tests\ and\ build\ examples\ of\ a\ local\ package uninstall\tRemove\ a\ Rust\ binary update\tUpdate\ dependencies\ as\ recorded\ in\ the\ local\ lock\ file vendor\tVendor\ all\ dependencies\ for\ a\ project\ locally verify-project\tCheck\ correctness\ of\ crate\ manifest version\tShow\ version\ information yank\tRemove\ a\ pushed\ crate\ from\ the\ index
++++ complete -c cargo -f -c cargo -n __fish_use_subcommand -a bench\tExecute\ all\ benchmarks\ of\ a\ local\ package\ build\tCompile\ a\ local\ package\ and\ all\ of\ its\ dependencies\ check\tCheck\ a\ local\ package\ and\ all\ of\ its\ dependencies\ for\ errors\ clean\tRemove\ artifacts\ that\ cargo\ has\ generated\ in\ the\ past\ clippy-preview\tChecks\ a\ package\ to\ catch\ common\ mistakes\ and\ improve\ your\ Rust\ code.\ doc\tBuild\ a\ package\'s\ documentation\ fetch\tFetch\ dependencies\ of\ a\ package\ from\ the\ network\ fix\tAutomatically\ fix\ lint\ warnings\ reported\ by\ rustc\ generate-lockfile\tGenerate\ the\ lockfile\ for\ a\ package\ git-checkout\tCheckout\ a\ copy\ of\ a\ Git\ repository\ init\tCreate\ a\ new\ cargo\ package\ in\ an\ existing\ directory\ install\tInstall\ a\ Rust\ binary.\ Default\ location\ is\ \$HOME/.cargo/bin\ locate-project\tPrint\ a\ JSON\ representation\ of\ a\ Cargo.toml\ file\'s\ location\ login\tSave\ an\ api\ token\ from\ the\ registry\ locally.\ If\ token\ is\ not\ specified,\ it\ will\ be\ read\ from\ stdin.\ metadata\tOutput\ the\ resolved\ dependencies\ of\ a\ package,\ the\ concrete\ used\ versions\ including\ overrides,\ in\ machine-readable\ format\ new\tCreate\ a\ new\ cargo\ package\ at\ \<path\>\ owner\tManage\ the\ owners\ of\ a\ crate\ on\ the\ registry\ package\tAssemble\ the\ local\ package\ into\ a\ distributable\ tarball\ pkgid\tPrint\ a\ fully\ qualified\ package\ specification\ publish\tUpload\ a\ package\ to\ the\ registry\ read-manifest\tPrint\ a\ JSON\ representation\ of\ a\ Cargo.toml\ manifest.\ run\tRun\ a\ binary\ or\ example\ of\ the\ local\ package\ rustc\tCompile\ a\ package\ and\ all\ of\ its\ dependencies\ rustdoc\tBuild\ a\ package\'s\ documentation,\ using\ specified\ custom\ flags.\ search\tSearch\ packages\ in\ crates.io\ test\tExecute\ all\ unit\ and\ integration\ tests\ and\ build\ examples\ of\ a\ local\ package\ uninstall\tRemove\ a\ Rust\ binary\ update\tUpdate\ dependencies\ as\ recorded\ in\ the\ local\ lock\ file\ vendor\tVendor\ all\ dependencies\ for\ a\ project\ locally\ verify-project\tCheck\ correctness\ of\ crate\ manifest\ version\tShow\ version\ information\ yank\tRemove\ a\ pushed\ crate\ from\ the\ index
complete: Completion 'bench	Execute all benchmarks of a local package build	Compile a local package and all of its dependencies check	Check a local package and all of its dependencies for errors clean	Remove artifacts that cargo has generated in the past clippy-preview	Checks a package to catch common mistakes and improve your Rust code. doc	Build a package's documentation fetch	Fetch dependencies of a package from the network fix	Automatically fix lint warnings reported by rustc generate-lockfile	Generate the lockfile for a package git-checkout	Checkout a copy of a Git repository init	Create a new cargo package in an existing directory install	Install a Rust binary. Default location is $HOME/.cargo/bin locate-project	Print a JSON representation of a Cargo.toml file's location login	Save an api token from the registry locally. If token is not specified, it will be read from stdin. metadata	Output the resolved dependencies of a package, the concrete used versions including overrides, in machine-readable format new	Create a new cargo package at <path> owner	Manage the owners of a crate on the registry package	Assemble the local package into a distributable tarball pkgid	Print a fully qualified package specification publish	Upload a package to the registry read-manifest	Print a JSON representation of a Cargo.toml manifest. run	Run a binary or example of the local package rustc	Compile a package and all of its dependencies rustdoc	Build a package's documentation, using specified custom flags. search	Search packages in crates.io test	Execute all unit and integration tests and build examples of a local package uninstall	Remove a Rust binary update	Update dependencies as recorded in the local lock file vendor	Vendor all dependencies for a project locally verify-project	Check correctness of crate manifest version	Show version information yank	Remove a pushed crate from the index' contained a syntax error
complete: Expected an argument, but found a redirection
```

</details>
