### PR TITLE
Work around `setpgid` error on older Apple platforms

### DIFF
--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -95,7 +95,7 @@ int execute_setpgid(pid_t pid, pid_t pgroup, bool is_parent) {
             FLOGF_SAFE(proc_pgroup, "setpgid(2) returned EPERM. Retrying");
             continue;
         }
-#ifdef __BSD__
+#if defined(__BSD__) || defined(__APPLE__)
         // POSIX.1 doesn't specify that zombie processes are required to be considered extant and/or
         // children of the parent for purposes of setpgid(2). In particular, FreeBSD (at least up to
         // 12.2) does not consider a child that has already forked, exec'd, and exited to "exist"


### PR DESCRIPTION
## Description

Expand the #7474 fix to Apple platforms. The issue affects older OS versions, including Mac OS X 10.4.11.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
