### PR TITLE
Enable OSC 7 when running in WezTerm

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -271,7 +271,7 @@ function __fish_config_interactive -d "Initializations that should be performed 
     # Notify terminals when $PWD changes (issue #906).
     # VTE based terminals, Terminal.app, iTerm.app (TODO), and foot support this.
     if not set -q FISH_UNIT_TESTS_RUNNING
-        and test 0"$VTE_VERSION" -ge 3405 -o "$TERM_PROGRAM" = Apple_Terminal -a (string match -r '\d+' 0"$TERM_PROGRAM_VERSION") -ge 309 -o "$TERM" = foot
+        and test 0"$VTE_VERSION" -ge 3405 -o "$TERM_PROGRAM" = Apple_Terminal -a (string match -r '\d+' 0"$TERM_PROGRAM_VERSION") -ge 309 -o "$TERM_PROGRAM" = WezTerm -o "$TERM" = foot
         function __update_cwd_osc --on-variable PWD --description 'Notify capable terminals when $PWD changes'
             if status --is-command-substitution || set -q INSIDE_EMACS
                 return


### PR DESCRIPTION
Over in https://github.com/wez/wezterm/issues/115#issuecomment-765869705 one of my users noted that fish had automatic OSC 7, but that it wasn't enabled under WezTerm.

You can detect WezTerm through the `$TERM_PROGRAM` environment.  In practical terms, all versions of wezterm in the wild support OSC 7 so a version check is not needed.

I'm not a fish user myself, but I did give the equivalent change to this a try on my Fedora 33 machine (it has an older version of fish).

I can see in this file that there's some stuff with `__fish_enable_focus` that you may also want to enable under wezterm; the escape sequence is supported as are panes, tabs and windows.
