### PR TITLE
Improve error when `help` fails to find a browser

### DIFF
--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -94,7 +94,7 @@ function help --description 'Show help for the fish shell'
 
     if not set -q fish_browser[1]
         printf (_ '%s: Could not find a web browser.\n') help
-        printf (_ 'Please set the variable $BROWSER or fish_help_browser and try again.\n\n')
+        printf (_ 'Please try `BROWSER=some_browser help`, `man fish-doc`, or `man fish-tutorial`.\n\n')
         return 1
     end
 


### PR DESCRIPTION
Now, it tells the user how to set the BROWSER variable and suggests `man` as an
alternative.

Previously, this message told the user to "set $BROWSER and try again". However,
when I first saw this error, I just saw fish's introductory "Type help for instructions on
how to use fish" and I didn't know how I can set `BROWSER` in fish. Moreover,
it is often the case that  no browser will work. For instance, I might be using fish over
ssh. I might not know what text-mode browser, if any, that system I ssh-d to has 
installed, or I might not want to use it.

A further improvement would be to report this message if a browser fails to start. I
didn't implement this because:

1. I don't know how to preserve the failing $status from the browser.
2. I'm not sure how to do this correctly for graphical browsers (which are immediately
disowned).

Please feel free to change my wording. I'm also not sure what to do about translations.

**Aside:** It is so nice this is now possible. The first time this happened to me,
`BROWSER=lynx help` suggested I try `env BROWSER=lynx help`, which of course
did not work. I think `man fish-doc` didn't exist back then either.