### PR TITLE
Change C casts to C++ ones

### DIFF
--- a/src/builtin_read.cpp
+++ b/src/builtin_read.cpp
@@ -617,7 +617,7 @@ int builtin_read(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
                 // is set to the remaining string.
                 split_about(buff.begin(), buff.end(), opts.delimiter.begin(), opts.delimiter.end(),
                             &splits, argc - 1);
-                assert(splits.size() <= (size_t)vars_left());
+                assert(splits.size() <= static_cast<size_t>(vars_left()));
                 for (const auto &split : splits) {
                     parser.set_var_and_fire(*var_ptr++, opts.place, split);
                 }

--- a/src/builtin_set_color.cpp
+++ b/src/builtin_set_color.cpp
@@ -185,7 +185,7 @@ int builtin_set_color(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     outputter_t outp;
 
     if (bold && enter_bold_mode) {
-        writembs_nofail(outp, tparm((char *)enter_bold_mode));
+        writembs_nofail(outp, tparm(const_cast<char *>(enter_bold_mode)));
     }
 
     if (underline && enter_underline_mode) {
@@ -207,12 +207,12 @@ int builtin_set_color(parser_t &parser, io_streams_t &streams, wchar_t **argv) {
     }
 
     if (bgcolor != nullptr && bg.is_normal()) {
-        writembs_nofail(outp, tparm((char *)exit_attribute_mode));
+        writembs_nofail(outp, tparm(const_cast<char *>(exit_attribute_mode)));
     }
 
     if (!fg.is_none()) {
         if (fg.is_normal() || fg.is_reset()) {
-            writembs_nofail(outp, tparm((char *)exit_attribute_mode));
+            writembs_nofail(outp, tparm(const_cast<char *>(exit_attribute_mode)));
         } else {
             if (!outp.write_color(fg, true /* is_fg */)) {
                 // We need to do *something* or the lack of any output messes up

--- a/src/common.h
+++ b/src/common.h
@@ -59,8 +59,8 @@ typedef std::vector<wcstring> wcstring_list_t;
 // Use Unicode "noncharacters" for internal characters as much as we can. This
 // gives us 32 "characters" for internal use that we can guarantee should not
 // appear in our input stream. See http://www.unicode.org/faq/private_use.html.
-#define RESERVED_CHAR_BASE (wchar_t)0xFDD0
-#define RESERVED_CHAR_END (wchar_t)0xFDF0
+#define RESERVED_CHAR_BASE static_cast<wchar_t>(0xFDD0)
+#define RESERVED_CHAR_END static_cast<wchar_t>(0xFDF0)
 // Split the available noncharacter values into two ranges to ensure there are
 // no conflicts among the places we use these special characters.
 #define EXPAND_RESERVED_BASE RESERVED_CHAR_BASE
@@ -86,7 +86,7 @@ typedef std::vector<wcstring> wcstring_list_t;
 // Note: We don't use the highest 8 bit range (0xF800 - 0xF8FF) because we know
 // of at least one use of a codepoint in that range: the Apple symbol (0xF8FF)
 // on Mac OS X. See http://www.unicode.org/faq/private_use.html.
-#define ENCODE_DIRECT_BASE (wchar_t)0xF600
+#define ENCODE_DIRECT_BASE static_cast<wchar_t>(0xF600)
 #define ENCODE_DIRECT_END (ENCODE_DIRECT_BASE + 256)
 
 // NAME_MAX is not defined on Solaris
@@ -399,7 +399,7 @@ void assert_is_background_thread(const char *who);
 /// Useful macro for asserting that a lock is locked. This doesn't check whether this thread locked
 /// it, which it would be nice if it did, but here it is anyways.
 void assert_is_locked(void *mutex, const char *who, const char *caller);
-#define ASSERT_IS_LOCKED(x) assert_is_locked((void *)(&x), #x, __FUNCTION__)
+#define ASSERT_IS_LOCKED(x) assert_is_locked(reinterpret_cast<void *>(&x), #x, __FUNCTION__)
 
 /// Format the specified size (in bytes, kilobytes, etc.) into the specified stringbuffer.
 wcstring format_size(long long sz);
@@ -842,7 +842,7 @@ template <>
 struct hash<const wcstring> {
     std::size_t operator()(const wcstring &w) const {
         std::hash<wcstring> hasher;
-        return hasher((wcstring)w);
+        return hasher(static_cast<wcstring>(w));
     }
 };
 }  // namespace std

--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -478,7 +478,8 @@ static void init_curses(const environment_t &vars) {
     }
 
     can_set_term_title = does_term_support_setting_title(vars);
-    term_has_xn = tigetflag((char *)"xenl") == 1;  // does terminal have the eat_newline_glitch
+    term_has_xn =
+        tigetflag(const_cast<char *>("xenl")) == 1;  // does terminal have the eat_newline_glitch
     update_fish_color_support(vars);
     // Invalidate the cached escape sequences since they may no longer be valid.
     cached_layouts.clear();

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -956,7 +956,7 @@ static bool get_mac_address(unsigned char macaddr[MAC_ADDRESS_MAX_LEN],
     const int dummy = socket(AF_INET, SOCK_STREAM, 0);
     if (dummy >= 0) {
         struct ifreq r;
-        strncpy((char *)r.ifr_name, interface, sizeof r.ifr_name - 1);
+        strncpy(const_cast<char *>(r.ifr_name), interface, sizeof r.ifr_name - 1);
         r.ifr_name[sizeof r.ifr_name - 1] = 0;
         if (ioctl(dummy, SIOCGIFHWADDR, &r) >= 0) {
             std::memcpy(macaddr, r.ifr_hwaddr.sa_data, MAC_ADDRESS_MAX_LEN);

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -411,8 +411,8 @@ int main(int argc, char **argv) {
 
     const char *dummy_argv[2] = {"fish", nullptr};
     if (!argv[0]) {
-        argv = (char **)dummy_argv;  //!OCLINT(parameter reassignment)
-        argc = 1;                    //!OCLINT(parameter reassignment)
+        argv = const_cast<char **>(dummy_argv);  //!OCLINT(parameter reassignment)
+        argc = 1;                                //!OCLINT(parameter reassignment)
     }
     fish_cmd_opts_t opts{};
     my_optind = fish_parse_opt(argc, argv, &opts);

--- a/src/fish_test_helper.cpp
+++ b/src/fish_test_helper.cpp
@@ -51,12 +51,12 @@ static void print_stdout_stderr() {
 
 static void print_pid_then_sleep() {
     // On some systems getpid is a long, on others it's an int, let's just cast it.
-    fprintf(stdout, "%ld\n", (long)getpid());
+    fprintf(stdout, "%ld\n", static_cast<long>(getpid()));
     fflush(nullptr);
     usleep(1000000 / 2);  //.5 secs
 }
 
-static void print_pgrp() { fprintf(stdout, "%ld\n", (long)getpgrp()); }
+static void print_pgrp() { fprintf(stdout, "%ld\n", static_cast<long>(getpgrp())); }
 
 static void print_fds() {
     bool needs_space = false;

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -39,7 +39,7 @@
 
 namespace g = grammar;
 
-#define CURSOR_POSITION_INVALID ((size_t)(-1))
+#define CURSOR_POSITION_INVALID static_cast<size_t>(-1)
 
 static const wchar_t *get_highlight_var_name(highlight_role_t role) {
     switch (role) {

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -269,13 +269,13 @@ void io_chain_t::print() const {
         return;
     }
 
-    std::fwprintf(stderr, L"Chain %p (%ld items):\n", this, (long)this->size());
+    std::fwprintf(stderr, L"Chain %p (%ld items):\n", this, static_cast<long>(this->size()));
     for (size_t i = 0; i < this->size(); i++) {
         const auto &io = this->at(i);
         if (io == nullptr) {
             std::fwprintf(stderr, L"\t(null)\n");
         } else {
-            std::fwprintf(stderr, L"\t%lu: fd:%d, ", (unsigned long)i, io->fd);
+            std::fwprintf(stderr, L"\t%lu: fd:%d, ", static_cast<unsigned long>(i), io->fd);
             io->print();
         }
     }

--- a/src/io.h
+++ b/src/io.h
@@ -27,7 +27,7 @@ struct fd_set_t {
 
     void add(int fd) {
         assert(fd >= 0 && "Invalid fd");
-        if ((size_t)fd >= fds.size()) {
+        if (static_cast<size_t>(fd) >= fds.size()) {
             fds.resize(fd + 1);
         }
         fds[fd] = true;
@@ -35,7 +35,7 @@ struct fd_set_t {
 
     bool contains(int fd) const {
         assert(fd >= 0 && "Invalid fd");
-        return (size_t)fd < fds.size() && fds[fd];
+        return static_cast<size_t>(fd) < fds.size() && fds[fd];
     }
 };
 

--- a/src/null_terminated_array.cpp
+++ b/src/null_terminated_array.cpp
@@ -35,16 +35,18 @@ static CharT **make_null_terminated_array_helper(
         const std::basic_string<CharT> &str = argv.at(i);
         *pointers++ = strings;  // store the current string pointer into self
         strings = std::copy(str.begin(), str.end(), strings);  // copy the string into strings
-        *strings++ = (CharT)(0);  // each string needs a null terminator
+        *strings++ = static_cast<CharT>(0);  // each string needs a null terminator
     }
     *pointers++ = nullptr;  // array of pointers needs a null terminator
 
     // Make sure we know what we're doing.
-    assert((unsigned char *)pointers - base == (std::ptrdiff_t)pointers_allocation_len);
-    assert((unsigned char *)strings - (unsigned char *)pointers ==
-           (std::ptrdiff_t)strings_allocation_len);
-    assert((unsigned char *)strings - base ==
-           (std::ptrdiff_t)(pointers_allocation_len + strings_allocation_len));
+    assert(reinterpret_cast<unsigned char *>(pointers) - base ==
+           static_cast<std::ptrdiff_t>(pointers_allocation_len));
+    assert(reinterpret_cast<unsigned char *>(strings) -
+               reinterpret_cast<unsigned char *>(pointers) ==
+           static_cast<std::ptrdiff_t>(strings_allocation_len));
+    assert(reinterpret_cast<unsigned char *>(strings) - base ==
+           static_cast<std::ptrdiff_t>(pointers_allocation_len + strings_allocation_len));
 
     return reinterpret_cast<CharT **>(base);
 }

--- a/src/null_terminated_array.h
+++ b/src/null_terminated_array.h
@@ -34,7 +34,7 @@ class null_terminated_array_t {
     }
 
     void free(void) {
-        ::free((void *)array);
+        ::free(reinterpret_cast<void *>(array));
         array = nullptr;
     }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -55,7 +55,7 @@ unsigned char index_for_color(rgb_color_t c) {
 static bool write_color_escape(outputter_t &outp, const char *todo, unsigned char idx, bool is_fg) {
     if (term_supports_color_natively(idx)) {
         // Use tparm to emit color escape.
-        writembs(outp, tparm((char *)todo, idx));
+        writembs(outp, tparm(const_cast<char *>(todo), idx));
         return true;
     }
 
@@ -302,7 +302,7 @@ void outputter_t::set_color(rgb_color_t c, rgb_color_t c2) {
     // Lastly, we set bold, underline, italics, dim, and reverse modes correctly.
     if (is_bold && !was_bold && enter_bold_mode && enter_bold_mode[0] != '\0' && !bg_set) {
         // The unconst cast is for NetBSD's benefit. DO NOT REMOVE!
-        writembs_nofail(*this, tparm((char *)enter_bold_mode));
+        writembs_nofail(*this, tparm(const_cast<char *>(enter_bold_mode)));
         was_bold = is_bold;
     }
 

--- a/src/pager.h
+++ b/src/pager.h
@@ -13,7 +13,7 @@
 #include "reader.h"
 #include "screen.h"
 
-#define PAGER_SELECTION_NONE ((size_t)(-1))
+#define PAGER_SELECTION_NONE static_cast<size_t>(-1)
 
 /// Represents rendering from the pager.
 class page_rendering_t {

--- a/src/parse_tree.cpp
+++ b/src/parse_tree.cpp
@@ -275,7 +275,8 @@ static inline parse_token_type_t parse_token_type_from_tokenizer_token(
         case token_type_t::comment:
             return parse_special_type_comment;
     }
-    FLOGF(error, L"Bad token type %d passed to %s", (int)tokenizer_token_type, __FUNCTION__);
+    FLOGF(error, L"Bad token type %d passed to %s", static_cast<int>(tokenizer_token_type),
+          __FUNCTION__);
     DIE("bad token type");
     return token_type_invalid;
 }

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -299,7 +299,7 @@ static void job_or_process_extent(bool process, const wchar_t *buff, size_t curs
         return;
     }
 
-    assert(cursor_pos >= (size_t)(begin - buff));
+    assert(cursor_pos >= static_cast<size_t>(begin - buff));
     const size_t pos = cursor_pos - (begin - buff);
 
     if (a) *a = begin;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1889,7 +1889,7 @@ static void acquire_tty_or_exit(pid_t shell_pgid) {
                 const wchar_t *fmt =
                     _(L"I appear to be an orphaned process, so I am quitting politely. "
                       L"My pid is %d.");
-                FLOGF(warning, fmt, (int)getpid());
+                FLOGF(warning, fmt, static_cast<int>(getpid()));
                 exit_without_destructors(1);
             }
 
@@ -3138,7 +3138,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
 
                     base_pos_old = parse_util_get_offset_from_line(el->text(), line_old);
 
-                    assert(base_pos_new != (size_t)(-1) && base_pos_old != (size_t)(-1));
+                    assert(base_pos_new != static_cast<size_t>(-1) &&
+                           base_pos_old != static_cast<size_t>(-1));
                     indent_old = indents.at(base_pos_old);
                     indent_new = indents.at(base_pos_new);
 

--- a/src/sanity.cpp
+++ b/src/sanity.cpp
@@ -24,7 +24,7 @@ void sanity_lose() {
 
 void validate_pointer(const void *ptr, const wchar_t *err, int null_ok) {
     // Test if the pointer data crosses a segment boundary.
-    if ((0x00000003L & (intptr_t)ptr) != 0) {
+    if ((0x00000003L & reinterpret_cast<intptr_t>(ptr)) != 0) {
         FLOGF(error, _(L"The pointer '%ls' is invalid"), err);
         sanity_lose();
     }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -1001,7 +1001,7 @@ void s_write(screen_t *s, const wcstring &left_prompt, const wcstring &right_pro
              const std::vector<highlight_spec_t> &colors, const std::vector<int> &indent,
              size_t cursor_pos, const page_rendering_t &pager, bool cursor_is_within_pager) {
     static relaxed_atomic_t<uint32_t> s_repaints{0};
-    FLOGF(screen, "Repaint %u", (unsigned)++s_repaints);
+    FLOGF(screen, "Repaint %u", static_cast<unsigned>(++s_repaints));
     screen_data_t::cursor_t cursor_arr;
 
     // Turn the command line into the explicit portion and the autosuggestion.
@@ -1155,7 +1155,7 @@ void s_reset(screen_t *s, screen_reset_mode_t mode) {
         if (screen_width > non_space_width) {
             bool justgrey = true;
             if (cur_term && enter_dim_mode) {
-                std::string dim = tparm((char *)enter_dim_mode);
+                std::string dim = tparm(const_cast<char *>(enter_dim_mode));
                 if (!dim.empty()) {
                     // Use dim if they have it, so the color will be based on their actual normal
                     // color and the background of the termianl.
@@ -1166,22 +1166,26 @@ void s_reset(screen_t *s, screen_reset_mode_t mode) {
             if (cur_term && justgrey && set_a_foreground) {
                 if (max_colors >= 238) {
                     // draw the string in a particular grey
-                    abandon_line_string.append(str2wcstring(tparm((char *)set_a_foreground, 237)));
+                    abandon_line_string.append(
+                        str2wcstring(tparm(const_cast<char *>(set_a_foreground), 237)));
                 } else if (max_colors >= 9) {
                     // bright black (the ninth color, looks grey)
-                    abandon_line_string.append(str2wcstring(tparm((char *)set_a_foreground, 8)));
+                    abandon_line_string.append(
+                        str2wcstring(tparm(const_cast<char *>(set_a_foreground), 8)));
                 } else if (max_colors >= 2 && enter_bold_mode) {
                     // we might still get that color by setting black and going bold for bright
-                    abandon_line_string.append(str2wcstring(tparm((char *)enter_bold_mode)));
-                    abandon_line_string.append(str2wcstring(tparm((char *)set_a_foreground, 0)));
+                    abandon_line_string.append(
+                        str2wcstring(tparm(const_cast<char *>(enter_bold_mode))));
+                    abandon_line_string.append(
+                        str2wcstring(tparm(const_cast<char *>(set_a_foreground), 0)));
                 }
             }
 
             abandon_line_string.append(get_omitted_newline_str());
 
             if (cur_term && exit_attribute_mode) {
-                abandon_line_string.append(str2wcstring(
-                    tparm((char *)exit_attribute_mode)));  // normal text ANSI escape sequence
+                abandon_line_string.append(str2wcstring(tparm(
+                    const_cast<char *>(exit_attribute_mode))));  // normal text ANSI escape sequence
             }
 
             int newline_glitch_width = term_has_xn ? 0 : 1;

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -448,7 +448,7 @@ static te_expr *factor(state *s) {
 
     while (s->type == TOK_INFIX &&
            (s->function == reinterpret_cast<const void *>(static_cast<te_fun2>(pow)))) {
-        auto t = (te_fun2)s->function;
+        auto t = reinterpret_cast<te_fun2>(const_cast<void *>(s->function));
         next_token(s);
 
         if (insertion) {
@@ -475,7 +475,7 @@ static te_expr *term(state *s) {
            (s->function == reinterpret_cast<const void *>(static_cast<te_fun2>(mul)) ||
             s->function == reinterpret_cast<const void *>(static_cast<te_fun2>(divide)) ||
             s->function == reinterpret_cast<const void *>(static_cast<te_fun2>(fmod)))) {
-        auto t = (te_fun2)s->function;
+        auto t = reinterpret_cast<te_fun2>(const_cast<void *>(s->function));
         next_token(s);
         ret = NEW_EXPR(TE_FUNCTION2, ret, factor(s));
         ret->function = reinterpret_cast<const void *>(t);
@@ -489,7 +489,7 @@ static te_expr *expr(state *s) {
     te_expr *ret = term(s);
 
     while (s->type == TOK_INFIX && (s->function == add || s->function == sub)) {
-        auto t = (te_fun2)s->function;
+        auto t = reinterpret_cast<te_fun2>(const_cast<void *>(s->function));
         next_token(s);
         ret = NEW_EXPR(TE_FUNCTION2, ret, term(s));
         ret->function = reinterpret_cast<const void *>(t);

--- a/src/topic_monitor.cpp
+++ b/src/topic_monitor.cpp
@@ -96,7 +96,8 @@ generation_list_t topic_monitor_t::updated_gens_in_data(acquired_lock<data_t> &d
     for (topic_t topic : topic_iter_t{}) {
         if (topics.get(topic)) {
             data->current_gens.at(topic) += 1;
-            FLOG(topic_monitor, "Updating topic", (int)topic, "to", data->current_gens.at(topic));
+            FLOG(topic_monitor, "Updating topic", static_cast<int>(topic), "to",
+                 data->current_gens.at(topic));
         }
     }
     // Report our change.

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -34,7 +34,7 @@
 
 // We can tweak the following typedef to allow us to simulate Windows-style 16 bit wchar's on Unix.
 using utf8_wchar_t = wchar_t;
-#define UTF8_WCHAR_MAX (wchar_t) std::numeric_limits<utf8_wchar_t>::max()
+#define UTF8_WCHAR_MAX static_cast<wchar_t>(std::numeric_limits<utf8_wchar_t>::max())
 
 using utf8_wstring_t = std::basic_string<utf8_wchar_t>;
 
@@ -176,7 +176,7 @@ static size_t utf8_to_wchar_internal(const char *in, size_t insize, utf8_wstring
     if (out_string != nullptr) out_string->clear();
 
     total = 0;
-    p = (unsigned char *)in;
+    p = reinterpret_cast<unsigned char *>(const_cast<char *>(in));
     lim = p + insize;
 
     for (; p < lim; p += n) {

--- a/src/wgetopt.cpp
+++ b/src/wgetopt.cpp
@@ -370,7 +370,7 @@ bool wgetopter_t::_handle_long_opt(int argc, wchar_t **argv, const struct woptio
                 std::fwprintf(stderr, _(L"%ls: Unrecognized option '%lc%ls'\n"), argv[0],
                               argv[woptind][0], nextchar);
         }
-        nextchar = (wchar_t *)L"";
+        nextchar = const_cast<wchar_t *>(L"");
         woptind++;
         *retval = '?';
         return true;

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -265,7 +265,7 @@ int fd_check_is_remote(int fd) {
     // Linux has constants for these like NFS_SUPER_MAGIC, SMB_SUPER_MAGIC, CIFS_MAGIC_NUMBER but
     // these are in varying headers. Simply hard code them.
     // NOTE: The cast is necessary for 32-bit systems because of the 4-byte CIFS_MAGIC_NUMBER
-    switch ((unsigned int)buf.f_type) {
+    switch (static_cast<unsigned int>(buf.f_type)) {
         case 0x6969:       // NFS_SUPER_MAGIC
         case 0x517B:       // SMB_SUPER_MAGIC
         case 0xFF534D42U:  // CIFS_MAGIC_NUMBER


### PR DESCRIPTION
Some were kept for compatibility.

Found with -Wold-style-cast

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Some of the C casts must remain. The pthread ones come to mind.