### PR TITLE
Fix typo (fist -> first)

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -18,7 +18,7 @@ msgstr ""
 "Project-Id-Version: fish 1.21.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-11-13 10:00-0300\n"
-"PO-Revision-Date: 2015-10-11 20:35-0300\n"
+"PO-Revision-Date: 2022-02-15 13:24+0100\n"
 "Last-Translator: Fábio Nogueira <deb-user-ba@ubuntu.com>\n"
 "Language-Team: Português Brasileiro <>\n"
 "Language: pt_BR\n"
@@ -73517,10 +73517,6 @@ msgstr ""
 
 #: /tmp/fish/implicit/share/completions/uniq.fish:11
 msgid "Precede each output line with count of its occurrence"
-msgstr ""
-
-#: /tmp/fish/implicit/share/completions/uniq.fish:14
-msgid "Avoid comparing fist N characters"
 msgstr ""
 
 #: /tmp/fish/implicit/share/completions/uniq.fish:16

--- a/share/completions/uniq.fish
+++ b/share/completions/uniq.fish
@@ -17,7 +17,7 @@ else # BSD
     complete -c uniq -s c -d 'Precede each output line with count of its occurrence'
     complete -c uniq -s d -d 'Only print duplicates'
     complete -c uniq -s f -d 'Avoid comparing first N fields' -x
-    complete -c uniq -s s -d 'Avoid comparing fist N characters' -x
+    complete -c uniq -s s -d 'Avoid comparing first N characters' -x
     complete -c uniq -s u -d 'Only print unique lines'
     complete -c uniq -s i -d 'Case insensitive comparision'
 end


### PR DESCRIPTION
## Description

Fix typo: "fist" should be "first"