### PR TITLE
Refuse $status as a command

### DIFF
--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -1124,6 +1124,16 @@ static bool detect_errors_in_decorated_statement(const wcstring &buff_src,
         }
     }
 
+    // $status specifically is invalid as a command,
+    // to avoid people trying `if $status`.
+    // We see this surprisingly regularly.
+    const wcstring &com = dst.command.source(buff_src, storage);
+    if (com == L"$status") {
+        parse_error_offset_source_start(parse_errors, source_start);
+        errored = append_syntax_error(parse_errors, source_start,
+                                      _(L"$status is not valid as a command. See `help conditions`"));
+    }
+
     const wcstring &unexp_command = dst.command.source(buff_src, storage);
     if (!unexp_command.empty()) {
         wcstring command;

--- a/tests/checks/expansion.fish
+++ b/tests/checks/expansion.fish
@@ -306,12 +306,10 @@ $fish -c 'echo {'
 #CHECKERR: fish: Unexpected end of string, incomplete parameter expansion
 #CHECKERR: echo {
 #CHECKERR: ^
-#CHECKERR: 
 $fish -c 'echo {}}'
 #CHECKERR: fish: Unexpected '}' for unopened brace expansion
 #CHECKERR: echo {}}
 #CHECKERR: ^
-#CHECKERR: 
 $fish -c 'command (asd)'
 #CHECKERR: fish: Command substitutions not allowed
 #CHECKERR: command (asd)

--- a/tests/checks/invocation.fish
+++ b/tests/checks/invocation.fish
@@ -78,3 +78,15 @@ and echo matched
 string match -rq "echo thisshouldneverbeintheconfig" < $tmp/full.prof
 and echo matched
 # CHECK: matched
+
+$fish --no-config -c 'echo notprinted; echo foo | exec true; echo banana'
+# CHECKERR: fish: The 'exec' command can not be used in a pipeline
+# CHECKERR: echo notprinted; echo foo | exec true; echo banana
+# CHECKERR: ^
+
+# Running multiple command lists continues even if one has a syntax error.
+$fish --no-config -c 'echo $$ oh no syntax error' -c 'echo this works'
+# CHECK: this works
+# CHECKERR: fish: $$ is not the pid. In fish, please use $fish_pid.
+# CHECKERR: echo $$ oh no syntax error
+# CHECKERR: ^

--- a/tests/checks/vars_as_commands.fish
+++ b/tests/checks/vars_as_commands.fish
@@ -1,4 +1,4 @@
-#RUN: %fish %s
+#RUN: %fish -C 'set -g fish (builtin realpath %fish)' %s
 # Test that using variables as command names work correctly.
 
 $EMPTY_VARIABLE
@@ -26,5 +26,25 @@ builtin $CMD1
 set CMD3 /usr/bin
 $CMD3 && echo $PWD
 #CHECK: /usr/bin
+
+# $status specifically is not valid, to avoid a common error
+# with `if $status`
+echo 'if $status; echo foo; end' | $fish --no-config
+#CHECKERR: fish: $status is not valid as a command. See `help conditions`
+#CHECKERR: if $status; echo foo; end
+#CHECKERR: ^
+echo 'not $status' | $fish --no-config
+#CHECKERR: fish: $status is not valid as a command. See `help conditions`
+#CHECKERR: not $status
+#CHECKERR: ^
+
+# Script doesn't run at all.
+echo 'echo foo; and $status' | $fish --no-config
+#CHECKERR: fish: $status is not valid as a command. See `help conditions`
+#CHECKERR: echo foo; and $status
+#CHECKERR: ^
+
+echo 'set -l status_cmd true; if $status_cmd; echo Heck yes this is true; end' | $fish --no-config
+#CHECK: Heck yes this is true
 
 exit 0


### PR DESCRIPTION
## Description

Another one from the "please no more" department:

Using $status as a command is *virtually guaranteed* to be an error. Nobody has commands called "0", and if they do they certainly don't want them called at semi-random just because some command failed or succeeded.

So, we forbid $status specifically, and print a special error.

It would also be possible to check if $status was used *after* the command wasn't found, but that means it can't be done statically anymore. And, like I said, using $status this way is unlikely to be on purpose, and if it was on purpose it wasn't necessary and you can skip the cutesy trick.

(the first commit is because the test was throwing path errors otherwise, I don't know since when they've been printed, but they are bogus regardless)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
