### PR TITLE
Saturate return value in builtin_set_query

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ fish next-minor
 Notable improvements and fixes
 ------------------------------
 
+- **Saturating error count** for ``set --query``. Previously, 256 errors were reported at 0 errors.
 
 Syntax changes and new commands
 -------------------------------

--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -49,7 +49,7 @@ The following options are available:
 
 - ``-e`` or ``--erase`` causes the specified shell variables to be erased
 
-- ``-q`` or ``--query`` test if the specified variable names are defined. Does not output anything, but the builtins exit status is the number of variables specified that were not defined.
+- ``-q`` or ``--query`` test if the specified variable names are defined. Does not output anything, but the builtins exit status is the number of variables specified that were not defined, saturating at 255 if more than 255 variables are not defined.
 
 - ``-n`` or ``--names`` List only the names of all defined variables, not their value. The names are guaranteed to be sorted.
 

--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -565,6 +565,13 @@ static int builtin_set_query(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
         free(dest);
     }
 
+    // The return value is cast to an 8-bit unsigned integer,
+    // so saturate the error count to 255.
+    // Otherwise 256 errors is reported as 0 errors.
+    if (retval > 255) {
+        retval = 255;
+    }
+
     return retval;
 }
 

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -682,4 +682,11 @@ echo $foo
 echo $bar
 #CHECK: 1 3
 
+
+# Test that `set -q` does not return 0 if there are 256 missing variables
+
+set -lq a(seq 1 256)
+echo $status
+#CHECK: 255
+
 true


### PR DESCRIPTION
## Description

`builtin_set_query` returns the number of missing variables. Because the return value passed to the shell is an 8-bit unsigned integer, if the number of missing variables is a multiple of 256, prior to this PR it would overflow to 0.

This PR saturates the return value at 255 if there are more than 255 missing variables.

This issue also seems to apply to `functions --query` and probably others; this PR only fixes `set --query` for now, but could be expanded to fix others.

Currently, it is fixed with an ad-hoc `if`-statement, but it could be fixed with some shared utility function like `int saturate_error_count_to_255(int)`:

```c
/* In builtin_set.cpp */
int builtin_set_query(…) {
    …
    return saturate_error_count_to_255(retval);
}

/* In builtin_functions.cpp */
int builtin_functions_query(…) {
    …
    return saturate_error_count_to_255(retval);
}
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
