### PR TITLE
Change ambiguous sentence in introduction

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -516,7 +516,7 @@ Without the quotes or braces, fish will try to expand a variable called ``$WORDs
 
 The latter syntax ``{$WORD}`` is a special case of :ref:`brace expansion <expand-brace>`.
 
-If $WORD here is undefined or an empty list, the "s" is not printed. However, it is printed if $WORD is the empty string (like after ``set WORD ""``).
+If $WORD is undefined or an empty list, the "s" is printed after the quotes expansion but not after the braces expansion. However, it is printed if $WORD is the empty string (like after ``set WORD ""``).
 
 Unlike all the other expansions, variable expansion also happens in double quoted strings. Inside double quotes (``"these"``), variables will always expand to exactly one argument. If they are empty or undefined, it will result in an empty string. If they have one element, they'll expand to that element. If they have more than that, the elements will be joined with spaces, unless the variable is a :ref:`path variable <variables-path>` - in that case it will use a colon (`:`) instead [#]_.
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -516,8 +516,6 @@ Without the quotes or braces, fish will try to expand a variable called ``$WORDs
 
 The latter syntax ``{$WORD}`` is a special case of :ref:`brace expansion <expand-brace>`.
 
-If $WORD is undefined or an empty list, the "s" is printed after the quotes expansion but not after the braces expansion. However, it is printed if $WORD is the empty string (like after ``set WORD ""``).
-
 Unlike all the other expansions, variable expansion also happens in double quoted strings. Inside double quotes (``"these"``), variables will always expand to exactly one argument. If they are empty or undefined, it will result in an empty string. If they have one element, they'll expand to that element. If they have more than that, the elements will be joined with spaces, unless the variable is a :ref:`path variable <variables-path>` - in that case it will use a colon (`:`) instead [#]_.
 
 Outside of double quotes, variables will expand to as many arguments as they have elements. That means an empty list will expand to nothing, a variable with one element will expand to that element, and a variable with multiple elements will expand to each of those elements separately.


### PR DESCRIPTION
## Description

I think that the word "here" is slightly ambiguous and so I changed it to specifically refer to brace variable expansion in the variable expansion section of the introduction. That is unless I misunderstood the behavior of quote vs curly braces variable expansion as I am quite new to fish.

Fixes issue #

## TODOs:

