### PR TITLE
fish_indent: Make indentation configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Scripting improvements
 - Range limits in index range expansions like `$x[$start..$end]` may be omitted: `$start` and `$end` default to 1 and -1 (the last item) respectively.
+- `fish_indent` now accepts an `-i`/`--indent` parameter to specify custom levels of indentation. As a result, the short flag for `--no-indent` has been renamed from `-i` to the more fitting `-I` (#6790).
 
 ### Interactive improvements
 

--- a/doc_src/cmds/fish_indent.rst
+++ b/doc_src/cmds/fish_indent.rst
@@ -20,7 +20,9 @@ The following options are available:
 
 - ``-w`` or ``--write`` indents a specified file and immediately writes to that file.
 
-- ``-i`` or ``--no-indent`` do not indent commands; only reformat to one job per line.
+- ``-i`` or ``--indent`` number of spaces per indentation level (default: 4).
+
+- ``-I`` or ``--no-indent`` do not indent commands; only reformat to one job per line.
 
 - ``-v`` or ``--version`` displays the current fish version and then exits.
 

--- a/share/completions/fish_indent.fish
+++ b/share/completions/fish_indent.fish
@@ -1,6 +1,7 @@
 complete -c fish_indent -s h -l help -d 'Display help and exit'
 complete -c fish_indent -s v -l version -d 'Display version and exit'
-complete -c fish_indent -s i -l no-indent -d 'Do not indent output, only reformat into one job per line'
+complete -c fish_indent -s i -l indent -d 'Number of indent spaces'
+complete -c fish_indent -s I -l no-indent -d 'Do not indent output, only reformat into one job per line'
 complete -c fish_indent -l ansi -d 'Colorize the output using ANSI escape sequences'
 complete -c fish_indent -l html -d 'Output in HTML format'
 complete -c fish_indent -s w -l write -d 'Write to file'

--- a/tests/checks/indent.fish
+++ b/tests/checks/indent.fish
@@ -180,7 +180,7 @@ switch beta
        echo delta
 end
 end
-' | $fish_indent -i
+' | $fish_indent -I
 #CHECK: if true
 #CHECK: else if false
 #CHECK: {{^}}echo alpha


### PR DESCRIPTION
Introduces a new `-i/--indent` option, allowing the user to override the
default indentation level of 4. I personally prefer 2 spaces-per-indent
and want to enable format-on-save for my personal fish scripts, but am
unable to do so currently because `fish_indent` insists on 4 spaces.

I also renamed the short option for `--no-indent` from `-i` to `-I` as I
could only find one reference to it in the fish codebase, and I really
don't expect end users will be using this. Additionally, with
indentation being configurable now, `--no-indent` becomes equivalent to
`--indent=0`.