### PR TITLE
string: Allow `string match --max`

### DIFF
--- a/doc_src/cmds/string-match.rst
+++ b/doc_src/cmds/string-match.rst
@@ -8,7 +8,7 @@ Synopsis
 
 ::
 
-    string match [(-a | --all)] [(-e | --entire)] [(-i | --ignore-case)] [(-r | --regex)] [(-n | --index)] [(-q | --quiet)] [(-v | --invert)] PATTERN [STRING...]
+    string match [(-a | --all)] [(-e | --entire)] [(-i | --ignore-case)] [(-m | --max) MAX] [(-r | --regex)] [(-n | --index)] [(-q | --quiet)] [(-v | --invert)] PATTERN [STRING...]
 
 .. END SYNOPSIS
 
@@ -28,6 +28,10 @@ If ``--index`` or ``-n`` is given, each match is reported as a 1-based start pos
 If ``--regex`` or ``-r`` is given, PATTERN is interpreted as a Perl-compatible regular expression, which does not have to match the entire STRING. For a regular expression containing capturing groups, multiple items will be reported for each match, one for the entire match and one for each capturing group. With this, only the matching part of the STRING will be reported, unless ``--entire`` is given.
 
 If ``--invert`` or ``-v`` is used the selected lines will be only those which do not match the given glob pattern or regular expression.
+
+If ``--max`` or ``-m`` is used ``string match`` will stop after MAX matching STRINGs - together with ``--all`` it will still print all the matches for those strings.
+
+If ``-q`` or ``--quiet`` is used ``string match`` will only return the exit status without output. It will also stop processing after the first match.
 
 Exit status: 0 if at least one match was found, or 1 otherwise.
 

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -668,3 +668,17 @@ echo $status
 # Unmatched capturing groups are treated as empty
 echo az | string replace -r -- 'a(b.+)?z' 'a:$1z'
 # CHECK: a:z
+
+# match --max
+string match -r -a -m 3 .at aatxatyatzat bat cat dat
+# CHECK: aat
+# CHECK: xat
+# CHECK: yat
+# CHECK: zat
+# CHECK: bat
+# CHECK: cat
+
+seq 1 100 | string match -m 3 '*0'
+# CHECK: 10
+# CHECK: 20
+# CHECK: 30


### PR DESCRIPTION
This is useful in some cases, it also allows faster processing.

As a bonus, also stop reading strings if ``--quiet`` is given - no use
in reading more than we can.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
