### PR TITLE
Add a "prompt_login" helper function

### DIFF
--- a/doc_src/cmds/prompt_login.rst
+++ b/doc_src/cmds/prompt_login.rst
@@ -1,0 +1,26 @@
+.. _cmd-prompt_login:
+
+prompt_login - describe the login suitable for prompt
+=====================================================
+
+Synopsis
+--------
+
+::
+
+    function fish_prompt
+        echo -n (prompt_login) (prompt_pwd) '$ '
+    end
+
+Description
+-----------
+
+``prompt_login`` is a function to describe the current login. It will show the user, the host and also whether the shell is running in a chroot (currently debian's debian_chroot is supported).
+
+Examples
+--------
+
+::
+
+    >_ prompt_login
+    root@bananablaster

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -16,12 +16,6 @@ function fish_prompt --description 'Write out the prompt'
         set suffix '#'
     end
 
-    # If we're running via SSH, change the host color.
-    set -l color_host $fish_color_host
-    if set -q SSH_TTY
-        set color_host $fish_color_host_remote
-    end
-
     # Write pipestatus
     # If the status was carried over (e.g. after `set`), don't bold it.
     set -l bold_flag --bold
@@ -34,5 +28,5 @@ function fish_prompt --description 'Write out the prompt'
     set -l statusb_color (set_color $bold_flag $fish_color_status)
     set -l prompt_status (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
 
-    echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal " "$prompt_status $suffix " "
+    echo -n -s (prompt_login)' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal " "$prompt_status $suffix " "
 end

--- a/share/functions/prompt_login.fish
+++ b/share/functions/prompt_login.fish
@@ -1,0 +1,28 @@
+function prompt_login --description "Print a description of the user and host suitable for the prompt"
+    if not set -q __fish_machine
+        set -g __fish_machine
+        set -l debian_chroot $debian_chroot
+
+        if  test -r /etc/debian_chroot
+            set debian_chroot (cat /etc/debian_chroot)
+        end
+
+        if set -q debian_chroot[1]
+            and test -n "$debian_chroot"
+            set -g __fish_machine "(chroot:$debian_chroot)"
+        end
+    end
+
+    # Prepend the chroot environment if present
+    if set -q __fish_machine[1]
+        echo -n -s (set_color yellow) "$__fish_machine" (set_color normal) ' '
+    end
+
+    # If we're running via SSH, change the host color.
+    set -l color_host $fish_color_host
+    if set -q SSH_TTY; and set -q fish_color_host_remote
+        set color_host $fish_color_host_remote
+    end
+
+    echo -n -s (set_color $fish_color_user) "$USER" (set_color normal) @ (set_color $color_host) (prompt_hostname) (set_color normal)
+end

--- a/share/tools/web_config/sample_prompts/default.fish
+++ b/share/tools/web_config/sample_prompts/default.fish
@@ -16,12 +16,6 @@ function fish_prompt --description 'Write out the prompt'
         set suffix '#'
     end
 
-    # If we're running via SSH, change the host color.
-    set -l color_host $fish_color_host
-    if set -q SSH_TTY
-        set color_host $fish_color_host_remote
-    end
-
     # Write pipestatus
     # If the status was carried over (e.g. after `set`), don't bold it.
     set -l bold_flag --bold
@@ -34,5 +28,5 @@ function fish_prompt --description 'Write out the prompt'
     set -l statusb_color (set_color $bold_flag $fish_color_status)
     set -l prompt_status (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
 
-    echo -n -s (set_color $fish_color_user) "$USER" $normal @ (set_color $color_host) (prompt_hostname) $normal ' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal " "$prompt_status $suffix " "
+    echo -n -s (prompt_login)' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal " "$prompt_status $suffix " "
 end

--- a/share/tools/web_config/sample_prompts/terlar.fish
+++ b/share/tools/web_config/sample_prompts/terlar.fish
@@ -4,17 +4,7 @@
 function fish_prompt --description 'Write out the prompt'
     set -l last_status $status
 
-    # User
-    set_color $fish_color_user
-    echo -n $USER
-    set_color normal
-
-    echo -n '@'
-
-    # Host
-    set_color $fish_color_host
-    echo -n (prompt_hostname)
-    set_color normal
+    prompt_login
 
     echo -n ':'
 


### PR DESCRIPTION
## Description

This prints a description of the "host". Currently that's

`(chroot:debianchroot) $USER@$hostname`

with the chroot part when needed. That means instead of having one "debian chroot" prompt, we support that out of the box.

This also switches the default and terlar prompts to use it, the other
prompts have slightly different coloring or logic here. It would be possible to allow that by adding options to prompt_host.

Part of #7884.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

## Questions:

- Is this wanted at all? Like I said I think having debian chroots off in a separate prompt just results in nobody using it because they would have to change the prompt *in the chroot* (which means allowing for `fish_config` to work there!), so the alternative seems to be not supporting that at all
- What about the name? `prompt_host` sounds like it might be `prompt_hostname`, but `prompt_chroot_user_at_host` is a bit wordy. `prompt_machine` perhaps?
- Support for things other than the debian chroot thing - do other systems have something similar? How about virtual machines? We already color the host differently if it's ssh.