### PR TITLE
Use `cargo run --example` to get list of examples

### DIFF
--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -12,17 +12,9 @@ for x in bench b build rustc t test
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l test -a "(cargo test --test 2>&1 | string replace -rf '^\s+' '')"
 end
 
-function __list_cargo_examples
-    if not test -d ./examples
-        return
-    end
-
-    find ./examples -mindepth 1 -maxdepth 1 -type f -name "*.rs" -or -type d \
-        | string replace -r './examples/(.*?)(?:.rs)?$' '$1'
-end
 for x in bench b build r run rustc t test
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bin -a "(cargo run --bin 2>&1 | string replace -rf '^\s+' '')"
-    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l example -a "(__list_cargo_examples)"
+    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l example -a "(cargo run --example 2>&1 | string replace -rf '^\s+' '')"
 end
 
 function __fish_cargo_packages


### PR DESCRIPTION
Fixes #8429

This behavior matches the way completions are found for `cargo run`,
`cargo test`, etc., and is more robust and correct compared to looking
at filenames.

## Description

Just use a simple `string replace` instead of trying to guess example binary names from filenames. See discussion on #8429 and https://github.com/rust-lang/cargo/pull/6505 for why this works.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

I don't _think_ any of the above should be necessary since this is basically just a tiny bugfix, but let me know and I can update the PR.