### PR TITLE
Make --no-config mode more comfortable

### DIFF
--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -512,6 +512,16 @@ int main(int argc, char **argv) {
     if (!opts.no_exec && !opts.no_config) {
         read_init(parser, paths);
     }
+
+    if (opts.no_config && !opts.no_exec) {
+        // If we have no config, we default to the default key bindings.
+        parser.vars().set_one(L"fish_key_bindings", ENV_UNEXPORT, L"fish_default_key_bindings");
+        if (function_exists(L"fish_default_key_bindings", parser)) {
+            std::vector<std::string> cmd {"fish_default_key_bindings"};
+            run_command_list(parser, &cmd, {});
+        }
+    }
+
     // Re-read the terminal modes after config, it might have changed them.
     term_copy_modes();
 

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -513,7 +513,7 @@ int main(int argc, char **argv) {
         read_init(parser, paths);
     }
 
-    if (opts.no_config && !opts.no_exec) {
+    if (opts.is_interactive_session && opts.no_config && !opts.no_exec) {
         // If we have no config, we default to the default key bindings.
         parser.vars().set_one(L"fish_key_bindings", ENV_UNEXPORT, L"fish_default_key_bindings");
         if (function_exists(L"fish_default_key_bindings", parser)) {


### PR DESCRIPTION
This calls the default keybindings because the fallback bindings are super awkward to use. This was called out specifically in #7921, I'm going for the targeted
fix for now.

It also sets $fish_complete_path to just the fish_data_dir one, just like the function path.

The idea is that --no-config mode is independent of the state of the *system*, any user or admin configuration. It won't, however, guarantee no functions will be called. Those are how we do things in fish.

The main remaining issue is that the colorscheme is entirely empty, so everything will be colored normal. We probably want to load the default theme, but I'm not sold on calling `fish_config theme choose fish\ default` here. We might want to hard-code the default theme in highlight.cpp directly - do the equivalent of https://github.com/fish-shell/fish-shell/blob/d1683958cfb83181df7de32d1f06bf890bdf40c4/share/functions/__fish_config_interactive.fish#L34-L49 directly in C++.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
