### PR TITLE
clang-tidy: simplify two bool returns

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1174,9 +1174,7 @@ static bool should_import_bash_history_line(const wcstring &line) {
     // In doing this test do not allow incomplete strings. Hence the "false" argument.
     parse_error_list_t errors;
     parse_util_detect_errors(line, &errors);
-    if (!errors.empty()) return false;
-
-    return true;
+    return errors.empty();
 }
 
 /// Import a bash command history file. Bash's history format is very simple: just lines with #s for

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -105,8 +105,7 @@ bool path_is_executable(const std::string &path) {
         if (errno != EACCES) wperror(L" stat");
         return false;
     }
-    if (!S_ISREG(buff.st_mode)) return false;
-    return true;
+    return S_ISREG(buff.st_mode);
 }
 
 /// \return 1 if the path is remote, 0 if local, -1 if unknown.


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>