### PR TITLE
Add support for git-* command auto-completion

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1870,9 +1870,20 @@ complete -c git -n '__fish_git_using_command bisect; and __fish_seen_argument --
 
 ## Custom commands (git-* commands installed in the PATH)
 complete -c git -n __fish_git_needs_command -a '(__fish_git_custom_commands)' -d 'Custom command'
+
+# Get the path to the generated completions
+# If $XDG_DATA_HOME is set, that's it, if not, it will be removed and ~/.local/share will remain.
+set -l generated_path $XDG_DATA_HOME/fish/generated_completions ~/.local/share/fish/generated_completions
+
+# We don't want to modify $fish_complete_path here, so we make a copy.
+set -l complete_dirs $fish_complete_path
+
+# Remove the path to the generated completions if it is in the list
+set -l ind (contains -i -- $generated_path[1] $complete_dirs); and set -e complete_dirs[$ind]
+
 # source git-* commands' autocompletion file if exists
 set -l __fish_git_custom_commands_completion
-for git_ext in $fish_complete_path/git-*.fish
+for git_ext in $complete_dirs/git-*.fish
     # ignore this completion as executable does not exists
     set -l cmd (string replace -r '.*/([^/]*)\.fish' '$1' $git_ext)
     not command -q $cmd

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1872,16 +1872,14 @@ complete -c git -n '__fish_git_using_command bisect; and __fish_seen_argument --
 complete -c git -n __fish_git_needs_command -a '(__fish_git_custom_commands)' -d 'Custom command'
 # source git-* commands' autocompletion file if exists
 set -l __fish_git_custom_commands_completion
-for complete_path in $fish_complete_path
-    for git_ext in $complete_path/git-*.fish
-        # ignore this completion as executable does not exists
-        set -l cmd (string replace '.fish' '' (basename $git_ext))
-        not command -q $cmd
-        and continue
-        # already sourced this git-* completion file from some other dir
-        contains -- $git_ext $__fish_git_custom_commands_completion
-        and continue
-        source $git_ext
-        set -a __fish_git_custom_commands_completion $git_ext
-    end
+for git_ext in $fish_complete_path/git-*.fish
+    # ignore this completion as executable does not exists
+    set -l cmd (string replace -r '.*/([^/]*)\.fish' '$1' $git_ext)
+    not command -q $cmd
+    and continue
+    # already sourced this git-* completion file from some other dir
+    contains -- $cmd $__fish_git_custom_commands_completion
+    and continue
+    source $git_ext
+    set -a __fish_git_custom_commands_completion $cmd
 end

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1870,3 +1870,18 @@ complete -c git -n '__fish_git_using_command bisect; and __fish_seen_argument --
 
 ## Custom commands (git-* commands installed in the PATH)
 complete -c git -n __fish_git_needs_command -a '(__fish_git_custom_commands)' -d 'Custom command'
+# source git-* commands' autocompletion file if exists
+set -l __fish_git_custom_commands_completion
+for complete_path in $fish_complete_path
+    for git_ext in $complete_path/git-*.fish
+        # ignore this completion as executable does not exists
+        set -l cmd (string replace '.fish' '' (basename $git_ext))
+        not command -q $cmd
+        and continue
+        # already sourced this git-* completion file from some other dir
+        contains -- $git_ext $__fish_git_custom_commands_completion
+        and continue
+        source $git_ext
+        set -a __fish_git_custom_commands_completion $git_ext
+    end
+end


### PR DESCRIPTION
Fixes issue #7071

## Description
This PR addresses #7071 by loading `git-*.fish` completion in the main `git.fish`.

This approach addresses the following
1. This does not add overheads to the existing `git` if the user had not installed any `git-*.fish` completion file, other than the searches for completion file during initialisation.
2. Even if the main-repo or vendor provides some `git-*.fish` completion file, this approach won't loads them if the user had not installed the executable. Therefore, it won't clutter the shell by loading unnecessary completion.
3. This follows the traditional loading approach where it only loads the first completion file `git-*.fish` it founds.
4. It directly addresses the issue of currently there is no way (other than eager loading by user) to add completions for `git <foo>`. This approach allows you to add `git-foo.fish` to your completion file and it will load it whens git is invoked.
5. By looking at the current `git.fish` it already tries to provide completion for custom `git-*` executable, so it makes sense to also load their completion, if exists, afterwards.

## TODOs:
<!-- Just check off what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
