### PR TITLE
Document addition of `string split --fields`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Scripting improvements
 - Range limits in index range expansions like `$x[$start..$end]` may be omitted: `$start` and `$end` default to 1 and -1 (the last item) respectively.
 - `string sub` has a new `--end` option to specify the end index of a substring (#6765).
+- `string split` has a new `--fields` option to specify fields to output, similar to `cut -f` (#6770).
 
 ### Interactive improvements
 


### PR DESCRIPTION
Noticed that this was missing from the changelog