### PR TITLE
fish_config: 'Webify' color definitions

### DIFF
--- a/share/tools/web_config/js/colorutils.js
+++ b/share/tools/web_config/js/colorutils.js
@@ -3,33 +3,33 @@
 term_256_colors =
     [
       // 247
-      'ffd7d7', 'd7afaf', 'af8787', '875f5f', '5f0000', '870000', 'af0000', 'd70000', 'ff0000',
-      'ff5f5f', 'd75f5f', 'd78787', 'ff8787', 'ffafaf', 'ffaf87', 'ffaf5f', 'ffaf00', 'ff875f',
-      'ff8700', 'ff5f00', 'd75f00', 'af5f5f', 'af5f00', 'd78700', 'd7875f', 'af875f', 'af8700',
-      '875f00', 'd7af87', 'ffd7af', 'ffd787', 'ffd75f', 'd7af00', 'd7af5f', 'ffd700', 'ffff5f',
-      'ffff00', 'ffff87', 'ffffaf', 'ffffd7', 'd7ff00', 'afd75f', 'd7d700', 'd7d787', 'd7d7af',
-      'afaf87', '87875f', '5f5f00', '878700', 'afaf00', 'afaf5f', 'd7d75f', 'd7ff5f', 'd7ff87',
-      '87ff00', 'afff00', 'afff5f', 'afd700', '87d700', '87af00', '5f8700', '87af5f', '5faf00',
-      'afd787', 'd7ffd7', 'd7ffaf', 'afffaf', 'afff87', '5fff00', '5fd700', '87d75f', '5fd75f',
-      '87ff5f', '5fff5f', '87ff87', 'afd7af', '87d787', '87d7af', '87af87', '5f875f', '5faf5f',
-      '005f00', '008700', '00af00', '00d700', '00ff00', '00ff5f', '5fff87', '00ff87', '87ffaf',
-      'afffd7', '5fd787', '00d75f', '5faf87', '00af5f', '5fffaf', '00ffaf', '5fd7af', '00d787',
-      '00875f', '00af87', '00d7af', '5fffd7', '87ffd7', '00ffd7', 'd7ffff', 'afd7d7', '87afaf',
-      '5f8787', '5fafaf', '87d7d7', '5fd7d7', '5fffff', '00ffff', '87ffff', 'afffff', '00d7d7',
-      '00d7ff', '5fd7ff', '5fafd7', '00afd7', '00afff', '0087af', '00afaf', '008787', '005f5f',
-      '005f87', '0087d7', '0087ff', '5fafff', '87afff', '5f87d7', '5f87ff', '005fd7', '005fff',
-      '005faf', '5f87af', '87afd7', 'afd7ff', '87d7ff', 'd7d7ff', 'afafd7', '8787af', 'afafff',
-      '8787d7', '8787ff', '5f5fff', '5f5fd7', '5f5faf', '5f5f87', '00005f', '000087', '0000af',
-      '0000d7', '0000ff', '5f00ff', '5f00d7', '5f00af', '5f0087', '8700af', '8700d7', '8700ff',
-      'af00ff', 'af00d7', 'd700ff', 'd75fff', 'd787ff', 'ffafd7', 'ffafff', 'ffd7ff', 'd7afff',
-      'd7afd7', 'af87af', 'af87d7', 'af87ff', '875fd7', '875faf', '875fff', 'af5fff', 'af5fd7',
-      'af5faf', 'd75fd7', 'd787d7', 'ff87ff', 'ff5fff', 'ff5fd7', 'ff00ff', 'ff00af', 'ff00d7',
-      'd700af', 'd700d7', 'af00af', '870087', '5f005f', '87005f', 'af005f', 'af0087', 'd70087',
-      'd7005f', 'ff0087', 'ff005f', 'ff5f87', 'd75f87', 'd75faf', 'ff5faf', 'ff87af', 'ff87d7',
-      'd787af', 'af5f87', '875f87', '000000', '080808', '121212', '1c1c1c', '262626', '303030',
-      '3a3a3a', '444444', '4e4e4e', '585858', '5f5f5f', '626262', '6c6c6c', '767676', '808080',
-      '878787', '8a8a8a', '949494', '9e9e9e', 'a8a8a8', 'afafaf', 'b2b2b2', 'bcbcbc', 'c6c6c6',
-      'd0d0d0', 'd7d7d7', 'dadada', 'e4e4e4', 'eeeeee', 'ffffff',
+      '#ffd7d7', '#d7afaf', '#af8787', '#875f5f', '#5f0000', '#870000', '#af0000', '#d70000', '#ff0000',
+      '#ff5f5f', '#d75f5f', '#d78787', '#ff8787', '#ffafaf', '#ffaf87', '#ffaf5f', '#ffaf00', '#ff875f',
+      '#ff8700', '#ff5f00', '#d75f00', '#af5f5f', '#af5f00', '#d78700', '#d7875f', '#af875f', '#af8700',
+      '#875f00', '#d7af87', '#ffd7af', '#ffd787', '#ffd75f', '#d7af00', '#d7af5f', '#ffd700', '#ffff5f',
+      '#ffff00', '#ffff87', '#ffffaf', '#ffffd7', '#d7ff00', '#afd75f', '#d7d700', '#d7d787', '#d7d7af',
+      '#afaf87', '#87875f', '#5f5f00', '#878700', '#afaf00', '#afaf5f', '#d7d75f', '#d7ff5f', '#d7ff87',
+      '#87ff00', '#afff00', '#afff5f', '#afd700', '#87d700', '#87af00', '#5f8700', '#87af5f', '#5faf00',
+      '#afd787', '#d7ffd7', '#d7ffaf', '#afffaf', '#afff87', '#5fff00', '#5fd700', '#87d75f', '#5fd75f',
+      '#87ff5f', '#5fff5f', '#87ff87', '#afd7af', '#87d787', '#87d7af', '#87af87', '#5f875f', '#5faf5f',
+      '#005f00', '#008700', '#00af00', '#00d700', '#00ff00', '#00ff5f', '#5fff87', '#00ff87', '#87ffaf',
+      '#afffd7', '#5fd787', '#00d75f', '#5faf87', '#00af5f', '#5fffaf', '#00ffaf', '#5fd7af', '#00d787',
+      '#00875f', '#00af87', '#00d7af', '#5fffd7', '#87ffd7', '#00ffd7', '#d7ffff', '#afd7d7', '#87afaf',
+      '#5f8787', '#5fafaf', '#87d7d7', '#5fd7d7', '#5fffff', '#00ffff', '#87ffff', '#afffff', '#00d7d7',
+      '#00d7ff', '#5fd7ff', '#5fafd7', '#00afd7', '#00afff', '#0087af', '#00afaf', '#008787', '#005f5f',
+      '#005f87', '#0087d7', '#0087ff', '#5fafff', '#87afff', '#5f87d7', '#5f87ff', '#005fd7', '#005fff',
+      '#005faf', '#5f87af', '#87afd7', '#afd7ff', '#87d7ff', '#d7d7ff', '#afafd7', '#8787af', '#afafff',
+      '#8787d7', '#8787ff', '#5f5fff', '#5f5fd7', '#5f5faf', '#5f5f87', '#00005f', '#000087', '#0000af',
+      '#0000d7', '#0000ff', '#5f00ff', '#5f00d7', '#5f00af', '#5f0087', '#8700af', '#8700d7', '#8700ff',
+      '#af00ff', '#af00d7', '#d700ff', '#d75fff', '#d787ff', '#ffafd7', '#ffafff', '#ffd7ff', '#d7afff',
+      '#d7afd7', '#af87af', '#af87d7', '#af87ff', '#875fd7', '#875faf', '#875fff', '#af5fff', '#af5fd7',
+      '#af5faf', '#d75fd7', '#d787d7', '#ff87ff', '#ff5fff', '#ff5fd7', '#ff00ff', '#ff00af', '#ff00d7',
+      '#d700af', '#d700d7', '#af00af', '#870087', '#5f005f', '#87005f', '#af005f', '#af0087', '#d70087',
+      '#d7005f', '#ff0087', '#ff005f', '#ff5f87', '#d75f87', '#d75faf', '#ff5faf', '#ff87af', '#ff87d7',
+      '#d787af', '#af5f87', '#875f87', '#000000', '#080808', '#121212', '#1c1c1c', '#262626', '#303030',
+      '#3a3a3a', '#444444', '#4e4e4e', '#585858', '#5f5f5f', '#626262', '#6c6c6c', '#767676', '#808080',
+      '#878787', '#8a8a8a', '#949494', '#9e9e9e', '#a8a8a8', '#afafaf', '#b2b2b2', '#bcbcbc', '#c6c6c6',
+      '#d0d0d0', '#d7d7d7', '#dadada', '#e4e4e4', '#eeeeee', '#ffffff',
     ]
 
     /* Given a color setting name like 'autosuggestion', return the user visible name we present */
