### PR TITLE
pactl completions: guard call to pacmd

### DIFF
--- a/share/completions/pactl.fish
+++ b/share/completions/pactl.fish
@@ -40,15 +40,15 @@ end
 
 # This is needed to filter out loaded modules
 function __fish_pa_complete_unloaded_modules
-    # We need to get just the module names
-    set -l loaded (__fish_pa_print_type modules | string replace -r '^\w*\t([-\w]+).*' '$1')
     if command -sq pulseaudio
-        pulseaudio --dump-modules | while read -l name description
-            # This is a potential source of slowness, but on my system it's instantaneous
-            # with 73 modules
-            if not contains -- $name $loaded
-                printf "%s\t%s\n" $name $description
-            end
+        # We need to get just the module names
+        set -l loaded (__fish_pa_print_type modules | string replace -r '^\w*\t([-\w]+).*' '$1')
+            pulseaudio --dump-modules | while read -l name description
+                # This is a potential source of slowness, but on my system it's instantaneous
+                # with 73 modules
+                if not contains -- $name $loaded
+                    printf "%s\t%s\n" $name $description
+                end
         end
     end
 end

--- a/share/completions/pactl.fish
+++ b/share/completions/pactl.fish
@@ -67,7 +67,7 @@ complete -f -c pactl -n "not __fish_seen_subcommand_from $commands" -a remove-sa
 complete -f -c pactl -n "__fish_seen_subcommand_from play-sample remove-sample" -a '(__fish_pa_complete_type samples)'
 
 complete -f -c pactl -n "__fish_seen_subcommand_from unload-module" -a '(__fish_pa_complete_type modules)'
-complete -f -c pactl -n "__fish_seen_subcommand_from load-module" -a '(__fish_pa_complete_unloaded_modules)'
+complete -f -c pactl -n "__fish_seen_subcommand_from load-module; and command -sq pulseaudio" -a '(__fish_pa_complete_unloaded_modules)'
 
 complete -f -c pactl -n "__fish_seen_subcommand_from move-sink-input; and not __fish_seen_subcommand_from (__fish_pa_print_type sink-inputs)" \
     -a '(__fish_pa_complete_type sink-inputs)'

--- a/share/completions/pactl.fish
+++ b/share/completions/pactl.fish
@@ -7,7 +7,9 @@
 
 
 # HACK: This is the list of commands from pacmd - used so we can use complete -w there
-set -l commands (pacmd help | string match -r '^ +[-\w]+' | string trim)
+if command -sq pacmd
+    set commands (pacmd help | string match -r '^ +[-\w]+' | string trim)
+end
 # These are the actual commands for pactl - we complete only these, and then the cmd commands in that completion
 set -l ctlcommands stat info list exit {upload,play,remove}-sample {load,unload}-module \
     move-{sink-input,source-output} suspend-{sink,source} set-{card-profile,default-sink,sink-port,source-port,port-latency-offset} \

--- a/share/completions/pactl.fish
+++ b/share/completions/pactl.fish
@@ -42,11 +42,13 @@ end
 function __fish_pa_complete_unloaded_modules
     # We need to get just the module names
     set -l loaded (__fish_pa_print_type modules | string replace -r '^\w*\t([-\w]+).*' '$1')
-    pulseaudio --dump-modules | while read -l name description
-        # This is a potential source of slowness, but on my system it's instantaneous
-        # with 73 modules
-        if not contains -- $name $loaded
-            printf "%s\t%s\n" $name $description
+    if command -sq pulseaudio
+        pulseaudio --dump-modules | while read -l name description
+            # This is a potential source of slowness, but on my system it's instantaneous
+            # with 73 modules
+            if not contains -- $name $loaded
+                printf "%s\t%s\n" $name $description
+            end
         end
     end
 end
@@ -67,7 +69,7 @@ complete -f -c pactl -n "not __fish_seen_subcommand_from $commands" -a remove-sa
 complete -f -c pactl -n "__fish_seen_subcommand_from play-sample remove-sample" -a '(__fish_pa_complete_type samples)'
 
 complete -f -c pactl -n "__fish_seen_subcommand_from unload-module" -a '(__fish_pa_complete_type modules)'
-complete -f -c pactl -n "__fish_seen_subcommand_from load-module; and command -sq pulseaudio" -a '(__fish_pa_complete_unloaded_modules)'
+complete -f -c pactl -n "__fish_seen_subcommand_from load-module" -a '(__fish_pa_complete_unloaded_modules)'
 
 complete -f -c pactl -n "__fish_seen_subcommand_from move-sink-input; and not __fish_seen_subcommand_from (__fish_pa_print_type sink-inputs)" \
     -a '(__fish_pa_complete_type sink-inputs)'

--- a/share/completions/pactl.fish
+++ b/share/completions/pactl.fish
@@ -5,15 +5,17 @@
 # TODO: Moar commands
 # set-port-latency-offset set-sink-formats
 
-
-# HACK: This is the list of commands from pacmd - used so we can use complete -w there
-if command -sq pacmd
-    set commands (pacmd help | string match -r '^ +[-\w]+' | string trim)
-end
 # These are the actual commands for pactl - we complete only these, and then the cmd commands in that completion
 set -l ctlcommands stat info list exit {upload,play,remove}-sample {load,unload}-module \
     move-{sink-input,source-output} suspend-{sink,source} set-{card-profile,default-sink,sink-port,source-port,port-latency-offset} \
     set-{sink,source,sink-input,source-output}-{volume,mute} set-sink-formats subscribe
+
+# HACK: This is the list of commands from pacmd - used so we can use complete -w there
+if command -sq pacmd
+    set commands (pacmd help | string match -r '^ +[-\w]+' | string trim)
+else
+    set commands $ctlcommands
+end
 
 function __fish_pa_complete_type
     pactl list short $argv


### PR DESCRIPTION
Recently moved to pipewire via the `pipewire-pulse` package on Arch Linux. You still end up pulling in `libpulse` (which contains `pactl`), but it allows uninstalling the `pulseaudio` package which provides `pacmd`, and if you do so these completions break.