### PR TITLE
Show one-line descriptions for functions and builtins using Alt-W

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -96,6 +96,7 @@ New or improved bindings
    to simplify rerunning the previous command with ``sudo`` (#7079).
 - ``__fish_toggle_comment_commandline`` (Alt-#) now uncomments and presents the last comment
   from history if the commandline is empty (#7137).
+- ``__fish_whatis_current_token`` (Alt-W) prints descriptions for functions and builtins (#7191)
 
 Improved prompts
 ^^^^^^^^^^^^^^^^

--- a/share/functions/__fish_whatis_current_token.fish
+++ b/share/functions/__fish_whatis_current_token.fish
@@ -3,39 +3,40 @@
 function __fish_whatis_current_token -d "Show man page entries or function description related to the token under the cursor"
     set -l token (commandline -pt)
 
-    if test -n "$token"
-        printf "\n"
-        set -l desc "$token: nothing appropriate."
+    test -n "$token"
+    or return
 
-        set -l tokentype (type --type $token 2>/dev/null)
+    printf "\n"
+    set -l desc "$token: nothing appropriate."
 
-        switch "$tokentype"
-            case "function"
-                set -l funcinfo (functions $token --details --verbose)
+    set -l tokentype (type --type $token 2>/dev/null)
 
-                test $funcinfo[5] != "n/a"
-                and set desc "$token - $funcinfo[5]"
+    switch "$tokentype"
+        case "function"
+            set -l funcinfo (functions $token --details --verbose)
 
-            case "builtin"
-                set desc (__fish_print_help $token | awk "/^$token /{print; exit}")
+            test $funcinfo[5] != "n/a"
+            and set desc "$token - $funcinfo[5]"
 
-            case "file"
-                set -l tmpdesc (whatis $token 2>/dev/null)
-                and set desc $tmpdesc
-        end
+        case "builtin"
+            set desc (__fish_print_help $token | awk "/^$token /{print; exit}")
 
-        printf "%s\n" $desc
-
-        set -l line_count (count (fish_prompt))
-        # Ensure line_count is greater than one to accomodate different
-        # versions of the `seq` command, some of which print the sequence in
-        # reverse order when the second argument is smaller than the first
-        if test $line_count -gt 1
-            for x in (seq 2 $line_count)
-                printf "\n"
-            end
-        end
-
-        commandline -f repaint
+        case "file"
+            set -l tmpdesc (whatis $token 2>/dev/null)
+            and set desc $tmpdesc
     end
+
+    printf "%s\n" $desc
+
+    set -l line_count (count (fish_prompt))
+    # Ensure line_count is greater than one to accomodate different
+    # versions of the `seq` command, some of which print the sequence in
+    # reverse order when the second argument is smaller than the first
+    if test $line_count -gt 1
+        for x in (seq 2 $line_count)
+            printf "\n"
+        end
+    end
+
+    commandline -f repaint
 end

--- a/share/functions/__fish_whatis_current_token.fish
+++ b/share/functions/__fish_whatis_current_token.fish
@@ -5,21 +5,23 @@ function __fish_whatis_current_token -d "Show man page entries or function descr
 
     if test -n "$token"
         printf "\n"
-        whatis $token 2>/dev/null
+        set -l desc "$token: nothing appropriate."
 
-        if test $status -eq 16 # no match found
-            set -l tokentype (type --type $token 2>/dev/null)
-            set -l desc ": nothing appropriate."
+        set -l tokentype (type --type $token 2>/dev/null)
 
-            if test "$tokentype" = "function"
+        switch "$tokentype"
+            case "function"
                 set -l funcinfo (functions $token --details --verbose)
 
                 test $funcinfo[5] != "n/a"
-                and set desc " - $funcinfo[5]"
-            end
+                and set desc "$token - $funcinfo[5]"
 
-            printf "%s%s\n" $token $desc
+            case "file"
+                set -l tmpdesc (whatis $token 2>/dev/null)
+                and set desc $tmpdesc
         end
+
+        printf "%s\n" $desc
 
         set -l line_count (count (fish_prompt))
         # Ensure line_count is greater than one to accomodate different

--- a/share/functions/__fish_whatis_current_token.fish
+++ b/share/functions/__fish_whatis_current_token.fish
@@ -16,6 +16,9 @@ function __fish_whatis_current_token -d "Show man page entries or function descr
                 test $funcinfo[5] != "n/a"
                 and set desc "$token - $funcinfo[5]"
 
+            case "builtin"
+                set desc (__fish_print_help $token | awk "/^$token /{print; exit}")
+
             case "file"
                 set -l tmpdesc (whatis $token 2>/dev/null)
                 and set desc $tmpdesc

--- a/share/functions/__fish_whatis_current_token.fish
+++ b/share/functions/__fish_whatis_current_token.fish
@@ -1,11 +1,25 @@
 # This function is typically bound to Alt-W, it is used to list man page entries
 # for the command under the cursor.
-function __fish_whatis_current_token -d "Show man page entries related to the token under the cursor"
-    set -l tok (commandline -pt)
+function __fish_whatis_current_token -d "Show man page entries or function description related to the token under the cursor"
+    set -l token (commandline -pt)
 
-    if test -n "$tok[1]"
+    if test -n "$token"
         printf "\n"
-        whatis $tok[1]
+        whatis $token 2>/dev/null
+
+        if test $status -eq 16 # no match found
+            set -l tokentype (type --type $token 2>/dev/null)
+            set -l desc ": nothing appropriate."
+
+            if test "$tokentype" = "function"
+                set -l funcinfo (functions $token --details --verbose)
+
+                test $funcinfo[5] != "n/a"
+                and set desc " - $funcinfo[5]"
+            end
+
+            printf "%s%s\n" $token $desc
+        end
 
         set -l line_count (count (fish_prompt))
         # Ensure line_count is greater than one to accomodate different


### PR DESCRIPTION
## Description

`__fish_whatis_current_token` (bound to `Alt-W` by default) currently prints information only for commands, using `whatis`. This PR aims to print information for builtins, functions (description specified with `-d`) and aliases in addition to the current implementation.

Even though man pages exist for builtins (and certain functions like `funced`), they aren't show by `whatis` because it isn't in $MANPATH (`man` works despite this by being overridden by a function; see `functions man`)

Closes #2083

## TODO

- [x] Print desciptions for:
    - [x] Builtins
    - [x] Functions (and aliases)
- [x] User-visible changes noted in CHANGELOG.rst
