### PR TITLE
Use test command instead of bracket command

### DIFF
--- a/share/completions/ant.fish
+++ b/share/completions/ant.fish
@@ -21,9 +21,9 @@ function __fish_complete_ant_targets -d "Print list of targets from build.xml an
         for target in $targets
             # Use [[:graph:]] and [[:print:]] to ignore ANSI escape code
             set -l tokens (string match -r '^\s([[:graph:]]+)(?:\s+([[:print:]]+))?' "$target")
-            if [ (count $tokens) -ge 3 ]
+            if test (count $tokens) -ge 3
                 echo $tokens[2]\t$tokens[3]
-            else if [ (count $tokens) -ge 2 ]
+            else if test (count $tokens) -ge 2
                 echo $tokens[2]
             end
         end
@@ -40,7 +40,7 @@ function __fish_complete_ant_targets -d "Print list of targets from build.xml an
         mkdir -p $cache_dir
 
         set -l cache_file $cache_dir/(__fish_md5 -s $buildfile)
-        if [ ! -s "$cache_file" ]
+        if test ! -s "$cache_file"
             # generate cache file if empty
             __parse_ant_targets_from_projecthelp $buildfile >$cache_file
         end
@@ -50,7 +50,7 @@ function __fish_complete_ant_targets -d "Print list of targets from build.xml an
 
     set -l tokens $argv
     set -l buildfile (realpath -eq $buildfile (__get_buildfile $tokens))
-    if [ $status -ne 0 ]
+    if test $status -ne 0
         return 1 # return nothing if buildfile does not exist
     end
 

--- a/share/completions/bundle.fish
+++ b/share/completions/bundle.fish
@@ -2,7 +2,7 @@
 
 function __fish_bundle_no_command -d 'Test if bundle has been given no subcommand'
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
     return 1
@@ -10,8 +10,8 @@ end
 
 function __fish_bundle_using_command -d 'Test if bundle has been given a specific subcommand'
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/completions/canto.fish
+++ b/share/completions/canto.fish
@@ -1,12 +1,12 @@
 
 function __fish_canto_using_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
-        if [ count $argv -gt 2 ]
-            if [ $argv[2] = $cmd[2] ]
+        if test count $argv -gt 2
+            if test $argv[2] = $cmd[2]
                 return 0
             end
         end

--- a/share/completions/composer.fish
+++ b/share/completions/composer.fish
@@ -1,7 +1,7 @@
 function __fish_composer_needs_command
     set -l cmd (commandline -opc)
 
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
 
@@ -11,8 +11,8 @@ end
 function __fish_composer_using_command
     set -l cmd (commandline -opc)
 
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/completions/cp.fish
+++ b/share/completions/cp.fish
@@ -35,7 +35,7 @@ else # BSD/macOS
     # netbsd:    cp [-R |   [H | L | P ]] [-fi ] [-pval    N] # -l: hard link instead of copy -N: don't copy file flags
     # dragonfly: cp [-R |   [H | L | P ]] [-fin] [-pvalx    ] # -x: don't traverse mount points
     # freebsd:   cp	[-R |   [H | L | P ]] [-fin] [-pvalxs   ] # -s: symlink instead of copy
-    if [ "$uname" = SunOS ] # annoying
+    if test "$uname" = SunOS # annoying
         complete -c cp -s r -d "Copy directories recursively"
         complete -c cp -s R -d "Like -r, but replicating pipes instead of reading pipes"
     else
@@ -51,26 +51,26 @@ else # BSD/macOS
     and complete -c cp -s n -d "Don't overwrite existing"
 
     complete -c cp -s p -d "Preserve attributes of source"
-    if [ "$uname" = SunOS ]
+    if test "$uname" = SunOS
         exit 0
     end
     complete -c cp -s v -d "Print filenames as they're copied"
-    if [ "$uname" = OpenBSD ]
+    if test "$uname" = OpenBSD
         exit 0
     end
     complete -c cp -s a -d "Archive mode (-pPR)"
-    if [ "$uname" = Darwin ]
+    if test "$uname" = Darwin
         complete -c cp -s c -d "Clone using clonefile(2)"
         complete -c cp -s X -d "Omit xattrs, resource forks"
         exit 0
     end
     complete -c cp -s l -d "Hard link instead of copying"
-    if [ "$uname" = NetBSD ]
+    if test "$uname" = NetBSD
         complete -c cp -s N -d "Don't copy file flags"
         exit 0
     end
     complete -c cp -s x -d "Don't traverse mount points"
