### PR TITLE
Fix pandoc completion error

### DIFF
--- a/share/completions/pandoc.fish
+++ b/share/completions/pandoc.fish
@@ -98,9 +98,9 @@ complete -c pandoc -r -f -l bibliography -k -a "(__fish_complete_suffix 'ria')"
 complete -c pandoc -r -f -l lua-filter -k -a "(__fish_complete_suffix 'lua')"
 
 # options that take files in DATADIR
-complete -c pandoc -r -s F -l filter -a "(find $datadir/filters/** | string replace -- '$datadir/filters/' '')"
-complete -c pandoc -r -l template -a "(find $datadir/templates/** | string replace -- '$datadir/templates/' '')"
-complete -c pandoc -r -f -l lua-filter -a "(find $datadir/** | string match -r '.lua\$' | string replace -- '$datadir/' '')"
+complete -c pandoc -r -s F -l filter -a "(find $datadir/filters -type f 2>/dev/null | string replace -- '$datadir/filters/' '')"
+complete -c pandoc -r -l template -a "(find $datadir/templates -type f 2>/dev/null | string replace -- '$datadir/templates/' '')"
+complete -c pandoc -r -f -l lua-filter -a "(find $datadir -type f 2>/dev/null | string match -r '.lua\$' | string replace -- '$datadir/' '')"
 
 # options that require arguments which cannot be autocompleted
 complete -c pandoc -x -l indented-code-classes


### PR DESCRIPTION
## Description

Pandoc completions would give an error if the folder `~/.pandoc` does exist as described in #7747 . This fixes #7747

I have checked that changes fix the error I noted by using:
```
$ complete -c pandoc -e
$ complete -c pandoc -r -l template -a "(find $datadir/templates -type f 2>/dev/null | string replace -- '$datadir/templates/' '')"
$ pandoc --template <TAB>
```
However do note that I have not tested if the expected completions work although the find commands seem to work and I see no reason for the completions not to.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
I have not done any of these, however I assume they are not relevant for such a small fix.
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
