### PR TITLE
vared: avoid using local variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Interactive improvements
 - ``less`` and other interactive commands would occasionally be stopped when run in a pipeline with fish functions; this has been fixed (:issue:`8699`).
 - Case-changing autosuggestions generated mid-token now correctly append only the suffix, instead of duplicating the token (:issue:`8820`).
 - ``ulimit`` learned a number of new options for the resource limits available on Linux, FreeBSD and NetBSD, and returns a specific warning if the limit specified is not available on the active operating system (:issue:`8823`).
+- The ``vared`` command can now successfully edit variables named "tmp" or "prompt" (:issue:`8836`).
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/share/functions/vared.fish
+++ b/share/functions/vared.fish
@@ -17,25 +17,18 @@ function vared --description "Edit variable value"
 
             case '*'
                 if test (count $$argv ) -lt 2
-                    set -l init ''
-                    if test -n "$$argv"
-                        set init $$argv
-                    end
-                    set -l prompt 'set_color green; echo '$argv'; set_color normal; echo "> "'
-                    if read -p $prompt -c $init tmp
+                    # Avoid using any local variables in this function, otherwise they can't be edited
+                    # https://github.com/fish-shell/fish-shell/issues/8836
 
-                        # If variable already exists, do not add any
-                        # switches, so we don't change export rules. But
-                        # if it does not exist, we make the variable
-                        # global, so that it will not die when this
-                        # function dies
+                    # The command substitution in this line controls the scope.
+                    # If variable already exists, do not add any switches, so we don't change
+                    # scoping or export rules. But if it does not exist, we make the variable
+                    # global, so that it will not die when this function dies.
 
-                        if test -n "$$argv"
-                            set $argv $tmp
-                        else
-                            set -g $argv $tmp
-                        end
-                    end
+                    read -p 'set_color green; echo '$argv'; set_color normal; echo "> "' \
+                        (if not set -q $argv; echo -g; end) \
+                        -c "$$argv" \
+                        $argv
                 else
                     printf (_ '%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\n') vared $argv (set_color $fish_color_command; echo) (set_color $fish_color_normal; echo) $argv (set_color normal; echo) $argv
                 end


### PR DESCRIPTION
The tmp and prompt variables collide with variables used as arguments.
Just avoid them entirely, at the cost of making the internals of the
functions somewhat more complicated.

Fixes issue #8836.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst
