### PR TITLE
Fix completions to cargo's `--example` option on macOS

### DIFF
--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -17,7 +17,7 @@ function __list_cargo_examples
         return
     end
 
-    find ./examples/ -mindepth 1 -maxdepth 1 -type f -name "*.rs" -or -type d \
+    find ./examples -mindepth 1 -maxdepth 1 -type f -name "*.rs" -or -type d \
         | string replace -r './examples/(.*?)(?:.rs)?$' '$1'
 end
 for x in bench b build r run rustc t test


### PR DESCRIPTION
## Description

The completions for the `--example` option are generated using `find`.
The `find` utility on macOS will produce the following output when the
path argument has a trailing slash:

```
~/bat $ find ./examples/
./examples/
./examples//cat.rs
./examples//advanced.rs
./examples//simple.rs
./examples//list_syntaxes_and_themes.rs
./examples//yaml.rs
```

And will produce this output if the path does NOT have a trailing slash:

```
~/bat $ find ./examples
./examples
./examples/cat.rs
./examples/advanced.rs
./examples/simple.rs
./examples/list_syntaxes_and_themes.rs
./examples/yaml.rs
```

The extra slash after `examples` ends up in the completion suggestions
which is incorrect:

```
~/bat $ cargo run --example <TAB>
/advanced  /cat  /list_syntaxes_and_themes  /simple  /yaml
```

Unlike on my Linux box where `find` doesn't output the trailing slash:

```
~/bat $ cargo run --example <TAB>
advanced  cat  inputs  list_syntaxes_and_themes  simple  yaml
```

Importantly, I get the same (correct) output on Linux even without the
trailing slash in the path argument to `find`.