### PR TITLE
Handle right prompts in webconfig

### DIFF
--- a/share/tools/web_config/js/controllers.js
+++ b/share/tools/web_config/js/controllers.js
@@ -198,6 +198,7 @@ controllers.controller("promptController", function($scope, $http) {
 
             // Update attributes of current prompt and select it
             $scope.samplePrompts[0].demo = selectedPrompt.demo;
+            $scope.samplePrompts[0].right = selectedPrompt.right;
             $scope.samplePrompts[0].function = selectedPrompt.function;
             $scope.samplePrompts[0].font_size = selectedPrompt.font_size;
             $scope.selectedPrompt = $scope.samplePrompts[0];

--- a/share/tools/web_config/partials/prompt.html
+++ b/share/tools/web_config/partials/prompt.html
@@ -2,7 +2,10 @@
 <!-- The first 'sample' prompt is the current one; the remainders are samples. This ought to be cleaned up. -->
 <div class="current_prompt" style="min-height: 7.5em;" ng-style="{'background-color': terminalBackgroundColor}">
 	<div class="prompt_demo_choice_label" style="color: #FFF;">{{ selectedPrompt.name }}</div>
-	<div ng-bind-html='selectedPrompt.demo | to_trusted' class="prompt_demo unbordered"></div>
+    <div style='display: flex'>
+	    <div ng-bind-html='selectedPrompt.demo | to_trusted' style='flex-grow: 1' class="prompt_demo unbordered"></div>
+	    <div ng-if='selectedPrompt.right' title="right prompt for {{selectedPrompt.name }}" ng-bind-html='selectedPrompt.right | to_trusted' class="prompt_demo unbordered" ng-click="selectPrompt(prompt)"></div>
+    </div>
 	<div style="position: absolute; right: 5px; bottom: 5px; color:">
 		<span class="save_button"
 			ng-show="showSaveButton"
@@ -15,7 +18,11 @@
 <div class="prompt_choices_list">
 	<div ng-repeat="prompt in samplePrompts">
 		<div class="prompt_demo_choice_label">{{ prompt.name }}</div>
-		<div ng-bind-html='prompt.demo | to_trusted' class="prompt_demo" ng-click="selectPrompt(prompt)"></div>
+        <div ng-if='prompt.right' style='display: flex;'>
+		    <div ng-bind-html='prompt.demo | to_trusted' class="prompt_demo" style='flex-grow: 1' ng-click="selectPrompt(prompt)"></div>
+		    <div ng-if='prompt.right' title="right prompt for {{prompt.name}}" ng-bind-html='prompt.right | to_trusted' class="prompt_demo" ng-click="selectPrompt(prompt)"></div>
+        </div>
+		<div ng-if='!prompt.right' ng-bind-html='prompt.demo | to_trusted' class="prompt_demo" ng-click="selectPrompt(prompt)"></div>
 	</div>
 </div>
 </div>

--- a/share/tools/web_config/sample_prompts/disco.fish
+++ b/share/tools/web_config/sample_prompts/disco.fish
@@ -1,0 +1,80 @@
+# name: Disco
+# author: Fabian Homborg
+
+function fish_prompt
+    set -l last_status $status
+
+    set -l normal (set_color normal)
+    set -l usercolor (set_color $fish_color_user)
+
+    set -l delim \U25BA
+    # If we don't have unicode use a simpler delimiter
+    string match -qi "*.utf-8" -- $LANG $LC_CTYPE $LC_ALL; or set delim ">"
+
+    fish_is_root_user; and set delim "#"
+
+    set -l cwd (set_color $fish_color_cwd)
+    if command -sq sha256sum
+        # randomized cwd color
+        set -l shas (pwd -P | sha256sum | string sub -l 6 | string match -ra ..)
+        # Increase color a bit so we don't get super dark colors.
+        # Really we want some contrast to the background (assuming black).
+        set -l col (for f in $shas; math --base=hex "min(255, 0x$f + 0x30)"; end | string replace 0x '' | string pad -c 0 -w 2 | string join "")
+
+        set cwd (set_color $col)
+    end
+
+    # Prompt status only if it's not 0
+    set -l prompt_status
+    test $last_status -ne 0; and set prompt_status (set_color $fish_color_error)"[$last_status]$normal"
+
+    # Only show host if in SSH or container
+    # Store this in a global variable because it's slow and unchanging
+    if not set -q prompt_host
+        set -g prompt_host ""
+        if set -q SSH_TTY
+            or begin
+                command -sq systemd-detect-virt
+                and systemd-detect-virt -q
+            end
+            set -l host (hostname)
+            set prompt_host $usercolor$USER$normal@(set_color $fish_color_host)$host$normal":"
+        end
+    end
+
+    # Shorten pwd if prompt is too long
+    set -l pwd (prompt_pwd)
+
+    echo -n -s $prompt_host $cwd $pwd $normal $prompt_status $delim
+end
+
+function fish_right_prompt
+    set -g __fish_git_prompt_showdirtystate 1
+    set -g __fish_git_prompt_showuntrackedfiles 1
+    set -g __fish_git_prompt_showupstream informative
+    set -g __fish_git_prompt_showcolorhints 1
+    set -g __fish_git_prompt_use_informative_chars 1
+    # Unfortunately this only works if we have a sensible locale
+    string match -qi "*.utf-8" -- $LANG $LC_CTYPE $LC_ALL
+    and set -g __fish_git_prompt_char_dirtystate \U1F4a9
+    set -g __fish_git_prompt_char_untrackedfiles "?"
+
+    set -l vcs (fish_vcs_prompt 2>/dev/null)
+
+    set -l d (set_color brgrey)(date "+%R")(set_color normal)
+
+    set -l duration "$cmd_duration$CMD_DURATION"
+    if test $duration -gt 100
+        set duration (math $duration / 1000)s
+    else
+        set duration
+    end
+
+    set -q VIRTUAL_ENV_DISABLE_PROMPT
+    or set -g VIRTUAL_ENV_DISABLE_PROMPT true
+    set -q VIRTUAL_ENV
+    and set -l venv (string replace -r '.*/' '' -- "$VIRTUAL_ENV")
+
+    set_color reset
+    string join " " -- $venv $duration $vcs $d
+end

--- a/share/tools/web_config/sample_prompts/scales.fish
+++ b/share/tools/web_config/sample_prompts/scales.fish
@@ -18,167 +18,167 @@ function fish_prompt
     end
     echo -n (set_color red)'❯'(set_color yellow)'❯'(set_color green)'❯ '
     set_color normal
+end
 
-    # And now define the right prompt so that it's brought along
-    function fish_right_prompt
-        set -l cmd_status $status
-        if test $cmd_status -ne 0
-            echo -n (set_color red)"✘ $cmd_status"
-        end
-
-        if not command -sq git
-            set_color normal
-            return
-        end
-
-        # Get the git directory for later use.
-        # Return if not inside a Git repository work tree.
-        if not set -l git_dir (command git rev-parse --git-dir 2>/dev/null)
-            set_color normal
-            return
-        end
-
-        # Get the current action ("merge", "rebase", etc.)
-        # and if there's one get the current commit hash too.
-        set -l commit ''
-        if set -l action (fish_print_git_action "$git_dir")
-            set commit (command git rev-parse HEAD 2> /dev/null | string sub -l 7)
-        end
-
-        # Get either the branch name or a branch descriptor.
-        set -l branch_detached 0
-        if not set -l branch (command git symbolic-ref --short HEAD 2>/dev/null)
-            set branch_detached 1
-            set branch (command git describe --contains --all HEAD 2>/dev/null)
-        end
-
-        # Get the commit difference counts between local and remote.
-        command git rev-list --count --left-right 'HEAD...@{upstream}' 2>/dev/null \
-            | read -d \t -l status_ahead status_behind
-        if test $status -ne 0
-            set status_ahead 0
-            set status_behind 0
-        end
-
-        # Get the stash status.
-        # (git stash list) is very slow. => Avoid using it.
-        set -l status_stashed 0
-        if test -f "$git_dir/refs/stash"
-            set status_stashed 1
-        else if test -r "$git_dir/commondir"
-            read -l commondir <"$git_dir/commondir"
-            if test -f "$commondir/refs/stash"
-                set status_stashed 1
-            end
-        end
-
-        # git-status' porcelain v1 format starts with 2 letters on each line:
-        #   The first letter (X) denotes the index state.
-        #   The second letter (Y) denotes the working directory state.
-        #
-        # The following table presents the possible combinations:
-        # * The underscore character denotes whitespace.
-        # * The cell values stand for the following file states:
-        #   a: added
-        #   d: deleted
-        #   m: modified
-        #   r: renamed
-        #   u: unmerged
-        #   t: untracked
-        # * Cells with more than one letter signify that both states
-        #   are simultaneously the case. This is possible since the git index
-        #   and working directory operate independently of each other.
-        # * Cells which are empty are unhandled by this code.
-        # * T (= type change) is undocumented.
-        #   See Git v1.7.8.2 release notes for more information.
-        #
-        #   \ Y→
-        #  X \
-        #  ↓  | A  | C  | D  | M  | R  | T  | U  | X  | B  | ?  | _
-        # ----+----+----+----+----+----+----+----+----+----+----+----
-        #  A  | u  |    | ad | am | r  | am | u  |    |    |    | a
-        #  C  |    |    | ad | am | r  | am | u  |    |    |    | a
-        #  D  |    |    | u  | am | r  | am | u  |    |    |    | a
-        #  M  |    |    | ad | am | r  | am | u  |    |    |    | a
-        #  R  | r  | r  | rd | rm | r  | rm | ur | r  | r  | r  | r
-        #  T  |    |    | ad | am | r  | am | u  |    |    |    | a
-        #  U  | u  | u  | u  | um | ur | um | u  | u  | u  | u  | u
-        #  X  |    |    |    | m  | r  | m  | u  |    |    |    |
-        #  B  |    |    |    | m  | r  | m  | u  |    |    |    |
-        #  ?  |    |    |    | m  | r  | m  | u  |    |    | t  |
-        #  _  |    |    | d  | m  | r  | m  | u  |    |    |    |
-        set -l porcelain_status (command git status --porcelain | string sub -l2)
-
-        set -l status_added 0
-        if string match -qr '[ACDMT][ MT]|[ACMT]D' $porcelain_status
-            set status_added 1
-        end
-        set -l status_deleted 0
-        if string match -qr '[ ACMRT]D' $porcelain_status
-            set status_deleted 1
-        end
-        set -l status_modified 0
-        if string match -qr '[MT]$' $porcelain_status
-            set status_modified 1
-        end
-        set -l status_renamed 0
-        if string match -qe R $porcelain_status
-            set status_renamed 1
-        end
-        set -l status_unmerged 0
-        if string match -qr 'AA|DD|U' $porcelain_status
-            set status_unmerged 1
-        end
-        set -l status_untracked 0
-        if string match -qe '\?\?' $porcelain_status
-            set status_untracked 1
-        end
-
-        set_color -o
-
-        if test -n "$branch"
-            if test $branch_detached -ne 0
-                set_color brmagenta
-            else
-                set_color green
-            end
-            echo -n " $branch"
-        end
-        if test -n "$commit"
-            echo -n ' '(set_color yellow)"$commit"
-        end
-        if test -n "$action"
-            set_color normal
-            echo -n (set_color white)':'(set_color -o brred)"$action"
-        end
-        if test $status_ahead -ne 0
-            echo -n ' '(set_color brmagenta)'⬆'
-        end
-        if test $status_behind -ne 0
-            echo -n ' '(set_color brmagenta)'⬇'
-        end
-        if test $status_stashed -ne 0
-            echo -n ' '(set_color cyan)'✭'
-        end
-        if test $status_added -ne 0
-            echo -n ' '(set_color green)'✚'
-        end
-        if test $status_deleted -ne 0
-            echo -n ' '(set_color red)'✖'
-        end
-        if test $status_modified -ne 0
-            echo -n ' '(set_color blue)'✱'
-        end
-        if test $status_renamed -ne 0
-            echo -n ' '(set_color magenta)'➜'
-        end
-        if test $status_unmerged -ne 0
-            echo -n ' '(set_color yellow)'═'
-        end
-        if test $status_untracked -ne 0
-            echo -n ' '(set_color white)'◼'
-        end
-
-        set_color normal
+# And now define the right prompt so that it's brought along
+function fish_right_prompt
+    set -l cmd_status $status
+    if test $cmd_status -ne 0
+        echo -n (set_color red)"✘ $cmd_status"
     end
+
+    if not command -sq git
+        set_color normal
+        return
+    end
+
+    # Get the git directory for later use.
+    # Return if not inside a Git repository work tree.
+    if not set -l git_dir (command git rev-parse --git-dir 2>/dev/null)
+        set_color normal
+        return
+    end
+
+    # Get the current action ("merge", "rebase", etc.)
+    # and if there's one get the current commit hash too.
+    set -l commit ''
+    if set -l action (fish_print_git_action "$git_dir")
+        set commit (command git rev-parse HEAD 2> /dev/null | string sub -l 7)
+    end
+
+    # Get either the branch name or a branch descriptor.
+    set -l branch_detached 0
+    if not set -l branch (command git symbolic-ref --short HEAD 2>/dev/null)
+        set branch_detached 1
+        set branch (command git describe --contains --all HEAD 2>/dev/null)
+    end
+
+    # Get the commit difference counts between local and remote.
+    command git rev-list --count --left-right 'HEAD...@{upstream}' 2>/dev/null \
+        | read -d \t -l status_ahead status_behind
+    if test $status -ne 0
+        set status_ahead 0
+        set status_behind 0
+    end
+
+    # Get the stash status.
+    # (git stash list) is very slow. => Avoid using it.
+    set -l status_stashed 0
+    if test -f "$git_dir/refs/stash"
+        set status_stashed 1
+    else if test -r "$git_dir/commondir"
+        read -l commondir <"$git_dir/commondir"
+        if test -f "$commondir/refs/stash"
+            set status_stashed 1
+        end
+    end
+
+    # git-status' porcelain v1 format starts with 2 letters on each line:
+    #   The first letter (X) denotes the index state.
+    #   The second letter (Y) denotes the working directory state.
+    #
+    # The following table presents the possible combinations:
+    # * The underscore character denotes whitespace.
+    # * The cell values stand for the following file states:
+    #   a: added
+    #   d: deleted
+    #   m: modified
+    #   r: renamed
+    #   u: unmerged
+    #   t: untracked
+    # * Cells with more than one letter signify that both states
+    #   are simultaneously the case. This is possible since the git index
+    #   and working directory operate independently of each other.
+    # * Cells which are empty are unhandled by this code.
+    # * T (= type change) is undocumented.
+    #   See Git v1.7.8.2 release notes for more information.
+    #
+    #   \ Y→
+    #  X \
+    #  ↓  | A  | C  | D  | M  | R  | T  | U  | X  | B  | ?  | _
+    # ----+----+----+----+----+----+----+----+----+----+----+----
+    #  A  | u  |    | ad | am | r  | am | u  |    |    |    | a
+    #  C  |    |    | ad | am | r  | am | u  |    |    |    | a
+    #  D  |    |    | u  | am | r  | am | u  |    |    |    | a
+    #  M  |    |    | ad | am | r  | am | u  |    |    |    | a
+    #  R  | r  | r  | rd | rm | r  | rm | ur | r  | r  | r  | r
+    #  T  |    |    | ad | am | r  | am | u  |    |    |    | a
+    #  U  | u  | u  | u  | um | ur | um | u  | u  | u  | u  | u
+    #  X  |    |    |    | m  | r  | m  | u  |    |    |    |
+    #  B  |    |    |    | m  | r  | m  | u  |    |    |    |
+    #  ?  |    |    |    | m  | r  | m  | u  |    |    | t  |
+    #  _  |    |    | d  | m  | r  | m  | u  |    |    |    |
+    set -l porcelain_status (command git status --porcelain | string sub -l2)
+
+    set -l status_added 0
+    if string match -qr '[ACDMT][ MT]|[ACMT]D' $porcelain_status
+        set status_added 1
+    end
+    set -l status_deleted 0
+    if string match -qr '[ ACMRT]D' $porcelain_status
+        set status_deleted 1
+    end
+    set -l status_modified 0
+    if string match -qr '[MT]$' $porcelain_status
+        set status_modified 1
+    end
+    set -l status_renamed 0
+    if string match -qe R $porcelain_status
+        set status_renamed 1
+    end
+    set -l status_unmerged 0
+    if string match -qr 'AA|DD|U' $porcelain_status
+        set status_unmerged 1
+    end
+    set -l status_untracked 0
+    if string match -qe '\?\?' $porcelain_status
+        set status_untracked 1
+    end
+
+    set_color -o
+
+    if test -n "$branch"
+        if test $branch_detached -ne 0
+            set_color brmagenta
+        else
+            set_color green
+        end
+        echo -n " $branch"
+    end
+    if test -n "$commit"
+        echo -n ' '(set_color yellow)"$commit"
+    end
+    if test -n "$action"
+        set_color normal
+        echo -n (set_color white)':'(set_color -o brred)"$action"
+    end
+    if test $status_ahead -ne 0
+        echo -n ' '(set_color brmagenta)'⬆'
+    end
+    if test $status_behind -ne 0
+        echo -n ' '(set_color brmagenta)'⬇'
+    end
+    if test $status_stashed -ne 0
+        echo -n ' '(set_color cyan)'✭'
+    end
+    if test $status_added -ne 0
+        echo -n ' '(set_color green)'✚'
+    end
+    if test $status_deleted -ne 0
+        echo -n ' '(set_color red)'✖'
+    end
+    if test $status_modified -ne 0
+        echo -n ' '(set_color blue)'✱'
+    end
+    if test $status_renamed -ne 0
+        echo -n ' '(set_color magenta)'➜'
+    end
+    if test $status_unmerged -ne 0
+        echo -n ' '(set_color yellow)'═'
+    end
+    if test $status_untracked -ne 0
+        echo -n ' '(set_color white)'◼'
+    end
+
+    set_color normal
 end


### PR DESCRIPTION
## Description

This allows webconfig to show and save fish_right_prompt if it is defined in a sample (or the current prompt).

It will *not* remove an existing fish_right_prompt if there is one.

It looks like this:

![Screenshot_20210414_205112](https://user-images.githubusercontent.com/5185367/114763869-96aa5300-9d63-11eb-9afe-1e2eaa266d60.png)

Fixes issue #736 (at least for fish_right_prompt, I don't think we need more).

In addition (and this is optional, it was just nice to get a better screenshot), this adds a slightly simplified version of my own prompt as the "Disco" sample. Here's a preview:

![Screenshot_20210414_202949](https://user-images.githubusercontent.com/5185367/114764107-d709d100-9d63-11eb-9ca6-39cde5da9781.png)

(the $PWD color depends on the sha of $PWD - this requires sha256sum to be available. if not it'll gracefully fallback to $fish_color_cwd. It will also only show user@host if necessary)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
