### PR TITLE
Activate untracked status in hg prompt

### DIFF
--- a/share/functions/fish_hg_prompt.fish
+++ b/share/functions/fish_hg_prompt.fish
@@ -62,7 +62,7 @@ function fish_hg_prompt --description 'Write out the hg prompt'
 
             # Add a character for each file status if we have one
             # HACK: To allow this to work both with and without '?' globs
-            set -l q '?'
+            set -l dq '?'
             switch $line
                 case 'A '
                     set -a hg_statuses added


### PR DESCRIPTION
Correction of a typo that prevented the display of untracked status on the detailed prompt.

## Description

The variable declared on line 65 and the one used on line 75 should be the same.
