### PR TITLE
Fix typo (verb clarification) in math.rst

### DIFF
--- a/doc_src/cmds/math.rst
+++ b/doc_src/cmds/math.rst
@@ -18,7 +18,7 @@ Description
 
 By default, the output is as a float with trailing zeroes trimmed. To get a fixed representation, the ``--scale`` option can be used, including ``--scale=0`` for integer output.
 
-Keep in mind that parameter expansion takes before expressions are evaluated. This can be very useful in order to perform calculations involving shell variables or the output of command substitutions, but it also means that parenthesis (``()``) and the asterisk (``*``) glob character have to be escaped or quoted. ``x`` can also be used to denote multiplication, but it needs to be followed by whitespace to distinguish it from hexadecimal numbers.
+Keep in mind that parameter expansion happens before expressions are evaluated. This can be very useful in order to perform calculations involving shell variables or the output of command substitutions, but it also means that parenthesis (``()``) and the asterisk (``*``) glob character have to be escaped or quoted. ``x`` can also be used to denote multiplication, but it needs to be followed by whitespace to distinguish it from hexadecimal numbers.
 
 ``math`` ignores whitespace between arguments and takes its input as multiple arguments (internally joined with a space), so ``math 2 +2`` and ``math "2 +    2"`` work the same. ``math 2 2`` is an error.
 


### PR DESCRIPTION
## Description
Was: "parameter expansion takes before expressions are evaluated."
Now: "parameter expansion happens before expressions are evaluated."

I suspect the original intent was to use "takes place," but I see "happens" as less idiomatic and therefore may benefit non-English-native users.

Fixes issue # N/A
Let me know if you'd like me to open an issue or use another tracker for record keeping.

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

No code was changed, so no changes to add to docs or tests to conduct. I do not believe this merits a changelog entry, but I can propose a line for that if desired.

Thanks for all the fish.