### PR TITLE
Fix typo in abbr docs

### DIFF
--- a/doc_src/cmds/abbr.rst
+++ b/doc_src/cmds/abbr.rst
@@ -63,7 +63,7 @@ Add a new abbreviation where ``gco`` will be replaced with ``git checkout`` glob
 
     abbr -a -U l less
 
-Add a new abbreviation where ``l`` will be replaced with ``less`` universal so all shells. Note that you omit the ``-U`` since it is the default.
+Add a new abbreviation where ``l`` will be replaced with ``less`` universal to all shells. Note that you omit the ``-U`` since it is the default.
 
 
 


### PR DESCRIPTION
## Description

Fixed a typo in the `abbr` command docs. Is as changelog entry required for a docs update?

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
