### PR TITLE
funced: edit the whole file, not just the function definition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Interactive improvements
 ------------------------
 - vi mode cursors are now set properly after control-C. (:issue:`8125`).
 - vi mode cursors are enabled in Apple Terminal (:issue:`8167`).
+- ``funced`` will try to edit the whole file containing a function definition, if there is one (:issue:`391`).
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc_src/cmds/funced.rst
+++ b/doc_src/cmds/funced.rst
@@ -17,6 +17,8 @@ Description
 
 If the ``$VISUAL`` environment variable is set, it will be used as the program to edit the function. If ``$VISUAL`` is unset but ``$EDITOR`` is set, that will be used. Otherwise, a built-in editor will be used. Note that to enter a literal newline using the built-in editor you should press :kbd:`Alt`\ +\ :kbd:`Enter`. Pressing :kbd:`Enter` signals that you are done editing the function. This does not apply to an external editor like emacs or vim.
 
+``funced`` will try to edit the original file that a function is defined in, which might include variable definitions or helper functions as well. If changes cannot be saved to the original file, a copy will be created in the user's function directory.
+
 If there is no function called ``NAME``, a new function will be created with the specified name.
 
 - ``-e command`` or ``--editor command`` Open the function body inside the text editor given by the command (for example, ``-e vi``). The special command ``fish`` will use the built-in editor (same as specifying ``-i``).

--- a/doc_src/cmds/funced.rst
+++ b/doc_src/cmds/funced.rst
@@ -17,7 +17,7 @@ Description
 
 If the ``$VISUAL`` environment variable is set, it will be used as the program to edit the function. If ``$VISUAL`` is unset but ``$EDITOR`` is set, that will be used. Otherwise, a built-in editor will be used. Note that to enter a literal newline using the built-in editor you should press :kbd:`Alt`\ +\ :kbd:`Enter`. Pressing :kbd:`Enter` signals that you are done editing the function. This does not apply to an external editor like emacs or vim.
 
-If there is no function called ``NAME`` a new function will be created with the specified name
+If there is no function called ``NAME``, a new function will be created with the specified name.
 
 - ``-e command`` or ``--editor command`` Open the function body inside the text editor given by the command (for example, ``-e vi``). The special command ``fish`` will use the built-in editor (same as specifying ``-i``).
 

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -107,7 +107,7 @@ function funced --description 'Edit function definition'
                 end
             end
 
-            if not source $tmpname
+            if not source <$tmpname
                 # Failed to source the function file. Prompt to try again.
                 echo # add a line between the parse error and the prompt
                 set -l repeat

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -104,6 +104,8 @@ function funced --description 'Edit function definition'
                 set -l new_checksum (__funced_md5 "$tmpname")
                 if test "$new_checksum" = "$checksum"
                     echo (_ "Editor exited but the function was not modified")
+                    # Don't source or save an unmodified file.
+                    break
                 end
             end
 

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -166,6 +166,9 @@ function funced --description 'Edit function definition'
                 end
             else if set -q _flag_save
                 funcsave $funcname
+            else
+                printf (_ "Run funcsave %s to save this function to the configuration directory.") $funcname
+                echo
             end
         end
         break


### PR DESCRIPTION
Fixes issue #391.

I'd appreciate feedback on the approach, as well as the following specifics
(plus anything else relevant):

- Are the error messages appropriate?
- When used without `--save`, all the extra parts of the file are lost (the
  function definition which has been sourced overrides the autoloaded files).
  They are still in effect but cannot be edited easily any more. Is this ok?
  Should we make `--save` the default? (I don't think so.)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst
