### PR TITLE
changelog: fix missiong inline literal end-string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Interactive improvements
 - Fish now automatically creates ``config.fish`` and the configuration directories in ``$XDG_CONFIG_HOME/fish`` (by default ``~/.config/fish``) if they do not already exist.
 - ``__fish_prepend_sudo`` now toggles sudo even when it took the commandline from history instead of only adding it.
 - Fish now defaults job-control to "full" meaning it more sensibly handles assigning the terminal and process groups (:issue:`5036`, :issue:`5832`, :issue:`7721`)
-- ``math`` learned two new functions, ``max`` and ``min`.
+- ``math`` learned two new functions, ``max`` and ``min``.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

When building the document with Sphinx, the following warning is displayed, so add end-string.
`../CHANGELOG.rst:29: WARNING: Inline literal start-string without end-string.`

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
