### PR TITLE
Add `set --function`

### DIFF
--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -33,11 +33,11 @@ With ``--show``, ``set`` will describe the given variable names, explaining how 
 
 The following options control variable scope:
 
-- ``-l`` or ``--local`` forces the specified shell variable to be given a scope that is local to the current block, even if a variable with the given name exists and is non-local
+- ``-f`` or ``--function`` scopes the variable to the currently executing function. It is erased when the function ends.
 
-- ``-f`` or ``--function`` makes the variable local to the current *function*. This is the same as defining it with ``--local`` outside of a block like ``begin`` or ``for``. When used outside of a function, it uses the top-level local scope instead.
+- ``-l`` or ``--local`` scopes the variable to the currently executing block. It is erased when the block ends. Outside of a block, this is the same as ``--function``.
 
-- ``-g`` or ``--global`` causes the specified shell variable to be given a global scope. Non-global variables disappear when the block they belong to ends
+- ``-g`` or ``--global`` causes the specified shell variable to be given a global scope. Global variables don't disappear and are available to all functions running in the same shell. They can even be modified.
 
 - ``-U`` or ``--universal`` causes the specified shell variable to be given a universal scope. If this option is supplied, the variable will be shared between all the current user's fish instances on the current computer, and will be preserved across restarts of the shell.
 

--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -35,6 +35,8 @@ The following options control variable scope:
 
 - ``-l`` or ``--local`` forces the specified shell variable to be given a scope that is local to the current block, even if a variable with the given name exists and is non-local
 
+- ``-f`` or ``--function`` makes the variable local to the current *function*. This is the same as defining it with ``--local`` outside of a block like ``begin`` or ``for``. When used outside of a function, it uses the top-level local scope instead.
+
 - ``-g`` or ``--global`` causes the specified shell variable to be given a global scope. Non-global variables disappear when the block they belong to ends
 
 - ``-U`` or ``--universal`` causes the specified shell variable to be given a universal scope. If this option is supplied, the variable will be shared between all the current user's fish instances on the current computer, and will be preserved across restarts of the shell.

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -875,14 +875,15 @@ There are three kinds of variables in fish: universal, global and local variable
 - Universal variables are shared between all fish sessions a user is running on one computer.
 - Global variables are specific to the current fish session, and will never be erased unless explicitly requested by using ``set -e``.
 - Local variables are specific to the current fish session, and associated with a specific block of commands, and automatically erased when a specific block goes out of scope. A block of commands is a series of commands that begins with one of the commands ``for``, ``while`` , ``if``, ``function``, ``begin`` or ``switch``, and ends with the command ``end``.
+- Function-local variables are the same as local variables outside of one of these blocks. They go out of scope when the current function ends.
 
-Variables can be explicitly set to be universal with the ``-U`` or ``--universal`` switch, global with the ``-g`` or ``--global`` switch, or local with the ``-l`` or ``--local`` switch.  The scoping rules when creating or updating a variable are:
+Variables can be explicitly set to be universal with the ``-U`` or ``--universal`` switch, global with ``-g`` or ``--global``, local to the current block with ``-l`` or ``--local``, or local to the current function with ``-f`` or ``--function``.  The scoping rules when creating or updating a variable are:
 
 - When a scope is explicitly given, it will be used. If a variable of the same name exists in a different scope, that variable will not be changed.
 
 - When no scope is given, but a variable of that name exists, the variable of the smallest scope will be modified. The scope will not be changed.
 
-- As a special case, when no scope is given and no variable has been defined the variable will belong to the scope of the currently executing *function*. This is different from the ``--local`` flag, which would make the variable local to the current *block*.
+- As a special case, when no scope is given and no variable has been defined the variable will belong to the scope of the currently executing *function*. This is different from the ``--local`` flag, which would make the variable local to the current *block*. Outside of a function, it is global, unlike with explicit function-scope.
 
 There can be many variables with the same name, but different scopes. When you :ref:`use a variable <expand-variable>`, the smallest scoped variable of that name will be used. If a local variable exists, it will be used instead of the global or universal variable of the same name.
 
@@ -897,6 +898,16 @@ Typically inside funcions you should use local scope::
         set -l file /path/to/my/file
         if not test -e "$file"
             set file /path/to/my/otherfile
+        end
+    end
+
+    # or
+
+    function something
+        if test -e /path/to/my/file
+            set -f file /path/to/my/file
+        else
+            set -f file /path/to/my/otherfile
         end
     end
 
@@ -922,16 +933,22 @@ If you want to set some personal customization, universal variables are nice::
 
 Here is an example of local vs function-scoped variables::
 
-    begin
-        # This is a nice local scope where all variables will die
-        set -l pirate 'There be treasure in them thar hills'
-        set captain Space, the final frontier
-    end
+  function test-scopes
+      begin
+          # This is a nice local scope where all variables will die
+          set -l pirate 'There be treasure in them thar hills'
+          set -f captain Space, the final frontier
+          # If no variable of that name was defined, it is function-local.
+          set gnu "In the beginning there was nothing, which exploded"
+      end
 
