### PR TITLE
Uncomment most recent comment if commandline is empty when using toggle comment binding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,6 +93,8 @@ New or improved bindings
 -  ``__fish_prepend_sudo`` (Alt-S) now toggles a ``sudo`` prefix (#7012).
 -  ``__fish_prepend_sudo`` (Alt-S) now uses the previous commandline if the current one is empty,
    to simplify rerunning the previous command with ``sudo`` (#7079).
+- ``__fish_toggle_comment_commandline`` (Alt-#) now uncomments and presents the last comment
+  from history if the commandline is empty (#7137).
 
 Improved prompts
 ^^^^^^^^^^^^^^^^

--- a/share/functions/__fish_toggle_comment_commandline.fish
+++ b/share/functions/__fish_toggle_comment_commandline.fish
@@ -4,12 +4,13 @@
 # retrieving the command from the shell history and removing the comment chars.
 #
 # This deliberately does not execute the command when removing the comment characters to give you an
-# opportunity to modify the command.
+# opportunity to modify the command. Also if the commandline is empty, the most recently commented
+# out history item is uncommented and presented.
 
 function __fish_toggle_comment_commandline --description 'Comment/uncomment the current command'
     set -l cmdlines (commandline -b)
     if test "$cmdlines" = ""
-        return
+        set cmdlines (history search -p "#" -z | read -z)
     end
     set -l cmdlines (printf '%s\n' '#'$cmdlines | string replace -r '^##' '')
     commandline -r $cmdlines

--- a/share/functions/__fish_toggle_comment_commandline.fish
+++ b/share/functions/__fish_toggle_comment_commandline.fish
@@ -10,7 +10,7 @@
 function __fish_toggle_comment_commandline --description 'Comment/uncomment the current command'
     set -l cmdlines (commandline -b)
     if test "$cmdlines" = ""
-        set cmdlines (history search -p "#" -z | read -z)
+        history search -p "#" -z | read -z cmdlines
     end
     set -l cmdlines (printf '%s\n' '#'$cmdlines | string replace -r '^##' '')
     commandline -r $cmdlines


### PR DESCRIPTION
## Description

The current behaviour of `__fish_toggle_comment_commandline` function (bound to `Alt+#`) is to do nothing if the command line is empty. This PR recalls the last comment and uncomments it instead if the command line is empty. This can be achieved by hitting '#' and 'Up', but it feels too clunky IMO and the first suggestion might not be what you want if an innocent `#` appeared in a previous command.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] User-visible changes noted in CHANGELOG.rst
