### PR TITLE
Expand the full view directory in prompt

### DIFF
--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -19,7 +19,13 @@ function prompt_pwd --description "Print the current working directory, shortene
     if [ $fish_prompt_pwd_dir_length -eq 0 ]
         echo $tmp
     else
+        set -q fish_prompt_dir_full_name_range
+        or set -l fish_prompt_dir_full_name_range 1
+        if [ $fish_prompt_dir_full_name_range -le 0 ]
+            set fish_prompt_dir_full_name_range 1
+        end
+        set -l folders (string split -rm$fish_prompt_dir_full_name_range / $tmp)
         # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
-        string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
+        echo (string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $folders[1]'/')(string join / $folders[2..-1])
     end
 end


### PR DESCRIPTION
## Description

Allows you to set the range in which the full directory is displayed in the prompt.

For example
If I was working in
```
/Users/hotoolong/.ghq/github.com/hotoolong/translate.nvim
```

By default, the display is as follows. (For my settings)

```
~/.g/g/h/translate.nvim (master|✔) $ 
```

If you set the full directory to display to 3,

```
set -g fish_prompt_dir_full_name_range 3
```

It appears as follows

```
~/.g/github.com/hotoolong/translate.nvim (master|✔) $
```

The following is similar issue.
#3566

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
