### PR TITLE
doc: add links to count and contains commands in list section

### DIFF
--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -970,6 +970,15 @@ When a list is exported as an environment variable, it is either space or colon 
 
 ``fish`` automatically creates lists from all environment variables whose name ends in PATH, by splitting them on colons. Other variables are not automatically split.
 
+Lists can be inspected with the :ref:`count <cmd-count>` or the :ref:`contains <cmd-contains>` commands::
+
+    count $smurf
+    # 2
+
+    contains blue $smurf
+    # key found, exits with status 0
+
+
 .. _variables-path:
 
 PATH variables


### PR DESCRIPTION
Hi

In this PR I completed the `smurf` examples of the section presenting list with links to 2 essential commands `count` and `contains`