### PR TITLE
doc: add links between the string-split and read commands

### DIFF
--- a/doc_src/cmds/read.rst
+++ b/doc_src/cmds/read.rst
@@ -32,7 +32,7 @@ The following options are available:
 
 - ``-p PROMPT_CMD`` or ``--prompt=PROMPT_CMD`` uses the output of the shell command ``PROMPT_CMD`` as the prompt for the interactive mode. The default prompt command is `set_color green; echo read; set_color normal; echo "> "`
 
-- ``-P PROMPT_STR`` or ``--prompt-str=PROMPT_STR`` uses the string as the prompt for the interactive mode. It is equivalent to `echo PROMPT_STR` and is provided solely to avoid the need to frame the prompt as a command. All special characters in the string are automatically escaped before being passed to the `echo` command.
+- ``-P PROMPT_STR`` or ``--prompt-str=PROMPT_STR`` uses the string as the prompt for the interactive mode. It is equivalent to `echo PROMPT_STR` and is provided solely to avoid the need to frame the prompt as a command. All special characters in the string are automatically escaped before being passed to the :ref:`echo <cmd-echo>` command.
 
 - ``-R RIGHT_PROMPT_CMD`` or ``--right-prompt=RIGHT_PROMPT_CMD`` uses the output of the shell command ``RIGHT_PROMPT_CMD`` as the right prompt for the interactive mode. There is no default right prompt command.
 
@@ -48,8 +48,7 @@ The following options are available:
 
 - ``-a`` or ``--list`` stores the result as a list in a single variable. This option is also available as ``--array`` for backwards compatibility.
 
-- ``-z`` or ``--null`` marks the end of the line with the NUL character, instead of newline. This also
-  disables interactive mode.
+- ``-z`` or ``--null`` marks the end of the line with the NUL character, instead of newline. This also disables interactive mode.
 
 - ``-L`` or ``--line`` reads each line into successive variables, and stops after each variable has been filled. This cannot be combined with the ``--delimiter`` option.
 

--- a/doc_src/cmds/string-split.rst
+++ b/doc_src/cmds/string-split.rst
@@ -20,7 +20,7 @@ Description
 
 ``string split`` splits each STRING on the separator SEP, which can be an empty string. If ``-m`` or ``--max`` is specified, at most MAX splits are done on each STRING. If ``-r`` or ``--right`` is given, splitting is performed right-to-left. This is useful in combination with ``-m`` or ``--max``. With ``-n`` or ``--no-empty``, empty results are excluded from consideration (e.g. ``hello\n\nworld`` would expand to two strings and not three). Exit status: 0 if at least one split was performed, or 1 otherwise.
 
-See also ``read --delimiter``.
+See also the ``--delimiter`` option of the :ref:`read <cmd-read>` command.
 
 ``string split0`` splits each STRING on the zero byte (NUL). Options are the same as ``string split`` except that no separator is given.
 


### PR DESCRIPTION
Hello

This PR adds various missing links between commands.