@@ -81,8 +81,8 @@ function adjust_lightness(color_str, func) {
     }
 
     /* More hacks */
-    if (color_str == 'black') color_str = '000000';
-    if (color_str == 'white') color_str = 'c0c0c0';
+    if (color_str == 'black') color_str = '#000000';
+    if (color_str == 'white') color_str = '#c0c0c0';
 
 
     rgb = parseInt(color_str, 16)
@@ -191,32 +191,32 @@ function master_color_for_color(color_str) {
     })
 }
 
-/* Given a color name, like 'normal' or 'red' or 'FF00F0', return an RGB color string (or empty
+/* Given a color name, like 'normal' or 'red' or '#FF00F0', return an RGB color string (or empty
    string) */
 function interpret_color(str) {
     str = str.toLowerCase();
-    if (str == 'black') return '000000';
-    if (str == 'red') return '800000';
-    if (str == 'green') return '008000';
-    if (str == 'brown') return '725000';
-    if (str == 'yellow') return '808000';
-    if (str == 'blue') return '000080';
-    if (str == 'magenta') return '800080';
-    if (str == 'purple') return '800080';
-    if (str == 'cyan') return '008080';
-    if (str == 'white') return 'c0c0c0';
-    if (str == 'grey') return 'e5e5e5';
-    if (str == 'brgrey') return '555555';
-    if (str == 'brblack') return '808080';
-    if (str == 'brred') return 'ff0000';
-    if (str == 'brgreen') return '00ff00';
-    if (str == 'brbrown') return 'ffff00';
-    if (str == 'bryellow') return 'ffff00';
-    if (str == 'brblue') return '0000ff';
-    if (str == 'brmagenta') return 'ff00ff';
-    if (str == 'brpurple') return 'ff00ff';
-    if (str == 'brcyan') return '00ffff';
-    if (str == 'brwhite') return 'ffffff';
+    if (str == 'black') return '#000000';
+    if (str == 'red') return '#800000';
+    if (str == 'green') return '#008000';
+    if (str == 'brown') return '#725000';
+    if (str == 'yellow') return '#808000';
+    if (str == 'blue') return '#000080';
+    if (str == 'magenta') return '#800080';
+    if (str == 'purple') return '#800080';
+    if (str == 'cyan') return '#008080';
+    if (str == 'white') return '#c0c0c0';
+    if (str == 'grey') return '#e5e5e5';
+    if (str == 'brgrey') return '#555555';
+    if (str == 'brblack') return '#808080';
+    if (str == 'brred') return '#ff0000';
+    if (str == 'brgreen') return '#00ff00';
+    if (str == 'brbrown') return '#ffff00';
+    if (str == 'bryellow') return '#ffff00';
+    if (str == 'brblue') return '#0000ff';
+    if (str == 'brmagenta') return '#ff00ff';
+    if (str == 'brpurple') return '#ff00ff';
+    if (str == 'brcyan') return '#00ffff';
+    if (str == 'brwhite') return '#ffffff';
     if (str == 'normal') return '';
     if (str == 'reset') return '';
     return str
@@ -228,15 +228,15 @@ var color_scheme_fish_default = {
     'preferred_background': 'black',
 
     'autosuggestion': '555 brblack',
-    'command': '005fd7',
-    'param': '00afff',
-    'redirection': '00afff',
-    'comment': '990000',
-    'error': 'ff0000',
-    'escape': '00a6b2',
-    'operator': '00a6b2',
-    'quote': '999900',
-    'end': '009900',
+    'command': '#005fd7',
+    'param': '#00afff',
+    'redirection': '#00afff',
+    'comment': '#990000',
+    'error': '#ff0000',
+    'escape': '#00a6b2',
+    'operator': '#00a6b2',
+    'quote': '#999900',
+    'end': '#009900',
     'search_match' : 'bryellow --background=brblack',
     'fish_pager_color_completion' : '',
     'fish_pager_color_description' : 'B3A06D yellow',
@@ -256,13 +256,13 @@ var color_scheme_fish_default = {
 
 
 var TomorrowTheme = {
-    tomorrow_night: {'Background': '1d1f21', 'Current Line': '282a2e', 'Selection': '373b41', 'Foreground': 'c5c8c6', 'Comment': '969896', 'Red': 'cc6666', 'Orange': 'de935f',  'Yellow': 'f0c674', 'Green': 'b5bd68', 'Aqua': '8abeb7', 'Blue': '81a2be', 'Purple': 'b294bb'
+    tomorrow_night: {'Background': '#1d1f21', 'Current Line': '#282a2e', 'Selection': '#373b41', 'Foreground': '#c5c8c6', 'Comment': '#969896', 'Red': '#cc6666', 'Orange': '#de935f',  'Yellow': '#f0c674', 'Green': '#b5bd68', 'Aqua': '#8abeb7', 'Blue': '#81a2be', 'Purple': '#b294bb'
     },
 
-    tomorrow: {'Background': 'ffffff', 'Current Line': 'efefef', 'Selection': 'd6d6d6', 'Foreground': '4d4d4c', 'Comment': '8e908c', 'Red': 'c82829', 'Orange': 'f5871f', 'Yellow': 'eab700', 'Green': '718c00', 'Aqua': '3e999f', 'Blue': '4271ae', 'Purple': '8959a8'
+    tomorrow: {'Background': '#ffffff', 'Current Line': '#efefef', 'Selection': '#d6d6d6', 'Foreground': '#4d4d4c', 'Comment': '#8e908c', 'Red': '#c82829', 'Orange': '#f5871f', 'Yellow': '#eab700', 'Green': '#718c00', 'Aqua': '#3e999f', 'Blue': '#4271ae', 'Purple': '#8959a8'
     },
 
-    tomorrow_night_bright: {'Background': '000000', 'Current Line': '2a2a2a', 'Selection': '424242', 'Foreground': 'eaeaea', 'Comment': '969896', 'Red': 'd54e53', 'Orange': 'e78c45', 'Yellow': 'e7c547', 'Green': 'b9ca4a', 'Aqua': '70c0b1', 'Blue': '7aa6da', 'Purple': 'c397d8'},
+    tomorrow_night_bright: {'Background': '#000000', 'Current Line': '#2a2a2a', 'Selection': '#424242', 'Foreground': '#eaeaea', 'Comment': '#969896', 'Red': '#d54e53', 'Orange': '#e78c45', 'Yellow': '#e7c547', 'Green': '#b9ca4a', 'Aqua': '#70c0b1', 'Blue': '#7aa6da', 'Purple': '#c397d8'},
 
     apply: function(theme, receiver){
         receiver['autosuggestion'] = theme['Comment']
@@ -280,11 +280,11 @@ var TomorrowTheme = {
 }
 
 var Base16Theme = {
-    base16_default_dark: { base00: '181818', base01: '282828', base02: '383838', base03: '585858', base04: 'b8b8b8', base05: 'd8d8d8', base06: 'e8e8e8', base07: 'f8f8f8', base08: 'ab4642', base09: 'dc9656', base0A: 'f7ca88', base0B: 'a1b56c', base0C: '86c1b9', base0D: '7cafc2', base0E: 'ba8baf', base0F: 'a16946' },
+    base16_default_dark: { base00: '#181818', base01: '#282828', base02: '#383838', base03: '#585858', base04: '#b8b8b8', base05: '#d8d8d8', base06: '#e8e8e8', base07: '#f8f8f8', base08: '#ab4642', base09: '#dc9656', base0A: '#f7ca88', base0B: '#a1b56c', base0C: '#86c1b9', base0D: '#7cafc2', base0E: '#ba8baf', base0F: '#a16946' },
 
-    base16_default_light: { base00: 'f8f8f8', base01: 'e8e8e8', base02: 'd8d8d8', base03: 'b8b8b8', base04: '585858', base05: '383838', base06: '282828', base07: '181818', base08: 'ab4642', base09: 'dc9656', base0A: 'f7ca88', base0B: 'a1b56c', base0C: '86c1b9', base0D: '7cafc2', base0E: 'ba8baf', base0F: 'a16946' },
+    base16_default_light: { base00: '#f8f8f8', base01: '#e8e8e8', base02: '#d8d8d8', base03: '#b8b8b8', base04: '#585858', base05: '#383838', base06: '#282828', base07: '#181818', base08: '#ab4642', base09: '#dc9656', base0A: '#f7ca88', base0B: '#a1b56c', base0C: '#86c1b9', base0D: '#7cafc2', base0E: '#ba8baf', base0F: '#a16946' },
 
-    base16_eighties: { base00: '2d2d2d', base01: '393939', base02: '515151', base03: '747369', base04: 'a09f93', base05: 'd3d0c8', base06: 'e8e6df', base07: 'f2f0ec', base08: 'f2777a', base09: 'f99157', base0A: 'ffcc66', base0B: '99cc99', base0C: '66cccc', base0D: '6699cc', base0E: 'cc99cc', base0F: 'd27b53' },
+    base16_eighties: { base00: '#2d2d2d', base01: '#393939', base02: '#515151', base03: '#747369', base04: '#a09f93', base05: '#d3d0c8', base06: '#e8e6df', base07: '#f2f0ec', base08: '#f2777a', base09: '#f99157', base0A: '#ffcc66', base0B: '#99cc99', base0C: '#66cccc', base0D: '#6699cc', base0E: '#cc99cc', base0F: '#d27b53' },
 
     apply: function(theme, receiver) {
         receiver['autosuggestion'] = theme.base03
@@ -305,29 +305,29 @@ var Base16Theme = {
 }
 
 var nord = {
-    nord0: '2e3440',
-    nord1: '3b4252',
-    nord2: '434c5e',
-    nord3: '4c566a',
-    nord4: 'd8dee9',
-    nord5: 'e5e9f0',
-    nord6: 'eceff4',
-    nord7: '8fbcbb',
-    nord8: '88c0d0',
-    nord9: '81a1c1',
-    nord10: '5e81ac',
-    nord11: 'bf616a',
-    nord12: 'd08770',
-    nord13: 'ebcb8b',
-    nord14: 'a3be8c',
-    nord15: 'b48ead',
+    nord0: '#2e3440',
+    nord1: '#3b4252',
+    nord2: '#434c5e',
+    nord3: '#4c566a',
+    nord4: '#d8dee9',
+    nord5: '#e5e9f0',
+    nord6: '#eceff4',
+    nord7: '#8fbcbb',
+    nord8: '#88c0d0',
+    nord9: '#81a1c1',
+    nord10: '#5e81ac',
+    nord11: '#bf616a',
+    nord12: '#d08770',
+    nord13: '#ebcb8b',
+    nord14: '#a3be8c',
+    nord15: '#b48ead',
 };
 
 var color_scheme_nord = {
     name: "Nord",
     colors: dict_values(nord),
 
-    preferred_background: '#' + nord.nord0,
+    preferred_background: nord.nord0,
 
     autosuggestion: nord.nord3,
     command: nord.nord9,
@@ -342,7 +342,7 @@ var color_scheme_nord = {
 };
 
 var solarized = {
-    base03: '002b36', base02: '073642', base01: '586e75', base00: '657b83', base0: '839496', base1: '93a1a1', base2: 'eee8d5', base3: 'fdf6e3', yellow: 'b58900', orange: 'cb4b16', red: 'dc322f', magenta: 'd33682', violet: '6c71c4', blue: '268bd2', cyan: '2aa198', green: '859900'
+    base03: '#002b36', base02: '#073642', base01: '#586e75', base00: '#657b83', base0: '#839496', base1: '#93a1a1', base2: '#eee8d5', base3: '#fdf6e3', yellow: '#b58900', orange: '#cb4b16', red: '#dc322f', magenta: '#d33682', violet: '#6c71c4', blue: '#268bd2', cyan: '#2aa198', green: '#859900'
 };
 
 /* Sample color schemes */
@@ -350,7 +350,7 @@ var color_scheme_solarized_light = {
     name: "Solarized Light",
     colors: dict_values(solarized),
 
-    preferred_background: '#' + solarized.base3,
+    preferred_background: solarized.base3,
 
     autosuggestion: solarized.base1,
     command: solarized.base01,
@@ -362,7 +362,7 @@ var color_scheme_solarized_light = {
     redirection: solarized.violet,
     search_match: 'bryellow --background=white',
     fish_pager_color_completion: 'green',
-    fish_pager_color_description: 'B3A06D',
+    fish_pager_color_description: '#B3A06D',
     fish_pager_color_prefix: 'cyan --underline',
     fish_pager_color_progress: 'brwhite --background=cyan',
 
@@ -372,7 +372,7 @@ var color_scheme_solarized_light = {
 var color_scheme_solarized_dark = {
     name: "Solarized Dark",
     colors: dict_values(solarized),
-    preferred_background: '#' + solarized.base03,
+    preferred_background: solarized.base03,
 
     autosuggestion: solarized.base01,
     command: solarized.base1,
@@ -383,8 +383,8 @@ var color_scheme_solarized_dark = {
     quote: solarized.base00,
     redirection: solarized.violet,
     search_match: 'bryellow --background=black',
-    fish_pager_color_completion: 'B3A06D',
-    fish_pager_color_description: 'B3A06D',
+    fish_pager_color_completion: '#B3A06D',
+    fish_pager_color_description: '#B3A06D',
     fish_pager_color_prefix: 'cyan --underline',
     fish_pager_color_progress: 'brwhite --background=cyan',
 
@@ -491,7 +491,7 @@ function construct_scheme_complementary(label, background, color_list) {
 }
 
 function construct_color_scheme_mono(label, background, from_end) {
-    var mono_colors = ['000000', '121212', '1c1c1c', '262626', '303030', '3a3a3a', '444444', '4e4e4e', '585858', '5f5f5f', '626262', '6c6c6c', '767676', '808080', '878787', '8a8a8a', '949494', '9e9e9e', 'a8a8a8', 'afafaf', 'b2b2b2', 'bcbcbc', 'c6c6c6', 'd0d0d0', 'd7d7d7', 'dadada', 'e4e4e4', 'eeeeee', 'ffffff'];
+    var mono_colors = ['#000000', '#121212', '#1c1c1c', '#262626', '#303030', '#3a3a3a', '#444444', '#4e4e4e', '#585858', '#5f5f5f', '#626262', '#6c6c6c', '#767676', '#808080', '#878787', '#8a8a8a', '#949494', '#9e9e9e', '#a8a8a8', '#afafaf', '#b2b2b2', '#bcbcbc', '#c6c6c6', '#d0d0d0', '#d7d7d7', '#dadada', '#e4e4e4', '#eeeeee', '#ffffff'];
 
     if (from_end) mono_colors.reverse();
 
@@ -500,7 +500,7 @@ function construct_color_scheme_mono(label, background, from_end) {
         preferred_background: background,
         colors: mono_colors,
 
-        autosuggestion: '777777',
+        autosuggestion: '#777777',
         command: mono_colors[0],
         comment: mono_colors[7],
         end: mono_colors[12],
@@ -512,62 +512,62 @@ function construct_color_scheme_mono(label, background, from_end) {
 }
 
 var additional_color_schemes = [
-    construct_scheme_analogous('Snow Day', 'white', ['164CC9', '325197', '072D83', '4C7AE4', '7596E4', '4319CC', '4C3499', '260885', '724EE5', '9177E5', '02BDBD', '248E8E', '007B7B', '39DEDE', '65DEDE']),
+    construct_scheme_analogous('Snow Day', 'white', ['#164CC9', '#325197', '#072D83', '#4C7AE4', '#7596E4', '#4319CC', '#4C3499', '#260885', '#724EE5', '#9177E5', '#02BDBD', '#248E8E', '#007B7B', '#39DEDE', '#65DEDE']),
 
-    construct_scheme_analogous('Lava', '#232323', ['FF9400', 'BF8330', 'A66000', 'FFAE40', 'FFC473', 'FFC000', 'BF9C30', 'A67D00', 'FFD040', 'FFDD73', 'FF4C00', 'BF5B30', 'A63100', 'FF7940', 'FF9D73']),
+    construct_scheme_analogous('Lava', '#232323', ['#FF9400', '#BF8330', '#A66000', '#FFAE40', '#FFC473', '#FFC000', '#BF9C30', '#A67D00', '#FFD040', '#FFDD73', '#FF4C00', '#BF5B30', '#A63100', '#FF7940', '#FF9D73']),
 
-    construct_scheme_analogous('Seaweed', '#232323', ['00BF32', '248F40', '007C21', '38DF64', '64DF85', '04819E', '206676', '015367', '38B2CE', '60B9CE', '8EEB00', '7CB02C', '5C9900', 'ACF53D', 'C0F56E']),
+    construct_scheme_analogous('Seaweed', '#232323', ['#00BF32', '#248F40', '#007C21', '#38DF64', '#64DF85', '#04819E', '#206676', '#015367', '#38B2CE', '#60B9CE', '#8EEB00', '#7CB02C', '#5C9900', '#ACF53D', '#C0F56E']),
 
-    construct_scheme_triad('Fairground', '#003', ['0772A1', '225E79', '024A68', '3BA3D0', '63AFD0', 'D9005B', 'A3295C', '8D003B', 'EC3B86', 'EC6AA1', 'FFE100', 'BFAE30', 'A69200', 'FFE840', 'FFEE73']),
+    construct_scheme_triad('Fairground', '#003', ['#0772A1', '#225E79', '#024A68', '#3BA3D0', '#63AFD0', '#D9005B', '#A3295C', '#8D003B', '#EC3B86', '#EC6AA1', '#FFE100', '#BFAE30', '#A69200', '#FFE840', '#FFEE73']),
 
-    construct_scheme_complementary('Bay Cruise', 'black', ['009999', '1D7373', '006363', '33CCCC', '5CCCCC', 'FF7400', 'BF7130', 'A64B00', 'FF9640', 'FFB273']),
+    construct_scheme_complementary('Bay Cruise', 'black', ['#009999', '#1D7373', '#006363', '#33CCCC', '#5CCCCC', '#FF7400', '#BF7130', '#A64B00', '#FF9640', '#FFB273']),
 
 {
     'name': 'Old School',
     'preferred_background': 'black',
 
-    colors: ['00FF00', '30BE30', '00A400', '44FF44', '7BFF7B', 'FF0000', 'BE3030', 'A40000', 'FF7B7B', '777777', 'CCCCCC'],
+    colors: ['#00FF00', '#30BE30', '#00A400', '#44FF44', '#7BFF7B', '#FF0000', '#BE3030', '#A40000', '#FF7B7B', '#777777', '#CCCCCC'],
 
-    autosuggestion: '777777',
-    command: '00FF00',
-    comment: '30BE30',
-    end: 'FF7B7B',
-    error: 'A40000',
-    param: '30BE30',
-    quote: '44FF44',
-    redirection: '7BFF7B'
+    autosuggestion: '#777777',
+    command: '#00FF00',
+    comment: '#30BE30',
+    end: '#FF7B7B',
+    error: '#A40000',
+    param: '#30BE30',
+    quote: '#44FF44',
+    redirection: '#7BFF7B'
 },
 
 {
     'name': 'Just a Touch',
     'preferred_background': 'black',
 
-    colors: ['B0B0B0', '969696', '789276', 'F4F4F4', 'A0A0F0', '666A80', 'F0F0F0', 'D7D7D7', 'B7B7B7', 'FFA779', 'FAFAFA'],
+    colors: ['#B0B0B0', '#969696', '#789276', '#F4F4F4', '#A0A0F0', '#666A80', '#F0F0F0', '#D7D7D7', '#B7B7B7', '#FFA779', '#FAFAFA'],
 
-    autosuggestion: '9C9C9C',
-    command: 'F4F4F4',
-    comment: 'B0B0B0',
-    end: '969696',
-    error: 'FFA779',
-    param: 'A0A0F0',
-    quote: '666A80',
-    redirection: 'FAFAFA'
+    autosuggestion: '#9C9C9C',
+    command: '#F4F4F4',
+    comment: '#B0B0B0',
+    end: '#969696',
+    error: '#FFA779',
+    param: '#A0A0F0',
+    quote: '#666A80',
+    redirection: '#FAFAFA'
 },
 
 {
     'name': 'Dracula',
     'preferred_background': '#282a36',
 
-    colors: ['282A36', '44475A', '44475A', 'F8F8F2', '6272A4', '8BE9FD', '50FA7B', 'FFB86C', 'FF79C6', 'BD93F9', 'FF5555', 'F1FA8C'],
+    colors: ['#282A36', '#44475A', '#44475A', '#F8F8F2', '#6272A4', '#8BE9FD', '#50FA7B', '#FFB86C', '#FF79C6', '#BD93F9', '#FF5555', '#F1FA8C'],
 
-    autosuggestion: 'BD93F9',
-    command: 'F8F8F2',
-    comment: '6272A4',
-    end: '50FA7B',
-    error: 'FFB86C',
-    param: 'FF79C6',
-    quote: 'F1FA8C',
-    redirection: '8BE9FD'
+    autosuggestion: '#BD93F9',
+    command: '#F8F8F2',
+    comment: '#6272A4',
+    end: '#50FA7B',
+    error: '#FFB86C',
+    param: '#FF79C6',
+    quote: '#F1FA8C',
+    redirection: '#8BE9FD'
 },
 
 construct_color_scheme_mono('Mono Lace', 'white', false),

--- a/share/tools/web_config/js/colorutils.js
+++ b/share/tools/web_config/js/colorutils.js
@@ -81,8 +81,8 @@ function adjust_lightness(color_str, func) {
     }
 
     /* More hacks */
-    if (color_str == 'black') color_str = '#000000';
-    if (color_str == 'white') color_str = '#c0c0c0';
+    if (color_str == 'black') color_str = '000000';
+    if (color_str == 'white') color_str = 'c0c0c0';
 
 
     rgb = parseInt(color_str, 16)

--- a/share/tools/web_config/js/controllers.js
+++ b/share/tools/web_config/js/controllers.js
@@ -74,7 +74,7 @@ controllers.controller("colorsController", function($scope, $http) {
         $scope.noteThemeChanged();
     }
 
-    $scope.sampleTerminalBackgroundColors = ['white', '#' + solarized.base3, '#300', '#003', '#' + solarized.base03, '#232323', '#'+nord.nord0, 'black'];
+    $scope.sampleTerminalBackgroundColors = ['white', solarized.base3, '#300', '#003', solarized.base03, '#232323', nord.nord0, 'black'];
 
     /* Array of FishColorSchemes */
     $scope.colorSchemes = [color_scheme_fish_default, color_scheme_solarized_light, color_scheme_solarized_dark, color_scheme_tomorrow, color_scheme_tomorrow_night, color_scheme_tomorrow_night_bright, color_scheme_nord, color_scheme_base16_default_dark, color_scheme_base16_default_light, color_scheme_base16_eighties];
@@ -140,6 +140,11 @@ controllers.controller("colorsController", function($scope, $http) {
             } else {
                 selected = $scope.selectedColorScheme[name];
             }
+
+            if (selected.startsWith('#')) {
+                selected = selected.substring(1);
+            }
+
             var postData = "what=" + name + "&color=" + selected + "&background_color=&bold=&underline=&dim=&reverse=&italics=";
             $http.post("set_color/", postData, { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }).success(function(data, status, headers, config) {
             	if (status == 200) {


### PR DESCRIPTION
## Description

### Summary

Fix missing colors in `fish_config`'s customization palette.

### Details

The colors defined in `colorutils.js` lack the leading
`#` character and do not fully follow the html/css spec
(https://www.w3.org/TR/css-color-4/#typedef-hex-color).

While this (somehow) works for the most part, a few
colors get lost along the way and do not display in
the customization selector nor in the preview when
selected.

To fix this, let's prepend the missing `#` character
to all colors defined in `colorutils` and adjust a
few other places that were already doing that (as to
avoid doubling up the '#'s).

### Examples

#### Before

Solarized - 3rd color missing:
![image](https://user-images.githubusercontent.com/369946/84609218-ec278200-ae6a-11ea-8b60-636c82d2a155.png)

Fish Default - One missing in each of the two bottom rows:
![image](https://user-images.githubusercontent.com/369946/84609297-43c5ed80-ae6b-11ea-86a9-f1d47299af5a.png)

#### After

Solarized:
![image](https://user-images.githubusercontent.com/369946/84609321-6a842400-ae6b-11ea-92c4-e554b92a4c66.png)

Fish Default:
![image](https://user-images.githubusercontent.com/369946/84609332-7bcd3080-ae6b-11ea-9ded-bf3efd22200c.png)


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
