### PR TITLE
Expand ~ paths in the history files

### DIFF
--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -4332,12 +4332,15 @@ void history_tests_t::test_history_path_detection() {
     vars.vars[L"HOME"] = tmpdir;
 
     history_t &history = history_t::history_with_name(L"path_detection");
-    history.add_pending_with_file_detection(L"cmd0 not/a/valid/path", tmpdir);
-    history.add_pending_with_file_detection(L"cmd1 " + filename, tmpdir);
-    history.add_pending_with_file_detection(L"cmd2 " + tmpdir + L"/" + filename, tmpdir);
+    history.add_pending_with_file_detection(L"cmd0 not/a/valid/path", vars);
+    history.add_pending_with_file_detection(L"cmd1 " + filename, vars);
+    history.add_pending_with_file_detection(L"cmd2 " + tmpdir + L"/" + filename, vars);
+    history.add_pending_with_file_detection(L"cmd2 ~/" + filename, vars);
+    history.add_pending_with_file_detection(L"cmd2 ~", vars);
+    history.add_pending_with_file_detection(L"cmd2 ~/invalid_path", vars);
     history.resolve_pending();
 
-    constexpr size_t hist_size = 3;
+    constexpr size_t hist_size = 6;
     if (history.size() != hist_size) {
         err(L"history has wrong size: %lu but expected %lu", (unsigned long)history.size(), (unsigned long)hist_size);
         history.clear();
@@ -4349,6 +4352,9 @@ void history_tests_t::test_history_path_detection() {
         {},
         {filename},
         {tmpdir + L"/" + filename},
+        {L"~/" + filename},
+        {L"~"},
+        {}
     };
 
     size_t lap;

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -468,7 +468,7 @@ bool autosuggest_validate_from_history(const history_item_t &item,
     }
 
     // Did the historical command have arguments that look like paths, which aren't paths now?
-    if (!all_paths_are_valid(item.get_required_paths(), working_directory)) {
+    if (!all_paths_are_valid(item.get_required_paths(), ctx.vars)) {
         return false;
     }
 

--- a/src/history.h
+++ b/src/history.h
@@ -163,7 +163,7 @@ class history_t {
 
     // Add a new pending history item to the end, and then begin file detection on the items to
     // determine which arguments are paths
-    void add_pending_with_file_detection(const wcstring &str, const wcstring &working_dir_slash);
+    void add_pending_with_file_detection(const wcstring &str, const environment_t &vars);
 
     // Resolves any pending history items, so that they may be returned in history searches.
     void resolve_pending();
@@ -285,12 +285,12 @@ wcstring history_session_id(const environment_t &vars);
 
 /// Given a list of paths and a working directory, return the paths that are valid
 /// This does disk I/O and may only be called in a background thread
-path_list_t valid_paths(const path_list_t &paths, const wcstring &working_directory);
+path_list_t valid_paths(const path_list_t &paths, const environment_t &envs);
 
 /// Given a list of paths and a working directory,
 /// return true if all paths in the list are valid
 /// Returns true for if paths is empty
-bool all_paths_are_valid(const path_list_t &paths, const wcstring &working_directory);
+bool all_paths_are_valid(const path_list_t &paths, const environment_t &envs);
 
 /// Sets private mode on. Once in private mode, it cannot be turned off.
 void start_private_mode(env_stack_t &vars);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -438,7 +438,8 @@ bool paths_are_equivalent(const wcstring &p1, const wcstring &p2) {
     return idx1 == len1 && idx2 == len2;
 }
 
-bool path_is_valid(const wcstring &path, const wcstring &working_directory) {
+bool path_is_valid(const wcstring &path, const environment_t &vars) {
+    auto working_directory = vars.get_pwd_slash();
     bool path_is_valid;
     // Some special paths are always valid.
     if (path.empty()) {
@@ -447,6 +448,10 @@ bool path_is_valid(const wcstring &path, const wcstring &working_directory) {
         path_is_valid = true;
     } else if (path == L".." || path == L"../") {
         path_is_valid = (!working_directory.empty() && working_directory != L"/");
+    } else if (path.at(0) == '~') {
+        wcstring tmp = path;
+        expand_tilde(tmp, vars);
+        path_is_valid = (0 == waccess(tmp, F_OK));
     } else if (path.at(0) != '/') {
         // Prepend the working directory. Note that we know path is not empty here.
         wcstring tmp = working_directory;

--- a/src/path.h
+++ b/src/path.h
@@ -77,7 +77,7 @@ void path_make_canonical(wcstring &path);
 /// slashes).
 bool paths_are_equivalent(const wcstring &p1, const wcstring &p2);
 
-bool path_is_valid(const wcstring &path, const wcstring &working_directory);
+bool path_is_valid(const wcstring &path, const environment_t &envs);
 
 /// Returns whether the two paths refer to the same file.
 bool paths_are_same_file(const wcstring &path1, const wcstring &path2);

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -3163,7 +3163,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 // space, or if in silent mode (#7230).
                 const editable_line_t *el = &command_line;
                 if (history != nullptr && !conf.in_silent_mode && may_add_to_history(el->text())) {
-                    history->add_pending_with_file_detection(el->text(), vars.get_pwd_slash());
+                    history->add_pending_with_file_detection(el->text(), vars);
                 }
                 rls.finished = true;
                 update_buff_pos(&command_line, command_line.size());


### PR DESCRIPTION
## Description

All paths prefixed with `~` were not detected as valid in the file history.
This change add a call to [expand_tilde](https://github.com/fish-shell/fish-shell/blob/e43913a547487e8fe57310b5fc90e93e922c7a6c/src/expand.cpp#L786) in `path_is_valid`.

Fixes issue #7582

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
