### PR TITLE
Use `--almost-all` in `la` function

### DIFF
--- a/share/functions/la.fish
+++ b/share/functions/la.fish
@@ -2,5 +2,5 @@
 # These are very common and useful
 #
 function la --wraps ls --description "List contents of directory, including hidden files in directory using long format"
-    ls -lah $argv
+    ls -lAh $argv
 end


### PR DESCRIPTION
## Description

`--almost-all` or `-A` option of `ls` is similar to `--all` / `-a`, except for that it doesn't show `.` or `..`. This is a more sensible default IMO.

I didn't bother to look up when this appeared across different implementations, but according to the date of [a StackOverflow answer](https://stackoverflow.com/a/22407549), this option has been existing for more than 7 years, from which we can safely assume any decent system with recent versions of fish should be shipped with a capable `ls` version.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
