### PR TITLE
Let '&' only separate as the first char of a word

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,11 @@ fish 3.4.0 (released ???)
 Notable improvements and fixes
 ------------------------------
 - Complimenting the ``prompt`` command in 3.3.0, ``fish_config`` gained a ``theme`` subcommand to show and pick from the sample themes (meaning color schemes) directly in the terminal, instead of having to open a webbrowser. For example ``fish_config theme choose Nord`` loads the Nord theme in the current session (:issue:`8132`). The current theme can be saved with ``fish_config theme dump`` and custom themes can be added by saving them in ``~/.config/fish/themes/``.
-- fish's command substitution syntax has been extended: ``$(cmd)`` now has the same meaning as ``(cmd)`` but it can be used inside double quotes, to prevent line splitting of the results. (:issue:`159`).
+- fish's command substitution syntax has been extended: ``$(cmd)`` now has the same meaning as ``(cmd)`` but it can be used inside double quotes, to prevent line splitting of the results (:issue:`159`).
 
 Deprecations and removed features
 ---------------------------------
+- A new feature flag ``ampersand-nobg-in-token`` makes ``&`` only act as background operator if followed by a separator. In combination with ``qmark-noglob`` this allows to write some URLs without quoting or escaping (:issue:`7991`)
 
 Scripting improvements
 ----------------------

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -233,6 +233,8 @@ These listed jobs can be removed with the :ref:`disown <cmd-disown>` command.
 
 At the moment, functions cannot be started in the background. Functions that are stopped and then restarted in the background using the :ref:`bg <cmd-bg>` command will not execute correctly.
 
+If the ``&`` character is followed by a non-separating character, it is not interpreted as background operator. Separating characters are whitespace and the characters ``;<>&|``.
+
 .. _syntax-function:
 
 Functions
@@ -1393,14 +1395,16 @@ Feature flags are how fish stages changes that might break scripts. Breaking cha
 You can see the current list of features via ``status features``::
 
     > status features
-    stderr-nocaret  on     3.0      ^ no longer redirects stderr
-    qmark-noglob    off    3.0      ? no longer globs
-    regex-easyesc   off    3.1      string replace -r needs fewer \\'s
+    stderr-nocaret          on  3.0 ^ no longer redirects stderr
+    qmark-noglob            off 3.0 ? no longer globs
+    regex-easyesc           off 3.1 string replace -r needs fewer \\'s
+    ampersand-nobg-in-token off 3.4 & only backgrounds if followed by a separating character
 
 There are two breaking changes in fish 3.0: caret ``^`` no longer redirects stderr, and question mark ``?`` is no longer a glob.
 
 There is one breaking change in fish 3.1: ``string replace -r`` does a superfluous round of escaping for the replacement, so escaping backslashes would look like ``string replace -ra '([ab])' '\\\\\\\$1' a``. This flag removes that if turned on, so ``'\\\\$1'`` is enough.
 
+There is one breaking change in fish 3.4: in ``echo https://example.com/?q=hello&qq=goodbye`` the ``&`` is no longer interpreted as backgrounding operator.
 
 These changes are off by default. They can be enabled on a per session basis::
 

