### PR TITLE
Fix $last_pid and re-disable non-interactive job control

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Scripting improvements
 - ``$last_pid`` now reports the pid of the last process in the pipeline, allowing it to be used in scripts (:issue:`5036`, :issue:`5832`, :issue:`7721`).
 - ``process-exit`` event handlers now receive the same value as ``$status`` in all cases, instead of receiving -1 when the exit was due to a signal.
 - ``process-exit`` event handlers for pid 0 also received ``JOB_EXIT`` events; this has been fixed.
+- ``job-exit`` event handlers may now be created with any of the pids from the job. The handler is passed the last pid in the job as its second argument, instead of the process group.
 
 Interactive improvements
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,6 @@ Interactive improvements
 - Commands entered before the previous command finishes will now be properly syntax highlighted.
 - fish now automatically creates ``config.fish`` and the configuration directories in ``$XDG_CONFIG_HOME/fish`` (by default ``~/.config/fish``) if they do not already exist (:issue:`7402`).
 - ``__fish_prepend_sudo`` now toggles sudo even when it took the commandline from history instead of only adding it.
-- fish now defaults job-control to "full" meaning it more sensibly handles assigning the terminal and process groups (:issue:`5036`, :issue:`5832`, :issue:`7721`)
 - ``backward-kill-path-component`` :kbd:`Control-W`) no longer erases parts of two tokens when the cursor is positioned immediately after ``/``. (:issue:`6258`).
 - ``$SHLVL`` is no longer incremented in non-interactive shells. This means it won't be set to values larger than 1 just because your environment happens to run some scripts in $SHELL in its startup path (:issue:`7864`).
 - fish no longer rings the bell when flashing the command line. The flashing should already be enough notification and the bell can be annoying (:issue:`7875`).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Scripting improvements
 - ``fish_indent`` allows to write inline variable assignments on multiple lines (ending in a backslash), instead of joining them into one line (:issue:`7955`).
 - fish gained a ``--no-config`` option to disable reading the configuration. This applies both to the user's and the admin's config.fish (typically in /etc/fish/config.fish) and snippets and also sets $fish_function_path to just the functions shipped with fish and disables universal variables and history. (:issue:`7921`, :issue:`1256`).
 - When universal variables are unavailable for some reason, setting a universal variable now sets a global variable instead (:issue:`7921`).
+- ``$last_pid`` now reports the pid of the last process in the pipeline, allowing it to be used in scripts (:issue:`5036`, :issue:`5832`, :issue:`7721`).
 - ``process-exit`` event handlers now receive the same value as ``$status`` in all cases, instead of receiving -1 when the exit was due to a signal.
 - ``process-exit`` event handlers for pid 0 also received ``JOB_EXIT`` events; this has been fixed.
 

--- a/doc_src/cmds/function.rst
+++ b/doc_src/cmds/function.rst
@@ -30,7 +30,7 @@ The following options are available:
 
 - ``-v`` or ``--on-variable VARIABLE_NAME`` tells fish to run this function when the variable VARIABLE_NAME changes value. Note that fish makes no guarantees on any particular timing or even that the function will be run for every single ``set``. Rather it will be run when the variable has been set at least once, possibly skipping some values or being run when the variable has been set to the same value (except for universal variables set in other shells - only changes in the value will be picked up for those).
 
-- ``-j PGID`` or ``--on-job-exit PGID`` tells fish to run this function when the job with group ID PGID exits. Instead of PGID, the string 'caller' can be specified. This is only legal when in a command substitution, and will result in the handler being triggered by the exit of the job which created this command substitution.
+- ``-j PID`` or ``--on-job-exit PID`` tells fish to run this function when the job containing a child process with the given PID exits. Instead of PID, the string 'caller' can be specified. This is only legal when in a command substitution, and will result in the handler being triggered by the exit of the job which created this command substitution.
 
 - ``-p PID`` or ``--on-process-exit PID`` tells fish to run this function when the fish child process
   with process ID PID exits. Instead of a PID, for backward compatibility,

--- a/src/common.h
+++ b/src/common.h
@@ -156,6 +156,13 @@ enum {
 };
 typedef unsigned int escape_flags_t;
 
+/// A user-visible job ID.
+using job_id_t = int;
+
+/// The non user-visible, never-recycled job ID.
+/// Every job has a unique positive value for this.
+using internal_job_id_t = uint64_t;
+
 /// Issue a debug message with printf-style string formating and automatic line breaking. The string
 /// will begin with the string \c program_name, followed by a colon and a whitespace.
 ///

