### PR TITLE
Remove exclusive args flag for "go run"

### DIFF
--- a/share/completions/go.fish
+++ b/share/completions/go.fish
@@ -21,7 +21,7 @@ complete -c go -n "__fish_seen_subcommand_from $__go_cmds_w_buildflags" -o mod -
 
 
 # Completions for go cmds that takes file arguments
-complete -c go -n "__fish_seen_subcommand_from build compile fix fmt install run test vet" -x -a "(
+complete -c go -n "__fish_seen_subcommand_from build compile fix fmt install test vet" -x -a "(
             __fish_complete_suffix .go
     )" --description File
 


### PR DESCRIPTION
## Description

`go run` compiles and runs a go program passing along the trailing args to the compiled program. Limiting `go run` to only complete *.go files means that if you are running a go file that takes a file path as a command line argument, you frustratingly cannot use tab completion.

I realise that this is a very naïve change. I welcome feedback and changes.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
