### PR TITLE
Fix redirection in `adb shell`

### DIFF
--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -49,7 +49,7 @@ function __fish_adb_run_command -d 'Runs adb with any -s parameters already give
 end
 
 function __fish_adb_list_packages
-    __fish_adb_run_command pm list packages 2>/dev/null | string replace 'package:' ''
+    __fish_adb_run_command pm list packages 2\>/dev/null | string replace 'package:' ''
 end
 
 
@@ -67,9 +67,9 @@ function __fish_adb_list_files
     end
 
     # Return list of directories suffixed with '/'
-    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type d 2>/dev/null | awk '{print $1"/"}'
+    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type d 2\>/dev/null | awk '{print $1"/"}'
     # Return list of files
-    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type f 2>/dev/null
+    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type f 2\>/dev/null
 end
 
 


### PR DESCRIPTION
`adb shell` by default sends stderr from the executed command to stdout, so that `adb pull nonexistent<TAB>` will complete the path using the error message from the `find` command: `adb pull find:\ nonexistent\*:\ No\ such\ file\ or\ directory`. If `>` is escaped, so that redirection is done inside the command executed by `adb shell`, no completion will be shown, as expected.