### PR TITLE
Add `--no-config` option

### DIFF
--- a/share/functions/fish_command_not_found.fish
+++ b/share/functions/fish_command_not_found.fish
@@ -11,6 +11,10 @@ if test -r /etc/os-release
     string replace -r '^ID(?:_LIKE)?\s*=(.*)' '$1' | string trim -c '\'"' | string split " ")
 end
 
+function __fish_default_command_not_found_handler
+    printf "fish: Unknown command: %s\n" (string escape -- $argv[1]) >&2
+end
+
 # If an old handler already exists, defer to that.
 if functions -q __fish_command_not_found_handler
     function fish_command_not_found

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -5,6 +5,8 @@ function fish_prompt --description 'Write out the prompt'
     set -l last_pipestatus $pipestatus
     set -lx __fish_last_status $status # Export for __fish_print_pipestatus.
     set -l normal (set_color normal)
+    set -q fish_color_status
+    or set -g fish_color_status --background=red white
 
     # Color the prompt differently when we're root
     set -l color_cwd $fish_color_cwd

--- a/share/tools/web_config/sample_prompts/default.fish
+++ b/share/tools/web_config/sample_prompts/default.fish
@@ -5,6 +5,8 @@ function fish_prompt --description 'Write out the prompt'
     set -l last_pipestatus $pipestatus
     set -lx __fish_last_status $status # Export for __fish_print_pipestatus.
     set -l normal (set_color normal)
+    set -q fish_color_status
+    or set -g fish_color_status --background=red white
 
     # Color the prompt differently when we're root
     set -l color_cwd $fish_color_cwd

--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -806,6 +806,7 @@ static int builtin_set_set(const wchar_t *cmd, set_cmd_opts_t &opts, int argc, c
         new_values = new_var_values_by_index(*split, argc, argv);
     }
 
