### PR TITLE
Rename fzf `--phony` completion to `--disabled`

### DIFF
--- a/share/completions/fzf.fish
+++ b/share/completions/fzf.fish
@@ -16,7 +16,7 @@ complete -c fzf -s d -l delimiter -d 'Field delimiter regex for --nth and --with
 complete -c fzf -l no-sort -d 'Do not sort the result'
 complete -c fzf -n 'string match "+*" -- (commandline -ct)' -a +s -d 'Do not sort the result'
 complete -c fzf -l tac -d 'Reverse the order of the input'
-complete -c fzf -l phony -d 'Do not perform search'
+complete -c fzf -l disabled -d 'Do not perform search'
 complete -c fzf -l tiebreak -d 'Sort criteria when breaking ties' -x -a 'length begin end index'
 
 # Interface


### PR DESCRIPTION
## Description

fzf renamed this option in [0.25.0](https://github.com/junegunn/fzf/releases/tag/0.25.0).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
