### PR TITLE
Make `fish_key_reader` exit normally

### DIFF
--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -575,7 +575,7 @@ int main(int argc, char *argv[]) {
                 exit(0);
             }
             case 'v': {
-                std::fwprintf(stderr, _(L"%ls, version %s\n"), program_name, get_fish_version());
+                std::fwprintf(stdout, _(L"%ls, version %s\n"), program_name, get_fish_version());
                 exit(0);
             }
             case 'w': {

--- a/src/fish_key_reader.cpp
+++ b/src/fish_key_reader.cpp
@@ -284,13 +284,12 @@ static bool parse_flags(int argc, char **argv, bool *continuous_mode) {
                 break;
             }
             case 'h': {
-                print_help("fish_key_reader", 0);
-                error = true;
-                break;
+                print_help("fish_key_reader", 1);
+                exit(0);
             }
             case 'v': {
-                std::fwprintf(stdout, L"%s\n", get_fish_version());
-                return false;
+                std::fwprintf(stdout, _(L"%ls, version %s\n"), program_name, get_fish_version());
+                exit(0);
             }
             default: {
                 // We assume getopt_long() has already emitted a diagnostic msg.


### PR DESCRIPTION
The `--help` and `--version` options were returning status 1 instead of 0.

This aligns the behavior of `fish`, `fish_indent`, and `fish_key_reader`.

Also the file descriptor passed to `print_help` was wrong.