### PR TITLE
Allow set --query to check for pathvarness

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,6 +75,7 @@ Scripting improvements
 - ``math`` now correctly prints negative values and values larger than ``2**31`` when in hex or octal bases (:issue:`8417`).
 - ``dirs`` always produces an exit status of 0, instead of sometimes returning 1 (:issue:`8211`).
 - ``cd ""`` no longer crashes fish (:issue:`8147`).
+- ``set --query`` can now query whether a variable is a pathvar via ``--path`` or ``--unpath`` (:issue:`8494`).
 
 Interactive improvements
 ------------------------

--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -90,7 +90,7 @@ The exporting rules when creating or updating a variable are identical to the sc
 - If a variable is not explicitly set to be either exported or unexported and has never before been defined, the variable will not be exported.
 
 
-In query mode, the scope to be examined can be specified.
+In query mode, the scope to be examined can be specified. Whether the variable has to be a path variable or exported can also be specified.
 
 In erase mode, if variable indices are specified, only the specified slices of the list variable will be erased.
 

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -509,6 +509,14 @@ struct query_t {
             return true;
         }
     }
+
+    bool pathvar_matches(const env_var_t &var) const {
+        if (has_pathvar_unpathvar) {
+            return var.is_pathvar() ? pathvar : unpathvar;
+        } else {
+            return true;
+        }
+    }
 };
 
 // Struct representing one level in the function variable stack.
@@ -802,6 +810,10 @@ maybe_t<env_var_t> env_scoped_impl_t::get(const wcstring &key, env_mode_flags_t 
     }
     // If the user requested only exported or unexported variables, enforce that here.
     if (result && !query.export_matches(*result)) {
+        result = none();
+    }
+    // Same for pathvars
+    if (result && !query.pathvar_matches(*result)) {
         result = none();
     }
     return result;

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -415,9 +415,29 @@ set --unpath __fish_test_PATH $__fish_test_PATH
 echo "$__fish_test_path_not $__fish_test_PATH" $__fish_test_path_not $__fish_test_PATH
 # CHECK: a b c 1 2 3 a b c 1 2 3
 
+set -q --path __fish_test_PATH
+and echo __fish_test_PATH is a pathvar
+or echo __fish_test_PATH is not a pathvar
+# CHECK: __fish_test_PATH is not a pathvar
+
+set -q --unpath __fish_test_PATH
+and echo __fish_test_PATH is not a pathvar
+or echo __fish_test_PATH is not not a pathvar
+# CHECK: __fish_test_PATH is not a pathvar
+
 set --path __fish_test_path_not $__fish_test_path_not
 echo "$__fish_test_path_not $__fish_test_PATH" $__fish_test_path_not $__fish_test_PATH
 # CHECK: a:b:c 1 2 3 a b c 1 2 3
+
+set -q --path __fish_test_path_not
+and echo __fish_test_path_not is a pathvar
+or echo __fish_test_path_not is not a pathvar
+# CHECK: __fish_test_path_not is a pathvar
+
+set -q --unpath __fish_test_path_not
+and echo __fish_test_path_not is not a pathvar
+or echo __fish_test_path_not is not not a pathvar
+# CHECK: __fish_test_path_not is not not a pathvar
 
 set --path __fish_test_PATH $__fish_test_PATH
 echo "$__fish_test_path_not $__fish_test_PATH" $__fish_test_path_not $__fish_test_PATH


### PR DESCRIPTION
Currently,

    set -q --unpath PATH

simply ignores the "--unpath" bit (and same for "--path").

This changes it, so just like exportedness you can check pathvarness.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
