### PR TITLE
Add "alacritty" to the list of TERM values of terminals supporting dynamic titles

### DIFF
--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -417,7 +417,8 @@ static bool initialize_curses_using_fallback(const char *term) {
 /// One situation in which this breaks down is with screen, since screen supports setting the
 /// terminal title if the underlying terminal does so, but will print garbage on terminals that
 /// don't. Since we can't see the underlying terminal below screen there is no way to fix this.
-static const wchar_t *const title_terms[] = {L"xterm", L"screen", L"tmux", L"nxterm", L"rxvt"};
+static const wchar_t *const title_terms[] = {L"xterm",  L"screen", L"tmux",
+                                             L"nxterm", L"rxvt",   L"alacritty"};
 static bool does_term_support_setting_title(const environment_t &vars) {
     const auto term_var = vars.get(L"TERM");
     if (term_var.missing_or_empty()) return false;


### PR DESCRIPTION
# Description

This change fixes support for "dynamic titles" for users of the Alacritty terminal.  Users with the terminfo for `alacritty` installed in their terminfo database would have their `TERM` values set to `alacritty` by default (as opposed to `xterm-256color`), which would break fish-shell's understanding.

Prior to this change, the [`does_term_support_setting_title`](https://github.com/fish-shell/fish-shell/blob/4d487f711d75f19ec78a3743ea60b04185a45fc0/src/env_dispatch.cpp#L421-L444) function would return `false` because the term value `alacritty` matches the pattern `tty` (causing [this line](https://github.com/fish-shell/fish-shell/blob/4d487f711d75f19ec78a3743ea60b04185a45fc0/src/env_dispatch.cpp#L440) to return `false`).  Other values of `TERM` not including the substrings `tty` or `/vc/` and not matching any of the prior patterns would instead be interpreted as having support for dynamic titles, but in this case because the string `alacritty` contains "tty", it would get interpreted as _not_ having support for dynamic titles.

I'd be happy to make any additional changes requested!

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
