### PR TITLE
Make less version check compatible with older Fish

### DIFF
--- a/share/functions/__fish_print_help.fish
+++ b/share/functions/__fish_print_help.fish
@@ -121,7 +121,7 @@ function __fish_print_help --description "Print help message for the specified f
             # similar to man, but add -F to quit paging when the help output is brief (#6227)
             # Also set -X for less < v530, see #8157.
             set -l lessopts isRF
-            if test "$(less --version | string match -rg 'less (\d+)')" -lt 530 2>/dev/null
+            if test (less --version | string match -r 'less (\d+)')[2] -lt 530 2>/dev/null
                 set lessopts "$lessopts"X
             end
 

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -93,7 +93,7 @@ function history --description "display or manipulate interactive command histor
                 if not set -qx LESS
                     set -x LESS --quit-if-one-screen
                     # Also set --no-init for less < v530, see #8157.
-                    if test "$(less --version | string match -rg 'less (\d+)')" -lt 530 2>/dev/null
+                    if test (less --version | string match -r 'less (\d+)')[2] -lt 530 2>/dev/null
                         set -x LESS $LESS --no-init
                     end
                 end


### PR DESCRIPTION
## Description

First of all, the background. I've been putting the git repo of fish in my `$fish_function_path` and `$fish_complete_path` for some time, to get faster bugfixes/better completions, due to the relatively long breaks during releases (especially my experiences with *cough, 3.2.0, cough*).

I'm aware this is a rare usage and not supported, but it works fine until today I noticed 05fdee1be781009f663fb995c26142002d612afa breaks `history`, due to usage of newer syntaxes and options. In my opinion, we should try not to break things unless necessary. In this particular case:

- `string match -g` is a valid usage, but explicitly specifying `[2]` would be better and backwards-compatible.
- `"$()"` is unnecessary, and I fear the "abuse" of this syntax will just lead to more confusion when people find out unquoted `$()` behaves differently. We should prefer the Fish way.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
