### PR TITLE
Indent line continuations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -271,6 +271,7 @@ Interactive improvements
 -  fish is now more resilient against broken terminal modes (:issue:`7133`, :issue:`4873`).
 -  fish handles being in control of the TTY without owning its own process group better, avoiding some hangs in special configurations (:issue:`7388`).
 -  Keywords can now be colored differently by setting the ``fish_color_keyword`` variable (but ``fish_color_command`` will still be used if it is unset) (:issue:`7678`).
+-  Just like new ``fish_indent``, the interactive reader will indent continuation lines that follow a line ending in a backslash, ``|``, ``&&`` or ``||`` (:issue:`7694`).
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -1445,6 +1445,12 @@ static void test_indents() {
              1, "\n# comment 2"        //
     );
 
+    add_test(&tests,      //
+             0, "begin",  //
+             1, "\n",     // "begin" is special because this newline belongs to the block header
+             1, "\n"      //
+    );
+
     int test_idx = 0;
     for (const test_t &test : tests) {
         // Construct the input text and expected indents.

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -1389,7 +1389,7 @@ static void test_indents() {
     add_test(&tests,                //
              0, "if", 1, " foo",    //
              1, "\nif", 2, " bar",  //
-             1, "\n",  // FIXME: this should be 2 but parse_util_compute_indents has a bug
+             2, "\n",               //
              1, "\nend\n");
 
     add_test(&tests,                //

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -1451,6 +1451,60 @@ static void test_indents() {
              1, "\n"      //
     );
 
+    // Continuation lines.
+    add_test(&tests,                            //
+             0, "echo 'continuation line' \\",  //
+             1, "\ncont",                       //
+             0, "\n"                            //
+    );
+    add_test(&tests,                                  //
+             0, "echo 'empty continuation line' \\",  //
+             1, "\n"                                  //
+    );
+    add_test(&tests,                                   //
+             0, "begin # continuation line in block",  //
+             1, "\necho \\",                           //
+             2, "\ncont"                               //
+    );
+    add_test(&tests,                                         //
+             0, "begin # empty continuation line in block",  //
+             1, "\necho \\",                                 //
+             2, "\n",                                        //
+             0, "\nend"                                      //
+    );
+    add_test(&tests,                                      //
+             0, "echo 'multiple continuation lines' \\",  //
+             1, "\nline1 \\",                             //
+             1, "\n# comment",                            //
+             1, "\n# more comment",                       //
+             1, "\nline2 \\",                             //
+             1, "\n"                                      //
+    );
+    add_test(&tests,                            //
+             0, "echo # comment ending in \\",  //
+             0, "\nline"                        //
+    );
+    add_test(&tests,                                            //
+             0, "echo 'multiple empty continuation lines' \\",  //
+             1, "\n\\",                                         //
+             1, "\n",                                           //
+             0, "\n"                                            //
+    );
+    add_test(&tests,                                                      //
+             0, "echo 'multiple statements with continuation lines' \\",  //
+             1, "\nline 1",                                               //
+             0, "\necho \\",                                              //
+             1, "\n"                                                      //
+    );
+    // This is an edge case, probably okay to change the behavior here.
+    add_test(&tests,                                              //
+             0, "begin", 1, " \\",                                //
+             2, "\necho 'continuation line in block header' \\",  //
+             2, "\n",                                             //
+             1, "\n",                                             //
+             0, "\nend"                                           //
+    );
+
     int test_idx = 0;
     for (const test_t &test : tests) {
         // Construct the input text and expected indents.

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -727,18 +727,14 @@ std::vector<int> parse_util_compute_indents(const wcstring &src) {
     // the newline "belongs" to the if statement as it ends its job.
     // But when rendered, it visually belongs to the job list.
 
-    // FIXME: if there's a middle newline, we will indent it wrongly.
-    // For example:
-    //    if true
-    //
-    //    end
-    // Here the middle newline should be indented by 1.
-
     size_t idx = src_size;
     int next_indent = iv.last_indent;
     while (idx--) {
         if (src.at(idx) == L'\n') {
-            indents.at(idx) = next_indent;
+            bool empty_middle_line = idx + 1 < src_size && src.at(idx + 1) == L'\n';
+            if (!empty_middle_line) {
+                indents.at(idx) = next_indent;
+            }
         } else {
             next_indent = indents.at(idx);
         }

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -698,12 +698,10 @@ std::vector<int> parse_util_compute_indents(const wcstring &src) {
             }
 
             // If this is a leaf node, apply the current indentation.
-            if (node.category == category_t::leaf) {
-                if (range.length > 0) {
-                    std::fill(indents.begin() + range.start, indents.begin() + range.end(), indent);
-                    last_leaf_end = range.start + range.length;
-                    last_indent = indent;
-                }
+            if (node.category == category_t::leaf && range.length > 0) {
+                std::fill(indents.begin() + range.start, indents.begin() + range.end(), indent);
+                last_leaf_end = range.start + range.length;
+                last_indent = indent;
             }
 
             node_visitor(*this).accept_children_of(&node);


### PR DESCRIPTION
Similar to what fish_indent does. After typing "echo \" and hitting return,
the cursor will be indented.

A possible annoyance is that when you have multiple indented lines

	echo 1 \
	    2 \
	    3 \
	    4 \

If you remove lines in the middle with Control-k, the lines below
the deleted one will start jumping around, as they are disconnected
from and reconnected to "echo".

## TODOs:
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
