### PR TITLE
 docs: Made the abort/edit history feature more discoverable.

### DIFF
--- a/doc_src/faq.rst
+++ b/doc_src/faq.rst
@@ -145,7 +145,7 @@ Note that fish has a default titlebar message, which will be used if the fish_ti
 
 How do I run a command from history?
 ------------------------------------
-Type some part of the command, and then hit the :kbd:`↑` (up) or :kbd:`↓` (down) arrow keys to navigate through history matches. Additional default key bindings include :kbd:`Control`\ +\ :kbd:`P` (up) and :kbd:`Control`\ +\ :kbd:`N` (down).
+Type some part of the command, and then hit the :kbd:`↑` (up) or :kbd:`↓` (down) arrow keys to navigate through history matches. Additional default key bindings include :kbd:`Control`\ +\ :kbd:`P` (up) and :kbd:`Control`\ +\ :kbd:`N` (down). See :ref:`Searchable command history <history-search>` for more information.
 
 Why doesn't history substitution ("!$" etc.) work?
 --------------------------------------------------

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -523,7 +523,7 @@ After a command has been executed, it is remembered in the history list. Any dup
 
 By pressing :kbd:`Alt`\ +\ :kbd:`↑` and :kbd:`Alt`\ +\ :kbd:`↓`, a history search is also performed, but instead of searching for a complete commandline, each commandline is broken into separate elements just like it would be before execution, and the history is searched for an element matching that under the cursor.
 
-History searches are case-insensitive unless the search string contains an uppercase character, and they can be aborted by pressing the escape key.
+History searches are case-insensitive unless the search string contains an uppercase character. You can stop a search to edit your search string by pressing :kbd:`Esc` or :kbd:`Page Down`.
 
 Prefixing the commandline with a space will prevent the entire line from being stored in the history.
 


### PR DESCRIPTION
First, I changed "the escape key" to :kbd:`Esc`. This makes this information
easier to find when scanning the docs because it stands out and because it is
more consistent with the docs's formatting of keyboard keys. Then I added "or
edit" after abort, because the escape key is not just for aborting a search.
Finally, I added a link from the FAQ to history-search to make this mechanism
easier to discover.

This was all to address confusion in former zsh and bash users as to how to
edit a search that is in progress, but this will also help new users. See https://github.com/fish-shell/fish-shell/pull/6686#issuecomment-872960760