### PR TITLE
Allow newlines after && and ||

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,8 @@ Notable improvements and fixes
 Syntax changes and new commands
 -------------------------------
 - A new ``fish_is_root_user`` simplifies checking for superuser privilege, largely for use in prompts (#7031).
--  Range limits in index range expansions like ``$x[$start..$end]`` may be omitted: ``$start`` and ``$end`` default to 1 and -1 (the last item) respectively.
+- Range limits in index range expansions like ``$x[$start..$end]`` may be omitted: ``$start`` and ``$end`` default to 1 and -1 (the last item) respectively.
+- Logical operators ``&&`` and ``||`` may have newlines before their right operand, matching POSIX sh.
 
 Scripting improvements
 ----------------------

--- a/src/ast.h
+++ b/src/ast.h
@@ -730,11 +730,12 @@ struct job_conjunction_continuation_t final
     : public branch_t<type_t::job_conjunction_continuation> {
     // The && or || token.
     token_t<parse_token_type_t::andand, parse_token_type_t::oror> conjunction;
+    maybe_newlines_t newlines;
 
     // The job itself.
     job_t job;
 
-    FIELDS(conjunction, job)
+    FIELDS(conjunction, newlines, job)
 };
 
 // An andor_job just wraps a job, but requires that the job have an 'and' or 'or' job_decorator.

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -1190,6 +1190,18 @@ static void test_parser() {
         err(L"bogus boolean statement error not detected on line %d", __LINE__);
     }
 
+    if (detect_errors(L"true && ") != PARSER_TEST_INCOMPLETE) {
+        err(L"unterminated conjunction not reported properly");
+    }
+
+    if (detect_errors(L"true && \n true")) {
+        err(L"newline after && reported as error");
+    }
+
+    if (detect_errors(L"true || \n") != PARSER_TEST_INCOMPLETE) {
+        err(L"unterminated conjunction not reported properly");
+    }
+
     say(L"Testing basic evaluation");
 
     // Ensure that we don't crash on infinite self recursion and mutual recursion. These must use
@@ -4341,7 +4353,7 @@ static void test_new_parser_correctness() {
         {L"true || false; and true", true},
         {L"true || ||", false},
         {L"|| true", false},
-        {L"true || \n\n false", false},
+        {L"true || \n\n false", true},
     };
 
     for (const auto &test : parser_tests) {

--- a/tests/checks/andandoror.fish
+++ b/tests/checks/andandoror.fish
@@ -93,6 +93,24 @@ end
 # CHECK: 3
 # CHECK: 4
 
+# Newlines
+true &&
+echo newline after conjunction
+# CHECK: newline after conjunction
+false ||
+echo newline after disjunction
+# CHECK: newline after disjunction
+
+true &&
+
+echo empty lines after conjunction
+# CHECK: empty lines after conjunction
+
+true &&
+# can have comments here!
+echo comment after conjunction
+# CHECK: comment after conjunction
+
 # --help works
 builtin and --help >/dev/null
 echo $status


### PR DESCRIPTION
We do the same for pipes (#1285). This matches POSIX sh behavior.

Are there any downsides to this? Making the grammar more flexible can make it more difficult to produce good error messages. If someone types `foo &&` by accident instead of `foo &` they will no longer get an error message. Seems like an acceptable price to pay.

We could also support newlines *before* these operators. That would be a trivial change, it's enough to [flip some bits](https://github.com/fish-shell/fish-shell/blob/master/src/ast.cpp#L529-L537) in the new AST.


## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
