### PR TITLE
fix pushd's behavior with invalid arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - On BSD systems, with the `-s` option, `fish_md5` does not use the given string, but `-s`. From now on the string is used.
 - Control-C no longer kills background jobs for which job control is disabled, matching POSIX semantics (#6828).
 - Improve Gradle completion
+- Fixed `pushd`'s behavior with respect to the directory stack when given an invalid argument
 
 ### Syntax changes and new commands
 

--- a/share/functions/pushd.fish
+++ b/share/functions/pushd.fish
@@ -76,6 +76,6 @@ function pushd --description 'Push directory to stack'
     end
 
     # argv[1] is a directory
-    set -g -p dirstack $PWD
-    cd $argv[1]
+    set -l old_pwd $PWD
+    cd $argv[1]; and set -g -p dirstack $old_pwd
 end


### PR DESCRIPTION
## Description

`pushd` currently adds `$PWD` to `$dirstack` without checking whether the directory change was successful. For example, `pushd ~/.config/fish/config.fish` from `~` will add prepend `~` to `$dirstack`, even though pushd was given an invalid argument. This also applies to directories the user may not have permission to `cd` into. The change in question fixes this.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
