### PR TITLE
Make default vi mode prompt a bit nicer to look at

### DIFF
--- a/share/functions/fish_default_mode_prompt.fish
+++ b/share/functions/fish_default_mode_prompt.fish
@@ -4,19 +4,19 @@ function fish_default_mode_prompt --description "Display the default mode for th
         or test "$fish_key_bindings" = fish_hybrid_key_bindings
         switch $fish_bind_mode
             case default
-                set_color --bold --background red white
+                set_color --bold red
                 echo '[N]'
             case insert
-                set_color --bold --background green white
+                set_color --bold green
                 echo '[I]'
             case replace_one
-                set_color --bold --background green white
+                set_color --bold green
                 echo '[R]'
             case replace
-                set_color --bold --background cyan white
+                set_color --bold cyan
                 echo '[R]'
             case visual
-                set_color --bold --background magenta white
+                set_color --bold magenta
                 echo '[V]'
         end
         set_color normal


### PR DESCRIPTION
## Description

The default vi mode prompt is kind of ugly, mostly because we include
this `[I]` with a super bright green background and white text,
which is particularly grating because most prompts don't actually have
a background.

So we get a ton of people asking "How do I remove this [I]" when they
could really benefit from having the mode shown.

There's a few ways to make this look nicer, the simplest is to just
keep the same colors but use them as foreground instead of background
colors, which looks much more understated.

The mode prompt is important, but not more than the actual contents of
the commandline, so it shouldn't have ALARMING colors.

Before:
![Screenshot_20210330_171830](https://user-images.githubusercontent.com/5185367/113013632-28b73680-917c-11eb-8236-1740abd63a90.png)

After:
![Screenshot_20210330_171804](https://user-images.githubusercontent.com/5185367/113013641-2a80fa00-917c-11eb-94a0-10044087f5fd.png)
## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

