### PR TITLE
completions: git switch only takes branch names

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1571,7 +1571,7 @@ complete -f -c git -n '__fish_git_using_command restore; and contains -- --stage
 complete -f -c git -n '__fish_git_using_command restore; and __fish_contains_opt -s s source' -a '(git ls-files)'
 # switch options
 complete -f -c git -n __fish_git_needs_command -a switch -d 'Switch to a branch'
-complete -k -f -c git -n '__fish_git_using_command switch' -a '(__fish_git_branches)'
+complete -k -f -c git -n '__fish_git_using_command switch' -a '(__fish_git_local_branches)'
 complete -k -f -c git -n '__fish_git_using_command switch' -a '(__fish_git_unique_remote_branches)' -d 'Unique Remote Branch'
 complete -f -c git -n '__fish_git_using_command switch' -r -s c -l create -d 'Create a new branch'
 complete -f -c git -n '__fish_git_using_command switch' -r -s C -l force-create -d 'Force create a new branch'


### PR DESCRIPTION
Trying to switch to a remote branch like "upstream/ver2" will error with "fatal: a branch is expected, got remote branch 'upstream/ver2'", so these completions should only print the branch name. There doesn't seem to be a function for printing just the branch names for remotes (branch names can have forward-slashes in them), so I have just left them out for now.
