### PR TITLE
Fallback to `cmd --help` when `man cmd` errors

### DIFF
--- a/share/functions/__fish_man_page.fish
+++ b/share/functions/__fish_man_page.fish
@@ -27,12 +27,16 @@ function __fish_man_page
             man "$maincmd-$args[2]"
         else if man "$maincmd" &>/dev/null
             man "$maincmd"
+        else if "$maincmd" "$args[2]" --help &>/dev/null
+            "$maincmd" "$args[2]" --help | less
         else
             printf \a
         end
     else
         if man "$maincmd" &>/dev/null
             man "$maincmd"
+        else if "$maincmd" --help &>/dev/null
+            "$maincmd" --help | less
         else
             printf \a
         end


### PR DESCRIPTION
## Description

In __fish_man_page.fish, call `cmd --help` (resp. `cmd sub --help`) when `man
cmd` (resp. `man cmd-sub`) does not exist.

I’m unsure if this is worth adding an entry in CHANGELOG.rst

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
