### PR TITLE
feat: add missing 'save' completion for funced

### DIFF
--- a/share/completions/funced.fish
+++ b/share/completions/funced.fish
@@ -1,3 +1,4 @@
 complete -c funced -xa "(functions -na)" -d "Save function"
 complete -c funced -s e -l editor -d 'Open function in external editor' -xa '(__fish_complete_command)'
 complete -c funced -s i -l interactive -d 'Edit in interactive mode'
+complete -c funced -s s -l save -d 'Autosave after successful edit'


### PR DESCRIPTION
Hello

The `funced` `-s/save` option is mentioned in the doc and in the code, but the completion was missing.