### PR TITLE
Autoload: Call the parser directly instead of going via "subshell"

### DIFF
--- a/src/autoload.cpp
+++ b/src/autoload.cpp
@@ -205,6 +205,14 @@ maybe_t<wcstring> autoload_t::resolve_command(const wcstring &cmd, const wcstrin
 }
 
 void autoload_t::perform_autoload(const wcstring &path, parser_t &parser) {
+    // We do the useful part of what exec_subshell does ourselves
+    // - we source the file.
+    // We don't create a buffer or check ifs or create a read_limit
+
     wcstring script_source = L"source " + escape_string(path, ESCAPE_ALL);
-    exec_subshell(script_source, parser, false /* do not apply exit status */);
+    auto prev_statuses = parser.get_last_statuses();
+    const cleanup_t put_back([&] {
+        parser.set_last_statuses(prev_statuses);
+    });
+    parser.eval(script_source, io_chain_t{});
 }

--- a/tests/checks/syntax-error-location.fish
+++ b/tests/checks/syntax-error-location.fish
@@ -32,3 +32,15 @@ $fish -c 'echo "unfinished "$(subshell' 2>| string replace -r '.*' '<$0>'
 # CHECK: <fish: Unexpected end of string, expecting ')'>
 # CHECK: <echo "unfinished "$(subshell>
 # CHECK: <                   ^>
+
+echo "function error" >$TMPDIR/error.fish
+$fish -c "set -g fish_function_path $(string escape $TMPDIR); error"
+# CHECKERR: ~/temp/error.fish (line 1): Missing end to balance this function definition
+# CHECKERR: function error
+# CHECKERR: ^
+# CHECKERR: from sourcing file ~/temp/error.fish
+# CHECKERR: source: Error while reading file '{{.*}}/error.fish'
+# CHECKERR: fish: Unknown command: error
+# CHECKERR: fish: 
+# CHECKERR: set -g fish_function_path {{.*}}; error
+# CHECKERR: ^


### PR DESCRIPTION
This used to call exec_subshell, which has two issues:

1. It creates a command substitution block which shows up in a stack
trace
2. It does much more work than necessary

This removes a useless "in command substitution" from an error message
in an autoloaded file, and it speeds up autoloading a bit (not
measurable in actual benchmarks, but microbenchmarks are 2x).

The stack trace goes from:

```
/tmp/autoloads/error.fish (line 1): Missing end to balance this function definition
function error
^
from sourcing file /tmp/autoloads/error.fish
in command substitution
```

to

```
/tmp/autoloads/error.fish (line 1): Missing end to balance this function definition
function error
^
from sourcing file /tmp/autoloads/error.fish
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

@ridiculousfish I'd like your eyes on this. I believe the subshell stuff *should* be unnecessary here?

(tbh I dislike the term "subshell" here because that's a specific thing in posixy shells and this is not it)