### PR TITLE
Add option to aliases to expand next command word like Bash

### DIFF
--- a/doc_src/cmds/alias.rst
+++ b/doc_src/cmds/alias.rst
@@ -27,26 +27,41 @@ You cannot create an alias to a function with the same name. Note that spaces ne
 
 The following options are available:
 
+- ``-e`` or ``--expand-next`` causes the alias to check the next command word for alias expansion. This feature can also be enabled by adding a trailing space at the end of ``DEFINITION``, for compatibility purposes.
+
 - ``-h`` or ``--help`` displays help about using this command.
 
-- ``-s`` or ``--save`` Automatically save the function created by the alias into your fish configuration directory using :ref:`funcsave <cmd-funcsave>`.
+- ``-s`` or ``--save`` automatically saves the function created by the alias into your fish configuration directory using :ref:`funcsave <cmd-funcsave>`.
 
 Example
 -------
 
 The following code will create ``rmi``, which runs ``rm`` with additional arguments on every invocation.
 
-
-
 ::
 
     alias rmi="rm -i"
-    
+
     # This is equivalent to entering the following function:
     function rmi --wraps rm --description 'alias rmi=rm -i'
         rm -i $argv
     end
-    
+
+Be careful when you use an alias with spaces in it:
+
+::
+
     # This needs to have the spaces escaped or "Chrome.app..." will be seen as an argument to "/Applications/Google":
     alias chrome='/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome banana'
 
+You can enable alias expansion of the second command word, useful for commands like sudo which takes another command.
+
+::
+
+    alias sudo='sudo' --expand-next
+    # or, for compatibility with Bash
+    alias sudo='sudo '
+
+    alias l="ls -l"
+    # this will execute `sudo ls -l`
+    sudo l

--- a/tests/checks/alias.fish
+++ b/tests/checks/alias.fish
@@ -8,13 +8,27 @@ my_alias
 # CHECK: ran foo
 # CHECK: foo ran
 
+alias expand1='echo '
+alias -e expand2='echo'
+alias str='test'
+expand1 str
+expand1
+expand2 str
+# CHECK: test
+# CHECK:
+# CHECK: test
+
 alias a-2='echo "hello there"'
 
 alias foo '"a b" c d e'
+
 # Bare `alias` should list the aliases we have created and nothing else
 # We have to exclude two aliases because they're an artifact of the unit test
 # framework and we can't predict the definition.
 alias | grep -Ev '^alias (fish_indent|fish_key_reader) '
 # CHECK: alias a-2 'echo "hello there"'
+# CHECK: alias expand1 'echo '
+# CHECK: alias expand2 echo
 # CHECK: alias foo '"a b" c d e'
 # CHECK: alias my_alias 'foo; and echo foo ran'
+# CHECK: alias str test


### PR DESCRIPTION
## Description

In bash, you can make the alias expansion work after a command by putting a trailing space at the end of the alias. This is very useful for commands like sudo or [doas](https://man.openbsd.org/doas).

According to the man page `bash(1)`:
> If the last character of the alias value is a blank, then the next command word following the alias is also checked for alias expansion.

https://linuxhandbook.com/run-alias-as-sudo/

I also added an “obvious” flag (`--expand-next`) in addition to the compatibility behavior.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
