### PR TITLE
In Fish MD5 on BSD now use given String and not -s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `fish --no-execute` will no longer complain about unknown commands or non-matching wildcards, as these could be defined differently at runtime (especially for functions). #977
 - `jobs --quiet PID` will no longer print 'no suitable job' if the job for PID does not exist (e.g. because it has finished). #6809
 - A variable `fish_kill_signal` will be set to the signal that terminated the last foreground job, or `0` if the job exited normally.
+- On BSD systems, with the `-s` option, `fish_md5` does not use the given string, but `-s`. From now on the string is used.
 
 ### Syntax changes and new commands
 

--- a/share/functions/__fish_md5.fish
+++ b/share/functions/__fish_md5.fish
@@ -15,7 +15,7 @@ function __fish_md5
         # BSD systems
         if set -q argv[2]
             if test $argv[1] = -s
-                md5 -s $argv[1]
+                md5 -s $argv[2]
             else
                 printf (_ "%s: Too many arguments %s\n") fish_md5 $argv
             end


### PR DESCRIPTION
## Description

On a BSD system the `-s` option was used instead of the string passed to `fish_md5`.

Fixes issue -

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [-] Changes to fish usage are reflected in user documentation/manpages.
- [-] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md

Changed to use given String and not option `-s`.
