### PR TITLE
Use pkg-config variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### For distributors and developers
 - fish source tarballs are now distributed using the XZ compression method (#5460).
 - Allow finishing builds on OS X <10.13.6 (previously builds would fail at the `codesign` step)
+- The pkg-config file now uses pkg-config variables
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - fish source tarballs are now distributed using the XZ compression method (#5460).
 - Allow finishing builds on OS X <10.13.6 (previously builds would fail at the `codesign` step)
 - The pkg-config file now uses pkg-config variables
+- The default values for the extra_completionsdir, extra_functionsdir and extra_confdir options now use the installation prefix instead of hardcoding `/usr/local`
 
 ---
 

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -29,15 +29,15 @@ set(rel_functionsdir "fish/vendor_functions.d")
 set(rel_confdir "fish/vendor_conf.d")
 
 set(extra_completionsdir
-    "/usr/local/share/${rel_completionsdir}"
+    "${datadir}/${rel_completionsdir}"
     CACHE STRING "Path for extra completions")
 
 set(extra_functionsdir
-    "/usr/local/share/${rel_functionsdir}"
+    "${datadir}/${rel_functionsdir}"
     CACHE STRING "Path for extra functions")
 
 set(extra_confdir
-    "/usr/local/share/${rel_confdir}"
+    "${datadir}/${rel_confdir}"
     CACHE STRING "Path for extra configuration")
 
 # These are the man pages that go in system manpath; all manpages go in the fish-specific manpath.

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -24,16 +24,20 @@ set(configure_input
 "This file was generated from a corresponding .in file.\
  DO NOT MANUALLY EDIT THIS FILE!")
 
+set(rel_completionsdir "fish/vendor_completions.d")
+set(rel_functionsdir "fish/vendor_functions.d")
+set(rel_confdir "fish/vendor_conf.d")
+
 set(extra_completionsdir
-    /usr/local/share/fish/vendor_completions.d
+    "/usr/local/share/${rel_completionsdir}"
     CACHE STRING "Path for extra completions")
 
 set(extra_functionsdir
-    /usr/local/share/fish/vendor_functions.d
+    "/usr/local/share/${rel_functionsdir}"
     CACHE STRING "Path for extra functions")
 
 set(extra_confdir
-    /usr/local/share/fish/vendor_conf.d
+    "/usr/local/share/${rel_confdir}"
     CACHE STRING "Path for extra configuration")
 
 # These are the man pages that go in system manpath; all manpages go in the fish-specific manpath.
@@ -99,7 +103,7 @@ fish_create_dirs(${rel_datadir}/fish/vendor_completions.d ${rel_datadir}/fish/ve
     ${rel_datadir}/fish/vendor_conf.d)
 
 fish_try_create_dirs(${rel_datadir}/pkgconfig)
-configure_file(fish.pc.in fish.pc.noversion)
+configure_file(fish.pc.in fish.pc.noversion @ONLY)
 
 add_custom_command(OUTPUT fish.pc
     COMMAND sed '/Version/d' fish.pc.noversion > fish.pc

--- a/fish.pc.in
+++ b/fish.pc.in
@@ -1,8 +1,8 @@
 prefix=@prefix@
-datadir=@datadir@
-completionsdir=@extra_completionsdir@
-functionsdir=@extra_functionsdir@
-confdir=@extra_confdir@
+datadir=${prefix}/@rel_datadir@
+completionsdir=${datadir}/@rel_completionsdir@
+functionsdir=${datadir}/@rel_functionsdir@
+confdir=${datadir}/@rel_confdir@
 
 Name: fish
 Description: fish, the friendly interactive shell


### PR DESCRIPTION
This allows all variables to be set properly when the prefix or datadir changes.

The generated .pc file looks like this:

    prefix=/usr/local
    datadir=${prefix}/share
    completionsdir=${datadir}/fish/vendor_completions.d
    functionsdir=${datadir}/fish/vendor_functions.d
    confdir=${datadir}/fish/vendor_conf.d

    Name: fish
    Description: fish, the friendly interactive shell
    URL: https://fishshell.com/
    Version: 3.1.0-402-g75ae172ba228-dirty

Closes: https://bugs.archlinux.org/task/65904