### PR TITLE
Run `fish_indent` on `funcsave`

### DIFF
--- a/share/functions/funcsave.fish
+++ b/share/functions/funcsave.fish
@@ -29,6 +29,7 @@ function funcsave --description "Save the current definition of all specified fu
         set -l funcpath "$funcdir/$funcname.fish"
         if functions -q -- $funcname
             functions --no-details -- $funcname >$funcpath
+            and fish_indent --write $funcpath
             and set -q _flag_quiet || printf (_ "%s: wrote %s\n") funcsave $funcpath
         else if test -w $funcpath
             rm $funcpath

--- a/share/functions/funcsave.fish
+++ b/share/functions/funcsave.fish
@@ -28,8 +28,7 @@ function funcsave --description "Save the current definition of all specified fu
     for funcname in $argv
         set -l funcpath "$funcdir/$funcname.fish"
         if functions -q -- $funcname
-            functions --no-details -- $funcname >$funcpath
-            and fish_indent --write $funcpath
+            functions --no-details -- $funcname | fish_indent >$funcpath
             and set -q _flag_quiet || printf (_ "%s: wrote %s\n") funcsave $funcpath
         else if test -w $funcpath
             rm $funcpath


### PR DESCRIPTION
## Description

`funced` already run `fish_indent` when the editor is fish:

https://github.com/fish-shell/fish-shell/blob/f254692759aa564420702a54e76feb133b50c25d/share/functions/funced.fish#L61-L75

It makes sense to have `funcsave` run it as well.

Maybe we should also run `fish_indent` after `funced` finishes?

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
