### PR TITLE
Prevent signals from tearing multi-char bindings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -120,6 +120,7 @@ Interactive improvements
 - ``funcsave`` will remove a saved copy of a function that has been erased with ``functions --erase``.
 - The Web-based configuration tool gained a number of improvements, including the ability to set pager colors.
 - The default ``fish_title`` prints a shorter title with shortened $PWD and no more redundant "fish" (:issue:`8641`).
+- Multi-char bindings can no longer be interrupted by signals. (:issue:`8628`).
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -673,9 +673,6 @@ void inputter_t::mapping_execute_matching_or_generic(const command_handler_t &co
 
     FLOGF(reader, L"no generic found, ignoring char...");
     auto evt = peeker.next();
-    if (evt.is_eof()) {
-        this->push_front(evt);
-    }
     peeker.consume();
 }
 
@@ -750,7 +747,11 @@ char_event_t inputter_t::read_char(const command_handler_t &command_handler) {
             // If we have EOF, we need to immediately quit.
             // There's no need to go through the input functions.
             return evt;
+        } else if (evt.is_check_exit()) {
+            // Allow the reader to check for exit conditions.
+            return evt;
         } else {
+            assert(evt.is_char() && "Should be char event");
             this->push_front(evt);
             mapping_execute_matching_or_generic(command_handler);
             // Regarding allow_commands, we're in a loop, but if a fish command is executed,

--- a/src/input_common.cpp
+++ b/src/input_common.cpp
@@ -2,6 +2,7 @@
 #include "config.h"
 
 #include <errno.h>
+#include <signal.h>
 #include <unistd.h>
 
 #include <cstring>
@@ -10,6 +11,7 @@
 #endif
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/select.h>
 #include <sys/time.h>
 #include <sys/types.h>
 
@@ -223,9 +225,27 @@ maybe_t<char_event_t> input_event_queue_t::readch_timed() {
     if (auto evt = try_pop()) {
         return evt;
     }
-    const uint64_t usec_per_msec = 1000;
-    uint64_t timeout_usec = static_cast<uint64_t>(wait_on_escape_ms) * usec_per_msec;
-    if (fd_readable_set_t::is_fd_readable(in_, timeout_usec)) {
+    // We are not prepared to handle a signal immediately; we only want to know if we get input on
+    // our fd before the timeout. Use pselect to block all signals; we will handle signals
+    // before the next call to getch().
+    sigset_t sigs;
+    sigfillset(&sigs);
+
+    // pselect expects timeouts in nanoseconds.
+    const uint64_t nsec_per_msec = 1000 * 1000;
+    const uint64_t nsec_per_sec = nsec_per_msec * 1000;
+    const uint64_t wait_nsec = wait_on_escape_ms * nsec_per_msec;
+    struct timespec timeout;
+    timeout.tv_sec = (wait_nsec) / nsec_per_sec;
+    timeout.tv_nsec = (wait_nsec) % nsec_per_sec;
+
+    // We have one fd of interest.
+    fd_set fdset;
+    FD_ZERO(&fdset);
+    FD_SET(in_, &fdset);
+
+    int res = pselect(in_ + 1, &fdset, nullptr, nullptr, &timeout, &sigs);
+    if (res > 0) {
         return readch();
     }
     return none();

--- a/src/input_common.cpp
+++ b/src/input_common.cpp
@@ -255,6 +255,15 @@ void input_event_queue_t::push_back(const char_event_t& ch) { queue_.push_back(c
 
 void input_event_queue_t::push_front(const char_event_t& ch) { queue_.push_front(ch); }
 
+void input_event_queue_t::promote_interruptions_to_front() {
+    // Find the first sequence of non-char events.
+    // EOF is considered a char: we don't want to pull EOF in front of real chars.
+    auto is_char = [](const char_event_t& ch) { return ch.is_char() || ch.is_eof(); };
+    auto first = std::find_if_not(queue_.begin(), queue_.end(), is_char);
+    auto last = std::find_if(first, queue_.end(), is_char);
+    std::rotate(queue_.begin(), first, last);
+}
+
 void input_event_queue_t::prepare_to_select() {}
 void input_event_queue_t::select_interrupted() {}
 input_event_queue_t::~input_event_queue_t() = default;

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -207,6 +207,9 @@ class input_event_queue_t {
     /// will be the next character returned by readch.
     void push_front(const char_event_t &ch);
 
+    /// Find the first sequence of non-char events, and promote them to the front.
+    void promote_interruptions_to_front();
+
     /// Add multiple characters or readline events to the front of the queue of unread characters.
     /// The order of the provided events is not changed, i.e. they are not inserted in reverse
     /// order.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1293,11 +1293,13 @@ void reader_write_title(const wcstring &cmd, parser_t &parser, bool reset_cursor
     wcstring_list_t lst;
     (void)exec_subshell(fish_title_command, parser, lst, false /* ignore exit status */);
     if (!lst.empty()) {
-        std::fputws(L"\x1B]0;", stdout);
+        wcstring title_line = L"\x1B]0;";
         for (const auto &i : lst) {
-            std::fputws(i.c_str(), stdout);
+            title_line += i;
         }
-        ignore_result(write(STDOUT_FILENO, "\a", 1));
+        title_line += L"\a";
+        std::string narrow = wcs2string(title_line);
+        ignore_result(write_loop(STDOUT_FILENO, narrow.data(), narrow.size()));
     }
 
     outputter_t::stdoutput().set_color(rgb_color_t::reset(), rgb_color_t::reset());

--- a/tests/pexpects/torn_escapes.py
+++ b/tests/pexpects/torn_escapes.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import os
+import signal
+from pexpect_helper import SpawnedProc
+
+
+sp = SpawnedProc()
+send, sendline, sleep, expect_prompt, expect_str, expect_re = (
+    sp.send,
+    sp.sendline,
+    sp.sleep,
+    sp.expect_prompt,
+    sp.expect_str,
+    sp.expect_re,
+)
+# Ensure that signals don't tear escape sequences. See #8628.
+expect_prompt()
+
+# Allow for long delays before matching escape.
+sendline(r"set -g fish_escape_delay_ms 2000")
+expect_prompt()
+
+# Set up a handler for SIGUSR1.
+sendline(r"set -g sigusr1_count 0")
+expect_prompt()
+
+sendline(
+    r"""
+    function usr1_handler --on-signal SIGUSR1;
+        set sigusr1_count (math $sigusr1_count + 1);
+        echo Got SIGUSR1 $sigusr1_count;
+        commandline -f repaint;
+    end
+""".strip().replace(
+        "\n", os.linesep
+    )
+)
+expect_prompt()
+
+# Set up a wacky binding with an escape.
+sendline(r"function wacky_handler; echo Wacky Handler; end")
+expect_prompt()
+
+sendline(r"bind abc\edef wacky_handler")
+expect_prompt()
+
+# We can respond to SIGUSR1.
+os.kill(sp.spawn.pid, signal.SIGUSR1)
+expect_str(r"Got SIGUSR1 1")
+sendline(r"")
+expect_prompt()
+
+# Our wacky binding works.
+send("abc\x1bdef")
+expect_str(r"Wacky Handler")
+sendline(r"")
+expect_prompt()
+
+# Now we interleave the sequence with SIGUSR1.
+# What we expect to happen is that the signal is "shuffled to the front" ahead of the key events.
+send("abc")
+sleep(0.05)
+os.kill(sp.spawn.pid, signal.SIGUSR1)
+sleep(0.05)
+send("\x1bdef")
+expect_str(r"Got SIGUSR1 2")
+expect_str(r"Wacky Handler")
+sendline(r"")
+expect_prompt()
+
+# As before but it comes after the ESC.
+# The signal will arrive while we are waiting in getch_timed().
+send("abc\x1b")
+sleep(0.05)
+os.kill(sp.spawn.pid, signal.SIGUSR1)
+sleep(0.05)
+send("def")
+expect_str(r"Got SIGUSR1 3")
+expect_str(r"Wacky Handler")
+sendline(r"")
+expect_prompt()


### PR DESCRIPTION
Say the user has a multi-char binding (typically an escape sequence), and a signal arrives partway through the binding. The signal has an event handler which enques some readline event, for example, `repaint`. Prior to this change, the readline event would cause the multi-char binding to fail. This would cause bits of the escape sequence to be printed to the screen.

Fix this by noticing when a sequence was "interrupted" by a non-char event, and then rotating a sequence of such interruptions to the front of the queue, allowing them to be handled and still anticipating the remaining characters in the binding.

Fixes #8628