### PR TITLE
Fix ant completion

### DIFF
--- a/share/completions/ant.fish
+++ b/share/completions/ant.fish
@@ -32,7 +32,7 @@ function __fish_complete_ant_targets -d "Print list of targets from build.xml an
         set -l buildfile $argv[1] # full path to buildfile
 
         set -l xdg_cache_home $XDG_CACHE_HOME[1]
-        if [ \( -z $xdg_cache_home \) -o \( ! -d $xdg_cache_home \) ]
+        if test -z "$xdg_cache_home"
             set xdg_cache_home $HOME/.cache
         end
 


### PR DESCRIPTION
## Description

If $xdg_chache_home is empty, this is not a valid fish expression:

```fish
[ \( -z \) -o \( ! -d \) ]
```

and results into an error.

## TODOs:

<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst 
