### PR TITLE
completion nmap: suppress warning when local scripts folder exists

### DIFF
--- a/share/completions/nmap.fish
+++ b/share/completions/nmap.fish
@@ -76,7 +76,7 @@ function __fish_complete_nmap_script
         set -g __fish_nmap_script_completion_cache_time (date +"%s")
         set -g __fish_nmap_script_completion_cache ""
         set -l cmd
-        for l in (nmap --script-help all|grep -A2 -B1 Categories:|grep -v '^\\(--\\|Categories:\\|https:\\)')
+        for l in (nmap --script-help all 2> /dev/null | grep -A2 -B1 Categories: | grep -v '^\\(--\\|Categories:\\|https:\\)')
             if string match -q -v --regex "^ " $l
                 set cmd $l
             else


### PR DESCRIPTION
## Description

When a folder `scripts` exists in the cwd, the completion for `nmap --script` outputs a warning:

```
Warning: File ./scripts/ exists, but Nmap is using /usr/bin/../share/nmap/scripts/ for security and consistency reasons.  set NMAPDIR=. to give priority to files in your local directory (may affect the other data files too).
```

This PR suppresses the warning.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
