### PR TITLE
Bind ctrl-r to search history if the commandline isn't empty

### DIFF
--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -1575,6 +1575,8 @@ Some bindings are shared between emacs- and vi-mode because they aren't text edi
 
 - :kbd:`Control`\ +\ :kbd:`L` clears and repaints the screen.
 
+- :kbd:`Control`\ +\ :kbd:`R` searches the history if there is something in the commandline. This is mainly to ease the transition from other shells, where ctrl+r initiates the history search.
+
 - :kbd:`Control`\ +\ :kbd:`W` moves the previous path component (everything up to the previous "/", ":" or "@") to the `killring <#killring>`__.
 
 - :kbd:`Control`\ +\ :kbd:`X` copies the current buffer to the system's clipboard, :kbd:`Control`\ +\ :kbd:`V` inserts the clipboard contents.

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -98,6 +98,9 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 
     bind --preset $argv \ed kill-word
 
+    # Let ctrl+r search history if there is something in the commandline.
+    bind --preset $argv \cr 'commandline | string length -q; and commandline -f history-search-backward'
+
     # term-specific special bindings
     switch "$TERM"
         case 'rxvt*'


### PR DESCRIPTION
This is super cheesy.

One of the most common feature requests we get is "control-r must
search", even tho just using history-search-backward via e.g. up-arrow
is perfectly capable. The only real difference is that ctrl-r search
in other shells allows editing the search term by default, while we
stop the history search and edit the new commandline in those cases.

So, since the major problem is muscle-memory on ctrl-r,
let's just use that!

This makes ctrl-r do nothing on empty commandlines, and do
history-search-backward otherwise, so the basic flow of "press ctrl-r
to start history search, enter your search term, press ctrl-r to cycle
through matches" just works (except the first ctrl-r is useless and it
doesn't show anything).

See #602.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
