### PR TITLE
3.5 feature flags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,20 @@ Notable improvements and fixes
 
 Deprecations and removed features
 ---------------------------------
+- The ``stderr-nocaret`` feature flag, introduced in fish 3.0 and enabled by default in fish 3.1, has been made read-only.
+  That means it is no longer possible to disable it, and code supporting the ``^`` redirection has been removed (:issue:`8857`, :issue:`8865`).
+- The following feature flags have been enabled by default:
+  - ``regex-easyesc``, which makes ``string replace -r`` not do a superfluous round of unescaping in the replacement expression.
+    That means e.g. to escape any "a" or "b" in an argument you can use ``string replace -ra '([ab])' '\\\\$1' foobar`` instead of needing 8 backslashes.
+    This flag was introduced in fish 3.1.
+  - ``ampersand-nobg-in-token``, which makes ``&`` not refer to backgrounding if it occurs in the middle of a word, so ``echo foo&bar`` will print "foo&bar".
+    This flag was introduced in fish 3.4.
+
+  To turn off these flags, add ``no-regex-easyesc`` or ``no-ampersand-nobg-in-token`` to $fish_features and restart fish::
+
+    set -Ua fish_features no-regex-easyesc
+
+  Like ``stderr-nocaret``, they will eventually be made read-only.
 - Most ``string`` subcommands no longer append a newline to their input if the input didn't have one (:issue:`8473`, :issue:`3847`)
 - Fish's escape sequence removal (like for ``string length --visible`` or to figure out how wide the prompt is) no longer has special support for non-standard color sequences like from Data General terminals, e.g. the Data General Dasher D220 from 1984. This removes a bunch of work in the common case, allowing ``string length --visible`` to be much faster with unknown escape sequences. We don't expect anyone to have ever used fish with such a terminal (:issue:`8769`).
 - Code to upgrade universal variables from fish before 3.0 has been removed. Users who upgrade directly from fishes before then will have to set their universal variables (including abbreviations) again. (:issue:`8781`)

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -188,7 +188,7 @@ For example, ``echo hello 2> output.stderr`` writes the standard error (file des
 
 It is an error to redirect a builtin, function, or block to a file descriptor above 2. However this is supported for external commands.
 
-.. [#] Previous versions of fish also allowed specifying this as ``^DESTINATION``, but that made another character special so it was deprecated and will be removed in the future. See :ref:`feature flags<featureflags>`.
+.. [#] Previous versions of fish also allowed specifying this as ``^DESTINATION``, but that made another character special so it was deprecated and removed. See :ref:`feature flags<featureflags>`.
 
 .. _pipes:
 
@@ -1581,8 +1581,8 @@ You can see the current list of features via ``status features``::
     > status features
     stderr-nocaret          on  3.0 ^ no longer redirects stderr
     qmark-noglob            off 3.0 ? no longer globs
-    regex-easyesc           off 3.1 string replace -r needs fewer \\'s
-    ampersand-nobg-in-token off 3.4 & only backgrounds if followed by a separating character
+    regex-easyesc           on  3.1 string replace -r needs fewer \\'s
+    ampersand-nobg-in-token on  3.4 & only backgrounds if followed by a separating character
 
 Here is what they mean:
 
@@ -1594,25 +1594,27 @@ Here is what they mean:
 
 These changes are introduced off by default. They can be enabled on a per session basis::
 
-    > fish --features qmark-noglob,stderr-nocaret
+    > fish --features qmark-noglob,regex-easyesc
 
 
 or opted into globally for a user::
 
 
-    > set -U fish_features stderr-nocaret qmark-noglob
+    > set -U fish_features regex-easyesc qmark-noglob
 
 Features will only be set on startup, so this variable will only take effect if it is universal or exported.
 
 You can also use the version as a group, so ``3.0`` is equivalent to "stderr-nocaret" and "qmark-noglob". Instead of a version, the special group ``all`` enables all features.
 
-Prefixing a feature with ``no-`` turns it off instead. E.g. to reenable the ``^`` redirection::
+Prefixing a feature with ``no-`` turns it off instead. E.g. to reenable the ``?`` single-character glob::
 
-  set -Ua fish_features no-stderr-nocaret
+  set -Ua fish_features no-qmark-noglob
 
 Currently, the following features are enabled by default:
 
-- stderr-nocaret - ``^`` no longer redirects stderr, use ``2>``. Enabled by default in fish 3.3.0.
+- stderr-nocaret - ``^`` no longer redirects stderr, use ``2>``. Enabled by default in fish 3.3.0. No longer changeable since fish 3.5.0.
+- regex-easyesc - ``string replace -r`` requires fewer backslashes in the replacement part. Enabled by default in fish 3.5.0.
+- ampersand-nobg-in-token - ``&`` in the middle of a word is a normal character instead of backgrounding. Enabled by default in fish 3.5.0.
 
 .. _event:
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1586,7 +1586,7 @@ You can see the current list of features via ``status features``::
 
 Here is what they mean:
 
-- ``stderr-nocaret`` was introduced in fish 3.0 (and made the default in 3.3). It makes ``^`` an ordinary character instead of denoting an stderr redirection, to make dealing with quoting and such easier. Use ``2>`` instead.
+- ``stderr-nocaret`` was introduced in fish 3.0 (and made the default in 3.3). It makes ``^`` an ordinary character instead of denoting an stderr redirection, to make dealing with quoting and such easier. Use ``2>`` instead. This can no longer be turned off since fish 3.5. The flag can still be tested for compatibility, but a ``no-stderr-nocaret`` value will simply be ignored.
 - ``qmark-noglob`` was also introduced in fish 3.0. It makes ``?`` an ordinary character instead of a single-character glob. Use a ``*`` instead (which will match multiple characters) or find other ways to match files like ``find``.
 - ``regex-easyesc`` was introduced in 3.1. It makes it so the replacement expression in ``string replace -r`` does one fewer round of escaping. Before, to escape a backslash you would have to use ``string replace -ra '([ab])' '\\\\\\\\$1'``. After, just ``'\\\\$1'`` is enough. Check your ``string replace`` cals if you use this anywhere.
 - ``ampersand-nobg-in-token`` was introduced in fish 3.4. It makes it so a ``&`` i no longer interpreted as the backgrounding operator in the middle of a token, so dealing with URLs becomes easier. Either put spaces or a semicolon after the ``&``. This is recommended formatting anyway, and ``fish_indent`` will have done it for you already.

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -885,7 +885,6 @@ static void escape_string_script(const wchar_t *orig_in, size_t in_len, wcstring
     const bool escape_all = static_cast<bool>(flags & ESCAPE_ALL);
     const bool no_quoted = static_cast<bool>(flags & ESCAPE_NO_QUOTED);
     const bool no_tilde = static_cast<bool>(flags & ESCAPE_NO_TILDE);
-    const bool no_caret = feature_test(features_t::stderr_nocaret);
     const bool no_qmark = feature_test(features_t::qmark_noglob);
 
     bool need_escape = false;
@@ -977,7 +976,6 @@ static void escape_string_script(const wchar_t *orig_in, size_t in_len, wcstring
                 case L'$':
                 case L' ':
                 case L'#':
-                case L'^':
                 case L'<':
                 case L'>':
                 case L'(':
@@ -993,7 +991,7 @@ static void escape_string_script(const wchar_t *orig_in, size_t in_len, wcstring
                 case L'"':
                 case L'%':
                 case L'~': {
-                    bool char_is_normal = (c == L'~' && no_tilde) || (c == L'^' && no_caret) ||
+                    bool char_is_normal = (c == L'~' && no_tilde) ||
                                           (c == L'?' && no_qmark);
                     if (!char_is_normal) {
                         need_escape = true;

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -791,16 +791,6 @@ static void test_tokenizer() {
         err(L"redirection_type_for_string failed on line %ld", (long)__LINE__);
     if (get_redir_mode(L"3</tmp/filetxt") != redirection_mode_t::input)
         err(L"redirection_type_for_string failed on line %ld", (long)__LINE__);
-
-    // Test ^ with our feature flag on and off.
-    auto saved_flags = fish_features();
-    mutable_fish_features().set(features_t::stderr_nocaret, false);
-    if (get_redir_mode(L"^") != redirection_mode_t::overwrite)
-        err(L"redirection_type_for_string failed on line %ld", (long)__LINE__);
-    mutable_fish_features().set(features_t::stderr_nocaret, true);
-    if (get_redir_mode(L"^") != none())
-        err(L"redirection_type_for_string failed on line %ld", (long)__LINE__);
-    mutable_fish_features() = saved_flags;
 }
 
 // Little function that runs in a background thread, bouncing to the main.

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -1942,16 +1942,10 @@ static void test_feature_flags() {
     say(L"Testing future feature flags");
     using ft = features_t;
     ft f;
-    do_test(f.test(ft::stderr_nocaret));
-    f.set(ft::stderr_nocaret, true);
-    do_test(f.test(ft::stderr_nocaret));
-    f.set(ft::stderr_nocaret, false);
-    do_test(!f.test(ft::stderr_nocaret));
-
     f.set_from_string(L"stderr-nocaret,nonsense");
     do_test(f.test(ft::stderr_nocaret));
     f.set_from_string(L"stderr-nocaret,no-stderr-nocaret,nonsense");
-    do_test(!f.test(ft::stderr_nocaret));
+    do_test(f.test(ft::stderr_nocaret));
 
     // Ensure every metadata is represented once.
     size_t counts[ft::flag_count] = {};

--- a/src/future_feature_flags.cpp
+++ b/src/future_feature_flags.cpp
@@ -21,7 +21,7 @@ const features_t::metadata_t features_t::metadata[features_t::flag_count] = {
     {string_replace_backslash, L"regex-easyesc", L"3.1", L"string replace -r needs fewer \\'s",
      true, false},
     {ampersand_nobg_in_token, L"ampersand-nobg-in-token", L"3.4",
-     L"& only backgrounds if followed by a separator", false, false},
+     L"& only backgrounds if followed by a separator", true, false},
 };
 
 const struct features_t::metadata_t *features_t::metadata_for(const wchar_t *name) {

--- a/src/future_feature_flags.cpp
+++ b/src/future_feature_flags.cpp
@@ -19,7 +19,7 @@ const features_t::metadata_t features_t::metadata[features_t::flag_count] = {
     {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr", true},
     {qmark_noglob, L"qmark-noglob", L"3.0", L"? no longer globs", false},
     {string_replace_backslash, L"regex-easyesc", L"3.1", L"string replace -r needs fewer \\'s",
-     false},
+     true},
     {ampersand_nobg_in_token, L"ampersand-nobg-in-token", L"3.4",
      L"& only backgrounds if followed by a separator", false},
 };

--- a/src/future_feature_flags.cpp
+++ b/src/future_feature_flags.cpp
@@ -16,7 +16,7 @@ features_t::features_t() {
 features_t features_t::global_features;
 
 const features_t::metadata_t features_t::metadata[features_t::flag_count] = {
-    {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr", true, true /* read-only */},
+    {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr (historical, can no longer be changed)", true, true /* read-only */},
     {qmark_noglob, L"qmark-noglob", L"3.0", L"? no longer globs", false, false},
     {string_replace_backslash, L"regex-easyesc", L"3.1", L"string replace -r needs fewer \\'s",
      true, false},

--- a/src/future_feature_flags.cpp
+++ b/src/future_feature_flags.cpp
@@ -16,12 +16,12 @@ features_t::features_t() {
 features_t features_t::global_features;
 
 const features_t::metadata_t features_t::metadata[features_t::flag_count] = {
-    {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr", true},
-    {qmark_noglob, L"qmark-noglob", L"3.0", L"? no longer globs", false},
+    {stderr_nocaret, L"stderr-nocaret", L"3.0", L"^ no longer redirects stderr", true, true /* read-only */},
+    {qmark_noglob, L"qmark-noglob", L"3.0", L"? no longer globs", false, false},
     {string_replace_backslash, L"regex-easyesc", L"3.1", L"string replace -r needs fewer \\'s",
-     true},
+     true, false},
     {ampersand_nobg_in_token, L"ampersand-nobg-in-token", L"3.4",
-     L"& only backgrounds if followed by a separator", false},
+     L"& only backgrounds if followed by a separator", false, false},
 };
 
 const struct features_t::metadata_t *features_t::metadata_for(const wchar_t *name) {
@@ -55,11 +55,17 @@ void features_t::set_from_string(const wcstring &str) {
         // future versions).
         // The special name 'all' may be used for those who like to live on the edge.
         if (const metadata_t *md = metadata_for(name)) {
-            this->set(md->flag, value);
+            // Only change it if it's not read-only.
+            // Don't complain if it is, this is typically set from a variable.
+            if (!md->read_only) {
+                this->set(md->flag, value);
+            }
         } else {
             for (const metadata_t &md : metadata) {
                 if (std::wcsstr(md.groups, name) || !std::wcscmp(name, L"all")) {
-                    this->set(md.flag, value);
+                    if (!md.read_only) {
+                        this->set(md.flag, value);
+                    }
                 }
             }
         }

--- a/src/future_feature_flags.h
+++ b/src/future_feature_flags.h
@@ -63,6 +63,9 @@ class features_t {
 
         /// Default flag value.
         const bool default_value;
+
+        /// Whether the value can still be changed or not.
+        const bool read_only;
     };
 
     /// The metadata, indexed by flag.

--- a/tests/checks/features-nocaret1.fish
+++ b/tests/checks/features-nocaret1.fish
@@ -1,2 +1,2 @@
 #RUN: %fish --features 'no-stderr-nocaret' -c 'status test-feature stderr-nocaret; echo nocaret: $status'
-# CHECK: nocaret: 1
+# CHECK: nocaret: 0

--- a/tests/checks/features-nocaret3.fish
+++ b/tests/checks/features-nocaret3.fish
@@ -1,2 +1,2 @@
 #RUN: %fish --features 'no-stderr-nocaret' -c 'echo -n careton:; echo ^/dev/null'
-# CHECK: careton:
+# CHECK: careton:^/dev/null

--- a/tests/checks/features-nocaret5.fish
+++ b/tests/checks/features-nocaret5.fish
@@ -1,2 +1,0 @@
-#RUN: %fish --features no-stderr-nocaret -c 'cat /abavojijsdfhdsjhfuihifoisj ^&1'
-# CHECK: {{cat|/abavojijsdfhdsjhfuihifoisj}}: {{.*}}

--- a/tests/checks/status.fish
+++ b/tests/checks/status.fish
@@ -53,7 +53,7 @@ eval test_function
 
 # Future Feature Flags
 status features
-#CHECK: stderr-nocaret          on  3.0 ^ no longer redirects stderr
+#CHECK: stderr-nocaret          on  3.0 ^ no longer redirects stderr (historical, can no longer be changed)
 #CHECK: qmark-noglob            off 3.0 ? no longer globs
 #CHECK: regex-easyesc           on  3.1 string replace -r needs fewer \'s
 #CHECK: ampersand-nobg-in-token on  3.4 & only backgrounds if followed by a separator

--- a/tests/checks/status.fish
+++ b/tests/checks/status.fish
@@ -56,7 +56,7 @@ status features
 #CHECK: stderr-nocaret          on  3.0 ^ no longer redirects stderr
 #CHECK: qmark-noglob            off 3.0 ? no longer globs
 #CHECK: regex-easyesc           on  3.1 string replace -r needs fewer \'s
-#CHECK: ampersand-nobg-in-token off 3.4 & only backgrounds if followed by a separator
+#CHECK: ampersand-nobg-in-token on  3.4 & only backgrounds if followed by a separator
 status test-feature stderr-nocaret
 echo $status
 #CHECK: 0

--- a/tests/checks/status.fish
+++ b/tests/checks/status.fish
@@ -55,7 +55,7 @@ eval test_function
 status features
 #CHECK: stderr-nocaret          on  3.0 ^ no longer redirects stderr
 #CHECK: qmark-noglob            off 3.0 ? no longer globs
-#CHECK: regex-easyesc           off 3.1 string replace -r needs fewer \'s
+#CHECK: regex-easyesc           on  3.1 string replace -r needs fewer \'s
 #CHECK: ampersand-nobg-in-token off 3.4 & only backgrounds if followed by a separator
 status test-feature stderr-nocaret
 echo $status


### PR DESCRIPTION
## Description

This changes the feature flags as discussed in #8857.

- regex-easyesc, introduced in 3.1, is enabled by default
- ampersand-nobg-in-token, introduced in 3.4, is enabled by default
- stderr-nocaret, introduced in 3.0 and enabled by default in 3.3, is made read-only and the caret redirection code is removed

Fixes issue #8857

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
