### PR TITLE
[RFC] Allow underscore separators in numeric literals in `math` builtin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,7 @@ Scripting improvements
 - ``$fish_user_paths`` is now automatically deduplicated to fix a common user error of appending to it in config.fish when it is universal (:issue:`8117`). :ref:`fish_add_path <cmd-fish_add_path>` remains the recommended way to add to $PATH.
 - ``return`` can now be used outside of functions. In scripts it does the same thing as :program:`exit`, in the command line it sets ``$status`` without exiting (:issue:`8148`).
 - An oversight prevented all syntax checks from running on commands given to ``fish -c`` (:issue:`8171`). This includes checks like e.g. ``exec`` not being allowed in a pipeline and ``$$`` not being a valid variable. Most of these would have triggered an assert or other error before.
+- ``math`` now allows you to use underscores as visual separators when writing numbers - for example, ``math 1_000 + 2_000`` returns ``3000`` (:issue:`8496`).
 - ``fish_indent`` now correctly reformats tokens that end with a backslash followed by a newline (:issue:`8197`).
 - ``commandline`` gained an ``--is-valid`` option to check if the command line is syntactically valid and complete. This allows basic implementation of transient prompts (:issue:`8142`).
 - ``commandline`` gained a ``--paging-full-mode`` option to check if the pager is showing all the possible lines (no "7 more rows" message) (:issue:`8485`).

--- a/doc_src/cmds/math.rst
+++ b/doc_src/cmds/math.rst
@@ -57,7 +57,10 @@ Syntax
 ``math`` knows some operators, constants, functions and can (obviously) read numbers.
 
 For numbers, ``.`` is always the radix character regardless of locale - ``2.5``, not ``2,5``.
-Scientific notation (``10e5``) and hexadecimal (``0xFF``) are also available.
+Scientific notation (``10e5``) is also available,
+and hexadecimal (``0xFF``) is available on most platforms.
+
+``math`` allows you to use underscores as visual separators for digit grouping, for example as in ``1_000_000``, ``0xAB_CD_EF`` and ``1_234.567_890``. Underscores may appear between any two digits. Leading and trailing underscores, multiple consecutive underscores, and underscores next to an ``x`` (as in ``0x_FF``) or ``e`` (as in ``10_e2``) are not allowed.
 
 Operators
 ---------

