### PR TITLE
Make `help` and `fish_config` work on Chrome OS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Scripting improvements
 
 Interactive improvements
 ------------------------
+- ``help`` and ``fish_config`` no longer open to a "Your file couldn't be accessed" page when fish is running in a Chrome OS Crostini Linux VM and URLs are opened in Chrome running outside the VM.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -142,12 +142,20 @@ function help --description 'Show help for the fish shell'
             set fish_help_page "index.html#$fish_help_item"
     end
 
+    # In Crostini Chrome OS Linux, the default browser opens URLs in Chrome running outside the
+    # linux VM. This browser does not have access to the Linux filesystem. This uses Garcon, see e.g.
+    # https://chromium.googlesource.com/chromiumos/platform2/+/master/vm_tools/garcon/#opening-urls
+    # https://source.chromium.org/search?q=garcon-url-handler
+    string match -q '*garcon-url-handler*' $fish_browser[1]
+    and set -l chromeos_linux_garcon
+
     set -l page_url
-    if test -f $__fish_help_dir/index.html
+    if test -f $__fish_help_dir/index.html; and not set -lq chromeos_linux_garcon
         # Help is installed, use it
         set page_url file://$__fish_help_dir/$fish_help_page
 
-        # For Windows (Cygwin, msys2 and WSL), we need to convert the base help dir to a Windows path before converting it to a file URL
+        # For Windows (Cygwin, msys2 and WSL), we need to convert the base
+        # help dir to a Windows path before converting it to a file URL
         # but only if a Windows browser is being used
         if type -q cygpath
             and string match -qr '(cygstart|\.exe)(\s+|$)' $fish_browser[1]

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -71,6 +71,16 @@ def is_termux():
     return "com.termux" in os.environ["PATH"] and find_executable("termux-open-url")
 
 
+def is_chromeos_garcon():
+    """ Return whether we are running in Chrome OS and the browser can't see local files """
+    # In Crostini Chrome OS Linux, the default browser opens URLs in Chrome
+    # running outside the linux VM. This browser does not have access to the
+    # Linux filesystem. This uses Garcon, see for example
+    # https://chromium.googlesource.com/chromiumos/platform2/+/master/vm_tools/garcon/#opening-urls
+    # https://source.chromium.org/search?q=garcon-url-handler
+    return "garcon-url-handler" in webbrowser.get().name
+
+
 # Disable CLI web browsers
 term = os.environ.pop("TERM", None)
 # This import must be done with an empty $TERM, otherwise a command-line browser may be started
@@ -1549,6 +1559,8 @@ def runThing():
             sys.exit(-1)
     elif is_termux():
         subprocess.call(["termux-open-url", url])
+    elif is_chromeos_garcon():
+        webbrowser.open(url)
     else:
         webbrowser.open(fileurl)
 

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -23,7 +23,7 @@ from itertools import chain
 COMMON_WSL_CMD_PATHS = (
     "/mnt/c/Windows/System32",
     "/windir/c/Windows/System32",
-    "/c/Windows/System32"
+    "/c/Windows/System32",
 )
 FISH_BIN_PATH = False  # will be set later
 IS_PY2 = sys.version_info[0] == 2
@@ -36,6 +36,21 @@ else:
     import http.server as SimpleHTTPServer
     import socketserver as SocketServer
     from urllib.parse import parse_qs
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+
+# Disable CLI web browsers
+term = os.environ.pop("TERM", None)
+# This import must be done with an empty $TERM, otherwise a command-line browser may be started
+# which will block the whole process - see https://docs.python.org/3/library/webbrowser.html
+import webbrowser
+
+if term:
+    os.environ["TERM"] = term
 
 
 def find_executable(exe, paths=()):
@@ -79,21 +94,6 @@ def is_chromeos_garcon():
     # https://chromium.googlesource.com/chromiumos/platform2/+/master/vm_tools/garcon/#opening-urls
     # https://source.chromium.org/search?q=garcon-url-handler
     return "garcon-url-handler" in webbrowser.get().name
-
-
-# Disable CLI web browsers
-term = os.environ.pop("TERM", None)
-# This import must be done with an empty $TERM, otherwise a command-line browser may be started
-# which will block the whole process - see https://docs.python.org/3/library/webbrowser.html
-import webbrowser
-
-if term:
-    os.environ["TERM"] = term
-
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 
 def run_fish_cmd(text):
@@ -992,7 +992,7 @@ class FishConfigHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 vars[name].exported = True
 
         # Do not return history as a variable, it may be so large the browser hangs.
-        vars.pop('history', None)
+        vars.pop("history", None)
 
         return [
             vars[key].get_json_obj()


### PR DESCRIPTION
When `fish` is running in the Chrome OS Linux VM (Crostini), both `help` and `fish_config` currently open a "file not found"
page. That is because on Crostini, `BROWSER` is usually set to `garcon-url-handler`, which opens URLs in the host OS Chrome
browser. That browser lacks access to the Linux file system.

This PR fixes these commands. `help` now opens the URL on www.fishshell.com.  `fish_config` now opens the URL for the
server it starts. Previously, it opened a local file that redirects to the same URL.

In the case of `help`, the situation could be improved further by starting a web server to serve help. I don't know of another way to access `/share/fish` from outside the VM without user intervention, and I think that might be a part of the security
model for the Crostini VM.

It's hard to write a test for this. I checked that `help math`, `python2 webconfig.py`, and `python3 webconfig.py` work on my
machine running in Crostini.

----------

I also rearranged the imports a little to group them together. It's in a separate commit, let me know if you prefer that I not do that.

Another alternative is to look much harder for a browser installed in the Linux VM. By default, none are installed, I think. I do think a Linux browser should be used if the user has installed it *and* put it into `BROWSER`, though.



## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
