### PR TITLE
__fish_print_hostnames: skip ssh host definitions containing wildcards

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -109,7 +109,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 
             # Print hosts from system wide ssh configuration file
             # Multiple names for a single host can be given separated by spaces, so just split it explicitly (#6698).
-            string replace -rfi '^\s*Host\s+(\S.*?)\s*$' '$1' -- $contents | string split " " | string match -v '*\**'
+            string replace -rfi '^\s*Host\s+(\S.*?)\s*$' '$1' -- $contents | string split " " | string match -rv '[\*\?]'
             # Also extract known_host paths.
             set known_hosts $known_hosts (string replace -rfi '.*KnownHostsFile\s*' '' -- $contents)
         end


### PR DESCRIPTION
## Description

In SSH client config, specified `Host` definitions can contain wildcards, e.g. `Host server*.mydomain` or `Host client??.mydomain`. While the `*` wildcard was already excluded when collecting hosts for `__fish_print_hostnames`, this change also excluses the `?` wildcard.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
