### PR TITLE
Escape double quotes when pasting

### DIFF
--- a/share/functions/fish_clipboard_paste.fish
+++ b/share/functions/fish_clipboard_paste.fish
@@ -27,14 +27,17 @@ function fish_clipboard_paste
     #
     # This eases pasting non-code (e.g. markdown or git commitishes).
     set -l quote_state (__fish_tokenizer_state -- (commandline -ct | string collect))
-    if contains -- $quote_state single single-escaped
+
+    if contains -- $quote_state single single-escaped double double-escaped
+        set -l quote_char \'
+        contains -- $quote_state double double-escaped; and set quote_char \"
+
         if status test-feature regex-easyesc
-            set data (string replace -ra "(['\\\])" '\\\\$1' -- $data)
+            set data (string replace -ra "([$quote_char\\\])" '\\\\$1' -- $data)
         else
-            set data (string replace -ra "(['\\\])" '\\\\\\\$1' -- $data)
+            set data (string replace -ra "([$quote_char\\\])" '\\\\\\\$1' -- $data)
         end
-    else if not contains -- $quote_state double double-escaped
-        and set -q data[2]
+    else if set -q data[2]
         # Leading whitespace in subsequent lines is unneded, since fish
         # already indents. Also gets rid of tabs (issue #5274).
         set -l tmp


### PR DESCRIPTION
## Description

To be more consistent in pasting I made fish escape double quotes too when single/double quotes are open.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
