### PR TITLE
vi-keybingings: Add missing abbr triggers for command terminators

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -54,11 +54,19 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M insert \n execute
 
     bind -s --preset -M insert "" self-insert
-    # Space expands abbrs _and_ inserts itself.
+
+    # Space and other command terminators expand abbrs _and_ inserts itself.
     bind -s --preset -M insert " " self-insert expand-abbr
-    bind --preset $argv ")" self-insert expand-abbr
+    bind -s --preset -M insert ";" self-insert expand-abbr
+    bind -s --preset -M insert "|" self-insert expand-abbr
+    bind -s --preset -M insert "&" self-insert expand-abbr
+    bind -s --preset -M insert "^" self-insert expand-abbr
+    bind -s --preset -M insert ">" self-insert expand-abbr
+    bind -s --preset -M insert "<" self-insert expand-abbr
+    # Closing a command substitution expands abbreviations
+    bind -s --preset -M insert ")" self-insert expand-abbr
     # Ctrl-space inserts space without expanding abbrs
-    bind -k nul 'commandline -i " "'
+    bind -s --preset -M insert -k nul 'commandline -i " "'
 
     # Add a way to switch from insert to normal (command) mode.
     # Note if we are paging, we want to stay in insert mode


### PR DESCRIPTION
## Description

Abbr expansion on command terminators were added back in ec74c739 in response to #6970, but vi mode was not updated.
