### PR TITLE
Deduplicate $fish_user_paths automatically

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -98,6 +98,21 @@ end
 
 # Add a handler for when fish_user_path changes, so we can apply the same changes to PATH
 function __fish_reconstruct_path -d "Update PATH when fish_user_paths changes" --on-variable fish_user_paths
+    # Deduplicate $fish_user_paths
+    # This should help with people appending to it in config.fish
+    set -l new_user_path
+    for path in (string split : -- $fish_user_paths)
+        if not contains -- $path $new_user_path
+            set -a new_user_path $path
+        end
+    end
+
+    if test (count $new_user_path) -lt (count $fish_user_paths)
+        # This will end up calling us again, so we return
+        set fish_user_paths $new_user_path
+        return
+    end
+
     set -l local_path $PATH
 
     for x in $__fish_added_user_paths

--- a/tests/checks/fish_user_paths.fish
+++ b/tests/checks/fish_user_paths.fish
@@ -1,0 +1,36 @@
+# RUN: %fish %s
+#
+# This deals with $PATH manipulation. We need to be careful not to step on anything.
+
+set -l tmpdir (mktemp -d)
+mkdir $tmpdir/bin
+mkdir $tmpdir/sbin
+mkdir $tmpdir/etc
+ln -s $tmpdir/bin $tmpdir/link
+
+# We set fish_user_paths to an empty global to have a starting point
+set -g fish_user_paths
+set fish_user_paths $tmpdir/bin
+
+# Confirm that it actually ends up in $PATH
+contains -- (builtin realpath $tmpdir/bin) $PATH
+and echo Have bin
+# CHECK: Have bin
+
+# Not adding duplicates
+set PATH $PATH
+set -l --path oldpath $PATH
+set -a fish_user_paths $tmpdir/bin
+test "$oldpath" = "$PATH"
+or begin
+    echo OH NO A DUPLICATE
+    echo NEW: $PATH
+    echo OLD: $oldpath
+end
+
+
+# Add a link to the same path.
+set -a fish_user_paths $tmpdir/link
+contains -- $tmpdir/link $PATH
+and echo Have bin
+# CHECK: Have bin


### PR DESCRIPTION
In the variable handler, we just go through the entire thing and keep
every element once.

If there's a duplicate, we set it again, which calls the handler
again.

This takes a bit of time, to be paid on each startup. On my system,
with 100 already deduplicated elements, that's about 4ms (compared to
~17ms for adding them to $PATH).

It's also semantically more complicated - now this variable
specifically is deduplicated? Do we just want "unique" variables that
can't have duplicates?

However: This entirely removes the pathological case of appending to
$fish_user_paths in config.fish (which should be an FAQ entry!), and the implementation is quite simple.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
