### PR TITLE
highlight: Also use the fallback variable if the main is empty

### DIFF
--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -134,7 +134,7 @@ Variable                                                   Meaning
 ``fish_color_search_match``                                history search matches and selected pager items (background only)
 ==========================================                 =====================================================================
 
-If a variable isn't set, fish usually tries ``$fish_color_normal``, except for:
+If a variable isn't set or is empty, fish usually tries ``$fish_color_normal``, except for:
 
 - ``$fish_color_keyword``, where it tries ``$fish_color_command`` first.
 - ``$fish_color_option``, where it tries ``$fish_color_param`` first.
@@ -178,7 +178,7 @@ Variable                                                   Meaning
 ``fish_pager_color_secondary_description``                 description of every second unselected completion
 ==========================================                 ===========================================================
 
-When the secondary or selected variables aren't set, the normal variables are used, except for ``$fish_pager_color_selected_background``, where the background of ``$fish_color_search_match`` is tried first.
+When the secondary or selected variables aren't set or are empty, the normal variables are used, except for ``$fish_pager_color_selected_background``, where the background of ``$fish_color_search_match`` is tried first.
 
 .. _abbreviations:
 

--- a/share/functions/fish_config.fish
+++ b/share/functions/fish_config.fish
@@ -236,7 +236,15 @@ function fish_config --description "Launch fish's web based configuration"
                         return 1
                     end
 
-                    set -l have_color 0
+                    set -l known_colors fish_color_{normal,command,keyword,quote,redirection,\
+                        end,error,param,option,comment,selection,operator,escape,autosuggestion,\
+                        cwd,user,host,host_remote,cancel,search_match} \
+                        fish_pager_color_{progress,background,prefix,completion,description,\
+                        selected_background,selected_prefix,selected_completion,selected_description,\
+                        secondary_background,secondary_prefix,secondary_completion,secondary_description}
+
+
+                    set -l have_colors
                     while read -lat toks
                         # We only allow color variables.
                         # Not the specific list, but something named *like* a color variable.
@@ -251,11 +259,19 @@ function fish_config --description "Launch fish's web based configuration"
                             set -eg $toks[1]
                         end
                         set $scope $toks
-                        set have_color 1
+                        set -a have_colors $toks[1]
                     end <$file
 
+                    # Set all colors that aren't mentioned to empty
+                    for c in $known_colors
+                        contains -- $c $have_colors
+                        and continue
+
+                        set $scope $c
+                    end
+
                     # Return true if we changed at least one color
-                    test $have_color -eq 1
+                    set -q have_colors[1]
                     return
                 case dump
                     # Write the current theme in .theme format, to stdout.

