### PR TITLE
Don't chomp `foo=` when completing `foo=br`

### DIFF
--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -1622,7 +1622,7 @@ void completer_t::perform_for_commandline(wcstring cmdline) {
     if (cmd_tok.location_in_or_at_end_of_source_range(cursor_pos)) {
         maybe_t<size_t> equal_sign_pos = variable_assignment_equals_pos(current_token);
         if (equal_sign_pos) {
-            complete_param_expand(current_token.substr(*equal_sign_pos + 1), true /* do_file */);
+            complete_param_expand(current_token, true /* do_file */);
             return;
         }
         // Complete command filename.


### PR DESCRIPTION
## Description

`complete_param_expand` knows how to handle cases like `foo=br` so we
don't need to bother sending just the `br` part. Furthermore, sending
just `br` is incorrect because we will end up replacing the entirety of
`foo=br` with the result of the completion. That is, `foo=br` will be
replaced with `bar` instead of being completed to `foo=bar`.

Fixes a bug where the following

```
$ foo=/vr<TAB>
```

will be completed to just

```
$ /var/
```

instead of

```
$ foo=/var/
```

This doesn't happen when the command is being invoked with `env` like `env foo=/vr<TAB`. It also only occurs when the completion requires replacement. So `foo=/va` will correctly be completed to `foo=/var/`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
