### PR TITLE
Update rustc.fish

### DIFF
--- a/share/completions/rustc.fish
+++ b/share/completions/rustc.fish
@@ -1,11 +1,11 @@
 complete -c rustc -s h -l help
 
 complete -c rustc -x -l cfg
-complete -c rustc -r -s L -a 'dylib= static= framework='
+complete -c rustc -r -s L -a 'dependency= crate= native= framework= all='
 complete -c rustc -x -s l -a 'dylib= static= framework='
-complete -c rustc -x -l crate-type -a 'bin lib rlib dylib staticlib'
+complete -c rustc -x -l crate-type -a 'bin lib rlib dylib staticlib proc-macro'
 complete -c rustc -r -l crate-name
-complete -c rustc -x -l emit -a 'asm llvm-bc llvm-ir obj link dep-info'
+complete -c rustc -x -l emit -a 'asm llvm-bc llvm-ir obj link dep-info metadata mir'
 complete -c rustc -x -l print -a 'crate-name file-names sysroot'
 complete -c rustc -s g
 complete -c rustc -s O


### PR DESCRIPTION


## Description

Update rustc completion options.

- [`-L`: add a directory to the library search path][1]
- [`--crate-type`: a list of types of crates for the compiler to emit][2]
- [`--emit`: specifies the types of output files to generate][3]

[1]: https://doc.rust-lang.org/stable/rustc/command-line-arguments.html#-l-add-a-directory-to-the-library-search-path
[2]: https://doc.rust-lang.org/stable/rustc/command-line-arguments.html#--crate-type-a-list-of-types-of-crates-for-the-compiler-to-emit
[3]: https://doc.rust-lang.org/stable/rustc/command-line-arguments.html#--emit-specifies-the-types-of-output-files-to-generate

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
