### PR TITLE
completions/unzip: Restrict filename suggestions to .zip files only

### DIFF
--- a/share/completions/unzip.fish
+++ b/share/completions/unzip.fish
@@ -1,3 +1,5 @@
+complete -c unzip -x -a "(__fish_complete_suffix .zip)"
+
 complete -c unzip -s p -d "extract files to pipe, no messages"
 complete -c unzip -s f -d "freshen existing files, create none"
 complete -c unzip -s u -d "update files, create if necessary"


### PR DESCRIPTION
## Description

This PR changes `unzip` completions to suggest only filenames ending with `.zip`, like how `gunzip` and `bunzip2` completions currently do for their respective files.
