### PR TITLE
completions/opam: add completions for "opam switch"

### DIFF
--- a/share/completions/opam.fish
+++ b/share/completions/opam.fish
@@ -102,3 +102,22 @@ complete -f -c opam -n '__fish_opam_using_command admin' -a check -d "Check a lo
 complete -f -c opam -n '__fish_opam_using_command admin' -a depexts -d "Add external dependencies."
 complete -f -c opam -n '__fish_opam_using_command admin' -a make -d "Initialize a repo for serving files."
 complete -f -c opam -n '__fish_opam_using_command admin' -a stats -d "Compute statistics."
+
+# opam switch
+set -l switchcommands create set remove export import reinstall list list-available show set-base set-description link
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'create' -d 'Create a new switch, and install the given compiler there'
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'set' -d 'Set the currently active switch'
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'remove' -d 'Remove the given switch from disk'
+complete -c opam -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'export' -d 'Save the current switch state to a file'
+complete -c opam -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'import' -d 'Import a saved switch state'
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'reinstall' -d 'Reinstall the given compiler switch and all its packages'
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'list' -d 'Lists installed switches'
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'list-available' -d 'Lists base packages that can be used to create a new switch'
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'show' -d 'Prints the name of the current switch'
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'set-base' -d 'Sets the packages forming the immutable base for the selected switch'
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and not __fish_seen_subcommand_from $switchcommands" -a 'link' -d 'Sets a local alias for a given switch'
+
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and __fish_seen_subcommand_from set" -a '(opam switch list --short)'
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and __fish_seen_subcommand_from remove" -a '(opam switch list --short)'
+
+complete -c opam -f -n "__fish_seen_subcommand_from switch; and __fish_seen_subcommand_from create" -a '(opam switch list-available --short)'


### PR DESCRIPTION
## Description

The completion script for [opam](https://opam.ocaml.org) is a good start, but not a real time-saver yet because it will not complete either sub-commands or their arguments.

For example, `opam switch set $switchName` is a frequent operation for many OCaml users, but without completion, the user has to type it from memory or look it up in `opam switch list`.

This is the first batch of changes intended to improve that.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
