### PR TITLE
Add `--fields` opt to `string split`

### DIFF
--- a/doc_src/cmds/string-split.rst
+++ b/doc_src/cmds/string-split.rst
@@ -8,8 +8,8 @@ Synopsis
 
 ::
 
-    string split [(-m | --max) MAX] [(-n | --no-empty)] [(-q | --quiet)] [(-r | --right)] SEP [STRING...]
-    string split0 [(-m | --max) MAX] [(-n | --no-empty)] [(-q | --quiet)] [(-r | --right)] [STRING...]
+    string split [(-f | --fields) FIELDS] [(-m | --max) MAX] [(-n | --no-empty)] [(-q | --quiet)] [(-r | --right)] SEP [STRING...]
+    string split0 [(-f | --fields) FIELDS] [(-m | --max) MAX] [(-n | --no-empty)] [(-q | --quiet)] [(-r | --right)] [STRING...]
 
 .. END SYNOPSIS
 
@@ -18,7 +18,7 @@ Description
 
 .. BEGIN DESCRIPTION
 
-``string split`` splits each STRING on the separator SEP, which can be an empty string. If ``-m`` or ``--max`` is specified, at most MAX splits are done on each STRING. If ``-r`` or ``--right`` is given, splitting is performed right-to-left. This is useful in combination with ``-m`` or ``--max``. With ``-n`` or ``--no-empty``, empty results are excluded from consideration (e.g. ``hello\n\nworld`` would expand to two strings and not three). Exit status: 0 if at least one split was performed, or 1 otherwise.
+``string split`` splits each STRING on the separator SEP, which can be an empty string. If ``-m`` or ``--max`` is specified, at most MAX splits are done on each STRING. If ``-r`` or ``--right`` is given, splitting is performed right-to-left. This is useful in combination with ``-m`` or ``--max``. With ``-n`` or ``--no-empty``, empty results are excluded from consideration (e.g. ``hello\n\nworld`` would expand to two strings and not three). Use ``-f`` or ``--fields`` to print out specific fields. Exit status: 0 if at least one split was performed, or 1 otherwise.
 
 See also the ``--delimiter`` option of the :ref:`read <cmd-read>` command.
 
@@ -48,6 +48,11 @@ Examples
     a
     b
     c
+
+    >_ string split -f1,3 '' abc
+    a
+    c
+
 
 NUL Delimited Examples
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/share/completions/amixer.fish
+++ b/share/completions/amixer.fish
@@ -1,6 +1,6 @@
 set -l cmds 'scontrols scontents controls contents sget sset cset cget set get'
 complete -c amixer -xa "$cmds" -n "not __fish_seen_subcommand_from $cmds"
-complete -c amixer -n '__fish_seen_subcommand_from sset sget get set' -xa "(amixer scontrols | cut --delimiter \' --fields 2)"
+complete -c amixer -n '__fish_seen_subcommand_from sset sget get set' -xa "(amixer scontrols | string split -f 2 \')"
 
 complete -c amixer -s h -l help -d 'this help'
 complete -c amixer -s c -l card -r -d 'select the card'

--- a/share/completions/fuser.fish
+++ b/share/completions/fuser.fish
@@ -1,7 +1,6 @@
 __fish_make_completion_signals
 for i in $__kill_signals
-    set number (echo $i | cut -d " " -f 1)
-    set name (echo $i | cut -d " " -f 2)
+    string split -f 1,2 " " -- $i | read --line number name
     complete -c fuser -o $number -d $name
     complete -c fuser -o $name -d $name
 end

--- a/share/completions/journalctl.fish
+++ b/share/completions/journalctl.fish
@@ -16,7 +16,7 @@ function __fish_journalctl_is_field
 end
 
 function __fish_journalctl_field_values
-    set -l token (commandline -t | cut -d"=" -f 1)
+    set -l token (commandline -t | string split -f1 =)
     command journalctl -F $token 2>/dev/null | while read value
         echo $token=$value
     end

--- a/share/completions/string.fish
+++ b/share/completions/string.fish
@@ -12,6 +12,7 @@ complete -x -c string -n "test (count (commandline -opc)) -ge 2; and contains --
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a split
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a split0
 complete -x -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr split0\?\$ -- (commandline -opc)[2]' -s m -l max -a "(seq 1 10)" -d "Specify maximum number of splits"
+complete -x -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr split0\?\$ -- (commandline -opc)[2]' -s f -l fields -a "(seq 1 10)" -d "Specify fields"
 complete -f -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr split0\?\$ -- (commandline -opc)[2]' -s r -l right -d "Split right-to-left"
 complete -f -c string -n 'test (count (commandline -opc)) -ge 2; and string match -qr split0\?\$ -- (commandline -opc)[2]' -s n -l no-empty -d "Empty results excluded"
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a collect

