### PR TITLE
Fix "Error: target STRING not available" error in fish_clipboard_paste for xclip

### DIFF
--- a/share/functions/fish_clipboard_paste.fish
+++ b/share/functions/fish_clipboard_paste.fish
@@ -7,7 +7,7 @@ function fish_clipboard_paste
     else if set -q DISPLAY; and type -q xsel
         set data (xsel --clipboard)
     else if set -q DISPLAY; and type -q xclip
-        set data (xclip -selection clipboard -o)
+        set data (xclip -selection clipboard -o 2>/dev/null)
     else if type -q powershell.exe
         set data (powershell.exe Get-Clipboard | string trim -r -c \r)
     end


### PR DESCRIPTION
## Description

Talk about your changes here.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
