### PR TITLE
Re-adds `git restore` and `git switch` completions

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1564,6 +1564,13 @@ complete -f -c git -n '__fish_git_using_command rev-parse' -a '(__fish_git_branc
 complete -f -c git -n '__fish_git_using_command rev-parse' -a '(__fish_git_heads)' -d Head
 complete -k -c git -n '__fish_git_using_command rev-parse' -a '(__fish_git_tags)' -d Tag
 
+### restore
+complete -f -c git -n '__fish_git_needs_command' -a restore -d 'Restore working tree files'
+complete -f -c git -n '__fish_git_using_command restore' -s s -l source -d 'Specify the source tree used to restore working tree'
+complete -f -c git -n '__fish_git_using_command restore' -s p -l patch -d 'Interactive mode'
+complete -f -c git -n '__fish_git_using_command restore' -s W -l worktree -d 'Restore working tree (default)'
+complete -f -c git -n '__fish_git_using_command restore' -s S -l staged -d 'Restore the index'
+
 ### revert
 complete -f -c git -n __fish_git_needs_command -a revert -d 'Revert an existing commit'
 complete -f -c git -n '__fish_git_using_command revert' -ka '(__fish_git_commits)'
@@ -1589,6 +1596,15 @@ complete -f -c git -n '__fish_git_using_command status' -s z -d 'Terminate entri
 complete -f -c git -n '__fish_git_using_command status' -s u -l untracked-files -x -a 'no normal all' -d 'The untracked files handling mode'
 complete -f -c git -n '__fish_git_using_command status' -l ignore-submodules -x -a 'none untracked dirty all' -d 'Ignore changes to submodules'
 # TODO options
+
+### switch
+complete -f -c git -n '__fish_git_needs_command' -a switch -d 'Switch to a branch'
+complete -k -f -c git -n '__fish_git_using_command switch; and not contains -- -- (commandline -op)' -a '(__fish_git_branches)'
+complete -f -c git -n '__fish_git_using_command switch' -s c -l create -d 'Create a new branch'
+complete -f -c git -n '__fish_git_using_command switch' -s C -l force-create -d 'Force create a new branch'
+complete -f -c git -n '__fish_git_using_command switch' -s d -l detach -d 'Switch to a commit for inspection and discardable experiment'
+complete -f -c git -n '__fish_git_using_command switch' -l no-guess -d 'Do not guess branch name from remote branch'
+complete -f -c git -n '__fish_git_using_command switch' -l orphan -d 'Create a new orphan branch'
 
 ### tag
 complete -f -c git -n __fish_git_needs_command -a tag -d 'Create, list, delete or verify a tag object signed with GPG'


### PR DESCRIPTION
These commands were already added in version 2.23.
See: ecacf346932c4bbee9f40871b2763595243f3c70

Original Author: Shun Sakai | sorairolake

## Description

This has already been part of fish a while ago, but for some reason seems to be missing in current versions. I readded it here from https://github.com/fish-shell/fish-shell/commit/ecacf346932c4bbee9f40871b2763595243f3c70

Absolutely no credit goes to myself :)

If I am missing some reason they were removed or something else please let me know!

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