-    if [ "$uname" = FreeBSD ]
+    if test "$uname" = FreeBSD
         complete -c cp -s s -d "Symlink instead of copying"
     end
 end

--- a/share/completions/eselect.fish
+++ b/share/completions/eselect.fish
@@ -18,7 +18,7 @@ function __fish_complete_eselect_action_options
     set -l cmdl (commandline -poc)
 
     # Alter further php completion
-    if [ (__fish_print_cmd_args_without_options)[2] = php ]
+    if test (__fish_print_cmd_args_without_options)[2] = php
         eselect php list-modules 2>/dev/null | string split " "
         return
     end
@@ -47,7 +47,7 @@ function __fish_complete_eselect_targets
     set -l cmdl (commandline -poc)
 
     # Disable further php completion
-    if [ (__fish_print_cmd_args_without_options)[2] = php ]
+    if test (__fish_print_cmd_args_without_options)[2] = php
         return
     end
 

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -2129,7 +2129,7 @@ for file in $PATH/git-*
     and continue
 
     complete -C "git-$subcommand " >/dev/null
-    if [ (complete -c git-$subcommand | count) -gt 0 ]
+    if test (complete -c git-$subcommand | count) -gt 0
         complete -c git -f -n "__fish_git_using_command $subcommand" -a "(__fish_git_complete_custom_command $subcommand)"
     end
     set -a __fish_git_custom_commands_completion $subcommand

--- a/share/completions/heroku.fish
+++ b/share/completions/heroku.fish
@@ -31,7 +31,7 @@ end
 
 function __fish_heroku_needs_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
     return 1
@@ -39,8 +39,8 @@ end
 
 function __fish_heroku_using_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/completions/invoke-rc.d.fish
