### PR TITLE
vmctl completion function call needs to be quoted

### DIFF
--- a/share/completions/vmctl.fish
+++ b/share/completions/vmctl.fish
@@ -7,4 +7,4 @@ function __fish_get_vmctl_vms
 end
 
 complete -c vmctl -xa 'console create load log reload reset start status stop pause unpause send receive' -n 'not __fish_seen_subcommand_from list console create load log reload reset start status stop pause unpause send receive'
-complete -c vmctl -n '__fish_seen_subcommand_from console reload reset start status stop pause unpause send receive' -xa (__fish_get_vmctl_vms)
+complete -c vmctl -n '__fish_seen_subcommand_from console reload reset start status stop pause unpause send receive' -xa '(__fish_get_vmctl_vms)'


### PR DESCRIPTION
When no VMs are running, `__fish_get_vmctl_vms` returns nothing, leaving `complete` without an argument for the `a` flag, which returns an error. I put the subcommand in quotes, so there will at least always be an empty string passed.