### PR TITLE
Skip more leading commands in `__fish_man_page`

### DIFF
--- a/share/functions/__fish_man_page.fish
+++ b/share/functions/__fish_man_page.fish
@@ -8,9 +8,9 @@ function __fish_man_page
         return
     end
 
-    #Skip leading `sudo`/`command` and display then manpage of following command
+    # Skip leading `sudo`/`command`/`xargs` and display then manpage of following command
     while set -q args[2]
-        and string match -qr -- '^(sudo|command|.*=.*)$' $args[1]
+        and string match -qr -- '^(sudo|command|xargs|.*=.*)$' $args[1]
         set -e args[1]
     end
 

--- a/share/functions/__fish_man_page.fish
+++ b/share/functions/__fish_man_page.fish
@@ -10,7 +10,7 @@ function __fish_man_page
 
     # Skip leading commands and display then manpage of following command
     while set -q args[2]
-        and string match -qr -- '^(and|begin|builtin|caffeinate|command|doas|entr|env|exec|git|if|mosh|nice|not|or|pipenv|prime-run|setsid|sudo|systemd-nspawn|time|watch|while|xargs|.*=.*)$' $args[1]
+        and string match -qr -- '^(and|begin|builtin|caffeinate|command|doas|entr|env|exec|if|mosh|nice|not|or|pipenv|prime-run|setsid|sudo|systemd-nspawn|time|watch|while|xargs|.*=.*)$' $args[1]
         set -e args[1]
     end
 

--- a/share/functions/__fish_man_page.fish
+++ b/share/functions/__fish_man_page.fish
@@ -8,9 +8,9 @@ function __fish_man_page
         return
     end
 
-    # Skip leading `sudo`/`command`/`xargs` and display then manpage of following command
+    # Skip leading commands and display then manpage of following command
     while set -q args[2]
-        and string match -qr -- '^(sudo|command|xargs|.*=.*)$' $args[1]
+        and string match -qr -- '^(and|begin|builtin|caffeinate|command|doas|entr|env|exec|git|if|mosh|nice|not|or|pipenv|prime-run|setsid|sudo|systemd-nspawn|time|watch|while|xargs|.*=.*)$' $args[1]
         set -e args[1]
     end
 


### PR DESCRIPTION
## Description

Like #8447 but for more commands.

The list is generated via the following command:
```fish
rg -l __fish_complete_subcommand $__fish_data_dir/completions | xargs basename | sort | string replace .fish '' | string join "|"
```

I excluded `git` and `ssh` from the list since their "subcommand" cannot be arbitrary program.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
