### PR TITLE
List only secret for gpg options that manage secret keys

### DIFF
--- a/share/functions/__fish_complete_gpg.fish
+++ b/share/functions/__fish_complete_gpg.fish
@@ -127,7 +127,7 @@ function __fish_complete_gpg -d "Internal function for gpg completion code dedup
     complete -c $__fish_complete_gpg_command -l export -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d 'Export all or the given keys from all keyrings'
     complete -c $__fish_complete_gpg_command -l export-ssh-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d 'Export all or the given keys in OpenSSH format'
     complete -c $__fish_complete_gpg_command -l send-keys -xa "(__fish_complete_gpg_key_id $__fish_complete_gpg_command)" -d "Same as --export but sends the keys to a keyserver"
-    complete -c $__fish_complete_gpg_command -l export-secret-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Same as --export, but exports the secret keys instead"
+    complete -c $__fish_complete_gpg_command -l export-secret-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command secret)" -d "Same as --export, but exports the secret keys instead"
     complete -c $__fish_complete_gpg_command -l export-secret-subkeys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Same as --export, but exports the secret keys instead"
 
     complete -c $__fish_complete_gpg_command -l import -d 'Import/merge keys'

--- a/share/functions/__fish_complete_gpg.fish
+++ b/share/functions/__fish_complete_gpg.fish
@@ -116,7 +116,7 @@ function __fish_complete_gpg -d "Internal function for gpg completion code dedup
     complete -c $__fish_complete_gpg_command -l lsign-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Sign a public key with your secret key but mark it as non exportable"
 
     complete -c $__fish_complete_gpg_command -l delete-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Remove key from the public keyring"
-    complete -c $__fish_complete_gpg_command -l delete-secret-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command --list-secret-key)" -d "Remove key from the secret and public keyring"
+    complete -c $__fish_complete_gpg_command -l delete-secret-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command --list-secret-keys)" -d "Remove key from the secret and public keyring"
     complete -c $__fish_complete_gpg_command -l delete-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Remove key from the public keyring"
     complete -c $__fish_complete_gpg_command -l delete-secret-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command --list-secret-keys)" -d "Remove key from the secret and public keyring"
     complete -c $__fish_complete_gpg_command -l delete-secret-and-public-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Same as --delete-key, but if a secret key exists, it will be removed first"

--- a/share/functions/__fish_complete_gpg.fish
+++ b/share/functions/__fish_complete_gpg.fish
@@ -101,7 +101,7 @@ function __fish_complete_gpg -d "Internal function for gpg completion code dedup
 
     complete -c $__fish_complete_gpg_command -s k -l list-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "List all keys from the public keyrings, or just the ones given on the command line"
     complete -c $__fish_complete_gpg_command -l list-public-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "List all keys from the public keyrings, or just the ones given on the command line"
-    complete -c $__fish_complete_gpg_command -s K -l list-secret-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "List all keys from the secret keyrings, or just the ones given on the command line"
+    complete -c $__fish_complete_gpg_command -s K -l list-secret-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command --list-secret-keys)" -d "List all keys from the secret keyrings, or just the ones given on the command line"
     complete -c $__fish_complete_gpg_command -l list-sigs -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Same as --list-keys, but the signatures are listed too"
 
     complete -c $__fish_complete_gpg_command -l check-sigs -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Same as --list-keys, but the signatures are listed and verified"

--- a/share/functions/__fish_complete_gpg.fish
+++ b/share/functions/__fish_complete_gpg.fish
@@ -47,7 +47,7 @@ function __fish_complete_gpg -d "Internal function for gpg completion code dedup
         complete -c $__fish_complete_gpg_command -l skip-hidden-recipients -d "During decryption, skip all anonymous recipients"
         complete -c $__fish_complete_gpg_command -l tofu-default-policy -xa "auto good unknown bad ask" -d "Set the default TOFU policy"
         complete -c $__fish_complete_gpg_command -l tofu-policy -xa "auto good unknown bad ask" -d "Set the default TOFU policy for the specified keys"
-        complete -c $__fish_complete_gpg_command -l try-secret-key -xa "(__fish_complete_gpg_key_id $__fish_complete_gpg_command)" -d "Specify keys to be used for trial decryption"
+        complete -c $__fish_complete_gpg_command -l try-secret-key -xa "(__fish_complete_gpg_key_id $__fish_complete_gpg_command --list-secret-keys)" -d "Specify keys to be used for trial decryption"
 
         complete -c $__fish_complete_gpg_command -l with-icao-spelling -d "Print the ICAO spelling of the fingerprint in addition to the hex digits"
         complete -c $__fish_complete_gpg_command -l with-key-origin -d "Include the locally held information on the origin and last update of a key in a key listing"

