### PR TITLE
Add basic completion for mvn -pl switch

### DIFF
--- a/share/completions/mvn.fish
+++ b/share/completions/mvn.fish
@@ -87,8 +87,13 @@ function __fish_mvn_profiles
     sed -n -e '/<profile>/{n; s!^.*<id>\([^<]*\)</id>.*$!\1!; p}' ~/.m2/settings.xml pom.xml 2>/dev/null
 end
 
+function __fish_mvn_projects
+    grep "<module>" pom.xml 2>/dev/null | sed 's/\s*<[^<]*>\(.*\)<[^<]*>/\1/'
+end
+
 complete -c mvn -f -r -o P -l activate-profiles -a "(__fish_mvn_profiles)" -d "Comma-delimited list of profiles to activate"
 
+complete -c mvn -f -r -o pl -l projects -a "(__fish_mvn_projects)" -d "Projects to build"
 
 #default properties for some plugins / profiles
 complete -c mvn -o DskipTests -d "Skipping JUnit Tests"


### PR DESCRIPTION
## Description

This patch introduces basic completion of the `-pl|--projects` switch for `mvn`. The implementation is quite naive but it's better than nothing. A more robust implementation would require either scanning the filesystem or running `mvn` which might slow down completion significantly.

Fixes issue #

## TODOs:
<!-- Just check off what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
