### PR TITLE
fix compilation under C++14

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -176,16 +176,6 @@ if(NOT POLICY CMP0067)
   list(APPEND CMAKE_REQUIRED_FLAGS "${CMAKE_CXX${CMAKE_CXX_STANDARD}_EXTENSION_COMPILE_OPTION}")
 endif()
 
-check_cxx_source_compiles("
-#include <memory>
-
-int main () {
-  std::unique_ptr<int> foo = std::make_unique<int>();
-}
-"
-  HAVE_STD__MAKE_UNIQUE
-)
-
 # Detect support for thread_local.
 check_cxx_source_compiles("
 int main () {

--- a/config_cmake.h.in
+++ b/config_cmake.h.in
@@ -130,9 +130,6 @@
 /* Define to 1 if the _nl_msg_cat_cntr symbol is exported. */
 #cmakedefine HAVE__NL_MSG_CAT_CNTR 1
 
-/* Define to 1 if std::make_unique is available. */
-#cmakedefine HAVE_STD__MAKE_UNIQUE 1
-
 /* Define to 1 if the _sys_errs array is available. */
 #cmakedefine HAVE__SYS__ERRS 1
 

--- a/src/common.h
+++ b/src/common.h
@@ -578,7 +578,7 @@ wcstring vformat_string(const wchar_t *format, va_list va_orig);
 void append_format(wcstring &str, const wchar_t *format, ...);
 void append_formatv(wcstring &target, const wchar_t *format, va_list va_orig);
 
-#ifdef HAVE_STD__MAKE_UNIQUE
+#ifdef __cpp_lib_make_unique
 using std::make_unique;
 #else
 /// make_unique implementation


### PR DESCRIPTION
Currently, setting CMAKE_CXX_STANDARD to 14 breaks compilation. The
CMake check used isn't working.

__cpp_lib_make_unique is a standard C++ macro.

Signed-off-by: Rosen Penev <rosenp@gmail.com>