### PR TITLE
doc: add links to 'source' command from 'eval' and 'functions'

### DIFF
--- a/doc_src/cmds/eval.rst
+++ b/doc_src/cmds/eval.rst
@@ -15,7 +15,7 @@ Description
 -----------
 ``eval`` evaluates the specified parameters as a command. If more than one parameter is specified, all parameters will be joined using a space character as a separator.
 
-If your command does not need access to stdin, consider using ``source`` instead.
+If your command does not need access to stdin, consider using :ref:`source <cmd-source>` instead.
 
 If no piping or other compound shell constructs are required, variable-expansion-as-command, as in  ``set cmd ls -la; $cmd``, is also an option.
 

--- a/doc_src/cmds/functions.rst
+++ b/doc_src/cmds/functions.rst
@@ -29,7 +29,7 @@ The following options are available:
 
 - ``-e`` or ``--erase`` causes the specified functions to be erased. This also means that it is prevented from autoloading.
 
-- ``-D`` or ``--details`` reports the path name where the specified function is defined or could be autoloaded, ``stdin`` if the function was defined interactively or on the command line or by reading stdin, ``-`` if the function was created via ``source``, and ``n/a`` if the function isn't available. (Functions created via ``alias`` will return ``-``, because ``alias`` uses ``source`` internally.) If the ``--verbose`` option is also specified then five lines are written:
+- ``-D`` or ``--details`` reports the path name where the specified function is defined or could be autoloaded, ``stdin`` if the function was defined interactively or on the command line or by reading stdin, ``-`` if the function was created via :ref:`source <cmd-source>`, and ``n/a`` if the function isn't available. (Functions created via :ref:`alias <cmd-alias>` will return ``-``, because ``alias`` uses ``source`` internally.) If the ``--verbose`` option is also specified then five lines are written:
 
     - the pathname as already described,
     - ``autoloaded``, ``not-autoloaded`` or ``n/a``,


### PR DESCRIPTION
Hi

This PR add more links pointing to the `source` command.
