### PR TITLE
Make more of share/functions print error messages to stderr

### DIFF
--- a/share/functions/__fish_md5.fish
+++ b/share/functions/__fish_md5.fish
@@ -5,7 +5,7 @@ function __fish_md5
             if test $argv[1] = -s
                 echo (echo $argv[2] | md5sum | string split ' ')[1]
             else
-                printf (_ "%s: Too many arguments %s\n") fish_md5 $argv
+                printf (_ "%s: Too many arguments %s\n") fish_md5 $argv >&2
             end
         else
             echo (md5sum $argv[1] | string split ' ')[1]
@@ -17,7 +17,7 @@ function __fish_md5
             if test $argv[1] = -s
                 md5 -s $argv[2]
             else
-                printf (_ "%s: Too many arguments %s\n") fish_md5 $argv
+                printf (_ "%s: Too many arguments %s\n") fish_md5 $argv >&2
             end
         else
             md5 -q $argv[1]

--- a/share/functions/__fish_print_help.fish
+++ b/share/functions/__fish_print_help.fish
@@ -37,7 +37,7 @@ function __fish_print_help --description "Print help message for the specified f
             set -a format -rLL={$cols}n
         end
     else
-        echo fish: (_ "Cannot format help; no parser found")
+        echo fish: (_ "Cannot format help; no parser found") >&2
         return 1
     end
 

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -5,7 +5,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
 
     if contains -- -h $argv
         or contains -- --help $argv
-        echo "Sorry but this function doesn't support -h or --help"
+        echo "Sorry but this function doesn't support -h or --help" >&2
         return 1
     end
 

--- a/share/functions/_validate_int.fish
+++ b/share/functions/_validate_int.fish
@@ -10,21 +10,21 @@ function _validate_int --no-scope-shadowing
 
     if not string match -qr '^-?\d+$' -- $_flag_value
         set -l msg (_ "%s: Value '%s' for flag '%s' is not an integer\n")
-        printf $msg $_argparse_cmd $_flag_value $_flag_name
+        printf $msg $_argparse_cmd $_flag_value $_flag_name >&2
         return 1
     end
 
     if set -q _flag_min
         and test $_flag_value -lt $_flag_min
         set -l msg (_ "%s: Value '%s' for flag '%s' less than min allowed of '%s'\n")
-        printf $msg $_argparse_cmd $_flag_value $_flag_name $_flag_min
+        printf $msg $_argparse_cmd $_flag_value $_flag_name $_flag_min >&2
         return 1
     end
 
     if set -q _flag_max
         and test $_flag_value -gt $_flag_max
         set -l msg (_ "%s: Value '%s' for flag '%s' greater than max allowed of '%s'\n")
-        printf $msg $_argparse_cmd $_flag_value $_flag_name $_flag_max
+        printf $msg $_argparse_cmd $_flag_value $_flag_name $_flag_max >&2
         return 1
     end
 

--- a/share/functions/cd.fish
+++ b/share/functions/cd.fish
@@ -5,7 +5,7 @@ function cd --description "Change directory"
     set -l MAX_DIR_HIST 25
 
     if test (count $argv) -gt (test "$argv[1]" = "--" && echo 2 || echo 1)
-        printf "%s\n" (_ "Too many args for cd command")
+        printf "%s\n" (_ "Too many args for cd command") >&2
         return 1
     end
 

--- a/share/functions/cdh.fish
+++ b/share/functions/cdh.fish
@@ -34,9 +34,9 @@ function cdh --description "Menu based cd command"
     set -l dirc (count $uniq_dirs)
     if test $dirc -gt (count $letters)
         set -l msg (_ 'This should not happen. Have you changed the cd function?')
-        printf "$msg\n"
+        printf "$msg\n" >&2
         set -l msg (_ 'There are %s unique dirs in your history but I can only handle %s')
-        printf "$msg\n" $dirc (count $letters)
+        printf "$msg\n" $dirc (count $letters) >&2
         return 1
     end
 
@@ -77,11 +77,11 @@ function cdh --description "Menu based cd command"
             cd $uniq_dirs[$choice]
             return
         else
-            printf "$msg\n" $dirc $choice
+            printf "$msg\n" $dirc $choice >&2
             return 1
         end
     else
-        printf "$msg\n" $dirc $choice
+        printf "$msg\n" $dirc $choice >&2
         return 1
     end
 end

--- a/share/functions/fish_update_completions.fish
+++ b/share/functions/fish_update_completions.fish
@@ -5,7 +5,7 @@ function fish_update_completions --description "Update man-page based completion
     if set -l python (__fish_anypython)
         $python $update_args
     else
-        printf "%s\n" (_ "python executable not found")
+        printf "%s\n" (_ "python executable not found") >&2
         return 1
     end
 end

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -1,7 +1,7 @@
 function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     if contains -- -h $argv
         or contains -- --help $argv
