### PR TITLE
A cli prompt selector

### DIFF
--- a/doc_src/cmds/fish_config.rst
+++ b/doc_src/cmds/fish_config.rst
@@ -8,23 +8,37 @@ Synopsis
 
 ::
 
-    fish_config [TAB]
+    fish_config
+    fish_config browse
+    fish_config prompt (choose | list | save | show)
 
 Description
 -----------
 
-``fish_config`` starts the web-based configuration interface.
+``fish_config`` is used to configure fish.
 
-The web interface allows you to view your functions, variables and history, and to make changes to your prompt and color configuration.
-
-``fish_config`` starts a local web server and then opens a web browser window; when you have finished, close the browser window and then press the Enter key to terminate the configuration session.
-
-``fish_config`` optionally accepts name of the initial configuration tab. For e.g. ``fish_config history`` will start configuration interface with history tab.
+Without arguments or with the ``browse`` command it starts the web-based configuration interface. The web interface allows you to view your functions, variables and history, and to make changes to your prompt and color configuration. It starts a local web server and opens a browser window. When you are finished, close the browser window and press the Enter key to terminate the configuration session.
 
 If the ``BROWSER`` environment variable is set, it will be used as the name of the web browser to open instead of the system default.
 
+With the ``prompt`` command ``fish_config`` can be used to view and choose a prompt from fish's sample prompts inside the terminal directly.
+
+Available subcommands for the ``prompt`` command:
+
+- ``choose`` loads a sample prompt in the current session.
+- ``list`` lists the names of the available sample prompts.
+- ``save`` saves the current prompt to a file (via :ref:`funcsave <cmd-funcsave>`).
+- ``show`` shows what the given sample prompts (or all) would look like.
 
 Example
 -------
 
-``fish_config`` opens a new web browser window and allows you to configure certain fish settings.
+``fish_config`` or ``fish_config browse`` opens a new web browser window and allows you to configure certain fish settings.
+
+``fish_config prompt show`` demos the available sample prompts.
+
+``fish_config prompt choose disco`` makes the disco prompt the prompt for the current session. This can also be used in :ref:`config.fish <initialization>` to set the prompt.
+
+``fish_config prompt save`` saves the current prompt to an :ref:`autoloaded <autoloading-functions>` file.
+
+``fish_config prompt save default`` chooses the default prompt and saves it.

--- a/share/completions/fish_config.fish
+++ b/share/completions/fish_config.fish
@@ -1,0 +1,14 @@
+complete fish_config -f
+set -l prompt_commands choose save show list
+complete fish_config -n '__fish_use_subcommand' -a prompt -d 'View and pick from the sample prompts'
+complete fish_config -n "__fish_seen_subcommand_from prompt; and not __fish_seen_subcommand_from $prompt_commands" \
+    -a choose -d 'View and pick from the sample prompts'
+complete fish_config -n "__fish_seen_subcommand_from prompt; and not __fish_seen_subcommand_from $prompt_commands" \
+    -a show -d 'Show what prompts would look like'
+complete fish_config -n "__fish_seen_subcommand_from prompt; and not __fish_seen_subcommand_from $prompt_commands" \
+    -a list -d 'List all available prompts'
+complete fish_config -n "__fish_seen_subcommand_from prompt; and not __fish_seen_subcommand_from $prompt_commands" \
+    -a save -d 'Save the current or given prompt to ~/.config/fish'
+complete fish_config -n '__fish_seen_subcommand_from prompt; and __fish_seen_subcommand_from choose save show' -a '(prompt list)'
+
+complete fish_config -n '__fish_use_subcommand' -a browse -d 'Open the web-based UI'

--- a/share/functions/fish_config.fish
+++ b/share/functions/fish_config.fish
@@ -1,14 +1,130 @@
 function fish_config --description "Launch fish's web based configuration"
-    set -lx __fish_bin_dir $__fish_bin_dir
-    if set -l python (__fish_anypython)
-        $python "$__fish_data_dir/tools/web_config/webconfig.py" $argv
-    else
-        echo (set_color $fish_color_error)Cannot launch the web configuration tool:(set_color normal)
-        echo (set_color -o)fish_config(set_color normal) requires Python.
-        echo Installing python will fix this, and also enable completions to be
-        echo automatically generated from man pages.\n
-        echo To change your prompt, create a (set_color -o)fish_prompt(set_color normal) function.
-        echo There are examples in (set_color $fish_color_valid_path)$__fish_data_dir/tools/web_config/sample_prompts(set_color normal).\n
-        echo You can tweak your colors by setting the (set_color $fish_color_search_match)\$fish_color_\*(set_color normal) variables.
+    argparse h/help -- $argv
+    or return
+
+    if set -q _flag_help
+        __fish_print_help fish_config
+        return 0
     end