--- a/share/functions/__fish_complete_gpg.fish
+++ b/share/functions/__fish_complete_gpg.fish
@@ -127,7 +127,7 @@ function __fish_complete_gpg -d "Internal function for gpg completion code dedup
     complete -c $__fish_complete_gpg_command -l export -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d 'Export all or the given keys from all keyrings'
     complete -c $__fish_complete_gpg_command -l export-ssh-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d 'Export all or the given keys in OpenSSH format'
     complete -c $__fish_complete_gpg_command -l send-keys -xa "(__fish_complete_gpg_key_id $__fish_complete_gpg_command)" -d "Same as --export but sends the keys to a keyserver"
-    complete -c $__fish_complete_gpg_command -l export-secret-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command secret)" -d "Same as --export, but exports the secret keys instead"
+    complete -c $__fish_complete_gpg_command -l export-secret-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command --list-secret-keys)" -d "Same as --export, but exports the secret keys instead"
     complete -c $__fish_complete_gpg_command -l export-secret-subkeys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Same as --export, but exports the secret keys instead"
 
     complete -c $__fish_complete_gpg_command -l import -d 'Import/merge keys'

--- a/share/functions/__fish_complete_gpg.fish
+++ b/share/functions/__fish_complete_gpg.fish
@@ -116,9 +116,9 @@ function __fish_complete_gpg -d "Internal function for gpg completion code dedup
     complete -c $__fish_complete_gpg_command -l lsign-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Sign a public key with your secret key but mark it as non exportable"
 
     complete -c $__fish_complete_gpg_command -l delete-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Remove key from the public keyring"
-    complete -c $__fish_complete_gpg_command -l delete-secret-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Remove key from the secret and public keyring"
+    complete -c $__fish_complete_gpg_command -l delete-secret-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command --list-secret-key)" -d "Remove key from the secret and public keyring"
     complete -c $__fish_complete_gpg_command -l delete-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Remove key from the public keyring"
-    complete -c $__fish_complete_gpg_command -l delete-secret-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Remove key from the secret and public keyring"
+    complete -c $__fish_complete_gpg_command -l delete-secret-keys -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command --list-secret-keys)" -d "Remove key from the secret and public keyring"
     complete -c $__fish_complete_gpg_command -l delete-secret-and-public-key -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Same as --delete-key, but if a secret key exists, it will be removed first"
 
     complete -c $__fish_complete_gpg_command -l gen-revoke -xa "(__fish_complete_gpg_user_id $__fish_complete_gpg_command)" -d "Generate a revocation certificate for the complete key"

--- a/share/functions/__fish_complete_gpg_key_id.fish
+++ b/share/functions/__fish_complete_gpg_key_id.fish
@@ -11,7 +11,8 @@ function __fish_complete_gpg_key_id -d 'Complete using gpg key ids' -a __fish_co
                 set -l __uid (string split ":" -- $garbage)
                 set -l uid (string replace -a '\x3a' ':' -- $__uid[10])
                 printf "%s\t%s\n" $keyid $uid
-            case "pub*"
+            # NOTE key is preceded by "sec" instead of "pub" when listing secret keys
+            case "pub*" "sec*"
                 # Extract key fingerprints (no subkeys)
                 set -l __pub (string split ":" -- $garbage)
                 set keyid $__pub[5]

--- a/share/functions/__fish_complete_gpg_key_id.fish
+++ b/share/functions/__fish_complete_gpg_key_id.fish
@@ -1,9 +1,10 @@
 # Helper function for contextual autocompletion of GPG key ids
 
-function __fish_complete_gpg_key_id -d 'Complete using gpg key ids' -a __fish_complete_gpg_command
+function __fish_complete_gpg_key_id -d 'Complete using gpg key ids' -a __fish_complete_gpg_command list_arg
     # Use user id as description
     set -l keyid
-    $__fish_complete_gpg_command --list-keys --with-colons | while read -l garbage
+    set -q list_arg[1]; or set list_arg --list-keys
+    $__fish_complete_gpg_command $list_arg --with-colons | while read -l garbage
         switch $garbage
             case "uid*"
                 # Extract user ids (note: gpg escapes colons as '\x3a')

