### PR TITLE
edit_command_buffer: Add line:col support for micro

### DIFF
--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -54,6 +54,8 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
             set -a editor --goto $f:$line:$col --wait
         case subl
             set -a editor $f:$line:$col --wait
+        case micro
+            set -a editor $f:$line:$col
         case '*'
             set -a editor $f
     end


### PR DESCRIPTION
Add support for https://micro-editor.github.io

> \>micro --help | rg buffer -B2
> [FILE]:LINE:COL
> +LINE:COL
>     	Specify a line and column to start the cursor at when opening a buffer