### PR TITLE
Support "$(cmd)" command substitution without line splitting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Deprecations and removed features
 
 Scripting improvements
 ----------------------
+- fish's command substitution syntax has been extended: ``$(cmd)`` now has the same meaning as ``(cmd)`` but it can be used inside double quotes, to prevent line splitting of the results. (:issue:`159`).
 - ``string collect`` supports a new ``--allow-empty`` option, which will output one empty argument in a command substitution that has no output (:issue:`8054`). This allows commands like ``test -n (echo -n | string collect --allow-empty)`` to work more reliably.
 
 Interactive improvements

--- a/doc_src/cmds/string-collect.rst
+++ b/doc_src/cmds/string-collect.rst
@@ -19,9 +19,11 @@ Description
 
 ``string collect`` collects its input into a single output argument, without splitting the output when used in a command substitution. This is useful when trying to collect multiline output from another command into a variable. Exit status: 0 if any output argument is non-empty, or 1 otherwise.
 
+A command like ``echo (cmd | string collect)`` is mostly equivalent to a quoted command substitution (``echo "$(cmd)"``). The main difference is that the former evaluates to zero or one elements whereas the quoted command substitution always evaluates to one element due to string interpolation.
+
 If invoked with multiple arguments instead of input, ``string collect`` preserves each argument separately, where the number of output arguments is equal to the number of arguments given to ``string collect``.
 
-Any trailing newlines on the input are trimmed, just as with ``"$(cmd)"`` substitution in sh. ``--no-trim-newlines`` can be used to disable this behavior, which may be useful when running a command such as ``set contents (cat filename | string collect -N)``.
+Any trailing newlines on the input are trimmed, just as with ``"$(cmd)"`` substitution. Use ``--no-trim-newlines`` to disable this behavior, which may be useful when running a command such as ``set contents (cat filename | string collect -N)``.
 
 With ``--allow-empty``, ``string collect`` always prints one (empty) argument. This can be used to prevent an argument from disappearing.
 
@@ -33,6 +35,11 @@ Examples
 .. BEGIN EXAMPLES
 
 ::
