### PR TITLE
safe_strerror(): use thread-safe strerror_r() when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ set(FISH_SRCS
     src/wcstringutil.cpp src/wgetopt.cpp src/wildcard.cpp src/wutil.cpp
     src/future_feature_flags.cpp src/redirection.cpp src/topic_monitor.cpp
     src/flog.cpp src/trace.cpp src/timer.cpp src/null_terminated_array.cpp
-    src/operation_context.cpp src/fd_monitor.cpp
+    src/operation_context.cpp src/fd_monitor.cpp src/safe_strerror.cpp
 )
 
 # Header files are just globbed.

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -85,7 +85,6 @@ check_struct_has_member("struct stat" st_mtimespec.tv_nsec "sys/stat.h"
     HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC LANGUAGE CXX)
 check_struct_has_member("struct stat" st_mtim.tv_nsec "sys/stat.h" HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC
     LANGUAGE CXX)
-check_cxx_symbol_exists(sys_errlist stdio.h HAVE_SYS_ERRLIST)
 check_include_file_cxx(sys/ioctl.h HAVE_SYS_IOCTL_H)
 check_include_file_cxx(sys/select.h HAVE_SYS_SELECT_H)
 check_include_files("sys/types.h;sys/sysctl.h" HAVE_SYS_SYSCTL_H)
@@ -117,8 +116,6 @@ if(HAVE_XLOCALE_H)
 endif()
 list(APPEND WCSTOD_L_INCLUDES "wchar.h")
 check_cxx_symbol_exists(wcstod_l "${WCSTOD_L_INCLUDES}" HAVE_WCSTOD_L)
-
-check_cxx_symbol_exists(_sys_errs stdlib.h HAVE__SYS__ERRS)
 
 cmake_push_check_state()
 set(CMAKE_EXTRA_INCLUDE_FILES termios.h sys/ioctl.h)

--- a/config_cmake.h.in
+++ b/config_cmake.h.in
@@ -85,9 +85,6 @@
 /* Define to 1 if `st_mtim.tv_nsec' is a member of `struct stat'. */
 #cmakedefine HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
 
-/* Define to 1 if the sys_errlist array is available. */
-#cmakedefine HAVE_SYS_ERRLIST 1
-
 /* Define to 1 if you have the <sys/ioctl.h> header file. */
 #cmakedefine HAVE_SYS_IOCTL_H 1
 
@@ -129,9 +126,6 @@
 
 /* Define to 1 if std::make_unique is available. */
 #cmakedefine HAVE_STD__MAKE_UNIQUE 1
