### PR TITLE
Move fish_greeting to a function

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -19,17 +19,6 @@ function __fish_config_interactive -d "Initializations that should be performed 
     set -g __fish_config_interactive_done
     set -g __fish_active_key_bindings
 
-    if not set -q fish_greeting
-        set -l line1 (_ 'Welcome to fish, the friendly interactive shell')
-        set -l line2 \n(printf (_ 'Type %shelp%s for instructions on how to use fish') (set_color green) (set_color normal))
-        set -U fish_greeting "$line1$line2"
-    end
-
-    if set -q fish_private_mode; and string length -q -- $fish_greeting
-        set -l line (_ "fish is running in private mode, history will not be persisted.")
-        set -g fish_greeting $fish_greeting.\n$line
-    end
-
     # usage: __init_uvar VARIABLE VALUES...
     function __init_uvar -d "Sets a universal variable if it's not already set"
         if not set --query $argv[1]
@@ -115,18 +104,12 @@ function __fish_config_interactive -d "Initializations that should be performed 
 
     #
     # Print a greeting.
-    # fish_greeting can be a function (preferred) or a variable.
+    # The default just prints a variable of the same name.
     #
     # NOTE: This status check is necessary to not print the greeting when `read`ing in scripts. See #7080.
     if status --is-interactive
-        if functions -q fish_greeting
-            fish_greeting
-        else
-            # The greeting used to be skipped when fish_greeting was empty (not just undefined)
-            # Keep it that way to not print superfluous newlines on old configuration
-            test -n "$fish_greeting"
-            and echo $fish_greeting
-        end
+        and functions -q fish_greeting
+        fish_greeting
     end
 
     #

--- a/share/functions/fish_greeting.fish
+++ b/share/functions/fish_greeting.fish
@@ -1,0 +1,17 @@
+function fish_greeting
+    if not set -q fish_greeting
+        set -l line1 (_ 'Welcome to fish, the friendly interactive shell')
+        set -l line2 \n(printf (_ 'Type %shelp%s for instructions on how to use fish') (set_color green) (set_color normal))
+        set -g fish_greeting "$line1$line2"
+    end
+
+    if set -q fish_private_mode
+        set -l line (_ "fish is running in private mode, history will not be persisted.")
+        set -g fish_greeting $fish_greeting.\n$line
+    end
+
+    # The greeting used to be skipped when fish_greeting was empty (not just undefined)
+    # Keep it that way to not print superfluous newlines on old configuration
+    test -n "$fish_greeting"
+    and echo $fish_greeting
+end


### PR DESCRIPTION
This adds a "fish_greeting" function that prints the variable of the
same name.

In doing so, it makes $fish_greeting default to a global
variable (this is of little cost because of the `_` builtin)

This means that:

- We have fewer universal variables by default
- If we change the default greeting people will actually get
  it (unless they have a leftover universal, of course)
- If the user changes their language the variable changes with it

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
