### PR TITLE
Fix launching fish_config on SailfishOS

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -81,6 +81,16 @@ def is_wsl():
     return False
 
 
+def is_sailfish_os():
+    """ Return whether we are running on Sailfish OS """
+    if "linux" in platform.system().lower() and os.access("/etc/sailfish-release", os.R_OK):
+        with open("/etc/sailfish-release", "r") as f:
+            # Find 'ID=sailfishos'
+            if "sailfishos" in f.read():
+                return True
+    return False 
+
+
 def is_termux():
     """ Return whether we are running under the Termux application for Android"""
     return "com.termux" in os.environ["PATH"] and find_executable("termux-open-url")
@@ -1637,7 +1647,7 @@ def runThing():
             sys.exit(-1)
     elif is_termux():
         subprocess.call(["termux-open-url", url])
-    elif is_chromeos_garcon():
+    elif is_chromeos_garcon() or is_sailfish_os():
         webbrowser.open(url)
     else:
         webbrowser.open(fileurl)


### PR DESCRIPTION
## Description

Sailfish OS 4.4.0 introduced sandboxing, which results in browsers (native or Android) not being to access `/tmp/` anymore to open the config file. Detect if we are running on Sailfish OS and launch the URL instead of the file. Tested on Sony Xperia XA2 Ultra (armv7hl) and Sony Xperia 10 II (aarch64) both running [Sailfish OS 4.4.0.48 EA](https://forum.sailfishos.org/t/release-notes-vanha-rauma-4-4-0/10656).

There is no issue of this yet, and AFAIK Sailfish OS is not officially supported platform either (it's basically just another Linux though). I created an [ugly but functional project](https://github.com/direc85/fish) for [Sailfish Application SDK](https://docs.sailfishos.org/Tools/Sailfish_SDK/), if you want to have a look at it (please don't!)

I use fish on my devices daily, it works, and it's great - hence the PR!

Thanks!

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
