### PR TITLE
Support CWD notifications in kitty

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -255,10 +255,11 @@ function __fish_config_interactive -d "Initializations that should be performed 
     end
 
     # Notify terminals when $PWD changes (issue #906).
-    # VTE based terminals, Terminal.app, iTerm.app (TODO), and foot support this.
+    # VTE based terminals, Terminal.app, iTerm.app (TODO), foot, and kitty support this.
     if not set -q FISH_UNIT_TESTS_RUNNING
         and begin
             string match -q -- 'foot*' $TERM
+            or string match -q -- 'xterm-kitty*' $TERM
             or test 0"$VTE_VERSION" -ge 3405
             or test "$TERM_PROGRAM" = Apple_Terminal && test (string match -r '\d+' 0"$TERM_PROGRAM_VERSION") -ge 309
             or test "$TERM_PROGRAM" = WezTerm


### PR DESCRIPTION
## Description

For upcoming SSH integration related features, kitty started to support parsing the current working directory from OSC 7.

In addition to the `file://` escaped URL format, it also supports `kitty-shell-cwd://$hostname$PWD`, which does not require URL escaping.

https://github.com/kovidgoyal/kitty/blob/a834f221f1e289fc9da47a3c8eb97e013537e413/kitty/utils.py#L941-L947

To allow fish 3.2.0+ to report CWD as well, the following code was added to kitty's shell integration. Please feel free to point out if there is anything wrong with it.

https://github.com/kovidgoyal/kitty/blob/7160027c14437f4f387ee1a310024ce139199976/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish#L98-L108

```fish
# Enable CWD reporting
if not contains "no-cwd" $_ksi
    # This function name is from fish and will override the builtin one if fish enabled this feature by default.
    # We provide this to ensure that fish 3.2.0 and above will work.
    # https://github.com/fish-shell/fish-shell/blob/3.2.0/share/functions/__fish_config_interactive.fish#L275
    function __update_cwd_osc --on-variable PWD -d "Report PWD changes to kitty"
        status is-command-substitution
        or echo -en "\e]7;kitty-shell-cwd://$hostname$PWD\a"
    end
    __update_cwd_osc
end
```

Are we allowed to add kitty cwd format? Maybe that would improve performance.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
