### PR TITLE
Fix nmap --script completion

### DIFF
--- a/share/completions/nmap.fish
+++ b/share/completions/nmap.fish
@@ -71,9 +71,12 @@ complete -c nmap -l max-os-tries -d 'Set the maximum number of OS detection trie
 # NMAP SCRIPTING ENGINE (NSE)
 complete -c nmap -o sC -d 'Scan: Scripts (default)'
 function __fish_complete_nmap_script
+    set -l now (date "+%s")
+
     # cache completion for 5 minutes (`nmap --script-help all` is slow)
-    if test -z "$__fish_nmap_script_completion_cache" -o (date -d "now - 5min" +"%s") -gt "$__fish_nmap_script_completion_cache_time"
-        set -g __fish_nmap_script_completion_cache_time (date +"%s")
+    # must use `math` because of differences between BSD and GNU `date`
+    if test -z "$__fish_nmap_script_completion_cache" -o (math $now - 5 "*" 60) -gt "$__fish_nmap_script_completion_cache_time"
+        set -g __fish_nmap_script_completion_cache_time $now
         set -g __fish_nmap_script_completion_cache ""
         set -l cmd
         for l in (nmap --script-help all 2> /dev/null | grep -A2 -B1 Categories: | grep -v '^\\(--\\|Categories:\\|https:\\)')


### PR DESCRIPTION
## Description

It's using GNU specific flags, which doesn't work on BSDs like macOS.

Instead this just formats the current time into
seconds and then the `math` builtin for calculating the 5 min timeout.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User\-visible changes noted in CHANGELOG.rst
