### PR TITLE
completions: fix scp remote path when /bin/ls does not exist

### DIFF
--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -54,7 +54,7 @@ complete -c scp -d "Local Path" -n "not string match @ -- (commandline -ct)"
 # Get the list of remote files from the scp target.
 complete -c scp -d "Remote Path" -f -n "commandline -ct | string match -e ':'" -a "
 (__scp_remote_target):( \
-        command ssh (__scp2ssh_port_number) -o 'BatchMode yes' (__scp_remote_target) /bin/ls\ -dp\ (__scp_remote_path_prefix | string unescape)\* 2>/dev/null |
+        command ssh (__scp2ssh_port_number) -o 'BatchMode yes' (__scp_remote_target) ls\ -dp\ (__scp_remote_path_prefix | string unescape)\* 2>/dev/null |
         string escape -n
 )
 "


### PR DESCRIPTION
## Description

This should fix issue #6724 
I gave a quick look and figured out what the problem was.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
