### PR TITLE
fish_vi_key_bindings: bind s to follow vim visual behaviour

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -302,6 +302,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     end
 
     bind -s --preset -M visual -m insert c kill-selection end-selection repaint-mode
+    bind -s --preset -M visual -m insert s kill-selection end-selection repaint-mode
     bind -s --preset -M visual -m default d kill-selection end-selection repaint-mode
     bind -s --preset -M visual -m default x kill-selection end-selection repaint-mode
     bind -s --preset -M visual -m default X kill-whole-line end-selection repaint-mode


### PR DESCRIPTION
## Description

This change adds a binding that sets the s key's behaviour to match the c key's in visual mode. This mirrors vim's behaviour (see `:h v_s` in vim or neovim). It's probably not something anyone other than me uses since I've gotten into the bad habit of using s for changing in visual mode, but it is how vim works and s is current unbound in visual mode, so I figure it might as well be supported.

~~Fixes issue #~~

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Not sure which of these ^ are applicable... let me know if there's anything else I need to do though!