### PR TITLE
Remove `.rs` extension from examples completions

### DIFF
--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -37,7 +37,7 @@ function __list_cargo_examples
     end
 
     find ./examples/ -mindepth 1 -maxdepth 1 -type f -name "*.rs" -or -type d \
-        | string replace -r './examples/(.*)(?:.rs)?$' '$1'
+        | string replace -r './examples/(.*?)(?:.rs)?$' '$1'
 end
 for x in bench build run rustc test
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bin -a "(cargo run --bin 2>&1 | string replace -rf '^\s+' '')"


### PR DESCRIPTION
## Description

Fix https://github.com/fish-shell/fish-shell/commit/0d3f4db33aa7223f8045c69264e789fbeecc8489, it broke `--example` completion which was previously working fine, it shows examples with `.rs` extension. I also don't know what does that commit fixed.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
