### PR TITLE
Add completion for azure cli (az)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,7 @@ Completions
   - Angular's ``ng`` (:issue:`8111`)
   - ``zef`` (:issue:`8114`)
   - ``rakudo`` (:issue:`8113`)
-  - ``az``
+  - ``az`` (:issue:`8141`)
 
 - Improvements to many completions.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Completions
   - Angular's ``ng`` (:issue:`8111`)
   - ``zef`` (:issue:`8114`)
   - ``rakudo`` (:issue:`8113`)
+  - ``az``
 
 - Improvements to many completions.
 

--- a/share/completions/az.fish
+++ b/share/completions/az.fish
@@ -1,0 +1,16 @@
+function __fish_az_complete
+  set -x _ARGCOMPLETE 1
+  set -x _ARGCOMPLETE_IFS \n
+  set -x _ARGCOMPLETE_SUPPRESS_SPACE 1
+  set -x _ARGCOMPLETE_SHELL fish
+  set -x COMP_LINE (commandline -p)
+  set -x COMP_POINT (string length (commandline -cp))
+  set -x COMP_TYPE
+  if set -q _ARC_DEBUG
+    az 8>&1 9>&2 1>/dev/null 2>&1
+  else
+    az 8>&1 9>&2 1>&9 2>&1
+  end
+end
+
+complete -c az -f -a '(__fish_az_complete)'

--- a/share/completions/az.fish
+++ b/share/completions/az.fish
@@ -1,16 +1,12 @@
 function __fish_az_complete
-  set -x _ARGCOMPLETE 1
-  set -x _ARGCOMPLETE_IFS \n
-  set -x _ARGCOMPLETE_SUPPRESS_SPACE 1
-  set -x _ARGCOMPLETE_SHELL fish
-  set -x COMP_LINE (commandline -p)
-  set -x COMP_POINT (string length (commandline -cp))
-  set -x COMP_TYPE
-  if set -q _ARC_DEBUG
-    az 8>&1 9>&2 1>/dev/null 2>&1
-  else
-    az 8>&1 9>&2 1>&9 2>&1
-  end
+  set -lx _ARGCOMPLETE 1
+  set -lx _ARGCOMPLETE_IFS \n
+  set -lx _ARGCOMPLETE_SUPPRESS_SPACE 1
+  set -lx _ARGCOMPLETE_SHELL fish
+  set -lx COMP_LINE (commandline -pc)
+  set -lx COMP_POINT (string length (commandline -cp))
+  set -lx COMP_TYPE
+  az 8>&1 9>&2 2>/dev/null
 end
 
 complete -c az -f -a '(__fish_az_complete)'


### PR DESCRIPTION
## Description

This introduces completions for the Azure CLI `az`. `az` uses the argcomplete library for its completions and the code I've used is little more than a boilerplate snippet to access those completions.

argcomplete has been compatible with fish for over 2 years now ([argcomplete!260](https://github.com/kislyuk/argcomplete/pull/260)), but this is (to my knowledge) the first time this is being added to fish-shell directly. The code is basically copied from a snippet mentioned in argcomplete!260, except I replaced `myscript` with `az`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
