### PR TITLE
edit_command_buffer: use "command" to ignore any functions with the same name

### DIFF
--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -2,7 +2,7 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
     set -l f (mktemp)
     or return 1
     if set -q f[1]
-        mv $f $f.fish
+        command mv $f $f.fish
         set f $f.fish
     else
         # We should never execute this block but better to be paranoid.
@@ -11,7 +11,7 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
         else
             set f /tmp/fish.$fish_pid.fish
         end
-        touch $f
+        command touch $f
         or return 1
     end
 


### PR DESCRIPTION
## Description

When function is defined with the same command name, it causes unwanted side effect.

For example, when we defined function "mv" like this
```
# Defined in /Users/rok/.config/fish/functions/mv.fish @ line 1
function mv
  command mv -n -v $argv
end
```

![image](https://user-images.githubusercontent.com/50316549/129654453-a576f62e-db85-4c73-8e71-f94637bb6747.png)


