### PR TITLE
Let `__fish_prepend_sudo` use the last commandline if there is no current one

### DIFF
--- a/doc_src/faq.rst
+++ b/doc_src/faq.rst
@@ -228,7 +228,7 @@ Why doesn't history substitution ("!$" etc.) work?
 --------------------------------------------------
 Because history substitution is an awkward interface that was invented before interactive line editing was even possible. Instead of adding this pseudo-syntax, fish opts for nice history searching and recall features.  Switching requires a small change of habits: if you want to modify an old line/word, first recall it, then edit.
 
-E.g. don't type "sudo !!" - first press Up, then Home, then type "sudo ". For ``sudo`` in particular there's a special binding, so you can press :kbd:`Alt`\ +\ :kbd:`S` to toggle a ``sudo`` prefix instead of typing ``sudo``.
+Most of the time, it's used as ``sudo !!``. In that case just press :kbd:`Alt`\ +\ :kbd:`S`, and it will recall your last commandline with `sudo` prefixed (or toggle a `sudo` prefix on the current commandline if there is anything).
 
 Fish's history recall is very simple yet effective:
 

--- a/doc_src/faq.rst
+++ b/doc_src/faq.rst
@@ -226,7 +226,9 @@ Change the value of the variable ``fish_greeting`` or create a ``fish_greeting``
 
 Why doesn't history substitution ("!$" etc.) work?
 --------------------------------------------------
-Because history substitution is an awkward interface that was invented before interactive line editing was even possible. Instead of adding this pseudo-syntax, fish opts for nice history searching and recall features.  Switching requires a small change of habits: if you want to modify an old line/word, first recall it, then edit.  E.g. don't type "sudo !!" - first press Up, then Home, then type "sudo ".
+Because history substitution is an awkward interface that was invented before interactive line editing was even possible. Instead of adding this pseudo-syntax, fish opts for nice history searching and recall features.  Switching requires a small change of habits: if you want to modify an old line/word, first recall it, then edit.
+
+E.g. don't type "sudo !!" - first press Up, then Home, then type "sudo ". For ``sudo`` in particular there's a special binding, so you can press :kbd:`Alt`\ +\ :kbd:`S` to toggle a ``sudo`` prefix instead of typing ``sudo``.
 
 Fish's history recall is very simple yet effective:
 

--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -1431,7 +1431,7 @@ Some bindings are shared between emacs- and vi-mode because they aren't text edi
 
 - :kbd:`Alt`\ +\ :kbd:`V` Same as :kbd:`Alt`\ +\ :kbd:`E`.
 
-- :kbd:`Alt`\ +\ :kbd:`S` Prepends `sudo` to the current commandline.
+- :kbd:`Alt`\ +\ :kbd:`S` Prepends `sudo` to the current commandline. If the commandline is empty, prepend `sudo` to the last commandline.
 
 - :kbd:`Control`\ +\ :kbd:`Space` Inserts a space without expanding an :ref:`abbreviation <abbreviations>`. For vi-mode this only applies to insert-mode.
 

--- a/share/functions/__fish_prepend_sudo.fish
+++ b/share/functions/__fish_prepend_sudo.fish
@@ -1,7 +1,9 @@
 function __fish_prepend_sudo -d "Prepend 'sudo ' to the beginning of the current commandline"
     set -l cmd (commandline -po)
     set -l cursor (commandline -C)
-    if test "$cmd[1]" != sudo
+    if test -z "$cmd"
+        commandline -r "sudo $history[1]"
+    else if test "$cmd[1]" != sudo
         commandline -C 0
         commandline -i "sudo "
         commandline -C (math $cursor + 5)


### PR DESCRIPTION
## Description

As we all know, `!!` is a frequently asked for feature, but 99.7% of the time it's specifically for `sudo !!`, which is just a super awkward interface.

This makes it so that `__fish_prepend_sudo` uses the previous commandline if the current commandline is empty, so we finally win on keystrokes against `sudo !!`. Truly that is the most important metric.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
