### PR TITLE
Remove text duplicate in tutorial

### DIFF
--- a/doc_src/tutorial.rst
+++ b/doc_src/tutorial.rst
@@ -397,7 +397,7 @@ To write them on the same line, use the semicolon (";"). That means the followin
 Exit Status
 -----------
 
-When a command exits, it returns a status code as a natural number. This indicates how the command fared - 0 usually means success, while the others signify kinds of failure. For instance fish's ``set --query`` returns the number of variables it queried that weren't set - ``set --query PATH`` usually returns 0, ``set --query arglbargl boogagoogoo`` usually returns 2.
+When a command exits, it returns a status code as a natural number.
 
 Unlike other shells, ``fish`` stores the exit status of the last command in ``$status`` instead of ``$?``.
 


### PR DESCRIPTION
## Description

These exact same sentences appear again just after the example snippet in the same section.