### PR TITLE
Fix duplicate `-p` flag in `fish` completion

### DIFF
--- a/share/completions/fish.fish
+++ b/share/completions/fish.fish
@@ -6,7 +6,7 @@ complete -c fish -s n -l no-execute -d "Only parse input, do not execute"
 complete -c fish -s i -l interactive -d "Run in interactive mode"
 complete -c fish -s l -l login -d "Run as a login shell"
 complete -c fish -s p -l profile -d "Output profiling information (excluding startup) to a file" -r
-complete -c fish -s p -l profile-startup -d "Output startup profiling information to a file" -r
+complete -c fish -l profile-startup -d "Output startup profiling information to a file" -r
 complete -c fish -s d -l debug -d "Specify debug categories" -x -a "(fish --print-debug-categories | string replace ' ' \t)"
 complete -c fish -s o -l debug-output -d "Where to direct debug output to" -rF
 complete -c fish -s D -l debug-stack-frames -d "Show specified # of frames with debug output" -x -a "(seq 128)\t\n"


### PR DESCRIPTION
## Description

Quoting the manpage:

>  • -p  or  --profile=PROFILE_FILE when fish exits, output timing information on all executed commands
>          to the specified file. This excludes time spent starting up and reading the configuration.
> 
>  • --profile-startup=PROFILE_FILE will write timing information for fish's startup to  the  specified
>          file. This is useful to profile your configuration.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