--- a/share/functions/fish_config.fish
+++ b/share/functions/fish_config.fish
@@ -149,27 +149,27 @@ function fish_config --description "Launch fish's web based configuration"
                     string replace -r '.*/([^/]*).theme$' '$1' $dir/*.theme
                     return
                 case demo
-                    echo -ns (set_color $fish_color_command) /bright/vixens
+                    echo -ns (set_color $fish_color_command || set_color $fish_color_normal) /bright/vixens
                     echo -ns (set_color normal) ' '
-                    echo -ns (set_color $fish_color_param) jump
+                    echo -ns (set_color $fish_color_param || set_color $fish_color_normal) jump
                     echo -ns (set_color normal) ' '
-                    echo -ns (set_color $fish_color_redirection) '|'
+                    echo -ns (set_color $fish_color_redirection || set_color $fish_color_normal) '|'
                     echo -ns (set_color normal) ' '
-                    echo -ns (set_color $fish_color_quote) '"fowl"'
+                    echo -ns (set_color $fish_color_quote || set_color $fish_color_normal) '"fowl"'
                     echo -ns (set_color normal) ' '
-                    echo -ns (set_color $fish_color_redirection) '> quack'
+                    echo -ns (set_color $fish_color_redirection || set_color $fish_color_normal) '> quack'
                     echo -ns (set_color normal) ' '
-                    echo -ns (set_color $fish_color_end) '&'
+                    echo -ns (set_color $fish_color_end || set_color $fish_color_normal) '&'
                     set_color normal
-                    echo -s (set_color $fish_color_comment) ' # This is a comment'
+                    echo -s (set_color $fish_color_comment || set_color $fish_color_normal) ' # This is a comment'
                     set_color normal
-                    echo -ns (set_color $fish_color_command) echo
+                    echo -ns (set_color $fish_color_command || set_color $fish_color_normal) echo
                     echo -ns (set_color normal) ' '
-                    echo -s (set_color $fish_color_error) "'" (set_color $fish_color_quote) "Errors are the portal to discovery"
+                    echo -s (set_color $fish_color_error || set_color $fish_color_normal) "'" (set_color $fish_color_quote || set_color $fish_color_normal) "Errors are the portal to discovery"
                     set_color normal
-                    echo -ns (set_color $fish_color_command) Th
+                    echo -ns (set_color $fish_color_command || set_color $fish_color_normal) Th
                     set_color normal
-                    set_color $fish_color_autosuggestion
+                    set_color $fish_color_autosuggestion || set_color $fish_color_normal
                     echo is is an autosuggestion
                     echo
                 case show

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -1457,12 +1457,61 @@ class FishConfigHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
         if p == "/set_color/":
             print("# Colorscheme: " + postvars.get("theme"))
+            have_colors = set()
+            known_colors = set(
+                (
+                    "fish_color_normal",
+                    "fish_color_command",
+                    "fish_color_keyword",
+                    "fish_color_quote",
+                    "fish_color_redirection",
+                    "fish_color_end",
+                    "fish_color_error",
+                    "fish_color_param",
+                    "fish_color_option",
+                    "fish_color_comment",
+                    "fish_color_selection",
+                    "fish_color_operator",
+                    "fish_color_escape",
+                    "fish_color_autosuggestion",
+                    "fish_color_cwd",
+                    "fish_color_user",
+                    "fish_color_host",
+                    "fish_color_host_remote",
+                    "fish_color_cancel",
+                    "fish_color_search_match",
+                    "fish_pager_color_progress",
+                    "fish_pager_color_background",
+                    "fish_pager_color_prefix",
+                    "fish_pager_color_completion",
+                    "fish_pager_color_description",
+                    "fish_pager_color_selected_background",
+                    "fish_pager_color_selected_prefix",
+                    "fish_pager_color_selected_completion",
+                    "fish_pager_color_selected_description",
+                    "fish_pager_color_secondary_background",
+                    "fish_pager_color_secondary_prefix",
+                    "fish_pager_color_secondary_completion",
+                    "fish_pager_color_secondary_description",
+                )
+            )
             for item in postvars.get("colors"):
                 what = item.get("what")
                 color = item.get("color")
 
                 if what:
+                    if not what.startswith("fish_pager_color_") and not what.startswith(
+                        "fish_color_"
+                    ):
+                        have_colors.add("fish_color_" + what)
+                    else:
+                        have_colors.add(what)
                     output = self.do_set_color_for_variable(what, color)
+
+            # Set all known colors that weren't defined in this theme
+            # to empty, to avoid keeping around coloration from an earlier theme.
+            for what in known_colors - have_colors:
+                output += "\n" + self.do_set_color_for_variable(what, "")
 
         elif p == "/get_function/":
             what = postvars.get("what")

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -337,8 +337,8 @@ rgb_color_t highlight_color_resolver_t::resolve_spec_uncached(const highlight_sp
     highlight_role_t role = is_background ? highlight.background : highlight.foreground;
 
     auto var = vars.get(get_highlight_var_name(role));
-    if (!var) var = vars.get(get_highlight_var_name(get_fallback(role)));
-    if (!var) var = vars.get(get_highlight_var_name(highlight_role_t::normal));
+    if (var.missing_or_empty()) var = vars.get(get_highlight_var_name(get_fallback(role)));
+    if (var.missing_or_empty()) var = vars.get(get_highlight_var_name(highlight_role_t::normal));
     if (var) result = parse_color(*var, is_background);
 
     // Handle modifiers.


### PR DESCRIPTION
Currently, when a variable like $fish_color_command is set but empty:

    set -g fish_color_command

what happens is that highlight parses it and ends up with a "normal"
color.

Change it so instead it sees that the variable is empty and goes
on to check the fallback variable, e.g. fish_color_normal.

That makes it easier to make themes that override variables.

This means that older themes that expect an empty variable to be
"normal" need to be updated to set it to "normal".

Following from this, we could make writing .theme files easier by no
longer requiring them to list all variables with specific values.
Either the theme reader could be updated to implicitly set known color
variables to empty, or the themes could feature empty values.

See #8787.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed - I don't know how to test this easily
- [ ] User-visible changes noted in CHANGELOG.rst
