### PR TITLE
Change vi-mode tilde to toggle character case

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -171,7 +171,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert cge backward-kill-word repaint-mode
     bind -s --preset -m insert cgE backward-kill-bigword repaint-mode
 
-    bind -s --preset '~' capitalize-word
+    bind -s --preset '~' togglecase-letter forward-char
     bind -s --preset gu downcase-word
     bind -s --preset gU upcase-word
 
@@ -252,6 +252,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M visual t forward-jump-till
     bind -s --preset -M visual F backward-jump
     bind -s --preset -M visual T backward-jump-till
+
+    bind -s --preset -M visual '~' togglecase-selection
 
     for key in $eol_keys
         bind -s --preset -M visual $key end-of-line

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -122,6 +122,8 @@ static const input_function_metadata_t input_function_metadata[] = {
     {readline_cmd_t::upcase_word, L"upcase-word"},
     {readline_cmd_t::downcase_word, L"downcase-word"},
     {readline_cmd_t::capitalize_word, L"capitalize-word"},
+    {readline_cmd_t::togglecase_letter, L"togglecase-letter"},
+    {readline_cmd_t::togglecase_selection, L"togglecase-selection"},
     {readline_cmd_t::execute, L"execute"},
     {readline_cmd_t::beginning_of_buffer, L"beginning-of-buffer"},
     {readline_cmd_t::end_of_buffer, L"end-of-buffer"},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -47,6 +47,8 @@ enum class readline_cmd_t {
     upcase_word,
     downcase_word,
     capitalize_word,
+    togglecase_letter,
+    togglecase_selection,
     execute,
     beginning_of_buffer,
     end_of_buffer,

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -3050,6 +3050,52 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             }
             break;
         }
+        case rl::togglecase_letter: {
+            editable_line_t *el = active_edit_line();
+            size_t str_pos = el->position;
+
+            if (str_pos < el->size()) {
+                wchar_t chr = el->text.at(str_pos);
+
+                bool make_uppercase = iswlower(chr);
+                if (make_uppercase) {
+                    chr = towupper(chr);
+                } else {
+                    chr = tolower(chr);
+                }
+
+                el->text.at(str_pos) = chr;
+            }
+
+            command_line_changed(el);
+            super_highlight_me_plenty();
+            reader_repaint_needed();
+            break;
+        }
+        case rl::togglecase_selection: {
+            editable_line_t *el = active_edit_line();
+
+            size_t start, len;
+            if (reader_get_selection(&start, &len)) {
+                for (size_t pos = start; pos < start + len; pos++) {
+                    wchar_t chr = el->text.at(pos);
+
+                    bool make_uppercase = iswlower(chr);
+                    if (make_uppercase) {
+                        chr = towupper(chr);
+                    } else {
+                        chr = tolower(chr);
+                    }
+
+                    el->text.at(pos) = chr;
+                }
+            }
+
+            command_line_changed(el);
+            super_highlight_me_plenty();
+            reader_repaint_needed();
+            break;
+        }
         case rl::upcase_word:
         case rl::downcase_word:
         case rl::capitalize_word: {


### PR DESCRIPTION
This updates the behavior of tilde to match the behavior found in vim.
In vim, tilde toggles the case of the character under the cursor and
advances one character. In visual mode, the case of each selected
character is toggled and the cursor position is unmodified. In fish,
tilde capitalizes the current letter and advances one word. There is
no current tilde command for visual mode.

## Description

This patch adds the readline commands `togglecase-letter` and `togglecase-selection` to accomplish this behavior. It also adds a visual-mode '~' binding to call `togglecase-selection`
