### PR TITLE
Add newline to history clear message for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - The default and example prompts print the correct exit status for commands prefixed with `not` (#6566).
 
 #### Improved terminal output
+- After clearing command history, success message ends in newline.
 
 #### Completions
 - Added completions for

--- a/po/de.po
+++ b/po/de.po
@@ -3593,7 +3593,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:5
-msgid "Command history cleared!"
+msgid "Command history cleared!\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:6

--- a/po/en.po
+++ b/po/en.po
@@ -3584,7 +3584,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:5
-msgid "Command history cleared!"
+msgid "Command history cleared!\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:6

--- a/po/fr.po
+++ b/po/fr.po
@@ -3802,8 +3802,8 @@ msgstr ""
 "interactive sera effacé\\n"
 
 #: /tmp/fish/explicit/share/functions/history.fish:5
-msgid "Command history cleared!"
-msgstr "Historique de commande effacé !"
+msgid "Command history cleared!\\n"
+msgstr "Historique de commande effacé !\\n"
 
 #: /tmp/fish/explicit/share/functions/history.fish:6
 msgid "You did not say 'yes' so I will not clear your command history\\n"

--- a/po/nb.po
+++ b/po/nb.po
@@ -3559,7 +3559,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:5
-msgid "Command history cleared!"
+msgid "Command history cleared!\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:6

--- a/po/nn.po
+++ b/po/nn.po
@@ -3559,7 +3559,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:5
-msgid "Command history cleared!"
+msgid "Command history cleared!\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:6

--- a/po/pl.po
+++ b/po/pl.po
@@ -3582,7 +3582,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:5
-msgid "Command history cleared!"
+msgid "Command history cleared!\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:6

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3588,7 +3588,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:5
-msgid "Command history cleared!"
+msgid "Command history cleared!\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:6

--- a/po/sv.po
+++ b/po/sv.po
@@ -3537,7 +3537,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:5
-msgid "Command history cleared!"
+msgid "Command history cleared!\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:6

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3558,7 +3558,7 @@ msgid ""
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:5
-msgid "Command history cleared!"
+msgid "Command history cleared!\\n"
 msgstr ""
 
 #: /tmp/fish/explicit/share/functions/history.fish:6

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -183,7 +183,7 @@ function history --description "display or manipulate interactive command histor
             read --local --prompt "echo 'Are you sure you want to clear history? (yes/no) '" choice
             if test "$choice" = yes
                 builtin history clear -- $argv
-                and printf (_ "Command history cleared!")
+                and printf (_ "Command history cleared!\n")
             else
                 printf (_ "You did not say 'yes' so I will not clear your command history\n")
             end


### PR DESCRIPTION
## Description

Command history clear message ends in a newline, like [the rest of related output](https://github.com/fish-shell/fish-shell/blob/9f984ee89781f6f5c7b8c69407ae6894927fbebf/share/functions/history.fish#L182-L189).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.md
