### PR TITLE
Synopses examples for vcs services now function as intended

### DIFF
--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -9,7 +9,7 @@ Synopsis
 ::
 
      function fish_prompt
-          echo -n (pwd)(fish_git_prompt) '$ '
+          printf '%s' $PWD (fish_git_prompt) ' $ '
      end
 
 Description

--- a/doc_src/cmds/fish_hg_prompt.rst
+++ b/doc_src/cmds/fish_hg_prompt.rst
@@ -9,7 +9,7 @@ Synopsis
 ::
 
      function fish_prompt
-          echo -n (pwd)(fish_hg_prompt) '$ '
+          printf '%s' $PWD (fish_hg_prompt) ' $ '
      end
 
 Description

--- a/doc_src/cmds/fish_svn_prompt.rst
+++ b/doc_src/cmds/fish_svn_prompt.rst
@@ -9,7 +9,7 @@ Synopsis
 ::
 
      function fish_prompt
-          echo -n (pwd)(fish_svn_prompt) '$ '
+          printf '%s' $PWD (fish_svn_prompt) ' $ '
      end
 
 Description

--- a/doc_src/cmds/fish_vcs_prompt.rst
+++ b/doc_src/cmds/fish_vcs_prompt.rst
@@ -9,7 +9,7 @@ Synopsis
 ::
 
      function fish_prompt
-          echo -n (pwd)(fish_vcs_prompt) '$ '
+          printf '%s' $PWD (fish_vcs_prompt) ' $ '
      end
 
 Description


### PR DESCRIPTION
## Description

The synopses examples for the various vcs services would not display the `PWD` when not in a git repository. I assume this was unintentional.

~## TODOs:~
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
~- [ ] Changes to fish usage are reflected in user documentation/manpages.~
~- [ ] Tests have been added for regressions fixed~
~- [ ] User-visible changes noted in CHANGELOG.rst~
