### PR TITLE
Disabled line length limit in `share/{completions,functions}`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,5 +21,8 @@ indent_size = 2
 [Dockerfile]
 indent_size = 2
 
+[share/{completions,functions}/**.fish]
+max_line_length = none
+
 [COMMIT_EDITMSG]
 max_line_length = 80


### PR DESCRIPTION
## Description

This disabled the line length limit from EditorConfig in `share/functions` and `share/completions`.

Many of the lines in `share/functions` and `share/completions` already violate the max
line length, and it can be difficult to try to maintain consistency while
fighting against the editor trying to wrap lines.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
