### PR TITLE
completions/sv.fish: update completion for sv, a part of runit.

### DIFF
--- a/share/completions/sv.fish
+++ b/share/completions/sv.fish
@@ -10,15 +10,24 @@ set -l commands \
     shutdown force-stop force-reload force-restart force-shutdown \
     try-restart check
 
-
 function __fish_complete_sv_list_services
-    for dir in $SVDIR /run/runit/service/ /etc/runit/current /etc/runit/runsvdir/
-        test -d $dir
-        and break
+    set -l svdir
+    for candidate_svdir in \
+        "$SVDIR" \
+        /run/runit/runsvdir/current \
+        /run/runit/service \
+        /etc/services \
+        /services
+        if test -d "$candidate_svdir"
+            set svdir "$candidate_svdir"
+            break
+        end
     end
-    set -l services (string match -r '[^/]*$' $dir/*)
-    set -l out (sv status $services 2>/dev/null)
-    and string replace -r "^(\w+: )(.*?):" '$2\t$1$2:' $out
+    set -q svdir[1]; or return
+    set -l services (command ls "$svdir")
+    set -l sv_status (sv status $services 2>/dev/null |
+                      string replace -ar ';.*$' '')
+    and string replace -r "^(\w+: )(.*?):" '$2\t$1' $sv_status
     or printf "%s\n" $services
 end
 


### PR DESCRIPTION
This should fix finding the correct active svdir in most cases.

Search for services in the following order:

$SVDIR                      - User defined override
/run/runit/runsvdir/current - Value patched in by Void[1]
/run/runit/service          - Value patched in by Artix[2]
/etc/service                - Value patched in by Debian[3]
/services                   - Default value for runit[4]

Also don't use /etc for searching since it is not guaranteed that there
is an instance of runsvdir running in that directory.

Finally return quietly if there is no svdir.

[1] https://github.com/void-linux/void-packages/blob/75403cef76a93199456befdcb8884fbac39adbb3/srcpkgs/runit/template#L29
[2] https://gitea.artixlinux.org/packagesR/runit/src/commit/c9d691ce864e5be6735025fc51c6d72fdb5aabb0/x86_64/core/PKGBUILD#L9
[3] https://sources.debian.org/src/runit/2.1.2-41/debian/patches/0001-default-directory-for-services-on-Debian-is-etc-servi.diff/
[4] hard-coded in sv.c