### PR TITLE
timedatectl: fix too many arguments

### DIFF
--- a/share/completions/timedatectl.fish
+++ b/share/completions/timedatectl.fish
@@ -5,7 +5,6 @@ complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a status
 complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a show -d 'Show properties of systemd-timedated'
 complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-time -d 'Set system time'
 complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-timezone -d 'Set system time zone'
-complete -c timedatectl -n "__fish_seen_subcommand_from set-timezone" -a (timedatectl list-timezones)
 complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a list-timezones -d 'Show known time zones'
 complete -c timedatectl -n "not __fish_seen_subcommand_from $commands" -a set-local-rtc -d 'Control whether RTC is in local time'
 complete -c timedatectl -n "__fish_seen_subcommand_from set-local-rtc" -a 'true false'


### PR DESCRIPTION
Fix

```
complete: Too many arguments

/usr/share/fish/completions/timedatectl.fish (line 8): 
complete -c timedatectl -n "__fish_seen_subcommand_from set-timezone" -a (timedatectl list-timezones)
^
from sourcing file /usr/share/fish/completions/timedatectl.fish
in command substitution

(Type 'help complete' for related documentation)
```

`timedatectl list-timezones` have 348 lines output.

[ci-skip]

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
