### PR TITLE
Clarify `functions -Dv`'s output

### DIFF
--- a/doc_src/cmds/functions.rst
+++ b/doc_src/cmds/functions.rst
@@ -33,7 +33,7 @@ The following options are available:
     - ``autoloaded``, ``not-autoloaded`` or ``n/a``,
     - the line number within the file or zero if not applicable,
     - ``scope-shadowing`` if the function shadows the vars in the calling function (the normal case if it wasn't defined with ``--no-scope-shadowing``), else ``no-scope-shadowing``, or ``n/a`` if the function isn't defined,
-    - the function description minimally escaped so it is a single line or ``n/a`` if the function isn't defined.
+    - the function description minimally escaped so it is a single line, or ``n/a`` if the function isn't defined or has no description.
 
 You should not assume that only five lines will be written since we may add additional information to the output in the future.
 


### PR DESCRIPTION
## Description

The last line of `functions -Dv` will be `n/a` if the function isn't defined **or has no description**. The current manpage doesn't mention the latter case.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
