### PR TITLE
Changing autosuggestions from search history to be case-insensitive

### DIFF
--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -346,11 +346,13 @@ void completions_sort_and_prioritize(completion_list_t *comps, completion_reques
 
     // Lastly, if this is for an autosuggestion, prefer to avoid completions that duplicate
     // arguments, and penalize files that end in tilde - they're frequently autosave files from e.g.
-    // emacs. Also prefer samecase to smartcase.
+    // emacs. Also prefer case insensitive to smartcase.
     if (flags & completion_request_t::autosuggestion) {
         stable_sort(comps->begin(), comps->end(), [](const completion_t &a, const completion_t &b) {
             if (a.match.case_fold != b.match.case_fold) {
-                return a.match.case_fold < b.match.case_fold;
+                //return a.match.case_fold < b.match.case_fold;
+                // Always return case insensitive if cases do not match
+                return false;
             }
             return compare_completions_by_duplicate_arguments(a, b) ||
                    compare_completions_by_tilde(a, b);


### PR DESCRIPTION
## Description
Edited the suggestion when the case of a command being typed is not the same as the case of the command from history to not consider the case of the character in the comparison between the two (prefer case insensitive to smart case).
Fixes issue #3126

## TODOs:
<!-- Just check off what we know has been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
