### PR TITLE
Add universal variable notifier based off of shared memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ add_library(fishlib STATIC ${FISH_SRCS})
 target_sources(fishlib PRIVATE ${FISH_HEADERS})
 target_link_libraries(fishlib
   ${CURSES_LIBRARY} ${CURSES_EXTRA_LIBRARY} Threads::Threads ${CMAKE_DL_LIBS}
-  ${PCRE2_LIB} ${Intl_LIBRARIES} ${ATOMIC_LIBRARY})
+  ${PCRE2_LIB} ${Intl_LIBRARIES} ${ATOMIC_LIBRARY} ${RT_LIBRARY})
 target_include_directories(fishlib PRIVATE
   ${CURSES_INCLUDE_DIRS})
 

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -225,6 +225,18 @@ IF (NOT LIBATOMIC_NOT_NEEDED)
     set(ATOMIC_LIBRARY "atomic")
 endif()
 
+check_cxx_source_compiles("
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+int main() {
+shm_open(\"cmake-shm-test-foo\", O_CREAT|O_RDWR, 0666);
+}"
+LIBRT_NOT_NEEDED)
+IF (NOT LIBRT_NOT_NEEDED)
+    set(RT_LIBRARY "rt")
+endif()
+
 # Check if mbrtowc implementation attempts to encode invalid UTF-8 sequences
 # Known culprits: at least some versions of macOS (confirmed Snow Leopard and Yosemite)
 try_run(mbrtowc_invalid_utf8_exit mbrtowc_invalid_utf8_compiles ${CMAKE_CURRENT_BINARY_DIR}

--- a/src/env_universal_common.h
+++ b/src/env_universal_common.h
@@ -171,6 +171,9 @@ class universal_notifier_t {
         // Strategy that uses a named pipe. Somewhat complex, but portable and doesn't require
         // polling most of the time.
         strategy_named_pipe,
+
+        // Strategy that uses a posix conditional variable in a shared memory section.
+        strategy_posix_shmem,
     };
 
    protected:

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3803,6 +3803,7 @@ static void trigger_or_wait_for_notification(universal_notifier_t::notifier_stra
             usleep(40000);
             break;
         }
+        case universal_notifier_t::strategy_posix_shmem:
         case universal_notifier_t::strategy_named_pipe:
         case universal_notifier_t::strategy_sigio: {
             break;  // nothing required


### PR DESCRIPTION
This is a conceptually more straight-forward solution for synchronizing data between multiple fish instances, using the textbook shared memory approach. My only concerns with the exceedingly clever SIGIO approach mainly stem from the subtleties involved with relying on side effects of async reads/writes to drive the notifier (e.g. the variety of differences in just when SIGIO is generated), and a fear that if we adopt asynchronous IO in the future that might cause issues with our current, exclusive interpretation of SIGIO.

I'm not sure how the SIGIO notifier is actually "notifying" since it just returns true/false when polled (I imagine the read loop has been modified so as to guarantee the notifier is polled prior to any operation that might read a universal variable?), but if it is desirable to use the notifier in a non-polling manner the `block()` method will sleep the calling thread until a uvar change is detected. If it's desired to use it in an asynchronous context with an event loop (e.g. with select/poll/epoll), it is trivial to add an anonymous pipe and use the self-pipe trick to provide an fd that can be given to the kernel to wait on by calling `notifier.block()` in a new thread and writing (then immediately reading) a byte to/from the pipe when awoken in a loop.

This notifier has been tested on Linux, FreeBSD, WSL, and macOS and passes all the tests. There is currently no `#ifdef` for selecting the strategy, suggestions are welcome.

The code currently uses the GCC atomic extensions (CMake patched accordingly) to atomically read/write the one- to four-byte fields in the shared memory. This may be overkill: presumably the pointer nature of the shared memory object would suffice to prevent the compiler from making assumptions that would lead to stale reads; the addition of a `volatile` modifier to the storage class of either the SHM pointer or the individual fields would definitely suffice, but that's apparently no longer "in vogue" (suggestions again welcome).

Closes #7429
