### PR TITLE
Add check to let Windows Terminal pass

### DIFF
--- a/share/functions/fish_vi_cursor.fish
+++ b/share/functions/fish_vi_cursor.fish
@@ -41,6 +41,7 @@ function fish_vi_cursor -d 'Set cursor shape for different vi modes'
         and not test -n "$KONSOLE_VERSION" -a "$KONSOLE_VERSION" -ge "200400" # konsole, but new.
         and not set -q ITERM_PROFILE
         and not set -q VTE_VERSION # which version is already checked above
+        and not set -q WT_PROFILE_ID
         and not set -q XTERM_VERSION
         and not string match -rq '^st(-.*)$' -- $TERM
         and not string match -q 'xterm-kitty*' -- $TERM


### PR DESCRIPTION
## Description

Because Windows Terminal sets the $WT_PROFILE_ID, use it to let the terminal use fish_vi_cursor function.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
