### PR TITLE
Allow profiling without startup time

### DIFF
--- a/doc_src/cmds/fish.rst
+++ b/doc_src/cmds/fish.rst
@@ -31,7 +31,9 @@ The following options are available:
 
 - ``-n`` or ``--no-execute`` do not execute any commands, only perform syntax checking
 
-- ``-p`` or ``--profile=PROFILE_FILE`` when fish exits, output timing information on all executed commands to the specified file
+- ``-p`` or ``--profile=PROFILE_FILE`` when fish exits, output timing information on all executed commands to the specified file. This excludes time spent starting up and reading the configuration.
+
+- ``--profile-startup=PROFILE_FILE`` will write timing information for fish's startup to the specified file. This is useful to profile your configuration.
 
 - ``-P`` or ``--private`` enables :ref:`private mode <private-mode>`, so fish will not access old or store new history.
 

--- a/share/completions/fish.fish
+++ b/share/completions/fish.fish
@@ -5,7 +5,8 @@ complete -c fish -s v -l version -d "Display version and exit"
 complete -c fish -s n -l no-execute -d "Only parse input, do not execute"
 complete -c fish -s i -l interactive -d "Run in interactive mode"
 complete -c fish -s l -l login -d "Run as a login shell"
-complete -c fish -s p -l profile -d "Output profiling information to specified file" -r
+complete -c fish -s p -l profile -d "Output profiling information (excluding startup) to a file" -r
+complete -c fish -s p -l profile-startup -d "Output startup profiling information to a file" -r
 complete -c fish -s d -l debug -d "Specify debug categories" -x -a "(fish --print-debug-categories | string replace ' ' \t)"
 complete -c fish -s o -l debug-output -d "Where to direct debug output to" -rF
 complete -c fish -s D -l debug-stack-frames -d "Show specified # of frames with debug output" -x -a "(seq 128)\t\n"

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -272,6 +272,10 @@ static void print_profile(const std::deque<profile_item_t> &items, FILE *out) {
     }
 }
 
+void parser_t::clear_profiling() {
+    profile_items.clear();
+}
+
 void parser_t::emit_profiling(const char *path) const {
     // Save profiling information. OK to not use CLO_EXEC here because this is called while fish is
     // exiting (and hence will not fork).

--- a/src/parser.h
+++ b/src/parser.h
@@ -400,6 +400,9 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     /// If profiling is not active, this returns nullptr.
     profile_item_t *create_profile_item();
 
+    /// Remove the profiling items.
+    void clear_profiling();
+
     /// Output profiling data to the given filename.
     void emit_profiling(const char *path) const;
 

--- a/tests/checks/invocation.fish
+++ b/tests/checks/invocation.fish
@@ -56,3 +56,25 @@ $fish -c 'string escape y$argv' -c 'string escape x$argv' 1 2 3
 
 # Should just do nothing.
 $fish --no-execute
+
+set -l tmp (mktemp -d)
+$fish --profile $tmp/normal.prof --profile-startup $tmp/startup.prof -ic exit
+
+# This should be the full file - just the one command we gave explicitly!
+cat $tmp/normal.prof
+# CHECK: Time{{\s+}}Sum{{\s+}}Command
+# CHECK: {{\d+\s+\d+\s+>}} exit
+
+string match -rq "builtin source " < $tmp/startup.prof
+and echo matched
+# CHECK: matched
+
+# See that sending both profiles to the same file works.
+$fish --profile $tmp/full.prof --profile-startup $tmp/full.prof -c 'echo thisshouldneverbeintheconfig'
+# CHECK: thisshouldneverbeintheconfig
+string match -rq "builtin source " < $tmp/full.prof
+and echo matched
+# CHECK: matched
+string match -rq "echo thisshouldneverbeintheconfig" < $tmp/full.prof
+and echo matched
+# CHECK: matched


### PR DESCRIPTION
## Description

Currently, profiling a command is a bit annoying, as you need to ignore a whole bunch of extraneous information related to fish's startup.

This changes it so `fish --profile` only writes profiling information from *after* startup - anything after reading the config and before executing the postconfig commands (I'm open to suggestions for a different cut-off point), and introduces a different `--profile-startup` option for profiling anything before.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst
