### PR TITLE
completion: support `--no` prefixes for mpv flag options

### DIFF
--- a/share/completions/mpv.fish
+++ b/share/completions/mpv.fish
@@ -3,8 +3,14 @@ for opt in $options
     complete -c mpv -l "$opt"
 end
 
+set -l flag_options (string replace -fr '^\s*--([\w-]+).*Flag.*' '$1' -- (command mpv --list-options 2>/dev/null))
+for flag_opt in $flag_options
+    complete -c mpv -l "no-$flag_opt"
+end
+
 complete -c mpv -l start -x -d "Seek to given position (%, s, hh:mm:ss)"
 complete -c mpv -l no-audio -d "Disable audio"
+complete -c mpv -l no-audio-display -d "Hide attached picture for audio"
 complete -c mpv -l no-video -d "Disable video"
 complete -c mpv -l fs -d "Fullscreen playback"
 complete -c mpv -l sub-file -r -d "Specify subtitle file"


### PR DESCRIPTION
## Description

mpv options that are labelled as "Flag" under `mpv --list-options` can be prefixed with `--no` to disable that option, but these `--no` prefixed options are currently not completed, so this addition fixes that. It also specifically adds the `--no-audio-display` option (because this is not marked as a "Flag" and so is not caught by the aforementioned changes) and adds a description for it.

~~Fixes issue #~~

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
