### PR TITLE
doc: homogenize commands titles

### DIFF
--- a/doc_src/cmds/breakpoint.rst
+++ b/doc_src/cmds/breakpoint.rst
@@ -1,6 +1,6 @@
 .. _cmd-breakpoint:
 
-breakpoint - Launch debug mode
+breakpoint - launch debug mode
 ==============================
 
 Synopsis

--- a/doc_src/cmds/emit.rst
+++ b/doc_src/cmds/emit.rst
@@ -1,6 +1,6 @@
 .. _cmd-emit:
 
-emit - Emit a generic event
+emit - emit a generic event
 ===========================
 
 Synopsis

--- a/doc_src/cmds/end.rst
+++ b/doc_src/cmds/end.rst
@@ -1,7 +1,7 @@
 .. _cmd-end:
 
-end - end a block of commands.
-==============================
+end - end a block of commands
+=============================
 
 Synopsis
 --------

--- a/doc_src/cmds/fish_update_completions.rst
+++ b/doc_src/cmds/fish_update_completions.rst
@@ -1,6 +1,6 @@
 .. _cmd-fish_update_completions:
 
-fish_update_completions - Update completions using manual pages
+fish_update_completions - update completions using manual pages
 ===============================================================
 
 Synopsis

--- a/doc_src/cmds/for.rst
+++ b/doc_src/cmds/for.rst
@@ -1,7 +1,7 @@
 .. _cmd-for:
 
-for - perform a set of commands multiple times.
-===============================================
+for - perform a set of commands multiple times
+==============================================
 
 Synopsis
 --------

--- a/doc_src/cmds/history.rst
+++ b/doc_src/cmds/history.rst
@@ -1,6 +1,6 @@
 .. _cmd-history:
 
-history - Show and manipulate command history
+history - show and manipulate command history
 =============================================
 
 Synopsis

--- a/doc_src/cmds/math.rst
+++ b/doc_src/cmds/math.rst
@@ -1,6 +1,6 @@
 .. _cmd-math:
 
-math - Perform mathematics calculations
+math - perform mathematics calculations
 =======================================
 
 Synopsis

--- a/doc_src/cmds/prompt_pwd.rst
+++ b/doc_src/cmds/prompt_pwd.rst
@@ -1,6 +1,6 @@
 .. _cmd-prompt_pwd:
 
-prompt_pwd - Print pwd suitable for prompt
+prompt_pwd - print pwd suitable for prompt
 ==========================================
 
 Synopsis

--- a/doc_src/cmds/realpath.rst
+++ b/doc_src/cmds/realpath.rst
@@ -1,6 +1,6 @@
 .. _cmd-realpath:
 
-realpath - Convert a path to an absolute path without symlinks
+realpath - convert a path to an absolute path without symlinks
 ==============================================================
 
 Synopsis

--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -1,7 +1,7 @@
 .. _cmd-set:
 
-set - display and change shell variables.
-=========================================
+set - display and change shell variables
+========================================
 
 Synopsis
 --------

--- a/doc_src/cmds/source.rst
+++ b/doc_src/cmds/source.rst
@@ -1,7 +1,7 @@
 .. _cmd-source:
 
-source - evaluate contents of file.
-===================================
+source - evaluate contents of file
+==================================
 
 Synopsis
 --------


### PR DESCRIPTION
Hi

This nitpicking PR fixes a few discrepancies by lowercasing a few rogue command titles and removing ending dots. This is observable in the command list page:

![image](https://user-images.githubusercontent.com/39315/78046766-dc25f900-7377-11ea-88f0-bc6247c85a76.png)
