### PR TITLE
Fix cd to empty string crashes shell

### DIFF
--- a/src/builtins/cd.cpp
+++ b/src/builtins/cd.cpp
@@ -36,6 +36,9 @@ maybe_t<int> builtin_cd(parser_t &parser, io_streams_t &streams, const wchar_t *
 
     wcstring dir_in;
     if (argv[optind]) {
+        if (argv[optind] == "") {
+            return 0;
+        }
         dir_in = argv[optind];
     } else {
         auto maybe_dir_in = parser.vars().get(L"HOME");


### PR DESCRIPTION
Issue:
```
~ _ fish -c 'cd ""'
terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::at: __n (which is 0) >= this->size() (which is 0)
fish: Job 1, 'fish -c 'cd ""'' terminated by signal SIGABRT (Abort)
```

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
