### PR TITLE
Allow flow control also in the shell

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1319,10 +1319,6 @@ void reader_init() {
     // Save the initial terminal mode.
     tcgetattr(STDIN_FILENO, &terminal_mode_on_startup);
 
-    // Disable flow control by default.
-    terminal_mode_on_startup.c_iflag &= ~IXON;
-    terminal_mode_on_startup.c_iflag &= ~IXOFF;
-
     // Set the mode used for program execution, initialized to the current mode.
     std::memcpy(&tty_modes_for_external_cmds, &terminal_mode_on_startup,
                 sizeof tty_modes_for_external_cmds);
@@ -1330,6 +1326,12 @@ void reader_init() {
 
     // Set the mode used for the terminal, initialized to the current mode.
     std::memcpy(&shell_modes, &terminal_mode_on_startup, sizeof shell_modes);
+
+    // Disable flow control by default.
+    tty_modes_for_external_cmds.c_iflag &= ~IXON;
+    tty_modes_for_external_cmds.c_iflag &= ~IXOFF;
+    shell_modes.c_iflag &= ~IXON;
+    shell_modes.c_iflag &= ~IXOFF;
 
     term_fix_modes(&shell_modes);
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -790,10 +790,6 @@ static void term_fix_modes(struct termios *modes) {
 
     // We ignore these anyway, so there is no need to sacrifice a character.
     modes->c_cc[VSUSP] = disabling_char;
-
-    // (these two are already disabled because of IXON/IXOFF)
-    modes->c_cc[VSTOP] = disabling_char;
-    modes->c_cc[VSTART] = disabling_char;
 }
 
 static void term_fix_external_modes(struct termios *modes) {

--- a/tests/pexpects/terminal.py
+++ b/tests/pexpects/terminal.py
@@ -3,7 +3,14 @@ from pexpect_helper import SpawnedProc
 
 # Set a 0 terminal size
 sp = SpawnedProc(args=["-d", "term-support"], dimensions=(0,0))
-sendline, expect_prompt, expect_str = sp.sendline, sp.expect_prompt, sp.expect_str
+send, sendline, sleep, expect_prompt, expect_re, expect_str = (
+    sp.send,
+    sp.sendline,
+    sp.sleep,
+    sp.expect_prompt,
+    sp.expect_re,
+    sp.expect_str,
+)
 
 expect_prompt()
 # Now confirm it defaulted to 80x24
@@ -13,3 +20,26 @@ expect_str("term-support: Terminal has 0 columns, falling back to default width"
 expect_str("term-support: Terminal has 0 rows, falling back to default height")
 expect_prompt()
 
+sendline("stty -a")
+expect_prompt()
+# Confirm flow control in the shell is disabled - we should ignore the ctrl-s in there.
+sendline("echo hello\x13hello")
+expect_prompt("hellohello")
+
+# Confirm it is off for external commands
+sendline("stty -a | string match -q '*-ixon -ixoff*'; echo $status")
+expect_prompt("0")
+
+# Turn flow control on
+sendline("stty ixon ixoff")
+expect_prompt()
+sendline("stty -a | string match -q '*ixon ixoff*'; echo $status")
+expect_prompt("0")
+
+# Confirm flow control in the shell is disabled - we should ignore the ctrl-s in there.
+sendline("echo hello\x13hello")
+# This should not match because we should not get any output.
+# Unfortunately we have to wait for the timeout to expire - set it to a second.
+expect_str("hellohello", timeout=1, shouldfail=True)
+send("\x11") # ctrl-q to resume flow
+expect_prompt("hellohello")


### PR DESCRIPTION
## Description

This specifically copies IXON/IXOFF from the terminal modes after a command to the shell-modes, so you can use

    stty ixon ixoff

to enable flow control (and `stty -ixon -ixoff` to disable it again). This brings with it the obvious issues that you lose two keychords (ctrl-s and ctrl-q by default, typically) and that it might be confusing if you're not familiar with it (unless your terminal tells you what happened, like e.g. konsole does).

It's technically *possible* someone ends up with flow control enabled accidentally - this doesn't check if the command was `stty` after all - but I'm assuming that's highly unlikely, and even if it did the shell would still basically work.

It also still disables flow control on startup so you specifically have to ask for it - we don't want to give up ctrl-s.

Fixes issue #7704.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Not sure how to test this - can we just send ctrl-s from pexpect? How do we then know it worked? Confirm that no output happened? Does this require waiting for a timeout?