### PR TITLE
New function __fish_preview_current_file to open current file in pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 #### New or improved bindings
 - New readline commands `undo` (Ctrl+_) and `redo` (Alt-/) can be used to revert changes to the command line or the pager search field (#6570).
+- New function `__fish_preview_current_file` (Alt+O) opens the current file at the cursor in a pager (#6838 #6855).
 
 #### Improved prompts
 - The default and example prompts print the correct exit status for commands prefixed with `not` (#6566).

--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -1324,6 +1324,8 @@ Some bindings are shared between emacs- and vi-mode because they aren't text edi
 
 - :kbd:`Alt`\ +\ :kbd:`L` lists the contents of the current directory, unless the cursor is over a directory argument, in which case the contents of that directory will be listed.
 
+- :kbd:`Alt`\ +\ :kbd:`O` opens the current file at the cursor in a pager.
+
 - :kbd:`Alt`\ +\ :kbd:`P` adds the string '``| less;``' to the end of the job under the cursor. The result is that the output of the command will be paged.
 
 - :kbd:`Alt`\ +\ :kbd:`W` prints a short description of the command under the cursor.

--- a/share/functions/__fish_preview_current_file.fish
+++ b/share/functions/__fish_preview_current_file.fish
@@ -1,0 +1,29 @@
+function __fish_preview_current_file --description "Open the file at the cursor in a pager"
+    set -l pager less --
+    set -q PAGER && echo $PAGER | read -at pager
+
+    # commandline -t will never return an empty list. However, the token
+    # could comprise multiple lines, so join them into a single string.
+    set -l file (commandline -t | string collect)
+    # count $file is 1
+
+    # $backslash will parsed as regex which may need additional escaping.
+    set -l backslash '\\\\'
+    not status test-feature regex-easyesc && set backslash $backslash$backslash
+    test -z $file && set file (string replace -ra -- '([ ;#^<>&|()"\'])' "$backslash\$1" (commandline -oc)[-1])
+    # count $file is 0 or 1
+
+    set -q file[1] || return
+    # Now file contains exactly one element, the unexpanded token.
+
+    # strip -option= from token if present
+    set file (string replace -r -- '^-[^\s=]*=(.*)' '$1' $file)
+    true # Clear $status from string replace, we don't want to return because of it.
+
+    eval set -l files $file || return # Return when eval fails.
+
+    if set -q files[1] && test -f $files[1]
+        $pager $files
+        commandline -f repaint
+    end
+end

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -84,6 +84,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv \e. history-token-search-backward
 
     bind --preset $argv \el __fish_list_current_token
+    bind --preset $argv \eo __fish_preview_current_file
     bind --preset $argv \ew __fish_whatis_current_token
     # ncurses > 6.0 sends a "delete scrollback" sequence along with clear.
     # This string replace removes it.


### PR DESCRIPTION
## Description

New function `__fish_preview_current_file` to open current file in pager. Bound to Alt+O by shared key bindings.

Fixes issue #6838

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
