### PR TITLE
Show autosuggestions when (left prompt + command) exceed right prompt

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -974,15 +974,15 @@ static screen_layout_t compute_layout(screen_t *s, size_t screen_width,
 
     // Case 3
     if (!done) {
-      calculated_width = left_prompt_width + first_command_line_width + autosuggest_total_width;
-      if (calculated_width < screen_width) {
-	result.left_prompt = left_prompt;
-	result.left_prompt_space = left_prompt_width;
-	result.autosuggestion = autosuggestion;
-	done = true;
-      }      
+        calculated_width = left_prompt_width + first_command_line_width + autosuggest_total_width;
+        if (calculated_width < screen_width) {
+            result.left_prompt = left_prompt;
+            result.left_prompt_space = left_prompt_width;
+            result.autosuggestion = autosuggestion;
+            done = true;
+        }
     }
-    
+
     // Case 4
     if (!done) {
         calculated_width = left_prompt_width + first_command_line_width;
@@ -990,15 +990,15 @@ static screen_layout_t compute_layout(screen_t *s, size_t screen_width,
             result.left_prompt = left_prompt;
             result.left_prompt_space = left_prompt_width;
 
-            // Need at least two characters to show an autosuggestion.	    
-	    size_t available_autosuggest_space =
-	      screen_width - (left_prompt_width + first_command_line_width);
-	    if (autosuggest_total_width > 0 && available_autosuggest_space > 2) {
-	      size_t truncation_offset = truncation_offset_for_width(autosuggest_truncated_widths,
-								     available_autosuggest_space - 2);
-	      result.autosuggestion = wcstring(autosuggestion, truncation_offset);
-	      result.autosuggestion.push_back(get_ellipsis_char());	      
-	    }	    
+            // Need at least two characters to show an autosuggestion.
+            size_t available_autosuggest_space =
+                screen_width - (left_prompt_width + first_command_line_width);
+            if (autosuggest_total_width > 0 && available_autosuggest_space > 2) {
+                size_t truncation_offset = truncation_offset_for_width(
+                    autosuggest_truncated_widths, available_autosuggest_space - 2);
+                result.autosuggestion = wcstring(autosuggestion, truncation_offset);
+                result.autosuggestion.push_back(get_ellipsis_char());
+            }
             done = true;
         }
     }


### PR DESCRIPTION
## Description

Currently when the (left prompt + command) exceeds the right prompt autosuggestions are not shown. With this change autosuggestions are shown. Existing tests look green:

https://travis-ci.org/github/ksralgp/fish-shell/builds/690675896

Fixes issue #6948 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.md
