### PR TITLE
env: remove trailing null-terminator from default path

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -244,7 +244,11 @@ static void setup_path() {
         // _CS_PATH: colon-separated paths to find POSIX utilities
         std::string cspath;
         cspath.resize(confstr(_CS_PATH, nullptr, 0));
-        confstr(_CS_PATH, &cspath[0], cspath.length());
+        if (cspath.length() > 0) {
+            confstr(_CS_PATH, &cspath[0], cspath.length());
+            // remove the trailing null-terminator
+            cspath.resize(cspath.length() - 1);
+        }
 #else
         std::string cspath = "/usr/bin:/bin";  // I doubt this is even necessary
 #endif


### PR DESCRIPTION
## Description
The default value of the `PATH` variable when fish reads its global `config.fish` has a null byte at the end of the last element. You can see this by adding `set -S PATH` to the very beginning of `/usr/local/share/fish/config.fish`:

```
# Main file for fish command completions. This file contains various
# common helper functions for the command completions. All actual
# completions are located in the completions subdirectory.
#
# Set default field separators
#
set -S PATH
...
```

Then run `env -u PATH /usr/local/bin/fish -c ''`:

```
> env -u PATH /usr/local/bin/fish -c ''
$PATH: set in global scope, exported, a path variable with 4 elements
$PATH[1]: |/usr/bin|
$PATH[2]: |/bin|
$PATH[3]: |/usr/sbin|
$PATH[4]: |/sbin\x00|
...
```

Note `$PATH[4]`. This happens because `confstr` writes a null-terminator at the end of the provided buffer, and the length of the `cspath` string includes it. After the fix, `PATH[4]` no longer ends with `\x00`.