### PR TITLE
Fix typo in __fish_tokenizer_state

### DIFF
--- a/share/functions/__fish_tokenizer_state.fish
+++ b/share/functions/__fish_tokenizer_state.fish
@@ -13,7 +13,7 @@ function __fish_tokenizer_state --description "Print the state of the tokenizer 
 
     set -l state normal
     if set -q _flag_initial_state
-        set str $_flag_initial_state
+        set state $_flag_initial_state
     end
 
     for char in (string split -- "" $argv[1])


### PR DESCRIPTION
## Description

It seems `str` is a typo because it's never used.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