--- a/share/completions/svn.fish
+++ b/share/completions/svn.fish
@@ -320,12 +320,12 @@ _svn_cmpl_ svn:keywords -a Id -d 'A compressed summary of all keywords'
 #
 # Completions for the 'relocate' subcommand
 #
-_svn_cmpl_ $relocate -xa '( svn info | string match "*URL:*" | cut -d " " -f 2 ) http:// ftp:// svn+ssh:// svn+ssh://(__fish_print_hostnames)'
+_svn_cmpl_ $relocate -xa '( svn info | string match "*URL:*" | string split -f2 " ") http:// ftp:// svn+ssh:// svn+ssh://(__fish_print_hostnames)'
 
 #
 # Completions for the 'switch', 'sw' subcommands
 #
-_svn_cmpl_ $switch -l relocate -d 'Relocate via URL-rewriting' -xa '( svn info | string match "*URL:*" | cut -d " " -f 2 ) http:// ftp:// svn+ssh:// svn+ssh://(__fish_print_hostnames)'
+_svn_cmpl_ $switch -l relocate -d 'Relocate via URL-rewriting' -xa '( svn info | string match "*URL:*" | string split -f2 " ") http:// ftp:// svn+ssh:// svn+ssh://(__fish_print_hostnames)'
 
 #
 # Completions for the 'status', 'st' subcommands

--- a/share/completions/tokei.fish
+++ b/share/completions/tokei.fish
@@ -3,7 +3,7 @@
 function __fish_tokei_supported_serializations
     # Expecting a line like:
     # tokei 10.0.1 compiled with serialization support: cbor, json, yaml
-    command tokei --help | grep 'with serialization support' | cut -d : -f 2 | string trim | string split ', '
+    command tokei --help | grep 'with serialization support' | string split --fields 2 : | string trim | string split ', '
 end
 
 complete -c tokei -s f -l files -d 'Print out statistics for individual files'

--- a/share/completions/useradd.fish
+++ b/share/completions/useradd.fish
@@ -7,7 +7,7 @@
 
 complete -c useradd -s c -l comment -d 'A comment about this user' -r
 complete -c useradd -s d -l home -d 'Home directory for the new user' -x -a '(__fish_complete_directories)'
-complete -c useradd -s G -l groups -d 'Supplementary groups' -xa '(__fish_append , (cut -d : -f 1 /etc/group))'
+complete -c useradd -s G -l groups -d 'Supplementary groups' -xa '(__fish_append , (string split -f1 : /etc/group))'
 complete -c useradd -s h -l help -d 'Display help message and exit'
 complete -c useradd -s m -l create-home -d 'The user\'s home directory will be created if it does not exist'
 complete -c useradd -s n -d 'A group having the same name as the user being added to the system will be created by default (when -g is not specified)'
@@ -18,5 +18,5 @@ complete -c useradd -s u -l uid -d 'The numerical value of the user\'s ID' -r
 complete -c useradd -s b -l base-dir -d 'The initial path prefix for a new user\'s home directory' -r -a '(__fish_complete_directories)'
 complete -c useradd -s e -l expiredate -d 'The date on which the user account is disabled' -r
 complete -c useradd -s f -l inactive -d 'The number of days after a password has expired before the account will be disabled' -r
-complete -c useradd -s g -l gid -d 'The group name or ID for a new user\'s initial group' -x -a '(string match -r "^[^#].*" < /etc/group | cut -d : -f 1,3 | string replace -a ":" \n)'
+complete -c useradd -s g -l gid -d 'The group name or ID for a new user\'s initial group' -x -a '(string match -r "^[^#].*" < /etc/group | string split -f1,3 ":" | string join ":" | string replace -a ":" \n)'
 complete -c useradd -s s -l shell -d 'Name of the new user\'s login shell' -x -a '(string match -r "^[^#].*" < /etc/shells)'

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -162,7 +162,7 @@ function help --description 'Show help for the fish shell'
         end
     else
         # Go to the web. Only include one dot in the version string
