### PR TITLE
Fix function wrapping for cd command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Scripting improvements
 Interactive improvements
 -------------------------
 - When there are multiple completion candidates, fish inserts their shared prefix. This prefix was computed in a case-insensitive way, resulting in wrong case in the completion pager. This was fixed by only inserting prefixes with matching case (:issue:`7744`).
+- Commands that wrap ``cd`` (using ``complete --wraps cd``) get the same completions as ``cd`` (:issue:`4693`).
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -1743,7 +1743,8 @@ void completer_t::perform_for_commandline(wcstring cmdline) {
         }
 
         // Hack. If we're cd, handle it specially (issue #1059, others).
-        handle_as_special_cd = (unesc_command == L"cd");
+        handle_as_special_cd =
+            (unesc_command == L"cd") || arg_data.visited_wrapped_commands.count(L"cd");
     }
 
     // Maybe apply variable assignments.


### PR DESCRIPTION
## Fix function wrapping for cd command

As @faho mentioned in the issue discussion `cd` command is treated specially, but when it goes through wrapping chain it gets broken.  

Indicator if command should be treated specially for `cd` is stored in `handle_as_special_cd` flag which was true only if first command in chain was equal to `cd` and ignored commands visited in wrap chain.  This PR fixes the bug by checking if `cd` was visited during walking through wrapping chain - all visited commands (without the initial command) are stored in `arg_data.visited_wrapped_commands`.  

I also added test section for checking correct wrapping of `cd` in functions 

Fixes issue #4693

