### PR TITLE
Allow `man` completions on catalina if `apropos` is overridden

### DIFF
--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -2,16 +2,20 @@
 # The whatis database is non-existent, so apropos tries (and fails) to create it every time,
 # which takes about half a second.
 #
-# So we disable this entirely in that case.
+# So we disable this entirely in that case, unless the user has overridden the system
+# `apropos` with their own, which presumably doesn't have the same problem.
 if test (uname) = Darwin
     set -l darwin_version (uname -r | string split .)
     # macOS 15 is Darwin 19, this is an issue at least up to 10.15.3.
     # If this is fixed in later versions uncomment the second check.
     if test "$darwin_version[1]" = 19 # -a "$darwin_version[2]" -le 3
-        function __fish_complete_man
+        set -l apropos (command -s apropos)
+        if test "$apropos" = "/usr/bin/apropos"
+            function __fish_complete_man
+            end
+            # (remember: exit when `source`ing only exits the file, not the shell)
+            exit
         end
-        # (remember: exit when `source`ing only exits the file, not the shell)
-        exit
     end
 end
 


### PR DESCRIPTION
## Description
It's pretty easy to fix catalina's apropos with [a small tweak](https://apple.stackexchange.com/a/375629), so it would be nice if fish's man completions worked for users who do this and override the default `apropos`. Making that work is just an extra check at the start of the completion handler so it seems worth it to me.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
