### PR TITLE
Include <termios.h> instead of <sys/termios.h>.

### DIFF
--- a/src/termsize.cpp
+++ b/src/termsize.cpp
@@ -8,7 +8,7 @@
 #include "wutil.h"
 
 #ifdef HAVE_WINSIZE
-#include <sys/termios.h>
+#include <termios.h>
 #endif
 
 // A counter which is incremented every SIGWINCH, or when the tty is otherwise invalidated.


### PR DESCRIPTION
Slipped by with ffa24eb3610dc2853c1a468b8aa2fd327cd0d3fa. Given
daf5ef1bbd4b8ceb005294c512004010010897b8, fish should be using
<termios.h> in all cases.

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
