### PR TITLE
Switch Gitter channel to Matrix channel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,8 +230,8 @@ Contact Us
 
 Questions, comments, rants and raves can be posted to the official fish
 mailing list at https://lists.sourceforge.net/lists/listinfo/fish-users
-or join us on our `gitter.im
-channel <https://gitter.im/fish-shell/fish-shell>`__. Or use the `fish tag
+or join us on our `Matrix
+channel <https://matrix.to/#/#fish-shell:matrix.org>`__. Or use the `fish tag
 on Unix & Linux Stackexchange <https://unix.stackexchange.com/questions/tagged/fish>`__.
 There is also a fish tag on Stackoverflow, but it is typically a poor fit.
 

--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -135,7 +135,7 @@ Resources
 
 - The `GitHub page <https://github.com/fish-shell/fish-shell/>`_
 
-- The official `Gitter channel <https://gitter.im/fish-shell/fish-shell>`_
+- The official `Matrix channel <https://matrix.to/#/#fish-shell:matrix.org>`_
 
 - The official mailing list at `fish-users@lists.sourceforge.net <https://lists.sourceforge.net/lists/listinfo/fish-users>`_
 

--- a/doc_src/tutorial.rst
+++ b/doc_src/tutorial.rst
@@ -768,4 +768,4 @@ Now in another shell::
 Ready for more?
 ---------------
 
-If you want to learn more about fish, there is :ref:`lots of detailed documentation <intro>`, the `official gitter channel <https://gitter.im/fish-shell/fish-shell>`__, an `official mailing list <https://lists.sourceforge.net/lists/listinfo/fish-users>`__, and the `github page <https://github.com/fish-shell/fish-shell/>`__.
+If you want to learn more about fish, there is :ref:`lots of detailed documentation <intro>`, the `official Matrix channel <https://matrix.to/#/#fish-shell:matrix.org>`__, an `official mailing list <https://lists.sourceforge.net/lists/listinfo/fish-users>`__, and the `github page <https://github.com/fish-shell/fish-shell/>`__.


### PR DESCRIPTION
## Description

I joined the Gitter channel and found out the community moved to Matrix, so I think the link should be updated.