### PR TITLE
Fix parallel build race condition for test targets

### DIFF
--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -113,6 +113,7 @@ endforeach(TESTTYPE)
 
 # Now add a dependency chain between the serial versions.
 # This ensures they run in order.
+add_dependencies(serial_test_low_level test_prep)
 add_dependencies(serial_test_fishscript serial_test_low_level)
 add_dependencies(serial_test_interactive serial_test_fishscript)
 


### PR DESCRIPTION
## Description

When executing `make test -jX` (with X > 1) to build and run tests in a build directory, there is a race condition between the `serial_test_low_level` target and the `test_prep` target (a dependency of `serial_test_fishscript` and `serial_test_interactive`).

As far as I can tell, these events happen in a serial build scenario (`make test` with the "Unix Makefiles" CMake generator):

1. The `fish_tests` binary is built and executed.
2. The `test_prep` target (a dependency of `serial_test_fishscript`) cleans up test directories.
3. Tests in `test.fish` are executed.

In a parallel build scenario, this often happens:

1. Build of the `fish_tests` binary is started.
2. The `test_prep` target cleans up test directories.
3. Build of the `fish_tests` binary is finished.
4. Execution of the `fish_tests` binary starts.
5. Execution of the `fish_tests` binary finishes.
6. Tests in `test.fish` are executed.

However, if building the `fish_tests` binary is fast enough but not instant (e.g when using ccache), this can happen:

1. Build of the `fish_tests` binary is started.
2. Build of the `fish_tests` binary is finished.
3. Execution of the `fish_tests` binary starts.
4. The `test_prep` target cleans up test directories.
5. `fish_tests` tests that depend on said test directories may, depending on timing, fail because they are wiped by `test_prep`.

Fix this by making `test_prep` a dependency of `serial_test_low_level` so that `test_prep` can't interfere with `fish_tests` execution.

I think that it's likely that this fixes/addresses the following bugs:

- #3825: history race failure
- #6477: history merge test fails on OpenBSD
- #7484: History race condition tests are failing
- #7710: Tests fail on latest commit

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
    - No changes to fish usage.
- [X] Tests have been added for regressions fixed
    - No regressions fixed.
- [ ] User-visible changes noted in CHANGELOG.rst
    - I could do that if I understood where to add a note. :slightly_smiling_face:
