### PR TITLE
(fish_hg_prompt) Added $fish_hg_executable setting

### DIFF
--- a/doc_src/cmds/fish_hg_prompt.rst
+++ b/doc_src/cmds/fish_hg_prompt.rst
@@ -25,6 +25,8 @@ By default, only the current branch is shown because ``hg status`` can be slow o
 
 If you enabled the informative status, there are numerous customization options, which can be controlled with fish variables.
 
+- ``$fish_hg_executable`` specifies Mercurial executable used (``hg`` by default, can be set to absolute path like ``set -U fish_hg_executable /usr/bin/hg``)
+
 - ``$fish_color_hg_clean``, ``$fish_color_hg_modified`` and ``$fish_color_hg_dirty`` are colors used when the repository has the respective status.
 
 Some colors for status symbols:

--- a/share/functions/fish_hg_prompt.fish
+++ b/share/functions/fish_hg_prompt.fish
@@ -20,10 +20,12 @@ set -g fish_prompt_hg_status_unmerged !
 
 set -g fish_prompt_hg_status_order added modified copied deleted untracked unmerged
 
+set -g fish_hg_executable 'hg'
+
 function fish_hg_prompt --description 'Write out the hg prompt'
     # If hg isn't installed, there's nothing we can do
     # Return 1 so the calling prompt can deal with it
-    if not command -sq hg
+    if not command -sq $fish_hg_executable
         return 1
     end
 
@@ -45,7 +47,7 @@ function fish_hg_prompt --description 'Write out the hg prompt'
     echo -n '|'
 
     # Disabling color and pager is always a good idea.
-    set -l repo_status (hg status | string sub -l 2 | sort -u)
+    set -l repo_status ($fish_hg_executable status | string sub -l 2 | sort -u)
 
     # Show nice color for a clean repo
     if test -z "$repo_status"


### PR DESCRIPTION
This can be useful in two scenarios:

a) Fish can be asked to use virtualenv- or user-installed mercurial
   when such is preferred to system installation:

     set -U fish_hg_executable ~/.virtualenvs/mercurial-3.8/bin/hg

b) … or simply system installation can be frozen by:

     set -U fish_hg_executable /usr/bin/hg

   (the latter avoids switching mercurial's in case user activates
   virtualenv containing another mercurial version)

By default `$fish_hg_executable` is simply `hg`, so evberything behaves as it used to.
