### PR TITLE
document `--no-config`

### DIFF
--- a/doc_src/cmds/fish.rst
+++ b/doc_src/cmds/fish.rst
@@ -29,6 +29,8 @@ The following options are available:
 
 - ``-l`` or ``--login`` specify that fish is to run as a login shell
 
+- ``-N`` or ``--no-config`` do not read configuration files
+
 - ``-n`` or ``--no-execute`` do not execute any commands, only perform syntax checking
 
 - ``-p`` or ``--profile=PROFILE_FILE`` when fish exits, output timing information on all executed commands to the specified file. This excludes time spent starting up and reading the configuration.

--- a/share/completions/fish.fish
+++ b/share/completions/fish.fish
@@ -2,6 +2,7 @@ complete -c fish -s c -l command -d "Run specified command instead of interactiv
 complete -c fish -s C -l init-command -d "Run specified command before session" -x -a "(__fish_complete_command)"
 complete -c fish -s h -l help -d "Display help and exit"
 complete -c fish -s v -l version -d "Display version and exit"
+complete -c fish -s N -l no-config -d "Do not read configuration files"
 complete -c fish -s n -l no-execute -d "Only parse input, do not execute"
 complete -c fish -s i -l interactive -d "Run in interactive mode"
 complete -c fish -s l -l login -d "Run as a login shell"


### PR DESCRIPTION
## Description

Documents `fish --no-config` added in #7921

I'm not sure if this was intentionally undocumented, but I used it today and noticed it was missing

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
