### PR TITLE
Add forward-single-char input command

### DIFF
--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -132,6 +132,8 @@ The following special input functions are available:
 
 - ``forward-char``, move one character to the right
 
+- ``forward-single-char``, move one character to the right; if an autosuggestion is available, only take a single char from it
+
 - ``forward-word``, move one word to the right
 
 - ``history-search-backward``, search the history for the previous match

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -162,6 +162,8 @@ The following special input functions are available:
 
 - ``kill-word``, move the next word to the killring
 
+- ``or``, only execute the next function if the previous succeeded (note: only some functions report success)
+
 - ``pager-toggle-search``, toggles the search field if the completions pager is visible.
 
 - ``repaint``, reexecutes the prompt functions and redraws the prompt. Multiple successive repaints are coalesced.

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -74,7 +74,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert \r execute
     bind -s --preset -m insert i repaint-mode
     bind -s --preset -m insert I beginning-of-line repaint-mode
-    bind -s --preset -m insert a forward-char repaint-mode
+    bind -s --preset -m insert a forward-single-char repaint-mode
     bind -s --preset -m insert A end-of-line repaint-mode
     bind -s --preset -m visual v begin-selection repaint-mode
 
@@ -103,9 +103,9 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset B backward-bigword
     bind -s --preset ge backward-word
     bind -s --preset gE backward-bigword
-    bind -s --preset w forward-word forward-char
-    bind -s --preset W forward-bigword forward-char
-    bind -s --preset e forward-char forward-word backward-char
+    bind -s --preset w forward-word forward-single-char
+    bind -s --preset W forward-bigword forward-single-char
+    bind -s --preset e forward-single-char forward-word backward-char
     bind -s --preset E forward-bigword backward-char
 
     # OS X SnowLeopard doesn't have these keys. Don't show an annoying error message.
@@ -118,10 +118,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # Vi moves the cursor back if, after deleting, it is at EOL.
     # To emulate that, move forward, then backward, which will be a NOP
     # if there is something to move forward to.
-    bind -s --preset -M default x delete-char forward-char backward-char
+    bind -s --preset -M default x delete-char forward-single-char backward-char
     bind -s --preset -M default X backward-delete-char
-    bind -s --preset -M insert -k dc delete-char forward-char backward-char
-    bind -s --preset -M default -k dc delete-char forward-char backward-char
+    bind -s --preset -M insert -k dc delete-char forward-single-char backward-char
+    bind -s --preset -M default -k dc delete-char forward-single-char backward-char
 
     # Backspace deletes a char in insert mode, but not in normal/default mode.
     bind -s --preset -M insert -k backspace backward-delete-char
@@ -140,10 +140,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset d0 backward-kill-line
     bind -s --preset dw kill-word
     bind -s --preset dW kill-bigword
-    bind -s --preset diw forward-char forward-char backward-word kill-word
-    bind -s --preset diW forward-char forward-char backward-bigword kill-bigword
-    bind -s --preset daw forward-char forward-char backward-word kill-word
-    bind -s --preset daW forward-char forward-char backward-bigword kill-bigword
+    bind -s --preset diw forward-single-char forward-single-char backward-word kill-word
+    bind -s --preset diW forward-single-char forward-single-char backward-bigword kill-bigword
+    bind -s --preset daw forward-single-char forward-single-char backward-word kill-word
+    bind -s --preset daW forward-single-char forward-single-char backward-bigword kill-bigword
     bind -s --preset de kill-word
     bind -s --preset dE kill-bigword
     bind -s --preset db backward-kill-word
@@ -153,7 +153,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset df begin-selection forward-jump kill-selection end-selection
     bind -s --preset dt begin-selection forward-jump backward-char kill-selection end-selection
     bind -s --preset dF begin-selection backward-jump kill-selection end-selection
-    bind -s --preset dT begin-selection backward-jump forward-char kill-selection end-selection
+    bind -s --preset dT begin-selection backward-jump forward-single-char kill-selection end-selection
     bind -s --preset dh backward-char delete-char
     bind -s --preset dl delete-char
     bind -s --preset di backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection
@@ -168,10 +168,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert c0 backward-kill-line repaint-mode
     bind -s --preset -m insert cw kill-word repaint-mode
     bind -s --preset -m insert cW kill-bigword repaint-mode
-    bind -s --preset -m insert ciw forward-char forward-char backward-word kill-word repaint-mode
-    bind -s --preset -m insert ciW forward-char forward-char backward-bigword kill-bigword repaint-mode
-    bind -s --preset -m insert caw forward-char forward-char backward-word kill-word repaint-mode
-    bind -s --preset -m insert caW forward-char forward-char backward-bigword kill-bigword repaint-mode
+    bind -s --preset -m insert ciw forward-single-char forward-single-char backward-word kill-word repaint-mode
+    bind -s --preset -m insert ciW forward-single-char forward-single-char backward-bigword kill-bigword repaint-mode
+    bind -s --preset -m insert caw forward-single-char forward-single-char backward-word kill-word repaint-mode
+    bind -s --preset -m insert caW forward-single-char forward-single-char backward-bigword kill-bigword repaint-mode
     bind -s --preset -m insert ce kill-word repaint-mode
     bind -s --preset -m insert cE kill-bigword repaint-mode
     bind -s --preset -m insert cb backward-kill-word repaint-mode
