### PR TITLE
completions: systemd improvement

### DIFF
--- a/share/completions/bootctl.fish
+++ b/share/completions/bootctl.fish
@@ -1,0 +1,25 @@
+set -l commands status install update remove is-installed random-seed systemd-efi-options reboot-to-firmware list set-default set-oneshot
+
+complete -c bootctl -f
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a status -d 'Show status of EFI variables'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a install -d 'Install systemd-boot'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a update -d 'Update systemd-boot'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a remove -d 'Remove systemd-boot'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a is-installed -d 'Test whether systemd-boot is installed'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a random-seed -d 'Initialize random seed'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a systemd-efi-options -d 'Query or set system options string'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a reboot-to-firmware -d 'Query or set reboot-to-firmware EFI flag'
+complete -c bootctl -n "__fish_seen_subcommand_from reboot-to-firmware" -a 'true false'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a list -d 'List boot loader entries'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a set-default -d 'Set default boot loader entry'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a set-oneshot -d 'Set default boot loader entry (Once)'
+
+complete -c bootctl -s h -l help -d 'Show this help'
+complete -c bootctl -l version -d 'Print version'
+complete -c bootctl -l esp-path -r -d 'Path to the EFI System Partition (ESP)'
+complete -c bootctl -l boot-path -r -d 'Path to the $BOOT partition'
+complete -c bootctl -s p -l print-esp-path -d 'Print path to the EFI System Partition'
+complete -c bootctl -s x -l print-boot-path -d 'Print path to the $BOOT partition'
+complete -c bootctl -l no-variables -d 'Do not touch EFI variables'
+complete -c bootctl -l no-pager -d 'Do not pipe output into a pager'
+complete -c bootctl -l graceful -d 'Do not print fail'

--- a/share/completions/coredumpctl.fish
+++ b/share/completions/coredumpctl.fish
@@ -1,0 +1,22 @@
+set -l commands list info dump debug
+
+complete -c coredumpctl -f
+complete -c coredumpctl -n "not __fish_seen_subcommand_from $commands" -d 'List available coredumps'
+complete -c coredumpctl -n "not __fish_seen_subcommand_from $commands" -d 'Show detailed information about coredump(s)'
+complete -c coredumpctl -n "not __fish_seen_subcommand_from $commands" -d 'Print first matching coredump to stdout'
+complete -c coredumpctl -n "not __fish_seen_subcommand_from $commands" -d 'Start a debugger for the first matching coredump'
+
+complete -c coredumpctl -s h -l help -d 'Show this help'
+complete -c coredumpctl -l version -d 'Print version string'
+complete -c coredumpctl -l no-pager -d 'Do not pipe output into a pager'
+complete -c coredumpctl -l no-legend -d 'Do not print the column headers'
+complete -c coredumpctl -l debugger -r -d 'Use the given DEBUGGER'
+complete -c coredumpctl -s 1 -d 'Show information about most recent entry only'
+complete -c coredumpctl -s S -l since -r -d 'Only print coredumps since the DATE'
+complete -c coredumpctl -s U -l until -r -d 'Only print coredumps until the DATE'
+complete -c coredumpctl -s r -l reverse -d 'Show the newest entries first'
+complete -c coredumpctl -s F -l field -r -d 'List all values a certain FIELD takes'
+complete -c coredumpctl -s o -l output -r -d 'Write output to FILE'
+complete -c coredumpctl -l file -r -d 'Use journal FILE'
+complete -c coredumpctl -s D -l directory -r -d 'Use journal files from DIRECTORY'
+complete -c coredumpctl -s q -l quiet -d 'Do not show info messages and privilege warning'

