### PR TITLE
math: Make function parentheses optional

### DIFF
--- a/doc_src/cmds/math.rst
+++ b/doc_src/cmds/math.rst
@@ -22,6 +22,8 @@ Keep in mind that parameter expansion happens before expressions are evaluated. 
 
 ``math`` ignores whitespace between arguments and takes its input as multiple arguments (internally joined with a space), so ``math 2 +2`` and ``math "2 +    2"`` work the same. ``math 2 2`` is an error.
 
+Parentheses for functions are optional - ``math sin pi`` prints ``0``.
+
 The following options are available:
 
 - ``-sN`` or ``--scale=N`` sets the scale of the result. ``N`` must be an integer or the word "max" for the maximum scale. A scale of zero causes results to be rounded down to the nearest integer. So ``3/2`` returns ``1`` rather than ``2`` which ``1.5`` would normally round to. This is for compatibility with ``bc`` which was the basis for this command prior to fish 3.0.0. Scale values greater than zero causes the result to be rounded using the usual rules to the specified number of decimal places.

--- a/doc_src/cmds/math.rst
+++ b/doc_src/cmds/math.rst
@@ -20,9 +20,10 @@ By default, the output is a floating-point number with trailing zeroes trimmed. 
 
 Keep in mind that parameter expansion happens before expressions are evaluated. This can be very useful in order to perform calculations involving shell variables or the output of command substitutions, but it also means that parenthesis (``()``) and the asterisk (``*``) glob character have to be escaped or quoted. ``x`` can also be used to denote multiplication, but it needs to be followed by whitespace to distinguish it from hexadecimal numbers.
 
+Parentheses for functions are optional - ``math sin pi`` prints ``0``. However, a comma will bind to the inner function, so ``math pow sin 3, 5`` is an error because it tries to give ``sin`` the arguments ``3`` and ``5``. When in doubt, use parentheses.
+
 ``math`` ignores whitespace between arguments and takes its input as multiple arguments (internally joined with a space), so ``math 2 +2`` and ``math "2 +    2"`` work the same. ``math 2 2`` is an error.
 
-Parentheses for functions are optional - ``math sin pi`` prints ``0``.
 
 The following options are available:
 
@@ -123,7 +124,7 @@ Examples
 
 ``math 0xFF`` outputs 255, ``math 0 x 3`` outputs 0 (because it computes 0 multiplied by 3).
 
-``math "bitand(0xFE, 0x2e)"`` outputs 46.
+``math bitand 0xFE, 0x2e`` outputs 46.
 
 ``math "bitor(9,2)"`` outputs 11.
 

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -193,3 +193,17 @@ echo $status
 
 math 'log2(8)'
 # CHECK: 3
+
+# same as sin(cos(2 x pi))
+math sin cos 2 x pi
+# CHECK: 0.841471
+# Inner function binds stronger, so this is interpreted as
+# pow(sin(3,5))
+
+math pow sin 3, 5
+# CHECKERR: math: Error: Too many arguments
+# CHECKERR: 'pow sin 3, 5'
+# CHECKERR: ^
+
+math sin pow 3, 5
+# CHECK: -0.890009

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -171,9 +171,7 @@ math "bitor(37 ^ 5, 255)"
 # CHECK: 69343999
 
 math 'log 16'
-# CHECKERR: math: Error: Missing opening parenthesis
-# CHECKERR: 'log 16'
-# CHECKERR:       ^
+# CHECK: 1.20412
 
 math 'log(16'
 # CHECKERR: math: Error: Missing closing parenthesis

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -207,3 +207,12 @@ math pow sin 3, 5
 
 math sin pow 3, 5
 # CHECK: -0.890009
+
+math pow 2, cos -pi
+# CHECK: 0.5
+
+# pow(2*cos(-pi), 2)
+# i.e. 2^2
+# i.e. 4
+math pow 2 x cos'(-pi)', 2
+# CHECK: 4


### PR DESCRIPTION
It's a bit annoying to use parentheses here because that requires
quoting or escaping.

This allows the parens to be omitted, so

```fish
math sin pi
```

is the same as

```fish
math 'sin(pi)'
```

Function calls have the lowest precedence, so

```fish
math sin 2 + 6
```

is the same as

```fish
math 'sin(2 + 6)'
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
