### PR TITLE
Fix Alt+L when using the "Informative" prompt

### DIFF
--- a/share/tools/web_config/sample_prompts/informative.fish
+++ b/share/tools/web_config/sample_prompts/informative.fish
@@ -15,7 +15,7 @@ function fish_prompt --description 'Informative prompt'
         set -l pipestatus_string (__fish_print_pipestatus "[" "] " "|" (set_color $fish_color_status) \
                                   (set_color --bold $fish_color_status) $last_pipestatus)
 
-        printf '[%s] %s%s@%s %s%s %s%s%s \f\r> ' (date "+%H:%M:%S") (set_color brblue) \
+        printf '[%s] %s%s@%s %s%s %s%s%s \n> ' (date "+%H:%M:%S") (set_color brblue) \
             $USER (prompt_hostname) (set_color $fish_color_cwd) $PWD $pipestatus_string \
             (set_color normal)
     end


### PR DESCRIPTION
I ran into problems described in https://github.com/fish-shell/fish-shell/issues/718 when using the demo "Informative" prompt. This seems to be a bug in the prompt -- this change fixes it, at least on my system. 

I tried this in tmux (TERM=screen) and gnome-terminal (TERM=xterm-256) with fish 3.1.2, on Linux.

## Description

Here's a "screenshot" of the problem fixed here:

```
[21:59:55] ilyagr@ilyagr /home/ilyagr/.julia  
> ls
artifacts/  clones/  compiled/  conda/  config/  dev/  environments/  logs/  packages/  prefs/  registries/
[21:59:58] ilyagr@ilyagr /home/ilyagr/.julia  
>  # PRESS Alt+L
[22:00:00] ilyagr@ilyagr /home/ilyagr/.julia  environments/  logs/  packages/  prefs/  registries/
> 
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
