### PR TITLE
`set -q`: Return 255 if no variable name was passed

### DIFF
--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -59,7 +59,7 @@ The following other options are available:
 
 - ``-e`` or ``--erase`` causes the specified shell variables to be erased
 
-- ``-q`` or ``--query`` test if the specified variable names are defined. Does not output anything, but the builtins exit status is the number of variables specified that were not defined, or 255 if more than 255 variables are not defined.
+- ``-q`` or ``--query`` test if the specified variable names are defined. Does not output anything, but the builtins exit status is the number of variables specified that were not defined, up to a maximum of 255. If no variable was given, it also returns 255.
 
 - ``-n`` or ``--names``: List only the names of all defined variables, not their value. The names are guaranteed to be sorted.
 

--- a/src/builtin_set.cpp
+++ b/src/builtin_set.cpp
@@ -466,6 +466,10 @@ static int builtin_set_query(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
     int retval = 0;
     env_mode_flags_t scope = compute_scope(opts);
 
+    // No variables given, this is an error.
+    // 255 is the maximum return code we allow.
+    if (argc == 0) return 255;
+
     for (int i = 0; i < argc; i++) {
         auto split = split_var_and_indexes(argv[i], scope, parser.vars(), streams);
         if (!split) {

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -820,3 +820,11 @@ function erase-funcvar
 end
 
 erase-funcvar
+
+set --query $this_is_not_set
+echo $status
+# CHECK: 255
+
+set --query
+echo $status
+# CHECK: 255


### PR DESCRIPTION
## Description

Previously this strictly returned the number of unset variables. So if
no variable was given, it would return *true*, which is highly
suspect.

Inspired by re-reading #4033.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Note: This is *technically* backwards-incompatible. In practice most code that triggers this is probably buggy.

E.g.

```fish
if set -q $foo
```

would enter that if-block (note the stray `$`), which would most likely expect the variable called "foo" to be defined.