### PR TITLE
Enhanced prepending commands to command line

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,7 +65,8 @@ New or improved bindings
 - The :kbd:`Control-Space` binding can be correctly customised (:issue:`7922`).
 - ``exit`` works correctly in bindings (:issue:`7967`).
 - The :kbd:`F1` binding, which opens the manual page for the current command, now works around a bug in certain ``less`` versions that fail to clear the screen (:issue:`7863`).
-- ``__fish_prepend_sudo`` now toggles sudo even when it took the commandline from history instead of only adding it.
+- The binding for :kbd:`Alt-S` now toggles sudo even when it took the commandline from history instead of only adding it.
+- The new interactive functions ``fish_commandline_prepend`` and ``fish_commandline_prepend`` allow to toggle a prefix/suffix on the commandline. (:issue:`7905`).
 - ``backward-kill-path-component`` :kbd:`Control-W`) no longer erases parts of two tokens when the cursor is positioned immediately after ``/``. (:issue:`6258`).
 
 Improved prompts

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -217,6 +217,10 @@ The following functions are included as normal functions, but are particularly u
 
 - ``fish_clipboard_paste``, paste the current selection from the system clipboard before the cursor
 
+- ``fish_commandline_append``, append the argument to the command-line. If the command-line already ends with the argument, this removes the suffix instead. Starts with the last command from history if the command-line is empty.
+
+- ``fish_commandline_prepend``, prepend the argument to the command-line. If the command-line already starts with the argument, this removes the prefix instead. Starts with the last command from history if the command-line is empty.
+
 Examples
 --------
 

--- a/doc_src/cmds/commandline.rst
+++ b/doc_src/cmds/commandline.rst
@@ -21,7 +21,7 @@ With ``CMD`` specified, the command line buffer is erased and replaced with the 
 
 The following options are available:
 
-- ``-C`` or ``--cursor`` set or get the current cursor position, not the contents of the buffer. If no argument is given, the current cursor position is printed, otherwise the argument is interpreted as the new cursor position.
+- ``-C`` or ``--cursor`` set or get the current cursor position, not the contents of the buffer. If no argument is given, the current cursor position is printed, otherwise the argument is interpreted as the new cursor position. If one of the options ``-j``, ``-p`` or ``-t`` is given, the position is relative to the respective substring instead of the entire command line buffer.
 
 - ``-f`` or ``--function`` causes any additional arguments to be interpreted as input functions, and puts them into the queue, so that they will be read before any additional actual key presses are. This option cannot be combined with any other option. See :ref:`bind <cmd-bind>` for a list of input functions.
 

--- a/share/functions/__fish_paginate.fish
+++ b/share/functions/__fish_paginate.fish
@@ -1,16 +1,8 @@
 function __fish_paginate -d "Paginate the current command using the users default pager"
-
     set -l cmd less
     if set -q PAGER
         echo $PAGER | read -at cmd
     end
 
-    if test -z (commandline -j | string join '')
-        commandline -i $history[1]
-    end
-
-    if commandline -j | not string match -q -r "$cmd *\$"
-        commandline -aj " &| $cmd"
-    end
-
+    fish_commandline_append " &| $cmd"
 end

--- a/share/functions/__fish_paginate.fish
+++ b/share/functions/__fish_paginate.fish
@@ -10,7 +10,7 @@ function __fish_paginate -d "Paginate the current command using the users defaul
     end
 
     if commandline -j | not string match -q -r "$cmd *\$"
-        commandline -aj " &| $cmd;"
+        commandline -aj " &| $cmd"
     end
 
 end

--- a/share/functions/__fish_prepend_sudo.fish
+++ b/share/functions/__fish_prepend_sudo.fish
@@ -1,19 +1,3 @@
-function __fish_prepend_sudo -d "Prepend 'sudo ' to the beginning of the current commandline"
-    # If there is no commandline, insert the last item from history
-    # and *then* toggle
-    if not commandline | string length -q
-        commandline -r "$history[1]"
-    end
-
-    set -l cmd (commandline -po)
-    set -l cursor (commandline -C)
-
-    if test "$cmd[1]" != sudo
-        commandline -C 0
-        commandline -i "sudo "
-        commandline -C (math $cursor + 5)
-    else
-        commandline -r (string sub --start=6 (commandline -p))
-        commandline -C -- (math $cursor - 5)
-    end
+function __fish_prepend_sudo -d " DEPRECATED: use fish_commandline_prepend instead. Prepend 'sudo ' to the beginning of the current commandline"
+    fish_commandline_prepend sudo
 end

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -98,8 +98,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv \ed 'set -l cmd (commandline); if test -z "$cmd"; echo; dirh; commandline -f repaint; else; commandline -f kill-word; end'
     bind --preset $argv \cd delete-or-exit
 
-    # Prepend 'sudo ' to the current commandline
-    bind --preset $argv \es __fish_prepend_sudo
+    bind --preset $argv \es "fish_commandline_prepend sudo"
 
     # Allow reading manpages by pressing F1 (many GUI applications) or Alt+h (like in zsh).
     bind --preset $argv -k f1 __fish_man_page

--- a/share/functions/fish_commandline_append.fish
+++ b/share/functions/fish_commandline_append.fish
@@ -1,0 +1,15 @@
+function fish_commandline_append --description "Append the given string to the command-line, or remove the suffix if already there"
+    if not commandline | string length -q
+        commandline -r $history[1]
+    end
+
+    set -l escaped (string escape --style=regex -- $argv[1])
+    set -l job (commandline -j | string collect)
+    if set job (string replace -r -- $escaped\$ "" $job)
+        set -l cursor (commandline -C)
+        commandline -rj -- $job
+        commandline -C $cursor
+    else
+        commandline -aj -- $argv[1]
+    end
+end