@@ -181,13 +181,13 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert cf begin-selection forward-jump kill-selection end-selection repaint-mode
     bind -s --preset -m insert ct begin-selection forward-jump backward-char kill-selection end-selection repaint-mode
     bind -s --preset -m insert cF begin-selection backward-jump kill-selection end-selection repaint-mode
-    bind -s --preset -m insert cT begin-selection backward-jump forward-char kill-selection end-selection repaint-mode
+    bind -s --preset -m insert cT begin-selection backward-jump forward-single-char kill-selection end-selection repaint-mode
     bind -s --preset -m insert ch backward-char begin-selection kill-selection end-selection repaint-mode
     bind -s --preset -m insert cl begin-selection kill-selection end-selection repaint-mode
     bind -s --preset -m insert ci backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection repaint-mode
     bind -s --preset -m insert ca backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection repaint-mode
 
-    bind -s --preset '~' togglecase-char forward-char
+    bind -s --preset '~' togglecase-char forward-single-char
     bind -s --preset gu downcase-word
     bind -s --preset gU upcase-word
 
@@ -201,10 +201,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset y0 backward-kill-line yank
     bind -s --preset yw kill-word yank
     bind -s --preset yW kill-bigword yank
-    bind -s --preset yiw forward-char forward-char backward-word kill-word yank
-    bind -s --preset yiW forward-char forward-char backward-bigword kill-bigword yank
-    bind -s --preset yaw forward-char forward-char backward-word kill-word yank
-    bind -s --preset yaW forward-char forward-char backward-bigword kill-bigword yank
+    bind -s --preset yiw forward-single-char forward-single-char backward-word kill-word yank
+    bind -s --preset yiW forward-single-char forward-single-char backward-bigword kill-bigword yank
+    bind -s --preset yaw forward-single-char forward-single-char backward-word kill-word yank
+    bind -s --preset yaW forward-single-char forward-single-char backward-bigword kill-bigword yank
     bind -s --preset ye kill-word yank
     bind -s --preset yE kill-bigword yank
     bind -s --preset yb backward-kill-word yank

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -89,6 +89,7 @@ static const input_function_metadata_t input_function_metadata[] = {
     {readline_cmd_t::end_of_line, L"end-of-line"},
     {readline_cmd_t::forward_char, L"forward-char"},
     {readline_cmd_t::backward_char, L"backward-char"},
+    {readline_cmd_t::forward_single_char, L"forward-single-char"},
     {readline_cmd_t::forward_word, L"forward-word"},
     {readline_cmd_t::backward_word, L"backward-word"},
     {readline_cmd_t::forward_bigword, L"forward-bigword"},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -14,6 +14,7 @@ enum class readline_cmd_t {
     end_of_line,
     forward_char,
     backward_char,
+    forward_single_char,
     forward_word,
     backward_word,
     forward_bigword,

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -69,6 +69,7 @@ enum class readline_cmd_t {
     forward_jump_till,
     backward_jump_till,
     func_and,
+    func_or,
     expand_abbr,
     delete_or_exit,
     cancel_commandline,

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -3532,6 +3532,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             // Some commands should have been handled internally by inputter_t::readch().
         case rl::self_insert:
         case rl::self_insert_notfirst:
+        case rl::func_or:
         case rl::func_and: {
             DIE("should have been handled by inputter_t::readch");
         }


### PR DESCRIPTION
Resolves #4984

## Description

There are two ways to solve the above issue: **change forward-char to only autocomplete one character** or **add a new input function that autocompletes one character**.

Downsides of changing forward-char:

- Changes existing behavior, which might annoy users.
- While power users may or may not know to use the `end` key to get the previous behavior, naive users will typically keep the right arrow pressed, which is a slight disruption to their workflow.

Downsides of adding an input function:

- Makes code slightly more complicated (one more function which has to be propagated through all keybindings files), in a way that is neither fundamental nor orthogonal.
- Some code ends up copy-pasted with subtle differences.
- Breaks symmetry in the code (eg readers might wonder "why isn't there a `backward-single-char` command?").

Downsides of the status quo (eg why I want this feature):

- I often find myself in a situation where I want to keep only the first few characters of a line auto-completion is giving me, without doing a word jump; for instance, I'm looking for `somecommand some/path` and fish is suggesting `somecommand someverylongsinglewordpath`. In these cases, being able to pick only the part of the auto-completion that interests me would be a boon.

Ultimately, which solution we pick is a matter of philosophy. I implemented the first one (forward-char doesn't autocomplete everything), which I personally prefer because it better fits a natural progression with other keybindings: **right-arrow** autocompletes a character, **ctrl+right-arrow** autocompletes a word, **end** autocompletes the entire line.

Pulling from fish's design page:

> Fish should be user friendly, but not at the expense of expressiveness. Most tradeoffs between power and ease of use can be avoided with careful design.

I think repurposing forward-char is more expressive. Naive users may not know how to use the more advanced binding (`end` key), but that can be mitigated with good documentation and changelog notes.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
