### PR TITLE
Use old-school "()" command substitution in fish_title

### DIFF
--- a/share/functions/fish_title.fish
+++ b/share/functions/fish_title.fish
@@ -4,7 +4,7 @@ function fish_title
         # If we're connected via ssh, we print the hostname.
         set -l ssh
         set -q SSH_TTY
-        and set ssh "[$(prompt_hostname | string sub -l 10)]"
+        and set ssh "["(prompt_hostname | string sub -l 10 | string collect)"]"
         # An override for the current command is passed as the first parameter.
         # This is used by `fg` to show the true process name, among others.
         if set -q argv[1]


### PR DESCRIPTION
Because we reload changed function files, a common issue on upgrading
to 3.4.0 is that fish_title causes errors.

So we simply use the oldschool syntax.

This could be good for a 3.4.1 release.