### PR TITLE
commandline: Add --is-complete option to query whether it's syntactically complete

### DIFF
--- a/doc_src/cmds/commandline.rst
+++ b/doc_src/cmds/commandline.rst
@@ -61,7 +61,7 @@ The following options output metadata about the commandline state:
 
 - ``-P`` or ``--paging-mode`` evaluates to true if the commandline is showing pager contents, such as tab completions
 
-- ``--is-complete`` returns true when the commandline is syntactically complete, i.e. would be executed when the ``execute`` bind function is called.
+- ``--is-valid`` returns true when the commandline is syntactically valid and complete. If it is, it would be executed when the ``execute`` bind function is called.
 
 Example
 -------

--- a/doc_src/cmds/commandline.rst
+++ b/doc_src/cmds/commandline.rst
@@ -61,6 +61,7 @@ The following options output metadata about the commandline state:
 
 - ``-P`` or ``--paging-mode`` evaluates to true if the commandline is showing pager contents, such as tab completions
 
+- ``--is-complete`` returns true when the commandline is syntactically complete, i.e. would be executed when the ``execute`` bind function is called.
 
 Example
 -------

--- a/doc_src/cmds/commandline.rst
+++ b/doc_src/cmds/commandline.rst
@@ -61,7 +61,7 @@ The following options output metadata about the commandline state:
 
 - ``-P`` or ``--paging-mode`` evaluates to true if the commandline is showing pager contents, such as tab completions
 
-- ``--is-valid`` returns true when the commandline is syntactically valid and complete. If it is, it would be executed when the ``execute`` bind function is called.
+- ``--is-valid`` returns true when the commandline is syntactically valid and complete. If it is, it would be executed when the ``execute`` bind function is called. If the commandline is incomplete, it returns 2, if it is erroneus, it returns 1.
 
 Example
 -------

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -396,8 +396,13 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
     if (is_valid) {
         if (!*current_buffer) return 1;
         parser_test_error_bits_t res =
-            parse_util_detect_errors(current_buffer, NULL, false /* do not accept incomplete */);
-        return res & PARSER_TEST_ERROR ? 1 : 0;
+            parse_util_detect_errors(current_buffer,
+                                     NULL,
+                                     true /* accept incomplete so we can tell the difference */);
+        if (res & PARSER_TEST_INCOMPLETE) {
+            return 2;
+        }
+        return res & PARSER_TEST_ERROR ? STATUS_CMD_ERROR : STATUS_CMD_OK;
     }
 
     switch (buffer_part) {

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -394,10 +394,9 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
     }
 
     if (is_valid) {
-        auto buff = reader_get_buffer();
-        if (!*buff) return 1;
+        if (rstate.text.empty()) return 1;
         parser_test_error_bits_t res =
-            parse_util_detect_errors(buff, NULL, false /* do not accept incomplete */);
+            parse_util_detect_errors(rstate.text, NULL, false /* do not accept incomplete */);
         return res & PARSER_TEST_ERROR ? 1 : 0;
     }
 

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -142,6 +142,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
     bool line_mode = false;
     bool search_mode = false;
     bool paging_mode = false;
+    bool is_complete = false;
     const wchar_t *begin = nullptr, *end = nullptr;
     const wchar_t *override_buffer = nullptr;
 
@@ -165,6 +166,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
                                                   {L"line", no_argument, nullptr, 'L'},
                                                   {L"search-mode", no_argument, nullptr, 'S'},
                                                   {L"paging-mode", no_argument, nullptr, 'P'},
+                                                  {L"is-complete", no_argument, nullptr, 1},
                                                   {nullptr, 0, nullptr, 0}};
 
     int opt;
@@ -234,6 +236,10 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
             }
             case 'P': {
                 paging_mode = true;
+                break;
+            }
+            case 1: {
+                is_complete = true;
                 break;
             }
             case 'h': {
@@ -385,6 +391,14 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
             builtin_print_error_trailer(parser, streams.err, cmd);
         }
         return STATUS_CMD_ERROR;
