### PR TITLE
fix 'socket file name too long' error

### DIFF
--- a/tests/checks/tmux-complete.fish
+++ b/tests/checks/tmux-complete.fish
@@ -1,15 +1,20 @@
 #RUN: %fish -C 'set -g fish %fish' %s
 #REQUIRES: command -v tmux
 
+set fish (builtin realpath $fish)
+
 # Isolated tmux.
 set -g tmpdir (mktemp -d)
-set -g tmux tmux -S $tmpdir/.tmux-socket -f /dev/null
+
+# Don't CD elsewhere, because tmux socket file is relative to CWD. Using
+# absolute path to socket file is prone to 'socket file name too long' error.
+cd $tmpdir
+
+set -g tmux tmux -S .tmux-socket -f /dev/null
 
 set -g sleep sleep .1
 set -q CI && set sleep sleep 1
 
-set fish (builtin realpath $fish)
-cd $tmpdir
 
 $tmux new-session -x 80 -y 10 -d $fish -C '
     # This is similar to "tests/interactive.config".

--- a/tests/checks/tmux-prompt.fish
+++ b/tests/checks/tmux-prompt.fish
@@ -1,6 +1,8 @@
 #RUN: %fish -C 'set -g fish %fish' %s
 #REQUIRES: command -v tmux
 
+set fish (builtin realpath $fish)
+
 # Isolated tmux.
 # Note $XDG_CONFIG_HOME typically has a leading double-dot,
 # so our uvars file will leak across runs; therefore
@@ -8,13 +10,14 @@
 set -g tmpdir (mktemp -d)/inner1/inner2/
 mkdir -p $tmpdir
 
-set -g tmux tmux -S $tmpdir/.tmux-socket -f /dev/null
+# Don't CD elsewhere, because tmux socket file is relative to CWD. Using
+# absolute path to socket file is prone to 'socket file name too long' error.
+cd $tmpdir
+
+set -g tmux tmux -S .tmux-socket -f /dev/null
 
 set -g sleep sleep .1
 set -q CI && set sleep sleep 1
-
-set fish (builtin realpath $fish)
-cd $tmpdir
 
 while set -e prompt_var
 end


### PR DESCRIPTION
## Description

In some setups (eg. macports) $tmpdir can expand to more than
100 symbols and tests fail with 'socket file name too long'
errors.

Using relative path to socket file fixes the issue.
