### PR TITLE
Hide whatis database building from the user

### DIFF
--- a/share/functions/__fish_apropos.fish
+++ b/share/functions/__fish_apropos.fish
@@ -44,7 +44,7 @@ if test $status -eq 0 -a (count $sysver) -eq 3
         if test $age -ge $max_age
             test -d "$dir" || mkdir -m 700 -p $dir
             /usr/libexec/makewhatis -o "$whatis" (man --path | string split :) >/dev/null 2>&1 </dev/null &
-            disown
+            disown $last_pid
         end
     end
 else

--- a/share/functions/__fish_apropos.fish
+++ b/share/functions/__fish_apropos.fish
@@ -44,6 +44,7 @@ if test $status -eq 0 -a (count $sysver) -eq 3
         if test $age -ge $max_age
             test -d "$dir" || mkdir -m 700 -p $dir
             /usr/libexec/makewhatis -o "$whatis" (man --path | string split :) >/dev/null 2>&1 </dev/null &
+            disown
         end
     end
 else


### PR DESCRIPTION
## Description

It's really an internal detail, but shows up in prompts that display how many background jobs are running.

By disowning it keeps running but won't show up in `jobs` or get killed if the user exits the shell.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

---

What do you think?
