### PR TITLE
completions/xbps-query: add missing `-p` completions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -106,6 +106,7 @@ Completions
   - ``dart``
 
 - Improvements to many completions, especially for ``git`` aliases (:issue:`8129`) and subcommands (:issue:`8134`).
+- Add missing completions for the ``-p`` option of ``xbps-query``.
 - The ``fish_is_nth_token`` function, which is particularly useful in completions for identifying the token number within the command line, replaces various internal functions to do the same (:issue:`8008`).
 
 Improved terminal support

--- a/share/completions/xbps-query.fish
+++ b/share/completions/xbps-query.fish
@@ -6,6 +6,39 @@ set -l progname xbps-query
 set -l listall "(__fish_print_xbps_packages)"
 set -l listinstalled "(__fish_print_xbps_packages -i)"
 
+function __fish_print_xbps_pkg_props
+        printf 'alternatives\tList of alternatives provided by the package\n'
+        printf 'architecture\tArchitecture of machine\n'
+        printf 'archive-compression-type\tType of archive\'s compression format\n'
+        printf 'automatic-install\tWas the package installed automatically\n'
+        printf 'build-options\tOptions used to build the package\n'
+        printf 'conf_files\tList of provided system configuration files\n'
+        printf 'conflicts\tList of packages the package conflicts with\n'
+        printf 'filename-sha256\tFilename\'s sha256\n'
+        printf 'filename-size\tFilename\'s size\n'
+        printf 'homepage\tHomepage of the package\n'
+        printf 'install-date\tDate the package was installed\n'
+        printf 'install-msg\tMessage printed during installation\n'
+        printf 'install-script\tPrint the package\'s install script\n'
+        printf 'installed_size\tSize of the package\n'
+        printf 'license\tLicense of the package\n'
+        printf 'maintainer\tMaintainer of the package\n'
+        printf 'metafile-sha256\tMetafile\'s sha256\n'
+        printf 'pkgver\tThe package\'s name/version tuple\n'
+        printf 'preserve\tWill files be preserved after update\n'
+        printf 'provides\tList of virtual packages provided by the package\n'
+        printf 'remove-msg\tMessage printed during removal\n'
+        printf 'remove-script\tPrint the package\'s removal script\n'
+        printf 'replaces\tList of packages the package replaces\n'
+        printf 'repository\tRepo where package was downloaded from\n'
+        printf 'run_depends\tList of packages required to run the package\n'
+        printf 'reverts\tList of versions the package reverts\n'
+        printf 'shlib-provides\tList of provided shared libraries\n'
+        printf 'shlib-requires\tList of required shared libraries\n'
+        printf 'short_desc\tShort description of the package\n'
+        printf 'source-revisions\tGit revision used to build the package\n'
+        printf 'state\tState of the package\n'
+end
 
 complete -c $progname -f
 complete -c $progname -a "$listinstalled"
@@ -17,7 +50,7 @@ complete -c $progname -s d -d 'Enable extra debugging shown to stderr'
 complete -c $progname -s h -d 'Show the help message'
 complete -c $progname -s i -d 'Ignore repositories defined in configuration files'
 complete -c $progname -s M -d 'For remote repositories, the data is fetched and stored in memory only'
-complete -c $progname -s p -d 'Only match this package property'
+complete -c $progname -s p -d 'Match one or more package properties' -xa "(__fish_complete_list , __fish_print_xbps_pkg_props)"
 complete -c $progname -s R -d 'Enable repository mode'
 complete -c $progname -l repository -d 'Append the specified repository to the top of the list'
 complete -c $progname -l regex -d 'Use Extended Regular Expressions'


### PR DESCRIPTION
## Description

Added missing completions for the `-p` option of `xbps-query`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
