### PR TITLE
remove redundant if conditions

### DIFF
--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -784,12 +784,8 @@ struct compiled_regex_t {
     }
 
     ~compiled_regex_t() {
-        if (match != nullptr) {
-            pcre2_match_data_free(match);
-        }
-        if (code != nullptr) {
-            pcre2_code_free(code);
-        }
+        pcre2_match_data_free(match);
+        pcre2_code_free(code);
     }
 };
 


### PR DESCRIPTION
All pcre2 resource free functions handle null pointer gracefully. Nothing would be done if a NULL pointer is passed to `pcre2_code_free` or `pcre2_match_data_free`.

1.  https://www.pcre.org/current/doc/html/pcre2_code_free.html
 2. https://www.pcre.org/current/doc/html/pcre2_match_data_free.html