--- a/share/functions/__fish_complete_gpg_user_id.fish
+++ b/share/functions/__fish_complete_gpg_user_id.fish
@@ -1,11 +1,11 @@
 # Helper function for contextual autocompletion of gpg user ids
 
-function __fish_complete_gpg_user_id -d "Complete using gpg user ids" -a __fish_complete_gpg_command
+function __fish_complete_gpg_user_id -d "Complete using gpg user ids" -a __fish_complete_gpg_command __key_type
     # gpg doesn't seem to like it when you use the whole key name as a
     # completion, so we skip the <EMAIL> part and use it as a description.
     # It also replaces \x3a from gpg's output with colons.
     #
     # TODO: I tried with <EMAIL> and it worked, this was possibly fixed in gpg.
     # Regardless, it's probably nicer as a description.
-    $__fish_complete_gpg_command --list-keys --with-colon | string split -a -f 10 : | string replace '\x3a' : | string replace -r '(.*) <(.*)>' '$1\t$2'
+    $__fish_complete_gpg_command (string join -- - --list $__key_type keys) --with-colon | string split -a -f 10 : | string replace '\x3a' : | string replace -r '(.*) <(.*)>' '$1\t$2'
 end

--- a/share/functions/__fish_complete_gpg_user_id.fish
+++ b/share/functions/__fish_complete_gpg_user_id.fish
@@ -1,11 +1,12 @@
 # Helper function for contextual autocompletion of gpg user ids
 
-function __fish_complete_gpg_user_id -d "Complete using gpg user ids" -a __fish_complete_gpg_command key_type
+function __fish_complete_gpg_user_id -d "Complete using gpg user ids" -a __fish_complete_gpg_command list_arg
     # gpg doesn't seem to like it when you use the whole key name as a
     # completion, so we skip the <EMAIL> part and use it as a description.
     # It also replaces \x3a from gpg's output with colons.
     #
     # TODO: I tried with <EMAIL> and it worked, this was possibly fixed in gpg.
     # Regardless, it's probably nicer as a description.
-    $__fish_complete_gpg_command (string join -- - --list $key_type keys) --with-colon | string split -a -f 10 : | string replace '\x3a' : | string replace -r '(.*) <(.*)>' '$1\t$2'
+    set -q list_arg[1]; or set list_arg --list-keys
+    $__fish_complete_gpg_command $list_arg --with-colon | string split -a -f 10 : | string replace '\x3a' : | string replace -r '(.*) <(.*)>' '$1\t$2'
 end

--- a/share/functions/__fish_complete_gpg_user_id.fish
+++ b/share/functions/__fish_complete_gpg_user_id.fish
@@ -1,11 +1,11 @@
 # Helper function for contextual autocompletion of gpg user ids
 
-function __fish_complete_gpg_user_id -d "Complete using gpg user ids" -a __fish_complete_gpg_command __key_type
+function __fish_complete_gpg_user_id -d "Complete using gpg user ids" -a __fish_complete_gpg_command key_type
     # gpg doesn't seem to like it when you use the whole key name as a
     # completion, so we skip the <EMAIL> part and use it as a description.
     # It also replaces \x3a from gpg's output with colons.
     #
     # TODO: I tried with <EMAIL> and it worked, this was possibly fixed in gpg.
     # Regardless, it's probably nicer as a description.
-    $__fish_complete_gpg_command (string join -- - --list $__key_type keys) --with-colon | string split -a -f 10 : | string replace '\x3a' : | string replace -r '(.*) <(.*)>' '$1\t$2'
+    $__fish_complete_gpg_command (string join -- - --list $key_type keys) --with-colon | string split -a -f 10 : | string replace '\x3a' : | string replace -r '(.*) <(.*)>' '$1\t$2'
 end


### PR DESCRIPTION
## Description

This modifies the internal `__fish_complete_gpg_user_id` to take an optional argument for the "key type" to modify `--list-keys` to something like `--list-secret-keys`. This is then used to list only secret keys with `gpg --export-secret-keys` completions. There are probably more uses where only secret keys should be listed, but this is what I found so far. I'll keep this as a draft for now in case I should limit other completions to only the secret keys.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

******

## TODOs (for this PR specifically)

- [x] `--delete-secret-key[s]`
- [x] `--try-secret-key`
- [x] `--list-secret-keys` (getting a list of secret keys to complete `--list-secret-keys` feels a little redundant :laughing:)
- [x] Also update `__fish_complete_gpg_key_id`?
- [x] Fix completions for secret key IDs, specifically `--try-secret-key` (the `pub*` case is never hit for secret keys)