### PR TITLE
Give tests a more generic name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: Test
 
 on: [push, pull_request]
 


### PR DESCRIPTION
## Description

Supersede #8448

The current check name doesn't make it clear that it's not only about C/C++ but rather the entire test suite.

Before:

<img width="829" alt="截屏2021-11-16 19 05 14" src="https://user-images.githubusercontent.com/44045911/141974287-90387e90-54f4-4ecb-a4a8-146a5e3dff54.png">

After:

<img width="837" alt="截屏2021-11-16 19 05 18" src="https://user-images.githubusercontent.com/44045911/141974294-d5feb06c-83fc-4206-8687-36e49636b9b6.png">

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