+
+    >_ echo "zero $(echo one\ntwo\nthree) four"
+    zero one
+    two
+    three four
 
     >_ echo \"(echo one\ntwo\nthree | string collect)\"
     "one

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -569,6 +569,8 @@ The output of a command (or an entire :ref:`pipeline <pipes>`) can be used as th
 
 When you write a command in parenthesis like ``outercommand (innercommand)``, the ``innercommand`` will be executed first. Its output will be taken and each line given as a separate argument to ``outercommand``, which will then be executed. [#]_
 
+A command substitution can have a dollar sign before the opening parenthesis like ``outercommand $(innercommand)``. This variant is also allowed inside double quotes. When using double quotes, the command output is not split up by lines.
+
 If the output is piped to :ref:`string split or string split0 <cmd-string-split>` as the last step, those splits are used as they appear instead of splitting lines.
 
 The exit status of the last run command substitution is available in the :ref:`status <variables-status>` variable if the substitution happens in the context of a :ref:`set <cmd-set>` command (so ``if set -l (something)`` checks if ``something`` returned true).
@@ -588,7 +590,7 @@ Examples::
 
     # Set the ``data`` variable to the contents of 'data.txt'
     # without splitting it into a list.
-    begin; set -l IFS; set data (cat data.txt); end
+    set data "$(cat data.txt)"
 
     # Set ``$data`` to the contents of data, splitting on NUL-bytes.
     set data (cat data | string split0)

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -573,7 +573,7 @@ If the output is piped to :ref:`string split or string split0 <cmd-string-split>
 
 The exit status of the last run command substitution is available in the :ref:`status <variables-status>` variable if the substitution happens in the context of a :ref:`set <cmd-set>` command (so ``if set -l (something)`` checks if ``something`` returned true).
 
-Only part of the output can be used, see :ref:`index range expansion <expand-index-range>` for details.
+To use only part of the output, refer to :ref:`index range expansion <expand-index-range>`.
 
 Fish has a default limit of 100 MiB on the data it will read in a command sustitution. If that limit is reached the command (all of it, not just the command substitution - the outer command won't be executed at all) fails and ``$status`` is set to 122. This is so command substitutions can't cause the system to go out of memory, because typically your operating system has a much lower limit, so reading more than that would be useless and harmful. This limit can be adjusted with the ``fish_read_limit`` variable (`0` meaning no limit). This limit also affects the :ref:`read <cmd-read>` command.
 

--- a/doc_src/tutorial.rst
+++ b/doc_src/tutorial.rst
@@ -400,11 +400,11 @@ Unlike other shells, fish does not split command substitutions on any whitespace
     -lgobject-2.0
     -lglib-2.0
 
-If you need a command substitutions output as one argument, without any splits, use ``string collect``::
+If you need a command substitutions output as one argument, without any splits, use quoted command substitution::
 
     > echo "first line
     second line" > myfile
-    > set myfile (cat myfile | string collect)
+    > set myfile "$(cat myfile)"
     > printf '|%s|' $myfile
     |first line
     second line|

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1390,8 +1390,12 @@ static bool unescape_string_internal(const wchar_t *const input, const size_t in
                 }
                 case L'$': {
                     if (unescape_special) {
-                        to_append_or_none = VARIABLE_EXPAND;
-                        vars_or_seps.push_back(input_position);
+                        bool is_cmdsub =
+                            input_position + 1 < input_len && input[input_position + 1] == L'(';
+                        if (!is_cmdsub) {
+                            to_append_or_none = VARIABLE_EXPAND;
+                            vars_or_seps.push_back(input_position);
+                        }
                     }
                     break;
                 }

--- a/src/common.h
+++ b/src/common.h
@@ -441,11 +441,11 @@ std::unique_ptr<T> make_unique(Args &&...args) {
 }
 #endif
 
-/// This functions returns the end of the quoted substring beginning at \c in. The type of quoting
-/// character is detemrined by examining \c in. Returns 0 on error.
+/// This functions returns the end of the quoted substring beginning at \c pos. Returns 0 on error.
 ///
-/// \param in the position of the opening quote.
-wchar_t *quote_end(const wchar_t *pos);
+/// \param pos the position of the opening quote.
+/// \param quote the quote to use, usually pointed to by \c pos.
+wchar_t *quote_end(const wchar_t *pos, wchar_t quote);
 
 /// This function should be called after calling `setlocale()` to perform fish specific locale
 /// initialization.
@@ -472,6 +472,10 @@ wcstring escape_string(const wchar_t *in, escape_flags_t flags,
                        escape_string_style_t style = STRING_STYLE_SCRIPT);
 wcstring escape_string(const wcstring &in, escape_flags_t flags,
                        escape_string_style_t style = STRING_STYLE_SCRIPT);
+
+/// Escape a string so that it may be inserted into a double-quoted string.
+/// This permits ownership transfer.
+wcstring escape_string_for_double_quotes(wcstring in);
 
 /// \return a string representation suitable for debugging (not for presenting to the user). This
 /// replaces non-ASCII characters with either tokens like <BRACE_SEP> or <\xfdd7>. No other escapes

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -761,7 +761,7 @@ static expand_result_t expand_cmdsubst(wcstring input, const operation_context_t
             wcstring whole_item;
             whole_item.reserve(paren_begin + 1 + sub_item2.size() + 1 +
                                tail_item.completion.size());
-            whole_item.append(input, 0, paren_begin);
+            whole_item.append(input, 0, paren_begin - have_dollar);
             whole_item.push_back(INTERNAL_SEPARATOR);
             whole_item.append(sub_item2);
             whole_item.push_back(INTERNAL_SEPARATOR);

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -5103,8 +5103,7 @@ static void test_error_messages() {
                        {L"echo foo\"$\"bar", ERROR_NO_VAR_NAME},
                        {L"echo \"foo\"$\"bar\"", ERROR_NO_VAR_NAME},
                        {L"echo foo $ bar", ERROR_NO_VAR_NAME},
-                       {L"echo foo$(foo)bar", ERROR_BAD_VAR_SUBCOMMAND1},
-                       {L"echo \"foo$(foo)bar\"", ERROR_BAD_VAR_SUBCOMMAND1}};
+                       {L"echo foo$(foo)bar", ERROR_BAD_VAR_SUBCOMMAND1}};
 
     parse_error_list_t errors;
     for (const auto &test : error_tests) {
@@ -5193,6 +5192,16 @@ static void test_highlighting() {
         {L")", highlight_role_t::operat},
         {L"|", highlight_role_t::statement_terminator},
         {L"cat", highlight_role_t::command},
+    });
+    highlight_tests.push_back({
+        {L"true", highlight_role_t::command},
+        {L"\"before", highlight_role_t::quote},
+        {L"$(", highlight_role_t::operat},
+        {L"true", highlight_role_t::command},
+        {L"param1", highlight_role_t::param},
+        {L")", highlight_role_t::operat},
+        {L"after\"", highlight_role_t::quote},
+        {L"param2", highlight_role_t::param},
     });
 
     // Redirections substitutions.

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -4654,6 +4654,8 @@ void history_tests_t::test_history_formats() {
         // We don't expect whitespace to be elided (#4908: except for leading/trailing whitespace)
         const wchar_t *expected[] = {L"EOF",
                                      L"sleep 123",
+                                     L"posix_cmd_sub $(is supported but only splits on newlines)",
+                                     L"posix_cmd_sub \"$(is supported)\"",
                                      L"a && echo valid construct",
                                      L"final line",
                                      L"echo supsup",
@@ -5102,8 +5104,7 @@ static void test_error_messages() {
                        {L"echo $", ERROR_NO_VAR_NAME},
                        {L"echo foo\"$\"bar", ERROR_NO_VAR_NAME},
                        {L"echo \"foo\"$\"bar\"", ERROR_NO_VAR_NAME},
-                       {L"echo foo $ bar", ERROR_NO_VAR_NAME},
-                       {L"echo foo$(foo)bar", ERROR_BAD_VAR_SUBCOMMAND1}};
+                       {L"echo foo $ bar", ERROR_NO_VAR_NAME}};
 
     parse_error_list_t errors;
     for (const auto &test : error_tests) {
@@ -5192,6 +5193,12 @@ static void test_highlighting() {
         {L")", highlight_role_t::operat},
         {L"|", highlight_role_t::statement_terminator},
         {L"cat", highlight_role_t::command},
+    });
+    highlight_tests.push_back({
+        {L"true", highlight_role_t::command},
+        {L"$(", highlight_role_t::operat},
+        {L"true", highlight_role_t::command},
+        {L")", highlight_role_t::operat},
     });
     highlight_tests.push_back({
         {L"true", highlight_role_t::command},

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -494,6 +494,9 @@ static size_t color_variable(const wchar_t *in, size_t in_len,
         wchar_t next = in[idx + 1];
         if (next == L'$' || valid_var_name_char(next)) {
             colors[idx] = highlight_role_t::operat;
+        } else if (next == L'(') {
+            colors[idx] = highlight_role_t::operat;
+            return idx + 1;
         } else {
             colors[idx] = highlight_role_t::error;
         }

--- a/src/parse_constants.h
+++ b/src/parse_constants.h
@@ -262,9 +262,6 @@ enum class pipeline_position_t {
 /// Error issued on $@.
 #define ERROR_NOT_ARGV_AT _(L"$@ is not supported. In fish, please use $argv.")
 
-/// Error issued on $(...).
-#define ERROR_BAD_VAR_SUBCOMMAND1 _(L"$(...) is not supported. In fish, please use '(%ls)'.")
-
 /// Error issued on $*.
 #define ERROR_NOT_ARGV_STAR _(L"$* is not supported. In fish, please use $argv.")
 

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -31,7 +31,7 @@ int parse_util_locate_slice(const wchar_t *in, wchar_t **begin, wchar_t **end,
 /// \return -1 on syntax error, 0 if no subshells exist and 1 on success
 int parse_util_locate_cmdsubst_range(const wcstring &str, size_t *inout_cursor_offset,
                                      wcstring *out_contents, size_t *out_start, size_t *out_end,
-                                     bool accept_incomplete);
+                                     bool accept_incomplete, bool *out_is_quoted = nullptr);
 
 /// Find the beginning and end of the command substitution under the cursor. If no subshell is
 /// found, the entire string is returned. If the current command substitution is not ended, i.e. the

--- a/tests/checks/cmdsub.fish
+++ b/tests/checks/cmdsub.fish
@@ -1,5 +1,8 @@
 #RUN: %fish %s
 
+echo $(echo 1\n2)
+# CHECK: 1 2
+
 # Command substitution inside double quotes strips trailing newline.
 echo "a$(echo b)c"
 # CHECK: abc

--- a/tests/checks/cmdsub.fish
+++ b/tests/checks/cmdsub.fish
@@ -1,0 +1,44 @@
+#RUN: %fish %s
+
+# Command substitution inside double quotes strips trailing newline.
+echo "a$(echo b)c"
+# CHECK: abc
+
+# Nesting
+echo "$(echo "$(echo a)")"
+# CHECK: a
+echo "$(echo $(echo b))"
+# CHECK: b
+
+echo "$(echo multiple).$(echo command).$(echo substitutions)"
+# CHECK: multiple.command.substitutions
+
+test -n "$()" || echo "empty list is interpolated to empty string"
+# CHECK: empty list is interpolated to empty string
+
+# Variables in command substitution output are not expanded.
+echo "$(echo \~ \$HOME)"
+# CHECK: ~ $HOME
+
+echo "$(printf %s 'quoted command substitution multiline output
+line 2
+line 3
+')"
+# CHECK: quoted command substitution multiline output
+# CHECK: line 2
+# CHECK: line 3
+
+echo trim any newlines "$(echo \n\n\n)" after cmdsub
+#CHECK: trim any newlines  after cmdsub
+
+echo i{1, (echo 2), "$(echo 3)"}
+# CHECK: i1 i2 i3
+
+echo "$(echo index\nrange\nexpansion)[2]"
+#CHECK: range
+
+echo "$(echo '"')"
+#CHECK: "
+
+echo "$(echo $(echo 1) ())"
+#CHECK: 1

--- a/tests/history_sample_bash
+++ b/tests/history_sample_bash
@@ -15,7 +15,8 @@ backticks `are not allowed`
 a && echo valid construct
 [[ x = y ]] && echo double brackets not allowed
 (( 1 = 2 )) && echo double parens not allowed
-posix_cmd_sub $(is not supported)
+posix_cmd_sub "$(is supported)"
+posix_cmd_sub $(is supported but only splits on newlines)
 sleep 123
 /** # see issue 7407
 jq <<"EOF"


### PR DESCRIPTION
This adds support for
- `echo "$(cmd)"` - quoted command substitution without line splitting
- `echo $(cmd)` - same as `echo (cmd)`

Closes #159

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
