### PR TITLE
docs: Use \ instead of \\ in examples

### DIFF
--- a/doc_src/cmds/echo.rst
+++ b/doc_src/cmds/echo.rst
@@ -64,7 +64,7 @@ Example
    > echo 'Hello World'
    Hello World
 
-   > echo -e 'Top\\nBottom'
+   > echo -e 'Top\nBottom'
    Top
    Bottom
 

--- a/doc_src/cmds/printf.rst
+++ b/doc_src/cmds/printf.rst
@@ -77,7 +77,7 @@ Example
 
 ::
 
-    printf '%s\\t%s\n' flounder fish
+    printf '%s\t%s\n' flounder fish
 
 Will print "flounder	fish" (separated with a tab character), followed by a newline character. This is useful for writing completions, as fish expects completion scripts to output the option followed by the description, separated with a tab character.
 

--- a/doc_src/cmds/printf.rst
+++ b/doc_src/cmds/printf.rst
@@ -77,7 +77,7 @@ Example
 
 ::
 
-    printf '%s\\t%s\\n' flounder fish
+    printf '%s\\t%s\n' flounder fish
 
 Will print "flounder	fish" (separated with a tab character), followed by a newline character. This is useful for writing completions, as fish expects completion scripts to output the option followed by the description, separated with a tab character.
 

--- a/doc_src/cmds/string-escape.rst
+++ b/doc_src/cmds/string-escape.rst
@@ -37,8 +37,8 @@ Examples
 
 ::
 
-    >_ echo \\x07 | string escape
-    cg
+    >_ echo \x07 | string escape
+    \cg
 
     >_ string escape --style=var 'a1 b2'\\u6161
     a1_20b2__c_E6_85_A1

--- a/doc_src/cmds/string-escape.rst
+++ b/doc_src/cmds/string-escape.rst
@@ -40,8 +40,8 @@ Examples
     >_ echo \x07 | string escape
     \cg
 
-    >_ string escape --style=var 'a1 b2'\\u6161
-    a1_20b2__c_E6_85_A1
+    >_ string escape --style=var 'a1 b2'\u6161
+    a1_20_b2_E6_85_A1_
 
 
 .. END EXAMPLES

--- a/doc_src/cmds/string-match.rst
+++ b/doc_src/cmds/string-match.rst
@@ -52,7 +52,7 @@ Match Glob Examples
     >_ string match -i 'a??B' Axxb
     Axxb
 
-    >_ echo 'ok?' | string match '*\\?'
+    >_ echo 'ok?' | string match '*\?'
     ok?
 
     # Note that only the second STRING will match here.

--- a/doc_src/cmds/string-replace.rst
+++ b/doc_src/cmds/string-replace.rst
@@ -59,7 +59,7 @@ Replace Regex Examples
     >_ string replace -r '(\\w+)\\s+(\\w+)' '$2 $1 $$' 'left right'
     right left $
 
-    >_ string replace -r '\\s*newline\\s*' '\\n' 'put a newline here'
+    >_ string replace -r '\\s*newline\\s*' '\n' 'put a newline here'
     put a
     here
 

--- a/doc_src/cmds/string-replace.rst
+++ b/doc_src/cmds/string-replace.rst
@@ -56,10 +56,10 @@ Replace Regex Examples
     >_ string replace -r -a '[^\\d.]+' ' ' '0 one two 3.14 four 5x'
     0 3.14 5
 
-    >_ string replace -r '(\\w+)\\s+(\\w+)' '$2 $1 $$' 'left right'
+    >_ string replace -r '(\\w+)\s+(\\w+)' '$2 $1 $$' 'left right'
     right left $
 
-    >_ string replace -r '\\s*newline\\s*' '\n' 'put a newline here'
+    >_ string replace -r '\s*newline\s*' '\n' 'put a newline here'
     put a
     here
 

--- a/doc_src/cmds/string-replace.rst
+++ b/doc_src/cmds/string-replace.rst
@@ -53,7 +53,7 @@ Replace Regex Examples
 
 ::
 
