### PR TITLE
string: Allow `collect --allow-empty` to avoid empty ellision

### DIFF
--- a/doc_src/cmds/string-collect.rst
+++ b/doc_src/cmds/string-collect.rst
@@ -8,7 +8,7 @@ Synopsis
 
 ::
 
-    string collect [(-N | --no-trim-newlines)] [STRING...]
+    string collect [(-N | --no-trim-newlines)] [(-n | --no-empty)] [STRING...]
 
 .. END SYNOPSIS
 
@@ -23,6 +23,7 @@ If invoked with multiple arguments instead of input, ``string collect`` preserve
 
 Any trailing newlines on the input are trimmed, just as with ``"$(cmd)"`` substitution in sh. ``--no-trim-newlines`` can be used to disable this behavior, which may be useful when running a command such as ``set contents (cat filename | string collect -N)``.
 
+With ``--no-empty``, ``string collect`` always prints one (empty) argument. This can be used to prevent an argument from disappearing.
 .. END DESCRIPTION
 
 Examples
@@ -42,5 +43,8 @@ Examples
     two
     three
     "
+
+    >_ echo foo(true | string collect --no-empty)bar
+    foobar
 
 .. END EXAMPLES

--- a/doc_src/cmds/string-collect.rst
+++ b/doc_src/cmds/string-collect.rst
@@ -8,7 +8,7 @@ Synopsis
 
 ::
 
-    string collect [(-N | --no-trim-newlines)] [(-n | --no-empty)] [STRING...]
+    string collect [(-a | --allow-empty)] [(-N | --no-trim-newlines)] [STRING...]
 
 .. END SYNOPSIS
 
@@ -23,7 +23,8 @@ If invoked with multiple arguments instead of input, ``string collect`` preserve
 
 Any trailing newlines on the input are trimmed, just as with ``"$(cmd)"`` substitution in sh. ``--no-trim-newlines`` can be used to disable this behavior, which may be useful when running a command such as ``set contents (cat filename | string collect -N)``.
 
-With ``--no-empty``, ``string collect`` always prints one (empty) argument. This can be used to prevent an argument from disappearing.
+With ``--allow-empty``, ``string collect`` always prints one (empty) argument. This can be used to prevent an argument from disappearing.
+
 .. END DESCRIPTION
 
 Examples
@@ -44,7 +45,7 @@ Examples
     three
     "
 
-    >_ echo foo(true | string collect --no-empty)bar
+    >_ echo foo(true | string collect --allow-empty)bar
     foobar
 
 .. END EXAMPLES

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1528,6 +1528,7 @@ static int string_split0(parser_t &parser, io_streams_t &streams, int argc, cons
 static int string_collect(parser_t &parser, io_streams_t &streams, int argc, const wchar_t **argv) {
     options_t opts;
     opts.no_trim_newlines_valid = true;
+    opts.no_empty_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
     if (retval != STATUS_CMD_OK) return retval;
@@ -1544,6 +1545,14 @@ static int string_collect(parser_t &parser, io_streams_t &streams, int argc, con
         }
         streams.out.append_with_separation(s, len, separation_type_t::explicitly);
         appended += len;
+    }
+
+    // If we haven't printed anything and "no_empty" is set,
+    // print something empty. Helps with empty ellision:
+    // echo (true | string collect --no-empty)"bar"
+    // prints "bar".
+    if (opts.no_empty && appended == 0) {
+        streams.out.append_with_separation(L"", 0, separation_type_t::explicitly);
     }
 
     return appended > 0 ? STATUS_CMD_OK : STATUS_CMD_ERROR;

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1527,8 +1527,8 @@ static int string_split0(parser_t &parser, io_streams_t &streams, int argc, cons
 
 static int string_collect(parser_t &parser, io_streams_t &streams, int argc, const wchar_t **argv) {
     options_t opts;
+    opts.allow_empty_valid = true;
     opts.no_trim_newlines_valid = true;
-    opts.no_empty_valid = true;
     int optind;
     int retval = parse_opts(&opts, &optind, 0, argc, argv, parser, streams);
     if (retval != STATUS_CMD_OK) return retval;
@@ -1549,9 +1549,9 @@ static int string_collect(parser_t &parser, io_streams_t &streams, int argc, con
 
     // If we haven't printed anything and "no_empty" is set,
     // print something empty. Helps with empty ellision:
-    // echo (true | string collect --no-empty)"bar"
+    // echo (true | string collect --allow-empty)"bar"
     // prints "bar".
-    if (opts.no_empty && appended == 0) {
+    if (opts.allow_empty && appended == 0) {
         streams.out.append_with_separation(L"", 0, separation_type_t::explicitly);
     }
 

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -667,7 +667,7 @@ string collect -N '' >/dev/null; and echo unexpected success; or echo expected f
 string collect \n\n >/dev/null; and echo unexpected success; or echo expected failure
 # CHECK: expected failure
 
-echo "foo"(true | string collect --no-empty)"bar"
+echo "foo"(true | string collect --allow-empty)"bar"
 # CHECK: foobar
 test -z (string collect)
 and echo Nothing
@@ -675,7 +675,7 @@ and echo Nothing
 test -n (string collect)
 and echo Something
 # CHECK: Something
-test -n (string collect -n)
+test -n (string collect -a)
 or echo No, actually nothing
 # CHECK: No, actually nothing
 

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -667,6 +667,18 @@ string collect -N '' >/dev/null; and echo unexpected success; or echo expected f
 string collect \n\n >/dev/null; and echo unexpected success; or echo expected failure
 # CHECK: expected failure
 
+echo "foo"(true | string collect --no-empty)"bar"
+# CHECK: foobar
+test -z (string collect)
+and echo Nothing
+# CHECK: Nothing
+test -n (string collect)
+and echo Something
+# CHECK: Something
+test -n (string collect -n)
+or echo No, actually nothing
+# CHECK: No, actually nothing
+
 # string collect in functions
 # This function outputs some newline-separated content, and some
 # explicitly un-separated content.


### PR DESCRIPTION
Currently we still have that issue where

    test -n (thing | string collect)

can return true if `thing` doesn't print anything, because the
collected argument will still be removed.

So, what we do is allow ~~`--no-empty`~~ `--allow-empty` to be used, in which case we
print one empty argument.

This means

    test -n (thing | string collect -a)

can now be safely used.

"~~no~~allow-empty" isn't the best name for this flag, but string's design
really incentivizes reusing names, and it's not *terrible*.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
