### PR TITLE
__fish_prepend_sudo: Toggle "sudo" on multiple presses

### DIFF
--- a/share/functions/__fish_prepend_sudo.fish
+++ b/share/functions/__fish_prepend_sudo.fish
@@ -7,11 +7,6 @@ function __fish_prepend_sudo -d "Prepend 'sudo ' to the beginning of the current
         commandline -C (math $cursor + 5)
     else
         commandline -r (string sub --start=6 (commandline -p))
-        set -l new_cursor (math $cursor - 5)
-        if test "$new_cursor" -lt 0
-          commandline -C 0
-        else
-          commandline -C $new_cursor
-        end
+        commandline -C -- (math $cursor - 5)
     end
 end

--- a/share/functions/__fish_prepend_sudo.fish
+++ b/share/functions/__fish_prepend_sudo.fish
@@ -1,9 +1,17 @@
 function __fish_prepend_sudo -d "Prepend 'sudo ' to the beginning of the current commandline"
-    set -l cmd (commandline -poc)
+    set -l cmd (commandline -po)
+    set -l cursor (commandline -C)
     if test "$cmd[1]" != sudo
-        set -l cursor (commandline -C)
         commandline -C 0
         commandline -i "sudo "
         commandline -C (math $cursor + 5)
+    else
+        commandline -r (string sub --start=6 (commandline -p))
+        set -l new_cursor (math $cursor - 5)
+        if test "$new_cursor" -lt 0
+          commandline -C 0
+        else
+          commandline -C $new_cursor
+        end
     end
 end


### PR DESCRIPTION
At the moment calling __fish_prepend_sudo multiple times does not toggle
sudo, and also unnecessarily uses the `-c` flag to `commandline` to see if
the first token on the commandline is "sudo".

This change removes the `-c` switch and also toggles "sudo" on multiple
calls to __fish_prepend_sudo, while maintaining the cursor position and
while maintaining any spaces between "sudo" and the next token on the
commandline.

The additional logic around the new_cursor position is because the
cursor could be in the "sudo" during the toggle.

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
