### PR TITLE
Assert `and` and `or` create no new scope

### DIFF
--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -635,6 +635,34 @@ end
 #CHECK: $var6[1]: |ghi|
 #CHECK: $var6[2]: |jkl|
 
+# `and` creates no new scope on its own
+true; and set -l var7a 89 179
+set -q var7a
+echo $status
+#CHECK: 0
+
+# `begin` of an `and` creates a new scope
+true; and begin
+    set -l var7b 359 719
+end
+set -q var7b
+echo $status
+#CHECK: 1
+
+# `or` creates no new scope on its own
+false; or set -l var8a 1439 2879
+set -q var8a
+echo $status
+#CHECK: 0
+
+# `begin` of an `or` creates a new scope
+false; or begin
+    set -l var8b 9091 9901
+end
+set -q var8b
+echo $status
+#CHECK: 1
+
 # Exporting works
 set -x TESTVAR0
 set -x TESTVAR1 a


### PR DESCRIPTION
## Assert `and` and `or` create no new scope

This PR suggests the addition of 2 set of tests that assert that variables declared as part of `and` and `or` statements get declared in the expected scope.

There's not issue related to this change. This PR comes as a result of a [brief conversation I had with @zanchey over Gitter](https://gitter.im/fish-shell/fish-shell?at=61d99374526fb77b316c0218).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

I believe none of the TODOs above apply.

I hope this is a good first contribution and I'm happy to make any change to it.