### PR TITLE
docs/jobs: Header is stripped in command substitution

### DIFF
--- a/doc_src/cmds/jobs.rst
+++ b/doc_src/cmds/jobs.rst
@@ -30,6 +30,8 @@ jobs accepts the following switches:
 
 On systems that supports this feature, jobs will print the CPU usage of each job since the last command was executed. The CPU usage is expressed as a percentage of full CPU activity. Note that on multiprocessor systems, the total activity may be more than 100\%.
 
+If used inside a command substitution, the column header that is usually printed is ommitted, making the output easier to parse.
+
 The exit status of ``jobs`` is ``0`` if there are running background jobs and ``1`` otherwise.
 
 no output.


### PR DESCRIPTION
## Description

If the `jobs` builtin is used inside a command substitution, the column headers are stripped and this wasn't documented in the man page:

```fish
> sleep 30 &
> jobs
Job     Group   CPU     State   Command
1       20538   0%      running sleep 30 &
> echo (jobs)
1       20538   0%      running sleep 30 &
```
