### PR TITLE
prompt_pwd: Allow keeping some directory components at full length

### DIFF
--- a/doc_src/cmds/prompt_pwd.rst
+++ b/doc_src/cmds/prompt_pwd.rst
@@ -17,7 +17,16 @@ Description
 
 ``prompt_pwd`` is a function to print the current working directory in a way suitable for prompts. It will replace the home directory with "~" and shorten every path component but the last to a default of one character.
 
-To change the number of characters per path component, set ``$fish_prompt_pwd_dir_length`` to the number of characters. Setting it to 0 or an invalid value will disable shortening entirely.
+To change the number of characters per path component, pass ``--dir-length=`` or set ``$fish_prompt_pwd_dir_length`` to the number of characters. Setting it to 0 or an invalid value will disable shortening entirely.
+
+To keep some components unshortened, pass ``--full-length-dirs=`` or set ``$fish_prompt_pwd_full_dirs`` to the number of components.
+
+Options
+-------
+
+- ``-h`` or ``--help`` displays the help and exits
+- ``-d`` or ``--dir-length=MAX`` causes the components to be shortened to MAX characters each. This overrides $fish_prompt_pwd_dir_length.
+- ``-D`` or ``--full-length-dirs=NUM`` keeps NUM components (counted from the right) as full length without shortening. This overrides $fish_prompt_pwd_full_dirs.
 
 Examples
 --------
@@ -38,3 +47,6 @@ Examples
     >_ set -g fish_prompt_pwd_dir_length 3
     >_ prompt_pwd
     /tmp/ban/sau/wit/mustard
+
+    >_ prompt_pwd --full-length-dirs=2 --dir-length=1
+    /t/b/s/with/mustard

--- a/doc_src/cmds/prompt_pwd.rst
+++ b/doc_src/cmds/prompt_pwd.rst
@@ -17,9 +17,11 @@ Description
 
 ``prompt_pwd`` is a function to print the current working directory in a way suitable for prompts. It will replace the home directory with "~" and shorten every path component but the last to a default of one character.
 
-To change the number of characters per path component, pass ``--dir-length=`` or set ``$fish_prompt_pwd_dir_length`` to the number of characters. Setting it to 0 or an invalid value will disable shortening entirely.
+To change the number of characters per path component, pass ``--dir-length=`` or set ``$fish_prompt_pwd_dir_length`` to the number of characters. Setting it to 0 or an invalid value will disable shortening entirely. This defaults to 1.
 
-To keep some components unshortened, pass ``--full-length-dirs=`` or set ``$fish_prompt_pwd_full_dirs`` to the number of components.
+To keep some components unshortened, pass ``--full-length-dirs=`` or set ``$fish_prompt_pwd_full_dirs`` to the number of components. This defaults to 1, keeping the last component.
+
+If any positional arguments are given, prompt_pwd shortens them instead of $PWD.
 
 Options
 -------

--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -39,6 +39,10 @@ function prompt_pwd --description 'Print the current working directory, shortene
                 set -l all (string split -m (math $fish_prompt_pwd_full_dirs - 1) -r / $tmp)
                 set tmp $all[1]
                 set full $all[2..]
+            else if test $fish_prompt_pwd_full_dirs -eq 0
+                # 0 means not even the last component is kept
+                string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*' '$1' $tmp
+                continue
             end
 
             string join / (string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp) $full

--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -1,12 +1,15 @@
 function prompt_pwd --description 'Print the current working directory, shortened to fit the prompt'
     set -l options h/help d/dir-length= D/full-length-dirs=
-    argparse -n prompt_pwd --max-args=0 $options -- $argv
+    argparse -n prompt_pwd $options -- $argv
     or return
 
     if set -q _flag_help
         __fish_print_help prompt_pwd
         return 0
     end
+
+    set -q argv[1]
+    or set argv $PWD
 
     set -ql _flag_d
     and set -l fish_prompt_pwd_dir_length $_flag_d
@@ -19,24 +22,26 @@ function prompt_pwd --description 'Print the current working directory, shortene
     and set fish_prompt_pwd_full_dirs $_flag_D
 
     set -q fish_prompt_pwd_full_dirs
-    or set -l fish_prompt_pwd_full_dirs 0
+    or set -l fish_prompt_pwd_full_dirs 1
 
-    # Replace $HOME with "~"
-    set -l realhome ~
-    set -l tmp (string replace -r '^'"$realhome"'($|/)' '~$1' $PWD)
+    for path in $argv
+        # Replace $HOME with "~"
+        set -l realhome ~
+        set -l tmp (string replace -r '^'"$realhome"'($|/)' '~$1' $path)
 
-    if test "$fish_prompt_pwd_dir_length" -eq 0
-        echo $tmp
-    else
-        # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
-        # with full-length-dirs components left at full length.
-        set -l full
-        if test $fish_prompt_pwd_full_dirs -gt 0
-            set -l all (string split -m (math $fish_prompt_pwd_full_dirs - 1) -r / $tmp)
-            set tmp $all[1]
-            set full $all[2..]
+        if test "$fish_prompt_pwd_dir_length" -eq 0
+            echo $tmp
+        else
+            # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
+            # with full-length-dirs components left at full length.
+            set -l full
+            if test $fish_prompt_pwd_full_dirs -gt 0
+                set -l all (string split -m (math $fish_prompt_pwd_full_dirs - 1) -r / $tmp)
+                set tmp $all[1]
+                set full $all[2..]
+            end
+
+            string join / (string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp) $full
         end
-
-        string join / (string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp) $full
     end
 end

--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -1,5 +1,5 @@
-function prompt_pwd --description "Print the current working directory, shortened to fit the prompt"
-    set -l options h/help
+function prompt_pwd --description 'Print the current working directory, shortened to fit the prompt'
+    set -l options h/help d/dir-length= D/full-length-dirs=
     argparse -n prompt_pwd --max-args=0 $options -- $argv
     or return
 
@@ -8,18 +8,35 @@ function prompt_pwd --description "Print the current working directory, shortene
         return 0
     end
 
-    # This allows overriding fish_prompt_pwd_dir_length from the outside (global or universal) without leaking it
+    set -ql _flag_d
+    and set -l fish_prompt_pwd_dir_length $_flag_d
+
     set -q fish_prompt_pwd_dir_length
     or set -l fish_prompt_pwd_dir_length 1
+
+    set -l fulldirs 0
+    set -ql _flag_D
+    and set fish_prompt_pwd_full_dirs $_flag_D
+
+    set -q fish_prompt_pwd_full_dirs
+    or set -l fish_prompt_pwd_full_dirs 0
 
     # Replace $HOME with "~"
     set -l realhome ~
     set -l tmp (string replace -r '^'"$realhome"'($|/)' '~$1' $PWD)
 
-    if [ $fish_prompt_pwd_dir_length -eq 0 ]
+    if test "$fish_prompt_pwd_dir_length" -eq 0
         echo $tmp
     else
         # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
-        string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
+        # with full-length-dirs components left at full length.
+        set -l full
+        if test $fish_prompt_pwd_full_dirs -gt 0
+            set -l all (string split -m (math $fish_prompt_pwd_full_dirs - 1) -r / $tmp)
+            set tmp $all[1]
+            set full $all[2..]
+        end
+
+        string join / (string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp) $full
     end
 end

--- a/tests/checks/prompt.fish
+++ b/tests/checks/prompt.fish
@@ -1,0 +1,13 @@
+#RUN: %fish %s
+
+prompt_pwd -d 1 /foo/bar/baz
+# CHECK: /f/b/baz
+
+prompt_pwd /usr/share/fish/tools/web_config/sample_prompts
+# CHECK: /u/s/f/t/w/sample_prompts
+
+prompt_pwd -D 2 /usr/share/fish/tools/web_config/sample_prompts
+# CHECK: /u/s/f/t/web_config/sample_prompts
+
+prompt_pwd -D 0 /usr/share/fish/tools/web_config/sample_prompts
+# CHECK: /u/s/f/t/w/sample_prompts

--- a/tests/checks/prompt.fish
+++ b/tests/checks/prompt.fish
@@ -10,4 +10,4 @@ prompt_pwd -D 2 /usr/share/fish/tools/web_config/sample_prompts
 # CHECK: /u/s/f/t/web_config/sample_prompts
 
 prompt_pwd -D 0 /usr/share/fish/tools/web_config/sample_prompts
-# CHECK: /u/s/f/t/w/sample_prompts
+# CHECK: /u/s/f/t/w/s


### PR DESCRIPTION
## Description

This allows specifying to `prompt_pwd` that you'd like to keep the last N components at full length instead of shortening them.

This can be done either by setting $fish_prompt_pwd_full_dirs to the number, or passing the new `--full-length-dirs`/`-D` option.

The rationale for that is that the earlier path components are typically slower changing and known - it's often something like ~/dev/. So by keeping these short, more space can be kept for the components at the end that are more important and faster changing.

Similarly, instead of setting `$fish_prompt_pwd_dir_length`, this adds a `--dir-length`/`-d` option for symmetry, and allows passing the directory so that we can better test this. Options are probably the much nicer interface here anyway.

(we have had someone open a PR about this years ago, which I rejected. I'm afraid I was wrong, sorry!)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
