### PR TITLE
Disable job control inside command substitutions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Notable improvements and fixes
 Deprecations and removed features
 ---------------------------------
 - A new feature flag ``ampersand-nobg-in-token`` makes ``&`` only act as background operator if followed by a separator. In combination with ``qmark-noglob`` this allows to write some URLs without quoting or escaping (:issue:`7991`)
+- Command substitutions no longer respect job control, instead running inside fish's own process group. This more closely matches other shells, and improves control-C reliability inside a command substitution.
 
 Scripting improvements
 ----------------------

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -1342,10 +1342,12 @@ end_execution_reason_t parse_execution_context_t::run_1_job(const ast::job_t &jo
     const auto &ld = parser->libdata();
 
     auto job_control_mode = get_job_control_mode();
+    // Run all command substitutions in our pgroup.
     bool wants_job_control =
-        (job_control_mode == job_control_t::all) ||
-        ((job_control_mode == job_control_t::interactive) && parser->is_interactive()) ||
-        (ctx.job_group && ctx.job_group->wants_job_control());
+        !parser->is_command_substitution() &&
+        ((job_control_mode == job_control_t::all) ||
+         ((job_control_mode == job_control_t::interactive) && parser->is_interactive()) ||
+         (ctx.job_group && ctx.job_group->wants_job_control()));
 
     job_t::properties_t props{};
     props.initial_background = job_node.bg.has_value();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -424,6 +424,18 @@ bool parser_t::is_function() const {
     return false;
 }
 
+bool parser_t::is_command_substitution() const {
+    for (const auto &b : block_list) {
+        if (b.type() == block_type_t::subst) {
+            return true;
+        } else if (b.type() == block_type_t::source) {
+            // If a function sources a file, don't descend further.
+            break;
+        }
+    }
+    return false;
+}
+
 maybe_t<wcstring> parser_t::get_function_name(int level) {
     if (level == 0) {
         // Return the function name for the level preceding the most recent breakpoint. If there

--- a/src/parser.h
+++ b/src/parser.h
@@ -285,6 +285,9 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     /// \return whether we are currently evaluating a function.
     bool is_function() const;
 
+    /// \return whether we are currently evaluating a command substitution.
+    bool is_command_substitution() const;
+
     /// Create a parser.
     parser_t();
     parser_t(std::shared_ptr<env_stack_t> vars);

--- a/tests/checks/sigint2.fish
+++ b/tests/checks/sigint2.fish
@@ -2,6 +2,21 @@
 # This hangs on OpenBSD
 #REQUIRES: test "$(uname)" != OpenBSD
 
+# Command subs run in same pgroup as fish, even if job control is 'all'.
+# Verify that they get the same pgroup across runs (presumably fish's).
+status job-control full
+set g1 ($helper print_pgrp)
+for i in (seq 10)
+    if test $g1 -ne ($helper print_pgrp)
+        echo "Unexpected pgroup"
+    end
+end
+status job-control interactive
+
+echo "Finished testing pgroups"
+#CHECK: Finished testing pgroups
+
+
 # Ensure that if child processes SIGINT, we exit our loops
 # Test for #3780
 

--- a/tests/pexpects/signals.py
+++ b/tests/pexpects/signals.py
@@ -19,6 +19,13 @@ import sys
 
 expect_prompt()
 
+# Verify that SIGINT inside a command sub cancels it.
+# Negate the pid to send to the pgroup (which should include sleep).
+sendline("while true; echo (sleep 1000); end")
+sleep(0.5)
+os.kill(-sp.spawn.pid, signal.SIGINT)
+expect_prompt()
+
 sendline("sleep 10 &")
 expect_prompt()
 


### PR DESCRIPTION
This disables job control inside command substitutions, regardless of `status job-control`. A reason is that control-C doesn't work reliably if it gets directed to the command substitution:

    while true ; echo (sleep 5) ; end

With job control, `sleep` owns the tty so gets the SIGINT, and so the loop just continues on. The simplest way to fix this is to match other shells and not use job control in cmdsubs.

Related is #1362. I think I was just wrong in that issue and it's correct to not use job control.
