### PR TITLE
Add completion for rclone

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,12 +39,13 @@ Completions
 ^^^^^^^^^^^
 - Added completions for:
   - brightnessctl (:issue:`8758`)
+  - rclone (:issue:`8819`)
   - tuned-adm (:issue:`8760`)
 
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-- CWD-reporting is now turned on for Kitty as well (:issue:`8806`)
+- CWD-reporting is now turned on for kitty as well (:issue:`8806`)
 
 Other improvements
 ------------------

--- a/share/completions/rclone.fish
+++ b/share/completions/rclone.fish
@@ -1,0 +1,1 @@
+rclone completion fish 2>/dev/null | source


### PR DESCRIPTION
rclone added fish completion in version 1.57.

https://github.com/rclone/rclone/blob/v1.57.0/docs/content/commands/rclone_completion_fish.md

Also change CHANGELOG to use `kitty` all lowercase official project name.