--- a/src/event.h
+++ b/src/event.h
@@ -43,6 +43,16 @@ extern const wchar_t *const event_filter_names[];
 
 /// Properties of an event.
 struct event_description_t {
+    /// Helper type for on-job-exit events.
+    struct job_spec_t {
+        // pid requested by the event, or ANY_PID for all.
+        pid_t pid;
+
+        // internal_job_id of the job to match.
+        // If this is 0, we match either all jobs (pid == ANY_PID) or no jobs (otherwise).
+        uint64_t internal_job_id;
+    };
+
     /// The event type.
     event_type_t type;
 
@@ -50,12 +60,12 @@ struct event_description_t {
     ///
     /// signal: Signal number for signal-type events.Use EVENT_ANY_SIGNAL to match any signal
     /// pid: Process id for process-type events. Use EVENT_ANY_PID to match any pid.
-    /// pgid: Process id for job-type events. This value is positive (or EVENT_ANY_PID).
+    /// jobspec: Info for on-job-exit events.
     /// caller_id: Internal job id for caller_exit type events
     union {
         int signal;
         pid_t pid;
-        pid_t pgid;
+        job_spec_t jobspec;
         uint64_t caller_id;
     } param1{};
 
@@ -103,7 +113,7 @@ struct event_t {
 
     /// Create a JOB_EXIT event. The pgid should be positive.
     /// The reported status is always 0 for historical reasons.
-    static event_t job_exit(pid_t pgid);
+    static event_t job_exit(pid_t pgid, internal_job_id_t jid);
 
     /// Create a caller_exit event.
     static event_t caller_exit(uint64_t internal_job_id, int job_id);

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1123,9 +1123,12 @@ bool exec_job(parser_t &parser, const shared_ptr<job_t> &j, const io_chain_t &bl
 
     // If exec_error then a backgrounded job would have been terminated before it was ever assigned
     // a pgroup, so error out before setting last_pid.
-    auto pgid = j->get_pgid();
-    if (!j->is_foreground() && pgid.has_value()) {
-        parser.vars().set_one(L"last_pid", ENV_GLOBAL, to_string(*pgid));
+    if (!j->is_foreground()) {
+        if (maybe_t<pid_t> last_pid = j->get_last_pid()) {
+            parser.vars().set_one(L"last_pid", ENV_GLOBAL, to_string(*last_pid));
+        } else {
+            parser.vars().set_empty(L"last_pid", ENV_GLOBAL);
+        }
     }
 
     j->continue_job(parser, !j->is_initially_background());

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -497,9 +497,6 @@ int main(int argc, char **argv) {
     misc_init();
     reader_init();
 
-    // And now enable "job control" for everything.
-    set_job_control_mode(job_control_t::all);
-
     parser_t &parser = parser_t::principal_parser();
 
     if (!opts.no_exec && !opts.no_config) {

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -388,7 +388,7 @@ wcstring functions_def(const wcstring &name) {
                 break;
             }
             case event_type_t::job_exit: {
-                append_format(out, L" --on-job-exit %d", d.param1.pgid);
+                append_format(out, L" --on-job-exit %d", d.param1.jobspec.pid);
                 break;
             }
             case event_type_t::caller_exit: {

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -953,6 +953,14 @@ bool job_t::is_foreground() const { return group->is_foreground(); }
 
 maybe_t<pid_t> job_t::get_pgid() const { return group->get_pgid(); }
 
+maybe_t<pid_t> job_t::get_last_pid() const {
+    for (auto iter = processes.rbegin(); iter != processes.rend(); ++iter) {
+        const process_t *proc = iter->get();
+        if (proc->pid > 0) return proc->pid;
+    }
+    return none();
+}
+
 job_id_t job_t::job_id() const { return group->get_id(); }
 
 void job_t::continue_job(parser_t &parser, bool in_foreground) {

--- a/src/proc.h
+++ b/src/proc.h
@@ -392,6 +392,11 @@ class job_t {
     /// This may also be fish itself.
     maybe_t<pid_t> get_pgid() const;
 
+    /// \return the pid of the last external process in the job.
+    /// This may be none if the job consists of just internal fish functions or builtins.
+    /// This will never be fish's own pid.
+    maybe_t<pid_t> get_last_pid() const;
+
     /// The id of this job.
     /// This is user-visible, is recycled, and may be -1.
     job_id_t job_id() const;

--- a/src/proc.h
+++ b/src/proc.h
@@ -298,13 +298,6 @@ class process_t {
 using process_ptr_t = std::unique_ptr<process_t>;
 using process_list_t = std::vector<process_ptr_t>;
 
-/// A user-visible job ID.
-using job_id_t = int;
-
-/// The non user-visible, never-recycled job ID.
-/// Every job has a unique positive value for this.
-using internal_job_id_t = uint64_t;
-
 /// A struct representing a job. A job is a pipeline of one or more processes.
 class job_t {
    public:

--- a/src/wait_handle.h
+++ b/src/wait_handle.h
@@ -23,6 +23,10 @@ struct wait_handle_t {
     /// The pid of this process.
     pid_t pid{};
 
+    /// The internal job id of the job which contained this process.
+    /// This is initially 0; it is set when the job is completed.
+    internal_job_id_t internal_job_id{};
+
     /// The "base name" of this process.
     /// For example if the process is "/bin/sleep" then this will be 'sleep'.
     wcstring base_name{};

--- a/tests/checks/jobs.fish
+++ b/tests/checks/jobs.fish
@@ -121,11 +121,6 @@ end
 emit bar
 #CHECK: foo
 #CHECK: caller
-# Since we are in a script context, this would not trigger "job control"
-# if it was set to "interactive"
-status is-full-job-control
-and echo is full job control
-#CHECK: is full job control
 
 # We can't rely on a *specific* pgid being assigned,
 # but we can rely on it not being fish's.

--- a/tests/checks/jobs.fish
+++ b/tests/checks/jobs.fish
@@ -25,6 +25,11 @@ sleep 0.1
 # (there should be none).
 ps -o stat | string match 'Z*'
 
+# Verify disown can be used with last_pid, even if it is separate from the pgroup.
+# This should silently succeed.
+command true | sleep 0.5 &
+disown $last_pid
+
 jobs -q
 echo $status
 #CHECK: 1


### PR DESCRIPTION
This is my proposal to fix `$last_pid`, and then re-disable job control in scripts.

`$last_pid` (and `%last` before it) has always been the pgroup of the last job run in the background. If job control is active, then means the first pid in the pipeline. But if job control is not active, then the job runs in fish's pgroup, so `$last_pid` is the pid of fish itself! This is completely useless: you can't use wait, disown, kill, fg, bg, etc.

This was fixed in [this commit](https://github.com/fish-shell/fish-shell/commit/325599979479ae04ebac1d0556519f973058993e) which unconditionally enabled job control. This made `$last_pid` sane, but regressed signal handling in scripts (see my comment in the commit).

I propose making `$last_pid` always be a real pid in the job, or empty if the job has no pids. This will make `$last_pid` useful, and more closely match other shells, fixing #5036, #5832, #7721 in the same way.

If there is more than one pid in the job, we have to decide which one to use. I think we should just match bash and zsh, which uses the last. For example in `sleep 1 | sleep 2` then bash will set `$!` to the second sleep; fish will do the same. It does not matter very much which pid we choose, as all commands that operate on jobs allow you to pass the pid of any process in the pipeline.

The one place where it did matter was in `--on-job-exit` events, where you really did have to pass the pgroup (and if you passed fish's pgroup it would fire for every job without job control). To fix that, this change allows `--on-job-exit` events to use any pid in the job, matching fg, disown, etc.

This is technically a breaking change but the existing `$last_pid` behavior is pretty useless; I doubt anyone depends on it. Note if you really want the pgroup, you can use `jobs -g PID` to get it.

### pgroup and job control background

Some background on pgroups and job control: each process lives in a process group. Process groups are identified by a pid, which refers to the "leader" of the group. Process groups do two major things:

1. You can signal an entire pgroup. For example, when you run a shell script, control-C will signal the script itself, and also any child processes currently running as part of the script. This is because the script and its children live in the same pgroup, and control-C directs SIGINT to that group.

2. pgroups multiplex the tty. The tty is owned by one process group at any given time. If a process not in the group attempts to read or write from the tty, it gets signalled instead (SIGTTOU or SIGTITN).

Now when job control is enabled, the shell will place each job into its own process group. This is why control-Z will background vim and not the shell: vim is in its own pgroup. But if you are running a script, usually you want the script and all of its children to be cancelled or backgrounded together; this is accomplished by having them share a pgroup. So this explains why job control is enabled by default only in interactive mode.
