### PR TITLE
Remove extra chars in -p and --load completions

### DIFF
--- a/share/completions/sysctl.fish
+++ b/share/completions/sysctl.fish
@@ -12,7 +12,7 @@ if sysctl -h >/dev/null 2>/dev/null
     complete -c sysctl -s N -l names -d 'Only print names'
     complete -c sysctl -s q -l quiet -d 'Be quiet when setting values'
     complete -c sysctl -s w -l write -d 'Write value'
-    complete -c sysctl -o 'p[FILE]' -l 'load[' -d 'Load in sysctl settings from the file specified or /etc/sysctl'
+    complete -c sysctl -s p -l load -d 'Load in sysctl settings from the file specified or /etc/sysctl' 
     complete -c sysctl -s a -l all -d 'Display all values currently available'
     complete -c sysctl -l deprecated -d 'Include deprecated parameters too'
     complete -c sysctl -s b -l binary -d 'Print value without new line'


### PR DESCRIPTION
## Description

Remove extra chars in -p and --load completions


Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
