### PR TITLE
Improved SSH completions

### DIFF
--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -1,7 +1,6 @@
-#
-# Load completions shared by ssh and scp.
-#
+# Load completions shared by various ssh tools like ssh, scp and sftp.
 __fish_complete_ssh scp
+
 
 # Helper functions to simplify the completions.
 function __scp2ssh_port_number
@@ -58,10 +57,11 @@ complete -c scp -d "Remote Path" -f -n "commandline -ct | string match -e ':'" -
         string escape -n
 )
 "
+complete -c scp -s 3 -d "Copies between two remote hosts are transferred through the local host"
 complete -c scp -s B -d "Batch mode"
 complete -c scp -s l -x -d "Bandwidth limit"
 complete -c scp -s P -x -d Port
 complete -c scp -s p -d "Preserves modification times, access times, and modes from the original file"
-complete -c scp -s q -d "Do not display progress bar"
 complete -c scp -s r -d "Recursively copy"
 complete -c scp -s S -d "Encryption program"
+complete -c scp -s T -d "Disable strict filename checking"

--- a/share/completions/sftp.fish
+++ b/share/completions/sftp.fish
@@ -1,24 +1,18 @@
+# Load completions shared by various ssh tools like ssh, scp and sftp.
+__fish_complete_ssh sftp
+
 complete -c sftp -x -a "(__fish_complete_user_at_hosts)"
 
-complete -c sftp -s 4 -d 'Use IPv4 addresses only'
-complete -c sftp -s 6 -d 'Use IPv6 addresses only'
 complete -c sftp -s a -d 'Attempt to continue interrupted transfers'
 complete -c sftp -s B -x -d 'Size of the buffer when transferring files'
 complete -c sftp -s b -F -d 'Reads a series of commands from an input batchfile'
-complete -c sftp -s C -d 'Enables compression'
-complete -c sftp -s c -x -d 'The cipher to use for encrypting data'
-complete -c sftp -s D -x -d 'Connect directly to a local sftp server'
-complete -c sftp -s F -F -d 'Alternative per-user configuration file'
+complete -c sftp -s D -x -d 'Connect directly to a local SFTP server'
 complete -c sftp -s f -d 'Flush files to disk after transfer'
-complete -c sftp -s i -F -d 'Identity (private key) file'
-complete -c sftp -s J -x -a "(__fish_complete_user_at_hosts)" -d 'ProxyJump host'
 complete -c sftp -s l -x -d 'Limits the used bandwidth (Kbit/s)'
-complete -c sftp -s o -x -d 'Set additional ssh_config options'
+complete -c sftp -s N -d 'Disables quiet mode'
 complete -c sftp -s P -x -d 'Port to connect to on the remote host'
 complete -c sftp -s p -d 'Preserve timestamps from the original files transferred'
-complete -c sftp -s q -d 'Quiet mode'
 complete -c sftp -s R -x -d 'How many requests may be outstanding'
 complete -c sftp -s r -d 'Recursively copy entire directories'
 complete -c sftp -s S -r -d 'Program to use for the encrypted connection'
 complete -c sftp -s s -x -d 'The SSH2 subsystem or the path for an sftp server'
-complete -c sftp -s v -d 'Raise logging level'

--- a/share/completions/ssh.fish
+++ b/share/completions/ssh.fish
@@ -1,53 +1,49 @@
-#
-# Load completions shared by ssh and scp.
-#
+# Load completions shared by various ssh tools like ssh, scp and sftp.
 __fish_complete_ssh ssh
 
 #
 # ssh specific completions
 #
-complete -x -c ssh -d Remote -a "(__fish_complete_user_at_hosts)"
-
-# Disable as username completion is not very useful.
-# complete -x -c ssh -d User -a "
-# (__fish_print_users | string match -r -v '^_')@
-# "
-
-complete -c ssh -n 'test (__fish_number_of_cmd_args_wo_opts) -ge 2' -d "Command to run" -x -a '(__fish_complete_subcommand --fcs-skip=2)'
-
-complete -c ssh -s a -d "Disables forwarding of the authentication agent"
-complete -c ssh -s A -d "Enables forwarding of the authentication agent"
-
-complete -x -c ssh -s b -d "Local address to bind to" -a '(__fish_print_addresses)'
-
-complete -x -c ssh -s e -d "Escape character" -a "\^ none"
-complete -c ssh -s f -d "Go to background"
-complete -c ssh -s g -d "Allow remote host to connect to local forwarded ports"
-complete -c ssh -s I -d "Smartcard device"
-complete -c ssh -s k -d "Disable forwarding of Kerberos tickets"
-complete -c ssh -s l -x -a "(__fish_complete_users)" -d User
-complete -c ssh -s m -d "MAC algorithm"
-complete -c ssh -s n -d "Prevent reading from stdin"
-complete -c ssh -s N -d "Do not execute remote command"
-complete -c ssh -s p -x -d Port
-complete -c ssh -s q -d "Quiet mode"
-complete -c ssh -s s -d Subsystem
-complete -c ssh -s t -d "Force pseudo-tty allocation"
-complete -c ssh -s T -d "Disable pseudo-tty allocation"
-complete -c ssh -s x -d "Disable X11 forwarding"
-complete -c ssh -s X -d "Enable X11 forwarding"
-complete -c ssh -s L -d "Locally forwarded ports"
-complete -c ssh -s R -d "Remotely forwarded ports"
-complete -c ssh -s D -d "Dynamic port forwarding"
-complete -c ssh -s c -d "Encryption cipher" -xa "(ssh -Q cipher)"
 
 # Also retrieve `user@host` entries from history
