### PR TITLE
Fire fish_postexec event on tokenization error

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2173,7 +2173,8 @@ parser_test_error_bits_t reader_shell_test(parser_t &parser, const wcstring &b) 
             error_desc.push_back(L'\n');
         }
         std::fwprintf(stderr, L"\n%ls", error_desc.c_str());
-        event_fire_generic(parser, L"fish_postexec");
+        wcstring_list_t argv(1, b);
+        event_fire_generic(parser, L"fish_postexec", &argv);
     }
     return res;
 }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2173,8 +2173,6 @@ parser_test_error_bits_t reader_shell_test(parser_t &parser, const wcstring &b) 
             error_desc.push_back(L'\n');
         }
         std::fwprintf(stderr, L"\n%ls", error_desc.c_str());
-        wcstring_list_t argv(1, b);
-        event_fire_generic(parser, L"fish_postexec", &argv);
     }
     return res;
 }
@@ -2947,6 +2945,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             } else {
                 // Result must be some combination including an error. The error message will
                 // already be printed, all we need to do is repaint.
+                wcstring_list_t argv(1, el->text());
+                event_fire_generic(parser(), L"fish_posterror", &argv);
                 s_reset(&screen, screen_reset_abandon_line);
                 reader_repaint_needed();
             }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2173,6 +2173,7 @@ parser_test_error_bits_t reader_shell_test(parser_t &parser, const wcstring &b) 
             error_desc.push_back(L'\n');
         }
         std::fwprintf(stderr, L"\n%ls", error_desc.c_str());
+        event_fire_generic(parser, L"fish_postexec");
     }
     return res;
 }


### PR DESCRIPTION
Fixes issue #6816 "shell integration with tokenization error"

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

CHANGELOG.md note could be:
A tokenization error (such as command-line containing just `)`) now raises the `fish_postexec` event, as documented.