### PR TITLE
Fix comment parsing inside command substitutions and brackets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,6 +93,7 @@ Scripting improvements
 - ``abbr -q`` returns the correct exit status when given multiple abbreviation names as arguments (:issue:`8431`).
 - ``command -v`` returns an exit status of 127 instead of 1 if no command was found (:issue:`8547`).
 - ``argparse`` with ``--ignore-unknown`` no longer breaks with multiple unknown options in a short option group (:issue:`8637`).
+- Comments inside command substitutions or brackets now correctly ignore parentheses, quotes, and brackets (:issue:`7866`, :issue:`8022`).
 
 Interactive improvements
 ------------------------

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -523,6 +523,13 @@ const wchar_t *quote_end(const wchar_t *pos, wchar_t quote) {
     return nullptr;
 }
 
+const wchar_t *comment_end(const wchar_t *pos) {
+    do {
+        pos++;
+    } while (*pos && *pos != L'\n');
+    return pos;
+}
+
 void fish_setlocale() {
     // Use various Unicode symbols if they can be encoded using the current locale, else a simple
     // ASCII char alternative. All of the can_be_encoded() invocations should return the same

--- a/src/common.h
+++ b/src/common.h
@@ -451,6 +451,11 @@ std::unique_ptr<T> make_unique(Args &&...args) {
 /// \param quote the quote to use, usually pointed to by \c pos.
 const wchar_t *quote_end(const wchar_t *pos, wchar_t quote);
 
+/// This functions returns the end of the comment substring beginning at \c pos.
+///
+/// \param pos the position where the comment starts, including the '#' symbol.
+const wchar_t *comment_end(const wchar_t *pos);
+
 /// This function should be called after calling `setlocale()` to perform fish specific locale
 /// initialization.
 void fish_setlocale();

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -133,6 +133,9 @@ class tokenizer_t : noncopyable_t {
     }
 };
 
+/// Tests if this character can delimit tokens.
+bool is_token_delimiter(wchar_t c, bool is_first, maybe_t<wchar_t> next);
+
 /// Returns only the first token from the specified string. This is a convenience function, used to
 /// retrieve the first token of a string. This can be useful for error messages, etc. On failure,
 /// returns the empty string.

--- a/tests/checks/basic.fish
+++ b/tests/checks/basic.fish
@@ -533,6 +533,23 @@ echo banana
 echo (echo hello\\)
 # CHECK: hello\
 
+# This used to be a parse error - #7866.
+echo (echo foo;#)
+     )
+# CHECK: foo
+echo (echo bar #'
+     )
+# CHECK: bar
+echo (#"
+      echo baz)
+# CHECK: baz
+
+# Make sure we don't match up brackets within comments (#8022).
+$fish -c 'echo f[oo # not valid, no matching ]'
+# CHECKERR: fish: Unexpected end of string, square brackets do not match
+# CHECKERR: echo f[oo # not valid, no matching ]
+# CHECKERR: {{      }}^
+
 # Should fail because $PWD is read-only.
 for PWD in foo bar
     true


### PR DESCRIPTION
This change avoids parsing brackets and quotes within comments.

This fixes the following examples (as well as those described in #7866 and #8022):
| Script | Before | After |
| - | - | - |
| <pre lang="fish">echo a (&#xA;    echo b  # I'm using an apostrophe &#xA;)</pre> | (line 1): Unexpected end of string, quotes are not balanced | `a b` |
| <pre lang="fish">echo a (&#xA;    echo b  # Oops, closing paren :)&#xA;)</pre> | (line 3): Unexpected ')' for unopened parenthesis | `a b` |
| <pre lang="fish">echo a[b #c]</pre> | `a[b #c]` | Unexpected end of string, square brackets do not match |

Fixes #7866, and fixes #8022.

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
  - _There are no changes in usage._
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst