### PR TITLE
build_tools/fish_xgettext.fish: avoid printing error message when

### DIFF
--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -22,34 +22,39 @@ set -l implicit_regex '(?:^| +)(?:complete|function).*? (?:-d|--description) (([
 # than messages which should be implicitly translated.
 set -l explicit_regex '.*\( *_ (([\'"]).+?(?<!\\\\)\\2) *\).*'
 
-rm -r /tmp/fish
+# Create temporary directory for these operations. OS X `mktemp` is somewhat restricted, so this block
+# works around that - based on share/functions/funced.fish.
+set -q TMPDIR
+or set -l TMPDIR /tmp
+set -l tmpdir (mktemp -d $TMPDIR/fish.XXXXXX)
+or exit 1
 
-mkdir -p /tmp/fish/implicit/share/completions /tmp/fish/implicit/share/functions
-mkdir -p /tmp/fish/explicit/share/completions /tmp/fish/explicit/share/functions
+mkdir -p $tmpdir/implicit/share/completions $tmpdir/implicit/share/functions
+mkdir -p $tmpdir/explicit/share/completions $tmpdir/explicit/share/functions
 
 for f in share/config.fish share/completions/*.fish share/functions/*.fish
     # Extract explicit attempts to translate a message. That is, those that are of the form
     # `(_ "message")`.
-    string replace --filter --regex $explicit_regex 'echo $1' <$f | fish >/tmp/fish/explicit/$f.tmp 2>/dev/null
+    string replace --filter --regex $explicit_regex 'echo $1' <$f | fish >$tmpdir/explicit/$f.tmp 2>/dev/null
     while read description
         echo 'N_ "'(string replace --all '"' '\\"' -- $description)'"'
-    end </tmp/fish/explicit/$f.tmp >/tmp/fish/explicit/$f
-    rm /tmp/fish/explicit/$f.tmp
+    end <$tmpdir/explicit/$f.tmp >$tmpdir/explicit/$f
+    rm $tmpdir/explicit/$f.tmp
 
     # Handle `complete` / `function` description messages. The `| fish` is subtle. It basically
     # avoids the need to use `source` with a command substitution that could affect the current
     # shell.
-    string replace --filter --regex $implicit_regex 'echo $1' <$f | fish >/tmp/fish/implicit/$f.tmp 2>/dev/null
+    string replace --filter --regex $implicit_regex 'echo $1' <$f | fish >$tmpdir/implicit/$f.tmp 2>/dev/null
     while read description
         # We don't use `string escape` as shown in the next comment because it produces output that
         # is not parsed correctly by xgettext. Instead just escape double-quotes and quote the
         # resulting string.
         echo 'N_ "'(string replace --all '"' '\\"' -- $description)'"'
-    end </tmp/fish/implicit/$f.tmp >/tmp/fish/implicit/$f
-    rm /tmp/fish/implicit/$f.tmp
+    end <$tmpdir/implicit/$f.tmp >$tmpdir/implicit/$f
+    rm $tmpdir/implicit/$f.tmp
 end
 
-xgettext -j -k -kN_ -LShell --from-code=UTF-8 -cDescription --no-wrap -o messages.pot /tmp/fish/explicit/share/*/*.fish
-xgettext -j -k -kN_ -LShell --from-code=UTF-8 -cDescription --no-wrap -o messages.pot /tmp/fish/implicit/share/*/*.fish
+xgettext -j -k -kN_ -LShell --from-code=UTF-8 -cDescription --no-wrap -o messages.pot $tmpdir/explicit/share/*/*.fish
+xgettext -j -k -kN_ -LShell --from-code=UTF-8 -cDescription --no-wrap -o messages.pot $tmpdir/implicit/share/*/*.fish
 
-rm -r /tmp/fish
+rm -r $tmpdir


### PR DESCRIPTION
 /tmp/fish doesn't exist.

 The command invocation used was `rm -r /tmp/fish`, when it should have
 used -rf.