### PR TITLE
Fixed completion errors for tshark when running as root

### DIFF
--- a/share/completions/tshark.fish
+++ b/share/completions/tshark.fish
@@ -5,14 +5,14 @@ __fish_complete_wireshark tshark
 function __fish_tshark_protocols
     set -l tok (commandline -ct | string collect)
     set -l tok_param (string replace -r -- '^-O' '' $tok)
-    command tshark -G protocols | while read -l -d \t name shortname identifier
+    command tshark -G protocols 2>/dev/null | while read -l -d \t name shortname identifier
         printf "%s%s\t%s\n" (string replace -r -- '(.+),[^,]*$' '$1,' $tok_param) $tok_no_comma $identifier $name
     end
 end
 
 complete -c tshark -s 2 -d 'Perform a two-pass analysis'
 # This is fairly expensive, but only done upon the user pressing tab.
-complete -c tshark -s e -d 'Add a field to the list of fields to display' -xa '(command tshark -G fields | awk -F\t \'{print $3"\t"$2}\')'
+complete -c tshark -s e -d 'Add a field to the list of fields to display' -xa '(command tshark -G fields 2> /dev/null | awk -F\t \'{print $3"\t"$2}\')'
 complete -c tshark -s E -d 'Set an option controlling the printing of fields' -xa '
 bom=y\t"Prepend output with the UTF-8 byte order mark"
 header=y\t"Print a list of the selected field names"
@@ -24,7 +24,7 @@ quote=\t"Set the quote character to use to surround fields d=\", s=\', n=no quot
 complete -c tshark -s F -d 'Set the output capture file format' -xa '(command tshark -F 2>| string replace -rf "\s+(\S+) - (.*)" \'$1\t$2\')'
 complete -c tshark -s G -d 'Print a glossary' -xa '(
 printf "help\tList available report types\n"
-command tshark -G help | string replace -rf "\s+-G (\S+)\s+(.*)" \'$1\t$2\'
+command tshark -G help 2>/dev/null | string replace -rf "\s+-G (\S+)\s+(.*)" \'$1\t$2\'
 )'
 complete -c tshark -s H -d 'Read a list of entries from a "hosts" file' -r
 complete -c tshark -s j -d 'Protocol match filter used for ek|json|jsonraw|pdml output file types' -x

--- a/share/functions/__fish_complete_wireshark.fish
+++ b/share/functions/__fish_complete_wireshark.fish
@@ -6,15 +6,15 @@ end
 
 function __fish_wireshark_interface
     # no remote capture yet
-    command tshark -D | string replace -r ".*\. (\S+)\s*\(?([^)]*)\)?\$" '$1\t$2'
+    command tshark -D 2>/dev/null | string replace -r ".*\. (\S+)\s*\(?([^)]*)\)?\$" '$1\t$2'
 end
 
 function __fish_wireshark_protocol
-    command tshark -G protocols | awk -F\t '{print $3"\t"$1}'
+    command tshark -G protocols 2>/dev/null | awk -F\t '{print $3"\t"$1}'
 end
 
 function __fish_wireshark_heuristic
-    command tshark -G heuristic-decodes | awk -F\t '{print $2"\t"$1}'
+    command tshark -G heuristic-decodes 2>/dev/null | awk -F\t '{print $2"\t"$1}'
 end
 
 function __fish_tshark_name_resolving_flags
@@ -67,10 +67,10 @@ packets:\t"Switch to the next file after it contains N packets"'
     complete -c $shark -l list-time-stamp-types -d 'List time stamp types supported for the interface'
     complete -c $shark -s p -l no-promiscuous-mode -d "Don't put the interface into promiscuous mode"
     complete -c $shark -s s -l snapshot-length -d 'Set the default snapshot length in bytes to use when capturing live data' -x
-    complete -c $shark -l time-stamp-type -d "Change the interface's timestamp method" -xa '(__fish_wireshark_choices (command tshark --list-time-stamp-types))'
+    complete -c $shark -l time-stamp-type -d "Change the interface's timestamp method" -xa '(__fish_wireshark_choices (command tshark --list-time-stamp-types 2>/dev/null))'
     complete -c $shark -s v -l version -d 'Print the version and exit'
     complete -c $shark -s w -d 'Write raw packet data to the given file ("-" means stdout)' -r
-    complete -c $shark -s y -l linktype -d 'Set the data link type to use while capturing packets' -xa '(__fish_wireshark_choices (command tshark -L))'
+    complete -c $shark -s y -l linktype -d 'Set the data link type to use while capturing packets' -xa '(__fish_wireshark_choices (command tshark -L 2>/dev/null))'
 
     switch $shark
         case dumpcap tshark
@@ -81,7 +81,7 @@ packets:\t"Switch to the next file after it contains N packets"'
     switch $shark
         case wireshark tshark
             complete -c $shark -s C -d 'Run with the given configuration profile' -xa '(
-set -l folders (tshark -G folders | awk \'/Personal configuration/{ print $NF}\')/profiles/*
+set -l folders (tshark -G folders 2>/dev/null | awk \'/Personal configuration/{ print $NF}\')/profiles/*
 string match -r "[^/]*\\$" -- $folders)'
             complete -c $shark -s d -d 'Specify how a layer type should be dissected' -xa '(__fish_tshark_decode_as)'
             complete -c $shark -l enable-protocol -d 'Enable dissection of the given protocol' -xa '(__fish_wireshark_protocol)'
@@ -92,7 +92,7 @@ string match -r "[^/]*\\$" -- $folders)'
             complete -c $shark -s n -d 'Disable network object name resolution (hostname, TCP and UDP port names)'
             complete -c $shark -s N -d 'Turn on name resolution only for particular types of addresses and port numbers' -xa '( __fish_tshark_name_resolving_flags)'
             complete -c $shark -s o -d 'Override a preference value' -xa '(
-    command tshark -G defaultprefs | string replace -rf -- \'^#([a-z].*):.*\' \'$1:\')'
+    command tshark -G defaultprefs 2>/dev/null | string replace -rf -- \'^#([a-z].*):.*\' \'$1:\')'
             complete -c $shark -s r -l read-file -d 'Read packet data from the given file' -r
             complete -c $shark -s R -l read-filter -d 'Apply the given read filter' -x
             complete -c $shark -s t -d 'Set the format of the packet timestamp printed in summary lines' -xa '


### PR DESCRIPTION
## Description

When running as root, many `tshark` completions show the following error:

> Running as user "root" and group "root". This could be dangerous.

This can be fixed by redirecting stderr.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
