### PR TITLE
Update `k3d` completions

### DIFF
--- a/share/completions/k3d.fish
+++ b/share/completions/k3d.fish
@@ -8,15 +8,11 @@ function __fish_k3d_no_subcommand --description 'Test if k3d has yet to be given
 end
 
 function __fish_k3d_print_clusters --description 'Print a list of k3d clusters'
-    for key in (k3d cluster list --no-headers | awk '{print $1}')
-        echo $key
-    end
+    k3d cluster list --no-headers | awk '{print $1}'
 end
 
 function __fish_k3d_print_nodes --description 'Print a list of k3d nodes'
-    for key in (k3d node list --no-headers | awk '{print $1}')
-        echo $key
-    end
+    k3d node list --no-headers | awk '{print $1}'
 end
 
 complete -f -c k3d -n '__fish_k3d_no_subcommand' -s h -l help -d "More information about a command"
@@ -32,9 +28,7 @@ complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -a list -d "List clu
 complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -a delete -d "Delete cluster(s)"
 complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -a start -d "Start existing k3d cluster(s)"
 complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -a stop -d "Stop existing k3d cluster(s)"
-complete -f -c k3d -n '__fish_seen_subcommand_from cluster; and __fish_seen_subcommand_from delete' -a '(__fish_k3d_print_clusters)' -d "Cluster"
-complete -f -c k3d -n '__fish_seen_subcommand_from cluster; and __fish_seen_subcommand_from start' -a '(__fish_k3d_print_clusters)' -d "Cluster"
-complete -f -c k3d -n '__fish_seen_subcommand_from cluster; and __fish_seen_subcommand_from stop' -a '(__fish_k3d_print_clusters)' -d "Cluster"
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster; and __fish_seen_subcommand_from delete start stop' -a '(__fish_k3d_print_clusters)' -d "Cluster"
 complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -s h -l help -d "Print usage"
 
 complete -f -c k3d -n '__fish_seen_subcommand_from image' -a import -d "Import image(s) from docker into k3d cluster(s)"
@@ -43,8 +37,8 @@ complete -f -c k3d -n '__fish_seen_subcommand_from image' -s h -l help -d "Print
 
 complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig' -a get -d "Get kubeconfig from cluster(s)"
 complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig' -a merge -d "Merge/write kubeconfig(s) from cluster(s) into existing kubeconfig/file"
-complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig get' -a '(__fish_k3d_print_clusters)' -d "Cluster"
-complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig get' -s a -l all -d "Get kubeconfig from all existing clusters"
+complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig get merge' -a '(__fish_k3d_print_clusters)' -d "Cluster"
+complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig get merge' -s a -l all -d "Get kubeconfig from all existing clusters"
 complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig' -s h -l help -d "Print usage"
 
 complete -f -c k3d -n '__fish_seen_subcommand_from node' -a create -d "Create a new k3s node in docker"
@@ -52,7 +46,5 @@ complete -f -c k3d -n '__fish_seen_subcommand_from node' -a delete -d "Delete no
 complete -f -c k3d -n '__fish_seen_subcommand_from node' -a list -d "List node(s)"
 complete -f -c k3d -n '__fish_seen_subcommand_from node' -a start -d "Start an existing k3d node"
 complete -f -c k3d -n '__fish_seen_subcommand_from node' -a stop -d "Stop an existing k3d node"
-complete -f -c k3d -n '__fish_seen_subcommand_from node; and __fish_seen_subcommand_from delete' -a '(__fish_k3d_print_nodes)' -d "Node"
-complete -f -c k3d -n '__fish_seen_subcommand_from node; and __fish_seen_subcommand_from start' -a '(__fish_k3d_print_nodes)' -d "Node"
-complete -f -c k3d -n '__fish_seen_subcommand_from node; and __fish_seen_subcommand_from stop' -a '(__fish_k3d_print_nodes)' -d "Node"
+complete -f -c k3d -n '__fish_seen_subcommand_from node; and __fish_seen_subcommand_from delete start stop' -a '(__fish_k3d_print_nodes)' -d "Node"
 complete -f -c k3d -n '__fish_seen_subcommand_from node' -s h -l help -d "Print usage"

--- a/share/completions/k3d.fish
+++ b/share/completions/k3d.fish
@@ -1,13 +1,58 @@
-# Disable file completion
-complete -c k3d -f
+function __fish_k3d_no_subcommand --description 'Test if k3d has yet to be given subcommands'
+    for i in (commandline -opc)
+        if contains -- $i cluster image kubeconfig node version
+            return 1
+        end
+    end
+    return 0
+end
 
