### PR TITLE
Prepend command to cat

### DIFF
--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -70,7 +70,7 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
     if test $editor_status -eq 0 -a -s $f
         # Set the command to the output of the edited command and move the cursor to the
         # end of the edited command.
-        commandline -r -- (cat $f)
+        commandline -r -- (command cat $f)
         commandline -C 999999
     else
         echo


### PR DESCRIPTION
*Problem:*
edit_command_buffer uses `cat` to return the modified content.
If a person has an alias for `cat` to a different command such `bat`** the editing will not be useful anymore since bat decorates the text with frames, line counts, etc

*Solution*
Appending command to cat, fish will ignore the alias and execute the real command according to this https://fishshell.com/docs/current/cmds/command.html

** https://github.com/sharkdp/bat

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