--- a/share/functions/fish_commandline_prepend.fish
+++ b/share/functions/fish_commandline_prepend.fish
@@ -1,0 +1,16 @@
+function fish_commandline_prepend --description "Prepend the given string to the command-line, or remove the prefix if already there"
+    if not commandline | string length -q
+        commandline -r $history[1]
+    end
+
+    set -l escaped (string escape --style=regex -- $argv[1])
+    set -l process (commandline -p | string collect)
+    if set process (string replace -r -- "^$escaped " "" $process)
+        commandline --replace -p -- $process
+    else
+        set -l cursor (commandline -C)
+        commandline -C 0 -p
+        commandline -i -- "$argv[1] "
+        commandline -C (math $cursor + (string length -- "$argv[1] "))
+    end
+end

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -344,7 +344,9 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
     }
 
     if ((buffer_part || tokenize || cut_at_cursor) &&
-        (cursor_mode || line_mode || search_mode || paging_mode)) {
+        (cursor_mode || line_mode || search_mode || paging_mode) &&
+        // Special case - we allow to get/set cursor position relative to the process/job/token.
+        !(buffer_part && cursor_mode)) {
         streams.err.append_format(BUILTIN_ERR_COMBO, argv[0]);
         builtin_print_error_trailer(parser, streams.err, cmd);
         return STATUS_INVALID_ARGS;
@@ -414,7 +416,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
 
     if (cursor_mode) {
         if (argc - w.woptind) {
-            long new_pos = fish_wcstol(argv[w.woptind]);
+            long new_pos = fish_wcstol(argv[w.woptind]) + (begin - current_buffer);
             if (errno) {
                 streams.err.append_format(BUILTIN_ERR_NOT_NUMBER, cmd, argv[w.woptind]);
                 builtin_print_error_trailer(parser, streams.err, cmd);
@@ -425,8 +427,8 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
                 std::max(0L, std::min(new_pos, static_cast<long>(std::wcslen(current_buffer))));
             reader_set_buffer(current_buffer, static_cast<size_t>(new_pos));
         } else {
-            streams.out.append_format(L"%lu\n",
-                                      static_cast<unsigned long>(reader_get_cursor_pos()));
+            size_t pos = reader_get_cursor_pos() - (begin - current_buffer);
+            streams.out.append_format(L"%lu\n", static_cast<unsigned long>(pos));
         }
         return STATUS_CMD_OK;
     }

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -372,25 +372,6 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
         buffer_part = STRING_MODE;
     }
 
-    if (cursor_mode) {
-        if (argc - w.woptind) {
-            long new_pos = fish_wcstol(argv[w.woptind]);
-            if (errno) {
-                streams.err.append_format(BUILTIN_ERR_NOT_NUMBER, cmd, argv[w.woptind]);
-                builtin_print_error_trailer(parser, streams.err, cmd);
-            }
-
-            current_buffer = reader_get_buffer();
-            new_pos =
-                std::max(0L, std::min(new_pos, static_cast<long>(std::wcslen(current_buffer))));
-            reader_set_buffer(current_buffer, static_cast<size_t>(new_pos));
-        } else {
-            streams.out.append_format(L"%lu\n",
-                                      static_cast<unsigned long>(reader_get_cursor_pos()));
-        }
-        return STATUS_CMD_OK;
-    }
-
     if (line_mode) {
         size_t pos = reader_get_cursor_pos();
         const wchar_t *buff = reader_get_buffer();
@@ -429,6 +410,25 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
         default: {
             DIE("unexpected buffer_part");
         }
+    }
+
+    if (cursor_mode) {
+        if (argc - w.woptind) {
+            long new_pos = fish_wcstol(argv[w.woptind]);
+            if (errno) {
+                streams.err.append_format(BUILTIN_ERR_NOT_NUMBER, cmd, argv[w.woptind]);
+                builtin_print_error_trailer(parser, streams.err, cmd);
+            }
+
+            current_buffer = reader_get_buffer();
+            new_pos =
+                std::max(0L, std::min(new_pos, static_cast<long>(std::wcslen(current_buffer))));
+            reader_set_buffer(current_buffer, static_cast<size_t>(new_pos));
+        } else {
+            streams.out.append_format(L"%lu\n",
+                                      static_cast<unsigned long>(reader_get_cursor_pos()));
+        }
+        return STATUS_CMD_OK;
     }
 
     int arg_count = argc - w.woptind;


### PR DESCRIPTION
## Description

There was a function called `__fish_prepend_sudo` which is very useful and I made some others for commands like `git`, `nvim` and so. But it is a bit messy to define myself a whole lot of functions with just a word changing between them. I just created a "super-prepending" function : `__fish_prepend`. There's no more need for `__fish_prepend_sudo` so I deleted it and changed its occurences in the other files.

This function is some lines longer than `__fish_prepend_sudo` because it needs to read arguments so it's obviously a little bit slower, but it doesn't affect the user experience and it has also a lot more features : 

* works with every imaginable value it gets (even with spaces)
* permits to prepend as to remove the gotten value
* with `-p` or `--previous` flags, you can add the last command in the history to the command line (#7079)
* if the first command on the line is `sudo` acts smartly with prepending (prepends/removes after the word `sudo` if the value is not `sudo` :+1:)
* has a small buit-in help with `-h` and `--help`

All it needs is at least one argument that isn't one of `-h`, `--help`, `-p` or `--previous` and it manages itself how to prepend or remove the value to/from the beginning of the lines. I put comments in the code so it's more readable, feel free to take a look!

## TODOs:

- [ ] ~~Changes to fish usage are reflected in user documentation/manpages.~~ There's no place in the doc for this function. However, fish users should know `__fish_prepend` replaces `__fish_prepend`...
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
