### PR TITLE
Clear to end of each line in left prompt

### DIFF
--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -5740,19 +5740,19 @@ void test_layout_cache() {
     for (size_t i = 0; i < layout_cache_t::prompt_cache_max_size; i++) {
         wcstring input = std::to_wstring(i);
         do_test(!seqs.find_prompt_layout(input));
-        seqs.add_prompt_layout({input, huge, input, {i, 0, 0}});
-        do_test(seqs.find_prompt_layout(input)->layout.line_count == i);
+        seqs.add_prompt_layout({input, huge, input, {{}, i, 0}});
+        do_test(seqs.find_prompt_layout(input)->layout.max_line_width == i);
     }
 
     size_t expected_evictee = 3;
     for (size_t i = 0; i < layout_cache_t::prompt_cache_max_size; i++) {
         if (i != expected_evictee)
-            do_test(seqs.find_prompt_layout(std::to_wstring(i))->layout.line_count == i);
+            do_test(seqs.find_prompt_layout(std::to_wstring(i))->layout.max_line_width == i);
     }
 
-    seqs.add_prompt_layout({L"whatever", huge, L"whatever", {100, 0, 0}});
+    seqs.add_prompt_layout({L"whatever", huge, L"whatever", {{}, 100, 0}});
     do_test(!seqs.find_prompt_layout(std::to_wstring(expected_evictee)));
-    do_test(seqs.find_prompt_layout(L"whatever", huge)->layout.line_count == 100);
+    do_test(seqs.find_prompt_layout(L"whatever", huge)->layout.max_line_width == 100);
 }
 
 void test_prompt_truncation() {
@@ -5762,7 +5762,16 @@ void test_prompt_truncation() {
 
     /// Helper to return 'layout' formatted as a string for easy comparison.
     auto format_layout = [&] {
-        return format_string(L"%lu,%lu,%lu", (unsigned long)layout.line_count,
+        wcstring line_breaks = L"";
+        bool first = true;
+        for (const size_t line_break : layout.line_breaks) {
+            if (!first) {
+                line_breaks.push_back(L',');
+            }
+            line_breaks.append(format_string(L"%lu", (unsigned long)line_break));
+            first = false;
+        }
+        return format_string(L"[%ls],%lu,%lu", line_breaks.c_str(),
                              (unsigned long)layout.max_line_width,
                              (unsigned long)layout.last_line_width);
     };
@@ -5774,12 +5783,22 @@ void test_prompt_truncation() {
 
     // No truncation.
     layout = cache.calc_prompt_layout(L"abcd", &trunc);
-    do_test(format_layout() == L"1,4,4");
+    do_test(format_layout() == L"[],4,4");
     do_test(trunc == L"abcd");
+
+    // Line break calculation.
+    layout = cache.calc_prompt_layout(join({
+                                          L"0123456789ABCDEF",  //
+                                          L"012345",            //
+                                          L"0123456789abcdef",  //
+                                          L"xyz"                //
+                                      }),
+                                      &trunc, 80);
+    do_test(format_layout() == L"[16,23,40],16,3");
 
     // Basic truncation.
     layout = cache.calc_prompt_layout(L"0123456789ABCDEF", &trunc, 8);
-    do_test(format_layout() == L"1,8,8");
+    do_test(format_layout() == L"[],8,8");
     do_test(trunc == ellipsis + L"9ABCDEF");
 
     // Multiline truncation.
@@ -5790,24 +5809,24 @@ void test_prompt_truncation() {
                                           L"xyz"                //
                                       }),
                                       &trunc, 8);
-    do_test(format_layout() == L"4,8,3");
+    do_test(format_layout() == L"[8,15,24],8,3");
     do_test(trunc == join({ellipsis + L"9ABCDEF", L"012345", ellipsis + L"9abcdef", L"xyz"}));
 
     // Escape sequences are not truncated.
     layout =
         cache.calc_prompt_layout(L"\x1B]50;CurrentDir=test/foo\x07NOT_PART_OF_SEQUENCE", &trunc, 4);
-    do_test(format_layout() == L"1,4,4");
+    do_test(format_layout() == L"[],4,4");
     do_test(trunc == ellipsis + L"\x1B]50;CurrentDir=test/foo\x07NCE");
 
     // Newlines in escape sequences are skipped.
     layout = cache.calc_prompt_layout(L"\x1B]50;CurrentDir=\ntest/foo\x07NOT_PART_OF_SEQUENCE",
                                       &trunc, 4);
-    do_test(format_layout() == L"1,4,4");
+    do_test(format_layout() == L"[],4,4");
     do_test(trunc == ellipsis + L"\x1B]50;CurrentDir=\ntest/foo\x07NCE");
 
     // We will truncate down to one character if we have to.
     layout = cache.calc_prompt_layout(L"Yay", &trunc, 1);
-    do_test(format_layout() == L"1,1,1");
+    do_test(format_layout() == L"[],1,1");
     do_test(trunc == ellipsis);
 }
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -213,9 +213,9 @@ void screen_force_clear_to_end();
 
 // Information about the layout of a prompt.
 struct prompt_layout_t {
-    size_t line_count;       // how many lines the prompt consumes
-    size_t max_line_width;   // width of the longest line
-    size_t last_line_width;  // width of the last line
+    std::vector<size_t> line_breaks;  // line breaks when rendering the prompt
+    size_t max_line_width;            // width of the longest line
+    size_t last_line_width;           // width of the last line
 };
 
 // Maintain a mapping of escape sequences to their widths for fast lookup.


### PR DESCRIPTION
## Description

Changes the left prompt rendering to include clr_eol for each rendered line. This prevents issues where if a multiline prompt changes between renderings, the previous prompt shows through.

Fixes #6532

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst