### PR TITLE
No more sys_errlist

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -108,7 +108,6 @@ check_struct_has_member("struct stat" st_mtimespec.tv_nsec "sys/stat.h"
     HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC LANGUAGE CXX)
 check_struct_has_member("struct stat" st_mtim.tv_nsec "sys/stat.h" HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC
     LANGUAGE CXX)
-check_cxx_symbol_exists(sys_errlist stdio.h HAVE_SYS_ERRLIST)
 check_include_file_cxx(sys/ioctl.h HAVE_SYS_IOCTL_H)
 check_include_file_cxx(sys/select.h HAVE_SYS_SELECT_H)
 check_include_files("sys/types.h;sys/sysctl.h" HAVE_SYS_SYSCTL_H)

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -142,8 +142,6 @@ endif()
 list(APPEND WCSTOD_L_INCLUDES "wchar.h")
 check_cxx_symbol_exists(wcstod_l "${WCSTOD_L_INCLUDES}" HAVE_WCSTOD_L)
 
-check_cxx_symbol_exists(_sys_errs stdlib.h HAVE__SYS__ERRS)
-
 cmake_push_check_state()
 set(CMAKE_EXTRA_INCLUDE_FILES termios.h sys/ioctl.h)
 check_type_size("struct winsize" STRUCT_WINSIZE LANGUAGE CXX)

--- a/config_cmake.h.in
+++ b/config_cmake.h.in
@@ -91,9 +91,6 @@
 /* Define to 1 if `st_mtim.tv_nsec' is a member of `struct stat'. */
 #cmakedefine HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
 
-/* Define to 1 if the sys_errlist array is available. */
-#cmakedefine HAVE_SYS_ERRLIST 1
-
 /* Define to 1 if you have the <sys/ioctl.h> header file. */
 #cmakedefine HAVE_SYS_IOCTL_H 1
 

--- a/config_cmake.h.in
+++ b/config_cmake.h.in
@@ -133,9 +133,6 @@
 /* Define to 1 if std::make_unique is available. */
 #cmakedefine HAVE_STD__MAKE_UNIQUE 1
 
-/* Define to 1 if the _sys_errs array is available. */
-#cmakedefine HAVE__SYS__ERRS 1
-
 /* Define to 1 to disable ncurses macros that conflict with the STL */
 #define NCURSES_NOMACROS 1
 

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -472,7 +472,10 @@ void safe_report_exec_error(int err, const char *actual_cmd, const char *const *
             FLOGF_SAFE(exec, "Failed to execute process '%s': Unsupported format.", actual_cmd);
             break;
         }
-        case EISDIR:
+        case EISDIR: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': File is a directory.", actual_cmd);
+            break;
+        }
         case ENOTDIR: {
             FLOGF_SAFE(exec, "Failed to execute process '%s': A path component is not a directory.", actual_cmd);
             break;

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -370,12 +370,11 @@ void safe_report_exec_error(int err, const char *actual_cmd, const char *const *
         }
 
         case ENOEXEC: {
-            const char *err_text = safe_strerror(err);
             FLOGF_SAFE(
                 exec,
-                "%s. The file '%s' is marked as an executable but could not be run by the "
+                "The file '%s' is marked as an executable but could not be run by the "
                 "operating system.",
-                err_text, actual_cmd);
+                actual_cmd);
             break;
         }
 
@@ -415,10 +414,31 @@ void safe_report_exec_error(int err, const char *actual_cmd, const char *const *
             FLOGF_SAFE(exec, "Out of memory");
             break;
         }
-
+        case EACCES: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': The file could not be accessed.", actual_cmd);
+            break;
+        }
+        case ETXTBSY: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': File is currently open for writing.", actual_cmd);
+            break;
+        }
+        case ELOOP: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': Too many layers of symbolic links.", actual_cmd);
+            break;
+        }
+        case EINVAL: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': Unsupported format.", actual_cmd);
+            break;
+        }
+        case ENOTDIR: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': A path component is not a directory.", actual_cmd);
+            break;
+        }
+        
         default: {
-            const char *err = safe_strerror(errno);
-            FLOGF_SAFE(exec, "%s", err);
+            char errnum_buff[64];
+            format_long_safe(errnum_buff, err);
+            FLOGF_SAFE(exec, "Failed to execute process '%s', unknown error number %d", actual_cmd, errnum_buff);
             break;
         }
     }

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -480,7 +480,7 @@ void safe_report_exec_error(int err, const char *actual_cmd, const char *const *
         default: {
             char errnum_buff[64];
             format_long_safe(errnum_buff, err);
-            FLOGF_SAFE(exec, "Failed to execute process '%s', unknown error number %d", actual_cmd, errnum_buff);
+            FLOGF_SAFE(exec, "Failed to execute process '%s', unknown error number %s", actual_cmd, errnum_buff);
             break;
         }
     }

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -239,7 +239,7 @@ pid_t execute_fork() {
         default: {
             char errno_buff[64];
             format_long_safe(errno_buff, errno);
-            FLOGF_SAFE(error, "setpgid: Unknown error number %s", errno_buff);
+            FLOGF_SAFE(error, "fork: Unknown error number %s", errno_buff);
             break;
         }
     }

--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -82,7 +82,7 @@ void report_setpgid_error(int err, bool is_parent, pid_t desired_pgid, const job
             break;
         }
         case ESRCH: {
-            FLOGF_SAFE(error, "setpgid: Process id %d does not match", pid_buff);
+            FLOGF_SAFE(error, "setpgid: Process ID %s does not match", pid_buff);
             break;
         }
         default: {
@@ -465,18 +465,35 @@ void safe_report_exec_error(int err, const char *actual_cmd, const char *const *
             break;
         }
         case ELOOP: {
-            FLOGF_SAFE(exec, "Failed to execute process '%s': Too many layers of symbolic links.", actual_cmd);
+            FLOGF_SAFE(exec, "Failed to execute process '%s': Too many layers of symbolic links. Maybe a loop?", actual_cmd);
             break;
         }
         case EINVAL: {
             FLOGF_SAFE(exec, "Failed to execute process '%s': Unsupported format.", actual_cmd);
             break;
         }
+        case EISDIR:
         case ENOTDIR: {
             FLOGF_SAFE(exec, "Failed to execute process '%s': A path component is not a directory.", actual_cmd);
             break;
         }
         
+        case EMFILE: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': Too many open files in this process.", actual_cmd);
+            break;
+        }
+        case ENFILE: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': Too many open files on the system.", actual_cmd);
+            break;
+        }
+        case ENAMETOOLONG: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': Name is too long.", actual_cmd);
+            break;
+        }
+        case EPERM: {
+            FLOGF_SAFE(exec, "Failed to execute process '%s': No permission. Either suid/sgid is forbidden or you lack capabilities.", actual_cmd);
+            break;
+        }
         default: {
             char errnum_buff[64];
             format_long_safe(errnum_buff, err);

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -203,10 +203,6 @@ int make_fd_blocking(int fd) {
     return err == -1 ? errno : 0;
 }
 
-static inline void safe_append(char *buffer, const char *s, size_t buffsize) {
-    std::strncat(buffer, s, buffsize - std::strlen(buffer) - 1);
-}
-
 /// Wide character realpath. The last path component does not need to be valid. If an error occurs,
 /// wrealpath() returns none() and errno is likely set.
 maybe_t<wcstring> wrealpath(const wcstring &pathname) {

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -207,24 +207,6 @@ static inline void safe_append(char *buffer, const char *s, size_t buffsize) {
     std::strncat(buffer, s, buffsize - std::strlen(buffer) - 1);
 }
 
-void safe_perror(const char *message) {
-    // Note we cannot use strerror, because on Linux it uses gettext, which is not safe.
-    int err = errno;
-
-    char buff[384];
-    buff[0] = '\0';
-
-    if (message) {
-        safe_append(buff, message, sizeof buff);
-        safe_append(buff, ": ", sizeof buff);
-    }
-    safe_append(buff, safe_strerror(err), sizeof buff);
-    safe_append(buff, "\n", sizeof buff);
-
-    ignore_result(write(STDERR_FILENO, buff, std::strlen(buff)));
-    errno = err;
-}
-
 /// Wide character realpath. The last path component does not need to be valid. If an error occurs,
 /// wrealpath() returns none() and errno is likely set.
 maybe_t<wcstring> wrealpath(const wcstring &pathname) {

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -40,12 +40,6 @@ int wunlink(const wcstring &file_name);
 /// Wide character version of perror().
 void wperror(const wchar_t *s);
 
-/// Async-safe version of perror().
-void safe_perror(const char *message);
-
-/// Async-safe version of std::strerror().
-const char *safe_strerror(int err);
-
 /// Wide character version of getcwd().
 wcstring wgetcwd();
 


### PR DESCRIPTION
## Description

This removes safe_strerror and safe_perror (which uses the former internally), and replaces it with hardcoded error messages.

The impetus for this is that glibc actually *removed* sys_errlist and according to #7006 we can't use strerror_r either.

I looked up the used errno values I could find. It's possible these are incomplete, in which case we get more "Unknown error $errno" messages, but I don't think that should be a common thing, and on current glibc that's already *all* of the errors here (except for the exec errors that we already explained).

Fixes issue #4183.

Ideally I would like this to be included in 3.4.0, provided we can get enough testing.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
