### PR TITLE
Read more fasterer

### DIFF
--- a/src/builtins/read.cpp
+++ b/src/builtins/read.cpp
@@ -494,8 +494,6 @@ maybe_t<int> builtin_read(parser_t &parser, io_streams_t &streams, const wchar_t
     do {
         buff.clear();
 
-        // TODO: Determine if the original set of conditions for interactive reads should be
-        // reinstated: if (isatty(0) && streams.stdin_fd == STDIN_FILENO && !split_null) {
         int stream_stdin_is_a_tty = isatty(streams.stdin_fd);
         if (stream_stdin_is_a_tty && !opts.split_null) {
             // Read interactively using reader_readline(). This does not support splitting on null.

--- a/tests/checks/read.fish
+++ b/tests/checks/read.fish
@@ -366,3 +366,12 @@ function-scoped-read
 # CHECK: $skamtebord[1]: |bar|
 # CHECK: $craaab: set in local scope, unexported, with 1 elements
 # CHECK: $craaab[1]: |baz|
+
+echo foo\nbar\nbaz | begin
+    read -l foo
+    read -l bar
+    cat
+    # CHECK: baz
+    echo $bar
+    # CHECK: bar
+end


### PR DESCRIPTION
We can't always read in chunks because we often can't bear to
overread:

```fish
echo foo\nbar | begin
    read -l foo
    read -l bar
end
```

needs to have the first read read `foo` and the second read `bar`. So
here we can only read one byte at a time.

However, when we are directly redirected:

```fish
echo foo | read foo
```

we can, because the data is only for us anyway. The stream will be
closed after, so anything not read just goes away. Nobody else is
there to read.

This dramatically speeds up `read` of long lines through a pipe. How
much depends on the length of the line.

With lines of 5000 characters it's about 15x, with lines of 50
characters about 2x, lines of 5 characters about 1.07x.

See #8542.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Tentatively scheduling this for after 3.4 because I am not entirely sure if the assumptions hold. Is there a case where we are directly redirected but the fd is used?