### PR TITLE
Added a ':' at the end of a french translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -3556,7 +3556,7 @@ msgstr ""
 
 #: /tmp/fish/explicit/share/functions/cdh.fish:5
 msgid "Select directory by letter or number: "
-msgstr "Sélectionner un dossier par lettre ou chiffre"
+msgstr "Sélectionner un dossier par lettre ou chiffre : "
 
 #: /tmp/fish/explicit/share/functions/cdh.fish:6
 msgid ""


### PR DESCRIPTION
## Description

Added a `:` at the end of a french translation ([here](https://github.com/lapingenieur/fish-shell/commit/f663324916476f4ae4d171a0a44f878d5e714be7))

Fixes issue #7819