### PR TITLE
Remove Unused `import`

### DIFF
--- a/build_tools/littlecheck.py
+++ b/build_tools/littlecheck.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import argparse
-from collections import deque
 import datetime
 import io
 import re


### PR DESCRIPTION
## Description

I removed the unused import according to a recommendation from LGTM (https://lgtm.com/projects/g/fish-shell/fish-shell/snapshot/13e62e8339baab4228b3bdfb00647ff51d926b41/files/build_tools/littlecheck.py?sort=name&dir=ASC&mode=heatmap).

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [  ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst
