### PR TITLE
Multi arg support for string split -f

### DIFF
--- a/doc_src/cmds/string-split.rst
+++ b/doc_src/cmds/string-split.rst
@@ -18,7 +18,9 @@ Description
 
 .. BEGIN DESCRIPTION
 
-``string split`` splits each STRING on the separator SEP, which can be an empty string. If ``-m`` or ``--max`` is specified, at most MAX splits are done on each STRING. If ``-r`` or ``--right`` is given, splitting is performed right-to-left. This is useful in combination with ``-m`` or ``--max``. With ``-n`` or ``--no-empty``, empty results are excluded from consideration (e.g. ``hello\n\nworld`` would expand to two strings and not three). Use ``-f`` or ``--fields`` to print out specific fields. Exit status: 0 if at least one split was performed, or 1 otherwise.
+``string split`` splits each STRING on the separator SEP, which can be an empty string. If ``-m`` or ``--max`` is specified, at most MAX splits are done on each STRING. If ``-r`` or ``--right`` is given, splitting is performed right-to-left. This is useful in combination with ``-m`` or ``--max``. With ``-n`` or ``--no-empty``, empty results are excluded from consideration (e.g. ``hello\n\nworld`` would expand to two strings and not three). Exit status: 0 if at least one split was performed, or 1 otherwise.
+
+Use ``-f`` or ``--fields`` to print out specific fields. Unless ``--allow-empty` is used, if a given field does not exist, then the command exits with status 1 and does not print anything.
 
 See also the ``--delimiter`` option of the :ref:`read <cmd-read>` command.
 
@@ -49,7 +51,7 @@ Examples
     b
     c
 
-    >_ string split -f1,3 '' abc
+    >_ string split --allow-empty -f1,3,5 '' abc
     a
     c
 

--- a/share/completions/xprop.fish
+++ b/share/completions/xprop.fish
@@ -1,6 +1,6 @@
 function __fish_xprop_list_properties
     # TODO search commandline for a target window ("-root" or "-name foo")
-    xprop -root | cut -d'(' -f 1
+    xprop -root | string split -f1 '('
 end
 
 complete -c xprop -o help -d "Display help and exit"
@@ -19,4 +19,3 @@ complete -c xprop -o set -d "Set property" -x -a " (__fish_xprop_list_properties
 complete -c xprop -o spy -d "Examine property updates forever"
 complete -c xprop -o f -d "Set format"
 complete -c xprop -d Property -x -a "( __fish_xprop_list_properties)"
-

--- a/share/functions/__fish_complete_gpg_user_id.fish
+++ b/share/functions/__fish_complete_gpg_user_id.fish
@@ -2,8 +2,7 @@
 
 function __fish_complete_gpg_user_id -d "Complete using gpg user ids" -a __fish_complete_gpg_command
     # gpg doesn't seem to like it when you use the whole key name as a
-    # completion, so we skip the <EMAIL> part and use it as a
-    # description.
-    # It also replaces colons with \x3a
-    $__fish_complete_gpg_command --list-keys --with-colon | cut -d : -f 10 | sed -ne 's/\\\x3a/:/g' -e 's/\(.*\) <\(.*\)>/\1'\t'\2/p'
+    # completion, so we skip the <EMAIL> part and use it as a description.
+    # It also replaces \x3a from gpg's output with colons.
+    $__fish_complete_gpg_command --list-keys --with-colon | string split -a -f 10 : | string replace '\x3a' : | string replace -rf '(.*) <(.*)>' '$1\t$2'
 end

--- a/share/functions/__fish_complete_groups.fish
+++ b/share/functions/__fish_complete_groups.fish
@@ -1,8 +1,12 @@
 
 function __fish_complete_groups --description "Print a list of local groups, with group members as the description"
     if command -sq getent
-        getent group | cut -d ':' -f 1,4 | string replace : \t
+        getent group | while read -l line
+            string split -f 1,4 : -- $line | string join \t
+        end
     else
-        cut -d ':' -f 1,4 /etc/group | string replace : \t
+        while read -l line
+            string split -f 1,4 : -- $line | string join \t
+        end </etc/group
     end
 end

--- a/share/functions/__fish_crux_packages.fish
+++ b/share/functions/__fish_crux_packages.fish
@@ -1,4 +1,4 @@
 # a function to obtain a list of installed packages with CRUX pkgutils
 function __fish_crux_packages -d 'Obtain a list of installed packages'
-    pkginfo -i | cut -d' ' -f1
+    pkginfo -i | string split -f1 ' '
 end

--- a/share/functions/__fish_systemctl_services.fish
+++ b/share/functions/__fish_systemctl_services.fish
@@ -1,13 +1,13 @@
 function __fish_systemctl_services
     if type -q systemctl
         if __fish_contains_opt user
-            systemctl --user list-unit-files --full --no-legend --no-pager --plain --type=service 2>/dev/null $argv | cut -f 1 -d ' '
-            systemctl --user list-units --state=loaded --full --no-legend --no-pager --plain --type=service 2>/dev/null | cut -f 1 -d ' '
+            systemctl --user list-unit-files --full --no-legend --no-pager --plain --type=service 2>/dev/null $argv | string split -f 1 ' '
+            systemctl --user list-units --state=loaded --full --no-legend --no-pager --plain --type=service 2>/dev/null | string split -f 1 ' '
         else
             # list-unit-files will also show disabled units
-            systemctl list-unit-files --full --no-legend --no-pager --plain --type=service 2>/dev/null $argv | cut -f 1 -d ' '
+            systemctl list-unit-files --full --no-legend --no-pager --plain --type=service 2>/dev/null $argv | string split -f 1 ' '
             # list-units will not show disabled units but will show instances (like wpa_supplicant@wlan0.service)
-            systemctl list-units --state=loaded --full --no-legend --no-pager --plain --type=service 2>/dev/null | cut -f 1 -d ' '
+            systemctl list-units --state=loaded --full --no-legend --no-pager --plain --type=service 2>/dev/null | string split -f 1 ' '
         end
     end
 end

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -107,6 +107,10 @@ string split --fields=1-3,5,9-7 "" 123456789
 # CHECK: 8
 # CHECK: 7
 
+string split -f1 ' ' 'a b' 'c d'
+# CHECK: a
+# CHECK: c
+
 seq 3 | string join ...
 # CHECK: 1...2...3
 

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -111,6 +111,9 @@ string split -f1 ' ' 'a b' 'c d'
 # CHECK: a
 # CHECK: c
 
+string split --allow-empty --fields=2,9 "" abc
+# CHECK: b
+
 seq 3 | string join ...
 # CHECK: 1...2...3
 


### PR DESCRIPTION
## Description

Addresses https://github.com/fish-shell/fish-shell/issues/6900

`string split -f` now correctly handles multi-line/args.
Note that this isn't meant to be a drop-in replacement for `cut`, but I will use it as a comparison:

Handling mutli-line input:
```fish
>printf "a b\nc d\n" | cut -d' ' -f1
a
c
>printf "a b\nc d\n"| string split -f1 ' '
a
c
```
Handling non-existent fields:
```fish
>printf "a b\nc d\n" | cut -d' ' -f99


(outputs two empty lines)
>printf "a b\nc d\n" | string split -f99 ' '
(exit 1, no output)
>printf "a b\nc d\n" | string split --allow-empty -f99 ' '
(exit 0, no output)
```

Handling mix of existing and non-existent fields:
```fish
>printf "a b\nc d\n" | cut -d' ' -f1,99
a
c
>printf "a b\nc d\n" | string split -f1,99 ' '
(exit 1, no output)
>printf "a b\nc d\n" | string split --allow-empty -f1,99 ' '
a
c
```

Handling multiple existing fields:
```fish
>printf "a b\nc d\n" | cut -d' ' -f1,2
a b
c d
(output is joined using the given delimiter)
>printf "a b\nc d\n" | string split -f1,2 ' '
a
b
c
d
```

Use in completions:
```fish
>printf "a b\nc d\n" | cut -d' ' -f1,2 | string replace -r ' ' \t
a	b
c	d
>printf "a b\nc d\n" | while read -l line
     string split -f1,2 ' ' -- $line | string join \t
 end
a	b
c	d
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
