### PR TITLE
Update terraform completions

### DIFF
--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -10,6 +10,10 @@ function __fish_terraform_needs_command
     return 1
 end
 
+function __fish_terraform_workspaces
+    terraform workspace list | string replace -r "^[\s\*]*" ""
+end
+
 # general options
 complete -f -c terraform -n "not __fish_terraform_needs_command" -o version -d "Print version information"
 complete -f -c terraform -o help -d "Show help"
@@ -20,21 +24,21 @@ set -l apply apply destroy
 complete -f -c terraform -n __fish_terraform_needs_command -a apply -d "Build or change infrastructure"
 complete -f -c terraform -n __fish_terraform_needs_command -a destroy -d "Destroy infrastructure"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o auto-approve -d "Skip interactive approval"
-complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o backup -d "Path to backup the existing state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from $apply" -o backup -d "Path to backup the existing state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o compact-warnings -d "Show only error summaries"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o lock-timeout -d "Duration to retry a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o input=true -d "Ask for input for variables if not directly set"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o no-color -d "If specified, output won't contain any color"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o parallelism -d "Limit the number of concurrent operations"
-complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o state -d "Path to a Terraform state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o state-out -d "Path to write state"
+complete -r -c terraform -n "__fish_seen_subcommand_from $apply" -o state -d "Path to a Terraform state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from $apply" -o state-out -d "Path to write state"
 
 ### console
 complete -f -c terraform -n __fish_terraform_needs_command -a console -d "Interactive console for Terraform interpolations"
-complete -f -c terraform -n "__fish_seen_subcommand_from console" -o state -d "Path to a Terraform state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from console" -o state -d "Path to a Terraform state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from console" -o var -d "Set a variable in the Terraform configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from console" -o var-file -d "Set variables from a file"
+complete -r -c terraform -n "__fish_seen_subcommand_from console" -o var-file -d "Set variables from a file"
 
 ### fmt
 complete -f -c terraform -n __fish_terraform_needs_command -a fmt -d "Rewrite config files to canonical format"
@@ -61,17 +65,17 @@ complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o type=apply -d
 
 ### import
 complete -f -c terraform -n __fish_terraform_needs_command -a import -d "Import existing infrastructure into Terraform"
-complete -f -c terraform -n "__fish_seen_subcommand_from import" -o backup -d "Path to backup the existing state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from import" -o backup -d "Path to backup the existing state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o config -d "Path to a directory of configuration files"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o allow-missing-config -d "Allow import without resource block"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o input=false -d "Disable interactive input prompts"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o lock-timeout -d "Duration to retry a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o no-color -d "If specified, output won't contain any color"
-complete -f -c terraform -n "__fish_seen_subcommand_from import" -o state -d "Path to a Terraform state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from import" -o state-out -d "Path to write state"
+complete -r -c terraform -n "__fish_seen_subcommand_from import" -o state -d "Path to a Terraform state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from import" -o state-out -d "Path to write state"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o var -d "Set a variable in the Terraform configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from import" -o var-file -d "Set variables from a file"
+complete -r -c terraform -n "__fish_seen_subcommand_from import" -o var-file -d "Set variables from a file"
 
 ### init
 complete -f -c terraform -n __fish_terraform_needs_command -a init -d "Initialize a new or existing Terraform configuration"
@@ -87,7 +91,7 @@ complete -f -c terraform -n "__fish_seen_subcommand_from init" -o lock-timeout -
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o no-color -d "If specified, output won't contain any color"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o plugin-dir -d "Directory containing plugin binaries"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o reconfigure -d "Ignore any saved configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from init" -o migrate-state -d "Reconfigure backend, migrating existing state"
+complete -r -c terraform -n "__fish_seen_subcommand_from init" -o migrate-state -d "Reconfigure backend, migrating existing state"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o upgrade -d "Install latest dependencies, ignoring lockfile"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o lockfile=readonly -d "Set dependency lockfile mode to readonly"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o ignore-remote-version -d "Ignore local and remote backend compatibility check"
@@ -102,7 +106,7 @@ complete -f -c terraform -n "__fish_seen_subcommand_from logout" -a "(__fish_pri
 
 ### output
 complete -f -c terraform -n __fish_terraform_needs_command -a output -d "Read an output from a state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from output" -o state -d "Path to the state file to read"
+complete -r -c terraform -n "__fish_seen_subcommand_from output" -o state -d "Path to the state file to read"
 complete -f -c terraform -n "__fish_seen_subcommand_from output" -o no-color -d "If specified, output won't contain any color"
 complete -f -c terraform -n "__fish_seen_subcommand_from output" -o json -d "Print output in JSON format"
 complete -f -c terraform -n "__fish_seen_subcommand_from output" -o raw -d "Print raw strings directly"
@@ -117,7 +121,7 @@ complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o lock-timeout -
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o no-color -d "If specified, output won't contain any color"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o out -d "Write a plan file to the given path"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o parallelism -d "Limit the number of concurrent operations"
-complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o state -d "Path to a Terraform state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from plan" -o state -d "Path to a Terraform state file"
 
 ### plan customization options are reusable across apply, destroy, and plan
 set -l plan apply destroy plan
@@ -128,7 +132,7 @@ complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o refresh=false
 complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o replace -d "Force replacement of resource using its address"
 complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o target -d "Resource to target"
 complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o var -d "Set a variable in the Terraform configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o var-file -d "Set variables from a file"
+complete -r -c terraform -n "__fish_seen_subcommand_from $plan" -o var-file -d "Set variables from a file"
 
 ### providers
 complete -f -c terraform -n __fish_terraform_needs_command -a providers -d "Print tree of modules with their provider requirements"
@@ -137,16 +141,16 @@ complete -f -c terraform -n "__fish_seen_subcommand_from providers" -a "lock mir
 ### refresh
 complete -f -c terraform -n __fish_terraform_needs_command -a refresh -d "Update local state file against real resources"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o compact-warnings -d "Show only error summaries"
-complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o backup -d "Path to backup the existing state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from refresh" -o backup -d "Path to backup the existing state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o input=true -d "Ask for input for variables if not directly set"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o lock-timeout -d "Duration to retry a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o no-color -d "If specified, output won't contain any color"
-complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o state -d "Path to a Terraform state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o state-out -d "Path to write state"
+complete -r -c terraform -n "__fish_seen_subcommand_from refresh" -o state -d "Path to a Terraform state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from refresh" -o state-out -d "Path to write state"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o target -d "Resource to target"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o var -d "Set a variable in the Terraform configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o var-file -d "Set variables from a file"
+complete -r -c terraform -n "__fish_seen_subcommand_from refresh" -o var-file -d "Set variables from a file"
 
 ### show
 complete -f -c terraform -n __fish_terraform_needs_command -a show -d "Inspect Terraform state or plan"
@@ -154,7 +158,7 @@ complete -f -c terraform -n "__fish_seen_subcommand_from show" -o no-color -d "I
 complete -f -c terraform -n "__fish_seen_subcommand_from validate" -o json -d "Produce output in JSON format"
 
 ### state
-complete -f -c terraform -n __fish_terraform_needs_command -a state -d "Advanced state management"
+complete -r -c terraform -n __fish_terraform_needs_command -a state -d "Advanced state management"
 complete -f -c terraform -n "__fish_seen_subcommand_from state" -a list -d "List resources in state"
 complete -f -c terraform -n "__fish_seen_subcommand_from state" -a mv -d "Move an item in the state"
 complete -f -c terraform -n "__fish_seen_subcommand_from state" -a pull -d "Pull current state and output to stdout"
@@ -166,12 +170,12 @@ complete -f -c terraform -n "__fish_seen_subcommand_from state" -a show -d "Show
 ### taint
 complete -f -c terraform -n __fish_terraform_needs_command -a taint -d "Manually mark a resource for recreation"
 complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o allow-missing -d "Succeed even if resource is missing"
-complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o backup -d "Path to backup the existing state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from taint" -o backup -d "Path to backup the existing state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o lock-timeout -d "Duration to retry a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o ignore-remote-version -d "Ignore local and remote backend compatibility check"
-complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o state -d "Path to a Terraform state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o state-out -d "Path to write state"
+complete -r -c terraform -n "__fish_seen_subcommand_from taint" -o state -d "Path to a Terraform state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from taint" -o state-out -d "Path to write state"
 
 ### test
 complete -f -c terraform -n __fish_terraform_needs_command -a test -d "Runs automated test of shared modules"
@@ -182,12 +186,12 @@ complete -f -c terraform -n "__fish_seen_subcommand_from test" -o no-color -d "I
 ### untaint
 complete -f -c terraform -n __fish_terraform_needs_command -a untaint -d "Manually unmark a resource as tainted"
 complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o allow-missing -d "Succeed even if resource is missing"
-complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o backup -d "Path to backup the existing state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from untaint" -o backup -d "Path to backup the existing state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o lock-timeout -d "Duration to retry a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o ignore-remote-version -d "Ignore local and remote backend compatibility check"
-complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o state -d "Path to a Terraform state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o state-out -d "Path to write state"
+complete -r -c terraform -n "__fish_seen_subcommand_from untaint" -o state -d "Path to a Terraform state file"
+complete -r -c terraform -n "__fish_seen_subcommand_from untaint" -o state-out -d "Path to write state"
 
 ### validate
 complete -f -c terraform -n __fish_terraform_needs_command -a validate -d "Validate the Terraform files"
@@ -198,8 +202,11 @@ complete -f -c terraform -n "__fish_seen_subcommand_from validate" -o no-color -
 complete -f -c terraform -n __fish_terraform_needs_command -a version -d "Print the Terraform version"
 
 ### workspace
+set -l workspace_commands list select new delete
+
 complete -f -c terraform -n __fish_terraform_needs_command -a workspace -d "Workspace management"
-complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a list -d "List workspaces"
-complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a select -d "Select an workspace"
-complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a new -d "Create a new workspace"
-complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a delete -d "Delete an existing workspace"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace && not __fish_seen_subcommand_from $workspace_commands" -a list -d "List workspaces"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace && not __fish_seen_subcommand_from $workspace_commands" -a select -d "Select an workspace"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace && not __fish_seen_subcommand_from $workspace_commands" -a new -d "Create a new workspace"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace && not __fish_seen_subcommand_from $workspace_commands" -a delete -d "Delete an existing workspace"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace && __fish_seen_subcommand_from select delete" -a "(__fish_terraform_workspaces)"

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -1,98 +1,119 @@
+# Returns 0 if the command has not had a subcommand yet
+# Does not currently account for -chdir
+function __fish_terraform_needs_command
+    set -l cmd (commandline -opc)
+
+    if test (count $cmd) -eq 1
+        return 0
+    end
+
+    return 1
+end
+
 # general options
-complete -f -c terraform -l version -d "Print version information"
-complete -f -c terraform -l help -d "Show help"
+complete -f -c terraform -n "not __fish_terraform_needs_command" -o version -d "Print version information"
+complete -f -c terraform -o help -d "Show help"
 
 ### apply/destroy
 set -l apply apply destroy
 
-complete -f -c terraform -n __fish_use_subcommand -a apply -d "Build or change infrastructure"
-complete -f -c terraform -n __fish_use_subcommand -a destroy -d "Destroy Terraform-managed infrastructure"
+complete -f -c terraform -n __fish_terraform_needs_command -a apply -d "Build or change infrastructure"
+complete -f -c terraform -n __fish_terraform_needs_command -a destroy -d "Destroy infrastructure"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o auto-approve -d "Skip interactive approval"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o backup -d "Path to backup the existing state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o compact-warnings -d "Show only error summaries"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o lock-timeout -d "Duration to retry a state lock"
-complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o input -d "Ask for input for variables if not directly set"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o input=true -d "Ask for input for variables if not directly set"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o no-color -d "If specified, output won't contain any color"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o parallelism -d "Limit the number of concurrent operations"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o state -d "Path to a Terraform state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o state-out -d "Path to write state"
 
 ### console
