### PR TITLE
edit_command_buffer: Add line:col support for Sublime Text

### DIFF
--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -41,18 +41,21 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
     set col (math $offset + 1)
 
     set -l basename (string match -r '[^/]*$' -- $editor[1])
-    if contains $basename vi vim nvim
-        set -a editor +$line +"norm $col|" $f
-    else if contains $basename emacs emacsclient gedit kak
-        set -a editor +$line:$col $f
-    else if contains $basename nano
-        set -a editor +$line,$col $f
-    else if contains $basename joe ee
-        set -a editor +$line $f
-    else if contains $basename code code-oss
-        set -a editor --goto $f:$line:$col --wait
-    else
-        set -a editor $f
+    switch $basename
+        case vi vim nvim
+            set -a editor +$line +"norm $col|" $f
+        case emacs emacsclient gedit kak
+            set -a editor +$line:$col $f
+        case nano
+            set -a editor +$line,$col $f
+        case joe ee
+            set -a editor +$line $f
+        case code code-oss
+            set -a editor --goto $f:$line:$col --wait
+        case subl
+            set -a editor $f:$line:$col --wait
+        case '*'
+            set -a editor $f
     end
 
     __fish_disable_bracketed_paste


### PR DESCRIPTION
Support [Sublime Text](https://www.sublimetext.com/) in `edit_command_buffer`.

---

```
$ subl --help
Sublime Text build 3210

Usage: subl [arguments] [files]         Edit the given files
   or: subl [arguments] [directories]   Open the given directories
   or: subl [arguments] -               Edit stdin

Arguments:
  --project <project>: Load the given project
  --command <command>: Run the given command
  -n or --new-window:  Open a new window
  -a or --add:         Add folders to the current window
  -w or --wait:        Wait for the files to be closed before returning
  -b or --background:  Don't activate the application
  -s or --stay:        Keep the application activated after closing the file
  -h or --help:        Show help (this message) and exit
  -v or --version:     Show version and exit

--wait is implied if reading from stdin. Use --stay to not switch back
to the terminal when a file is closed (only relevant if waiting for a file).

Filenames may be given a :line or :line:column suffix to open at a specific
location.
```