+
+    set -l cmd $argv[1]
+    set -e argv[1]
+
+    set -q cmd[1]
+    or set cmd browse
+
+    # The web-based configuration UI
+    # Also opened with just `fish_config` or `fish_config browse`.
+    if contains -- $cmd browse
+        set -lx __fish_bin_dir $__fish_bin_dir
+        if set -l python (__fish_anypython)
+            $python "$__fish_data_dir/tools/web_config/webconfig.py" $argv
+        else
+            echo (set_color $fish_color_error)Cannot launch the web configuration tool:(set_color normal)
+            echo (set_color -o)"fish_config browse"(set_color normal) requires Python.
+            echo Installing python will fix this, and also enable completions to be
+            echo automatically generated from man pages.\n
+            echo To change your prompt, use (set_color -o)"fish_config prompt"(set_color normal) or create a (set_color -o)"fish_prompt"(set_color normal) function.
+            echo To list the samples use (set_color -o)"fish_config prompt show"(set_color normal).\n
+
+            echo You can tweak your colors by setting the (set_color $fish_color_search_match)\$fish_color_\*(set_color normal) variables.
+        end
+        return 0
+    end
+
+    if not contains -- $cmd prompt
+        echo No such subcommand: $cmd >&2
+        return 1
+    end
+        
+    # prompt - for prompt switching
+    set -l cmd $argv[1]
+    set -e argv[1]
+
+    if contains -- $cmd list; and set -q argv[1]
+        echo "Too many arguments" >&2
+        return 1
+    end
+
+    set -l prompt_dir $__fish_data_dir/sample_prompts $__fish_data_dir/tools/web_config/sample_prompts
+    switch $cmd
+        case show
+            set -l fish (status fish-path)
+            set -l prompts $prompt_dir/$argv.fish
+            set -q prompts[1]; or set prompts $prompt_dir/*.fish
+            for p in $prompts
+                if not test -e "$p"
+                    continue
+                end
+                set -l promptname (string replace -r '.*/([^/]*).fish$' '$1' $p)
+                echo -s (set_color --underline) $promptname (set_color normal)
+                $fish -c "functions -e fish_right_prompt; source $p;
+                    false
+                    fish_prompt
+                    echo (set_color normal)
+                    if functions -q fish_right_prompt;
+                        echo right prompt: (false; fish_right_prompt)
+                    end"
+                echo
+            end
+        case list ''
+            string replace -r '.*/([^/]*).fish$' '$1' $prompt_dir/*.fish
+            return
+        case choose
+            if set -q argv[2]
+                echo "Too many arguments" >&2
+                return 1
+            end
+            if not set -q argv[1]
+                echo "Too few arguments" >&2
+                return 1
+            end
+
+            set -l have 0
+            for f in $prompt_dir/$argv[1].fish
+                if test -f $f
+                    source $f
+                    set have 1
+                    break
+                end
+            end
+            if test $have -eq 0
+                echo "No such prompt: '$argv[1]'" >&2
+                return 1
+            end
+        case save
+            read -P"Overwrite prompt? [y/N]" -l yesno
+            if string match -riq 'y(es)?' -- $yesno
+                echo Overwriting
+                cp $__fish_config_dir/functions/fish_prompt.fish{,.bak}
+
+                if set -q argv[1]
+                    set -l have 0
+                    for f in $prompt_dir/$argv[1].fish
+                        if test -f $f
+                            set have 1
+                            source $f
+                            or return 2
+                        end
+                    end
+                    if test $have -eq 0
+                        echo "No such prompt: '$argv[1]'" >&2
+                        return 1
+                    end
+                end
+
+                funcsave fish_prompt
+                or return
+
+                functions -q fish_right_prompt
+                and funcsave fish_right_prompt
+
+                return
+            else
+                echo Not overwriting
+                return 1
+            end
+    end
+
+    return 0
 end


### PR DESCRIPTION
It's a bit weird to *have* to fire up a browser to get fish_config to
choose a prompt.

So this adds `prompt`:

- `prompt list` shows all the available prompt names
- `prompt show` demos the available sample prompts
- `prompt choose` sources a prompt
- `prompt save` makes the choice permanent

Part of #3625.

This means that you can e.g. pick the "informative" prompt by adding `prompt choose informative` to config.fish, and it will just always `source` the one from the currently installed fish (so it will update when we update the sample). This is on purpose and has basically no overhead, so it's entirely acceptable - we might even want to recommend it in the docs.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] This does not currently correctly show the right prompt, which is awkward
to do because we'd have to move it to the right (and this involves width-without-color, see #7784).
- [x] How about the name? `prompt`, or maybe a more general "config tool"? A special mode for `fish_config`, so if you do `fish_config prompt` it'll run in the terminal, `fish_config` will keep opening the browser?
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
