### PR TITLE
Escape commas when expanding command substitutions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -95,6 +95,7 @@ Scripting improvements
 - ``argparse`` with ``--ignore-unknown`` no longer breaks with multiple unknown options in a short option group (:issue:`8637`).
 - Comments inside command substitutions or brackets now correctly ignore parentheses, quotes, and brackets (:issue:`7866`, :issue:`8022`).
 - ``complete -C`` supports a new ``--escape`` option, which turns on escaping in returned completion strings (:issue:`3469`).
+- Commas in process output are no longer used as separators in brace expansion (:issue:`5048`).
 
 Interactive improvements
 ------------------------

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -987,6 +987,7 @@ static void escape_string_script(const wchar_t *orig_in, size_t in_len, wcstring
                 case L']':
                 case L'{':
                 case L'}':
+                case L',':
                 case L'?':
                 case L'*':
                 case L'|':

--- a/tests/checks/expansion.fish
+++ b/tests/checks/expansion.fish
@@ -50,12 +50,12 @@ end
 echo { alpha, beta }\ {lambda, gamma }, | string replace -r ',$' ''
 #CHECK: alpha lambda, beta lambda, alpha gamma, beta gamma
 
-# expansion with subshells
-for name in { (echo Meg), (echo Jo) }
+# expansion with subshells (#5048)
+for name in { (echo Meg), (echo Jo,etc.) }
     echo $name
 end
 #CHECK: Meg
-#CHECK: Jo
+#CHECK: Jo,etc.
 
 # subshells with expansion
 for name in (for name in {Beth, Amy}; printf "$name\n"; end)

--- a/tests/checks/test.fish
+++ b/tests/checks/test.fish
@@ -49,7 +49,7 @@ t 5,2
 # CHECKERR: {{.*}}test.fish (line {{\d+}}):
 # CHECKERR: test $argv[1] -eq 5
 # CHECKERR: ^
-# CHECKERR: in function 't' with arguments '5,2'
+# CHECKERR: in function 't' with arguments '5\,2'
 # CHECKERR: called on line {{\d+}} of file {{.*}}test.fish
 
 test -x /usr/bin/go /usr/local/bin/go


### PR DESCRIPTION
Fixes issue #5048.

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
