### PR TITLE
Avoid failing tests if a username starting with `haha` exists

### DIFF
--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3228,11 +3228,11 @@ static void test_autosuggest_suggest_special() {
                                        __LINE__);
 
     // Don't crash on ~ (issue #2696). Note this is cwd dependent.
-    if (system("mkdir -p '~hahaha/path1/path2/'")) err(L"mkdir failed");
-    perform_one_autosuggestion_cd_test(L"cd ~haha", L"ha/path1/path2/", vars, __LINE__);
-    perform_one_autosuggestion_cd_test(L"cd ~hahaha/", L"path1/path2/", vars, __LINE__);
-    perform_one_completion_cd_test(L"cd ~haha", L"ha/", vars, __LINE__);
-    perform_one_completion_cd_test(L"cd ~hahaha/", L"path1/", vars, __LINE__);
+    if (system("mkdir -p '~absolutelynosuchuser/path1/path2/'")) err(L"mkdir failed");
+    perform_one_autosuggestion_cd_test(L"cd ~absolutelynosuchus", L"er/path1/path2/", vars, __LINE__);
+    perform_one_autosuggestion_cd_test(L"cd ~absolutelynosuchuser/", L"path1/path2/", vars, __LINE__);
+    perform_one_completion_cd_test(L"cd ~absolutelynosuchus", L"er/", vars, __LINE__);
+    perform_one_completion_cd_test(L"cd ~absolutelynosuchuser/", L"path1/", vars, __LINE__);
 
     parser_t::principal_parser().vars().remove(L"HOME", ENV_LOCAL | ENV_EXPORT);
     popd();


### PR DESCRIPTION
## Description

Currently if the local machine has one or more users starting with `haha`, then the cd completion tests fail, because `~haha` will complete to those username(s).

To ensure that only the directory completions expected by the test are surfaced, switch the tests to use a less likely to collide prefix, `~absolutelynosuchus`

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [n/a] Changes to fish usage are reflected in user documentation/manpages.
- [n/a] Tests have been added for regressions fixed
- [n/a] User-visible changes noted in CHANGELOG.md

This is an infrastructure improvement, there is no user-visible impact.
