### PR TITLE
doc: make <kbd> style more prominent

### DIFF
--- a/doc_src/_static/custom.css
+++ b/doc_src/_static/custom.css
@@ -1,1 +1,10 @@
 .sphinxsidebar ul.current > li.current { font-weight: bold }
+
+kbd {
+  background-color: #f9f9f9;
+  border: 1px solid #aaa;
+  border-radius: .2em;
+  box-shadow: 0.1em 0.1em 0.2em rgba(0,0,0,0.1);
+  color: #000;
+  padding: 0.1em 0.3em;
+}


### PR DESCRIPTION
Hello

I know there are ongoing discussions about building a new nice graphical design for the fish documentation.
But I think there are also minor improvements to the current style that could improve readability regardless of the final skin.

The first low hanging fruit I would like to tackle are the keyboard shortcuts (`<kbd>`). An image is worth 1000 words, so here's a before/after comparison:

before
![image](https://user-images.githubusercontent.com/39315/76683877-a955d400-6607-11ea-9e58-b24aac2ff6a3.png)

after
![image](https://user-images.githubusercontent.com/39315/76683882-b2df3c00-6607-11ea-8b7f-c190fd9a7bd5.png)

This style is the one used on Wikipedia so it would feel familiar to a lot of people.