### PR TITLE
fish_hg_prompt should return 1 when not in a mercurial directory

### DIFF
--- a/share/functions/fish_hg_prompt.fish
+++ b/share/functions/fish_hg_prompt.fish
@@ -28,7 +28,7 @@ function fish_hg_prompt --description 'Write out the hg prompt'
     end
 
     set -l root (fish_print_hg_root)
-    or return 0
+    or return 1
 
     # Read branch and bookmark
     set -l branch (cat $root/branch 2>/dev/null; or echo default)


### PR DESCRIPTION
## Description

fish_hg_prompt should return 1 if the PWD is not part of a Mercurial working copy.  Returning 0 prevents the calling script from correctly handling the error.  For example, fish_vcs_prompt will never call fish_svn_prompt on a system that has mercurial installed.

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
