### PR TITLE
webconfig.py: minor polish of `is_chromeos_garcon`

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -93,7 +93,10 @@ def is_chromeos_garcon():
     # Linux filesystem. This uses Garcon, see for example
     # https://chromium.googlesource.com/chromiumos/platform2/+/master/vm_tools/garcon/#opening-urls
     # https://source.chromium.org/search?q=garcon-url-handler
-    return "garcon-url-handler" in webbrowser.get().name
+    try:
+        return "garcon-url-handler" in webbrowser.get().name
+    except AttributeError:
+        return False
 
 
 def run_fish_cmd(text):


### PR DESCRIPTION
The `name` attribute I used in commit f725cd402d0324b2660a1fda2ac299d5ac146593
is undocumented, and [someone discovered] that it does not exist for one 
possible browser on MacOS. This should make the code work correctly even in that case. 

This probably doesn't currently cause a problem, at least when 
`isMacOS10_12_5_OrLater()` is true, because of the ordering of the if 
statements in the `runThing` function.

[someone discovered]: https://bugs.python.org/issue43424#msg409087

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages. (there are none)
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst (there are none)
