### PR TITLE
Provide completions for `complete` without `-c`

### DIFF
--- a/share/completions/complete.fish
+++ b/share/completions/complete.fish
@@ -1,5 +1,6 @@
 # Completions for complete
 
+complete -c complete -xa '(__fish_complete_command)'
 complete -c complete -s c -l command -d "Command to add completion to" -xa '(__fish_complete_command)'
 complete -c complete -s p -l path -d "Path to add completion to" -r
 complete -c complete -s s -l short-option -d "POSIX-style short option to complete" -x


### PR DESCRIPTION
## Description

Since #7321 `-c` is optional for `command`, but this is not the case for its completions.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
