### PR TITLE
clang-tidy: replace push_back with emplace_back

### DIFF
--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -171,7 +171,7 @@ static bool pushd(const char *path) {
         err(L"getcwd() from pushd() failed: errno = %d", errno);
         return false;
     }
-    pushed_dirs.push_back(cwd);
+    pushed_dirs.emplace_back(cwd);
 
     // We might need to create the directory. We don't care if this fails due to the directory
     // already being present.
@@ -2099,7 +2099,7 @@ struct pwd_environment_t : public test_environment_t {
         auto res = test_environment_t::get_names(flags);
         res.clear();
         if (std::count(res.begin(), res.end(), L"PWD") == 0) {
-            res.push_back(L"PWD");
+            res.emplace_back(L"PWD");
         }
         return res;
     }
@@ -5508,7 +5508,7 @@ static void test_highlighting() {
         for (const highlight_component_t &comp : components) {
             if (!text.empty() && !comp.nospace) {
                 text.push_back(L' ');
-                expected_colors.push_back(highlight_spec_t{});
+                expected_colors.emplace_back();
             }
             text.append(comp.txt);
             expected_colors.resize(text.size(), comp.color);

--- a/src/iothread.cpp
+++ b/src/iothread.cpp
@@ -329,7 +329,7 @@ void iothread_perform_on_main(const void_function_t &func) {
         wait_until_done.set_value();
     };
     // Append it. Ensure we don't hold the lock after.
-    s_main_thread_queue.acquire()->requests.push_back(std::move(handler));
+    s_main_thread_queue.acquire()->requests.emplace_back(std::move(handler));
 
     // Tell the signaller and then wait until our future is set.
     get_notify_signaller().post();


### PR DESCRIPTION
clang-tidy marks these as needing emplace_back as the types to not
match.

Signed-off-by: Rosen Penev <rosenp@gmail.com>