### PR TITLE
Fix underflow in `commandline` jump functions

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -433,7 +433,12 @@ bool inputter_t::mapping_is_match(const input_mapping_t &m) {
     return true;
 }
 
-void inputter_t::queue_ch(const char_event_t &ch) { event_queue_.push_back(ch); }
+void inputter_t::queue_ch(const char_event_t &ch) {
+    if (ch.is_readline()) {
+        function_push_args(ch.get_readline());
+    }
+    event_queue_.push_back(ch);
+}
 
 void inputter_t::push_front(const char_event_t &ch) { event_queue_.push_front(ch); }
 


### PR DESCRIPTION
This patch fixes an underflow in the jump family of readline commands when called via `commandline -f` outside of a bind context such as `commandline -f backward-jump`. To reproduce, run that command at a prompt and the shell will crash with a buffer underflow.

## Description

This happens because the jump commands have non-zero arity, requiring a character event to be pushed on the function args stack. Pushing the character event is handled in `function_push_args`, called by `inputter_t::mapping_execute`, which checks the arity of the function and enqueues the required number of charcter events. However, `builtin_commandline` calls `reader_queue_ch`, which in turn calls `inputter_t::queue_ch`, which immediately enqueues the readline event without calling `function_push_args`, so the character event is never pushed on the arg stack.

This patch adds a check in inputter_t::queue_ch which checks if the character event is a readline event, and if so, calls `function_push_args`.