### PR TITLE
fix Subversion prompt

### DIFF
--- a/share/functions/fish_svn_prompt.fish
+++ b/share/functions/fish_svn_prompt.fish
@@ -70,7 +70,7 @@ set -g __fish_svn_prompt_char_token_broken_color --bold magenta
 function __fish_svn_prompt_parse_status --argument flag_status_string --description "helper function that does pretty formatting on svn status"
     # SVN status symbols
     # Do not change these! These are the expected characters that are output from `svn status`, they are taken from `svn help status`
-    set -l __fish_svn_prompt_chars A C D I M R X \\\? ! \~ L + S K O T B
+    set -l __fish_svn_prompt_chars A C D I M R X '\?' ! '~' L '\+' S K O T B
     # this sets up an array of all the types of status codes that could be returned.
     set -l __fish_svn_prompt_flag_names added conflicted deleted ignored modified replaced unversioned_external unversioned missing versioned_obstructed locked scheduled switched token_present token_other token_stolen token_broken
     # iterate over the different status types
@@ -78,7 +78,7 @@ function __fish_svn_prompt_parse_status --argument flag_status_string --descript
         # resolve the name of the variable for the character representing the current status type
         set -l flag_index (contains -i $flag_type $__fish_svn_prompt_flag_names)
         # check to see if the status string for this column contains the character representing the current status type
-        if test (count (string match -e $__fish_svn_prompt_chars[$flag_index] -- $flag_status_string)) -eq 1
+        if string match -q -r $__fish_svn_prompt_chars[$flag_index] -- $flag_status_string
             # if it does, then get the names of the variables for the display character and colour to format it with
             set -l flag_var_display __fish_svn_prompt_char_{$flag_type}_display
             set -l flag_var_color __fish_svn_prompt_char_{$flag_type}_color

--- a/share/functions/fish_svn_prompt.fish
+++ b/share/functions/fish_svn_prompt.fish
@@ -67,18 +67,18 @@ set -g __fish_svn_prompt_char_token_broken_color --bold magenta
 
 # ==============================
 
-function __fish_svn_prompt_parse_status --argument flag_status_string --description "helper function that does pretty formatting on svn status"
+function __fish_svn_prompt_parse_status --description "helper function that does pretty formatting on svn status"
     # SVN status symbols
     # Do not change these! These are the expected characters that are output from `svn status`, they are taken from `svn help status`
-    set -l __fish_svn_prompt_chars A C D I M R X '\?' ! '~' L '\+' S K O T B
+    set -l __fish_svn_prompt_chars A C D I M R X '?' ! '~' L + S K O T B
     # this sets up an array of all the types of status codes that could be returned.
     set -l __fish_svn_prompt_flag_names added conflicted deleted ignored modified replaced unversioned_external unversioned missing versioned_obstructed locked scheduled switched token_present token_other token_stolen token_broken
     # iterate over the different status types
     for flag_type in $__fish_svn_prompt_flag_names
         # resolve the name of the variable for the character representing the current status type
         set -l flag_index (contains -i $flag_type $__fish_svn_prompt_flag_names)
-        # check to see if the status string for this column contains the character representing the current status type
-        if string match -q -r $__fish_svn_prompt_chars[$flag_index] -- $flag_status_string
+        # check to see if the status list for this column contains the character representing the current status type
+        if contains -- $__fish_svn_prompt_chars[$flag_index] $argv
             # if it does, then get the names of the variables for the display character and colour to format it with
             set -l flag_var_display __fish_svn_prompt_char_{$flag_type}_display
             set -l flag_var_color __fish_svn_prompt_char_{$flag_type}_color
@@ -116,11 +116,12 @@ function fish_svn_prompt --description "Prompt function for svn"
         # get the output for a particular column
         # 1. echo the whole status flag text
         # 2. cut out the current column of characters
-        # 3. remove spaces and newline characters
-        set -l column_status (printf '%s\n' $svn_status_lines | cut -c $col | sort -u | tr -d ' \n')
+        # 3. remove duplicates
+        # 4. remove spaces
+        set -l column_status (printf '%s\n' $svn_status_lines | cut -c $col | sort -u | tr -d ' ')
 
-        # check that the character count is not zero (this would indicate that there are status flags in this column)
-        if [ (count $column_status) -ne 0 ]
+        # check that the column status list does not only contain an empty element (if it does, this column is empty)
+        if [ (count $column_status) -gt 1 -o -n $column_status[1] ]
 
             # parse the status flags for this column and create the formatting by calling out to the helper function
             set -l svn_status_flags (__fish_svn_prompt_parse_status $column_status)

--- a/share/functions/fish_svn_prompt.fish
+++ b/share/functions/fish_svn_prompt.fish
@@ -121,7 +121,7 @@ function fish_svn_prompt --description "Prompt function for svn"
         set -l column_status (printf '%s\n' $svn_status_lines | cut -c $col | sort -u | tr -d ' ')
 
         # check that the column status list does not only contain an empty element (if it does, this column is empty)
-        if [ (count $column_status) -gt 1 -o -n $column_status[1] ]
+        if [ (count $column_status) -gt 1 -o -n "$column_status[1]" ]
 
             # parse the status flags for this column and create the formatting by calling out to the helper function
             set -l svn_status_flags (__fish_svn_prompt_parse_status $column_status)

--- a/share/functions/fish_svn_prompt.fish
+++ b/share/functions/fish_svn_prompt.fish
@@ -70,15 +70,15 @@ set -g __fish_svn_prompt_char_token_broken_color --bold magenta
 function __fish_svn_prompt_parse_status --argument flag_status_string --description "helper function that does pretty formatting on svn status"
     # SVN status symbols
     # Do not change these! These are the expected characters that are output from `svn status`, they are taken from `svn help status`
-    set -l __fish_svn_prompt_chars A C D I M R X \? ! ~ L + S K O T B
+    set -l __fish_svn_prompt_chars A C D I M R X \\\? ! \~ L + S K O T B
     # this sets up an array of all the types of status codes that could be returned.
-    set -l __fish_svn_prompt_flag_names added conflicted deleted ignored modified replaced unversioned_external unversioned missing locked scheduled switched token_present token_other token_stolen token_broken
+    set -l __fish_svn_prompt_flag_names added conflicted deleted ignored modified replaced unversioned_external unversioned missing versioned_obstructed locked scheduled switched token_present token_other token_stolen token_broken
     # iterate over the different status types
     for flag_type in $__fish_svn_prompt_flag_names
         # resolve the name of the variable for the character representing the current status type
         set -l flag_index (contains -i $flag_type $__fish_svn_prompt_flag_names)
         # check to see if the status string for this column contains the character representing the current status type
-        if test (count (string match $__fish_svn_prompt_chars[$flag_index] -- $flag_status_string)) -eq 1
+        if test (count (string match -e $__fish_svn_prompt_chars[$flag_index] -- $flag_status_string)) -eq 1
             # if it does, then get the names of the variables for the display character and colour to format it with
             set -l flag_var_display __fish_svn_prompt_char_{$flag_type}_display
             set -l flag_var_color __fish_svn_prompt_char_{$flag_type}_color
@@ -117,15 +117,13 @@ function fish_svn_prompt --description "Prompt function for svn"
         # 1. echo the whole status flag text
         # 2. cut out the current column of characters
         # 3. remove spaces and newline characters
-        set -l column_status (printf '%s\n' $svn_status_lines | cut -c $col | tr -d ' \n')
+        set -l column_status (printf '%s\n' $svn_status_lines | cut -c $col | sort -u | tr -d ' \n')
 
         # check that the character count is not zero (this would indicate that there are status flags in this column)
         if [ (count $column_status) -ne 0 ]
 
-            # we only want to display unique status flags (eg: if there are 5 modified files, the prompt should only show the modified status once)
-            set -l column_unique_status (echo $column_status | sort -u)
             # parse the status flags for this column and create the formatting by calling out to the helper function
-            set -l svn_status_flags (__fish_svn_prompt_parse_status $column_unique_status)
+            set -l svn_status_flags (__fish_svn_prompt_parse_status $column_status)
 
             # the default separator is empty
             set -l prompt_separator ""


### PR DESCRIPTION
- after switching to "string match", some SVN status symbols need
  proper escaping
- the __fish_svn_prompt_flag_names list was missing
  "versioned_obstructed" and was therefore not in line with
  the symbols from __fish_svn_prompt_chars
- when checking for individual SVN status symbols, use
  "string match -e" to handle the case where multiple different
  symbols appear in one status column
- use "sort -u" before merging all symbols from a column into
  one line

Fixes #6715
