### PR TITLE
Enable OSC 0 when running in WezTerm

### DIFF
--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -487,7 +487,8 @@ static bool initialize_curses_using_fallback(const char *term) {
 /// terminal title if the underlying terminal does so, but will print garbage on terminals that
 /// don't. Since we can't see the underlying terminal below screen there is no way to fix this.
 static const wchar_t *const title_terms[] = {L"xterm",  L"screen", L"tmux",
-                                             L"nxterm", L"rxvt",   L"alacritty"};
+                                             L"nxterm", L"rxvt",   L"alacritty",
+                                             L"wezterm"};
 static bool does_term_support_setting_title(const environment_t &vars) {
     const auto term_var = vars.get(L"TERM");
     if (term_var.missing_or_empty()) return false;


### PR DESCRIPTION
WezTerm [has support for OSC 0](https://wezfurlong.org/wezterm/escape-sequences.html#operating-system-command-sequences) (dynamic titles) but somehow this wasn't being picked up by the checks currently in place. To solve this, I added the `TERM` value as a hard-coded accepted value for OSC 0 support.