### PR TITLE
Highlight redirection target as valid if it contains to-be-defined var

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -268,6 +268,7 @@ Interactive improvements
 -  ``bind`` now shows ``\x7f`` for the del key instead of a literal DEL character (:issue:`7631`)
 -  Paths containing variables or tilde expansion are only suggested when they are still valid (:issue:`7582`).
 -  Syntax highlighting can now color a command as invalid even if executed quickly (:issue:`5912`)
+-  Redirection targets are no longer highlighted as error if they contain variables which will likely be defined by the current commandline (:issue:`6654`).
 -  fish is now more resilient against broken terminal modes (:issue:`7133`, :issue:`4873`).
 -  fish handles being in control of the TTY without owning its own process group better, avoiding some hangs in special configurations (:issue:`7388`).
 -  Keywords can now be colored differently by setting the ``fish_color_keyword`` variable (but ``fish_color_command`` will still be used if it is unset) (:issue:`7678`).

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -5086,6 +5086,43 @@ static void test_highlighting() {
     });
 
     highlight_tests.push_back({
+        {L"for", highlight_role_t::keyword},
+        {L"x", highlight_role_t::param},
+        {L"in", highlight_role_t::keyword},
+        {L"set-by-for-1", highlight_role_t::param},
+        {L"set-by-for-2", highlight_role_t::param},
+        {L";", highlight_role_t::statement_terminator},
+        {L"echo", highlight_role_t::command},
+        {L">", highlight_role_t::redirection},
+        {L"$x", highlight_role_t::redirection},
+        {L";", highlight_role_t::statement_terminator},
+        {L"end", highlight_role_t::keyword},
+    });
+
+    highlight_tests.push_back({
+        {L"set", highlight_role_t::command},
+        {L"x", highlight_role_t::param},
+        {L"set-by-set", highlight_role_t::param},
+        {L";", highlight_role_t::statement_terminator},
+        {L"echo", highlight_role_t::command},
+        {L">", highlight_role_t::redirection},
+        {L"$x", highlight_role_t::redirection},
+        {L"2>", highlight_role_t::redirection},
+        {L"$totally_not_x", highlight_role_t::error},
+        {L"<", highlight_role_t::redirection},
+        {L"$x_but_its_an_impostor", highlight_role_t::error},
+    });
+
+    highlight_tests.push_back({
+        {L"x", highlight_role_t::param, ns},
+        {L"=", highlight_role_t::operat, ns},
+        {L"set-by-variable-override", highlight_role_t::param, ns},
+        {L"echo", highlight_role_t::command},
+        {L">", highlight_role_t::redirection},
+        {L"$x", highlight_role_t::redirection},
+    });
+
+    highlight_tests.push_back({
         {L"end", highlight_role_t::error},
         {L";", highlight_role_t::statement_terminator},
         {L"if", highlight_role_t::keyword},


### PR DESCRIPTION
If a variable is undefined, but it looks like it will be defined by the
current command line, assume the user knows what they are doing.
This should cover most real-world occurrences.

Closes #6654

## TODOs:
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst