### PR TITLE
Fix dirs returns false when $dirstack is empty

### DIFF
--- a/share/functions/dirs.fish
+++ b/share/functions/dirs.fish
@@ -16,4 +16,5 @@ function dirs --description 'Print directory stack'
 
     # Replace $HOME with ~.
     string replace -r '^'"$HOME"'($|/)' '~$1' -- $PWD $dirstack | string join " "
+    return 0
 end


### PR DESCRIPTION
## Description

In fish 3.3.1, when `$dirstack` is empty, `dirs` returns false. This is undesirable, because no error occurred. 

It happens because the `string join` at the end doesn't join anything, so it returns false. The solution is just to add a `return 0` at the end of the function.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
