### PR TITLE
Better documentation of forward-char

### DIFF
--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -89,10 +89,11 @@ The following special input functions are available:
     only execute the next function if the previous succeeded (note: only some functions report success)
 
 ``accept-autosuggestion``
-    accept the current autosuggestion completely
+    accept the current autosuggestion
 
 ``backward-char``
-    moves one character to the left
+    move one character to the left.
+    If the completion pager is active, select the previous completion instead.
 
 ``backward-bigword``
     move one whitespace-delimited word to the left
@@ -179,13 +180,15 @@ The following special input functions are available:
     move one whitespace-delimited word to the right
 
 ``forward-char``
-    move one character to the right
+    move one character to the right; or if at the end of the commandline, accept the current autosuggestion.
+    If the completion pager is active, select the next completion instead.
 
 ``forward-single-char``
-    move one character to the right; if an autosuggestion is available, only take a single char from it
+    move one character to the right; or if at the end of the commandline, accept a single char from the current autosuggestion.
 
 ``forward-word``
-    move one word to the right
+    move one word to the right; or if at the end of the commandline, accept one word
+    from the current autosuggestion.
 
 ``history-search-backward``
     search the history for the previous match
@@ -230,7 +233,8 @@ The following special input functions are available:
     move the next word to the killring
 
 ``nextd-or-forward-word``
-    if the commandline is empty, then move forward in the directory history, otherwise move one word to the right
+    if the commandline is empty, then move forward in the directory history, otherwise move one word to the right.
+    If at the end of the commandline, accept the current autosuggestion.
 
 ``or``
     only execute the next function if the previous succeeded (note: only some functions report success)


### PR DESCRIPTION
This makes it match the code in reader.cpp, and explains why the default
binding of `right` accepts the complete line.

## Description

Motivation: I wanted to bind `right` to have a less drastic effect than
accepting the whole line, and I was confused by the docs apparently saying that
all the default binding does is move the cursor.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
  - Does not change the code
- [x] Tests have been added for regressions fixed
  - Does not change the code
- [ ] User-visible changes noted in CHANGELOG.rst
  - Seems too minor to mention
