### PR TITLE
fix deleted constructors

### DIFF
--- a/src/env_universal_common.h
+++ b/src/env_universal_common.h
@@ -179,13 +179,11 @@ class universal_notifier_t {
         strategy_named_pipe,
     };
 
+    universal_notifier_t(const universal_notifier_t &) = delete;
+    universal_notifier_t &operator=(const universal_notifier_t &) = delete;
+
    protected:
     universal_notifier_t();
-
-   private:
-    // No copying.
-    universal_notifier_t &operator=(const universal_notifier_t &);
-    universal_notifier_t(const universal_notifier_t &x);
 
    public:
     static notifier_strategy_t resolve_default_strategy();

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -42,8 +42,8 @@ class pending_signals_t {
     pending_signals_t() = default;
 
     /// No copying.
-    pending_signals_t(const pending_signals_t &);
-    void operator=(const pending_signals_t &);
+    pending_signals_t(const pending_signals_t &) = delete;
+    pending_signals_t& operator=(const pending_signals_t &) = delete;
 
     /// Mark a signal as pending. This may be called from a signal handler.
     /// We expect only one signal handler to execute at once.

--- a/src/parser.h
+++ b/src/parser.h
@@ -269,10 +269,6 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     /// to profile_items). deque does not move items on reallocation.
     std::deque<profile_item_t> profile_items;
 
-    // No copying allowed.
-    parser_t(const parser_t &);
-    parser_t &operator=(const parser_t &);
-
     /// Adds a job to the beginning of the job list.
     void job_add(shared_ptr<job_t> job);
 
@@ -290,6 +286,10 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     static std::shared_ptr<parser_t> principal;
 
    public:
+    // No copying allowed.
+    parser_t(const parser_t &) = delete;
+    parser_t &operator=(const parser_t &) = delete;
+
     /// Get the "principal" parser, whatever that is.
     static parser_t &principal_parser();
 


### PR DESCRIPTION
Some of these have C++98 heritage. C++11 allows public deleted copy/move stuff. 