### PR TITLE
Fix Sphinx warning about CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ Improved prompts
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+- *This placeholder silences a sphinx doc warning, so the last section is not empty.*
+
+--------------
 
 fish 3.2.1 (released March 18, 2021)
 ====================================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,8 +30,6 @@ Improved prompts
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
---------------
-
 fish 3.2.1 (released March 18, 2021)
 ====================================
 


### PR DESCRIPTION
When building `sphinx-manpages` and/or `sphinx-docs`, a warning is issued:

```
../CHANGELOG.rst:33: WARNING: Document or section may not begin with a transition.
```

## Description

This is almost identical to the fix in commit 84a89f5195a31b53c56cde644279b3e88232b601. 

Based on a previous discussion with @faho , I didn't bother with creating an issue, and I'm just making the pull request. 🙂 
