### PR TITLE
Add color to ls output on OpenBSD when colorls is installed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Interactive improvements
 - ``wait`` and ``on-process-exit`` work correctly with jobs that have already exited (:issue:`7210`).
 - Completion scripts are now loaded when calling a command via a relative path (like ``./git``) (:issue:`6001`, :issue:`7992`).
 - ``__fish_print_help`` (used for ``--help`` output for fish's builtins) now respects $LESS and uses a better default value (:issue:`7997`).
+- ls output is colorized on OpenBSD if colorls utility is installed
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,7 @@ The following optional features also have specific requirements:
    ``wl-copy``/``wl-paste`` or ``pbcopy``/``pbpaste`` utilities
 -  full completions for ``yarn`` and ``npm`` require the
    ``all-the-package-names`` NPM module
+-  ``colorls`` is used, if its installed, to add color when running ``ls``
 
 Switching to fish
 ~~~~~~~~~~~~~~~~~

--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -17,6 +17,14 @@ function __fish_set_lscolors --description 'Set $LS_COLORS if possible'
     end
 end
 
+function __fish_ls_command --description 'Use colorls if it is installed'
+    if command -sq colorls
+        command colorls $argv
+    else
+        command ls $argv
+    end
+end
+
 function ls --description "List contents of directory"
     # Make ls use colors and show indicators if we are on a system that supports that feature and writing to stdout.
     #
@@ -24,17 +32,12 @@ function ls --description "List contents of directory"
     # BSD, macOS and others support colors with ls -G.
     # GNU ls and FreeBSD ls takes --color=auto. Order of this test is important because ls also takes -G but it has a different meaning.
     # Solaris 11's ls command takes a --color flag.
-    # OpenBSD requires the separate colorls program
+    # OpenBSD requires the separate colorls program for color support.
     # Also test -F because we'll want to define this function even with an ls that can't do colors (like NetBSD).
-    if not set -q __fish_ls_command
-        if which colorls >/dev/null 2>/dev/null
-            set -g __fish_ls_command colorls
-        else
-            set -g __fish_ls_command ls
-        end
+    if not set -q __fish_ls_color_opt
         set -g __fish_ls_color_opt
         for opt in --color=auto -G --color -F
-            if command $__fish_ls_command $opt / >/dev/null 2>/dev/null
+            if __fish_ls_command $opt / >/dev/null 2>/dev/null
                 set -g __fish_ls_color_opt $opt
                 break
             end
@@ -46,5 +49,5 @@ function ls --description "List contents of directory"
 
     isatty stdout
     and set -a opt -F
-    command $__fish_ls_command $__fish_ls_color_opt $argv
+    __fish_ls_command $__fish_ls_color_opt $argv
 end

--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -24,11 +24,17 @@ function ls --description "List contents of directory"
     # BSD, macOS and others support colors with ls -G.
     # GNU ls and FreeBSD ls takes --color=auto. Order of this test is important because ls also takes -G but it has a different meaning.
     # Solaris 11's ls command takes a --color flag.
+    # OpenBSD requires the separate colorls program
     # Also test -F because we'll want to define this function even with an ls that can't do colors (like NetBSD).
-    if not set -q __fish_ls_color_opt
+    if not set -q __fish_ls_command
+        if which colorls >/dev/null 2>/dev/null
+            set -g __fish_ls_command colorls
+        else
+            set -g __fish_ls_command ls
+        end
         set -g __fish_ls_color_opt
         for opt in --color=auto -G --color -F
-            if command ls $opt / >/dev/null 2>/dev/null
+            if command $__fish_ls_command $opt / >/dev/null 2>/dev/null
                 set -g __fish_ls_color_opt $opt
                 break
             end
@@ -40,5 +46,5 @@ function ls --description "List contents of directory"
 
     isatty stdout
     and set -a opt -F
-    command ls $__fish_ls_color_opt $argv
+    command $__fish_ls_command $__fish_ls_color_opt $argv
 end

--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -17,14 +17,6 @@ function __fish_set_lscolors --description 'Set $LS_COLORS if possible'
     end
 end
 
-function __fish_ls_command --description 'Use colorls if it is installed'
-    if command -sq colorls
-        command colorls $argv
-    else
-        command ls $argv
-    end
-end
-
 function ls --description "List contents of directory"
     # Make ls use colors and show indicators if we are on a system that supports that feature and writing to stdout.
     #
@@ -37,7 +29,7 @@ function ls --description "List contents of directory"
     if not set -q __fish_ls_color_opt
         set -g __fish_ls_color_opt
         for opt in --color=auto -G --color -F
-            if __fish_ls_command $opt / >/dev/null 2>/dev/null
+            if command ls $opt / >/dev/null 2>/dev/null
                 set -g __fish_ls_color_opt $opt
                 break
             end
@@ -49,5 +41,11 @@ function ls --description "List contents of directory"
 
     isatty stdout
     and set -a opt -F
-    __fish_ls_command $__fish_ls_color_opt $argv
+
+    if command -sq colorls
+        command colorls $__fish_ls_color_opt $argv
+    else
+        command ls $__fish_ls_color_opt $argv
+    end
+
 end


### PR DESCRIPTION
## Description

Adds color to ls output on OpenBSD when colorls is installed.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst
