### PR TITLE
Human readable file sizes when ls -l is used instead of ll

### DIFF
--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -39,6 +39,6 @@ function ls --description "List contents of directory"
     __fish_set_lscolors
 
     isatty stdout
-    and set -a opt -F
+    and set -a opt -Fh
     command ls $__fish_ls_color_opt $argv
 end


### PR DESCRIPTION
## Description

Adding the `-h` option in the `ls` function means that `ls -l` outputs human-readable file sizes like `ll`

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
I'm unsure as to exactly what I need to do:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
