### PR TITLE
Fast and functional replacement for __fish_describe_command for Macos

### DIFF
--- a/share/functions/__fish_apropos.fish
+++ b/share/functions/__fish_apropos.fish
@@ -1,13 +1,3 @@
-# macOS 10.15 "Catalina" has some major issues.
-# The whatis database is non-existent, so apropos tries (and fails) to create it every time,
-# which takes about half a second.
-#
-# Instead, we build a whatis database in the user cache directory
-# and override the MANPATH using that directory before we run `apropos`
-#
-# the cache is rebuilt one a day
-#
-
 if not type -q apropos
     function __fish_apropos
     end
@@ -15,6 +5,14 @@ if not type -q apropos
 end
 
 function __fish_apropos
+    # macOS 10.15 "Catalina" has some major issues.
+    # The whatis database is non-existent, so apropos tries (and fails) to create it every time,
+    # which takes about half a second.
+    #
+    # Instead, we build a whatis database in the user cache directory
+    # and override the MANPATH using that directory before we run `apropos`
+    #
+    # the cache is rebuilt once a day
     if test (uname) = Darwin
         set -l cache $HOME/.cache/fish/
         if test -n "$XDG_CACHE_HOME"

--- a/share/functions/__fish_apropos.fish
+++ b/share/functions/__fish_apropos.fish
@@ -1,0 +1,41 @@
+# macOS 10.15 "Catalina" has some major issues.
+# The whatis database is non-existent, so apropos tries (and fails) to create it every time,
+# which takes about half a second.
+#
+# Instead, we build a whatis database in the user cache directory
+# and override the MANPATH using that directory before we run `apropos`
+#
+# the cache is rebuilt one a day
+#
+
+if not type -q apropos
+    function __fish_apropos
+    end
+    exit
+end
+
+function __fish_apropos
+    if test (uname) = Darwin
+        set -l cache $HOME/.cache/fish/
+        if test -n "$XDG_CACHE_HOME"
+            set cache $XDG_CACHE_HOME/fish
+        end
+
+        set -l db $cache/whatis
+        set -l max_age 86400 # one day
+        set -l age $max_age
+
+        if test -f $db
+            set age (math (date +%s) - (stat -f %m $db))
+        end
+
+        if test $age -ge $max_age
+            echo "making cache $age $max_age"
+            mkdir -m 700 -p $cache
+            /usr/libexec/makewhatis -o $db (man --path | string split :) >/dev/null 2>&1
+        end
+        MANPATH="$cache" apropos $argv
+    else
+        apropos $argv
+    end
+end

--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -1,22 +1,3 @@
-# macOS 10.15 "Catalina" has some major issues.
-# The whatis database is non-existent, so apropos tries (and fails) to create it every time,
-# which takes about half a second.
-#
-# So we disable this entirely in that case, unless the user has overridden the system
-# `apropos` with their own, which presumably doesn't have the same problem.
-if test (uname) = Darwin
-    set -l darwin_version (uname -r | string split .)
-    # macOS 15 is Darwin 19, this is an issue up to and including 10.15.3.
-    if test "$darwin_version[1]" = 19 -a "$darwin_version[2]" -le 3
-        set -l apropos (command -s apropos)
-        if test "$apropos" = /usr/bin/apropos
-            function __fish_complete_man
-            end
-            # (remember: exit when `source`ing only exits the file, not the shell)
-            exit
-        end
-    end
-end
 
 function __fish_complete_man
     # Try to guess what section to search in. If we don't know, we
@@ -51,7 +32,7 @@ function __fish_complete_man
 
     if test -n "$token"
         # Do the actual search
-        apropos $token 2>/dev/null | awk '
+        __fish_apropos $token 2>/dev/null | awk '
                 BEGIN { FS="[\t ]- "; OFS="\t"; }
                 # BSD/Darwin
                 /^[^( \t]+\('$section'\)/ {

--- a/share/functions/__fish_describe_command.fish
+++ b/share/functions/__fish_describe_command.fish
@@ -29,7 +29,7 @@ function __fish_apropos
         if test $age -ge $max_age
             echo "making cache $age $max_age"
             mkdir -m 700 -p $cache
-            man --path | string split : | xargs /usr/libexec/makewhatis -o $db >/dev/null 2>&1
+            /usr/libexec/makewhatis -o $db (man --path | string split :) >/dev/null 2>&1
         end
         MANPATH="$cache" apropos $argv
     else

--- a/share/functions/__fish_describe_command.fish
+++ b/share/functions/__fish_describe_command.fish
@@ -2,41 +2,6 @@
 # This function is used internally by the fish command completion code
 #
 
-# macOS 10.15 "Catalina" has some major issues.
-# The whatis database is non-existent, so apropos tries (and fails) to create it every time,
-# which takes about half a second.
-#
-# Instead, we build a whatis database in the user cache directory
-# and override the MANPATH using that directory before we run `apropos`
-#
-# the cache is rebuilt one a day
-#
-function __fish_apropos
-    if test (uname) = Darwin
-        set -l cache $HOME/.cache/fish/
-        if test -n "$XDG_CACHE_HOME"
-            set cache $XDG_CACHE_HOME/fish
-        end
-
-        set -l db $cache/whatis
-        set -l max_age 86400 # one day
-        set -l age $max_age
-
-        if test -f $db
-            set age (math (date +%s) - (stat -f %m $db))
-        end
-
-        if test $age -ge $max_age
-            echo "making cache $age $max_age"
-            mkdir -m 700 -p $cache
-            /usr/libexec/makewhatis -o $db (man --path | string split :) >/dev/null 2>&1
-        end
-        MANPATH="$cache" apropos $argv
-    else
-        apropos $argv
-    end
-end
-
 # Perform this check once at startup rather than on each invocation
 if not type -q apropos
     function __fish_describe_command


### PR DESCRIPTION
## Description

Macos no longer comes with a whatis database, which makes `__fish_describe_command` and `__fish_complete_man` command very slow, since `apropos` rebuilds the database every time it is invoked.

Trying to update the whatis database as root also doesn't work, because it's on a read only file system.

The solution I implemented, simply creates a whatis database in the user directory at `~/.cache/fish/whatis`

The whatis cache is being updated at most once a day.

The result of these changes on macos are:
* instant command completion
* instant man completion
* correctly working command descriptions

Fixes issues #6270, #6611, #6615 and possibly others.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
