### PR TITLE
Run `fish_indent` on all files

### DIFF
--- a/share/completions/make.fish
+++ b/share/completions/make.fish
@@ -12,7 +12,7 @@ function __fish_print_make_targets --argument-names directory file
     if make --version 2>/dev/null | string match -q 'GNU*'
         # https://stackoverflow.com/a/26339924
         make $makeflags -pRrq : 2>/dev/null |
-            awk -F: '/^# Files/,/^# Finished Make data base/ {
+        awk -F: '/^# Files/,/^# Finished Make data base/ {
                 if ($1 == "# Not a target") skip = 1;
                 if ($1 !~ "^[#.\t]") { if (!skip) print $1; skip=0 }
             }' 2>/dev/null

--- a/share/completions/openssl.fish
+++ b/share/completions/openssl.fish
@@ -3,5 +3,5 @@ function __fish_openssl_subcommand_options --description "Print options for open
     openssl list -options $cmd[2] | string replace -r -- '^(\S*)\s*.*' '-$1'
 end
 
-complete -c openssl -n '__fish_use_subcommand' -x -a "(openssl list -1 -commands -cipher-commands -digest-commands)"
+complete -c openssl -n __fish_use_subcommand -x -a "(openssl list -1 -commands -cipher-commands -digest-commands)"
 complete -c openssl -n 'not __fish_use_subcommand && string match -qr -- "^-" (commandline -ct)' -a "(__fish_openssl_subcommand_options)"

--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -10,7 +10,7 @@ if test (uname) = Darwin
     # If this is fixed in later versions uncomment the second check.
     if test "$darwin_version[1]" = 19 # -a "$darwin_version[2]" -le 3
         set -l apropos (command -s apropos)
-        if test "$apropos" = "/usr/bin/apropos"
+        if test "$apropos" = /usr/bin/apropos
             function __fish_complete_man
             end
             # (remember: exit when `source`ing only exits the file, not the shell)


### PR DESCRIPTION
Caught a couple of strays that weren't processed last time this was done.

Is the formatting for that pipe into awk  in `make.fish` working as intended?