-        echo "Sorry but this function doesn't support -h or --help"
+        echo "Sorry but this function doesn't support -h or --help" >&2
         return 1
     end
 

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -54,7 +54,7 @@ function funced --description 'Edit function definition'
     set -l editor_cmd
     echo $editor | read -ta editor_cmd
     if not type -q -f "$editor_cmd[1]"
-        echo (_ "funced: The value for \$EDITOR '$editor' could not be used because the command '$editor_cmd[1]' could not be found")
+        echo (_ "funced: The value for \$EDITOR '$editor' could not be used because the command '$editor_cmd[1]' could not be found") >&2
         set editor fish
     end
 

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -13,7 +13,7 @@ function help --description 'Show help for the fish shell'
         if string match -q string $argv[1]
             set fish_help_item (string join '-' $argv[1] $argv[2])
         else
-            echo "help: Expected at most 1 args, got 2"
+            echo "help: Expected at most 1 args, got 2" >&2
             return 1
         end
     end
@@ -93,8 +93,8 @@ function help --description 'Show help for the fish shell'
     end
 
     if not set -q fish_browser[1]
-        printf (_ '%s: Could not find a web browser.\n') help
-        printf (_ 'Please try `BROWSER=some_browser help`, `man fish-doc`, or `man fish-tutorial`.\n\n')
+        printf (_ '%s: Could not find a web browser.\n') help >&2
+        printf (_ 'Please try `BROWSER=some_browser help`, `man fish-doc`, or `man fish-tutorial`.\n\n') >&2
         return 1
     end
 

--- a/share/functions/nextd.fish
+++ b/share/functions/nextd.fish
@@ -13,7 +13,7 @@ function nextd --description "Move forward in the directory history"
         if test $argv[1] -ge 0 2>/dev/null
             set times $argv[1]
         else
-            printf (_ "%s: The number of positions to skip must be a non-negative integer\n") nextd
+            printf (_ "%s: The number of positions to skip must be a non-negative integer\n") nextd >&2
             return 1
         end
     end

--- a/share/functions/open.fish
+++ b/share/functions/open.fish
@@ -14,7 +14,7 @@ if not command -sq open
         end
 
         if not set -q argv[1]
-            printf (_ "%ls: Expected at least %d args, got only %d\n") open 1 0
+            printf (_ "%ls: Expected at least %d args, got only %d\n") open 1 0 >&2
             return 1
         end
 
@@ -34,7 +34,7 @@ if not command -sq open
                 disown $last_pid 2>/dev/null
             end
         else
-            echo (_ 'No open utility found. Try installing "xdg-open" or "xdg-utils".')
+            echo (_ 'No open utility found. Try installing "xdg-open" or "xdg-utils".') >&2
         end
     end
 end

--- a/share/functions/prevd.fish
+++ b/share/functions/prevd.fish
@@ -13,7 +13,7 @@ function prevd --description "Move back in the directory history"
         if test $argv[1] -ge 0 2>/dev/null
             set times $argv[1]
         else
-            printf (_ "%s: The number of positions to skip must be a non-negative integer\n") nextd
+            printf (_ "%s: The number of positions to skip must be a non-negative integer\n") prevd >&2
             return 1
         end
     end

--- a/share/functions/pushd.fish
+++ b/share/functions/pushd.fish
@@ -25,7 +25,7 @@ function pushd --description 'Push directory to stack'
     if not set -q argv[1]
         # check that the stack isn't empty
         if not set -q dirstack[1]
-            echo "pushd: no other directory"
+            echo "pushd: no other directory" >&2
             return 1
         end
 
@@ -48,7 +48,7 @@ function pushd --description 'Push directory to stack'
         if test -n "$rot_r"
             # check the rotation in range
             if test $rot_r -ge (count $stack)
-                echo "pushd: -$rot_r: directory stack index out of range"
+                echo "pushd: -$rot_r: directory stack index out of range" >&2
                 return 1
             end
 
@@ -57,7 +57,7 @@ function pushd --description 'Push directory to stack'
 
         # check the rotation in range
         if test $rot_l -ge (count $stack)
-            echo "pushd: +$rot_l: directory stack index out of range"
+            echo "pushd: +$rot_l: directory stack index out of range" >&2
             return 1
         else
             # rotate stack unless rot_l is 0

--- a/share/functions/realpath.fish
+++ b/share/functions/realpath.fish
@@ -49,7 +49,7 @@ function realpath -d "return an absolute path without symlinks"
     end
 
     if not set -q argv[1]
-        printf (_ "%ls: Expected at least %d args, got only %d\n") realpath 1 0
+        printf (_ "%ls: Expected at least %d args, got only %d\n") realpath 1 0 >&2
         return 1
     end
 

--- a/share/functions/seq.fish
+++ b/share/functions/seq.fish
@@ -36,13 +36,13 @@ if not command -sq seq
                 set step $argv[2]
                 set to $argv[3]
             case '*'
