### PR TITLE
Fix Git status in Acidhub prompt

### DIFF
--- a/share/tools/web_config/sample_prompts/acidhub.fish
+++ b/share/tools/web_config/sample_prompts/acidhub.fish
@@ -8,7 +8,7 @@ function fish_prompt -d "Write out the prompt"
     if set -l git_branch (command git symbolic-ref HEAD 2>/dev/null | string replace refs/heads/ '')
         set git_branch (set_color -o blue)"$git_branch"
         set -l git_status
-        if command git diff-index HEAD -- --quiet
+        if not command git diff-index --quiet HEAD --
             if set -l count (command git rev-list --count --left-right $upstream...HEAD 2>/dev/null)
                 echo $count | read -l ahead behind
                 if test "$ahead" -gt 0

--- a/share/tools/web_config/sample_prompts/acidhub.fish
+++ b/share/tools/web_config/sample_prompts/acidhub.fish
@@ -8,7 +8,7 @@ function fish_prompt -d "Write out the prompt"
     if set -l git_branch (command git symbolic-ref HEAD 2>/dev/null | string replace refs/heads/ '')
         set git_branch (set_color -o blue)"$git_branch"
         set -l git_status
-        if command git diff-index --quiet HEAD --
+        if command git diff-index HEAD -- --quiet
             if set -l count (command git rev-list --count --left-right $upstream...HEAD 2>/dev/null)
                 echo $count | read -l ahead behind
                 if test "$ahead" -gt 0
@@ -18,7 +18,7 @@ function fish_prompt -d "Write out the prompt"
                     set git_status "$git_status"(set_color red)⬇
                 end
             end
-            for i in (git status --porcelain | string sub -l 2 | uniq)
+            for i in (git status --porcelain | string sub -l 2 | sort | uniq)
                 switch $i
                     case "."
                         set git_status "$git_status"(set_color green)✚


### PR DESCRIPTION
## Description

Fix 1: The --quiet flag must be at the end of the command. The way it was I would never get any status symbol in my prompt as the command failed.
Fix 2: After adding files to git, but before committing them, git status is unsorted. This gave me the output "M A M A" after `uniq`, which resulted in 4 status symbols instead of 2. Sorting them before filtering them fixed the problem.

Not sure if these changes needs to be reflected in docs or the changelog.

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