-# Only suggest the following commands if none have been used yet
-complete -rc k3d -n __fish_use_subcommand -a create -d "Create a resource [cluster, node]"
-complete -rc k3d -n __fish_use_subcommand -a delete -d "Delete a resource [cluster, node]"
-complete -rc k3d -n __fish_use_subcommand -a get -d "Get a resource [cluster, node, kubeconfig]"
-complete -rc k3d -n __fish_use_subcommand -a help -d "Help menu"
-complete -rc k3d -n __fish_use_subcommand -a load -d "Load an in image into a cluster"
-complete -rc k3d -n __fish_use_subcommand -a start -d "Start a resource [cluster, node]"
-complete -rc k3d -n __fish_use_subcommand -a stop -d "Stop a resource [cluster, node]"
-complete -rc k3d -n __fish_use_subcommand -a version -d "Print k3d version"
-complete -rc k3d -l help -d "Show usage help"
+function __fish_k3d_print_clusters --description 'Print a list of k3d clusters'
+    for key in (k3d cluster list --no-headers | awk '{print $1}')
+        echo $key
+    end
+end
+
+function __fish_k3d_print_nodes --description 'Print a list of k3d nodes'
+    for key in (k3d node list --no-headers | awk '{print $1}')
+        echo $key
+    end
+end
+
+complete -f -c k3d -n '__fish_k3d_no_subcommand' -s h -l help -d "More information about a command"
+complete -f -c k3d -n '__fish_k3d_no_subcommand' -l version -d "Show k3d and default k3s version"
+complete -f -c k3d -n '__fish_k3d_no_subcommand' -a cluster -d "Manage cluster(s)"
+complete -f -c k3d -n '__fish_k3d_no_subcommand' -a version -d "Show k3d and default k3s version"
+complete -f -c k3d -n '__fish_k3d_no_subcommand' -a image -d "Handle container images"
+complete -f -c k3d -n '__fish_k3d_no_subcommand' -a kubeconfig -d "Manage kubeconfig(s)"
+complete -f -c k3d -n '__fish_k3d_no_subcommand' -a node -d "Manage node(s)"
+
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -a create -d "Create a new cluster"
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -a list -d "List cluster(s)"
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -a delete -d "Delete cluster(s)"
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -a start -d "Start existing k3d cluster(s)"
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -a stop -d "Stop existing k3d cluster(s)"
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster; and __fish_seen_subcommand_from delete' -a '(__fish_k3d_print_clusters)' -d "Cluster"
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster; and __fish_seen_subcommand_from start' -a '(__fish_k3d_print_clusters)' -d "Cluster"
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster; and __fish_seen_subcommand_from stop' -a '(__fish_k3d_print_clusters)' -d "Cluster"
+complete -f -c k3d -n '__fish_seen_subcommand_from cluster' -s h -l help -d "Print usage"
+
+complete -f -c k3d -n '__fish_seen_subcommand_from image' -a import -d "Import image(s) from docker into k3d cluster(s)"
+complete -f -c k3d -n '__fish_seen_subcommand_from image' -a help -d "Print usage"
+complete -f -c k3d -n '__fish_seen_subcommand_from image' -s h -l help -d "Print usage"
+
+complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig' -a get -d "Get kubeconfig from cluster(s)"
+complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig' -a merge -d "Merge/write kubeconfig(s) from cluster(s) into existing kubeconfig/file"
+complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig get' -a '(__fish_k3d_print_clusters)' -d "Cluster"
+complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig get' -s a -l all -d "Get kubeconfig from all existing clusters"
+complete -f -c k3d -n '__fish_seen_subcommand_from kubeconfig' -s h -l help -d "Print usage"
+
+complete -f -c k3d -n '__fish_seen_subcommand_from node' -a create -d "Create a new k3s node in docker"
+complete -f -c k3d -n '__fish_seen_subcommand_from node' -a delete -d "Delete node(s)"
+complete -f -c k3d -n '__fish_seen_subcommand_from node' -a list -d "List node(s)"
+complete -f -c k3d -n '__fish_seen_subcommand_from node' -a start -d "Start an existing k3d node"
+complete -f -c k3d -n '__fish_seen_subcommand_from node' -a stop -d "Stop an existing k3d node"
+complete -f -c k3d -n '__fish_seen_subcommand_from node; and __fish_seen_subcommand_from delete' -a '(__fish_k3d_print_nodes)' -d "Node"
+complete -f -c k3d -n '__fish_seen_subcommand_from node; and __fish_seen_subcommand_from start' -a '(__fish_k3d_print_nodes)' -d "Node"
+complete -f -c k3d -n '__fish_seen_subcommand_from node; and __fish_seen_subcommand_from stop' -a '(__fish_k3d_print_nodes)' -d "Node"
+complete -f -c k3d -n '__fish_seen_subcommand_from node' -s h -l help -d "Print usage"


### PR DESCRIPTION
## Description

Update `k3d completions to match the stable 3.0.0 release and include completion for subcommands.

For example `k3d cluster start` will suggest the name of existing k3d clusters
