### PR TITLE
__fish_seen_subcommand_from and __fish_seen_argument update

### DIFF
--- a/share/functions/__fish_seen_argument.fish
+++ b/share/functions/__fish_seen_argument.fish
@@ -1,11 +1,11 @@
-function __fish_seen_argument
+function __fish_seen_argument --description 'Check whether argument used'
     argparse 's/short=+' 'o/old=+' 'l/long=+' -- $argv
 
-    set -l cmd (commandline -co)
+    set -l cmd (commandline -poc)
     set -e cmd[1]
     for t in $cmd
         for s in $_flag_s
-            if string match -qr "^-[A-z0-9]*"$s"[A-z0-9]*\$" -- $t
+            if string match -qr "^-[A-z0-9]*$s[A-z0-9]*\$" -- $t
                 return 0
             end
         end

--- a/share/functions/__fish_seen_subcommand.fish
+++ b/share/functions/__fish_seen_subcommand.fish
@@ -1,0 +1,10 @@
+function __fish_seen_subcommand --description 'Check whether subcommand used'
+  set -l cmd (commandline -poc)
+  set -e cmd[1]
+  for i in $cmd
+      if contains -- $i $argv
+          return 0
+      end
+  end
+  return 1
+end


### PR DESCRIPTION
## Description

- `__fish_seen_subcommand.fish` added to have consistent naming with `__fish_seen_argument.fish`. `__fish_seen_subcommand_from.fish` is not removed but saved to backward compatibility.
- `-p` option added to commandline in `__fish_seen_argument.fish` (backward incompatible change)
