### PR TITLE
docs: Fix missing semicolon in Bash group command example

### DIFF
--- a/doc_src/fish_for_bash_users.rst
+++ b/doc_src/fish_for_bash_users.rst
@@ -294,7 +294,7 @@ This includes things like:
 
     (foo; bar) | baz
     # when it should really have been:
-    { foo; bar } | baz
+    { foo; bar; } | baz
     # becomes
     begin; foo; bar; end | baz
 


### PR DESCRIPTION
## Description

Fix missing semicolon in Bash group command example in `fish_for_bash_users.rst`

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
