### PR TITLE
Fix sphinx doc warning

### DIFF
--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -100,6 +100,7 @@ Sometimes commands take numbers directly as options, like ``foo -55``. To allow 
 The ``#`` must follow the short flag letter (if any), and other modifiers like ``=`` are not allowed, except for ``-`` (for backwards compatibility)::
 
   m#maximum
+
 This does not read numbers given as ``+NNN``, only those that look like flags - ``-NNN``.
 
 Note: Optional arguments


### PR DESCRIPTION
~/src/fish-shell/doc_src/cmds/argparse.rst:103: WARNING: Literal block ends without a blank line; unexpected unindent.
~/src/fish-shell/doc_src/cmds/argparse.rst:103: WARNING: Literal block ends without a blank line; unexpected unindent.

## Description

Talk about your changes here.

Fixes issue #7683

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [NA] Changes to fish usage are reflected in user documentation/manpages.
- [NA] Tests have been added for regressions fixed
- [NA] User-visible changes noted in CHANGELOG.rst
