### PR TITLE
Fix `fish_key_reader` wrapper check

### DIFF
--- a/share/functions/fish_key_reader.fish
+++ b/share/functions/fish_key_reader.fish
@@ -1,7 +1,7 @@
 # check if command fish_key_reader works and is the same version that
 # came with this fish. This will happen one time.
 command -sq fish_key_reader
-and command fish_key_reader --version 2>&1 | string match -q -- $version
+and command fish_key_reader --version 2>&1 | string match -rq -- $version
 # if alias doesn't define the function here, this is an autoloaded "nothing".
 # the command (if there is one) will be used by default.
 or alias fish_key_reader=(string escape $__fish_bin_dir/fish_key_reader)


### PR DESCRIPTION
## Description

This is an unexpected change in https://github.com/fish-shell/fish-shell/commit/9fb70371742d4f666b6ac2ea438d9b23cd75643b#diff-64ac4593cbbcb4d504e43eea2431a1f049cdb4d594317f9053370a1ea8d9b344, which makes the command always evaluate to false and creates an unnecessary alias.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
