### PR TITLE
clang-tidy: replace size comparisons with empty

### DIFF
--- a/src/builtin_functions.cpp
+++ b/src/builtin_functions.cpp
@@ -288,7 +288,7 @@ maybe_t<int> builtin_functions(parser_t &parser, io_streams_t &streams, const wc
                 buff.append(name);
                 buff.append(L", ");
             }
-            if (names.size() > 0) {
+            if (!names.empty()) {
                 // Trim trailing ", "
                 buff.resize(buff.size() - 2, '\0');
             }

--- a/src/builtin_string.cpp
+++ b/src/builtin_string.cpp
@@ -1539,7 +1539,7 @@ static int string_split_maybe0(parser_t &parser, io_streams_t &streams, int argc
     int retval = parse_opts(&opts, &optind, is_split0 ? 0 : 1, argc, argv, parser, streams);
     if (retval != STATUS_CMD_OK) return retval;
 
-    if (opts.fields.size() < 1 && opts.allow_empty) {
+    if (opts.fields.empty() && opts.allow_empty) {
         streams.err.append_format(BUILTIN_ERR_COMBO2, cmd,
                                   _(L"--allow-empty is only valid with --fields"));
         return STATUS_INVALID_ARGS;
@@ -1584,7 +1584,7 @@ static int string_split_maybe0(parser_t &parser, io_streams_t &streams, int argc
                 // Remove the last element if it is empty.
                 if (splits.back().empty()) splits.pop_back();
             }
-            if (opts.fields.size() > 0) {
+            if (!opts.fields.empty()) {
                 // Print nothing and return error if any of the supplied
                 // fields do not exist, unless `--allow-empty` is used.
                 if (!opts.allow_empty) {

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2505,7 +2505,7 @@ static void test_path() {
     do_test(path_apply_working_directory(L"abc/", L"/def/") == L"/def/abc/");
     do_test(path_apply_working_directory(L"/abc/", L"/def/") == L"/abc/");
     do_test(path_apply_working_directory(L"/abc", L"/def/") == L"/abc");
-    do_test(path_apply_working_directory(L"", L"/def/") == L"");
+    do_test(path_apply_working_directory(L"", L"/def/").empty());
     do_test(path_apply_working_directory(L"abc", L"") == L"abc");
 }
 
@@ -3258,15 +3258,15 @@ static void test_complete() {
 
     // But not with the command prefix.
     completions = do_complete(L"echo (command scuttlebut", {});
-    do_test(completions.size() == 0);
+    do_test(completions.empty());
 
     // Not with the builtin prefix.
     completions = do_complete(L"echo (builtin scuttlebut", {});
-    do_test(completions.size() == 0);
+    do_test(completions.empty());
 
     // Not after a redirection.
     completions = do_complete(L"echo hi > scuttlebut", {});
-    do_test(completions.size() == 0);
+    do_test(completions.empty());
 
     // Trailing spaces (#1261).
     completion_mode_t no_files{};
@@ -3319,7 +3319,7 @@ static void test_complete() {
     do_test(completions.size() == 1);
     do_test(completions.at(0).completion == L"stfile");
     completions = do_complete(L"something abc=stfile", {});
-    do_test(completions.size() == 0);
+    do_test(completions.empty());
     completions = do_complete(L"something abc=stfile", completion_request_t::fuzzy_match);
     do_test(completions.size() == 1);
     do_test(completions.at(0).completion == L"abc=testfile");
@@ -3785,7 +3785,7 @@ static void test_undo() {
 
     editable_line_t line;
     do_test(!line.undo());  // nothing to undo
-    do_test(line.text() == L"");
+    do_test(line.text().empty());
     do_test(line.position() == 0);
     line.push_edit(edit_t(0, 0, L"a b c"));
     do_test(line.text() == L"a b c");
@@ -5547,7 +5547,7 @@ static void test_split_string_tok() {
     do_test((splits == wcstring_list_t{L"hello", L"world"}));
 
     splits = split_string_tok(L" stuff ", wcstring(L" "), 0);
-    do_test((splits == wcstring_list_t{}));
+    do_test((splits.empty()));
 
     splits = split_string_tok(L" stuff ", wcstring(L" "), 1);
     do_test((splits == wcstring_list_t{L" stuff "}));

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2806,7 +2806,7 @@ static int read_i(parser_t &parser) {
     }
 
     // If we are the last reader, then kill remaining jobs before exiting.
-    if (reader_data_stack.size() == 0) {
+    if (reader_data_stack.empty()) {
         // Send the exit event and then commit to not executing any more fish script.
         s_exit_state = exit_state_t::running_handlers;
         event_fire_generic(parser, L"fish_exit");
@@ -2992,7 +2992,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             break;
         }
         case rl::cancel_commandline: {
-            if (command_line.size()) {
+            if (!command_line.empty()) {
                 outputter_t &outp = outputter_t::stdoutput();
                 // Move cursor to the end of the line.
                 update_buff_pos(&command_line, command_line.size());


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>