### PR TITLE
completions: add wg-quick

### DIFF
--- a/share/completions/wg-quick.fish
+++ b/share/completions/wg-quick.fish
@@ -1,18 +1,12 @@
 set -l valid_subcmds up down strip save
 
-function __wg_complete_interfaces
-    wg show 2>| string replace -rf 'Unable to access interface (.*): Operation not permitted' '$1'
-end
-
-function __wg_subcmd --no-scope-shadowing
-    set -l subcmd $argv[1]
-    set -e argv[1]
-    complete -f -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a $subcmd $argv
+function __fish_wg_complete_interfaces
+    LC_ALL=C wg show 2>| string replace -rf 'Unable to access interface (.*): Operation not permitted' '$1'
 end
 
 complete -c wg-quick -f
-complete -k -c wg-quick -n "__fish_seen_subcommand_from $valid_subcmds" -a '(__wg_complete_interfaces | sort)'
-__wg_subcmd up -d 'Add and set up an interface'
-__wg_subcmd down -d 'Tear down and remove an interface' 
-__wg_subcmd strip -d 'Output config for use with wg'
-__wg_subcmd save -d 'Saves the configuration of an existing interface'
+complete -c wg-quick -n "__fish_seen_subcommand_from $valid_subcmds" -a '(__fish_wg_complete_interfaces)'
+complete -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a up -d 'Add and set up an interface'
+complete -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a down -d 'Tear down and remove an interface'
+complete -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a strip -d 'Output config for use with wg'
+complete -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a save -d 'Saves the configuration of an existing interface'

--- a/share/completions/wg-quick.fish
+++ b/share/completions/wg-quick.fish
@@ -1,0 +1,18 @@
+set -l valid_subcmds up down strip save
+
+function __wg_complete_interfaces
+    wg show 2>| string replace -rf 'Unable to access interface (.*): Operation not permitted' '$1'
+end
+
+function __wg_subcmd --no-scope-shadowing
+    set -l subcmd $argv[1]
+    set -e argv[1]
+    complete -f -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a $subcmd $argv
+end
+
+complete -c wg-quick -f
+complete -k -c wg-quick -n "__fish_seen_subcommand_from $valid_subcmds" -a '(__wg_complete_interfaces | sort)'
+__wg_subcmd up -d 'Add and set up an interface'
+__wg_subcmd down -d 'Tear down and remove an interface' 
+__wg_subcmd strip -d 'Output config for use with wg'
+__wg_subcmd save -d 'Saves the configuration of an existing interface'


### PR DESCRIPTION
## Description

Adds completions for the Wireguard `wg-quick` utility.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