+++ b/share/completions/invoke-rc.d.fish
@@ -1,6 +1,6 @@
 function __fish_print_debian_services --description 'Prints services installed'
     for service in /etc/init.d/*
-        if [ -x $service ]
+        if test -x $service
             basename $service
         end
     end
@@ -8,7 +8,7 @@ end
 
 function __fish_invoke_rcd_has_service
     set -l tokens (commandline -opc)
-    if [ (count $tokens) -eq 2 ]
+    if test (count $tokens) -eq 2
         return 0
     else
         return 1

--- a/share/completions/iptables.fish
+++ b/share/completions/iptables.fish
@@ -12,7 +12,7 @@ function __fish_iptables_current_table
             case "-*t*"
                 set next_is_table 0
             case "*"
-                if [ $next_is_table -eq 0 ]
+                if test $next_is_table -eq 0
                     echo $token
                     return 0
                 end
@@ -37,7 +37,7 @@ end
 
 function __fish_iptables_chains
     set -l table (__fish_iptables_current_table)
-    [ -z $table ]
+    test -z $table
     and set -l table "*"
     set -l prerouting "PREROUTING	For packets that are coming in"
     set -l input "INPUT	For packets destined to local sockets"

--- a/share/completions/iw.fish
+++ b/share/completions/iw.fish
@@ -208,7 +208,7 @@ function __fish_complete_iw
                         printf '%s\t%s\n' show "Show coalesce status" \
                             disable "Disable coalesce" \
                             enable "Enable coalesce"
-                    else if [ "$cmd[5]" = enable ] && not set -q cmd[6]
+                    else if test "$cmd[5]" = enable && not set -q cmd[6]
                         __fish_complete_path # Enable takes a config file
                     end
                 case hwsim

--- a/share/completions/jhipster.fish
+++ b/share/completions/jhipster.fish
@@ -4,7 +4,7 @@
 function __fish_prog_needs_command
     set -l cmd (commandline -opc)
     echo $cmd
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
     return 1

--- a/share/completions/kmutil.fish
+++ b/share/completions/kmutil.fish
@@ -6,6 +6,6 @@
 #        kmutil <clear-staging|trigger-panic-medic>
 #        kmutil -h
 
-if [ (command -v kmutil) = /usr/bin/kmutil ]
+if test (command -v kmutil) = /usr/bin/kmutil
     command kmutil --generate-completion-script=fish | source
 end

--- a/share/completions/lein.fish
+++ b/share/completions/lein.fish
@@ -1,6 +1,6 @@
 function __fish_lein_needs_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
     return 1

--- a/share/completions/ls.fish
+++ b/share/completions/ls.fish
@@ -138,10 +138,10 @@ else
     # -S in common, -f in common, -t in common
     # -c in common, -u in common
     ## These options are not standardized:
-    if [ "$uname" != OpenBSD ]
+    if test "$uname" != OpenBSD
         complete -c ls -s h -d "Human-readable sizes"
         complete -c ls -s b -d "C escapes for non-graphic characters"
-        if [ "$uname" = SunOS ]
+        if test "$uname" = SunOS
             complete -c ls -s e -d "Like -l, but fixed time format with seconds"
             complete -c ls -s @ -d "Like -l, but xattrs shown instead of ACLs"
             complete -c ls -s E -d "Like -l, but fixed time format with nanoseconds"

--- a/share/completions/mix.fish
+++ b/share/completions/mix.fish
@@ -2,7 +2,7 @@
 
 function __fish_mix_needs_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
     return 1
@@ -10,8 +10,8 @@ end
 
 function __fish_mix_using_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -10,7 +10,7 @@ set -l npm_install "npm install --global"
 function __fish_npm_needs_command
     set -l cmd (commandline -opc)
 
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
 
@@ -20,8 +20,8 @@ end
 function __fish_npm_using_command
     set -l cmd (commandline -opc)
 
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/completions/opam.fish
+++ b/share/completions/opam.fish
@@ -1,7 +1,7 @@
 function __fish_opam_using_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end
@@ -10,8 +10,8 @@ end
 
 function __fish_opam_at_color
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 2 ]
-        if [ $cmd[-1] = --color ]
+    if test (count $cmd) -gt 2
+        if test $cmd[-1] = --color
             return 0
         end
     end
@@ -20,7 +20,7 @@ end
 
 function __fish_opam_needs_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
     return 1

--- a/share/completions/pyenv.fish
+++ b/share/completions/pyenv.fish
@@ -2,7 +2,7 @@
 
 function __fish_pyenv_needs_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
     return 1
@@ -10,8 +10,8 @@ end
 
 function __fish_pyenv_using_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/completions/rbenv.fish
+++ b/share/completions/rbenv.fish
@@ -2,7 +2,7 @@
 
 function __fish_rbenv_needs_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
 
@@ -11,8 +11,8 @@ end
 
 function __fish_rbenv_using_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/completions/ruby-build.fish
+++ b/share/completions/ruby-build.fish
@@ -1,6 +1,6 @@
 function __fish_ruby-build_needs_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
     return 1

--- a/share/completions/sbt.fish
+++ b/share/completions/sbt.fish
@@ -33,8 +33,8 @@ complete -c sbt -f -a '(string split "\n" "
     and not contains -- "client" (commandline -cpo)'
 
 # These cannot be combined with any other commands and require an argument
-complete -c sbt -f -n '[ (count (commandline -cpo)) = 1 ]' -a new -d 'Create a new sbt project from the given template'
-complete -c sbt -f -n '[ (count (commandline -cpo)) = 1 ]' -a client -d 'Connect to a server with an interactive sbt prompt'
+complete -c sbt -f -n 'test  (count (commandline -cpo)) = 1 ' -a new -d 'Create a new sbt project from the given template'
+complete -c sbt -f -n 'test  (count (commandline -cpo)) = 1 ' -a client -d 'Connect to a server with an interactive sbt prompt'
 
 
 ###########

--- a/share/completions/sfdx.fish
+++ b/share/completions/sfdx.fish
@@ -2,8 +2,8 @@
 
 function __fish_sfdx_using_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/completions/shortcuts.fish
+++ b/share/completions/shortcuts.fish
@@ -5,7 +5,7 @@
 # imagine my surprise when I found fish function stirngs in binaries in /usr/bin!
 
 # checking the path is as expected is about as far as we're going with validation
-if [ (command -v shortcuts) = /usr/bin/shortcuts ]
+if test (command -v shortcuts) = /usr/bin/shortcuts
     command shortcuts --generate-completion-script=fish | source
 end
 
@@ -13,9 +13,9 @@ end
 
 # function __fish_shortcuts_using_command
 #     set cmd (commandline -opc)
-#     if [ (count $cmd) -eq (count $argv) ]
+#     if test  (count $cmd) -eq (count $argv) 
 #         for i in (seq (count $argv))
-#             if [ $cmd[$i] != $argv[$i] ]
+#             if test  $cmd[$i] != $argv[$i] 
 #                 return 1
 #             end
 #         end

--- a/share/completions/tmuxinator.fish
+++ b/share/completions/tmuxinator.fish
@@ -1,7 +1,7 @@
 function __fish_tmuxinator_using_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/completions/travis.fish
+++ b/share/completions/travis.fish
@@ -1,6 +1,6 @@
 function __fish_travis_needs_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq 1 ]
+    if test (count $cmd) -eq 1
         return 0
     end
     return 1
@@ -8,8 +8,8 @@ end
 
 function __fish_travis_using_command
     set -l cmd (commandline -opc)
-    if [ (count $cmd) -gt 1 ]
-        if [ $argv[1] = $cmd[2] ]
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
             return 0
         end
     end

--- a/share/config.fish
+++ b/share/config.fish
@@ -186,7 +186,7 @@ if status --is-login
 
             # Populate path according to config files
             for path_file in $argv[2] $argv[3]/*
-                if [ -f $path_file ]
+                if test -f $path_file
                     while read -l entry
                         if not contains -- $entry $result
                             test -n "$entry"
@@ -207,7 +207,7 @@ if status --is-login
         end
 
         __fish_macos_set_env PATH /etc/paths '/etc/paths.d'
-        if [ -n "$MANPATH" ]
+        if test -n "$MANPATH"
             __fish_macos_set_env MANPATH /etc/manpaths '/etc/manpaths.d'
         end
         functions -e __fish_macos_set_env
@@ -264,6 +264,6 @@ for file in $__fish_config_dir/conf.d/*.fish $__fish_sysconf_dir/conf.d/*.fish $
     set sourcelist $sourcelist $basename
     # Also skip non-files or unreadable files.
     # This allows one to use e.g. symlinks to /dev/null to "mask" something (like in systemd).
-    [ -f $file -a -r $file ]
+    test -f $file -a -r $file
     and source $file
 end

--- a/share/functions/__fish_complete_mysql.fish
+++ b/share/functions/__fish_complete_mysql.fish
@@ -7,7 +7,7 @@ function __fish_mysql_query -a query
             set -a mysql_cmd -$flag $$flagvar
         end
     end
-    if [ -n "$_flag_p" ]
+    if test -n "$_flag_p"
         set -a mysql_cmd -p$_flag_p
     end
     echo $query | $mysql_cmd 2>/dev/null

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -389,7 +389,7 @@ function __fish_git_prompt_informative_status
         end
     else
         for i in $__fish_git_prompt_status_order
-            if [ $$i != 0 ]
+            if test $$i != 0
                 set -l color_var ___fish_git_prompt_color_$i
                 set -l color_done_var ___fish_git_prompt_color_{$i}_done
                 set -l symbol_var ___fish_git_prompt_char_$i

--- a/share/functions/fish_svn_prompt.fish
+++ b/share/functions/fish_svn_prompt.fish
@@ -121,7 +121,7 @@ function fish_svn_prompt --description "Prompt function for svn"
         set -l column_status (printf '%s\n' $svn_status_lines | cut -c $col | sort -u | tr -d ' ')
 
         # check that the column status list does not only contain an empty element (if it does, this column is empty)
-        if [ (count $column_status) -gt 1 -o -n "$column_status[1]" ]
+        if test (count $column_status) -gt 1 -o -n "$column_status[1]"
 
             # parse the status flags for this column and create the formatting by calling out to the helper function
             set -l svn_status_flags (__fish_svn_prompt_parse_status $column_status)

--- a/share/functions/funcsave.fish
+++ b/share/functions/funcsave.fish
@@ -30,7 +30,7 @@ function funcsave --description "Save the current definition of all specified fu
         if functions -q -- $funcname
             functions --no-details -- $funcname >$funcpath
             and set -q _flag_quiet || printf (_ "%s: wrote %s\n") funcsave $funcpath
-        else if [ -w $funcpath ]
+        else if test -w $funcpath
             rm $funcpath
             and set -q _flag_quiet || printf (_ "%s: removed %s\n") funcsave $funcpath
         else

--- a/share/tools/web_config/sample_prompts/nim.fish
+++ b/share/tools/web_config/sample_prompts/nim.fish
@@ -64,7 +64,7 @@ function fish_prompt
     set_color -o white
     echo -n @
 
-    if [ -z "$SSH_CLIENT" ]
+    if test -z "$SSH_CLIENT"
         set_color -o blue
     else
         set_color -o cyan


### PR DESCRIPTION
VSCode find and replace params:
find: `\[ (.*) \]`
replace: `test $1`
files to include: `*.fish`
files to exclude: `tests/**`

Manually removed a few matches that were incorrect, such as the comments in `ls.fish`.
Ran `fish_indent` to clean up formatting.
Manually reviewed changes and they seem fine.

`test` is the fishier way of doing things, it's more common in the code base, and it runs a whole 1% faster by my benchmarks 😄