### PR TITLE
Added openssl completions

### DIFF
--- a/share/completions/openssl.fish
+++ b/share/completions/openssl.fish
@@ -1,0 +1,7 @@
+function __fish_openssl_subcommand_options --description "Print options for openssl subcommand"
+    set -l cmd (commandline -poc)
+    openssl list -options $cmd[2] | string replace -r -- '^(\S*)\s*.*' '-$1'
+end
+
+complete -c openssl -n '__fish_use_subcommand' -x -a "(openssl list -1 -commands -cipher-commands -digest-commands)"
+complete -c openssl -n 'not __fish_use_subcommand && string match -qr -- "^-" (commandline -ct)' -a "(__fish_openssl_subcommand_options)"


### PR DESCRIPTION
## Description

More than one time, I wished fish had autocompletions for `openssl`. But `openssl` with all its dozens  of subcommands and hundreds of options is so complex, I thought it would require an insane amount of work.

Now, actually that's the shortest completion file I've ever written. :laughing: It turns out openssl is pretty good in completing itself with subcommands and options.

I think it's far from being perfect since there is no completion for further arguments and there also is no description text, but it is still an improvement to the current non-completion.

Maybe it is a bit hacky. If you know whether this could be done in a better way, please let me know.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
