### PR TITLE
Fish greeting

### DIFF
--- a/share/functions/fish_greeting.fish
+++ b/share/functions/fish_greeting.fish
@@ -1,8 +1,6 @@
 function fish_greeting
     if not set -q fish_greeting
-        set -l line1 (_ 'Welcome to fish, the friendly interactive shell')
-        set -l line2 \n(printf (_ 'Type %shelp%s for instructions on how to use fish') (set_color green) (set_color normal))
-        set -g fish_greeting "$line1$line2"
+        set -g fish_greeting (random choice 🐟 🐠 🐡)
     end
 
     if set -q fish_private_mode


### PR DESCRIPTION
🐟

In the honor of [April fish day][1], I would like to float the suggestion to make the default Fish greeting into a _fish_ greeting: a random (friendly) fish emoji.

This ticket is meant to pool together discussion about improving the default towards something that flows well with Fish's principles and values. I did however want to propose something that holds water instead of just babbling aimlessly.

It might be a bit of a bottle at sea, but it is also kind of a letter of appreciation to Fish. Even though this the first of April, I don't think anything I've written here will wash away after tomorrow, if you get my drift.

I'm aware there are different schools of thought about this, and changes to the defaults might make some waves. I'm hoping we can swim against the tide of anchoring into more configurations and not water it down too much. Suggestions, improvements, and perspectives are happily welcome.

[1]: https://en.wikipedia.org/wiki/April_Fools%27_Day#April_fish


## Motivation

🐡

Fish's philosophy of friendliness is what immediately drew me to it and what made me a fan from day one: a friendly shell for humans, out of the box. I was delighted when I first installed it. There were however, a few small kinks.

One of my first minor fixes to my setup was the default prompt message.

```
Welcome to fish, the friendly interactive shell
Type _help_ for instructions on how to use fish

> echo "Swim away, Fugu fish! Swim away!"
Swim away, Fugu fish! Swim away!
```

It is friendly, sure. But to get that one every new session (not only the very first one, which would make sense), I thought it was more that what's needed. (Explaining to new users how to type 'help' is probably worthwhile in a few cases, but is unfortunately probably useful only on 1 invocation out of 10^n. The Readme can also provide that hint.)

I took a few minutes to Google how to change this, and added the following to my config, a choice I've been enjoying ever since:

```
1:  set fish_greeting (random choice 🐟 🐠 🐡)
```

So now, every prompt greets me with a nicely random:
```
🐠

>
```

Which is just a great way to start a shell for me. Just small enough not to take away from my concentration, just nice and random enough to make me smile inside.

Thinking about fish today, I wanted to share my setup with other users and give other people the option to opt-in, but it's just one line in config. So I would like to see if there's some consensus to be worked out about changing the default to something that is setup-less, friendly out of the box with a new Fish installation. I was initially thinking of making a plugin or other kind of installable, but it seemed a little overkill before pinging folks here.

In the spirit of not putting a burden on the user to do more setup, but just to provide them with friendly defaults, I humbly propose this change to core.


## TODOs
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

