### PR TITLE
Only show smartcase-matches if there is no exact match

### DIFF
--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3077,8 +3077,8 @@ static void test_complete() {
     struct test_complete_vars_t : environment_t {
         wcstring_list_t get_names(int flags) const override {
             UNUSED(flags);
-            return {L"Foo1", L"Foo2",  L"Foo3",   L"Bar1",   L"Bar2",
-                    L"Bar3", L"alpha", L"ALPHA!", L"gamma1", L"GAMMA2"};
+            return {L"Foo1",  L"Foo2",   L"Foo3",   L"Bar1",   L"Bar2",  L"Bar3",
+                    L"alpha", L"ALPHA!", L"gamma1", L"GAMMA2", L"Delta", L"DELTA"};
         }
 
         maybe_t<env_var_t> get(const wcstring &key,
@@ -3102,24 +3102,31 @@ static void test_complete() {
 
     completions = do_complete(L"$", {});
     completions_sort_and_prioritize(&completions);
-    do_test(completions.size() == 10);
+    do_test(completions.size() == 12);
     do_test(completions.at(0).completion == L"alpha");
     do_test(completions.at(1).completion == L"ALPHA!");
     do_test(completions.at(2).completion == L"Bar1");
     do_test(completions.at(3).completion == L"Bar2");
     do_test(completions.at(4).completion == L"Bar3");
-    do_test(completions.at(5).completion == L"Foo1");
-    do_test(completions.at(6).completion == L"Foo2");
-    do_test(completions.at(7).completion == L"Foo3");
-    do_test(completions.at(8).completion == L"gamma1");
-    do_test(completions.at(9).completion == L"GAMMA2");
+    do_test(completions.at(5).completion == L"DELTA");
+    do_test(completions.at(6).completion == L"Delta");
+    do_test(completions.at(7).completion == L"Foo1");
+    do_test(completions.at(8).completion == L"Foo2");
+    do_test(completions.at(9).completion == L"Foo3");
+    do_test(completions.at(10).completion == L"gamma1");
+    do_test(completions.at(11).completion == L"GAMMA2");
 
     // Smartcase test. Lowercase inputs match both lowercase and uppercase.
-    completions = do_complete(L"$a", {});
+    completions = do_complete(L"$d", {});
     completions_sort_and_prioritize(&completions);
     do_test(completions.size() == 2);
-    do_test(completions.at(0).completion == L"$ALPHA!");
-    do_test(completions.at(1).completion == L"lpha");
+    do_test(completions.at(0).completion == L"$DELTA");
+    do_test(completions.at(1).completion == L"$Delta");
+    // But only if there is no exact match (#7738).
+    completions = do_complete(L"$a", {});
+    completions_sort_and_prioritize(&completions);
+    do_test(completions.size() == 1);
+    do_test(completions.at(0).completion == L"lpha");
 
     completions = do_complete(L"$F", {});
     completions_sort_and_prioritize(&completions);

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -870,7 +870,6 @@ static void term_steal() {
         shell_modes.c_iflag &= ~IXOFF;
     }
 
-
     while (true) {
         if (tcsetattr(STDIN_FILENO, TCSANOW, &shell_modes) == -1) {
             if (errno == EIO) redirect_tty_output();
@@ -1949,23 +1948,6 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
         // This completion survived.
         surviving_completions.push_back(el);
         all_matches_exact_or_prefix = all_matches_exact_or_prefix && el.match.is_exact_or_prefix();
-    }
-
-    if (surviving_completions.size() == 1) {
-        // After sorting and stuff only one completion is left, use it.
-        //
-        // TODO: This happens when smartcase kicks in, e.g.
-        // the token is "cma" and the options are "cmake/" and "CMakeLists.txt"
-        // it would be nice if we could figure
-        // out how to use it more.
-        const completion_t &c = surviving_completions.at(0);
-
-        // If this is a replacement completion, check that we know how to replace it, e.g. that
-        // the token doesn't contain evil operators like {}.
-        if (!(c.flags & COMPLETE_REPLACES_TOKEN) || reader_can_replace(tok, c.flags)) {
-            completion_insert(c.completion, token_end, c.flags);
-        }
-        return true;
     }
 
     bool use_prefix = false;

--- a/src/wcstringutil.cpp
+++ b/src/wcstringutil.cpp
@@ -230,12 +230,10 @@ uint32_t string_fuzzy_match_t::rank() const {
     // Combine our type and our case fold into a single number, such that better matches are
     // smaller. Treat 'exact' types the same as 'prefix' types; this is because we do not
     // prefer exact matches to prefix matches when presenting completions to the user.
-    // Treat smartcase the same as samecase; see #3978.
     auto effective_type = (type == contain_type_t::exact ? contain_type_t::prefix : type);
-    auto effective_case = (case_fold == case_fold_t::smartcase ? case_fold_t::samecase : case_fold);
 
     // Type dominates fold.
-    return static_cast<uint32_t>(effective_type) * 8 + static_cast<uint32_t>(effective_case);
+    return static_cast<uint32_t>(effective_type) * 8 + static_cast<uint32_t>(case_fold);
 }
 
 template <bool Fuzzy, typename T>


### PR DESCRIPTION
This makes smartcase completion a bit less smart. I'm not sure if that's okay.
This allows to remove the workaround for #7738
