### PR TITLE
Allow configuration of fish_clipboard{copy,paste}

### DIFF
--- a/share/functions/fish_clipboard_copy.fish
+++ b/share/functions/fish_clipboard_copy.fish
@@ -2,7 +2,9 @@ function fish_clipboard_copy
     # Copy the current selection, or the entire commandline if that is empty.
     set -l cmdline (commandline --current-selection | string collect)
     test -n "$cmdline"; or set cmdline (commandline | string collect)
-    if type -q pbcopy
+    if set -q fish_user_clipboard_copy_command
+        printf '%s' $cmdline | $fish_user_clipboard_copy_command
+    else if type -q pbcopy
         printf '%s' $cmdline | pbcopy
     else if set -q WAYLAND_DISPLAY; and type -q wl-copy
         printf '%s' $cmdline | wl-copy

--- a/share/functions/fish_clipboard_paste.fish
+++ b/share/functions/fish_clipboard_paste.fish
@@ -1,6 +1,8 @@
 function fish_clipboard_paste
     set -l data
-    if type -q pbpaste
+    if set -q fish_user_clipboard_paste_command
+        set data ($fish_user_clipboard_paste_command 2>/dev/null)
+    else if type -q pbpaste
         set data (pbpaste 2>/dev/null)
     else if set -q WAYLAND_DISPLAY; and type -q wl-paste
         set data (wl-paste 2>/dev/null)


### PR DESCRIPTION
## Description

This is a simple POC for making fish_clipboard_copy/fish_clipboard_paste
customizable. The default logic is sound, but can be enhanced by allowing a
custom choice of programs. This can be used to (for example) use
`reattach-to-user-namespace` on older macOS versions, or implement custom logic
like OSC 52-based clipboard access.

While the user can easily override the default functions with autoloads, the
normalization provided by the default functions is quite solid, and it's a shame
to force the user to duplicate it (and this not benefit from improvements) to
override the program selection logic.

The variable names are subject to change, and documentation and a change log entry
are still needed.

Additionally, we may want to add tests -- I will need guidance there.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
