### PR TITLE
Reword documentation for `filename` in `man status`

### DIFF
--- a/doc_src/cmds/status.rst
+++ b/doc_src/cmds/status.rst
@@ -54,7 +54,7 @@ The following operations (sub-commands) are available:
 
 - ``current-command`` prints the name of the currently-running function or command, like the deprecated ``_`` variable.
 
-- ``filename`` prints the filename of the currently running script. Also ``current-filename``, ``-f`` or ``--current-filename``. This depends on how the script was called - if it was called via a symlink, the symlink will be returned, and if the current script was received via ``source`` it will be ``-``.
+- ``filename`` prints the filename of the currently-running script. Also ``current-filename``, ``-f`` or ``--current-filename``. If the current script was called via a symlink, this will return the symlink. If the current script was received by piping into ``source``, then this will return ``-``.
 
 - ``basename`` prints just the filename of the running script, without any path-components before.
 


### PR DESCRIPTION
## Description

The original text of the `filename` section of `man status` is:

```
       o filename  prints  the filename of the currently running script.
         Also current-filename, -f or --current-filename.  This  depends
         on  how the script was called - if it was called via a symlink,
         the symlink will be returned, and if  the  current  script  was
         received via source it will be -.
```

I was confused by the last line of this, because if you `source` a script (like `source path/to/script.fish`) then `status filename` returns the script name, not `-`. So I reworded to:

```
       o filename  prints  the  filename of the currently-running script. Also
         current-filename, -f or --current-filename. If the current script was
         called  via  a  symlink, this will return the symlink. If the current
         script was received by piping into source, then this will return -.
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
