### PR TITLE
Fix Sphinx warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Interactive improvements
 - Fish now automatically creates ``config.fish`` and the configuration directories in ``$XDG_CONFIG_HOME/fish`` (by default ``~/.config/fish``) if they do not already exist.
 - ``__fish_prepend_sudo`` now toggles sudo even when it took the commandline from history instead of only adding it.
 - Fish now defaults job-control to "full" meaning it more sensibly handles assigning the terminal and process groups (:issue:`5036`, :issue:`5832`, :issue:`7721`)
-- ``backward-kill-path-component`` (Control+W) no longer erases parts of two tokens when the cursor is positioned immediately after `` /``. (:issue:`6258`).
+- ``backward-kill-path-component`` (Control+W) no longer erases parts of two tokens when the cursor is positioned immediately after ``/``. (:issue:`6258`).
 - ``math`` learned two new functions, ``max`` and ``min``.
 - ``$SHLVL`` is no longer incremented in non-interactive shells. This means it won't be set to values larger than 1 just because your environment happens to run some scripts in $SHELL in its startup path (:issue:`7864`).
 - Fish no longer rings the bell when flashing. The flashing should already be enough notification and the bell can be annoying (:issue:`7875`).


### PR DESCRIPTION
## Description

For some reason, the space in seems to cause a problem. I verified that the generated HTML looks good. 

```
../CHANGELOG.rst:30: WARNING: Inline literal start-string without end-string.
```
<img width="922" alt="Screen Shot 2021-03-30 at 10 59 47 AM" src="https://user-images.githubusercontent.com/5694899/113019558-5cc43480-9147-11eb-86c5-e61fbad128c0.png">
