### PR TITLE
Shorten `set --show` output

### DIFF
--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -575,7 +575,6 @@ static void show_scope(const wchar_t *var_name, int scope, io_streams_t &streams
 
     const auto var = vars.get(var_name, scope);
     if (!var) {
-        streams.out.append_format(_(L"$%ls: not set in %ls scope\n"), var_name, scope_name);
         return;
     }
 
@@ -595,8 +594,8 @@ static void show_scope(const wchar_t *var_name, int scope, io_streams_t &streams
         }
         const wcstring value = vals[i];
         const wcstring escaped_val = escape_string(value, ESCAPE_NO_QUOTED, STRING_STYLE_SCRIPT);
-        streams.out.append_format(_(L"$%ls[%d]: length=%d value=|%ls|\n"), var_name, i + 1,
-                                  value.size(), escaped_val.c_str());
+        streams.out.append_format(_(L"$%ls[%d]: |%ls|\n"), var_name, i + 1,
+                                  escaped_val.c_str());
     }
 }
 
@@ -613,7 +612,6 @@ static int builtin_set_show(const wchar_t *cmd, const set_cmd_opts_t &opts, int 
             show_scope(name.c_str(), ENV_LOCAL, streams, vars);
             show_scope(name.c_str(), ENV_GLOBAL, streams, vars);
             show_scope(name.c_str(), ENV_UNIVERSAL, streams, vars);
-            streams.out.push_back(L'\n');
         }
     } else {
         for (int i = 0; i < argc; i++) {
@@ -634,7 +632,6 @@ static int builtin_set_show(const wchar_t *cmd, const set_cmd_opts_t &opts, int 
             show_scope(arg, ENV_LOCAL, streams, vars);
             show_scope(arg, ENV_GLOBAL, streams, vars);
             show_scope(arg, ENV_UNIVERSAL, streams, vars);
-            streams.out.push_back(L'\n');
         }
     }
 

--- a/tests/checks/cmdsub-limit.fish
+++ b/tests/checks/cmdsub-limit.fish
@@ -13,10 +13,8 @@ end
 # Command sub just under the limit should succeed
 set a (subme 511)
 set --show a
-#CHECK: $a: not set in local scope
 #CHECK: $a: set in global scope, unexported, with 1 elements
-#CHECK: $a[1]: length=511 value=|{{x{510}x}}|
-#CHECK: $a: not set in universal scope
+#CHECK: $a[1]: |{{x{510}x}}|
 
 # Command sub at the limit should fail
 set b (string repeat -n 512 x)
@@ -25,9 +23,6 @@ test $saved_status -eq 122
 or echo expected status 122, saw $saved_status >&2
 set --show b
 
-#CHECK: $b: not set in local scope
-#CHECK: $b: not set in global scope
-#CHECK: $b: not set in universal scope
 #CHECKERR: {{.*}}: Too much data emitted by command substitution so it was discarded
 #CHECKERR: set b (string repeat -n 512 x)
 #CHECKERR:       ^
@@ -37,10 +32,8 @@ set --show b
 set c (subme 513)
 set --show c
 
-#CHECK: $c: not set in local scope
 #CHECK: $c: set in global scope, unexported, with 1 elements
-#CHECK: $c[1]: length=0 value=||
-#CHECK: $c: not set in universal scope
+#CHECK: $c[1]: ||
 #CHECKERR: {{.*}}: Too much data emitted by command substitution so it was discarded
 #CHECKERR:     set -l x (string repeat -n $argv x)
 #CHECKERR:              ^

--- a/tests/checks/function.fish
+++ b/tests/checks/function.fish
@@ -13,54 +13,43 @@ end
 
 frob
 #CHECK: $foo: set in local scope, unexported, with 1 elements
-#CHECK: $foo[1]: length=9 value=|local foo|
+#CHECK: $foo[1]: |local foo|
 #CHECK: $foo: set in global scope, unexported, with 1 elements
-#CHECK: $foo[1]: length=10 value=|global foo|
-#CHECK: $foo: not set in universal scope
-#CHECK: 
+#CHECK: $foo[1]: |global foo|
 #CHECK: $bar: set in local scope, unexported, with 5 elements
-#CHECK: $bar[1]: length=3 value=|one|
-#CHECK: $bar[2]: length=8 value=|two    2|
-#CHECK: $bar[3]: length=1 value=|\t|
-#CHECK: $bar[4]: length=0 value=||
-#CHECK: $bar[5]: length=1 value=|3|
+#CHECK: $bar[1]: |one|
+#CHECK: $bar[2]: |two    2|
+#CHECK: $bar[3]: |\t|
+#CHECK: $bar[4]: ||
+#CHECK: $bar[5]: |3|
 #CHECK: $bar: set in global scope, unexported, with 5 elements
-#CHECK: $bar[1]: length=3 value=|one|
-#CHECK: $bar[2]: length=8 value=|two    2|
-#CHECK: $bar[3]: length=1 value=|\t|
-#CHECK: $bar[4]: length=0 value=||
-#CHECK: $bar[5]: length=1 value=|3|
-#CHECK: $bar: not set in universal scope
-#CHECK: 
+#CHECK: $bar[1]: |one|
+#CHECK: $bar[2]: |two    2|
+#CHECK: $bar[3]: |\t|
+#CHECK: $bar[4]: ||
+#CHECK: $bar[5]: |3|
 #CHECK: $baz: set in local scope, unexported, with 0 elements
 #CHECK: $baz: set in global scope, unexported, with 0 elements
-#CHECK: $baz: not set in universal scope
 
 set foo 'bad foo'
 set bar 'bad bar'
 set baz 'bad baz'
 frob
 #CHECK: $foo: set in local scope, unexported, with 1 elements
-#CHECK: $foo[1]: length=9 value=|local foo|
+#CHECK: $foo[1]: |local foo|
 #CHECK: $foo: set in global scope, unexported, with 1 elements
-#CHECK: $foo[1]: length=10 value=|global foo|
-#CHECK: $foo: not set in universal scope
-#CHECK: 
+#CHECK: $foo[1]: |global foo|
 #CHECK: $bar: set in local scope, unexported, with 5 elements
-#CHECK: $bar[1]: length=3 value=|one|
-#CHECK: $bar[2]: length=8 value=|two    2|
-#CHECK: $bar[3]: length=1 value=|\t|
-#CHECK: $bar[4]: length=0 value=||
-#CHECK: $bar[5]: length=1 value=|3|
+#CHECK: $bar[1]: |one|
+#CHECK: $bar[2]: |two    2|
+#CHECK: $bar[3]: |\t|
+#CHECK: $bar[4]: ||
+#CHECK: $bar[5]: |3|
 #CHECK: $bar: set in global scope, unexported, with 1 elements
-#CHECK: $bar[1]: length=7 value=|bad bar|
-#CHECK: $bar: not set in universal scope
-#CHECK: 
+#CHECK: $bar[1]: |bad bar|
 #CHECK: $baz: set in local scope, unexported, with 0 elements
 #CHECK: $baz: set in global scope, unexported, with 1 elements
-#CHECK: $baz[1]: length=7 value=|bad baz|
-#CHECK: $baz: not set in universal scope
-#CHECK: 
+#CHECK: $baz[1]: |bad baz|
 
 # This sequence of tests originally verified that functions `name2` and
 # `name4` were created. See issue #2068. That behavior is not what we want.

--- a/tests/checks/loops.fish
+++ b/tests/checks/loops.fish
@@ -148,28 +148,16 @@ begin
 end
 set --show loop_var
 #CHECK: $loop_var: set in local scope, unexported, with 1 elements
-#CHECK: $loop_var[1]: length=1 value=|c|
-#CHECK: $loop_var: not set in global scope
-#CHECK: $loop_var: not set in universal scope
-#CHECK: 
+#CHECK: $loop_var[1]: |c|
 #CHECK: $loop_var: set in local scope, unexported, with 1 elements
-#CHECK: $loop_var[1]: length=1 value=|b|
+#CHECK: $loop_var[1]: |b|
 #CHECK: $loop_var: set in global scope, unexported, with 1 elements
-#CHECK: $loop_var[1]: length=10 value=|global_val|
-#CHECK: $loop_var: not set in universal scope
-#CHECK: 
-#CHECK: $loop_var: not set in local scope
+#CHECK: $loop_var[1]: |global_val|
 #CHECK: $loop_var: set in global scope, unexported, with 1 elements
-#CHECK: $loop_var[1]: length=10 value=|global_val|
-#CHECK: $loop_var: not set in universal scope
-#CHECK: 
+#CHECK: $loop_var[1]: |global_val|
 #CHECK: $loop_var: set in local scope, unexported, with 1 elements
-#CHECK: $loop_var[1]: length=2 value=|cc|
+#CHECK: $loop_var[1]: |cc|
 #CHECK: $loop_var: set in global scope, unexported, with 1 elements
-#CHECK: $loop_var[1]: length=10 value=|global_val|
-#CHECK: $loop_var: not set in universal scope
-#CHECK: 
-#CHECK: $loop_var: not set in local scope
+#CHECK: $loop_var[1]: |global_val|
 #CHECK: $loop_var: set in global scope, unexported, with 1 elements
-#CHECK: $loop_var[1]: length=10 value=|global_val|
-#CHECK: $loop_var: not set in universal scope
+#CHECK: $loop_var[1]: |global_val|

--- a/tests/checks/read.fish
+++ b/tests/checks/read.fish
@@ -249,15 +249,10 @@ end
 
 # Confirm reading non-interactively works -- \#4206 regression
 echo abc\ndef | $fish -i -c 'read a; read b; set --show a; set --show b'
-#CHECK: $a: not set in local scope
 #CHECK: $a: set in global scope, unexported, with 1 elements
-#CHECK: $a[1]: length=3 value=|abc|
-#CHECK: $a: not set in universal scope
-#CHECK: 
-#CHECK: $b: not set in local scope
+#CHECK: $a[1]: |abc|
 #CHECK: $b: set in global scope, unexported, with 1 elements
-#CHECK: $b[1]: length=3 value=|def|
-#CHECK: $b: not set in universal scope
+#CHECK: $b[1]: |def|
 
 # Test --delimiter (and $IFS, for now)
 echo a=b | read -l foo bar

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -470,7 +470,6 @@ while set -q EDITOR
     set -e EDITOR
 end
 set -Ux EDITOR emacs -nw
-# CHECK: $EDITOR: not set in global scope
 # CHECK: $EDITOR: set in universal scope, exported, with 2 elements
 $FISH -c 'set -S EDITOR' | string match -r -e 'global|universal'
 
@@ -486,37 +485,27 @@ set --show 'argle bargle'
 # Verify behavior of `set --show`
 set semiempty ''
 set --show semiempty
-#CHECK: $semiempty: not set in local scope
 #CHECK: $semiempty: set in global scope, unexported, with 1 elements
-#CHECK: $semiempty[1]: length=0 value=||
-#CHECK: $semiempty: not set in universal scope
+#CHECK: $semiempty[1]: ||
 
 set -U var1 hello
 set --show var1
-#CHECK: $var1: not set in local scope
-#CHECK: $var1: not set in global scope
 #CHECK: $var1: set in universal scope, unexported, with 1 elements
-#CHECK: $var1[1]: length=5 value=|hello|
+#CHECK: $var1[1]: |hello|
 
 set -l var1
 set -g var1 goodbye "and don't come back"
 set --show var1
 #CHECK: $var1: set in local scope, unexported, with 0 elements
 #CHECK: $var1: set in global scope, unexported, with 2 elements
-#CHECK: $var1[1]: length=7 value=|goodbye|
-#CHECK: $var1[2]: length=19 value=|and don\'t come back|
+#CHECK: $var1[1]: |goodbye|
+#CHECK: $var1[2]: |and don\'t come back|
 #CHECK: $var1: set in universal scope, unexported, with 1 elements
-#CHECK: $var1[1]: length=5 value=|hello|
+#CHECK: $var1[1]: |hello|
 
 set -g var2
 set --show _unset_var var2
-#CHECK: $_unset_var: not set in local scope
-#CHECK: $_unset_var: not set in global scope
-#CHECK: $_unset_var: not set in universal scope
-#CHECK: 
-#CHECK: $var2: not set in local scope
 #CHECK: $var2: set in global scope, unexported, with 0 elements
-#CHECK: $var2: not set in universal scope
 
 # Appending works
 set -g var3a a b c
@@ -524,28 +513,22 @@ set -a var3a
 set -a var3a d
 set -a var3a e f
 set --show var3a
-#CHECK: $var3a: not set in local scope
 #CHECK: $var3a: set in global scope, unexported, with 6 elements
-#CHECK: $var3a[1]: length=1 value=|a|
-#CHECK: $var3a[2]: length=1 value=|b|
-#CHECK: $var3a[3]: length=1 value=|c|
-#CHECK: $var3a[4]: length=1 value=|d|
-#CHECK: $var3a[5]: length=1 value=|e|
-#CHECK: $var3a[6]: length=1 value=|f|
-#CHECK: $var3a: not set in universal scope
+#CHECK: $var3a[1]: |a|
+#CHECK: $var3a[2]: |b|
+#CHECK: $var3a[3]: |c|
+#CHECK: $var3a[4]: |d|
+#CHECK: $var3a[5]: |e|
+#CHECK: $var3a[6]: |f|
 set -g var3b
 set -a var3b
 set --show var3b
-#CHECK: $var3b: not set in local scope
 #CHECK: $var3b: set in global scope, unexported, with 0 elements
-#CHECK: $var3b: not set in universal scope
 set -g var3c
 set -a var3c 'one string'
 set --show var3c
-#CHECK: $var3c: not set in local scope
 #CHECK: $var3c: set in global scope, unexported, with 1 elements
-#CHECK: $var3c[1]: length=10 value=|one string|
-#CHECK: $var3c: not set in universal scope
+#CHECK: $var3c[1]: |one string|
 
 # Prepending works
 set -g var4a a b c
@@ -553,44 +536,36 @@ set -p var4a
 set -p var4a d
 set -p var4a e f
 set --show var4a
-#CHECK: $var4a: not set in local scope
 #CHECK: $var4a: set in global scope, unexported, with 6 elements
-#CHECK: $var4a[1]: length=1 value=|e|
-#CHECK: $var4a[2]: length=1 value=|f|
-#CHECK: $var4a[3]: length=1 value=|d|
-#CHECK: $var4a[4]: length=1 value=|a|
-#CHECK: $var4a[5]: length=1 value=|b|
-#CHECK: $var4a[6]: length=1 value=|c|
-#CHECK: $var4a: not set in universal scope
+#CHECK: $var4a[1]: |e|
+#CHECK: $var4a[2]: |f|
+#CHECK: $var4a[3]: |d|
+#CHECK: $var4a[4]: |a|
+#CHECK: $var4a[5]: |b|
+#CHECK: $var4a[6]: |c|
 set -g var4b
 set -p var4b
 set --show var4b
-#CHECK: $var4b: not set in local scope
 #CHECK: $var4b: set in global scope, unexported, with 0 elements
-#CHECK: $var4b: not set in universal scope
 set -g var4c
 set -p var4c 'one string'
 set --show var4c
-#CHECK: $var4c: not set in local scope
 #CHECK: $var4c: set in global scope, unexported, with 1 elements
-#CHECK: $var4c[1]: length=10 value=|one string|
-#CHECK: $var4c: not set in universal scope
+#CHECK: $var4c[1]: |one string|
 
 # Appending and prepending at same time works
 set -g var5 abc def
 set -a -p var5 0 x 0
 set --show var5
-#CHECK: $var5: not set in local scope
 #CHECK: $var5: set in global scope, unexported, with 8 elements
-#CHECK: $var5[1]: length=1 value=|0|
-#CHECK: $var5[2]: length=1 value=|x|
-#CHECK: $var5[3]: length=1 value=|0|
-#CHECK: $var5[4]: length=3 value=|abc|
-#CHECK: $var5[5]: length=3 value=|def|
-#CHECK: $var5[6]: length=1 value=|0|
-#CHECK: $var5[7]: length=1 value=|x|
-#CHECK: $var5[8]: length=1 value=|0|
-#CHECK: $var5: not set in universal scope
+#CHECK: $var5[1]: |0|
+#CHECK: $var5[2]: |x|
+#CHECK: $var5[3]: |0|
+#CHECK: $var5[4]: |abc|
+#CHECK: $var5[5]: |def|
+#CHECK: $var5[6]: |0|
+#CHECK: $var5[7]: |x|
+#CHECK: $var5[8]: |0|
 
 # Setting local scope when no local scope of the var uses the closest scope
 set -g var6 ghi jkl
@@ -599,13 +574,12 @@ begin
     set --show var6
 end
 #CHECK: $var6: set in local scope, unexported, with 3 elements
-#CHECK: $var6[1]: length=3 value=|ghi|
-#CHECK: $var6[2]: length=3 value=|jkl|
-#CHECK: $var6[3]: length=3 value=|mno|
+#CHECK: $var6[1]: |ghi|
+#CHECK: $var6[2]: |jkl|
+#CHECK: $var6[3]: |mno|
 #CHECK: $var6: set in global scope, unexported, with 2 elements
-#CHECK: $var6[1]: length=3 value=|ghi|
-#CHECK: $var6[2]: length=3 value=|jkl|
-#CHECK: $var6: not set in universal scope
+#CHECK: $var6[1]: |ghi|
+#CHECK: $var6[2]: |jkl|
 
 # Exporting works
 set -x TESTVAR0
@@ -631,24 +605,13 @@ function test_ifforwhile_scope
 end
 test_ifforwhile_scope
 #CHECK: $ifvar1: set in local scope, unexported, with 1 elements
-#CHECK: $ifvar1[1]: length=4 value=|val1|
-#CHECK: $ifvar1: not set in global scope
-#CHECK: $ifvar1: not set in universal scope
-#CHECK: 
+#CHECK: $ifvar1[1]: |val1|
 #CHECK: $ifvar2: set in local scope, unexported, with 1 elements
-#CHECK: $ifvar2[1]: length=4 value=|val2|
-#CHECK: $ifvar2: not set in global scope
-#CHECK: $ifvar2: not set in universal scope
-#CHECK: 
+#CHECK: $ifvar2[1]: |val2|
 #CHECK: $ifvar3: set in local scope, unexported, with 1 elements
-#CHECK: $ifvar3[1]: length=4 value=|val3|
-#CHECK: $ifvar3: not set in global scope
-#CHECK: $ifvar3: not set in universal scope
-#CHECK: 
+#CHECK: $ifvar3[1]: |val3|
 #CHECK: $whilevar1: set in local scope, unexported, with 1 elements
-#CHECK: $whilevar1[1]: length=4 value=|val3|
-#CHECK: $whilevar1: not set in global scope
-#CHECK: $whilevar1: not set in universal scope
+#CHECK: $whilevar1[1]: |val3|
 
 # $status should always be read-only, setting it makes no sense because it's immediately overwritten.
 set -g status 5


### PR DESCRIPTION
Changes it from

```
$fish_color_user: not set in local scope
$fish_color_user: set in global scope, unexported, with 1 elements
$fish_color_user[1]: length=3 value=|080|
$fish_color_user: set in universal scope, unexported, with 1 elements
$fish_color_user[1]: length=7 value=|brgreen|

```

(with the trailing empty line - not just a newline)

to

```
$fish_color_user: set in global scope, unexported, with 1 elements
$fish_color_user[1]: |080|
$fish_color_user: set in universal scope, unexported, with 1 elements
$fish_color_user[1]: |brgreen|
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
