### PR TITLE
Fix typo in `set_colors` command documentation

### DIFF
--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -13,7 +13,7 @@ Synopsis
 Description
 -----------
 
-``set_color`` is used to control the color and styling of text in the terminal. ``VALUE`` describes that styling. It's a reserved color name like *red* or a RGB color value given as 3 or 6 hexadecimal digits ("F27" or "FF2277"). A special keyword *normal* resets text formatting to terminal defaults.
+``set_color`` is used to control the color and styling of text in the terminal. ``VALUE`` describes that styling. It can be a reserved color name like *red* or a RGB color value given as 3 or 6 hexadecimal digits ("F27" or "FF2277"). A special keyword *normal* resets text formatting to terminal defaults.
 
 Valid colors include:
 

--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -13,7 +13,7 @@ Synopsis
 Description
 -----------
 
-``set_color`` is used to control the color and styling of text in the terminal. ``VALUE`` describes that styling. It can be a reserved color name like *red* or a RGB color value given as 3 or 6 hexadecimal digits ("F27" or "FF2277"). A special keyword *normal* resets text formatting to terminal defaults.
+``set_color`` is used to control the color and styling of text in the terminal. ``VALUE`` describes that styling. ``VALUE`` can be a reserved color name like *red* or a RGB color value given as 3 or 6 hexadecimal digits ("F27" or "FF2277"). A special keyword *normal* resets text formatting to terminal defaults.
 
 Valid colors include:
 


### PR DESCRIPTION
## Description

Referencing the [previous commit](https://github.com/fish-shell/fish-shell/commit/1643df0d23483f84c79c0c45b014b6d4b8ca8ab4#diff-4c6511de5a67fc5797b0baa3c8fa664dfa2e0f40ea0e93539add05205054eb09R16) that touched this text to try figure out what the intended wording was. An alternative could be to replace `It` with `VALUE` because `It` could be interpreted ambiguously in this context.