--- a/src/builtin_status.cpp
+++ b/src/builtin_status.cpp
@@ -148,10 +148,14 @@ static bool set_status_cmd(const wchar_t *cmd, status_cmd_opts_t &opts, status_c
 
 /// Print the features and their values.
 static void print_features(io_streams_t &streams) {
+    size_t max_len = std::numeric_limits<size_t>::min();
+    for (const auto &md : features_t::metadata) {
+        max_len = std::max(max_len, wcslen(md.name));
+    }
     for (const auto &md : features_t::metadata) {
         int set = feature_test(md.flag);
-        streams.out.append_format(L"%ls\t%s\t%ls\t%ls\n", md.name, set ? "on" : "off", md.groups,
-                                  md.description);
+        streams.out.append_format(L"%-*ls%-3s %ls %ls\n", max_len + 1, md.name, set ? "on" : "off",
+                                  md.groups, md.description);
     }
 }
 

--- a/src/fish_indent.cpp
+++ b/src/fish_indent.cpp
@@ -41,6 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "fds.h"
 #include "fish_version.h"
 #include "flog.h"
+#include "future_feature_flags.h"
 #include "highlight.h"
 #include "operation_context.h"
 #include "output.h"
@@ -852,6 +853,12 @@ int main(int argc, char *argv[]) {
     // (e.g., "# -*- coding: <encoding-name> -*-").
     setlocale(LC_ALL, "");
     env_init();
+
+    if (auto features_var = env_stack_t::globals().get(L"fish_features")) {
+        for (const wcstring &s : features_var->as_list()) {
+            mutable_fish_features().set_from_string(s);
+        }
+    }
 
     // Types of output we support.
     enum {

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2773,6 +2773,7 @@ static void test_word_motion() {
     test_1_word_motion(word_motion_right, move_word_style_punctuation, L"^a^ bcd^");
     test_1_word_motion(word_motion_right, move_word_style_punctuation, L"a^b^ cde^");
     test_1_word_motion(word_motion_right, move_word_style_punctuation, L"^ab^ cde^");
+    test_1_word_motion(word_motion_right, move_word_style_punctuation, L"^ab^&cd^ ^& ^e^ f^&");
 
     test_1_word_motion(word_motion_right, move_word_style_whitespace, L"^^a-b-c^ d-e-f");
     test_1_word_motion(word_motion_right, move_word_style_whitespace, L"^a-b-c^\n d-e-f^ ");
@@ -5197,6 +5198,15 @@ static void test_highlighting() {
     });
 
     highlight_tests.push_back({
+        {L"echo", highlight_role_t::command},
+        {L"foo&bar", highlight_role_t::param},
+        {L"foo", highlight_role_t::param, /*nospace=*/true},
+        {L"&", highlight_role_t::statement_terminator},
+        {L"echo", highlight_role_t::command},
+        {L"&>", highlight_role_t::redirection},
+    });
+
+    highlight_tests.push_back({
         {L"if command", highlight_role_t::keyword},
         {L"ls", highlight_role_t::command},
         {L"; ", highlight_role_t::statement_terminator},
@@ -5489,6 +5499,8 @@ static void test_highlighting() {
     highlight_tests.push_back({{L"$EMPTY_VARIABLE", highlight_role_t::error}});
     highlight_tests.push_back({{L"\"$EMPTY_VARIABLE\"", highlight_role_t::error}});
 
+    const auto saved_flags = fish_features();
+    mutable_fish_features().set(features_t::ampersand_nobg_in_token, true);
     for (const highlight_component_list_t &components : highlight_tests) {
         // Generate the text.
         wcstring text;
@@ -5523,6 +5535,7 @@ static void test_highlighting() {
             }
         }
     }
+    mutable_fish_features() = saved_flags;
     vars.remove(L"VARIABLE_IN_COMMAND", ENV_DEFAULT);
     vars.remove(L"VARIABLE_IN_COMMAND2", ENV_DEFAULT);
 }

--- a/src/future_feature_flags.cpp
+++ b/src/future_feature_flags.cpp
@@ -20,6 +20,8 @@ const features_t::metadata_t features_t::metadata[features_t::flag_count] = {
     {qmark_noglob, L"qmark-noglob", L"3.0", L"? no longer globs", false},
     {string_replace_backslash, L"regex-easyesc", L"3.1", L"string replace -r needs fewer \\'s",
      false},
+    {ampersand_nobg_in_token, L"ampersand-nobg-in-token", L"3.4",
+     L"& only backgrounds if followed by a separating character", false},
 };
 
 const struct features_t::metadata_t *features_t::metadata_for(const wchar_t *name) {

--- a/src/future_feature_flags.h
+++ b/src/future_feature_flags.h
@@ -22,6 +22,9 @@ class features_t {
         /// Whether string replace -r double-unescapes the replacement.
         string_replace_backslash,
 
+        /// Whether "&" is not-special if followed by a word character.
+        ampersand_nobg_in_token,
+
         /// The number of flags.
         flag_count
     };

--- a/tests/checks/features-ampersand-nobg-in-token1.fish
+++ b/tests/checks/features-ampersand-nobg-in-token1.fish
@@ -1,4 +1,4 @@
-#RUN: %fish --features=ampersand-nobg-in-token %s
+#RUN: %fish --features=ampersand-nobg-in-token -C 'set -g fish_indent %fish_indent' %s
 
 echo no&background
 # CHECK: no&background
@@ -10,3 +10,6 @@ echo background &
 # CHECK: background
 
 wait
+
+echo no&bg | fish_features=ampersand-nobg-in-token $fish_indent --check
+echo $status #CHECK: 0

--- a/tests/checks/features-ampersand-nobg-in-token1.fish
+++ b/tests/checks/features-ampersand-nobg-in-token1.fish
@@ -1,0 +1,12 @@
+#RUN: %fish --features=ampersand-nobg-in-token %s
+
+echo no&background
+# CHECK: no&background
+
+echo background&
+# CHECK: background
+
+echo background &
+# CHECK: background
+
+wait

--- a/tests/checks/status.fish
+++ b/tests/checks/status.fish
@@ -54,9 +54,10 @@ eval test_function
 
 # Future Feature Flags
 status features
-#CHECK: stderr-nocaret	on	3.0	^ no longer redirects stderr
-#CHECK: qmark-noglob	off	3.0	? no longer globs
-#CHECK: regex-easyesc	off	3.1	string replace -r needs fewer \'s
+#CHECK: stderr-nocaret          on  3.0 ^ no longer redirects stderr
+#CHECK: qmark-noglob            off 3.0 ? no longer globs
+#CHECK: regex-easyesc           off 3.1 string replace -r needs fewer \'s
+#CHECK: ampersand-nobg-in-token off 3.4 & only backgrounds if followed by a separating character
 status test-feature stderr-nocaret
 echo $status
 #CHECK: 0


### PR DESCRIPTION
This is a quick PR as a conversation starter.

Personally, I've always hated how `&` has this exalted position in the syntax - it terminates commands (so `thing & otherthing` is two commands! you don't need to use `thing &; otherthing`) and it's even interpreted in the middle of words!

`thing&` and `echo foo&` both trigger backgrounding, 

This is quite awkward in combination with URLs:

```
curl https://example.com/thing?foo=bar&duran=duran
```

complains about `duran=duran` being invalid syntax (because it's `set duran duran`, duh)!

So this makes it so `&` is only treated specially at the start of a word.

Inside words, the `&` will simply be used as a regular old char.

It's technically a compatibility break both with old fish and with
posix shells, but as it's always possible to just add a space I do not
consider that to be important.

`&&` and `&>` are also impacted - currently both

```
echo bar&>foo
```

and

```
echo bar&&echo foo
```

are allowed and do a `&>` redirection or `&&` conjunction,
respectively. I consider that awful behavior to begin with, and doubt anyone is using it on purpose.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
