### PR TITLE
Complete custom "git-foo" commands from "git foo" commandlines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -356,6 +356,7 @@ Completions
 -  The ``make`` completions no longer second-guess make's file detection, fixing target completion in some cases (:issue:`7535`).
 -  The command completions now correctly print the description even if the command was fully matched (like in ``ls<TAB>``).
 -  The ``set`` completions no longer hide variables starting with ``__``, they are sorted last instead.
+-  Completion scripts for custom Git subcommands like ``git-xyz`` are now loaded with Git completions. The completions can now be defined directly on the subcommand (using ``complete git-xyz``), and completion for ``git xyz`` will work. (:issue:`7075`, :issue:`7652`)
 
 Changes not visible to users
 ----------------------------


### PR DESCRIPTION
Since #7075, git-foo.fish files are sourced when Git completions are loaded.
However, at least Cobra (CLI framework for Go) provides completions like

	complete -c git-foo ...

This means that completions are only offered when typing "git-foo <TAB>"
and not on "git foo <TAB>". Fix this by forwarding the completion requests.

This patch breaks git-foo.fish files that directly add competions to "git" using

	complete -c git -n '__fish_git_using_command foo' ...

Since we forward to "git-foo" which has no custom completions, "git foo"
would get default file completions. I don't know if this pattern is used
already. Since #7075 is not released yet, it is probably not common.

cc @soraxas 

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
