### PR TITLE
Explicitly pipe through fish_indent when using funcsave

### DIFF
--- a/share/functions/funcsave.fish
+++ b/share/functions/funcsave.fish
@@ -27,7 +27,7 @@ function funcsave --description "Save the current definition of all specified fu
     set -l retval 0
     for funcname in $argv
         if functions -q -- $funcname
-            functions -- $funcname >$funcdir/$funcname.fish
+            functions -- $funcname | fish_indent >$funcdir/$funcname.fish
         else
             printf (_ "%s: Unknown function '%s'\n") funcsave $funcname
             set retval 1


### PR DESCRIPTION
## Description

Using `funcsave` sometimes produces a file with improper indentation. I've not
been able to reproduce it reliably, and `functions funcname > file.fish` always
seems to produce properly indeneted code. Explicitly piping through `fish_indent`
fixes the problem.
