### PR TITLE
[Documentation] Correct Emacs bindings in vi insert mode

### DIFF
--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -1548,12 +1548,12 @@ It is also possible to add all emacs-mode bindings to vi-mode by using something
 
 
     function fish_user_key_bindings
-        # Execute this once per mode that emacs bindings should be used in
-        fish_default_key_bindings -M insert
         # Without an argument, fish_vi_key_bindings will default to
         # resetting all bindings.
         # The argument specifies the initial mode (insert, "default" or visual).
         fish_vi_key_bindings insert
+        # Execute this once per mode that emacs bindings should be used in
+        fish_default_key_bindings -M insert
     end
 
 


### PR DESCRIPTION
## Description

The original instruction does not actually enable Emacs key bindings in Vi mode. This fixes it.