### PR TITLE
Implement `d;` and `d,`

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -166,6 +166,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset dl delete-char
     bind -s --preset di backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection
     bind -s --preset da backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection
+    bind -s --preset 'd;' begin-selection repeat-jump kill-selection end-selection
+    bind -s --preset 'd,' begin-selection repeat-jump-reverse kill-selection end-selection
 
     bind -s --preset -m insert s delete-char repaint-mode
     bind -s --preset -m insert S kill-whole-line repaint-mode


### PR DESCRIPTION
With this change I fix address one of the several issues raised in #4019 in a pretty obvious way: some bindings is missing and I'm adding two of them.

As discussed there, this is not the best way to face the inadequacy of the vi-mode that fish offers, but at the moment this is the most I can do (in terms of my time/knowledge/understanding of the existing code/programmer experience). I hope I'll be able to to something better in the future, beside possibly fixing similar issues. (For instance <kbd>y</kbd><kbd>;</kbd> and <kbd>y</kbd><kbd>,</kbd> should be easy to write too.)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
 