### PR TITLE
convert const ref to rvalue ref

### DIFF
--- a/src/fd_monitor.cpp
+++ b/src/fd_monitor.cpp
@@ -199,7 +199,7 @@ void fd_monitor_t::run_in_background() {
     }
 }
 
-void fd_monitor_t::poke_in_background(const poke_list_t &pokelist) {
+void fd_monitor_t::poke_in_background(poke_list_t pokelist) {
     ASSERT_IS_BACKGROUND_THREAD();
     auto poker = [&pokelist](fd_monitor_item_t &item) {
         int fd = item.fd.fd();

--- a/src/fd_monitor.h
+++ b/src/fd_monitor.h
@@ -110,7 +110,7 @@ class fd_monitor_t {
     // Poke items in the pokelist, removing any items that close their FD.
     // The pokelist is consumed after this.
     // This is only called in the background thread.
-    void poke_in_background(const poke_list_t &pokelist);
+    void poke_in_background(poke_list_t pokelist);
 
     // The list of items to monitor. This is only accessed on the background thread.
     item_list_t items_{};

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -282,7 +282,7 @@ shared_ptr<const io_data_t> io_chain_t::io_for_fd(int fd) const {
     return nullptr;
 }
 
-void output_stream_t::append_narrow_buffer(const separated_buffer_t &buffer) {
+void output_stream_t::append_narrow_buffer(separated_buffer_t buffer) {
     for (const auto &rhs_elem : buffer.elements()) {
         append_with_separation(str2wcstring(rhs_elem.contents), rhs_elem.separation);
     }

--- a/src/io.h
+++ b/src/io.h
@@ -381,7 +381,7 @@ class output_stream_t : noncopyable_t, nonmovable_t {
     void push_back(wchar_t c) { append(c); }
 
     // Append data from a narrow buffer, widening it.
-    void append_narrow_buffer(const separated_buffer_t &buffer);
+    void append_narrow_buffer(separated_buffer_t buffer);
 
     /// Append a format string.
     void append_format(const wchar_t *format, ...) {


### PR DESCRIPTION
clang-tidy wrongly sees an std::move to a const ref parameter and
believes it to be pointless. The copy constructor however is deleted.

Signed-off-by: Rosen Penev <rosenp@gmail.com>