-function __ssh_history_completions --argument-names limit
-    if string match -q ""
-        set limit 100
-    end
-
-    history --prefix ssh --max=$limit | string replace -rf '.* ([A-Za-z0-9._:-]+@[A-Za-z0-9._:-]+).*' '$1'
+function __ssh_history_completions
+    history --prefix ssh --max=100 | string replace -rf '.* ([A-Za-z0-9._:-]+@[A-Za-z0-9._:-]+).*' '$1'
 end
 
-complete -k -c ssh -a '(__ssh_history_completions 100)' -f -d Remote
+complete -c ssh -d Remote -xa "(__fish_complete_user_at_hosts)"
+complete -c ssh -d Remote -k -fa '(__ssh_history_completions)'
+
+complete -c ssh -n 'test (__fish_number_of_cmd_args_wo_opts) -ge 2' -d "Command to run" -xa '(__fish_complete_subcommand --fcs-skip=2)'
+
+complete -c ssh -s a -d "Disables forwarding of the authentication agent"
+complete -c ssh -s B -d "Bind to the address of that interface" -xa '(__fish_print_interfaces)'
+complete -c ssh -s b -d "Local address to bind to" -xa '(__fish_print_addresses)'
+complete -c ssh -s E -d "Append debug logs to log_file" -rF
+complete -c ssh -s e -d "Escape character" -xa "\^ none"
+complete -c ssh -s f -d "Go to background"
+complete -c ssh -s G -d "Print configuration after evaluating Host"
+complete -c ssh -s g -d "Allow remote host to connect to local forwarded ports"
+complete -c ssh -s I -d "Specify the PKCS#11 library" -r
+complete -c ssh -s K -d "Enables GSSAPI-based authentication"
+complete -c ssh -s k -d "Disables forwarding of GSSAPI credentials"
+complete -c ssh -s L -d "Specify local port forwarding" -x
+complete -c ssh -s l -x -a "(__fish_complete_users)" -d User
+complete -c ssh -s M -d "Places the ssh client into master mode"
+complete -c ssh -s m -d "MAC algorithm" -xa "(__fish_complete_list , __fish_ssh_macs)"
+complete -c ssh -s N -d "Do not execute remote command"
+complete -c ssh -s n -d "Prevent reading from stdin"
+complete -c ssh -s O -d "Control an active connection multiplexing master process" -x
+complete -c ssh -s p -d Port -x
+complete -c ssh -s Q -d "List supported algorithms" -xa "(ssh -Q help)"
+complete -c ssh -s R -d "Specify remote/reverse port forwarding" -x
+complete -c ssh -s S -d "Location of a control socket for connection sharing" -r
+complete -c ssh -s s -d Subsystem
+complete -c ssh -s T -d "Disable pseudo-tty allocation"
+complete -c ssh -s t -d "Force pseudo-tty allocation"
+complete -c ssh -s V -d "Display version number"
+complete -c ssh -s W -d "Forward stdin/stdout to host:port over secure channel" -x
+complete -c ssh -s w -d "Requests tunnel device forwarding" -x
+complete -c ssh -s X -d "Enable X11 forwarding"
+complete -c ssh -s x -d "Disable X11 forwarding"
+complete -c ssh -s Y -d "Enables trusted X11 forwarding"
+complete -c ssh -s y -d "Send log information using syslog"

--- a/share/functions/__fish_complete_ssh.fish
+++ b/share/functions/__fish_complete_ssh.fish
@@ -1,58 +1,114 @@
 function __fish_complete_ssh -d "common completions for ssh commands" --argument-names command
-    complete -c $command -s 1 -d "Protocol version 1 only"
-    complete -c $command -s 2 -d "Protocol version 2 only"
-    complete -c $command -s 4 -d "IPv4 addresses only"
-    complete -c $command -s 6 -d "IPv6 addresses only"
+    complete -c $command -s 4 -d "IPv4 only"
+    complete -c $command -s 6 -d "IPv6 only"
+    complete -c $command -s A -d "Enables forwarding of the authentication agent"
     complete -c $command -s C -d "Compress all data"
