### PR TITLE
Disown PIDs as well as PGIDs

### DIFF
--- a/src/builtin_disown.cpp
+++ b/src/builtin_disown.cpp
@@ -36,7 +36,7 @@ static int disown_job(const wchar_t *cmd, parser_t &parser, io_streams_t &stream
     // within the context of a subjob which will cause the parent job to crash in exec_job().
     // Instead, we set a flag and the parser removes the job from the jobs list later.
     j->mut_flags().disown_requested = true;
-    if (pgid) add_disowned_pgid(*pgid);
+    add_disowned_job(j);
 
     return STATUS_CMD_OK;
 }

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -341,7 +341,11 @@ static void reap_disowned_pids() {
     auto disowned_pids = s_disowned_pids.acquire();
     auto try_reap1 = [](pid_t pid) {
         int status;
-        return waitpid(pid, &status, WNOHANG) > 0;
+        int ret = waitpid(pid, &status, WNOHANG) > 0;
+        if (ret) {
+            FLOGF(proc_reap_external, "Reaped disowned PID or PGID %d", pid);
+        }
+        return ret;
     };
     disowned_pids->erase(std::remove_if(disowned_pids->begin(), disowned_pids->end(), try_reap1),
                          disowned_pids->end());

--- a/src/proc.h
+++ b/src/proc.h
@@ -551,9 +551,9 @@ void hup_jobs(const job_list_t &jobs);
 /// \return 1 if transferred, 0 if no transfer was necessary, -1 on error.
 int terminal_maybe_give_to_job_group(const job_group_t *jg, bool continuing_from_stopped);
 
-/// Add a pid to the list of pids we wait on even though they are not associated with any jobs.
-/// Used to avoid zombie processes after disown.
-void add_disowned_pgid(pid_t pgid);
+/// Add a job to the list of PIDs/PGIDs we wait on even though they are not associated with any
+/// jobs. Used to avoid zombie processes after disown.
+void add_disowned_job(job_t *j);
 
 bool have_proc_stat();
 


### PR DESCRIPTION
This series addresses the findings in #7183, where jobs started in the same PGID                                                
as fish (ie in non-job-control mode) are disowned but not waited on, creating                                                   
zombie processes.                                                                                                              
                                                                                                                                
All PIDs of a job's processes are added to the disown list and waited on (or                         
removed when they become invalid). However, this does also lead to both the PGID                                               
and PIDs for some jobs being added to the list, which might be unnecessary   
duplication. Comments are appreciated.                                  
                                                                                                                                
I think this probably needs tests, but I'm not sure what the best approach would
be.                                                                                  
                                                                                                            
Fixes #7183.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
