### PR TITLE
Add a $status_generation variable to track when $status was changed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,7 @@ Interactive improvements
 -  Control-Z is now available for binding (#7152).
 -  ``fish_key_reader`` sets the exit status to 0 when used with ``--help`` or ``--version`` (#6964).
 -  ``fish_key_reader`` and ``fish_indent`` send output from ``--version`` to standard output, matching other fish binaries (#6964).
+-  A new variable ``$status_generation`` is incremented only when the previous command produces a status. This can be used, for example, to check whether a failure status is a holdover due to a background job, or actually produced by the last run command.
 
 
 New or improved bindings

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,8 +21,9 @@ Notable improvements and fixes
 -  A new ``fish_add_path`` helper function to add paths to $PATH without producing duplicates, to be used interactively or in ``config.fish`` (#6960).
 - ``fish_preexec`` and ``fish_postexec`` events are no longer triggered for empty commands.
 - The ``test`` builtin now better shows where an error occured (#6030).
-- builtins may now output before all data is read. For example, `string replace` no longer has to read all of stdin before it can begin to output.
+- builtins may now output before all data is read. For example, ``string replace`` no longer has to read all of stdin before it can begin to output.
 - A number of new debugging categories have been added, including ``config``, ``path``, ``reader`` and ``screen`` (#6511). See the output of ``fish --print-debug-categories`` for the full list.
+- ``set`` and backgrounded jobs no longer overwrite ``$pipestatus``.
 
 Syntax changes and new commands
 -------------------------------

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -215,9 +215,10 @@ int main () {
 check_cxx_source_compiles("
 #include <atomic>
 #include <cstdint>
-std::atomic<uint64_t> x;
+std::atomic<uint64_t> x (0);
 int main() {
-   return x;
+uint64_t i = x.load(std::memory_order_relaxed);
+return std::atomic_is_lock_free(&x);
 }"
 LIBATOMIC_NOT_NEEDED)
 IF (NOT LIBATOMIC_NOT_NEEDED)

--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -1225,6 +1225,8 @@ You can change the settings of ``fish`` by changing the values of certain variab
 
 - ``status``, the `exit status <#variables-status>`_ of the last foreground job to exit. If the job was terminated through a signal, the exit status will be 128 plus the signal number.
 
+- ``status_generation``, the "generation" count of ``$status``. This will be incremented only when the previous command produced an explicit status. (For example, background jobs will not increment this).
+
 - ``USER``, the current username. This variable can be changed by the user.
 
 - ``version``, the version of the currently running fish (also available as ``FISH_VERSION`` for backward compatibility).

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -1,6 +1,8 @@
 # name: Classic + Vcs
 # author: Lily Ballard
 
+set __fish_prompt_status_generation $status_generation
+
 function fish_prompt --description 'Write out the prompt'
     set -l last_pipestatus $pipestatus
     set -l last_status $status
@@ -23,7 +25,12 @@ function fish_prompt --description 'Write out the prompt'
     end
 
     # Write pipestatus
-    set -l prompt_status (__fish_print_pipestatus $last_status " [" "]" "|" (set_color $fish_color_status) (set_color --bold $fish_color_status) $last_pipestatus)
+    set -l bold_flag '--bold'
+    if test $__fish_prompt_status_generation = $status_generation
+        set bold_flag
+    end
+    set __fish_prompt_status_generation $status_generation
+    set -l prompt_status (__fish_print_pipestatus $last_status " [" "]" "|" (set_color $fish_color_status) (set_color $bold_flag $fish_color_status) $last_pipestatus)
 
     echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal $prompt_status $suffix " "
 end

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -20,7 +20,7 @@ struct builtin_data_t {
     // Name of the builtin.
     const wchar_t *name;
     // Function pointer to the builtin implementation.
-    int (*func)(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+    maybe_t<int> (*func)(parser_t &parser, io_streams_t &streams, wchar_t **argv);
     // Description of what the builtin does.
     const wchar_t *desc;
 

--- a/src/builtin_argparse.cpp
+++ b/src/builtin_argparse.cpp
@@ -684,7 +684,7 @@ static void set_argparse_result_vars(env_stack_t &vars, const argparse_cmd_opts_
 /// an external command also means its output has to be in a form that can be eval'd. Because our
 /// version is a builtin it can directly set variables local to the current scope (e.g., a
 /// function). It doesn't need to write anything to stdout that then needs to be eval'd.
-int builtin_argparse(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_argparse(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     argparse_cmd_opts_t opts;

--- a/src/builtin_argparse.h
+++ b/src/builtin_argparse.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_ARGPARSE_H
 #define FISH_BUILTIN_ARGPARSE_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_argparse(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_argparse(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_bg.cpp
+++ b/src/builtin_bg.cpp
@@ -37,7 +37,7 @@ static int send_to_bg(parser_t &parser, io_streams_t &streams, job_t *j) {
 }
 
 /// Builtin for putting a job in the background.
-int builtin_bg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_bg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     help_only_cmd_opts_t opts;

--- a/src/builtin_bg.h
+++ b/src/builtin_bg.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_BG_H
 #define FISH_BUILTIN_BG_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_bg(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_bg(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_bind.cpp
+++ b/src/builtin_bind.cpp
@@ -413,7 +413,7 @@ int parse_cmd_opts(bind_cmd_opts_t &opts, int *optind,  //!OCLINT(high ncss meth
 }
 
 /// The bind builtin, used for setting character sequences.
-int builtin_bind_t::builtin_bind(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_bind_t::builtin_bind(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     bind_cmd_opts_t opts;

--- a/src/builtin_bind.h
+++ b/src/builtin_bind.h
@@ -11,7 +11,7 @@ struct bind_cmd_opts_t;
 
 class builtin_bind_t {
    public:
-    int builtin_bind(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+    maybe_t<int> builtin_bind(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 
     builtin_bind_t() : input_mappings_(input_mappings()) {}
 
@@ -38,7 +38,7 @@ class builtin_bind_t {
                   io_streams_t &streams);
 };
 
-inline int builtin_bind(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+inline maybe_t<int> builtin_bind(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     builtin_bind_t bind;
     return bind.builtin_bind(parser, streams, argv);
 }

--- a/src/builtin_block.cpp
+++ b/src/builtin_block.cpp
@@ -70,7 +70,7 @@ static int parse_cmd_opts(block_cmd_opts_t &opts, int *optind,  //!OCLINT(high n
 }
 
 /// The block builtin, used for temporarily blocking events.
-int builtin_block(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_block(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     block_cmd_opts_t opts;

--- a/src/builtin_block.h
+++ b/src/builtin_block.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_BLOCK_H
 #define FISH_BUILTIN_BLOCK_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_block(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_block(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_builtin.cpp
+++ b/src/builtin_builtin.cpp
@@ -65,7 +65,7 @@ static int parse_cmd_opts(builtin_cmd_opts_t &opts, int *optind, int argc, wchar
 /// The builtin builtin, used for giving builtins precedence over functions. Mostly handled by the
 /// parser. All this code does is some additional operational modes, such as printing a list of all
 /// builtins, printing help, etc.
-int builtin_builtin(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_builtin(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     builtin_cmd_opts_t opts;

--- a/src/builtin_builtin.h
+++ b/src/builtin_builtin.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_BUILTIN_H
 #define FISH_BUILTIN_BUILTIN_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_builtin(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_builtin(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_cd.cpp
+++ b/src/builtin_cd.cpp
@@ -20,7 +20,7 @@
 
 /// The cd builtin. Changes the current directory to the one specified or to $HOME if none is
 /// specified. The directory can be relative to any directory in the CDPATH variable.
-int builtin_cd(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_cd(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     help_only_cmd_opts_t opts;

--- a/src/builtin_cd.h
+++ b/src/builtin_cd.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_CD_H
 #define FISH_BUILTIN_CD_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_cd(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_cd(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_command.cpp
+++ b/src/builtin_command.cpp
@@ -73,7 +73,7 @@ static int parse_cmd_opts(command_cmd_opts_t &opts, int *optind, int argc, wchar
 
 /// Implementation of the builtin 'command'. Actual command running is handled by the parser, this
 /// just processes the flags.
-int builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     command_cmd_opts_t opts;

--- a/src/builtin_command.h
+++ b/src/builtin_command.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_COMMAND_H
 #define FISH_BUILTIN_COMMAND_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_command(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -121,7 +121,7 @@ static void write_part(const wchar_t *begin, const wchar_t *end, int cut_at_curs
 }
 
 /// The commandline builtin. It is used for specifying a new value for the commandline.
-int builtin_commandline(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     // Pointer to what the commandline builtin considers to be the current contents of the command
     // line buffer.
     const wchar_t *current_buffer = nullptr;

--- a/src/builtin_commandline.h
+++ b/src/builtin_commandline.h
@@ -7,5 +7,5 @@
 
 class parser_t;
 
-int builtin_commandline(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -110,7 +110,7 @@ static void builtin_complete_remove(const wcstring_list_t &cmds, const wcstring_
 
 /// The complete builtin. Used for specifying programmable tab-completions. Calls the functions in
 // complete.cpp for any heavy lifting.
-int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     ASSERT_IS_MAIN_THREAD();
 
     wchar_t *cmd = argv[0];

--- a/src/builtin_complete.h
+++ b/src/builtin_complete.h
@@ -7,5 +7,5 @@
 
 class parser_t;
 
-int builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_complete(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_contains.cpp
+++ b/src/builtin_contains.cpp
@@ -58,7 +58,7 @@ static int parse_cmd_opts(contains_cmd_opts_t &opts, int *optind, int argc, wcha
 
 /// Implementation of the builtin contains command, used to check if a specified string is part of
 /// a list.
-int builtin_contains(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_contains(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     contains_cmd_opts_t opts;

--- a/src/builtin_contains.h
+++ b/src/builtin_contains.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_CONTAINS_H
 #define FISH_BUILTIN_CONTAINS_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_contains(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_contains(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_disown.cpp
+++ b/src/builtin_disown.cpp
@@ -42,7 +42,7 @@ static int disown_job(const wchar_t *cmd, parser_t &parser, io_streams_t &stream
 }
 
 /// Builtin for removing jobs from the job list.
-int builtin_disown(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_disown(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     help_only_cmd_opts_t opts;

--- a/src/builtin_disown.h
+++ b/src/builtin_disown.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_DISOWN_H
 #define FISH_BUILTIN_DISOWN_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_disown(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_disown(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_echo.cpp
+++ b/src/builtin_echo.cpp
@@ -180,7 +180,7 @@ static bool builtin_echo_parse_numeric_sequence(const wchar_t *str, size_t *cons
 ///
 /// Bash only respects -n if it's the first argument. We'll do the same. We also support a new,
 /// fish specific, option -s to mean "no spaces".
-int builtin_echo(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_echo(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     UNUSED(cmd);
     int argc = builtin_count_args(argv);

--- a/src/builtin_echo.h
+++ b/src/builtin_echo.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_ECHO_H
 #define FISH_BUILTIN_ECHO_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_echo(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_echo(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_emit.cpp
+++ b/src/builtin_emit.cpp
@@ -11,7 +11,7 @@
 #include "wutil.h"  // IWYU pragma: keep
 
 /// Implementation of the builtin emit command, used to create events.
-int builtin_emit(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_emit(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     help_only_cmd_opts_t opts;

--- a/src/builtin_emit.h
+++ b/src/builtin_emit.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_EMIT_H
 #define FISH_BUILTIN_EMIT_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_emit(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_emit(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_eval.cpp
+++ b/src/builtin_eval.cpp
@@ -15,7 +15,7 @@
 #include "wutil.h"  // IWYU pragma: keep
 
 /// Implementation of eval builtin.
-int builtin_eval(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_eval(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     int argc = builtin_count_args(argv);
     if (argc <= 1) {
         return STATUS_CMD_OK;

--- a/src/builtin_eval.h
+++ b/src/builtin_eval.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_EVAL_H
 #define FISH_BUILTIN_EVAL_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_eval(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_eval(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_exit.cpp
+++ b/src/builtin_exit.cpp
@@ -58,7 +58,7 @@ static int parse_cmd_opts(exit_cmd_opts_t &opts, int *optind,  //!OCLINT(high nc
 }
 
 /// The exit builtin. Calls reader_exit to exit and returns the value specified.
-int builtin_exit(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_exit(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     exit_cmd_opts_t opts;

--- a/src/builtin_exit.h
+++ b/src/builtin_exit.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_EXIT_H
 #define FISH_BUILTIN_EXIT_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_exit(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_exit(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_fg.cpp
+++ b/src/builtin_fg.cpp
@@ -21,7 +21,7 @@
 #include "wutil.h"  // IWYU pragma: keep
 
 /// Builtin for putting a job in the foreground.
-int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     help_only_cmd_opts_t opts;

--- a/src/builtin_fg.h
+++ b/src/builtin_fg.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_FG_H
 #define FISH_BUILTIN_FG_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_fg(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_function.cpp
+++ b/src/builtin_function.cpp
@@ -199,7 +199,7 @@ static int validate_function_name(int argc, const wchar_t *const *argv, wcstring
 
 /// Define a function. Calls into `function.cpp` to perform the heavy lifting of defining a
 /// function.
-int builtin_function(parser_t &parser, io_streams_t &streams, const wcstring_list_t &c_args,
+maybe_t<int> builtin_function(parser_t &parser, io_streams_t &streams, const wcstring_list_t &c_args,
                      const parsed_source_ref_t &source, const ast::block_statement_t &func_node) {
     assert(source && "Missing source in builtin_function");
     // The wgetopt function expects 'function' as the first argument. Make a new wcstring_list with

--- a/src/builtin_function.h
+++ b/src/builtin_function.h
@@ -12,6 +12,6 @@ namespace ast {
 struct block_statement_t;
 }
 
-int builtin_function(parser_t &parser, io_streams_t &streams, const wcstring_list_t &c_args,
+maybe_t<int> builtin_function(parser_t &parser, io_streams_t &streams, const wcstring_list_t &c_args,
                      const parsed_source_ref_t &source, const ast::block_statement_t &func_node);
 #endif

--- a/src/builtin_functions.cpp
+++ b/src/builtin_functions.cpp
@@ -284,7 +284,7 @@ static int report_function_metadata(const wchar_t *funcname, bool verbose, io_st
 }
 
 /// The functions builtin, used for listing and erasing functions.
-int builtin_functions(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_functions(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     functions_cmd_opts_t opts;

--- a/src/builtin_functions.h
+++ b/src/builtin_functions.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_FUNCTIONS_H
 #define FISH_BUILTIN_FUNCTIONS_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_functions(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_functions(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_history.cpp
+++ b/src/builtin_history.cpp
@@ -200,7 +200,7 @@ static int parse_cmd_opts(history_cmd_opts_t &opts, int *optind,  //!OCLINT(high
 }
 
 /// Manipulate history of interactive commands executed by the user.
-int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     history_cmd_opts_t opts;

--- a/src/builtin_history.h
+++ b/src/builtin_history.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_HISTORY_H
 #define FISH_BUILTIN_HISTORY_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_history(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_jobs.cpp
+++ b/src/builtin_jobs.cpp
@@ -121,7 +121,7 @@ static void builtin_jobs_print(const job_t *j, int mode, int header, io_streams_
 }
 
 /// The jobs builtin. Used for printing running jobs. Defined in builtin_jobs.c.
-int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     bool found = false;

--- a/src/builtin_jobs.h
+++ b/src/builtin_jobs.h
@@ -7,5 +7,5 @@
 
 class parser_t;
 
-int builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_jobs(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_math.cpp
+++ b/src/builtin_math.cpp
@@ -232,7 +232,7 @@ static int evaluate_expression(const wchar_t *cmd, const parser_t &parser, io_st
 }
 
 /// The math builtin evaluates math expressions.
-int builtin_math(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_math(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     math_cmd_opts_t opts;

--- a/src/builtin_math.h
+++ b/src/builtin_math.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_MATH_H
 #define FISH_BUILTIN_MATH_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_math(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_math(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_printf.cpp
+++ b/src/builtin_printf.cpp
@@ -737,7 +737,7 @@ int builtin_printf_state_t::print_formatted(const wchar_t *format, int argc, wch
 }
 
 /// The printf builtin.
-int builtin_printf(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_printf(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     help_only_cmd_opts_t opts;

--- a/src/builtin_printf.h
+++ b/src/builtin_printf.h
@@ -7,5 +7,5 @@
 
 class parser_t;
 
-int builtin_printf(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_printf(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_pwd.cpp
+++ b/src/builtin_pwd.cpp
@@ -19,7 +19,7 @@ static const struct woption long_options[] = {{L"help", no_argument, nullptr, 'h
                                               {L"logical", no_argument, nullptr, 'L'},
                                               {L"physical", no_argument, nullptr, 'P'},
                                               {nullptr, 0, nullptr, 0}};
-int builtin_pwd(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_pwd(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     UNUSED(parser);
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);

--- a/src/builtin_pwd.h
+++ b/src/builtin_pwd.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_PWD_H
 #define FISH_BUILTIN_PWD_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_pwd(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_pwd(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_random.cpp
+++ b/src/builtin_random.cpp
@@ -27,7 +27,7 @@ static std::minstd_rand get_seeded_engine() {
 }
 
 /// The random builtin generates random numbers.
-int builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     help_only_cmd_opts_t opts;

--- a/src/builtin_random.h
+++ b/src/builtin_random.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_RANDOM_H
 #define FISH_BUILTIN_RANDOM_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_random(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_read.cpp
+++ b/src/builtin_read.cpp
@@ -428,7 +428,7 @@ static int validate_read_args(const wchar_t *cmd, read_cmd_opts_t &opts, int arg
 }
 
 /// The read builtin. Reads from stdin and stores the values in environment variables.
-int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     wcstring buff;

--- a/src/builtin_read.h
+++ b/src/builtin_read.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_READ_H
 #define FISH_BUILTIN_READ_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_realpath.cpp
+++ b/src/builtin_realpath.cpp
@@ -17,7 +17,7 @@
 /// An implementation of the external realpath command. Doesn't support any options.
 /// In general scripts shouldn't invoke this directly. They should just use `realpath` which
 /// will fallback to this builtin if an external command cannot be found.
-int builtin_realpath(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_realpath(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     help_only_cmd_opts_t opts;
     int argc = builtin_count_args(argv);

--- a/src/builtin_realpath.h
+++ b/src/builtin_realpath.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_REALPATH_H
 #define FISH_BUILTIN_REALPATH_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_realpath(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_realpath(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_return.cpp
+++ b/src/builtin_return.cpp
@@ -57,7 +57,7 @@ static int parse_cmd_opts(return_cmd_opts_t &opts, int *optind,  //!OCLINT(high 
 }
 
 /// Function for handling the return builtin.
-int builtin_return(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_return(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     return_cmd_opts_t opts;

--- a/src/builtin_return.h
+++ b/src/builtin_return.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_RETURN_H
 #define FISH_BUILTIN_RETURN_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_return(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_return(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -805,7 +805,6 @@ static int builtin_set_set(const wchar_t *cmd, set_cmd_opts_t &opts, int argc, w
 
 /// The set builtin creates, updates, and erases (removes, deletes) variables.
 maybe_t<int> builtin_set(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
-    const int incoming_exit_status = parser.get_last_status();
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     set_cmd_opts_t opts;
@@ -838,6 +837,6 @@ maybe_t<int> builtin_set(parser_t &parser, io_streams_t &streams, wchar_t **argv
         retval = builtin_set_set(cmd, opts, argc, argv, parser, streams);
     }
 
-    if (retval == STATUS_CMD_OK && opts.preserve_failure_exit_status) retval = incoming_exit_status;
+    if (retval == STATUS_CMD_OK && opts.preserve_failure_exit_status) return none();
     return retval;
 }

--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -804,7 +804,7 @@ static int builtin_set_set(const wchar_t *cmd, set_cmd_opts_t &opts, int argc, w
 }
 
 /// The set builtin creates, updates, and erases (removes, deletes) variables.
-int builtin_set(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_set(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     const int incoming_exit_status = parser.get_last_status();
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);

--- a/src/builtin_set.h
+++ b/src/builtin_set.h
@@ -7,5 +7,5 @@
 
 class parser_t;
 
-int builtin_set(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_set(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_set_color.cpp
+++ b/src/builtin_set_color.cpp
@@ -67,7 +67,7 @@ static char dim_esc[] = "\x1B[2m";
 #endif
 
 /// set_color builtin.
-int builtin_set_color(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_set_color(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     // By the time this is called we should have initialized the curses subsystem.
     assert(curses_initialized);
 

--- a/src/builtin_set_color.h
+++ b/src/builtin_set_color.h
@@ -7,5 +7,5 @@
 
 class parser_t;
 
-int builtin_set_color(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_set_color(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_source.cpp
+++ b/src/builtin_source.cpp
@@ -22,7 +22,7 @@
 
 /// The  source builtin, sometimes called `.`. Evaluates the contents of a file in the current
 /// context.
-int builtin_source(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_source(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     ASSERT_IS_MAIN_THREAD();
     const wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);

--- a/src/builtin_source.h
+++ b/src/builtin_source.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_SOURCE_H
 #define FISH_BUILTIN_SOURCE_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_source(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_source(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_status.cpp
+++ b/src/builtin_status.cpp
@@ -274,7 +274,7 @@ static int parse_cmd_opts(status_cmd_opts_t &opts, int *optind,  //!OCLINT(high 
 }
 
 /// The status builtin. Gives various status information on fish.
-int builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     status_cmd_opts_t opts;

--- a/src/builtin_status.h
+++ b/src/builtin_status.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_STATUS_H
 #define FISH_BUILTIN_STATUS_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_status(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1451,7 +1451,7 @@ string_subcommands[] = {
     {nullptr, nullptr}};
 
 /// The string builtin, for manipulating strings.
-int builtin_string(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_string(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     if (argc <= 1) {

--- a/src/builtin_string.h
+++ b/src/builtin_string.h
@@ -7,5 +7,5 @@
 
 class parser_t;
 
-int builtin_string(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_string(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_test.cpp
+++ b/src/builtin_test.cpp
@@ -845,7 +845,7 @@ static bool unary_primary_evaluate(test_expressions::token_t token, const wcstri
 /// supports a more limited range of functionality.
 ///
 /// Return status is the final shell status, i.e. 0 for true, 1 for false and 2 for error.
-int builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     UNUSED(parser);
     using namespace test_expressions;
 

--- a/src/builtin_test.h
+++ b/src/builtin_test.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_TEST_H
 #define FISH_BUILTIN_TEST_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_ulimit.cpp
+++ b/src/builtin_ulimit.cpp
@@ -149,7 +149,7 @@ static int set_limit(int resource, int hard, int soft, rlim_t value, io_streams_
 }
 
 /// The ulimit builtin, used for setting resource limits.
-int builtin_ulimit(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_ulimit(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     wchar_t *cmd = argv[0];
     int argc = builtin_count_args(argv);
     bool report_all = false;

--- a/src/builtin_ulimit.h
+++ b/src/builtin_ulimit.h
@@ -7,5 +7,5 @@
 
 class parser_t;
 
-int builtin_ulimit(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_ulimit(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/builtin_wait.cpp
+++ b/src/builtin_wait.cpp
@@ -172,7 +172,7 @@ static bool find_job_by_name(const wchar_t *proc, std::vector<job_id_t> &ids,
 
 /// The following function is invoked on the main thread, because the job operation is not thread
 /// safe. It waits for child jobs, not for child processes individually.
-int builtin_wait(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
+maybe_t<int> builtin_wait(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     ASSERT_IS_MAIN_THREAD();
     int retval = STATUS_CMD_OK;
     const wchar_t *cmd = argv[0];

--- a/src/builtin_wait.h
+++ b/src/builtin_wait.h
@@ -2,8 +2,10 @@
 #ifndef FISH_BUILTIN_WAIT_H
 #define FISH_BUILTIN_WAIT_H
 
+#include "maybe.h"
+
 class parser_t;
 struct io_streams_t;
 
-int builtin_wait(parser_t &parser, io_streams_t &streams, wchar_t **argv);
+maybe_t<int> builtin_wait(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 #endif

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -95,6 +95,7 @@ static const std::vector<electric_var_t> electric_variables{
     {L"hostname", electric_var_t::freadonly},
     {L"pipestatus", electric_var_t::freadonly | electric_var_t::fcomputed},
     {L"status", electric_var_t::freadonly | electric_var_t::fcomputed},
+    {L"status_generation", electric_var_t::freadonly | electric_var_t::fcomputed},
     {L"umask", electric_var_t::fcomputed},
     {L"version", electric_var_t::freadonly},
 };
@@ -701,6 +702,9 @@ maybe_t<env_var_t> env_scoped_impl_t::try_get_computed(const wcstring &key) cons
     } else if (key == L"status") {
         const auto &js = perproc_data().statuses;
         return env_var_t(L"status", to_string(js.status));
+    } else if (key == L"status_generation") {
+        auto status_generation = reader_status_count();
+        return env_var_t(L"status_generation", to_string(status_generation));
     } else if (key == L"fish_kill_signal") {
         const auto &js = perproc_data().statuses;
         return env_var_t(L"fish_kill_signal", to_string(js.kill_signal));

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -289,7 +289,11 @@ static void run_internal_process_or_short_circuit(parser_t &parser, const std::s
         if (p->is_last_in_job) {
             FLOGF(exec_job_status, L"Set status of job %d (%ls) to %d using short circuit",
                   j->job_id(), j->preview().c_str(), p->status);
-            parser.set_last_statuses(j->get_statuses());
+            auto statuses = j->get_statuses();
+            if (statuses) {
+                parser.set_last_statuses(statuses.value());
+                parser.libdata().status_count++;
+            }
         }
     } else {
         run_internal_process(p, std::move(outdata), std::move(errdata), ios);

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -293,6 +293,13 @@ static void run_internal_process_or_short_circuit(parser_t &parser, const std::s
             if (statuses) {
                 parser.set_last_statuses(statuses.value());
                 parser.libdata().status_count++;
+            } else if (j->flags().negate) {
+                // Special handling for `not set var (substitution)`.
+                // If there is no status, but negation was requested,
+                // take the last status and negate it.
+                auto last_statuses = parser.get_last_statuses();
+                last_statuses.status = !last_statuses.status;
+                parser.set_last_statuses(last_statuses);
             }
         }
     } else {

--- a/src/maybe.h
+++ b/src/maybe.h
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <type_traits>
+#include <utility>
 
 namespace maybe_detail {
 // Template magic to make maybe_t<T> copyable iff T is copyable.

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -393,6 +393,7 @@ end_execution_reason_t parse_execution_context_t::run_function_statement(
     buffered_output_stream_t errs(0);
     io_streams_t streams(outs, errs);
     int err = builtin_function(*parser, streams, arguments, pstree, statement);
+    parser->libdata().status_count++;
     parser->set_last_statuses(statuses_t::just(err));
 
     wcstring errtext = errs.contents();

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -392,13 +392,17 @@ end_execution_reason_t parse_execution_context_t::run_function_statement(
     buffered_output_stream_t outs(0);
     buffered_output_stream_t errs(0);
     io_streams_t streams(outs, errs);
-    int err = builtin_function(*parser, streams, arguments, pstree, statement);
-    parser->libdata().status_count++;
-    parser->set_last_statuses(statuses_t::just(err));
+    int err_code = 0;
+    maybe_t<int> err = builtin_function(*parser, streams, arguments, pstree, statement);
+    if (err) {
+        err_code = err.value();
+        parser->libdata().status_count++;
+        parser->set_last_statuses(statuses_t::just(err_code));
+    }
 
     wcstring errtext = errs.contents();
     if (!errtext.empty()) {
-        return this->report_error(err, header, L"%ls", errtext.c_str());
+        return this->report_error(err_code, header, L"%ls", errtext.c_str());
     }
     return result;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -649,7 +649,8 @@ eval_res_t parser_t::eval(const parsed_source_ref_t &ps, const io_chain_t &io,
         auto status = proc_status_t::from_exit_code(get_last_status());
         bool break_expand = false;
         bool was_empty = true;
-        return eval_res_t{status, break_expand, was_empty};
+        bool no_status = true;
+        return eval_res_t{status, break_expand, was_empty, no_status};
     }
 }
 
@@ -713,8 +714,10 @@ eval_res_t parser_t::eval_node(const parsed_source_ref_t &ps, const T &node,
 
     // Check the exec count so we know if anything got executed.
     const size_t prev_exec_count = libdata().exec_count;
+    const size_t prev_status_count = libdata().status_count;
     end_execution_reason_t reason = execution_context->eval_node(node, scope_block);
     const size_t new_exec_count = libdata().exec_count;
+    const size_t new_status_count = libdata().status_count;
 
     exc.restore();
     this->pop_block(scope_block);
@@ -728,7 +731,8 @@ eval_res_t parser_t::eval_node(const parsed_source_ref_t &ps, const T &node,
         auto status = proc_status_t::from_exit_code(this->get_last_status());
         bool break_expand = (reason == end_execution_reason_t::error);
         bool was_empty = !break_expand && prev_exec_count == new_exec_count;
-        return eval_res_t{status, break_expand, was_empty};
+        bool no_status = prev_status_count == new_status_count;
+        return eval_res_t{status, break_expand, was_empty, no_status};
     }
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -142,6 +142,9 @@ struct library_data_t {
     /// A counter incremented every time a command executes.
     uint64_t exec_count{0};
 
+    /// A counter incremented every time a command produces a $status.
+    uint64_t status_count{0};
+
     /// Last reader run count.
     uint64_t last_exec_run_counter{UINT64_MAX};
 
@@ -219,9 +222,12 @@ struct eval_res_t {
     /// If set, no commands were executed and there we no errors.
     bool was_empty{false};
 
+    /// If set, no commands produced a $status value.
+    bool no_status{false};
+
     /* implicit */ eval_res_t(proc_status_t status, bool break_expand = false,
-                              bool was_empty = false)
-        : status(status), break_expand(break_expand), was_empty(was_empty) {}
+                              bool was_empty = false, bool no_status = false)
+        : status(status), break_expand(break_expand), was_empty(was_empty), no_status(no_status) {}
 };
 
 class parser_t : public std::enable_shared_from_this<parser_t> {

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -999,6 +999,7 @@ void job_t::continue_job(parser_t &parser, bool in_foreground) {
         const auto &p = processes.back();
         if (p->status.normal_exited() || p->status.signal_exited()) {
             parser.set_last_statuses(get_statuses());
+            parser.libdata().status_count++;
         }
     }
 }

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -167,17 +167,30 @@ bool job_t::signal(int signal) {
     return true;
 }
 
-statuses_t job_t::get_statuses() const {
+maybe_t<statuses_t> job_t::get_statuses() const {
     statuses_t st{};
+    bool has_status = false;
+    int laststatus = 0;
     st.pipestatus.reserve(processes.size());
     for (const auto &p : processes) {
         auto status = p->status;
+        if (status.is_empty()) {
+            // Corner case for if a variable assignment is part of a pipeline.
+            // e.g. `false | set foo bar | true` will push 1 in the second spot,
+            // for a complete pipestatus of `1 1 0`.
+            st.pipestatus.push_back(laststatus);
+            continue;
+        }
         if (status.signal_exited()) {
             st.kill_signal = status.signal_code();
         }
+        laststatus = status.status_value();
+        has_status = true;
         st.pipestatus.push_back(status.status_value());
     }
-    int laststatus = st.pipestatus.back();
+    if (!has_status) {
+        return none();
+    }
     st.status = flags().negate ? !laststatus : laststatus;
     return st;
 }
@@ -998,8 +1011,11 @@ void job_t::continue_job(parser_t &parser, bool in_foreground) {
         // finished.
         const auto &p = processes.back();
         if (p->status.normal_exited() || p->status.signal_exited()) {
-            parser.set_last_statuses(get_statuses());
-            parser.libdata().status_count++;
+            auto statuses = get_statuses();
+            if (statuses) {
+                parser.set_last_statuses(statuses.value());
+                parser.libdata().status_count++;
+            }
         }
     }
 }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2187,7 +2187,7 @@ void set_env_cmd_duration(struct timeval *after, struct timeval *before, env_sta
     vars.set_one(ENV_CMD_DURATION, ENV_UNEXPORT, std::to_wstring((secs * 1000) + (usecs / 1000)));
 }
 
-void reader_run_command(parser_t &parser, const wcstring &cmd) {
+eval_res_t reader_run_command(parser_t &parser, const wcstring &cmd) {
     struct timeval time_before, time_after;
 
     wcstring ft = tok_command(cmd);
@@ -2201,7 +2201,7 @@ void reader_run_command(parser_t &parser, const wcstring &cmd) {
 
     gettimeofday(&time_before, nullptr);
 
-    parser.eval(cmd, io_chain_t{});
+    auto eval_res = parser.eval(cmd, io_chain_t{});
     job_reap(parser, true);
 
     gettimeofday(&time_after, nullptr);
@@ -2218,6 +2218,8 @@ void reader_run_command(parser_t &parser, const wcstring &cmd) {
     if (have_proc_stat()) {
         proc_update_jiffies(parser);
     }
+
+    return eval_res;
 }
 
 parser_test_error_bits_t reader_shell_test(parser_t &parser, const wcstring &b) {
@@ -2487,6 +2489,13 @@ static relaxed_atomic_t<uint64_t> run_count{0};
 /// Returns the current interactive loop count
 uint64_t reader_run_count() { return run_count; }
 
+static relaxed_atomic_t<uint64_t> status_count{0};
+
+/// Returns the current "generation" of interactive status.
+/// This is not incremented if the command being run produces no status,
+/// (e.g. background job, or variable assignment).
+uint64_t reader_status_count() { return status_count; }
+
 /// Read interactively. Read input from stdin while providing editing facilities.
 static int read_i(parser_t &parser) {
     reader_push(parser, history_session_id(parser.vars()));
@@ -2530,8 +2539,11 @@ static int read_i(parser_t &parser) {
             data->command_line_changed(&data->command_line);
             wcstring_list_t argv(1, command);
             event_fire_generic(parser, L"fish_preexec", &argv);
-            reader_run_command(parser, command);
+            auto eval_res = reader_run_command(parser, command);
             signal_clear_cancel();
+            if (!eval_res.no_status) {
+                status_count++;
+            }
             event_fire_generic(parser, L"fish_postexec", &argv);
             // Allow any pending history items to be returned in the history array.
             if (data->history) {

--- a/src/reader.h
+++ b/src/reader.h
@@ -290,4 +290,8 @@ wcstring completion_apply_to_command_line(const wcstring &val_str, complete_flag
 /// been executed between invocations of code.
 uint64_t reader_run_count();
 
+/// Returns the current "generation" of interactive status. Useful for determining whether the
+/// previous command produced a status.
+uint64_t reader_status_count();
+
 #endif

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -270,6 +270,30 @@ __fish_test_shadow
 env | string match '__fish_test_env17=*'
 # CHECK: __fish_test_env17=UNSHADOWED
 
+# Test that set var (command substitution) works with if/while.
+
+if set fish_test_18 (false)
+    echo Test 18 fail
+else
+    echo Test 18 pass
+end
+# CHECK: Test 18 pass
+
+if not set fish_test_18 (true)
+    echo Test 18 fail
+else
+    echo Test 18 pass
+end
+# CHECK: Test 18 pass
+
+set __fish_test_18_status pass
+while set fish_test_18 (false); or not set fish_test_18 (true)
+    set __fish_test_18_status fail
+    break
+end
+echo Test 18 $__fish_test_18_status
+# CHECK: Test 18 pass
+
 # Test that local exported variables are copied to functions (#1091)
 function __fish_test_local_export
     echo $var

--- a/tests/pexpects/postexec.py
+++ b/tests/pexpects/postexec.py
@@ -41,6 +41,16 @@ sendline("sleep 1000 &; sleep 2000 &")
 expect_str("pipestatus:0|1, generation:%d, command:sleep 1000 &; sleep 2000 &" % generation)
 expect_prompt()
 
+# valid variable assignment
+sendline("set foo bar")
+expect_str("pipestatus:0|1, generation:%d, command:set foo bar" % generation)
+expect_prompt()
+
+# valid variable assignment with background job
+sendline("set foo bar; sleep 1000 &")
+expect_str("pipestatus:0|1, generation:%d, command:set foo bar; sleep 1000 &" % generation)
+expect_prompt()
+
 # Increments $status_generation if any job was foreground.
 sendline("false|true; sleep 1000 &")
 generation += 1
@@ -76,6 +86,18 @@ generation += 1
 expect_str("pipestatus:0, generation:%d, command:function fail; false; end" % generation)
 expect_prompt()
 
+# or an invalid variable assignment
+sendline("set '!@#$' value")
+generation += 1
+expect_str("pipestatus:2, generation:%d, command:set '!@#$' value" % generation)
+expect_prompt()
+
+# or a variable query
+sendline("set -q fish_pid")
+generation += 1
+expect_str("pipestatus:0, generation:%d, command:set -q fish_pid" % generation)
+expect_prompt()
+
 # This is just to set a memorable pipestatus.
 sendline("true|false|true")
 generation += 1
@@ -95,4 +117,9 @@ expect_prompt()
 # Or a combination of begin/end block and backgrounded job.
 sendline("begin; sleep 200 &; end; sleep 400 &")
 expect_str("pipestatus:0|1|0, generation:%d, command:begin; sleep 200 &; end; sleep 400 &" % generation)
+expect_prompt()
+
+# Or a combination with variable assignments
+sendline("begin; set foo bar; sleep 1000 &; end; set bar baz; sleep 2000 &")
+expect_str("pipestatus:0|1|0, generation:%d, command:begin; set foo bar; sleep 1000 &; end; set bar baz; sleep 2000 &" % generation)
 expect_prompt()

--- a/tests/pexpects/postexec.py
+++ b/tests/pexpects/postexec.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from pexpect_helper import SpawnedProc
+
+sp = SpawnedProc()
+sendline, expect_prompt, expect_str = sp.sendline, sp.expect_prompt, sp.expect_str
+
+# Test fish_postexec and $status_generation for interactive shells.
+expect_prompt()
+
+sendline("function test_fish_postexec --on-event fish_postexec; printf 'pipestatus:%s, generation:%d, command:%s\\n' (string join '|' $pipestatus) $status_generation $argv; end")
+expect_prompt()
+
+generation = 1
+
+# fish_postexec is called when foreground job ends.
+sendline("true")
+generation += 1
+expect_str("pipestatus:0, generation:%d, command:true" % generation)
+expect_prompt()
+
+# Command has multiple jobs.
+sendline("true;false")
+generation += 1
+expect_str("pipestatus:1, generation:%d, command:true;false" % generation)
+expect_prompt()
+
+# Command is a pipeline.
+sendline("true|false")
+generation += 1
+expect_str("pipestatus:0|1, generation:%d, command:true|false" % generation)
+expect_prompt()
+
+# Does not increment $status_generation for background jobs.
+# status, pipestatus remain unchanged
+sendline("sleep 1000 &")
+expect_str("pipestatus:0|1, generation:%d, command:sleep 1000 &" % generation)
+expect_prompt()
+
+# multiple backgrounded jobs
+sendline("sleep 1000 &; sleep 2000 &")
+expect_str("pipestatus:0|1, generation:%d, command:sleep 1000 &; sleep 2000 &" % generation)
+expect_prompt()
+
+# Increments $status_generation if any job was foreground.
+sendline("false|true; sleep 1000 &")
+generation += 1
+expect_str("pipestatus:1|0, generation:%d, command:false|true; sleep 1000 &" % generation)
+expect_prompt()
+
+sendline("sleep 1000 &; true|false|true")
+generation += 1
+expect_str("pipestatus:0|1|0, generation:%d, command:sleep 1000 &; true|false|true" % generation)
+expect_prompt()
+
+# Increments $status_generation for empty if/while blocks.
+sendline("if true;end")
+generation += 1
+expect_str("pipestatus:0, generation:%d, command:if true;end" % generation)
+expect_prompt()
+
+sendline("while false;end")
+generation += 1
+expect_str("pipestatus:0, generation:%d, command:while false;end" % generation)
+expect_prompt()
+
+# or non-matching if.
+sendline("if false;false;end")
+generation += 1
+expect_str("pipestatus:0, generation:%d, command:if false;false;end" % generation)
+expect_prompt()
+
+# or a function definition.
+# This is an implementation detail, but the test case should prevent regressions.
+sendline("function fail; false; end")
+generation += 1
+expect_str("pipestatus:0, generation:%d, command:function fail; false; end" % generation)
+expect_prompt()
+
+# This is just to set a memorable pipestatus.
+sendline("true|false|true")
+generation += 1
+expect_str("pipestatus:0|1|0")
+expect_prompt()
+
+# Does not increment $status_generation for empty begin/end block.
+sendline("begin;end")
+expect_str("pipestatus:0|1|0, generation:%d, command:begin;end" % generation)
+expect_prompt()
+
+# Or begin/end block with only backgrounded jobs.
+sendline("begin; sleep 200 &; sleep 400 &; end")
+expect_str("pipestatus:0|1|0, generation:%d, command:begin; sleep 200 &; sleep 400 &; end" % generation)
+expect_prompt()
+
+# Or a combination of begin/end block and backgrounded job.
+sendline("begin; sleep 200 &; end; sleep 400 &")
+expect_str("pipestatus:0|1|0, generation:%d, command:begin; sleep 200 &; end; sleep 400 &" % generation)
+expect_prompt()


### PR DESCRIPTION
## Description

Attempt to differentiate between explicitly setting $status and implicitly re-using a previous $status value through a `$status_generation` electric variable. Currently this only affects backgrounded jobs and variable assignments.

This variable will be automatically incremented after every interactive command, except `command &` or `set foo bar`.

This will allow tools like "undistract me" to correctly report the exit status of the last command, by ignoring `$status` in `fish_postexec` iff the value of `$status_generation` is the same in pre and post exec.

It could potentially be extended to support something like `return --previous` in fish script, if the feature is useful enough to warrant that complexity.

Fixes #6815 #6998

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.md
