### PR TITLE
fish_vi_cursor: add support for alternative foot terminfos

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -258,14 +258,16 @@ function __fish_config_interactive -d "Initializations that should be performed 
     # Notify terminals when $PWD changes (issue #906).
     # VTE based terminals, Terminal.app, iTerm.app (TODO), and foot support this.
     if not set -q FISH_UNIT_TESTS_RUNNING
-        and test 0"$VTE_VERSION" -ge 3405 -o "$TERM_PROGRAM" = Apple_Terminal -a (string match -r '\d+' 0"$TERM_PROGRAM_VERSION") -ge 309 -o "$TERM_PROGRAM" = WezTerm -o "$TERM" = foot
-        function __update_cwd_osc --on-variable PWD --description 'Notify capable terminals when $PWD changes'
-            if status --is-command-substitution || set -q INSIDE_EMACS
-                return
+        if string match -q -- 'foot*' $TERM
+            or test 0"$VTE_VERSION" -ge 3405 -o "$TERM_PROGRAM" = Apple_Terminal -a (string match -r '\d+' 0"$TERM_PROGRAM_VERSION") -ge 309 -o "$TERM_PROGRAM" = WezTerm
+            function __update_cwd_osc --on-variable PWD --description 'Notify capable terminals when $PWD changes'
+                if status --is-command-substitution || set -q INSIDE_EMACS
+                    return
+                end
+                printf \e\]7\;file://%s%s\a $hostname (string escape --style=url $PWD)
             end
-            printf \e\]7\;file://%s%s\a $hostname (string escape --style=url $PWD)
+            __update_cwd_osc # Run once because we might have already inherited a PWD from an old tab
         end
-        __update_cwd_osc # Run once because we might have already inherited a PWD from an old tab
     end
 
     # Create empty configuration directores if they do not already exist

--- a/share/functions/fish_vi_cursor.fish
+++ b/share/functions/fish_vi_cursor.fish
@@ -51,7 +51,7 @@ function fish_vi_cursor -d 'Set cursor shape for different vi modes'
             and not string match -q 'xterm-kitty*' -- $TERM
             and not string match -q 'rxvt*' -- $TERM
             and not string match -q 'alacritty*' -- $TERM
-            and not string match -q 'foot' -- $TERM
+            and not string match -q 'foot*' -- $TERM
             return
         end
 


### PR DESCRIPTION
Foot has several terminfos:

* foot - the default one
* foot-direct - 24-bit color terminfo, similar to xterm-direct (used by e.g. emacs)
* foot-extra - alternative to the ncurses provided terminfo, with a couple of extra, non-standard
capabilities
* foot-extra-direct - 24-bit color version of the above

There may also be other distro-custom terminfo names (serving the same purpose as foot-extra*)

Related to issue #8391

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
