### PR TITLE
fixed typo

### DIFF
--- a/doc_src/cmds/functions.rst
+++ b/doc_src/cmds/functions.rst
@@ -49,7 +49,7 @@ You should not assume that only five lines will be written since we may add addi
 
 - ``-t`` or ``--handlers-type TYPE`` will show all event handlers matching the given type
 
-The default behavior of ``functions``, when called with no arguments, is to print the names of all defined functions. Unless the ``-a`` option is given, no functions starting with underscores are not included in the output.
+The default behavior of ``functions``, when called with no arguments, is to print the names of all defined functions. Unless the ``-a`` option is given, no functions starting with underscores are included in the output.
 
 If any non-option parameters are given, the definition of the specified functions are printed.
 


### PR DESCRIPTION
removed the word "not" to resolve an (unintended) negation of negation.

## Description

just fixed a typo, i.e. a negation of the negation of the negation.

Fixes issue #

## TODOs:
- [x ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
