### PR TITLE
vi mode: support increment/decrement of the next number

### DIFF
--- a/share/functions/change_number.fish
+++ b/share/functions/change_number.fish
@@ -1,28 +1,28 @@
 function change_number
     set -l cursor_position (commandline -C)
     set -l current_buffer (commandline -b)
-    set -l num 0
+    set -l count 0
     set -l split_str (string split '' $current_buffer)
-    set -l the_num (math $cursor_position + 1)
-    set -l line_char $split_str[$the_num]
-    set -l new_string ""
+    set -l char_position (math $cursor_position + 1)
+    set -l buffer_char $split_str[$char_position]
+    set new_string ""
     
-    string match -qr '^[0-9]+$' $line_char
+    string match -qr '^[0-9]+$' $buffer_char
     or return
 
     if test "$argv[1]" = increase
-        set new_num (math $line_char + 1)
+        set new_num (math $buffer_char + 1)
     else if test "$argv[1]" = decrease
-        set new_num (math $line_char - 1)
+        set new_num (math $buffer_char - 1)
     end
 
     for x in (string split '' $current_buffer)
-        if [ $num = $cursor_position ]
-            set -l new_string "$new_string$new_num"
+        if [ $count = $cursor_position ]
+            set new_string $new_string$new_num
         else
-            set -l new_string "$new_string$x"
+            set new_string $new_string$x
         end
-        set num (math $num + 1)
+        set count (math $count + 1)
     end
     
     commandline -r $new_string

--- a/share/functions/change_number.fish
+++ b/share/functions/change_number.fish
@@ -1,31 +1,121 @@
-function change_number
+function change_number 
     set -l cursor_position (commandline -C)
     set -l current_buffer (commandline -b)
     set -l count 0
-    set -l split_str (string split '' $current_buffer)
+    set -l split_str (string split '' \ $current_buffer)
+    set list_size (count $split_str)
+    set -l split_str $split_str[2..$list_size]
     set -l char_position (math $cursor_position + 1)
     set -l buffer_char $split_str[$char_position]
     set new_string ""
+    set full_num ""
+    set new_num ""
     
     string match -qr '^[0-9]+$' $buffer_char
     or return
 
-    if test "$argv[1]" = increase
-        set new_num (math $buffer_char + 1)
-    else if test "$argv[1]" = decrease
-        set new_num (math $buffer_char - 1)
+    set last_num (math $char_position + 1) 
+
+    while string match -qr '^[0-9]+$' $split_str[$last_num]
+        set last_num (math $last_num + 1)
+        set cursor_position (math $cursor_position + 1)
     end
 
-    for x in (string split '' $current_buffer)
-        if [ $count = $cursor_position ]
-            set new_string $new_string$new_num
+    set append false
+    set neg false
+    set z_count 0
+
+    for x in $split_str
+        if [ $x = '-' ]
+            set full_num $full_num$x
+        else if string match -qr '^[0-9]+$' $x
+            if [ $x = 0 ]
+                if [ $count != $cursor_position ]
+                    if not $append
+                        set z_count (math $z_count + 1)
+                    end
+                end
+            end
+            set full_num $full_num$x
+
         else
+            set new_string $new_string$full_num$x
+            set full_num ''
+            set z_count 0
+        end
+
+        if $append
             set new_string $new_string$x
         end
+            
+        if [ $count = $cursor_position ]
+            set append true
+            set math_str (math $full_num + 1)
+            if string match -qr '-' \ $math_str
+                set neg true
+            else
+                set neg false
+            end
+
+            if test "$argv[1]" = increase
+                set math_str (math $full_num + 1)
+                if string match -qr '-' \ $math_str
+                    set neg true
+                else
+                    set neg false
+                end
+
+                if [ $full_num = \-1 ]
+                    set new_num (printf "%0"(math $z_count + 0)"d" (math $full_num + 1))
+                    echo $new_num
+                else
+                    if $neg
+                        set new_num (printf "%0"(math $z_count + 2)"d" (math $full_num + 1))
+                    else
+                        set new_num (printf "%0"(math $z_count + 1)"d" (math $full_num + 1))
+                    end
+                end
+
+            else if test "$argv[1]" = decrease
+                set math_str (math $full_num - 1)
+                if string match -qr '-' \ $math_str
+                    set neg true
+                else
+                    set neg false
+                end
+
+                if $neg
+                    set new_num (printf "%0"(math $z_count + 2)"d" (math $full_num - 1))
+                else
+                    set new_num (printf "%0"(math $z_count + 1)"d" (math $full_num - 1))
+                end
+            end
+            set new_string $new_string$new_num
+            set full_num ''
+        end
         set count (math $count + 1)
+    end 
+    set new_split (string split '' \ $new_string)
+    set new_list_size (count $new_split)
+    set new_split $new_split[2..$new_list_size]
+    if [ $new_split[(math $cursor_position + 1)] = '-' ]
+        set cursor_position (math $cursor_position + 1)
+    else if string match -qr '^[0-9]+$' $new_split[$char_position] 
+        set cursor_position $cursor_position
+    else
+        set cursor_position (math $cursor_position - 1) 
     end
     
-    commandline -r $new_string
+    if [ $new_split[1] = '-' ]
+        commandline -r \ $new_string
+        commandline -f beginning-of-line
+        commandline -f delete-char
+        commandline -f forward-char
+        # commandline -f end-of-line
+    else
+        commandline -r $new_string
+    end
     commandline -C $cursor_position
     commandline -f repaint
 end
