### PR TITLE
Fix delete-key in st

### DIFF
--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -111,6 +111,8 @@ function fish_default_key_bindings -d "Default (Emacs-like) key bindings for fis
 
     # term-specific special bindings
     switch "$TERM"
+        case 'st-256color'
+            bind --preset $argv \e\[P delete-char
         case 'rxvt*'
             bind --preset $argv \e\[8~ end-of-line
             bind --preset $argv \eOc forward-word


### PR DESCRIPTION
In 'simple terminal' the delete key prints \e\[P by default, which ich related to the different approach the authors of st are taking on the matter of shell configuration. The main problem is the malfunction of the delete key, so we have to use a workaround like this.