### PR TITLE
git prompt: resilient check for git stash

### DIFF
--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -414,7 +414,7 @@ function fish_git_prompt --description "Prompt function for Git"
             end
 
             if set -q __fish_git_prompt_showstashstate
-                and test -r $git_dir/refs/stash
+                and test -r $git_dir/logs/refs/stash
                 set s $___fish_git_prompt_char_stashstate
             end
 


### PR DESCRIPTION
The refs/stash file is deleted by "git gc". The prompt won't display
stash information until another "git stash" command is run.

Using "git rev-parse stash" seems more resilient.

Based the choice on "git stash" test cases:
https://github.com/git/git/blob/master/t/t3903-stash.sh

There is still one edge case that I know of:
- If there is a branch named "stash", and no actual stashes,
this will report that there are stashes
