### PR TITLE
funced : changed 'rm' to 'command rm'

### DIFF
--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -130,7 +130,7 @@ function funced --description 'Edit function definition'
     end
 
     set -l stat $status
-    rm $tmpname >/dev/null
+    command rm $tmpname >/dev/null
     and rmdir $tmpdir >/dev/null
     return $stat
 end


### PR DESCRIPTION
## Description

If `rm` is aliased to `rm -i` (ask before deleting) then `rm` will always ask to delete the cache file after funced edited the file, which is anoying. With this change, it won't be asking anymore. (This file is meant to be deleted at the end of `funced` so it's not a problem at all)

## Tests

I made the exact same modifications in `funced` in my session and it worked perfectly.