### PR TITLE
Update bzr.fish

### DIFF
--- a/share/completions/bzr.fish
+++ b/share/completions/bzr.fish
@@ -42,7 +42,7 @@ complete -f -c bzr -n '__fish_seen_subcommand_from ignore' -l default-rules -d '
 # mv command
 complete -f -c bzr -n __fish_use_subcommand -a mv -d 'Move or rename a versioned file'
 complete -f -c bzr -n '__fish_seen_subcommand_from mv' -l auto -d 'Automatically guess renames'
-complete -f -c bzr -n '__fish_seen_subcommand_from mv' -l after -d 'Move only the bzr identifier of the file, because the file has already been moved'
+complete -f -c bzr -n '__fish_seen_subcommand_from mv' -l after -d 'Move the bzr id of the file, since file has been moved'
 
 # status command
 complete -f -c bzr -n __fish_use_subcommand -a status -d 'Summarize changes in working copy'
@@ -58,7 +58,7 @@ complete -f -c bzr -n __fish_use_subcommand -a diff -d 'Show detailed diffs'
 
 # merge command
 complete -f -c bzr -n __fish_use_subcommand -a merge -d 'Pull in changes from another branch'
-complete -f -c bzr -n '__fish_seen_subcommand_from merge' -l pull -d 'If the destination is already completely merged into the source, pull from the source rather than merging'
+complete -f -c bzr -n '__fish_seen_subcommand_from merge' -l pull -d 'Pull from source instead of merge. If completely merged into the source.'
 complete -f -c bzr -n '__fish_seen_subcommand_from merge' -l remember -d 'Remember the specified location as a default'
 complete -f -c bzr -n '__fish_seen_subcommand_from merge' -l force -d 'Merge even if the destination tree has uncommitted changes'
 complete -f -c bzr -n '__fish_seen_subcommand_from merge' -l reprocess -d 'Reprocess to reduce spurious conflicts'
@@ -72,7 +72,7 @@ complete -f -c bzr -n '__fish_seen_subcommand_from merge' -l revision -s r -d 'S
 
 # commit command
 complete -f -c bzr -n __fish_use_subcommand -a commit -d 'Save some or all changes'
-complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l show-diff -s p -d 'When no message is supplied, show the diff along with the status summary in the message editor'
+complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l show-diff -s p -d 'If no message is supplied display the diff and status summary in message editor'
 complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l file -s F -d 'Take commit message from this file'
 complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l exclude -s x -d 'Do not consider changes made to a given path'
 complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l message -s m -d 'Description of the new revision'
@@ -81,7 +81,7 @@ complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l commit-time -d 'Ma
 complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l unchanged -d 'Commit even if nothing has changed'
 complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l fixes -d 'Mark a bug as being fixed by this revision'
 complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l strict -d 'Refuse to commit if there are unknown files in the working tree'
-complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l lossy -d 'When committing to a foreign version control system do not push data that can not be natively represented'
+complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l lossy -d 'If committing to a foreign vcs do not push data that can’t be natively represented'
 complete -f -c bzr -n '__fish_seen_subcommand_from commit' -l local -d 'Perform a local commit in a bound branch.  Local commits are not pushed to the master branch until a normal commit is performed'
 
 # send command


### PR DESCRIPTION
Address *most* of the completion requests for `bzr.fish`.

The last one in the excess char count list: 
128 chars: Perform a local commit in a bound branch.  Local commits are not pushed to the master branch until a normal commit is performed

I did not edit. This has information relevant to the application, that if shortened, would be detrimental (imo) to the function of the application.

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
