### PR TITLE
completions/set:  add --path and --unpath

### DIFF
--- a/share/completions/set.fish
+++ b/share/completions/set.fish
@@ -80,6 +80,8 @@ complete -c set -n __fish_is_first_token -s n -l names -d "List the names of the
 complete -c set -n __fish_is_first_token -s a -l append -d "Append value to a list"
 complete -c set -n __fish_is_first_token -s p -l prepend -d "Prepend value to a list"
 complete -c set -n __fish_is_first_token -s S -l show -d "Show variable"
+complete -c set -n __fish_is_first_token -l path -d "Make variable as a path variable"
+complete -c set -n __fish_is_first_token -l unpath -d "Make variable not as a path variable"
 
 #TODO: add CPP code to generate list of read-only variables and exclude them from the following completions
 


### PR DESCRIPTION
## Description

Add missing options:
```
--path causes the specified variable to be treated as a path variable, meaning it will automatically be split on colons, and joined using colons when quoted (echo "$PATH") or exported.
--unpath causes the specified variable to not be treated as a path variable. Variables with a name ending in "PATH" are automatically path variables, so this can be used to treat such a variable normally.
```

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
