### PR TITLE
Account for mktemp failures

### DIFF
--- a/build_tools/list_committers_since.fish
+++ b/build_tools/list_committers_since.fish
@@ -13,7 +13,9 @@ if not contains -- $TAG (git tag)
 end
 
 set -l committers_to_tag (mktemp)
+or exit 1
 set -l committers_from_tag (mktemp)
+or exit 1
 
 # You might think it would be better to case-insensitively sort/compare the names
 # to produce a more natural-looking list.

--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -1,5 +1,6 @@
 function edit_command_buffer --description 'Edit the command buffer in an external editor'
     set -l f (mktemp)
+    or return 1
     if set -q f[1]
         mv $f $f.fish
         set f $f.fish

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -80,6 +80,7 @@ function funced --description 'Edit function definition'
     set -q TMPDIR
     or set -l TMPDIR /tmp
     set -l tmpdir (mktemp -d $TMPDIR/fish.XXXXXX)
+    or return 1
     set -l tmpname $tmpdir/$funcname.fish
 
     if functions -q -- $funcname

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -169,6 +169,7 @@ function help --description 'Show help for the fish shell'
             set -q TMPDIR
             or set -l TMPDIR /tmp
             set -l tmpdir (mktemp -d $TMPDIR/help.XXXXXX)
+            or return 1
             set -l tmpname $tmpdir/help.html
             echo '<meta http-equiv="refresh" content="0;URL=\''$clean_url'\'" />' >$tmpname
             set page_url file://$tmpname

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -26,7 +26,7 @@ function psub --description "Read from stdin into a file and output the filename
         # that the command substitution exits without needing to wait for
         # all the commands to exit.
         set dirname (mktemp -d $tmpdir/.psub.XXXXXXXXXX)
-        or return
+        or return 1
         set filename $dirname/psub.fifo"$_flag_suffix"
         command mkfifo $filename
         # Note that if we were to do the obvious `cat >$filename &`, we would deadlock
@@ -35,9 +35,11 @@ function psub --description "Read from stdin into a file and output the filename
         command tee $filename >/dev/null &
     else if test -z "$_flag_suffix"
         set filename (mktemp $tmpdir/.psub.XXXXXXXXXX)
+        or return 1
         command cat >$filename
     else
         set dirname (mktemp -d $tmpdir/.psub.XXXXXXXXXX)
+        or return 1
         set filename "$dirname/psub$_flag_suffix"
         command cat >$filename
     end


### PR DESCRIPTION
## Description

Discussed in #7477, catches when `mktemp` errors out and exits the script / function.

I can try to add some error case that exports `TMPDIR` to some place that can't be written, if you find it necessary.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst