### PR TITLE
doc: Add note about opening help in web browser

### DIFF
--- a/doc_src/tutorial.rst
+++ b/doc_src/tutorial.rst
@@ -77,6 +77,24 @@ Getting Help
     set - handle shell variables
       Synopsis...
 
+.. note::
+
+    If the ``help`` command failed like::
+
+        > help set
+        gio: file:///usr/share/doc/fish/cmds/set.html: No application is registered as handling this file
+
+    then you need to register a web browser to handle these files::
+
+        > # Detect a MIME type
+        > xdg-mime query filetype /usr/share/doc/fish/cmds/set.html
+        application/x-extension-html
+        > # Detect your default browser (*.desktop files are mostly in /usr/share/applications/)
+        > xdg-settings get default-web-browser
+        firefox.desktop
+        > # Register the browser for the MIME type
+        > xdg-mime default firefox.desktop application/x-extension-html
+
 
 
 Syntax Highlighting


### PR DESCRIPTION
## Description

Hello, I was reading the Fish tutorial, tried myself commands by commands, and had a problem with the `help` command (my browser could not open the given help). Hopefully, I found a solution on StackOverflow after a while. However, I think it would be super to note it directly in the tutorial to save readers time with troubleshooting.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
