### PR TITLE
Allow finishing build on OS X <10.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### For distributors and developers
 - fish source tarballs are now distributed using the XZ compression method (#5460).
+- Allow finishing builds on OS X <10.13.6 (previously builds would fail at the `codesign` step)
 
 ---
 

--- a/cmake/Mac.cmake
+++ b/cmake/Mac.cmake
@@ -9,16 +9,27 @@ set(MAC_INJECT_GET_TASK_ALLOW ON CACHE BOOL "Inject get-task-allow on Mac")
 
 function(CODESIGN_ON_MAC target)
   if(APPLE)
+    execute_process(COMMAND sw_vers "-productVersion" OUTPUT_VARIABLE OSX_VERSION)
     if(MAC_INJECT_GET_TASK_ALLOW)
       set(ENTITLEMENTS "--entitlements" "${CMAKE_SOURCE_DIR}/osx/fish_debug.entitlements")
     else()
       set(ENTITLEMENTS "")
     endif(MAC_INJECT_GET_TASK_ALLOW)
-    add_custom_command(
-      TARGET ${target}
-      POST_BUILD
-      COMMAND codesign --force --deep --options runtime ${ENTITLEMENTS} --sign "${MAC_CODESIGN_ID}" $<TARGET_FILE:${target}>
-      VERBATIM
-    )
+    if(OSX_VERSION VERSION_LESS "10.13.6")
+      # `-options runtime` is only available in OS X from 10.13.6 and up
+      add_custom_command(
+        TARGET ${target}
+        POST_BUILD
+        COMMAND codesign --force --deep ${ENTITLEMENTS} --sign "${MAC_CODESIGN_ID}" $<TARGET_FILE:${target}>
+        VERBATIM
+      )
+    else()
+      add_custom_command(
+        TARGET ${target}
+        POST_BUILD
+        COMMAND codesign --force --deep --options runtime ${ENTITLEMENTS} --sign "${MAC_CODESIGN_ID}" $<TARGET_FILE:${target}>
+        VERBATIM
+      )
+    endif()
   endif()
 endfunction(CODESIGN_ON_MAC target)


### PR DESCRIPTION
## Description

Building on OS X versions prior to 10.13.6 fails at the very end when running `codesign`.
The `-options runtime`-argument isn't available on these earlier versions of the OS.

Simply running codesign without that argument on OS X <10.13.6 seems to produce a runnable binary with no security warnings. I'm on OS X 10.12.6, and but have not tested on setups than other my own, so I could have a lax security setting allowing this to work.
In any case the situation for people OS X <10.13.6 should be better as the build will at least finish with the.

Fixes issue https://github.com/fish-shell/fish-shell/issues/6792

This code change is most easily understood when ignoring whitespace (`git diff -w`: https://github.com/fish-shell/fish-shell/pull/6791/files?w=1)

Apple docs: https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087724


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
   _I don't think we need to change the docs. This is more a incompatibility fix/bug than a new feature or change._
- [ ] Tests have been added for regressions fixed
  _Unless, a specific setup for building on an older OS X setup becomes part of CI (I don't think it should), we can't write a test for this._
- [x] User-visible changes noted in CHANGELOG.md