-complete -f -c terraform -n __fish_use_subcommand -a console -d "Interactive console for Terraform interpolations"
+complete -f -c terraform -n __fish_terraform_needs_command -a console -d "Interactive console for Terraform interpolations"
 complete -f -c terraform -n "__fish_seen_subcommand_from console" -o state -d "Path to a Terraform state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from console" -o var -d "Set a variable in the Terraform configuration"
 complete -f -c terraform -n "__fish_seen_subcommand_from console" -o var-file -d "Set variables from a file"
 
-### env
-complete -f -c terraform -n __fish_use_subcommand -a env -d "Environment management"
-complete -f -c terraform -n "__fish_seen_subcommand_from env" -a list -d "List environments"
-complete -f -c terraform -n "__fish_seen_subcommand_from env" -a select -d "Select an environment"
-complete -f -c terraform -n "__fish_seen_subcommand_from env" -a new -d "Create a new environment"
-complete -f -c terraform -n "__fish_seen_subcommand_from env" -a delete -d "Delete an existing environment"
-
-### workspace
-complete -f -c terraform -n __fish_use_subcommand -a workspace -d "Workspace management"
-complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a list -d "List workspaces"
-complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a select -d "Select an workspace"
-complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a new -d "Create a new workspace"
-complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a delete -d "Delete an existing workspace"
-
 ### fmt
-complete -f -c terraform -n __fish_use_subcommand -a fmt -d "Rewrite config files to canonical format"
-complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o list -d "List files whose formatting differs"
-complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o write -d "Write result to source file"
+complete -f -c terraform -n __fish_terraform_needs_command -a fmt -d "Rewrite config files to canonical format"
+complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o list=false -d "Don't list files whose formatting differs"
+complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o write=false -d "Don't write to source files"
 complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o diff -d "Display diffs of formatting changes"
+complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o check -d "Check if the input is formatted"
+complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o recursive -d "Also process files in subdirectories"
 
 ### get
-complete -f -c terraform -n __fish_use_subcommand -a get -d "Download and install modules for the configuration"
+complete -f -c terraform -n __fish_terraform_needs_command -a get -d "Download and install modules for the configuration"
 complete -f -c terraform -n "__fish_seen_subcommand_from get" -o update -d "Check modules for updates"
 complete -f -c terraform -n "__fish_seen_subcommand_from get" -o no-color -d "If specified, output won't contain any color"
 
 ### graph
-complete -f -c terraform -n __fish_use_subcommand -a graph -d "Create a visual graph of Terraform resources"
+complete -f -c terraform -n __fish_terraform_needs_command -a graph -d "Create a visual graph of Terraform resources"
+complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o plan -d "Use specified plan file instead of current directory"
 complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o draw-cycles -d "Highlight any cycles in the graph"
-complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o no-color -d "If specified, output won't contain any color"
-complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o type -d "Type of graph to output"
+complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o type=plan -d "Output plan graph"
+complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o type=plan-refresh-only -d "Output plan graph assuming refresh only"
+complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o type=plan-destroy -d "Output plan graph assuming destroy"
+complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o type=apply -d "Output apply graph"
 
 ### import
-complete -f -c terraform -n __fish_use_subcommand -a import -d "Import existing infrastructure into Terraform"
+complete -f -c terraform -n __fish_terraform_needs_command -a import -d "Import existing infrastructure into Terraform"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o backup -d "Path to backup the existing state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o config -d "Path to a directory of configuration files"
-complete -f -c terraform -n "__fish_seen_subcommand_from import" -o input -d "Ask for input for variables if not directly set"
-complete -f -c terraform -n "__fish_seen_subcommand_from import" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o allow-missing-config -d "Allow import without resource block"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o input=false -d "Disable interactive input prompts"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o lock-timeout -d "Duration to retry a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o no-color -d "If specified, output won't contain any color"
-complete -f -c terraform -n "__fish_seen_subcommand_from import" -o provider -d "Specific provider to use for import"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o state -d "Path to a Terraform state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o state-out -d "Path to write state"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o var -d "Set a variable in the Terraform configuration"
 complete -f -c terraform -n "__fish_seen_subcommand_from import" -o var-file -d "Set variables from a file"
 
 ### init
-complete -f -c terraform -n __fish_use_subcommand -a init -d "Initialize a new or existing Terraform configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from init" -o backend -d "Configure the backend for this environment"
+complete -f -c terraform -n __fish_terraform_needs_command -a init -d "Initialize a new or existing Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o backend=false -d "Disable backend initialization"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o cloud=false -d "Disable backend initialization"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o backend-config -d "Backend configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from init" -o get -d "Download modules for this configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from init" -o input -d "Ask for input if necessary"
-complete -f -c terraform -n "__fish_seen_subcommand_from init" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o force-copy -d "Suppress prompts about copying state data"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o from-module -d "Copy the module into target directory before init"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o get=false -d "Disable downloading modules for this configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o input=false -d "Disable interactive prompts"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o lock=false -d "Don't hold state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o lock-timeout -d "Duration to retry a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o no-color -d "If specified, output won't contain any color"
-complete -f -c terraform -n "__fish_seen_subcommand_from init" -o force-copy -d "Suppress prompts about copying state data"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o plugin-dir -d "Directory containing plugin binaries"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o reconfigure -d "Ignore any saved configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o migrate-state -d "Reconfigure backend, migrating existing state"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o upgrade -d "Install latest dependencies, ignoring lockfile"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o lockfile=readonly -d "Set dependency lockfile mode to readonly"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o ignore-remote-version -d "Ignore local and remote backend compatibility check"
+
+### login
+complete -f -c terraform -n __fish_terraform_needs_command -a login -d "Retrieves auth token for the given hostname"
+complete -f -c terraform -n "__fish_seen_subcommand_from login" -a "(__fish_print_hostnames)"
+
+### logout
+complete -f -c terraform -n __fish_terraform_needs_command -a logout -d "Removes auth token for the given hostname"
+complete -f -c terraform -n "__fish_seen_subcommand_from logout" -a "(__fish_print_hostnames)"
 
 ### output