-
-/* Define to 1 if the _sys_errs array is available. */
-#cmakedefine HAVE__SYS__ERRS 1
 
 /* Define to 1 to disable ncurses macros that conflict with the STL */
 #define NCURSES_NOMACROS 1

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -401,6 +401,7 @@ int main(int argc, char **argv) {
     int my_optind = 0;
 
     program_name = L"fish";
+    errno_list_init();
     set_main_thread();
     setup_fork_guards();
     signal_unblock_all();
@@ -536,6 +537,7 @@ int main(int argc, char **argv) {
     if (debug_output) {
         fclose(debug_output);
     }
+    errno_list_free();
     exit_without_destructors(exit_status);
     return EXIT_FAILURE;  // above line should always exit
 }

--- a/src/safe_strerror.cpp
+++ b/src/safe_strerror.cpp
@@ -1,0 +1,72 @@
+#include "config.h"
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+
+// strerror is not thread-safe and strerror_r is not async-safe (see
+// man signal-safety) glibc strerror_r can hang in certain real-world
+// scenarios. (cf github issues #472, #1830, #4183)
+
+// To work around that, pre-generate a read-only list of messages at
+// startup which can be safely returned.
+
+// Since INT_MAX is pretty big, let's look at various OS maximum value for errno:
+//
+// Linux [1-133]
+// https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h
+//
+// FreeBSD (userspace visible) [1-97]
+// https://github.com/freebsd/freebsd/blob/master/sys/sys/errno.h
+//
+// OpenBSD (userspace visible) [1-95]
+// https://github.com/openbsd/src/blob/master/sys/sys/errno.h
+//
+// Apple (userspace visible) [1-88]
+// https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/errno.h.auto.html
+//
+// Solaris [1-151]
+// http://fxr.watson.org/fxr/source/common/sys/errno.h?v=OPENSOLARIS
+//
+static const int max_errno = 200;
+static const char *errno_list[max_errno] = {};
+
+void errno_list_init()
+{
+    // save errno
+    int err = errno;
+    char buf[512] = {};
+
+    for (int i = 0; i < max_errno; i++) {
+	const char *s = strerror(i);
+	if (!s) {
+	    snprintf(buf, sizeof(buf)-1, "Unknown error %d", i);
+	    s = buf;
+	}
+	errno_list[i] = strdup(s);
+	if (!errno_list[i]) {
+	    // alloc error
+	    fprintf(stderr, "fish: coud not alloc memory for safe_errno()\n");
+	}
+    }
+
+    // restore errno
+    errno = err;
+}
+
+void errno_list_free()
+{
+    // free(null) is a no-op
+    for (int i = 0; i < max_errno; i++) {
+	free((void *)errno_list[i]);
+	errno_list[i] = nullptr;
+    }
+}
+
+const char *safe_strerror(int err)
+{
+    const char *s = nullptr;
+    if (0 <= err && err < max_errno)
+	s = errno_list[err];
+    return s ? s : "Unknown error";
+}

--- a/src/safe_strerror.h
+++ b/src/safe_strerror.h
@@ -1,0 +1,8 @@
+#ifndef FISH_SAFE_STRERROR_H
+#define FISH_SAFE_STRERROR_H
+
+void errno_list_init();
+void errno_list_free();
+const char *safe_strerror(int err);
+
+#endif

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -294,44 +294,6 @@ static inline void safe_append(char *buffer, const char *s, size_t buffsize) {
     std::strncat(buffer, s, buffsize - std::strlen(buffer) - 1);
 }
 
-// In general, strerror is not async-safe, and therefore we cannot use it directly. So instead we
-// have to grub through sys_nerr and sys_errlist directly On GNU toolchain, this will produce a
-// deprecation warning from the linker (!!), which appears impossible to suppress!
-const char *safe_strerror(int err) {
-#if defined(__UCLIBC__)
-    // uClibc does not have sys_errlist, however, its strerror is believed to be async-safe.
-    // See issue #808.
-    return std::strerror(err);
-#elif defined(HAVE__SYS__ERRS) || defined(HAVE_SYS_ERRLIST)
-#ifdef HAVE_SYS_ERRLIST
-    if (err >= 0 && err < sys_nerr && sys_errlist[err] != nullptr) {
-        return sys_errlist[err];
-    }
-#elif defined(HAVE__SYS__ERRS)
-    extern const char _sys_errs[];
-    extern const int _sys_index[];
-    extern int _sys_num_err;
-
-    if (err >= 0 && err < _sys_num_err) {
-        return &_sys_errs[_sys_index[err]];
-    }
-#endif  // either HAVE__SYS__ERRS or HAVE_SYS_ERRLIST
-#endif  // defined(HAVE__SYS__ERRS) || defined(HAVE_SYS_ERRLIST)
-
-    int saved_err = errno;
-    static char buff[384];  // use a shared buffer for this case
-    char errnum_buff[64];
-    format_long_safe(errnum_buff, err);
-
-    buff[0] = '\0';
-    safe_append(buff, "unknown error (errno was ", sizeof buff);
-    safe_append(buff, errnum_buff, sizeof buff);
-    safe_append(buff, ")", sizeof buff);
-
-    errno = saved_err;
-    return buff;
-}
-
 void safe_perror(const char *message) {
     // Note we cannot use strerror, because on Linux it uses gettext, which is not safe.
     int err = errno;

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -18,6 +18,7 @@
 
 #include "common.h"
 #include "maybe.h"
+#include "safe_strerror.h"
 
 /// Sets CLO_EXEC on a given fd according to the value of \p should_set.
 int set_cloexec(int fd, bool should_set = true);
@@ -61,9 +62,6 @@ void wperror(const wchar_t *s);
 
 /// Async-safe version of perror().
 void safe_perror(const char *message);
-
-/// Async-safe version of std::strerror().
-const char *safe_strerror(int err);
 
 /// Wide character version of getcwd().
 wcstring wgetcwd();


### PR DESCRIPTION
## Description

* add cmake check for strerror_r()
* make safe_strerror() return simple, safe, always-initialized struct
  holding the error message in a stack allocated array
* remove unsafe fallback code returning static array

The static array solution was not thread-safe as the same memory is
shared and written in by all threads.

This removes the linker warnings mentionned in the comments on
platform supporting strerror_r():

    $ make
    ld: libfishlib.a(wutil.cpp.o): in function `safe_strerror(int)':
    wutil.cpp:307: warning: `sys_errlist' is deprecated; use `strerror' or `strerror_r' instead
    ld: wutil.cpp:307: warning: `sys_nerr' is deprecated; use `strerror' or `strerror_r' instead
    ld: libfishlib.a(wutil.cpp.o): in function `safe_strerror(int)':
    wutil.cpp:307: warning: `sys_errlist' is deprecated; use `strerror' or `strerror_r' instead
