### PR TITLE
Explanation of list range example wrong way round.

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -716,7 +716,7 @@ In index brackets, fish understands ranges written like ``a..b`` ('a' and 'b' be
 If a list has 5 elements the indices go from 1 to 5, so a range of ``2..16`` will only go from element 2 to element 5.
 
 If the end is negative the range always goes up, so ``2..-2`` will go from element 2 to 4, and ``2..-16`` won't go anywhere because there is no way to go from the second element to one that doesn't exist, while going up.
-If the start is negative the range always goes down, so ``-2..1`` will go from element 4 to 1, and ``-16..2`` won't go anywhere because there is no way to go from the second element to one that doesn't exist, while going down.
+If the start is negative the range always goes down, so ``-2..1`` will go from element 4 to 1, and ``-16..2`` won't go anywhere because there is no way to go from an element that doesn't exist to the second element, while going down.
 
 A missing starting index in a range defaults to 1. This is allowed if the range is the first index expression of the sequence. Similarly, a missing ending index, defaulting to -1 is allowed for the last index range in the sequence.
 


### PR DESCRIPTION
## Description

I'm assuming the first number before the *..* is the FROM and the number after it is the TO.

Fixes issue #

## TODOs:
