### PR TITLE
clang-tidy: remove redundant initializer

### DIFF
--- a/src/topic_monitor.cpp
+++ b/src/topic_monitor.cpp
@@ -23,7 +23,7 @@ wcstring generation_list_t::describe() const {
     return result;
 }
 
-binary_semaphore_t::binary_semaphore_t() : sem_ok_(false) {
+binary_semaphore_t::binary_semaphore_t() {
     // sem_init always fails with ENOSYS on Mac and has an annoying deprecation warning.
     // On BSD sem_init uses a file descriptor under the hood which doesn't get CLOEXEC (see #7304).
     // So use fast semaphores on Linux only.


### PR DESCRIPTION
It's already defaulted to false.

Signed-off-by: Rosen Penev <rosenp@gmail.com>