### PR TITLE
Allow unzip versions not patched by Debian to enjoy .{jar,aar} completions

### DIFF
--- a/share/completions/unzip.fish
+++ b/share/completions/unzip.fish
@@ -41,6 +41,10 @@ if unzip -v 2>/dev/null | string match -eq Debian
 else
 
     # all tokens should be zip files
-    complete -c unzip -xa '(__fish_complete_suffix .zip)'
+    complete -c unzip -xa '(
+        __fish_complete_suffix .zip
+        __fish_complete_suffix .jar
+        __fish_complete_suffix .aar
+    )'
 
 end


### PR DESCRIPTION
A minor follow-up to #6866 (e658a88ab0066987fcec90c40b3e454836e75eb2).
These file types should be properly handled by other unzip flavors too,
regardless of Debian's/non-Linux Unixes' idiosyncrasies.