-complete -f -c terraform -n __fish_use_subcommand -a output -d "Read an output from a state file"
+complete -f -c terraform -n __fish_terraform_needs_command -a output -d "Read an output from a state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from output" -o state -d "Path to the state file to read"
 complete -f -c terraform -n "__fish_seen_subcommand_from output" -o no-color -d "If specified, output won't contain any color"
-complete -f -c terraform -n "__fish_seen_subcommand_from output" -o module -d "Return the outputs for a specific module"
 complete -f -c terraform -n "__fish_seen_subcommand_from output" -o json -d "Print output in JSON format"
+complete -f -c terraform -n "__fish_seen_subcommand_from output" -o raw -d "Print raw strings directly"
 
 ### plan
-complete -f -c terraform -n __fish_use_subcommand -a plan -d "Generate and show an execution plan"
-
+complete -f -c terraform -n __fish_terraform_needs_command -a plan -d "Generate and show an execution plan"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o compact-warnings -d "Show only error summaries"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o detailed-exitcode -d "Return detailed exit codes"
-complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o input -d "Ask for input for variables if not directly set"
-complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o input=true -d "Ask for input for variables if not directly set"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o lock=false -d "Don't hold a state lock during the operation"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o lock-timeout -d "Duration to retry a state lock"
-complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o module-depth -d "Depth of modules to show in the output"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o no-color -d "If specified, output won't contain any color"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o out -d "Write a plan file to the given path"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o parallelism -d "Limit the number of concurrent operations"
@@ -101,29 +122,24 @@ complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o state -d "Path
 ### plan customization options are reusable across apply, destroy, and plan
 set -l plan apply destroy plan
 
-complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o destroy -d "Generate a plan to destroy all resources"
-complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o refresh -d "Update state prior to checking for differences"
+complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o destroy -d "Select \"destroy\" planning mode"
+complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o refresh-only -d "Select \"refresh only\" planning mode"
+complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o refresh=false -d "Skip checking for external changes"
+complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o replace -d "Force replacement of resource using its address"
 complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o target -d "Resource to target"
 complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o var -d "Set a variable in the Terraform configuration"
 complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o var-file -d "Set variables from a file"
 
-### push
-complete -f -c terraform -n __fish_use_subcommand -a push -d "Upload this Terraform module to Atlas to run"
-complete -f -c terraform -n "__fish_seen_subcommand_from push" -o atlas-address -d "An alternate address to an Atlas instance"
-complete -f -c terraform -n "__fish_seen_subcommand_from push" -o upload-modules -d "Lock modules and upload completely"
-complete -f -c terraform -n "__fish_seen_subcommand_from push" -o name -d "Name of the configuration in Atlas"
-complete -f -c terraform -n "__fish_seen_subcommand_from push" -o token -d "Access token to use to upload"
-complete -f -c terraform -n "__fish_seen_subcommand_from push" -o overwrite -d "Variable keys that should overwrite values in Atlas"
-complete -f -c terraform -n "__fish_seen_subcommand_from push" -o var -d "Set a variable in the Terraform configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from push" -o var-file -d "Set variables from a file"
-complete -f -c terraform -n "__fish_seen_subcommand_from push" -o vcs -d "Upload only files committed to your VCS"
-complete -f -c terraform -n "__fish_seen_subcommand_from push" -o no-color -d "If specified, output won't contain any color"
+### providers
+complete -f -c terraform -n __fish_terraform_needs_command -a providers -d "Print tree of modules with their provider requirements"
+complete -f -c terraform -n "__fish_seen_subcommand_from providers" -a "lock mirror schema"
 
 ### refresh
-complete -f -c terraform -n __fish_use_subcommand -a refresh -d "Update local state file against real resources"
+complete -f -c terraform -n __fish_terraform_needs_command -a refresh -d "Update local state file against real resources"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o compact-warnings -d "Show only error summaries"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o backup -d "Path to backup the existing state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o input -d "Ask for input for variables if not directly set"
-complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o input=true -d "Ask for input for variables if not directly set"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o lock-timeout -d "Duration to retry a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o no-color -d "If specified, output won't contain any color"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o state -d "Path to a Terraform state file"
@@ -133,35 +149,57 @@ complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o var -d "Set
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o var-file -d "Set variables from a file"
 
 ### show
-complete -f -c terraform -n __fish_use_subcommand -a show -d "Inspect Terraform state or plan"
-complete -f -c terraform -n "__fish_seen_subcommand_from show" -o module-depth -d "Depth of modules to show in the output"
+complete -f -c terraform -n __fish_terraform_needs_command -a show -d "Inspect Terraform state or plan"
 complete -f -c terraform -n "__fish_seen_subcommand_from show" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from validate" -o json -d "Produce output in JSON format"
+
+### state
+complete -f -c terraform -n __fish_terraform_needs_command -a state -d "Advanced state management"
+complete -f -c terraform -n "__fish_seen_subcommand_from state" -a list -d "List resources in state"
+complete -f -c terraform -n "__fish_seen_subcommand_from state" -a mv -d "Move an item in the state"
+complete -f -c terraform -n "__fish_seen_subcommand_from state" -a pull -d "Pull current state and output to stdout"
+complete -f -c terraform -n "__fish_seen_subcommand_from state" -a push -d "Update remote state from local state"
+complete -f -c terraform -n "__fish_seen_subcommand_from state" -a replace-provider -d "Replace provider in the state"
+complete -f -c terraform -n "__fish_seen_subcommand_from state" -a rm -d "Remove instance from the state"
+complete -f -c terraform -n "__fish_seen_subcommand_from state" -a show -d "Show a resource in the state"
 
 ### taint
-complete -f -c terraform -n __fish_use_subcommand -a taint -d "Manually mark a resource for recreation"
+complete -f -c terraform -n __fish_terraform_needs_command -a taint -d "Manually mark a resource for recreation"
 complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o allow-missing -d "Succeed even if resource is missing"
 complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o backup -d "Path to backup the existing state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o lock-timeout -d "Duration to retry a state lock"
-complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o module -d "The module path where the resource lives"
-complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o ignore-remote-version -d "Ignore local and remote backend compatibility check"
 complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o state -d "Path to a Terraform state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o state-out -d "Path to write state"
 
+### test
+complete -f -c terraform -n __fish_terraform_needs_command -a test -d "Runs automated test of shared modules"
+complete -f -c terraform -n "__fish_seen_subcommand_from test" -o compact-warnings -d "Show only error summaries"
+complete -f -c terraform -n "__fish_seen_subcommand_from test" -o junit-xml -d "Also write test results to provided JUnit XML file"
+complete -f -c terraform -n "__fish_seen_subcommand_from test" -o no-color -d "If specified, output won't contain any color"
+
 ### untaint
-complete -f -c terraform -n __fish_use_subcommand -a untaint -d "Manually unmark a resource as tainted"
+complete -f -c terraform -n __fish_terraform_needs_command -a untaint -d "Manually unmark a resource as tainted"
 complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o allow-missing -d "Succeed even if resource is missing"
 complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o backup -d "Path to backup the existing state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o lock=false -d "Don't hold a state lock"
 complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o lock-timeout -d "Duration to retry a state lock"
-complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o module -d "The module path where the resource lives"
-complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o ignore-remote-version -d "Ignore local and remote backend compatibility check"
 complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o state -d "Path to a Terraform state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o state-out -d "Path to write state"
 
 ### validate
-complete -f -c terraform -n __fish_use_subcommand -a validate -d "Validate the Terraform files"
+complete -f -c terraform -n __fish_terraform_needs_command -a validate -d "Validate the Terraform files"
+complete -f -c terraform -n "__fish_seen_subcommand_from validate" -o json -d "Produce output in JSON format"
 complete -f -c terraform -n "__fish_seen_subcommand_from validate" -o no-color -d "If specified, output won't contain any color"
 
 ### version
-complete -f -c terraform -n __fish_use_subcommand -a version -d "Print the Terraform version"
+complete -f -c terraform -n __fish_terraform_needs_command -a version -d "Print the Terraform version"
+
+### workspace
+complete -f -c terraform -n __fish_terraform_needs_command -a workspace -d "Workspace management"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a list -d "List workspaces"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a select -d "Select an workspace"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a new -d "Create a new workspace"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a delete -d "Delete an existing workspace"

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -2,41 +2,25 @@
 complete -f -c terraform -l version -d "Print version information"
 complete -f -c terraform -l help -d "Show help"
 
-### apply
+### apply/destroy
+set -l apply apply destroy
+
 complete -f -c terraform -n __fish_use_subcommand -a apply -d "Build or change infrastructure"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o backup -d "Path to backup the existing state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o lock -d "Lock the state file when locking is supported"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o lock-timeout -d "Duration to retry a state lock"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o input -d "Ask for input for variables if not directly set"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o no-color -d "If specified, output won't contain any color"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o parallelism -d "Limit the number of concurrent operations"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o refresh -d "Update state prior to checking for differences"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o state -d "Path to a Terraform state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o state-out -d "Path to write state"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o target -d "Resource to target"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o var -d "Set a variable in the Terraform configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o var-file -d "Set variables from a file"
+complete -f -c terraform -n __fish_use_subcommand -a destroy -d "Destroy Terraform-managed infrastructure"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o backup -d "Path to backup the existing state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o lock-timeout -d "Duration to retry a state lock"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o input -d "Ask for input for variables if not directly set"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o parallelism -d "Limit the number of concurrent operations"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o state -d "Path to a Terraform state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o state-out -d "Path to write state"
 
 ### console
 complete -f -c terraform -n __fish_use_subcommand -a console -d "Interactive console for Terraform interpolations"
 complete -f -c terraform -n "__fish_seen_subcommand_from console" -o state -d "Path to a Terraform state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from console" -o var -d "Set a variable in the Terraform configuration"
 complete -f -c terraform -n "__fish_seen_subcommand_from console" -o var-file -d "Set variables from a file"
-
-### destroy
-complete -f -c terraform -n __fish_use_subcommand -a destroy -d "Destroy Terraform-managed infrastructure"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o backup -d "Path to backup the existing state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o force -d "Don't ask for input for destroy confirmation"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o lock -d "Lock the state file when locking is supported"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o lock-timeout -d "Duration to retry a state lock"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o no-color -d "If specified, output won't contain any color"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o parallelism -d "Limit the number of concurrent operations"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o refresh -d "Update state prior to checking for differences"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o state -d "Path to a Terraform state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o state-out -d "Path to write state"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o target -d "Resource to target"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o var -d "Set a variable in the Terraform configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o var-file -d "Set variables from a file"
 
 ### env
 complete -f -c terraform -n __fish_use_subcommand -a env -d "Environment management"
@@ -103,7 +87,7 @@ complete -f -c terraform -n "__fish_seen_subcommand_from output" -o json -d "Pri
 
 ### plan
 complete -f -c terraform -n __fish_use_subcommand -a plan -d "Generate and show an execution plan"
-complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o destroy -d "Generate a plan to destroy all resources"
+
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o detailed-exitcode -d "Return detailed exit codes"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o input -d "Ask for input for variables if not directly set"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o lock -d "Lock the state file when locking is supported"
@@ -112,11 +96,16 @@ complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o module-depth -
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o no-color -d "If specified, output won't contain any color"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o out -d "Write a plan file to the given path"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o parallelism -d "Limit the number of concurrent operations"
-complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o refresh -d "Update state prior to checking for differences"
 complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o state -d "Path to a Terraform state file"
-complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o target -d "Resource to target"
-complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o var -d "Set a variable in the Terraform configuration"
-complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o var-file -d "Set variables from a file"
+
+### plan customization options are reusable across apply, destroy, and plan
+set -l plan apply destroy plan
+
+complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o destroy -d "Generate a plan to destroy all resources"
+complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o refresh -d "Update state prior to checking for differences"
+complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o target -d "Resource to target"
+complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o var -d "Set a variable in the Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from $plan" -o var-file -d "Set variables from a file"
 
 ### push
 complete -f -c terraform -n __fish_use_subcommand -a push -d "Upload this Terraform module to Atlas to run"

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -1,178 +1,178 @@
 # general options
