### PR TITLE
help function: special case string commands

### DIFF
--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -1,6 +1,6 @@
 function help --description 'Show help for the fish shell'
     set -l options h/help
-    argparse -n help --max-args=1 $options -- $argv
+    argparse -n help $options -- $argv
     or return
 
     if set -q _flag_help
@@ -9,6 +9,15 @@ function help --description 'Show help for the fish shell'
     end
 
     set -l fish_help_item $argv[1]
+    if test (count $argv) -gt 1
+        if string match -q string $argv[1]
+            set fish_help_item (string join '-' $argv[1] $argv[2])
+        else
+            echo "help: Expected at most 1 args, got 2"
+            return 1
+        end
+    end
+
     set -l help_topics syntax completion editor job-control todo bugs history killring help
     set -a help_topics color prompt title variables builtin-overview changes expand
     set -a help_topics expand-variable expand-home expand-brace expand-wildcard


### PR DESCRIPTION
> @ammgws
> 23:11
> The help function currently only accepts max of one argument, however regarding the builtin string functions, I often find myself typing `help string replace` instead of `help string-replace`, due to the former being the way the command is actually used. Would a special case for `help string xxx` be welcome?
> @faho
> 23:14
> @ammgws Sure, sounds good!
