### PR TITLE
Add missing options for `bind`

### DIFF
--- a/share/completions/bind.fish
+++ b/share/completions/bind.fish
@@ -53,6 +53,9 @@ complete -c bind -s K -l key-names -d 'Print names of available keys'
 complete -c bind -s M -l mode -d 'Specify the bind mode that the bind is used in' -xa '(bind -L)'
 complete -c bind -s m -l sets-mode -d 'Change current mode after bind is executed' -xa '(bind -L)'
 complete -c bind -s L -l list-modes -d 'Display a list of defined bind modes'
+complete -c bind -s s -l silent -d 'Operate silently'
+complete -c bind -l preset -d 'Operate on preset bindings'
+complete -c bind -l user -d 'Operate on user bindings'
 
 complete -c bind -n __fish_bind_test1 -a '(bind --key-names)' -d 'Key name' -x
 complete -c bind -n __fish_bind_test2 -a '(bind --function-names)' -d 'Function name' -x


### PR DESCRIPTION
## Description

Add `-s/--silent` `--preset` `--user` completions for `bind` which are presented in man pages.

> bind [(-M | --mode) MODE] [(-m | --sets-mode) NEW_MODE] [--preset | --user] [(-s | --silent)] [(-k | --key)] SEQUENCE COMMAND [COMMAND...]

> • --preset  and  --user specify if bind should operate on user or preset bind‐
         ings. User bindings take precedence over preset bindings when fish looks  up
         mappings.  By  default, all bind invocations work on the "user" level except
         for listing, which will show both levels. All invocations except for insert‐
         ing new bindings can operate on both levels at the same time (if both --pre‐
         set and --user are given). --preset should only be used in full binding sets
         (like when working on fish_vi_key_bindings).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
