### PR TITLE
Split history commands in `__fish_toggle_comment_commandline`

### DIFF
--- a/share/functions/__fish_toggle_comment_commandline.fish
+++ b/share/functions/__fish_toggle_comment_commandline.fish
@@ -10,7 +10,7 @@
 function __fish_toggle_comment_commandline --description 'Comment/uncomment the current command'
     set -l cmdlines (commandline -b)
     if test "$cmdlines" = ""
-        history search -p "#" -z | read -z cmdlines
+        set cmdlines (history search -p "#" --max=1)
     end
     set -l cmdlines (printf '%s\n' '#'$cmdlines | string replace -r '^##' '')
     commandline -r $cmdlines


### PR DESCRIPTION
## Description

#7137 added history commands retrieving to `__fish_toggle_comment_commandline`. However, the lines are not correctly split:

```
$ # echo a
  # echo b
  # echo c
$ history search -p "#" -z | read -z cmdlines
$ set -S cmdlines
$cmdlines: set in global scope, unexported, with 1 elements
$cmdlines[1]: |#echo a\n#echo b\n#echo c|
```

This results in an inconsistency if toggling comments on multiple lines repeatedly:

https://user-images.githubusercontent.com/44045911/122663262-b890dd80-d1cb-11eb-967d-adae59349a14.mov


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
