### PR TITLE
completions: speed up kdeconnect-cli device discovery

### DIFF
--- a/share/completions/kdeconnect-cli.fish
+++ b/share/completions/kdeconnect-cli.fish
@@ -1,3 +1,7 @@
+function __complete_devices
+    kdeconnect-cli --shell-device-autocompletion=zsh | string replace -rf '(\w+)\[(.*)]' '$1\t$2'
+end
+
 complete -c kdeconnect-cli -s l -l list-devices -d "List all devices"
 complete -c kdeconnect-cli -s a -l list-available -d "List available (paired and reachable) devices"
 complete -c kdeconnect-cli -l id-only -d "Make --list-devices or --list-available print the devices id, to ease scripting"
@@ -12,7 +16,7 @@ complete -c kdeconnect-cli -l list-notifications -d "Display the notifications o
 complete -c kdeconnect-cli -l lock -d "Lock the specified device"
 complete -c kdeconnect-cli -l send-sms -f -r -d "Sends an SMS. Requires destination" # message
 complete -c kdeconnect-cli -l destination -f -r -d "Phone number to send the message" # phone number
-complete -c kdeconnect-cli -s d -l device -f -r -a '(kdeconnect-cli -l --id-only)' -d "Device ID" # dev
+complete -c kdeconnect-cli -s d -l device -f -r -a '(__complete_devices)'
 complete -c kdeconnect-cli -s n -l name -f -r -d "Device Name" # name
 complete -c kdeconnect-cli -l encryption-info -d "Get encryption info about said device"
 complete -c kdeconnect-cli -l list-commands -d "Lists remote commands and their ids"

--- a/share/completions/kdeconnect-cli.fish
+++ b/share/completions/kdeconnect-cli.fish
@@ -1,5 +1,6 @@
 function __complete_devices
-    kdeconnect-cli --shell-device-autocompletion=zsh | string replace -rf '(\w+)\[(.*)]' '$1\t$2'
+    kdeconnect-cli --shell-device-autocompletion=zsh | string replace -rf -- '(\w+)\[(.*)]' '$1\t$2'
+    or kdeconnect-cli --list-devices 2>/dev/null | string replace -rf -- '- (.*): (\w+) .*' '$2\t$1'
 end
 
 complete -c kdeconnect-cli -s l -l list-devices -d "List all devices"


### PR DESCRIPTION
Over 150 times faster now. Also added device name and status to the completion description.
This is done by using the `--shell-device-autocompletion` flag provided by `kdeconnect-cli`.

**Before**
```
>time complete -C"kdeconnect-cli -d"
-d689ccf9fd5f3272d	Device ID
-d689ccf9fd5f3272d	Device ID
________________________________________________________
Executed in    4.04 secs      fish           external
   usr time   24.87 millis    2.08 millis   22.79 millis
   sys time   14.60 millis    0.12 millis   14.48 millis
```

**After**
```
>time complete -C"kdeconnect-cli -d"
-d689ccf9fd5f3272d	Pixel 4 (paired)
________________________________________________________
Executed in   22.38 millis    fish           external
   usr time    9.54 millis    2.04 millis    7.51 millis
   sys time   11.23 millis    0.00 millis   11.23 millis
```