### PR TITLE
Darkmode for docs and webconfig

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -909,7 +909,7 @@ If you want to set something in config.fish, or set something in a function and 
        set -g fish_cursor_visual underscore
     end
 
-    # Set my language (also :ref:`exported <variables-export>`):
+    # Set my language
     set -gx LANG de_DE.UTF-8
 
 If you want to set some personal customization, universal variables are nice::

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -344,7 +344,7 @@ kbd {
 
 @media (prefers-color-scheme: dark) {
     body {
-        background: linear-gradient(to top, #171f2f 0%,#03131a 100%);
+        background: linear-gradient(to top, #1f1f3f 0%,#051f3a 100%);
     }
     div#fmain {
         color: #DDD;

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -343,12 +343,12 @@ kbd {
 }
 
 @media (prefers-color-scheme: dark) {
-  body {
-    background: linear-gradient(to top, #272f4f 0%,#03133a 100%);
-  }
+    body {
+        background: linear-gradient(to top, #171f2f 0%,#03131a 100%);
+    }
     div#fmain {
         color: #DDD;
-        background-color: #151525;
+        background-color: #202028;
         box-shadow: 0 0 5px 1px #000;
     }
 
@@ -362,7 +362,7 @@ kbd {
     }
 
     div.sphinxsidebar a, div.footer {
-        color: #BBB;
+        color: #CCC;
     }
 
     div.sphinxsidebar h3 a, div.related a, div.sphinxsidebar h3 {

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -42,7 +42,9 @@ div.section {
     width: 100%;
 }
 
-div.related a:hover {
+div.related a:hover,
+div.footer a:hover,
+div.sphinxsidebar a:hover {
     color: #0095C4;
 }
 
@@ -114,10 +116,6 @@ div.sphinxsidebarwrapper > h3:first-child {
 
 div.sphinxsidebarwrapper > ul > li > ul > li {
     margin-bottom: 0.4em;
-}
-
-div.sphinxsidebar a:hover {
-    color: #0095C4;
 }
 
 form.inline-search input,
@@ -241,10 +239,6 @@ div.footer {
     text-align: right;
     width: auto;
     margin-right: 10px;
-}
-
-div.footer a:hover {
-    color: #0095C4;
 }
 
 .refcount {

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -1,5 +1,9 @@
 @import url("classic.css");
 
+:root {
+  color-scheme: light dark; /* both supported */
+}
+
 html {
     background: none;
     min-height: 100%;
@@ -336,4 +340,66 @@ kbd {
 .footnote, .footnote-reference {
     background-color: #ddddea;
     font-size: 90%;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(to top, #272f4f 0%,#03133a 100%);
+  }
+    div#fmain {
+        color: #DDD;
+        background-color: #151525;
+        box-shadow: 0 0 5px 1px #000;
+    }
+
+    div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
+        background-color: inherit;
+        color: inherit;
+    }
+
+    .footnote, .footnote-reference {
+        background-color: #101020;
+    }
+
+    div.sphinxsidebar a, div.footer {
+        color: #BBB;
+    }
+
+    div.sphinxsidebar h3 a, div.related a, div.sphinxsidebar h3 {
+        color: #AAA;
+    }
+    .highlight {
+        background: #000;
+    }
+    kbd {
+        background-color: #111;
+        border: 1px solid #444;
+        box-shadow: 0.1em 0.1em 0.2em rgba(100,100,100,0.1);
+        color: #FFF;
+    }
+    table.docutils th {
+        background-color: #222;
+    }
+
+    table.docutils td {
+        background-color: #111;
+    }
+    input {
+        background-color: #222;
+        color: #AAA;
+    }
+
+    div.body a {
+        color: #2092da;
+    }
+    dt:target, span.highlighted {
+        background-color: #404060;
+    }
+    table.docutils {
+        border: 1px solid #222;
+    }
+
+    table.docutils td, table.docutils th {
+        border: 1px solid #222 !important;
+    }
 }

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -333,7 +333,7 @@ kbd {
   padding: 0.1em 0.3em;
 }
 
-.footnote {
+.footnote, .footnote-reference {
     background-color: #ddddea;
     font-size: 90%;
 }

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -636,3 +636,31 @@ img.delete_icon {
         margin-bottom: 0;
     }
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: linear-gradient(to top, #272f4f 0%,#03133a 100%);
+        color: #DDD;
+    }
+
+    div#ancestor {
+        box-shadow: 0 0 5px 1px #000;
+    }
+    .tab {
+        background-color: black;
+    }
+    .selected_tab {
+        background-color: #151525;
+    }
+
+    #tab_contents {
+        background-color: #151525;
+    }
+    .detail, .selected_master_elem {
+        background-color: black;
+    }
+    input {
+        background-color: #222;
+        color: #AAA;
+    }
+}

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -639,7 +639,7 @@ img.delete_icon {
 
 @media (prefers-color-scheme: dark) {
     body {
-        background: linear-gradient(to top, #171f2f 0%,#03131a 100%);
+        background: linear-gradient(to top, #1f1f3f 0%,#051f3a 100%);
         color: #DDD;
     }
 

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -639,7 +639,7 @@ img.delete_icon {
 
 @media (prefers-color-scheme: dark) {
     body {
-        background: linear-gradient(to top, #272f4f 0%,#03133a 100%);
+        background: linear-gradient(to top, #171f2f 0%,#03131a 100%);
         color: #DDD;
     }
 
@@ -650,11 +650,11 @@ img.delete_icon {
         background-color: black;
     }
     .selected_tab {
-        background-color: #151525;
+        background-color: #202028;
     }
 
     #tab_contents {
-        background-color: #151525;
+        background-color: #202028;
     }
     .detail, .selected_master_elem {
         background-color: black;

--- a/share/tools/web_config/partials/functions.html
+++ b/share/tools/web_config/partials/functions.html
@@ -2,7 +2,7 @@
     <div class="master">
         <div ng-repeat="func in functions">
             <div id="master_{{func}}" ng-class="{'master_element': true, 'selected_master_elem': func == selectedFunction }" ng-style="'color: #aaaaaa'" ng-click="selectFunction(func)">
-                <span class="master_element_text" style="font-size: 11pt; color: #222;">{{ func }}</span>
+                <span class="master_element_text">{{ func }}</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description

This uses the prefers-color-scheme media query to choose between a dark and a light colorscheme for both the docs and fish_config. It's pure css, no script or anything.

If you want to test drive it without having to build the docs yourself, I've uploaded a version of the docs (sadly not fish_config, it's a static site) at https://bean.solutions/fish-doc/.

To see the changes, you'll have to set your dark mode preference or open up the devtools and force-enable it there. Firefox on linux should "just work" if you have a dark system colorscheme, chromium needs to be started as `chromium --force-dark-mode`.

Some screenshots:

### fish_config

![Screenshot 2021-06-02 at 18-32-20 fish shell configuration](https://user-images.githubusercontent.com/5185367/120518266-b0fec580-c3d1-11eb-93dd-2e1eb87f80e6.png)
![Screenshot 2021-06-02 at 18-32-31 fish shell configuration](https://user-images.githubusercontent.com/5185367/120518268-b1975c00-c3d1-11eb-89c1-b354adbfa0a4.png)
![Screenshot 2021-06-02 at 18-42-22 fish shell configuration](https://user-images.githubusercontent.com/5185367/120518892-57e36180-c3d2-11eb-9b04-54cfb6e22ac8.png)
![Screenshot 2021-06-02 at 18-32-47 fish shell configuration](https://user-images.githubusercontent.com/5185367/120518273-b2c88900-c3d1-11eb-9653-62752c06099a.png)

#### The docs
![Screenshot 2021-06-02 at 18-33-35 The fish language — fish-shell 3 2 2-356-gad3873079 documentation](https://user-images.githubusercontent.com/5185367/120518274-b2c88900-c3d1-11eb-8a38-f7ddd942cc6b.png)
![Screenshot 2021-06-02 at 18-33-49 Interactive use — fish-shell 3 2 2-356-gad3873079 documentation](https://user-images.githubusercontent.com/5185367/120518276-b3611f80-c3d1-11eb-9f3f-67d31e7f4624.png)
![Screenshot 2021-06-02 at 18-34-05 The fish language — fish-shell 3 2 2-356-gad3873079 documentation](https://user-images.githubusercontent.com/5185367/120518279-b3f9b600-c3d1-11eb-9699-2246cca53657.png)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst