### PR TITLE
docs: Fix markup for code blocks

### DIFF
--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -48,8 +48,6 @@ To use this command, pass the option specifications (``OPTION_SPEC``), then a ma
 
 A simple example::
 
-::
-
     argparse --name=my_function 'h/help' 'n/name=' -- $argv
     or return
 
@@ -58,17 +56,13 @@ If ``$argv`` is empty then there is nothing to parse and ``argparse`` returns ze
 
 The ``or return`` means that the function returns ``argparse``'s status if it failed, so if it goes on ``argparse`` succeeded.
 
-The ``--`` argument is required. You do not have to include any arguments after the ``--`` but you must include the ``--``. For example, this is acceptable:
-
-::
+The ``--`` argument is required. You do not have to include any arguments after the ``--`` but you must include the ``--``. For example, this is acceptable::
 
     set -l argv
     argparse 'h/help' 'n/name' -- $argv
 
 
-But this is not:
-
-::
+But this is not::
 
     set -l argv
     argparse 'h/help' 'n/name' $argv

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -195,33 +195,22 @@ The following special input functions are available:
 Examples
 --------
 
-::
+Exit the shell when :kbd:`Control`\ +\ :kbd:`D` is pressed::
 
     bind \cd 'exit'
 
-Causes ``fish`` to exit when :kbd:`Control`\ +\ :kbd:`D` is pressed.
-
-
-
-::
+Perform a history search when :kbd:`Page Up` is pressed::
 
     bind -k ppage history-search-backward
 
-Performs a history search when the :kbd:`Page Up` key is pressed.
-
-
-
-::
+Turn on Vi key bindings and rebind :kbd:`Control`\ +\ :kbd:`C` to clear the input line::
 
     set -g fish_key_bindings fish_vi_key_bindings
     bind -M insert \cc kill-whole-line repaint
 
-Turns on Vi key bindings and rebinds :kbd:`Control`\ +\ :kbd:`C` to clear the input line.
+Launch ``git diff`` and repaint the commandline afterwards when :kbd:`Control`\ +\ :kbd:`G` is pressed::
 
-::
    bind \cg 'git diff; commandline -f repaint'
-
-Causes :kbd:`Control`\ +\ :kbd:`G` to launch ``git diff`` and repaint the commandline afterwards.
 
 .. _cmd-bind-termlimits:
 

--- a/doc_src/cmds/complete.rst
+++ b/doc_src/cmds/complete.rst
@@ -133,6 +133,7 @@ To implement an alias, use the ``-w`` or ``--wraps`` option:
 Now hub inherits all of the completions from git. Note this can also be specified in a function declaration (``function thing -w otherthing``).
 
 ::
+
    complete -c git
 
 Show all completions for ``git``.

--- a/doc_src/cmds/fish_add_path.rst
+++ b/doc_src/cmds/fish_add_path.rst
@@ -50,20 +50,20 @@ Example
 ::
 
    # I just installed mycoolthing and need to add it to the path to use it.
-   fish_add_path /opt/mycoolthing/bin
+   > fish_add_path /opt/mycoolthing/bin
 
    # I want my ~/.local/bin to be checked first.
-   fish_add_path -m ~/.local/bin
+   > fish_add_path -m ~/.local/bin
 
    # I prefer using a global fish_user_paths
-   fish_add_path -g ~/.local/bin ~/.otherbin /usr/local/sbin
+   > fish_add_path -g ~/.local/bin ~/.otherbin /usr/local/sbin
 
    # I want to append to the entire $PATH because this directory contains fallbacks
-   fish_add_path -aP /opt/fallback/bin
+   > fish_add_path -aP /opt/fallback/bin
 
    # I want to add the bin/ directory of my current $PWD (say /home/nemo/)
    > fish_add_path -v bin/
    set fish_user_paths /home/nemo/bin /usr/bin /home/nemo/.local/bin
 
    # I have installed ruby via homebrew
-   fish_add_path /usr/local/opt/ruby/bin
+   > fish_add_path /usr/local/opt/ruby/bin

--- a/doc_src/cmds/read.rst
+++ b/doc_src/cmds/read.rst
@@ -58,9 +58,9 @@ If no option to determine how to split like ``--delimiter``, ``--line`` or ``--t
 
 With the ``--line`` option, ``read`` reads a line of input from standard input into each provided variable, stopping when each variable has been filled. The line is not tokenized.
 
