### PR TITLE
`FISH_USE_POSIX_SPAWN` and `HAVE_SPAWN_H` fixes

### DIFF
--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -10,7 +10,7 @@
 
 #include <cstring>
 #include <memory>
-#ifdef FISH_USE_POSIX_SPAWN
+#ifdef HAVE_SPAWN_H
 #include <spawn.h>
 #endif
 #include <cwchar>

--- a/src/postfork.h
+++ b/src/postfork.h
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 #include "maybe.h"
-#if HAVE_SPAWN_H
+#ifdef HAVE_SPAWN_H
 #include <spawn.h>
 #endif
 #ifndef FISH_USE_POSIX_SPAWN
@@ -53,7 +53,7 @@ pid_t execute_fork();
 void safe_report_exec_error(int err, const char *actual_cmd, const char *const *argv,
                             const char *const *envv);
 
-#ifdef FISH_USE_POSIX_SPAWN
+#if FISH_USE_POSIX_SPAWN
 /// A RAII type which wraps up posix_spawn's data structures.
 class posix_spawner_t {
    public:


### PR DESCRIPTION
## Description

`FISH_USE_POSIX_SPAWN` is always defined, thanks to the lines

https://github.com/fish-shell/fish-shell/blob/9f54c8d88b4e02f8b6b3f74c18dd57060ef035c4/src/postfork.h#L15-L17

So replace `#ifdef` with `#if` to fix compilation on platforms lacking `spawn.h`. Also make the `spawn.h` inclusion condition consistent across files.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
