### PR TITLE
Display symbols for control characters in the commandline buffer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -137,6 +137,7 @@ Improved terminal output
 -  Autosuggestions now show up also when the cursor passes the right
    prompt (#6948).
 -  The cursor shape in Vi mode changes properly in  Windows Terminal (#6999).
+-  Non-printable ASCII control characters in the commandline are display using graphic Unicode symbols.
 -  The spurious warning about terminal size in small terminals has been removed (#6980).
 -  Dynamic titles are now enabled in Alacritty with its new terminfo entry (#7073).
 -  The width computation for certain emoji agrees better with terminals. In particular, flags now have width 2. (#7237).

--- a/src/ast.h
+++ b/src/ast.h
@@ -249,7 +249,7 @@ struct node_t {
     }
 
     /// Try casting to a concrete node type, except returns nullptr on failure.
-    /// Example ussage:
+    /// Example usage:
     ///     if (const auto *job_list = node->try_as<job_list_t>()) job_list->...
     template <typename To>
     To *try_as() {

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -239,6 +239,8 @@ int fish_get_emoji_width(wchar_t c) {
 #include "widecharwidth/widechar_width.h"
 
 int fish_wcwidth(wchar_t wc) {
+    wc = character_to_render(wc);
+
     // The system version of wcwidth should accurately reflect the ability to represent characters
     // in the console session, but knows nothing about the capabilities of other terminal emulators
     // or ttys. Use it from the start only if we are logged in to the physical console.
@@ -260,6 +262,7 @@ int fish_wcwidth(wchar_t wc) {
     // or standalone with a 1 width. Since that's literally not expressible with wcwidth(),
     // we take the position that the typical way for them to show up is composed.
     if (wc >= L'\u1160' && wc <= L'\u11FF') return 0;
+
     int width = widechar_wcwidth(wc);
 
     switch (width) {

--- a/src/fallback.h
+++ b/src/fallback.h
@@ -29,6 +29,19 @@ extern int g_guessed_fish_emoji_width;
 int fish_wcwidth(wchar_t wc);
 int fish_wcswidth(const wchar_t *str, size_t n);
 
+constexpr int character_to_render(wchar_t c) {
+    // Display non-printable control characters as a graphic symbol.
+    // This is to prevent control characters like \t and \v from moving the
+    // cursor in a way we don't handle.  The ones we do handle are \r and
+    // \n. They are never rendered directly by s_write_char; check for them
+    // anyway to compute the correct width of the commandline (not sure if
+    // it matters).
+    // See https://unicode-table.com/en/blocks/control-pictures/
+    return (c >= L'\u0000' && c <= L'\u001F' && c != L'\n' && c != L'\r')  //
+               ? c + L'\u2400'                                             //
+               : c;
+}
+
 // Replacement for mkostemp(str, O_CLOEXEC)
 // This uses mkostemp if available,
 // otherwise it uses mkstemp followed by fcntl

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -608,6 +608,7 @@ static void s_move(screen_t *s, int new_x, int new_y) {
 static void s_write_char(screen_t *s, wchar_t c, size_t width) {
     scoped_buffer_t outp(*s);
     s->actual.cursor.x += width;
+    c = character_to_render(c);
     s->outp().writech(c);
     if (s->actual.cursor.x == s->actual.screen_width && allow_soft_wrap()) {
         s->soft_wrap_location = screen_data_t::cursor_t{0, s->actual.cursor.y + 1};


### PR DESCRIPTION
Represent tabs on the commandline as "␉", and so on for other ASCII control
characters, see https://unicode-table.com/en/blocks/control-pictures/.
This makes the fish reader use a reasonable width for these characters.

You can see how this works by inserting some control characters on the command line:

	set chars
	for x in (seq 1 0x1F)
		set -a chars (printf "%02x\\\\x%02x" $x $x)
	end
	eval set chars $chars
	commandline -i "echo '" $chars

Fixes #6923
Fixes #5274

We could extend this approach to display a fallback symbol for every unknown
control/nonprintable character.

An alternative way to handle tabs would be to just replace them with spaces
when inserted.  However, this seems slightly better because it still allows
to use tabs and other control characters inside quotes.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
