### PR TITLE
Fix paste-o that duplicated documentation header.

### DIFF
--- a/doc_src/cmds/fish_is_root_user.rst
+++ b/doc_src/cmds/fish_is_root_user.rst
@@ -1,4 +1,4 @@
-.. _cmd-fg:
+.. _cmd-fish_is_root_user:
 
 fish_is_root_user - check if the current user is root
 =====================================================


### PR DESCRIPTION
## Description

Copy and paste left the documentation header for `fg` intact on the new `fish_is_root_user`. This resulted in a build warning and most likely incorrect docs. Update header to resolve warning and produce likely correct docs.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
