### PR TITLE
documentation, variable name definition

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -873,7 +873,7 @@ Shell variables
 
 Variables are a way to save data and pass it around. They can be used just by the shell, or they can be ":ref:`exported <variables-export>`", so that a copy of the variable is available to any external command the shell starts. An exported variable is referred to as an "environment variable".
 
-To set a variable value, use the :ref:`set <cmd-set>` command. A variable name can not be empty and can contain only letters, digits, and underscores. It may begin and end with any of those characters.
+To set a variable value, use the :ref:`set <cmd-set>` command. A variable name can not be empty and can contain only letters, digits, and underscores. It may begin and end with any of those characters, but may not consist of numbers only.
 
 Example:
 
@@ -1532,7 +1532,7 @@ Shell variable and function names
 
 The names given to variables and functions (so called "identifiers") have to follow certain rules:
 
-- A variable name cannot be empty. It can contain only letters, digits, and underscores. It may begin and end with any of those characters.
+- A variable name cannot be empty. It can contain only letters, digits, and underscores. It may begin and end with any of those characters, but may not consist of numbers only.
 
 - A function name cannot be empty. It may not begin with a hyphen ("-") and may not contain a slash ("/"). All other characters, including a space, are valid.
 


### PR DESCRIPTION
Nitpickery - technically the sentences were incorrect, noticed while writing a regex to verify fish_vars.
Maybe it's useless for most people ... 

## Description

I originally just mentally translated the English sentence to a regex to check for valid variable names (e.g. `9_red_ballons_9`), and later noticed my tests failed, as it would allow me to `set 99 100` - which would break set theory, and people will get upset. :-) 

PS my first PR, hope I did not miss anything
- [x] read guidelines
- [x] read code of conduct