### PR TITLE
tinyexpr: convert typedef to using manually

### DIFF
--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -68,14 +68,14 @@ static int get_arity(const int type) {
     return 0;
 }
 
-typedef struct te_expr {
+using te_expr = struct te_expr {
     int type;
     union {
         double value;
         void *function;
     };
     te_expr *parameters[];
-} te_expr;
+};
 
 using te_builtin = struct {
     const wchar_t *name;


### PR DESCRIPTION
clang-tidy fails hard at transforming this.

Signed-off-by: Rosen Penev <rosenp@gmail.com>