-complete -f -c terraform -l version -d 'Print version information'
-complete -f -c terraform -l help -d 'Show help'
+complete -f -c terraform -l version -d "Print version information"
+complete -f -c terraform -l help -d "Show help"
 
 ### apply
-complete -f -c terraform -n __fish_use_subcommand -a apply -d 'Build or change infrastructure'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o input -d 'Ask for input for variables if not directly set'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o parallelism -d 'Limit the number of concurrent operations'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o refresh -d 'Update state prior to checking for differences'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o state-out -d 'Path to write state'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o target -d 'Resource to target'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from apply' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n __fish_use_subcommand -a apply -d "Build or change infrastructure"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o backup -d "Path to backup the existing state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o lock-timeout -d "Duration to retry a state lock"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o input -d "Ask for input for variables if not directly set"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o parallelism -d "Limit the number of concurrent operations"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o refresh -d "Update state prior to checking for differences"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o state -d "Path to a Terraform state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o state-out -d "Path to write state"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o target -d "Resource to target"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o var -d "Set a variable in the Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from apply" -o var-file -d "Set variables from a file"
 
 ### console
-complete -f -c terraform -n __fish_use_subcommand -a console -d 'Interactive console for Terraform interpolations'
-complete -f -c terraform -n '__fish_seen_subcommand_from console' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from console' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from console' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n __fish_use_subcommand -a console -d "Interactive console for Terraform interpolations"
+complete -f -c terraform -n "__fish_seen_subcommand_from console" -o state -d "Path to a Terraform state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from console" -o var -d "Set a variable in the Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from console" -o var-file -d "Set variables from a file"
 
 ### destroy
-complete -f -c terraform -n __fish_use_subcommand -a destroy -d 'Destroy Terraform-managed infrastructure'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o force -d 'Don\'t ask for input for destroy confirmation'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o parallelism -d 'Limit the number of concurrent operations'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o refresh -d 'Update state prior to checking for differences'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o state-out -d 'Path to write state'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o target -d 'Resource to target'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from destroy' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n __fish_use_subcommand -a destroy -d "Destroy Terraform-managed infrastructure"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o backup -d "Path to backup the existing state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o force -d "Don't ask for input for destroy confirmation"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o lock-timeout -d "Duration to retry a state lock"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o parallelism -d "Limit the number of concurrent operations"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o refresh -d "Update state prior to checking for differences"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o state -d "Path to a Terraform state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o state-out -d "Path to write state"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o target -d "Resource to target"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o var -d "Set a variable in the Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from destroy" -o var-file -d "Set variables from a file"
 
 ### env
-complete -f -c terraform -n __fish_use_subcommand -a env -d 'Environment management'
-complete -f -c terraform -n '__fish_seen_subcommand_from env' -a list -d 'List environments'
-complete -f -c terraform -n '__fish_seen_subcommand_from env' -a select -d 'Select an environment'
-complete -f -c terraform -n '__fish_seen_subcommand_from env' -a new -d 'Create a new environment'
-complete -f -c terraform -n '__fish_seen_subcommand_from env' -a delete -d 'Delete an existing environment'
+complete -f -c terraform -n __fish_use_subcommand -a env -d "Environment management"
+complete -f -c terraform -n "__fish_seen_subcommand_from env" -a list -d "List environments"
+complete -f -c terraform -n "__fish_seen_subcommand_from env" -a select -d "Select an environment"
+complete -f -c terraform -n "__fish_seen_subcommand_from env" -a new -d "Create a new environment"
+complete -f -c terraform -n "__fish_seen_subcommand_from env" -a delete -d "Delete an existing environment"
 
 ### workspace
-complete -f -c terraform -n __fish_use_subcommand -a workspace -d 'Workspace management'
-complete -f -c terraform -n '__fish_seen_subcommand_from workspace' -a list -d 'List workspaces'
-complete -f -c terraform -n '__fish_seen_subcommand_from workspace' -a select -d 'Select an workspace'
-complete -f -c terraform -n '__fish_seen_subcommand_from workspace' -a new -d 'Create a new workspace'
-complete -f -c terraform -n '__fish_seen_subcommand_from workspace' -a delete -d 'Delete an existing workspace'
+complete -f -c terraform -n __fish_use_subcommand -a workspace -d "Workspace management"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a list -d "List workspaces"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a select -d "Select an workspace"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a new -d "Create a new workspace"
+complete -f -c terraform -n "__fish_seen_subcommand_from workspace" -a delete -d "Delete an existing workspace"
 
 ### fmt
-complete -f -c terraform -n __fish_use_subcommand -a fmt -d 'Rewrite config files to canonical format'
-complete -f -c terraform -n '__fish_seen_subcommand_from fmt' -o list -d 'List files whose formatting differs'
-complete -f -c terraform -n '__fish_seen_subcommand_from fmt' -o write -d 'Write result to source file'
-complete -f -c terraform -n '__fish_seen_subcommand_from fmt' -o diff -d 'Display diffs of formatting changes'
+complete -f -c terraform -n __fish_use_subcommand -a fmt -d "Rewrite config files to canonical format"
+complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o list -d "List files whose formatting differs"
+complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o write -d "Write result to source file"
+complete -f -c terraform -n "__fish_seen_subcommand_from fmt" -o diff -d "Display diffs of formatting changes"
 
 ### get
-complete -f -c terraform -n __fish_use_subcommand -a get -d 'Download and install modules for the configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from get' -o update -d 'Check modules for updates'
-complete -f -c terraform -n '__fish_seen_subcommand_from get' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n __fish_use_subcommand -a get -d "Download and install modules for the configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from get" -o update -d "Check modules for updates"
+complete -f -c terraform -n "__fish_seen_subcommand_from get" -o no-color -d "If specified, output won't contain any color"
 
 ### graph
