### PR TITLE
clang-tidy: const reference conversions

### DIFF
--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -201,7 +201,7 @@ struct options_t {  //!OCLINT(too many fields)
     escape_string_style_t escape_style = STRING_STYLE_SCRIPT;
 };
 
-static size_t width_without_escapes(wcstring ins) {
+static size_t width_without_escapes(const wcstring &ins) {
     ssize_t width = 0;
     // TODO: this is the same as fish_wcwidth_min_0 from screen.cpp
     // Make that reusable (and add a wcswidth version).

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -722,8 +722,8 @@ static launch_result_t exec_block_or_func_process(parser_t &parser, const std::s
 
 static proc_performer_t get_performer_for_builtin(
     process_t *p, job_t *job, const io_chain_t &io_chain,
-    const std::shared_ptr<output_stream_t> output_stream,
-    const std::shared_ptr<output_stream_t> errput_stream) {
+    const std::shared_ptr<output_stream_t> &output_stream,
+    const std::shared_ptr<output_stream_t> &errput_stream) {
     assert(p->type == process_type_t::builtin && "Process must be a builtin");
 
     // Determine if we have a "direct" redirection for stdin.


### PR DESCRIPTION
These are only read from.

Signed-off-by: Rosen Penev <rosenp@gmail.com>