### PR TITLE
Update /etc/config.fish to use current syntax

### DIFF
--- a/etc/config.fish
+++ b/etc/config.fish
@@ -5,10 +5,10 @@
 
 # This file is run by all fish instances.
 # To include configuration only for login shells, use
-# if status --is-login
+# if status is-login
 #    ...
 # end
 # To include configuration only for interactive shells, use
-# if status --is-interactive
+# if status is-interactive
 #   ...
 # end


### PR DESCRIPTION
The long option usage of `status` is deprecated and to be removed by fish 3.0.