### PR TITLE
Import named regex captures as fish variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Notable improvements and fixes
    or non-matching wildcards, as these could be defined differently at
    runtime (especially for functions). This makes it usable as a static syntax checker (#977).
 -  ``type`` is now a builtin and therefore much faster (#7342).
+-  ``string match --regex`` now imports named PCRE2 capture groups as fish variables (#7459).
 
 Syntax changes and new commands
 -------------------------------

--- a/doc_src/cmds/string-match.rst
+++ b/doc_src/cmds/string-match.rst
@@ -27,6 +27,8 @@ If ``--index`` or ``-n`` is given, each match is reported as a 1-based start pos
 
 If ``--regex`` or ``-r`` is given, PATTERN is interpreted as a Perl-compatible regular expression, which does not have to match the entire STRING. For a regular expression containing capturing groups, multiple items will be reported for each match, one for the entire match and one for each capturing group. With this, only the matching part of the STRING will be reported, unless ``--entire`` is given.
 
+When matching via regular expressions, it is possible to directly import matches as fish variables by means of named capture groups using the PCRE2 syntax. This behavior is automatic and occurs in addition to any other match reporting. The default behavior with `--regex` results in the initialization of fish variables in the default scope containing the matched text corresponding to each named capture group. A named capture group matching a zero-length string will be initialized as a fish variable containing a likewise empty string (i.e. the equivalent of `""`), but a named capture group that did not match will result in an empty (null) fish variable. When `--regex` is used in conjunction with `--all`, this behavior changes slightly: for each of the *n* matching sequences, the *n*th index of each named variable will contain the contents of the corresponding named capture group for the *n*th match, but will contain an empty string if the group was empty or if the group did not match.
+
 If ``--invert`` or ``-v`` is used the selected lines will be only those which do not match the given glob pattern or regular expression.
 
 Exit status: 0 if at least one match was found, or 1 otherwise.
@@ -103,5 +105,22 @@ Match Regex Examples
 
     >_ string match -r -i '0x[0-9a-f]{1,8}' 'int magic = 0xBadC0de;'
     0xBadC0de
+
+    >_ echo $version
+    3.1.2-1575-ga2ff32d90
+    >_ string match -rq '(?<major>\d+).(?<minor>\d+).(?<revision>\d+)' -- $version
+    >_ echo "You are using fish $major!"
+    You are using fish 3!
+
+    >_ string match -raq ' *(?<sentence>[^.!?]+)(?<punctuation>[.!?])?' "hello, friend. goodbye"
+    >_ printf "%s\n" -- $sentence
+    hello, friend
+    goodbye
+    >_ printf "%s\n" -- $punctuation
+    .
+
+    >_ string match -rq '(?<word>hello)' 'hi'
+    >_ count $word
+    0
 
 .. END EXAMPLES

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1,6 +1,8 @@
 // Implementation of the string builtin.
 #include "config.h"  // IWYU pragma: keep
 
+#include <functional>
+
 #define PCRE2_CODE_UNIT_WIDTH WCHAR_T_BITS
 #ifdef _WIN32
 #define PCRE2_STATIC
@@ -885,93 +887,139 @@ class pcre2_matcher_t : public string_matcher_t {
         return opts.invert_match ? match_result_t::no_match : match_result_t::match;
     }
 
-    void import_vars(const wcstring &haystack, bool match_found, bool first_time) {
-        PCRE2_SPTR name_table;
-        uint32_t name_entry_size;
-        uint32_t name_count;
+    class regex_importer_t {
+       private:
+        std::map<wcstring, std::vector<wcstring>> matches_;
+        parser_t &parser_;
+        const wcstring &haystack_;
+        const compiled_regex_t &regex_;
+        /// fish variables may be empty, but there's no such thing as a fish array that contains
+        /// an empty value/index. Since a match may evaluate to a literal empty string, we can't
+        /// use that as a sentinel value in place of null/none to indicate that no matches were
+        /// found, which is required to determine whether, in the case of a single
+        /// `string match -r` invocation without `--all` we export a variable set to "" or an
+        /// empty variable.
+        bool match_found_ = false;
+        bool skip_import_ = true;
 
-        pcre2_pattern_info(regex.code, PCRE2_INFO_NAMETABLE, &name_table);
-        pcre2_pattern_info(regex.code, PCRE2_INFO_NAMEENTRYSIZE, &name_entry_size);
-        pcre2_pattern_info(regex.code, PCRE2_INFO_NAMECOUNT, &name_count);
+       public:
+        regex_importer_t(parser_t &parser, const wcstring &haystack, const compiled_regex_t &regex)
+            : parser_(parser), haystack_(haystack), regex_(regex) {}
 
-        struct name_table_entry_t {
+        /// Enumerates the named groups in the compiled PCRE2 expression, validates the names of
+        /// the groups as variable names, and initializes their value (overriding any previous
+        /// contents).
+        bool init() {
+            PCRE2_SPTR name_table;
+            uint32_t name_entry_size;
+            uint32_t name_count;
+
+            pcre2_pattern_info(regex_.code, PCRE2_INFO_NAMETABLE, &name_table);
+            pcre2_pattern_info(regex_.code, PCRE2_INFO_NAMEENTRYSIZE, &name_entry_size);
+            pcre2_pattern_info(regex_.code, PCRE2_INFO_NAMECOUNT, &name_count);
+
+            struct name_table_entry_t {
 #if PCRE2_CODE_UNIT_WIDTH == 8
-            uint8_t match_index_msb;
-            uint8_t match_index_lsb;
-            char name[];
+                uint8_t match_index_msb;
+                uint8_t match_index_lsb;
+                char name[];
 #elif PCRE2_CODE_UNIT_WIDTH == 16
-            uint16_t match_index;
-            char16_t name[];
+                uint16_t match_index;
+                char16_t name[];
 #else
-            uint32_t match_index;
+                uint32_t match_index;
 #if WCHAR_T_BITS == PCRE2_CODE_UNIT_WIDTH
-            wchar_t name[];
+                wchar_t name[];
 #else
-            char32_t name[];
+                char32_t name[];
 #endif  // WCHAR_T_BITS
 #endif  // PCRE2_CODE_UNIT_WIDTH
-        };
-
-        auto &vars = this->parser.vars();
-        PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(regex.match);
-        auto *names = static_cast<name_table_entry_t *>((void *)(name_table));
-        for (uint32_t i = 0; i < name_count; ++i) {
-            auto &name_entry = names[i * name_entry_size];
-
-            if (first_time) {
-                // Make sure we clear out any existing values matching the named groups, because
-                // we'll be appending instead of overwriting from here on out.
-                vars.set_empty(name_entry.name, ENV_DEFAULT);
-            }
-
-            // A named group may actually correspond to multiple group numbers, each of which
-            // might have to be enumerated.
-            PCRE2_SPTR first = nullptr;
-            PCRE2_SPTR last = nullptr;
-            int entry_size = pcre2_substring_nametable_scan(
-                regex.code, (PCRE2_SPTR)(name_entry.name), &first, &last);
-            if (entry_size <= 0) {
-                FLOGF(warning, L"PCRE2 failure retrieving named matches");
-                continue;
-            }
-
-            auto append_value = [&](wcstring &&value) {
-                wcstring_list_t values{};
-                vars.get(name_entry.name, ENV_DEFAULT)->to_list(values);
-                values.emplace_back(value);
-                vars.set(name_entry.name, ENV_DEFAULT, values);
             };
 
+            auto *names = static_cast<name_table_entry_t *>((void *)(name_table));
+            for (uint32_t i = 0; i < name_count; ++i) {
+                auto &name_entry = names[i * name_entry_size];
+
+                // TODO: Validate names to ensure compliance with fish variable requirements, make
+                // sure no special read-only variables are being set. Return false in case of
+                // validation failure.
+                matches_.emplace(name_entry.name, std::vector<wcstring>{});
+            }
+
+            skip_import_ = false;
+            return true;
+        }
+
+        /// This member function should be called each time a match is found
+        void import_vars(bool match_found) {
+            match_found_ |= match_found;
             if (!match_found) {
-                if (!opts.all) {
-                    append_value(L"");
-                }
-                continue;
+                return;
             }
 
-            bool value_found = false;
-            for (auto group_ptr = first; group_ptr <= last; group_ptr += entry_size) {
-                int group_num = group_ptr[0];
-
-                PCRE2_SIZE *capture = ovector + (2 * group_num);
-                PCRE2_SIZE begin = capture[0];
-                PCRE2_SIZE end = capture[1];
-
-                if (begin != PCRE2_UNSET && end != PCRE2_UNSET && end >= begin) {
-                    append_value(haystack.substr(begin, end - begin));
-                    value_found = true;
-                    break;
+            PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(regex_.match);
+            for (const auto &kv : matches_) {
+                const auto &name = kv.first;
+                // A named group may actually correspond to multiple group numbers, each of which
+                // might have to be enumerated.
+                PCRE2_SPTR first = nullptr;
+                PCRE2_SPTR last = nullptr;
+                int entry_size = pcre2_substring_nametable_scan(
+                    regex_.code, (PCRE2_SPTR)(name.c_str()), &first, &last);
+                if (entry_size <= 0) {
+                    FLOGF(warning, L"PCRE2 failure retrieving named matches");
+                    continue;
                 }
-            }
 
-            // We don't have a way of having empty values in the middle of a multi-entry fish array,
-            // so we compromise by leaving the value unset in the case of !opts.all but assign an
-            // empty value otherwise. (opts.all is always true if !first_time)
-            if (!value_found && opts.all) {
-                append_value(wcstring{});
+                if (!match_found) {
+                    matches_[name].emplace_back(L"");
+                    continue;
+                }
+
+                bool value_found = false;
+                for (auto group_ptr = first; group_ptr <= last; group_ptr += entry_size) {
+                    int group_num = group_ptr[0];
+
+                    PCRE2_SIZE *capture = ovector + (2 * group_num);
+                    PCRE2_SIZE begin = capture[0];
+                    PCRE2_SIZE end = capture[1];
+
+                    if (begin != PCRE2_UNSET && end != PCRE2_UNSET && end >= begin) {
+                        matches_[name].emplace_back(haystack_.substr(begin, end - begin));
+                        value_found = true;
+                        break;
+                    }
+                }
+
+                // If there are multiple named groups and --all was used, we need to ensure that the
+                // indexes are always in sync between the variables. If an optional named group
+                // didn't match but its brethren did, we need to make sure to put *something* in the
+                // resulting array, and unfortunately fish doesn't support empty/null members so
+                // we're going to have to use an empty string as the sentinel value.
+                if (!value_found) {
+                    matches_[name].emplace_back(wcstring{});
+                }
             }
         }
-    }
+
+        ~regex_importer_t() {
+            if (skip_import_) {
+                return;
+            }
+
+            auto &vars = parser_.vars();
+            for (const auto &kv : matches_) {
+                const auto &name = kv.first;
+                const auto &value = kv.second;
+
+                if (!match_found_) {
+                    vars.set_empty(name, ENV_DEFAULT);
+                } else {
+                    vars.set(name, ENV_DEFAULT, value);
+                }
+            }
+        }
+    };
 
    public:
     pcre2_matcher_t(const wchar_t *argv0_, const wcstring &pattern, const options_t &opts,
@@ -991,15 +1039,26 @@ class pcre2_matcher_t : public string_matcher_t {
             return false;
         }
 
+        maybe_t<regex_importer_t> var_importer;
+        if (opts.import_vars) {
+            var_importer.emplace(this->parser, arg, this->regex);
+
+            // We must manually init the importer rather than relegating this to the constructor
+            // because it will validate the names it is importing to make sure they're all legal and
+            // writeable.
+            if (!var_importer->init()) {
+                // TODO: Report error
+                return false;
+            }
+        }
+
         // See pcre2demo.c for an explanation of this logic.
         PCRE2_SIZE arglen = arg.length();
         auto rc = report_match(arg, pcre2_match(regex.code, PCRE2_SPTR(arg.c_str()), arglen, 0, 0,
                                                regex.match, nullptr));
 
-        if (rc != match_result_t::pcre2_error && opts.import_vars) {
-            // Must call even if no matches were found to make sure no previous values are
-            // erroneously kept.
-            import_vars(arg, rc == match_result_t::match, true /* first time */);
+        if (opts.import_vars) {
+            var_importer->import_vars(rc == match_result_t::match);
         }
 
         switch (rc) {
@@ -1033,7 +1092,7 @@ class pcre2_matcher_t : public string_matcher_t {
 
             // Call import_vars() before modifying the ovector
             if (rc == match_result_t::match && opts.import_vars) {
-                import_vars(arg, true /* match found */, false /* !first_time */);
+                var_importer->import_vars(true /* match found */);
             }
 
             if (rc == match_result_t::no_match) {

--- a/tests/checks/regex-import.fish
+++ b/tests/checks/regex-import.fish
@@ -2,32 +2,32 @@
 # Tests for importing named regex groups as fish variables
 
 # Capture first match
-echo "hello world" | string match --regex -q --import -- '(?<words>[^ ]+) ?'
+echo "hello world" | string match --regex -q -- '(?<words>[^ ]+) ?'
 printf "%s\n" $words
 # CHECK: hello
 
 # Capture multiple matches
-echo "hello world" | string match --regex -q --import --all -- '(?<words>[^ ]+) ?'
+echo "hello world" | string match --regex -q --all -- '(?<words>[^ ]+) ?'
 printf "%s\n" $words
 # CHECK: hello
 # CHECK: world
 
 # Capture multiple variables
-echo "hello world" | string match -rqI -- '^(?<word1>[^ ]+) (?<word2>.*)$'
+echo "hello world" | string match -rq -- '^(?<word1>[^ ]+) (?<word2>.*)$'
 printf "%s\n" $word1 $word2
 # CHECK: hello
 # CHECK: world
 
 # Clear variables on no match
 set foo foo
-echo "foo" | string match -rqI -- '^(?<foo>bar)$'
+echo "foo" | string match -rq -- '^(?<foo>bar)$'
 echo $foo
 # CHECK:
 
 # Named group may be empty in some of the matches
 set word
 set punctuation
-echo "hello world, boy!" | string match -a -qrI -- '(?<word>[^ .,!;]+)(?<punctuation>[.,!;])?'
+echo "hello world, boy!" | string match -a -qr -- '(?<word>[^ .,!;]+)(?<punctuation>[.,!;])?'
 echo $word
 # CHECK: hello world boy
 printf "%s\n" $punctuation

--- a/tests/checks/regex-import.fish
+++ b/tests/checks/regex-import.fish
@@ -1,0 +1,36 @@
+#RUN: %fish %s
+# Tests for importing named regex groups as fish variables
+
+# Capture first match
+echo "hello world" | string match --regex -q --import -- '(?<words>[^ ]+) ?'
+printf "%s\n" $words
+# CHECK: hello
+
+# Capture multiple matches
+echo "hello world" | string match --regex -q --import --all -- '(?<words>[^ ]+) ?'
+printf "%s\n" $words
+# CHECK: hello
+# CHECK: world
+
+# Capture multiple variables
+echo "hello world" | string match -rqI -- '^(?<word1>[^ ]+) (?<word2>.*)$'
+printf "%s\n" $word1 $word2
+# CHECK: hello
+# CHECK: world
+
+# Clear variables on no match
+set foo foo
+echo "foo" | string match -rqI -- '^(?<foo>bar)$'
+echo $foo
+# CHECK:
+
+# Named group may be empty in some of the matches
+set word
+set punctuation
+echo "hello world, boy!" | string match -a -qrI -- '(?<word>[^ .,!;]+)(?<punctuation>[.,!;])?'
+echo $word
+# CHECK: hello world boy
+printf "%s\n" $punctuation
+# CHECK:
+# CHECK: ,
+# CHECK: !

--- a/tests/checks/regex-import.fish
+++ b/tests/checks/regex-import.fish
@@ -34,3 +34,7 @@ printf "%s\n" $punctuation
 # CHECK:
 # CHECK: ,
 # CHECK: !
+
+# Verify read-only variables may not be imported
+echo hello | string match -rq "(?<version>.*)"
+# CHECKERR: Modification of read-only variable "version" is not allowed


### PR DESCRIPTION
 Add support for importing named regex matches

The new commandline switch `string match --regex --import` will import
as fish variables any named capture groups with the matched captures as
the value(s).

Example:

```fish
~/fish-shell > set spec (identify fish.png)
~/fish-shell > printf "%s\n" "$spec"
fish.png PNG 275x275 275x275+0+0 8-bit sRGB 8.43KB 0.000u 0:00.000
~/fish-shell > string match -rq --import "^(?<file>[^ ]+) (?<fmt>[^ ]+) (?<width>\d+)x(?<height>\d+)" -- "$spec"
~/fish-shell> printf "$file\n * width: $width\n * height: $height\n"
fish.png
 * width: 275
 * height: 275
```