--- a/src/builtins/math.cpp
+++ b/src/builtins/math.cpp
@@ -178,6 +178,8 @@ static const wchar_t *math_describe_error(const te_error_t &error) {
             return _(L"Unexpected token");
         case TE_ERROR_LOGICAL_OPERATOR:
             return _(L"Logical operations are not supported, use `test` instead");
+        case TE_ERROR_BAD_UNDERSCORE:
+            return _(L"Underscore separators must be between digits");
         case TE_ERROR_UNKNOWN:
             return _(L"Expression is bogus");
         default:

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3000,6 +3000,52 @@ static void test_wcstod() {
     tod_test(L"nope", "nope");
 }
 
+static void test_fish_wcstod_underscores() {
+    say(L"Testing fish_wcstod_underscores");
+
+    auto compare = [](const wchar_t *underscores, const wchar_t *clean) {
+        say(underscores);
+        // Test that fish_wcstod_underscores treats s_underscores the same way that wcstod treats s_clean.
+        wchar_t *underscores_end = nullptr;
+        wchar_t *clean_end = nullptr;
+        double underscores_val = fish_wcstod_underscores(underscores, &underscores_end);
+        double clean_val = wcstod(clean, &clean_end);
+        do_test((std::isnan(underscores_val) && std::isnan(clean_val)) ||
+                fabs(underscores_val - clean_val) <= __DBL_EPSILON__);
+        do_test(wcslen(underscores) - (size_t)(underscores_end - underscores) ==
+                wcslen(clean) - (size_t)(clean_end - clean));
+    };
+
+    compare(L"2e0_2 hello", L"2e02 hello");
+    compare(L"2e0_0_2 hello", L"2e002 hello");
+    compare(L"0x0", L"0x0");
+    compare(L"0x1..", L"0x1..");
+    compare(L"0x0_0", L"0x00");
+    compare(L"0x_", L"0x_");
+    compare(L"0x_0", L"0x_0");
+    compare(L"0x0_", L"0x0_");
+    compare(L"0x0_2p3", L"0x2p3");
+    compare(L"0x2p_3", L"0x2p_3");
+    compare(L"0x2_p3", L"0x2_p3");
+    compare(L"0x2p3_", L"0x2p3_");
+    compare(L"0x2p3__", L"0x2p3__");
+    compare(L"0x2p0_3", L"0x2p03");
+    compare(L"0x2p-0_3", L"0x2p-03");
+    compare(L"-0x2p-0_3", L"-0x2p-03");
+    compare(L"0x2p0__3", L"0x2p0__3");
+    compare(L"0x2p_03", L"0x2p_03");
+    compare(L"0x2_p03", L"0x2_p03");
+    compare(L"0x0123_", L"0x0123_");
+    compare(L"0x0123._", L"0x0123._");
+    compare(L"0x0123_.", L"0x0123_.");
+    compare(L" 0x1", L" 0x1");
+    compare(L"0xF_FP2", L"0xFFP2");
+    compare(L"0x1234_5678", L"0x12345678");
+    compare(L"0x12.34_5678", L"0x12.345678");
+    compare(L"0x1234_56.78", L"0x123456.78");
+    compare(L"0x1__2", L"0x1__2");
+}
+
 static void test_dup2s() {
     using std::make_shared;
     io_chain_t chain;
@@ -6792,6 +6838,7 @@ static const test_t s_tests[]{
     {TEST_GROUP("abbreviations"), test_abbreviations},
     {TEST_GROUP("builtins/test"), test_test},
     {TEST_GROUP("wcstod"), test_wcstod},
+    {TEST_GROUP("fish_wcstod_underscores"), test_fish_wcstod_underscores},
     {TEST_GROUP("dup2s"), test_dup2s},
     {TEST_GROUP("dup2s"), test_dup2s_fd_for_target_fd},
     {TEST_GROUP("path"), test_path},

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -356,6 +356,10 @@ static void next_token(state *s) {
                         s->type = TOK_ERROR;
                         s->error = TE_ERROR_LOGICAL_OPERATOR;
                         break;
+                    case '_':
+                        s->type = TOK_ERROR;
+                        s->error = TE_ERROR_BAD_UNDERSCORE;
+                        break;
                     default:
                         s->type = TOK_ERROR;
                         s->error = TE_ERROR_MISSING_OPERATOR;

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -272,7 +272,7 @@ static void next_token(state *s) {
 
         /* Try reading a number. */
         if ((s->next[0] >= '0' && s->next[0] <= '9') || s->next[0] == '.') {
-            s->value = fish_wcstod(s->next, const_cast<wchar_t **>(&s->next));
+            s->value = fish_wcstod_underscores(s->next, const_cast<wchar_t **>(&s->next));
             s->type = TOK_NUMBER;
         } else {
             /* Look for a function call. */

--- a/src/tinyexpr.h
+++ b/src/tinyexpr.h
@@ -37,7 +37,8 @@ typedef enum {
     TE_ERROR_MISSING_OPERATOR = 6,
     TE_ERROR_UNEXPECTED_TOKEN = 7,
     TE_ERROR_LOGICAL_OPERATOR = 8,
-    TE_ERROR_UNKNOWN = 9
+    TE_ERROR_BAD_UNDERSCORE = 9,
+    TE_ERROR_UNKNOWN = 10
 } te_error_type_t;
 
 typedef struct te_error_t {

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -133,6 +133,7 @@ long long fish_wcstoll(const wchar_t *str, const wchar_t **endptr = nullptr, int
 unsigned long long fish_wcstoull(const wchar_t *str, const wchar_t **endptr = nullptr,
                                  int base = 10);
 double fish_wcstod(const wchar_t *str, wchar_t **endptr);
+double fish_wcstod_underscores(const wchar_t *str, wchar_t **endptr);
 
 /// Class for representing a file's inode. We use this to detect and avoid symlink loops, among
 /// other things. While an inode / dev pair is sufficient to distinguish co-existing files, Linux

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -261,3 +261,73 @@ math pow 2 x cos'(-pi)', 2
 math 'ncr(0/0, 1)'
 # CHECKERR: math: Error: Result is infinite
 # CHECKERR: 'ncr(0/0, 1)'
+
+math 0_1
+# CHECK: 1
+math 0x0_A
+# CHECK: 10
+math 1_000 + 2_000
+# CHECK: 3000
+math 1_0_0_0
+# CHECK: 1000
+math 0_0.5_0 + 0_1.0_0
+# CHECK: 1.5
+math 2e0_0_2
+# CHECK: 200
+math -0_0.5_0_0E0_0_3
+# CHECK: -500
+math 20e-0_1
+# CHECK: 2
+math 0x0_2.0_0_0P0_2
+# CHECK: 8
+math -0x8p-0_3
+# CHECK: -1
+
+math 0__1
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '0__1'
+# CHECKERR:   ^
+math _1
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '_1'
+# CHECKERR:  ^
+math 1_
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '1_'
+# CHECKERR:   ^
+math _0x0
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '_0x0'
+# CHECKERR:  ^
+math 1_.0
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '1_.0'
+# CHECKERR:   ^
+math 1._0
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '1._0'
+# CHECKERR:    ^
+math 1_e1
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '1_e1'
+# CHECKERR:   ^
+math 0_x0
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '0_x0'
+# CHECKERR:   ^
+math 0x1_p1
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '0x1_p1'
+# CHECKERR:     ^
+math 1e_1
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '1e_1'
+# CHECKERR:    ^
+math 0x_0
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '0x_0'
+# CHECKERR:    ^
+math 0x1p_1
+# CHECKERR: math: Error: Underscore separators must be between digits
+# CHECKERR: '0x1p_1'
+# CHECKERR:      ^


### PR DESCRIPTION
## Description

This adds support for underscore separators in the `math` builtin.

After trying a few different things, this solution felt simplest. We have our own parser that preprocesses out the underscores and passes the pruned-down string to `strtod`/`wcstod`.

There are a few smaller things I'm not sure about:

- I initially opted to disallow underscores next to base or exponent specifiers, but actually `0x_FF` and `1.23_e3` read nicely. I think I'd like to support these. Does anyone have strong feelings about the specific rules of where we allow underscores? Other languages differ. Here's [Python](https://www.python.org/dev/peps/pep-0515/) for reference.
- The tinyexpr code around my changes could be cleaned up but I wanted to keep the PR diff small.
- Our docs say that the `math` builtin supports hex, but we use `strtod` under the hood to parse and AFAICT OpenBSD `strtod` doesn't allow hex (I don't have an OpenBSD machine to test this on so I'm not sure). I made a small drive-by change in the `math` man page, see the PR.
- I know you are all busy in the middle of the 3.4 release, I added a changelog entry but TBH I was not sure where to put it. No hurry on this, either.

Fixes issue #8496

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
