### PR TITLE
Complete users for `id` command

### DIFF
--- a/share/completions/id.fish
+++ b/share/completions/id.fish
@@ -1,3 +1,10 @@
+complete -c id -xa "(__fish_complete_users)"
+
+if string match -eq 'GNU coreutils' (id --version 2>&1)
+    complete -c id -s Z -l context -d "Print security context"
+    complete -c id -s z -l zero -d "Delimit entries with NUL"
+end
+
 complete -c id -s g -l group -d "Print effective group id"
 complete -c id -s G -l groups -d "Print all group ids"
 complete -c id -s n -l name -d "Print name, not number"


### PR DESCRIPTION
## Description

Complete user names for `id` command. Besides, I added two further options.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
