### PR TITLE
Don't assume $__fish_git_prompt_char_cleanstate is non-empty

### DIFF
--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -403,7 +403,10 @@ function fish_git_prompt --description "Prompt function for Git"
                 and test "$dirty" != false
                 and test "$untracked" != false
             end
-            set informative_status "$space"(__fish_git_prompt_informative_status $git_dir)
+            set informative_status (__fish_git_prompt_informative_status $git_dir)
+            if test -n "$informative_status"
+                set informative_status "$space$informative_status"
+            end
         else
             # This has to be set explicitly.
             if test "$dirty" = true
@@ -533,7 +536,9 @@ function __fish_git_prompt_informative_status
     set -l state (math $dirtystate + $invalidstate + $stagedstate + $untrackedfiles + $stashstate 2>/dev/null)
     if test -z "$state"
         or test "$state" = 0
-        set info $___fish_git_prompt_color_cleanstate$___fish_git_prompt_char_cleanstate$___fish_git_prompt_color_cleanstate_done
+        if test -n "$___fish_git_prompt_char_cleanstate"
+            set info $___fish_git_prompt_color_cleanstate$___fish_git_prompt_char_cleanstate$___fish_git_prompt_color_cleanstate_done
+        end
     else
         for i in $___fish_git_prompt_status_order
             if [ $$i != 0 ]


### PR DESCRIPTION
This fixes the case where an empty "clean state" character
can cause a spurious space character at the end of the git prompt.

## Description

I've been trying to integrate fish_git_prompt into a custom prompt and running into minor issues. The first was fixed by discovering the undocumented argument where you can pass in a format string. The second is fixed by this commit. When running the prompt in informative mode with `$__fish_git_prompt_char_cleanstate` set to an empty string while inside a clean repository, the prompt looks like this:

`(master )`

Note the spurious space after `master`. Minor but a bit ugly/annoying. Even when passing in "%s" as the argument to fish_git_prompt and running the result through `string trim`, the output will still be `master ` with a trailing space, presumably because some color codes are getting in the way of the trim operation. So this commit adds a couple simple checks in and around the informative status function to make sure we aren't echoing spurious output.

Thanks!

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
