### PR TITLE
Fix string match example

### DIFF
--- a/doc_src/cmds/string-match.rst
+++ b/doc_src/cmds/string-match.rst
@@ -66,7 +66,6 @@ Match Glob Examples
 
     >_ string match 'foo?' 'foo1' 'foo' 'foo2'
     foo1
-    foo
     foo2
 
 Match Regex Examples


### PR DESCRIPTION
The `?` requires a char, so `foo` cannot match.
