### PR TITLE
__fish_list_current_token: Do not use eval

### DIFF
--- a/share/functions/__fish_list_current_token.fish
+++ b/share/functions/__fish_list_current_token.fish
@@ -2,7 +2,7 @@
 # of the directory under the cursor.
 
 function __fish_list_current_token -d "List contents of token under the cursor if it is a directory, otherwise list the contents of the current directory"
-    set -l val (eval echo (commandline -t))
+    set -l val (commandline -t)
     printf "\n"
     if test -d $val
         ls $val


### PR DESCRIPTION
Similarly to b0e3cc4b5 (__fish_complete_suffix: Remove `eval`, 2019-12-28), this use of eval is unsafe and can spew errors if invoked on an incomplete brace expansion.

## Examples
```
$ (exit)
```
With the cursor on this token, `Alt-L` will execute `exit` - the shell exits after the next command.

```
$ this-dir-does-not-exist\n-o\ntrue
```
With the cursor on this token, `Alt-L` will attempt listing the contents of both `this-dir-does-not-exit` and `true` whilst also passing `-o` to the `ls` command.

## TODOs:
- [ ] Tests have been added for regressions fixed

I could not find a good way of testing this, since the function relies on `commandline -t`. I'll happily add a test if this is easily possible somehow.