### PR TITLE
src/builtin_type.cpp: add missing gettext call.

### DIFF
--- a/src/builtin_type.cpp
+++ b/src/builtin_type.cpp
@@ -190,7 +190,7 @@ maybe_t<int> builtin_type(parser_t &parser, io_streams_t &streams, wchar_t **arg
                 if (opts.path || opts.force_path) {
                     streams.out.append_format(L"%ls\n", path.c_str());
                 } else {
-                    streams.out.append_format(L"%ls is %ls\n", name, path.c_str());
+                    streams.out.append_format(_(L"%ls is %ls\n"), name, path.c_str());
                 }
             } else if (opts.type) {
                 streams.out.append(_(L"file\n"));


### PR DESCRIPTION
The string "%ls is %ls", which is printed when `type <command>` is ran
for a command in PATH, couldn't be localized, since it was missing _()
around it.