### PR TITLE
completions: Add support for lightdm and dm-tool commands

### DIFF
--- a/share/completions/dm-tool.fish
+++ b/share/completions/dm-tool.fish
@@ -10,7 +10,7 @@ complete -c dm-tool -n "not __fish_seen_subcommand_from $cmds" -l session-bus -d
 complete -c dm-tool -n "not __fish_seen_subcommand_from $cmds" -xa "$cmds"
 
 # switch-to-user
-set -l session_users "(dm-tool list-seats | grep UserName | sed 's/.*UserName=//' | sed 's/\'//g')"
+set -l session_users "(dm-tool list-seats | string replace -rf '.*UserName=' '' | string trim -c '\'')"
 set -l has_user "__fish_seen_subcommand_from $session_users"
 complete -c dm-tool -n "__fish_seen_subcommand_from switch-to-user; and not $has_user" -xa "$session_users"
 

--- a/share/completions/dm-tool.fish
+++ b/share/completions/dm-tool.fish
@@ -1,0 +1,16 @@
+# Completions for the dm-tool command (part of the lightdm display manager)
+
+set -l cmds 'add-local-x-seat add-nested-seat add-seat list-seats lock switch-to-greeter switch-to-guest switch-to-user'
+
+complete -c dm-tool -f
+complete -c dm-tool -n "not __fish_seen_subcommand_from $cmds" -s h -l help -x -d "Show help options"
+complete -c dm-tool -n "not __fish_seen_subcommand_from $cmds" -s v -l version -x -d "Show release version"
+complete -c dm-tool -n "not __fish_seen_subcommand_from $cmds" -l session-bus -d "Connect using the session bus"
+
+complete -c dm-tool -n "not __fish_seen_subcommand_from $cmds" -xa "$cmds"
+
+# switch-to-user
+set -l session_users "(dm-tool list-seats | grep UserName | sed 's/.*UserName=//' | sed 's/\'//g')"
+set -l has_user "__fish_seen_subcommand_from $session_users"
+complete -c dm-tool -n "__fish_seen_subcommand_from switch-to-user; and not $has_user" -xa "$session_users"
+

--- a/share/completions/lightdm.fish
+++ b/share/completions/lightdm.fish
@@ -1,0 +1,14 @@
+# Completions for the lightdm command
+
+complete -c lightdm -f
+complete -c lightdm -s h -l help -x -d "Show help options"
+complete -c lightdm -s c -l config -r -F -d "Use configuration file"
+complete -c lightdm -s d -l debug -d "Print debugging messages"
+complete -c lightdm -l test-mode -d "Skip things requiring root access"
+complete -c lightdm -l pid-file -r -F -d "File to write PID into"
+complete -c lightdm -l xsessions-dir -r -F -d "Directory to load X sessions from"
+complete -c lightdm -l xgreeters-dir -r -F -d "Directory to load X greeters from"
+complete -c lightdm -l log-dir -r -F -d "Directory to write logs to"
+complete -c lightdm -l run-dir -r -F -d "Directory to store running state"
+complete -c lightdm -l cache-dir -r -F -d "Directory to cache information"
+complete -c lightdm -s v -l version -x -d "Show release version"


### PR DESCRIPTION
Improve completion for the LightDM display manager, by adding support for the lightdm and dm-tool commands.

Refer to the [lightdm(1)](https://man.freebsd.org/lightdm) and [dm-tool(1)](https://man.freebsd.org/dm-tool) manpages for details of the command syntax.