### PR TITLE
completions/snap: workaround snap interfaces deprecation notice

### DIFF
--- a/share/completions/snap.fish
+++ b/share/completions/snap.fish
@@ -65,7 +65,7 @@ end
 function __fish_snap_interfaces -d 'List of interfaces'
     for snap in (__fish_snap_installed_snaps)
         if test $snap != core
-            snap interfaces $snap | string replace -r '[- ]*([^ ]*)[ ]+([^ ]+)' '$2$1' | string match -v "*Slot*"
+            snap interfaces $snap 2>/dev/null | string replace -r '[- ]*([^ ]*)[ ]+([^ ]+)' '$2$1' | string match -v "*Slot*"
         end
     end
 end


### PR DESCRIPTION
The `snap interfaces` command prints out a deprecation notice to stderr. This breaks the completion
support for interfaces, connect and disconnect commands like so:

```
$ snap connect <TAB>error: no interfaces found
error: no interfaces found

...
'snap interfaces' is deprecated; use 'snap connections'.

'snap interfaces' is deprecated; use 'snap connections'.

'snap interfaces' is deprecated; use 'snap connections'.
error: no interfaces found
error: no interfaces found

'snap interfaces' is deprecated; use 'snap connections'.
```

Ultimately, the snap command completion should switch to `snap connections`. However, for now try to workaround the notice by redirecting stderr.