### PR TITLE
Add missing options for `complete`

### DIFF
--- a/share/completions/complete.fish
+++ b/share/completions/complete.fish
@@ -6,6 +6,7 @@ complete -c complete -s s -l short-option -d "POSIX-style short option to comple
 complete -c complete -s l -l long-option -d "GNU-style long option to complete" -x
 complete -c complete -s o -l old-option -d "Old style long option to complete" -x
 complete -c complete -s f -l no-files -d "Don't use file completion"
+complete -c complete -s F -l force-files -d "Use file completion even if another applicable complete doesn't"
 complete -c complete -s r -l require-parameter -d "Require parameter"
 complete -c complete -s x -l exclusive -d "Require parameter and don't use file completion"
 complete -c complete -s a -l arguments -d "Space-separated list of possible option arguments" -x
@@ -15,6 +16,7 @@ complete -c complete -s h -l help -d "Display help and exit"
 complete -c complete -s C -l do-complete -d "Print completions for a commandline specified as a parameter"
 complete -c complete -s n -l condition -d "Completion only used if command has zero exit status" -x
 complete -c complete -s w -l wraps -d "Inherit completions from specified command" -xa '(__fish_complete_command)'
+complete -c complete -s k -l keep-order -d "Keep order of option arguments instead of sorting alphabetically"
 
 # Deprecated options
 

--- a/share/completions/complete.fish
+++ b/share/completions/complete.fish
@@ -6,7 +6,7 @@ complete -c complete -s s -l short-option -d "POSIX-style short option to comple
 complete -c complete -s l -l long-option -d "GNU-style long option to complete" -x
 complete -c complete -s o -l old-option -d "Old style long option to complete" -x
 complete -c complete -s f -l no-files -d "Don't use file completion"
-complete -c complete -s F -l force-files -d "Use file completion even if another applicable complete doesn't"
+complete -c complete -s F -l force-files -d "Always use file completion"
 complete -c complete -s r -l require-parameter -d "Require parameter"
 complete -c complete -s x -l exclusive -d "Require parameter and don't use file completion"
 complete -c complete -s a -l arguments -d "Space-separated list of possible option arguments" -x


### PR DESCRIPTION
## Description

I noticed `-F/--force-files` and `-k/--keep-order` option in presented in [man pages](https://github.com/fish-shell/fish-shell/blob/master/doc_src/cmds/complete.rst) but no in the completions.

Improvements of the descriptions welcome.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