-    complete -xc $command -s c -d "Encryption algorithm" -a "blowfish 3des des"
-    complete -r -c $command -s F -d "Configuration file"
-    complete -r -c $command -s i -d "Identity file"
-    complete -x -c $command -s o -d Options -a "
-		AddressFamily
-		BatchMode
-		BindAddress
-		ChallengeResponseAuthentication
-		CheckHostIP
-		Cipher
-		Ciphers
-		Compression
-		CompressionLevel
-		ConnectionAttempts
-		ConnectTimeout
-		ControlMaster
-		ControlPath
-		GlobalKnownHostsFile
-		GSSAPIAuthentication
-		GSSAPIDelegateCredentials
-		Host
-		HostbasedAuthentication
-		HostKeyAlgorithms
-		HostKeyAlias
-		HostName
-		IdentityFile
-		IdentitiesOnly
-		LogLevel
-		MACs
-		NoHostAuthenticationForLocalhost
-		NumberOfPasswordPrompts
-		PasswordAuthentication
-		Port
-		PreferredAuthentications
-		Protocol
-		ProxyCommand
-		PubkeyAuthentication
-		RhostsRSAAuthentication
-		RSAAuthentication
-		SendEnv
-		ServerAliveInterval
-		ServerAliveCountMax
-		SmartcardDevice
-		StrictHostKeyChecking
-		TCPKeepAlive
-		UsePrivilegedPort
-		User
-		UserKnownHostsFile
-		VerifyHostKeyDNS
-	"
+    complete -c $command -s c -d "Encryption algorithm" -xa "(__fish_complete_list , __fish_ssh_ciphers)"
+    complete -c $command -s F -d "Configuration file" -rF
+    complete -c $command -s i -d "Identity key file" -rF
+    complete -c $command -s J -d 'ProxyJump host' -xa "(__fish_complete_user_at_hosts)"
+    complete -c $command -s o -d Options -xa "
+        AddKeysToAgent
+        AddressFamily
+        BatchMode
+        BindAddress
+        BindInterface
+        CanonicalDomains
+        CanonicalizeFallbackLocal
+        CanonicalizeHostname
+        CanonicalizeMaxDots
+        CanonicalizePermittedCNAMEs
+        CASignatureAlgorithms
+        CertificateFile
+        ChallengeResponseAuthentication
+        CheckHostIP
+        Ciphers
+        ClearAllForwardings
+        Compression
+        ConnectionAttempts
+        ConnectTimeout
+        ControlMaster
+        ControlPath
+        ControlPersist
+        DynamicForward
+        EscapeChar
+        ExitOnForwardFailure
+        FingerprintHash
+        ForwardAgent
+        ForwardX11
+        ForwardX11Timeout
+        ForwardX11Trusted
+        GatewayPorts
+        GlobalKnownHostsFile
+        GSSAPIAuthentication
+        GSSAPIClientIdentity
+        GSSAPIDelegateCredentials
+        GSSAPIKexAlgorithms
+        GSSAPIKeyExchange
+        GSSAPIRenewalForcesRekey
+        GSSAPIServerIdentity
+        GSSAPITrustDns
+        HashKnownHosts
+        Host
+        HostbasedAuthentication
+        HostbasedKeyTypes
+        HostKeyAlgorithms
+        HostKeyAlias
+        Hostname
+        IdentitiesOnly
+        IdentityAgent
+        IdentityFile
+        IPQoS
+        KbdInteractiveAuthentication
+        KbdInteractiveDevices
+        KexAlgorithms
+        LocalCommand
+        LocalForward
+        LogLevel
+        MACs
+        Match
+        NoHostAuthenticationForLocalhost
+        NumberOfPasswordPrompts
+        PasswordAuthentication
+        PermitLocalCommand
+        PKCS11Provider
+        Port
+        PreferredAuthentications
+        ProxyCommand
+        ProxyJump
+        ProxyUseFdpass
+        PubkeyAcceptedKeyTypes
+        PubkeyAuthentication
+        RekeyLimit
+        RemoteCommand
+        RemoteForward
+        RequestTTY
+        SendEnv
+        ServerAliveCountMax
+        ServerAliveInterval
+        SetEnv
+        StreamLocalBindMask
+        StreamLocalBindUnlink
+        StrictHostKeyChecking
+        TCPKeepAlive
+        Tunnel
+        TunnelDevice
+        UpdateHostKeys
+        User
+        UserKnownHostsFile
+        VerifyHostKeyDNS
+        VisualHostKey
+        XAuthLocation
+    "
+    complete -c $command -s q -d "Quiet mode"
     complete -c $command -s v -d "Verbose mode"
+end
+
+
+function __fish_ssh_ciphers -d "List of possible SSH cipher algorithms"
+    ssh -Q cipher
+end
+
+function __fish_ssh_macs -d "List of possible SSH MAC algorithms"
+    ssh -Q mac
 end


### PR DESCRIPTION
Brought ssh/scp/sftp completions up to date with OpenSSH_8.4p1.

- use __fish_complete_ssh also for sftp
- removed old options -1 and -2 (no longer supported by modern openssh and nobody should use SSHv1 anyway)
- added several newer options
- cleaned up and sorted completion code


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
