### PR TITLE
completions: fix pacmd completions when using pipewire-pulse.

### DIFF
--- a/share/completions/pacmd.fish
+++ b/share/completions/pacmd.fish
@@ -1,13 +1,13 @@
 # Pulseaudio's pacmd
 # This covers the most useful commands
-set -l commands (pacmd help | string match -r '^ +[-\w]+' | string trim)
+set -l commands (pacmd help 2>/dev/null | string match -r '^ +[-\w]+' | string trim)
 complete -f -c pacmd
 complete -f -c pacmd -w pactl
 
 # These descriptions are a bit wordy and unnecessary
 # Sample: set-source-port Change the port of a source (args: index|name, port-name)
 # Or: list-source-outputs List source outputs
-complete -f -c pacmd -n "not __fish_seen_subcommand_from $commands" -a "(pacmd help | string match ' *' | string trim | string replace -r '\s+' '\t')"
+complete -f -c pacmd -n "not __fish_seen_subcommand_from $commands" -a "(pacmd help 2>/dev/null | string match ' *' | string trim | string replace -r '\s+' '\t')"
 
 # Since we wrapped pactl, we can also use functions defined there
 complete -f -c pacmd -n "__fish_seen_subcommand_from describe-module" -a '(__fish_pa_complete_type modules)'

--- a/share/completions/pactl.fish
+++ b/share/completions/pactl.fish
@@ -12,7 +12,7 @@ set -l ctlcommands stat info list exit {upload,play,remove}-sample {load,unload}
 
 # HACK: This is the list of commands from pacmd - used so we can use complete -w there
 if command -sq pacmd
-    set commands (pacmd help | string match -r '^ +[-\w]+' | string trim)
+    set commands (pacmd help 2>/dev/null | string match -r '^ +[-\w]+' | string trim)
 else
     set commands $ctlcommands
 end


### PR DESCRIPTION
In such cases, `pacmd help` prints

  No PulseAudio daemon running, or not running as session daemon.

to stderr, which ends up printed to the user terminal.

Should I add some fallback for when `pacmd` is available but `pacmd help` failed? The completions still seem to work...

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