+

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -268,6 +268,12 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # in vim (and maybe in vi), <BS> deletes the changes
     # but this binding just move cursor backward, not delete the changes
     bind -s --preset -M replace -k backspace backward-char
+    
+    #
+    # increment or decrement numbers with ctrl+x ctrl+a
+    #
+    bind -s --preset -M default \ca vi_inc
+    bind -s --preset -M default \cx vi_dec
 
     #
     # visual mode

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -272,8 +272,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     #
     # increment or decrement numbers with ctrl+x ctrl+a
     #
-    bind -s --preset -M default \ca vi_inc
-    bind -s --preset -M default \cx vi_dec
+    bind -s --preset -M default \ca 'change_number increase'
+    bind -s --preset -M default \cx 'change_number decrease'
 
     #
     # visual mode

--- a/share/functions/vi_increment_decrement.fish
+++ b/share/functions/vi_increment_decrement.fish
@@ -1,34 +1,30 @@
-alias vi_dec 'vi_increment_decrement subtract'
-alias vi_inc 'vi_increment_decrement add'
+function change_number
+    set -l cursor_position (commandline -C)
+    set -l current_buffer (commandline -b)
+    set -l num 0
+    set -l split_str (string split '' $current_buffer)
+    set -l the_num (math $cursor_position + 1)
+    set -l line_char $split_str[$the_num]
+    set -l new_string ""
+    
+    string match -qr '^[0-9]+$' $line_char
+    or return
 
-function vi_increment_decrement --description 'increment or decrement numbers with ctrl+x ctrl+a'
-    set lnum (commandline --cursor)
-    set lstr (commandline -b)
-    set num 0
-    set split_str (string split '' $lstr)
-    set the_num (math $lnum + 1)
-    set lchar $split_str[$the_num]
-    set new_string ""
-
-    if string match -qr '^[0-9]+$' $lchar
-        if [ $argv = 'add' ]
-            set new_num (math $lchar + 1)
-        else if [ $argv = 'subtract' ]
-            set new_num (math $lchar - 1)
-        end
-
-        for x in (string split '' $lstr)
-            if [ $num = $lnum ]
-                set new_string (echo $new_string$new_num | string collect)
-            else
-                set new_string (echo $new_string$x | string collect)
-            end
-            set num (math $num + 1)
-        end
-        commandline -r $new_string
-        commandline -C $lnum
-        commandline -f repaint
-    else
-        return
+    if [ $argv = 'increase' ]
+        set new_num (math $line_char + 1)
+    else if [ $argv = 'decrease' ]
+        set new_num (math $line_char - 1)
     end
+
+    for x in (string split '' $current_buffer)
+        if [ $num = $cursor_position ]
+            set new_string (echo $new_string$new_num | string collect)
+        else
+            set new_string (echo $new_string$x | string collect)
+        end
+        set num (math $num + 1)
+    end
+    commandline -r $new_string
+    commandline -C $cursor_position
+    commandline -f repaint
 end

--- a/share/functions/vi_increment_decrement.fish
+++ b/share/functions/vi_increment_decrement.fish
@@ -1,0 +1,34 @@
+alias vi_dec 'vi_increment_decrement subtract'
+alias vi_inc 'vi_increment_decrement add'
+
+function vi_increment_decrement --description 'increment or decrement numbers with ctrl+x ctrl+a'
+    set lnum (commandline --cursor)
+    set lstr (commandline -b)
+    set num 0
+    set split_str (string split '' $lstr)
+    set the_num (math $lnum + 1)
+    set lchar $split_str[$the_num]
+    set new_string ""
+
+    if string match -qr '^[0-9]+$' $lchar
+        if [ $argv = 'add' ]
+            set new_num (math $lchar + 1)
+        else if [ $argv = 'subtract' ]
+            set new_num (math $lchar - 1)
+        end
+
+        for x in (string split '' $lstr)
+            if [ $num = $lnum ]
+                set new_string (echo $new_string$new_num | string collect)
+            else
+                set new_string (echo $new_string$x | string collect)
+            end
+            set num (math $num + 1)
+        end
+        commandline -r $new_string
+        commandline -C $lnum
+        commandline -f repaint
+    else
+        return
+    end
+end

--- a/share/functions/vi_increment_decrement.fish
+++ b/share/functions/vi_increment_decrement.fish
@@ -10,20 +10,21 @@ function change_number
     string match -qr '^[0-9]+$' $line_char
     or return
 
-    if [ $argv = 'increase' ]
+    if test "$argv[1]" = increase
         set new_num (math $line_char + 1)
-    else if [ $argv = 'decrease' ]
+    else if test "$argv[1]" = decrease
         set new_num (math $line_char - 1)
     end
 
     for x in (string split '' $current_buffer)
         if [ $num = $cursor_position ]
-            set new_string (echo $new_string$new_num | string collect)
+            set -l new_string "$new_string$new_num"
         else
-            set new_string (echo $new_string$x | string collect)
+            set -l new_string "$new_string$x"
         end
         set num (math $num + 1)
     end
+    
     commandline -r $new_string
     commandline -C $cursor_position
     commandline -f repaint


### PR DESCRIPTION
## Description

use ctrl+a and ctrl+x to increment or decrement a number in vi default mode 

Fixes issue #8320 

## TODOs:
- [x]  fix incrementing individual digits in a multi-digit number. (treat the number as one and increment it)
- [x] fix incrementing negative numbers (doesn't change back to a positive/remove - operator 
- [ ] 
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
