### PR TITLE
Fix string collect examples

### DIFF
--- a/doc_src/cmds/string-collect.rst
+++ b/doc_src/cmds/string-collect.rst
@@ -35,12 +35,12 @@ Examples
     >_ echo \"(echo one\ntwo\nthree | string collect)\"
     "one
     two
-    three
-    "
+    three"
 
     >_ echo \"(echo one\ntwo\nthree | string collect -N)\"
     "one
     two
-    three"
+    three
+    "
 
 .. END EXAMPLES


### PR DESCRIPTION
collect -N leaves the trailing newline, not the other way around.