-If no variable names are provided, ``read`` enters a special case that simply provides redirection from standard input to standard output, useful for command substitution. For instance, the fish shell command below can be used to read data that should be provided via a command line argument from the console instead of hardcoding it in the command itself, allowing the command to both be reused as-is in various contexts with different input values and preventing possibly sensitive text from being included in the shell history:
+If no variable names are provided, ``read`` enters a special case that simply provides redirection from standard input to standard output, useful for command substitution. For instance, the fish shell command below can be used to read data that should be provided via a command line argument from the console instead of hardcoding it in the command itself, allowing the command to both be reused as-is in various contexts with different input values and preventing possibly sensitive text from being included in the shell history::
 
-``mysql -uuser -p(read)``
+    mysql -uuser -p(read)
 
 When running in this mode, ``read`` does not split the input in any way and text is redirected to standard output without any further processing or manipulation.
 

--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -924,7 +924,7 @@ Variables can be explicitly set to be universal with the ``-U`` or ``--universal
 
 - When no scope is given, but a variable of that name exists, the variable of the smallest scope will be modified. The scope will not be changed.
 
-- As a special case, when no scope is given and no variable has been defined the variable will belong to the scope of the currently executing *function*. Note that this is different from the ``--local`` flag``, which would make the variable local to the current *block*.
+- As a special case, when no scope is given and no variable has been defined the variable will belong to the scope of the currently executing *function*. Note that this is different from the ``--local`` flag, which would make the variable local to the current *block*.
 
 There can be many variables with the same name, but different scopes. When you :ref:`use a variable <expand-variable>`, the smallest scoped variable of that name will be used. If a local variable exists, it will be used instead of the global or universal variable of the same name.
 
@@ -1052,7 +1052,7 @@ Variables can be explicitly set to be exported with the ``-x`` or ``--export`` s
 
 - Otherwise, by default, the variable will not be exported.
 
-- If a variable has local scope and is exported, any function called receives a _copy_ of it, so any changes it makes to the variable disappear once the function returns.
+- If a variable has local scope and is exported, any function called receives a *copy* of it, so any changes it makes to the variable disappear once the function returns.
 
 - Global variables are accessible to functions whether they are exported or not.
 
@@ -1219,7 +1219,7 @@ The options will be *removed* from $argv, so $argv[2] is the second *positional*
 PATH variables
 --------------
 
-Path variables are a special kind of variable used to support colon-delimited path lists including PATH, CDPATH, MANPATH, PYTHONPATH, etc. All variables that end in ``PATH`` (case-sensitive) become PATH variables.
+Path variables are a special kind of variable used to support colon-delimited path lists including PATH, CDPATH, MANPATH, PYTHONPATH, etc. All variables that end in "PATH" (case-sensitive) become PATH variables.
 
 PATH variables act as normal lists, except they are are implicitly joined and split on colons.
 

--- a/doc_src/tutorial.rst
+++ b/doc_src/tutorial.rst
@@ -332,7 +332,7 @@ You can access individual elements with square brackets. Indexing starts at 1 fr
     /usr/local/bin
 
 
-You can also access ranges of elements, known as "slices:"
+You can also access ranges of elements, known as "slices":
 
 
 
@@ -650,7 +650,7 @@ To remove /usr/local/bin from ``$PATH``, you can write::
 
     > set PATH (string match -v /usr/local/bin $PATH)
 
-For compatibility with other shells and external commands, $PATH is a :ref:`path variable<variables-path>`, and so will be joined with colons (not spaces) when you quote it:
+For compatibility with other shells and external commands, $PATH is a :ref:`path variable<variables-path>`, and so will be joined with colons (not spaces) when you quote it::
 
     > echo "$PATH"
     /usr/local/sbin:/usr/local/bin:/usr/bin


### PR DESCRIPTION
## Description

Tried to fix all the cases where code blocks were displaying incorrectly.

## Screenshots

<img width="839" alt="argparse" src="https://user-images.githubusercontent.com/5209296/95663454-644a3f80-0b0d-11eb-9347-4ff5f850bd1c.png">

<img width="849" alt="bind" src="https://user-images.githubusercontent.com/5209296/95663477-8cd23980-0b0d-11eb-8953-7e31a0b04275.png">

<img width="824" alt="complete" src="https://user-images.githubusercontent.com/5209296/95663507-bc814180-0b0d-11eb-945a-699730021517.png">

<img width="821" alt="tutorial" src="https://user-images.githubusercontent.com/5209296/95663541-fce0bf80-0b0d-11eb-99bb-44c84e4d3c90.png">

<img width="838" alt="fish_add_path" src="https://user-images.githubusercontent.com/5209296/95663520-cefb7b00-0b0d-11eb-880a-9d4c6f21bab9.png">