-        set -l version_string (echo $version| cut -d . -f 1,2)
+        set -l version_string (string split . -f 1,2 -- $version | string join .)
         set page_url https://fishshell.com/docs/$version_string/$fish_help_page
         # We don't need a trampoline for a remote URL.
         set need_trampoline

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -433,28 +433,18 @@ static wcstring construct_short_opts(options_t *opts) {  //!OCLINT(high npath co
 // Note that several long flags share the same short flag. That is okay. The caller is expected
 // to indicate that a max of one of the long flags sharing a short flag is valid.
 // Remember: adjust share/completions/string.fish when `string` options change
-static const struct woption long_options[] = {{L"all", no_argument, nullptr, 'a'},
-                                              {L"chars", required_argument, nullptr, 'c'},
-                                              {L"count", required_argument, nullptr, 'n'},
-                                              {L"entire", no_argument, nullptr, 'e'},
-                                              {L"filter", no_argument, nullptr, 'f'},
-                                              {L"ignore-case", no_argument, nullptr, 'i'},
-                                              {L"index", no_argument, nullptr, 'n'},
-                                              {L"invert", no_argument, nullptr, 'v'},
-                                              {L"left", no_argument, nullptr, 'l'},
-                                              {L"length", required_argument, nullptr, 'l'},
-                                              {L"max", required_argument, nullptr, 'm'},
-                                              {L"no-empty", no_argument, nullptr, 'n'},
-                                              {L"no-newline", no_argument, nullptr, 'N'},
-                                              {L"no-quoted", no_argument, nullptr, 'n'},
-                                              {L"quiet", no_argument, nullptr, 'q'},
-                                              {L"regex", no_argument, nullptr, 'r'},
-                                              {L"right", no_argument, nullptr, 'r'},
-                                              {L"start", required_argument, nullptr, 's'},
-                                              {L"style", required_argument, nullptr, 1},
-                                              {L"no-trim-newlines", no_argument, nullptr, 'N'},
-                                              {L"fields", required_argument, nullptr, 'f'},
-                                              {nullptr, 0, nullptr, 0}};
+static const struct woption long_options[] = {
+    {L"all", no_argument, nullptr, 'a'},          {L"chars", required_argument, nullptr, 'c'},
+    {L"count", required_argument, nullptr, 'n'},  {L"entire", no_argument, nullptr, 'e'},
+    {L"filter", no_argument, nullptr, 'f'},       {L"ignore-case", no_argument, nullptr, 'i'},
+    {L"index", no_argument, nullptr, 'n'},        {L"invert", no_argument, nullptr, 'v'},
+    {L"left", no_argument, nullptr, 'l'},         {L"length", required_argument, nullptr, 'l'},
+    {L"max", required_argument, nullptr, 'm'},    {L"no-empty", no_argument, nullptr, 'n'},
+    {L"no-newline", no_argument, nullptr, 'N'},   {L"no-quoted", no_argument, nullptr, 'n'},
+    {L"quiet", no_argument, nullptr, 'q'},        {L"regex", no_argument, nullptr, 'r'},
+    {L"right", no_argument, nullptr, 'r'},        {L"start", required_argument, nullptr, 's'},
+    {L"style", required_argument, nullptr, 1},    {L"no-trim-newlines", no_argument, nullptr, 'N'},
+    {L"fields", required_argument, nullptr, 'f'}, {nullptr, 0, nullptr, 0}};
 
 static const std::unordered_map<char, decltype(*handle_flag_N)> flag_to_function = {
     {'N', handle_flag_N}, {'a', handle_flag_a}, {'c', handle_flag_c}, {'e', handle_flag_e},

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -260,15 +260,47 @@ static int handle_flag_f(wchar_t **argv, parser_t &parser, io_streams_t &streams
         return STATUS_CMD_OK;
     } else if (opts->fields_valid) {
         for (const wcstring &s : split_string(w.woptarg, L',')) {
-            int field = fish_wcstoi(wcsdup(s.c_str()));
-            if (field <= 0 || field == INT_MIN || errno == ERANGE) {
-                string_error(streams, _(L"%ls: Invalid fields value '%ls'\n"), argv[0], w.woptarg);
-                return STATUS_INVALID_ARGS;
-            } else if (errno) {
-                string_error(streams, BUILTIN_ERR_NOT_NUMBER, argv[0], w.woptarg);
-                return STATUS_INVALID_ARGS;
+            wcstring_list_t range = split_string(s, L'-');
+            if (range.size() == 2) {
+                int begin = fish_wcstoi(wcsdup(range.at(0).c_str()));
+                if (begin <= 0 || begin == INT_MIN || errno == ERANGE) {
+                    string_error(streams, _(L"%ls: Invalid range value for field '%ls'\n"), argv[0],
+                                 w.woptarg);
+                    return STATUS_INVALID_ARGS;
+                } else if (errno) {
+                    string_error(streams, BUILTIN_ERR_NOT_NUMBER, argv[0], w.woptarg);
+                    return STATUS_INVALID_ARGS;
+                }
+                int end = fish_wcstoi(wcsdup(range.at(1).c_str()));
+                if (end <= 0 || end == INT_MIN || errno == ERANGE) {
+                    string_error(streams, _(L"%ls: Invalid range value for field '%ls'\n"), argv[0],
+                                 w.woptarg);
+                    return STATUS_INVALID_ARGS;
+                } else if (errno) {
+                    string_error(streams, BUILTIN_ERR_NOT_NUMBER, argv[0], w.woptarg);
+                    return STATUS_INVALID_ARGS;
+                }
+                if (begin <= end) {
+                    for (int i = begin; i <= end; i++) {
+                        opts->fields.push_back(i);
+                    }
+                } else {
+                    for (int i = begin; i >= end; i--) {
+                        opts->fields.push_back(i);
+                    }
+                }
+            } else {
+                int field = fish_wcstoi(wcsdup(s.c_str()));
+                if (field <= 0 || field == INT_MIN || errno == ERANGE) {
+                    string_error(streams, _(L"%ls: Invalid fields value '%ls'\n"), argv[0],
+                                 w.woptarg);
+                    return STATUS_INVALID_ARGS;
+                } else if (errno) {
+                    string_error(streams, BUILTIN_ERR_NOT_NUMBER, argv[0], w.woptarg);
+                    return STATUS_INVALID_ARGS;
+                }
+                opts->fields.push_back(field);
             }
-            opts->fields.push_back(field);
         }
         return STATUS_CMD_OK;
     }

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1166,9 +1166,12 @@ static int string_split_maybe0(parser_t &parser, io_streams_t &streams, int argc
         if (opts.fields.size() > 0) {
             for (const auto &field : opts.fields) {
                 // field indexing starts from 1
-                if (field - 1 < (long)split_count) {
-                    buff.append(splits.at(field - 1), separation_type_t::explicitly);
+                if (field - 1 >= (long)split_count) {
+                    return STATUS_CMD_ERROR;
                 }
+            }
+            for (const auto &field : opts.fields) {
+                buff.append(splits.at(field - 1), separation_type_t::explicitly);
             }
         } else {
             for (const wcstring &split : splits) {

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1,5 +1,5 @@
 // Implementation of the string builtin.
-#include "config.h"
+#include "config.h"  // IWYU pragma: keep
 
 #define PCRE2_CODE_UNIT_WIDTH WCHAR_T_BITS
 #ifdef _WIN32

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -95,8 +95,8 @@ string split --fields=3,2 "" abc
 # CHECK: c
 # CHECK: b
 
-string split --fields=2,9 "" abc
-# CHECK: b
+string split --fields=2,9 "" abc; or echo "exit 1"
+# CHECK: exit 1
 
 string split --fields=1-3,5,9-7 "" 123456789
 # CHECK: 1

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -64,6 +64,16 @@ string split "" abc
 # CHECK: b
 # CHECK: c
 
+string split --fields=2 "" abc
+# CHECK: b
+
+string split --fields=2,3 "" abc
+# CHECK: b
+# CHECK: c
+
+string split --fields=2,9 "" abc
+# CHECK: b
+
 seq 3 | string join ...
 # CHECK: 1...2...3
 

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -67,12 +67,21 @@ string split "" abc
 string split --fields=2 "" abc
 # CHECK: b
 
-string split --fields=2,3 "" abc
-# CHECK: b
+string split --fields=3,2 "" abc
 # CHECK: c
+# CHECK: b
 
 string split --fields=2,9 "" abc
 # CHECK: b
+
+string split --fields=1-3,5,9-7 "" 123456789
+# CHECK: 1
+# CHECK: 2
+# CHECK: 3
+# CHECK: 5
+# CHECK: 9
+# CHECK: 8
+# CHECK: 7
 
 seq 3 | string join ...
 # CHECK: 1...2...3


### PR DESCRIPTION
## Description

Adds `--fields` option to `string split`, similar to the one `cut` has.

- Fields can be specified as a comma separated string
- Indexing starts at 1. Non-positive fields error out the function
- Each field is printed on a newline, same as current `string split` behaviour
- Non-existent fields cause function to error out (whereas `cut` skips over them)

```
> string split --fields=1,9,3 ";" "a;b;c"
[ret 1]
>
>echo "a;b;c" | cut -d';' -f1,9,3
a;c
```

Fixes issue #

...Need to find out the issue where this may have been mentioned...

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added
- [ ] User-visible changes noted in CHANGELOG.md
     