### PR TITLE
Move the cursor to the beginning before printing right prompt

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -877,6 +877,9 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
 
         // Output any rprompt if this is the first line.
         if (i == 0 && right_prompt_width > 0) {  //!OCLINT(Use early exit/continue)
+            // Move the cursor to the beginning of the line first to be independent of the width.
+            // This helps prevent staircase effects if fish and the terminal disagree.
+            s_move(scr, 0, 0);
             s_move(scr, static_cast<int>(screen_width - right_prompt_width), static_cast<int>(i));
             set_color(highlight_spec_t{});
             s_write_str(scr, right_prompt.c_str());

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -900,6 +900,10 @@ static void s_update(screen_t *scr, const wcstring &left_prompt, const wcstring 
         }
     }
 
+    // Also move the cursor to the beginning of the line here,
+    // in case we're wrong about the width anywhere.
+    s_move(scr, 0, 0);
+
     // Clear remaining lines (if any) if we haven't cleared the screen.
     if (!has_cleared_screen && need_clear_screen && clr_eol) {
         set_color(highlight_spec_t{});


### PR DESCRIPTION
This makes the right prompt position independent of the width of the
commandline, which prevents staircase effects. That means, with "X"
standing in as a character that the terminal and fish disagree on:

```
> echo X           rightprompt
```

will stay like that instead of creating a staircase like

```
> echo X            rightpromp
t> echo X             rightpromp
pt> echo X
```

and so on.

The cursor still won't be *correct*, but it will be wrong in a less
annoying way.

A screenshot:

![Screenshot_20210517_173936](https://user-images.githubusercontent.com/5185367/118516801-f0bd8000-b736-11eb-91d7-9e990212730d.png)

Here fish and gnome-terminal disagree on the width of `☆` (U+2606 WHITE STAR). The first shell has the staircase effect, the second has this patch applied.

The cursor is still *wrong* - the final line has `echo ☆123`, and the cursor is logically *after the 3*. However, that's much less annoying than the staircase.

The cost of this is one cursor move to the start (a `\r`, typically) and longer move to the right prompt per printing of the right prompt, which should be acceptable.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
