### PR TITLE
run through clang-tidy

### DIFF
--- a/src/builtin_set_color.cpp
+++ b/src/builtin_set_color.cpp
@@ -38,7 +38,7 @@ static void print_colors(io_streams_t &streams) {
 
     for (const auto &color_name : rgb_color_t::named_color_names()) {
         if (!streams.out_is_redirected && isatty(STDOUT_FILENO)) {
-            rgb_color_t color = rgb_color_t(color_name);
+            auto color = rgb_color_t(color_name);
             outp.set_color(color, rgb_color_t::none());
         }
         outp.writestr(color_name);

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1142,7 +1142,7 @@ static int string_split_maybe0(parser_t &parser, io_streams_t &streams, int argc
     int retval = parse_opts(&opts, &optind, is_split0 ? 0 : 1, argc, argv, parser, streams);
     if (retval != STATUS_CMD_OK) return retval;
 
-    if (opts.fields.size() < 1 && opts.allow_empty) {
+    if (opts.fields.empty() && opts.allow_empty) {
         streams.err.append_format(BUILTIN_ERR_COMBO2, cmd,
                                   _(L"--allow-empty is only valid with --fields"));
         return STATUS_INVALID_ARGS;
@@ -1186,7 +1186,7 @@ static int string_split_maybe0(parser_t &parser, io_streams_t &streams, int argc
                 if (splits.back().empty()) splits.pop_back();
             }
             auto &buff = streams.out.buffer();
-            if (opts.fields.size() > 0) {
+            if (!opts.fields.empty()) {
                 // Print nothing and return error if any of the supplied
                 // fields do not exist, unless `--allow-empty` is used.
                 if (!opts.allow_empty) {

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -692,7 +692,7 @@ class string_matcher_t {
 
     virtual ~string_matcher_t() = default;
     virtual bool report_matches(const wcstring &arg) = 0;
-    int match_count() const { return total_matched; }
+    __warn_unused int match_count() const { return total_matched; }
 };
 
 class wildcard_matcher_t : public string_matcher_t {
@@ -949,7 +949,7 @@ class string_replacer_t {
         : argv0(argv0_), opts(std::move(opts_)), total_replaced(0), streams(streams_) {}
 
     virtual ~string_replacer_t() = default;
-    int replace_count() const { return total_replaced; }
+    __warn_unused int replace_count() const { return total_replaced; }
     virtual bool replace_matches(const wcstring &arg) = 0;
 };
 

--- a/src/builtin_test.cpp
+++ b/src/builtin_test.cpp
@@ -96,13 +96,13 @@ class number_t {
 
     // Compare two numbers. Returns an integer -1, 0, 1 corresponding to whether we are less than,
     // equal to, or greater than the rhs.
-    int compare(number_t rhs) const {
+    __warn_unused int compare(number_t rhs) const {
         if (this->base != rhs.base) return (this->base > rhs.base) - (this->base < rhs.base);
         return (this->delta > rhs.delta) - (this->delta < rhs.delta);
     }
 
     // Return true if the number is a tty()/
-    bool isatty() const {
+    __warn_unused bool isatty() const {
         if (delta != 0.0 || base > INT_MAX || base < INT_MIN) return false;
         return ::isatty(static_cast<int>(base));
     }

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -105,9 +105,9 @@ using complete_entry_opt_t = struct complete_entry_opt {
     // Completion flags.
     complete_flags_t flags;
 
-    wcstring localized_desc() const { return C_(desc); }
+    __warn_unused wcstring localized_desc() const { return C_(desc); }
 
-    size_t expected_dash_count() const {
+    __warn_unused size_t expected_dash_count() const {
         switch (this->type) {
             case option_type_args_only:
                 return 0;
@@ -140,7 +140,7 @@ class completion_entry_t {
     const unsigned int order;
 
     /// Getters for option list.
-    const option_list_t &get_options() const;
+    __warn_unused const option_list_t &get_options() const;
 
     /// Adds or removes an option.
     void add_option(const complete_entry_opt_t &opt);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -71,11 +71,11 @@ struct electric_var_t {
     const wchar_t *name;
     uint32_t flags;
 
-    bool readonly() const { return flags & freadonly; }
+    __warn_unused bool readonly() const { return flags & freadonly; }
 
-    bool computed() const { return flags & fcomputed; }
+    __warn_unused bool computed() const { return flags & fcomputed; }
 
-    bool exports() const { return flags & fexports; }
+    __warn_unused bool exports() const { return flags & fexports; }
 
     static const electric_var_t *for_name(const wcstring &name);
 };
@@ -445,7 +445,7 @@ struct query_t {
         user = mode & ENV_USER;
     }
 
-    bool export_matches(const env_var_t &var) const {
+    __warn_unused bool export_matches(const env_var_t &var) const {
         if (has_export_unexport) {
             return var.exports() ? exports : unexports;
         } else {
@@ -478,7 +478,7 @@ class env_node_t {
         return none();
     }
 
-    bool exports() const { return export_gen > 0; }
+    __warn_unused bool exports() const { return export_gen > 0; }
 
     void changed_exported() { export_gen = next_export_generation(); }
 };
@@ -499,13 +499,14 @@ class env_scoped_impl_t : public environment_t {
         assert(locals_ && globals_ && "Nodes cannot be null");
     }
 
-    maybe_t<env_var_t> get(const wcstring &key, env_mode_flags_t mode = ENV_DEFAULT) const override;
-    wcstring_list_t get_names(int flags) const override;
+    __warn_unused maybe_t<env_var_t> get(const wcstring &key,
+                                         env_mode_flags_t mode = ENV_DEFAULT) const override;
+    __warn_unused wcstring_list_t get_names(int flags) const override;
 
     perproc_data_t &perproc_data() { return perproc_data_; }
-    const perproc_data_t &perproc_data() const { return perproc_data_; }
+    __warn_unused const perproc_data_t &perproc_data() const { return perproc_data_; }
 
-    std::shared_ptr<environment_t> snapshot() const;
+    __warn_unused std::shared_ptr<environment_t> snapshot() const;
 
     ~env_scoped_impl_t() override = default;
 
@@ -538,10 +539,10 @@ class env_scoped_impl_t : public environment_t {
     // populated. A maybe_t<maybe_t<...>> is a bridge too far.
     // These may populate result with none() if a variable is present which does not match the
     // query.
-    maybe_t<env_var_t> try_get_computed(const wcstring &key) const;
-    maybe_t<env_var_t> try_get_local(const wcstring &key) const;
-    maybe_t<env_var_t> try_get_global(const wcstring &key) const;
-    maybe_t<env_var_t> try_get_universal(const wcstring &key) const;
+    __warn_unused maybe_t<env_var_t> try_get_computed(const wcstring &key) const;
+    __warn_unused maybe_t<env_var_t> try_get_local(const wcstring &key) const;
+    __warn_unused maybe_t<env_var_t> try_get_global(const wcstring &key) const;
+    __warn_unused maybe_t<env_var_t> try_get_universal(const wcstring &key) const;
 
     /// Invoke a function on the current (nonzero) export generations, in order.
     template <typename Func>
@@ -556,10 +557,10 @@ class env_scoped_impl_t : public environment_t {
     }
 
     /// \return whether the current export array is empty or out-of-date.
-    bool export_array_needs_regeneration() const;
+    __warn_unused bool export_array_needs_regeneration() const;
 
     /// \return a newly allocated export array.
-    std::shared_ptr<const null_terminated_array_t<char>> create_export_array() const;
+    __warn_unused std::shared_ptr<const null_terminated_array_t<char>> create_export_array() const;
 };
 
 /// Get the exported variables into a variable table.
@@ -887,7 +888,7 @@ class env_stack_impl_t final : public env_scoped_impl_t {
 
     /// Remove a variable from the chain \p node.
     /// \return true if the variable was found and removed.
-    bool remove_from_chain(const env_node_ref_t &node, const wcstring &key) const {
+    __warn_unused bool remove_from_chain(const env_node_ref_t &node, const wcstring &key) const {
         for (auto cursor = node; cursor; cursor = cursor->next) {
             auto iter = cursor->env.find(key);
             if (iter != cursor->env.end()) {
@@ -923,7 +924,7 @@ class env_stack_impl_t final : public env_scoped_impl_t {
 
     /// Get a pointer to an existing variable, or nullptr.
     /// This is used for inheriting pathvar and export status.
-    const env_var_t *find_variable(const wcstring &key) const {
+    __warn_unused const env_var_t *find_variable(const wcstring &key) const {
         env_node_ref_t node = find_in_chain(locals_, key);
         if (!node) node = find_in_chain(globals_, key);
         if (node) {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -1220,7 +1220,7 @@ void env_stack_t::set_last_statuses(statuses_t s) {
 /// If they don't already exist initialize the `COLUMNS` and `LINES` env vars to reasonable
 /// defaults. They will be updated later by the `get_current_winsize()` function if they need to be
 /// adjusted.
-void env_stack_t::set_termsize() {
+void env_stack_t::set_termsize() const {
     auto &vars = env_stack_t::globals();
     auto cols = get(L"COLUMNS");
     if (cols.missing_or_empty()) vars.set_one(L"COLUMNS", ENV_GLOBAL, DFLT_TERM_COL_STR);

--- a/src/env.h
+++ b/src/env.h
@@ -295,7 +295,7 @@ class env_stack_t final : public environment_t {
     void set_last_statuses(statuses_t s);
 
     /// Update the termsize variable.
-    void set_termsize();
+    void set_termsize() const;
 
     /// Sets up argv as the given list of strings.
     void set_argv(wcstring_list_t argv);

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -342,7 +342,7 @@ void env_universal_t::generate_callbacks_and_update_exports(const var_table_t &n
 
         // See if the value has changed.
         const env_var_t &new_entry = kv.second;
-        var_table_t::const_iterator existing = this->vars.find(key);
+        auto existing = this->vars.find(key);
 
         bool old_exports = (existing != this->vars.end() && existing->second.exports());
         bool export_changed = (old_exports != new_entry.exports());

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -1314,7 +1314,7 @@ class universal_notifier_named_pipe_t : public universal_notifier_t {
         }
     }
 
-    int notification_fd() const override {
+    __warn_unused int notification_fd() const override {
         if (polling_due_to_readable_fd) {
             // We are in polling mode because we think our fd is readable. This means that, if we
             // return it to be select()'d on, we'll be called back immediately. So don't return it.
@@ -1358,7 +1358,7 @@ class universal_notifier_named_pipe_t : public universal_notifier_t {
         }
     }
 
-    unsigned long usec_delay_between_polls() const override {
+    __warn_unused unsigned long usec_delay_between_polls() const override {
         unsigned long readback_delay = ULONG_MAX;
         if (this->readback_time_usec > 0) {
             // How long until the readback?

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -207,9 +207,9 @@ static void run_internal_process(process_t *p, std::string &&outdata, std::strin
 
         proc_status_t success_status{};
 
-        bool skip_out() const { return outdata.empty() || src_outfd < 0; }
+        __warn_unused bool skip_out() const { return outdata.empty() || src_outfd < 0; }
 
-        bool skip_err() const { return errdata.empty() || src_errfd < 0; }
+        __warn_unused bool skip_err() const { return errdata.empty() || src_errfd < 0; }
     };
 
     auto f = std::make_shared<write_fields_t>();

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -478,8 +478,8 @@ static void test_format() {
 
 /// Helper to convert a narrow string to a sequence of hex digits.
 static char *str2hex(const char *input) {
-    char *output = (char *)malloc(5 * std::strlen(input) + 1);
-    char *p = output;
+    auto output = (char *)malloc(5 * std::strlen(input) + 1);
+    auto p = output;
     for (; *input; input++) {
         sprintf(p, "0x%02X ", (int)*input & 0xFF);
         p += 5;
@@ -1502,7 +1502,7 @@ static void test_utf82wchar(const char *src, size_t slen, const wchar_t *dst, si
 // Annoying variant to handle uchar to avoid narrowing conversion warnings.
 static void test_utf82wchar(const unsigned char *usrc, size_t slen, const wchar_t *dst, size_t dlen,
                             int flags, size_t res, const char *descr) {
-    const char *src = reinterpret_cast<const char *>(usrc);
+    auto src = reinterpret_cast<const char *>(usrc);
     return test_utf82wchar(src, slen, dst, dlen, flags, res, descr);
 }
 
@@ -1547,7 +1547,7 @@ static void test_wchar2utf8(const wchar_t *src, size_t slen, const char *dst, si
 // Annoying variant to handle uchar to avoid narrowing conversion warnings.
 static void test_wchar2utf8(const wchar_t *src, size_t slen, const unsigned char *udst, size_t dlen,
                             int flags, size_t res, const char *descr) {
-    const char *dst = reinterpret_cast<const char *>(udst);
+    auto dst = reinterpret_cast<const char *>(udst);
     return test_wchar2utf8(src, slen, dst, dlen, flags, res, descr);
 }
 
@@ -1854,7 +1854,7 @@ static bool expand_test(const wchar_t *in, expand_flags_t flags, ...) {
     va_end(va);
 
     std::set<wcstring> remaining(expected.begin(), expected.end());
-    completion_list_t::const_iterator out_it = output.begin(), out_end = output.end();
+    auto out_it = output.begin(), out_end = output.end();
     for (; out_it != out_end; ++out_it) {
         if (!remaining.erase(out_it->completion)) {
             res = false;
@@ -1879,7 +1879,7 @@ static bool expand_test(const wchar_t *in, expand_flags_t flags, ...) {
             }
             msg += L"], found [";
             first = true;
-            for (completion_list_t::const_iterator it = output.begin(), end = output.end();
+            for (auto it = output.begin(), end = output.end();
                  it != end; ++it) {
                 if (!first) msg += L", ";
                 first = false;
@@ -2485,7 +2485,7 @@ int builtin_test(parser_t &parser, io_streams_t &streams, wchar_t **argv);
 static bool run_one_test_test(int expected, wcstring_list_t &lst, bool bracket) {
     parser_t &parser = parser_t::principal_parser();
     size_t i, count = lst.size();
-    wchar_t **argv = new wchar_t *[count + 3];
+    auto argv = new wchar_t *[count + 3];
     argv[0] = (wchar_t *)(bracket ? L"[" : L"test");
     for (i = 0; i < count; i++) {
         argv[i + 1] = (wchar_t *)lst.at(i).c_str();

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -348,13 +348,13 @@ static void test_unescape_sane() {
         {L"'\\143'", L"\\143"},       {L"\\n", L"\n"}  // \n normally becomes newline
     };
     wcstring output;
-    for (size_t i = 0; i < sizeof tests / sizeof *tests; i++) {
-        bool ret = unescape_string(tests[i].input, &output, UNESCAPE_DEFAULT);
+    for (auto test : tests) {
+        bool ret = unescape_string(test.input, &output, UNESCAPE_DEFAULT);
         if (!ret) {
-            err(L"Failed to unescape '%ls'\n", tests[i].input);
-        } else if (output != tests[i].expected) {
-            err(L"In unescaping '%ls', expected '%ls' but got '%ls'\n", tests[i].input,
-                tests[i].expected, output.c_str());
+            err(L"Failed to unescape '%ls'\n", test.input);
+        } else if (output != test.expected) {
+            err(L"In unescaping '%ls', expected '%ls' but got '%ls'\n", test.input, test.expected,
+                output.c_str());
         }
     }
 
@@ -1879,12 +1879,11 @@ static bool expand_test(const wchar_t *in, expand_flags_t flags, ...) {
             }
             msg += L"], found [";
             first = true;
-            for (auto it = output.begin(), end = output.end();
-                 it != end; ++it) {
+            for (auto &it : output) {
                 if (!first) msg += L", ";
                 first = false;
                 msg += '"';
-                msg += it->completion;
+                msg += it.completion;
                 msg += '"';
             }
             msg += L"]";
@@ -2372,8 +2371,7 @@ static void test_1_word_motion(word_motion_t motion, move_word_style_t style,
     std::set<size_t> stops;
 
     // Carets represent stops and should be cut out of the command.
-    for (size_t i = 0; i < test.size(); i++) {
-        wchar_t wc = test.at(i);
+    for (wchar_t wc : test) {
         if (wc == L'^') {
             stops.insert(command.size());
         } else {
@@ -3330,8 +3328,8 @@ static void test_input() {
     }
 
     // Push the desired binding to the queue.
-    for (size_t idx = 0; idx < desired_binding.size(); idx++) {
-        input.queue_ch(desired_binding.at(idx));
+    for (wchar_t idx : desired_binding) {
+        input.queue_ch(idx);
     }
 
     // Now test.
@@ -3949,7 +3947,7 @@ void history_tests_t::test_history_races() {
     history_t(L"race_test").clear();
 
     pid_t children[RACE_COUNT];
-    for (size_t i = 0; i < RACE_COUNT; i++) {
+    for (int &i : children) {
         pid_t pid = fork();
         if (!pid) {
             // Child process.
@@ -3958,14 +3956,14 @@ void history_tests_t::test_history_races() {
             exit_without_destructors(0);
         } else {
             // Parent process.
-            children[i] = pid;
+            i = pid;
         }
     }
 
     // Wait for all children.
-    for (size_t i = 0; i < RACE_COUNT; i++) {
+    for (int i : children) {
         int stat;
-        waitpid(children[i], &stat, WUNTRACED);
+        waitpid(i, &stat, WUNTRACED);
     }
 
     // Compute the expected lines.
@@ -4044,8 +4042,8 @@ void history_tests_t::test_history_merge() {
     const wcstring alt_texts[count] = {L"History Alt 1", L"History Alt 2", L"History Alt 3"};
 
     // Make sure history is clear.
-    for (size_t i = 0; i < count; i++) {
-        hists[i]->clear();
+    for (auto &hist : hists) {
+        hist->clear();
     }
 
     // Make sure we don't add an item in the same second as we created the history.
@@ -4057,8 +4055,8 @@ void history_tests_t::test_history_merge() {
     }
 
     // Save them.
-    for (size_t i = 0; i < count; i++) {
-        hists[i]->save();
+    for (auto &hist : hists) {
+        hist->save();
     }
 
     // Make sure each history contains what it ought to, but they have not leaked into each other.
@@ -4074,21 +4072,21 @@ void history_tests_t::test_history_merge() {
     // is newer, since we only pick up items whose timestamp is before the birth stamp.
     time_barrier();
     std::unique_ptr<history_t> everything = make_unique<history_t>(name);
-    for (size_t i = 0; i < count; i++) {
-        do_test(history_contains(everything, texts[i]));
+    for (const auto &text : texts) {
+        do_test(history_contains(everything, text));
     }
 
     // Tell all histories to merge. Now everybody should have everything.
-    for (size_t i = 0; i < count; i++) {
-        hists[i]->incorporate_external_changes();
+    for (auto &hist : hists) {
+        hist->incorporate_external_changes();
     }
 
     // Everyone should also have items in the same order (#2312)
     wcstring_list_t hist_vals1;
     hists[0]->get_history(hist_vals1);
-    for (size_t i = 0; i < count; i++) {
+    for (auto &hist : hists) {
         wcstring_list_t hist_vals2;
-        hists[i]->get_history(hist_vals2);
+        hist->get_history(hist_vals2);
         do_test(hist_vals1 == hist_vals2);
     }
 
@@ -4304,8 +4302,8 @@ static void test_new_parser_correctness() {
         {L"true || \n\n false", true},
     };
 
-    for (size_t i = 0; i < sizeof parser_tests / sizeof *parser_tests; i++) {
-        const parser_test_t *test = &parser_tests[i];
+    for (const auto &parser_test : parser_tests) {
+        const parser_test_t *test = &parser_test;
 
         parse_node_tree_t parse_tree;
         bool success = parse_tree_from_string(test->src, parse_flag_none, &parse_tree, nullptr);
@@ -4452,21 +4450,20 @@ static void test_new_parser_ll2() {
         {L"function", L"function", L"", parse_statement_decoration_none},
         {L"function --help", L"function", L"--help", parse_statement_decoration_none}};
 
-    for (size_t i = 0; i < sizeof tests / sizeof *tests; i++) {
+    for (const auto &test : tests) {
         wcstring cmd, args;
         enum parse_statement_decoration_t deco = parse_statement_decoration_none;
-        bool success = test_1_parse_ll2(tests[i].src, &cmd, &args, &deco);
-        if (!success)
-            err(L"Parse of '%ls' failed on line %ld", tests[i].cmd.c_str(), (long)__LINE__);
-        if (cmd != tests[i].cmd)
+        bool success = test_1_parse_ll2(test.src, &cmd, &args, &deco);
+        if (!success) err(L"Parse of '%ls' failed on line %ld", test.cmd.c_str(), (long)__LINE__);
+        if (cmd != test.cmd)
             err(L"When parsing '%ls', expected command '%ls' but got '%ls' on line %ld",
-                tests[i].src.c_str(), tests[i].cmd.c_str(), cmd.c_str(), (long)__LINE__);
-        if (args != tests[i].args)
+                test.src.c_str(), test.cmd.c_str(), cmd.c_str(), (long)__LINE__);
+        if (args != test.args)
             err(L"When parsing '%ls', expected args '%ls' but got '%ls' on line %ld",
-                tests[i].src.c_str(), tests[i].args.c_str(), args.c_str(), (long)__LINE__);
-        if (deco != tests[i].deco)
+                test.src.c_str(), test.args.c_str(), args.c_str(), (long)__LINE__);
+        if (deco != test.deco)
             err(L"When parsing '%ls', expected decoration %d but got %d on line %ld",
-                tests[i].src.c_str(), (int)tests[i].deco, (int)deco, (long)__LINE__);
+                test.src.c_str(), (int)test.deco, (int)deco, (long)__LINE__);
     }
 
     check_function_help<grammar::plain_statement>(L"function -h");
@@ -4516,9 +4513,9 @@ static void test_new_parser_errors() {
         {L"if true ; case ; end", parse_error_unbalancing_case},
     };
 
-    for (size_t i = 0; i < sizeof tests / sizeof *tests; i++) {
-        const wcstring src = tests[i].src;
-        parse_error_code_t expected_code = tests[i].code;
+    for (auto test : tests) {
+        const wcstring src = test.src;
+        parse_error_code_t expected_code = test.code;
 
         parse_error_list_t errors;
         parse_node_tree_t parse_tree;
@@ -4534,8 +4531,8 @@ static void test_new_parser_errors() {
             err(L"Source '%ls' was expected to produce error code %lu, but instead produced error "
                 L"code %lu",
                 src.c_str(), expected_code, (unsigned long)errors.at(0).code);
-            for (size_t i = 0; i < errors.size(); i++) {
-                err(L"\t\t%ls", errors.at(i).describe(src, true).c_str());
+            for (auto &error : errors) {
+                err(L"\t\t%ls", error.describe(src, true).c_str());
             }
         }
     }
@@ -4597,8 +4594,7 @@ static bool string_matches_format(const wcstring &string, const wchar_t *format)
     bool result = true;
     wcstring_list_t components = separate_by_format_specifiers(format);
     size_t idx = 0;
-    for (size_t i = 0; i < components.size(); i++) {
-        const wcstring &component = components.at(i);
+    for (auto &component : components) {
         size_t where = string.find(component, idx);
         if (where == wcstring::npos) {
             result = false;
@@ -4632,8 +4628,8 @@ static void test_error_messages() {
                        {L"echo \"foo$(foo)bar\"", ERROR_BAD_VAR_SUBCOMMAND1}};
 
     parse_error_list_t errors;
-    for (size_t i = 0; i < sizeof error_tests / sizeof *error_tests; i++) {
-        const struct error_test_t *test = &error_tests[i];
+    for (const auto &error_test : error_tests) {
+        const struct error_test_t *test = &error_test;
         errors.clear();
         parse_util_detect_errors(test->src, &errors, false /* allow_incomplete */);
         do_test(!errors.empty());

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -1728,7 +1728,7 @@ class test_lru_t : public lru_cache_t<test_lru_t, int> {
 
     void entry_was_evicted(const wcstring &key, int val) { evicted.emplace_back(key, val); }
 
-    std::vector<value_type> values() const {
+    __warn_unused std::vector<value_type> values() const {
         std::vector<value_type> result;
         for (const auto &p : *this) {
             result.emplace_back(p);
@@ -1736,7 +1736,7 @@ class test_lru_t : public lru_cache_t<test_lru_t, int> {
         return result;
     }
 
-    std::vector<int> ints() const {
+    __warn_unused std::vector<int> ints() const {
         std::vector<int> result;
         for (const auto &p : *this) {
             result.push_back(p.second);
@@ -1800,8 +1800,8 @@ static void test_lru() {
 struct pwd_environment_t : public environment_t {
     std::map<wcstring, wcstring> extras;
 
-    maybe_t<env_var_t> get(const wcstring &key,
-                                   env_mode_flags_t mode = ENV_DEFAULT) const override {
+    __warn_unused maybe_t<env_var_t> get(const wcstring &key,
+                                         env_mode_flags_t mode = ENV_DEFAULT) const override {
         UNUSED(mode);
         if (key == L"PWD") {
             return env_var_t{wgetcwd(), 0};
@@ -1813,7 +1813,7 @@ struct pwd_environment_t : public environment_t {
         return {};
     }
 
-    wcstring_list_t get_names(int flags) const override {
+    __warn_unused wcstring_list_t get_names(int flags) const override {
         UNUSED(flags);
         return {L"PWD"};
     }
@@ -2791,13 +2791,13 @@ static void test_complete() {
     say(L"Testing complete");
 
     struct test_complete_vars_t : environment_t {
-        wcstring_list_t get_names(int flags) const override {
+        __warn_unused wcstring_list_t get_names(int flags) const override {
             UNUSED(flags);
             return {L"Foo1", L"Foo2", L"Foo3", L"Bar1", L"Bar2", L"Bar3"};
         }
 
-        maybe_t<env_var_t> get(const wcstring &key,
-                               env_mode_flags_t mode = ENV_DEFAULT) const override {
+        __warn_unused maybe_t<env_var_t> get(const wcstring &key,
+                                             env_mode_flags_t mode = ENV_DEFAULT) const override {
             UNUSED(mode);
             if (key == L"PWD") {
                 return env_var_t{wgetcwd(), 0};

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -163,7 +163,7 @@ static bool pushd(const char *path) {
         err(L"getcwd() from pushd() failed: errno = %d", errno);
         return false;
     }
-    pushed_dirs.push_back(cwd);
+    pushed_dirs.emplace_back(cwd);
 
     // We might need to create the directory. We don't care if this fails due to the directory
     // already being present.
@@ -1726,12 +1726,12 @@ class test_lru_t : public lru_cache_t<test_lru_t, int> {
 
     std::vector<value_type> evicted;
 
-    void entry_was_evicted(const wcstring &key, int val) { evicted.push_back({key, val}); }
+    void entry_was_evicted(const wcstring &key, int val) { evicted.emplace_back(key, val); }
 
     std::vector<value_type> values() const {
         std::vector<value_type> result;
         for (const auto &p : *this) {
-            result.push_back(p);
+            result.emplace_back(p);
         }
         return result;
     }
@@ -1755,12 +1755,12 @@ static void test_lru() {
     for (int i = 0; i < total_nodes; i++) {
         do_test(cache.size() == size_t(std::min(i, 16)));
         do_test(cache.values() == expected_values);
-        if (i < 4) expected_evicted.push_back({to_string(i), i});
+        if (i < 4) expected_evicted.emplace_back(to_string(i), i);
         // Adding the node the first time should work, and subsequent times should fail.
         do_test(cache.insert(to_string(i), i));
         do_test(!cache.insert(to_string(i), i + 1));
 
-        expected_values.push_back({to_string(i), i});
+        expected_values.emplace_back(to_string(i), i);
         while (expected_values.size() > test_lru_t::test_capacity) {
             expected_values.erase(expected_values.begin());
         }
@@ -4898,7 +4898,7 @@ static void test_highlighting() {
         for (const highlight_component_t &comp : components) {
             if (!text.empty() && !comp.nospace) {
                 text.push_back(L' ');
-                expected_colors.push_back(highlight_spec_t{});
+                expected_colors.emplace_back();
             }
             text.append(comp.txt);
             expected_colors.resize(text.size(), comp.color);

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -94,7 +94,7 @@ static bool should_test_function(const char *func_name) {
     if (!s_arguments || !s_arguments[0]) {
         result = true;
     } else {
-        for (size_t i = 0; s_arguments[i] != NULL; i++) {
+        for (size_t i = 0; s_arguments[i] != nullptr; i++) {
             if (!std::strncmp(func_name, s_arguments[i], std::strlen(s_arguments[i]))) {
                 // Prefix match.
                 result = true;
@@ -159,7 +159,7 @@ static std::vector<std::string> pushed_dirs;
 /// Helper to chdir and then update $PWD.
 static bool pushd(const char *path) {
     char cwd[PATH_MAX] = {};
-    if (getcwd(cwd, sizeof cwd) == NULL) {
+    if (getcwd(cwd, sizeof cwd) == nullptr) {
         err(L"getcwd() from pushd() failed: errno = %d", errno);
         return false;
     }
@@ -979,7 +979,7 @@ static void test_debounce_timeout() {
 
 static parser_test_error_bits_t detect_argument_errors(const wcstring &src) {
     parse_node_tree_t tree;
-    if (!parse_tree_from_string(src, parse_flag_none, &tree, NULL, symbol_argument_list)) {
+    if (!parse_tree_from_string(src, parse_flag_none, &tree, nullptr, symbol_argument_list)) {
         return PARSER_TEST_ERROR;
     }
 
@@ -1277,44 +1277,46 @@ static void test_indents() {
         int indent;
     };
 
-    const indent_component_t components1[] = {{L"if foo", 0}, {L"end", 0}, {NULL, -1}};
+    const indent_component_t components1[] = {{L"if foo", 0}, {L"end", 0}, {nullptr, -1}};
 
     const indent_component_t components2[] = {{L"if foo", 0},
                                               {L"", 1},  // trailing newline!
-                                              {NULL, -1}};
+                                              {nullptr, -1}};
 
     const indent_component_t components3[] = {{L"if foo", 0},
                                               {L"foo", 1},
                                               {L"end", 0},  // trailing newline!
-                                              {NULL, -1}};
+                                              {nullptr, -1}};
 
     const indent_component_t components4[] = {{L"if foo", 0}, {L"if bar", 1}, {L"end", 1},
-                                              {L"end", 0},    {L"", 0},       {NULL, -1}};
+                                              {L"end", 0},    {L"", 0},       {nullptr, -1}};
 
-    const indent_component_t components5[] = {{L"if foo", 0}, {L"if bar", 1}, {L"", 2}, {NULL, -1}};
+    const indent_component_t components5[] = {
+        {L"if foo", 0}, {L"if bar", 1}, {L"", 2}, {nullptr, -1}};
 
-    const indent_component_t components6[] = {{L"begin", 0}, {L"foo", 1}, {L"", 1}, {NULL, -1}};
+    const indent_component_t components6[] = {{L"begin", 0}, {L"foo", 1}, {L"", 1}, {nullptr, -1}};
 
     const indent_component_t components7[] = {{L"begin", 0}, {L";", 1}, {L"end", 0},
-                                              {L"foo", 0},   {L"", 0},  {NULL, -1}};
+                                              {L"foo", 0},   {L"", 0},  {nullptr, -1}};
 
     const indent_component_t components8[] = {{L"if foo", 0}, {L"if bar", 1}, {L"baz", 2},
-                                              {L"end", 1},    {L"", 1},       {NULL, -1}};
+                                              {L"end", 1},    {L"", 1},       {nullptr, -1}};
 
-    const indent_component_t components9[] = {{L"switch foo", 0}, {L"", 1}, {NULL, -1}};
+    const indent_component_t components9[] = {{L"switch foo", 0}, {L"", 1}, {nullptr, -1}};
 
-    const indent_component_t components10[] = {
-        {L"switch foo", 0}, {L"case bar", 1}, {L"case baz", 1}, {L"quux", 2}, {L"", 2}, {NULL, -1}};
+    const indent_component_t components10[] = {{L"switch foo", 0}, {L"case bar", 1},
+                                               {L"case baz", 1},   {L"quux", 2},
+                                               {L"", 2},           {nullptr, -1}};
 
     const indent_component_t components11[] = {{L"switch foo", 0},
                                                {L"cas", 1},  // parse error indentation handling
-                                               {NULL, -1}};
+                                               {nullptr, -1}};
 
     const indent_component_t components12[] = {{L"while false", 0},
                                                {L"# comment", 1},   // comment indentation handling
                                                {L"command", 1},     // comment indentation handling
                                                {L"# comment2", 1},  // comment indentation handling
-                                               {NULL, -1}};
+                                               {nullptr, -1}};
 
     const indent_component_t *tests[] = {components1, components2,  components3,  components4,
                                          components5, components6,  components7,  components8,
@@ -1323,7 +1325,7 @@ static void test_indents() {
         const indent_component_t *components = tests[which];
         // Count how many we have.
         size_t component_count = 0;
-        while (components[component_count].txt != NULL) {
+        while (components[component_count].txt != nullptr) {
             component_count++;
         }
 
@@ -1360,7 +1362,7 @@ static void test_indents() {
 
 static void test_parse_util_cmdsubst_extent() {
     const wchar_t *a = L"echo (echo (echo hi";
-    const wchar_t *begin = NULL, *end = NULL;
+    const wchar_t *begin = nullptr, *end = nullptr;
 
     parse_util_cmdsubst_extent(a, 0, &begin, &end);
     if (begin != a || end != begin + std::wcslen(begin)) {
@@ -1432,7 +1434,7 @@ static struct wcsfilecmp_test {
                         {L"a00b", L"a0b", -1},
                         {L"a0b", L"a00b", 1},
                         {L"a-b", L"azb", 1},
-                        {NULL, NULL, 0}};
+                        {nullptr, nullptr, 0}};
 
 /// Verify the behavior of the `wcsfilecmp()` function.
 static void test_wcsfilecmp() {
@@ -1456,7 +1458,7 @@ static void test_utility_functions() {
 static void test_utf82wchar(const char *src, size_t slen, const wchar_t *dst, size_t dlen,
                             int flags, size_t res, const char *descr) {
     size_t size;
-    wchar_t *mem = NULL;
+    wchar_t *mem = nullptr;
 
 #if WCHAR_MAX == 0xffff
     // Hack: if wchar is only UCS-2, and the UTF-8 input string contains astral characters, then
@@ -1475,7 +1477,7 @@ static void test_utf82wchar(const char *src, size_t slen, const wchar_t *dst, si
 #endif
 
     if (!dst) {
-        size = utf8_to_wchar(src, slen, NULL, flags);
+        size = utf8_to_wchar(src, slen, nullptr, flags);
     } else {
         mem = (wchar_t *)malloc(dlen * sizeof(*mem));
         if (!mem) {
@@ -1507,7 +1509,7 @@ static void test_utf82wchar(const unsigned char *usrc, size_t slen, const wchar_
 static void test_wchar2utf8(const wchar_t *src, size_t slen, const char *dst, size_t dlen,
                             int flags, size_t res, const char *descr) {
     size_t size;
-    char *mem = NULL;
+    char *mem = nullptr;
 
 #if WCHAR_MAX == 0xffff
     // Hack: if wchar is simulating UCS-2, and the wchar_t input string contains astral characters,
@@ -1582,8 +1584,8 @@ static void test_utf8() {
                     sizeof(wbom2) / sizeof(*wbom2), "ubom2 skip BOM");
     test_utf82wchar(ubom2, sizeof(ubom2), wbom22, sizeof(wbom22) / sizeof(*wbom22), 0,
                     sizeof(wbom22) / sizeof(*wbom22), "ubom2 BOM");
-    test_utf82wchar(uc080, sizeof(uc080), NULL, 0, 0, 0, "uc080 c0 80 - forbitten by rfc3629");
-    test_utf82wchar(ub2, sizeof(ub2), NULL, 0, 0, 3, "ub2 resulted in forbitten wchars (len)");
+    test_utf82wchar(uc080, sizeof(uc080), nullptr, 0, 0, 0, "uc080 c0 80 - forbitten by rfc3629");
+    test_utf82wchar(ub2, sizeof(ub2), nullptr, 0, 0, 3, "ub2 resulted in forbitten wchars (len)");
     test_utf82wchar(ub2, sizeof(ub2), wb2, sizeof(wb2) / sizeof(*wb2), 0, 0,
                     "ub2 resulted in forbitten wchars");
     test_utf82wchar(ub2, sizeof(ub2), L"\x0a", 1, UTF8_IGNORE_ERROR, 1,
@@ -1594,15 +1596,16 @@ static void test_utf8() {
                     "u2/w2 2 octets chars");
     test_utf82wchar(u3, sizeof(u3), w3, sizeof(w3) / sizeof(*w3), 0, sizeof(w3) / sizeof(*w3),
                     "u3/w3 3 octets chars");
-    test_utf82wchar("\xff", 1, NULL, 0, 0, 0, "broken utf-8 0xff symbol");
-    test_utf82wchar("\xfe", 1, NULL, 0, 0, 0, "broken utf-8 0xfe symbol");
-    test_utf82wchar("\x8f", 1, NULL, 0, 0, 0, "broken utf-8, start from 10 higher bits");
-    test_utf82wchar((const char *)NULL, 0, NULL, 0, 0, 0, "invalid params, all 0");
-    test_utf82wchar(u1, 0, NULL, 0, 0, 0, "invalid params, src buf not NULL");
-    test_utf82wchar((const char *)NULL, 10, NULL, 0, 0, 0, "invalid params, src length is not 0");
+    test_utf82wchar("\xff", 1, nullptr, 0, 0, 0, "broken utf-8 0xff symbol");
+    test_utf82wchar("\xfe", 1, nullptr, 0, 0, 0, "broken utf-8 0xfe symbol");
+    test_utf82wchar("\x8f", 1, nullptr, 0, 0, 0, "broken utf-8, start from 10 higher bits");
+    test_utf82wchar((const char *)nullptr, 0, nullptr, 0, 0, 0, "invalid params, all 0");
+    test_utf82wchar(u1, 0, nullptr, 0, 0, 0, "invalid params, src buf not NULL");
+    test_utf82wchar((const char *)nullptr, 10, nullptr, 0, 0, 0,
+                    "invalid params, src length is not 0");
 
     // UCS-4 -> UTF-8 string.
-    const char *const nullc = NULL;
+    const char *const nullc = nullptr;
     test_wchar2utf8(wbom, sizeof(wbom) / sizeof(*wbom), ubom, sizeof(ubom), UTF8_SKIP_BOM,
                     sizeof(ubom), "BOM");
     test_wchar2utf8(wb2, sizeof(wb2) / sizeof(*wb2), nullc, 0, 0, 0, "prohibited wchars");
@@ -1614,10 +1617,10 @@ static void test_utf8() {
                     "w2/u2 2 octets chars");
     test_wchar2utf8(w3, sizeof(w3) / sizeof(*w3), u3, sizeof(u3), 0, sizeof(u3),
                     "w3/u3 3 octets chars");
-    test_wchar2utf8(NULL, 0, nullc, 0, 0, 0, "invalid params, all 0");
+    test_wchar2utf8(nullptr, 0, nullc, 0, 0, 0, "invalid params, all 0");
     test_wchar2utf8(w1, 0, nullc, 0, 0, 0, "invalid params, src buf not NULL");
     test_wchar2utf8(w1, sizeof(w1) / sizeof(*w1), u1, 0, 0, 0, "invalid params, dst is not NULL");
-    test_wchar2utf8(NULL, 10, nullc, 0, 0, 0, "invalid params, src length is not 0");
+    test_wchar2utf8(nullptr, 10, nullc, 0, 0, 0, "invalid params, src length is not 0");
 
     test_wchar2utf8(wm, sizeof(wm) / sizeof(*wm), um, sizeof(um), 0, sizeof(um),
                     "wm/um mixed languages");
@@ -1630,7 +1633,8 @@ static void test_utf8() {
                     "um/wm mixed languages");
     test_utf82wchar(um, sizeof(um), wm, sizeof(wm) / sizeof(*wm) + 1, 0, sizeof(wm) / sizeof(*wm),
                     "um/wm boundaries +1");
-    test_utf82wchar(um, sizeof(um), NULL, 0, 0, sizeof(wm) / sizeof(*wm), "um/wm calculate length");
+    test_utf82wchar(um, sizeof(um), nullptr, 0, 0, sizeof(wm) / sizeof(*wm),
+                    "um/wm calculate length");
 
 // The following tests won't pass on systems (e.g., Cygwin) where sizeof wchar_t is 2. That's
 // due to several reasons but the primary one is that narrowing conversions of literals assigned
@@ -1650,8 +1654,8 @@ static void test_utf8() {
                     "calculate length, ignore bad chars");
     test_utf82wchar(ub1, sizeof(ub1), wb1, sizeof(wb1) / sizeof(*wb1), UTF8_IGNORE_ERROR,
                     sizeof(wb1) / sizeof(*wb1), "ub1/wb1 ignore bad chars");
-    test_utf82wchar(ub1, sizeof(ub1), NULL, 0, 0, 0, "ub1 calculate length of bad chars");
-    test_utf82wchar(ub1, sizeof(ub1), NULL, 0, UTF8_IGNORE_ERROR, sizeof(wb1) / sizeof(*wb1),
+    test_utf82wchar(ub1, sizeof(ub1), nullptr, 0, 0, 0, "ub1 calculate length of bad chars");
+    test_utf82wchar(ub1, sizeof(ub1), nullptr, 0, UTF8_IGNORE_ERROR, sizeof(wb1) / sizeof(*wb1),
                     "ub1 calculate length, ignore bad chars");
 #endif
 }
@@ -1844,7 +1848,7 @@ static bool expand_test(const wchar_t *in, expand_flags_t flags, ...) {
     wcstring_list_t expected;
 
     va_start(va, flags);
-    while ((arg = va_arg(va, wchar_t *)) != NULL) {
+    while ((arg = va_arg(va, wchar_t *)) != nullptr) {
         expected.push_back(wcstring(arg));
     }
     va_end(va);
@@ -1940,7 +1944,7 @@ static void test_expand() {
     // This is checking that .* does NOT match . and ..
     // (https://github.com/fish-shell/fish-shell/issues/270). But it does have to match literal
     // components (e.g. "./*" has to match the same as "*".
-    const wchar_t *const wnull = NULL;
+    const wchar_t *const wnull = nullptr;
     expand_test(L"test/fish_expand_test/.*", noflags, L"test/fish_expand_test/.foo", wnull,
                 L"Expansion not correctly handling dotfiles");
 
@@ -2324,9 +2328,9 @@ static void test_pager_layout() {
         {22, L"abcdefghij  (1234567…)"},   {21, L"abcdefghij  (123456…)"},
         {20, L"abcdefghij  (12345…)"},     {19, L"abcdefghij  (1234…)"},
         {18, L"abcdefgh…  (1234…)"},       {17, L"abcdefg…  (1234…)"},
-        {16, L"abcdefg…  (123…)"},         {0, NULL}  // sentinel terminator
+        {16, L"abcdefg…  (123…)"},         {0, nullptr}  // sentinel terminator
     };
-    for (size_t i = 0; testcases1[i].expected != NULL; i++) {
+    for (size_t i = 0; testcases1[i].expected != nullptr; i++) {
         testcases1[i].run(pager);
     }
 
@@ -2339,9 +2343,9 @@ static void test_pager_layout() {
         {22, L"abcdefghijklmnop…  (1)"},   {21, L"abcdefghijklmno…  (1)"},
         {20, L"abcdefghijklmn…  (1)"},     {19, L"abcdefghijklm…  (1)"},
         {18, L"abcdefghijkl…  (1)"},       {17, L"abcdefghijk…  (1)"},
-        {16, L"abcdefghij…  (1)"},         {0, NULL}  // sentinel terminator
+        {16, L"abcdefghij…  (1)"},         {0, nullptr}  // sentinel terminator
     };
-    for (size_t i = 0; testcases2[i].expected != NULL; i++) {
+    for (size_t i = 0; testcases2[i].expected != nullptr; i++) {
         testcases2[i].run(pager);
     }
 
@@ -2354,9 +2358,9 @@ static void test_pager_layout() {
         {22, L"abcdefghijklmnopqrst"}, {21, L"abcdefghijklmnopqrst"},
         {20, L"abcdefghijklmnopqrst"}, {19, L"abcdefghijklmnopqr…"},
         {18, L"abcdefghijklmnopq…"},   {17, L"abcdefghijklmnop…"},
-        {16, L"abcdefghijklmno…"},     {0, NULL}  // sentinel terminator
+        {16, L"abcdefghijklmno…"},     {0, nullptr}  // sentinel terminator
     };
-    for (size_t i = 0; testcases3[i].expected != NULL; i++) {
+    for (size_t i = 0; testcases3[i].expected != nullptr; i++) {
         testcases3[i].run(pager);
     }
 }
@@ -2490,7 +2494,7 @@ static bool run_one_test_test(int expected, wcstring_list_t &lst, bool bracket) 
         argv[i + 1] = (wchar_t *)L"]";
         i++;
     }
-    argv[i + 1] = NULL;
+    argv[i + 1] = nullptr;
     io_streams_t streams(0);
     int result = builtin_test(parser, streams, argv);
 
@@ -2912,8 +2916,8 @@ static void test_complete() {
     // Trailing spaces (#1261).
     completion_mode_t no_files{};
     no_files.no_files = true;
-    complete_add(L"foobarbaz", false, wcstring(), option_type_args_only, no_files, NULL, L"qux",
-                 NULL, COMPLETE_AUTO_SPACE);
+    complete_add(L"foobarbaz", false, wcstring(), option_type_args_only, no_files, nullptr, L"qux",
+                 nullptr, COMPLETE_AUTO_SPACE);
     completions = do_complete(L"foobarbaz ", {});
     do_test(completions.size() == 1);
     do_test(completions.at(0).completion == L"qux");
@@ -3673,7 +3677,7 @@ bool poll_notifier(const std::unique_ptr<universal_notifier_t> &note) {
         FD_ZERO(&fds);
         FD_SET(fd, &fds);
         struct timeval tv = {0, 0};
-        if (select(fd + 1, &fds, NULL, NULL, &tv) > 0 && FD_ISSET(fd, &fds)) {
+        if (select(fd + 1, &fds, nullptr, nullptr, &tv) > 0 && FD_ISSET(fd, &fds)) {
             result = note->notification_fd_became_readable(fd);
         }
     }
@@ -3874,7 +3878,7 @@ void history_tests_t::test_history() {
         }
 
         // Record this item.
-        history_item_t item(value, time(NULL));
+        history_item_t item(value, time(nullptr));
         item.required_paths = paths;
         before.push_back(item);
         history.add(item);
@@ -3905,10 +3909,10 @@ void history_tests_t::test_history() {
 
 // Wait until the next second.
 static void time_barrier() {
-    time_t start = time(NULL);
+    time_t start = time(nullptr);
     do {
         usleep(1000);
-    } while (time(NULL) == start);
+    } while (time(nullptr) == start);
 }
 
 static wcstring_list_t generate_history_lines(size_t item_count, int pid) {
@@ -4152,7 +4156,7 @@ static bool history_equals(history_t &hist, const wchar_t *const *strings) {
     for (;;) {
         const wchar_t *expected = strings[array_idx];
         history_item_t item = hist.item_at_index(history_idx);
-        if (expected == NULL) {
+        if (expected == nullptr) {
             if (!item.empty()) {
                 err(L"Expected empty item at history index %lu", history_idx);
             }
@@ -4181,7 +4185,7 @@ void history_tests_t::test_history_formats() {
     } else {
         // Note: This is backwards from what appears in the file.
         const wchar_t *const expected[] = {
-            L"#def", L"echo #abc", L"function yay\necho hi\nend", L"cd foobar", L"ls /", NULL};
+            L"#def", L"echo #abc", L"function yay\necho hi\nend", L"cd foobar", L"ls /", nullptr};
 
         history_t &test_history = history_t::history_with_name(name);
         if (!history_equals(test_history, expected)) {
@@ -4196,7 +4200,7 @@ void history_tests_t::test_history_formats() {
         err(L"Couldn't open file tests/%ls", name);
     } else {
         const wchar_t *const expected[] = {L"echo this has\\\nbackslashes",
-                                           L"function foo\necho bar\nend", L"echo alpha", NULL};
+                                           L"function foo\necho bar\nend", L"echo alpha", nullptr};
 
         history_t &test_history = history_t::history_with_name(name);
         if (!history_equals(test_history, expected)) {
@@ -4219,7 +4223,7 @@ void history_tests_t::test_history_formats() {
                                      L"export XVAR='exported'",
                                      L"history --help",
                                      L"echo foo",
-                                     NULL};
+                                     nullptr};
         history_t &test_history = history_t::history_with_name(L"bash_import");
         test_history.populate_from_bash(f);
         if (!history_equals(test_history, expected)) {
@@ -4237,7 +4241,7 @@ void history_tests_t::test_history_formats() {
         // We simply invoke get_string_representation. If we don't die, the test is a success.
         history_t &test_history = history_t::history_with_name(name);
         const wchar_t *expected[] = {L"no_newline_at_end_of_file", L"corrupt_prefix",
-                                     L"this_command_is_ok", NULL};
+                                     L"this_command_is_ok", nullptr};
         if (!history_equals(test_history, expected)) {
             err(L"test_history_formats failed for %ls\n", name);
         }
@@ -4304,7 +4308,7 @@ static void test_new_parser_correctness() {
         const parser_test_t *test = &parser_tests[i];
 
         parse_node_tree_t parse_tree;
-        bool success = parse_tree_from_string(test->src, parse_flag_none, &parse_tree, NULL);
+        bool success = parse_tree_from_string(test->src, parse_flag_none, &parse_tree, nullptr);
         if (success && !test->ok) {
             err(L"\"%ls\" should NOT have parsed, but did", test->src);
         } else if (!success && test->ok) {
@@ -4375,7 +4379,7 @@ static bool test_1_parse_ll2(const wcstring &src, wcstring *out_cmd, wcstring *o
     *out_deco = parse_statement_decoration_none;
 
     parse_node_tree_t tree;
-    if (!parse_tree_from_string(src, parse_flag_none, &tree, NULL)) {
+    if (!parse_tree_from_string(src, parse_flag_none, &tree, nullptr)) {
         return false;
     }
 
@@ -4408,7 +4412,7 @@ static bool test_1_parse_ll2(const wcstring &src, wcstring *out_cmd, wcstring *o
 template <typename Type>
 static void check_function_help(const wchar_t *src) {
     parse_node_tree_t tree;
-    if (!parse_tree_from_string(src, parse_flag_none, &tree, NULL)) {
+    if (!parse_tree_from_string(src, parse_flag_none, &tree, nullptr)) {
         err(L"Failed to parse '%ls'", src);
     }
 
@@ -4478,7 +4482,7 @@ static void test_new_parser_ad_hoc() {
     // Ensure that 'case' terminates a job list.
     const wcstring src = L"switch foo ; case bar; case baz; end";
     parse_node_tree_t parse_tree;
-    bool success = parse_tree_from_string(src, parse_flag_none, &parse_tree, NULL);
+    bool success = parse_tree_from_string(src, parse_flag_none, &parse_tree, nullptr);
     if (!success) {
         err(L"Parsing failed");
     }
@@ -4545,10 +4549,10 @@ static wcstring_list_t separate_by_format_specifiers(const wchar_t *format) {
     const wchar_t *end = format + std::wcslen(format);
     while (cursor < end) {
         const wchar_t *next_specifier = std::wcschr(cursor, '%');
-        if (next_specifier == NULL) {
+        if (next_specifier == nullptr) {
             next_specifier = end;
         }
-        assert(next_specifier != NULL);
+        assert(next_specifier != nullptr);
 
         // Don't return empty strings.
         if (next_specifier > cursor) {
@@ -4988,7 +4992,7 @@ static void run_one_string_test(const wchar_t *const *argv, int expected_rc,
     streams.stdin_is_directly_redirected = false;  // read from argv instead of stdin
     int rc = builtin_string(parser, streams, const_cast<wchar_t **>(argv));
     wcstring args;
-    for (int i = 0; argv[i] != NULL; i++) {
+    for (int i = 0; argv[i] != nullptr; i++) {
         args += escape_string(argv[i], ESCAPE_ALL) + L' ';
     }
     args.resize(args.size() - 1);
@@ -5009,263 +5013,293 @@ static void test_string() {
         int expected_rc;
         const wchar_t *expected_out;
     } string_tests[] = {
-        {{L"string", L"escape", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"escape", L"", 0}, STATUS_CMD_OK, L"''\n"},
-        {{L"string", L"escape", L"-n", L"", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"escape", L"a", 0}, STATUS_CMD_OK, L"a\n"},
-        {{L"string", L"escape", L"\x07", 0}, STATUS_CMD_OK, L"\\cg\n"},
-        {{L"string", L"escape", L"\"x\"", 0}, STATUS_CMD_OK, L"'\"x\"'\n"},
-        {{L"string", L"escape", L"hello world", 0}, STATUS_CMD_OK, L"'hello world'\n"},
-        {{L"string", L"escape", L"-n", L"hello world", 0}, STATUS_CMD_OK, L"hello\\ world\n"},
-        {{L"string", L"escape", L"hello", L"world", 0}, STATUS_CMD_OK, L"hello\nworld\n"},
-        {{L"string", L"escape", L"-n", L"~", 0}, STATUS_CMD_OK, L"\\~\n"},
+        {{L"string", L"escape", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"escape", L"", nullptr}, STATUS_CMD_OK, L"''\n"},
+        {{L"string", L"escape", L"-n", L"", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"escape", L"a", nullptr}, STATUS_CMD_OK, L"a\n"},
+        {{L"string", L"escape", L"\x07", nullptr}, STATUS_CMD_OK, L"\\cg\n"},
+        {{L"string", L"escape", L"\"x\"", nullptr}, STATUS_CMD_OK, L"'\"x\"'\n"},
+        {{L"string", L"escape", L"hello world", nullptr}, STATUS_CMD_OK, L"'hello world'\n"},
+        {{L"string", L"escape", L"-n", L"hello world", nullptr}, STATUS_CMD_OK, L"hello\\ world\n"},
+        {{L"string", L"escape", L"hello", L"world", nullptr}, STATUS_CMD_OK, L"hello\nworld\n"},
+        {{L"string", L"escape", L"-n", L"~", nullptr}, STATUS_CMD_OK, L"\\~\n"},
 
-        {{L"string", L"join", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"join", L"", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"join", L"", L"", L"", L"", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"join", L"", L"a", L"b", L"c", 0}, STATUS_CMD_OK, L"abc\n"},
-        {{L"string", L"join", L".", L"fishshell", L"com", 0}, STATUS_CMD_OK, L"fishshell.com\n"},
-        {{L"string", L"join", L"/", L"usr", 0}, STATUS_CMD_ERROR, L"usr\n"},
-        {{L"string", L"join", L"/", L"usr", L"local", L"bin", 0},
+        {{L"string", L"join", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"join", L"", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"join", L"", L"", L"", L"", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"join", L"", L"a", L"b", L"c", nullptr}, STATUS_CMD_OK, L"abc\n"},
+        {{L"string", L"join", L".", L"fishshell", L"com", nullptr},
+         STATUS_CMD_OK,
+         L"fishshell.com\n"},
+        {{L"string", L"join", L"/", L"usr", nullptr}, STATUS_CMD_ERROR, L"usr\n"},
+        {{L"string", L"join", L"/", L"usr", L"local", L"bin", nullptr},
          STATUS_CMD_OK,
          L"usr/local/bin\n"},
-        {{L"string", L"join", L"...", L"3", L"2", L"1", 0}, STATUS_CMD_OK, L"3...2...1\n"},
-        {{L"string", L"join", L"-q", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"join", L"-q", L".", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"join", L"-q", L".", L".", 0}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"join", L"...", L"3", L"2", L"1", nullptr}, STATUS_CMD_OK, L"3...2...1\n"},
+        {{L"string", L"join", L"-q", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"join", L"-q", L".", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"join", L"-q", L".", L".", nullptr}, STATUS_CMD_ERROR, L""},
 
-        {{L"string", L"length", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"length", L"", 0}, STATUS_CMD_ERROR, L"0\n"},
-        {{L"string", L"length", L"", L"", L"", 0}, STATUS_CMD_ERROR, L"0\n0\n0\n"},
-        {{L"string", L"length", L"a", 0}, STATUS_CMD_OK, L"1\n"},
-        {{L"string", L"length", L"\U0002008A", 0}, STATUS_CMD_OK, L"1\n"},
-        {{L"string", L"length", L"um", L"dois", L"três", 0}, STATUS_CMD_OK, L"2\n4\n4\n"},
-        {{L"string", L"length", L"um", L"dois", L"três", 0}, STATUS_CMD_OK, L"2\n4\n4\n"},
-        {{L"string", L"length", L"-q", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"length", L"-q", L"", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"length", L"-q", L"a", 0}, STATUS_CMD_OK, L""},
+        {{L"string", L"length", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"length", L"", nullptr}, STATUS_CMD_ERROR, L"0\n"},
+        {{L"string", L"length", L"", L"", L"", nullptr}, STATUS_CMD_ERROR, L"0\n0\n0\n"},
+        {{L"string", L"length", L"a", nullptr}, STATUS_CMD_OK, L"1\n"},
+        {{L"string", L"length", L"\U0002008A", nullptr}, STATUS_CMD_OK, L"1\n"},
+        {{L"string", L"length", L"um", L"dois", L"três", nullptr}, STATUS_CMD_OK, L"2\n4\n4\n"},
+        {{L"string", L"length", L"um", L"dois", L"três", nullptr}, STATUS_CMD_OK, L"2\n4\n4\n"},
+        {{L"string", L"length", L"-q", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"length", L"-q", L"", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"length", L"-q", L"a", nullptr}, STATUS_CMD_OK, L""},
 
-        {{L"string", L"match", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"match", L"", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"", L"", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"match", L"?", L"a", 0}, STATUS_CMD_OK, L"a\n"},
-        {{L"string", L"match", L"*", L"", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"match", L"**", L"", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"match", L"*", L"xyzzy", 0}, STATUS_CMD_OK, L"xyzzy\n"},
-        {{L"string", L"match", L"**", L"plugh", 0}, STATUS_CMD_OK, L"plugh\n"},
-        {{L"string", L"match", L"a*b", L"axxb", 0}, STATUS_CMD_OK, L"axxb\n"},
-        {{L"string", L"match", L"a??b", L"axxb", 0}, STATUS_CMD_OK, L"axxb\n"},
-        {{L"string", L"match", L"-i", L"a??B", L"axxb", 0}, STATUS_CMD_OK, L"axxb\n"},
-        {{L"string", L"match", L"-i", L"a??b", L"Axxb", 0}, STATUS_CMD_OK, L"Axxb\n"},
-        {{L"string", L"match", L"a*", L"axxb", 0}, STATUS_CMD_OK, L"axxb\n"},
-        {{L"string", L"match", L"*a", L"xxa", 0}, STATUS_CMD_OK, L"xxa\n"},
-        {{L"string", L"match", L"*a*", L"axa", 0}, STATUS_CMD_OK, L"axa\n"},
-        {{L"string", L"match", L"*a*", L"xax", 0}, STATUS_CMD_OK, L"xax\n"},
-        {{L"string", L"match", L"*a*", L"bxa", 0}, STATUS_CMD_OK, L"bxa\n"},
-        {{L"string", L"match", L"*a", L"a", 0}, STATUS_CMD_OK, L"a\n"},
-        {{L"string", L"match", L"a*", L"a", 0}, STATUS_CMD_OK, L"a\n"},
-        {{L"string", L"match", L"a*b*c", L"axxbyyc", 0}, STATUS_CMD_OK, L"axxbyyc\n"},
-        {{L"string", L"match", L"\\*", L"*", 0}, STATUS_CMD_OK, L"*\n"},
-        {{L"string", L"match", L"a*\\", L"abc\\", 0}, STATUS_CMD_OK, L"abc\\\n"},
-        {{L"string", L"match", L"a*\\?", L"abc?", 0}, STATUS_CMD_OK, L"abc?\n"},
+        {{L"string", L"match", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"match", L"", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"", L"", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"match", L"?", L"a", nullptr}, STATUS_CMD_OK, L"a\n"},
+        {{L"string", L"match", L"*", L"", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"match", L"**", L"", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"match", L"*", L"xyzzy", nullptr}, STATUS_CMD_OK, L"xyzzy\n"},
+        {{L"string", L"match", L"**", L"plugh", nullptr}, STATUS_CMD_OK, L"plugh\n"},
+        {{L"string", L"match", L"a*b", L"axxb", nullptr}, STATUS_CMD_OK, L"axxb\n"},
+        {{L"string", L"match", L"a??b", L"axxb", nullptr}, STATUS_CMD_OK, L"axxb\n"},
+        {{L"string", L"match", L"-i", L"a??B", L"axxb", nullptr}, STATUS_CMD_OK, L"axxb\n"},
+        {{L"string", L"match", L"-i", L"a??b", L"Axxb", nullptr}, STATUS_CMD_OK, L"Axxb\n"},
+        {{L"string", L"match", L"a*", L"axxb", nullptr}, STATUS_CMD_OK, L"axxb\n"},
+        {{L"string", L"match", L"*a", L"xxa", nullptr}, STATUS_CMD_OK, L"xxa\n"},
+        {{L"string", L"match", L"*a*", L"axa", nullptr}, STATUS_CMD_OK, L"axa\n"},
+        {{L"string", L"match", L"*a*", L"xax", nullptr}, STATUS_CMD_OK, L"xax\n"},
+        {{L"string", L"match", L"*a*", L"bxa", nullptr}, STATUS_CMD_OK, L"bxa\n"},
+        {{L"string", L"match", L"*a", L"a", nullptr}, STATUS_CMD_OK, L"a\n"},
+        {{L"string", L"match", L"a*", L"a", nullptr}, STATUS_CMD_OK, L"a\n"},
+        {{L"string", L"match", L"a*b*c", L"axxbyyc", nullptr}, STATUS_CMD_OK, L"axxbyyc\n"},
+        {{L"string", L"match", L"\\*", L"*", nullptr}, STATUS_CMD_OK, L"*\n"},
+        {{L"string", L"match", L"a*\\", L"abc\\", nullptr}, STATUS_CMD_OK, L"abc\\\n"},
+        {{L"string", L"match", L"a*\\?", L"abc?", nullptr}, STATUS_CMD_OK, L"abc?\n"},
 
-        {{L"string", L"match", L"?", L"", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"?", L"ab", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"??", L"a", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"?a", L"a", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"a?", L"a", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"a??B", L"axxb", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"a*b", L"axxbc", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"*b", L"bbba", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"0x[0-9a-fA-F][0-9a-fA-F]", L"0xbad", 0}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"?", L"", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"?", L"ab", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"??", L"a", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"?a", L"a", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"a?", L"a", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"a??B", L"axxb", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"a*b", L"axxbc", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"*b", L"bbba", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"0x[0-9a-fA-F][0-9a-fA-F]", L"0xbad", nullptr},
+         STATUS_CMD_ERROR,
+         L""},
 
-        {{L"string", L"match", L"-a", L"*", L"ab", L"cde", 0}, STATUS_CMD_OK, L"ab\ncde\n"},
-        {{L"string", L"match", L"*", L"ab", L"cde", 0}, STATUS_CMD_OK, L"ab\ncde\n"},
-        {{L"string", L"match", L"-n", L"*d*", L"cde", 0}, STATUS_CMD_OK, L"1 3\n"},
-        {{L"string", L"match", L"-n", L"*x*", L"cde", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"-q", L"a*", L"b", L"c", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"-q", L"a*", L"b", L"a", 0}, STATUS_CMD_OK, L""},
+        {{L"string", L"match", L"-a", L"*", L"ab", L"cde", nullptr}, STATUS_CMD_OK, L"ab\ncde\n"},
+        {{L"string", L"match", L"*", L"ab", L"cde", nullptr}, STATUS_CMD_OK, L"ab\ncde\n"},
+        {{L"string", L"match", L"-n", L"*d*", L"cde", nullptr}, STATUS_CMD_OK, L"1 3\n"},
+        {{L"string", L"match", L"-n", L"*x*", L"cde", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"-q", L"a*", L"b", L"c", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"-q", L"a*", L"b", L"a", nullptr}, STATUS_CMD_OK, L""},
 
-        {{L"string", L"match", L"-r", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"match", L"-r", L"", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"-r", L"", L"", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"match", L"-r", L".", L"a", 0}, STATUS_CMD_OK, L"a\n"},
-        {{L"string", L"match", L"-r", L".*", L"", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"match", L"-r", L"a*b", L"b", 0}, STATUS_CMD_OK, L"b\n"},
-        {{L"string", L"match", L"-r", L"a*b", L"aab", 0}, STATUS_CMD_OK, L"aab\n"},
-        {{L"string", L"match", L"-r", L"-i", L"a*b", L"Aab", 0}, STATUS_CMD_OK, L"Aab\n"},
-        {{L"string", L"match", L"-r", L"-a", L"a[bc]", L"abadac", 0}, STATUS_CMD_OK, L"ab\nac\n"},
-        {{L"string", L"match", L"-r", L"a", L"xaxa", L"axax", 0}, STATUS_CMD_OK, L"a\na\n"},
-        {{L"string", L"match", L"-r", L"-a", L"a", L"xaxa", L"axax", 0},
+        {{L"string", L"match", L"-r", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"match", L"-r", L"", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"-r", L"", L"", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"match", L"-r", L".", L"a", nullptr}, STATUS_CMD_OK, L"a\n"},
+        {{L"string", L"match", L"-r", L".*", L"", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"match", L"-r", L"a*b", L"b", nullptr}, STATUS_CMD_OK, L"b\n"},
+        {{L"string", L"match", L"-r", L"a*b", L"aab", nullptr}, STATUS_CMD_OK, L"aab\n"},
+        {{L"string", L"match", L"-r", L"-i", L"a*b", L"Aab", nullptr}, STATUS_CMD_OK, L"Aab\n"},
+        {{L"string", L"match", L"-r", L"-a", L"a[bc]", L"abadac", nullptr},
+         STATUS_CMD_OK,
+         L"ab\nac\n"},
+        {{L"string", L"match", L"-r", L"a", L"xaxa", L"axax", nullptr}, STATUS_CMD_OK, L"a\na\n"},
+        {{L"string", L"match", L"-r", L"-a", L"a", L"xaxa", L"axax", nullptr},
          STATUS_CMD_OK,
          L"a\na\na\na\n"},
-        {{L"string", L"match", L"-r", L"a[bc]", L"abadac", 0}, STATUS_CMD_OK, L"ab\n"},
-        {{L"string", L"match", L"-r", L"-q", L"a[bc]", L"abadac", 0}, STATUS_CMD_OK, L""},
-        {{L"string", L"match", L"-r", L"-q", L"a[bc]", L"ad", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"-r", L"(a+)b(c)", L"aabc", 0}, STATUS_CMD_OK, L"aabc\naa\nc\n"},
-        {{L"string", L"match", L"-r", L"-a", L"(a)b(c)", L"abcabc", 0},
+        {{L"string", L"match", L"-r", L"a[bc]", L"abadac", nullptr}, STATUS_CMD_OK, L"ab\n"},
+        {{L"string", L"match", L"-r", L"-q", L"a[bc]", L"abadac", nullptr}, STATUS_CMD_OK, L""},
+        {{L"string", L"match", L"-r", L"-q", L"a[bc]", L"ad", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"-r", L"(a+)b(c)", L"aabc", nullptr},
+         STATUS_CMD_OK,
+         L"aabc\naa\nc\n"},
+        {{L"string", L"match", L"-r", L"-a", L"(a)b(c)", L"abcabc", nullptr},
          STATUS_CMD_OK,
          L"abc\na\nc\nabc\na\nc\n"},
-        {{L"string", L"match", L"-r", L"(a)b(c)", L"abcabc", 0}, STATUS_CMD_OK, L"abc\na\nc\n"},
-        {{L"string", L"match", L"-r", L"(a|(z))(bc)", L"abc", 0}, STATUS_CMD_OK, L"abc\na\nbc\n"},
-        {{L"string", L"match", L"-r", L"-n", L"a", L"ada", L"dad", 0},
+        {{L"string", L"match", L"-r", L"(a)b(c)", L"abcabc", nullptr},
+         STATUS_CMD_OK,
+         L"abc\na\nc\n"},
+        {{L"string", L"match", L"-r", L"(a|(z))(bc)", L"abc", nullptr},
+         STATUS_CMD_OK,
+         L"abc\na\nbc\n"},
+        {{L"string", L"match", L"-r", L"-n", L"a", L"ada", L"dad", nullptr},
          STATUS_CMD_OK,
          L"1 1\n2 1\n"},
-        {{L"string", L"match", L"-r", L"-n", L"-a", L"a", L"bacadae", 0},
+        {{L"string", L"match", L"-r", L"-n", L"-a", L"a", L"bacadae", nullptr},
          STATUS_CMD_OK,
          L"2 1\n4 1\n6 1\n"},
-        {{L"string", L"match", L"-r", L"-n", L"(a).*(b)", L"a---b", 0},
+        {{L"string", L"match", L"-r", L"-n", L"(a).*(b)", L"a---b", nullptr},
          STATUS_CMD_OK,
          L"1 5\n1 1\n5 1\n"},
-        {{L"string", L"match", L"-r", L"-n", L"(a)(b)", L"ab", 0},
+        {{L"string", L"match", L"-r", L"-n", L"(a)(b)", L"ab", nullptr},
          STATUS_CMD_OK,
          L"1 2\n1 1\n2 1\n"},
-        {{L"string", L"match", L"-r", L"-n", L"(a)(b)", L"abab", 0},
+        {{L"string", L"match", L"-r", L"-n", L"(a)(b)", L"abab", nullptr},
          STATUS_CMD_OK,
          L"1 2\n1 1\n2 1\n"},
-        {{L"string", L"match", L"-r", L"-n", L"-a", L"(a)(b)", L"abab", 0},
+        {{L"string", L"match", L"-r", L"-n", L"-a", L"(a)(b)", L"abab", nullptr},
          STATUS_CMD_OK,
          L"1 2\n1 1\n2 1\n3 2\n3 1\n4 1\n"},
-        {{L"string", L"match", L"-r", L"*", L"", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"match", L"-r", L"-a", L"a*", L"b", 0}, STATUS_CMD_OK, L"\n\n"},
-        {{L"string", L"match", L"-r", L"foo\\Kbar", L"foobar", 0}, STATUS_CMD_OK, L"bar\n"},
-        {{L"string", L"match", L"-r", L"(foo)\\Kbar", L"foobar", 0}, STATUS_CMD_OK, L"bar\nfoo\n"},
-        {{L"string", L"match", L"-r", L"(?=ab\\K)", L"ab", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"match", L"-r", L"(?=ab\\K)..(?=cd\\K)", L"abcd", 0}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"match", L"-r", L"*", L"", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"match", L"-r", L"-a", L"a*", L"b", nullptr}, STATUS_CMD_OK, L"\n\n"},
+        {{L"string", L"match", L"-r", L"foo\\Kbar", L"foobar", nullptr}, STATUS_CMD_OK, L"bar\n"},
+        {{L"string", L"match", L"-r", L"(foo)\\Kbar", L"foobar", nullptr},
+         STATUS_CMD_OK,
+         L"bar\nfoo\n"},
+        {{L"string", L"match", L"-r", L"(?=ab\\K)", L"ab", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"match", L"-r", L"(?=ab\\K)..(?=cd\\K)", L"abcd", nullptr},
+         STATUS_CMD_OK,
+         L"\n"},
 
-        {{L"string", L"replace", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"replace", L"", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"replace", L"", L"", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"replace", L"", L"", L"", 0}, STATUS_CMD_ERROR, L"\n"},
-        {{L"string", L"replace", L"", L"", L" ", 0}, STATUS_CMD_ERROR, L" \n"},
-        {{L"string", L"replace", L"a", L"b", L"", 0}, STATUS_CMD_ERROR, L"\n"},
-        {{L"string", L"replace", L"a", L"b", L"a", 0}, STATUS_CMD_OK, L"b\n"},
-        {{L"string", L"replace", L"a", L"b", L"xax", 0}, STATUS_CMD_OK, L"xbx\n"},
-        {{L"string", L"replace", L"a", L"b", L"xax", L"axa", 0}, STATUS_CMD_OK, L"xbx\nbxa\n"},
-        {{L"string", L"replace", L"bar", L"x", L"red barn", 0}, STATUS_CMD_OK, L"red xn\n"},
-        {{L"string", L"replace", L"x", L"bar", L"red xn", 0}, STATUS_CMD_OK, L"red barn\n"},
-        {{L"string", L"replace", L"--", L"x", L"-", L"xyz", 0}, STATUS_CMD_OK, L"-yz\n"},
-        {{L"string", L"replace", L"--", L"y", L"-", L"xyz", 0}, STATUS_CMD_OK, L"x-z\n"},
-        {{L"string", L"replace", L"--", L"z", L"-", L"xyz", 0}, STATUS_CMD_OK, L"xy-\n"},
-        {{L"string", L"replace", L"-i", L"z", L"X", L"_Z_", 0}, STATUS_CMD_OK, L"_X_\n"},
-        {{L"string", L"replace", L"-a", L"a", L"A", L"aaa", 0}, STATUS_CMD_OK, L"AAA\n"},
-        {{L"string", L"replace", L"-i", L"a", L"z", L"AAA", 0}, STATUS_CMD_OK, L"zAA\n"},
-        {{L"string", L"replace", L"-q", L"x", L">x<", L"x", 0}, STATUS_CMD_OK, L""},
-        {{L"string", L"replace", L"-a", L"x", L"", L"xxx", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"replace", L"-a", L"***", L"_", L"*****", 0}, STATUS_CMD_OK, L"_**\n"},
-        {{L"string", L"replace", L"-a", L"***", L"***", L"******", 0}, STATUS_CMD_OK, L"******\n"},
-        {{L"string", L"replace", L"-a", L"a", L"b", L"xax", L"axa", 0},
+        {{L"string", L"replace", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"replace", L"", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"replace", L"", L"", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"replace", L"", L"", L"", nullptr}, STATUS_CMD_ERROR, L"\n"},
+        {{L"string", L"replace", L"", L"", L" ", nullptr}, STATUS_CMD_ERROR, L" \n"},
+        {{L"string", L"replace", L"a", L"b", L"", nullptr}, STATUS_CMD_ERROR, L"\n"},
+        {{L"string", L"replace", L"a", L"b", L"a", nullptr}, STATUS_CMD_OK, L"b\n"},
+        {{L"string", L"replace", L"a", L"b", L"xax", nullptr}, STATUS_CMD_OK, L"xbx\n"},
+        {{L"string", L"replace", L"a", L"b", L"xax", L"axa", nullptr},
+         STATUS_CMD_OK,
+         L"xbx\nbxa\n"},
+        {{L"string", L"replace", L"bar", L"x", L"red barn", nullptr}, STATUS_CMD_OK, L"red xn\n"},
+        {{L"string", L"replace", L"x", L"bar", L"red xn", nullptr}, STATUS_CMD_OK, L"red barn\n"},
+        {{L"string", L"replace", L"--", L"x", L"-", L"xyz", nullptr}, STATUS_CMD_OK, L"-yz\n"},
+        {{L"string", L"replace", L"--", L"y", L"-", L"xyz", nullptr}, STATUS_CMD_OK, L"x-z\n"},
+        {{L"string", L"replace", L"--", L"z", L"-", L"xyz", nullptr}, STATUS_CMD_OK, L"xy-\n"},
+        {{L"string", L"replace", L"-i", L"z", L"X", L"_Z_", nullptr}, STATUS_CMD_OK, L"_X_\n"},
+        {{L"string", L"replace", L"-a", L"a", L"A", L"aaa", nullptr}, STATUS_CMD_OK, L"AAA\n"},
+        {{L"string", L"replace", L"-i", L"a", L"z", L"AAA", nullptr}, STATUS_CMD_OK, L"zAA\n"},
+        {{L"string", L"replace", L"-q", L"x", L">x<", L"x", nullptr}, STATUS_CMD_OK, L""},
+        {{L"string", L"replace", L"-a", L"x", L"", L"xxx", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"replace", L"-a", L"***", L"_", L"*****", nullptr}, STATUS_CMD_OK, L"_**\n"},
+        {{L"string", L"replace", L"-a", L"***", L"***", L"******", nullptr},
+         STATUS_CMD_OK,
+         L"******\n"},
+        {{L"string", L"replace", L"-a", L"a", L"b", L"xax", L"axa", nullptr},
          STATUS_CMD_OK,
          L"xbx\nbxb\n"},
 
-        {{L"string", L"replace", L"-r", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"replace", L"-r", L"", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"replace", L"-r", L"", L"", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"replace", L"-r", L"", L"", L"", 0}, STATUS_CMD_OK, L"\n"},  // pcre2 behavior
-        {{L"string", L"replace", L"-r", L"", L"", L" ", 0},
+        {{L"string", L"replace", L"-r", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"replace", L"-r", L"", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"replace", L"-r", L"", L"", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"replace", L"-r", L"", L"", L"", nullptr},
+         STATUS_CMD_OK,
+         L"\n"},  // pcre2 behavior
+        {{L"string", L"replace", L"-r", L"", L"", L" ", nullptr},
          STATUS_CMD_OK,
          L" \n"},  // pcre2 behavior
-        {{L"string", L"replace", L"-r", L"a", L"b", L"", 0}, STATUS_CMD_ERROR, L"\n"},
-        {{L"string", L"replace", L"-r", L"a", L"b", L"a", 0}, STATUS_CMD_OK, L"b\n"},
-        {{L"string", L"replace", L"-r", L".", L"x", L"abc", 0}, STATUS_CMD_OK, L"xbc\n"},
-        {{L"string", L"replace", L"-r", L".", L"", L"abc", 0}, STATUS_CMD_OK, L"bc\n"},
-        {{L"string", L"replace", L"-r", L"(\\w)(\\w)", L"$2$1", L"ab", 0}, STATUS_CMD_OK, L"ba\n"},
-        {{L"string", L"replace", L"-r", L"(\\w)", L"$1$1", L"ab", 0}, STATUS_CMD_OK, L"aab\n"},
-        {{L"string", L"replace", L"-r", L"-a", L".", L"x", L"abc", 0}, STATUS_CMD_OK, L"xxx\n"},
-        {{L"string", L"replace", L"-r", L"-a", L"(\\w)", L"$1$1", L"ab", 0},
+        {{L"string", L"replace", L"-r", L"a", L"b", L"", nullptr}, STATUS_CMD_ERROR, L"\n"},
+        {{L"string", L"replace", L"-r", L"a", L"b", L"a", nullptr}, STATUS_CMD_OK, L"b\n"},
+        {{L"string", L"replace", L"-r", L".", L"x", L"abc", nullptr}, STATUS_CMD_OK, L"xbc\n"},
+        {{L"string", L"replace", L"-r", L".", L"", L"abc", nullptr}, STATUS_CMD_OK, L"bc\n"},
+        {{L"string", L"replace", L"-r", L"(\\w)(\\w)", L"$2$1", L"ab", nullptr},
+         STATUS_CMD_OK,
+         L"ba\n"},
+        {{L"string", L"replace", L"-r", L"(\\w)", L"$1$1", L"ab", nullptr},
+         STATUS_CMD_OK,
+         L"aab\n"},
+        {{L"string", L"replace", L"-r", L"-a", L".", L"x", L"abc", nullptr},
+         STATUS_CMD_OK,
+         L"xxx\n"},
+        {{L"string", L"replace", L"-r", L"-a", L"(\\w)", L"$1$1", L"ab", nullptr},
          STATUS_CMD_OK,
          L"aabb\n"},
-        {{L"string", L"replace", L"-r", L"-a", L".", L"", L"abc", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"replace", L"-r", L"a", L"x", L"bc", L"cd", L"de", 0},
+        {{L"string", L"replace", L"-r", L"-a", L".", L"", L"abc", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"replace", L"-r", L"a", L"x", L"bc", L"cd", L"de", nullptr},
          STATUS_CMD_ERROR,
          L"bc\ncd\nde\n"},
-        {{L"string", L"replace", L"-r", L"a", L"x", L"aba", L"caa", 0},
+        {{L"string", L"replace", L"-r", L"a", L"x", L"aba", L"caa", nullptr},
          STATUS_CMD_OK,
          L"xba\ncxa\n"},
-        {{L"string", L"replace", L"-r", L"-a", L"a", L"x", L"aba", L"caa", 0},
+        {{L"string", L"replace", L"-r", L"-a", L"a", L"x", L"aba", L"caa", nullptr},
          STATUS_CMD_OK,
          L"xbx\ncxx\n"},
-        {{L"string", L"replace", L"-r", L"-i", L"A", L"b", L"xax", 0}, STATUS_CMD_OK, L"xbx\n"},
-        {{L"string", L"replace", L"-r", L"-i", L"[a-z]", L".", L"1A2B", 0},
+        {{L"string", L"replace", L"-r", L"-i", L"A", L"b", L"xax", nullptr},
+         STATUS_CMD_OK,
+         L"xbx\n"},
+        {{L"string", L"replace", L"-r", L"-i", L"[a-z]", L".", L"1A2B", nullptr},
          STATUS_CMD_OK,
          L"1.2B\n"},
-        {{L"string", L"replace", L"-r", L"A", L"b", L"xax", 0}, STATUS_CMD_ERROR, L"xax\n"},
-        {{L"string", L"replace", L"-r", L"a", L"$1", L"a", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"replace", L"-r", L"(a)", L"$2", L"a", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"replace", L"-r", L"*", L".", L"a", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"replace", L"-ra", L"x", L"\\c", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"replace", L"-r", L"^(.)", L"\t$1", L"abc", L"x", 0},
+        {{L"string", L"replace", L"-r", L"A", L"b", L"xax", nullptr}, STATUS_CMD_ERROR, L"xax\n"},
+        {{L"string", L"replace", L"-r", L"a", L"$1", L"a", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"replace", L"-r", L"(a)", L"$2", L"a", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"replace", L"-r", L"*", L".", L"a", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"replace", L"-ra", L"x", L"\\c", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"replace", L"-r", L"^(.)", L"\t$1", L"abc", L"x", nullptr},
          STATUS_CMD_OK,
          L"\tabc\n\tx\n"},
 
-        {{L"string", L"split", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"split", L":", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"split", L".", L"www.ch.ic.ac.uk", 0},
+        {{L"string", L"split", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"split", L":", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"split", L".", L"www.ch.ic.ac.uk", nullptr},
          STATUS_CMD_OK,
          L"www\nch\nic\nac\nuk\n"},
-        {{L"string", L"split", L"..", L"....", 0}, STATUS_CMD_OK, L"\n\n\n"},
-        {{L"string", L"split", L"-m", L"x", L"..", L"....", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"split", L"-m1", L"..", L"....", 0}, STATUS_CMD_OK, L"\n..\n"},
-        {{L"string", L"split", L"-m0", L"/", L"/usr/local/bin/fish", 0},
+        {{L"string", L"split", L"..", L"....", nullptr}, STATUS_CMD_OK, L"\n\n\n"},
+        {{L"string", L"split", L"-m", L"x", L"..", L"....", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"split", L"-m1", L"..", L"....", nullptr}, STATUS_CMD_OK, L"\n..\n"},
+        {{L"string", L"split", L"-m0", L"/", L"/usr/local/bin/fish", nullptr},
          STATUS_CMD_ERROR,
          L"/usr/local/bin/fish\n"},
-        {{L"string", L"split", L"-m2", L":", L"a:b:c:d", L"e:f:g:h", 0},
+        {{L"string", L"split", L"-m2", L":", L"a:b:c:d", L"e:f:g:h", nullptr},
          STATUS_CMD_OK,
          L"a\nb\nc:d\ne\nf\ng:h\n"},
-        {{L"string", L"split", L"-m1", L"-r", L"/", L"/usr/local/bin/fish", 0},
+        {{L"string", L"split", L"-m1", L"-r", L"/", L"/usr/local/bin/fish", nullptr},
          STATUS_CMD_OK,
          L"/usr/local/bin\nfish\n"},
-        {{L"string", L"split", L"-r", L".", L"www.ch.ic.ac.uk", 0},
+        {{L"string", L"split", L"-r", L".", L"www.ch.ic.ac.uk", nullptr},
          STATUS_CMD_OK,
          L"www\nch\nic\nac\nuk\n"},
-        {{L"string", L"split", L"--", L"--", L"a--b---c----d", 0},
+        {{L"string", L"split", L"--", L"--", L"a--b---c----d", nullptr},
          STATUS_CMD_OK,
          L"a\nb\n-c\n\nd\n"},
-        {{L"string", L"split", L"-r", L"..", L"....", 0}, STATUS_CMD_OK, L"\n\n\n"},
-        {{L"string", L"split", L"-r", L"--", L"--", L"a--b---c----d", 0},
+        {{L"string", L"split", L"-r", L"..", L"....", nullptr}, STATUS_CMD_OK, L"\n\n\n"},
+        {{L"string", L"split", L"-r", L"--", L"--", L"a--b---c----d", nullptr},
          STATUS_CMD_OK,
          L"a\nb-\nc\n\nd\n"},
-        {{L"string", L"split", L"", L"", 0}, STATUS_CMD_ERROR, L"\n"},
-        {{L"string", L"split", L"", L"a", 0}, STATUS_CMD_ERROR, L"a\n"},
-        {{L"string", L"split", L"", L"ab", 0}, STATUS_CMD_OK, L"a\nb\n"},
-        {{L"string", L"split", L"", L"abc", 0}, STATUS_CMD_OK, L"a\nb\nc\n"},
-        {{L"string", L"split", L"-m1", L"", L"abc", 0}, STATUS_CMD_OK, L"a\nbc\n"},
-        {{L"string", L"split", L"-r", L"", L"", 0}, STATUS_CMD_ERROR, L"\n"},
-        {{L"string", L"split", L"-r", L"", L"a", 0}, STATUS_CMD_ERROR, L"a\n"},
-        {{L"string", L"split", L"-r", L"", L"ab", 0}, STATUS_CMD_OK, L"a\nb\n"},
-        {{L"string", L"split", L"-r", L"", L"abc", 0}, STATUS_CMD_OK, L"a\nb\nc\n"},
-        {{L"string", L"split", L"-r", L"-m1", L"", L"abc", 0}, STATUS_CMD_OK, L"ab\nc\n"},
-        {{L"string", L"split", L"-q", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"split", L"-q", L":", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"split", L"-q", L"x", L"axbxc", 0}, STATUS_CMD_OK, L""},
+        {{L"string", L"split", L"", L"", nullptr}, STATUS_CMD_ERROR, L"\n"},
+        {{L"string", L"split", L"", L"a", nullptr}, STATUS_CMD_ERROR, L"a\n"},
+        {{L"string", L"split", L"", L"ab", nullptr}, STATUS_CMD_OK, L"a\nb\n"},
+        {{L"string", L"split", L"", L"abc", nullptr}, STATUS_CMD_OK, L"a\nb\nc\n"},
+        {{L"string", L"split", L"-m1", L"", L"abc", nullptr}, STATUS_CMD_OK, L"a\nbc\n"},
+        {{L"string", L"split", L"-r", L"", L"", nullptr}, STATUS_CMD_ERROR, L"\n"},
+        {{L"string", L"split", L"-r", L"", L"a", nullptr}, STATUS_CMD_ERROR, L"a\n"},
+        {{L"string", L"split", L"-r", L"", L"ab", nullptr}, STATUS_CMD_OK, L"a\nb\n"},
+        {{L"string", L"split", L"-r", L"", L"abc", nullptr}, STATUS_CMD_OK, L"a\nb\nc\n"},
+        {{L"string", L"split", L"-r", L"-m1", L"", L"abc", nullptr}, STATUS_CMD_OK, L"ab\nc\n"},
+        {{L"string", L"split", L"-q", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"split", L"-q", L":", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"split", L"-q", L"x", L"axbxc", nullptr}, STATUS_CMD_OK, L""},
 
-        {{L"string", L"sub", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"sub", L"abcde", 0}, STATUS_CMD_OK, L"abcde\n"},
-        {{L"string", L"sub", L"-l", L"x", L"abcde", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"sub", L"-s", L"x", L"abcde", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"sub", L"-l0", L"abcde", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"sub", L"-l2", L"abcde", 0}, STATUS_CMD_OK, L"ab\n"},
-        {{L"string", L"sub", L"-l5", L"abcde", 0}, STATUS_CMD_OK, L"abcde\n"},
-        {{L"string", L"sub", L"-l6", L"abcde", 0}, STATUS_CMD_OK, L"abcde\n"},
-        {{L"string", L"sub", L"-l-1", L"abcde", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"sub", L"-s0", L"abcde", 0}, STATUS_INVALID_ARGS, L""},
-        {{L"string", L"sub", L"-s1", L"abcde", 0}, STATUS_CMD_OK, L"abcde\n"},
-        {{L"string", L"sub", L"-s5", L"abcde", 0}, STATUS_CMD_OK, L"e\n"},
-        {{L"string", L"sub", L"-s6", L"abcde", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"sub", L"-s-1", L"abcde", 0}, STATUS_CMD_OK, L"e\n"},
-        {{L"string", L"sub", L"-s-5", L"abcde", 0}, STATUS_CMD_OK, L"abcde\n"},
-        {{L"string", L"sub", L"-s-6", L"abcde", 0}, STATUS_CMD_OK, L"abcde\n"},
-        {{L"string", L"sub", L"-s1", L"-l0", L"abcde", 0}, STATUS_CMD_OK, L"\n"},
-        {{L"string", L"sub", L"-s1", L"-l1", L"abcde", 0}, STATUS_CMD_OK, L"a\n"},
-        {{L"string", L"sub", L"-s2", L"-l2", L"abcde", 0}, STATUS_CMD_OK, L"bc\n"},
-        {{L"string", L"sub", L"-s-1", L"-l1", L"abcde", 0}, STATUS_CMD_OK, L"e\n"},
-        {{L"string", L"sub", L"-s-1", L"-l2", L"abcde", 0}, STATUS_CMD_OK, L"e\n"},
-        {{L"string", L"sub", L"-s-3", L"-l2", L"abcde", 0}, STATUS_CMD_OK, L"cd\n"},
-        {{L"string", L"sub", L"-s-3", L"-l4", L"abcde", 0}, STATUS_CMD_OK, L"cde\n"},
-        {{L"string", L"sub", L"-q", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"sub", L"-q", L"abcde", 0}, STATUS_CMD_OK, L""},
+        {{L"string", L"sub", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"sub", L"abcde", nullptr}, STATUS_CMD_OK, L"abcde\n"},
+        {{L"string", L"sub", L"-l", L"x", L"abcde", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"sub", L"-s", L"x", L"abcde", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"sub", L"-l0", L"abcde", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"sub", L"-l2", L"abcde", nullptr}, STATUS_CMD_OK, L"ab\n"},
+        {{L"string", L"sub", L"-l5", L"abcde", nullptr}, STATUS_CMD_OK, L"abcde\n"},
+        {{L"string", L"sub", L"-l6", L"abcde", nullptr}, STATUS_CMD_OK, L"abcde\n"},
+        {{L"string", L"sub", L"-l-1", L"abcde", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"sub", L"-s0", L"abcde", nullptr}, STATUS_INVALID_ARGS, L""},
+        {{L"string", L"sub", L"-s1", L"abcde", nullptr}, STATUS_CMD_OK, L"abcde\n"},
+        {{L"string", L"sub", L"-s5", L"abcde", nullptr}, STATUS_CMD_OK, L"e\n"},
+        {{L"string", L"sub", L"-s6", L"abcde", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"sub", L"-s-1", L"abcde", nullptr}, STATUS_CMD_OK, L"e\n"},
+        {{L"string", L"sub", L"-s-5", L"abcde", nullptr}, STATUS_CMD_OK, L"abcde\n"},
+        {{L"string", L"sub", L"-s-6", L"abcde", nullptr}, STATUS_CMD_OK, L"abcde\n"},
+        {{L"string", L"sub", L"-s1", L"-l0", L"abcde", nullptr}, STATUS_CMD_OK, L"\n"},
+        {{L"string", L"sub", L"-s1", L"-l1", L"abcde", nullptr}, STATUS_CMD_OK, L"a\n"},
+        {{L"string", L"sub", L"-s2", L"-l2", L"abcde", nullptr}, STATUS_CMD_OK, L"bc\n"},
+        {{L"string", L"sub", L"-s-1", L"-l1", L"abcde", nullptr}, STATUS_CMD_OK, L"e\n"},
+        {{L"string", L"sub", L"-s-1", L"-l2", L"abcde", nullptr}, STATUS_CMD_OK, L"e\n"},
+        {{L"string", L"sub", L"-s-3", L"-l2", L"abcde", nullptr}, STATUS_CMD_OK, L"cd\n"},
+        {{L"string", L"sub", L"-s-3", L"-l4", L"abcde", nullptr}, STATUS_CMD_OK, L"cde\n"},
+        {{L"string", L"sub", L"-q", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"sub", L"-q", L"abcde", nullptr}, STATUS_CMD_OK, L""},
 
-        {{L"string", L"trim", 0}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"trim", nullptr}, STATUS_CMD_ERROR, L""},
         {{L"string", L"trim", L""}, STATUS_CMD_ERROR, L"\n"},
         {{L"string", L"trim", L" "}, STATUS_CMD_OK, L"\n"},
         {{L"string", L"trim", L"  \f\n\r\t"}, STATUS_CMD_OK, L"\n"},
@@ -5295,24 +5329,24 @@ static void test_string() {
 
     const auto saved_flags = fish_features();
     const struct string_test qmark_noglob_tests[] = {
-        {{L"string", L"match", L"a*b?c", L"axxb?c", 0}, STATUS_CMD_OK, L"axxb?c\n"},
-        {{L"string", L"match", L"*?", L"a", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"*?", L"ab", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"?*", L"a", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"?*", L"ab", 0}, STATUS_CMD_ERROR, L""},
-        {{L"string", L"match", L"a*\\?", L"abc?", 0}, STATUS_CMD_ERROR, L""}};
+        {{L"string", L"match", L"a*b?c", L"axxb?c", nullptr}, STATUS_CMD_OK, L"axxb?c\n"},
+        {{L"string", L"match", L"*?", L"a", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"*?", L"ab", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"?*", L"a", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"?*", L"ab", nullptr}, STATUS_CMD_ERROR, L""},
+        {{L"string", L"match", L"a*\\?", L"abc?", nullptr}, STATUS_CMD_ERROR, L""}};
     mutable_fish_features().set(features_t::qmark_noglob, true);
     for (const auto &t : qmark_noglob_tests) {
         run_one_string_test(t.argv, t.expected_rc, t.expected_out);
     }
 
     const struct string_test qmark_glob_tests[] = {
-        {{L"string", L"match", L"a*b?c", L"axxbyc", 0}, STATUS_CMD_OK, L"axxbyc\n"},
-        {{L"string", L"match", L"*?", L"a", 0}, STATUS_CMD_OK, L"a\n"},
-        {{L"string", L"match", L"*?", L"ab", 0}, STATUS_CMD_OK, L"ab\n"},
-        {{L"string", L"match", L"?*", L"a", 0}, STATUS_CMD_OK, L"a\n"},
-        {{L"string", L"match", L"?*", L"ab", 0}, STATUS_CMD_OK, L"ab\n"},
-        {{L"string", L"match", L"a*\\?", L"abc?", 0}, STATUS_CMD_OK, L"abc?\n"}};
+        {{L"string", L"match", L"a*b?c", L"axxbyc", nullptr}, STATUS_CMD_OK, L"axxbyc\n"},
+        {{L"string", L"match", L"*?", L"a", nullptr}, STATUS_CMD_OK, L"a\n"},
+        {{L"string", L"match", L"*?", L"ab", nullptr}, STATUS_CMD_OK, L"ab\n"},
+        {{L"string", L"match", L"?*", L"a", nullptr}, STATUS_CMD_OK, L"a\n"},
+        {{L"string", L"match", L"?*", L"ab", nullptr}, STATUS_CMD_OK, L"ab\n"},
+        {{L"string", L"match", L"a*\\?", L"abc?", nullptr}, STATUS_CMD_OK, L"abc?\n"}};
     mutable_fish_features().set(features_t::qmark_noglob, false);
     for (const auto &t : qmark_glob_tests) {
         run_one_string_test(t.argv, t.expected_rc, t.expected_out);
@@ -5345,7 +5379,7 @@ long return_timezone_hour(time_t tstamp, const wchar_t *timezone) {
 /// Verify that setting special env vars have the expected effect on the current shell process.
 static void test_timezone_env_vars() {
     // Confirm changing the timezone affects fish's idea of the local time.
-    time_t tstamp = time(NULL);
+    time_t tstamp = time(nullptr);
 
     long first_tstamp = return_timezone_hour(tstamp, L"UTC-1");
     long second_tstamp = return_timezone_hour(tstamp, L"UTC-2");
@@ -5761,7 +5795,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    srandom((unsigned int)time(NULL));
+    srandom((unsigned int)time(nullptr));
     configure_thread_assertions_for_testing();
 
     // Set the program name to this sentinel value

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -791,7 +791,7 @@ static void test_fd_monitor() {
 
     // Items which will never receive data or be called back.
     item_maker_t item_never(fd_monitor_item_t::kNoTimeout);
-    item_maker_t item_hugetimeout(100000000llu * usec_per_msec);
+    item_maker_t item_hugetimeout(100000000LLU * usec_per_msec);
 
     // Item which should get no data, and time out.
     item_maker_t item0_timeout(16 * usec_per_msec);

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3323,8 +3323,8 @@ static void test_input() {
 
     {
         auto input_mapping = input_mappings();
-        input_mapping->add(prefix_binding.c_str(), L"up-line");
-        input_mapping->add(desired_binding.c_str(), L"down-line");
+        input_mapping->add(prefix_binding, L"up-line");
+        input_mapping->add(desired_binding, L"down-line");
     }
 
     // Push the desired binding to the queue.

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -1800,7 +1800,7 @@ static void test_lru() {
 struct pwd_environment_t : public environment_t {
     std::map<wcstring, wcstring> extras;
 
-    virtual maybe_t<env_var_t> get(const wcstring &key,
+    maybe_t<env_var_t> get(const wcstring &key,
                                    env_mode_flags_t mode = ENV_DEFAULT) const override {
         UNUSED(mode);
         if (key == L"PWD") {

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2184,7 +2184,7 @@ static void test_path() {
     do_test(path_apply_working_directory(L"abc/", L"/def/") == L"/def/abc/");
     do_test(path_apply_working_directory(L"/abc/", L"/def/") == L"/abc/");
     do_test(path_apply_working_directory(L"/abc", L"/def/") == L"/abc");
-    do_test(path_apply_working_directory(L"", L"/def/") == L"");
+    do_test(path_apply_working_directory(L"", L"/def/").empty());
     do_test(path_apply_working_directory(L"abc", L"") == L"abc");
 }
 
@@ -2901,15 +2901,15 @@ static void test_complete() {
 
     // But not with the command prefix.
     completions = do_complete(L"echo (command scuttlebut", {});
-    do_test(completions.size() == 0);
+    do_test(completions.empty());
 
     // Not with the builtin prefix.
     completions = do_complete(L"echo (builtin scuttlebut", {});
-    do_test(completions.size() == 0);
+    do_test(completions.empty());
 
     // Not after a redirection.
     completions = do_complete(L"echo hi > scuttlebut", {});
-    do_test(completions.size() == 0);
+    do_test(completions.empty());
 
     // Trailing spaces (#1261).
     completion_mode_t no_files{};
@@ -2962,7 +2962,7 @@ static void test_complete() {
     do_test(completions.size() == 1);
     do_test(completions.at(0).completion == L"stfile");
     completions = do_complete(L"something abc=stfile", {});
-    do_test(completions.size() == 0);
+    do_test(completions.empty());
     completions = do_complete(L"something abc=stfile", completion_request_t::fuzzy_match);
     do_test(completions.size() == 1);
     do_test(completions.at(0).completion == L"abc=testfile");
@@ -3377,7 +3377,7 @@ static void test_undo() {
 
     editable_line_t line;
     do_test(!line.undo());  // nothing to undo
-    do_test(line.text() == L"");
+    do_test(line.text().empty());
     do_test(line.position() == 0);
     line.push_edit(edit_t(0, 0, L"a b c"));
     do_test(line.text() == L"a b c");
@@ -4416,7 +4416,7 @@ static void check_function_help(const wchar_t *src) {
 
     tnode_t<grammar::job_list> node{&tree, &tree.at(0)};
     auto node_list = node.descendants<Type>();
-    if (node_list.size() == 0) {
+    if (node_list.empty()) {
         err(L"Failed to find node of type '%ls'", token_type_description(Type::token));
     } else if (node_list.size() > 1) {
         err(L"Found too many nodes of type '%ls'", token_type_description(Type::token));

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3780,7 +3780,7 @@ class history_tests_t {
 };
 
 static wcstring random_string() {
-    wcstring result = L"";
+    wcstring result;
     size_t max = 1 + random() % 32;
     while (max--) {
         wchar_t c = 1 + random() % ESCAPE_TEST_CHAR;

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -781,7 +781,7 @@ static void test_fd_monitor() {
         item_maker_t(const item_maker_t &) = delete;
 
         // Write 42 bytes to our write end.
-        void write42() {
+        void write42() const {
             char buff[42] = {0};
             (void)write_loop(writer.fd(), buff, sizeof buff);
         }

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -797,7 +797,7 @@ class highlighter_t {
     // Colors the source range of a node with a given color.
     void color_node(const parse_node_t &node, highlight_spec_t color);
     // return whether a plain statement is 'cd'.
-    bool is_cd(tnode_t<g::plain_statement> stmt) const;
+    __warn_unused bool is_cd(tnode_t<g::plain_statement> stmt) const;
 
    public:
     // Constructor

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -841,7 +841,7 @@ void highlighter_t::color_command(tnode_t<g::tok_string> node) {
 
     // Get an iterator to the colors associated with the argument.
     const size_t arg_start = source_range->start;
-    const color_array_t::iterator colors = color_array.begin() + arg_start;
+    const auto colors = color_array.begin() + arg_start;
     color_string_internal(cmd_str, highlight_role_t::command, colors);
 }
 
@@ -854,7 +854,7 @@ void highlighter_t::color_argument(tnode_t<g::tok_string> node) {
 
     // Get an iterator to the colors associated with the argument.
     const size_t arg_start = source_range->start;
-    const color_array_t::iterator arg_colors = color_array.begin() + arg_start;
+    const auto arg_colors = color_array.begin() + arg_start;
 
     // Color this argument without concern for command substitutions.
     color_string_internal(arg_str, highlight_role_t::param, arg_colors);
@@ -884,7 +884,7 @@ void highlighter_t::color_argument(tnode_t<g::tok_string> node) {
 
         // Compute the cursor's position within the cmdsub. We must be past the open paren (hence >)
         // but can be at the end of the string or closed paren (hence <=).
-        size_t cursor_subpos = CURSOR_POSITION_INVALID;
+        auto cursor_subpos = CURSOR_POSITION_INVALID;
         if (cursor_pos != CURSOR_POSITION_INVALID && cursor_pos > arg_subcmd_start &&
             cursor_pos <= arg_subcmd_end) {
             // The -1 because the cmdsub_contents does not include the open paren.

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -57,7 +57,7 @@ struct input_mapping_t {
     }
 
     /// \return true if this is a generic mapping, i.e. acts as a fallback.
-    bool is_generic() const { return seq.empty(); }
+    __warn_unused bool is_generic() const { return seq.empty(); }
 };
 
 /// A struct representing the mapping from a terminfo key name to a terminfo character sequence.

--- a/src/iothread.cpp
+++ b/src/iothread.cpp
@@ -120,7 +120,7 @@ struct thread_pool_t {
     static void *run_trampoline(void *vpool);
 
     /// Attempt to spawn a new pthread.
-    bool spawn() const;
+    __warn_unused bool spawn() const;
 
     /// No copying or moving.
     thread_pool_t(const thread_pool_t &) = delete;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -503,7 +503,7 @@ rgb_color_t parse_color(const env_var_t &var, bool is_background) {
         }
 
         if (!color_name.empty()) {
-            rgb_color_t color = rgb_color_t(color_name);
+            auto color = rgb_color_t(color_name);
             if (!color.is_none()) {
                 candidates.push_back(color);
             }

--- a/src/parse_tree.cpp
+++ b/src/parse_tree.cpp
@@ -371,7 +371,7 @@ struct parse_stack_element_t {
     explicit parse_stack_element_t(production_element_t e, node_offset_t idx)
         : type(production_element_type(e)), keyword(production_element_keyword(e)), node_idx(idx) {}
 
-    wcstring describe() const {
+    __warn_unused wcstring describe() const {
         wcstring result = token_type_description(type);
         if (keyword != parse_keyword_none) {
             append_format(result, L" <%ls>", keyword_description(keyword));
@@ -380,7 +380,7 @@ struct parse_stack_element_t {
     }
 
     /// Returns a name that we can show to the user, e.g. "a command".
-    wcstring user_presentable_description() const {
+    __warn_unused wcstring user_presentable_description() const {
         return token_type_user_presentable_description(type, keyword);
     }
 };
@@ -508,7 +508,7 @@ class parse_ll_t {
     void report_tokenizer_error(const tok_t &tok);
 
     /// Indicate if we hit a fatal error.
-    bool has_fatal_error() const { return this->fatal_errored; }
+    __warn_unused bool has_fatal_error() const { return this->fatal_errored; }
 
     /// Indicate whether we want to generate error messages.
     void set_should_generate_error_messages(bool flag) {

--- a/src/postfork.h
+++ b/src/postfork.h
@@ -23,7 +23,7 @@ class process_t;
 /// Called by both parent and child; this is an unavoidable race inherent to Unix.
 /// If is_parent is set, then we are the parent process and should swallow EACCESS.
 /// \return 0 on success, an errno error code on failure.
-int execute_setpgid(pid_t pid, pid_t pgrp, bool is_parent);
+int execute_setpgid(pid_t pid, pid_t pgroup, bool is_parent);
 
 /// Report the error code \p err for a failed setpgid call.
 /// Note not all errors should be reported; in particular EACCESS is expected and benign in the

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1430,7 +1430,7 @@ static std::function<autosuggestion_result_t(void)> get_autosuggestion_performer
     // this should use shared_ptr
     return [=]() -> autosuggestion_result_t {
         ASSERT_IS_BACKGROUND_THREAD();
-        const autosuggestion_result_t nothing = {};
+        autosuggestion_result_t nothing = {};
         operation_context_t ctx = get_bg_context(vars, generation_count);
         if (ctx.check_cancel()) {
             return nothing;

--- a/src/screen.h
+++ b/src/screen.h
@@ -272,9 +272,9 @@ class layout_cache_t {
 
     /// Computes a prompt layout for \p prompt_str, perhaps truncating it to \p desired_line_width.
     /// \return the layout, and optionally the truncated prompt itself, by reference.
-    prompt_layout_t calc_prompt_layout(
-        const wcstring &prompt_str, wcstring *out_trunc_prompt = nullptr,
-        size_t desired_line_width = std::numeric_limits<size_t>::max());
+    prompt_layout_t calc_prompt_layout(const wcstring &prompt_str,
+                                       wcstring *out_trunc_prompt = nullptr,
+                                       size_t max_line_width = std::numeric_limits<size_t>::max());
 
     void clear() {
         esc_cache_.clear();


### PR DESCRIPTION
most of these are minor.

bumping the version to C++17 allowed a few more warnings including modernize-use-nodiscard.
