### PR TITLE
Add completion for qmk

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Completions
   - ``zef`` (:issue:`8114`)
   - ``rakudo`` (:issue:`8113`)
   - ``az`` (:issue:`8141`)
+  - ``qmk`` (:issue:`8180`)
 
 - Improvements to many completions.
 

--- a/share/completions/az.fish
+++ b/share/completions/az.fish
@@ -1,12 +1,1 @@
-function __fish_az_complete
-  set -lx _ARGCOMPLETE 1
-  set -lx _ARGCOMPLETE_IFS \n
-  set -lx _ARGCOMPLETE_SUPPRESS_SPACE 1
-  set -lx _ARGCOMPLETE_SHELL fish
-  set -lx COMP_LINE (commandline -pc)
-  set -lx COMP_POINT (string length (commandline -cp))
-  set -lx COMP_TYPE
-  az 8>&1 9>&2 2>/dev/null
-end
-
-complete -c az -f -a '(__fish_az_complete)'
+complete -c az -f -a '(__fish_argcomplete_complete az)'

--- a/share/completions/qmk.fish
+++ b/share/completions/qmk.fish
@@ -1,12 +1,1 @@
-function __fish_qmk_complete
-  set -lx _ARGCOMPLETE 1
-  set -lx _ARGCOMPLETE_IFS \n
-  set -lx _ARGCOMPLETE_SUPPRESS_SPACE 1
-  set -lx _ARGCOMPLETE_SHELL fish
-  set -lx COMP_LINE (commandline -pc)
-  set -lx COMP_POINT (string length (commandline -cp))
-  set -lx COMP_TYPE
-  qmk 8>&1 9>&2 2>/dev/null
-end
-
-complete -c qmk -f -a '(__fish_qmk_complete)'
+complete -c qmk -f -a '(__fish_argcomplete_complete qmk)'

--- a/share/completions/qmk.fish
+++ b/share/completions/qmk.fish
@@ -1,0 +1,12 @@
+function __fish_qmk_complete
+  set -lx _ARGCOMPLETE 1
+  set -lx _ARGCOMPLETE_IFS \n
+  set -lx _ARGCOMPLETE_SUPPRESS_SPACE 1
+  set -lx _ARGCOMPLETE_SHELL fish
+  set -lx COMP_LINE (commandline -pc)
+  set -lx COMP_POINT (string length (commandline -cp))
+  set -lx COMP_TYPE
+  qmk 8>&1 9>&2 2>/dev/null
+end
+
+complete -c qmk -f -a '(__fish_qmk_complete)'

--- a/share/functions/__fish_argcomplete_complete.fish
+++ b/share/functions/__fish_argcomplete_complete.fish
@@ -1,0 +1,10 @@
+function __fish_argcomplete_complete
+  set -lx _ARGCOMPLETE 1
+  set -lx _ARGCOMPLETE_IFS \n
+  set -lx _ARGCOMPLETE_SUPPRESS_SPACE 1
+  set -lx _ARGCOMPLETE_SHELL fish
+  set -lx COMP_LINE (commandline -pc)
+  set -lx COMP_POINT (string length (commandline -cp))
+  set -lx COMP_TYPE
+  $argv 8>&1 9>&2 2>/dev/null
+end


### PR DESCRIPTION
## Description

This PR adds completion for `qmk`. `qmk` is a CLI for managing, compiling and flashing firmware for custom keyboards. The code is based on the `az` completion since both programs use the same mechanism through argcomplete (see #8141  for reference)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
