### PR TITLE
git prompt: Fix shell hang when in detached HEAD repo

### DIFF
--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -656,7 +656,7 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
                 # Shorten the sha ourselves to 8 characters - this should be good for most repositories,
                 # and even for large ones it should be good for most commits
                 if set -q sha
-                    set branch (string match -r '^.{8}' -- $sha)…
+                    set branch (string match -r '^.{8}' -- $sha)...
                 else
                     set branch unknown
                 end


### PR DESCRIPTION
Setting illegal ASCII character will cause the shell hang.
Use ASCII ... instead.

Signed-off-by: Colin Xu <colin.xu@gmail.com>

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