-                printf (_ "%s: Expected 1, 2 or 3 arguments, got %d\n") seq (count $argv)
+                printf (_ "%s: Expected 1, 2 or 3 arguments, got %d\n") seq (count $argv) >&2
                 return 1
         end
 
         for i in $from $step $to
             if not string match -rq -- '^-?[0-9]*([0-9]*|\.[0-9]+)$' $i
-                printf (_ "%s: '%s' is not a number\n") seq $i
+                printf (_ "%s: '%s' is not a number\n") seq $i >&2
                 return 1
             end
         end

--- a/share/functions/vared.fish
+++ b/share/functions/vared.fish
@@ -12,7 +12,7 @@ function vared --description "Edit variable value"
                 return 0
 
             case '-*'
-                printf (_ "%s: Unknown option %s\n") vared $argv
+                printf (_ "%s: Unknown option %s\n") vared $argv >&2
                 return 1
 
             case '*'
@@ -30,10 +30,10 @@ function vared --description "Edit variable value"
                         -c "$$argv" \
                         $argv
                 else
-                    printf (_ '%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\n') vared $argv (set_color $fish_color_command; echo) (set_color $fish_color_normal; echo) $argv (set_color normal; echo) $argv
+                    printf (_ '%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\n') vared $argv (set_color $fish_color_command; echo) (set_color $fish_color_normal; echo) $argv (set_color normal; echo) $argv >&2
                 end
         end
     else
-        printf (_ '%s: Expected exactly one argument, got %s.\n\nSynopsis:\n\t%svared%s VARIABLE\n') vared (count $argv) (set_color $fish_color_command; echo) (set_color $fish_color_normal; echo)
+        printf (_ '%s: Expected exactly one argument, got %s.\n\nSynopsis:\n\t%svared%s VARIABLE\n') vared (count $argv) (set_color $fish_color_command; echo) (set_color $fish_color_normal; echo) >&2
     end
 end


### PR DESCRIPTION
## Description

Hi. I was using `some_fish_func > some_file.something` and had a bug in my program (where I misused `pushd` in some irrelevant way). This caused me to notice that `pushd` logged its error message to stdout and not stderr, since it sort of[^sorta] corrupted the file.

My personal feelings here is that it is typically Bad Form for programs to use stdout for writing messages intended for the user, especially error messages (with some exceptions of course).

I have fish-shell checked out from prior patches so I took a peek. I noticed that most functions do the "right thing" and log their complaints to stderr, which I interpreted to mean that probably a patch fixing `pushd` would probably be appreciated. Unfortunately, at this point my "What If I Fixed It All" brain kicked in, so I started looking to see if there's anything else that this applies to, and there is.

That dream was pretty short-lived though, since fixing each part requires figuring out if it's program output vs an error... and I really don't want to break anything in this patch. So I ended up just doing the obvious bits.

... And after a while of doing with that, I decided that I really don't have time to shave this yak, especially given that I'm probably missing a lot of places anyway. Really, someone who knows the code better is probably the person who should finish that task (or not[^ornot]).

So this is just a start on the problem, and only addresses a small handful of cases. I don't *think* it makes anything worse though, so at least there's that.

---

Anyway, of the changes in this patch, I think the directory manipulation stuff and `seq` are the most important. It's likely that those are used often enough in scripts for their stdout to frequently be captured as a string, which would just result in bad behavior.

I think the cases which are least important are ones that are almost certainly only used interactively. For some reason, I still touched a few of these. That said, I'm (of course) willing to revert any of these changes if you'd prefer.

## TODOs:

- [x] Changes to fish usage are reflected in user documentation/manpages.

    No changes. 

- [ ] Tests have been added for regressions fixed

    Adding tests for this would be a nightmare. Please do not ask this of me.

- [ ] User-visible changes noted in CHANGELOG.rst

    I think this is *technically* user visible, but in practice most of the users who notice will just be finding new bugs in their code.

    I guess maybe some code attempts to parse one of these error messages from stdout, but such code is very fragile anyway.

---

P.S. *While I'm here*, since it's *technically* related... I think it would be good for fish to have `printf`/`echo` variants[^eprintf] that automatically use stderr. (TBH I mostly want this as a user, because the redirect syntax is weird and hard for me to remember I have to look it up every time). That said, if you used it consistently, it would make auditing stuff like this in the future easier... at least after you switched to use it (it seems unlikely to make it any easier to do the first time).

[^sorta]: Well, the file would be corrupted anyway because of the bug, this just made it happen slightly sooner.

[^ornot]: I won't judge if nothing happens after this PR. I get it -- it's very hard in open source to find the resources for projects like "ensure all the sites where we $frobnicate are Good And Proper", especially if it only gets hit in failure modes.

    For stuff like this it is especially hard, since it seems somewhat resistant to automation  -- any tooling would have to figure out what is an error message vs what is the real output. (But maybe there are some heuristics which would work enough of the time to be useful here)

[^eprintf]: For example, they could be `eprintf` and... uh... `eecho`?... `errcho`? ... Uh, coming up with a name better than those is left as an exercise for the reader.