### PR TITLE
Creating cache for xbps-query in __fish_print_packages.fish

### DIFF
--- a/share/functions/__fish_print_packages.fish
+++ b/share/functions/__fish_print_packages.fish
@@ -253,15 +253,15 @@ function __fish_print_packages
         if not set -q only_installed
             set -l cache_file $xdg_cache_home/.xbps-cache.$USER
             if test -f $cache_file
-                cat $cache_file
                 set -l age (math (date +%s) - (stat -c '%Y' $cache_file))
                 set -l max_age 300
                 if test $age -lt $max_age
+                    cat $cache_file
                     return
                 end
             end
             # prints: <package name>	Package
-            xbps-query -Rsl | sed 's/^... \([^ ]*\)-.* .*/\1/; s/$/\t'Package'/' >$cache_file &
+            xbps-query -Rsl | sed 's/^... \([^ ]*\)-.* .*/\1/; s/$/\t'Package'/' tee $cache_file
             return
         else
             xbps-query -l | sed 's/^.. \([^ ]*\)-.* .*/\1/' # TODO: actually put package versions in tab for locally installed packages

--- a/share/functions/__fish_print_packages.fish
+++ b/share/functions/__fish_print_packages.fish
@@ -261,7 +261,7 @@ function __fish_print_packages
                 end
             end
             # prints: <package name>	Package
-            xbps-query -Rsl | sed 's/^... \([^ ]*\)-.* .*/\1/; s/$/\t'Package'/' tee $cache_file
+            xbps-query -Rsl | sed 's/^... \([^ ]*\)-.* .*/\1/; s/$/\t'Package'/' | tee $cache_file
             return
         else
             xbps-query -l | sed 's/^.. \([^ ]*\)-.* .*/\1/' # TODO: actually put package versions in tab for locally installed packages


### PR DESCRIPTION
## Description

I use Void Linux on daily basis and I've been glad to see that completion rules for xbps utils were added to the repo. But I've also noticed that whether the cache-file is not found it's actually created but I have to retype the whole command to make the completion work.

This occurs only after the cache-file is deleted (or not created yet) but I dare offer you my minor patch.

Hope it would be useful. Fish is amazing!