### PR TITLE
Fixed __fish_adb_get_devices

### DIFF
--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -14,7 +14,7 @@ function __fish_adb_get_devices -d 'Run adb devices and parse output'
     set -l procs (ps -Ao comm= | string match 'adb')
     # Don't run adb devices unless the server is already started - it takes a while to init
     if set -q procs[1]
-        adb devices -l | string replace -rf '(\S+) +.' '$1'\t | string replace -r \t'.*model:(\S+).*' \t'$1'
+        adb devices -l | string replace -rf '(\S+).*model:(\S+).*' '$1'\t'$2'
     end
 end
 


### PR DESCRIPTION
## Description

This PR fixes adb completion for devices(`__fish_adb_get_devices`) also including the first line `List of devices attached` as `List  (f devices attached)` in the completion list.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
