### PR TITLE
jobs: suppress "No suitable job" if -q is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Notable improvements and fixes
 - `fish --no-execute` will no longer complain about unknown commands or non-matching wildcards, as these could be defined differently at runtime (especially for functions). #977
+- `jobs --quiet PID` will no longer print 'no suitable job' if the job for PID does not exist (e.g. because it has finished). #6809
 
 ### Syntax changes and new commands
 

--- a/src/builtin_jobs.cpp
+++ b/src/builtin_jobs.cpp
@@ -209,7 +209,9 @@ int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                     builtin_jobs_print(j, mode, false, streams);
                     found = true;
                 } else {
-                    streams.err.append_format(_(L"%ls: No suitable job: %ls\n"), cmd, argv[i]);
+                    if (mode != JOBS_PRINT_NOTHING) {
+                        streams.err.append_format(_(L"%ls: No suitable job: %ls\n"), cmd, argv[i]);
+                    }
                     return STATUS_CMD_ERROR;
                 }
             }

--- a/tests/checks/jobs.fish
+++ b/tests/checks/jobs.fish
@@ -24,6 +24,21 @@ jobs -c
 #CHECK: Command
 #CHECK: sleep
 #CHECK: sleep
+jobs 1
+echo $status
+#CHECK: 1
+#CHECKERR: jobs: No suitable job: 1
+jobs foo
+echo $status
+#CHECK: 2
+#CHECKERR: jobs: 'foo' is not a valid process id
+jobs -q 1
+echo $status
+#CHECK: 1
+jobs -q foo
+echo $status
+#CHECK: 2
+#CHECKERR: jobs: 'foo' is not a valid process id
 disown foo
 #CHECKERR: disown: 'foo' is not a valid job specifier
 disown (jobs -p)


### PR DESCRIPTION
## Description

This allows code of the form `if jobs -q $some_pid` in scripts to check whether a previously started job is still running. Previously this would return the correct value, but also print an error message.

The invalid argument errors will still be printed.
Added test cases for both.

Fixes issue #6809

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
    Sort of. The documentation already describes the expected behaviour:
    > `-q` or `--quiet` prints no output for evaluation of jobs by exit status only
- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.md
