### PR TITLE
Add a flag to disable the missing-interpreter hack

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -118,6 +118,12 @@ static bool is_thompson_shell_payload(const char *p, size_t n) {
 /// such as Actually Portable Executable.
 /// N.B.: this is called after fork, it must not allocate heap memory.
 bool is_thompson_shell_script(const char *path) {
+    // Don't perform this check if the user disabled it
+    auto var = env_stack_t::globals().get(L"fish_missing_interpreter_hack");
+    if (!var.missing_or_empty() && !bool_from_string(var->as_string()))
+        return false;
+
+
     // Paths ending in ".fish" are never considered Thompson shell scripts.
     if (const char *lastdot = strrchr(path, '.')) {
         if (0 == strcmp(lastdot, ".fish")) {


### PR DESCRIPTION
It's normally expected that script files should have their interpreter
specified at the top of the file with a line like

```
#!/bin/sh
```

This convention was introduced in 40+ years ago (in 1980), and the
kernel wisely rejects any script which doesn't have an interpreter.  The
POSIX shell retains compatibility with scripts written before then by
using a heuristic to determine if the file being executed "looks like a
shell script" and assumes the shell as an interpreter if so.

fish implements this heuristic.

Unfortunately, the heuristic in question will happily accept pretty much
anything that looks like any script at all, regardless of the language,
leading to confusing errors when (for example) trying to run a Python
script through `/bin/sh`.

Instead of trying to "improve" the heuristic, add an option to disable
it entirely, for people who don't mind losing compatibility with shell
scripts that were written before they were born.

Fixes #8086

## Description

This adds a `fish_missing_interpreter_hack` variable which allows disabling the heuristic by setting it to `0`.  If it's unset, the heuristic is enabled by default (although maybe we could reconsider that).

I got inspiration for the variable from some similarly-themed variables like `fish_use_posix_spawn` and `fish_allow_singlebyte_locale`.  I'm not sure if using `env_stack_t::globals()` is evil or not, but it seemed better than the large number of changes that would have been require to wire-through `vars` from all the different paths (I started with this approach, but abandoned it).

I've skipped the documentation and tests changes until the implementation is pinned down.

Here's a small transcript of some manual testing:

```
lis@fedora-toolbox-35 ~/src/fish-shell
(master) > build/fish

lis@fedora-toolbox-35 ~/src/fish-shell
(master) > cat evil
echo 'this is not a script'

lis@fedora-toolbox-35 ~/src/fish-shell
(master) > ./evil
this is not a script

lis@fedora-toolbox-35 ~/src/fish-shell
(master) > set fish_missing_interpreter_hack 0

lis@fedora-toolbox-35 ~/src/fish-shell
(master) > ./evil
exec: Failed to execute process: './evil' the file could not be run by the operating system.

lis@fedora-toolbox-35 ~/src/fish-shell
(master) [126]> set fish_missing_interpreter_hack 1

lis@fedora-toolbox-35 ~/src/fish-shell
(master) [126]> ./evil
this is not a script
```