### PR TITLE
Adds sub-command clear-session to history command. Issue #5791

### DIFF
--- a/doc_src/cmds/history.rst
+++ b/doc_src/cmds/history.rst
@@ -13,6 +13,7 @@ Synopsis
     history merge
     history save
     history clear
+    history clear-session
     history ( -h | --help )
 
 Description
@@ -31,6 +32,8 @@ The following operations (sub-commands) are available:
 - ``save`` immediately writes all changes to the history file. The shell automatically saves the history file; this option is provided for internal use and should not normally need to be used by the user.
 
 - ``clear`` clears the history file. A prompt is displayed before the history is erased asking you to confirm you really want to clear all history unless ``builtin history`` is used.
+
+- ``clear-session`` clears the history file from all activity of the current session. Note: If ``history merge`` or ``builtin history merge`` is run in a session only the history after this will be erased.
 
 The following options are available:
 

--- a/share/completions/history.fish
+++ b/share/completions/history.fish
@@ -1,5 +1,5 @@
 # Note that when a completion file is sourced a new block scope is created so `set -l` works.
-set -l __fish_history_all_commands search delete save merge clear
+set -l __fish_history_all_commands search delete save merge clear clear-session
 
 complete -c history -s h -l help -d "Display help and exit"
 
@@ -33,3 +33,5 @@ complete -f -c history -n "not __fish_seen_subcommand_from $__fish_history_all_c
     -a merge -d "Incorporate history changes from other sessions"
 complete -f -c history -n "not __fish_seen_subcommand_from $__fish_history_all_commands" \
     -a clear -d "Clears history file"
+complete -f -c history -n "not __fish_seen_subcommand_from $__fish_history_all_commands" \
+    -a clear-session -d "Clears all history from the current session"

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -62,13 +62,15 @@ function history --description "display or manipulate interactive command histor
         set hist_cmd search
     else if set -q _flag_merge
         set hist_cmd merge
+    else if set -q _flag_clear-session
+        set hist_cmd clear-session
     end
 
     # If a history command has not already been specified check the first non-flag argument for a
     # command. This allows the flags to appear before or after the subcommand.
     if not set -q hist_cmd[1]
         and set -q argv[1]
-        if contains $argv[1] search delete merge save clear
+        if contains $argv[1] search delete merge save clear clear-session
             set hist_cmd $argv[1]
             set -e argv[1]
         end
@@ -190,7 +192,12 @@ function history --description "display or manipulate interactive command histor
             else
                 printf (_ "You did not say 'yes' so I will not clear your command history\n")
             end
+        case clear-session # clears only session
+            __fish_unexpected_hist_args $argv
+            and return 1
 
+            builtin history clear-session -- $argv
+            printf (_ "Command history for session cleared!\n")
         case '*'
             printf "%ls: unexpected subcommand '%ls'\n" $cmd $hist_cmd
             return 2

--- a/src/builtin_history.cpp
+++ b/src/builtin_history.cpp
@@ -21,12 +21,15 @@
 #include "wgetopt.h"
 #include "wutil.h"  // IWYU pragma: keep
 
-enum hist_cmd_t { HIST_SEARCH = 1, HIST_DELETE, HIST_CLEAR, HIST_MERGE, HIST_SAVE, HIST_UNDEF };
+enum hist_cmd_t { HIST_SEARCH = 1, HIST_DELETE, HIST_CLEAR, HIST_MERGE, HIST_SAVE, HIST_UNDEF,
+    HIST_CLEAR_SESSION };
 
 // Must be sorted by string, not enum or random.
 static const enum_map<hist_cmd_t> hist_enum_map[] = {
-    {HIST_CLEAR, L"clear"}, {HIST_DELETE, L"delete"}, {HIST_MERGE, L"merge"},
-    {HIST_SAVE, L"save"},   {HIST_SEARCH, L"search"}, {HIST_UNDEF, nullptr}};
+    {HIST_CLEAR, L"clear"}, {HIST_CLEAR_SESSION, L"clear-session"},
+    {HIST_DELETE, L"delete"}, {HIST_MERGE, L"merge"},
+    {HIST_SAVE, L"save"}, {HIST_SEARCH, L"search"},
+    {HIST_UNDEF, nullptr}, };
 
 struct history_cmd_opts_t {
     hist_cmd_t hist_cmd = HIST_UNDEF;
@@ -284,6 +287,15 @@ maybe_t<int> builtin_history(parser_t &parser, io_streams_t &streams, const wcha
                 break;
             }
             history->clear();
+            history->save();
+            break;
+        }
+        case HIST_CLEAR_SESSION: {
+            if (check_for_unexpected_hist_args(opts, cmd, args, streams)) {
+                status = STATUS_INVALID_ARGS;
+                break;
+            }
+            history->clear_session();
             history->save();
             break;
         }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -781,8 +781,6 @@ bool history_impl_t::rewrite_to_temporary_file(int existing_fd, int dst_fd) {
         FLOGF(history_file, L"Error %d when writing to temporary history file", err);
     }
 