-    echo $pirate
-    # This will not output anything, since the pirate was local
-    echo $captain
-    # This will output the good Captain's speech since $captain had function-scope.
+      echo $pirate
+      # This will not output anything, since the pirate was local
+      echo $captain
+      # This will output the good Captain's speech since $captain had function-scope.
+      echo $gnu
+      # Will output Sir Terry's wisdom.
+  end
 
 .. _variables-override:
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -870,20 +870,20 @@ So you set a variable with ``set``, and use it with a ``$`` and the name.
 Variable scope
 ^^^^^^^^^^^^^^
 
-There are three kinds of variables in fish: universal, global and local variables.
+There are four kinds of variables in fish: universal, global, function and local variables.
 
 - Universal variables are shared between all fish sessions a user is running on one computer.
 - Global variables are specific to the current fish session, and will never be erased unless explicitly requested by using ``set -e``.
-- Local variables are specific to the current fish session, and associated with a specific block of commands, and automatically erased when a specific block goes out of scope. A block of commands is a series of commands that begins with one of the commands ``for``, ``while`` , ``if``, ``function``, ``begin`` or ``switch``, and ends with the command ``end``.
-- Function-local variables are the same as local variables outside of one of these blocks. They go out of scope when the current function ends.
+- Function variables are specific to the currently executing function. They are erased ("go out of scope") when the current function ends.
+- Local variables are specific to the current block of commands, and automatically erased when a specific block goes out of scope. A block of commands is a series of commands that begins with one of the commands ``for``, ``while`` , ``if``, ``function``, ``begin`` or ``switch``, and ends with the command ``end``. Outside of a block, this is the same as the function scope.
 
-Variables can be explicitly set to be universal with the ``-U`` or ``--universal`` switch, global with ``-g`` or ``--global``, local to the current block with ``-l`` or ``--local``, or local to the current function with ``-f`` or ``--function``.  The scoping rules when creating or updating a variable are:
+Variables can be explicitly set to be universal with the ``-U`` or ``--universal`` switch, global with ``-g`` or ``--global``, function-scoped with ``-f`` or ``--function`` and local to the current block with ``-l`` or ``--local``.  The scoping rules when creating or updating a variable are:
 
 - When a scope is explicitly given, it will be used. If a variable of the same name exists in a different scope, that variable will not be changed.
 
 - When no scope is given, but a variable of that name exists, the variable of the smallest scope will be modified. The scope will not be changed.
 
-- As a special case, when no scope is given and no variable has been defined the variable will belong to the scope of the currently executing *function*. This is different from the ``--local`` flag, which would make the variable local to the current *block*. Outside of a function, it is global, unlike with explicit function-scope.
+- When no scope is given and no variable of that name exists, the variable is created in function scope if inside a function, or global scope if no function is executing.
 
 There can be many variables with the same name, but different scopes. When you :ref:`use a variable <expand-variable>`, the smallest scoped variable of that name will be used. If a local variable exists, it will be used instead of the global or universal variable of the same name.
 
@@ -949,6 +949,8 @@ Here is an example of local vs function-scoped variables::
       echo $gnu
       # Will output Sir Terry's wisdom.
   end
+
+When in doubt, use function-scoped variables. When you need to make a variable accessible everywhere, make it global. When you need to persistently store configuration, make it universal. When you want to use a variable only in a short block, make it local.
 
 .. _variables-override:
 
@@ -1038,7 +1040,7 @@ Variables can be explicitly set to be exported with the ``-x`` or ``--export`` s
 
 - Otherwise, by default, the variable will not be exported.
 
-- If a variable has local scope and is exported, any function called receives a *copy* of it, so any changes it makes to the variable disappear once the function returns.
+- If a variable has function or local scope and is exported, any function called receives a *copy* of it, so any changes it makes to the variable disappear once the function returns.
 
 - Global variables are accessible to functions whether they are exported or not.
 

--- a/src/env.h
+++ b/src/env.h
@@ -26,23 +26,24 @@ enum {
     ENV_DEFAULT = 0,
     /// Flag for local (to the current block) variable.
     ENV_LOCAL = 1 << 0,
+    ENV_FUNCTION = 1 << 1,
     /// Flag for global variable.
-    ENV_GLOBAL = 1 << 1,
+    ENV_GLOBAL = 1 << 2,
     /// Flag for universal variable.
-    ENV_UNIVERSAL = 1 << 2,
+    ENV_UNIVERSAL = 1 << 3,
     /// Flag for exported (to commands) variable.
-    ENV_EXPORT = 1 << 3,
+    ENV_EXPORT = 1 << 4,
     /// Flag for unexported variable.
-    ENV_UNEXPORT = 1 << 4,
+    ENV_UNEXPORT = 1 << 5,
     /// Flag to mark a variable as a path variable.
-    ENV_PATHVAR = 1 << 5,
+    ENV_PATHVAR = 1 << 6,
     /// Flag to unmark a variable as a path variable.
-    ENV_UNPATHVAR = 1 << 6,
+    ENV_UNPATHVAR = 1 << 7,
     /// Flag for variable update request from the user. All variable changes that are made directly
     /// by the user, such as those from the `read` and `set` builtin must have this flag set. It
     /// serves one purpose: to indicate that an error should be returned if the user is attempting
     /// to modify a var that should not be modified by direct user action; e.g., a read-only var.
-    ENV_USER = 1 << 7,
+    ENV_USER = 1 << 8,
 };
 typedef uint32_t env_mode_flags_t;
 

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -727,23 +727,23 @@ begin
 end
 
 # Function scope:
