### PR TITLE
Fix completion for `--exact` option to `fzf`

### DIFF
--- a/share/completions/fzf.fish
+++ b/share/completions/fzf.fish
@@ -3,7 +3,7 @@ complete -c fzf -f
 # Search mode
 complete -c fzf -l no-extended -d no-extended
 complete -c fzf -n 'string match "+*" -- (commandline -ct)' -a +x -d no-extended
-complete -c fzf -s e -l --exact -d 'Enable exact-match'
+complete -c fzf -s e -l exact -d 'Enable exact-match'
 complete -c fzf -n 'string match "+*" -- (commandline -ct)' -a +i -d 'case-sensitive match'
 complete -c fzf -s i -d 'Case-insensitive match'
 complete -c fzf -l literal -d 'Do not normalize latin script letters for matching'


### PR DESCRIPTION
These double hyphens will make the completion resolve to `----exact`
which isn't a valid option.

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
