### PR TITLE
Skip C/C++ CI on files under `share`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: C/C++ CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'share/**'
+  pull_request:
+    paths-ignore:
+      - 'share/**'
 
 env:
   CTEST_PARALLEL_LEVEL: "1"


### PR DESCRIPTION
## Description

The checks probably won't hurt but are unnecessary after all.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