-    >_ string replace -r -a '[^\\d.]+' ' ' '0 one two 3.14 four 5x'
+    >_ string replace -r -a '[^\d.]+' ' ' '0 one two 3.14 four 5x'
     0 3.14 5
 
     >_ string replace -r '(\w+)\s+(\w+)' '$2 $1 $$' 'left right'

--- a/doc_src/cmds/string-replace.rst
+++ b/doc_src/cmds/string-replace.rst
@@ -56,7 +56,7 @@ Replace Regex Examples
     >_ string replace -r -a '[^\\d.]+' ' ' '0 one two 3.14 four 5x'
     0 3.14 5
 
-    >_ string replace -r '(\\w+)\s+(\\w+)' '$2 $1 $$' 'left right'
+    >_ string replace -r '(\w+)\s+(\w+)' '$2 $1 $$' 'left right'
     right left $
 
     >_ string replace -r '\s*newline\s*' '\n' 'put a newline here'

--- a/doc_src/cmds/string-split.rst
+++ b/doc_src/cmds/string-split.rst
@@ -66,9 +66,9 @@ NUL Delimited Examples
     42
 
     >_ # Sort a list of elements which may contain newlines
-    >_ set foo beta alpha\\ngamma
+    >_ set foo beta alpha\ngamma
     >_ set foo (string join0 $foo | sort -z | string split0)
     >_ string escape $foo[1]
-    alpha\\ngamma
+    alpha\ngamma
 
 .. END EXAMPLES

--- a/doc_src/cmds/string.rst
+++ b/doc_src/cmds/string.rst
@@ -314,4 +314,4 @@ In contrast to ``grep``, ``string``\ s `match` defaults to glob-mode, while `rep
 
 Like ``sed``\ s `s/` command, ``string replace`` still prints strings that don't match. ``sed``\ s `-n` in combination with a `/p` modifier or command is like ``string replace -f``.
 
-``string split somedelimiter`` is a replacement for ``tr somedelimiter \\n``.
+``string split somedelimiter`` is a replacement for ``tr somedelimiter \n``.

--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -1293,7 +1293,7 @@ Variable                                                   Meaning
 ``fish_color_comment``                                     comments like '# important'
 ``fish_color_selection``                                   selected text in vi visual mode
 ``fish_color_operator``                                    parameter expansion operators like '*' and '~'
-``fish_color_escape``                                      character escapes like '\\n' and '\\x70'
+``fish_color_escape``                                      character escapes like '\n' and '\\x70'
 ``fish_color_autosuggestion``                              autosuggestions (the proposed rest of a command)
 ``fish_color_cwd``                                         the current working directory in the default prompt
 ``fish_color_user``                                        the username in the default prompt

--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -1293,7 +1293,7 @@ Variable                                                   Meaning
 ``fish_color_comment``                                     comments like '# important'
 ``fish_color_selection``                                   selected text in vi visual mode
 ``fish_color_operator``                                    parameter expansion operators like '*' and '~'
-``fish_color_escape``                                      character escapes like '\n' and '\\x70'
+``fish_color_escape``                                      character escapes like '\n' and '\x70'
 ``fish_color_autosuggestion``                              autosuggestions (the proposed rest of a command)
 ``fish_color_cwd``                                         the current working directory in the default prompt
 ``fish_color_user``                                        the username in the default prompt


### PR DESCRIPTION
Escaping characters (i.e., `\n` and `\t`) are [expanded when unquoted][1]
and besides a few exceptions, are left untouched when quoted. So unless
one really wants a literal "backslash followed by n" string, using `\\n`
is unnecessary and decreases the command's readability.

This documentation-only pull request fixes all the `\\` instances where
it should be `\` instead. 

Note that in most examples, the double `\\` is innocuous. In some, it
produces a different result. In those cases, the example output was also
adjusted accordingly (see the fixed `string escape` examples).

[1]: https://fishshell.com/docs/current/index.html#escaping-characters

[ci skip]