### PR TITLE
Fix `git.fish` test failing because of an alias

### DIFF
--- a/tests/checks/git.fish
+++ b/tests/checks/git.fish
@@ -24,7 +24,7 @@ git init >/dev/null 2>&1
 # Note: We *can't* list all here because in addition to aliases,
 # git also uses all commands in $PATH called `git-something` as custom commands,
 # so this depends on system state!
-complete -C'git ' | grep '^add'
+complete -C'git ' | grep '^add\s'
 # (note: actual tab character in the check here)
 #CHECK: add	Add file contents to the index
 


### PR DESCRIPTION
I have an alias `adda=add :/` in my global `.gitconfig`, which
made the test fail. This is the fix.
## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
