### PR TITLE
Ensure web_config works on WSL

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -1546,6 +1546,7 @@ def runThing():
             subprocess.call([cmd_path, "/c", "start %s" % url])
         else:
             print("Please add the directory containing cmd.exe to your $PATH")
+            sys.exit(-1)
     elif is_termux():
         subprocess.call(["termux-open-url", url])
     else:


### PR DESCRIPTION
web_config could sometimes fail on WSL if the user chose not to append
windows directories to their linux $PATH. This change ensures that the
cmd.exe executable is found in most cases even if windows directories
are not appended to $PATH on linux.

An error message letting the user know that cmd.exe was not found, and
that they should add the cmd.exe dir to their $PATH before running
fish_config is displayed if cmd.exe is still not found.

## Description

To check for cmd.exe, I added a (constant) variable named `COMMON_WSL_CMD_PATHS` which is a tuple containing (at the moment) 3 common paths which may be the directories `cmd.exe` is in. Also, I modified the `find_executable()` function to take a `paths` argument which defaults to an empty tuple.

If the system is detected to be WSL, the `COMMON_WSL_CMD_PATHS` is passed as the `paths` argument to the `find_executable()` function, and `cmd.exe` is attempted to be found. If `cmd.exe` is still not found, an error message is printed and the program exits with a non-zero status code.

I tested this on my machine and `web_config` successfully launched the default Windows web browser on WSL 2 with these changes.

Fixes issue #7741

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Edit: added a description
