### PR TITLE
fish_vcs_prompt: allow argv passthrough

### DIFF
--- a/share/functions/fish_vcs_prompt.fish
+++ b/share/functions/fish_vcs_prompt.fish
@@ -1,8 +1,8 @@
 function fish_vcs_prompt --description "Print the prompts for all available vcsen"
     # If a prompt succeeded, we assume that it's printed the correct info.
     # This is so we don't try svn if git already worked.
-    fish_git_prompt
-    or fish_hg_prompt
+    fish_git_prompt $argv
+    or fish_hg_prompt $argv
     # The svn prompt is disabled by default because it's quite slow on common svn repositories.
     # To enable it uncomment it.
     # You can also only use it in specific directories by checking $PWD.


### PR DESCRIPTION
`fish_git_prompt` encloses its output in brackets, however this can be changed by supplying a format string to it, i.e. `fish_git_prompt %s`.

However when using `fish_vcs_prompt` there's no way to pass on the arg to `fish_git_prompt`, so you need to manually remove it.

`fish_hg_prompt` doesn't have the same format string support as `fish_git_prompt`, but I suppose it could be added later if needed.
