### PR TITLE
fix(cd): remove duplicated comment introducing the cd builtin

### DIFF
--- a/src/builtin_cd.cpp
+++ b/src/builtin_cd.cpp
@@ -20,8 +20,6 @@
 
 /// The cd builtin. Changes the current directory to the one specified or to $HOME if none is
 /// specified. The directory can be relative to any directory in the CDPATH variable.
-/// The cd builtin. Changes the current directory to the one specified or to $HOME if none is
-/// specified. The directory can be relative to any directory in the CDPATH variable.
 int builtin_cd(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);


### PR DESCRIPTION
Hi

Nothing problematic. I've stumbled upon this comment which is repeated for no reason for `cd`.
Probably the result of an extra copy-paste.
