### PR TITLE
Enable stderr-nocaret by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Syntax changes and new commands
 Deprecations and removed features
 ---------------------------------
 - The ``fish_history`` value "default" is no longer an alias for "fish" (:issue:`7650`).
+- Redirection to standard error with the ``^`` character has been disabled by default. It can be turned back on using the ``stderr-nocaret`` feature flag, but will eventually be disabled completely (:issue:`7105`).
 
 Scripting improvements
 ----------------------

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -664,7 +664,7 @@ static void test_tokenizer() {
     using tt = token_type_t;
     const token_type_t types[] = {
         tt::string,     tt::redirect,   tt::string,   tt::redirect, tt::string, tt::string,
-        tt::string,     tt::redirect,   tt::redirect, tt::string,   tt::pipe,   tt::redirect,
+        tt::string,     tt::string,     tt::string,   tt::pipe,     tt::redirect,
         tt::andand,     tt::background, tt::oror,     tt::pipe,     tt::andand, tt::oror,
         tt::background, tt::pipe,       tt::string,   tt::end,      tt::string};
 
@@ -770,8 +770,6 @@ static void test_tokenizer() {
     };
 
     if (get_redir_mode(L"<") != redirection_mode_t::input)
-        err(L"redirection_type_for_string failed on line %ld", (long)__LINE__);
-    if (get_redir_mode(L"^") != redirection_mode_t::overwrite)
         err(L"redirection_type_for_string failed on line %ld", (long)__LINE__);
     if (get_redir_mode(L">") != redirection_mode_t::overwrite)
         err(L"redirection_type_for_string failed on line %ld", (long)__LINE__);
@@ -1885,7 +1883,7 @@ static void test_feature_flags() {
     say(L"Testing future feature flags");
     using ft = features_t;
     ft f;
-    do_test(!f.test(ft::stderr_nocaret));
+    do_test(f.test(ft::stderr_nocaret));
     f.set(ft::stderr_nocaret, true);
     do_test(f.test(ft::stderr_nocaret));
     f.set(ft::stderr_nocaret, false);

--- a/src/future_feature_flags.cpp
+++ b/src/future_feature_flags.cpp
@@ -16,7 +16,7 @@ features_t::features_t() {
 features_t features_t::global_features;
 
 const features_t::metadata_t features_t::metadata[features_t::flag_count] = {
-    {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr", false},
+    {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr", true},
     {qmark_noglob, L"qmark-noglob", L"3.0", L"? no longer globs", false},
     {string_replace_backslash, L"regex-easyesc", L"3.1", L"string replace -r needs fewer \\'s",
      false},

--- a/src/future_feature_flags.cpp
+++ b/src/future_feature_flags.cpp
@@ -6,15 +6,20 @@
 
 #include "wcstringutil.h"
 
-features_t::features_t() = default;
+features_t::features_t() {
+    for (const metadata_t &md : metadata) {
+        this->set(md.flag, md.default_value);
+    }
+}
 
 /// The set of features applying to this instance.
 features_t features_t::global_features;
 
 const features_t::metadata_t features_t::metadata[features_t::flag_count] = {
-    {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr"},
-    {qmark_noglob, L"qmark-noglob", L"3.0", L"? no longer globs"},
-    {string_replace_backslash, L"regex-easyesc", L"3.1", L"string replace -r needs fewer \\'s"},
+    {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr", false},
+    {qmark_noglob, L"qmark-noglob", L"3.0", L"? no longer globs", false},
+    {string_replace_backslash, L"regex-easyesc", L"3.1", L"string replace -r needs fewer \\'s",
+     false},
 };
 
 const struct features_t::metadata_t *features_t::metadata_for(const wchar_t *name) {

--- a/src/future_feature_flags.h
+++ b/src/future_feature_flags.h
@@ -57,6 +57,9 @@ class features_t {
 
         /// User-presentable description of the feature flag.
         const wchar_t *description;
+
+        /// Default flag value.
+        const bool default_value;
     };
 
     /// The metadata, indexed by flag.

--- a/tests/checks/status.fish
+++ b/tests/checks/status.fish
@@ -54,12 +54,12 @@ eval test_function
 
 # Future Feature Flags
 status features
-#CHECK: stderr-nocaret	off	3.0	^ no longer redirects stderr
+#CHECK: stderr-nocaret	on	3.0	^ no longer redirects stderr
 #CHECK: qmark-noglob	off	3.0	? no longer globs
 #CHECK: regex-easyesc	off	3.1	string replace -r needs fewer \'s
 status test-feature stderr-nocaret
 echo $status
-#CHECK: 1
+#CHECK: 0
 status test-feature not-a-feature
 echo $status
 #CHECK: 2


### PR DESCRIPTION
* Teaches the feature flags about a default value - I'm not sure this is the best approach and would appreciate feedback.
* Enable stderr-nocaret by default.

Work on #7105.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst
