### PR TITLE
Reject bindings that conflict with already bound bindings

### DIFF
--- a/src/builtin_bind.h
+++ b/src/builtin_bind.h
@@ -36,6 +36,8 @@ class builtin_bind_t {
     bool list_one(const wcstring &seq, const wcstring &bind_mode, bool user, io_streams_t &streams);
     bool list_one(const wcstring &seq, const wcstring &bind_mode, bool user, bool preset,
                   io_streams_t &streams);
+    bool check_conflicts(const wcstring &seq, const wchar_t *bind_mode, bool user, io_streams_t &streams);
+    bool check_conflicts(const wcstring &seq, const wchar_t *bind_mode, io_streams_t &streams);
 };
 
 inline int builtin_bind(parser_t &parser, io_streams_t &streams, wchar_t **argv) {

--- a/tests/checks/bind.fish
+++ b/tests/checks/bind.fish
@@ -87,4 +87,12 @@ bind --erase --user --preset \t
 bind \t
 # CHECK: bind --preset \t complete
 
+# Prefix conflicts
+bind prefix true
+bind prefixbanana true
+# CHECKERR: bind: Sequence 'prefixbanana' has already bound sequence 'prefix' as a prefix
+bind thingsuffix true
+bind thing true
+# CHECKERR: bind: Sequence 'thing' is prefix of already bound sequence 'thingsuffix'
+
 exit 0


### PR DESCRIPTION
In e.g. #6834, the reporter bound `\e\[` to something. That *can't* work.

At best it would effectively disable all bindings that have it as a prefix (including all arrow keys!).

So whenever a binding is added, this goes through all bindings and checks if anything prefixes the new sequence or if the new sequence is a prefix of it. If it is it prints an error without adding the binding. That means that:

```fish
bind \e\[ something
bind -k left
```

will fail without binding left, and doing it the other way around it will fail without binding `\e\[`.

One exception is if the prefix ends in an escape (like just `\e`). In that case we should disambiguate it with the escape timeout, so there is no problem. (also the default `""` binding and different modes are handled)

This is one solution to conflicting bindings - erroring out. Other solutions are:

- If there is an ambiguity run a timeout (e.g. if `abc` and `abcdef` are bound, wait after `c` for `d`)
- If a conflict happens remove the earlier bindings

I don't think removing bindings is what you'd want especially in the `\e\[` case (we could even blacklist that one because it makes no sense to bind), and a timeout is a larger change, and one I'm not sold on.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md

I would appreciate some testing, since I could have entirely overlooked some cases. It's also likely this triggers for people who are otherwise happy (one of those "your config was technically always broken" situations).