### PR TITLE
Webconfig: Remove dependency on cgi module

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 import binascii
-import cgi
 
 try:
     from html import escape as escape_html
@@ -1315,17 +1314,19 @@ class FishConfigHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             return self.send_error(403)
         self.path = p
 
-        ctype, pdict = cgi.parse_header(self.headers["content-type"])
+        # This is cheesy, we want just the actual content-type.
+        # In some cases it'll give us the encoding as well,
+        # ("application/json;charset=utf-8")
+        # but we don't currently care.
+        ctype = self.headers["content-type"].split(";")[0]
 
-        if ctype == "multipart/form-data":
-            postvars = cgi.parse_multipart(self.rfile, pdict)
-        elif ctype == "application/x-www-form-urlencoded":
+        if ctype == "application/x-www-form-urlencoded":
             length = int(self.headers["content-length"])
             url_str = self.rfile.read(length).decode("utf-8")
             postvars = parse_qs(url_str, keep_blank_values=1)
         elif ctype == "application/json":
             length = int(self.headers["content-length"])
-            url_str = self.rfile.read(length).decode(pdict["charset"])
+            url_str = self.rfile.read(length).decode("utf-8")
             postvars = json.loads(url_str)
         else:
             postvars = {}


### PR DESCRIPTION
This is slated for removal in python 3.10, see
https://www.python.org/dev/peps/pep-0594/#cgi.

We currently only use it for three things:

- escape_html in old python versions that didn't have that in the html
  module
- Parsing multipart/form-data
- Figuring out the charset for json

We keep the first one - if loading escape_html from html fails we fall
back to cgi.

We remove the second - I can't find any case where we use
multipart/form-data. Any place we post data we either explicitly pass
application/x-www-form-urlencoded or implicitly use application/json.

The third is the tricky bit. This drops charset detection under the
assumption that we're never going to encounter anything other than
utf-8 (or ascii, which is a utf-8 subset). I'm not sure that holds,
but if it doesn't we can just add a regex to parse the charset.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Note: Because python 3.10 is expected in October 2021 and we might not be making another release until then, I would like this to be included in 3.2.0, or we'd have to make a 3.2.1 with it later.