### PR TITLE
Add vi 'y' bindings and some i / a support

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -153,6 +153,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset dT begin-selection backward-jump forward-char kill-selection end-selection
     bind -s --preset dh backward-char delete-char
     bind -s --preset dl delete-char
+    bind -s --preset di backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection
+    bind -s --preset da backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection
 
     bind -s --preset -m insert s delete-char repaint-mode
     bind -s --preset -m insert S kill-whole-line repaint-mode
@@ -179,6 +181,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert cT begin-selection backward-jump forward-char kill-selection end-selection repaint-mode
     bind -s --preset -m insert ch backward-char begin-selection kill-selection end-selection repaint-mode
     bind -s --preset -m insert cl begin-selection kill-selection end-selection repaint-mode
+    bind -s --preset -m insert ci backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection repaint-mode
+    bind -s --preset -m insert ca backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection repaint-mode
 
     bind -s --preset '~' capitalize-word
     bind -s --preset gu downcase-word
@@ -204,6 +208,14 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset yB backward-kill-bigword yank
     bind -s --preset yge backward-kill-word yank
     bind -s --preset ygE backward-kill-bigword yank
+    bind -s --preset yf begin-selection forward-jump kill-selection yank end-selection
+    bind -s --preset yt begin-selection forward-jump-till kill-selection yank end-selection
+    bind -s --preset yF begin-selection backward-jump kill-selection yank end-selection
+    bind -s --preset yT begin-selection backward-jump-till kill-selection yank end-selection
+    bind -s --preset yh backward-char begin-selection kill-selection yank end-selection
+    bind -s --preset yl begin-selection kill-selection yank end-selection
+    bind -s --preset yi backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection yank end-selection
+    bind -s --preset ya backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection yank end-selection
 
     bind -s --preset f forward-jump
     bind -s --preset F backward-jump


### PR DESCRIPTION
## Description

Many people have mentioned wanting support for changing / yanking /
deleting between "" and '', meaning the commands `ci' ci" yi' yi" di' di"`,
so this adds that support in a generic, and thus potentially confusing way.
The concept is that we check for the character backwards and forwards
before making the selection.  Unfortunately, this will also work for *any*
character that isn't `w` or `W`, so `cia` could change everything between
two `a` characters.
Looking through the [bind documentation](https://fishshell.com/docs/current/cmds/bind.html)
and input handler at `src/input.cpp`,
this is the best possible solution I could come up with until
`forward-jump` and `backward-jump` can accept input in the call to `bind`,
and not just from stdin, meaning we can write a binding as:
```
bind di\" backward-jump-till \" and repeat-jump-reverse ...`
```
If that were done, then other commands such as `di)` to go between `()` would
be possible.
There are also some added `y` bindings not part of #6648.
Let me know if you need anything else.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
