### PR TITLE
Is this a typo?

### DIFF
--- a/doc_src/cmds/test.rst
+++ b/doc_src/cmds/test.rst
@@ -179,7 +179,7 @@ Parentheses and the ``-o`` and ``-a`` operators can be combined to produce more 
 
     if test \( -f /foo -o -f /bar \) -a \( -f /baz -o -f /bat \)
         echo Success.
-    end.
+    end
 
 
 Numerical comparisons will simply fail if one of the operands is not a number:


### PR DESCRIPTION
I copied the code, and gave me the following error:

> Missing end to balance this function 

## Description
I deleted a period after the `end`, and the error that I was having disappeared.

I am a noob. If this pull-request is not appropriate, I am sorry.