### PR TITLE
Fix misleading comment in fish_prompt.fish

### DIFF
--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -19,7 +19,7 @@ function fish_prompt --description 'Write out the prompt'
     end
 
     # Write pipestatus
-    # If the status was carried over (e.g. after `set`), don't bold it.
+    # If the status was carried over (i.e. when no command is issued), don't bold it.
     set -l bold_flag --bold
     set -q __fish_prompt_status_generation; or set -g __fish_prompt_status_generation $status_generation
     if test $__fish_prompt_status_generation = $status_generation

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -19,7 +19,7 @@ function fish_prompt --description 'Write out the prompt'
     end
 
     # Write pipestatus
-    # If the status was carried over (i.e. when no command is issued), don't bold it.
+    # If the status was carried over (if no command is issued or if `set` leaves the status untouched), don't bold it.
     set -l bold_flag --bold
     set -q __fish_prompt_status_generation; or set -g __fish_prompt_status_generation $status_generation
     if test $__fish_prompt_status_generation = $status_generation

--- a/share/tools/web_config/sample_prompts/default.fish
+++ b/share/tools/web_config/sample_prompts/default.fish
@@ -19,7 +19,7 @@ function fish_prompt --description 'Write out the prompt'
     end
 
     # Write pipestatus
-    # If the status was carried over (e.g. after `set`), don't bold it.
+    # If the status was carried over (i.e. when no command is issued), don't bold it.
     set -l bold_flag --bold
     set -q __fish_prompt_status_generation; or set -g __fish_prompt_status_generation $status_generation
     if test $__fish_prompt_status_generation = $status_generation

--- a/share/tools/web_config/sample_prompts/default.fish
+++ b/share/tools/web_config/sample_prompts/default.fish
@@ -19,7 +19,7 @@ function fish_prompt --description 'Write out the prompt'
     end
 
     # Write pipestatus
-    # If the status was carried over (i.e. when no command is issued), don't bold it.
+    # If the status was carried over (if no command is issued or if `set` leaves the status untouched), don't bold it.
     set -l bold_flag --bold
     set -q __fish_prompt_status_generation; or set -g __fish_prompt_status_generation $status_generation
     if test $__fish_prompt_status_generation = $status_generation


### PR DESCRIPTION
## Description

This variable’s only purpose seems to be to stop being bold if the status is no longer fresh.
I’ve updated the comment to reflect this.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
