### PR TITLE
Add max and min math functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Interactive improvements
 - Fish now automatically creates ``config.fish`` and the configuration directories in ``$XDG_CONFIG_HOME/fish`` (by default ``~/.config/fish``) if they do not already exist.
 - ``__fish_prepend_sudo`` now toggles sudo even when it took the commandline from history instead of only adding it.
 - Fish now defaults job-control to "full" meaning it more sensibly handles assigning the terminal and process groups (:issue:`5036`, :issue:`5832`, :issue:`7721`)
+- ``math`` learned two new functions, ``max`` and ``min`.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc_src/cmds/math.rst
+++ b/doc_src/cmds/math.rst
@@ -88,6 +88,8 @@ Functions
 - ``ln`` - the base-e logarithm
 - ``log`` or ``log10`` - the base-10 logarithm
 - ``log2`` - the base-2 logarithm
+- ``max`` - returns the larger of two numbers
+- ``min`` - returns the smaller of two numbers
 - ``ncr`` - "from n choose r" combination function - how many subsets of size r can be taken from n (order doesn't matter)
 - ``npr`` - the number of subsets of size r that can be taken from a set of n elements (including different order)
 - ``pow(x,y)`` returns x to the y (and can be written as ``x ^ y``)

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -182,6 +182,20 @@ static constexpr double bit_xor(double a, double b) {
     return static_cast<double>(static_cast<long long>(a) ^ static_cast<long long>(b));
 }
 
+static double max(double a, double b) {
+    if (std::isnan(a)) return a;
+    if (std::isnan(b)) return b;
+    if (a == b) return std::signbit(a) ? b : a; // treat +0 as larger than -0
+    return a > b ? a : b;
+}
+
+static double min(double a, double b) {
+    if (std::isnan(a)) return a;
+    if (std::isnan(b)) return b;
+    if (a == b) return std::signbit(a) ? a : b; // treat -0 as smaller than +0
+    return a < b ? a : b;
+}
+
 static const te_builtin functions[] = {
     /* must be in alphabetical order */
     {L"abs", reinterpret_cast<void *>(static_cast<te_fun1>(fabs)), TE_FUNCTION1},
@@ -203,6 +217,8 @@ static const te_builtin functions[] = {
     {L"log", reinterpret_cast<void *>(static_cast<te_fun1>(log10)), TE_FUNCTION1},
     {L"log10", reinterpret_cast<void *>(static_cast<te_fun1>(log10)), TE_FUNCTION1},
     {L"log2", reinterpret_cast<void *>(static_cast<te_fun1>(log2)), TE_FUNCTION1},
+    {L"max", reinterpret_cast<void *>(static_cast<te_fun2>(max)), TE_FUNCTION2},
+    {L"min", reinterpret_cast<void *>(static_cast<te_fun2>(min)), TE_FUNCTION2},
     {L"ncr", reinterpret_cast<void *>(static_cast<te_fun2>(ncr)), TE_FUNCTION2},
     {L"npr", reinterpret_cast<void *>(static_cast<te_fun2>(npr)), TE_FUNCTION2},
     {L"pi", reinterpret_cast<void *>(static_cast<te_fun0>(pi)), TE_FUNCTION0},

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -33,6 +33,12 @@ math -- -4 / 2
 math -- '-4 * 2'
 # CHECK: -8
 
+# Validate max and min
+math 'max(1,2)'
+math 'min(1,2)'
+# CHECK: 2
+# CHECK: 1
+
 # Validate some rounding functions
 math 'round(3/2)'
 math 'floor(3/2)'
@@ -100,10 +106,10 @@ not math 'ncr(1)'
 # CHECKERR: 'ncr(1)'
 # CHECKERR:       ^
 
-# There is no "max" function.
-not math 'max()'
+# There is no "blah" function.
+not math 'blah()'
 # CHECKERR: math: Error: Unknown function
-# CHECKERR: 'max()'
+# CHECKERR: 'blah()'
 # CHECKERR:    ^
 
 math n + 4


### PR DESCRIPTION
## Description

Adds `max` and `min` math functions.

fixes #7856 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
