### PR TITLE
Add --unescaped option to `complete -C`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -94,6 +94,7 @@ Scripting improvements
 - ``command -v`` returns an exit status of 127 instead of 1 if no command was found (:issue:`8547`).
 - ``argparse`` with ``--ignore-unknown`` no longer breaks with multiple unknown options in a short option group (:issue:`8637`).
 - Comments inside command substitutions or brackets now correctly ignore parentheses, quotes, and brackets (:issue:`7866`, :issue:`8022`).
+- ``complete -C`` supports a new ``--escape`` option, which turns on escaping in returned completion strings (:issue:`3469`).
 
 Interactive improvements
 ------------------------

--- a/doc_src/cmds/complete.rst
+++ b/doc_src/cmds/complete.rst
@@ -9,7 +9,7 @@ Synopsis
 .. synopsis::
 
     complete ((-c | --command) | (-p | --path)) COMMAND [OPTIONS] 
-    complete ((-C | --do-complete)) STRING
+    complete ((-C | --do-complete)) [STRING] [--escape] 
 
 Description
 -----------
@@ -48,6 +48,8 @@ the fish manual.
 - ``-n CONDITION`` or ``--condition CONDITION`` specifies that this completion should only be used if the CONDITION (a shell command) returns 0. This makes it possible to specify completions that should only be used in some cases.
 
 - ``-C STRING`` or ``--do-complete=STRING`` makes complete try to find all possible completions for the specified string. If there is no STRING, the current commandline is used instead.
+
+- When using ``-C``, specify ``--escape`` to escape special characters in completions.
 
 Command specific tab-completions in ``fish`` are based on the notion of options and arguments. An option is a parameter which begins with a hyphen, such as ``-h``, ``-help`` or ``--help``. Arguments are parameters that do not begin with a hyphen. Fish recognizes three styles of options, the same styles as the GNU getopt library. These styles are:
 

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -9,6 +9,8 @@ complete -c complete_test_alpha3 --no-files -w 'complete_test_alpha2 extra2'
 
 complete -C'complete_test_alpha1 arg1 '
 # CHECK: complete_test_alpha1 arg1
+complete --escape -C'complete_test_alpha1 arg1 '
+# CHECK: complete_test_alpha1\ arg1\
 complete -C'complete_test_alpha2 arg2 '
 # CHECK: complete_test_alpha1 extra1 arg2
 complete -C'complete_test_alpha3 arg3 '


### PR DESCRIPTION
This PR is meant to fix #3469.

It is based on https://github.com/krobelus/fish-shell/commit/38b4fe5db278d5dfb1a0009013a74ce626077451 by @krobelus, except that it gates the feature behind a new `--unescaped` flag to not break existing scripts that use `complete -C`.

There should probably be more tests, but I'm not familiar enough to know what tests should be added. I'd appreciate some guidance on what those should look like. https://github.com/krobelus/fish-shell/commit/38b4fe5db278d5dfb1a0009013a74ce626077451 has some more tests that might be relevant.
