### PR TITLE
Change fish_trace prefix to "->" instead of plusses

### DIFF
--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -19,7 +19,8 @@ bool trace_enabled(const parser_t &parser) {
 void trace_argv(const parser_t &parser, const wchar_t *command, const wcstring_list_t &argv) {
     // Format into a string to prevent interleaving with flog in other threads.
     // Add the + prefix.
-    wcstring trace_text(parser.blocks().size(), '+');
+    wcstring trace_text(parser.blocks().size() - 1, L'-');
+    trace_text.push_back(L'>');
 
     if (command && command[0]) {
         trace_text.push_back(L' ');
@@ -29,7 +30,7 @@ void trace_argv(const parser_t &parser, const wchar_t *command, const wcstring_l
         trace_text.push_back(L' ');
         trace_text.append(escape_string(arg, ESCAPE_ALL));
     }
-    trace_text.push_back('\n');
+    trace_text.push_back(L'\n');
     log_extra_to_flog_file(trace_text);
 }
 

--- a/tests/checks/trace.fish
+++ b/tests/checks/trace.fish
@@ -13,11 +13,11 @@ end
 # CHECK: 2
 # CHECK: 3
 
-# CHECKERR: + for 1 2 3
-# CHECKERR: ++ echo 1
-# CHECKERR: ++ echo 2
-# CHECKERR: ++ echo 3
-# CHECKERR: + end for
+# CHECKERR: > for 1 2 3
+# CHECKERR: -> echo 1
+# CHECKERR: -> echo 2
+# CHECKERR: -> echo 3
+# CHECKERR: > end for
 
 while true
     and true
@@ -27,12 +27,12 @@ end
 
 # CHECK: inside
 
-# CHECKERR: + while
-# CHECKERR: + true
-# CHECKERR: + true
-# CHECKERR: ++ echo inside
-# CHECKERR: ++ break
-# CHECKERR: + end while
+# CHECKERR: > while
+# CHECKERR: > true
+# CHECKERR: > true
+# CHECKERR: -> echo inside
+# CHECKERR: -> break
+# CHECKERR: > end while
 
 while true && true
     echo inside2
@@ -41,12 +41,12 @@ end
 
 # CHECK: inside2
 
-# CHECKERR: + while
-# CHECKERR: + true
-# CHECKERR: + true
-# CHECKERR: ++ echo inside2
-# CHECKERR: ++ break
-# CHECKERR: + end while
+# CHECKERR: > while
+# CHECKERR: > true
+# CHECKERR: > true
+# CHECKERR: -> echo inside2
+# CHECKERR: -> break
+# CHECKERR: > end while
 
 if true && false
 else if false || true
@@ -56,17 +56,17 @@ end
 
 # CHECK: inside3
 
-# CHECKERR: + if
-# CHECKERR: + true
-# CHECKERR: + false
-# CHECKERR: + else if
-# CHECKERR: + false
-# CHECKERR: + true
-# CHECKERR: ++ echo inside3
-# CHECKERR: + end if
+# CHECKERR: > if
+# CHECKERR: > true
+# CHECKERR: > false
+# CHECKERR: > else if
+# CHECKERR: > false
+# CHECKERR: > true
+# CHECKERR: -> echo inside3
+# CHECKERR: > end if
 
 set -e fish_trace
-# CHECKERR: + set -e fish_trace
+# CHECKERR: > set -e fish_trace
 
 echo untraced
 # CHECK: untraced


### PR DESCRIPTION
This matches what we do in --profile's output:

```
> source /home/alfa/.config/fish/config.fish
--> set -gx XDG_CACHE_HOME /home/alfa/.cache
--> set -gx XDG_CONFIG_HOME /home/alfa/.config
--> set -gx XDG_DATA_HOME /home/alfa/.local/share
```

instead of

```
+ source /home/alfa/.config/fish/config.fish
+++ set -gx XDG_CACHE_HOME /home/alfa/.cache
+++ set -gx XDG_CONFIG_HOME /home/alfa/.config
+++ set -gx XDG_DATA_HOME /home/alfa/.local/share
```

Which just seems more readable to me.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
