### PR TITLE
Added descriptions to __fish_print_addresses

### DIFF
--- a/share/completions/msfdb.fish
+++ b/share/completions/msfdb.fish
@@ -24,7 +24,7 @@ complete -c msfdb -l db-port -x -d 'Database port'
 complete -c msfdb -l db-pool -x -d 'Database connection pool size'
 
 # Web Service Options
-complete -c msfdb -s a -l address -x -a "(__fish_print_addresses)" -d 'Bind to host address'
+complete -c msfdb -s a -l address -x -a "(__fish_print_addresses --all)" -d 'Bind to host address'
 complete -c msfdb -s p -l port -x -d 'Web service port'
 complete -c msfdb -l ssl -d 'Enable SSL'
 complete -c msfdb -l no-ssl -d 'Disable SSL'

--- a/share/completions/ssh.fish
+++ b/share/completions/ssh.fish
@@ -18,19 +18,7 @@ complete -c ssh -n 'test (__fish_number_of_cmd_args_wo_opts) -ge 2' -d "Command 
 complete -c ssh -s a -d "Disables forwarding of the authentication agent"
 complete -c ssh -s A -d "Enables forwarding of the authentication agent"
 
-
-function __ssh_print_local_addresses_with_labels
-    if command -sq ip
-        command ip --oneline address | string replace -r '\d+:\s+(\S+)\s+\S+\s+(.+)/.*' '$2\t$1'
-    else if command -sq ifconfig
-        # This is for OSX/BSD/anything else that doesn't have `ip` installed.
-        # Since ifconfig output is not guaranteed to be the same on these systems,
-        # for now we will limit the completions to just the IP address.
-        # TODO: check ifconfig output on each system and rework below to include label.
-        ifconfig | awk '/^\tinet/ { print $2 } '
-    end
-end
-complete -x -c ssh -s b -d "Local address to bind to" -a '(__ssh_print_local_addresses_with_labels)'
+complete -x -c ssh -s b -d "Local address to bind to" -a '(__fish_print_addresses)'
 
 complete -x -c ssh -s e -d "Escape character" -a "\^ none"
 complete -c ssh -s f -d "Go to background"

--- a/share/functions/__fish_complete_bittorrent.fish
+++ b/share/functions/__fish_complete_bittorrent.fish
@@ -16,7 +16,7 @@ function __fish_complete_bittorrent
     complete -c $argv -l timeout_check_interval -x --description "Time between checking timeouts"
     complete -c $argv -l max_slice_length -x --description "Maximum outgoing slice length"
     complete -c $argv -l max_rate_period -x --description "Maximum time to guess rate"
-    complete -c $argv -l bind -x --description "IP to bind to locally" -a "(__fish_print_addresses)"
+    complete -c $argv -l bind -x --description "IP to bind to locally" -a "(__fish_print_addresses --all)"
     complete -c $argv -l display_interval -x --description "Time between screen updates"
     complete -c $argv -l rerequest_interval -x --description "Time to wait between requesting more peers"
     complete -c $argv -l min_peers -x --description "Minimum number of peers to not do requesting"

--- a/share/functions/__fish_print_addresses.fish
+++ b/share/functions/__fish_print_addresses.fish
@@ -1,6 +1,11 @@
-function __fish_print_addresses --description "Print a list of known network addresses"
+function __fish_print_addresses --description "List own network addresses with interface as description"
+    # if --all is given, also print 0.0.0.0 and ::
+    if contains -- --all $argv
+        echo -e "0.0.0.0\tall"
+        echo -e "::\tall"
+    end
     if command -sq ip
-        command ip --oneline address | string replace -r '(\S+\s+){3}(.+)/.*' '$2'
+        command ip --oneline address | string replace -r '^\d+:\s+(\S+)\s+inet6?\s+([^\s/]+).*' '$2\t$1'
     else if command -sq ifconfig
         # This is for OSX/BSD
         # There's also linux ifconfig but that has at least two different output formats


### PR DESCRIPTION
## Description

- Added descriptions to __fish_print_addresses
- added --all flag to include 0.0.0.0 and ::
- adapted use of this function in existing completions
- fixes #7787


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