+    bool have_shadowing_global = check_global_scope_exists(cmd, opts, split->varname, streams, parser);
     // Set the value back in the variable stack and fire any events.
     std::vector<event_t> evts;
     int retval = env_set_reporting_errors(cmd, split->varname, scope, std::move(new_values),
@@ -815,7 +816,7 @@ static int builtin_set_set(const wchar_t *cmd, set_cmd_opts_t &opts, int argc, c
     }
 
     if (retval != STATUS_CMD_OK) return retval;
-    return check_global_scope_exists(cmd, opts, split->varname, streams, parser);
+    return have_shadowing_global;
 }
 
 /// The set builtin creates, updates, and erases (removes, deletes) variables.

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -1158,10 +1158,12 @@ mod_result_t env_stack_impl_t::set(const wcstring &key, env_mode_flags_t mode,
     mod_result_t result{ENV_OK};
     if (query.has_scope) {
         // The user requested a particular scope.
-        if (query.universal) {
+        //
+        // If we don't have uvars, fall back to using globals
+        if (query.universal && uvars()) {
             set_universal(key, std::move(val), query);
             result.uvar_modified = true;
-        } else if (query.global) {
+        } else if (query.global || (query.universal && !uvars())) {
             set_in_node(globals_, key, std::move(val), flags);
             result.global_modified = true;
         } else if (query.local) {

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -274,6 +274,9 @@ void env_init(const struct config_paths_t *paths, bool do_uvars) {
         vars.set_one(FISH_SYSCONFDIR_VAR, ENV_GLOBAL, paths->sysconf);
         vars.set_one(FISH_HELPDIR_VAR, ENV_GLOBAL, paths->doc);
         vars.set_one(FISH_BIN_DIR, ENV_GLOBAL, paths->bin);
+        wcstring scstr = paths->data;
+        scstr.append(L"/functions");
+        vars.set_one(L"fish_function_path", ENV_GLOBAL, scstr);
     }
 
     // Some `su`s keep $USER when changing to root.

--- a/src/env.h
+++ b/src/env.h
@@ -80,7 +80,7 @@ struct statuses_t {
 };
 
 /// Initialize environment variable data.
-void env_init(const struct config_paths_t *paths = nullptr);
+void env_init(const struct config_paths_t *paths = nullptr, bool do_uvars = true);
 
 /// Various things we need to initialize at run-time that don't really fit any of the other init
 /// routines.

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -478,7 +478,7 @@ int main(int argc, char **argv) {
         paths = determine_config_directory_paths(argv[0]);
     }
     if (!opts.no_exec) {
-        env_init(&paths);
+        env_init(&paths, !opts.no_config);
     }
 
     // Set features early in case other initialization depends on them.

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -74,6 +74,8 @@ class fish_cmd_opts_t {
     std::vector<std::string> postconfig_cmds;
     /// Whether to print rusage-self stats after execution.
     bool print_rusage_self{false};
+    /// Whether no-config is set.
+    bool no_config{false};
     /// Whether no-exec is set.
     bool no_exec{false};
     /// Whether this is a login shell.
@@ -261,7 +263,7 @@ static int run_command_list(parser_t &parser, std::vector<std::string> *cmds,
 
 /// Parse the argument list, return the index of the first non-flag arguments.
 static int fish_parse_opt(int argc, char **argv, fish_cmd_opts_t *opts) {
-    static const char *const short_opts = "+hPilnvc:C:p:d:f:D:o:";
+    static const char *const short_opts = "+hPilNnvc:C:p:d:f:D:o:";
     static const struct option long_opts[] = {
         {"command", required_argument, nullptr, 'c'},
         {"init-command", required_argument, nullptr, 'C'},
@@ -271,6 +273,7 @@ static int fish_parse_opt(int argc, char **argv, fish_cmd_opts_t *opts) {
         {"debug-stack-frames", required_argument, nullptr, 'D'},
         {"interactive", no_argument, nullptr, 'i'},
         {"login", no_argument, nullptr, 'l'},
+        {"no-config", no_argument, nullptr, 'N'},
         {"no-execute", no_argument, nullptr, 'n'},
         {"print-rusage-self", no_argument, nullptr, 1},
         {"print-debug-categories", no_argument, nullptr, 2},
@@ -329,6 +332,10 @@ static int fish_parse_opt(int argc, char **argv, fish_cmd_opts_t *opts) {
             }
             case 'l': {
                 opts->is_login = true;
+                break;
+            }
+            case 'N': {
+                opts->no_config = true;
                 break;
             }
             case 'n': {
@@ -467,8 +474,10 @@ int main(int argc, char **argv) {
 
     struct config_paths_t paths;
     // If we're not executing, there's no need to find the config.
-    if (!opts.no_exec) {
+    if (!opts.no_exec && !opts.no_config) {
         paths = determine_config_directory_paths(argv[0]);
+    }
+    if (!opts.no_exec) {
         env_init(&paths);
     }
 
@@ -491,7 +500,7 @@ int main(int argc, char **argv) {
 
     parser_t &parser = parser_t::principal_parser();
 
-    if (!opts.no_exec) {
+    if (!opts.no_exec && !opts.no_config) {
         read_init(parser, paths);
     }
     // Re-read the terminal modes after config, it might have changed them.

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -336,6 +336,8 @@ static int fish_parse_opt(int argc, char **argv, fish_cmd_opts_t *opts) {
             }
             case 'N': {
                 opts->no_config = true;
+                // --no-config implies private mode, we won't be saving history
+                opts->enable_private_mode = true;
                 break;
             }
             case 'n': {

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -474,7 +474,7 @@ int main(int argc, char **argv) {
 
     struct config_paths_t paths;
     // If we're not executing, there's no need to find the config.
-    if (!opts.no_exec && !opts.no_config) {
+    if (!opts.no_exec) {
         paths = determine_config_directory_paths(argv[0]);
     }
     if (!opts.no_exec) {

--- a/tests/checks/no-config.fish
+++ b/tests/checks/no-config.fish
@@ -1,0 +1,16 @@
+#RUN: %fish --no-config %s
+
+functions | string match help
+# CHECK: help
+
+# Universal variables are disabled, we fall back to setting them as global
+set -U
+# CHECK:
+set -U foo bar
+set -S foo
+# CHECK: $foo: set in global scope, unexported, with 1 elements
+# CHECK: $foo[1]: |bar|
+
+set -S fish_function_path fish_complete_path
+# CHECK: $fish_function_path: set in global scope, unexported, with 1 elements
+# CHECK: $fish_function_path[1]: |{{.*}}|


### PR DESCRIPTION
## Description

This adds a `--no-config` option to fish, to let it start up without reading the config.

In particular it will:

- Keep $fish_function_path set to *just* the datadir (so /usr/share/fish/functions - just the stuff we ship). No sysconfdir, no vendor directory, nothing else. ($fish_complete_path isn't set at all at the moment)
- Disable universal variables. If you try to *set* a universal variable, it will be silently set as a global instead (this is a general change - if fish doesn't manage to set up universal variables, `set -U var val` is "redirected" to global). They aren't read at all.
- Disables history by enabling private mode
- Runs *no* config.fish or conf.d snippets

My hope is that this is basically "independent" of the system entirely. I'm not sure I caught all the places we write something or read something, so anyone else checking is appreciated.

One big issue with this is that it's very uncomfortable interactively because we don't set the colors or set up the handler for $fish_key_bindings. Both of those things happen in `__fish_config_interactive`, which isn't started.

The bindings can be improved later -  {up,down}-or-search shouldn't be functions and then we can just add them to the hardcoded defaults. The colors are tricky because they're usually defined as uvars and we want to allow unsetting a color.

There are a few things we could be doing differently - for instance it would also be possible to do without $fish_function_path entirely, by leaving it unset. This is awkward because fish isn't fully operational without the functions. It's gotten *better* since e.g. `type` and `eval` are no longer functions, but `psub` still is.

Fixes #1256 
Rerun of #5417, #5416
Helps with #5394.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