+    }
+
+    if (is_complete) {
+        auto buff = reader_get_buffer();
+        if (!*buff) return 1;
+        parser_test_error_bits_t res =
+            parse_util_detect_errors(buff, NULL, false /* do not accept incomplete */);
+        return res & PARSER_TEST_ERROR ? 1 : 0;
     }
 
     switch (buffer_part) {

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -394,9 +394,9 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
     }
 
     if (is_valid) {
-        if (rstate.text.empty()) return 1;
+        if (!*current_buffer) return 1;
         parser_test_error_bits_t res =
-            parse_util_detect_errors(rstate.text, NULL, false /* do not accept incomplete */);
+            parse_util_detect_errors(current_buffer, NULL, false /* do not accept incomplete */);
         return res & PARSER_TEST_ERROR ? 1 : 0;
     }
 

--- a/src/builtin_commandline.cpp
+++ b/src/builtin_commandline.cpp
@@ -142,7 +142,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
     bool line_mode = false;
     bool search_mode = false;
     bool paging_mode = false;
-    bool is_complete = false;
+    bool is_valid = false;
     const wchar_t *begin = nullptr, *end = nullptr;
     const wchar_t *override_buffer = nullptr;
 
@@ -166,7 +166,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
                                                   {L"line", no_argument, nullptr, 'L'},
                                                   {L"search-mode", no_argument, nullptr, 'S'},
                                                   {L"paging-mode", no_argument, nullptr, 'P'},
-                                                  {L"is-complete", no_argument, nullptr, 1},
+                                                  {L"is-valid", no_argument, nullptr, 1},
                                                   {nullptr, 0, nullptr, 0}};
 
     int opt;
@@ -239,7 +239,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
                 break;
             }
             case 1: {
-                is_complete = true;
+                is_valid = true;
                 break;
             }
             case 'h': {
@@ -393,7 +393,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
         return STATUS_CMD_ERROR;
     }
 
-    if (is_complete) {
+    if (is_valid) {
         auto buff = reader_get_buffer();
         if (!*buff) return 1;
         parser_test_error_bits_t res =

--- a/tests/checks/commandline.fish
+++ b/tests/checks/commandline.fish
@@ -1,0 +1,13 @@
+#RUN: %fish %s
+
+commandline --input "echo foo | bar" --is-valid
+and echo Valid
+# CHECK: Valid
+
+commandline --input "echo foo | " --is-valid
+or echo Invalid
+# CHECK: Invalid
+
+commandline --input '' --is-valid
+or echo Invalid
+# CHECK: Invalid

--- a/tests/checks/commandline.fish
+++ b/tests/checks/commandline.fish
@@ -5,9 +5,15 @@ and echo Valid
 # CHECK: Valid
 
 commandline --input "echo foo | " --is-valid
-or echo Invalid
-# CHECK: Invalid
+or echo Invalid $status
+# CHECK: Invalid 2
 
+# TODO: This seems a bit awkward?
+# The empty commandline is an error, not incomplete?
 commandline --input '' --is-valid
-or echo Invalid
-# CHECK: Invalid
+or echo Invalid $status
+# CHECK: Invalid 1
+
+commandline --input 'echo $$' --is-valid
+or echo Invalid $status
+# CHECK: Invalid 1


### PR DESCRIPTION
This means querying when the commandline is in a state that it could
be executed. Because our `execute` bind function also inserts a
newline if it isn't.

One case that's not handled right now: `execute` also expands
abbreviations, those can technically make the commandline invalid
again.

Unfortunately we have no real way to *check* without doing the
replacement.

Also since abbreviations are only available in command position when
you _execute_ them the commandline will most likely be valid.

This is enough to make transient prompts work:

```fish
function reset-transient --on-event fish_postexec
    set -g TRANSIENT 0
end

function maybe_execute
    if commandline --is-complete
        set -g TRANSIENT 1
        commandline -f repaint
    else
        set -g TRANSIENT 0
    end
    commandline -f execute
end

bind \r maybe_execute
```

and then in `fish_prompt` react to $TRANSIENT being set to 1.

As far as I'm concerned that means it:

Fixes #7602

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
