### PR TITLE
Normalize and document __fish_status_to_signal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -101,6 +101,7 @@ Scripting improvements
 - ``string`` subcommands now quit early when used with ``--quiet`` (:issue:`7495`).
 -  Failed redirections will now set ``$status`` (:issue:`7540`).
 -  ``read`` can now read interactively from other files, so e.g. forcing it to read from the terminal via ``read </dev/tty`` works (:issue:`7358`).
+-  The previously internal function ``__fish_status_to_signal`` is now ``fish_status_to_signal``, documented, and ready for external use.
 
 Interactive improvements
 ------------------------

--- a/doc_src/cmds/fish_status_to_signal.rst
+++ b/doc_src/cmds/fish_status_to_signal.rst
@@ -9,7 +9,7 @@ Synopsis
 ::
 
     function fish_prompt
-        echo -n (fish_status_to_signal $pipestatus) (prompt_pwd) '$ '
+        echo -n (fish_status_to_signal $pipestatus | string join '|') (prompt_pwd) '$ '
     end
 
 Description

--- a/doc_src/cmds/fish_status_to_signal.rst
+++ b/doc_src/cmds/fish_status_to_signal.rst
@@ -1,0 +1,29 @@
+.. _cmd-fish_status_to_signal:
+
+fish_status_to_signal - Convert exit codes to human-friendly signals
+====================================================================
+
+Synopsis
+--------
+
+::
+
+    function fish_prompt
+        echo -n (fish_status_to_signal $pipestatus) (prompt_pwd) '$ '
+    end
+
+Description
+-----------
+
+``fish_status_to_signal`` converts exit codes to their corresponding human-friendly signals if one exists.
+This is likely to be useful for prompts in conjunction with the ``$status`` and ``$pipestatus`` variables.
+
+Example
+-------
+
+::
+
+    >_ sleep 5
+    ^C⏎
+    >_ fish_status_to_signal $status
+    SIGINT

--- a/share/functions/__fish_print_pipestatus.fish
+++ b/share/functions/__fish_print_pipestatus.fish
@@ -23,7 +23,7 @@ function __fish_print_pipestatus --description "Print pipestatus for prompt"
     # SIGPIPE (141 = 128 + 13) is usually not a failure, see #6375.
     if not contains $last_status 0 141
         set -l sep $brace_sep_color$separator$status_color
-        set -l last_pipestatus_string (__fish_status_to_signal $argv | string join "$sep")
+        set -l last_pipestatus_string (fish_status_to_signal $argv | string join "$sep")
         set -l last_status_string ""
         if test $last_status -ne $argv[-1]
             set last_status_string " "$status_color$last_status

--- a/share/functions/fish_status_to_signal.fish
+++ b/share/functions/fish_status_to_signal.fish
@@ -1,4 +1,4 @@
-function __fish_status_to_signal --description "Print signal name from argument (\$status), or just argument"
+function fish_status_to_signal --description "Print signal name from argument (\$status), or just argument"
     for arg in $argv
         if test $arg -gt 128
             set -l signals SIGHUP SIGINT SIGQUIT SIGILL SIGTRAP SIGABRT SIGBUS \


### PR DESCRIPTION
## Description

Converts `__fish_status_to_signal` to `fish_status_to_signal` for external use. Documents `fish_status_to_signal` and adds it to the changelog.

Fixes #7595

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
