### PR TITLE
Handle absolute path in CMAKE_INSTALL_DATADIR

### DIFF
--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -14,8 +14,8 @@ set(bindir ${CMAKE_INSTALL_BINDIR})
 set(sysconfdir ${CMAKE_INSTALL_SYSCONFDIR})
 set(mandir ${CMAKE_INSTALL_MANDIR})
 
-set(rel_datadir ${CMAKE_INSTALL_DATADIR})
 set(datadir ${CMAKE_INSTALL_FULL_DATADIR})
+file(RELATIVE_PATH rel_datadir ${CMAKE_INSTALL_PREFIX} ${datadir})
 
 set(docdir ${CMAKE_INSTALL_DOCDIR})
 


### PR DESCRIPTION
Cmake accepts both absolute and relative paths in CMAKE_INSTALL_DATADIR.
For the latter case CMAKE_INSTALL_PREFIX is being prepended
automatically. %{rel_datadir} is derived from CMAKE_INSTALL_DATADIR
which was assumed to be relative and otherwise causes issues in a .pc
file where prefix is being prepended unconditionally.

Make sure %{rel_datadir} is relative by calculating RELATIVE_PATH from
CMAKE_INSTALL_PREFIX to CMAKE_INSTALL_FULL_DATADIR which is known to be
absolute.

Fixes #8150