### PR TITLE
Consistency-fix for word motions

### DIFF
--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2537,7 +2537,10 @@ static void test_word_motion() {
 
     test_1_word_motion(word_motion_left, move_word_style_path_components,
                        L"^echo /^foo/^bar{^aaa,^bbb,^ccc}^bak/^");
-    test_1_word_motion(word_motion_right, move_word_style_punctuation, L"^a ^bcd^");
+
+    test_1_word_motion(word_motion_right, move_word_style_punctuation, L"^a^ bcd^");
+    test_1_word_motion(word_motion_right, move_word_style_punctuation, L"a^b^ cde^");
+    test_1_word_motion(word_motion_right, move_word_style_punctuation, L"^ab^ cde^");
 }
 
 /// Test is_potential_path.

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2479,12 +2479,13 @@ static void test_1_word_motion(word_motion_t motion, move_word_style_t style,
 
     size_t idx, end;
     if (motion == word_motion_left) {
-        idx = command.size();
+        idx = *std::max_element(stops.begin(), stops.end());
         end = 0;
     } else {
-        idx = 0;
+        idx = *std::min_element(stops.begin(), stops.end());
         end = command.size();
     }
+    stops.erase(idx);
 
     move_word_state_machine_t sm(style);
     while (idx != end) {
@@ -2521,22 +2522,22 @@ static void test_1_word_motion(word_motion_t motion, move_word_style_t style,
 /// Test word motion (forward-word, etc.). Carets represent cursor stops.
 static void test_word_motion() {
     say(L"Testing word motion");
-    test_1_word_motion(word_motion_left, move_word_style_punctuation, L"^echo ^hello_^world.^txt");
-    test_1_word_motion(word_motion_right, move_word_style_punctuation, L"echo^ hello^_world^.txt^");
+    test_1_word_motion(word_motion_left, move_word_style_punctuation, L"^echo ^hello_^world.^txt^");
+    test_1_word_motion(word_motion_right, move_word_style_punctuation, L"^echo^ hello^_world^.txt^");
 
     test_1_word_motion(word_motion_left, move_word_style_punctuation,
-                       L"echo ^foo_^foo_^foo/^/^/^/^/^    ");
+                       L"echo ^foo_^foo_^foo/^/^/^/^/^    ^");
     test_1_word_motion(word_motion_right, move_word_style_punctuation,
-                       L"echo^ foo^_foo^_foo^/^/^/^/^/    ^");
+                       L"^echo^ foo^_foo^_foo^/^/^/^/^/    ^");
 
-    test_1_word_motion(word_motion_left, move_word_style_path_components, L"^/^foo/^bar/^baz/");
-    test_1_word_motion(word_motion_left, move_word_style_path_components, L"^echo ^--foo ^--bar");
+    test_1_word_motion(word_motion_left, move_word_style_path_components, L"^/^foo/^bar/^baz/^");
+    test_1_word_motion(word_motion_left, move_word_style_path_components, L"^echo ^--foo ^--bar^");
     test_1_word_motion(word_motion_left, move_word_style_path_components,
-                       L"^echo ^hi ^> /^dev/^null");
+                       L"^echo ^hi ^> /^dev/^null^");
 
     test_1_word_motion(word_motion_left, move_word_style_path_components,
-                       L"^echo /^foo/^bar{^aaa,^bbb,^ccc}^bak/");
-    test_1_word_motion(word_motion_right, move_word_style_punctuation, L"a ^bcd^");
+                       L"^echo /^foo/^bar{^aaa,^bbb,^ccc}^bak/^");
+    test_1_word_motion(word_motion_right, move_word_style_punctuation, L"^a ^bcd^");
 }
 
 /// Test is_potential_path.

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -687,8 +687,11 @@ bool move_word_state_machine_t::consume_char_punctuation(wchar_t c) {
                 consumed = true;
                 if (iswspace(c)) {
                     state = s_whitespace;
+                } else if (iswalnum(c)) {
+                    state = s_alphanumeric;
                 } else {
-                    // Don't allow switching type (ws->nonws) after non-whitespace.
+                    // Don't allow switching type (ws->nonws) after non-whitespace and
+                    // non-alphanumeric.
                     state = s_rest;
                 }
                 break;


### PR DESCRIPTION
## Description

Make the behavior of word-movements more consistent when the cursor is on the last letter of a word.

Fixes issue #7353

The word motion tests were adapted so that the first (or last) caret character specifies the starting location of the cursor (before, the start was always the first (or last) character in the string).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
