### PR TITLE
Speed up, fix fish_status_to_signal

### DIFF
--- a/share/functions/fish_status_to_signal.fish
+++ b/share/functions/fish_status_to_signal.fish
@@ -3,8 +3,12 @@ function fish_status_to_signal --description "Print signal name from argument (\
     for arg in $argv
         if test $arg -gt 128
             # Important: each element of $__kill_signals is a string like "10 USR1"
-            string replace -r --filter '^'(math $arg-128)' ' SIG $__kill_signals |
-                read -l signal && echo $signal || echo $arg
+            if set -l signal_names (string replace -r --filter '^'(math $arg-128)' ' SIG $__kill_signals)
+                # Some signals have multiple mnemonics. Pick the first one.
+                echo $signal_names[1]
+            else
+                echo $arg
+            end
         else
             echo $arg
         end

--- a/share/functions/fish_status_to_signal.fish
+++ b/share/functions/fish_status_to_signal.fish
@@ -1,13 +1,13 @@
 function fish_status_to_signal --description "Print signal name from argument (\$status), or just argument"
     for arg in $argv
         if test $arg -gt 128
-            set -l signals SIGHUP SIGINT SIGQUIT SIGILL SIGTRAP SIGABRT SIGBUS \
-                SIGFPE SIGKILL SIGUSR1 SIGSEGV SIGUSR2 SIGPIPE SIGALRM \
-                SIGTERM SIGSTKFLT SIGCHLD SIGCONT SIGSTOP SIGTSTP \
-                SIGTTIN SIGTTOU SIGURG SIGXCPU SIGXFSZ SIGVTALRM \
-                SIGPROF SIGWINCH SIGIO SIGPWR SIGSYS
             set -l sigix (math $arg - 128)
-            if test $sigix -le (count $signals)
+            if test $sigix -le 31 # 31 = number of named signals below
+                set -l signals SIGHUP SIGINT SIGQUIT SIGILL SIGTRAP SIGABRT SIGBUS \
+                    SIGFPE SIGKILL SIGUSR1 SIGSEGV SIGUSR2 SIGPIPE SIGALRM \
+                    SIGTERM SIGSTKFLT SIGCHLD SIGCONT SIGSTOP SIGTSTP \
+                    SIGTTIN SIGTTOU SIGURG SIGXCPU SIGXFSZ SIGVTALRM \
+                    SIGPROF SIGWINCH SIGIO SIGPWR SIGSYS
                 echo $signals[$sigix]
             else
                 echo $arg

--- a/share/functions/fish_status_to_signal.fish
+++ b/share/functions/fish_status_to_signal.fish
@@ -1,15 +1,10 @@
 function fish_status_to_signal --description "Print signal name from argument (\$status), or just argument"
+    __fish_make_completion_signals # Make sure signals are cached
     for arg in $argv
         if test $arg -gt 128
-            set -l sigix (math $arg-128)
-            if test $sigix -le 31 # 31 = number of named signals below
-                set -l signals HUP INT QUIT ILL TRAP ABRT BUS FPE KILL USR1 \
-                    SEGV USR2 PIPE ALRM TERM STKFLT CHLD CONT STOP TSTP \
-                    TTIN TTOU URG XCPU XFSZ VTALRM PROF WINCH IO PWR SYS
-                echo SIG$signals[$sigix]
-            else
-                echo $arg
-            end
+            # Important: each element of $__kill_signals is a string like "10 USR1"
+            string replace -r --filter "^$(math $arg-128) " SIG $__kill_signals |
+                read -l signal && echo $signal || echo $arg
         else
             echo $arg
         end

--- a/share/functions/fish_status_to_signal.fish
+++ b/share/functions/fish_status_to_signal.fish
@@ -3,7 +3,7 @@ function fish_status_to_signal --description "Print signal name from argument (\
     for arg in $argv
         if test $arg -gt 128
             # Important: each element of $__kill_signals is a string like "10 USR1"
-            string replace -r --filter "^$(math $arg-128) " SIG $__kill_signals |
+            string replace -r --filter '^'(math $arg-128)' ' SIG $__kill_signals |
                 read -l signal && echo $signal || echo $arg
         else
             echo $arg

--- a/share/functions/fish_status_to_signal.fish
+++ b/share/functions/fish_status_to_signal.fish
@@ -1,14 +1,12 @@
 function fish_status_to_signal --description "Print signal name from argument (\$status), or just argument"
     for arg in $argv
         if test $arg -gt 128
-            set -l sigix (math $arg - 128)
+            set -l sigix (math $arg-128)
             if test $sigix -le 31 # 31 = number of named signals below
-                set -l signals SIGHUP SIGINT SIGQUIT SIGILL SIGTRAP SIGABRT SIGBUS \
-                    SIGFPE SIGKILL SIGUSR1 SIGSEGV SIGUSR2 SIGPIPE SIGALRM \
-                    SIGTERM SIGSTKFLT SIGCHLD SIGCONT SIGSTOP SIGTSTP \
-                    SIGTTIN SIGTTOU SIGURG SIGXCPU SIGXFSZ SIGVTALRM \
-                    SIGPROF SIGWINCH SIGIO SIGPWR SIGSYS
-                echo $signals[$sigix]
+                set -l signals HUP INT QUIT ILL TRAP ABRT BUS FPE KILL USR1 \
+                    SEGV USR2 PIPE ALRM TERM STKFLT CHLD CONT STOP TSTP \
+                    TTIN TTOU URG XCPU XFSZ VTALRM PROF WINCH IO PWR SYS
+                echo SIG$signals[$sigix]
             else
                 echo $arg
             end


### PR DESCRIPTION
## Description

Some super small changes to `fish_status_to_signal` that grant a massive speed boost.
Running `(count $signals)` is slow, and silly considering that we know the number already. 
And this list of signals is never, ever going to change, so it won't waste any developer time in the future.

```fish
# In config.fish
set -g list (seq 255)

function new_status_to_signal
    for arg in $argv
        if test $arg -gt 128
            set -l sigix (math $arg - 128)
            if test $sigix -le 31
                set -l signals SIGHUP SIGINT SIGQUIT SIGILL SIGTRAP SIGABRT SIGBUS \
                    SIGFPE SIGKILL SIGUSR1 SIGSEGV SIGUSR2 SIGPIPE SIGALRM \
                    SIGTERM SIGSTKFLT SIGCHLD SIGCONT SIGSTOP SIGTSTP \
                    SIGTTIN SIGTTOU SIGURG SIGXCPU SIGXFSZ SIGVTALRM \
                    SIGPROF SIGWINCH SIGIO SIGPWR SIGSYS
                echo $signals[$sigix]
            else
                echo $arg
            end
        else
            echo $arg
        end
    end
    return 0
end
```

```fish
ilan@arch ~> hyperfine --shell=fish "fish_status_to_signal \$list" "new_status_to_signal \$list"
Benchmark 1: fish_status_to_signal $list
  Time (mean ± σ):      23.4 ms ±   3.0 ms    [User: 15.6 ms, System: 10.0 ms]
  Range (min … max):    12.9 ms …  37.4 ms    103 runs
 
Benchmark 2: new_status_to_signal $list
  Time (mean ± σ):      11.7 ms ±   0.9 ms    [User: 7.3 ms, System: 6.0 ms]
  Range (min … max):     6.7 ms …  14.5 ms    177 runs
 
Summary
  'new_status_to_signal $list' ran
    1.99 ± 0.30 times faster than 'fish_status_to_signal $list'
```
