### PR TITLE
Colourise diff(1) output, if supported

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -103,6 +103,7 @@ Interactive improvements
    revealed.
 -  The output of ``time`` is now properly aligned in all cases (#6726).
 -  The ``pwd`` command supports the long options ``--logical`` and ``--physical``, matching other implementations (#6787).
+-  ``diff`` will now colourise output, if supported (#7308).
 
 
 New or improved bindings

--- a/share/functions/diff.fish
+++ b/share/functions/diff.fish
@@ -1,5 +1,5 @@
 # Use colours in diff output, if supported
-if command diff --color=auto /dev/null /dev/null 2>&1
+if command -vq diff; and command diff --color=auto /dev/null{,} >/dev/null 2>&1
     function diff
         command diff --color=auto $argv
     end

--- a/share/functions/diff.fish
+++ b/share/functions/diff.fish
@@ -1,0 +1,6 @@
+# Use colours in diff output, if supported
+if command diff --color=auto /dev/null /dev/null 2>&1
+    function diff
+        command diff --color=auto $argv
+    end
+end


### PR DESCRIPTION
## Description

This adds a simple wrapper to enable colour support for diff(1), like those for ls(1) and grep(1).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
