### PR TITLE
fish_bell option to enable or disable bell on reader_t::flash().

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Interactive improvements
 - ``__fish_prepend_sudo`` now toggles sudo even when it took the commandline from history instead of only adding it.
 - Fish now defaults job-control to "full" meaning it more sensibly handles assigning the terminal and process groups (:issue:`5036`, :issue:`5832`, :issue:`7721`)
 - ``math`` learned two new functions, ``max`` and ``min`.
+- Terminal bells are now off by default. Enable them by setting ``fish_bell``.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1196,6 +1196,8 @@ You can change the settings of fish by changing the values of certain variables.
 
 - ``fish_ambiguous_width`` controls the computed width of ambiguous-width characters. This should be set to 1 if your terminal renders these characters as single-width (typical), or 2 if double-width.
 
+- ``fish_bell``, if set, causes fish to emit BEL characters. This happens when a history search finds nothing, when no suitable completions are found, or when an undo or redo fails. Useful over bad network connections to distinguish failed user interaction from network lag.
+
 - ``fish_emoji_width`` controls whether fish assumes emoji render as 2 cells or 1 cell wide. This is necessary because the correct value changed from 1 to 2 in Unicode 9, and some terminals may not be aware. Set this if you see graphical glitching related to emoji (or other "special" characters). It should usually be auto-detected.
 
 - ``FISH_DEBUG`` and ``FISH_DEBUG_OUTPUT`` control what debug output fish generates and where it puts it, analogous to the ``--debug`` and ``--debug-output`` options. These have to be set on startup, via e.g. ``FISH_DEBUG='reader*' FISH_DEBUG_OUTPUT=/tmp/fishlog fish``.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1834,10 +1834,12 @@ void reader_data_t::flash() {
 
     layout_data_t old_data = std::move(rendered_layout);
 
-    ignore_result(write(STDOUT_FILENO, "\a", 1));
-    // The write above changed the timestamp of stdout; ensure we don't therefore reset our screen.
-    // See #3693.
-    s_save_status(&screen);
+    if (vars().get(L"fish_bell")) {
+        ignore_result(write(STDOUT_FILENO, "\a", 1));
+        // The write above changed the timestamp of stdout; ensure we don't therefore reset our screen.
+        // See #3693.
+        s_save_status(&screen);
+    }
 
     pollint.tv_sec = 0;
     pollint.tv_nsec = 100 * 1000000;


### PR DESCRIPTION
`fish_bell`'s behaviour is documented in doc_src/language.rst.

## Description

The option was added because visual (and especially audio) feedback after
failed user interaction is usually unnecessary and can be extremely annoying.
It is only useful over bad networks, when it isn't clear whether the
interaction failed or there is network lag.

The terminal bell is still useful for other things, like notifying on the completion of a long command, so disabling the terminal bell entirely is not preferable to many users.

## TODOs:

<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
