### PR TITLE
Block TTY control signals in processes started from subshells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - A variable `fish_kill_signal` will be set to the signal that terminated the last foreground job, or `0` if the job exited normally.
 - On BSD systems, with the `-s` option, `fish_md5` does not use the given string, but `-s`. From now on the string is used.
 - Control-C no longer kills background jobs for which job control is disabled, matching POSIX semantics (#6828).
+- Commands run from subshells and event handlers block signals SIGTTIN, SIGTTOU and SIGTSTP, matching Bash's behavior (#6300, #6624).
 
 ### Syntax changes and new commands
 

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -1257,6 +1257,7 @@ end_execution_reason_t parse_execution_context_t::run_1_job(tnode_t<g::job> job_
     props.wants_terminal = wants_job_control && !ld.is_event;
     props.skip_notification =
         ld.is_subshell || ld.is_block || ld.is_event || !parser->is_interactive();
+    props.in_subshell = ld.is_subshell;
     props.from_event_handler = ld.is_event;
     props.job_control = wants_job_control;
 

--- a/src/proc.h
+++ b/src/proc.h
@@ -335,6 +335,9 @@ class job_t {
         /// Whether the job wants to own the terminal when in the foreground.
         bool wants_terminal{};
 
+        /// Whether this job is within a subshell.
+        bool in_subshell{};
+
         /// Whether this job was created as part of an event handler.
         bool from_event_handler{};
 
@@ -500,6 +503,7 @@ class job_t {
         return !is_completed() && is_constructed() && !flags().disown_requested;
     }
     bool skip_notification() const { return properties.skip_notification; }
+    bool in_subshell() const { return properties.in_subshell; }
     bool from_event_handler() const { return properties.from_event_handler; }
 
     /// \return whether we should report process exit events.


### PR DESCRIPTION
Same for processes started from event handlers.

This is consistent with the bash equivalent: from
https://www.gnu.org/software/bash/manual/html_node/Signals.html

	Commands run as a result of command substitution ignore the
	keyboard-generated job control signals SIGTTIN, SIGTTOU, and SIGTSTP.

Fixes #6300 (caused by SIGTTOU from subshell)
Fixes #6624 (caused by SIGTTIN from subshell)
Probably also #6692 which shows very similar symptoms to #6624, but I
have't been able to reproduce that.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
