### PR TITLE
Skip pre/post exec events for empty commands (#4829)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Notable improvements and fixes
 -  A new ``fish_add_path`` helper function to add paths to $PATH without producing duplicates, to be used interactively or in config.fish (#6960)
 -  The ``_`` helper function to call into fish's gettext catalog has been made a builtin for simplicity and performance (#7036)
 -  ``:`` (for doing nothing) and ``.`` (as a less readable name for ``source``) have also been made proper builtins rather than wrapper functions (#6854).
+- ``fish_preexec`` and ``fish_postexec`` events are no longer triggered
+  for empty commands.
 
 Syntax changes and new commands
 -------------------------------

--- a/doc_src/cmds/function.rst
+++ b/doc_src/cmds/function.rst
@@ -52,11 +52,11 @@ By using one of the event handler switches, a function can be made to run automa
 
 - ``fish_command_not_found``, which is emitted whenever a command lookup failed.
 
-- ``fish_preexec``, which is emitted right before executing an interactive command. The commandline is passed as the first parameter.
+- ``fish_preexec``, which is emitted right before executing an interactive command. The commandline is passed as the first parameter. Not emitted if command is empty.
 
 - ``fish_posterror``, which is emitted right after executing a command with syntax errors. The commandline is passed as the first parameter.
 
-- ``fish_postexec``, which is emitted right after executing an interactive command. The commandline is passed as the first parameter.
+- ``fish_postexec``, which is emitted right after executing an interactive command. The commandline is passed as the first parameter. Not emitted if command is empty.
 
 - ``fish_exit`` is emitted right before fish exits.
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2478,10 +2478,10 @@ static int read_i(parser_t &parser) {
             data->command_line.clear();
             data->command_line_changed(&data->command_line);
             wcstring_list_t argv(1, command);
-            event_fire_generic(parser, L"fish_preexec", &argv);
+            if (!command.empty()) event_fire_generic(parser, L"fish_preexec", &argv);
             reader_run_command(parser, command);
             parser.clear_cancel();
-            event_fire_generic(parser, L"fish_postexec", &argv);
+            if (!command.empty()) event_fire_generic(parser, L"fish_postexec", &argv);
             // Allow any pending history items to be returned in the history array.
             if (data->history) {
                 data->history->resolve_pending();


### PR DESCRIPTION
## Description

In the same vein as #4926, firing `fish_preexec` and `fish_postexec` for empty commands is inconsistent with the way `$status`, `history` and `$CMD_DURATION` treat empty commands. `fish_postexec`, for example, receives an incorrect value for `$CMD_DURATION` when an empty command is processed.

As suggested in #4829, this patch skips firing of these events for empty commands altogether.

Fixes issue #4829

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
