### PR TITLE
Change vi-mode tilde to toggle character case

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -187,7 +187,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert ci backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection repaint-mode
     bind -s --preset -m insert ca backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection repaint-mode
 
-    bind -s --preset '~' capitalize-word
+    bind -s --preset '~' togglecase-char forward-char
     bind -s --preset gu downcase-word
     bind -s --preset gU upcase-word
 
@@ -291,6 +291,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M visual -m default X kill-whole-line end-selection repaint-mode
     bind -s --preset -M visual -m default y kill-selection yank end-selection repaint-mode
     bind -s --preset -M visual -m default '"*y' "commandline -s | xsel -p; commandline -f end-selection repaint-mode"
+    bind -s --preset -M visual -m default '~' togglecase-selection end-selection repaint-mode
 
     bind -s --preset -M visual -m default \cc end-selection repaint-mode
     bind -s --preset -M visual -m default \e end-selection repaint-mode

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -123,6 +123,8 @@ static const input_function_metadata_t input_function_metadata[] = {
     {readline_cmd_t::upcase_word, L"upcase-word"},
     {readline_cmd_t::downcase_word, L"downcase-word"},
     {readline_cmd_t::capitalize_word, L"capitalize-word"},
+    {readline_cmd_t::togglecase_char, L"togglecase-char"},
+    {readline_cmd_t::togglecase_selection, L"togglecase-selection"},
     {readline_cmd_t::execute, L"execute"},
     {readline_cmd_t::beginning_of_buffer, L"beginning-of-buffer"},
     {readline_cmd_t::end_of_buffer, L"end-of-buffer"},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -48,6 +48,8 @@ enum class readline_cmd_t {
     upcase_word,
     downcase_word,
     capitalize_word,
+    togglecase_char,
+    togglecase_selection,
     execute,
     beginning_of_buffer,
     end_of_buffer,


### PR DESCRIPTION
This updates the behavior of tilde to match the behavior found in vim.
In vim, tilde toggles the case of the character under the cursor and
advances one character. In visual mode, the case of each selected
character is toggled, the cursor position moves to the beginning of
the selection, and the mode is changed to normal. In fish, tilde
capitalizes the current letter and advances one word. There is no
current tilde command for visual mode in fish.

## Description

This patch adds the readline commands `togglecase-letter` and
`togglecase-selection` to match the behavior of vim more closely. The
only difference is that in visual mode, the cursor is not modified.
Modifying the cursor in visual mode would require either moving it in
`togglecase-selection`, which seems outside its scope or adding
something like a `move-to-selection-start` readline command.