### PR TITLE
Add fc(1posix) - process the command history list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Notable improvements and fixes
 Syntax changes and new commands
 -------------------------------
 
+- New command ``fc`` to process the command history list.
+
 Scripting improvements
 ----------------------
 

--- a/share/functions/fc.fish
+++ b/share/functions/fc.fish
@@ -1,0 +1,52 @@
+function fc --description 'Edit the command history list in an external editor'
+    set -l f (mktemp)
+    if set -q f[1]
+        mv $f $f.fish
+        set f $f.fish
+    else
+        # We should never execute this block but better to be paranoid.
+        if set -q TMPDIR
+            set f $TMPDIR/fish.$fish_pid.fish
+        else
+            set f /tmp/fish.$fish_pid.fish
+        end
+        touch $f
+        or return 1
+    end
+
+    # Edit the command line with the users preferred editor or vim or emacs.
+    set -l editor
+    if set -q VISUAL
+        echo $VISUAL | read -at editor
+    else if set -q EDITOR
+        echo $EDITOR | read -at editor
+    else
+        echo
+        echo (_ 'External editor requested but $VISUAL or $EDITOR not set.')
+        echo (_ 'Please set VISUAL or EDITOR to your preferred editor.')
+        commandline -f repaint
+        return 1
+    end
+
+    string join \n $history[(math -$argv[2])..(math -$argv[1])] >$f
+    __fish_disable_bracketed_paste
+    $editor $f
+    set -l editor_status $status
+    __fish_enable_bracketed_paste
+
+    # Here we're checking the exit status of the editor.
+    if test $editor_status -eq 0 -a -s $f
+        # Set the command to the output of the edited command and move the cursor to the
+        # end of the edited command.
+        commandline -r -- (cat $f)
+        commandline -C 999999
+    else
+        echo
+        echo (_ "Ignoring the output of your editor since its exit status was non-zero")
+        echo (_ "or the file was empty")
+    end
+    command rm $f
+    # We've probably opened something that messed with the screen.
+    # A repaint seems in order.
+    commandline -f repaint
+end


### PR DESCRIPTION
## Description

This is useful to combine and rerun several commands.
For example having the last 4 commands in $history:

$ string join \n $history[1..4]
./test
git clean -dfx
ls
make

$ fc -4 -1

opens an editor where you can drop the ls, maybe move the git command to
the start, join all lines with '; and' and save. Now the prompt contains
one command, ready to be executed.

Note that the numbering is inverted to $history to comply with POSIX.

The implementation is based on share/functions/edit_command_buffer.fish.

fc is specified by POSIX in

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fc.html

For now only the first and last options are implemented.

Fixes #5030

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