-set -f actuallyglobal "this one is global"
-set -qg actuallyglobal
-and echo "Yep, it's global"
-# CHECK: Yep, it's global
-set -S actuallyglobal
-#CHECK: $actuallyglobal: set in global scope, unexported, with 1 elements
-#CHECK: $actuallyglobal[1]: |this one is global|
+set -f actuallystilllocal "this one is still local"
+set -ql actuallystilllocal
+and echo "Yep, it's local"
+# CHECK: Yep, it's local
+set -S actuallystilllocal
+#CHECK: $actuallystilllocal: set in local scope, unexported, with 1 elements
+#CHECK: $actuallystilllocal[1]: |this one is still local|
 
-# Blocks aren't functions, "function" scope is still global:
+# Blocks aren't functions, "function" scope is still top-level local:
 begin
-    set -f stillglobal "as global as the moon is wet"
-    echo $stillglobal
-    # CHECK: as global as the moon is wet
+    set -f stilllocal "as local as the moon is wet"
+    echo $stilllocal
+    # CHECK: as local as the moon is wet
 end
-set -S stillglobal
-#CHECK: $stillglobal: set in global scope, unexported, with 1 elements
-#CHECK: $stillglobal[1]: |as global as the moon is wet|
+set -S stilllocal
+#CHECK: $stilllocal: set in local scope, unexported, with 1 elements
+#CHECK: $stilllocal[1]: |as local as the moon is wet|
 
 function test-function-scope
     set -f funcvar "function"

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -745,6 +745,8 @@ set -S stilllocal
 #CHECK: $stilllocal: set in local scope, unexported, with 1 elements
 #CHECK: $stilllocal[1]: |as local as the moon is wet|
 
+set -g globalvar global
+
 function test-function-scope
     set -f funcvar "function"
     echo $funcvar
@@ -785,6 +787,13 @@ function test-function-scope
     # function scope *is* the outermost local scope,
     # so that `set -f` altered the same funcvariable as that `set -l` outside!
     # CHECK: orange
+
+    set -f globalvar function
+    set -S globalvar
+    #CHECK: $globalvar: set in local scope, unexported, with 1 elements
+    #CHECK: $globalvar[1]: |function|
+    #CHECK: $globalvar: set in global scope, unexported, with 1 elements
+    #CHECK: $globalvar[1]: |global|
 end
         
 test-function-scope


### PR DESCRIPTION
~~This makes the "unspecified" scope available - the one that is used
when no variable exists.~~

~~It's either the enclosing function's topmost local scope, or global
scope if there is no function.~~ (after deliberation, using global felt awkward because that would make the variable available *everywhere*, so we're just local)

This removes the need to declare variables locally before use. E.g.:

```fish
set -l thing
if condition
    set thing one
else
    set thing two
end
```

could be written as

```fish
if condition
    set -f thing one
else
    set -f thing two
end
```

Note: Many scripts shipped with fish use workarounds like `and`/`or`
instead of `if`, so it isn't easy to find good examples.

Also, if there isn't an else-branch in that above, just with

```fish
if condition
    set -f thing one
end
```

that means something different from setting it before! Now, if
`condition` isn't true, it would use a global (or universal) variable of
te same name!

Some more interesting parts:

Because it *is* a local scope, setting a variable `-f` and
`-l` in the toplevel of a function ends up the same:

```fish
function foo2
    set -l foo bar
    set -f foo baz # modifies the *same* variable!
end
```

but setting it locally inside a block creates a new local variable
that shadows the function-scoped variable:

```fish
function foo3
    set -f foo bar
    begin
        set -l foo banana
        # $foo is banana
    end
    # $foo is bar again
end
```

This is how local variables already work. "Local" is actually "block-scoped".

Also `set --show` will only show the closest local scope, so it won't
show a shadowed function-level variable. Again, this is how local
variables already work, and could be done as a separate change.

Fixes #565

One of the tests explicitly checks one case mentioned by @ridiculousfish in https://github.com/fish-shell/fish-shell/issues/565#issuecomment-259046107:

```fish
function f
    set -l fruit banana
    if true
        set -f fruit orange
    end
    echo $fruit #banana
end
```

This isn't an issue, because function scope *is* the outermost local scope of the function. There is no difference. It's not a new node.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
