### PR TITLE
string/trim: Add VT to list of default chars

### DIFF
--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -177,7 +177,7 @@ typedef struct {  //!OCLINT(too many fields)
     long start = 0;
     long end = 0;
 
-    const wchar_t *chars_to_trim = L" \f\n\r\t";
+    const wchar_t *chars_to_trim = L" \f\n\r\t\v";
     const wchar_t *arg1 = nullptr;
     const wchar_t *arg2 = nullptr;
 


### PR DESCRIPTION
In line with https://en.cppreference.com/w/cpp/string/byte/isspace