### PR TITLE
Updated metasploit completions

### DIFF
--- a/share/completions/msfconsole.fish
+++ b/share/completions/msfconsole.fish
@@ -19,6 +19,7 @@ complete -c msfconsole -s m -l module-path -xa "(__fish_complete_directories)" -
 # Console options
 complete -c msfconsole -s a -l ask -d 'Ask before exiting Metasploit'
 complete -c msfconsole -s H -l history-file -F -d 'Save command history to the specified file'
+complete -c msfconsole -s l -l logger -xa 'Stdout Flatfile StdoutWithoutTimestamps TimestampColorlessFlatfile Stderr' -d 'Specify a logger to use'
 complete -c msfconsole -s L -l real-readline -d 'Use the system Readline library'
 complete -c msfconsole -s o -l output -F -d 'Output to the specified file'
 complete -c msfconsole -s p -l plugin -x -d 'Load a plugin on startup'

--- a/share/completions/msfvenom.fish
+++ b/share/completions/msfvenom.fish
@@ -52,6 +52,7 @@ complete -c msfvenom -s p -l payload -xa "(__fish_complete_msf_payloads)" -d 'Pa
 complete -c msfvenom -l list-options -d 'List options for payload'
 complete -c msfvenom -s f -l format -xa "(__fish_complete_msf_formats)" -d 'Output format'
 complete -c msfvenom -s e -l encoder -xa "(__fish_complete_msf_encoders)" -d 'The encoder to use'
+complete -c msfvenom -l service-name -x -d 'Service name to use when generating a service binary'
 complete -c msfvenom -l sec-name -x -d 'Section name when generating Windows binaries'
 complete -c msfvenom -l smallest -d 'Generate the smallest possible payload'
 complete -c msfvenom -l encrypt -xa "(__fish_complete_msf_encrypt)" -d 'Type of encryption to apply to the shellcode'


### PR DESCRIPTION
## Description

Just a small update for metasploit completions.

Don't know whether I should target `master` or `Integration_3.2.0`. Initial support for these completions will be in 3.2.0 anyway, so this can probably be backported.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
