### PR TITLE
Skip leading `command` in `__fish_man_page`

### DIFF
--- a/share/functions/__fish_man_page.fish
+++ b/share/functions/__fish_man_page.fish
@@ -8,9 +8,9 @@ function __fish_man_page
         return
     end
 
-    #Skip `sudo` and display then manpage of following command
+    #Skip leading `sudo`/`command` and display then manpage of following command
     while set -q args[2]
-        and string match -qr -- '^(sudo|.*=.*)$' $args[1]
+        and string match -qr -- '^(sudo|command|.*=.*)$' $args[1]
         set -e args[1]
     end
 


### PR DESCRIPTION
## Description

Both `sudo` and `command` will be followed by a program name, `__fish_man_page` should handle the latter as well.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
