### PR TITLE
Fix typo

### DIFF
--- a/share/completions/mkdocs.fish
+++ b/share/completions/mkdocs.fish
@@ -18,9 +18,9 @@ complete -n 'contains build (commandline -poc)' -c mkdocs -s d -l site-dir -r -d
 complete -n 'not __fish_seen_subcommand_from build gh-deploy new serve' -f -c mkdocs -a gh-deploy -d 'Deploy your documentation to GitHub Pages'
 complete -n 'contains gh-deploy (commandline -poc)' -f -c mkdocs -s c -l clean -d 'Remove old site_dir before building (the default)'
 complete -n 'contains gh-deploy (commandline -poc)' -c mkdocs -s f -l config-file -r -d 'Provide a specific MkDocs config'
-complete -n 'contains gh-deploy (commandline -poc)' -f -c mkdocs -s m -l message -r -d 'A commit message to use when committing to the Github Pages remote branch'
-complete -n 'contains gh-deploy (commandline -poc)' -f -c mkdocs -s b -l remote-branch -r -d 'The remote branch to commit to for Github Pages'
-complete -n 'contains gh-deploy (commandline -poc)' -f -c mkdocs -s r -l remote-name -r -d 'The remote name to commit to for Github Pages'
+complete -n 'contains gh-deploy (commandline -poc)' -f -c mkdocs -s m -l message -r -d 'A commit message to use when committing to the GitHub Pages remote branch'
+complete -n 'contains gh-deploy (commandline -poc)' -f -c mkdocs -s b -l remote-branch -r -d 'The remote branch to commit to for GitHub Pages'
+complete -n 'contains gh-deploy (commandline -poc)' -f -c mkdocs -s r -l remote-name -r -d 'The remote name to commit to for GitHub Pages'
 complete -n 'contains gh-deploy (commandline -poc)' -f -c mkdocs -l force -d 'Force the push to the repository'
 
 ## new

--- a/tests/checks/invocation.fish
+++ b/tests/checks/invocation.fish
@@ -19,7 +19,7 @@ if not set -q GITHUB_WORKFLOW
     # CHECK: login shell
     # CHECK: interactive
 else
-    # Github Action doesn't start this in a terminal, so fish would complain.
+    # GitHub Action doesn't start this in a terminal, so fish would complain.
     # Instead, we just fake the result, since we have no way to indicate a skipped test.
     echo not login shell
     echo interactive


### PR DESCRIPTION
## Description

Use "Git**H**ub" instead of "Github".

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
