### PR TITLE
Css: Update font stack

### DIFF
--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -228,7 +228,7 @@ tr, pre {
 
 code {
     /* Make inline-code better visible */
-    background-color: rgba(0,0,0, .08);
+    background-color: rgba(20,20,80, .1);
     padding-left: 5px;
     padding-right: 5px;
 }
@@ -519,6 +519,6 @@ div.body .internal.reference:link {
     }
 
     code {
-        background-color: rgba(255, 255, 255, .08);
+        background-color: rgba(200, 200, 255, .1);
     }
 }

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -222,8 +222,15 @@ div.body a:hover {
     color: #00B0E4;
 }
 
-tr, code, pre {
+tr, pre {
     background-color: inherit;
+}
+
+code {
+    /* Make inline-code better visible */
+    background-color: rgba(0,0,0, .08);
+    padding-left: 5px;
+    padding-right: 5px;
 }
 
 tt, code, pre, dl > dt span ~ em, #synopsis p, #synopsis code {
@@ -509,5 +516,9 @@ div.body .internal.reference:link {
     /* The table background on fishfish Beta r1 */
     th, dl.field-list > dt {
         background-color: #121;
+    }
+
+    code {
+        background-color: rgba(255, 255, 255, .08);
     }
 }

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -11,6 +11,19 @@ html {
 
 body {
     background: linear-gradient(to bottom, #a7cfdf 0%,#23538a 100%);
+    /* Pick a font.
+       sans-serif is the Browser default. This is great because the user could change it.
+       Unfortunately the defaults are decades old and e.g. on Windows still use Arial in Firefox and Edge,
+       and this seems unlikely to change.
+       So we use system-ui, which is "the system's interface font".
+       Unfortunately on Windows *that* depends on the locale, and e.g. in Chinese it apparently
+       picks a font that is okay at chinese characters but fairly bad at latin ones.
+       So we prefer the standard Windows font Segoe.
+       If that's installed anywhere else that's unfortunate but not horrible because it's an okay font.
+
+       See e.g. https://github.com/twbs/bootstrap/issues/22328
+    */
+    font-family: "Segoe UI", system-ui, sans-serif;
 }
 
 div#fmain {
@@ -128,7 +141,8 @@ ul li.toctree-l1 {
 
 form.inline-search input,
 div.sphinxsidebar input {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    /* Inputs typically have different default fonts, remove that idea */
+    font-family: inherit;
     border: 1px solid #999999;
     font-size: smaller;
     border-radius: 3px;
@@ -213,7 +227,22 @@ tr, code, pre {
 }
 
 tt, code, pre, dl > dt span ~ em, #synopsis p, #synopsis code {
-    font-family: monospace, fixed;
+    /* Pick a monospace font.
+       ui-monospace is the monospace version of system-ui - the system's monospace font.
+       Unfortunately it's barely supported anywhere (at time of writing only Safari does!),
+       and because monospace has the same limitations as sans-serif - Browser defaults are awful -
+       we hardcode a list of normal monospace fonts.
+       SFMono is San Francisco, Apple's font. Menlo is an older Apple one.
+       Consolas is a Windows font.
+       Ubuntu is the ubuntu monospace version, Hack is the default KDE monospace font,
+       Liberation is an arial-like.
+
+       NOTE: Under no circumstances can "Source Code Pro" appear in this list for a while as it had massive bugs on macOS.
+       It would not appear at all when colored.
+       This is unfortunate because it's the default Gnome monospace font.
+       Instead we use Noto, which is a common monospace font that is often installed for emoji support.
+    */
+    font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, "Ubuntu Mono", "Hack", "Noto Sans Mono", Liberation Mono, monospace;
 }
 
 #synopsis .line {

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -14,11 +14,6 @@ body {
     border-radius: 8px;
 }
 
-code {
-    font-family: "Source Code Pro", "DejaVu Sans Mono", Menlo, "Ubuntu Mono", Consolas, Monaco,
-        "Lucida Console", monospace, fixed;
-}
-
 #parent {
     width: 100%;
     min-height: 480px;

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -1,6 +1,7 @@
 body {
     background: linear-gradient(to bottom, #a7cfdf 0%, #23538a 100%);
-    font-family: monospace, fixed;
+    /* List explained in the doc theme pydoctheme.css */
+    font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, "Ubuntu Mono", "Hack", "Noto Sans Mono", Liberation Mono, monospace;
     color: #222;
 }
 


### PR DESCRIPTION
## Description

Unfortunately, the "monospace" and "sans-serif" font families are basically broken. The browser defaults have ossified, e.g. Firefox and Edge on Windows still default to Arial. (this situation, for the record, is horrible)

So, instead we try to use the "system-ui" font. Unfortunately there's a few caveats here:

1. Windows picks a different font depending on locale, and if the locale isn't latin-based it might not be good for latin text. So we prefer "Segoe UI", the latin windows font.
2. For monospace fonts there is "ui-monospace", but that's only supported in Safari, so we still need to give fonts that systems may use by default.

Online version at https://bean.solutions/fish-doc/.

## Screenshots

(in Firefox on Linux)

Before

![Screenshot 2022-01-12 at 17-38-03 Fish for bash users — fish-shell 3 3 1-885-gb1ec8af5e documentation](https://user-images.githubusercontent.com/5185367/149204016-f3d798db-3b6e-4f69-9ec6-f9a97a23d0bc.png)

After

![Screenshot 2022-01-12 at 19-57-24 Fish for bash users — fish-shell 3 3 1-885-gb1ec8af5e documentation](https://user-images.githubusercontent.com/5185367/149204270-4577bfbe-826e-4858-801b-e9125b43b781.png)

Note also how there's a colored background behind the inline-code blocks. This is also in light mode, and allows distinguishing the two even if the fonts are similar (like here).

@zanchey If you are comfortable with this I would like it for 3.4.

I do not believe this should ever make anything *worse*. Technically it's possible you'd get e.g. Segoe on linux, but Segoe is an okay font, and very very likely nicer than what "sans-serif" would pick for you.
