### PR TITLE
Fix `set -U` when `fish_variables` is a symlink

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -275,6 +275,7 @@ Interactive improvements
 -  Just like new ``fish_indent``, the interactive reader will indent continuation lines that follow a line ending in a backslash, ``|``, ``&&`` or ``||`` (:issue:`7694`).
 -  Commands with a trailing escaped space are saved in history correctly (:issue:`7661`).
 -  ``fish_prompt`` no longer mangles Unicode characters in the private-use range U+F600-U+F700. (:issue:`7723`).
+- ``set -U`` now behaves correctly when ``fish_variables`` is a symbolic link instead of overwriting it with a regular file (:issue:`7466`)
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/checks/symlink-universal-variables.fish
+++ b/tests/checks/symlink-universal-variables.fish
@@ -1,0 +1,18 @@
+#RUN: %fish -C 'set -g fish %fish' %s
+begin
+    set -gx XDG_CONFIG_HOME (mktemp -d)
+    mkdir -p $XDG_CONFIG_HOME/fish
+    set -l target_file $XDG_CONFIG_HOME/fish/target_fish_variables
+    set -l fish_variables $XDG_CONFIG_HOME/fish/fish_variables
+
+    echo > $target_file
+    ln -sf $target_file $fish_variables
+    $fish -c 'set -U variable value'
+
+    if test -L $fish_variables
+       echo fish_variables is still a symlink
+    else
+       echo fish_variables has been overwritten
+    end
+    # CHECK: fish_variables is still a symlink
+end


### PR DESCRIPTION
Previously, `set -U` would overwrite the symlink with a regular file.

Fixes https://github.com/fish-shell/fish-shell/issues/7466

This is a very naive implementation of the solution that the issue thread seemed to agree on. 

Can we rely on `wrealpath` always returning a valid path? Or should we fall back to `vars_path` if `wstat` returns something dodgy?

I wasn't sure which section of the CHANGELOG.rst this belongs it. I put it into "interactive improvements". But perhaps it's a "scripting improvement"? Or a "notable bugfix"?

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
