### PR TITLE
abbr: improve error handling when --erase called with no args

### DIFF
--- a/share/functions/abbr.fish
+++ b/share/functions/abbr.fish
@@ -39,6 +39,7 @@ function abbr --description "Manage abbreviations"
         __fish_abbr_add $argv
         return
     else if set -q _flag_erase[1]
+        set -q argv[1]; or return 1
         __fish_abbr_erase $argv
         return
     else if set -q _flag_rename[1]


### PR DESCRIPTION
Before

```fish
> abbr --erase
set: Erase needs a variable name

/usr/share/fish/functions/abbr.fish (line 116): 
    set -e $abbr_var_names
    ^
in function '__fish_abbr_erase'
	called on line 42 of file /usr/share/fish/functions/abbr.fish
in function 'abbr' with arguments '--erase'

(Type 'help set' for related documentation)
[2]>
```

After

```fish
> abbr --erase
[1]>
```