### PR TITLE
clang-tidy: run through normal checks

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -739,7 +739,7 @@ static expand_result_t expand_cmdsubst(wcstring input, const operation_context_t
         }
         wcstring sub_res_joined;
         sub_res_joined.reserve(approx_size);
-        for (const wcstring &line : sub_res) {
+        for (wcstring &line : sub_res) {
             sub_res_joined.append(escape_string_for_double_quotes(std::move(line)));
             sub_res_joined.push_back(L'\n');
         }

--- a/src/fds.cpp
+++ b/src/fds.cpp
@@ -100,7 +100,7 @@ fd_event_signaller_t::fd_event_signaller_t() {
 int fd_event_signaller_t::write_fd() const { return write_.fd(); }
 #endif
 
-bool fd_event_signaller_t::try_consume() {
+bool fd_event_signaller_t::try_consume() const {
     // If we are using eventfd, we want to read a single uint64.
     // If we are using pipes, read a lot; note this may leave data on the pipe if post has been
     // called many more times. In no case do we care about the data which is read.

--- a/src/fds.h
+++ b/src/fds.h
@@ -130,7 +130,7 @@ class fd_event_signaller_t {
     /// If an event is signalled, consume it; otherwise return.
     /// This does not block.
     /// This retries on EINTR.
-    bool try_consume();
+    bool try_consume() const;
 
     /// Mark that an event has been received. This may be coalesced.
     /// This retries on EINTR.

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -6217,7 +6217,7 @@ void test_prompt_truncation() {
 
     /// Helper to return 'layout' formatted as a string for easy comparison.
     auto format_layout = [&] {
-        wcstring line_breaks = L"";
+        wcstring line_breaks;
         bool first = true;
         for (const size_t line_break : layout.line_breaks) {
             if (!first) {

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -824,7 +824,7 @@ class highlighter_t {
     void visit(const ast::variable_assignment_t &varas);
     void visit(const ast::semi_nl_t &semi_nl);
     void visit(const ast::decorated_statement_t &stmt);
-    void visit(const ast::block_statement_t &header);
+    void visit(const ast::block_statement_t &block);
 
     // Visit an argument, perhaps knowing that our command is cd.
     void visit(const ast::argument_t &arg, bool cmd_is_cd = false);

--- a/src/iothread.h
+++ b/src/iothread.h
@@ -80,7 +80,7 @@ class debounce_t {
 
     /// One-argument form with no completion.
     /// The result is a token which is only of interest to the tests.
-    uint64_t perform(std::function<void()> func);
+    uint64_t perform(std::function<void()> handler);
 
     explicit debounce_t(long timeout_msec = 0);
     ~debounce_t();

--- a/src/output.h
+++ b/src/output.h
@@ -56,7 +56,7 @@ class outputter_t {
     bool write_color(rgb_color_t color, bool is_fg);
 
     /// Set the foreground and background color.
-    void set_color(rgb_color_t c, rgb_color_t c2);
+    void set_color(rgb_color_t fg, rgb_color_t bg);
 
     /// Write a wide character to the receiver.
     void writech(wchar_t ch) { writestr(&ch, 1); }


### PR DESCRIPTION
There's a .clang-tidy file in here.

Signed-off-by: Rosen Penev <rosenp@gmail.com>
