### PR TITLE
docs: Add completions for fish_key_reader

### DIFF
--- a/doc_src/cmds/fish_key_reader.rst
+++ b/doc_src/cmds/fish_key_reader.rst
@@ -21,10 +21,6 @@ The following options are available:
 
 - ``-c`` or ``--continuous`` begins a session where multiple key sequences can be inspected. By default the program exits after capturing a single key sequence.
 
-- ``-d`` or ``--debug=CATEGORY_GLOB`` enables debug output and specifies a glob for matching debug categories (like ``fish -d``). Defaults to empty.
-
-- ``-D`` or ``--debug-stack-frames=DEBUG_LEVEL`` specify how many stack frames to display when debug messages are written. The default is zero. A value of 3 or 4 is usually sufficient to gain insight into how a given debug call was reached but you can specify a value up to 128.
-
 - ``-h`` or ``--help`` prints usage information.
 
 - ``-v`` or ``--version`` prints fish_key_reader's version and exits.

--- a/share/completions/fish_key_reader.fish
+++ b/share/completions/fish_key_reader.fish
@@ -1,0 +1,3 @@
+complete -c fish_key_reader -s h -l help -d 'Display help and exit'
+complete -c fish_key_reader -s v -l version -d 'Display version and exit'
+complete -c fish_key_reader -s c -l continuous -d 'Start a continuous session'


### PR DESCRIPTION
Noticed my `fish_key_reader` completions were the autogenerated ones.

```
> cat ~/.local/share/fish/generated_completions/fish_key_reader.fish
# fish_key_reader
# Autogenerated from man page /usr/local/share/man/man1/fish_key_reader.1
complete -c fish_key_reader -s c -l continuous --description 'o 2.'
complete -c fish_key_reader -s d -l debug -s d --description 'o 2.'
complete -c fish_key_reader -s D -l debug-stack-frames --description 'o 2.'
complete -c fish_key_reader -s h -l help --description 'o 2.'
complete -c fish_key_reader -s v -l version --description '.'
```

I also removed the debug options because [fish_key_reader.cpp](https://github.com/fish-shell/fish-shell/blob/master/src/fish_key_reader.cpp#L273-L278) doesn't expect them.