-    session_cleared = false; //have handled clear-session
-
     return err == 0;
 }
 

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -250,8 +250,6 @@ struct history_impl_t {
     // (used in deduplication).
     std::unordered_map<wcstring, bool> deleted_items{};
 
-    bool session_cleared{false};
-
     // The buffer containing the history file contents.
     std::unique_ptr<history_file_contents_t> file_contents{};
 
@@ -890,7 +888,6 @@ bool history_impl_t::save_internal_via_rewrite() {
                 FLOGF(error, _(L"Error when renaming history file: %s"), error);
             }
 
-            // We did ihttps://equmenia.se/kalender/regionstamma-equmenia-nord-2021/t
             done = true;
         }
     }
@@ -1105,7 +1102,6 @@ void history_impl_t::clear_session() {
 
     new_items.clear();
     first_unwritten_new_item_index = 0;
-    session_cleared = true;
 }
 
 bool history_impl_t::is_default() const { return name == DFLT_FISH_HISTORY_SESSION_ID; }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -332,6 +332,9 @@ struct history_impl_t {
     // Irreversibly clears history.
     void clear();
 
+    // Clears only session.
+    void clear_session();
+
     // Populates from older location ()in config path, rather than data path).
     void populate_from_config_path();
 
@@ -1073,6 +1076,15 @@ void history_impl_t::clear() {
     this->clear_file_state();
 }
 
+void history_impl_t::clear_session() {
+    for (size_t i = 0; i < new_items.size(); i++) {
+        deleted_items.insert(new_items.at(i).str());
+    }
+
+    new_items.clear();
+    first_unwritten_new_item_index = 0;
+}
+
 bool history_impl_t::is_default() const { return name == DFLT_FISH_HISTORY_SESSION_ID; }
 
 bool history_impl_t::is_empty() {
@@ -1490,6 +1502,8 @@ bool history_t::search(history_search_type_t search_type, const wcstring_list_t 
 }
 
 void history_t::clear() { impl()->clear(); }
+
+void history_t::clear_session() { impl()->clear_session(); }
 
 void history_t::populate_from_config_path() { impl()->populate_from_config_path(); }
 

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -751,8 +751,9 @@ bool history_impl_t::rewrite_to_temporary_file(int existing_fd, int dst_fd) {
         }
     }
 
-    // Insert all items in new_items
-    for (auto iter = new_items.cbegin(); iter != new_items.cend(); ++iter) {
+    // Insert any unwritten new items
+    for (auto iter = new_items.cbegin() + this->first_unwritten_new_item_index;
+         iter != new_items.cend(); ++iter) {
         if (iter->should_write_to_disk()) {
             lru.add_item(*iter);
         }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -211,11 +211,6 @@ bool history_item_t::matches_search(const wcstring &term, enum history_search_ty
     DIE("unexpected history_search_type_t value");
 }
 
-typedef struct  {
-    wcstring item_string; // the command issued
-    bool only_session; // If previous instances is to be remved
-} history_deleted_item_t;
-
 struct history_impl_t {
     // Add a new history item to the end. If pending is set, the item will not be returned by
     // item_at_index until a call to resolve_pending(). Pending items are tracked with an offset
@@ -245,8 +240,7 @@ struct history_impl_t {
     uint32_t disable_automatic_save_counter{0};
 
     // Deleted item contents.
-    //std::unordered_set<history_deleted_item_t> deleted_items{};
-    // boolean describes if it should be deleted only in this session or in all
+    // Boolean describes if it should be deleted only in this session or in all
     // (used in deduplication).
     std::unordered_map<wcstring, bool> deleted_items{};
 
@@ -300,7 +294,7 @@ struct history_impl_t {
 
     // Attempts to rewrite the existing file to a target temporary file
     // Returns false on error, true on success
-    bool rewrite_to_temporary_file(int existing_fd, int dst_fd);
+    bool rewrite_to_temporary_file(int existing_fd, int dst_fd) const;
 
     // Saves history by rewriting the file.
     bool save_internal_via_rewrite();
@@ -716,7 +710,7 @@ void history_impl_t::remove_ephemeral_items() {
 // Given the fd of an existing history file, or -1 if none, write
 // a new history file to temp_fd. Returns true on success, false
 // on error
-bool history_impl_t::rewrite_to_temporary_file(int existing_fd, int dst_fd) {
+bool history_impl_t::rewrite_to_temporary_file(int existing_fd, int dst_fd) const {
     // We are reading FROM existing_fd and writing TO dst_fd
     // dst_fd must be valid; existing_fd does not need to be
     assert(dst_fd >= 0);
@@ -887,6 +881,7 @@ bool history_impl_t::save_internal_via_rewrite() {
                 FLOGF(error, _(L"Error when renaming history file: %s"), error);
             }
 
+            // We did it
             done = true;
         }
     }

--- a/src/history.h
+++ b/src/history.h
@@ -193,6 +193,9 @@ class history_t : noncopyable_t, nonmovable_t {
     // Irreversibly clears history.
     void clear();
 
+    // Irreversibly clears history for the current session.
+    void clear_session();
+
     // Populates from older location (in config path, rather than data path).
     void populate_from_config_path();
 

--- a/tests/checks/history.fish
+++ b/tests/checks/history.fish
@@ -30,12 +30,16 @@ builtin history --clear abc def
 # First with the history function.
 history clear --contains
 #CHECKERR: history: you cannot use any options with the clear command
+history clear-session --contains
+#CHECKERR: history: you cannot use any options with the clear-session command
 history merge -t
 #CHECKERR: history: you cannot use any options with the merge command
 history save xyz
 #CHECKERR: history: save expected 0 args, got 1
 history --prefix clear
 #CHECKERR: history: you cannot use any options with the clear command
+history --prefix clear-session
+#CHECKERR: history: you cannot use any options with the clear-session command
 history --show-time merge
 #CHECKERR: history: you cannot use any options with the merge command
 
@@ -47,10 +51,14 @@ builtin history save --prefix
 #CHECKERR: history: you cannot use any options with the save command
 builtin history clear --show-time
 #CHECKERR: history: you cannot use any options with the clear command
+builtin history clear-session --show-time
+#CHECKERR: history: you cannot use any options with the clear-session command
 builtin history merge xyz
 #CHECKERR: history merge: Expected 0 args, got 1
 builtin history clear abc def
 #CHECKERR: history clear: Expected 0 args, got 2
+builtin history clear-session abc def
+#CHECKERR: history clear-session: Expected 0 args, got 2
 builtin history --contains save
 #CHECKERR: history: you cannot use any options with the save command
 builtin history -t merge

--- a/tests/pexpects/history.py
+++ b/tests/pexpects/history.py
@@ -156,3 +156,25 @@ sendline(" ")
 expect_prompt()
 send("\x1b[A")
 expect_re("echo TERM") # not ephemeral!
+
+# Verify that clear-session works as expected
+# Note: This test depends on that history merge resets the session from history clear-sessions point of view.
+sendline("builtin history clear")
+expect_prompt()
+
+# create before history
+sendline("echo before1")
+expect_prompt()
+sendline("echo before2")
+expect_prompt()
+# "reset" session with history merge
+sendline("history merge")
+expect_prompt()
+# create after history
+sendline("echo after")
+expect_prompt()
+#clear session
+sendline("history clear-session")
+expect_prompt()
+sendline("history search --exact 'echo after' | cat")
+expect_prompt("\r\n")


### PR DESCRIPTION
## Description
Adds sub-command ``clear-session`` to ``history`` command. Which clear current session history. If ``history merge`` or ``builtin history merge`` is run in a session only the history after this will be erased.

## Implementation
A function ``clear_session`` witch does this is added to ``src/history.cpp`` where it first puts all of the commands in ``new_items`` into ``deleted_items``after this ``new_items`` is cleared and ``first_unwritten_new_item_index`` is reset.

Documentation is updated in ``doc_src`` and completion. Tests were written for the added code (no unit test in ``fish_tests.cpp``).

Fixes issue #5791

## Additional notes
We have done this as part in a school project and it is our first contribution to open-source.

## TODO

- [x] Make test pass
- [x] Make it not affect old history via de-duplication.


