### PR TITLE
Fix typo in __fish_print_pipestatus

### DIFF
--- a/share/functions/__fish_print_pipestatus.fish
+++ b/share/functions/__fish_print_pipestatus.fish
@@ -15,7 +15,7 @@ function __fish_print_pipestatus --description "Print pipestatus for prompt"
 
     if not set -q argv[1]
         echo error: missing argument >&2
-        status print-stacktrace >&2
+        status print-stack-trace >&2
         return 1
     end
 


### PR DESCRIPTION
## Description

It should be `status print-stack-trace`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
