### PR TITLE
feat(completion): add missing -P option to read command

### DIFF
--- a/share/completions/read.fish
+++ b/share/completions/read.fish
@@ -1,6 +1,7 @@
 # Completion for builtin read
 complete -c read -s h -l help -d "Display help and exit"
 complete -c read -s p -l prompt -d "Set prompt command" -x
+complete -c read -s P -l prompt-str -d "Set prompt using provided string" -x
 complete -c read -s x -l export -d "Export variable to subprocess"
 complete -c read -s g -l global -d "Make variable scope global"
 complete -c read -s l -l local -d "Make variable scope local"


### PR DESCRIPTION
Hello

This PR adds `-P/--prompt-str` completion to `read`. This option is already documented so nothing to change in the doc.