### PR TITLE
Don't escape tildes that come from custom completions

### DIFF
--- a/src/builtins/complete.cpp
+++ b/src/builtins/complete.cpp
@@ -139,6 +139,7 @@ maybe_t<int> builtin_complete(parser_t &parser, io_streams_t &streams, const wch
     wcstring_list_t path;
     wcstring_list_t wrap_targets;
     bool preserve_order = false;
+    bool escape_tildes = true;
 
     static const wchar_t *const short_options = L":a:c:p:s:l:o:d:fFrxeuAn:C::w:hk";
     static const struct woption long_options[] = {
@@ -249,6 +250,7 @@ maybe_t<int> builtin_complete(parser_t &parser, io_streams_t &streams, const wch
                 break;
             }
             case 'a': {
+                escape_tildes = false;
                 comp = w.woptarg;
                 assert(comp);
                 break;
@@ -420,6 +422,9 @@ maybe_t<int> builtin_complete(parser_t &parser, io_streams_t &streams, const wch
         int flags = COMPLETE_AUTO_SPACE;
         if (preserve_order) {
             flags |= COMPLETE_DONT_SORT;
+        }
+        if (!escape_tildes) {
+            flags |= COMPLETE_DONT_ESCAPE_TILDES;
         }
 
         if (remove) {


### PR DESCRIPTION
## Description

This is just a simple PR to add the `--unescaped` option suggested by @faho in https://github.com/fish-shell/fish-shell/issues/4570#issuecomment-718082497. I didn't bother adding tests/documentation because I wasn't sure if this is the best solution but if y'all are OK with this change, I can go through and flesh out the PR.

Fixes issue #4570

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] ~~Is it OK to reuse the `-u` option that was previously `--unauthoritative` but was removed in 19112980ee5c3703e50f42a9e05781e5a32f1e88?~~
- [ ] Do we need/want a short option for this?
- [ ] Should we update bundled completions that use `__fish_complete_directories`, `__fish_complete_suffix`, etc.?
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst