### PR TITLE
systemctl completions: Use --plain where appropriate

### DIFF
--- a/share/functions/__fish_systemctl.fish
+++ b/share/functions/__fish_systemctl.fish
@@ -74,12 +74,11 @@ function __fish_systemctl --description 'Call systemctl with some options from t
     # Output looks like
     # systemd-tmpfiles-clean.timer      [more whitespace] loaded    active     waiting   Daily Cleanup[...]
     # Use the last part as the description.
-    # Note that in some cases this prints a "●" or "*" (with C locale) marker at the beginning of the line. We have to remove it.
-    systemctl --no-legend --no-pager --all list-units $passflags | string trim -c ' *●' | string replace -r "(?: +(\S+)){4}" \t'$1'
+    systemctl --full --no-legend --no-pager --plain --all list-units $passflags | string replace -r "(?: +(\S+)){4}" \t'$1'
     # We need this for disabled/static units. Also instance units without an active instance.
     # Output looks like
     # systemd-tmpfiles-clean.timer               static
     # Just use the state as the description, since we won't get it here.
     # This is an issue for units that appear in both.
-    systemctl --no-legend --no-pager --all list-unit-files $passflags | string trim -c ' *●' | string replace -r "(?: +(\S+)){1}" \t'$1'
+    systemctl --full --no-legend --no-pager --plain --all list-unit-files $passflags | string replace -r "(?: +(\S+)){1}" \t'$1'
 end

--- a/share/functions/__fish_systemctl_services.fish
+++ b/share/functions/__fish_systemctl_services.fish
@@ -1,13 +1,13 @@
 function __fish_systemctl_services
     if type -q systemctl
         if __fish_contains_opt user
-            systemctl --user list-unit-files --no-legend --type=service 2>/dev/null $argv | cut -f 1 -d ' '
-            systemctl --user list-units --state=loaded --no-legend --type=service 2>/dev/null | cut -f 1 -d ' '
+            systemctl --user list-unit-files --full --no-legend --no-pager --plain --type=service 2>/dev/null $argv | cut -f 1 -d ' '
+            systemctl --user list-units --state=loaded --full --no-legend --no-pager --plain --type=service 2>/dev/null | cut -f 1 -d ' '
         else
             # list-unit-files will also show disabled units
-            systemctl list-unit-files --no-legend --type=service 2>/dev/null $argv | cut -f 1 -d ' '
+            systemctl list-unit-files --full --no-legend --no-pager --plain --type=service 2>/dev/null $argv | cut -f 1 -d ' '
             # list-units will not show disabled units but will show instances (like wpa_supplicant@wlan0.service)
-            systemctl list-units --state=loaded --no-legend --type=service 2>/dev/null | cut -f 1 -d ' '
+            systemctl list-units --state=loaded --full --no-legend --no-pager --plain --type=service 2>/dev/null | cut -f 1 -d ' '
         end
     end
 end


### PR DESCRIPTION
The --plain flag drops the '●'-glyph and generally makes the output more
suitable for automated processing.

## Description

This undoes db7dfddc3be3ba2fd48bfcebecca4c1179c10901 and fixes #6740 in another way.

The changes anticipate systemd/systemd#15458, but are backward compatible.