### PR TITLE
Expand wildcards on tab

### DIFF
--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -674,11 +674,11 @@ void completer_t::complete_cmd(const wcstring &str_cmd) {
     completion_list_t possible_comp;
 
     // Append all possible executables
-    expand_result_t result =
-        expand_string(str_cmd, &this->completions,
-                      this->expand_flags() | expand_flag::special_for_command |
-                          expand_flag::for_completions | expand_flag::executables_only,
-                      ctx);
+    expand_result_t result = expand_string(
+        str_cmd, &this->completions,
+        this->expand_flags() | expand_flag::special_for_command | expand_flag::for_completions |
+            expand_flag::preserve_home_tildes | expand_flag::executables_only,
+        ctx);
     if (result == expand_result_t::cancel) {
         return;
     }
@@ -690,10 +690,10 @@ void completer_t::complete_cmd(const wcstring &str_cmd) {
     // updated with choices for the user.
     expand_result_t ignore =
         // Append all matching directories
-        expand_string(
-            str_cmd, &this->completions,
-            this->expand_flags() | expand_flag::for_completions | expand_flag::directories_only,
-            ctx);
+        expand_string(str_cmd, &this->completions,
+                      this->expand_flags() | expand_flag::for_completions |
+                          expand_flag::preserve_home_tildes | expand_flag::directories_only,
+                      ctx);
     UNUSED(ignore);
 
     if (str_cmd.empty() || (str_cmd.find(L'/') == wcstring::npos && str_cmd.at(0) != L'~')) {
@@ -1106,8 +1106,8 @@ bool completer_t::complete_param_for_command(const wcstring &cmd_orig, const wcs
 void completer_t::complete_param_expand(const wcstring &str, bool do_file,
                                         bool handle_as_special_cd) {
     if (ctx.check_cancel()) return;
-    expand_flags_t flags =
-        this->expand_flags() | expand_flag::skip_cmdsubst | expand_flag::for_completions;
+    expand_flags_t flags = this->expand_flags() | expand_flag::skip_cmdsubst |
+                           expand_flag::for_completions | expand_flag::preserve_home_tildes;
 
     if (!do_file) flags |= expand_flag::skip_wildcards;
 

--- a/src/complete.h
+++ b/src/complete.h
@@ -87,6 +87,9 @@ class completion_t {
     completion_t(completion_t &&) noexcept;
     completion_t &operator=(completion_t &&) noexcept;
 
+    /// \return whether this replaces its token.
+    bool replaces_token() const { return flags & COMPLETE_REPLACES_TOKEN; }
+
     // Compare two completions. No operating overlaoding to make this always explicit (there's
     // potentially multiple ways to compare completions).
     //

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -858,43 +858,6 @@ void expand_tilde(wcstring &input, const environment_t &vars) {
     }
 }
 
-static void unexpand_tildes(const wcstring &input, const environment_t &vars,
-                            completion_list_t *completions) {
-    // If input begins with tilde, then try to replace the corresponding string in each completion
-    // with the tilde. If it does not, there's nothing to do.
-    if (input.empty() || input.at(0) != L'~') return;
-
-    // We only operate on completions that replace their contents. If we don't have any, we're done.
-    // In particular, empty vectors are common.
-    bool has_candidate_completion = false;
-    for (const auto &completion : *completions) {
-        if (completion.flags & COMPLETE_REPLACES_TOKEN) {
-            has_candidate_completion = true;
-            break;
-        }
-    }
-    if (!has_candidate_completion) return;
-
-    size_t tail_idx;
-    wcstring username_with_tilde = L"~";
-    username_with_tilde.append(get_home_directory_name(input, &tail_idx));
-
-    // Expand username_with_tilde.
-    wcstring home = username_with_tilde;
-    expand_tilde(home, vars);
-
-    // Now for each completion that starts with home, replace it with the username_with_tilde.
-    for (auto &comp : *completions) {
-        if ((comp.flags & COMPLETE_REPLACES_TOKEN) &&
-            string_prefixes_string(home, comp.completion)) {
-            comp.completion.replace(0, home.size(), username_with_tilde);
-
-            // And mark that our tilde is literal, so it doesn't try to escape it.
-            comp.flags |= COMPLETE_DONT_ESCAPE_TILDES;
-        }
-    }
-}
-
 // If the given path contains the user's home directory, replace that with a tilde. We don't try to
 // be smart about case insensitivity, etc.
 wcstring replace_home_directory_with_tilde(const wcstring &str, const environment_t &vars) {
@@ -970,6 +933,10 @@ class expander_t {
 
     expander_t(const operation_context_t &ctx, expand_flags_t flags, parse_error_list_t *errors)
         : ctx(ctx), flags(flags), errors(errors) {}
+
+    // Given an original input string, if it starts with a tilde, "unexpand" the expanded home
+    // directory.  Note this may be just a tilde or a user name like ~foo/.
+    void unexpand_tildes(const wcstring &input, completion_list_t *completions) const;
 
    public:
     static expand_result_t expand_string(wcstring input, completion_receiver_t *out_completions,
@@ -1137,6 +1104,50 @@ expand_result_t expander_t::stage_wildcards(wcstring path_to_expand, completion_
     return result;
 }
 
+void expander_t::unexpand_tildes(const wcstring &input, completion_list_t *completions) const {
+    // If input begins with tilde, then try to replace the corresponding string in each completion
+    // with the tilde. If it does not, there's nothing to do.
+    if (input.empty() || input.at(0) != L'~') return;
+
+    // This is a subtle kludge. We need to decide whether to unexpand tildes for all
+    // completions, or only those which replace their tokens. The problem is that we're sloppy
+    // about setting the COMPLETE_REPLACES_TOKEN flag, except when we're completing in the
+    // wildcard stage, because no other clients of string expansion care. Example:
+    //   HOME=/foo
+    //   mkdir ~/foo # makes /foo/foo
+    //   cd ~/<tab>
+    // Here we are likely to get a completion 'foo' which may match $HOME, but it extends its token
+    // instead of replacing it, so we don't modify it (it will just be appended to the original ~/).
+    //
+    // However if we are not completing, just expanding, then expansion just produces the full paths
+    // so we should unconditionally unexpand tildes.
+    bool only_replacers = bool(flags & expand_flag::for_completions);
+
+    // Helper to decide whether to process a completion.
+    auto should_process = [=](const completion_t &c) {
+        return only_replacers ? c.replaces_token() : true;
+    };
+
+    // Early out if none qualify.
+    if (std::none_of(completions->begin(), completions->end(), should_process)) return;
+
+    // Get the username_with_tilde (like ~bert) and expand it into a home directory.
+    size_t tail_idx;
+    wcstring username_with_tilde = L"~" + get_home_directory_name(input, &tail_idx);
+    wcstring home = username_with_tilde;
+    expand_tilde(home, ctx.vars);
+
+    // Now for each completion that starts with home, replace it with the username_with_tilde.
+    for (auto &comp : *completions) {
+        if (should_process(comp) && string_prefixes_string(home, comp.completion)) {
+            comp.completion.replace(0, home.size(), username_with_tilde);
+
+            // And mark that our tilde is literal, so it doesn't try to escape it.
+            comp.flags |= COMPLETE_DONT_ESCAPE_TILDES;
+        }
+    }
+}
+
 expand_result_t expander_t::expand_string(wcstring input, completion_receiver_t *out_completions,
                                           expand_flags_t flags, const operation_context_t &ctx,
                                           parse_error_list_t *errors) {
@@ -1196,8 +1207,10 @@ expand_result_t expander_t::expand_string(wcstring input, completion_receiver_t 
     }
 
     if (total_result == expand_result_t::ok) {
-        // Hack to un-expand tildes (see #647).
-        unexpand_tildes(input, ctx.vars, &completions);
+        // Unexpand tildes if we want to preserve them (see #647).
+        if (flags.get(expand_flag::preserve_home_tildes)) {
+            expand.unexpand_tildes(input, &completions);
+        }
         if (!out_completions->add_list(std::move(completions))) {
             total_result = append_overflow_error(errors);
         }

--- a/src/expand.h
+++ b/src/expand.h
@@ -40,6 +40,8 @@ enum class expand_flag {
     directories_only,
     /// Generate descriptions, stored in the description field of completions.
     gen_descriptions,
+    /// Un-expand home directories to tildes after.
+    preserve_home_tildes,
     /// Allow fuzzy matching.
     fuzzy_match,
     /// Disallow directory abbreviations like /u/l/b for /usr/local/bin. Only applicable if

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -763,6 +763,9 @@ class reader_data_t : public std::enable_shared_from_this<reader_data_t> {
     /// incorporating changes from the commandline builtin.
     void apply_commandline_state_changes();
 
+    /// Compute completions and update the pager and/or commandline as needed.
+    void compute_and_apply_completions(readline_cmd_t c, readline_loop_state_t &rls);
+
     void move_word(editable_line_t *el, bool move_right, bool erase, enum move_word_style_t style,
                    bool newv);
 
@@ -2759,6 +2762,68 @@ void reader_data_t::apply_commandline_state_changes() {
     }
 }
 
+void reader_data_t::compute_and_apply_completions(readline_cmd_t c, readline_loop_state_t &rls) {
+    assert((c == readline_cmd_t::complete || c == readline_cmd_t::complete_and_search) &&
+           "Invalid command");
+    editable_line_t *el = &command_line;
+
+    // Remove a trailing backslash. This may trigger an extra repaint, but this is
+    // rare.
+    if (is_backslashed(el->text(), el->position())) {
+        delete_char();
+    }
+
+    // Get the string; we have to do this after removing any trailing backslash.
+    const wchar_t *const buff = el->text().c_str();
+
+    // Figure out the extent of the command substitution surrounding the cursor.
+    // This is because we only look at the current command substitution to form
+    // completions - stuff happening outside of it is not interesting.
+    const wchar_t *cmdsub_begin, *cmdsub_end;
+    parse_util_cmdsubst_extent(buff, el->position(), &cmdsub_begin, &cmdsub_end);
+
+    // Figure out the extent of the token within the command substitution. Note we
+    // pass cmdsub_begin here, not buff.
+    const wchar_t *token_begin, *token_end;
+    parse_util_token_extent(cmdsub_begin, el->position() - (cmdsub_begin - buff), &token_begin,
+                            &token_end, nullptr, nullptr);
+
+    // Hack: the token may extend past the end of the command substitution, e.g. in
+    // (echo foo) the last token is 'foo)'. Don't let that happen.
+    if (token_end > cmdsub_end) token_end = cmdsub_end;
+
+    // Construct a copy of the string from the beginning of the command substitution
+    // up to the end of the token we're completing.
+    const wcstring buffcpy = wcstring(cmdsub_begin, token_end);
+
+    // Ensure that `commandline` inside the completions gets the current state.
+    update_commandline_state();
+
+    completion_request_flags_t complete_flags = {completion_request_t::descriptions,
+                                                 completion_request_t::fuzzy_match};
+    rls.comp = complete(buffcpy, complete_flags, parser_ref->context());
+
+    // User-supplied completions may have changed the commandline - prevent buffer
+    // overflow.
+    if (token_begin > buff + el->text().size()) token_begin = buff + el->text().size();
+    if (token_end > buff + el->text().size()) token_end = buff + el->text().size();
+
+    // Munge our completions.
+    completions_sort_and_prioritize(&rls.comp);
+
+    // Record our cycle_command_line.
+    cycle_command_line = el->text();
+    cycle_cursor_pos = token_end - buff;
+
+    rls.complete_did_insert = handle_completions(rls.comp, token_begin - buff, token_end - buff);
+
+    // Show the search field if requested and if we printed a list of completions.
+    if (c == readline_cmd_t::complete_and_search && !rls.complete_did_insert && !pager.empty()) {
+        pager.set_search_field_shown(true);
+        select_completion_in_direction(selection_motion_t::next);
+    }
+}
+
 static relaxed_atomic_t<uint64_t> run_count{0};
 
 /// Returns the current interactive loop count
@@ -3075,9 +3140,6 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
         case rl::complete:
         case rl::complete_and_search: {
             if (!conf.complete_ok) break;
-
-            // Use the command line only; it doesn't make sense to complete in any other line.
-            editable_line_t *el = &command_line;
             if (is_navigating_pager_contents() ||
                 (!rls.comp.empty() && !rls.complete_did_insert && rls.last_cmd == rl::complete)) {
                 // The user typed complete more than once in a row. If we are not yet fully
@@ -3090,63 +3152,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 }
             } else {
                 // Either the user hit tab only once, or we had no visible completion list.
-                // Remove a trailing backslash. This may trigger an extra repaint, but this is
-                // rare.
-                if (is_backslashed(el->text(), el->position())) {
-                    delete_char();
-                }
-
-                // Get the string; we have to do this after removing any trailing backslash.
-                const wchar_t *const buff = el->text().c_str();
-
-                // Figure out the extent of the command substitution surrounding the cursor.
-                // This is because we only look at the current command substitution to form
-                // completions - stuff happening outside of it is not interesting.
-                const wchar_t *cmdsub_begin, *cmdsub_end;
-                parse_util_cmdsubst_extent(buff, el->position(), &cmdsub_begin, &cmdsub_end);
-
-                // Figure out the extent of the token within the command substitution. Note we
-                // pass cmdsub_begin here, not buff.
-                const wchar_t *token_begin, *token_end;
-                parse_util_token_extent(cmdsub_begin, el->position() - (cmdsub_begin - buff),
-                                        &token_begin, &token_end, nullptr, nullptr);
-
-                // Hack: the token may extend past the end of the command substitution, e.g. in
-                // (echo foo) the last token is 'foo)'. Don't let that happen.
-                if (token_end > cmdsub_end) token_end = cmdsub_end;
-
-                // Construct a copy of the string from the beginning of the command substitution
-                // up to the end of the token we're completing.
-                const wcstring buffcpy = wcstring(cmdsub_begin, token_end);
-
-                // Ensure that `commandline` inside the completions gets the current state.
-                update_commandline_state();
-
-                // std::fwprintf(stderr, L"Complete (%ls)\n", buffcpy.c_str());
-                completion_request_flags_t complete_flags = {completion_request_t::descriptions,
-                                                             completion_request_t::fuzzy_match};
-                rls.comp = complete(buffcpy, complete_flags, parser_ref->context());
-
-                // User-supplied completions may have changed the commandline - prevent buffer
-                // overflow.
-                if (token_begin > buff + el->text().size()) token_begin = buff + el->text().size();
-                if (token_end > buff + el->text().size()) token_end = buff + el->text().size();
-
-                // Munge our completions.
-                completions_sort_and_prioritize(&rls.comp);
-
-                // Record our cycle_command_line.
-                cycle_command_line = el->text();
-                cycle_cursor_pos = token_end - buff;
-
-                rls.complete_did_insert =
-                    handle_completions(rls.comp, token_begin - buff, token_end - buff);
-
-                // Show the search field if requested and if we printed a list of completions.
-                if (c == rl::complete_and_search && !rls.complete_did_insert && !pager.empty()) {
-                    pager.set_search_field_shown(true);
-                    select_completion_in_direction(selection_motion_t::next);
-                }
+                compute_and_apply_completions(c, rls);
             }
             break;
         }

--- a/tests/pexpects/wildcard_tab.py
+++ b/tests/pexpects/wildcard_tab.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import signal
+from pexpect_helper import SpawnedProc
+
+sp = SpawnedProc()
+send, sendline, sleep, expect_prompt, expect_re, expect_str = (
+    sp.send,
+    sp.sendline,
+    sp.sleep,
+    sp.expect_prompt,
+    sp.expect_re,
+    sp.expect_str,
+)
+
+expect_prompt()
+
+sendline("cd (mktemp -d)")
+expect_prompt()
+
+sendline("touch aaa1 aaa2 aaa3")
+expect_prompt()
+
+send("cat *")
+sleep(0.1)
+send("\t")
+expect_str("cat aaa1 aaa2 aaa3")
+sendline("")
+expect_prompt()
+
+send("cat *2")
+sleep(0.1)
+send("\t")
+expect_str("cat aaa2")
+sendline("")
+expect_prompt()
+
+# Globs that fail to expand are left alone.
+send("cat qqq*")
+sleep(0.1)
+send("\t")
+expect_str("cat qqq*")
+sendline("")
+expect_prompt()
+
+# Special characters in expanded globs are properly escaped.
+sendline(r"touch bb\*bbQ cc\;ccQ")
+expect_prompt()
+send("cat *Q")
+sleep(0.1)
+send("\t")
+expect_str(r"cat bb\*bbQ cc\;ccQ")
+sendline("")
+expect_prompt()


### PR DESCRIPTION
Prior to this change, if you tab-completed a token with a wildcard (glob), we would invoke ordinary completions. Instead, expand the wildcard, replacing the wildcard with the result of expansions. If the wildcard fails to expand,  flash the command line to signal an error and do not modify it.

Example:

    > touch file(seq 4)
    > echo file*<tab>

becomes:

    > echo file1 file2 file3 file4
	
whereas before the tab would have just added a space.

Some things to note:

1. If the expansion would produce more than 256 items, we flash the command line and do nothing, since it would make the commandline overfull.
2. The wildcard token can be brought back through Undo (ctrl-Z).

Fixes #954.
