### PR TITLE
Add `status dirname` and `status basename` convenience commands

### DIFF
--- a/doc_src/cmds/status.rst
+++ b/doc_src/cmds/status.rst
@@ -19,6 +19,8 @@ Synopsis
     status is-interactive-job-control
     status current-command
     status filename
+    status basename
+    status dirname
     status fish-path
     status function
     status line-number
@@ -52,7 +54,11 @@ The following operations (sub-commands) are available:
 
 - ``current-command`` prints the name of the currently-running function or command, like the deprecated ``_`` variable.
 
-- ``filename`` prints the filename of the currently running script. Also ``current-filename``, ``-f`` or ``--current-filename``.
+- ``filename`` prints the filename of the currently running script. Also ``current-filename``, ``-f`` or ``--current-filename``. This depends on how the script was called - if it was called via a symlink, the symlink will be returned, and if the current script was received via ``source`` it will be ``-``.
+
+- ``basename`` prints just the filename of the running script, without any path-components before.
+
+- ``dirname`` prints just the path to the running script, without the actual filename itself. This can be relative to $PWD (including just "."), depending on how the script was called. This is the same as passing the ``filename`` to ``dirname(3)``. It's useful if you want to use other files in the current script's directory or similar.
 
 - ``fish-path`` prints the absolute path to the currently executing instance of fish.
 

--- a/tests/checks/status-command.fish
+++ b/tests/checks/status-command.fish
@@ -36,3 +36,18 @@ echo $status
 echo (status is-command-substitution; echo $status)
 # CHECK: 1
 # CHECK: 0
+
+test (status filename) = (status dirname)/(status basename)
+
+status basename
+#CHECK: status-command.fish
+
+status dirname | string match -q '*checks'
+echo $status
+#CHECK: 0
+
+echo "status dirname" | source
+#CHECK: .
+
+$FISH_PATH -c 'status dirname'
+#CHECK: Standard input


### PR DESCRIPTION
## Description

There's a terrible number of fishscripts that start with

    set path (dirname (status filename))

And that's really just a bit boring.

So let's let it be

    set path (status dirname)

And while we're at it, add "status basename" as well.

There are some alternatives here, including:

- Making `dirname` a builtin - this doesn't solve the problem of having that boilerplate and it has the problems associated with overriding system commands

- Adding a variable - tbh I'm not super fond of adding more electric variables unless necessary

- Adding an option to `status filename` - `status filename --dir-only` - this is a bit uglier, it does cut down on the number of subcommands, but I don't think that's much of an issue

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
