### PR TITLE
Allow disabling autosuggestions and syntax highlighting

### DIFF
--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -29,6 +29,9 @@ To accept the autosuggestion (replacing the command line contents), press :kbd:`
 
 Autosuggestions are a powerful way to quickly summon frequently entered commands, by typing the first few characters. They are also an efficient technique for navigating through directory hierarchies.
 
+If you don't like autosuggestions, you can disable them by setting ``$fish_autosuggestion_enabled`` to 0::
+
+  set -g fish_autosuggestion_enabled 0
 
 .. _tab-completion:
 
@@ -80,6 +83,16 @@ Detected errors include:
 - Mismatched parenthesis
 
 To customize the syntax highlighting, you can set the environment variables listed in the :ref:`Variables for changing highlighting colors <variables-color>` section.
+
+Fish also provides pre-made color themes you can pick with :ref:`fish_config <cmd-fish_config>`. Running just ``fish_config`` opens a browser interface, or you can use ``fish_config theme`` in the terminal.
+
+For example, to disable nearly all coloring::
+
+  fish_config theme choose none
+
+Or, to see all themes, right in your terminal::
+
+  fish_config theme show
 
 .. _variables-color:
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1244,6 +1244,8 @@ You can change the settings of fish by changing the values of certain variables.
 
 - ``fish_emoji_width`` controls whether fish assumes emoji render as 2 cells or 1 cell wide. This is necessary because the correct value changed from 1 to 2 in Unicode 9, and some terminals may not be aware. Set this if you see graphical glitching related to emoji (or other "special" characters). It should usually be auto-detected.
 
+- ``fish_autosuggestion_enabled`` controls if :ref:`autosuggestions` are enabled. Set it to 0 to disable, anything else to enable. By default they are on.
+
 - ``fish_handle_reflow``, determines whether fish should try to repaint the commandline when the terminal resizes. In terminals that reflow text this should be disabled. Set it to 1 to enable, anything else to disable.
 
 - ``fish_key_bindings``, the name of the function that sets up the keyboard shortcuts for the :ref:`command-line editor <editor>`.

--- a/doc_src/tutorial.rst
+++ b/doc_src/tutorial.rst
@@ -112,6 +112,15 @@ This tells you that there exists a file that starts with ``somefi``, which is us
 
 These colors, and many more, can be changed by running ``fish_config``, or by modifying :ref:`color variables <variables-color>` directly.
 
+For example, if you want to disable (almost) all coloring::
+
+  fish_config theme choose none
+
+This picks the "none" theme. To see all themes::
+
+  fish_config theme show
+
+Just running ``fish_config`` will open up a browser interface that allows you to pick from the available themes.
 
 Wildcards
 ---------
@@ -194,6 +203,10 @@ And history too. Type a command once, and you can re-summon it by just typing a 
 
 
 To accept the autosuggestion, hit :kbd:`→` (right arrow) or :kbd:`Control`\ +\ :kbd:`F`. To accept a single word of the autosuggestion, :kbd:`Alt`\ +\ :kbd:`→` (right arrow). If the autosuggestion is not what you want, just ignore it.
+
+If you don't like autosuggestions, you can disable them by setting ``$fish_autosuggestion_enabled`` to 0::
+
+  set -g fish_autosuggestion_enabled 0
 
 Tab Completions
 ---------------

--- a/share/tools/web_config/themes/none.theme
+++ b/share/tools/web_config/themes/none.theme
@@ -1,0 +1,31 @@
+# name: '(Almost) No Colors'
+# preferred_background: 'black'
+
+fish_color_autosuggestion brblack
+fish_color_cancel
+fish_color_command
+fish_color_comment
+fish_color_cwd normal
+fish_color_cwd_root normal
+fish_color_end
+fish_color_error
+fish_color_escape
+fish_color_history_current
+fish_color_host normal
+fish_color_keyword
+fish_color_match
+fish_color_normal normal
+fish_color_operator
+fish_color_param
+fish_color_quote
+fish_color_redirection
+fish_color_search_match -r
+fish_color_selection -r
+fish_color_status normal
+fish_color_user normal
+fish_color_valid_path
+fish_pager_color_completion normal
+fish_pager_color_description brblack
+fish_pager_color_prefix '--underline'
+fish_pager_color_progress brblack
+fish_pager_color_selected_background --background=brblack

--- a/share/tools/web_config/themes/none.theme
+++ b/share/tools/web_config/themes/none.theme
@@ -16,6 +16,7 @@ fish_color_keyword
 fish_color_match
 fish_color_normal normal
 fish_color_operator
+fish_color_option
 fish_color_param
 fish_color_quote
 fish_color_redirection

--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -234,6 +234,14 @@ static void handle_fish_history_change(const env_stack_t &vars) {
     reader_change_history(history_session_id(vars));
 }
 
+static void handle_autosuggestion_change(const env_stack_t &vars) {
+    bool enabled = true;
+    if (auto val = vars.get(L"fish_autosuggestion_enabled")) {
+        if (val->as_string() == L"0") enabled = false;
+    }
+    reader_set_autosuggestion_enabled(enabled);
+}
+
 static void handle_function_path_change(const env_stack_t &vars) {
     UNUSED(vars);
     function_invalidate_path();
@@ -335,6 +343,7 @@ static std::unique_ptr<const var_dispatch_table_t> create_dispatch_table() {
     var_dispatch_table->add(L"fish_function_path", handle_function_path_change);
     var_dispatch_table->add(L"fish_read_limit", handle_read_limit_change);
     var_dispatch_table->add(L"fish_history", handle_fish_history_change);
+    var_dispatch_table->add(L"fish_autosuggestion_enabled", handle_autosuggestion_change);
     var_dispatch_table->add(L"TZ", handle_tz_change);
     var_dispatch_table->add(L"fish_use_posix_spawn", handle_fish_use_posix_spawn_change);
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -603,7 +603,7 @@ struct layout_data_t {
 class reader_data_t : public std::enable_shared_from_this<reader_data_t> {
    public:
     /// Configuration for the reader.
-    const reader_config_t conf;
+    reader_config_t conf;
     /// The parser being used.
     std::shared_ptr<parser_t> parser_ref;
     /// String containing the whole current commandline.
@@ -2609,6 +2609,18 @@ void reader_change_history(const wcstring &name) {
         data->history->save();
         data->history = history_t::with_name(name);
         commandline_state_snapshot()->history = data->history;
+    }
+}
+
+void reader_set_autosuggestion_enabled(bool enable) {
+    // We don't need to _change_ if we're not initialized yet.
+    reader_data_t *data = current_data_or_null();
+    if (data) {
+        if (data->conf.autosuggest_ok != enable) {
+            data->conf.autosuggest_ok = enable;
+            data->force_exec_prompt_and_repaint = true;
+            data->inputter.queue_char(readline_cmd_t::repaint);
+        }
     }
 }
 

--- a/src/reader.h
+++ b/src/reader.h
@@ -149,6 +149,9 @@ void restore_term_mode();
 /// Change the history file for the current command reading context.
 void reader_change_history(const wcstring &name);
 
+/// Enable or disable autosuggestions.
+void reader_set_autosuggestion_enabled(bool enable);
+
 /// Write the title to the titlebar. This function is called just before a new application starts
 /// executing and just after it finishes.
 ///


### PR DESCRIPTION
## Description

This allows essentially disabling autosuggestions and syntax highlighting.

For autosuggestions, it adds a variable $fish_autosuggestion_enabled. If set to 0, this will disable suggestions. If set to anything else (or unset), it will keep them enabled.

For highlighting, it adds a "none" theme that disables most colors. It keeps colors for the search match, selection, suggestions and pager descriptions, but sets them to either brblack or --reverse. Everything else is set to "normal". Especially the selection and pager *need* to have color or they aren't discernable at all.

The rationale here is that these features don't impact any scripting. They don't create a language dialect. They also aren't hard to implement, especially since the suggestions change is *already implemented* (to allow for interactive `read`).

So we should allow for simple matters of taste.

One issue here is that the git prompt colors currently can't be set via a theme file, ~~so most likely the git branch will still show up as green~~ (EDIT: This is incorrect, the branch isn't colored by default, please ignore the green in the below screenshots - it's left over from my config). This would either require us to rename the color variables to `fish_color_git` or similar, or allow `__fish` variables to be set in themes (this was quite locked down on purpose, so people don't try to put other things in).

Screenshots:

![Screenshot_20211022_171321](https://user-images.githubusercontent.com/5185367/138480722-b8206f62-8839-40a5-9774-7695320f9055.png)
![Screenshot_20211022_171506](https://user-images.githubusercontent.com/5185367/138480726-1729487d-2444-405d-bb1d-411e72091b7b.png)
![Screenshot_20211022_193324](https://user-images.githubusercontent.com/5185367/138498575-173b5ee2-fb76-4d25-986a-350231a80e7a.png)

(as a personal note, I absolutely hate using fish without suggestions - I feel like I have my arm tied behind my back!)

Fixes #1363.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
