### PR TITLE
Add support for copy and paste in WSL

### DIFF
--- a/share/functions/fish_clipboard_copy.fish
+++ b/share/functions/fish_clipboard_copy.fish
@@ -12,5 +12,7 @@ function fish_clipboard_copy
         printf '%s' $cmdline | xsel --clipboard 2>/dev/null
     else if type -q xclip
         printf '%s' $cmdline | xclip -selection clipboard 2>/dev/null
+    else if type -q clip.exe
+        printf '%s' $cmdline | clip.exe
     end
 end

--- a/share/functions/fish_clipboard_paste.fish
+++ b/share/functions/fish_clipboard_paste.fish
@@ -8,6 +8,8 @@ function fish_clipboard_paste
         set data (xsel --clipboard 2>/dev/null)
     else if type -q xclip
         set data (xclip -selection clipboard -o 2>/dev/null)
+    else if type -q powershell.exe
+        set data (powershell.exe Get-Clipboard | string trim -r -c \r)
     end
 
     # Issue 6254: Handle zero-length clipboard content


### PR DESCRIPTION
## Description

The necessary commands for copying from and pasting to the Windows clipboard (through WSL) has been integrated to `fish_clipboard_copy` and `fish_clipboard_paste` respectively.

Fixes issue #7454 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
