### PR TITLE
Support `.jar` and `.aar` files in `unzip` completions

### DIFF
--- a/share/completions/unzip.fish
+++ b/share/completions/unzip.fish
@@ -28,7 +28,11 @@ complete -c unzip -s M -d "pipe through `more` pager"
 if unzip -v 2>/dev/null | string match -eq Debian
 
     # the first non-switch argument should be the zipfile
-    complete -c unzip -n __fish_is_first_token -xa '(__fish_complete_suffix .zip)'
+    complete -c unzip -n __fish_is_first_token -xa '(
+        __fish_complete_suffix .zip
+        __fish_complete_suffix .jar
+        __fish_complete_suffix .aar
+    )'
 
     # Files thereafter are either files to include or exclude from the operation
     set -l zipfile


### PR DESCRIPTION
## Description
I've been dealing with these a lot recently (android dev...), and it's
pretty annoying that unzip completions don't recognize them (They're
just zip files with a weird file extension).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