-complete -f -c terraform -n __fish_use_subcommand -a graph -d 'Create a visual graph of Terraform resources'
-complete -f -c terraform -n '__fish_seen_subcommand_from graph' -o draw-cycles -d 'Highlight any cycles in the graph'
-complete -f -c terraform -n '__fish_seen_subcommand_from graph' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from graph' -o type -d 'Type of graph to output'
+complete -f -c terraform -n __fish_use_subcommand -a graph -d "Create a visual graph of Terraform resources"
+complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o draw-cycles -d "Highlight any cycles in the graph"
+complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from graph" -o type -d "Type of graph to output"
 
 ### import
-complete -f -c terraform -n __fish_use_subcommand -a import -d 'Import existing infrastructure into Terraform'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o config -d 'Path to a directory of configuration files'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o input -d 'Ask for input for variables if not directly set'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o provider -d 'Specific provider to use for import'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o state-out -d 'Path to write state'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from import' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n __fish_use_subcommand -a import -d "Import existing infrastructure into Terraform"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o backup -d "Path to backup the existing state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o config -d "Path to a directory of configuration files"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o input -d "Ask for input for variables if not directly set"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o lock-timeout -d "Duration to retry a state lock"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o provider -d "Specific provider to use for import"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o state -d "Path to a Terraform state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o state-out -d "Path to write state"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o var -d "Set a variable in the Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from import" -o var-file -d "Set variables from a file"
 
 ### init
-complete -f -c terraform -n __fish_use_subcommand -a init -d 'Initialize a new or existing Terraform configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from init' -o backend -d 'Configure the backend for this environment'
-complete -f -c terraform -n '__fish_seen_subcommand_from init' -o backend-config -d 'Backend configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from init' -o get -d 'Download modules for this configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from init' -o input -d 'Ask for input if necessary'
-complete -f -c terraform -n '__fish_seen_subcommand_from init' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_seen_subcommand_from init' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_seen_subcommand_from init' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from init' -o force-copy -d 'Suppress prompts about copying state data'
+complete -f -c terraform -n __fish_use_subcommand -a init -d "Initialize a new or existing Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o backend -d "Configure the backend for this environment"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o backend-config -d "Backend configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o get -d "Download modules for this configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o input -d "Ask for input if necessary"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o lock-timeout -d "Duration to retry a state lock"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from init" -o force-copy -d "Suppress prompts about copying state data"
 
 ### output
-complete -f -c terraform -n __fish_use_subcommand -a output -d 'Read an output from a state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from output' -o state -d 'Path to the state file to read'
-complete -f -c terraform -n '__fish_seen_subcommand_from output' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from output' -o module -d 'Return the outputs for a specific module'
-complete -f -c terraform -n '__fish_seen_subcommand_from output' -o json -d 'Print output in JSON format'
+complete -f -c terraform -n __fish_use_subcommand -a output -d "Read an output from a state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from output" -o state -d "Path to the state file to read"
+complete -f -c terraform -n "__fish_seen_subcommand_from output" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from output" -o module -d "Return the outputs for a specific module"
+complete -f -c terraform -n "__fish_seen_subcommand_from output" -o json -d "Print output in JSON format"
 
 ### plan
-complete -f -c terraform -n __fish_use_subcommand -a plan -d 'Generate and show an execution plan'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o destroy -d 'Generate a plan to destroy all resources'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o detailed-exitcode -d 'Return detailed exit codes'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o input -d 'Ask for input for variables if not directly set'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o module-depth -d 'Depth of modules to show in the output'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o out -d 'Write a plan file to the given path'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o parallelism -d 'Limit the number of concurrent operations'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o refresh -d 'Update state prior to checking for differences'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o target -d 'Resource to target'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from plan' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n __fish_use_subcommand -a plan -d "Generate and show an execution plan"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o destroy -d "Generate a plan to destroy all resources"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o detailed-exitcode -d "Return detailed exit codes"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o input -d "Ask for input for variables if not directly set"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o lock-timeout -d "Duration to retry a state lock"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o module-depth -d "Depth of modules to show in the output"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o out -d "Write a plan file to the given path"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o parallelism -d "Limit the number of concurrent operations"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o refresh -d "Update state prior to checking for differences"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o state -d "Path to a Terraform state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o target -d "Resource to target"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o var -d "Set a variable in the Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from plan" -o var-file -d "Set variables from a file"
 
 ### push
-complete -f -c terraform -n __fish_use_subcommand -a push -d 'Upload this Terraform module to Atlas to run'
-complete -f -c terraform -n '__fish_seen_subcommand_from push' -o atlas-address -d 'An alternate address to an Atlas instance'
-complete -f -c terraform -n '__fish_seen_subcommand_from push' -o upload-modules -d 'Lock modules and upload completely'
-complete -f -c terraform -n '__fish_seen_subcommand_from push' -o name -d 'Name of the configuration in Atlas'
-complete -f -c terraform -n '__fish_seen_subcommand_from push' -o token -d 'Access token to use to upload'
-complete -f -c terraform -n '__fish_seen_subcommand_from push' -o overwrite -d 'Variable keys that should overwrite values in Atlas'
-complete -f -c terraform -n '__fish_seen_subcommand_from push' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from push' -o var-file -d 'Set variables from a file'
-complete -f -c terraform -n '__fish_seen_subcommand_from push' -o vcs -d 'Upload only files committed to your VCS'
-complete -f -c terraform -n '__fish_seen_subcommand_from push' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n __fish_use_subcommand -a push -d "Upload this Terraform module to Atlas to run"
+complete -f -c terraform -n "__fish_seen_subcommand_from push" -o atlas-address -d "An alternate address to an Atlas instance"
+complete -f -c terraform -n "__fish_seen_subcommand_from push" -o upload-modules -d "Lock modules and upload completely"
+complete -f -c terraform -n "__fish_seen_subcommand_from push" -o name -d "Name of the configuration in Atlas"
+complete -f -c terraform -n "__fish_seen_subcommand_from push" -o token -d "Access token to use to upload"
+complete -f -c terraform -n "__fish_seen_subcommand_from push" -o overwrite -d "Variable keys that should overwrite values in Atlas"
+complete -f -c terraform -n "__fish_seen_subcommand_from push" -o var -d "Set a variable in the Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from push" -o var-file -d "Set variables from a file"
+complete -f -c terraform -n "__fish_seen_subcommand_from push" -o vcs -d "Upload only files committed to your VCS"
+complete -f -c terraform -n "__fish_seen_subcommand_from push" -o no-color -d "If specified, output won't contain any color"
 
 ### refresh
