### PR TITLE
Remove completion files for `ls` aliases; just use `function --wraps`

### DIFF
--- a/share/completions/la.fish
+++ b/share/completions/la.fish
@@ -1,1 +1,0 @@
-complete -c la -w ls

--- a/share/completions/ll.fish
+++ b/share/completions/ll.fish
@@ -1,1 +1,0 @@
-complete -c ll -w ls

--- a/share/functions/la.fish
+++ b/share/functions/la.fish
@@ -1,6 +1,6 @@
 #
 # These are very common and useful
 #
-function la --description "List contents of directory, including hidden files in directory using long format"
+function la --wraps ls --description "List contents of directory, including hidden files in directory using long format"
     ls -lah $argv
 end

--- a/share/functions/ll.fish
+++ b/share/functions/ll.fish
@@ -1,6 +1,6 @@
 #
 # These are very common and useful
 #
-function ll --description "List contents of directory using long format"
+function ll --wraps ls --description "List contents of directory using long format"
     ls -lh $argv
 end


### PR DESCRIPTION
## Description

This PR fixes a minor bug I encountered. If a user adds their own alias for `ll` (e.g., with `alias ll 'exa -l'`) and then persists the alias with `funcsave ll`, the alias/function will wrap both `exa` and `ls` and both sets of completions will be suggested. I don't encounter this bug when the completion files are absent.