### PR TITLE
Fix is_wsl() on wsl2

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -47,7 +47,8 @@ def is_wsl():
     """ Return whether we are running under the Windows Subsystem for Linux """
     if "linux" in platform.system().lower() and os.access("/proc/version", os.R_OK):
         with open("/proc/version", "r") as f:
-            if "microsoft" in f.read():
+            # Find 'Microsoft' for wsl1 and 'microsoft' for wsl2
+            if "microsoft" in f.read().lower():
                 return True
     return False
 

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -47,7 +47,7 @@ def is_wsl():
     """ Return whether we are running under the Windows Subsystem for Linux """
     if "linux" in platform.system().lower() and os.access("/proc/version", os.R_OK):
         with open("/proc/version", "r") as f:
-            if "Microsoft" in f.read():
+            if "microsoft" in f.read():
                 return True
     return False
 


### PR DESCRIPTION
On wsl2, /proc/version contains no "Microsoft" as wsl1 do.
Changing "Microsoft" to "microsoft" will make it work on both wsl1 and wsl2.