### PR TITLE
chore: bump copyright year 2019 → 2020

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 Fish is a smart and user-friendly command line shell.
 
 Copyright (C) 2005-2009 Axel Liljencrantz
-Copyright (C) 2009-2019 fish-shell contributors
+Copyright (C) 2009-2020 fish-shell contributors
 
 fish is free software.
 

--- a/doc_src/conf.py
+++ b/doc_src/conf.py
@@ -53,7 +53,7 @@ highlight_language = "fish-docs-samples"
 # -- Project information -----------------------------------------------------
 
 project = "fish-shell"
-copyright = "2019, fish-shell developers"
+copyright = "2020, fish-shell developers"
 author = "fish-shell developers"
 
 # Parsing FISH-BUILD-VERSION-FILE is possible but hard to ensure that it is in the right place

--- a/doc_src/license.rst
+++ b/doc_src/license.rst
@@ -1,7 +1,7 @@
 License
 ========
 
-``fish`` Copyright © 2005-2009 Axel Liljencrantz, 2009-2019 fish-shell contributors. ``fish`` is released under the GNU General Public License, version 2.
+``fish`` Copyright © 2005-2009 Axel Liljencrantz, 2009-2020 fish-shell contributors. ``fish`` is released under the GNU General Public License, version 2.
 
 ``fish`` includes other code licensed under the GNU General Public License, version 2, including GNU ``printf``.
 


### PR DESCRIPTION
Hi

After greping for `2019` over the codebase, it seems to be the only dates that need update.