-complete -f -c terraform -n __fish_use_subcommand -a refresh -d 'Update local state file against real resources'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o input -d 'Ask for input for variables if not directly set'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o state-out -d 'Path to write state'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o target -d 'Resource to target'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o var -d 'Set a variable in the Terraform configuration'
-complete -f -c terraform -n '__fish_seen_subcommand_from refresh' -o var-file -d 'Set variables from a file'
+complete -f -c terraform -n __fish_use_subcommand -a refresh -d "Update local state file against real resources"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o backup -d "Path to backup the existing state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o input -d "Ask for input for variables if not directly set"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o lock-timeout -d "Duration to retry a state lock"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o state -d "Path to a Terraform state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o state-out -d "Path to write state"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o target -d "Resource to target"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o var -d "Set a variable in the Terraform configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o var-file -d "Set variables from a file"
 
 ### show
-complete -f -c terraform -n __fish_use_subcommand -a show -d 'Inspect Terraform state or plan'
-complete -f -c terraform -n '__fish_seen_subcommand_from show' -o module-depth -d 'Depth of modules to show in the output'
-complete -f -c terraform -n '__fish_seen_subcommand_from show' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n __fish_use_subcommand -a show -d "Inspect Terraform state or plan"
+complete -f -c terraform -n "__fish_seen_subcommand_from show" -o module-depth -d "Depth of modules to show in the output"
+complete -f -c terraform -n "__fish_seen_subcommand_from show" -o no-color -d "If specified, output won't contain any color"
 
 ### taint
-complete -f -c terraform -n __fish_use_subcommand -a taint -d 'Manually mark a resource for recreation'
-complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o allow-missing -d 'Succeed even if resource is missing'
-complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o module -d 'The module path where the resource lives'
-complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from taint' -o state-out -d 'Path to write state'
+complete -f -c terraform -n __fish_use_subcommand -a taint -d "Manually mark a resource for recreation"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o allow-missing -d "Succeed even if resource is missing"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o backup -d "Path to backup the existing state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o lock-timeout -d "Duration to retry a state lock"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o module -d "The module path where the resource lives"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o state -d "Path to a Terraform state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from taint" -o state-out -d "Path to write state"
 
 ### untaint
-complete -f -c terraform -n __fish_use_subcommand -a untaint -d 'Manually unmark a resource as tainted'
-complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o allow-missing -d 'Succeed even if resource is missing'
-complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o backup -d 'Path to backup the existing state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o lock -d 'Lock the state file when locking is supported'
-complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o lock-timeout -d 'Duration to retry a state lock'
-complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o module -d 'The module path where the resource lives'
-complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o no-color -d 'If specified, output won\'t contain any color'
-complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o state -d 'Path to a Terraform state file'
-complete -f -c terraform -n '__fish_seen_subcommand_from untaint' -o state-out -d 'Path to write state'
+complete -f -c terraform -n __fish_use_subcommand -a untaint -d "Manually unmark a resource as tainted"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o allow-missing -d "Succeed even if resource is missing"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o backup -d "Path to backup the existing state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o lock -d "Lock the state file when locking is supported"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o lock-timeout -d "Duration to retry a state lock"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o module -d "The module path where the resource lives"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o no-color -d "If specified, output won't contain any color"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o state -d "Path to a Terraform state file"
+complete -f -c terraform -n "__fish_seen_subcommand_from untaint" -o state-out -d "Path to write state"
 
 ### validate
-complete -f -c terraform -n __fish_use_subcommand -a validate -d 'Validate the Terraform files'
-complete -f -c terraform -n '__fish_seen_subcommand_from validate' -o no-color -d 'If specified, output won\'t contain any color'
+complete -f -c terraform -n __fish_use_subcommand -a validate -d "Validate the Terraform files"
+complete -f -c terraform -n "__fish_seen_subcommand_from validate" -o no-color -d "If specified, output won't contain any color"
 
 ### version
-complete -f -c terraform -n __fish_use_subcommand -a version -d 'Print the Terraform version'
+complete -f -c terraform -n __fish_use_subcommand -a version -d "Print the Terraform version"


### PR DESCRIPTION
## Description

This PR updates the built-in completions for Terraform, which were outdated.

The completions have been checked against the official help commands of the Terraform CLI version 1.1.7.

Terraform uses old style options (long names, but single hyphen, e.g. `-no-color`), which doesn't play super nicely with some of the completion mechanics it seems. For the time being, the global `-chdir=PATH` option isn't supported, as I wasn't sure how to nicely parse it out and still determine whether a subcommand was still needed. In general, having `-option=arg` style options appears problematic, as the completion automatically inserts a whitespace after the `=` symbol. However, Terraform doesn't seem to particularly mind getting the arguments in `-option arg` format either, so this is not a major issue. That being said, for cases where the Terraform help command shows only a single option (e.g. `-lock=false` or `-input=true`), I have opted to put the whole phrase as completion, as the Terraform documentation does not appear to expect other options to be passed in:

![image](https://user-images.githubusercontent.com/828553/162218800-04f717ed-29d8-4534-81b9-01f37d6e6eed.png)

The subcommands for `state` and `workspace` do not have further completions at this time.

While by no means complete, all in all, I still think this is a worthwhile PR, since it improves the completion over the status quo.

Note that I opted to replace single quotes with double quotes, since variable interpretation didn't seem to play nicely with single quote strings. There does not appear to be a de facto standard across all other completion scripts, but it does provide a bit of a dirty diff. I can revert and use string concatenation if preferred.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages [N/A]
- [x] Tests have been added for regressions fixed [N/A]
- [ ] User-visible changes noted in CHANGELOG.rst
