### PR TITLE
Add cargo abbr completions

### DIFF
--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -10,22 +10,22 @@ set -l __fish_cargo_subcommands (cargo --list 2>&1 | string replace -rf '^\s+([^
 complete -c cargo -f -c cargo -n __fish_use_subcommand -a "$__fish_cargo_subcommands"
 complete -c cargo -x -c cargo -n '__fish_seen_subcommand_from help' -a "$__fish_cargo_subcommands"
 
-for x in bench build clean doc fetch generate-lockfile \
+for x in bench b build clean doc fetch generate-lockfile \
     locate-project package pkgid publish \
-    read-manifest run rustc test update \
+    read-manifest r run rustc t test update \
     verify-project
     complete -c cargo -r -n "__fish_seen_subcommand_from $x" -l manifest-path -d 'path to the manifest to compile'
 end
 
-for x in bench build clean doc rustc test update
+for x in bench b build clean doc rustc t test update
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -s p -l spec -d 'Package to build'
 end
 
-for x in bench build clean doc run rustc test
+for x in bench b build clean doc r run rustc t test
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l target -d 'Build for the target triple'
 end
 
-for x in bench build rustc test
+for x in bench b build rustc t test
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bench -a "(cargo bench --bench 2>&1 | string replace -rf '^\s+' '')"
     complete -c cargo -n "__fish_seen_subcommand_from $x" -l lib -d 'Only this package\'s library'
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l test -a "(cargo test --test 2>&1 | string replace -rf '^\s+' '')"
@@ -37,22 +37,22 @@ function __list_cargo_examples
     end
 
     find ./examples/ -mindepth 1 -maxdepth 1 -type f -name "*.rs" -or -type d \
-        | string replace -r './examples/(.*)(?:.rs)?$' '$1'
+        | string replace -r './examples/(.*?)(?:.rs)?$' '$1'
 end
-for x in bench build run rustc test
+for x in bench b build r run rustc t test
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bin -a "(cargo run --bin 2>&1 | string replace -rf '^\s+' '')"
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l example -a "(__list_cargo_examples)"
 end
 
-for x in build run rustc test
+for x in b build r run rustc t test
     complete -c cargo -n "__fish_seen_subcommand_from $x" -l release -d 'Build artifacts in release mode, with optimizations'
 end
 
-for x in bench test
+for x in bench t test
     complete -c cargo -n "__fish_seen_subcommand_from $x" -l no-run -d 'Compile but do not run'
 end
 
-for x in bench build doc run rustc test
+for x in bench b build doc r run rustc t test
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -s j -l jobs -d 'Number of jobs to run in parallel'
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l features -d 'Space-separated list of features to also build'
     complete -c cargo -n "__fish_seen_subcommand_from $x" -l no-default-features -d 'Do not build the `default` feature'


### PR DESCRIPTION
## Description

Cargo supports some abbr but fish completions does not support it.
```
    build, b    Compile the current package
    check, c    Analyze the current package and report errors, but don't build object files
    clean       Remove the target directory
    doc         Build this package's and its dependencies' documentation
    new         Create a new cargo package
    init        Create a new cargo package in an existing directory
    run, r      Run a binary or example of the local package
    test, t     Run the tests
    bench       Run the benchmarks
    update      Update dependencies listed in Cargo.lock
    search      Search registry for crates
    publish     Package and upload this package to the registry
    install     Install a Rust binary. Default location is $HOME/.cargo/bin
    uninstall   Uninstall a Rust binary
```

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
