### PR TITLE
Make ":" and "." proper builtins

### DIFF
--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -814,11 +814,11 @@ There are three kinds of variables in fish: universal, global and local variable
 
 Variables can be explicitly set to be universal with the ``-U`` or ``--universal`` switch, global with the ``-g`` or ``--global`` switch, or local with the ``-l`` or ``--local`` switch.  The scoping rules when creating or updating a variable are:
 
-- If a variable is explicitly set to a scope (universal, global or local), that setting will be honored. If a variable of the same name exists in a different scope, that variable will not be changed.
+- When a scope is explicitly given, it will be used. If a variable of the same name exists in a different scope, that variable will not be changed.
 
-- If a variable is not explicitly set to a scope, but has been previously defined, the variable scope is not changed.
+- When no scope is given, but a variable of that name exists, the variable of the smallest scope will be modified. The scope will not be changed.
 
-- If a variable is not explicitly set to a scope and has not been defined, the variable will be local to the currently executing function. Note that this is different from using the ``-l`` or ``--local`` flag. If one of those flags is used, the variable will be local to the most inner currently executing block, while without these the variable will be local to the function. If no function is executing, the variable will be global.
+- As a special case, when no scope is given and no variable has been defined the variable will belong to the scope of the currently executing *function*. Note that this is different from the ``--local`` flag``, which would make the variable local to the current *block*.
 
 There may be many variables with the same name, but different scopes. When using a variable, the variable scope will be searched from the inside out, i.e. a local variable will be used rather than a global variable with the same name, a global variable will be used rather than a universal variable with the same name.
 
@@ -829,10 +829,13 @@ The following code will not output anything::
     begin
         # This is a nice local scope where all variables will die
         set -l pirate 'There be treasure in them thar hills'
+        set captain Space, the final frontier
     end
 
     echo $pirate
     # This will not output anything, since the pirate was local
+    echo $captain
+    # This will output the good Captain's speech since $captain had function-scope.
 
 .. _variables-override:
 

--- a/share/config.fish
+++ b/share/config.fish
@@ -154,16 +154,6 @@ end
 # in UTF-8 (with non-ASCII characters).
 __fish_set_locale
 
-# "." alias for source; deprecated
-function . -d 'Evaluate a file (deprecated, use "source")' --no-scope-shadowing --wraps source
-    if [ (count $argv) -eq 0 ] && isatty 0
-        echo "source: using source via '.' is deprecated, and stdin doesn't work."\n"Did you mean 'source' or './'?" >&2
-        return 1
-    else
-        source $argv
-    end
-end
-
 # Upgrade pre-existing abbreviations from the old "key=value" to the new "key value" syntax.
 # This needs to be in share/config.fish because __fish_config_interactive is called after sourcing
 # config.fish, which might contain abbr calls.

--- a/share/config.fish
+++ b/share/config.fish
@@ -106,15 +106,6 @@ else if not contains -- $__fish_data_dir/completions $fish_complete_path
     set -a fish_complete_path $__fish_data_dir/completions
 end
 
-# This cannot be in an autoload-file because `:.fish` is an invalid filename on windows.
-function : -d "no-op function"
-    # for compatibility with sh, bash, and others.
-    # Often used to insert a comment into a chain of commands without having
-    # it eat up the remainder of the line, handy in Makefiles.
-    # This command always succeeds
-    true
-end
-
 # Add a handler for when fish_user_path changes, so we can apply the same changes to PATH
 function __fish_reconstruct_path -d "Update PATH when fish_user_paths changes" --on-variable fish_user_paths
     set -l local_path $PATH

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -168,7 +168,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
     #
     # Only a few builtins take filenames; initialize the rest with no file completions
     #
-    complete -c(builtin -n | string match -rv '(source|cd|exec|realpath|set|\\[|test|for)') --no-files
+    complete -c(builtin -n | string match -rv '(.|:|source|cd|exec|realpath|set|\\[|test|for)') --no-files
 
     # Reload key bindings when binding variable change
     function __fish_reload_key_bindings -d "Reload key bindings when binding variable change" --on-variable fish_key_bindings

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -342,6 +342,7 @@ int builtin_false(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 // Functions that are bound to builtin_generic are handled directly by the parser.
 // NOTE: These must be kept in sorted order!
 static const builtin_data_t builtin_datas[] = {
+    {L".", &builtin_source, N_(L"Evaluate contents of file")},
     {L":", &builtin_true, N_(L"Return a successful result")},
     {L"[", &builtin_test, N_(L"Test a condition")},
     {L"and", &builtin_generic, N_(L"Execute command if previous command succeeded")},

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -317,20 +317,14 @@ static int builtin_breakpoint(parser_t &parser, io_streams_t &streams, wchar_t *
 int builtin_true(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     UNUSED(parser);
     UNUSED(streams);
-    if (argv[1] != nullptr) {
-        streams.err.append_format(BUILTIN_ERR_ARG_COUNT1, argv[0], 0, builtin_count_args(argv) - 1);
-        return STATUS_INVALID_ARGS;
-    }
+    UNUSED(argv);
     return STATUS_CMD_OK;
 }
 
 int builtin_false(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     UNUSED(parser);
     UNUSED(streams);
-    if (argv[1] != nullptr) {
-        streams.err.append_format(BUILTIN_ERR_ARG_COUNT1, argv[0], 0, builtin_count_args(argv) - 1);
-        return STATUS_INVALID_ARGS;
-    }
+    UNUSED(argv);
     return STATUS_CMD_ERROR;
 }
 

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -342,6 +342,7 @@ int builtin_false(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
 // Functions that are bound to builtin_generic are handled directly by the parser.
 // NOTE: These must be kept in sorted order!
 static const builtin_data_t builtin_datas[] = {
+    {L":", &builtin_true, N_(L"Return a successful result")},
     {L"[", &builtin_test, N_(L"Test a condition")},
     {L"and", &builtin_generic, N_(L"Execute command if previous command succeeded")},
     {L"argparse", &builtin_argparse, N_(L"Parse options in fish script")},

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -62,7 +62,6 @@ complete
 # CHECK: complete {{.*}}
 # CHECK: complete {{.*}}
 # CHECK: complete {{.*}}
-# CHECK: complete {{.*}}
 
 # Recursive calls to complete (see #3474)
 complete -c complete_test_recurse1 -xa '(echo recursing 1>&2; complete -C"complete_test_recurse1 ")'


### PR DESCRIPTION
## Description

We've tried to remove "." before, to disastrous results, so these aren't going anywhere. Since it's *simpler* to implement them in C++ than script, and since that makes fish just a little more functional without share/config.fish, I'd like to add them to C++ and make them real builtins.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
