### PR TITLE
docs: fix formatting for commandline examples

### DIFF
--- a/doc_src/cmds/commandline.rst
+++ b/doc_src/cmds/commandline.rst
@@ -83,7 +83,7 @@ The `echo $flounder >&` is the first process, `less` the second and `and echo $c
 
 `$flounder` is the current token.
 
-More examples::
+More examples:
 
 
 ::

--- a/doc_src/cmds/status.rst
+++ b/doc_src/cmds/status.rst
@@ -23,7 +23,7 @@ Synopsis
     status function
     status line-number
     status stack-trace
-    status job-control CONTROL-TYPE
+    status job-control CONTROL_TYPE
     status features
     status test-feature FEATURE
 
@@ -63,7 +63,7 @@ The following operations (sub-commands) are available:
 
 - ``stack-trace`` prints a stack trace of all function calls on the call stack. Also ``print-stack-trace``, ``-t`` or ``--print-stack-trace``.
 
-- ``job-control CONTROL-TYPE`` sets the job control type, which can be ``none``, ``full``, or ``interactive``. Also ``-j CONTROL-TYPE`` or ``--job-control=CONTROL-TYPE``.
+- ``job-control CONTROL_TYPE`` sets the job control type, which can be ``none``, ``full``, or ``interactive``. Also ``-j CONTROL_TYPE`` or ``--job-control CONTROL_TYPE``.
 
 - ``features`` lists all available feature flags.
 


### PR DESCRIPTION
## Description

The `commandline` examples broke in https://github.com/fish-shell/fish-shell/commit/d659ee336dd7b98d48b8e34c37ec1c63a7308b25.

<img width="835" alt="commandline1" src="https://user-images.githubusercontent.com/5209296/79532177-f7f8f280-8039-11ea-9b98-9f1747f0d06e.png">

After:

<img width="844" alt="commandline2" src="https://user-images.githubusercontent.com/5209296/79532178-f8918900-8039-11ea-8ffe-16b34b296818.png">
