### PR TITLE
Fix sphinx warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,8 +45,6 @@ For distributors and developers
 -------------------------------
 
 
---------------
-
 fish 3.2.0 (released ???)
 =========================
 
@@ -75,7 +73,7 @@ Notable improvements and fixes
    (:issue:`6924`).
 -  fish is less aggressive about resetting terminal modes, such as flow control, after every command.
    Although flow control remains off by default, enterprising users can now enable it for external commands with
-   ``stty`` (:issue:`2315`). 
+   ``stty`` (:issue:`2315`).
 -  A new **``fish_add_path`` helper function to add paths to $PATH** without producing duplicates,
    to be used interactively or in ``config.fish`` (:issue:`6960`, :issue:`7028`).
    For example::
@@ -252,7 +250,7 @@ Interactive improvements
 -  fish now creates the path in the environment variable ``XDG_RUNTIME_DIR`` if it does not exist, before using it for runtime data storage (:issue:`7335`).
 -  ``set_color --print-colors`` now also respects the bold, dim, underline, reverse, italic and background modifiers, to better show their effect (:issue:`7314`).
 -  The fish Web configuration tool (``fish_config``) shows prompts correctly on Termux for Android (:issue:`7298`) and detects Windows Services for Linux 2 properly (:issue:`7027`). It also starts the browser in another thread, avoiding hangs in some circumstances, especially with firefox developer edition (:issue:`7158`).
--  ``funcsave`` has a new ``--directory`` option to specify the location of the saved function (:issue:`7041`). 
+-  ``funcsave`` has a new ``--directory`` option to specify the location of the saved function (:issue:`7041`).
 -  ``help`` works properly on MSYS2 (:issue:`7113`) and only uses cmd.exe if running on WSL (:issue:`6797`).
 -  Resuming a piped job by its number, like ``fg %1``, works correctly (:issue:`7406`). Resumed jobs show the correct title in the terminal emulator (:issue:`7444`).
 -  Commands run from key bindings now use the same TTY modes as normal commands (:issue:`7483`).
@@ -433,7 +431,7 @@ Deprecations and removed features
 
 -  The ``fish_color_match`` variable is no longer used. (Previously this controlled the color of matching quotes and parens when using ``read``).
 -  fish 3.2.0 will be the last release in which the redirection to standard error with the ``^`` character is enabled.
-   The ``stderr-nocaret`` feature flag will be changed to "on" in future releases. 
+   The ``stderr-nocaret`` feature flag will be changed to "on" in future releases.
 -  ``string`` is now a reserved word and cannot be used for function names (see above).
 -  ``fish_vi_cursor``'s option ``--force-iterm`` has been deprecated (see above).
 -  ``command``, ``jobs`` and ``type`` long-form option ``--quiet`` is deprecated in favor of ``--query`` (see above).


### PR DESCRIPTION
```
[100%] Building HTML documentation with Sphinx
../CHANGELOG.rst:48: WARNING: Document or section may not begin with a transition.
../CHANGELOG.rst:48: WARNING: Document or section may not begin with a transition.
```

## Description

Trivial fix to address a sphinx warning with `CHANGLELOG.rst`.  However, I do not think the blank headers introduced with e487f193b8e204b84a196f595414719ea332d819 look very good in the final generated document. 

![Screen Shot 2021-02-08 at 8 39 33 AM](https://user-images.githubusercontent.com/5694899/107234340-2ee52e00-69e9-11eb-8004-b5b34ea67b49.png)
