### PR TITLE
Migrate ll and la function.

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -42,6 +42,9 @@ if status --is-interactive
         set -q fish_term24bit
         or set -g fish_term24bit 1
     end
+
+    abbr --add --global ll ls -lh
+    abbr --add --global la ls -lah
 else
     # Hook up the default as the principal command_not_found handler
     # in case we are not interactive

--- a/share/functions/la.fish
+++ b/share/functions/la.fish
@@ -1,7 +1,0 @@
-#
-# These are very common and useful
-#
-function la --description "List contents of directory, including hidden files in directory using long format"
-    ls -lah $argv
-end
-

--- a/share/functions/ll.fish
+++ b/share/functions/ll.fish
@@ -1,6 +1,0 @@
-#
-# These are very common and useful
-#
-function ll --description "List contents of directory using long format"
-    ls -lh $argv
-end


### PR DESCRIPTION
Migrate ll and la function to use abbr. In this case it's better we
don't need to do anything special with argv. Use the global scope to be
faster.