--- a/share/completions/hostnamectl.fish
+++ b/share/completions/hostnamectl.fish
@@ -1,0 +1,18 @@
+set -l commands status set-hostname set-icon-name set-chassis set-deployment set-location
+
+complete -c hostnamectl -f
+complete -c hostnamectl -n "not __fish_seen_subcommand_from $commands" -a status -d 'Show current hostname settings'
+complete -c hostnamectl -n "not __fish_seen_subcommand_from $commands" -a set-hostname -d 'Set system hostname'
+complete -c hostnamectl -n "not __fish_seen_subcommand_from $commands" -a set-icon-name -d 'Set icon name for host'
+complete -c hostnamectl -n "not __fish_seen_subcommand_from $commands" -a set-chassis -d 'Set chassis type for host'
+complete -c hostnamectl -n "not __fish_seen_subcommand_from $commands" -a set-deployment -d 'Set deployment environment for host'
+complete -c hostnamectl -n "not __fish_seen_subcommand_from $commands" -a set-location -d 'Set location for host'
+
+complete -c hostnamectl -s h -l help -d 'Show this help'
+complete -c hostnamectl -l version -d 'Show package version'
+complete -c hostnamectl -l no-ask-password -d 'Do not prompt for password'
+complete -c hostnamectl -s H -l host -r -d 'Operate on remote HOST'
+complete -c hostnamectl -s M -l machine -r -d 'Operate on local CONTAINER'
+complete -c hostnamectl -l transient -d 'Only set transient hostname'
+complete -c hostnamectl -l static -d 'Only set static hostname'
+complete -c hostnamectl -l pretty -d 'Only set pretty hostname'

--- a/share/completions/timedatectl.fish
+++ b/share/completions/timedatectl.fish
@@ -1,19 +1,27 @@
-set -l commands status set-time{,zone} list-timezones set-local-rtc set-ntp
+set -l commands status show set-time set-timezone list-timezones set-local-rtc set-ntp timesync-status show-timesync
 
 complete -c timedatectl -f
-complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a status
-complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-time
-complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-timezone
-complete -c timedatectl -n "__fish_seen_subcommand_from set-timezone" -a "(timedatectl list-timezones)"
-complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a list-timezones
-complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-local-rtc -d "Maintain RTC in local time"
-complete -c timedatectl -n "__fish_seen_subcommand_from set-local-rtc" -a "true false"
-complete -c timedatectl -n "__fish_seen_subcommand_from set-local-rtc" -l adjust-system-clock -d 'Synchronize system clock from the RTC'
-complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-ntp -d "Use NTP"
-complete -c timedatectl -n "__fish_seen_subcommand_from set-ntp" -a "true false"
-complete -c timedatectl -l no-ask-password -d "Don't ask for password"
-complete -c timedatectl -s H -l host -d 'Execute the operation on a remote host'
-complete -c timedatectl -s M -l machine -d 'Execute operation on a local container'
-complete -c timedatectl -s h -l help -d 'Print a short help text and exit'
-complete -c timedatectl -l version -d 'Print a short version string and exit'
+complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a status -d 'Show current time settings'
+complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a show -d 'Show properties of systemd-timedated'
+complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-time -d 'Set system time'
+complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-timezone -d 'Set system time zone'
+complete -c timedatectl -n "__fish_seen_subcommand_from set-timezone" -a (timedatectl list-timezones)
+complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a list-timezones -d 'Show known time zones'
+complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-local-rtc -d 'Control whether RTC is in local time'
+complete -c timedatectl -n "__fish_seen_subcommand_from set-local-rtc" -a 'true false'
+complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-ntp -d 'Control network time sync'
+complete -c timedatectl -n "__fish_seen_subcommand_from set-ntp" -a 'true false'
+complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a timesync-status -d 'Show status of systemd-timesyncd'
+complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a show-timesync -d 'Show properties of systemd-timesyncd'
+
+complete -c timedatectl -s h -l help -d 'Show this help message'
+complete -c timedatectl -l version -d 'Show package version'
 complete -c timedatectl -l no-pager -d 'Do not pipe output into a pager'
+complete -c timedatectl -l no-ask-password -d 'Do not prompt for password'
+complete -c timedatectl -s H -l host -r -d 'Operate on remote HOST'
+complete -c timedatectl -s M -l machine -r -d 'Operate on local CONTAINER'
+complete -c timedatectl -l adjust-system-clock -d 'Adjust system clock when changing local RTC mode'
+complete -c timedatectl -l monitor -d 'Monitor status of systemd-timesyncd'
+complete -c timedatectl -s p -l property -r -d 'Show only properties by this NAME'
+complete -c timedatectl -s a -l all -d 'Show all properties'
+complete -c timedatectl -l value -d 'Only show properties with values'


### PR DESCRIPTION
## Description

- `timedatectl.fish`: add missing 2 commands and some options
- `bootctl.fish`: new completion for systemd-boot
- `coredumpctl.fish`: new completion for systemd-coredump
- `hostnamectl.fish`: new completion for systemd-hostnamed

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
