### PR TITLE
Make reflow handling configurable

### DIFF
--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -1249,6 +1249,8 @@ You can change the settings of fish by changing the values of certain variables.
 
 - ``fish_greeting``, the greeting message printed on startup. This is printed by a function of the same name that can be overridden for more complicated changes (see :ref:`funced <cmd-funced>`
 
+- ``fish_handle_reflow``, determines whether fish should try to repaint the commandline when the terminal resizes. In terminals that reflow text this should be disabled. Set it to 1 to enable, anything else to disable.
+
 - ``fish_history``, the current history session name. If set, all subsequent commands within an
   interactive fish session will be logged to a separate file identified by the value of the
   variable. If unset, or set to ``default``, the default session name "fish" is used. If set to an

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -251,6 +251,13 @@ function __fish_config_interactive -d "Initializations that should be performed 
         if string match -q -- 'alacritty*' $TERM
             return
         end
+        # Konsole since version 21.04(.00)
+        # Note that this is optional, but since we have no way of detecting it
+        # we go with the default, which is true.
+        if set -q KONSOLE_VERSION
+            and test "$KONSOLE_VERSION" -ge 210400 2>/dev/null
+            return
+        end
         commandline -f repaint >/dev/null 2>/dev/null
     end
 


### PR DESCRIPTION
## Description

As part of #7491, we turned off our own reflow for some terminals - VTE and alacritty, but declined to turn it off for iTerm (as that apparently behaves better with it on?).

Which shows that 1. it's an awkward list to keep, 2. some of these have it configurable (this PR adds Konsole to the list, which *definitely* has)

So what we do is to add a variable called `$fish_handle_reflow`. If that is set to 1, we will reflow. If not, we won't.

Then we move the list to *before* the winch handler and just set the variable default - if we detect it's a terminal that can do reflow, we turn ours off, otherwise we keep it turned on.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst


----

As a personal note: I would really really really pretty please with a cherry on top love it if terminals managed to get something together to just *tell* us if this works, instead of us keeping weird lists and leaving it to the user to fix problems.