### PR TITLE
 completions: fix long `heroku.fish` descriptions #6981

### DIFF
--- a/share/completions/heroku.fish
+++ b/share/completions/heroku.fish
@@ -78,11 +78,10 @@ complete $heroku_looking -xa plugins -d 'manage plugins to the heroku gem'
 complete $heroku_looking -xa regions -d 'list available regions'
 complete $heroku_looking -xa stack -d 'manage the stack for an app'
 complete $heroku_looking -xa status -d 'check status of heroku platform'
-complete $heroku_looking -xa twofactor
 complete $heroku_looking -xa update -d 'update the heroku client'
 complete $heroku_looking -xa version -d 'display version'
 
-complete $heroku_looking -xa git:clone -d "APP DIRECTORY clones a heroku app to your local machine at DIRECTORY (defaults to app name)"
+complete $heroku_looking -xa git:clone -d "clones heroku application to machine at DIRECTORY. defaults to app name."
 complete $heroku_looking -xa git:remote -d "adds a git remote to an app repo (-a APP)"
 
 # Addons subcommands


### PR DESCRIPTION
## Description

Fixes issue https://github.com/fish-shell/fish-shell/issues/6981 `heroku.fish`

Shortened description strings. Removed comments from the file as they're not helpful.

remove heroku-two-factor as it is deprecated per: https://github.com/heroku/heroku-two-factor
update complete $heroku_looking -xa git:clone to make it as short as possible without losing meaning. (Now 72 Characters as opposed to 92 per https://gist.github.com/ammgws/a0f49d719a5145675c76ff161627c111)

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
