### PR TITLE
Disable single-line if statements in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,7 @@
 BasedOnStyle: Google
 ColumnLimit: 100
 IndentWidth: 4
+AllowShortIfStatementsOnASingleLine: false
 
 # Place config.h first always.
 IncludeCategories:

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -17,9 +17,12 @@ static tok_flags_t tokenizer_flags_from_parse_flags(parse_tree_flags_t flags) {
     tok_flags_t tok_flags = 0;
     // Note we do not need to respect parse_flag_show_blank_lines, no clients are interested in
     // them.
-    if (flags & parse_flag_include_comments) tok_flags |= TOK_SHOW_COMMENTS;
-    if (flags & parse_flag_accept_incomplete_tokens) tok_flags |= TOK_ACCEPT_UNFINISHED;
-    if (flags & parse_flag_continue_after_error) tok_flags |= TOK_CONTINUE_AFTER_ERROR;
+    if (flags & parse_flag_include_comments)
+        tok_flags |= TOK_SHOW_COMMENTS;
+    if (flags & parse_flag_accept_incomplete_tokens)
+        tok_flags |= TOK_ACCEPT_UNFINISHED;
+    if (flags & parse_flag_continue_after_error)
+        tok_flags |= TOK_CONTINUE_AFTER_ERROR;
     return tok_flags;
 }
 
@@ -293,7 +296,8 @@ const wchar_t *ast_type_to_string(type_t type) {
 
 /// Delete an untyped node.
 void node_deleter_t::operator()(node_t *n) {
-    if (!n) return;
+    if (!n)
+        return;
     switch (n->type) {
 #define ELEM(T)                \
     case type_t::T:            \
@@ -320,7 +324,8 @@ using enable_if_t = typename std::enable_if<B, T>::type;
 struct source_range_visitor_t {
     template <typename Node>
     enable_if_t<Node::Category == category_t::leaf> visit(const Node &node) {
-        if (node.unsourced) any_unsourced = true;
+        if (node.unsourced)
+            any_unsourced = true;
         // Union with our range.
         if (node.range.length > 0) {
             if (total.length == 0) {
@@ -350,7 +355,8 @@ struct source_range_visitor_t {
 maybe_t<source_range_t> node_t::try_source_range() const {
     source_range_visitor_t v;
     node_visitor(v).accept(this);
-    if (v.any_unsourced) return none();
+    if (v.any_unsourced)
+        return none();
     return v.total;
 }
 
@@ -623,7 +629,8 @@ class ast_t::populator_t {
 
         // Ignore additional parse errors while unwinding.
         // These may come about e.g. from `true | and`.
-        if (unwinding_) return;
+        if (unwinding_)
+            return;
         unwinding_ = true;
 
         FLOGF(ast_construction, L"%*sparse error - begin unwinding", spaces(), "");
@@ -765,7 +772,8 @@ class ast_t::populator_t {
     // overloading purposes.
     bool can_parse(job_conjunction_t *) {
         const auto &token = peek_token();
-        if (token.type != parse_token_type_t::string) return false;
+        if (token.type != parse_token_type_t::string)
+            return false;
         switch (peek_token().keyword) {
             case parse_keyword_t::kw_end:
             case parse_keyword_t::kw_else:
@@ -786,7 +794,8 @@ class ast_t::populator_t {
 
     bool can_parse(variable_assignment_t *) {
         // Do we have a variable assignment at all?
-        if (!peek_token(0).may_be_variable_assignment) return false;
+        if (!peek_token(0).may_be_variable_assignment)
+            return false;
 
         // What is the token after it?
         switch (peek_type(1)) {
@@ -1053,7 +1062,8 @@ class ast_t::populator_t {
 
     template <typename AstNode>
     unique_ptr<AstNode> try_parse() {
-        if (!can_parse((AstNode *)nullptr)) return nullptr;
+        if (!can_parse((AstNode *)nullptr))
+            return nullptr;
         return allocate_visit<AstNode>();
     }
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -198,9 +198,11 @@ void accept_field_visitor(FieldVisitor &v, bool /*reverse*/, Field &field) {
 // Call visit_field on visitor \p v, for the field \p field and also \p rest.
 template <typename FieldVisitor, typename Field, typename... Rest>
 void accept_field_visitor(FieldVisitor &v, bool reverse, Field &field, Rest &...rest) {
-    if (!reverse) visit_1_field(v, field);
+    if (!reverse)
+        visit_1_field(v, field);
     accept_field_visitor<FieldVisitor, Rest...>(v, reverse, rest...);
-    if (reverse) visit_1_field(v, field);
+    if (reverse)
+        visit_1_field(v, field);
 }
 
 }  // namespace template_goo
@@ -253,13 +255,15 @@ struct node_t {
     ///     if (const auto *job_list = node->try_as<job_list_t>()) job_list->...
     template <typename To>
     To *try_as() {
-        if (this->type == To::AstType) return as<To>();
+        if (this->type == To::AstType)
+            return as<To>();
         return nullptr;
     }
 
     template <typename To>
     const To *try_as() const {
-        if (this->type == To::AstType) return as<To>();
+        if (this->type == To::AstType)
+            return as<To>();
         return nullptr;
     }
 
@@ -277,20 +281,23 @@ struct node_t {
 
     /// \return the source range for this node, or an empty range {0, 0} if unsourced.
     source_range_t source_range() const {
-        if (auto r = try_source_range()) return *r;
+        if (auto r = try_source_range())
+            return *r;
         return source_range_t{0, 0};
     }
 
     /// \return the source code for this node, or none if unsourced.
     maybe_t<wcstring> try_source(const wcstring &orig) const {
-        if (auto r = try_source_range()) return orig.substr(r->start, r->length);
+        if (auto r = try_source_range())
+            return orig.substr(r->start, r->length);
         return none();
     }
 
     /// \return the source code for this node, or an empty string if unsourced.
     wcstring source(const wcstring &orig) const {
         wcstring res{};
-        if (auto s = try_source(orig)) res = s.acquire();
+        if (auto s = try_source(orig))
+            res = s.acquire();
         return res;
     }
 
@@ -377,7 +384,8 @@ struct list_t : public node_t {
 
     /// \return a node at a given index, or nullptr if out of range.
     const ContentsNode *at(size_t idx, bool reverse = false) const {
-        if (idx >= count()) return nullptr;
+        if (idx >= count())
+            return nullptr;
         return contents[reverse ? count() - idx - 1 : idx].get();
     }
 
@@ -771,7 +779,8 @@ void node_t::base_accept(FieldVisitor &v, bool reverse) {
 template <parse_token_type_t... Toks>
 bool token_t<Toks...>::allows_token(parse_token_type_t type) {
     for (parse_token_type_t t : {Toks...}) {
-        if (type == t) return true;
+        if (type == t)
+            return true;
     }
     return false;
 }
@@ -780,7 +789,8 @@ bool token_t<Toks...>::allows_token(parse_token_type_t type) {
 template <parse_keyword_t... KWs>
 bool keyword_t<KWs...>::allows_keyword(parse_keyword_t kw) {
     for (parse_keyword_t k : {KWs...}) {
-        if (k == kw) return true;
+        if (k == kw)
+            return true;
     }
     return false;
 }
@@ -876,7 +886,8 @@ class node_visitation_t {
     // Optional pointers get visited if not null.
     template <typename Node>
     void visit_optional_field(optional_t<Node> &node) {
-        if (node.contents) v_.visit(*node.contents);
+        if (node.contents)
+            v_.visit(*node.contents);
     }
 
     // Define our custom implementations of non-node fields.
@@ -926,7 +937,8 @@ class traversal_t {
 
     // \return the next node, or nullptr if exhausted.
     const node_t *next() {
-        if (stack_.empty()) return nullptr;
+        if (stack_.empty())
+            return nullptr;
         const node_t *node = stack_.back();
         stack_.pop_back();
 

--- a/src/autoload.cpp
+++ b/src/autoload.cpp
@@ -171,7 +171,8 @@ maybe_t<wcstring> autoload_t::resolve_command(const wcstring &cmd, const environ
 
 maybe_t<wcstring> autoload_t::resolve_command(const wcstring &cmd, const wcstring_list_t &paths) {
     // Are we currently in the process of autoloading this?
-    if (current_autoloading_.count(cmd) > 0) return none();
+    if (current_autoloading_.count(cmd) > 0)
+        return none();
 
     // Check to see if our paths have changed. If so, replace our cache.
     // Note we don't have to modify autoloadable_files_. We'll naturally detect if those have
@@ -182,7 +183,8 @@ maybe_t<wcstring> autoload_t::resolve_command(const wcstring &cmd, const wcstrin
 
     // Do we have an entry to load?
     auto mfile = cache_->check(cmd);
-    if (!mfile) return none();
+    if (!mfile)
+        return none();
 
     // Is this file the same as what we previously autoloaded?
     auto iter = autoloaded_files_.find(cmd);

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -156,7 +156,8 @@ int parse_help_only_cmd_opts(struct help_only_cmd_opts_t &opts, int *optind, int
 void builtin_print_help(parser_t &parser, const io_streams_t &streams, const wchar_t *name,
                         wcstring *error_message) {
     // This won't ever work if no_exec is set.
-    if (no_exec()) return;
+    if (no_exec())
+        return;
     const wcstring name_esc = escape_string(name, ESCAPE_ALL);
     wcstring cmd = format_string(L"__fish_print_help %ls ", name_esc.c_str());
     io_chain_t ios;
@@ -210,7 +211,8 @@ static maybe_t<int> builtin_generic(parser_t &parser, io_streams_t &streams, con
     help_only_cmd_opts_t opts;
     int optind;
     int retval = parse_help_only_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -283,7 +285,8 @@ static maybe_t<int> builtin_break_continue(parser_t &parser, io_streams_t &strea
             has_loop = true;
             break;
         }
-        if (b.is_function_call()) break;
+        if (b.is_function_call())
+            break;
     }
     if (!has_loop) {
         wcstring error_message = format_string(_(L"%ls: Not inside of loop\n"), argv[0]);
@@ -457,7 +460,8 @@ static bool cmd_needs_help(const wcstring &cmd) { return contains(help_builtins,
 
 /// Execute a builtin command
 proc_status_t builtin_run(parser_t &parser, const wcstring_list_t &argv, io_streams_t &streams) {
-    if (argv.empty()) return proc_status_t::from_exit_code(STATUS_INVALID_ARGS);
+    if (argv.empty())
+        return proc_status_t::from_exit_code(STATUS_INVALID_ARGS);
     const wcstring &cmdname = argv.front();
 
     // We can be handed a keyword by the parser as if it was a command. This happens when the user
@@ -481,12 +485,15 @@ proc_status_t builtin_run(parser_t &parser, const wcstring_list_t &argv, io_stre
         // If the builtin itself produced an error, use that error.
         // Otherwise use any errors from writing to out and writing to err, in that order.
         int code = builtin_ret ? *builtin_ret : 0;
-        if (code == 0) code = out_ret;
-        if (code == 0) code = err_ret;
+        if (code == 0)
+            code = out_ret;
+        if (code == 0)
+            code = err_ret;
 
         // The exit code is cast to an 8-bit unsigned integer, so saturate to 255. Otherwise,
         // multiples of 256 are reported as 0.
-        if (code > 255) code = 255;
+        if (code > 255)
+            code = 255;
 
         // Handle the case of an empty status.
         if (code == 0 && !builtin_ret.has_value()) {

--- a/src/builtin_argparse.cpp
+++ b/src/builtin_argparse.cpp
@@ -72,7 +72,8 @@ static int check_for_mutually_exclusive_flags(const argparse_cmd_opts_t &opts,
                                               io_streams_t &streams) {
     for (const auto &kv : opts.options) {
         const auto &opt_spec = kv.second;
-        if (opt_spec->num_seen == 0) continue;
+        if (opt_spec->num_seen == 0)
+            continue;
 
         // We saw this option at least once. Check all the sets of mutually exclusive options to see
         // if this option appears in any of them.
@@ -82,24 +83,30 @@ static int check_for_mutually_exclusive_flags(const argparse_cmd_opts_t &opts,
                 // other mutually exclusive options have been seen.
                 for (const auto &xflag : xarg_set) {
                     auto xopt_spec_iter = opts.options.find(xflag);
-                    if (xopt_spec_iter == opts.options.end()) continue;
+                    if (xopt_spec_iter == opts.options.end())
+                        continue;
 
                     const auto &xopt_spec = xopt_spec_iter->second;
                     // Ignore this flag in the list of mutually exclusive flags.
-                    if (xopt_spec->short_flag == opt_spec->short_flag) continue;
+                    if (xopt_spec->short_flag == opt_spec->short_flag)
+                        continue;
 
                     // If it is a different flag check if it has been seen.
                     if (xopt_spec->num_seen) {
                         wcstring flag1;
-                        if (opt_spec->short_flag_valid) flag1 = wcstring(1, opt_spec->short_flag);
+                        if (opt_spec->short_flag_valid)
+                            flag1 = wcstring(1, opt_spec->short_flag);
                         if (!opt_spec->long_flag.empty()) {
-                            if (opt_spec->short_flag_valid) flag1 += L"/";
+                            if (opt_spec->short_flag_valid)
+                                flag1 += L"/";
                             flag1 += opt_spec->long_flag;
                         }
                         wcstring flag2;
-                        if (xopt_spec->short_flag_valid) flag2 = wcstring(1, xopt_spec->short_flag);
+                        if (xopt_spec->short_flag_valid)
+                            flag2 = wcstring(1, xopt_spec->short_flag);
                         if (!xopt_spec->long_flag.empty()) {
-                            if (xopt_spec->short_flag_valid) flag2 += L"/";
+                            if (xopt_spec->short_flag_valid)
+                                flag2 += L"/";
                             flag2 += xopt_spec->long_flag;
                         }
                         // We want the flag order to be deterministic. Primarily to make unit
@@ -259,7 +266,8 @@ static bool parse_option_spec_sep(argparse_cmd_opts_t &opts, const option_spec_r
             counter++;
         } else {
             // Try to parse any other flag modifiers
-            if (!parse_flag_modifiers(opts, opt_spec, option_spec, &s, streams)) return false;
+            if (!parse_flag_modifiers(opts, opt_spec, option_spec, &s, streams))
+                return false;
         }
     }
 
@@ -422,7 +430,8 @@ static int parse_cmd_opts(argparse_cmd_opts_t &opts, int *optind,  //!OCLINT(hig
         }
     }
 
-    if (opts.print_help) return STATUS_CMD_OK;
+    if (opts.print_help)
+        return STATUS_CMD_OK;
 
     if (argc == w.woptind || std::wcscmp(L"--", argv[w.woptind - 1]) == 0) {
         // The user didn't specify any option specs.
@@ -435,7 +444,8 @@ static int parse_cmd_opts(argparse_cmd_opts_t &opts, int *optind,  //!OCLINT(hig
         // If any error happens, the backtrace will show which argparse it was.
         const wchar_t *fn = parser.get_function_name(1);
 
-        if (!fn) fn = L"argparse";
+        if (!fn)
+            fn = L"argparse";
         opts.name = fn;
     }
 
@@ -447,15 +457,18 @@ static void populate_option_strings(const argparse_cmd_opts_t &opts, wcstring *s
                                     std::vector<woption> *long_options) {
     for (const auto &kv : opts.options) {
         const auto &opt_spec = kv.second;
-        if (opt_spec->short_flag_valid) short_options->push_back(opt_spec->short_flag);
+        if (opt_spec->short_flag_valid)
+            short_options->push_back(opt_spec->short_flag);
 
         int arg_type = no_argument;
         if (opt_spec->num_allowed == -1) {
             arg_type = optional_argument;
-            if (opt_spec->short_flag_valid) short_options->append(L"::");
+            if (opt_spec->short_flag_valid)
+                short_options->append(L"::");
         } else if (opt_spec->num_allowed > 0) {
             arg_type = required_argument;
-            if (opt_spec->short_flag_valid) short_options->append(L":");
+            if (opt_spec->short_flag_valid)
+                short_options->append(L":");
         }
 
         if (!opt_spec->long_flag.empty()) {
@@ -469,7 +482,8 @@ static void populate_option_strings(const argparse_cmd_opts_t &opts, wcstring *s
 static int validate_arg(parser_t &parser, const argparse_cmd_opts_t &opts, option_spec_t *opt_spec,
                         bool is_long_flag, const wchar_t *woptarg, io_streams_t &streams) {
     // Obviously if there is no arg validation command we assume the arg is okay.
-    if (opt_spec->validation_command.empty()) return STATUS_CMD_OK;
+    if (opt_spec->validation_command.empty())
+        return STATUS_CMD_OK;
 
     wcstring_list_t cmd_output;
 
@@ -516,7 +530,8 @@ static int validate_and_store_implicit_int(parser_t &parser, const argparse_cmd_
     assert(found != opts.options.end());
     const auto &opt_spec = found->second;
     int retval = validate_arg(parser, opts, opt_spec.get(), long_idx != -1, val, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     // It's a valid integer so store it and return success.
     opt_spec->vals.clear();
@@ -543,7 +558,8 @@ static int handle_flag(parser_t &parser, const argparse_cmd_opts_t &opts, option
 
     if (woptarg) {
         int retval = validate_arg(parser, opts, opt_spec, long_idx != -1, woptarg, streams);
-        if (retval != STATUS_CMD_OK) return retval;
+        if (retval != STATUS_CMD_OK)
+            return retval;
     }
 
     if (opt_spec->num_allowed == -1 || opt_spec->num_allowed == 1) {
@@ -590,9 +606,11 @@ static int argparse_parse_flags(parser_t &parser, argparse_cmd_opts_t &opts,
                 // or just ignoring the error (e.g. in completions).
                 opts.argv.push_back(arg_contents - 1);
                 // Work around weirdness with wgetopt, which crashes if we `continue` here.
-                if (w.woptind == argc) break;
+                if (w.woptind == argc)
+                    break;
             }
-            if (retval != STATUS_CMD_OK) return retval;
+            if (retval != STATUS_CMD_OK)
+                return retval;
             long_idx = -1;
             continue;
         } else if (opt == 1) {
@@ -610,7 +628,8 @@ static int argparse_parse_flags(parser_t &parser, argparse_cmd_opts_t &opts,
         assert(found != opts.options.end());
 
         int retval = handle_flag(parser, opts, found->second.get(), long_idx, w.woptarg, streams);
-        if (retval != STATUS_CMD_OK) return retval;
+        if (retval != STATUS_CMD_OK)
+            return retval;
         long_idx = -1;
     }
 
@@ -623,7 +642,8 @@ static int argparse_parse_flags(parser_t &parser, argparse_cmd_opts_t &opts,
 // arguments provided to the `argparse` command.
 static int argparse_parse_args(argparse_cmd_opts_t &opts, const wcstring_list_t &args,
                                parser_t &parser, io_streams_t &streams) {
-    if (args.empty()) return STATUS_CMD_OK;
+    if (args.empty())
+        return STATUS_CMD_OK;
 
     // "+" means stop at nonopt, "-" means give nonoptions the option character code `1`, and don't
     // reorder.
@@ -645,10 +665,12 @@ static int argparse_parse_args(argparse_cmd_opts_t &opts, const wcstring_list_t 
     int optind;
     int retval = argparse_parse_flags(parser, opts, short_options.c_str(), long_options.data(), cmd,
                                       argc, argv, &optind, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     retval = check_for_mutually_exclusive_flags(opts, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     for (int i = optind; argv[i]; i++) {
         opts.argv.push_back(argv[i]);
@@ -678,7 +700,8 @@ static int check_min_max_args_constraints(const argparse_cmd_opts_t &opts, const
 static void set_argparse_result_vars(env_stack_t &vars, const argparse_cmd_opts_t &opts) {
     for (const auto &kv : opts.options) {
         const auto &opt_spec = kv.second;
-        if (!opt_spec->num_seen) continue;
+        if (!opt_spec->num_seen)
+            continue;
 
         if (opt_spec->short_flag_valid) {
             vars.set(var_name_prefix + opt_spec->short_flag, ENV_LOCAL, opt_spec->vals);
@@ -688,7 +711,8 @@ static void set_argparse_result_vars(env_stack_t &vars, const argparse_cmd_opts_
             // escape_string(long_flag, 0, STRING_STYLE_VAR).
             wcstring long_flag = opt_spec->long_flag;
             for (auto &pos : long_flag) {
-                if (!iswalnum(pos)) pos = L'_';
+                if (!iswalnum(pos))
+                    pos = L'_';
             }
             vars.set(var_name_prefix + long_flag, ENV_LOCAL, opt_spec->vals);
         }
@@ -729,13 +753,16 @@ maybe_t<int> builtin_argparse(parser_t &parser, io_streams_t &streams, const wch
     while (optind < argc) args.push_back(argv[optind++]);
 
     retval = parse_exclusive_args(opts, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     retval = argparse_parse_args(opts, args, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     retval = check_min_max_args_constraints(opts, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     set_argparse_result_vars(parser.vars(), opts);
     return retval;

--- a/src/builtin_bg.cpp
+++ b/src/builtin_bg.cpp
@@ -44,7 +44,8 @@ maybe_t<int> builtin_bg(parser_t &parser, io_streams_t &streams, const wchar_t *
 
     int optind;
     int retval = parse_help_only_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -86,7 +87,8 @@ maybe_t<int> builtin_bg(parser_t &parser, io_streams_t &streams, const wchar_t *
         pids.push_back(pid);
     }
 
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     // Background all existing jobs that match the pids.
     // Non-existent jobs aren't an error, but information about them is useful.

--- a/src/builtin_bind.cpp
+++ b/src/builtin_bind.cpp
@@ -196,7 +196,8 @@ bool builtin_bind_t::erase(const wchar_t *const *seq, bool all, const wchar_t *m
     }
 
     bool res = false;
-    if (mode == nullptr) mode = DEFAULT_BIND_MODE;  //!OCLINT(parameter reassignment)
+    if (mode == nullptr)
+        mode = DEFAULT_BIND_MODE;  //!OCLINT(parameter reassignment)
 
     while (*seq) {
         if (use_terminfo) {
@@ -408,7 +409,8 @@ maybe_t<int> builtin_bind_t::builtin_bind(parser_t &parser, io_streams_t &stream
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.list_modes) {
         list_modes(streams);
@@ -420,7 +422,8 @@ maybe_t<int> builtin_bind_t::builtin_bind(parser_t &parser, io_streams_t &stream
     }
 
     // Default to user mode
-    if (!opts.have_preset && !opts.have_user) opts.user = true;
+    if (!opts.have_preset && !opts.have_user)
+        opts.user = true;
     switch (opts.mode) {
         case BIND_ERASE: {
             const wchar_t *bind_mode = opts.bind_mode_given ? opts.bind_mode : nullptr;

--- a/src/builtin_block.cpp
+++ b/src/builtin_block.cpp
@@ -77,7 +77,8 @@ maybe_t<int> builtin_block(parser_t &parser, io_streams_t &streams, const wchar_
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);

--- a/src/builtin_builtin.cpp
+++ b/src/builtin_builtin.cpp
@@ -72,7 +72,8 @@ maybe_t<int> builtin_builtin(parser_t &parser, io_streams_t &streams, const wcha
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);

--- a/src/builtin_cd.cpp
+++ b/src/builtin_cd.cpp
@@ -27,7 +27,8 @@ maybe_t<int> builtin_cd(parser_t &parser, io_streams_t &streams, const wchar_t *
 
     int optind;
     int retval = parse_help_only_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -52,7 +53,8 @@ maybe_t<int> builtin_cd(parser_t &parser, io_streams_t &streams, const wchar_t *
         streams.err.append_format(_(L"%ls: The directory '%ls' does not exist\n"), cmd,
                                   dir_in.c_str());
 
-        if (!parser.is_interactive()) streams.err.append(parser.current_line());
+        if (!parser.is_interactive())
+            streams.err.append(parser.current_line());
 
         return STATUS_CMD_ERROR;
     }
@@ -74,7 +76,8 @@ maybe_t<int> builtin_cd(parser_t &parser, io_streams_t &streams, const wchar_t *
             // - if in another directory there was a *file* by the correct name
             // we prefer *that* error because it's more specific
             if (errno == ENOENT) {
-                if (!best_errno) best_errno = errno;
+                if (!best_errno)
+                    best_errno = errno;
                 continue;
             } else if (errno == ENOTDIR) {
                 best_errno = errno;

--- a/src/builtin_command.cpp
+++ b/src/builtin_command.cpp
@@ -79,7 +79,8 @@ maybe_t<int> builtin_command(parser_t &parser, io_streams_t &streams, const wcha
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -98,13 +99,15 @@ maybe_t<int> builtin_command(parser_t &parser, io_streams_t &streams, const wcha
         if (opts.all_paths) {
             wcstring_list_t paths = path_get_paths(command_name, parser.vars());
             for (const auto &path : paths) {
-                if (!opts.quiet) streams.out.append_format(L"%ls\n", path.c_str());
+                if (!opts.quiet)
+                    streams.out.append_format(L"%ls\n", path.c_str());
                 ++found;
             }
         } else {  // Either find_path explicitly or just quiet.
             wcstring path;
             if (path_get_path(command_name, &path, parser.vars())) {
-                if (!opts.quiet) streams.out.append_format(L"%ls\n", path.c_str());
+                if (!opts.quiet)
+                    streams.out.append_format(L"%ls\n", path.c_str());
                 ++found;
             }
         }

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -102,7 +102,8 @@ static void write_part(const wchar_t *begin, const wchar_t *end, int cut_at_curs
         wcstring buff(begin, end - begin);
         tokenizer_t tok(buff.c_str(), TOK_ACCEPT_UNFINISHED);
         while (auto token = tok.next()) {
-            if ((cut_at_cursor) && (token->offset + token->length >= pos)) break;
+            if ((cut_at_cursor) && (token->offset + token->length >= pos))
+                break;
 
             if (token->type == token_type_t::string) {
                 wcstring tmp = tok.text_of(*token);
@@ -303,7 +304,8 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
                 // Don't enqueue a repaint if we're currently in the middle of one,
                 // because that's an infinite loop.
                 if (mc == rl::repaint_mode || mc == rl::force_repaint || mc == rl::repaint) {
-                    if (ld.is_repaint) continue;
+                    if (ld.is_repaint)
+                        continue;
                 }
 
                 // HACK: Execute these right here and now so they can affect any insertions/changes

--- a/src/builtin_complete.cpp
+++ b/src/builtin_complete.cpp
@@ -270,7 +270,8 @@ maybe_t<int> builtin_complete(parser_t &parser, io_streams_t &streams, const wch
             case 'C': {
                 do_complete = true;
                 have_do_complete_param = w.woptarg != nullptr;
-                if (have_do_complete_param) do_complete_param = w.woptarg;
+                if (have_do_complete_param)
+                    do_complete_param = w.woptarg;
                 break;
             }
             case 'h': {

--- a/src/builtin_contains.cpp
+++ b/src/builtin_contains.cpp
@@ -65,7 +65,8 @@ maybe_t<int> builtin_contains(parser_t &parser, io_streams_t &streams, const wch
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -78,7 +79,8 @@ maybe_t<int> builtin_contains(parser_t &parser, io_streams_t &streams, const wch
     } else {
         for (int i = optind + 1; i < argc; i++) {
             if (!std::wcscmp(needle, argv[i])) {
-                if (opts.print_index) streams.out.append_format(L"%d\n", i - optind);
+                if (opts.print_index)
+                    streams.out.append_format(L"%d\n", i - optind);
                 return STATUS_CMD_OK;
             }
         }

--- a/src/builtin_disown.cpp
+++ b/src/builtin_disown.cpp
@@ -26,7 +26,8 @@ static int disown_job(const wchar_t *cmd, parser_t &parser, io_streams_t &stream
     // Stopped disowned jobs must be manually signaled; explain how to do so.
     auto pgid = j->get_pgid();
     if (j->is_stopped()) {
-        if (pgid) killpg(*pgid, SIGCONT);
+        if (pgid)
+            killpg(*pgid, SIGCONT);
         const wchar_t *fmt =
             _(L"%ls: job %d ('%ls') was stopped and has been signalled to continue.\n");
         streams.err.append_format(fmt, cmd, j->job_id(), j->command_wcstr());
@@ -49,7 +50,8 @@ maybe_t<int> builtin_disown(parser_t &parser, io_streams_t &streams, const wchar
 
     int optind;
     int retval = parse_help_only_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);

--- a/src/builtin_echo.cpp
+++ b/src/builtin_echo.cpp
@@ -108,7 +108,8 @@ static unsigned int builtin_echo_digit(wchar_t wc, unsigned int base) {
         }
     }
 
-    if (base != 16) return UINT_MAX;
+    if (base != 16)
+        return UINT_MAX;
 
     switch (wc) {
         case L'8':
@@ -177,7 +178,8 @@ static bool builtin_echo_parse_numeric_sequence(const wchar_t *str, size_t *cons
     unsigned char val = 0;  // resulting character
     for (idx = start; idx < start + max_digits; idx++) {
         unsigned int digit = builtin_echo_digit(str[idx], base);
-        if (digit == UINT_MAX) break;
+        if (digit == UINT_MAX)
+            break;
         val = val * base + digit;
     }
 
@@ -201,7 +203,8 @@ maybe_t<int> builtin_echo(parser_t &parser, io_streams_t &streams, const wchar_t
     echo_cmd_opts_t opts;
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     // The special character \c can be used to indicate no more output.
     bool continue_output = true;

--- a/src/builtin_emit.cpp
+++ b/src/builtin_emit.cpp
@@ -18,7 +18,8 @@ maybe_t<int> builtin_emit(parser_t &parser, io_streams_t &streams, const wchar_t
 
     int optind;
     int retval = parse_help_only_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);

--- a/src/builtin_eval.cpp
+++ b/src/builtin_eval.cpp
@@ -23,7 +23,8 @@ maybe_t<int> builtin_eval(parser_t &parser, io_streams_t &streams, const wchar_t
 
     wcstring new_cmd;
     for (int i = 1; i < argc; ++i) {
-        if (i > 1) new_cmd += L' ';
+        if (i > 1)
+            new_cmd += L' ';
         new_cmd += argv[i];
     }
 

--- a/src/builtin_exit.cpp
+++ b/src/builtin_exit.cpp
@@ -65,7 +65,8 @@ maybe_t<int> builtin_exit(parser_t &parser, io_streams_t &streams, const wchar_t
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);

--- a/src/builtin_fg.cpp
+++ b/src/builtin_fg.cpp
@@ -28,7 +28,8 @@ maybe_t<int> builtin_fg(parser_t &parser, io_streams_t &streams, const wchar_t *
 
     int optind;
     int retval = parse_help_only_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -101,7 +102,8 @@ maybe_t<int> builtin_fg(parser_t &parser, io_streams_t &streams, const wchar_t *
 
     wcstring ft = tok_command(job->command());
     // For compatibility with fish 2.0's $_, now replaced with `status current-command`
-    if (!ft.empty()) parser.set_var_and_fire(L"_", ENV_EXPORT, std::move(ft));
+    if (!ft.empty())
+        parser.set_var_and_fire(L"_", ENV_EXPORT, std::move(ft));
     reader_write_title(job->command(), parser);
 
     parser.job_promote(job);

--- a/src/builtin_function.cpp
+++ b/src/builtin_function.cpp
@@ -60,7 +60,8 @@ static int parse_cmd_opts(function_cmd_opts_t &opts, int *optind,  //!OCLINT(hig
     wgetopter_t w;
     bool handling_named_arguments = false;
     while ((opt = w.wgetopt_long(argc, argv, short_options, long_options, nullptr)) != -1) {
-        if (opt != 'a' && opt != 1) handling_named_arguments = false;
+        if (opt != 'a' && opt != 1)
+            handling_named_arguments = false;
         switch (opt) {
             case 1: {
                 if (handling_named_arguments) {
@@ -217,14 +218,16 @@ maybe_t<int> builtin_function(parser_t &parser, io_streams_t &streams,
     // A valid function name has to be the first argument.
     wcstring function_name;
     int retval = validate_function_name(argc, argv, function_name, cmd, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
     argv++;
     argc--;
 
     function_cmd_opts_t opts;
     int optind;
     retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_error_trailer(parser, streams.err, cmd);

--- a/src/builtin_functions.cpp
+++ b/src/builtin_functions.cpp
@@ -197,7 +197,8 @@ maybe_t<int> builtin_functions(parser_t &parser, io_streams_t &streams, const wc
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -335,7 +336,8 @@ maybe_t<int> builtin_functions(parser_t &parser, io_streams_t &streams, const wc
             return STATUS_CMD_ERROR;
         }
 
-        if (function_copy(current_func, new_func)) return STATUS_CMD_OK;
+        if (function_copy(current_func, new_func))
+            return STATUS_CMD_OK;
         return STATUS_CMD_ERROR;
     }
 
@@ -345,7 +347,8 @@ maybe_t<int> builtin_functions(parser_t &parser, io_streams_t &streams, const wc
             res++;
         } else {
             if (!opts.query) {
-                if (i != optind) streams.out.append(L"\n");
+                if (i != optind)
+                    streams.out.append(L"\n");
                 const wchar_t *funcname = argv[i];
                 if (!opts.no_metadata) {
                     report_function_metadata(funcname, opts.verbose, streams, parser, true);

--- a/src/builtin_history.cpp
+++ b/src/builtin_history.cpp
@@ -207,7 +207,8 @@ maybe_t<int> builtin_history(parser_t &parser, io_streams_t &streams, const wcha
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -217,7 +218,8 @@ maybe_t<int> builtin_history(parser_t &parser, io_streams_t &streams, const wcha
     // Use the default history if we have none (which happens if invoked non-interactively, e.g.
     // from webconfig.py.
     std::shared_ptr<history_t> history = reader_get_history();
-    if (!history) history = history_t::with_name(history_session_id(parser.vars()));
+    if (!history)
+        history = history_t::with_name(history_session_id(parser.vars()));
 
     // If a history command hasn't already been specified via a flag check the first word.
     // Note that this can be simplified after we eliminate allowing subcommands as flags.
@@ -238,10 +240,13 @@ maybe_t<int> builtin_history(parser_t &parser, io_streams_t &streams, const wcha
     const wcstring_list_t args(argv + optind, argv + argc);
 
     // Establish appropriate defaults.
-    if (opts.hist_cmd == HIST_UNDEF) opts.hist_cmd = HIST_SEARCH;
+    if (opts.hist_cmd == HIST_UNDEF)
+        opts.hist_cmd = HIST_SEARCH;
     if (!opts.history_search_type_defined) {
-        if (opts.hist_cmd == HIST_SEARCH) opts.search_type = history_search_type_t::contains_glob;
-        if (opts.hist_cmd == HIST_DELETE) opts.search_type = history_search_type_t::exact;
+        if (opts.hist_cmd == HIST_SEARCH)
+            opts.search_type = history_search_type_t::contains_glob;
+        if (opts.hist_cmd == HIST_DELETE)
+            opts.search_type = history_search_type_t::exact;
     }
 
     int status = STATUS_CMD_OK;

--- a/src/builtin_math.cpp
+++ b/src/builtin_math.cpp
@@ -126,11 +126,13 @@ static const wchar_t *math_get_arg_stdin(wcstring *storage, const io_streams_t &
         }
 
         if (rc == 0) {  // EOF
-            if (arg.empty()) return nullptr;
+            if (arg.empty())
+                return nullptr;
             break;
         }
 
-        if (ch == '\n') break;  // we're done
+        if (ch == '\n')
+            break;  // we're done
 
         arg += ch;
     }
@@ -157,7 +159,8 @@ static const wchar_t *math_get_arg(int *argidx, const wchar_t **argv, wcstring *
 }
 
 static const wchar_t *math_describe_error(const te_error_t &error) {
-    if (error.position == 0) return L"NO ERROR?!?";
+    if (error.position == 0)
+        return L"NO ERROR?!?";
 
     switch (error.type) {
         case TE_ERROR_NONE:
@@ -282,7 +285,8 @@ maybe_t<int> builtin_math(parser_t &parser, io_streams_t &streams, const wchar_t
     // if (argc == 0) return STATUS_CMD_OK;
 
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -292,7 +296,8 @@ maybe_t<int> builtin_math(parser_t &parser, io_streams_t &streams, const wchar_t
     wcstring expression;
     wcstring storage;
     while (const wchar_t *arg = math_get_arg(&optind, argv, &storage, streams)) {
-        if (!expression.empty()) expression.push_back(L' ');
+        if (!expression.empty())
+            expression.push_back(L' ');
         expression.append(arg);
     }
 

--- a/src/builtin_printf.cpp
+++ b/src/builtin_printf.cpp
@@ -202,14 +202,16 @@ static int octal_to_bin(wchar_t c) {
 
 void builtin_printf_state_t::nonfatal_error(const wchar_t *fmt, ...) {
     // Don't error twice.
-    if (early_exit) return;
+    if (early_exit)
+        return;
 
     va_list va;
     va_start(va, fmt);
     wcstring errstr = vformat_string(fmt, va);
     va_end(va);
     streams.err.append(errstr);
-    if (!string_suffixes_string(L"\n", errstr)) streams.err.push_back(L'\n');
+    if (!string_suffixes_string(L"\n", errstr))
+        streams.err.push_back(L'\n');
 
     // We set the exit code to error, because one occurred,
     // but we don't do an early exit so we still print what we can.
@@ -218,35 +220,40 @@ void builtin_printf_state_t::nonfatal_error(const wchar_t *fmt, ...) {
 
 void builtin_printf_state_t::fatal_error(const wchar_t *fmt, ...) {
     // Don't error twice.
-    if (early_exit) return;
+    if (early_exit)
+        return;
 
     va_list va;
     va_start(va, fmt);
     wcstring errstr = vformat_string(fmt, va);
     va_end(va);
     streams.err.append(errstr);
-    if (!string_suffixes_string(L"\n", errstr)) streams.err.push_back(L'\n');
+    if (!string_suffixes_string(L"\n", errstr))
+        streams.err.push_back(L'\n');
 
     this->exit_code = STATUS_CMD_ERROR;
     this->early_exit = true;
 }
 void builtin_printf_state_t::append_output(wchar_t c) {
     // Don't output if we're done.
-    if (early_exit) return;
+    if (early_exit)
+        return;
 
     streams.out.push_back(c);
 }
 
 void builtin_printf_state_t::append_output(const wchar_t *c) {
     // Don't output if we're done.
-    if (early_exit) return;
+    if (early_exit)
+        return;
 
     streams.out.append(c);
 }
 
 void builtin_printf_state_t::append_format_output(const wchar_t *fmt, ...) {
     // Don't output if we're done.
-    if (early_exit) return;
+    if (early_exit)
+        return;
 
     va_list va;
     va_start(va, fmt);
@@ -290,7 +297,8 @@ uintmax_t raw_string_to_scalar_type(const wchar_t *s, wchar_t **end) {
 template <>
 long double raw_string_to_scalar_type(const wchar_t *s, wchar_t **end) {
     double val = std::wcstod(s, end);
-    if (**end == L'\0') return val;
+    if (**end == L'\0')
+        return val;
     // The conversion using the user's locale failed. That may be due to the string not being a
     // valid floating point value. It could also be due to the locale using different separator
     // characters than the normal english convention. So try again by forcing the use of a locale
@@ -372,7 +380,8 @@ long builtin_printf_state_t::print_esc(const wchar_t *escstart, bool octal_0) {
         // A hexadecimal \xhh escape sequence must have 1 or 2 hex. digits.
         for (esc_length = 0, ++p; esc_length < 2 && iswxdigit(*p); ++esc_length, ++p)
             esc_value = esc_value * 16 + hex_to_bin(*p);
-        if (esc_length == 0) this->fatal_error(_(L"missing hexadecimal number in escape"));
+        if (esc_length == 0)
+            this->fatal_error(_(L"missing hexadecimal number in escape"));
         this->append_output(ENCODE_DIRECT_BASE + esc_value % 256);
     } else if (is_octal_digit(*p)) {
         // Parse \0ooo (if octal_0 && *p == L'0') or \ooo (otherwise). Allow \ooo if octal_0 && *p
@@ -744,7 +753,8 @@ maybe_t<int> builtin_printf(parser_t &parser, io_streams_t &streams, const wchar
 
     int optind;
     int retval = parse_help_only_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);

--- a/src/builtin_random.cpp
+++ b/src/builtin_random.cpp
@@ -34,7 +34,8 @@ maybe_t<int> builtin_random(parser_t &parser, io_streams_t &streams, const wchar
 
     int optind;
     int retval = parse_help_only_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -83,7 +84,8 @@ maybe_t<int> builtin_random(parser_t &parser, io_streams_t &streams, const wchar
             step = 1;
         } else if (arg_count == 1) {
             long long seed = parse_ll(argv[optind]);
-            if (parse_error) return STATUS_INVALID_ARGS;
+            if (parse_error)
+                return STATUS_INVALID_ARGS;
             engine.seed(static_cast<uint32_t>(seed));
             return STATUS_CMD_OK;
         } else if (arg_count == 2) {

--- a/src/builtin_read.cpp
+++ b/src/builtin_read.cpp
@@ -335,9 +335,12 @@ static int read_one_char_at_a_time(int fd, wcstring &buff, int nchars, bool spli
             exit_res = STATUS_READ_TOO_MUCH;
             break;
         }
-        if (eof) break;
-        if (!split_null && res == L'\n') break;
-        if (split_null && res == L'\0') break;
+        if (eof)
+            break;
+        if (!split_null && res == L'\n')
+            break;
+        if (split_null && res == L'\0')
+            break;
 
         buff.push_back(res);
         if (nchars > 0 && static_cast<size_t>(nchars) <= buff.size()) {
@@ -443,7 +446,8 @@ maybe_t<int> builtin_read(parser_t &parser, io_streams_t &streams, const wchar_t
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
     if (!opts.to_stdout) {
         argc -= optind;
         argv += optind;
@@ -459,7 +463,8 @@ maybe_t<int> builtin_read(parser_t &parser, io_streams_t &streams, const wchar_t
     }
 
     retval = validate_read_args(cmd, opts, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     // stdin may have been explicitly closed
     if (streams.stdin_fd < 0) {
@@ -555,7 +560,8 @@ maybe_t<int> builtin_read(parser_t &parser, io_streams_t &streams, const wchar_t
 
         if (!opts.have_delimiter) {
             auto ifs = parser.vars().get(L"IFS");
-            if (!ifs.missing_or_empty()) opts.delimiter = ifs->as_string();
+            if (!ifs.missing_or_empty())
+                opts.delimiter = ifs->as_string();
         }
 
         if (opts.delimiter.empty()) {

--- a/src/builtin_realpath.cpp
+++ b/src/builtin_realpath.cpp
@@ -68,7 +68,8 @@ maybe_t<int> builtin_realpath(parser_t &parser, io_streams_t &streams, const wch
     int optind;
 
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);

--- a/src/builtin_return.cpp
+++ b/src/builtin_return.cpp
@@ -64,7 +64,8 @@ maybe_t<int> builtin_return(parser_t &parser, io_streams_t &streams, const wchar
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);

--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -254,7 +254,8 @@ static bool validate_path_warning_on_colons(const wchar_t *cmd,
                                             const wcstring_list_t &list, io_streams_t &streams,
                                             const environment_t &vars) {
     // Always allow setting an empty value.
-    if (list.empty()) return true;
+    if (list.empty())
+        return true;
 
     bool any_success = false;
 
@@ -405,7 +406,8 @@ maybe_t<split_var_t> split_var_and_indexes(const wchar_t *arg, env_mode_flags_t 
         }
 
         // Convert negative index to a positive index.
-        if (l_ind < 0) l_ind = varsize + l_ind + 1;
+        if (l_ind < 0)
+            l_ind = varsize + l_ind + 1;
 
         if (p[0] == L'.' && p[1] == L'.') {
             p += 2;
@@ -423,7 +425,8 @@ maybe_t<split_var_t> split_var_and_indexes(const wchar_t *arg, env_mode_flags_t 
             }
 
             // Convert negative index to a positive index.
-            if (l_ind2 < 0) l_ind2 = varsize + l_ind2 + 1;
+            if (l_ind2 < 0)
+                l_ind2 = varsize + l_ind2 + 1;
 
             int direction = l_ind2 < l_ind ? -1 : 1;
             for (long jjj = l_ind; jjj * direction <= l_ind2 * direction; jjj += direction) {
@@ -457,13 +460,20 @@ static wcstring_list_t erased_at_indexes(wcstring_list_t input, std::vector<long
 
 static env_mode_flags_t compute_scope(const set_cmd_opts_t &opts) {
     int scope = ENV_USER;
-    if (opts.local) scope |= ENV_LOCAL;
-    if (opts.global) scope |= ENV_GLOBAL;
-    if (opts.exportv) scope |= ENV_EXPORT;
-    if (opts.unexport) scope |= ENV_UNEXPORT;
-    if (opts.universal) scope |= ENV_UNIVERSAL;
-    if (opts.pathvar) scope |= ENV_PATHVAR;
-    if (opts.unpathvar) scope |= ENV_UNPATHVAR;
+    if (opts.local)
+        scope |= ENV_LOCAL;
+    if (opts.global)
+        scope |= ENV_GLOBAL;
+    if (opts.exportv)
+        scope |= ENV_EXPORT;
+    if (opts.unexport)
+        scope |= ENV_UNEXPORT;
+    if (opts.universal)
+        scope |= ENV_UNIVERSAL;
+    if (opts.pathvar)
+        scope |= ENV_PATHVAR;
+    if (opts.unpathvar)
+        scope |= ENV_UNPATHVAR;
     return scope;
 }
 
@@ -490,7 +500,8 @@ static int builtin_set_list(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
                 std::shared_ptr<history_t> history =
                     history_t::with_name(history_session_id(parser.vars()));
                 for (size_t i = 1; i < history->size() && val.size() < 64; i++) {
-                    if (i > 1) val += L' ';
+                    if (i > 1)
+                        val += L' ';
                     val += expand_escape_string(history->item_at_index(i).str());
                 }
             } else {
@@ -508,7 +519,8 @@ static int builtin_set_list(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
                 streams.out.append(L" ");
                 streams.out.append(val);
 
-                if (shorten) streams.out.push_back(get_ellipsis_char());
+                if (shorten)
+                    streams.out.push_back(get_ellipsis_char());
             }
         }
 
@@ -533,12 +545,14 @@ static int builtin_set_query(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
 
         if (split->indexes.empty()) {
             // No indexes, just increment if our variable is missing.
-            if (!split->var) retval++;
+            if (!split->var)
+                retval++;
         } else {
             // Increment for every index out of range.
             long varsize = split->varsize();
             for (long idx : split->indexes) {
-                if (idx < 1 || idx > varsize) retval++;
+                if (idx < 1 || idx > varsize)
+                    retval++;
             }
         }
     }
@@ -585,7 +599,8 @@ static void show_scope(const wchar_t *var_name, int scope, io_streams_t &streams
                 streams.out.append(get_ellipsis_char() > 256 ? L"\u22EF" : get_ellipsis_str());
                 streams.out.push_back(L'\n');
             }
-            if (i >= 50 && i < vals.size() - 50) continue;
+            if (i >= 50 && i < vals.size() - 50)
+                continue;
         }
         const wcstring value = vals[i];
         const wcstring escaped_val = escape_string(value, ESCAPE_NO_QUOTED, STRING_STYLE_SCRIPT);
@@ -602,7 +617,8 @@ static int builtin_set_show(const wchar_t *cmd, const set_cmd_opts_t &opts, int 
         wcstring_list_t names = parser.vars().get_names(ENV_USER);
         sort(names.begin(), names.end());
         for (const auto &name : names) {
-            if (name == L"history") continue;
+            if (name == L"history")
+                continue;
             show_scope(name.c_str(), ENV_LOCAL, streams, vars);
             show_scope(name.c_str(), ENV_GLOBAL, streams, vars);
             show_scope(name.c_str(), ENV_UNIVERSAL, streams, vars);
@@ -662,7 +678,8 @@ static int builtin_set_erase(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
                 handle_env_return(retval, cmd, split->varname, streams);
             }
         } else {  // remove just the specified indexes of the var
-            if (!split->var) return STATUS_CMD_ERROR;
+            if (!split->var)
+                return STATUS_CMD_ERROR;
             wcstring_list_t result = erased_at_indexes(split->var->as_list(), split->indexes);
             retval = env_set_reporting_errors(cmd, split->varname, scope, std::move(result),
                                               streams, parser.vars(), &evts);
@@ -679,7 +696,8 @@ static int builtin_set_erase(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
             ret = retval;
         } else {
             retval = check_global_scope_exists(cmd, opts, split->varname, streams, parser);
-            if (retval != STATUS_CMD_OK) ret = retval;
+            if (retval != STATUS_CMD_OK)
+                ret = retval;
         }
     }
     return ret;
@@ -727,7 +745,8 @@ static wcstring_list_t new_var_values_by_index(const split_var_t &split, int arg
     // Note unlike the append/prepend case, we start with a variable in the same scope as we are
     // setting.
     wcstring_list_t result;
-    if (split.var) result = split.var->as_list();
+    if (split.var)
+        result = split.var->as_list();
 
     // For each (index, argument) pair, set the element in our \p result to the replacement string.
     // Extend the list with empty strings as needed. The indexes are 1-based.
@@ -737,7 +756,8 @@ static wcstring_list_t new_var_values_by_index(const split_var_t &split, int arg
         // Convert from 1-based to 0-based.
         size_t idx = static_cast<size_t>(lidx - 1);
         // Extend as needed with empty strings.
-        if (idx >= result.size()) result.resize(idx + 1);
+        if (idx >= result.size())
+            result.resize(idx + 1);
         result.at(idx) = argv[i];
     }
     return result;
@@ -813,7 +833,8 @@ static int builtin_set_set(const wchar_t *cmd, set_cmd_opts_t &opts, int argc, c
         event_fire(parser, evt);
     }
 
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
     return check_global_scope_exists(cmd, opts, split->varname, streams, parser);
 }
 
@@ -825,7 +846,8 @@ maybe_t<int> builtin_set(parser_t &parser, io_streams_t &streams, const wchar_t 
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
     argv += optind;
     argc -= optind;
 
@@ -835,7 +857,8 @@ maybe_t<int> builtin_set(parser_t &parser, io_streams_t &streams, const wchar_t 
     }
 
     retval = validate_cmd_opts(cmd, opts, argc, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.query) {
         retval = builtin_set_query(cmd, opts, argc, argv, parser, streams);
@@ -851,6 +874,7 @@ maybe_t<int> builtin_set(parser_t &parser, io_streams_t &streams, const wchar_t 
         retval = builtin_set_set(cmd, opts, argc, argv, parser, streams);
     }
 
-    if (retval == STATUS_CMD_OK && opts.preserve_failure_exit_status) return none();
+    if (retval == STATUS_CMD_OK && opts.preserve_failure_exit_status)
+        return none();
     return retval;
 }

--- a/src/builtin_source.cpp
+++ b/src/builtin_source.cpp
@@ -30,7 +30,8 @@ maybe_t<int> builtin_source(parser_t &parser, io_streams_t &streams, const wchar
 
     int optind;
     int retval = parse_help_only_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);

--- a/src/builtin_status.cpp
+++ b/src/builtin_status.cpp
@@ -73,7 +73,8 @@ const enum_map<status_cmd_t> status_enum_map[] = {
 #define CHECK_FOR_UNEXPECTED_STATUS_ARGS(status_cmd)                                        \
     if (!args.empty()) {                                                                    \
         const wchar_t *subcmd_str = enum_to_str(status_cmd, status_enum_map);               \
-        if (!subcmd_str) subcmd_str = L"default";                                           \
+        if (!subcmd_str)                                                                    \
+            subcmd_str = L"default";                                                        \
         streams.err.append_format(BUILTIN_ERR_ARG_COUNT2, cmd, subcmd_str, 0, args.size()); \
         retval = STATUS_INVALID_ARGS;                                                       \
         break;                                                                              \
@@ -281,7 +282,8 @@ maybe_t<int> builtin_status(parser_t &parser, io_streams_t &streams, const wchar
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -383,7 +385,8 @@ maybe_t<int> builtin_status(parser_t &parser, io_streams_t &streams, const wchar
             CHECK_FOR_UNEXPECTED_STATUS_ARGS(opts.status_cmd)
             const wchar_t *fn = parser.get_function_name(opts.level);
 
-            if (!fn) fn = _(L"Not a function");
+            if (!fn)
+                fn = _(L"Not a function");
             streams.out.append_format(L"%ls\n", fn);
             break;
         }

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -92,7 +92,8 @@ class arg_iterator_t {
             if (n == 0) {
                 // If we still have buffer contents, flush them,
                 // in case there was no trailing sep.
-                if (buffer_.empty()) return false;
+                if (buffer_.empty())
+                    return false;
                 storage_ = str2wcstring(buffer_);
                 buffer_.clear();
                 return true;
@@ -490,30 +491,54 @@ static int handle_flag_w(const wchar_t **argv, parser_t &parser, io_streams_t &s
 /// not require an argument depending on the meaning.
 static wcstring construct_short_opts(options_t *opts) {  //!OCLINT(high npath complexity)
     wcstring short_opts(L":");
-    if (opts->all_valid) short_opts.append(L"a");
-    if (opts->char_to_pad_valid) short_opts.append(L"c:");
-    if (opts->chars_to_trim_valid) short_opts.append(L"c:");
-    if (opts->count_valid) short_opts.append(L"n:");
-    if (opts->entire_valid) short_opts.append(L"e");
-    if (opts->filter_valid) short_opts.append(L"f");
-    if (opts->ignore_case_valid) short_opts.append(L"i");
-    if (opts->index_valid) short_opts.append(L"n");
-    if (opts->invert_valid) short_opts.append(L"v");
-    if (opts->left_valid) short_opts.append(L"l");
-    if (opts->length_valid) short_opts.append(L"l:");
-    if (opts->max_valid) short_opts.append(L"m:");
-    if (opts->no_newline_valid) short_opts.append(L"N");
-    if (opts->no_quoted_valid) short_opts.append(L"n");
-    if (opts->quiet_valid) short_opts.append(L"q");
-    if (opts->regex_valid) short_opts.append(L"r");
-    if (opts->right_valid) short_opts.append(L"r");
-    if (opts->start_valid) short_opts.append(L"s:");
-    if (opts->end_valid) short_opts.append(L"e:");
-    if (opts->no_empty_valid) short_opts.append(L"n");
-    if (opts->no_trim_newlines_valid) short_opts.append(L"N");
-    if (opts->fields_valid) short_opts.append(L"f:");
-    if (opts->allow_empty_valid) short_opts.append(L"a");
-    if (opts->width_valid) short_opts.append(L"w:");
+    if (opts->all_valid)
+        short_opts.append(L"a");
+    if (opts->char_to_pad_valid)
+        short_opts.append(L"c:");
+    if (opts->chars_to_trim_valid)
+        short_opts.append(L"c:");
+    if (opts->count_valid)
+        short_opts.append(L"n:");
+    if (opts->entire_valid)
+        short_opts.append(L"e");
+    if (opts->filter_valid)
+        short_opts.append(L"f");
+    if (opts->ignore_case_valid)
+        short_opts.append(L"i");
+    if (opts->index_valid)
+        short_opts.append(L"n");
+    if (opts->invert_valid)
+        short_opts.append(L"v");
+    if (opts->left_valid)
+        short_opts.append(L"l");
+    if (opts->length_valid)
+        short_opts.append(L"l:");
+    if (opts->max_valid)
+        short_opts.append(L"m:");
+    if (opts->no_newline_valid)
+        short_opts.append(L"N");
+    if (opts->no_quoted_valid)
+        short_opts.append(L"n");
+    if (opts->quiet_valid)
+        short_opts.append(L"q");
+    if (opts->regex_valid)
+        short_opts.append(L"r");
+    if (opts->right_valid)
+        short_opts.append(L"r");
+    if (opts->start_valid)
+        short_opts.append(L"s:");
+    if (opts->end_valid)
+        short_opts.append(L"e:");
+    if (opts->no_empty_valid)
+        short_opts.append(L"n");
+    if (opts->no_trim_newlines_valid)
+        short_opts.append(L"N");
+    if (opts->fields_valid)
+        short_opts.append(L"f:");
+    if (opts->allow_empty_valid)
+        short_opts.append(L"a");
+    if (opts->width_valid)
+        short_opts.append(L"w:");
     return short_opts;
 }
 
@@ -564,7 +589,8 @@ static int parse_opts(options_t *opts, int *optind, int n_req_args, int argc, co
         auto fn = flag_to_function.find(opt);
         if (fn != flag_to_function.end()) {
             int retval = fn->second(argv, parser, streams, w, opts);
-            if (retval != STATUS_CMD_OK) return retval;
+            if (retval != STATUS_CMD_OK)
+                return retval;
         } else if (opt == ':') {
             streams.err.append(L"string ");  // clone of string_error
             builtin_missing_argument(parser, streams, cmd, argv[w.woptind - 1],
@@ -612,14 +638,16 @@ static int string_escape(parser_t &parser, io_streams_t &streams, int argc, cons
     opts.style_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     // Currently, only the script style supports options.
     // Ignore them for other styles for now.
     escape_flags_t flags = 0;
     if (opts.escape_style == STRING_STYLE_SCRIPT) {
         flags = ESCAPE_ALL;
-        if (opts.no_quoted) flags |= ESCAPE_NO_QUOTED;
+        if (opts.no_quoted)
+            flags |= ESCAPE_NO_QUOTED;
     }
 
     int nesc = 0;
@@ -644,7 +672,8 @@ static int string_unescape(parser_t &parser, io_streams_t &streams, int argc,
     int nesc = 0;
     unescape_flags_t flags = 0;
 
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     arg_iterator_t aiter(argv, optind, streams);
     while (const wcstring *arg = aiter.nextstr()) {
@@ -666,7 +695,8 @@ static int string_join_maybe0(parser_t &parser, io_streams_t &streams, int argc,
     opts.quiet_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, is_join0 ? 0 : 1, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     const wcstring sep = is_join0 ? wcstring(1, L'\0') : wcstring(opts.arg1);
     int nargs = 0;
@@ -702,7 +732,8 @@ static int string_length(parser_t &parser, io_streams_t &streams, int argc, cons
     opts.quiet_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     int nnonempty = 0;
     arg_iterator_t aiter(argv, optind, streams);
@@ -753,8 +784,10 @@ class wildcard_matcher_t final : public string_matcher_t {
         }
         if (opts.entire) {
             if (!wcpattern.empty()) {
-                if (wcpattern.front() != ANY_STRING) wcpattern.insert(0, 1, ANY_STRING);
-                if (wcpattern.back() != ANY_STRING) wcpattern.push_back(ANY_STRING);
+                if (wcpattern.front() != ANY_STRING)
+                    wcpattern.insert(0, 1, ANY_STRING);
+                if (wcpattern.back() != ANY_STRING)
+                    wcpattern.push_back(ANY_STRING);
             } else {
                 // If the pattern is empty, this becomes one ANY_STRING that matches everything.
                 wcpattern.push_back(ANY_STRING);
@@ -1036,7 +1069,8 @@ class pcre2_matcher_t final : public string_matcher_t {
         }
 
         ~regex_importer_t() {
-            if (!do_import_) return;
+            if (!do_import_)
+                return;
             for (auto &kv : matches_) {
                 const wcstring &name = kv.first;
                 wcstring_list_t &value = kv.second;
@@ -1083,7 +1117,8 @@ class pcre2_matcher_t final : public string_matcher_t {
                 total_matched++;
         }
 
-        if (opts.invert_match) return true;
+        if (opts.invert_match)
+            return true;
 
         // Report any additional matches.
         for (auto *ovector = pcre2_get_ovector_pointer(regex.match); opts.all; total_matched++) {
@@ -1091,7 +1126,8 @@ class pcre2_matcher_t final : public string_matcher_t {
             PCRE2_SIZE offset = ovector[1];  // start at end of previous match
 
             if (ovector[0] == ovector[1]) {
-                if (ovector[0] == arglen) break;
+                if (ovector[0] == arglen)
+                    break;
                 options = PCRE2_NOTEMPTY_ATSTART | PCRE2_ANCHORED;
             }
 
@@ -1109,7 +1145,8 @@ class pcre2_matcher_t final : public string_matcher_t {
             }
 
             if (rc == match_result_t::no_match) {
-                if (options == 0 /* all matches found now */) break;
+                if (options == 0 /* all matches found now */)
+                    break;
                 ovector[1] = offset + 1;
             }
         }
@@ -1140,7 +1177,8 @@ static int string_match(parser_t &parser, io_streams_t &streams, int argc, const
     opts.index_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 1, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
     const wchar_t *pattern = opts.arg1;
 
     if (opts.entire && opts.index) {
@@ -1165,7 +1203,8 @@ static int string_match(parser_t &parser, io_streams_t &streams, int argc, const
         if (!matcher->report_matches(*arg)) {
             return STATUS_INVALID_ARGS;
         }
-        if (opts.quiet && matcher->match_count() > 0) return STATUS_CMD_OK;
+        if (opts.quiet && matcher->match_count() > 0)
+            return STATUS_CMD_OK;
     }
 
     if (matcher->match_count() == 0) {
@@ -1182,7 +1221,8 @@ static int string_pad(parser_t &parser, io_streams_t &streams, int argc, const w
     opts.width_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     size_t pad_char_width = fish_wcwidth(opts.char_to_pad);
     if (pad_char_width == 0) {
@@ -1203,7 +1243,8 @@ static int string_pad(parser_t &parser, io_streams_t &streams, int argc, const w
     while (const wcstring *arg = aiter_width.nextstr()) {
         wcstring input_string = *arg;
         ssize_t width = fish_wcswidth(input_string);
-        if (width > max_width) max_width = width;
+        if (width > max_width)
+            max_width = width;
         inputs.push_back(std::move(input_string));
     }
 
@@ -1343,8 +1384,10 @@ bool literal_replacer_t::replace_matches(const wcstring &arg) {
 /// A return value of true means all is well (even if no replacements were performed), false
 /// indicates an unrecoverable error.
 bool regex_replacer_t::replace_matches(const wcstring &arg) {
-    if (!regex.code) return false;   // pcre2_compile() failed
-    if (!replacement) return false;  // replacement was an invalid string
+    if (!regex.code)
+        return false;  // pcre2_compile() failed
+    if (!replacement)
+        return false;  // replacement was an invalid string
 
     // clang-format off
     // SUBSTITUTE_OVERFLOW_LENGTH causes pcre to return the needed buffer length if the passed one is to small
@@ -1376,7 +1419,8 @@ bool regex_replacer_t::replace_matches(const wcstring &arg) {
         } else {
             bufsize = outlen;
             auto new_output = static_cast<wchar_t *>(realloc(output, sizeof(wchar_t) * bufsize));
-            if (new_output) output = new_output;
+            if (new_output)
+                output = new_output;
         }
     }
 
@@ -1408,7 +1452,8 @@ static int string_replace(parser_t &parser, io_streams_t &streams, int argc, con
     opts.regex_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 2, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     const wchar_t *pattern = opts.arg1;
     const wchar_t *replacement = opts.arg2;
@@ -1422,8 +1467,10 @@ static int string_replace(parser_t &parser, io_streams_t &streams, int argc, con
 
     arg_iterator_t aiter(argv, optind, streams);
     while (const wcstring *arg = aiter.nextstr()) {
-        if (!replacer->replace_matches(*arg)) return STATUS_INVALID_ARGS;
-        if (opts.quiet && replacer->replace_count() > 0) return STATUS_CMD_OK;
+        if (!replacer->replace_matches(*arg))
+            return STATUS_INVALID_ARGS;
+        if (opts.quiet && replacer->replace_count() > 0)
+            return STATUS_CMD_OK;
     }
 
     return replacer->replace_count() > 0 ? STATUS_CMD_OK : STATUS_CMD_ERROR;
@@ -1442,7 +1489,8 @@ static int string_split_maybe0(parser_t &parser, io_streams_t &streams, int argc
     opts.allow_empty_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, is_split0 ? 0 : 1, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.fields.size() < 1 && opts.allow_empty) {
         streams.err.append_format(BUILTIN_ERR_COMBO2, cmd,
@@ -1467,7 +1515,8 @@ static int string_split_maybe0(parser_t &parser, io_streams_t &streams, int argc
         }
         all_splits.push_back(splits);
         // If we're quiet, we return early if we've found something to split.
-        if (opts.quiet && splits.size() > 1) return STATUS_CMD_OK;
+        if (opts.quiet && splits.size() > 1)
+            return STATUS_CMD_OK;
         split_count += splits.size();
         arg_count++;
     }
@@ -1487,7 +1536,8 @@ static int string_split_maybe0(parser_t &parser, io_streams_t &streams, int argc
                 // In contrast to split, where a\nb\n is three - "a", "b" and "".
                 //
                 // Remove the last element if it is empty.
-                if (splits.back().empty()) splits.pop_back();
+                if (splits.back().empty())
+                    splits.pop_back();
             }
             if (opts.fields.size() > 0) {
                 // Print nothing and return error if any of the supplied
@@ -1530,7 +1580,8 @@ static int string_collect(parser_t &parser, io_streams_t &streams, int argc, con
     opts.no_trim_newlines_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     arg_iterator_t aiter(argv, optind, streams, /* don't split */ false);
     size_t appended = 0;
@@ -1565,7 +1616,8 @@ static wcstring wcsrepeat(const wcstring &to_repeat, size_t count) {
 // Helper function to abstract the repeat until logic from string_repeat
 // returns the to_repeat string, repeated until max char has been reached.
 static wcstring wcsrepeat_until(const wcstring &to_repeat, size_t max) {
-    if (to_repeat.length() == 0) return wcstring();
+    if (to_repeat.length() == 0)
+        return wcstring();
     size_t count = max / to_repeat.length();
     size_t mod = max % to_repeat.length();
 
@@ -1580,7 +1632,8 @@ static int string_repeat(parser_t &parser, io_streams_t &streams, int argc, cons
     opts.no_newline_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     bool all_empty = true;
     bool first = true;
@@ -1629,7 +1682,8 @@ static int string_sub(parser_t &parser, io_streams_t &streams, int argc, const w
     opts.length = -1;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.length != -1 && opts.end != 0) {
         streams.err.append_format(BUILTIN_ERR_COMBO2, cmd,
@@ -1676,7 +1730,8 @@ static int string_sub(parser_t &parser, io_streams_t &streams, int argc, const w
             streams.out.append(L'\n');
         }
         nsub++;
-        if (opts.quiet) return STATUS_CMD_OK;
+        if (opts.quiet)
+            return STATUS_CMD_OK;
     }
 
     return nsub > 0 ? STATUS_CMD_OK : STATUS_CMD_ERROR;
@@ -1690,7 +1745,8 @@ static int string_trim(parser_t &parser, io_streams_t &streams, int argc, const 
     opts.quiet_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     // If neither left or right is specified, we do both.
     if (!opts.left && !opts.right) {
@@ -1732,14 +1788,16 @@ static int string_transform(parser_t &parser, io_streams_t &streams, int argc, c
     opts.quiet_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     int n_transformed = 0;
     arg_iterator_t aiter(argv, optind, streams);
     while (const wcstring *arg = aiter.nextstr()) {
         wcstring transformed(*arg);
         std::transform(transformed.begin(), transformed.end(), transformed.begin(), func);
-        if (transformed != *arg) n_transformed++;
+        if (transformed != *arg)
+            n_transformed++;
         if (!opts.quiet) {
             streams.out.append(transformed);
             streams.out.append(L'\n');
@@ -1801,7 +1859,8 @@ maybe_t<int> builtin_string(parser_t &parser, io_streams_t &streams, const wchar
             return wcscmp(cmd1.name, cmd2.name) < 0;
         });
     const string_subcommand *subcmd = nullptr;
-    if (binsearch != end && wcscmp(subcmd_name, binsearch->name) == 0) subcmd = &*binsearch;
+    if (binsearch != end && wcscmp(subcmd_name, binsearch->name) == 0)
+        subcmd = &*binsearch;
 
     if (subcmd == nullptr) {
         streams.err.append_format(BUILTIN_ERR_INVALID_SUBCMD, cmd, subcmd_name);

--- a/src/builtin_test.cpp
+++ b/src/builtin_test.cpp
@@ -97,17 +97,22 @@ class number_t {
     // Compare two numbers. Returns an integer -1, 0, 1 corresponding to whether we are less than,
     // equal to, or greater than the rhs.
     int compare(number_t rhs) const {
-        if (this->base != rhs.base) return (this->base > rhs.base) - (this->base < rhs.base);
+        if (this->base != rhs.base)
+            return (this->base > rhs.base) - (this->base < rhs.base);
         return (this->delta > rhs.delta) - (this->delta < rhs.delta);
     }
 
     // Return true if the number is a tty().
     bool isatty(const io_streams_t *streams) const {
-        if (delta != 0.0 || base > INT_MAX || base < INT_MIN) return false;
+        if (delta != 0.0 || base > INT_MAX || base < INT_MIN)
+            return false;
         int bint = static_cast<int>(base);
-        if (bint == 0) return ::isatty(streams->stdin_fd);
-        if (bint == 1) return !streams->out_is_redirected && ::isatty(STDOUT_FILENO);
-        if (bint == 2) return !streams->err_is_redirected && ::isatty(STDERR_FILENO);
+        if (bint == 0)
+            return ::isatty(streams->stdin_fd);
+        if (bint == 1)
+            return !streams->out_is_redirected && ::isatty(STDOUT_FILENO);
+        if (bint == 2)
+            return !streams->err_is_redirected && ::isatty(STDERR_FILENO);
         return ::isatty(bint);
     }
 };
@@ -163,7 +168,8 @@ const token_info_t *token_for_string(const wcstring &str) {
         {L")", {test_paren_close, 0}}};
 
     auto t = token_infos.find(str);
-    if (t != token_infos.end()) return &t->second;
+    if (t != token_infos.end())
+        return &t->second;
     return &token_infos.find(L"")->second;
 }
 
@@ -334,7 +340,8 @@ unique_ptr<expression> test_parser::parse_unary_expression(unsigned int start, u
 /// Parse a combining expression (AND, OR).
 unique_ptr<expression> test_parser::parse_combining_expression(unsigned int start,
                                                                unsigned int end) {
-    if (start >= end) return nullptr;
+    if (start >= end)
+        return nullptr;
 
     std::vector<unique_ptr<expression>> subjects;
     std::vector<token_t> combiners;
@@ -394,7 +401,8 @@ unique_ptr<expression> test_parser::parse_unary_primary(unsigned int start, unsi
 
     // All our unary primaries are prefix, so the operator is at start.
     const token_info_t *info = token_for_string(arg(start));
-    if (!(info->flags & UNARY_PRIMARY)) return nullptr;
+    if (!(info->flags & UNARY_PRIMARY))
+        return nullptr;
 
     return make_unique<unary_primary>(info->tok, range_t(start, start + 2), arg(start + 1));
 }
@@ -428,7 +436,8 @@ unique_ptr<expression> test_parser::parse_binary_primary(unsigned int start, uns
 
     // All our binary primaries are infix, so the operator is at start + 1.
     const token_info_t *info = token_for_string(arg(start + 1));
-    if (!(info->flags & BINARY_PRIMARY)) return nullptr;
+    if (!(info->flags & BINARY_PRIMARY))
+        return nullptr;
 
     return make_unique<binary_primary>(info->tok, range_t(start, start + 3), arg(start),
                                        arg(start + 2));
@@ -436,15 +445,18 @@ unique_ptr<expression> test_parser::parse_binary_primary(unsigned int start, uns
 
 unique_ptr<expression> test_parser::parse_parenthentical(unsigned int start, unsigned int end) {
     // We need at least three arguments: open paren, argument, close paren.
-    if (start + 3 >= end) return nullptr;
+    if (start + 3 >= end)
+        return nullptr;
 
     // Must start with an open expression.
     const token_info_t *open_paren = token_for_string(arg(start));
-    if (open_paren->tok != test_paren_open) return nullptr;
+    if (open_paren->tok != test_paren_open)
+        return nullptr;
 
     // Parse a subexpression.
     unique_ptr<expression> subexpr = parse_expression(start + 1, end);
-    if (!subexpr) return nullptr;
+    if (!subexpr)
+        return nullptr;
 
     // Parse a close paren.
     unsigned close_index = subexpr->range.end;
@@ -468,10 +480,14 @@ unique_ptr<expression> test_parser::parse_primary(unsigned int start, unsigned i
     }
 
     unique_ptr<expression> expr = nullptr;
-    if (!expr) expr = parse_parenthentical(start, end);
-    if (!expr) expr = parse_unary_primary(start, end);
-    if (!expr) expr = parse_binary_primary(start, end);
-    if (!expr) expr = parse_just_a_string(start, end);
+    if (!expr)
+        expr = parse_parenthentical(start, end);
+    if (!expr)
+        expr = parse_unary_primary(start, end);
+    if (!expr)
+        expr = parse_binary_primary(start, end);
+    if (!expr)
+        expr = parse_just_a_string(start, end);
     return expr;
 }
 
@@ -623,7 +639,8 @@ bool combining_expression::evaluate(io_streams_t *streams, wcstring_list_t &erro
         assert(combiners.size() + 1 == subjects.size());
 
         // One-element case.
-        if (subjects.size() == 1) return subjects.front()->evaluate(streams, errors);
+        if (subjects.size() == 1)
+            return subjects.front()->evaluate(streams, errors);
 
         // Evaluate our lists, remembering that AND has higher precedence than OR. We can
         // visualize this as a sequence of OR expressions of AND expressions.
@@ -667,7 +684,8 @@ bool parenthetical_expression::evaluate(io_streams_t *streams, wcstring_list_t &
 static bool parse_double(const wchar_t *arg, double *out_res) {
     // Consume leading spaces.
     while (arg && *arg != L'\0' && iswspace(*arg)) arg++;
-    if (!arg) return false;
+    if (!arg)
+        return false;
     errno = 0;
     wchar_t *end = nullptr;
     *out_res = fish_wcstod(arg, &end);
@@ -855,7 +873,8 @@ maybe_t<int> builtin_test(parser_t &parser, io_streams_t &streams, const wchar_t
     using namespace test_expressions;
 
     // The first argument should be the name of the command ('test').
-    if (!argv[0]) return STATUS_INVALID_ARGS;
+    if (!argv[0])
+        return STATUS_INVALID_ARGS;
 
     // Whether we are invoked with bracket '[' or not.
     const wchar_t *program_name = argv[0];

--- a/src/builtin_type.cpp
+++ b/src/builtin_type.cpp
@@ -106,7 +106,8 @@ maybe_t<int> builtin_type(parser_t &parser, io_streams_t &streams, const wchar_t
 
     int optind;
     int retval = parse_cmd_opts(opts, &optind, argc, argv, parser, streams);
-    if (retval != STATUS_CMD_OK) return retval;
+    if (retval != STATUS_CMD_OK)
+        return retval;
 
     if (opts.print_help) {
         builtin_print_help(parser, streams, cmd);
@@ -174,7 +175,8 @@ maybe_t<int> builtin_type(parser_t &parser, io_streams_t &streams, const wchar_t
             } else if (opts.type) {
                 streams.out.append(L"function\n");
             }
-            if (!opts.all) continue;
+            if (!opts.all)
+                continue;
         }
 
         // Builtins
@@ -186,7 +188,8 @@ maybe_t<int> builtin_type(parser_t &parser, io_streams_t &streams, const wchar_t
             } else if (opts.type) {
                 streams.out.append(_(L"builtin\n"));
             }
-            if (!opts.all) continue;
+            if (!opts.all)
+                continue;
         }
 
         // Commands
@@ -204,7 +207,8 @@ maybe_t<int> builtin_type(parser_t &parser, io_streams_t &streams, const wchar_t
                 streams.out.append(_(L"file\n"));
                 break;
             }
-            if (!opts.all) break;
+            if (!opts.all)
+                break;
         }
 
         if (!found && !opts.query && !opts.path) {

--- a/src/builtin_ulimit.cpp
+++ b/src/builtin_ulimit.cpp
@@ -124,7 +124,8 @@ static int set_limit(int resource, int hard, int soft, rlim_t value, io_streams_
     struct rlimit ls;
 
     getrlimit(resource, &ls);
-    if (hard) ls.rlim_max = value;
+    if (hard)
+        ls.rlim_max = value;
     if (soft) {
         ls.rlim_cur = value;
 

--- a/src/builtin_wait.cpp
+++ b/src/builtin_wait.cpp
@@ -130,7 +130,8 @@ static bool iswnumeric(const wchar_t *n) {
 /// See if the process described by \c proc matches the commandline \c cmd.
 static bool match_pid(const wcstring &cmd, const wchar_t *proc) {
     // Don't wait for itself
-    if (std::wcscmp(proc, L"wait") == 0) return false;
+    if (std::wcscmp(proc, L"wait") == 0)
+        return false;
 
     // Get the command to match against. We're only interested in the last path component.
     const wcstring base_cmd = wbasename(cmd);
@@ -143,7 +144,8 @@ static bool find_job_by_name(const wchar_t *proc, std::vector<job_id_t> &ids,
     bool found = false;
 
     for (const auto &j : parser.jobs()) {
-        if (j->command().empty()) continue;
+        if (j->command().empty())
+            continue;
 
         if (match_pid(j->command(), proc)) {
             if (!contains(ids, j->job_id())) {
@@ -155,7 +157,8 @@ static bool find_job_by_name(const wchar_t *proc, std::vector<job_id_t> &ids,
 
         // Check if the specified pid is a child process of the job.
         for (const process_ptr_t &p : j->processes) {
-            if (p->actual_cmd.empty()) continue;
+            if (p->actual_cmd.empty())
+                continue;
 
             if (match_pid(p->actual_cmd, proc)) {
                 if (!contains(ids, j->job_id())) {
@@ -243,7 +246,8 @@ maybe_t<int> builtin_wait(parser_t &parser, io_streams_t &streams, const wchar_t
             }
         }
 
-        if (waited_job_ids.empty()) return STATUS_INVALID_ARGS;
+        if (waited_job_ids.empty())
+            return STATUS_INVALID_ARGS;
 
         retval = wait_for_backgrounds_specified(parser, waited_job_ids, any_flag);
     }

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -21,8 +21,10 @@ static int simple_icase_compare(const wchar_t *s1, const wchar_t *s2) {
         wchar_t c2 = s2[idx];
 
         // "Canonicalize" to lower case.
-        if (L'A' <= c1 && c1 <= L'Z') c1 = L'a' + (c1 - L'A');
-        if (L'A' <= c2 && c2 <= L'Z') c2 = L'a' + (c2 - L'A');
+        if (L'A' <= c1 && c1 <= L'Z')
+            c1 = L'a' + (c1 - L'A');
+        if (L'A' <= c2 && c2 <= L'Z')
+            c2 = L'a' + (c2 - L'A');
 
         if (c1 != c2) {
             return c1 < c2 ? -1 : 1;
@@ -151,7 +153,8 @@ bool rgb_color_t::try_parse_rgb(const wcstring &name) {
     size_t digit_idx = 0, len = name.size();
 
     // Skip any leading #.
-    if (len > 0 && name.at(0) == L'#') digit_idx++;
+    if (len > 0 && name.at(0) == L'#')
+        digit_idx++;
 
     bool success = false;
     size_t i;
@@ -159,7 +162,8 @@ bool rgb_color_t::try_parse_rgb(const wcstring &name) {
         // Format: FA3
         for (i = 0; i < 3; i++) {
             int val = parse_hex_digit(name.at(digit_idx++));
-            if (val < 0) break;
+            if (val < 0)
+                break;
             data.color.rgb[i] = val * 16 + val;
         }
         success = (i == 3);
@@ -168,7 +172,8 @@ bool rgb_color_t::try_parse_rgb(const wcstring &name) {
         for (i = 0; i < 3; i++) {
             int hi = parse_hex_digit(name.at(digit_idx++));
             int lo = parse_hex_digit(name.at(digit_idx++));
-            if (lo < 0 || hi < 0) break;
+            if (lo < 0 || hi < 0)
+                break;
             data.color.rgb[i] = hi * 16 + lo;
         }
         success = (i == 3);
@@ -332,16 +337,21 @@ color24_t rgb_color_t::to_color24() const {
 uint8_t rgb_color_t::to_name_index() const {
     // TODO: This should look for the nearest color.
     assert(type == type_named || type == type_rgb);
-    if (type == type_named) return data.name_idx;
-    if (type == type_rgb) return term16_color_for_rgb(data.color.rgb);
+    if (type == type_named)
+        return data.name_idx;
+    if (type == type_rgb)
+        return term16_color_for_rgb(data.color.rgb);
     return static_cast<uint8_t>(-1);  // this is an error
 }
 
 void rgb_color_t::parse(const wcstring &str) {
     bool success = false;
-    if (!success) success = try_parse_special(str);
-    if (!success) success = try_parse_named(str);
-    if (!success) success = try_parse_rgb(str);
+    if (!success)
+        success = try_parse_special(str);
+    if (!success)
+        success = try_parse_named(str);
+    if (!success)
+        success = try_parse_rgb(str);
     if (!success) {
         std::memset(&this->data, 0, sizeof this->data);
         this->type = type_none;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -199,7 +199,8 @@ bool is_windows_subsystem_for_linux() {
     wchar_t text[1024];
     wcstring_list_t backtrace_text;
 
-    if (skip_levels + max_frames < n_frames) n_frames = skip_levels + max_frames;
+    if (skip_levels + max_frames < n_frames)
+        n_frames = skip_levels + max_frames;
 
     for (int i = skip_levels; i < n_frames; i++) {
         Dl_info info;
@@ -224,7 +225,8 @@ bool is_windows_subsystem_for_linux() {
 }
 
 [[gnu::noinline]] void show_stackframe(const wchar_t msg_level, int frame_count, int skip_levels) {
-    if (frame_count < 1) return;
+    if (frame_count < 1)
+        return;
 
     wcstring_list_t bt = demangled_backtrace(frame_count, skip_levels + 2);
     debug_shared(msg_level, L"Backtrace:\n" + join_strings(bt, L'\n') + L'\n');
@@ -280,22 +282,27 @@ static size_t count_ascii_prefix(const char *in, size_t in_len) {
 
     // Consume the unaligned prefix.
     for (const char *cursor = in; cursor < aligned_start; cursor++) {
-        if (cursor[0] & 0x80) return &cursor[0] - in;
+        if (cursor[0] & 0x80)
+            return &cursor[0] - in;
     }
 
     // Consume the aligned middle.
     for (const char *cursor = aligned_start; cursor < aligned_end; cursor += sizeof(WordType)) {
         if (*reinterpret_cast<const WordType *>(cursor) & 0x80808080) {
-            if (cursor[0] & 0x80) return &cursor[0] - in;
-            if (cursor[1] & 0x80) return &cursor[1] - in;
-            if (cursor[2] & 0x80) return &cursor[2] - in;
+            if (cursor[0] & 0x80)
+                return &cursor[0] - in;
+            if (cursor[1] & 0x80)
+                return &cursor[1] - in;
+            if (cursor[2] & 0x80)
+                return &cursor[2] - in;
             return &cursor[3] - in;
         }
     }
 
     // Consume the unaligned suffix.
     for (const char *cursor = aligned_end; cursor < in + in_len; cursor++) {
-        if (cursor[0] & 0x80) return &cursor[0] - in;
+        if (cursor[0] & 0x80)
+            return &cursor[0] - in;
     }
     return in_len;
 }
@@ -307,7 +314,8 @@ static size_t count_ascii_prefix(const char *in, size_t in_len) {
 /// This function encodes illegal character sequences in a reversible way using the private use
 /// area.
 static wcstring str2wcs_internal(const char *in, const size_t in_len) {
-    if (in_len == 0) return wcstring();
+    if (in_len == 0)
+        return wcstring();
     assert(in != nullptr);
 
     wcstring result;
@@ -332,7 +340,8 @@ static wcstring str2wcs_internal(const char *in, const size_t in_len) {
         result.insert(result.end(), &in[in_pos], &in[in_pos + ascii_prefix_length]);
         in_pos += ascii_prefix_length;
         assert(in_pos <= in_len && "Position overflowed length");
-        if (in_pos == in_len) break;
+        if (in_pos == in_len)
+            break;
 
         // We have found a non-ASCII character.
         bool use_encode_direct = false;
@@ -411,7 +420,8 @@ wcstring str2wcstring(const std::string &in, size_t len) {
 std::string wcs2string(const wcstring &input) { return wcs2string(input.data(), input.size()); }
 
 std::string wcs2string(const wchar_t *in, size_t len) {
-    if (len == 0) return std::string{};
+    if (len == 0)
+        return std::string{};
     std::string result;
     wcs2string_appending(in, len, &result);
     return result;
@@ -507,11 +517,13 @@ wchar_t *quote_end(const wchar_t *pos) {
     while (true) {
         pos++;
 
-        if (!*pos) return nullptr;
+        if (!*pos)
+            return nullptr;
 
         if (*pos == L'\\') {
             pos++;
-            if (!*pos) return nullptr;
+            if (!*pos)
+                return nullptr;
         } else {
             if (*pos == c) {
                 return const_cast<wchar_t *>(pos);
@@ -614,17 +626,20 @@ void debug_safe(int level, const char *msg, const char *param1, const char *para
                 const char *param11, const char *param12) {
     const char *const params[] = {param1, param2, param3, param4,  param5,  param6,
                                   param7, param8, param9, param10, param11, param12};
-    if (!msg) return;
+    if (!msg)
+        return;
 
     // Can't call fwprintf, that may allocate memory Just call write() over and over.
-    if (level > debug_level) return;
+    if (level > debug_level)
+        return;
     int errno_old = errno;
 
     size_t param_idx = 0;
     const char *cursor = msg;
     while (*cursor != '\0') {
         const char *end = std::strchr(cursor, '%');
-        if (end == nullptr) end = cursor + std::strlen(cursor);
+        if (end == nullptr)
+            end = cursor + std::strlen(cursor);
 
         ignore_result(write(STDERR_FILENO, cursor, end - cursor));
 
@@ -632,7 +647,8 @@ void debug_safe(int level, const char *msg, const char *param1, const char *para
             // Handle a format string.
             assert(param_idx < sizeof params / sizeof *params);
             const char *format = params[param_idx++];
-            if (!format) format = "(null)";
+            if (!format)
+                format = "(null)";
             ignore_result(write(STDERR_FILENO, format, std::strlen(format)));
             cursor = end + 2;
         } else if (end[0] == '\0') {
@@ -652,7 +668,8 @@ void debug_safe(int level, const char *msg, const char *param1, const char *para
 
 // Careful to not negate LLONG_MIN.
 static unsigned long long absolute_value(long long x) {
-    if (x >= 0) return static_cast<unsigned long long>(x);
+    if (x >= 0)
+        return static_cast<unsigned long long>(x);
     x = -(x + 1);
     return static_cast<unsigned long long>(x) + 1;
 }
@@ -744,7 +761,8 @@ wcstring reformat_for_screen(const wcstring &msg, const termsize_t &termsize) {
             } else if (overflow) {
                 // In case of overflow, we print a newline, except if we already are at position 0.
                 wchar_t *token = wcsndup(start, pos - start);
-                if (line_width != 0) buff.push_back(L'\n');
+                if (line_width != 0)
+                    buff.push_back(L'\n');
                 buff.append(format_string(L"%ls-\n", token));
                 free(token);
                 line_width = 0;
@@ -799,20 +817,25 @@ static bool unescape_string_url(const wchar_t *in, wcstring *out) {
     std::string result;
     result.reserve(out->size());
     for (wchar_t c = *in; c; c = *++in) {
-        if (c > 0x7F) return false;  // invalid character means we can't decode the string
+        if (c > 0x7F)
+            return false;  // invalid character means we can't decode the string
         if (c == '%') {
             int c1 = in[1];
-            if (c1 == 0) return false;  // found unexpected end of string
+            if (c1 == 0)
+                return false;  // found unexpected end of string
             if (c1 == '%') {
                 result.push_back('%');
                 in++;
             } else {
                 int c2 = in[2];
-                if (c2 == 0) return false;  // string ended prematurely
+                if (c2 == 0)
+                    return false;  // string ended prematurely
                 long d1 = convert_digit(c1, 16);
-                if (d1 < 0) return false;
+                if (d1 < 0)
+                    return false;
                 long d2 = convert_digit(c2, 16);
-                if (d2 < 0) return false;
+                if (d2 < 0)
+                    return false;
                 result.push_back(16 * d1 + d2);
                 in += 2;
             }
@@ -863,11 +886,13 @@ static bool unescape_string_var(const wchar_t *in, wcstring *out) {
     result.reserve(out->size());
     bool prev_was_hex_encoded = false;
     for (wchar_t c = *in; c; c = *++in) {
-        if (c > 0x7F) return false;  // invalid character means we can't decode the string
+        if (c > 0x7F)
+            return false;  // invalid character means we can't decode the string
         if (c == '_') {
             int c1 = in[1];
             if (c1 == 0) {
-                if (prev_was_hex_encoded) break;
+                if (prev_was_hex_encoded)
+                    break;
                 return false;  // found unexpected escape char at end of string
             }
             if (c1 == '_') {
@@ -875,11 +900,14 @@ static bool unescape_string_var(const wchar_t *in, wcstring *out) {
                 in++;
             } else if (is_hex_digit(c1)) {
                 int c2 = in[2];
-                if (c2 == 0) return false;  // string ended prematurely
+                if (c2 == 0)
+                    return false;  // string ended prematurely
                 long d1 = convert_hex_digit(c1);
-                if (d1 < 0) return false;
+                if (d1 < 0)
+                    return false;
                 long d2 = convert_hex_digit(c2);
-                if (d2 < 0) return false;
+                if (d2 < 0)
+                    return false;
                 result.push_back(16 * d1 + d2);
                 in += 2;
                 prev_was_hex_encoded = true;
@@ -1015,7 +1043,8 @@ static void escape_string_script(const wchar_t *orig_in, size_t in_len, wcstring
                                           (c == L'?' && no_qmark);
                     if (!char_is_normal) {
                         need_escape = true;
-                        if (escape_all) out += L'\\';
+                        if (escape_all)
+                            out += L'\\';
                     }
                     out += *in;
                     break;
@@ -1150,7 +1179,8 @@ wcstring escape_string(const wcstring &in, escape_flags_t flags, escape_string_s
 
 /// Helper to return the last character in a string, or none.
 static maybe_t<wchar_t> string_last_char(const wcstring &str) {
-    if (str.empty()) return none();
+    if (str.empty())
+        return none();
     return str.back();
 }
 
@@ -1176,7 +1206,8 @@ maybe_t<size_t> read_unquoted_escape(const wchar_t *input, wcstring *result, boo
             in_pos--;
 
             // It's an error, unless we're allowing incomplete escapes.
-            if (!allow_incomplete) errored = true;
+            if (!allow_incomplete)
+                errored = true;
             break;
         }
         // Numeric escape sequences. No prefix means octal escape, otherwise hexadecimal.
@@ -1209,7 +1240,8 @@ maybe_t<size_t> read_unquoted_escape(const wchar_t *input, wcstring *result, boo
                     max_val = WCHAR_MAX;
 
                     // Don't exceed the largest Unicode code point - see #1107.
-                    if (0x10FFFF < max_val) max_val = static_cast<wchar_t>(0x10FFFF);
+                    if (0x10FFFF < max_val)
+                        max_val = static_cast<wchar_t>(0x10FFFF);
                     break;
                 }
                 case L'x': {
@@ -1310,7 +1342,8 @@ maybe_t<size_t> read_unquoted_escape(const wchar_t *input, wcstring *result, boo
             break;
         }
         default: {
-            if (unescape_special) result->push_back(INTERNAL_SEPARATOR);
+            if (unescape_special)
+                result->push_back(INTERNAL_SEPARATOR);
             result_char_or_none = c;
             break;
         }
@@ -1319,7 +1352,8 @@ maybe_t<size_t> read_unquoted_escape(const wchar_t *input, wcstring *result, boo
     if (!errored && result_char_or_none.has_value()) {
         result->push_back(*result_char_or_none);
     }
-    if (errored) return none();
+    if (errored)
+        return none();
 
     return in_pos;
 }
@@ -1446,7 +1480,8 @@ static bool unescape_string_internal(const wchar_t *const input, const size_t in
                                 result[braces.back()] = L'{';
                                 // We also need to turn all spaces back.
                                 for (size_t i = braces.back() + 1; i < result.size(); i++) {
-                                    if (result[i] == BRACE_SPACE) result[i] = L' ';
+                                    if (result[i] == BRACE_SPACE)
+                                        result[i] = L' ';
                                 }
                                 to_append_or_none = L'}';
                             }
@@ -1621,7 +1656,8 @@ bool unescape_string(const wchar_t *input, wcstring *output, unescape_flags_t es
             break;
         }
     }
-    if (!success) output->clear();
+    if (!success)
+        output->clear();
     return success;
 }
 
@@ -1647,7 +1683,8 @@ bool unescape_string(const wcstring &input, wcstring *output, unescape_flags_t e
             break;
         }
     }
-    if (!success) output->clear();
+    if (!success)
+        output->clear();
     return success;
 }
 
@@ -1859,9 +1896,12 @@ void redirect_tty_output() {
     if (fd == -1) {
         __fish_assert("Could not open /dev/null!", __FILE__, __LINE__, errno);
     }
-    if (tcgetattr(STDIN_FILENO, &t) == -1 && errno == EIO) dup2(fd, STDIN_FILENO);
-    if (tcgetattr(STDOUT_FILENO, &t) == -1 && errno == EIO) dup2(fd, STDOUT_FILENO);
-    if (tcgetattr(STDERR_FILENO, &t) == -1 && errno == EIO) dup2(fd, STDERR_FILENO);
+    if (tcgetattr(STDIN_FILENO, &t) == -1 && errno == EIO)
+        dup2(fd, STDIN_FILENO);
+    if (tcgetattr(STDOUT_FILENO, &t) == -1 && errno == EIO)
+        dup2(fd, STDOUT_FILENO);
+    if (tcgetattr(STDERR_FILENO, &t) == -1 && errno == EIO)
+        dup2(fd, STDERR_FILENO);
     close(fd);
 }
 
@@ -1887,18 +1927,23 @@ bool valid_var_name(const wcstring &str) {
 }
 
 bool valid_var_name(const wchar_t *str) {
-    if (str[0] == L'\0') return false;
+    if (str[0] == L'\0')
+        return false;
     for (size_t i = 0; str[i] != L'\0'; i++) {
-        if (!valid_var_name_char(str[i])) return false;
+        if (!valid_var_name_char(str[i]))
+            return false;
     }
     return true;
 }
 
 /// Test if the string is a valid function name.
 bool valid_func_name(const wcstring &str) {
-    if (str.empty()) return false;
-    if (str.at(0) == L'-') return false;
-    if (str.find_first_of(L'/') != wcstring::npos) return false;
+    if (str.empty())
+        return false;
+    if (str.at(0) == L'-')
+        return false;
+    if (str.find_first_of(L'/') != wcstring::npos)
+        return false;
     return true;
 }
 
@@ -1911,7 +1956,8 @@ std::string get_executable_path(const char *argv0) {
     // This is basically grabbing exec_path after argc, argv, envp, ...: for us
     // https://opensource.apple.com/source/adv_cmds/adv_cmds-163/ps/print.c
     uint32_t buffSize = sizeof buff;
-    if (_NSGetExecutablePath(buff, &buffSize) == 0) return std::string(buff);
+    if (_NSGetExecutablePath(buff, &buffSize) == 0)
+        return std::string(buff);
 #elif defined(__BSD__) && defined(KERN_PROC_PATHNAME) && !defined(__NetBSD__)
     // BSDs do not have /proc by default, (although it can be mounted as procfs via the Linux
     // compatibility layer). We can use sysctl instead: per sysctl(3), passing in a process ID of -1

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -307,7 +307,8 @@ static void unique_completions_retaining_order(completion_list_t *comps) {
 }
 
 void completions_sort_and_prioritize(completion_list_t *comps, completion_request_flags_t flags) {
-    if (comps->empty()) return;
+    if (comps->empty())
+        return;
 
     // Find the best rank.
     uint32_t best_rank = UINT32_MAX;
@@ -398,9 +399,12 @@ class completer_t {
 
     expand_flags_t expand_flags() const {
         expand_flags_t result{};
-        if (this->type() == COMPLETE_AUTOSUGGEST) result |= expand_flag::skip_cmdsubst;
-        if (this->fuzzy()) result |= expand_flag::fuzzy_match;
-        if (this->wants_descriptions()) result |= expand_flag::gen_descriptions;
+        if (this->type() == COMPLETE_AUTOSUGGEST)
+            result |= expand_flag::skip_cmdsubst;
+        if (this->fuzzy())
+            result |= expand_flag::fuzzy_match;
+        if (this->wants_descriptions())
+            result |= expand_flag::gen_descriptions;
         return result;
     }
 
@@ -523,9 +527,12 @@ void complete_add(const wchar_t *cmd, bool cmd_is_path, const wcstring &option,
     opt.type = option_type;
     opt.result_mode = result_mode;
 
-    if (comp) opt.comp = comp;
-    if (condition) opt.condition = condition;
-    if (desc) opt.desc = desc;
+    if (comp)
+        opt.comp = comp;
+    if (condition)
+        opt.condition = condition;
+    if (desc)
+        opt.desc = desc;
     opt.flags = flags;
 
     c.add_option(opt);
@@ -631,12 +638,14 @@ void completer_t::complete_strings(const wcstring &wc_escaped, const description
 /// for the executable.
 void completer_t::complete_cmd_desc(const wcstring &str) {
     ASSERT_IS_MAIN_THREAD();
-    if (!ctx.parser) return;
+    if (!ctx.parser)
+        return;
 
     wcstring cmd;
     size_t pos = str.find_last_of(L'/');
     if (pos != std::string::npos) {
-        if (pos + 1 > str.length()) return;
+        if (pos + 1 > str.length())
+            return;
         cmd = wcstring(str, pos + 1);
     } else {
         cmd = str;
@@ -644,7 +653,8 @@ void completer_t::complete_cmd_desc(const wcstring &str) {
 
     // Using apropos with a single-character search term produces far to many results - require at
     // least two characters if we don't know the location of the whatis-database.
-    if (cmd.length() < 2) return;
+    if (cmd.length() < 2)
+        return;
 
     if (wildcard_has(cmd, false)) {
         return;
@@ -677,7 +687,8 @@ void completer_t::complete_cmd_desc(const wcstring &str) {
     // A typical entry is the command name, followed by a tab, followed by a description.
     for (const wcstring &elstr : list) {
         // Skip keys that are too short.
-        if (elstr.size() < cmd.size()) continue;
+        if (elstr.size() < cmd.size())
+            continue;
 
         // Skip cases without a tab, or without a description, or bizarre cases where the tab is
         // part of the command.
@@ -706,7 +717,8 @@ void completer_t::complete_cmd_desc(const wcstring &str) {
     for (auto &completion : completions.get_list()) {
         const wcstring &el = completion.completion;
         auto new_desc_iter = lookup.find(el);
-        if (new_desc_iter != lookup.end()) completion.description = new_desc_iter->second;
+        if (new_desc_iter != lookup.end())
+            completion.description = new_desc_iter->second;
     }
 }
 
@@ -891,7 +903,8 @@ static size_t short_option_pos(const wcstring &arg, const option_list_t &options
         }
         if (match == nullptr) {
             // The first character after the dash is not a valid option.
-            if (pos == 1) return wcstring::npos;
+            if (pos == 1)
+                return wcstring::npos;
             return pos - 1;
         }
         if (match->result_mode.requires_param) {
@@ -986,17 +999,22 @@ bool completer_t::complete_param_for_command(const wcstring &cmd_orig, const wcs
                 for (const complete_entry_opt_t &o : options) {
                     const wchar_t *arg;
                     if (o.type == option_type_short) {
-                        if (short_opt_pos == wcstring::npos) continue;
-                        if (o.option.at(0) != str.at(short_opt_pos)) continue;
+                        if (short_opt_pos == wcstring::npos)
+                            continue;
+                        if (o.option.at(0) != str.at(short_opt_pos))
+                            continue;
                         last_option_requires_param = o.result_mode.requires_param;
                         arg = str.c_str() + short_opt_pos + 1;
                     } else {
                         arg = param_match2(&o, str.c_str());
                     }
                     if (arg != nullptr && this->condition_test(o.condition)) {
-                        if (o.result_mode.requires_param) use_common = false;
-                        if (o.result_mode.no_files) use_files = false;
-                        if (o.result_mode.force_files) has_force = true;
+                        if (o.result_mode.requires_param)
+                            use_common = false;
+                        if (o.result_mode.no_files)
+                            use_files = false;
+                        if (o.result_mode.force_files)
+                            has_force = true;
                         complete_from_args(arg, o.comp, o.localized_desc(), o.flags);
                     }
                 }
@@ -1011,9 +1029,12 @@ bool completer_t::complete_param_for_command(const wcstring &cmd_orig, const wcs
                     if (o.type == option_type_single_long && param_match(&o, popt.c_str()) &&
                         this->condition_test(o.condition)) {
                         old_style_match = true;
-                        if (o.result_mode.requires_param) use_common = false;
-                        if (o.result_mode.no_files) use_files = false;
-                        if (o.result_mode.force_files) has_force = true;
+                        if (o.result_mode.requires_param)
+                            use_common = false;
+                        if (o.result_mode.no_files)
+                            use_files = false;
+                        if (o.result_mode.force_files)
+                            has_force = true;
                         complete_from_args(str, o.comp, o.localized_desc(), o.flags);
                     }
                 }
@@ -1027,7 +1048,8 @@ bool completer_t::complete_param_for_command(const wcstring &cmd_orig, const wcs
                         // token, so that it can be differed from a regular argument.
                         // Here we are testing the previous argument for a GNU-style match,
                         // to see how we should complete the current argument
-                        if (!o.result_mode.requires_param) continue;
+                        if (!o.result_mode.requires_param)
+                            continue;
 
                         bool match = false;
                         if (o.type == option_type_short) {
@@ -1040,9 +1062,12 @@ bool completer_t::complete_param_for_command(const wcstring &cmd_orig, const wcs
                             match = param_match(&o, popt.c_str());
                         }
                         if (match && this->condition_test(o.condition)) {
-                            if (o.result_mode.requires_param) use_common = false;
-                            if (o.result_mode.no_files) use_files = false;
-                            if (o.result_mode.force_files) has_force = true;
+                            if (o.result_mode.requires_param)
+                                use_common = false;
+                            if (o.result_mode.no_files)
+                                use_files = false;
+                            if (o.result_mode.force_files)
+                                has_force = true;
                             complete_from_args(str, o.comp, o.localized_desc(), o.flags);
                         }
                     }
@@ -1057,7 +1082,8 @@ bool completer_t::complete_param_for_command(const wcstring &cmd_orig, const wcs
         // Now we try to complete an option itself
         for (const complete_entry_opt_t &o : options) {
             // If this entry is for the base command, check if any of the arguments match.
-            if (!this->condition_test(o.condition)) continue;
+            if (!this->condition_test(o.condition))
+                continue;
             if (o.option.empty()) {
                 use_files = use_files && (!(o.result_mode.no_files));
                 has_force = has_force || o.result_mode.force_files;
@@ -1075,14 +1101,18 @@ bool completer_t::complete_param_for_command(const wcstring &cmd_orig, const wcs
                     // str has no short option at all (but perhaps it is the
                     // prefix of a single long option).
                     // Only complete short options if there is no character after the dash.
-                    if (str != L"-") continue;
+                    if (str != L"-")
+                        continue;
                 } else {
                     // Only complete when the last short option has no parameter yet..
-                    if (short_opt_pos + 1 != str.size()) continue;
+                    if (short_opt_pos + 1 != str.size())
+                        continue;
                     // .. and it does not require one ..
-                    if (last_option_requires_param) continue;
+                    if (last_option_requires_param)
+                        continue;
                     // .. and the option is not already there.
-                    if (str.find(optchar) != wcstring::npos) continue;
+                    if (str.find(optchar) != wcstring::npos)
+                        continue;
                 }
                 // It's a match.
                 wcstring desc = o.localized_desc();
@@ -1156,11 +1186,13 @@ bool completer_t::complete_param_for_command(const wcstring &cmd_orig, const wcs
 /// Perform generic (not command-specific) expansions on the specified string.
 void completer_t::complete_param_expand(const wcstring &str, bool do_file,
                                         bool handle_as_special_cd) {
-    if (ctx.check_cancel()) return;
+    if (ctx.check_cancel())
+        return;
     expand_flags_t flags =
         this->expand_flags() | expand_flag::skip_cmdsubst | expand_flag::for_completions;
 
-    if (!do_file) flags |= expand_flag::skip_wildcards;
+    if (!do_file)
+        flags |= expand_flag::skip_wildcards;
 
     if (handle_as_special_cd && do_file) {
         if (this->type() == COMPLETE_AUTOSUGGEST) {
@@ -1171,7 +1203,8 @@ void completer_t::complete_param_expand(const wcstring &str, bool do_file,
     }
 
     // Squelch file descriptions per issue #254.
-    if (this->type() == COMPLETE_AUTOSUGGEST || do_file) flags.clear(expand_flag::gen_descriptions);
+    if (this->type() == COMPLETE_AUTOSUGGEST || do_file)
+        flags.clear(expand_flag::gen_descriptions);
 
     // We have the following cases:
     //
@@ -1208,7 +1241,8 @@ void completer_t::complete_param_expand(const wcstring &str, bool do_file,
     if (complete_from_start) {
         // Don't do fuzzy matching for files if the string begins with a dash (issue #568). We could
         // consider relaxing this if there was a preceding double-dash argument.
-        if (string_prefixes_string(L"-", str)) flags.clear(expand_flag::fuzzy_match);
+        if (string_prefixes_string(L"-", str))
+            flags.clear(expand_flag::fuzzy_match);
 
         if (expand_string(str, &this->completions, flags, ctx) == expand_result_t::error) {
             FLOGF(complete, L"Error while expanding string '%ls'", str.c_str());
@@ -1228,7 +1262,8 @@ bool completer_t::complete_variable(const wcstring &str, size_t start_offset) {
         bool anchor_start = !fuzzy();
         maybe_t<string_fuzzy_match_t> match =
             string_fuzzy_match_string(var, env_name, anchor_start);
-        if (!match) continue;
+        if (!match)
+            continue;
 
         wcstring comp;
         complete_flags_t flags = 0;
@@ -1251,13 +1286,15 @@ bool completer_t::complete_variable(const wcstring &str, size_t start_offset) {
                     std::shared_ptr<history_t> history =
                         history_t::with_name(history_session_id(ctx.vars));
                     for (size_t i = 1; i < history->size() && desc.size() < 64; i++) {
-                        if (i > 1) desc += L' ';
+                        if (i > 1)
+                            desc += L' ';
                         desc += expand_escape_string(history->item_at_index(i).str());
                     }
                 } else {
                     // Can't use ctx.vars here, it could be any variable.
                     auto var = ctx.vars.get(env_name);
-                    if (!var) continue;
+                    if (!var)
+                        continue;
 
                     wcstring value = expand_escape_variable(*var);
                     desc = format_string(COMPLETE_VAR_DESC_VAL, value.c_str());
@@ -1348,11 +1385,13 @@ bool completer_t::try_complete_user(const wcstring &str) {
     const wchar_t *cmd = str.c_str();
     const wchar_t *first_char = cmd;
 
-    if (*first_char != L'~' || std::wcschr(first_char, L'/')) return false;
+    if (*first_char != L'~' || std::wcschr(first_char, L'/'))
+        return false;
 
     const wchar_t *user_name = first_char + 1;
     const wchar_t *name_end = std::wcschr(user_name, L'~');
-    if (name_end) return false;
+    if (name_end)
+        return false;
 
     double start_time = timef();
     bool result = false;
@@ -1386,7 +1425,8 @@ bool completer_t::try_complete_user(const wcstring &str) {
         }
 
         // If we've spent too much time (more than 200 ms) doing this give up.
-        if (timef() - start_time > 0.2) break;
+        if (timef() - start_time > 0.2)
+            break;
     }
 
     endpwent();
@@ -1397,7 +1437,8 @@ bool completer_t::try_complete_user(const wcstring &str) {
 // If we have variable assignments, attempt to apply them in our parser. As soon as the return
 // value goes out of scope, the variables will be removed from the parser.
 cleanup_t completer_t::apply_var_assignments(const wcstring_list_t &var_assignments) {
-    if (!ctx.parser || var_assignments.empty()) return cleanup_t{[] {}};
+    if (!ctx.parser || var_assignments.empty())
+        return cleanup_t{[] {}};
     env_stack_t &vars = ctx.parser->vars();
     assert(&vars == &ctx.vars &&
            "Don't know how to tab complete with a parser but a different variable set");
@@ -1426,7 +1467,8 @@ cleanup_t completer_t::apply_var_assignments(const wcstring_list_t &var_assignme
             }
         }
         ctx.parser->vars().set(variable_name, ENV_LOCAL | ENV_EXPORT, std::move(vals));
-        if (ctx.check_cancel()) break;
+        if (ctx.check_cancel())
+            break;
     }
     return cleanup_t([=] { ctx.parser->pop_block(block); });
 }
@@ -1434,7 +1476,8 @@ cleanup_t completer_t::apply_var_assignments(const wcstring_list_t &var_assignme
 // Complete a command by invoking user-specified completions.
 void completer_t::complete_custom(const wcstring &cmd, const wcstring &cmdline,
                                   custom_arg_data_t *ad) {
-    if (ctx.check_cancel()) return;
+    if (ctx.check_cancel())
+        return;
 
     bool is_autosuggest = this->type() == COMPLETE_AUTOSUGGEST;
     // Perhaps set a transient commandline so that custom completions
@@ -1449,7 +1492,8 @@ void completer_t::complete_custom(const wcstring &cmd, const wcstring &cmdline,
 
     // Maybe apply variable assignments.
     cleanup_t restore_vars{apply_var_assignments(*ad->var_assignments)};
-    if (ctx.check_cancel()) return;
+    if (ctx.check_cancel())
+        return;
 
     if (!complete_param_for_command(
             cmd, ad->previous_argument, ad->current_argument, !ad->had_ddash,
@@ -1467,8 +1511,10 @@ void completer_t::complete_custom(const wcstring &cmd, const wcstring &cmdline,
 void completer_t::walk_wrap_chain(const wcstring &cmd, const wcstring &cmdline,
                                   source_range_t cmdrange, custom_arg_data_t *ad) {
     // Limit our recursion depth. This prevents cycles in the wrap chain graph from overflowing.
-    if (ad->wrap_depth > 24) return;
-    if (ctx.cancel_checker()) return;
+    if (ad->wrap_depth > 24)
+        return;
+    if (ctx.cancel_checker())
+        return;
 
     // Extract command from the command line and invoke the receiver with it.
     complete_custom(cmd, cmdline, ad);
@@ -1542,13 +1588,16 @@ void completer_t::escape_opening_brackets(const wcstring &argument) {
             }
         }
     }
-    if (!have_unquoted_unescaped_bracket) return;
+    if (!have_unquoted_unescaped_bracket)
+        return;
     // Since completion_apply_to_command_line will escape the completion, we need to provide an
     // unescaped version.
     wcstring unescaped_argument;
-    if (!unescape_string(argument, &unescaped_argument, UNESCAPE_INCOMPLETE)) return;
+    if (!unescape_string(argument, &unescaped_argument, UNESCAPE_INCOMPLETE))
+        return;
     for (completion_t &comp : completions.get_list()) {
-        if (comp.flags & COMPLETE_REPLACES_TOKEN) continue;
+        if (comp.flags & COMPLETE_REPLACES_TOKEN)
+            continue;
         comp.flags |= COMPLETE_REPLACES_TOKEN;
         if (comp.flags & COMPLETE_DONT_ESCAPE) {
             // If the completion won't be escaped, we need to do it here.
@@ -1600,7 +1649,8 @@ void completer_t::perform_for_commandline(wcstring cmdline) {
         ++ctx.parser->libdata().complete_recursion_level;
     };
     cleanup_t decrement{[this]() {
-        if (ctx.parser) --ctx.parser->libdata().complete_recursion_level;
+        if (ctx.parser)
+            --ctx.parser->libdata().complete_recursion_level;
     }};
 
     const size_t cursor_pos = cmdline.size();
@@ -1628,9 +1678,11 @@ void completer_t::perform_for_commandline(wcstring cmdline) {
     // This is a list of (escaped) strings of the form VAR=VAL.
     wcstring_list_t var_assignments;
     for (const tok_t &tok : tokens) {
-        if (tok.location_in_or_at_end_of_source_range(cursor_pos)) break;
+        if (tok.location_in_or_at_end_of_source_range(cursor_pos))
+            break;
         wcstring tok_src = tok.get_source(cmdline);
-        if (!variable_assignment_equals_pos(tok_src)) break;
+        if (!variable_assignment_equals_pos(tok_src))
+            break;
         var_assignments.push_back(std::move(tok_src));
     }
     tokens.erase(tokens.begin(), tokens.begin() + var_assignments.size());
@@ -1638,7 +1690,8 @@ void completer_t::perform_for_commandline(wcstring cmdline) {
     // Empty process (cursor is after one of ;, &, |, \n, &&, || modulo whitespace).
     if (tokens.empty()) {
         // Don't autosuggest anything based on the empty string (generalizes #1631).
-        if (is_autosuggest) return;
+        if (is_autosuggest)
+            return;
 
         complete_cmd(L"");
         complete_abbr(L"");
@@ -1649,8 +1702,10 @@ void completer_t::perform_for_commandline(wcstring cmdline) {
     const tok_t &cur_tok = tokens.back();
 
     // Since fish does not currently support redirect in command position, we return here.
-    if (cmd_tok.type != token_type_t::string) return;
-    if (cur_tok.type == token_type_t::error) return;
+    if (cmd_tok.type != token_type_t::string)
+        return;
+    if (cur_tok.type == token_type_t::error)
+        return;
     for (const auto &tok : tokens) {  // If there was an error, it was in the last token.
         assert(tok.type == token_type_t::string || tok.type == token_type_t::redirect);
     }
@@ -1745,7 +1800,8 @@ void completer_t::perform_for_commandline(wcstring cmdline) {
 
     // Maybe apply variable assignments.
     cleanup_t restore_vars{apply_var_assignments(var_assignments)};
-    if (ctx.check_cancel()) return;
+    if (ctx.check_cancel())
+        return;
 
     // This function wants the unescaped string.
     complete_param_expand(current_argument, do_file, handle_as_special_cd);
@@ -1773,11 +1829,13 @@ completion_list_t complete(const wcstring &cmd_with_subcmds, completion_request_
 /// Print the short switch \c opt, and the argument \c arg to the specified
 /// wcstring, but only if \c argument isn't an empty string.
 static void append_switch(wcstring &out, wchar_t opt, const wcstring &arg) {
-    if (arg.empty()) return;
+    if (arg.empty())
+        return;
     append_format(out, L" -%lc %ls", opt, escape_string(arg, ESCAPE_ALL).c_str());
 }
 static void append_switch(wcstring &out, const wcstring &opt, const wcstring &arg) {
-    if (arg.empty()) return;
+    if (arg.empty())
+        return;
     append_format(out, L" --%ls %ls", opt.c_str(), escape_string(arg, ESCAPE_ALL).c_str());
 }
 static void append_switch(wcstring &out, wchar_t opt) { append_format(out, L" -%lc", opt); }
@@ -1790,7 +1848,8 @@ static wcstring completion2string(const complete_entry_opt_t &o, const wcstring 
     wcstring out;
     out.append(L"complete");
 
-    if (o.flags & COMPLETE_DONT_SORT) append_switch(out, L'k');
+    if (o.flags & COMPLETE_DONT_SORT)
+        append_switch(out, L'k');
 
     if (o.result_mode.no_files && o.result_mode.requires_param) {
         append_switch(out, L"exclusive");
@@ -1844,7 +1903,8 @@ wcstring complete_print(const wcstring &cmd) {
     sort(all_completions.begin(), all_completions.end(), compare_completions_by_order);
 
     for (const completion_entry_t &e : all_completions) {
-        if (!cmd.empty() && e.cmd != cmd) continue;
+        if (!cmd.empty() && e.cmd != cmd)
+            continue;
         const option_list_t &options = e.get_options();
         for (const complete_entry_opt_t &o : options) {
             out.append(completion2string(o, e.cmd, e.cmd_is_path));
@@ -1855,7 +1915,8 @@ wcstring complete_print(const wcstring &cmd) {
     auto locked_wrappers = wrapper_map.acquire();
     for (const auto &entry : *locked_wrappers) {
         const wcstring &src = entry.first;
-        if (!cmd.empty() && src != cmd) continue;
+        if (!cmd.empty() && src != cmd)
+            continue;
         for (const wcstring &target : entry.second) {
             out.append(L"complete ");
             out.append(escape_string(src, ESCAPE_ALL));
@@ -1885,7 +1946,8 @@ bool complete_add_wrapper(const wcstring &command, const wcstring &new_target) {
     // If the command and the target are the same,
     // there's no point in following the wrap-chain because we'd only complete the same thing.
     // TODO: This should maybe include full cycle detection.
-    if (command == new_target) return false;
+    if (command == new_target)
+        return false;
 
     auto locked_map = wrapper_map.acquire();
     wrapper_map_t &wraps = *locked_map;
@@ -1924,6 +1986,7 @@ wcstring_list_t complete_get_wrap_targets(const wcstring &command) {
     auto locked_map = wrapper_map.acquire();
     wrapper_map_t &wraps = *locked_map;
     auto iter = wraps.find(command);
-    if (iter == wraps.end()) return {};
+    if (iter == wraps.end())
+        return {};
     return iter->second;
 }

--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -192,7 +192,8 @@ static void guess_emoji_width(const environment_t &vars) {
 void env_dispatch_var_change(const wcstring &key, env_stack_t &vars) {
     ASSERT_IS_MAIN_THREAD();
     // Do nothing if not yet fully initialized.
-    if (!s_var_dispatch_table) return;
+    if (!s_var_dispatch_table)
+        return;
 
     s_var_dispatch_table->dispatch(key, vars);
 }
@@ -339,7 +340,8 @@ static void update_fish_color_support(const environment_t &vars) {
     bool support_term256 = false;
     bool support_term24bit = false;
 
-    if (auto term_var = vars.get(L"TERM")) term = term_var->as_string();
+    if (auto term_var = vars.get(L"TERM"))
+        term = term_var->as_string();
 
     if (auto fish_term256 = vars.get(L"fish_term256")) {
         // $fish_term256
@@ -352,7 +354,8 @@ static void update_fish_color_support(const environment_t &vars) {
     } else if (term.find(L"xterm") != wcstring::npos) {
         // Assume that all 'xterm's can handle 256, except for Terminal.app from Snow Leopard
         wcstring term_program;
-        if (auto tp = vars.get(L"TERM_PROGRAM")) term_program = tp->as_string();
+        if (auto tp = vars.get(L"TERM_PROGRAM"))
+            term_program = tp->as_string();
         if (term_program == L"Apple_Terminal") {
             auto tpv = vars.get(L"TERM_PROGRAM_VERSION");
             if (tpv && fish_wcstod(tpv->as_string().c_str(), nullptr) > 299) {
@@ -436,15 +439,19 @@ static bool initialize_curses_using_fallback(const char *term) {
     // seeing if the fallback name can be used.
     auto &vars = env_stack_t::globals();
     auto term_var = vars.get(L"TERM");
-    if (term_var.missing_or_empty()) return false;
+    if (term_var.missing_or_empty())
+        return false;
 
     auto term_env = wcs2string(term_var->as_string());
-    if (term_env == DEFAULT_TERM1 || term_env == DEFAULT_TERM2) return false;
+    if (term_env == DEFAULT_TERM1 || term_env == DEFAULT_TERM2)
+        return false;
 
-    if (is_interactive_session()) FLOGF(warning, _(L"Using fallback terminal type '%s'."), term);
+    if (is_interactive_session())
+        FLOGF(warning, _(L"Using fallback terminal type '%s'."), term);
 
     int err_ret;
-    if (setupterm(const_cast<char *>(term), STDOUT_FILENO, &err_ret) == OK) return true;
+    if (setupterm(const_cast<char *>(term), STDOUT_FILENO, &err_ret) == OK)
+        return true;
     if (is_interactive_session()) {
         FLOGF(warning, _(L"Could not set up terminal using the fallback terminal type '%s'."),
               term);
@@ -465,24 +472,33 @@ static const wchar_t *const title_terms[] = {L"xterm",  L"screen", L"tmux",
                                              L"nxterm", L"rxvt",   L"alacritty"};
 static bool does_term_support_setting_title(const environment_t &vars) {
     const auto term_var = vars.get(L"TERM");
-    if (term_var.missing_or_empty()) return false;
+    if (term_var.missing_or_empty())
+        return false;
 
     const wcstring term_str = term_var->as_string();
     const wchar_t *term = term_str.c_str();
     bool recognized = contains(title_terms, term_var->as_string());
-    if (!recognized) recognized = !std::wcsncmp(term, L"xterm-", const_strlen(L"xterm-"));
-    if (!recognized) recognized = !std::wcsncmp(term, L"screen-", const_strlen(L"screen-"));
-    if (!recognized) recognized = !std::wcsncmp(term, L"tmux-", const_strlen(L"tmux-"));
+    if (!recognized)
+        recognized = !std::wcsncmp(term, L"xterm-", const_strlen(L"xterm-"));
+    if (!recognized)
+        recognized = !std::wcsncmp(term, L"screen-", const_strlen(L"screen-"));
+    if (!recognized)
+        recognized = !std::wcsncmp(term, L"tmux-", const_strlen(L"tmux-"));
     if (!recognized) {
-        if (std::wcscmp(term, L"linux") == 0) return false;
-        if (std::wcscmp(term, L"dumb") == 0) return false;
+        if (std::wcscmp(term, L"linux") == 0)
+            return false;
+        if (std::wcscmp(term, L"dumb") == 0)
+            return false;
         // NetBSD
-        if (std::wcscmp(term, L"vt100") == 0) return false;
-        if (std::wcscmp(term, L"wsvt25") == 0) return false;
+        if (std::wcscmp(term, L"vt100") == 0)
+            return false;
+        if (std::wcscmp(term, L"wsvt25") == 0)
+            return false;
 
         char buf[PATH_MAX];
         int retval = ttyname_r(STDIN_FILENO, buf, PATH_MAX);
-        if (retval != 0 || std::strstr(buf, "tty") || std::strstr(buf, "/vc/")) return false;
+        if (retval != 0 || std::strstr(buf, "tty") || std::strstr(buf, "/vc/"))
+            return false;
     }
 
     return true;

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -103,8 +103,10 @@ static void set_signal_observed(int sig, bool val) {
 static bool handler_matches(const event_handler_t &classv, const event_t &instance,
                             bool &only_once) {
     only_once = false;
-    if (classv.desc.type == event_type_t::any) return true;
-    if (classv.desc.type != instance.desc.type) return false;
+    if (classv.desc.type == event_type_t::any)
+        return true;
+    if (classv.desc.type != instance.desc.type)
+        return false;
 
     switch (classv.desc.type) {
         case event_type_t::signal: {
@@ -114,7 +116,8 @@ static bool handler_matches(const event_handler_t &classv, const event_t &instan
             return instance.desc.str_param1 == classv.desc.str_param1;
         }
         case event_type_t::exit: {
-            if (classv.desc.param1.pid == EVENT_ANY_PID) return true;
+            if (classv.desc.param1.pid == EVENT_ANY_PID)
+                return true;
             only_once = true;
             return classv.desc.param1.pid == instance.desc.param1.pid;
         }
@@ -139,7 +142,8 @@ static int event_is_blocked(parser_t &parser, const event_t &e) {
     const block_t *block;
     size_t idx = 0;
     while ((block = parser.block_at_index(idx++))) {
-        if (event_block_list_blocks_type(block->event_blocks)) return true;
+        if (event_block_list_blocks_type(block->event_blocks))
+            return true;
     }
     return event_block_list_blocks_type(parser.global_event_blocks);
 }
@@ -315,9 +319,11 @@ static void event_fire_internal(parser_t &parser, const event_t &event) {
 void event_fire_delayed(parser_t &parser) {
     auto &ld = parser.libdata();
     // Do not invoke new event handlers from within event handlers.
-    if (ld.is_event) return;
+    if (ld.is_event)
+        return;
     // Do not invoke new event handlers if we are unwinding (#6649).
-    if (signal_check_cancel()) return;
+    if (signal_check_cancel())
+        return;
 
     std::vector<shared_ptr<const event_t>> to_send;
     to_send.swap(ld.blocked_events);
@@ -431,7 +437,8 @@ void event_print(io_streams_t &streams, maybe_t<event_type_t> type_filter) {
         }
 
         if (!last_type || *last_type != evt->desc.type) {
-            if (last_type) streams.out.append(L"\n");
+            if (last_type)
+                streams.out.append(L"\n");
             last_type = evt->desc.type;
             streams.out.append_format(L"Event %ls\n", event_name_for_type(*last_type));
         }
@@ -464,7 +471,8 @@ void event_fire_generic(parser_t &parser, const wchar_t *name, const wcstring_li
 
     event_t ev(event_type_t::generic);
     ev.desc.str_param1 = name;
-    if (args) ev.arguments = *args;
+    if (args)
+        ev.arguments = *args;
     event_fire(parser, ev);
 }
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -93,7 +93,8 @@ static int exit_code_from_exec_error(int err) {
 /// \return true if either there is no NUL byte, or there is a line containing a lowercase letter
 /// before the first NUL byte.
 static bool is_thompson_shell_payload(const char *p, size_t n) {
-    if (!memchr(p, '\0', n)) return true;
+    if (!memchr(p, '\0', n))
+        return true;
     bool haslower = false;
     for (; *p; p++) {
         if (islower(*p) || *p == '$' || *p == '`') {
@@ -214,7 +215,8 @@ static bool can_use_posix_spawn_for_job(const std::shared_ptr<job_t> &job,
     // to add a dup2 action, it would be ignored and the CLO_EXEC bit would remain. So don't use
     // posix_spawn in this case; instead we'll call fork() and clear the CLO_EXEC bit manually.
     for (const auto &action : dup2s.get_actions()) {
-        if (action.src == action.target) return false;
+        if (action.src == action.target)
+            return false;
     }
     if (job->wants_job_control()) {  //!OCLINT(collapsible if statements)
         // We are going to use job control; therefore when we launch this job it will get its own
@@ -443,7 +445,8 @@ static launch_result_t fork_child_for_process(const std::shared_ptr<job_t> &job,
     // The parent attempts to send the child to its pgroup.
     // EACCESS is an expected benign error as the child may have called exec().
     if (int err = execute_setpgid(p->pid, pgid, true /* is parent */)) {
-        if (err != EACCES) report_setpgid_error(err, true /* is_parent */, pgid, job.get(), p);
+        if (err != EACCES)
+            report_setpgid_error(err, true /* is_parent */, pgid, job.get(), p);
     }
     terminal_maybe_give_to_job_group(job->group.get(), false);
     return launch_result_t::ok;
@@ -507,8 +510,10 @@ static void handle_builtin_output(parser_t &parser, const std::shared_ptr<job_t>
     std::string errbuff = wcs2string(err.contents());
 
     // Some historical behavior.
-    if (!outbuff.empty()) fflush(stdout);
-    if (!errbuff.empty()) fflush(stderr);
+    if (!outbuff.empty())
+        fflush(stdout);
+    if (!errbuff.empty())
+        fflush(stderr);
 
     // Construct and run our background process.
     run_internal_process_or_short_circuit(parser, j, p, std::move(outbuff), std::move(errbuff),
@@ -884,7 +889,8 @@ static launch_result_t exec_process_in_job(parser_t &parser, process_t *p,
 
     const block_t *block = nullptr;
     cleanup_t pop_block([&]() {
-        if (block) parser.pop_block(block);
+        if (block)
+            parser.pop_block(block);
     });
     if (!p->variable_assignments.empty()) {
         block = parser.push_block(block_t::variable_assignment_block());
@@ -951,10 +957,12 @@ static launch_result_t exec_process_in_job(parser_t &parser, process_t *p,
 // Any such process (only one per job) will be called the "deferred" process.
 static process_t *get_deferred_process(const shared_ptr<job_t> &j) {
     // Common case is no deferred proc.
-    if (j->processes.size() <= 1) return nullptr;
+    if (j->processes.size() <= 1)
+        return nullptr;
 
     // Skip execs, which can only appear at the front.
-    if (j->processes.front()->type == process_type_t::exec) return nullptr;
+    if (j->processes.front()->type == process_type_t::exec)
+        return nullptr;
 
     // Find the last non-external process, and return it if it pipes into an extenal process.
     for (auto i = j->processes.rbegin(); i != j->processes.rend(); ++i) {
@@ -972,7 +980,8 @@ static void abort_pipeline_from(const shared_ptr<job_t> &job, const process_t *f
     bool found = false;
     for (process_ptr_t &p : job->processes) {
         found = found || (p.get() == failed_proc);
-        if (found) p->mark_aborted_before_launch();
+        if (found)
+            p->mark_aborted_before_launch();
     }
     assert(found && "Process not present in job");
 }
@@ -982,11 +991,13 @@ static void abort_pipeline_from(const shared_ptr<job_t> &job, const process_t *f
 // \return true if we should allow exec, false to disallow it.
 static bool allow_exec_with_background_jobs(parser_t &parser) {
     // If we're not interactive, we cannot warn.
-    if (!parser.is_interactive()) return true;
+    if (!parser.is_interactive())
+        return true;
 
     // Construct the list of running background jobs.
     job_list_t bgs = jobs_requiring_warning_on_exit(parser);
-    if (bgs.empty()) return true;
+    if (bgs.empty())
+        return true;
 
     // Compare run counts, so we only warn once.
     uint64_t current_run_count = reader_run_count();

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -68,10 +68,12 @@ static void remove_internal_separator(wcstring *s, bool conv);
 ///
 /// \param in the string to test
 static bool expand_is_clean(const wcstring &in) {
-    if (in.empty()) return true;
+    if (in.empty())
+        return true;
 
     // Test characters that have a special meaning in the first character position.
-    if (std::wcschr(UNCLEAN_FIRST, in.at(0)) != nullptr) return false;
+    if (std::wcschr(UNCLEAN_FIRST, in.at(0)) != nullptr)
+        return false;
 
     // Test characters that have a special meaning in any character position.
     return in.find_first_of(UNCLEAN) == wcstring::npos;
@@ -80,7 +82,8 @@ static bool expand_is_clean(const wcstring &in) {
 /// Append a syntax error to the given error list.
 static void append_syntax_error(parse_error_list_t *errors, size_t source_start, const wchar_t *fmt,
                                 ...) {
-    if (!errors) return;
+    if (!errors)
+        return;
 
     parse_error_t error;
     error.source_start = source_start;
@@ -100,7 +103,8 @@ static void append_syntax_error(parse_error_list_t *errors, size_t source_start,
 /// could consequently be recorded more than once.
 static void append_cmdsub_error(parse_error_list_t *errors, size_t source_start, const wchar_t *fmt,
                                 ...) {
-    if (!errors) return;
+    if (!errors)
+        return;
 
     parse_error_t error;
     error.source_start = source_start;
@@ -113,7 +117,8 @@ static void append_cmdsub_error(parse_error_list_t *errors, size_t source_start,
     va_end(va);
 
     for (const auto &it : *errors) {
-        if (error.text == it.text) return;
+        if (error.text == it.text)
+            return;
     }
 
     errors->push_back(error);
@@ -145,7 +150,8 @@ wcstring expand_escape_variable(const env_var_t &var) {
 
     for (size_t j = 0; j < lst.size(); j++) {
         const wcstring &el = lst.at(j);
-        if (j) buff.append(L"  ");
+        if (j)
+            buff.append(L"  ");
 
         // We want to use quotes if we have more than one string, or the string contains a space.
         bool prefer_quotes = lst.size() > 1 || el.find(L' ') != wcstring::npos;
@@ -335,7 +341,8 @@ static expand_result_t expand_variables(wcstring instr, completion_receiver_t *o
             var_name_stop++;
             break;
         }
-        if (!valid_var_name_char(nc)) break;
+        if (!valid_var_name_char(nc))
+            break;
         var_name_stop++;
     }
     assert(var_name_stop >= var_name_start && "Bogus variable name indexes");
@@ -516,7 +523,8 @@ static expand_result_t expand_braces(wcstring &&instr, expand_flags_t flags,
     for (const wchar_t *pos = in; (*pos) && !syntax_error; pos++) {
         switch (*pos) {
             case BRACE_BEGIN: {
-                if (brace_count == 0) brace_begin = pos;
+                if (brace_count == 0)
+                    brace_begin = pos;
                 brace_count++;
                 break;
             }
@@ -530,7 +538,8 @@ static expand_result_t expand_braces(wcstring &&instr, expand_flags_t flags,
                 break;
             }
             case BRACE_SEP: {
-                if (brace_count == 1) last_sep = pos;
+                if (brace_count == 1)
+                    last_sep = pos;
                 break;
             }
             default: {
@@ -596,7 +605,8 @@ static expand_result_t expand_braces(wcstring &&instr, expand_flags_t flags,
             expand_braces(std::move(whole_item), flags, out, errors);
 
             item_begin = pos + 1;
-            if (pos == brace_end) break;
+            if (pos == brace_end)
+                break;
         }
 
         if (*pos == BRACE_BEGIN) {
@@ -775,7 +785,8 @@ static void expand_home_directory(wcstring &input, const environment_t &vars) {
         }
 
         maybe_t<wcstring> realhome;
-        if (home) realhome = normalize_path(*home);
+        if (home)
+            realhome = normalize_path(*home);
 
         if (realhome) {
             input.replace(input.begin(), input.begin() + tail_idx, *realhome);
@@ -805,7 +816,8 @@ static void unexpand_tildes(const wcstring &input, const environment_t &vars,
                             completion_list_t *completions) {
     // If input begins with tilde, then try to replace the corresponding string in each completion
     // with the tilde. If it does not, there's nothing to do.
-    if (input.empty() || input.at(0) != L'~') return;
+    if (input.empty() || input.at(0) != L'~')
+        return;
 
     // We only operate on completions that replace their contents. If we don't have any, we're done.
     // In particular, empty vectors are common.
@@ -816,7 +828,8 @@ static void unexpand_tildes(const wcstring &input, const environment_t &vars,
             break;
         }
     }
-    if (!has_candidate_completion) return;
+    if (!has_candidate_completion)
+        return;
 
     size_t tail_idx;
     wcstring username_with_tilde = L"~";
@@ -1204,10 +1217,12 @@ expand_result_t expand_to_command_and_args(const wcstring &instr, const operatio
         bool first = true;
         for (auto &comp : completions) {
             if (first) {
-                if (out_cmd) *out_cmd = std::move(comp.completion);
+                if (out_cmd)
+                    *out_cmd = std::move(comp.completion);
                 first = false;
             } else {
-                if (out_args) out_args->push_back(std::move(comp.completion));
+                if (out_args)
+                    out_args->push_back(std::move(comp.completion));
             }
         }
     }
@@ -1229,7 +1244,8 @@ static std::string escape_single_quoted_hack_hack_hack_hack(const char *str) {
     for (size_t i = 0; i < len; i++) {
         char c = str[i];
         // Escape backslashes and single quotes only.
-        if (c == '\\' || c == '\'') result.push_back('\\');
+        if (c == '\\' || c == '\'')
+            result.push_back('\\');
         result.push_back(c);
     }
     result.push_back('\'');
@@ -1263,7 +1279,8 @@ bool fish_xdm_login_hack_hack_hack_hack(std::vector<std::string> *cmds, int argc
 }
 
 maybe_t<wcstring> expand_abbreviation(const wcstring &src, const environment_t &vars) {
-    if (src.empty()) return none();
+    if (src.empty())
+        return none();
 
     wcstring esc_src = escape_string(src, 0, STRING_STYLE_VAR);
     if (esc_src.empty()) {

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -99,7 +99,8 @@ int fish_mkstemp_cloexec(char *name_template) {
 }
 
 [[gnu::unused]] static int wcsncasecmp_fallback(const wchar_t *a, const wchar_t *b, size_t count) {
-    if (count == 0) return 0;
+    if (count == 0)
+        return 0;
 
     if (*a == 0) {
         return *b == 0 ? 0 : -1;
@@ -107,7 +108,8 @@ int fish_mkstemp_cloexec(char *name_template) {
         return 1;
     }
     int diff = towlower(*a) - towlower(*b);
-    if (diff != 0) return diff;
+    if (diff != 0)
+        return diff;
     return wcsncasecmp_fallback(a + 1, b + 1, count - 1);
 }
 
@@ -168,13 +170,15 @@ size_t wcslcpy(wchar_t *dst, const wchar_t *src, size_t siz) {
     // Copy as many bytes as will fit.
     if (n != 0 && --n != 0) {
         do {
-            if ((*d++ = *s++) == 0) break;
+            if ((*d++ = *s++) == 0)
+                break;
         } while (--n != 0);
     }
 
     // Not enough room in dst, add NUL and traverse rest of src.
     if (n == 0) {
-        if (siz != 0) *d = '\0';  // NUL-terminate dst
+        if (siz != 0)
+            *d = '\0';  // NUL-terminate dst
         while (*s++)
             ;  // ignore rest of src
     }
@@ -230,7 +234,8 @@ static int fish_get_emoji_width(wchar_t c) {
     (void)c;
     // Respect an explicit value. If we don't have one, use the guessed value. Do not try to fall
     // back to wcwidth(), it's hopeless.
-    if (g_fish_emoji_width > 0) return g_fish_emoji_width;
+    if (g_fish_emoji_width > 0)
+        return g_fish_emoji_width;
     return g_guessed_fish_emoji_width;
 }
 
@@ -259,7 +264,8 @@ int fish_wcwidth(wchar_t wc) {
     // These can either appear in combined form, taking 0 width themselves,
     // or standalone with a 1 width. Since that's literally not expressible with wcwidth(),
     // we take the position that the typical way for them to show up is composed.
-    if (wc >= L'\u1160' && wc <= L'\u11FF') return 0;
+    if (wc >= L'\u1160' && wc <= L'\u11FF')
+        return 0;
     int width = widechar_wcwidth(wc);
 
     switch (width) {
@@ -356,7 +362,8 @@ int flock(int fd, int op) {
     fl.l_whence = SEEK_SET;
     rc = fcntl(fd, op & LOCK_NB ? F_SETLK : F_SETLKW, &fl);
 
-    if (rc && (errno == EAGAIN)) errno = EWOULDBLOCK;
+    if (rc && (errno == EAGAIN))
+        errno = EWOULDBLOCK;
 
     return rc;
 }

--- a/src/fd_monitor.cpp
+++ b/src/fd_monitor.cpp
@@ -80,7 +80,8 @@ void fd_monitor_t::poke_item(fd_monitor_item_id_t item_id) {
 
 uint64_t fd_monitor_item_t::usec_remaining(const time_point_t &now) const {
     assert(last_time.has_value() && "Should always have a last_time");
-    if (timeout_usec == kNoTimeout) return kNoTimeout;
+    if (timeout_usec == kNoTimeout)
+        return kNoTimeout;
     assert(now >= *last_time && "steady clock went backwards!");
     uint64_t since = static_cast<uint64_t>(
         std::chrono::duration_cast<std::chrono::microseconds>(now - *last_time).count());
@@ -132,7 +133,8 @@ void fd_monitor_t::run_in_background() {
 
         for (auto &item : items_) {
             fds.add(item.fd.fd());
-            if (!item.last_time.has_value()) item.last_time = now;
+            if (!item.last_time.has_value())
+                item.last_time = now;
             timeout_usec = std::min(timeout_usec, item.usec_remaining(now));
         }
 
@@ -159,7 +161,8 @@ void fd_monitor_t::run_in_background() {
         auto servicer = [&fds, &now](fd_monitor_item_t &item) {
             int fd = item.fd.fd();
             bool remove = !item.service_item(fds, now);
-            if (remove) FLOG(fd_monitor, "Removing fd", fd);
+            if (remove)
+                FLOG(fd_monitor, "Removing fd", fd);
             return remove;
         };
 
@@ -204,7 +207,8 @@ void fd_monitor_t::poke_in_background(const poke_list_t &pokelist) {
     auto poker = [&pokelist](fd_monitor_item_t &item) {
         int fd = item.fd.fd();
         bool remove = !item.poke_item(pokelist);
-        if (remove) FLOG(fd_monitor, "Removing fd", fd);
+        if (remove)
+            FLOG(fd_monitor, "Removing fd", fd);
         return remove;
     };
     items_.erase(std::remove_if(items_.begin(), items_.end(), poker), items_.end());

--- a/src/fds.cpp
+++ b/src/fds.cpp
@@ -30,7 +30,8 @@ static constexpr uint64_t kUsecPerMsec = 1000;
 static constexpr uint64_t kUsecPerSec = 1000 * kUsecPerMsec;
 
 void autoclose_fd_t::close() {
-    if (fd_ < 0) return;
+    if (fd_ < 0)
+        return;
     exec_close(fd_);
     fd_ = -1;
 }
@@ -64,7 +65,8 @@ int select_wrapper_t::select(uint64_t timeout_usec) {
 
 // static
 bool select_wrapper_t::is_fd_readable(int fd, uint64_t timeout_usec) {
-    if (fd < 0) return false;
+    if (fd < 0)
+        return false;
     select_wrapper_t s;
     s.add(fd);
     int res = s.select(timeout_usec);
@@ -163,7 +165,8 @@ static autoclose_fd_t heightenize_fd(autoclose_fd_t fd, bool input_has_cloexec) 
         return fd;
     }
     if (fd.fd() >= k_first_high_fd) {
-        if (!input_has_cloexec) set_cloexec(fd.fd());
+        if (!input_has_cloexec)
+            set_cloexec(fd.fd());
         return fd;
     }
 #if defined(F_DUPFD_CLOEXEC)
@@ -218,10 +221,12 @@ maybe_t<autoclose_pipes_t> make_autoclose_pipes() {
 
     // Ensure our fds are out of the user range.
     read_end = heightenize_fd(std::move(read_end), already_cloexec);
-    if (!read_end.valid()) return none();
+    if (!read_end.valid())
+        return none();
 
     write_end = heightenize_fd(std::move(write_end), already_cloexec);
-    if (!write_end.valid()) return none();
+    if (!write_end.valid())
+        return none();
 
     return autoclose_pipes_t(std::move(read_end), std::move(write_end));
 }
@@ -294,11 +299,13 @@ int fd_check_is_remote(int fd) {
     // ST_LOCAL is a flag to statvfs, which is itself standardized.
     // In practice the only system to use this path is NetBSD.
     struct statvfs buf {};
-    if (fstatvfs(fd, &buf) < 0) return -1;
+    if (fstatvfs(fd, &buf) < 0)
+        return -1;
     return (buf.f_flag & ST_LOCAL) ? 0 : 1;
 #elif defined(MNT_LOCAL)
     struct statfs buf {};
-    if (fstatfs(fd, &buf) < 0) return -1;
+    if (fstatfs(fd, &buf) < 0)
+        return -1;
     return (buf.f_flags & MNT_LOCAL) ? 0 : 1;
 #else
     return -1;

--- a/src/fds.h
+++ b/src/fds.h
@@ -44,7 +44,8 @@ class autoclose_fd_t {
 
     // Resets to a new fd, taking ownership.
     void reset(int fd) {
-        if (fd == fd_) return;
+        if (fd == fd_)
+            return;
         close();
         fd_ = fd;
     }

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -431,7 +431,8 @@ int main(int argc, char **argv) {
     // --debug-output takes precedence, otherwise $FISH_DEBUG_OUTPUT is used.
     if (opts.debug_output.empty()) {
         const char *var = getenv("FISH_DEBUG_OUTPUT");
-        if (var) opts.debug_output = var;
+        if (var)
+            opts.debug_output = var;
     }
 
     FILE *debug_output = nullptr;
@@ -454,10 +455,14 @@ int main(int argc, char **argv) {
     }
 
     // Apply our options.
-    if (opts.is_login) mark_login();
-    if (opts.no_exec) mark_no_exec();
-    if (opts.is_interactive_session) set_interactive_session(true);
-    if (opts.enable_private_mode) start_private_mode(env_stack_t::globals());
+    if (opts.is_login)
+        mark_login();
+    if (opts.no_exec)
+        mark_no_exec();
+    if (opts.is_interactive_session)
+        set_interactive_session(true);
+    if (opts.enable_private_mode)
+        start_private_mode(env_stack_t::globals());
 
     // Only save (and therefore restore) the fg process group if we are interactive. See issues
     // #197 and #1002.

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -242,7 +242,8 @@ struct pretty_printer_t {
     // Return the gap ranges from our ast.
     std::vector<source_range_t> compute_gaps() const {
         auto range_compare = [](source_range_t r1, source_range_t r2) {
-            if (r1.start != r2.start) return r1.start < r2.start;
+            if (r1.start != r2.start)
+                return r1.start < r2.start;
             return r1.length < r2.length;
         };
         // Collect the token ranges into a list.
@@ -250,7 +251,8 @@ struct pretty_printer_t {
         for (const node_t &node : ast) {
             if (node.category == category_t::leaf) {
                 auto r = node.source_range();
-                if (r.length > 0) tok_ranges.push_back(r);
+                if (r.length > 0)
+                    tok_ranges.push_back(r);
             }
         }
         // Place a zero length range at end to aid in our inverting.
@@ -297,7 +299,8 @@ struct pretty_printer_t {
 
             // If there is no and-or tail then we always use a newline.
             if (andors && andors->count() > 0) {
-                if (condition) mark_semi_from_input(*condition);
+                if (condition)
+                    mark_semi_from_input(*condition);
                 // Mark all but last of the andor list.
                 for (uint32_t i = 0; i + 1 < andors->count(); i++) {
                     mark_semi_from_input(andors->at(i)->job.semi_nl);
@@ -315,11 +318,13 @@ struct pretty_printer_t {
                     prev_job_semi_nl = job.semi_nl.contents.get();
 
                     // Is this an 'and' or 'or' job?
-                    if (!job.decorator) continue;
+                    if (!job.decorator)
+                        continue;
 
                     // Now see if we want to mark 'prev' as allowing a semi.
                     // Did we have a previous semi_nl which was a newline?
-                    if (!prev || substr(prev->range) != L";") continue;
+                    if (!prev || substr(prev->range) != L";")
+                        continue;
 
                     // Is there a newline between them?
                     assert(prev->range.start <= job.decorator->range.start &&
@@ -370,7 +375,8 @@ struct pretty_printer_t {
     bool emit_gap_text(source_range_t range, gap_flags_t flags) {
         wcstring gap_text = substr(range);
         // Common case: if we are only spaces, do nothing.
-        if (gap_text.find_first_not_of(L' ') == wcstring::npos) return false;
+        if (gap_text.find_first_not_of(L' ') == wcstring::npos)
+            return false;
 
         // Look to see if there is an escaped newline.
         // Emit it if either we allow it, or it comes before the first comment.
@@ -404,11 +410,13 @@ struct pretty_printer_t {
             if (needs_nl) {
                 emit_newline();
                 needs_nl = false;
-                if (tok_text == L"\n") continue;
+                if (tok_text == L"\n")
+                    continue;
             } else if (gap_text_mask_newline) {
                 // We only respect mask_newline the first time through the loop.
                 gap_text_mask_newline = false;
-                if (tok_text == L"\n") continue;
+                if (tok_text == L"\n")
+                    continue;
             }
 
             if (tok->type == token_type_t::comment) {
@@ -430,7 +438,8 @@ struct pretty_printer_t {
                 DIE("Gap text should only have comments and newlines");
             }
         }
-        if (needs_nl) emit_newline();
+        if (needs_nl)
+            emit_newline();
         return needs_nl;
     }
 
@@ -474,7 +483,8 @@ struct pretty_printer_t {
             // end
             // Here the comment is the gap text before the end, but we want the indent from the
             // command.
-            if (range.start < indents.size()) current_indent = indents.at(range.start);
+            if (range.start < indents.size())
+                current_indent = indents.at(range.start);
 
             // If this range contained an error, append the gap text without modification.
             // For example in: echo foo "

--- a/src/fish_key_reader.cpp
+++ b/src/fish_key_reader.cpp
@@ -54,12 +54,14 @@ static bool should_exit(wchar_t wc) {
     recent_chars[2] = recent_chars[3];
     recent_chars[3] = c;
     if (c == shell_modes.c_cc[VINTR]) {
-        if (recent_chars[2] == shell_modes.c_cc[VINTR]) return true;
+        if (recent_chars[2] == shell_modes.c_cc[VINTR])
+            return true;
         std::fwprintf(stderr, L"Press [ctrl-%c] again to exit\n", shell_modes.c_cc[VINTR] + 0x40);
         return false;
     }
     if (c == shell_modes.c_cc[VEOF]) {
-        if (recent_chars[2] == shell_modes.c_cc[VEOF]) return true;
+        if (recent_chars[2] == shell_modes.c_cc[VEOF])
+            return true;
         std::fwprintf(stderr, L"Press [ctrl-%c] again to exit\n", shell_modes.c_cc[VEOF] + 0x40);
         return false;
     }
@@ -210,7 +212,8 @@ static double output_elapsed_time(double prev_tstamp, bool first_char_seen) {
     double now = timef();
     long long int delta_tstamp_us = 1000000 * (now - prev_tstamp);
 
-    if (delta_tstamp_us >= 200000 && first_char_seen) std::fputwc(L'\n', stderr);
+    if (delta_tstamp_us >= 200000 && first_char_seen)
+        std::fputwc(L'\n', stderr);
     if (delta_tstamp_us >= 1000000) {
         std::fwprintf(stderr, L"              ");
     } else {
@@ -323,7 +326,8 @@ static bool parse_flags(int argc, char **argv, bool *continuous_mode) {
         }
     }
 
-    if (error) return false;
+    if (error)
+        return false;
 
     argc -= optind;
     if (argc != 0) {
@@ -338,7 +342,8 @@ int main(int argc, char **argv) {
     program_name = L"fish_key_reader";
     bool continuous_mode = false;
 
-    if (!parse_flags(argc, argv, &continuous_mode)) return 1;
+    if (!parse_flags(argc, argv, &continuous_mode))
+        return 1;
 
     if (!isatty(STDIN_FILENO)) {
         std::fwprintf(stderr, L"Stdin must be attached to a tty.\n");

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -109,7 +109,8 @@ static bool should_test_function(const char *func_name, bool default_on = true) 
             }
         }
     }
-    if (result) s_test_run_count++;
+    if (result)
+        s_test_run_count++;
     return result;
 }
 
@@ -1976,7 +1977,8 @@ static void test_lru() {
     for (int i = 0; i < total_nodes; i++) {
         do_test(cache.size() == size_t(std::min(i, 16)));
         do_test(cache.values() == expected_values);
-        if (i < 4) expected_evicted.push_back({to_string(i), i});
+        if (i < 4)
+            expected_evicted.push_back({to_string(i), i});
         // Adding the node the first time should work, and subsequent times should fail.
         do_test(cache.insert(to_string(i), i));
         do_test(!cache.insert(to_string(i), i + 1));
@@ -2006,7 +2008,8 @@ static void test_lru() {
             for (int v : vs) {
                 append_format(ret, L"%d,", v);
             }
-            if (!ret.empty()) ret.pop_back();
+            if (!ret.empty())
+                ret.pop_back();
             return ret;
         };
         err(L"LRU stable sort failed. Expected %ls, got %ls\n", commajoin(new_ints).c_str(),
@@ -2113,7 +2116,8 @@ static bool expand_test(const wchar_t *in, expand_flags_t flags, ...) {
             wcstring msg = L"Expected [";
             bool first = true;
             for (const wcstring &exp : expected) {
-                if (!first) msg += L", ";
+                if (!first)
+                    msg += L", ";
                 first = false;
                 msg += '"';
                 msg += exp;
@@ -2122,7 +2126,8 @@ static bool expand_test(const wchar_t *in, expand_flags_t flags, ...) {
             msg += L"], found [";
             first = true;
             for (const auto &completion : output) {
-                if (!first) msg += L", ";
+                if (!first)
+                    msg += L", ";
                 first = false;
                 msg += '"';
                 msg += completion.completion;
@@ -2166,21 +2171,36 @@ static void test_expand() {
     // aaa
     // aaa2
     //    x
-    if (system("mkdir -p test/fish_expand_test/")) err(L"mkdir failed");
-    if (system("mkdir -p test/fish_expand_test/bb/")) err(L"mkdir failed");
-    if (system("mkdir -p test/fish_expand_test/baz/")) err(L"mkdir failed");
-    if (system("mkdir -p test/fish_expand_test/bax/")) err(L"mkdir failed");
-    if (system("mkdir -p test/fish_expand_test/lol/nub/")) err(L"mkdir failed");
-    if (system("mkdir -p test/fish_expand_test/aaa/")) err(L"mkdir failed");
-    if (system("mkdir -p test/fish_expand_test/aaa2/")) err(L"mkdir failed");
-    if (system("touch test/fish_expand_test/.foo")) err(L"touch failed");
-    if (system("touch test/fish_expand_test/bb/x")) err(L"touch failed");
-    if (system("touch test/fish_expand_test/bar")) err(L"touch failed");
-    if (system("touch test/fish_expand_test/bax/xxx")) err(L"touch failed");
-    if (system("touch test/fish_expand_test/baz/xxx")) err(L"touch failed");
-    if (system("touch test/fish_expand_test/baz/yyy")) err(L"touch failed");
-    if (system("touch test/fish_expand_test/lol/nub/q")) err(L"touch failed");
-    if (system("touch test/fish_expand_test/aaa2/x")) err(L"touch failed");
+    if (system("mkdir -p test/fish_expand_test/"))
+        err(L"mkdir failed");
+    if (system("mkdir -p test/fish_expand_test/bb/"))
+        err(L"mkdir failed");
+    if (system("mkdir -p test/fish_expand_test/baz/"))
+        err(L"mkdir failed");
+    if (system("mkdir -p test/fish_expand_test/bax/"))
+        err(L"mkdir failed");
+    if (system("mkdir -p test/fish_expand_test/lol/nub/"))
+        err(L"mkdir failed");
+    if (system("mkdir -p test/fish_expand_test/aaa/"))
+        err(L"mkdir failed");
+    if (system("mkdir -p test/fish_expand_test/aaa2/"))
+        err(L"mkdir failed");
+    if (system("touch test/fish_expand_test/.foo"))
+        err(L"touch failed");
+    if (system("touch test/fish_expand_test/bb/x"))
+        err(L"touch failed");
+    if (system("touch test/fish_expand_test/bar"))
+        err(L"touch failed");
+    if (system("touch test/fish_expand_test/bax/xxx"))
+        err(L"touch failed");
+    if (system("touch test/fish_expand_test/baz/xxx"))
+        err(L"touch failed");
+    if (system("touch test/fish_expand_test/baz/yyy"))
+        err(L"touch failed");
+    if (system("touch test/fish_expand_test/lol/nub/q"))
+        err(L"touch failed");
+    if (system("touch test/fish_expand_test/aaa2/x"))
+        err(L"touch failed");
 
     // This is checking that .* does NOT match . and ..
     // (https://github.com/fish-shell/fish-shell/issues/270). But it does have to match literal
@@ -2263,7 +2283,8 @@ static void test_expand() {
         err(L"Expansion not correctly handling literal path components in dotfiles");
     }
 
-    if (!pushd("test/fish_expand_test")) return;
+    if (!pushd("test/fish_expand_test"))
+        return;
 
     expand_test(L"b/xx", fuzzy_comp, L"bax/xxx", L"baz/xxx", wnull, L"Wrong fuzzy matching 5");
 
@@ -2363,19 +2384,26 @@ static void test_abbreviations() {
     };
     for (const auto &kv : abbreviations) {
         int ret = vars.set_one(L"_fish_abbr_" + kv.first, ENV_LOCAL, kv.second);
-        if (ret != 0) err(L"Unable to set abbreviation variable");
+        if (ret != 0)
+            err(L"Unable to set abbreviation variable");
     }
 
-    if (expand_abbreviation(L"", vars)) err(L"Unexpected success with empty abbreviation");
-    if (expand_abbreviation(L"nothing", vars)) err(L"Unexpected success with missing abbreviation");
+    if (expand_abbreviation(L"", vars))
+        err(L"Unexpected success with empty abbreviation");
+    if (expand_abbreviation(L"nothing", vars))
+        err(L"Unexpected success with missing abbreviation");
 
     auto mresult = expand_abbreviation(L"gc", vars);
-    if (!mresult) err(L"Unexpected failure with gc abbreviation");
-    if (*mresult != L"git checkout") err(L"Wrong abbreviation result for gc");
+    if (!mresult)
+        err(L"Unexpected failure with gc abbreviation");
+    if (*mresult != L"git checkout")
+        err(L"Wrong abbreviation result for gc");
 
     mresult = expand_abbreviation(L"foo", vars);
-    if (!mresult) err(L"Unexpected failure with foo abbreviation");
-    if (*mresult != L"bar") err(L"Wrong abbreviation result for foo");
+    if (!mresult)
+        err(L"Unexpected failure with foo abbreviation");
+    if (*mresult != L"bar")
+        err(L"Wrong abbreviation result for foo");
 
     maybe_t<wcstring> result;
     auto expand_abbreviation_in_command = [](const wcstring &cmdline, size_t cursor_pos,
@@ -2388,46 +2416,55 @@ static void test_abbreviations() {
         return none_t();
     };
     result = expand_abbreviation_in_command(L"just a command", 3, vars);
-    if (result) err(L"Command wrongly expanded on line %ld", (long)__LINE__);
+    if (result)
+        err(L"Command wrongly expanded on line %ld", (long)__LINE__);
     result = expand_abbreviation_in_command(L"gc somebranch", 0, vars);
-    if (!result) err(L"Command not expanded on line %ld", (long)__LINE__);
+    if (!result)
+        err(L"Command not expanded on line %ld", (long)__LINE__);
 
     result = expand_abbreviation_in_command(L"gc somebranch", const_strlen(L"gc"), vars);
-    if (!result) err(L"gc not expanded");
+    if (!result)
+        err(L"gc not expanded");
     if (result != L"git checkout somebranch")
         err(L"gc incorrectly expanded on line %ld to '%ls'", (long)__LINE__, result->c_str());
 
     // Space separation.
     result = expand_abbreviation_in_command(L"gx somebranch", const_strlen(L"gc"), vars);
-    if (!result) err(L"gx not expanded");
+    if (!result)
+        err(L"gx not expanded");
     if (result != L"git checkout somebranch")
         err(L"gc incorrectly expanded on line %ld to '%ls'", (long)__LINE__, result->c_str());
 
     result = expand_abbreviation_in_command(L"echo hi ; gc somebranch",
                                             const_strlen(L"echo hi ; g"), vars);
-    if (!result) err(L"gc not expanded on line %ld", (long)__LINE__);
+    if (!result)
+        err(L"gc not expanded on line %ld", (long)__LINE__);
     if (result != L"echo hi ; git checkout somebranch")
         err(L"gc incorrectly expanded on line %ld", (long)__LINE__);
 
     result = expand_abbreviation_in_command(L"echo (echo (echo (echo (gc ",
                                             const_strlen(L"echo (echo (echo (echo (gc"), vars);
-    if (!result) err(L"gc not expanded on line %ld", (long)__LINE__);
+    if (!result)
+        err(L"gc not expanded on line %ld", (long)__LINE__);
     if (result != L"echo (echo (echo (echo (git checkout ")
         err(L"gc incorrectly expanded on line %ld to '%ls'", (long)__LINE__, result->c_str());
 
     // If commands should be expanded.
     result = expand_abbreviation_in_command(L"if gc", const_strlen(L"if gc"), vars);
-    if (!result) err(L"gc not expanded on line %ld", (long)__LINE__);
+    if (!result)
+        err(L"gc not expanded on line %ld", (long)__LINE__);
     if (result != L"if git checkout")
         err(L"gc incorrectly expanded on line %ld to '%ls'", (long)__LINE__, result->c_str());
 
     // Others should not be.
     result = expand_abbreviation_in_command(L"of gc", const_strlen(L"of gc"), vars);
-    if (result) err(L"gc incorrectly expanded on line %ld", (long)__LINE__);
+    if (result)
+        err(L"gc incorrectly expanded on line %ld", (long)__LINE__);
 
     // Others should not be.
     result = expand_abbreviation_in_command(L"command gc", const_strlen(L"command gc"), vars);
-    if (result) err(L"gc incorrectly expanded on line %ld", (long)__LINE__);
+    if (result)
+        err(L"gc incorrectly expanded on line %ld", (long)__LINE__);
 
     vars.pop();
 }
@@ -2483,15 +2520,19 @@ static void test_pager_navigation() {
     pager.set_term_size(termsize_t::defaults());
     page_rendering_t render = pager.render();
 
-    if (render.term_width != 80) err(L"Wrong term width");
-    if (render.term_height != 24) err(L"Wrong term height");
+    if (render.term_width != 80)
+        err(L"Wrong term width");
+    if (render.term_height != 24)
+        err(L"Wrong term height");
 
     size_t rows = 4, cols = 5;
 
     // We have 19 completions. We can fit into 6 columns with 4 rows or 5 columns with 4 rows; the
     // second one is better and so is what we ought to have picked.
-    if (render.rows != rows) err(L"Wrong row count");
-    if (render.cols != cols) err(L"Wrong column count");
+    if (render.rows != rows)
+        err(L"Wrong row count");
+    if (render.cols != cols)
+        err(L"Wrong column count");
 
     // Initially expect to have no completion index.
     if (render.selected_completion_idx != (size_t)(-1)) {
@@ -2740,12 +2781,16 @@ static void test_is_potential_path() {
     say(L"Testing is_potential_path");
 
     // Directories
-    if (system("mkdir -p test/is_potential_path_test/alpha/")) err(L"mkdir failed");
-    if (system("mkdir -p test/is_potential_path_test/beta/")) err(L"mkdir failed");
+    if (system("mkdir -p test/is_potential_path_test/alpha/"))
+        err(L"mkdir failed");
+    if (system("mkdir -p test/is_potential_path_test/beta/"))
+        err(L"mkdir failed");
 
     // Files
-    if (system("touch test/is_potential_path_test/aardvark")) err(L"touch failed");
-    if (system("touch test/is_potential_path_test/gamma")) err(L"touch failed");
+    if (system("touch test/is_potential_path_test/aardvark"))
+        err(L"touch failed");
+    if (system("touch test/is_potential_path_test/gamma"))
+        err(L"touch failed");
 
     const wcstring wd = L"test/is_potential_path_test/";
     const wcstring_list_t wds({L".", wd});
@@ -2779,7 +2824,8 @@ static bool run_one_test_test(int expected, const wcstring_list_t &lst, bool bra
     wcstring_list_t argv;
     argv.push_back(bracket ? L"[" : L"test");
     argv.insert(argv.end(), lst.begin(), lst.end());
-    if (bracket) argv.push_back(L"]");
+    if (bracket)
+        argv.push_back(L"]");
 
     null_terminated_array_t<wchar_t> cargv(argv);
 
@@ -3147,17 +3193,26 @@ static void test_complete() {
     do_test(completions.at(1).completion == L"$Foo1");
     do_test(completions.at(2).completion == L"$gamma1");
 
-    if (system("mkdir -p 'test/complete_test'")) err(L"mkdir failed");
-    if (system("touch 'test/complete_test/has space'")) err(L"touch failed");
-    if (system("touch 'test/complete_test/bracket[abc]'")) err(L"touch failed");
+    if (system("mkdir -p 'test/complete_test'"))
+        err(L"mkdir failed");
+    if (system("touch 'test/complete_test/has space'"))
+        err(L"touch failed");
+    if (system("touch 'test/complete_test/bracket[abc]'"))
+        err(L"touch failed");
 #ifndef __CYGWIN__  // Square brackets are not legal path characters on WIN32/CYGWIN
-    if (system(R"(touch 'test/complete_test/gnarlybracket\[abc]')")) err(L"touch failed");
+    if (system(R"(touch 'test/complete_test/gnarlybracket\[abc]')"))
+        err(L"touch failed");
 #endif
-    if (system("touch 'test/complete_test/testfile'")) err(L"touch failed");
-    if (system("chmod 700 'test/complete_test/testfile'")) err(L"chmod failed");
-    if (system("mkdir -p 'test/complete_test/foo1'")) err(L"mkdir failed");
-    if (system("mkdir -p 'test/complete_test/foo2'")) err(L"mkdir failed");
-    if (system("mkdir -p 'test/complete_test/foo3'")) err(L"mkdir failed");
+    if (system("touch 'test/complete_test/testfile'"))
+        err(L"touch failed");
+    if (system("chmod 700 'test/complete_test/testfile'"))
+        err(L"chmod failed");
+    if (system("mkdir -p 'test/complete_test/foo1'"))
+        err(L"mkdir failed");
+    if (system("mkdir -p 'test/complete_test/foo2'"))
+        err(L"mkdir failed");
+    if (system("mkdir -p 'test/complete_test/foo3'"))
+        err(L"mkdir failed");
 
     completions = do_complete(L"echo (test/complete_test/testfil", {});
     do_test(completions.size() == 1);
@@ -3249,7 +3304,8 @@ static void test_complete() {
     do_test(completions.size() == 1);
     do_test(completions.at(0).completion == L"stfile");
 
-    if (!pushd("test/complete_test")) return;
+    if (!pushd("test/complete_test"))
+        return;
     completions = do_complete(L"cat te", {});
     do_test(completions.size() == 1);
     do_test(completions.at(0).completion == L"stfile");
@@ -3322,7 +3378,8 @@ static void test_complete() {
     do_test(comma_join(complete_get_wrap_targets(L"wrapper3")) == L"wrapper1");
 
     // Test cd wrapping chain
-    if (!pushd("test/complete_test")) err(L"pushd(\"test/complete_test\") failed");
+    if (!pushd("test/complete_test"))
+        err(L"pushd(\"test/complete_test\") failed");
 
     complete_add_wrapper(L"cdwrap1", L"cd");
     complete_add_wrapper(L"cdwrap2", L"cdwrap1");
@@ -3482,10 +3539,14 @@ static void perform_one_completion_cd_test(const wcstring &command, const wcstri
 // Testing test_autosuggest_suggest_special, in particular for properly handling quotes and
 // backslashes.
 static void test_autosuggest_suggest_special() {
-    if (system("mkdir -p 'test/autosuggest_test/0foobar'")) err(L"mkdir failed");
-    if (system("mkdir -p 'test/autosuggest_test/1foo bar'")) err(L"mkdir failed");
-    if (system("mkdir -p 'test/autosuggest_test/2foo  bar'")) err(L"mkdir failed");
-    if (system("mkdir -p 'test/autosuggest_test/3foo\\bar'")) err(L"mkdir failed");
+    if (system("mkdir -p 'test/autosuggest_test/0foobar'"))
+        err(L"mkdir failed");
+    if (system("mkdir -p 'test/autosuggest_test/1foo bar'"))
+        err(L"mkdir failed");
+    if (system("mkdir -p 'test/autosuggest_test/2foo  bar'"))
+        err(L"mkdir failed");
+    if (system("mkdir -p 'test/autosuggest_test/3foo\\bar'"))
+        err(L"mkdir failed");
     if (system("mkdir -p test/autosuggest_test/4foo\\'bar")) {
         err(L"mkdir failed");  // a path with a single quote
     }
@@ -3549,7 +3610,8 @@ static void test_autosuggest_suggest_special() {
     perform_one_autosuggestion_cd_test(L"cd test/autosuggest_test/start/", L"unique2/unique3/",
                                        vars, __LINE__);
 
-    if (!pushd(wcs2string(wd).c_str())) return;
+    if (!pushd(wcs2string(wd).c_str()))
+        return;
     perform_one_autosuggestion_cd_test(L"cd 0", L"foobar/", vars, __LINE__);
     perform_one_autosuggestion_cd_test(L"cd \"0", L"foobar/", vars, __LINE__);
     perform_one_autosuggestion_cd_test(L"cd '0", L"foobar/", vars, __LINE__);
@@ -3574,7 +3636,8 @@ static void test_autosuggest_suggest_special() {
                                        __LINE__);
 
     // Don't crash on ~ (issue #2696). Note this is cwd dependent.
-    if (system("mkdir -p '~absolutelynosuchuser/path1/path2/'")) err(L"mkdir failed");
+    if (system("mkdir -p '~absolutelynosuchuser/path1/path2/'"))
+        err(L"mkdir failed");
     perform_one_autosuggestion_cd_test(L"cd ~absolutelynosuchus", L"er/path1/path2/", vars,
                                        __LINE__);
     perform_one_autosuggestion_cd_test(L"cd ~absolutelynosuchuser/", L"path1/path2/", vars,
@@ -3640,7 +3703,8 @@ static bool history_contains(history_t *history, const wcstring &txt) {
     size_t i;
     for (i = 1;; i++) {
         history_item_t item = history->item_at_index(i);
-        if (item.empty()) break;
+        if (item.empty())
+            break;
 
         if (item.str() == txt) {
             result = true;
@@ -3784,7 +3848,8 @@ static int test_universal_helper(int x) {
 
 static void test_universal() {
     say(L"Testing universal variables");
-    if (system("mkdir -p test/fish_uvars_test/")) err(L"mkdir failed");
+    if (system("mkdir -p test/fish_uvars_test/"))
+        err(L"mkdir failed");
 
     const int threads = 1;
     for (int i = 0; i < threads; i++) {
@@ -3808,7 +3873,8 @@ static void test_universal() {
                 expected_val = env_var_t(format_string(L"val_%d_%d", i, j), 0);
             }
             const maybe_t<env_var_t> var = uvars.get(key);
-            if (j == 0) assert(!expected_val);
+            if (j == 0)
+                assert(!expected_val);
             if (var != expected_val) {
                 const wchar_t *missing_desc = L"<missing>";
                 err(L"Wrong value for key %ls: expected %ls, got %ls\n", key.c_str(),
@@ -3893,7 +3959,8 @@ static bool callback_data_less_than(const callback_data_t &a, const callback_dat
 
 static void test_universal_callbacks() {
     say(L"Testing universal callbacks");
-    if (system("mkdir -p test/fish_uvars_test/")) err(L"mkdir failed");
+    if (system("mkdir -p test/fish_uvars_test/"))
+        err(L"mkdir failed");
     callback_data_list_t callbacks;
     env_universal_t uvars1(UVARS_TEST_PATH);
     env_universal_t uvars2(UVARS_TEST_PATH);
@@ -3965,7 +4032,8 @@ static void test_universal_formats() {
 static void test_universal_ok_to_save() {
     // Ensure we don't try to save after reading from a newer fish.
     say(L"Testing universal Ok to save");
-    if (system("mkdir -p test/fish_uvars_test/")) err(L"mkdir failed");
+    if (system("mkdir -p test/fish_uvars_test/"))
+        err(L"mkdir failed");
     constexpr const char contents[] = "# VERSION: 99999.99\n";
     FILE *fp = fopen(wcs2string(UVARS_TEST_PATH).c_str(), "w");
     assert(fp && "Failed to open UVARS_TEST_PATH for writing");
@@ -3991,7 +4059,8 @@ static void test_universal_ok_to_save() {
 }
 
 bool poll_notifier(const std::unique_ptr<universal_notifier_t> &note) {
-    if (note->poll()) return true;
+    if (note->poll())
+        return true;
 
     bool result = false;
     int fd = note->notification_fd();
@@ -4129,7 +4198,8 @@ void history_tests_t::test_history() {
     auto set_expected = [&](const std::function<bool(const wcstring &)> &filt) {
         expected.clear();
         for (const auto &s : items) {
-            if (filt(s)) expected.push_back(s);
+            if (filt(s))
+                expected.push_back(s);
         }
         std::reverse(expected.begin(), expected.end());
     };
@@ -4186,7 +4256,8 @@ void history_tests_t::test_history() {
         wcstring value = wcstring(L"test item ") + to_string(i);
 
         // Maybe add some backslashes.
-        if (i % 3 == 0) value.append(L"(slashies \\\\\\ slashies)");
+        if (i % 3 == 0)
+            value.append(L"(slashies \\\\\\ slashies)");
 
         // Generate some paths.
         path_list_t paths;
@@ -4309,7 +4380,8 @@ void history_tests_t::test_history_races() {
     size_t hist_idx;
     for (hist_idx = 1;; hist_idx++) {
         history_item_t item = hist.item_at_index(hist_idx);
-        if (item.empty()) break;
+        if (item.empty())
+            break;
 
         bool found = false;
         for (wcstring_list_t &list : expected_lines) {
@@ -4440,7 +4512,8 @@ void history_tests_t::test_history_merge() {
                                    L"Item_#3496_4", L"Item_#3496_5", L"Item_#3496_6"};
     for (size_t i = 0; i < sizeof more_texts / sizeof *more_texts; i++) {
         // time_barrier because merging will ignore items that may be newer
-        if (i > 0) time_barrier();
+        if (i > 0)
+            time_barrier();
         writer->add(more_texts[i]);
         writer->incorporate_external_changes();
         reader->incorporate_external_changes();
@@ -4758,7 +4831,8 @@ static void test_new_parser_fuzzing() {
     bool log_it = true;
     unsigned long max_len = 5;
     for (unsigned long len = 0; len < max_len; len++) {
-        if (log_it) std::fwprintf(stderr, L"%lu / %lu...", len, max_len);
+        if (log_it)
+            std::fwprintf(stderr, L"%lu / %lu...", len, max_len);
 
         // We wish to look at all permutations of 4 elements of 'fuzzes' (with replacement).
         // Construct an int and keep incrementing it.
@@ -4767,10 +4841,12 @@ static void test_new_parser_fuzzing() {
                                       &src)) {
             ast::ast_t::parse(src);
         }
-        if (log_it) std::fwprintf(stderr, L"done (%lu)\n", permutation);
+        if (log_it)
+            std::fwprintf(stderr, L"done (%lu)\n", permutation);
     }
     double end = timef();
-    if (log_it) say(L"All fuzzed in %f seconds!", end - start);
+    if (log_it)
+        say(L"All fuzzed in %f seconds!", end - start);
 }
 
 // Parse a statement, returning the command, args (joined by spaces), and the decoration. Returns
@@ -4783,7 +4859,8 @@ static bool test_1_parse_ll2(const wcstring &src, wcstring *out_cmd, wcstring *o
     *out_deco = statement_decoration_t::none;
 
     auto ast = ast_t::parse(src);
-    if (ast.errored()) return false;
+    if (ast.errored())
+        return false;
 
     // Get the statement. Should only have one.
     const decorated_statement_t *statement = nullptr;
@@ -4808,8 +4885,10 @@ static bool test_1_parse_ll2(const wcstring &src, wcstring *out_cmd, wcstring *o
     // Return arguments separated by spaces.
     bool first = true;
     for (const ast::argument_or_redirection_t &arg : statement->args_or_redirs) {
-        if (!arg.is_argument()) continue;
-        if (!first) out_joined_args->push_back(L' ');
+        if (!arg.is_argument())
+            continue;
+        if (!first)
+            out_joined_args->push_back(L' ');
         out_joined_args->append(arg.source(src));
         first = false;
     }
@@ -4868,7 +4947,8 @@ static void test_new_parser_ll2() {
         wcstring cmd, args;
         enum statement_decoration_t deco = statement_decoration_t::none;
         bool success = test_1_parse_ll2(test.src, &cmd, &args, &deco);
-        if (!success) err(L"Parse of '%ls' failed on line %ld", test.cmd.c_str(), (long)__LINE__);
+        if (!success)
+            err(L"Parse of '%ls' failed on line %ld", test.cmd.c_str(), (long)__LINE__);
         if (cmd != test.cmd)
             err(L"When parsing '%ls', expected command '%ls' but got '%ls' on line %ld",
                 test.src.c_str(), test.cmd.c_str(), cmd.c_str(), (long)__LINE__);
@@ -5012,7 +5092,8 @@ static wcstring_list_t separate_by_format_specifiers(const wchar_t *format) {
 
         cursor++;
         // Flag
-        if (std::wcschr(L"#0- +'", *cursor)) cursor++;
+        if (std::wcschr(L"#0- +'", *cursor))
+            cursor++;
         // Minimum field width
         while (iswdigit(*cursor)) cursor++;
         // Precision
@@ -5088,11 +5169,15 @@ static void test_error_messages() {
 
 static void test_highlighting() {
     say(L"Testing syntax highlighting");
-    if (!pushd("test/fish_highlight_test/")) return;
+    if (!pushd("test/fish_highlight_test/"))
+        return;
     cleanup_t pop{[] { popd(); }};
-    if (system("mkdir -p dir")) err(L"mkdir failed");
-    if (system("touch foo")) err(L"touch failed");
-    if (system("touch bar")) err(L"touch failed");
+    if (system("mkdir -p dir"))
+        err(L"mkdir failed");
+    if (system("touch foo"))
+        err(L"touch failed");
+    if (system("touch bar"))
+        err(L"touch failed");
 
     // Here are the components of our source and the colors we expect those to be.
     struct highlight_component_t {
@@ -5423,7 +5508,8 @@ static void test_highlighting() {
         do_test(expected_colors.size() == colors.size());
         for (size_t i = 0; i < text.size(); i++) {
             // Hackish space handling. We don't care about the colors in spaces.
-            if (text.at(i) == L' ') continue;
+            if (text.at(i) == L' ')
+                continue;
 
             if (expected_colors.at(i) != colors.at(i)) {
                 const wcstring spaces(i, L' ');
@@ -5932,7 +6018,8 @@ static void test_env_vars() {
 }
 
 static void test_env_snapshot() {
-    if (system("mkdir -p test/fish_env_snapshot_test/")) err(L"mkdir failed");
+    if (system("mkdir -p test/fish_env_snapshot_test/"))
+        err(L"mkdir failed");
     bool pushed = pushd("test/fish_env_snapshot_test");
     do_test(pushed);
     auto &vars = parser_t::principal_parser().vars();
@@ -5969,7 +6056,8 @@ static void test_illegal_command_exit_code() {
     // We need to be in an empty directory so that none of the wildcards match a file that might be
     // in the fish source tree. In particular we need to ensure that "?" doesn't match a file
     // named by a single character. See issue #3852.
-    if (!pushd("test/temp")) return;
+    if (!pushd("test/temp"))
+        return;
 
     struct command_result_tuple_t {
         const wchar_t *txt;
@@ -6522,104 +6610,193 @@ int main(int argc, char **argv) {
     // Set PWD from getcwd - fixes #5599
     env_stack_t::principal().set_pwd_from_getcwd();
 
-    if (should_test_function("utility_functions")) test_utility_functions();
-    if (should_test_function("string_split")) test_split_string_tok();
-    if (should_test_function("wwrite_to_fd")) test_wwrite_to_fd();
-    if (should_test_function("env_vars")) test_env_vars();
-    if (should_test_function("env")) test_env_snapshot();
-    if (should_test_function("str_to_num")) test_str_to_num();
-    if (should_test_function("enum")) test_enum_set();
-    if (should_test_function("enum")) test_enum_array();
-    if (should_test_function("highlighting")) test_highlighting();
-    if (should_test_function("new_parser_ll2")) test_new_parser_ll2();
+    if (should_test_function("utility_functions"))
+        test_utility_functions();
+    if (should_test_function("string_split"))
+        test_split_string_tok();
+    if (should_test_function("wwrite_to_fd"))
+        test_wwrite_to_fd();
+    if (should_test_function("env_vars"))
+        test_env_vars();
+    if (should_test_function("env"))
+        test_env_snapshot();
+    if (should_test_function("str_to_num"))
+        test_str_to_num();
+    if (should_test_function("enum"))
+        test_enum_set();
+    if (should_test_function("enum"))
+        test_enum_array();
+    if (should_test_function("highlighting"))
+        test_highlighting();
+    if (should_test_function("new_parser_ll2"))
+        test_new_parser_ll2();
     if (should_test_function("new_parser_fuzzing"))
         test_new_parser_fuzzing();  // fuzzing is expensive
-    if (should_test_function("new_parser_correctness")) test_new_parser_correctness();
-    if (should_test_function("new_parser_ad_hoc")) test_new_parser_ad_hoc();
-    if (should_test_function("new_parser_errors")) test_new_parser_errors();
-    if (should_test_function("error_messages")) test_error_messages();
-    if (should_test_function("escape")) test_unescape_sane();
-    if (should_test_function("escape")) test_escape_crazy();
-    if (should_test_function("escape")) test_escape_quotes();
-    if (should_test_function("format")) test_format();
-    if (should_test_function("convert")) test_convert();
-    if (should_test_function("convert")) test_convert_private_use();
-    if (should_test_function("convert_ascii")) test_convert_ascii();
-    if (should_test_function("perf_convert_ascii", false)) perf_convert_ascii();
-    if (should_test_function("convert_nulls")) test_convert_nulls();
-    if (should_test_function("tokenizer")) test_tokenizer();
-    if (should_test_function("fd_monitor")) test_fd_monitor();
-    if (should_test_function("iothread")) test_iothread();
-    if (should_test_function("pthread")) test_pthread();
-    if (should_test_function("debounce")) test_debounce();
-    if (should_test_function("debounce")) test_debounce_timeout();
-    if (should_test_function("parser")) test_parser();
-    if (should_test_function("cancellation")) test_cancellation();
-    if (should_test_function("indents")) test_indents();
-    if (should_test_function("utf8")) test_utf8();
-    if (should_test_function("feature_flags")) test_feature_flags();
-    if (should_test_function("escape_sequences")) test_escape_sequences();
-    if (should_test_function("pcre2_escape")) test_pcre2_escape();
-    if (should_test_function("lru")) test_lru();
-    if (should_test_function("expand")) test_expand();
-    if (should_test_function("expand")) test_expand_overflow();
-    if (should_test_function("fuzzy_match")) test_fuzzy_match();
-    if (should_test_function("ifind")) test_ifind();
-    if (should_test_function("ifind_fuzzy")) test_ifind_fuzzy();
-    if (should_test_function("abbreviations")) test_abbreviations();
-    if (should_test_function("test")) test_test();
-    if (should_test_function("wcstod")) test_wcstod();
-    if (should_test_function("dup2s")) test_dup2s();
-    if (should_test_function("dup2s")) test_dup2s_fd_for_target_fd();
-    if (should_test_function("path")) test_path();
-    if (should_test_function("pager_navigation")) test_pager_navigation();
-    if (should_test_function("pager_layout")) test_pager_layout();
-    if (should_test_function("word_motion")) test_word_motion();
-    if (should_test_function("is_potential_path")) test_is_potential_path();
-    if (should_test_function("colors")) test_colors();
-    if (should_test_function("complete")) test_complete();
-    if (should_test_function("autoload")) test_autoload();
-    if (should_test_function("input")) test_input();
-    if (should_test_function("line_iterator")) test_line_iterator();
-    if (should_test_function("undo")) test_undo();
-    if (should_test_function("universal")) test_universal();
-    if (should_test_function("universal")) test_universal_output();
-    if (should_test_function("universal")) test_universal_parsing();
-    if (should_test_function("universal")) test_universal_parsing_legacy();
-    if (should_test_function("universal")) test_universal_callbacks();
-    if (should_test_function("universal")) test_universal_formats();
-    if (should_test_function("universal")) test_universal_ok_to_save();
-    if (should_test_function("notifiers")) test_universal_notifiers();
-    if (should_test_function("completion_insertions")) test_completion_insertions();
-    if (should_test_function("autosuggestion_ignores")) test_autosuggestion_ignores();
-    if (should_test_function("autosuggestion_combining")) test_autosuggestion_combining();
-    if (should_test_function("autosuggest_suggest_special")) test_autosuggest_suggest_special();
-    if (should_test_function("history")) history_tests_t::test_history();
-    if (should_test_function("history_merge")) history_tests_t::test_history_merge();
-    if (should_test_function("history_paths")) history_tests_t::test_history_path_detection();
+    if (should_test_function("new_parser_correctness"))
+        test_new_parser_correctness();
+    if (should_test_function("new_parser_ad_hoc"))
+        test_new_parser_ad_hoc();
+    if (should_test_function("new_parser_errors"))
+        test_new_parser_errors();
+    if (should_test_function("error_messages"))
+        test_error_messages();
+    if (should_test_function("escape"))
+        test_unescape_sane();
+    if (should_test_function("escape"))
+        test_escape_crazy();
+    if (should_test_function("escape"))
+        test_escape_quotes();
+    if (should_test_function("format"))
+        test_format();
+    if (should_test_function("convert"))
+        test_convert();
+    if (should_test_function("convert"))
+        test_convert_private_use();
+    if (should_test_function("convert_ascii"))
+        test_convert_ascii();
+    if (should_test_function("perf_convert_ascii", false))
+        perf_convert_ascii();
+    if (should_test_function("convert_nulls"))
+        test_convert_nulls();
+    if (should_test_function("tokenizer"))
+        test_tokenizer();
+    if (should_test_function("fd_monitor"))
+        test_fd_monitor();
+    if (should_test_function("iothread"))
+        test_iothread();
+    if (should_test_function("pthread"))
+        test_pthread();
+    if (should_test_function("debounce"))
+        test_debounce();
+    if (should_test_function("debounce"))
+        test_debounce_timeout();
+    if (should_test_function("parser"))
+        test_parser();
+    if (should_test_function("cancellation"))
+        test_cancellation();
+    if (should_test_function("indents"))
+        test_indents();
+    if (should_test_function("utf8"))
+        test_utf8();
+    if (should_test_function("feature_flags"))
+        test_feature_flags();
+    if (should_test_function("escape_sequences"))
+        test_escape_sequences();
+    if (should_test_function("pcre2_escape"))
+        test_pcre2_escape();
+    if (should_test_function("lru"))
+        test_lru();
+    if (should_test_function("expand"))
+        test_expand();
+    if (should_test_function("expand"))
+        test_expand_overflow();
+    if (should_test_function("fuzzy_match"))
+        test_fuzzy_match();
+    if (should_test_function("ifind"))
+        test_ifind();
+    if (should_test_function("ifind_fuzzy"))
+        test_ifind_fuzzy();
+    if (should_test_function("abbreviations"))
+        test_abbreviations();
+    if (should_test_function("test"))
+        test_test();
+    if (should_test_function("wcstod"))
+        test_wcstod();
+    if (should_test_function("dup2s"))
+        test_dup2s();
+    if (should_test_function("dup2s"))
+        test_dup2s_fd_for_target_fd();
+    if (should_test_function("path"))
+        test_path();
+    if (should_test_function("pager_navigation"))
+        test_pager_navigation();
+    if (should_test_function("pager_layout"))
+        test_pager_layout();
+    if (should_test_function("word_motion"))
+        test_word_motion();
+    if (should_test_function("is_potential_path"))
+        test_is_potential_path();
+    if (should_test_function("colors"))
+        test_colors();
+    if (should_test_function("complete"))
+        test_complete();
+    if (should_test_function("autoload"))
+        test_autoload();
+    if (should_test_function("input"))
+        test_input();
+    if (should_test_function("line_iterator"))
+        test_line_iterator();
+    if (should_test_function("undo"))
+        test_undo();
+    if (should_test_function("universal"))
+        test_universal();
+    if (should_test_function("universal"))
+        test_universal_output();
+    if (should_test_function("universal"))
+        test_universal_parsing();
+    if (should_test_function("universal"))
+        test_universal_parsing_legacy();
+    if (should_test_function("universal"))
+        test_universal_callbacks();
+    if (should_test_function("universal"))
+        test_universal_formats();
+    if (should_test_function("universal"))
+        test_universal_ok_to_save();
+    if (should_test_function("notifiers"))
+        test_universal_notifiers();
+    if (should_test_function("completion_insertions"))
+        test_completion_insertions();
+    if (should_test_function("autosuggestion_ignores"))
+        test_autosuggestion_ignores();
+    if (should_test_function("autosuggestion_combining"))
+        test_autosuggestion_combining();
+    if (should_test_function("autosuggest_suggest_special"))
+        test_autosuggest_suggest_special();
+    if (should_test_function("history"))
+        history_tests_t::test_history();
+    if (should_test_function("history_merge"))
+        history_tests_t::test_history_merge();
+    if (should_test_function("history_paths"))
+        history_tests_t::test_history_path_detection();
     if (!is_windows_subsystem_for_linux()) {
         // this test always fails under WSL
-        if (should_test_function("history_races")) history_tests_t::test_history_races();
+        if (should_test_function("history_races"))
+            history_tests_t::test_history_races();
     }
-    if (should_test_function("history_formats")) history_tests_t::test_history_formats();
-    if (should_test_function("string")) test_string();
-    if (should_test_function("illegal_command_exit_code")) test_illegal_command_exit_code();
-    if (should_test_function("maybe")) test_maybe();
-    if (should_test_function("layout_cache")) test_layout_cache();
-    if (should_test_function("prompt")) test_prompt_truncation();
-    if (should_test_function("normalize")) test_normalize_path();
-    if (should_test_function("dirname")) test_dirname_basename();
-    if (should_test_function("topics")) test_topic_monitor();
-    if (should_test_function("topics")) test_topic_monitor_torture();
-    if (should_test_function("pipes")) test_pipes();
-    if (should_test_function("fd_event")) test_fd_event_signaller();
-    if (should_test_function("timer_format")) test_timer_format();
+    if (should_test_function("history_formats"))
+        history_tests_t::test_history_formats();
+    if (should_test_function("string"))
+        test_string();
+    if (should_test_function("illegal_command_exit_code"))
+        test_illegal_command_exit_code();
+    if (should_test_function("maybe"))
+        test_maybe();
+    if (should_test_function("layout_cache"))
+        test_layout_cache();
+    if (should_test_function("prompt"))
+        test_prompt_truncation();
+    if (should_test_function("normalize"))
+        test_normalize_path();
+    if (should_test_function("dirname"))
+        test_dirname_basename();
+    if (should_test_function("topics"))
+        test_topic_monitor();
+    if (should_test_function("topics"))
+        test_topic_monitor_torture();
+    if (should_test_function("pipes"))
+        test_pipes();
+    if (should_test_function("fd_event"))
+        test_fd_event_signaller();
+    if (should_test_function("timer_format"))
+        test_timer_format();
     // history_tests_t::test_history_speed();
 
-    if (should_test_function("termsize")) termsize_tester_t::test();
+    if (should_test_function("termsize"))
+        termsize_tester_t::test();
 
     say(L"Encountered %d errors in low-level tests", err_count);
-    if (s_test_run_count == 0) say(L"*** No Tests Were Actually Run! ***");
+    if (s_test_run_count == 0)
+        say(L"*** No Tests Were Actually Run! ***");
 
     if (err_count != 0) {
         return 1;

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -118,20 +118,23 @@ static void autoload_names(std::unordered_set<wcstring> &names, int get_hidden) 
     // TODO: justfy this.
     auto &vars = env_stack_t::principal();
     const auto path_var = vars.get(L"fish_function_path");
-    if (path_var.missing_or_empty()) return;
+    if (path_var.missing_or_empty())
+        return;
 
     const wcstring_list_t &path_list = path_var->as_list();
 
     for (i = 0; i < path_list.size(); i++) {
         const wcstring &ndir_str = path_list.at(i);
         dir_t dir(ndir_str);
-        if (!dir.valid()) continue;
+        if (!dir.valid())
+            continue;
 
         wcstring name;
         while (dir.read(name)) {
             const wchar_t *fn = name.c_str();
             const wchar_t *suffix;
-            if (!get_hidden && fn[0] == L'_') continue;
+            if (!get_hidden && fn[0] == L'_')
+                continue;
 
             suffix = std::wcsrchr(fn, L'.');
             if (suffix && (std::wcscmp(suffix, L".fish") == 0)) {
@@ -174,7 +177,8 @@ void function_add(wcstring name, wcstring description, function_properties_ref_t
 }
 
 std::shared_ptr<const function_properties_t> function_get_properties(const wcstring &name) {
-    if (parser_keywords_is_reserved(name)) return nullptr;
+    if (parser_keywords_is_reserved(name))
+        return nullptr;
     auto funcset = function_set.acquire();
     if (auto info = funcset->get_info(name)) {
         return info->props;
@@ -184,7 +188,8 @@ std::shared_ptr<const function_properties_t> function_get_properties(const wcstr
 
 int function_exists(const wcstring &cmd, parser_t &parser) {
     ASSERT_IS_MAIN_THREAD();
-    if (parser_keywords_is_reserved(cmd)) return 0;
+    if (parser_keywords_is_reserved(cmd))
+        return 0;
     try_autoload(cmd, parser);
     auto funcset = function_set.acquire();
     return funcset->funcs.find(cmd) != funcset->funcs.end();
@@ -198,7 +203,8 @@ void function_load(const wcstring &cmd, parser_t &parser) {
 }
 
 int function_exists_no_autoload(const wcstring &cmd) {
-    if (parser_keywords_is_reserved(cmd)) return 0;
+    if (parser_keywords_is_reserved(cmd))
+        return 0;
     auto funcset = function_set.acquire();
 
     // Check if we either have the function, or it could be autoloaded.
@@ -223,7 +229,8 @@ void function_remove(const wcstring &name) {
 bool function_get_definition(const wcstring &name, wcstring &out_definition) {
     const auto funcset = function_set.acquire();
     const function_info_t *func = funcset->get_info(name);
-    if (!func || !func->props) return false;
+    if (!func || !func->props)
+        return false;
     // We want to preserve comments that the AST attaches to the header (#5285).
     // Take everything from the end of the header to the 'end' keyword.
     const auto &props = func->props;
@@ -307,7 +314,8 @@ bool function_is_autoloaded(const wcstring &name) {
 int function_get_definition_lineno(const wcstring &name) {
     const auto funcset = function_set.acquire();
     const function_info_t *func = funcset->get_info(name);
-    if (!func) return -1;
+    if (!func)
+        return -1;
     // return one plus the number of newlines at offsets less than the start of our function's
     // statement (which includes the header).
     // TODO: merge with line_offset_of_character_at_offset?

--- a/src/future_feature_flags.cpp
+++ b/src/future_feature_flags.cpp
@@ -25,7 +25,8 @@ const features_t::metadata_t features_t::metadata[features_t::flag_count] = {
 const struct features_t::metadata_t *features_t::metadata_for(const wchar_t *name) {
     assert(name && "null flag name");
     for (const auto &md : metadata) {
-        if (!std::wcscmp(name, md.name)) return &md;
+        if (!std::wcscmp(name, md.name))
+            return &md;
     }
     return nullptr;
 }
@@ -34,7 +35,8 @@ void features_t::set_from_string(const wcstring &str) {
     wcstring_list_t entries = split_string(str, L',');
     const wchar_t *whitespace = L"\t\n\v\f\r ";
     for (wcstring entry : entries) {
-        if (entry.empty()) continue;
+        if (entry.empty())
+            continue;
 
         // Trim leading and trailing whitespace
         entry.erase(0, entry.find_first_not_of(whitespace));

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -205,14 +205,16 @@ bool is_potential_path(const wcstring &potential_path_fragment, const wcstring_l
                        const operation_context_t &ctx, path_flags_t flags) {
     ASSERT_IS_BACKGROUND_THREAD();
 
-    if (ctx.check_cancel()) return false;
+    if (ctx.check_cancel())
+        return false;
 
     const bool require_dir = static_cast<bool>(flags & PATH_REQUIRE_DIR);
     wcstring clean_potential_path_fragment;
     bool has_magic = false;
 
     wcstring path_with_magic(potential_path_fragment);
-    if (flags & PATH_EXPAND_TILDE) expand_tilde(path_with_magic, ctx.vars);
+    if (flags & PATH_EXPAND_TILDE)
+        expand_tilde(path_with_magic, ctx.vars);
 
     for (auto c : path_with_magic) {
         switch (c) {
@@ -250,14 +252,16 @@ bool is_potential_path(const wcstring &potential_path_fragment, const wcstring_l
     case_sensitivity_cache_t case_sensitivity_cache;
 
     for (const wcstring &wd : directories) {
-        if (ctx.check_cancel()) return false;
+        if (ctx.check_cancel())
+            return false;
         wcstring abs_path = path_apply_working_directory(clean_potential_path_fragment, wd);
         if (flags & PATH_FOR_CD) {
             abs_path = normalize_path(abs_path);
         }
 
         // Skip this if it's empty or we've already checked it.
-        if (abs_path.empty() || checked_paths.count(abs_path)) continue;
+        if (abs_path.empty() || checked_paths.count(abs_path))
+            continue;
         checked_paths.insert(abs_path);
 
         // If we end with a slash, then it must be a directory.
@@ -288,7 +292,8 @@ bool is_potential_path(const wcstring &potential_path_fragment, const wcstring_l
                 wcstring ent;
                 bool is_dir = false;
                 while (wreaddir_resolving(dir, dir_name, ent, require_dir ? &is_dir : nullptr)) {
-                    if (ctx.check_cancel()) return false;
+                    if (ctx.check_cancel())
+                        return false;
 
                     // Maybe skip directories.
                     if (require_dir && !is_dir) {
@@ -324,7 +329,8 @@ static bool is_potential_cd_path(const wcstring &path, const wcstring &working_d
             cdpath.missing_or_empty() ? wcstring_list_t{L"."} : cdpath->as_list();
 
         for (auto next_path : pathsv) {
-            if (next_path.empty()) next_path = L".";
+            if (next_path.empty())
+                next_path = L".";
             // Ensure that we use the working directory for relative cdpaths like ".".
             directories.push_back(path_apply_working_directory(next_path, working_directory));
         }
@@ -341,7 +347,8 @@ static bool statement_get_expanded_command(const wcstring &src,
                                            const operation_context_t &ctx, wcstring *out_cmd) {
     // Get the command. Try expanding it. If we cannot, it's an error.
     maybe_t<wcstring> cmd = stmt.command.source(src);
-    if (!cmd) return false;
+    if (!cmd)
+        return false;
     expand_result_t err = expand_to_command_and_args(*cmd, ctx, out_cmd, nullptr);
     return err == expand_result_t::ok;
 }
@@ -353,9 +360,12 @@ rgb_color_t highlight_color_resolver_t::resolve_spec_uncached(const highlight_sp
     highlight_role_t role = is_background ? highlight.background : highlight.foreground;
 
     auto var = vars.get(get_highlight_var_name(role));
-    if (!var) var = vars.get(get_highlight_var_name(get_fallback(role)));
-    if (!var) var = vars.get(get_highlight_var_name(highlight_role_t::normal));
-    if (var) result = parse_color(*var, is_background);
+    if (!var)
+        var = vars.get(get_highlight_var_name(get_fallback(role)));
+    if (!var)
+        var = vars.get(get_highlight_var_name(highlight_role_t::normal));
+    if (var)
+        result = parse_color(*var, is_background);
 
     // Handle modifiers.
     if (!is_background && highlight.valid_path) {
@@ -365,11 +375,16 @@ rgb_color_t highlight_color_resolver_t::resolve_spec_uncached(const highlight_sp
             if (result.is_normal())
                 result = result2;
             else {
-                if (result2.is_bold()) result.set_bold(true);
-                if (result2.is_underline()) result.set_underline(true);
-                if (result2.is_italics()) result.set_italics(true);
-                if (result2.is_dim()) result.set_dim(true);
-                if (result2.is_reverse()) result.set_reverse(true);
+                if (result2.is_bold())
+                    result.set_bold(true);
+                if (result2.is_underline())
+                    result.set_underline(true);
+                if (result2.is_italics())
+                    result.set_italics(true);
+                if (result2.is_dim())
+                    result.set_dim(true);
+                if (result2.is_reverse())
+                    result.set_reverse(true);
             }
         }
     }
@@ -620,7 +635,8 @@ static void color_string_internal(const wcstring &buffstr, highlight_spec_t base
                         // Consume
                         for (int i = 0; i < chars && in_pos < buff_len; i++) {
                             long d = convert_digit(buffstr.at(in_pos), base);
-                            if (d < 0) break;
+                            if (d < 0)
+                                break;
                             res = (res * base) + d;
                             in_pos++;
                         }
@@ -630,7 +646,8 @@ static void color_string_internal(const wcstring &buffstr, highlight_spec_t base
                         fill_end = in_pos;
 
                         // It's an error if we exceeded the max value.
-                        if (res > max_val) fill_color = highlight_role_t::error;
+                        if (res > max_val)
+                            fill_color = highlight_role_t::error;
 
                         // Subtract one from in_pos, so that the increment in the loop will move to
                         // the next character.
@@ -930,7 +947,8 @@ static bool range_is_potential_path(const wcstring &src, const source_range_t &r
     if (unescape_string_in_place(&token, UNESCAPE_SPECIAL)) {
         // Big hack: is_potential_path expects a tilde, but unescape_string gives us HOME_DIRECTORY.
         // Put it back.
-        if (!token.empty() && token.at(0) == HOME_DIRECTORY) token.at(0) = L'~';
+        if (!token.empty() && token.at(0) == HOME_DIRECTORY)
+            token.at(0) = L'~';
 
         const wcstring_list_t working_directory_list(1, working_directory);
         result = is_potential_path(token, working_directory_list, ctx, PATH_EXPAND_TILDE);
@@ -1002,7 +1020,8 @@ void highlighter_t::visit(const ast::token_base_t &tok) {
         default:
             break;
     }
-    if (role) color_node(tok, *role);
+    if (role)
+        color_node(tok, *role);
 }
 
 void highlighter_t::visit(const ast::semi_nl_t &semi_nl) {
@@ -1038,12 +1057,14 @@ void highlighter_t::visit(const ast::variable_assignment_t &varas) {
 
 void highlighter_t::visit(const ast::decorated_statement_t &stmt) {
     // Color any decoration.
-    if (stmt.opt_decoration) this->visit(*stmt.opt_decoration);
+    if (stmt.opt_decoration)
+        this->visit(*stmt.opt_decoration);
 
     // Color the command's source code.
     // If we get no source back, there's nothing to color.
     maybe_t<wcstring> cmd = stmt.command.try_source(this->buff);
-    if (!cmd.has_value()) return;
+    if (!cmd.has_value())
+        return;
 
     wcstring expanded_cmd;
     bool is_valid_cmd = false;
@@ -1116,9 +1137,11 @@ static bool contains_pending_variable(const std::vector<wcstring> &pending_varia
     for (const auto &var_name : pending_variables) {
         size_t pos = -1;
         while ((pos = haystack.find(var_name, pos + 1)) != wcstring::npos) {
-            if (pos == 0 || haystack.at(pos - 1) != L'$') continue;
+            if (pos == 0 || haystack.at(pos - 1) != L'$')
+                continue;
             size_t end = pos + var_name.size();
-            if (end < haystack.size() && valid_var_name_char(haystack.at(end))) continue;
+            if (end < haystack.size() && valid_var_name_char(haystack.at(end)))
+                continue;
             return true;
         }
     }
@@ -1215,7 +1238,8 @@ void highlighter_t::visit(const ast::redirection_t &redir) {
                         // Ensure that the parent ends with the path separator. This will ensure
                         // that we get an error if the parent directory is not really a
                         // directory.
-                        if (!string_suffixes_string(L"/", parent)) parent.push_back(L'/');
+                        if (!string_suffixes_string(L"/", parent))
+                            parent.push_back(L'/');
 
                         // Now the file is considered writable if the parent directory is
                         // writable.
@@ -1265,16 +1289,20 @@ static bool command_is_valid(const wcstring &cmd, enum statement_decoration_t de
     bool is_valid = false;
 
     // Builtins
-    if (!is_valid && builtin_ok) is_valid = builtin_exists(cmd);
+    if (!is_valid && builtin_ok)
+        is_valid = builtin_exists(cmd);
 
     // Functions
-    if (!is_valid && function_ok) is_valid = function_exists_no_autoload(cmd);
+    if (!is_valid && function_ok)
+        is_valid = function_exists_no_autoload(cmd);
 
     // Abbreviations
-    if (!is_valid && abbreviation_ok) is_valid = expand_abbreviation(cmd, vars).has_value();
+    if (!is_valid && abbreviation_ok)
+        is_valid = expand_abbreviation(cmd, vars).has_value();
 
     // Regular commands
-    if (!is_valid && command_ok) is_valid = path_get_path(cmd, nullptr, vars);
+    if (!is_valid && command_ok)
+        is_valid = path_get_path(cmd, nullptr, vars);
 
     // Implicit cd
     if (!is_valid && implicit_cd_ok) {
@@ -1295,7 +1323,8 @@ highlighter_t::color_array_t highlighter_t::highlight() {
     std::fill(this->color_array.begin(), this->color_array.end(), highlight_spec_t{});
 
     this->visit_children(*ast.top());
-    if (ctx.check_cancel()) return std::move(color_array);
+    if (ctx.check_cancel())
+        return std::move(color_array);
 
     // Color every comment.
     const auto &extras = ast.extras();
@@ -1317,8 +1346,10 @@ highlighter_t::color_array_t highlighter_t::highlight() {
     if (io_ok) {
         for (const ast::node_t &node : ast) {
             const ast::argument_t *arg = node.try_as<ast::argument_t>();
-            if (!arg || arg->unsourced) continue;
-            if (ctx.check_cancel()) break;
+            if (!arg || arg->unsourced)
+                continue;
+            if (ctx.check_cancel())
+                break;
             if (range_is_potential_path(buff, arg->range, ctx, working_directory)) {
                 // Don't color highlight_role_t::error because it looks dorky. For example,
                 // trying to cd into a non-directory would show an underline and also red.

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -69,7 +69,8 @@ struct terminfo_mapping_t {
     maybe_t<std::string> seq;
 
     terminfo_mapping_t(const wchar_t *name, const char *s) : name(name) {
-        if (s) seq.emplace(s);
+        if (s)
+            seq.emplace(s);
     }
 
     terminfo_mapping_t(const wchar_t *name, std::string s) : name(name), seq(std::move(s)) {}
@@ -278,7 +279,8 @@ static relaxed_atomic_bool_t s_input_initialized{false};
 /// initializations for our input subsystem.
 void init_input() {
     ASSERT_IS_MAIN_THREAD();
-    if (s_input_initialized) return;
+    if (s_input_initialized)
+        return;
     s_input_initialized = true;
 
     s_terminfo_mappings = create_input_terminfo();
@@ -325,14 +327,16 @@ void inputter_t::prepare_to_select() /* override */ {
     // Fire any pending events and reap stray processes, including printing exit status messages.
     auto &parser = *this->parser_;
     event_fire_delayed(parser);
-    if (job_reap(parser, true)) reader_schedule_prompt_repaint();
+    if (job_reap(parser, true))
+        reader_schedule_prompt_repaint();
 }
 
 void inputter_t::select_interrupted() /* override */ {
     // Fire any pending events and reap stray processes, including printing exit status messages.
     auto &parser = *this->parser_;
     event_fire_delayed(parser);
-    if (job_reap(parser, true)) reader_schedule_prompt_repaint();
+    if (job_reap(parser, true))
+        reader_schedule_prompt_repaint();
 
     // Tell the reader an event occurred.
     if (reader_reading_interrupted()) {
@@ -400,7 +404,8 @@ void inputter_t::mapping_execute(const input_mapping_t &m,
 
     // !has_functions && !has_commands: only set bind mode
     if (!has_commands && !has_functions) {
-        if (!m.sets_mode.empty()) input_set_bind_mode(*parser_, m.sets_mode);
+        if (!m.sets_mode.empty())
+            input_set_bind_mode(*parser_, m.sets_mode);
         return;
     }
 
@@ -430,7 +435,8 @@ void inputter_t::mapping_execute(const input_mapping_t &m,
     }
 
     // Empty bind mode indicates to not reset the mode (#2871)
-    if (!m.sets_mode.empty()) input_set_bind_mode(*parser_, m.sets_mode);
+    if (!m.sets_mode.empty())
+        input_set_bind_mode(*parser_, m.sets_mode);
 }
 
 void inputter_t::queue_char(const char_event_t &ch) {
@@ -602,7 +608,8 @@ maybe_t<input_mapping_t> inputter_t::find_mapping(event_queue_peeker_t *peeker) 
 
         // Defer generic mappings until the end.
         if (m.is_generic()) {
-            if (!generic) generic = &m;
+            if (!generic)
+                generic = &m;
             continue;
         }
 
@@ -709,10 +716,12 @@ char_event_t inputter_t::read_char(const command_handler_t &command_handler) {
                 case readline_cmd_t::func_or: {
                     // If previous function has right status, we keep reading tokens
                     if (evt.get_readline() == readline_cmd_t::func_and) {
-                        if (function_status_) return readch();
+                        if (function_status_)
+                            return readch();
                     } else {
                         assert(evt.get_readline() == readline_cmd_t::func_or);
-                        if (!function_status_) return readch();
+                        if (!function_status_)
+                            return readch();
                     }
                     // Else we flush remaining tokens
                     do {
@@ -805,7 +814,8 @@ std::shared_ptr<const mapping_list_t> input_mapping_set_t::all_mappings() {
 /// Create a list of terminfo mappings.
 static std::vector<terminfo_mapping_t> create_input_terminfo() {
     assert(curses_initialized);
-    if (!cur_term) return {};  // setupterm() failed so we can't referency any key definitions
+    if (!cur_term)
+        return {};  // setupterm() failed so we can't referency any key definitions
 
 #define TERMINFO_ADD(key) \
     { (L## #key) + 4, key }

--- a/src/intern.cpp
+++ b/src/intern.cpp
@@ -21,7 +21,8 @@ static bool string_less_than_string(const wchar_t *a, const wchar_t *b) {
 owning_lock<std::vector<const wchar_t *>> string_table;
 
 static const wchar_t *intern_with_dup(const wchar_t *in, bool dup) {
-    if (!in) return nullptr;
+    if (!in)
+        return nullptr;
 
     auto table = string_table.acquire();
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -239,7 +239,8 @@ bool io_chain_t::append_from_specs(const redirection_spec_list_t &specs, const w
                         FLOGF(warning, NOCLOB_ERROR, spec.target.c_str());
                     } else {
                         FLOGF(warning, FILE_ERROR, spec.target.c_str());
-                        if (should_flog(warning)) wperror(L"open");
+                        if (should_flog(warning))
+                            wperror(L"open");
                     }
                     // If opening a file fails, insert a closed FD instead of the file redirection
                     // and return false. This lets execution potentially recover and at least gives
@@ -302,7 +303,8 @@ const wcstring &output_stream_t::contents() const { return g_empty_string; }
 int output_stream_t::flush_and_check_error() { return STATUS_CMD_OK; }
 
 void fd_output_stream_t::append(const wchar_t *s, size_t amt) {
-    if (errored_) return;
+    if (errored_)
+        return;
     int res = wwrite_to_fd(s, amt, this->fd_);
     if (res < 0) {
         // TODO: this error is too aggressive, e.g. if we got SIGINT we should not complain.

--- a/src/io.h
+++ b/src/io.h
@@ -90,7 +90,8 @@ class separated_buffer_t {
 
     /// Append a string \p str of a given length \p len, with separation type \p sep.
     void append(const char *str, size_t len, separation_type_t sep = separation_type_t::inferred) {
-        if (!try_add_size(len)) return;
+        if (!try_add_size(len))
+            return;
         // Try merging with the last element.
         if (sep == separation_type_t::inferred && last_inferred()) {
             elements_.back().contents.append(str, len);
@@ -101,7 +102,8 @@ class separated_buffer_t {
 
     /// Append a string \p str with separation type \p sep.
     void append(std::string &&str, separation_type_t sep = separation_type_t::inferred) {
-        if (!try_add_size(str.size())) return;
+        if (!try_add_size(str.size()))
+            return;
         // Try merging with the last element.
         if (sep == separation_type_t::inferred && last_inferred()) {
             elements_.back().contents.append(str);
@@ -135,7 +137,8 @@ class separated_buffer_t {
     /// Mark that we are about to add the given size \p delta to the buffer. \return true if we
     /// succeed, false if we exceed buffer_limit.
     bool try_add_size(size_t delta) {
-        if (discard_) return false;
+        if (discard_)
+            return false;
         size_t proposed_size = contents_size_ + delta;
         if ((proposed_size < delta) || (buffer_limit_ > 0 && proposed_size > buffer_limit_)) {
             clear();

--- a/src/iothread.cpp
+++ b/src/iothread.cpp
@@ -322,12 +322,14 @@ void iothread_service_main() {
     // Perform each completion in order.
     for (const void_function_t &func : queue.completions) {
         // ensure we don't invoke empty functions, that raises an exception
-        if (func) func();
+        if (func)
+            func();
     }
 
     // Perform each main thread request.
     for (const void_function_t &func : queue.requests) {
-        if (func) func();
+        if (func)
+            func();
     }
 }
 

--- a/src/job_group.cpp
+++ b/src/job_group.cpp
@@ -77,7 +77,8 @@ job_group_ref_t job_group_t::resolve_group_for_job(const job_t &job,
         needs_new_group = true;
     }
 
-    if (!needs_new_group) return proposed;
+    if (!needs_new_group)
+        return proposed;
 
     // We share a cancel group unless we are a background job.
     // For example, if we write "begin ; true ; sleep 1 &; end" the `begin` and `true` should cancel

--- a/src/kill.cpp
+++ b/src/kill.cpp
@@ -31,7 +31,8 @@ void kill_add(wcstring str) {
 static void kill_remove(const wcstring &s) {
     ASSERT_IS_MAIN_THREAD();
     auto iter = std::find(kill_list.begin(), kill_list.end(), s);
-    if (iter != kill_list.end()) kill_list.erase(iter);
+    if (iter != kill_list.end())
+        kill_list.erase(iter);
 }
 
 void kill_replace(const wcstring &old, const wcstring &newv) {

--- a/src/lru.h
+++ b/src/lru.h
@@ -194,7 +194,8 @@ class lru_cache_t {
     // Evicts the node for a given key, returning true if a node was evicted.
     bool evict_node(const wcstring &key) {
         auto where = this->node_map.find(key);
-        if (where == this->node_map.end()) return false;
+        if (where == this->node_map.end())
+            return false;
         evict_node(&where->second);
         return true;
     }

--- a/src/maybe.h
+++ b/src/maybe.h
@@ -85,7 +85,8 @@ struct maybe_impl_t {
         }
     }
     maybe_impl_t &operator=(const maybe_impl_t &v) {
-        if (&v == this) return *this;
+        if (&v == this)
+            return *this;
         if (!v.filled) {
             reset();
         } else {
@@ -197,7 +198,8 @@ class maybe_t : private maybe_detail::conditionally_copyable_t<T> {
 
     // Compare values for equality.
     bool operator==(const maybe_t &rhs) const {
-        if (this->has_value() && rhs.has_value()) return this->value() == rhs.value();
+        if (this->has_value() && rhs.has_value())
+            return this->value() == rhs.value();
         return this->has_value() == rhs.has_value();
     }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -68,7 +68,8 @@ static bool write_color_escape(outputter_t &outp, const char *todo, unsigned cha
         // TODO: enter bold mode in builtin_set_color in the same circumstance- doing that combined
         // with what we do here, will make the brights actually work for virtual consoles/ancient
         // emulators.
-        if (max_colors == 8 && idx > 8) idx -= 8;
+        if (max_colors == 8 && idx > 8)
+            idx -= 8;
         snprintf(buff, sizeof buff, "\x1B[%dm", ((idx > 7) ? 82 : 30) + idx + !is_fg * 10);
     } else {
         snprintf(buff, sizeof buff, "\x1B[%d;5;%dm", is_fg ? 38 : 48, idx);
@@ -79,7 +80,8 @@ static bool write_color_escape(outputter_t &outp, const char *todo, unsigned cha
 }
 
 static bool write_foreground_color(outputter_t &outp, unsigned char idx) {
-    if (!cur_term) return false;
+    if (!cur_term)
+        return false;
     if (set_a_foreground && set_a_foreground[0]) {
         return write_color_escape(outp, set_a_foreground, idx, true);
     } else if (set_foreground && set_foreground[0]) {
@@ -89,7 +91,8 @@ static bool write_foreground_color(outputter_t &outp, unsigned char idx) {
 }
 
 static bool write_background_color(outputter_t &outp, unsigned char idx) {
-    if (!cur_term) return false;
+    if (!cur_term)
+        return false;
     if (set_a_background && set_a_background[0]) {
         return write_color_escape(outp, set_a_background, idx, false);
     } else if (set_background && set_background[0]) {
@@ -107,7 +110,8 @@ void outputter_t::flush_to(int fd) {
 
 // Exported for builtin_set_color's usage only.
 bool outputter_t::write_color(rgb_color_t color, bool is_fg) {
-    if (!cur_term) return false;
+    if (!cur_term)
+        return false;
     bool supports_term24bit =
         static_cast<bool>(output_get_color_support() & color_support_term24bit);
     if (!supports_term24bit || !color.is_rgb()) {
@@ -149,7 +153,8 @@ bool outputter_t::write_color(rgb_color_t color, bool is_fg) {
 void outputter_t::set_color(rgb_color_t fg, rgb_color_t bg) {
     // Test if we have at least basic support for setting fonts, colors and related bits - otherwise
     // just give up...
-    if (!cur_term || !exit_attribute_mode) return;
+    if (!cur_term || !exit_attribute_mode)
+        return;
 
     const rgb_color_t normal = rgb_color_t::normal();
     bool bg_set = false, last_bg_set = false;
@@ -402,7 +407,8 @@ rgb_color_t parse_color(const env_var_t &var, bool is_background) {
     }
     rgb_color_t result = best_color(candidates, output_get_color_support());
 
-    if (result.is_none()) result = rgb_color_t::normal();
+    if (result.is_none())
+        result = rgb_color_t::normal();
 
     result.set_bold(is_bold);
     result.set_underline(is_underline);

--- a/src/output.h
+++ b/src/output.h
@@ -45,7 +45,8 @@ class outputter_t {
 
     /// Flush output, if we have a set fd and our buffering count is 0.
     void maybe_flush() {
-        if (fd_ >= 0 && buffer_count_ == 0) flush_to(fd_);
+        if (fd_ >= 0 && buffer_count_ == 0)
+            flush_to(fd_);
     }
 
    public:

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -61,7 +61,8 @@ inline bool selection_direction_is_cardinal(selection_motion_t dir) {
 
 /// Returns numer / denom, rounding up. As a "courtesy" 0/0 is 0.
 static size_t divide_round_up(size_t numer, size_t denom) {
-    if (numer == 0) return 0;
+    if (numer == 0)
+        return 0;
     assert(denom > 0);
     bool has_rem = (numer % denom) != 0;
     return numer / denom + (has_rem ? 1 : 0);
@@ -87,7 +88,8 @@ static size_t print_max(const wcstring &str, highlight_spec_t color, size_t max,
         }
         auto width_c = size_t(iwidth_c);
 
-        if (width_c > remaining) break;
+        if (width_c > remaining)
+            break;
 
         wchar_t ellipsis = get_ellipsis_char();
         if ((width_c == remaining) && (has_more || i + 1 < str.size())) {
@@ -219,7 +221,8 @@ void pager_t::completion_print(size_t cols, const size_t *width_by_column, size_
 
     for (size_t row = row_start; row < row_stop; row++) {
         for (size_t col = 0; col < cols; col++) {
-            if (lst.size() <= col * rows + row) continue;
+            if (lst.size() <= col * rows + row)
+                continue;
 
             size_t idx = col * rows + row;
             const comp_t *el = &lst.at(idx);
@@ -246,7 +249,8 @@ static void mangle_1_completion_description(wcstring *str) {
 
     // Skip leading spaces.
     for (; leading < len; leading++) {
-        if (!iswspace(str->at(leading))) break;
+        if (!iswspace(str->at(leading)))
+            break;
     }
 
     // Compress runs of spaces to a single space.
@@ -279,7 +283,8 @@ static void join_completions(comp_info_list_t *comps) {
     for (size_t i = 0; i < comps->size(); i++) {
         const comp_t &new_comp = comps->at(i);
         const wcstring &desc = new_comp.desc;
-        if (desc.empty()) continue;
+        if (desc.empty())
+            continue;
 
         // See if it's in the table.
         size_t prev_idx_plus_one = desc_table[desc];
@@ -330,11 +335,13 @@ void pager_t::measure_completion_infos(comp_info_list_t *infos, const wcstring &
 
         for (size_t j = 0; j < comp_strings.size(); j++) {
             // If there's more than one, append the length of ', '.
-            if (j >= 1) comp->comp_width += 2;
+            if (j >= 1)
+                comp->comp_width += 2;
 
             // fish_wcswidth() can return -1 if it can't calculate the width. So be cautious.
             int comp_width = fish_wcswidth(comp_strings.at(j));
-            if (comp_width >= 0) comp->comp_width += prefix_len + comp_width;
+            if (comp_width >= 0)
+                comp->comp_width += prefix_len + comp_width;
         }
 
         // fish_wcswidth() can return -1 if it can't calculate the width. So be cautious.
@@ -346,7 +353,8 @@ void pager_t::measure_completion_infos(comp_info_list_t *infos, const wcstring &
 // Indicates if the given completion info passes any filtering we have.
 bool pager_t::completion_info_passes_filter(const comp_t &info) const {
     // If we have no filter, everything passes.
-    if (!search_field_shown || this->search_field_line.empty()) return true;
+    if (!search_field_shown || this->search_field_line.empty())
+        return true;
 
     const wcstring &needle = this->search_field_line.text();
 
@@ -380,7 +388,8 @@ void pager_t::set_completions(const completion_list_t &raw_completions) {
     unfiltered_completion_infos = process_completions_into_infos(raw_completions);
 
     // Maybe join them.
-    if (prefix == L"-") join_completions(&unfiltered_completion_infos);
+    if (prefix == L"-")
+        join_completions(&unfiltered_completion_infos);
 
     // Compute their various widths.
     measure_completion_infos(&unfiltered_completion_infos, prefix);
@@ -440,7 +449,8 @@ bool pager_t::completion_try_print(size_t cols, const wcstring &prefix, const co
     for (size_t col = 0; col < cols; col++) {
         for (size_t row = 0; row < row_count; row++) {
             const size_t comp_idx = col * row_count + row;
-            if (comp_idx >= lst.size()) continue;
+            if (comp_idx >= lst.size())
+                continue;
             const comp_t &c = lst.at(comp_idx);
             width_by_column[col] = std::max(width_by_column[col], c.preferred_width());
         }
@@ -575,7 +585,8 @@ page_rendering_t pager_t::render() const {
 
 bool pager_t::rendering_needs_update(const page_rendering_t &rendering) const {
     // Common case is no pager.
-    if (this->empty() && rendering.screen_data.empty()) return false;
+    if (this->empty() && rendering.screen_data.empty())
+        return false;
 
     return (this->empty() && !rendering.screen_data.empty()) ||     // Do update after clear().
            rendering.term_width != this->available_term_width ||    //
@@ -791,7 +802,8 @@ size_t pager_t::visual_selected_completion_index(size_t rows, size_t cols) const
         }
 
         // If we are still beyond the last selection, clamp it.
-        if (result >= completion_infos.size()) result = completion_infos.size() - 1;
+        if (result >= completion_infos.size())
+            result = completion_infos.size() - 1;
     }
     assert(result == PAGER_SELECTION_NONE || result < completion_infos.size());
     return result;
@@ -818,7 +830,8 @@ const completion_t *pager_t::selected_completion(const page_rendering_t &renderi
 /// we go west. So if we have N rows, and our selected index is N + 2, then our row is 2 (mod by N)
 /// and our column is 1 (divide by N).
 size_t pager_t::get_selected_row(const page_rendering_t &rendering) const {
-    if (rendering.rows == 0) return PAGER_SELECTION_NONE;
+    if (rendering.rows == 0)
+        return PAGER_SELECTION_NONE;
 
     return selected_completion_idx == PAGER_SELECTION_NONE
                ? PAGER_SELECTION_NONE
@@ -826,7 +839,8 @@ size_t pager_t::get_selected_row(const page_rendering_t &rendering) const {
 }
 
 size_t pager_t::get_selected_column(const page_rendering_t &rendering) const {
-    if (rendering.rows == 0) return PAGER_SELECTION_NONE;
+    if (rendering.rows == 0)
+        return PAGER_SELECTION_NONE;
 
     return selected_completion_idx == PAGER_SELECTION_NONE
                ? PAGER_SELECTION_NONE

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -151,7 +151,8 @@ parse_execution_context_t::infinite_recursive_statement_in_job_list(const ast::j
 
     // Get the first job in the job list.
     const ast::job_conjunction_t *jc = jobs.at(0);
-    if (!jc) return nullptr;
+    if (!jc)
+        return nullptr;
     const ast::job_t *job = &jc->job;
 
     // Helper to return if a statement is infinitely recursive in this function.
@@ -160,11 +161,13 @@ parse_execution_context_t::infinite_recursive_statement_in_job_list(const ast::j
         // Ignore non-decorated statements like `if`, etc.
         const ast::decorated_statement_t *dc =
             stat.contents.contents->try_as<ast::decorated_statement_t>();
-        if (!dc) return nullptr;
+        if (!dc)
+            return nullptr;
 
         // Ignore statements with decorations like 'builtin' or 'command', since those
         // are not infinite recursion. In particular that is what enables 'wrapper functions'.
-        if (dc->decoration() != statement_decoration_t::none) return nullptr;
+        if (dc->decoration() != statement_decoration_t::none)
+            return nullptr;
 
         // Check the command.
         wcstring cmd = dc->command.source(pstree->src);
@@ -255,7 +258,8 @@ bool parse_execution_context_t::job_is_simple_block(const ast::job_t &job) const
     // Helper to check if an argument_or_redirection_list_t has no redirections.
     auto no_redirs = [](const argument_or_redirection_list_t &list) -> bool {
         for (const argument_or_redirection_t &val : list) {
-            if (val.is_redirection()) return false;
+            if (val.is_redirection())
+                return false;
         }
         return true;
     };
@@ -538,7 +542,8 @@ end_execution_reason_t parse_execution_context_t::run_switch_statement(
     }
 
     end_execution_reason_t result = end_execution_reason_t::ok;
-    if (trace_enabled(*parser)) trace_argv(*parser, L"switch", {switch_value_expanded});
+    if (trace_enabled(*parser))
+        trace_argv(*parser, L"switch", {switch_value_expanded});
     block_t *sb = parser->push_block(block_t::switch_block());
 
     // Expand case statements.
@@ -569,7 +574,8 @@ end_execution_reason_t parse_execution_context_t::run_switch_statement(
                 }
             }
         }
-        if (matching_case_item) break;
+        if (matching_case_item)
+            break;
     }
 
     if (matching_case_item) {
@@ -717,7 +723,8 @@ parse_execution_context_t::ast_args_list_t parse_execution_context_t::get_argume
     const ast::argument_or_redirection_list_t &args) {
     ast_args_list_t result;
     for (const ast::argument_or_redirection_t &v : args) {
-        if (v.is_argument()) result.push_back(&v.argument());
+        if (v.is_argument())
+            result.push_back(&v.argument());
     }
     return result;
 }
@@ -839,7 +846,8 @@ end_execution_reason_t parse_execution_context_t::populate_plain_process(
         return ret;
     }
     // For no-exec, having an empty command is okay. We can't do anything more with it tho.
-    if (no_exec()) return end_execution_reason_t::ok;
+    if (no_exec())
+        return end_execution_reason_t::ok;
     assert(!cmd.empty() && "expand_command should not produce an empty command");
 
     // Determine the process type.
@@ -867,7 +875,8 @@ end_execution_reason_t parse_execution_context_t::populate_plain_process(
 
         if (!has_command && !use_implicit_cd) {
             // No command. If we're --no-execute return okay - it might be a function.
-            if (no_exec()) return end_execution_reason_t::ok;
+            if (no_exec())
+                return end_execution_reason_t::ok;
             return this->handle_command_not_found(cmd, statement, no_cmd_err_code);
         }
     }
@@ -948,7 +957,8 @@ end_execution_reason_t parse_execution_context_t::expand_arguments_from_nodes(
             case expand_result_t::wildcard_no_match: {
                 if (glob_behavior == failglob) {
                     // For no_exec, ignore the error - this might work at runtime.
-                    if (no_exec()) return end_execution_reason_t::ok;
+                    if (no_exec())
+                        return end_execution_reason_t::ok;
                     // Report the unmatched wildcard error and stop processing.
                     return report_error(STATUS_UNMATCHED_WILDCARD, *arg_node, WILDCARD_ERR_MSG,
                                         get_source(*arg_node).c_str());
@@ -983,7 +993,8 @@ end_execution_reason_t parse_execution_context_t::determine_redirections(
     const ast::argument_or_redirection_list_t &list, redirection_spec_list_t *out_redirections) {
     // Get all redirection nodes underneath the statement.
     for (const ast::argument_or_redirection_t &arg_or_redir : list) {
-        if (!arg_or_redir.is_redirection()) continue;
+        if (!arg_or_redir.is_redirection())
+            continue;
         const ast::redirection_t &redir_node = arg_or_redir.redirection();
 
         maybe_t<pipe_or_redir_t> oper = pipe_or_redir_t::from_string(get_source(redir_node.oper));
@@ -1079,7 +1090,8 @@ end_execution_reason_t parse_execution_context_t::populate_block_process(
 end_execution_reason_t parse_execution_context_t::apply_variable_assignments(
     process_t *proc, const ast::variable_assignment_list_t &variable_assignment_list,
     const block_t **block) {
-    if (variable_assignment_list.empty()) return end_execution_reason_t::ok;
+    if (variable_assignment_list.empty())
+        return end_execution_reason_t::ok;
     *block = parser->push_block(block_t::variable_assignment_block());
     for (const ast::variable_assignment_t &variable_assignment : variable_assignment_list) {
         const wcstring &source = get_source(variable_assignment);
@@ -1112,7 +1124,8 @@ end_execution_reason_t parse_execution_context_t::apply_variable_assignments(
         for (auto &completion : expression_expanded) {
             vals.emplace_back(std::move(completion.completion));
         }
-        if (proc) proc->variable_assignments.push_back({variable_name, vals});
+        if (proc)
+            proc->variable_assignments.push_back({variable_name, vals});
         parser->set_var_and_fire(variable_name, ENV_LOCAL | ENV_EXPORT, std::move(vals));
     }
     return end_execution_reason_t::ok;
@@ -1129,9 +1142,11 @@ end_execution_reason_t parse_execution_context_t::populate_job_process(
     end_execution_reason_t result =
         this->apply_variable_assignments(proc, variable_assignments, &block);
     cleanup_t scope([&]() {
-        if (block) parser->pop_block(block);
+        if (block)
+            parser->pop_block(block);
     });
-    if (result != end_execution_reason_t::ok) return result;
+    if (result != end_execution_reason_t::ok)
+        return result;
 
     switch (specific_statement.type) {
         case type_t::not_statement: {
@@ -1234,22 +1249,26 @@ static bool remove_job(parser_t &parser, job_t *job) {
 /// `sleep 1 | not time true` will time the whole job!
 static bool job_node_wants_timing(const ast::job_t &job_node) {
     // Does our job have the job-level time prefix?
-    if (job_node.time) return true;
+    if (job_node.time)
+        return true;
 
     // Helper to return true if a node is 'not time ...' or 'not not time...' or...
     auto is_timed_not_statement = [](const ast::statement_t &stat) {
         const auto *ns = stat.contents->try_as<ast::not_statement_t>();
         while (ns) {
-            if (ns->time) return true;
+            if (ns->time)
+                return true;
             ns = ns->contents.try_as<ast::not_statement_t>();
         }
         return false;
     };
 
     // Do we have a 'not time ...' anywhere in our pipeline?
-    if (is_timed_not_statement(job_node.statement)) return true;
+    if (is_timed_not_statement(job_node.statement))
+        return true;
     for (const ast::job_continuation_t &jc : job_node.continuation) {
-        if (is_timed_not_statement(jc.statement)) return true;
+        if (is_timed_not_statement(jc.statement))
+            return true;
     }
     return false;
 }
@@ -1261,7 +1280,8 @@ end_execution_reason_t parse_execution_context_t::run_1_job(const ast::job_t &jo
     }
 
     // We definitely do not want to execute anything if we're told we're --no-execute!
-    if (no_exec()) return end_execution_reason_t::ok;
+    if (no_exec())
+        return end_execution_reason_t::ok;
 
     // Get terminal modes.
     struct termios tmodes = {};
@@ -1294,7 +1314,8 @@ end_execution_reason_t parse_execution_context_t::run_1_job(const ast::job_t &jo
         end_execution_reason_t result =
             this->apply_variable_assignments(nullptr, job_node.variables, &block);
         cleanup_t scope([&]() {
-            if (block) parser->pop_block(block);
+            if (block)
+                parser->pop_block(block);
         });
 
         const ast::node_t *specific_statement = job_node.statement.contents.get();

--- a/src/parse_tree.cpp
+++ b/src/parse_tree.cpp
@@ -46,7 +46,8 @@ wcstring parse_error_t::describe_with_prefix(const wcstring &src, const wcstring
     wcstring result = prefix;
     switch (code) {
         default:
-            if (skip_caret && this->text.empty()) return L"";
+            if (skip_caret && this->text.empty())
+                return L"";
             break;
         case parse_error_andor_in_pipeline:
             append_format(result, EXEC_ERR_MSG,
@@ -101,7 +102,8 @@ wcstring parse_error_t::describe_with_prefix(const wcstring &src, const wcstring
     }
 
     // Append the line of text.
-    if (!result.empty()) result.push_back(L'\n');
+    if (!result.empty())
+        result.push_back(L'\n');
     result.append(src, line_start, line_end - line_start);
 
     // Append the caret line. The input source may include tabs; for that reason we
@@ -147,13 +149,15 @@ void parse_error_offset_source_start(parse_error_list_t *errors, size_t amt) {
 /// Returns a string description for the given token type.
 const wchar_t *token_type_description(parse_token_type_t type) {
     const wchar_t *description = enum_to_str(type, token_enum_map);
-    if (description) return description;
+    if (description)
+        return description;
     return L"unknown_token_type";
 }
 
 const wchar_t *keyword_description(parse_keyword_t type) {
     const wchar_t *keyword = enum_to_str(type, keyword_enum_map);
-    if (keyword) return keyword;
+    if (keyword)
+        return keyword;
     return L"unknown_keyword";
 }
 

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -43,7 +43,8 @@
 static constexpr int var_err_len = 16;
 
 int parse_util_lineno(const wchar_t *str, size_t offset) {
-    if (!str) return 0;
+    if (!str)
+        return 0;
 
     int res = 1;
     for (size_t i = 0; i < offset && str[i] != L'\0'; i++) {
@@ -74,11 +75,14 @@ size_t parse_util_get_offset_from_line(const wcstring &str, int line) {
     size_t i;
     int count = 0;
 
-    if (line < 0) return static_cast<size_t>(-1);
-    if (line == 0) return 0;
+    if (line < 0)
+        return static_cast<size_t>(-1);
+    if (line == 0)
+        return 0;
 
     for (i = 0;; i++) {
-        if (!buff[i]) return static_cast<size_t>(-1);
+        if (!buff[i])
+            return static_cast<size_t>(-1);
 
         if (buff[i] == L'\n') {
             count++;
@@ -93,9 +97,12 @@ size_t parse_util_get_offset(const wcstring &str, int line, long line_offset) {
     size_t off = parse_util_get_offset_from_line(str, line);
     size_t off2 = parse_util_get_offset_from_line(str, line + 1);
 
-    if (off == static_cast<size_t>(-1)) return static_cast<size_t>(-1);
-    if (off2 == static_cast<size_t>(-1)) off2 = str.length() + 1;
-    if (line_offset < 0) line_offset = 0;  //!OCLINT(parameter reassignment)
+    if (off == static_cast<size_t>(-1))
+        return static_cast<size_t>(-1);
+    if (off2 == static_cast<size_t>(-1))
+        off2 = str.length() + 1;
+    if (line_offset < 0)
+        line_offset = 0;  //!OCLINT(parameter reassignment)
 
     if (static_cast<size_t>(line_offset) >= off2 - off - 1) {
         line_offset = off2 - off - 1;  //!OCLINT(parameter reassignment)
@@ -187,12 +194,14 @@ static int parse_util_locate_brackets_range(const wcstring &str, size_t *inout_c
                                             size_t *out_end, bool accept_incomplete,
                                             wchar_t open_type, wchar_t close_type) {
     // Clear the return values.
-    if (out_contents != nullptr) out_contents->clear();
+    if (out_contents != nullptr)
+        out_contents->clear();
     *out_start = 0;
     *out_end = str.size();
 
     // Nothing to do if the offset is at or past the end of the string.
-    if (*inout_cursor_offset >= str.size()) return 0;
+    if (*inout_cursor_offset >= str.size())
+        return 0;
 
     // Defer to the wonky version.
     const wchar_t *const buff = str.c_str();
@@ -265,7 +274,8 @@ void parse_util_cmdsubst_extent(const wchar_t *buff, size_t cursor_pos, const wc
             bp = end;
             // pos is where to begin looking for the next one. But if we reached the end there's no
             // next one.
-            if (begin >= end) break;
+            if (begin >= end)
+                break;
             pos = begin + 1;
         } else if (begin >= cursor) {
             // This command substitution starts at or after the cursor. Since it was the first
@@ -279,8 +289,10 @@ void parse_util_cmdsubst_extent(const wchar_t *buff, size_t cursor_pos, const wc
         }
     }
 
-    if (a != nullptr) *a = ap;
-    if (b != nullptr) *b = bp;
+    if (a != nullptr)
+        *a = ap;
+    if (b != nullptr)
+        *b = bp;
 }
 
 /// Get the beginning and end of the job or process definition under the cursor.
@@ -291,8 +303,10 @@ static void job_or_process_extent(bool process, const wchar_t *buff, size_t curs
     const wchar_t *begin = nullptr, *end = nullptr;
     int finished = 0;
 
-    if (a) *a = nullptr;
-    if (b) *b = nullptr;
+    if (a)
+        *a = nullptr;
+    if (b)
+        *b = nullptr;
     parse_util_cmdsubst_extent(buff, cursor_pos, &begin, &end);
     if (!end || !begin) {
         return;
@@ -301,8 +315,10 @@ static void job_or_process_extent(bool process, const wchar_t *buff, size_t curs
     assert(cursor_pos >= static_cast<size_t>(begin - buff));
     const size_t pos = cursor_pos - (begin - buff);
 
-    if (a) *a = begin;
-    if (b) *b = end;
+    if (a)
+        *a = begin;
+    if (b)
+        *b = end;
 
     const wcstring buffcpy(begin, end);
     tokenizer_t tok(buffcpy.c_str(), TOK_ACCEPT_UNFINISHED);
@@ -324,11 +340,14 @@ static void job_or_process_extent(bool process, const wchar_t *buff, size_t curs
             case token_type_t::comment: {
                 if (tok_begin >= pos) {
                     finished = 1;
-                    if (b) *b = const_cast<wchar_t *>(begin) + tok_begin;
+                    if (b)
+                        *b = const_cast<wchar_t *>(begin) + tok_begin;
                 } else {
                     // Statement at cursor might start after this token.
-                    if (a) *a = const_cast<wchar_t *>(begin) + tok_begin + token->length;
-                    if (tokens) tokens->clear();
+                    if (a)
+                        *a = const_cast<wchar_t *>(begin) + tok_begin + token->length;
+                    if (tokens)
+                        tokens->clear();
                 }
                 continue;  // Do not add this to tokens
             }
@@ -336,7 +355,8 @@ static void job_or_process_extent(bool process, const wchar_t *buff, size_t curs
                 break;
             }
         }
-        if (tokens) tokens->push_back(*token);
+        if (tokens)
+            tokens->push_back(*token);
     }
 }
 
@@ -411,10 +431,14 @@ void parse_util_token_extent(const wchar_t *buff, size_t cursor_pos, const wchar
         }
     }
 
-    if (tok_begin) *tok_begin = a;
-    if (tok_end) *tok_end = b;
-    if (prev_begin) *prev_begin = pa;
-    if (prev_end) *prev_end = pb;
+    if (tok_begin)
+        *tok_begin = a;
+    if (tok_end)
+        *tok_end = b;
+    if (prev_begin)
+        *prev_begin = pa;
+    if (prev_end)
+        *prev_end = pb;
 
     assert(pa >= buff);
     assert(pa <= (buff + bufflen));
@@ -457,11 +481,13 @@ static wchar_t get_quote(const wcstring &cmd_str, size_t len) {
     const wchar_t *const cmd = cmd_str.c_str();
 
     while (true) {
-        if (!cmd[i]) break;
+        if (!cmd[i])
+            break;
 
         if (cmd[i] == L'\\') {
             i++;
-            if (!cmd[i]) break;
+            if (!cmd[i])
+                break;
             i++;
         } else {
             if (cmd[i] == L'\'' || cmd[i] == L'\"') {
@@ -487,12 +513,14 @@ void parse_util_get_parameter_info(const wcstring &cmd, const size_t pos, wchar_
 
     tokenizer_t tok(cmd.c_str(), TOK_ACCEPT_UNFINISHED);
     while (auto token = tok.next()) {
-        if (token->offset > pos) break;
+        if (token->offset > pos)
+            break;
 
         if (token->type == token_type_t::string)
             last_quote = get_quote(tok.text_of(*token), pos - token->offset);
 
-        if (out_type != nullptr) *out_type = token->type;
+        if (out_type != nullptr)
+            *out_type = token->type;
 
         prev_pos = token->offset;
     }
@@ -508,7 +536,8 @@ void parse_util_get_parameter_info(const wcstring &cmd, const size_t pos, wchar_
         }
     }
 
-    if (quote) *quote = last_quote;
+    if (quote)
+        *quote = last_quote;
 
     if (offset != nullptr) {
         if (finished) {
@@ -551,11 +580,13 @@ wcstring parse_util_escape_string_with_quote(const wcstring &cmd, wchar_t quote,
                     result.append({L'\\', L'\\'});
                     break;
                 case L'$':
-                    if (quote == L'"') result.push_back(L'\\');
+                    if (quote == L'"')
+                        result.push_back(L'\\');
                     result.push_back(L'$');
                     break;
                 default:
-                    if (c == quote) result.push_back(L'\\');
+                    if (c == quote)
+                        result.push_back(L'\\');
                     result.push_back(c);
                     break;
             }
@@ -711,9 +742,11 @@ std::vector<int> parse_util_compute_indents(const wcstring &src) {
         void record_line_continuations_until(size_t offset) {
             wcstring gap_text = src.substr(last_leaf_end, offset - last_leaf_end);
             size_t escaped_nl = gap_text.find(L"\\\n");
-            if (escaped_nl == wcstring::npos) return;
+            if (escaped_nl == wcstring::npos)
+                return;
             auto line_end = gap_text.begin() + escaped_nl;
-            if (std::find(gap_text.begin(), line_end, L'#') != line_end) return;
+            if (std::find(gap_text.begin(), line_end, L'#') != line_end)
+                return;
             auto end = src.begin() + offset;
             auto newline = src.begin() + last_leaf_end + escaped_nl + 1;
             // The gap text might contain multiple newlines if there are multiple lines that
@@ -783,7 +816,8 @@ std::vector<int> parse_util_compute_indents(const wcstring &src) {
 /// Append a syntax error to the given error list.
 static bool append_syntax_error(parse_error_list_t *errors, size_t source_location,
                                 const wchar_t *fmt, ...) {
-    if (!errors) return true;
+    if (!errors)
+        return true;
     parse_error_t error;
     error.source_start = source_location;
     error.source_length = 0;
@@ -811,7 +845,8 @@ bool parse_util_argument_is_help(const wcstring &s) { return s == L"-h" || s == 
 // there are no arguments.
 static const ast::argument_t *get_first_arg(const ast::argument_or_redirection_list_t &list) {
     for (const ast::argument_or_redirection_t &v : list) {
-        if (v.is_argument()) return &v.argument();
+        if (v.is_argument())
+            return &v.argument();
     }
     return nullptr;
 }
@@ -973,7 +1008,8 @@ parser_test_error_bits_t parse_util_detect_errors_in_argument(const ast::argumen
                                                               const wcstring &arg_src,
                                                               parse_error_list_t *out_errors) {
     maybe_t<source_range_t> source_range = arg.try_source_range();
-    if (!source_range.has_value()) return 0;
+    if (!source_range.has_value())
+        return 0;
 
     size_t source_start = source_range->start;
     parser_test_error_bits_t err = 0;
@@ -1068,7 +1104,8 @@ static bool detect_errors_in_backgrounded_job(const ast::job_t &job,
                                               parse_error_list_t *parse_errors) {
     using namespace ast;
     auto source_range = job.try_source_range();
-    if (!source_range) return false;
+    if (!source_range)
+        return false;
 
     bool errored = false;
     // Disallow background in the following cases:
@@ -1077,7 +1114,8 @@ static bool detect_errors_in_backgrounded_job(const ast::job_t &job,
     // if foo & ; end
     // while foo & ; end
     const job_conjunction_t *job_conj = job.parent->try_as<job_conjunction_t>();
-    if (!job_conj) return false;
+    if (!job_conj)
+        return false;
 
     if (job_conj->parent->try_as<if_clause_t>()) {
         errored = append_syntax_error(parse_errors, source_range->start,
@@ -1090,7 +1128,8 @@ static bool detect_errors_in_backgrounded_job(const ast::job_t &job,
         // Find the index of ourselves in the job list.
         size_t index;
         for (index = 0; index < jlist->count(); index++) {
-            if (jlist->at(index) == job_conj) break;
+            if (jlist->at(index) == job_conj)
+                break;
         }
         assert(index < jlist->count() && "Should have found the job in the list");
 
@@ -1213,7 +1252,8 @@ static bool detect_errors_in_decorated_statement(const wcstring &buff_src,
             bool found_loop = false;
             for (const node_t *ancestor = &dst; ancestor != nullptr; ancestor = ancestor->parent) {
                 const auto *block = ancestor->try_as<block_statement_t>();
-                if (!block) continue;
+                if (!block)
+                    continue;
                 if (block->header->type == type_t::for_header ||
                     block->header->type == type_t::while_header) {
                     // This is a loop header, so we can break or continue.
@@ -1317,20 +1357,24 @@ parser_test_error_bits_t parse_util_detect_errors(const ast::ast_t &ast, const w
             errored |= detect_errors_in_decorated_statement(buff_src, *stmt, &storage, out_errors);
         } else if (const auto *block = node.try_as<block_statement_t>()) {
             // If our 'end' had no source, we are unsourced.
-            if (block->end.unsourced) has_unclosed_block = true;
+            if (block->end.unsourced)
+                has_unclosed_block = true;
             errored |= detect_errors_in_block_redirection_list(block->args_or_redirs, out_errors);
         } else if (const auto *ifs = node.try_as<if_statement_t>()) {
             // If our 'end' had no source, we are unsourced.
-            if (ifs->end.unsourced) has_unclosed_block = true;
+            if (ifs->end.unsourced)
+                has_unclosed_block = true;
             errored |= detect_errors_in_block_redirection_list(ifs->args_or_redirs, out_errors);
         } else if (const auto *switchs = node.try_as<switch_statement_t>()) {
             // If our 'end' had no source, we are unsourced.
-            if (switchs->end.unsourced) has_unclosed_block = true;
+            if (switchs->end.unsourced)
+                has_unclosed_block = true;
             errored |= detect_errors_in_block_redirection_list(switchs->args_or_redirs, out_errors);
         }
     }
 
-    if (errored) res |= PARSER_TEST_ERROR;
+    if (errored)
+        res |= PARSER_TEST_ERROR;
 
     if (has_unclosed_block || has_unclosed_pipe || has_unclosed_conjunction)
         res |= PARSER_TEST_INCOMPLETE;
@@ -1375,7 +1419,8 @@ parser_test_error_bits_t parse_util_detect_errors(const wcstring &buff_src,
 
     // Early parse error, stop here.
     if (!parse_errors.empty()) {
-        if (out_errors) vec_append(*out_errors, std::move(parse_errors));
+        if (out_errors)
+            vec_append(*out_errors, std::move(parse_errors));
         return PARSER_TEST_ERROR;
     }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -165,7 +165,8 @@ void parser_t::pop_block(const block_t *expected) {
     block_t old = block_list.front();
     block_list.pop_front();
 
-    if (old.wants_pop_env) vars().pop();
+    if (old.wants_pop_env)
+        vars().pop();
 
     // Figure out if `status is-block` should consider us to be in a block now.
     bool new_is_block = false;
@@ -235,7 +236,8 @@ block_t *parser_t::current_block() { return block_at_index(0); }
 static void print_profile(const std::deque<profile_item_t> &items, FILE *out) {
     for (size_t idx = 0; idx < items.size(); idx++) {
         const profile_item_t &item = items.at(idx);
-        if (item.skipped || item.cmd.empty()) continue;
+        if (item.skipped || item.cmd.empty())
+            continue;
 
         long long total_time = item.duration;
 
@@ -244,13 +246,16 @@ static void print_profile(const std::deque<profile_item_t> &items, FILE *out) {
         long long self_time = item.duration;
         for (size_t i = idx + 1; i < items.size(); i++) {
             const profile_item_t &nested_item = items.at(i);
-            if (nested_item.skipped) continue;
+            if (nested_item.skipped)
+                continue;
 
             // If the eval level is not larger, then we have exhausted nested items.
-            if (nested_item.level <= item.level) break;
+            if (nested_item.level <= item.level)
+                break;
 
             // If the eval level is exactly one more than our level, it is a directly nested item.
-            if (nested_item.level == item.level + 1) self_time -= nested_item.duration;
+            if (nested_item.level == item.level + 1)
+                self_time -= nested_item.duration;
         }
 
         if (std::fwprintf(out, L"%lld\t%lld\t", self_time, total_time) < 0) {
@@ -337,7 +342,8 @@ static void append_block_description_to_stack_trace(const parser_t &parser, cons
             // Print arguments on the same line.
             wcstring args_str;
             for (const wcstring &arg : b.function_args) {
-                if (!args_str.empty()) args_str.push_back(L' ');
+                if (!args_str.empty())
+                    args_str.push_back(L' ');
                 // We can't quote the arguments because we print this in quotes.
                 // As a special-case, add the empty argument as "".
                 if (!arg.empty()) {
@@ -407,7 +413,8 @@ wcstring parser_t::stack_trace() const {
         // It might make sense in the future to continue printing the stack trace of the code
         // that invoked the event, if this is a programmatic event, but we can't currently
         // detect that.
-        if (b.type() == block_type_t::event) break;
+        if (b.type() == block_type_t::event)
+            break;
     }
     return trace;
 }
@@ -568,14 +575,16 @@ void parser_t::job_promote(job_t *job) {
 
 job_t *parser_t::job_get(job_id_t id) {
     for (const auto &job : job_list) {
-        if (id <= 0 || job->job_id() == id) return job.get();
+        if (id <= 0 || job->job_id() == id)
+            return job.get();
     }
     return nullptr;
 }
 
 const job_t *parser_t::job_get(job_id_t id) const {
     for (const auto &job : job_list) {
-        if (id <= 0 || job->job_id() == id) return job.get();
+        if (id <= 0 || job->job_id() == id)
+            return job.get();
     }
     return nullptr;
 }
@@ -672,7 +681,8 @@ eval_res_t parser_t::eval_node(const parsed_source_ref_t &ps, const T &node,
         // Did fish itself get a signal?
         int sig = signal_check_cancel();
         // Has this job group been cancelled?
-        if (!sig) sig = cancel_group->get_cancel_signal();
+        if (!sig)
+            sig = cancel_group->get_cancel_signal();
         return sig;
     };
 

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -46,7 +46,8 @@ static bool path_get_path_core(const wcstring &cmd, wcstring *out_path,
             return false;
         }
         if (S_ISREG(buff.st_mode)) {
-            if (out_path) out_path->assign(cmd);
+            if (out_path)
+                out_path->assign(cmd);
             return true;
         }
         errno = EACCES;
@@ -62,7 +63,8 @@ static bool path_get_path_core(const wcstring &cmd, wcstring *out_path,
 
     int err = ENOENT;
     for (auto next_path : *pathsv) {
-        if (next_path.empty()) continue;
+        if (next_path.empty())
+            continue;
         append_path_component(next_path, cmd);
         std::string narrow = wcs2string(next_path);
         if (access(narrow.c_str(), X_OK) == 0) {
@@ -74,7 +76,8 @@ static bool path_get_path_core(const wcstring &cmd, wcstring *out_path,
                 continue;
             }
             if (S_ISREG(buff.st_mode)) {
-                if (out_path) *out_path = std::move(next_path);
+                if (out_path)
+                    *out_path = std::move(next_path);
                 return true;
             }
             err = EACCES;
@@ -90,13 +93,16 @@ bool path_get_path(const wcstring &cmd, wcstring *out_path, const environment_t 
 }
 
 bool path_is_executable(const std::string &path) {
-    if (access(path.c_str(), X_OK)) return false;
+    if (access(path.c_str(), X_OK))
+        return false;
     struct stat buff;
     if (stat(path.c_str(), &buff) == -1) {
-        if (errno != EACCES) wperror(L" stat");
+        if (errno != EACCES)
+            wperror(L" stat");
         return false;
     }
-    if (!S_ISREG(buff.st_mode)) return false;
+    if (!S_ISREG(buff.st_mode))
+        return false;
     return true;
 }
 
@@ -108,19 +114,23 @@ wcstring_list_t path_get_paths(const wcstring &cmd, const environment_t &vars) {
     // looking for matching commands in the PATH var.
     if (cmd.find(L'/') != wcstring::npos) {
         std::string narrow = wcs2string(cmd);
-        if (path_is_executable(narrow)) paths.push_back(cmd);
+        if (path_is_executable(narrow))
+            paths.push_back(cmd);
         return paths;
     }
 
     auto path_var = vars.get(L"PATH");
-    if (!path_var) return paths;
+    if (!path_var)
+        return paths;
 
     const wcstring_list_t &pathsv = path_var->as_list();
     for (auto path : pathsv) {
-        if (path.empty()) continue;
+        if (path.empty())
+            continue;
         append_path_component(path, cmd);
         std::string narrow = wcs2string(path);
-        if (path_is_executable(narrow)) paths.push_back(path);
+        if (path_is_executable(narrow))
+            paths.push_back(path);
     }
 
     return paths;
@@ -145,7 +155,8 @@ wcstring_list_t path_apply_cdpath(const wcstring &dir, const wcstring &wd,
         // Always append $PWD
         cdpathsv.push_back(L".");
         for (wcstring next_path : cdpathsv) {
-            if (next_path.empty()) next_path = L".";
+            if (next_path.empty())
+                next_path = L".";
             if (next_path == L".") {
                 // next_path is just '.', and we have a working directory, so use the wd instead.
                 next_path = wd;
@@ -159,7 +170,8 @@ wcstring_list_t path_apply_cdpath(const wcstring &dir, const wcstring &wd,
             }
 
             expand_tilde(next_path, env_vars);
-            if (next_path.empty()) continue;
+            if (next_path.empty())
+                continue;
 
             wcstring whole_path = std::move(next_path);
             append_path_component(whole_path, dir);
@@ -173,7 +185,8 @@ wcstring_list_t path_apply_cdpath(const wcstring &dir, const wcstring &wd,
 maybe_t<wcstring> path_get_cdpath(const wcstring &dir, const wcstring &wd,
                                   const environment_t &env_vars) {
     int err = ENOENT;
-    if (dir.empty()) return none();
+    if (dir.empty())
+        return none();
     assert(!wd.empty() && wd.back() == L'/');
     auto paths = path_apply_cdpath(dir, wd, env_vars);
 
@@ -208,7 +221,8 @@ maybe_t<wcstring> path_as_implicit_cd(const wcstring &path, const wcstring &wd,
 // If the given path looks like it's relative to the working directory, then prepend that working
 // directory. This operates on unescaped paths only (so a ~ means a literal ~).
 wcstring path_apply_working_directory(const wcstring &path, const wcstring &working_directory) {
-    if (path.empty() || working_directory.empty()) return path;
+    if (path.empty() || working_directory.empty())
+        return path;
 
     // We're going to make sure that if we want to prepend the wd, that the string has no leading
     // "/".
@@ -275,14 +289,17 @@ static int create_directory(const wcstring &d) {
     int stat_res = 0;
 
     while ((stat_res = wstat(d, &buf)) != 0) {
-        if (errno != EAGAIN) break;
+        if (errno != EAGAIN)
+            break;
     }
 
     if (stat_res == 0) {
-        if (S_ISDIR(buf.st_mode)) ok = true;
+        if (S_ISDIR(buf.st_mode))
+            ok = true;
     } else if (errno == ENOENT) {
         wcstring dir = wdirname(d);
-        if (!create_directory(dir) && !wmkdir(d, 0700)) ok = true;
+        if (!create_directory(dir) && !wmkdir(d, 0700))
+            ok = true;
     }
 
     return ok ? 0 : -1;
@@ -379,11 +396,13 @@ void path_make_canonical(wcstring &path) {
         prev_was_slash = is_slash;
     }
     assert(trailing <= len);
-    if (trailing < len) path.resize(trailing);
+    if (trailing < len)
+        path.resize(trailing);
 }
 
 bool paths_are_equivalent(const wcstring &p1, const wcstring &p2) {
-    if (p1 == p2) return true;
+    if (p1 == p2)
+        return true;
 
     size_t len1 = p1.size(), len2 = p2.size();
 
@@ -397,7 +416,8 @@ bool paths_are_equivalent(const wcstring &p1, const wcstring &p2) {
         wchar_t c1 = p1.at(idx1), c2 = p2.at(idx2);
 
         // If the characters are different, the strings are not equivalent.
-        if (c1 != c2) break;
+        if (c1 != c2)
+            break;
 
         idx1++;
         idx2++;
@@ -434,7 +454,8 @@ bool path_is_valid(const wcstring &path, const wcstring &working_directory) {
 }
 
 bool paths_are_same_file(const wcstring &path1, const wcstring &path2) {
-    if (paths_are_equivalent(path1, path2)) return true;
+    if (paths_are_equivalent(path1, path2))
+        return true;
 
     struct stat s1, s2;
     if (wstat(path1, &s1) == 0 && wstat(path2, &s2) == 0) {

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -216,7 +216,8 @@ pid_t execute_fork() {
 // Given an error code, if it is the first error, record it.
 // \return whether we have any error.
 bool posix_spawner_t::check_fail(int err) {
-    if (error_ == 0) error_ = err;
+    if (error_ == 0)
+        error_ = err;
     return error_ != 0;
 }
 
@@ -233,13 +234,15 @@ posix_spawner_t::posix_spawner_t(const job_t *j, const dup2_list_t &dup2s) {
     // Initialize our fields. This may fail.
     {
         posix_spawnattr_t attr;
-        if (check_fail(posix_spawnattr_init(&attr))) return;
+        if (check_fail(posix_spawnattr_init(&attr)))
+            return;
         this->attr_ = attr;
     }
 
     {
         posix_spawn_file_actions_t actions;
-        if (check_fail(posix_spawn_file_actions_init(&actions))) return;
+        if (check_fail(posix_spawn_file_actions_init(&actions)))
+            return;
         this->actions_ = actions;
     }
 
@@ -263,21 +266,27 @@ posix_spawner_t::posix_spawner_t(const job_t *j, const dup2_list_t &dup2s) {
 
     // Set our flags.
     short flags = 0;
-    if (reset_signal_handlers) flags |= POSIX_SPAWN_SETSIGDEF;
-    if (reset_sigmask) flags |= POSIX_SPAWN_SETSIGMASK;
-    if (desired_pgid.has_value()) flags |= POSIX_SPAWN_SETPGROUP;
+    if (reset_signal_handlers)
+        flags |= POSIX_SPAWN_SETSIGDEF;
+    if (reset_sigmask)
+        flags |= POSIX_SPAWN_SETSIGMASK;
+    if (desired_pgid.has_value())
+        flags |= POSIX_SPAWN_SETPGROUP;
 
-    if (check_fail(posix_spawnattr_setflags(attr(), flags))) return;
+    if (check_fail(posix_spawnattr_setflags(attr(), flags)))
+        return;
 
     if (desired_pgid.has_value()) {
-        if (check_fail(posix_spawnattr_setpgroup(attr(), *desired_pgid))) return;
+        if (check_fail(posix_spawnattr_setpgroup(attr(), *desired_pgid)))
+            return;
     }
 
     // Everybody gets default handlers.
     if (reset_signal_handlers) {
         sigset_t sigdefault;
         get_signals_with_handlers(&sigdefault);
-        if (check_fail(posix_spawnattr_setsigdefault(attr(), &sigdefault))) return;
+        if (check_fail(posix_spawnattr_setsigdefault(attr(), &sigdefault)))
+            return;
     }
 
     // No signals blocked.
@@ -285,13 +294,15 @@ posix_spawner_t::posix_spawner_t(const job_t *j, const dup2_list_t &dup2s) {
         sigset_t sigmask;
         sigemptyset(&sigmask);
         blocked_signals_for_job(*j, &sigmask);
-        if (check_fail(posix_spawnattr_setsigmask(attr(), &sigmask))) return;
+        if (check_fail(posix_spawnattr_setsigmask(attr(), &sigmask)))
+            return;
     }
 
     // Apply our dup2s.
     for (const auto &act : dup2s.get_actions()) {
         if (act.target < 0) {
-            if (check_fail(posix_spawn_file_actions_addclose(actions(), act.src))) return;
+            if (check_fail(posix_spawn_file_actions_addclose(actions(), act.src)))
+                return;
         } else {
             if (check_fail(posix_spawn_file_actions_adddup2(actions(), act.src, act.target)))
                 return;
@@ -300,7 +311,8 @@ posix_spawner_t::posix_spawner_t(const job_t *j, const dup2_list_t &dup2s) {
 }
 
 maybe_t<pid_t> posix_spawner_t::spawn(const char *cmd, char *const argv[], char *const envp[]) {
-    if (get_error()) return none();
+    if (get_error())
+        return none();
     pid_t pid = -1;
     if (check_fail(posix_spawn(&pid, cmd, &*actions_, &*attr_, argv, envp))) {
         // The shebang wasn't introduced until UNIX Seventh Edition, so if
@@ -440,8 +452,10 @@ static char *get_interpreter(const char *command, char *buffer, size_t buff_size
         while (idx + 1 < buff_size) {
             char ch;
             ssize_t amt = read(fd, &ch, sizeof ch);
-            if (amt <= 0) break;
-            if (ch == '\n') break;
+            if (amt <= 0)
+                break;
+            if (ch == '\n')
+                break;
             buffer[idx++] = ch;
         }
         buffer[idx++] = '\0';

--- a/src/proc.h
+++ b/src/proc.h
@@ -365,7 +365,8 @@ class job_t {
     /// untruncated job string when we don't care what the job is, only which of the currently
     /// running jobs it is.
     wcstring preview() const {
-        if (processes.empty()) return L"";
+        if (processes.empty())
+            return L"";
         // Note argv0 may be empty in e.g. a block process.
         const wchar_t *argv0 = processes.front()->argv0();
         wcstring result = argv0 ? argv0 : L"null";

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -199,17 +199,22 @@ static size_t cursor_position_after_edit(const edit_t &edit) {
 /// Whether we want to append this string to the previous edit.
 static bool want_to_coalesce_insertion_of(const editable_line_t &el, const wcstring &str) {
     // The previous edit must support coalescing.
-    if (!el.undo_history.may_coalesce) return false;
+    if (!el.undo_history.may_coalesce)
+        return false;
     // Only consolidate single character inserts.
-    if (str.size() != 1) return false;
+    if (str.size() != 1)
+        return false;
     // Make an undo group after every space.
-    if (str.at(0) == L' ' && !el.undo_history.try_coalesce) return false;
+    if (str.at(0) == L' ' && !el.undo_history.try_coalesce)
+        return false;
     assert(!el.undo_history.edits.empty());
     const edit_t &last_edit = el.undo_history.edits.back();
     // Don't add to the last edit if it deleted something.
-    if (last_edit.length != 0) return false;
+    if (last_edit.length != 0)
+        return false;
     // Must not have moved the cursor!
-    if (cursor_position_after_edit(last_edit) != el.position()) return false;
+    if (cursor_position_after_edit(last_edit) != el.position())
+        return false;
     return true;
 }
 
@@ -244,7 +249,8 @@ void editable_line_t::push_edit(edit_t &&edit) {
     }
 
     bool edit_does_nothing = edit.length == 0 && edit.replacement.empty();
-    if (edit_does_nothing) return;
+    if (edit_does_nothing)
+        return;
     if (undo_history.edits_applied != undo_history.edits.size()) {
         // After undoing some edits, the user is making a new edit;
         // we are about to create a new edit branch.
@@ -362,7 +368,8 @@ class reader_history_search_t {
 
             wcstring_list_t local_tokens;
             while (auto token = tok.next()) {
-                if (token->type != token_type_t::string) continue;
+                if (token->type != token_type_t::string)
+                    continue;
                 wcstring text = tok.text_of(*token);
                 if (text.find(needle) != wcstring::npos) {
                     local_tokens.emplace_back(std::move(text));
@@ -425,7 +432,8 @@ class reader_history_search_t {
 
     /// Go to the beginning (earliest) of the search.
     void go_to_beginning() {
-        if (matches_.empty()) return;
+        if (matches_.empty())
+            return;
         match_index_ = matches_.size() - 1;
     }
 
@@ -458,7 +466,8 @@ class reader_history_search_t {
         history_search_flags_t flags = history_search_no_dedup;
         // Make the search case-insensitive unless we have an uppercase character.
         wcstring low = wcstolower(text);
-        if (low == text) flags |= history_search_ignore_case;
+        if (low == text)
+            flags |= history_search_ignore_case;
         // We can skip dedup in history_search_t because we do it ourselves in skips_.
         search_ = history_search_t(
             hist, text,
@@ -794,7 +803,8 @@ static void term_fix_modes(struct termios *modes) {
     // This permits separately binding nul (typically control-space).
     // POSIX calls out -1 as a special value which should be ignored.
 #ifdef _POSIX_VDISABLE
-    if (_POSIX_VDISABLE != -1) disabling_char = _POSIX_VDISABLE;
+    if (_POSIX_VDISABLE != -1)
+        disabling_char = _POSIX_VDISABLE;
 #endif
 
     // We ignore these anyway, so there is no need to sacrifice a character.
@@ -845,7 +855,8 @@ static void redirect_tty_after_sighup() {
 static void term_donate(bool quiet = false) {
     while (true) {
         if (tcsetattr(STDIN_FILENO, TCSANOW, &tty_modes_for_external_cmds) == -1) {
-            if (errno == EIO) redirect_tty_output();
+            if (errno == EIO)
+                redirect_tty_output();
             if (errno != EINTR) {
                 if (!quiet) {
                     FLOGF(warning, _(L"Could not set terminal mode for new job"));
@@ -883,7 +894,8 @@ void term_steal() {
     term_copy_modes();
     while (true) {
         if (tcsetattr(STDIN_FILENO, TCSANOW, &shell_modes) == -1) {
-            if (errno == EIO) redirect_tty_output();
+            if (errno == EIO)
+                redirect_tty_output();
             if (errno != EINTR) {
                 FLOGF(warning, _(L"Could not set terminal mode for shell"));
                 perror("tcsetattr");
@@ -972,7 +984,8 @@ bool reader_data_t::is_repaint_needed(const std::vector<highlight_spec_t> *mcolo
     // change, by comparing it to what is present in rendered_layout.
     // The pager is the problem child, it has its own update logic.
     auto check = [](bool val, const wchar_t *reason) {
-        if (val) FLOG(reader_render, L"repaint needed because", reason, L"change");
+        if (val)
+            FLOG(reader_render, L"repaint needed because", reason, L"change");
         return val;
     };
 
@@ -1155,14 +1168,17 @@ maybe_t<edit_t> reader_expand_abbreviation_in_command(const wcstring &cmdline, s
     const ast::string_t *matching_cmd_node = nullptr;
     for (const node_t &n : ast) {
         const auto *stmt = n.try_as<decorated_statement_t>();
-        if (!stmt) continue;
+        if (!stmt)
+            continue;
 
         // Skip if we have a decoration.
-        if (stmt->opt_decoration) continue;
+        if (stmt->opt_decoration)
+            continue;
 
         // See if the command's source range range contains our cursor, including at the end.
         auto msource = stmt->command.try_source_range();
-        if (!msource) continue;
+        if (!msource)
+            continue;
 
         // Now see if its source range contains our cursor, including at the end.
         if (subcmd_cursor_pos >= msource->start &&
@@ -1219,7 +1235,8 @@ int reader_test_and_clear_interrupted() {
 }
 
 void reader_write_title(const wcstring &cmd, parser_t &parser, bool reset_cursor_position) {
-    if (!term_supports_setting_title()) return;
+    if (!term_supports_setting_title())
+        return;
 
     scoped_push<bool> noninteractive{&parser.libdata().is_interactive, false};
     scoped_push<bool> in_title(&parser.libdata().suppress_fish_trace, true);
@@ -1357,7 +1374,8 @@ void reader_init() {
 /// Restore the term mode if we own the terminal. It's important we do this before
 /// restore_foreground_process_group, otherwise we won't think we own the terminal.
 void restore_term_mode() {
-    if (getpgrp() != tcgetpgrp(STDIN_FILENO)) return;
+    if (getpgrp() != tcgetpgrp(STDIN_FILENO))
+        return;
 
     if (tcsetattr(STDIN_FILENO, TCSANOW, &terminal_mode_on_startup) == -1 && errno == EIO) {
         redirect_tty_output();
@@ -1466,7 +1484,8 @@ void reader_data_t::delete_char(bool backward) {
     }
     size_t pos_end = pos;
 
-    if (el->position() == 0 && backward) return;
+    if (el->position() == 0 && backward)
+        return;
 
     // Fake composed character sequences by continuing to delete until we delete a character of
     // width at least 1.
@@ -1484,7 +1503,8 @@ void reader_data_t::delete_char(bool backward) {
 /// using syntax highlighting, etc.
 /// Returns true if the string changed.
 void reader_data_t::insert_string(editable_line_t *el, const wcstring &str) {
-    if (str.empty()) return;
+    if (str.empty())
+        return;
 
     command_line_has_transient_edit = false;
     if (!history_search.active() && want_to_coalesce_insertion_of(*el, str)) {
@@ -1495,7 +1515,8 @@ void reader_data_t::insert_string(editable_line_t *el, const wcstring &str) {
         el->undo_history.may_coalesce = el->undo_history.try_coalesce || (str.size() == 1);
     }
 
-    if (el == &command_line) suppress_autosuggestion = false;
+    if (el == &command_line)
+        suppress_autosuggestion = false;
     // The pager needs to be refiltered.
     if (el == &this->pager.search_field_line) {
         command_line_changed(el);
@@ -1566,7 +1587,8 @@ wcstring completion_apply_to_command_line(const wcstring &val, complete_flags_t 
         }
 
         if (add_space) {
-            if (!have_space_after_token) sb.append(L" ");
+            if (!have_space_after_token)
+                sb.append(L" ");
             move_cursor += 1;
         }
         sb.append(end);
@@ -1626,7 +1648,8 @@ wcstring completion_apply_to_command_line(const wcstring &val, complete_flags_t 
             // This is a quoted parameter, first print a quote.
             result.insert(new_cursor_pos++, wcstring(&quote, 1));
         }
-        if (!have_space_after_token) result.insert(new_cursor_pos, L" ");
+        if (!have_space_after_token)
+            result.insert(new_cursor_pos, L" ");
         new_cursor_pos++;
     }
     *inout_cursor_pos = new_cursor_pos;
@@ -1645,7 +1668,8 @@ void reader_data_t::completion_insert(const wcstring &val, size_t token_end,
     editable_line_t *el = active_edit_line();
 
     // Move the cursor to the end of the token.
-    if (el->position() != token_end) update_buff_pos(el, token_end);
+    if (el->position() != token_end)
+        update_buff_pos(el, token_end);
 
     size_t cursor = el->position();
     wcstring new_command_line = completion_apply_to_command_line(val, flags, el->text(), &cursor,
@@ -1684,7 +1708,8 @@ static std::function<autosuggestion_t(void)> get_autosuggestion_performer(
             const history_item_t &item = searcher.current_item();
 
             // Skip items with newlines because they make terrible autosuggestions.
-            if (item.str().find(L'\n') != wcstring::npos) continue;
+            if (item.str().find(L'\n') != wcstring::npos)
+                continue;
 
             if (autosuggest_validate_from_history(item, working_directory, ctx)) {
                 // The command autosuggestion was handled specially, so we're done.
@@ -1695,17 +1720,20 @@ static std::function<autosuggestion_t(void)> get_autosuggestion_performer(
         }
 
         // Maybe cancel here.
-        if (ctx.check_cancel()) return nothing;
+        if (ctx.check_cancel())
+            return nothing;
 
         // Here we do something a little funny. If the line ends with a space, and the cursor is not
         // at the end, don't use completion autosuggestions. It ends up being pretty weird seeing
         // stuff get spammed on the right while you go back to edit a line
         const wchar_t last_char = search_string.at(search_string.size() - 1);
         const bool cursor_at_end = (cursor_pos == search_string.size());
-        if (!cursor_at_end && iswspace(last_char)) return nothing;
+        if (!cursor_at_end && iswspace(last_char))
+            return nothing;
 
         // On the other hand, if the line ends with a quote, don't go dumping stuff after the quote.
-        if (std::wcschr(L"'\"", last_char) && cursor_at_end) return nothing;
+        if (std::wcschr(L"'\"", last_char) && cursor_at_end)
+            return nothing;
 
         // Try normal completions.
         completion_request_flags_t complete_flags = completion_request_t::autosuggestion;
@@ -1770,7 +1798,8 @@ void reader_data_t::update_autosuggestion() {
     }
 
     // Do nothing if we've already kicked off this autosuggest request.
-    if (el.text() == in_flight_autosuggest_request) return;
+    if (el.text() == in_flight_autosuggest_request)
+        return;
     in_flight_autosuggest_request = el.text();
 
     // Clear the autosuggestion and kick it off in the background.
@@ -1803,7 +1832,8 @@ void reader_data_t::accept_autosuggestion(bool full, bool single, move_word_styl
             size_t want;
             for (want = command_line.size(); want < autosuggestion.text.size(); want++) {
                 wchar_t wc = autosuggestion.text.at(want);
-                if (!state.consume_char(wc)) break;
+                if (!state.consume_char(wc))
+                    break;
             }
             size_t have = command_line.size();
             replace_substring(&command_line, command_line.size(), 0,
@@ -1864,7 +1894,8 @@ static bool reader_can_replace(const wcstring &in, int flags) {
 
     // Test characters that have a special meaning in any character position.
     while (*str) {
-        if (std::wcschr(REPLACE_UNCLEAN, *str)) return false;
+        if (std::wcschr(REPLACE_UNCLEAN, *str))
+            return false;
         str++;
     }
 
@@ -1944,14 +1975,17 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
     bool all_matches_exact_or_prefix = true;
     for (const completion_t &el : comp) {
         // Ignore completions with a less suitable match rank than the best.
-        if (el.rank() > best_rank) continue;
+        if (el.rank() > best_rank)
+            continue;
 
         // Only use completions that match replace_token.
         bool completion_replace_token = static_cast<bool>(el.flags & COMPLETE_REPLACES_TOKEN);
-        if (completion_replace_token != will_replace_token) continue;
+        if (completion_replace_token != will_replace_token)
+            continue;
 
         // Don't use completions that want to replace, if we cannot replace them.
-        if (completion_replace_token && !reader_can_replace(tok, el.flags)) continue;
+        if (completion_replace_token && !reader_can_replace(tok, el.flags))
+            continue;
 
         // This completion survived.
         surviving_completions.push_back(el);
@@ -1993,7 +2027,8 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
                 size_t idx, max = std::min(common_prefix.size(), el.completion.size());
 
                 for (idx = 0; idx < max; idx++) {
-                    if (common_prefix.at(idx) != el.completion.at(idx)) break;
+                    if (common_prefix.at(idx) != el.completion.at(idx))
+                        break;
                 }
 
                 // idx is now the length of the new common prefix.
@@ -2001,7 +2036,8 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
                 prefix_is_partial_completion = true;
 
                 // Early out if we decide there's no common prefix.
-                if (idx == 0) break;
+                if (idx == 0)
+                    break;
             }
         }
 
@@ -2015,7 +2051,8 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
         if (use_prefix) {
             // We got something. If more than one completion contributed, then it means we have
             // a prefix; don't insert a space after it.
-            if (prefix_is_partial_completion) flags |= COMPLETE_NO_SPACE;
+            if (prefix_is_partial_completion)
+                flags |= COMPLETE_NO_SPACE;
             completion_insert(common_prefix, token_end, flags);
             cycle_command_line = command_line.text();
             cycle_cursor_pos = command_line.position();
@@ -2032,7 +2069,8 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
     // Print the completion list.
     wcstring prefix;
     if (will_replace_token || !all_matches_exact_or_prefix) {
-        if (use_prefix) prefix = std::move(common_prefix);
+        if (use_prefix)
+            prefix = std::move(common_prefix);
     } else if (tok.size() + common_prefix.size() <= PREFIX_MAX_LEN) {
         prefix = tok + common_prefix;
     } else {
@@ -2273,7 +2311,8 @@ void reader_data_t::replace_current_token(wcstring &&new_token) {
     const wchar_t *buff = el->text().c_str();
     parse_util_token_extent(buff, el->position(), &begin, &end, nullptr, nullptr);
 
-    if (!begin || !end) return;
+    if (!begin || !end)
+        return;
 
     size_t offset = begin - buff;
     size_t length = end - begin;
@@ -2311,7 +2350,8 @@ void reader_data_t::move_word(editable_line_t *el, bool move_right, bool erase,
                               enum move_word_style_t style, bool newv) {
     // Return if we are already at the edge.
     const size_t boundary = move_right ? el->size() : 0;
-    if (el->position() == boundary) return;
+    if (el->position() == boundary)
+        return;
 
     // When moving left, a value of 1 means the character at index 0.
     move_word_state_machine_t state(style);
@@ -2322,12 +2362,14 @@ void reader_data_t::move_word(editable_line_t *el, bool move_right, bool erase,
     while (buff_pos != boundary) {
         size_t idx = (move_right ? buff_pos : buff_pos - 1);
         wchar_t c = command_line[idx];
-        if (!state.consume_char(c)) break;
+        if (!state.consume_char(c))
+            break;
         buff_pos = (move_right ? buff_pos + 1 : buff_pos - 1);
     }
 
     // Always consume at least one character.
-    if (buff_pos == start_buff_pos) buff_pos = (move_right ? buff_pos + 1 : buff_pos - 1);
+    if (buff_pos == start_buff_pos)
+        buff_pos = (move_right ? buff_pos + 1 : buff_pos - 1);
 
     // If we are moving left, buff_pos-1 is the index of the first character we do not delete
     // (possibly -1). If we are moving right, then buff_pos is that index - possibly el->size().
@@ -2362,7 +2404,8 @@ void reader_data_t::set_buffer_maintaining_pager(const wcstring &b, size_t pos, 
     command_line_changed(&command_line);
 
     // Don't set a position past the command line length.
-    if (pos > command_line_len) pos = command_line_len;  //!OCLINT(parameter reassignment)
+    if (pos > command_line_len)
+        pos = command_line_len;  //!OCLINT(parameter reassignment)
     update_buff_pos(&command_line, pos);
 
     // Clear history search and pager contents.
@@ -2389,7 +2432,8 @@ static eval_res_t reader_run_command(parser_t &parser, const wcstring &cmd) {
     wcstring ft = tok_command(cmd);
 
     // For compatibility with fish 2.0's $_, now replaced with `status current-command`
-    if (!ft.empty()) parser.vars().set_one(L"_", ENV_GLOBAL, ft);
+    if (!ft.empty())
+        parser.vars().set_one(L"_", ENV_GLOBAL, ft);
 
     outputter_t &outp = outputter_t::stdoutput();
     reader_write_title(cmd, parser);
@@ -2405,7 +2449,8 @@ static eval_res_t reader_run_command(parser_t &parser, const wcstring &cmd) {
 
     // update the execution duration iff a command is requested for execution
     // issue - #4926
-    if (!ft.empty()) set_env_cmd_duration(&time_after, &time_before, parser.vars());
+    if (!ft.empty())
+        set_env_cmd_duration(&time_after, &time_before, parser.vars());
 
     term_steal();
 
@@ -2470,7 +2515,8 @@ static std::function<highlight_result_t(void)> get_highlight_performer(parser_t 
     auto vars = parser.vars().snapshot();
     uint32_t generation_count = read_generation_count();
     return [=]() -> highlight_result_t {
-        if (text.empty()) return {};
+        if (text.empty())
+            return {};
         operation_context_t ctx = get_bg_context(vars, generation_count);
         std::vector<highlight_spec_t> colors(text.size(), highlight_spec_t{});
         highlight_shell(text, colors, ctx, io_ok);
@@ -2480,11 +2526,13 @@ static std::function<highlight_result_t(void)> get_highlight_performer(parser_t 
 
 /// Highlight the command line in a super, plentiful way.
 void reader_data_t::super_highlight_me_plenty() {
-    if (!conf.highlight_ok) return;
+    if (!conf.highlight_ok)
+        return;
 
     // Do nothing if this text is already in flight.
     const editable_line_t *el = &command_line;
-    if (el->text() == in_flight_highlight_request) return;
+    if (el->text() == in_flight_highlight_request)
+        return;
     in_flight_highlight_request = el->text();
 
     FLOG(reader_render, L"Highlighting");
@@ -2497,7 +2545,8 @@ void reader_data_t::super_highlight_me_plenty() {
 
 void reader_data_t::finish_highlighting_before_exec() {
     // Early-out if highlighting is not OK.
-    if (!conf.highlight_ok) return;
+    if (!conf.highlight_ok)
+        return;
 
     // Decide if our current highlighting is OK. If not we will do a quick highlight without I/O.
     bool current_highlight_ok = false;
@@ -2519,7 +2568,8 @@ void reader_data_t::finish_highlighting_before_exec() {
 
             // Note iothread_service_main_with_timeout will reentrantly modify us,
             // by invoking a completion.
-            if (in_flight_highlight_request.empty()) break;
+            if (in_flight_highlight_request.empty())
+                break;
             now = sc::steady_clock::now();
         }
 
@@ -2620,12 +2670,15 @@ void reader_data_t::import_history_if_necessary() {
 static bool try_warn_on_background_jobs(reader_data_t *data) {
     ASSERT_IS_MAIN_THREAD();
     // Have we already warned?
-    if (data->did_warn_for_bg_jobs) return false;
+    if (data->did_warn_for_bg_jobs)
+        return false;
     // Are we the top-level reader?
-    if (reader_data_stack.size() > 1) return false;
+    if (reader_data_stack.size() > 1)
+        return false;
     // Do we have background jobs?
     auto bg_jobs = jobs_requiring_warning_on_exit(data->parser());
-    if (bg_jobs.empty()) return false;
+    if (bg_jobs.empty())
+        return false;
     // Print the warning!
     print_exit_warning_for_jobs(bg_jobs);
     data->did_warn_for_bg_jobs = true;
@@ -2636,7 +2689,8 @@ static bool try_warn_on_background_jobs(reader_data_t *data) {
 /// \return true if we should exit.
 static bool check_exit_loop_maybe_warning(reader_data_t *data) {
     // sighup always forces exit.
-    if (s_sighup_received) return true;
+    if (s_sighup_received)
+        return true;
 
     // Check if an exit is requested.
     if (data->exit_loop_requested) {
@@ -2652,7 +2706,8 @@ static bool check_exit_loop_maybe_warning(reader_data_t *data) {
 static bool selection_is_at_top(const reader_data_t *data) {
     const pager_t *pager = &data->pager;
     size_t row = pager->get_selected_row(data->current_page_rendering);
-    if (row != 0 && row != PAGER_SELECTION_NONE) return false;
+    if (row != 0 && row != PAGER_SELECTION_NONE)
+        return false;
 
     size_t col = pager->get_selected_column(data->current_page_rendering);
     return !(col != 0 && col != PAGER_SELECTION_NONE);
@@ -2754,11 +2809,13 @@ static int read_i(parser_t &parser) {
 /// the string, which indicates if there is a trailing backslash.
 static bool is_backslashed(const wcstring &str, size_t pos) {
     // note pos == str.size() is OK.
-    if (pos > str.size()) return false;
+    if (pos > str.size())
+        return false;
 
     size_t count = 0, idx = pos;
     while (idx--) {
-        if (str.at(idx) != L'\\') break;
+        if (str.at(idx) != L'\\')
+            break;
         count++;
     }
 
@@ -2788,7 +2845,8 @@ static bool text_ends_in_comment(const wcstring &text) {
 
 /// \return true if an event is a normal character that should be inserted into the buffer.
 static bool event_is_normal_char(const char_event_t &evt) {
-    if (!evt.is_char()) return false;
+    if (!evt.is_char())
+        return false;
     auto c = evt.get_char();
     return !fish_reserved_codepoint(c) && c > 31 && c != 127;
 }
@@ -2923,7 +2981,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 update_buff_pos(&command_line, command_line.size());
                 autosuggestion.clear();
                 // Repaint also changes the actual cursor position
-                if (this->is_repaint_needed()) this->layout_and_repaint(L"cancel");
+                if (this->is_repaint_needed())
+                    this->layout_and_repaint(L"cancel");
 
                 auto fish_color_cancel = vars.get(L"fish_color_cancel");
                 if (fish_color_cancel) {
@@ -2977,7 +3036,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             exec_mode_prompt();
             if (!mode_prompt_buff.empty()) {
                 s_reset_line(&screen, true /* redraw prompt */);
-                if (this->is_repaint_needed()) this->layout_and_repaint(L"mode");
+                if (this->is_repaint_needed())
+                    this->layout_and_repaint(L"mode");
                 parser().libdata().is_repaint = false;
                 break;
             }
@@ -2996,7 +3056,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
         }
         case rl::complete:
         case rl::complete_and_search: {
-            if (!conf.complete_ok) break;
+            if (!conf.complete_ok)
+                break;
 
             // Use the command line only; it doesn't make sense to complete in any other line.
             editable_line_t *el = &command_line;
@@ -3035,7 +3096,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
 
                 // Hack: the token may extend past the end of the command substitution, e.g. in
                 // (echo foo) the last token is 'foo)'. Don't let that happen.
-                if (token_end > cmdsub_end) token_end = cmdsub_end;
+                if (token_end > cmdsub_end)
+                    token_end = cmdsub_end;
 
                 // Construct a copy of the string from the beginning of the command substitution
                 // up to the end of the token we're completing.
@@ -3048,8 +3110,10 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
 
                 // User-supplied completions may have changed the commandline - prevent buffer
                 // overflow.
-                if (token_begin > buff + el->text().size()) token_begin = buff + el->text().size();
-                if (token_end > buff + el->text().size()) token_end = buff + el->text().size();
+                if (token_begin > buff + el->text().size())
+                    token_begin = buff + el->text().size();
+                if (token_end > buff + el->text().size())
+                    token_end = buff + el->text().size();
 
                 // Munge our completions.
                 completions_sort_and_prioritize(&rls.comp);
@@ -3089,7 +3153,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
 
             while (*end && *end != L'\n') end++;
 
-            if (end == begin && *end) end++;
+            if (end == begin && *end)
+                end++;
 
             size_t len = end - begin;
             if (len) {
@@ -3112,7 +3177,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             while (begin > buff && *begin != L'\n') begin--;
 
             // If we landed on a newline, don't delete it.
-            if (*begin == L'\n') begin++;
+            if (*begin == L'\n')
+                begin++;
             assert(end >= begin);
             size_t len = std::max<size_t>(end - begin, 1);
             begin = end - len;
@@ -3361,7 +3427,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 bool found = history_search.move_in_direction(dir);
 
                 // Signal that we've found nothing
-                if (!found) flash();
+                if (!found)
+                    flash();
 
                 if (!found && !was_active_before) {
                     history_search.reset();
@@ -3688,7 +3755,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
         }
 
         case rl::begin_selection: {
-            if (!selection) selection = selection_data_t{};
+            if (!selection)
+                selection = selection_data_t{};
             size_t pos = command_line.position();
             selection->begin = pos;
             selection->start = pos;
@@ -3702,7 +3770,8 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
         }
 
         case rl::swap_selection_start_stop: {
-            if (!selection) break;
+            if (!selection)
+                break;
             size_t tmp = selection->begin;
             selection->begin = command_line.position();
             selection->start = command_line.position();
@@ -3858,12 +3927,14 @@ maybe_t<wcstring> reader_data_t::readline(int nchars_or_0) {
 
     // Get the current terminal modes. These will be restored when the function returns.
     struct termios old_modes {};
-    if (tcgetattr(conf.in, &old_modes) == -1 && errno == EIO) redirect_tty_output();
+    if (tcgetattr(conf.in, &old_modes) == -1 && errno == EIO)
+        redirect_tty_output();
 
     // Set the new modes.
     if (tcsetattr(conf.in, TCSANOW, &shell_modes) == -1) {
         int err = errno;
-        if (err == EIO) redirect_tty_output();
+        if (err == EIO)
+            redirect_tty_output();
 
         // This check is required to work around certain issues with fish's approach to
         // terminal control when launching interactive processes while in non-interactive
@@ -3896,7 +3967,8 @@ maybe_t<wcstring> reader_data_t::readline(int nchars_or_0) {
             this->update_autosuggestion();
             this->super_highlight_me_plenty();
         }
-        if (this->is_repaint_needed()) this->layout_and_repaint(L"toplevel");
+        if (this->is_repaint_needed())
+            this->layout_and_repaint(L"toplevel");
         this->force_exec_prompt_and_repaint = false;
     };
 
@@ -3924,7 +3996,8 @@ maybe_t<wcstring> reader_data_t::readline(int nchars_or_0) {
         maybe_t<char_event_t> event_needing_handling{};
         while (true) {
             event_needing_handling = read_normal_chars(rls);
-            if (event_needing_handling.has_value()) break;
+            if (event_needing_handling.has_value())
+                break;
 
             if (rls.nchars <= command_line.size()) {
                 event_needing_handling.reset();
@@ -4034,7 +4107,8 @@ maybe_t<wcstring> reader_data_t::readline(int nchars_or_0) {
         // The order of the two conditions below is important. Try to restore the mode
         // in all cases, but only complain if interactive.
         if (tcsetattr(conf.in, TCSANOW, &old_modes) == -1 && is_interactive_session()) {
-            if (errno == EIO) redirect_tty_output();
+            if (errno == EIO)
+                redirect_tty_output();
             wperror(L"tcsetattr");  // return to previous mode
         }
         outputter_t::stdoutput().set_color(rgb_color_t::reset(), rgb_color_t::reset());
@@ -4145,7 +4219,8 @@ std::shared_ptr<history_t> reader_get_history() {
 /// Sets the command line contents, clearing the pager.
 void reader_set_buffer(const wcstring &b, size_t pos) {
     reader_data_t *data = current_data_or_null();
-    if (!data) return;
+    if (!data)
+        return;
 
     data->pager.clear();
     data->set_buffer_maintaining_pager(b, pos);
@@ -4154,7 +4229,8 @@ void reader_set_buffer(const wcstring &b, size_t pos) {
 
 size_t reader_get_cursor_pos() {
     reader_data_t *data = current_data_or_null();
-    if (!data) return static_cast<size_t>(-1);
+    if (!data)
+        return static_cast<size_t>(-1);
 
     return data->command_line.position();
 }

--- a/src/reader.h
+++ b/src/reader.h
@@ -106,7 +106,8 @@ class editable_line_t {
 
     void clear() {
         undo_history.clear();
-        if (empty()) return;
+        if (empty())
+            return;
         set_text_bypassing_undo_history(L"");
         set_position(0);
     }

--- a/src/redirection.cpp
+++ b/src/redirection.cpp
@@ -12,7 +12,8 @@ dup2_list_t::~dup2_list_t() = default;
 maybe_t<int> redirection_spec_t::get_target_as_fd() const {
     errno = 0;
     int result = fish_wcstoi(target.c_str());
-    if (errno || result < 0) return none();
+    if (errno || result < 0)
+        return none();
     return result;
 }
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -66,8 +66,10 @@ layout_cache_t layout_cache_t::shared;
 /// specified wide character string. All of \c seq must match, but str may be longer than seq.
 static size_t try_sequence(const char *seq, const wchar_t *str) {
     for (size_t i = 0;; i++) {
-        if (!seq[i]) return i;
-        if (seq[i] != str[i]) return 0;
+        if (!seq[i])
+            return i;
+        if (seq[i] != str[i])
+            return 0;
     }
 
     DIE("unexpectedly fell off end of try_sequence()");
@@ -174,7 +176,8 @@ static bool is_csi_style_escape_seq(const wchar_t *code, size_t *resulting_lengt
         wchar_t widechar = code[cursor];
 
         // If we're not in ASCII, just stop.
-        if (widechar > 127) break;
+        if (widechar > 127)
+            break;
 
         // If we're the end character, then consume it and then stop.
         if (widechar >= L'@' && widechar <= L'~') {
@@ -192,7 +195,8 @@ static bool is_csi_style_escape_seq(const wchar_t *code, size_t *resulting_lengt
 /// such sequences. This function only handles those escape sequences for setting color that rely on
 /// the terminfo definition and which might use a different pattern.
 static bool is_color_escape_seq(const wchar_t *code, size_t *resulting_length) {
-    if (!cur_term) return false;
+    if (!cur_term)
+        return false;
 
     // Detect these terminfo color escapes with parameter value up to max_colors, all of which
     // don't move the cursor.
@@ -204,7 +208,8 @@ static bool is_color_escape_seq(const wchar_t *code, size_t *resulting_length) {
     };
 
     for (auto p : esc) {
-        if (!p) continue;
+        if (!p)
+            continue;
 
         for (int k = 0; k < max_colors; k++) {
             size_t esc_seq_len = try_sequence(tparm(const_cast<char *>(p), k), code);
@@ -221,7 +226,8 @@ static bool is_color_escape_seq(const wchar_t *code, size_t *resulting_length) {
 /// Detect whether the escape sequence sets one of the terminal attributes that affects how text is
 /// displayed other than the color.
 static bool is_visual_escape_seq(const wchar_t *code, size_t *resulting_length) {
-    if (!cur_term) return false;
+    if (!cur_term)
+        return false;
     const char *const esc2[] = {
         enter_bold_mode,     exit_attribute_mode, enter_underline_mode,   exit_underline_mode,
         enter_standout_mode, exit_standout_mode,  enter_blink_mode,       enter_protected_mode,
@@ -230,7 +236,8 @@ static bool is_visual_escape_seq(const wchar_t *code, size_t *resulting_length) 
         enter_dim_mode,      enter_blink_mode,    enter_alt_charset_mode, exit_alt_charset_mode};
 
     for (auto p : esc2) {
-        if (!p) continue;
+        if (!p)
+            continue;
         // Test both padded and unpadded version, just to be safe. Most versions of tparm don't
         // actually seem to do anything these days.
         size_t esc_seq_len =
@@ -249,19 +256,28 @@ static bool is_visual_escape_seq(const wchar_t *code, size_t *resulting_length) 
 /// the escape sequence based on querying terminfo and other heuristics.
 size_t layout_cache_t::escape_code_length(const wchar_t *code) {
     assert(code != nullptr);
-    if (*code != L'\x1B') return 0;
+    if (*code != L'\x1B')
+        return 0;
 
     size_t esc_seq_len = this->find_escape_code(code);
-    if (esc_seq_len) return esc_seq_len;
+    if (esc_seq_len)
+        return esc_seq_len;
 
     bool found = is_color_escape_seq(code, &esc_seq_len);
-    if (!found) found = is_visual_escape_seq(code, &esc_seq_len);
-    if (!found) found = is_screen_name_escape_seq(code, &esc_seq_len);
-    if (!found) found = is_osc_escape_seq(code, &esc_seq_len);
-    if (!found) found = is_three_byte_escape_seq(code, &esc_seq_len);
-    if (!found) found = is_csi_style_escape_seq(code, &esc_seq_len);
-    if (!found) found = is_two_byte_escape_seq(code, &esc_seq_len);
-    if (found) this->add_escape_code(wcstring(code, esc_seq_len));
+    if (!found)
+        found = is_visual_escape_seq(code, &esc_seq_len);
+    if (!found)
+        found = is_screen_name_escape_seq(code, &esc_seq_len);
+    if (!found)
+        found = is_osc_escape_seq(code, &esc_seq_len);
+    if (!found)
+        found = is_three_byte_escape_seq(code, &esc_seq_len);
+    if (!found)
+        found = is_csi_style_escape_seq(code, &esc_seq_len);
+    if (!found)
+        found = is_two_byte_escape_seq(code, &esc_seq_len);
+    if (found)
+        this->add_escape_code(wcstring(code, esc_seq_len));
     return esc_seq_len;
 }
 
@@ -272,7 +288,8 @@ const layout_cache_t::prompt_cache_entry_t *layout_cache_t::find_prompt_layout(
     for (auto iter = start; iter != end; ++iter) {
         if (iter->text == input && iter->max_line_width == max_line_width) {
             // Found it. Move it to the front if not already there.
-            if (iter != start) prompt_cache_.splice(start, prompt_cache_, iter);
+            if (iter != start)
+                prompt_cache_.splice(start, prompt_cache_, iter);
             return &*prompt_cache_.begin();
         }
     }
@@ -305,7 +322,8 @@ static size_t measure_run_from(const wchar_t *input, size_t start, size_t *out_e
             // This is the start of an escape code; we assume it has width 0.
             // -1 because we are going to increment in the loop.
             size_t len = cache.escape_code_length(&input[idx]);
-            if (len > 0) idx += len - 1;
+            if (len > 0)
+                idx += len - 1;
         } else if (input[idx] == L'\t') {
             width = next_tab_stop(width);
         } else {
@@ -313,7 +331,8 @@ static size_t measure_run_from(const wchar_t *input, size_t start, size_t *out_e
             width += fish_wcwidth_min_0(input[idx]);
         }
     }
-    if (out_end) *out_end = idx;
+    if (out_end)
+        *out_end = idx;
     return width;
 }
 
@@ -361,7 +380,8 @@ prompt_layout_t layout_cache_t::calc_prompt_layout(const wcstring &prompt_str,
                                                    size_t max_line_width) {
     // FIXME: we could avoid allocating trunc_prompt if max_line_width is SIZE_T_MAX.
     if (const auto *entry = this->find_prompt_layout(prompt_str, max_line_width)) {
-        if (out_trunc_prompt) out_trunc_prompt->assign(entry->trunc_text);
+        if (out_trunc_prompt)
+            out_trunc_prompt->assign(entry->trunc_text);
         return entry->layout;
     }
 
@@ -526,7 +546,8 @@ static void s_desired_append_char(screen_t *s, wchar_t b, highlight_spec_t c, in
 /// \param new_x the new x position
 /// \param new_y the new y position
 static void s_move(screen_t *s, int new_x, int new_y) {
-    if (s->actual.cursor.x == new_x && s->actual.cursor.y == new_y) return;
+    if (s->actual.cursor.x == new_x && s->actual.cursor.y == new_y)
+        return;
 
     const scoped_buffer_t buffering(*s);
 
@@ -652,7 +673,8 @@ static size_t line_shared_prefix(const line_t &a, const line_t &b) {
                     while (idx > 1 && (fish_wcwidth(c->char_at(idx - 1)) < 1 ||
                                        fish_wcwidth(c->char_at(idx)) < 1))
                         idx--;
-                    if (idx == 1 && fish_wcwidth(c->char_at(idx)) < 1) idx = 0;
+                    if (idx == 1 && fish_wcwidth(c->char_at(idx)) < 1)
+                        idx = 0;
                 }
             }
             break;
@@ -732,7 +754,8 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
     // Determine how many lines have stuff on them; we need to clear lines with stuff that we don't
     // want.
     const size_t lines_with_stuff = std::max(actual_lines_before_reset, scr->actual.line_count());
-    if (scr->desired.line_count() < lines_with_stuff) need_clear_screen = true;
+    if (scr->desired.line_count() < lines_with_stuff)
+        need_clear_screen = true;
 
     // Output the left prompt if it has changed.
     if (left_prompt != scr->actual_left_prompt) {
@@ -789,7 +812,8 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
         if (skip_prefix > 0) {
             size_t skip_width =
                 shared_prefix < skip_prefix ? skip_prefix : o_line.wcswidth_min_0(shared_prefix);
-            if (skip_width > skip_remaining) skip_remaining = skip_width;
+            if (skip_width > skip_remaining)
+                skip_remaining = skip_width;
         }
 
         if (!should_clear_screen_this_line) {
@@ -813,7 +837,8 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
         size_t j = 0;
         for (; j < o_line.size(); j++) {
             size_t width = fish_wcwidth_min_0(o_line.char_at(j));
-            if (skip_remaining < width) break;
+            if (skip_remaining < width)
+                break;
             skip_remaining -= width;
             current_width += width;
         }
@@ -821,7 +846,8 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
         // Skip over zero-width characters (e.g. combining marks at the end of the prompt).
         for (; j < o_line.size(); j++) {
             int width = fish_wcwidth_min_0(o_line.char_at(j));
-            if (width > 0) break;
+            if (width > 0)
+                break;
         }
 
         // Now actually output stuff.
@@ -839,7 +865,8 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
                 s_write_mbs(scr, clr_eos);
                 has_cleared_screen = true;
             }
-            if (done) break;
+            if (done)
+                break;
 
             perform_any_impending_soft_wrap(scr, current_width, static_cast<int>(i));
             s_move(scr, current_width, static_cast<int>(i));
@@ -917,7 +944,8 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
 
 /// Returns true if we are using a dumb terminal.
 static bool is_dumb() {
-    if (!cur_term) return true;
+    if (!cur_term)
+        return true;
     return !cursor_up || !cursor_down || !cursor_left || !cursor_right;
 }
 
@@ -941,7 +969,8 @@ static size_t truncation_offset_for_width(const std::vector<size_t> &width_by_of
     assert(!width_by_offset.empty() && width_by_offset.at(0) == 0);
     size_t i;
     for (i = 1; i < width_by_offset.size(); i++) {
-        if (width_by_offset.at(i) > max_width) break;
+        if (width_by_offset.at(i) > max_width)
+            break;
     }
     // i is the first index that did not fit; i-1 is therefore the last that did.
     return i - 1;

--- a/src/screen.h
+++ b/src/screen.h
@@ -262,7 +262,8 @@ class layout_cache_t {
         // element that is less than or equal to entry.
         if (where != esc_cache_.begin()) {
             const wcstring &candidate = where[-1];
-            if (string_prefixes_string(candidate.c_str(), entry)) return candidate.size();
+            if (string_prefixes_string(candidate.c_str(), entry))
+                return candidate.size();
         }
         return 0;
     }

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -145,7 +145,8 @@ static const struct lookup_entry signal_table[] = {
 
 /// Test if \c name is a string describing the signal named \c canonical.
 static int match_signal_name(const wchar_t *canonical, const wchar_t *name) {
-    if (wcsncasecmp(name, L"sig", const_strlen("sig")) == 0) name += 3;
+    if (wcsncasecmp(name, L"sig", const_strlen("sig")) == 0)
+        name += 3;
 
     return wcscasecmp(canonical + const_strlen("sig"), name) == 0;
 }
@@ -158,7 +159,8 @@ int wcs2sig(const wchar_t *str) {
     }
 
     int res = fish_wcstoi(str);
-    if (errno || res < 0) return -1;
+    if (errno || res < 0)
+        return -1;
     return res;
 }
 
@@ -284,7 +286,8 @@ void signal_reset_handlers() {
         if (data.signal == SIGHUP) {
             struct sigaction oact;
             sigaction(SIGHUP, nullptr, &oact);
-            if (oact.sa_handler == SIG_IGN) continue;
+            if (oact.sa_handler == SIG_IGN)
+                continue;
         }
         sigaction(data.signal, &act, nullptr);
     }
@@ -370,7 +373,8 @@ void signal_set_handlers_once(bool interactive) {
     std::call_once(s_noninter_once, signal_set_handlers, false);
 
     static std::once_flag s_inter_once;
-    if (interactive) std::call_once(s_inter_once, set_interactive_handlers);
+    if (interactive)
+        std::call_once(s_inter_once, set_interactive_handlers);
 }
 
 void signal_handle(int sig) {
@@ -396,8 +400,10 @@ void get_signals_with_handlers(sigset_t *set) {
         // If SIGHUP is being ignored (e.g., because were were run via `nohup`) don't reset it.
         // We don't special case other signals because if they're being ignored that shouldn't
         // affect processes we spawn. They should get the default behavior for those signals.
-        if (data.signal == SIGHUP && act.sa_handler == SIG_IGN) continue;
-        if (act.sa_handler != SIG_DFL) sigaddset(set, data.signal);
+        if (data.signal == SIGHUP && act.sa_handler == SIG_IGN)
+            continue;
+        if (act.sa_handler != SIG_DFL)
+            sigaddset(set, data.signal);
     }
 }
 

--- a/src/termsize.cpp
+++ b/src/termsize.cpp
@@ -45,8 +45,10 @@ termsize_container_t &termsize_container_t::shared() {
 termsize_t termsize_container_t::data_t::current() const {
     // This encapsulates our ordering logic. If we have a termsize from a tty, use it; otherwise use
     // what we have seen from the environment.
-    if (this->last_from_tty) return *this->last_from_tty;
-    if (this->last_from_env) return *this->last_from_env;
+    if (this->last_from_tty)
+        return *this->last_from_tty;
+    if (this->last_from_env)
+        return *this->last_from_env;
     return termsize_t::defaults();
 }
 
@@ -82,7 +84,8 @@ termsize_t termsize_container_t::updating(parser_t &parser) {
     }
 
     // Announce any updates.
-    if (new_size != prev_size) set_columns_lines_vars(new_size, parser);
+    if (new_size != prev_size)
+        set_columns_lines_vars(new_size, parser);
     return new_size;
 }
 
@@ -124,7 +127,8 @@ termsize_t termsize_container_t::initialize(const environment_t &vars) {
 
 void termsize_container_t::handle_columns_lines_var_change(const environment_t &vars) {
     // Do nothing if we are the ones setting it.
-    if (setting_env_vars_) return;
+    if (setting_env_vars_)
+        return;
 
     // Construct a new termsize from COLUMNS and LINES, then set it in our data.
     termsize_t new_termsize{

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -212,7 +212,8 @@ static void pop_timer() {
 }
 
 cleanup_t push_timer(bool enabled) {
-    if (!enabled) return {[] {}};
+    if (!enabled)
+        return {[] {}};
     active_timers.emplace_back(timer_snapshot_t::take());
     return {[] { pop_timer(); }};
 }

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -62,9 +62,12 @@ enum {
 };
 
 static int get_arity(const int type) {
-    if (type == TE_FUNCTION3) return 3;
-    if (type == TE_FUNCTION2) return 2;
-    if (type == TE_FUNCTION1) return 1;
+    if (type == TE_FUNCTION3)
+        return 3;
+    if (type == TE_FUNCTION2)
+        return 2;
+    if (type == TE_FUNCTION1)
+        return 1;
     return 0;
 }
 
@@ -124,7 +127,8 @@ static te_expr *new_expr(const int type, const te_expr *parameters[]) {
 }
 
 static void te_free_parameters(te_expr *n) {
-    if (!n) return;
+    if (!n)
+        return;
     int arity = get_arity(n->type);
     // Free all parameters from the back to the front.
     while (arity > 0) {
@@ -134,7 +138,8 @@ static void te_free_parameters(te_expr *n) {
 }
 
 void te_free(te_expr *n) {
-    if (!n) return;
+    if (!n)
+        return;
     te_free_parameters(n);
     free(n);
 }
@@ -144,25 +149,32 @@ static constexpr double tau() { return 2 * M_PI; }
 static constexpr double e() { return M_E; }
 
 static double fac(double a) { /* simplest version of fac */
-    if (a < 0.0) return NAN;
-    if (a > UINT_MAX) return INFINITY;
+    if (a < 0.0)
+        return NAN;
+    if (a > UINT_MAX)
+        return INFINITY;
     auto ua = static_cast<unsigned int>(a);
     unsigned long int result = 1, i;
     for (i = 1; i <= ua; i++) {
-        if (i > ULONG_MAX / result) return INFINITY;
+        if (i > ULONG_MAX / result)
+            return INFINITY;
         result *= i;
     }
     return static_cast<double>(result);
 }
 
 static double ncr(double n, double r) {
-    if (n < 0.0 || r < 0.0 || n < r) return NAN;
-    if (n > UINT_MAX || r > UINT_MAX) return INFINITY;
+    if (n < 0.0 || r < 0.0 || n < r)
+        return NAN;
+    if (n > UINT_MAX || r > UINT_MAX)
+        return INFINITY;
     unsigned long int un = static_cast<unsigned int>(n), ur = static_cast<unsigned int>(r), i;
     unsigned long int result = 1;
-    if (ur > un / 2) ur = un - ur;
+    if (ur > un / 2)
+        ur = un - ur;
     for (i = 1; i <= ur; i++) {
-        if (result > ULONG_MAX / (un - ur + i)) return INFINITY;
+        if (result > ULONG_MAX / (un - ur + i))
+            return INFINITY;
         result *= un - ur + i;
         result /= i;
     }
@@ -184,16 +196,22 @@ static constexpr double bit_xor(double a, double b) {
 }
 
 static double max(double a, double b) {
-    if (std::isnan(a)) return a;
-    if (std::isnan(b)) return b;
-    if (a == b) return std::signbit(a) ? b : a;  // treat +0 as larger than -0
+    if (std::isnan(a))
+        return a;
+    if (std::isnan(b))
+        return b;
+    if (a == b)
+        return std::signbit(a) ? b : a;  // treat +0 as larger than -0
     return a > b ? a : b;
 }
 
 static double min(double a, double b) {
-    if (std::isnan(a)) return a;
-    if (std::isnan(b)) return b;
-    if (a == b) return std::signbit(a) ? a : b;  // treat -0 as smaller than +0
+    if (std::isnan(a))
+        return a;
+    if (std::isnan(b))
+        return b;
+    if (a == b)
+        return std::signbit(a) ? a : b;  // treat -0 as smaller than +0
     return a < b ? a : b;
 }
 
@@ -483,7 +501,8 @@ static te_expr *power(state *s) {
     /* <power>     =    {("-" | "+")} <base> */
     int sign = 1;
     while (s->type == TOK_INFIX && (s->function == add || s->function == sub)) {
-        if (s->function == sub) sign = -sign;
+        if (s->function == sub)
+            sign = -sign;
         next_token(s);
     }
 
@@ -561,7 +580,8 @@ static te_expr *expr(state *s) {
 #define M(e) te_eval(n->parameters[e])
 
 double te_eval(const te_expr *n) {
-    if (!n) return NAN;
+    if (!n)
+        return NAN;
 
     switch (n->type) {
         case TE_CONSTANT:
@@ -584,7 +604,8 @@ double te_eval(const te_expr *n) {
 
 static void optimize(te_expr *n) {
     /* Evaluates as much as possible. */
-    if (n->type == TE_CONSTANT) return;
+    if (n->type == TE_CONSTANT)
+        return;
 
     const int arity = get_arity(n->type);
     bool known = true;
@@ -628,7 +649,8 @@ te_expr *te_compile(const wchar_t *expression, te_error_t *error) {
         return nullptr;
     } else {
         optimize(root);
-        if (error) error->position = 0;
+        if (error)
+            error->position = 0;
         return root;
     }
 }

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -292,7 +292,8 @@ static int parse_fd(const wchar_t *start, const wchar_t *end) {
     for (const wchar_t *cursor = start; cursor < end; ++cursor) {
         assert(L'0' <= *cursor && *cursor <= L'9' && "Not a digit");
         big_fd = big_fd * 10 + (*cursor - L'0');
-        if (big_fd > INT_MAX) return -1;
+        if (big_fd > INT_MAX)
+            return -1;
     }
     assert(big_fd <= INT_MAX && "big_fd should be in range");
     return static_cast<int>(big_fd);
@@ -336,7 +337,8 @@ maybe_t<pipe_or_redir_t> pipe_or_redir_t::from_string(const wchar_t *buff) {
     // Try consuming a given character.
     // Return true if consumed. On success, advances cursor.
     auto try_consume = [&cursor](wchar_t c) -> bool {
-        if (*cursor != c) return false;
+        if (*cursor != c)
+            return false;
         cursor++;
         return true;
     };
@@ -362,7 +364,8 @@ maybe_t<pipe_or_redir_t> pipe_or_redir_t::from_string(const wchar_t *buff) {
         }
         case L'>': {
             consume(L'>');
-            if (try_consume(L'>')) result.mode = redirection_mode_t::append;
+            if (try_consume(L'>'))
+                result.mode = redirection_mode_t::append;
             if (try_consume(L'|')) {
                 // Note we differ from bash here.
                 // Consider `echo foo 2>| bar`
@@ -389,7 +392,8 @@ maybe_t<pipe_or_redir_t> pipe_or_redir_t::from_string(const wchar_t *buff) {
                 // Note 'echo abc >>? file' is valid: it means append and noclobber.
                 // But here "noclobber" means the file must not exist, so appending
                 // can be ignored.
-                if (try_consume(L'?')) result.mode = redirection_mode_t::noclob;
+                if (try_consume(L'?'))
+                    result.mode = redirection_mode_t::noclob;
             }
             break;
         }
@@ -421,7 +425,8 @@ maybe_t<pipe_or_redir_t> pipe_or_redir_t::from_string(const wchar_t *buff) {
                     // This is a redirection to an fd.
                     result.mode = redirection_mode_t::fd;
                 }
-                if (try_consume(L'?')) result.mode = redirection_mode_t::noclob;
+                if (try_consume(L'?'))
+                    result.mode = redirection_mode_t::noclob;
                 break;
             }
         }
@@ -436,7 +441,8 @@ maybe_t<pipe_or_redir_t> pipe_or_redir_t::from_string(const wchar_t *buff) {
                 result.fd = STDOUT_FILENO;
                 result.stderr_merge = true;
                 result.mode = redirection_mode_t::overwrite;
-                if (try_consume(L'>')) result.mode = redirection_mode_t::append;  // like &>>
+                if (try_consume(L'>'))
+                    result.mode = redirection_mode_t::append;  // like &>>
                 if (try_consume(L'?'))
                     result.mode = redirection_mode_t::noclob;  // like &>? or &>>?
             } else {
@@ -898,11 +904,14 @@ maybe_t<size_t> variable_assignment_equals_pos(const wcstring &txt) {
     for (size_t i = 0; i < txt.size(); i++) {
         wchar_t c = txt[i];
         if (state == init) {
-            if (!valid_var_name_char(c)) return {};
+            if (!valid_var_name_char(c))
+                return {};
             state = has_some_variable_identifier;
         } else {
-            if (c == '=') return {i};
-            if (!valid_var_name_char(c)) return {};
+            if (c == '=')
+                return {i};
+            if (!valid_var_name_char(c))
+                return {};
         }
     }
     return {};

--- a/src/topic_monitor.cpp
+++ b/src/topic_monitor.cpp
@@ -13,7 +13,8 @@
 wcstring generation_list_t::describe() const {
     wcstring result;
     for (generation_t gen : this->as_array()) {
-        if (!result.empty()) result.push_back(L',');
+        if (!result.empty())
+            result.push_back(L',');
         if (gen == invalid_generation) {
             result.append(L"-1");
         } else {
@@ -49,7 +50,8 @@ binary_semaphore_t::binary_semaphore_t() : sem_ok_(false) {
 binary_semaphore_t::~binary_semaphore_t() {
     // We never use sem_t on Mac. The #ifdef avoids deprecation warnings.
 #ifndef __APPLE__
-    if (sem_ok_) (void)sem_destroy(&sem_);
+    if (sem_ok_)
+        (void)sem_destroy(&sem_);
 #endif
 }
 
@@ -62,7 +64,8 @@ void binary_semaphore_t::post() {
     if (sem_ok_) {
         int res = sem_post(&sem_);
         // sem_post is non-interruptible.
-        if (res < 0) die(L"sem_post");
+        if (res < 0)
+            die(L"sem_post");
     } else {
         // Write exactly one byte.
         ssize_t ret;
@@ -70,7 +73,8 @@ void binary_semaphore_t::post() {
             const uint8_t v = 0;
             ret = write(pipes_.write.fd(), &v, sizeof v);
         } while (ret < 0 && errno == EINTR);
-        if (ret < 0) die(L"write");
+        if (ret < 0)
+            die(L"write");
     }
 }
 
@@ -81,7 +85,8 @@ void binary_semaphore_t::wait() {
             res = sem_wait(&sem_);
         } while (res < 0 && errno == EINTR);
         // Other errors here are very unexpected.
-        if (res < 0) die(L"sem_wait");
+        if (res < 0)
+            die(L"sem_wait");
     } else {
         int fd = pipes_.read.fd();
         // We must read exactly one byte.
@@ -94,9 +99,11 @@ void binary_semaphore_t::wait() {
 #endif
             uint8_t ignored;
             auto amt = read(fd, &ignored, sizeof ignored);
-            if (amt == 1) break;
+            if (amt == 1)
+                break;
             // EAGAIN should only be returned in TSan case.
-            if (amt < 0 && errno != EINTR && errno != EAGAIN) die(L"read");
+            if (amt < 0 && errno != EINTR && errno != EAGAIN)
+                die(L"read");
         }
     }
 }
@@ -252,7 +259,8 @@ generation_list_t topic_monitor_t::await_gens(const generation_list_t &input_gen
 }
 
 bool topic_monitor_t::check(generation_list_t *gens, bool wait) {
-    if (!gens->any_valid()) return false;
+    if (!gens->any_valid())
+        return false;
 
     generation_list_t current = updated_gens();
     bool changed = false;

--- a/src/topic_monitor.h
+++ b/src/topic_monitor.h
@@ -104,7 +104,8 @@ class generation_list_t {
     bool any_valid() const {
         bool valid = false;
         for (auto gen : as_array()) {
-            if (gen != invalid_generation) valid = true;
+            if (gen != invalid_generation)
+                valid = true;
         }
         return valid;
     }

--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -10,7 +10,8 @@ static const wcstring VAR_fish_trace = L"fish_trace";
 
 bool trace_enabled(const parser_t &parser) {
     const auto &ld = parser.libdata();
-    if (ld.suppress_fish_trace) return false;
+    if (ld.suppress_fish_trace)
+        return false;
     // TODO: this variable lookup is somewhat expensive, consider how to make this cheaper.
     return !parser.vars().get(VAR_fish_trace).missing_or_empty();
 }
@@ -35,5 +36,6 @@ void trace_argv(const parser_t &parser, const wchar_t *command, const wcstring_l
 }
 
 void trace_if_enabled(const parser_t &parser, const wchar_t *command, const wcstring_list_t &argv) {
-    if (trace_enabled(parser)) trace_argv(parser, command, argv);
+    if (trace_enabled(parser))
+        trace_argv(parser, command, argv);
 }

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -128,7 +128,8 @@ static int __utf8_forbitten(unsigned char octet);
 
 static int __wchar_forbitten(utf8_wchar_t sym) {
     // Surrogate pairs.
-    if (sym >= 0xd800 && sym <= 0xdfff) return -1;
+    if (sym >= 0xd800 && sym <= 0xdfff)
+        return -1;
     return 0;
 }
 
@@ -171,16 +172,19 @@ static size_t utf8_to_wchar_internal(const char *in, size_t insize, utf8_wstring
     utf8_wchar_t high;
     size_t n, total, i, n_bits;
 
-    if (in == nullptr || insize == 0) return 0;
+    if (in == nullptr || insize == 0)
+        return 0;
 
-    if (out_string != nullptr) out_string->clear();
+    if (out_string != nullptr)
+        out_string->clear();
 
     total = 0;
     p = reinterpret_cast<unsigned char *>(const_cast<char *>(in));
     lim = p + insize;
 
     for (; p < lim; p += n) {
-        if (__utf8_forbitten(*p) != 0 && (flags & UTF8_IGNORE_ERROR) == 0) return 0;
+        if (__utf8_forbitten(*p) != 0 && (flags & UTF8_IGNORE_ERROR) == 0)
+            return 0;
 
         // Get number of bytes for one wide character.
         n = 1;  // default: 1 byte. Used when skipping bytes
@@ -196,13 +200,15 @@ static size_t utf8_to_wchar_internal(const char *in, size_t insize, utf8_wstring
             n = 4;
             high = static_cast<utf8_wchar_t>(*p & 0x07);
         } else {
-            if ((flags & UTF8_IGNORE_ERROR) == 0) return 0;
+            if ((flags & UTF8_IGNORE_ERROR) == 0)
+                return 0;
             continue;
         }
 
         // Does the sequence header tell us truth about length?
         if (static_cast<size_t>(lim - p) <= n - 1) {
-            if ((flags & UTF8_IGNORE_ERROR) == 0) return 0;
+            if ((flags & UTF8_IGNORE_ERROR) == 0)
+                return 0;
             n = 1;
             continue;  // skip
         }
@@ -210,17 +216,20 @@ static size_t utf8_to_wchar_internal(const char *in, size_t insize, utf8_wstring
         // Validate sequence. All symbols must have higher bits set to 10xxxxxx.
         if (n > 1) {
             for (i = 1; i < n; i++) {
-                if ((p[i] & 0xc0) != _NXT) break;
+                if ((p[i] & 0xc0) != _NXT)
+                    break;
             }
             if (i != n) {
-                if ((flags & UTF8_IGNORE_ERROR) == 0) return 0;
+                if ((flags & UTF8_IGNORE_ERROR) == 0)
+                    return 0;
                 n = 1;
                 continue;  // skip
             }
         }
 
         total++;
-        if (out_string == nullptr) continue;
+        if (out_string == nullptr)
+            continue;
 
         uint32_t out_val = 0;
         n_bits = 0;
@@ -272,7 +281,8 @@ static size_t wchar_to_utf8_internal(const utf8_wchar_t *in, size_t insize, char
     unsigned char *p, *lim;
     size_t total, n;
 
-    if (in == nullptr || insize == 0 || (outsize == 0 && out != nullptr)) return 0;
+    if (in == nullptr || insize == 0 || (outsize == 0 && out != nullptr))
+        return 0;
 
     w = in;
     wlim = w + insize;
@@ -281,15 +291,18 @@ static size_t wchar_to_utf8_internal(const utf8_wchar_t *in, size_t insize, char
     total = 0;
     for (; w < wlim; w++) {
         if (__wchar_forbitten(*w) != 0) {
-            if ((flags & UTF8_IGNORE_ERROR) == 0) return 0;
+            if ((flags & UTF8_IGNORE_ERROR) == 0)
+                return 0;
             continue;
         }
 
-        if (*w == _BOM && (flags & UTF8_SKIP_BOM) != 0) continue;
+        if (*w == _BOM && (flags & UTF8_SKIP_BOM) != 0)
+            continue;
 
         const int32_t w_wide = *w;
         if (w_wide < 0) {
-            if ((flags & UTF8_IGNORE_ERROR) == 0) return 0;
+            if ((flags & UTF8_IGNORE_ERROR) == 0)
+                return 0;
             continue;
         }
         if (w_wide <= 0x0000007f) {
@@ -306,8 +319,10 @@ static size_t wchar_to_utf8_internal(const utf8_wchar_t *in, size_t insize, char
 
         total += n;
 
-        if (out == nullptr) continue;
-        if (size_t(lim - p) <= n - 1) return 0;  // no space left
+        if (out == nullptr)
+            continue;
+        if (size_t(lim - p) <= n - 1)
+            return 0;  // no space left
 
         // Extract the wchar_t as big-endian. If wchar_t is UCS-16, the first two bytes will be 0.
         unsigned char oc[4];

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -20,12 +20,16 @@ static int wcsfilecmp_leading_digits(const wchar_t **a, const wchar_t **b) {
     const wchar_t *a_end, *b_end;
 
     long a_num = fish_wcstol(*a, &a_end, 10);
-    if (errno > 0) return 0;  // invalid number -- fallback to simple string compare
+    if (errno > 0)
+        return 0;  // invalid number -- fallback to simple string compare
     long b_num = fish_wcstol(*b, &b_end, 10);
-    if (errno > 0) return 0;  // invalid number -- fallback to simple string compare
+    if (errno > 0)
+        return 0;  // invalid number -- fallback to simple string compare
 
-    if (a_num < b_num) return -1;
-    if (a_num > b_num) return 1;
+    if (a_num < b_num)
+        return -1;
+    if (a_num > b_num)
+        return 1;
     *a = a_end;
     *b = b_end;
     return 0;
@@ -59,14 +63,17 @@ int wcsfilecmp(const wchar_t *a, const wchar_t *b) {
             retval = wcsfilecmp_leading_digits(&a, &b);
             // If we know the strings aren't logically equal or we've reached the end of one or both
             // strings we can stop iterating over the chars in each string.
-            if (retval || *a == 0 || *b == 0) break;
+            if (retval || *a == 0 || *b == 0)
+                break;
         }
 
         wint_t al = towupper(*a);
         wint_t bl = towupper(*b);
         // Sort dashes after Z - see #5634
-        if (al == L'-') al = L'[';
-        if (bl == L'-') bl = L'[';
+        if (al == L'-')
+            al = L'[';
+        if (bl == L'-')
+            bl = L'[';
 
         if (al < bl) {
             retval = -1;
@@ -80,7 +87,8 @@ int wcsfilecmp(const wchar_t *a, const wchar_t *b) {
         }
     }
 
-    if (retval != 0) return retval;  // we already know the strings aren't logically equal
+    if (retval != 0)
+        return retval;  // we already know the strings aren't logically equal
 
     if (*a == 0) {
         if (*b == 0) {
@@ -112,7 +120,8 @@ int wcsfilecmp_glob(const wchar_t *a, const wchar_t *b) {
             retval = wcsfilecmp_leading_digits(&a, &b);
             // If we know the strings aren't logically equal or we've reached the end of one or both
             // strings we can stop iterating over the chars in each string.
-            if (retval || *a == 0 || *b == 0) break;
+            if (retval || *a == 0 || *b == 0)
+                break;
         }
 
         wint_t al = towlower(*a);
@@ -129,7 +138,8 @@ int wcsfilecmp_glob(const wchar_t *a, const wchar_t *b) {
         }
     }
 
-    if (retval != 0) return retval;  // we already know the strings aren't logically equal
+    if (retval != 0)
+        return retval;  // we already know the strings aren't logically equal
 
     if (*a == 0) {
         if (*b == 0) {

--- a/src/wcstringutil.cpp
+++ b/src/wcstringutil.cpp
@@ -71,7 +71,8 @@ bool string_prefixes_string(const wchar_t *proposed_prefix, const wchar_t *value
     for (size_t idx = 0; proposed_prefix[idx] != L'\0'; idx++) {
         // Note if the prefix is longer than value, then we will compare a nonzero prefix character
         // against a zero value character, and so we'll return false;
-        if (proposed_prefix[idx] != value[idx]) return false;
+        if (proposed_prefix[idx] != value[idx])
+            return false;
     }
     // We must have that proposed_prefix[idx] == L'\0', so we have a prefix match.
     return true;
@@ -83,7 +84,8 @@ bool string_prefixes_string(const char *proposed_prefix, const std::string &valu
 
 bool string_prefixes_string(const char *proposed_prefix, const char *value) {
     for (size_t idx = 0; proposed_prefix[idx] != L'\0'; idx++) {
-        if (proposed_prefix[idx] != value[idx]) return false;
+        if (proposed_prefix[idx] != value[idx])
+            return false;
     }
     return true;
 }
@@ -146,7 +148,8 @@ maybe_t<string_fuzzy_match_t> string_fuzzy_match_t::try_create(const wcstring &s
     // Use icase if the input contains any uppercase characters, smartcase otherwise.
     auto get_case_fold = [&] {
         for (wchar_t c : string) {
-            if (towlower(c) != static_cast<wint_t>(c)) return case_fold_t::icase;
+            if (towlower(c) != static_cast<wint_t>(c))
+                return case_fold_t::icase;
         }
         return case_fold_t::smartcase;
     };
@@ -219,11 +222,13 @@ size_t ifind_impl(const T &haystack, const T &needle) {
     std::locale locale;
 
     auto ieq = [&locale](char_t c1, char_t c2) {
-        if (c1 == c2 || std::toupper(c1, locale) == std::toupper(c2, locale)) return true;
+        if (c1 == c2 || std::toupper(c1, locale) == std::toupper(c2, locale))
+            return true;
 
         // In fuzzy matching treat treat `-` and `_` as equal (#3584).
         if (Fuzzy) {
-            if ((c1 == '-' || c1 == '_') && (c2 == '-' || c2 == '_')) return true;
+            if ((c1 == '-' || c1 == '_') && (c2 == '-' || c2 == '_'))
+                return true;
         }
         return false;
     };
@@ -264,7 +269,8 @@ wcstring_list_t split_string_tok(const wcstring &val, const wcstring &seps, size
     while (pos < end && out.size() + 1 < max_results) {
         // Skip leading seps.
         pos = val.find_first_not_of(seps, pos);
-        if (pos == wcstring::npos) break;
+        if (pos == wcstring::npos)
+            break;
 
         // Find next sep.
         size_t next_sep = val.find_first_of(seps, pos);
@@ -285,7 +291,8 @@ wcstring_list_t split_string_tok(const wcstring &val, const wcstring &seps, size
 }
 
 wcstring join_strings(const wcstring_list_t &vals, wchar_t sep) {
-    if (vals.empty()) return wcstring{};
+    if (vals.empty())
+        return wcstring{};
 
     // Reserve the size we will need.
     // count-1 separators, plus the length of all strings.

--- a/src/wcstringutil.h
+++ b/src/wcstringutil.h
@@ -85,7 +85,8 @@ struct string_fuzzy_match_t {
     // \return if our match requires a full replacement, i.e. is not a strict extension of our
     // existing string. This is false only if our case matches, and our type is prefix or exact.
     bool requires_full_replacement() const {
-        if (case_fold != case_fold_t::samecase) return true;
+        if (case_fold != case_fold_t::samecase)
+            return true;
         switch (type) {
             case contain_type_t::exact:
             case contain_type_t::prefix:
@@ -150,7 +151,8 @@ inline wcstring to_string(int x) { return to_string(static_cast<long>(x)); }
 inline wcstring to_string(size_t x) { return to_string(static_cast<unsigned long long>(x)); }
 
 inline bool bool_from_string(const std::string &x) {
-    if (x.empty()) return false;
+    if (x.empty())
+        return false;
     switch (x.front()) {
         case 'Y':
         case 'T':
@@ -240,14 +242,16 @@ bool wcs2string_callback(const wchar_t *input, size_t len, const Func &func) {
             // do nothing
         } else if (wc >= ENCODE_DIRECT_BASE && wc < ENCODE_DIRECT_BASE + 256) {
             converted[0] = wc - ENCODE_DIRECT_BASE;
-            if (!func(converted, 1)) return false;
+            if (!func(converted, 1))
+                return false;
         } else if (MB_CUR_MAX == 1) {  // single-byte locale (C/POSIX/ISO-8859)
             // If `wc` contains a wide character we emit a question-mark.
             if (wc & ~0xFF) {
                 wc = '?';
             }
             converted[0] = wc;
-            if (!func(converted, 1)) return false;
+            if (!func(converted, 1))
+                return false;
         } else {
             std::memset(converted, 0, sizeof converted);
             size_t len = std::wcrtomb(converted, wc, &state);
@@ -255,7 +259,8 @@ bool wcs2string_callback(const wchar_t *input, size_t len, const Func &func) {
                 wcs2string_bad_char(wc);
                 std::memset(&state, 0, sizeof(state));
             } else {
-                if (!func(converted, len)) return false;
+                if (!func(converted, len))
+                    return false;
             }
         }
     }
@@ -283,13 +288,15 @@ class line_iterator_t {
 
     /// Advances to the next line. \return true on success, false if we have exhausted the string.
     bool next() {
-        if (current == coll.end()) return false;
+        if (current == coll.end())
+            return false;
         auto newline_or_end = std::find(current, coll.cend(), '\n');
         storage.assign(current, newline_or_end);
         current = newline_or_end;
 
         // Skip the newline.
-        if (current != coll.cend()) ++current;
+        if (current != coll.cend())
+            ++current;
         return true;
     }
 };

--- a/src/wgetopt.cpp
+++ b/src/wgetopt.cpp
@@ -178,14 +178,16 @@ int wgetopter_t::_advance_to_next_argv(  //!OCLINT(high cyclomatic complexity)
     if (woptind == argc) {
         // Set the next-arg-index to point at the non-options that we previously skipped, so the
         // caller will digest them.
-        if (first_nonopt != last_nonopt) woptind = first_nonopt;
+        if (first_nonopt != last_nonopt)
+            woptind = first_nonopt;
         return EOF;
     }
 
     // If we have come to a non-option and did not permute it, either stop the scan or describe
     // it to the caller and pass it by.
     if ((argv[woptind][0] != '-' || argv[woptind][1] == '\0')) {
-        if (ordering == REQUIRE_ORDER) return EOF;
+        if (ordering == REQUIRE_ORDER)
+            return EOF;
         woptarg = argv[woptind++];
         return 1;
     }
@@ -202,7 +204,8 @@ int wgetopter_t::_handle_short_opt(int argc, string_array_t argv) {
     const wchar_t *temp = std::wcschr(shortopts, c);
 
     // Increment `woptind' when we start to process its last character.
-    if (*nextchar == '\0') ++woptind;
+    if (*nextchar == '\0')
+        ++woptind;
 
     if (temp == nullptr || c == ':') {
         if (wopterr) {
@@ -211,7 +214,8 @@ int wgetopter_t::_handle_short_opt(int argc, string_array_t argv) {
         }
         woptopt = c;
 
-        if (*nextchar != '\0') woptind++;
+        if (*nextchar != '\0')
+            woptind++;
         return '?';
     }
 
@@ -291,7 +295,8 @@ void wgetopter_t::_update_long_opt(int argc, string_array_t argv, const struct w
     }
 
     nextchar += std::wcslen(nextchar);
-    if (longind != nullptr) *longind = option_index;
+    if (longind != nullptr)
+        *longind = option_index;
     if (pfound->flag) {
         *(pfound->flag) = pfound->val;
         *retval = 0;
@@ -422,12 +427,14 @@ bool wgetopter_t::_handle_long_opt(int argc, string_array_t argv, const struct w
 // If LONG_ONLY is nonzero, '-' as well as '--' can introduce long-named options.
 int wgetopter_t::_wgetopt_internal(int argc, string_array_t argv, const wchar_t *optstring,
                                    const struct woption *longopts, int *longind, int long_only) {
-    if (!initialized) _wgetopt_initialize(optstring);
+    if (!initialized)
+        _wgetopt_initialize(optstring);
     woptarg = nullptr;
 
     if (nextchar == nullptr || *nextchar == '\0') {
         int retval = _advance_to_next_argv(argc, argv, longopts);
-        if (retval != 0) return retval;
+        if (retval != 0)
+            return retval;
     }
 
     // Decode the current option-ARGV-element.
@@ -447,7 +454,8 @@ int wgetopter_t::_wgetopt_internal(int argc, string_array_t argv, const wchar_t 
         (argv[woptind][1] == '-' ||
          (long_only && (argv[woptind][2] || !std::wcschr(shortopts, argv[woptind][1]))))) {
         int retval;
-        if (_handle_long_opt(argc, argv, longopts, longind, long_only, &retval)) return retval;
+        if (_handle_long_opt(argc, argv, longopts, longind, long_only, &retval))
+            return retval;
     }
 
     return _handle_short_opt(argc, argv);

--- a/src/wildcard.cpp
+++ b/src/wildcard.cpp
@@ -75,7 +75,8 @@ static bool wildcard_has_impl(const wchar_t *str, size_t len, bool internal) {
     } else {
         wchar_t prev = 0;
         for (; str < end; str++) {
-            if (((*str == L'*') || (*str == L'?' && qmark_is_wild)) && (prev != L'\\')) return true;
+            if (((*str == L'*') || (*str == L'?' && qmark_is_wild)) && (prev != L'\\'))
+                return true;
             prev = *str;
         }
     }
@@ -228,7 +229,8 @@ static wildcard_result_t wildcard_complete_internal(const wchar_t *const str, si
     if (next_wc_char_pos == wcstring::npos) {
         // Try matching.
         maybe_t<string_fuzzy_match_t> match = string_fuzzy_match_string(wc, str);
-        if (!match) return wildcard_result_t::no_match;
+        if (!match)
+            return wildcard_result_t::no_match;
 
         // If we're not allowing fuzzy match, then we require a prefix match.
         bool needs_prefix_match = !(params.expand_flags & expand_flag::fuzzy_match);
@@ -434,8 +436,10 @@ static const wchar_t *file_get_desc(int lstat_res, const struct stat &lbuf, int 
             return COMPLETE_SYMLINK_DESC;
         }
 
-        if (err == ENOENT) return COMPLETE_ROTTEN_SYMLINK_DESC;
-        if (err == ELOOP) return COMPLETE_LOOP_SYMLINK_DESC;
+        if (err == ENOENT)
+            return COMPLETE_ROTTEN_SYMLINK_DESC;
+        if (err == ELOOP)
+            return COMPLETE_LOOP_SYMLINK_DESC;
         // On unknown errors we do nothing. The file will be given the default 'File'
         // description or one based on the suffix.
     } else if (S_ISCHR(buf.st_mode)) {
@@ -510,7 +514,8 @@ static bool wildcard_test_flags_then_complete(const wcstring &filepath, const wc
         desc = file_get_desc(lstat_res, lstat_buf, stat_res, stat_buf, stat_errno);
 
         if (file_size >= 0) {
-            if (!desc.empty()) desc.append(L", ");
+            if (!desc.empty())
+                desc.append(L", ");
             desc.append(format_size(file_size));
         }
     }
@@ -651,7 +656,8 @@ class wildcard_expander_t {
         append_path_component(abs_path, filepath);
 
         // We must normalize the path to allow 'cd ..' to operate on logical paths.
-        if (flags & expand_flag::special_for_cd) abs_path = normalize_path(abs_path);
+        if (flags & expand_flag::special_for_cd)
+            abs_path = normalize_path(abs_path);
 
         size_t before = this->resolved_completions->size();
         if (wildcard_test_flags_then_complete(abs_path, filename, wildcard.c_str(), this->flags,
@@ -809,7 +815,8 @@ void wildcard_expander_t::expand_literal_intermediate_segment_with_fuzz(const wc
         // Skip cases that don't match or match exactly. The match-exactly case was handled directly
         // in expand().
         const maybe_t<string_fuzzy_match_t> match = string_fuzzy_match_string(wc_segment, name_str);
-        if (!match || match->is_samecase_exact()) continue;
+        if (!match || match->is_samecase_exact())
+            continue;
 
         wcstring new_full_path = base_dir + name_str;
         new_full_path.push_back(L'/');


### PR DESCRIPTION
This switches our clang-format to disallow single-line if statements.

Instead of

     if (retval != STATUS_CMD_OK) return retval;

we now have:

     if (retval != STATUS_CMD_OK)
          return retval;

I think @faho made a comment that he disliked single-line if statements and I agree. Does anyone want to keep them?