### PR TITLE
Use `xdg-open [URL]` on Sailfish OS

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -1696,8 +1696,10 @@ def runThing():
             sys.exit(-1)
     elif is_termux():
         subprocess.call(["termux-open-url", url])
-    elif is_chromeos_garcon() or is_sailfish_os():
+    elif is_chromeos_garcon():
         webbrowser.open(url)
+    elif is_sailfish_os():
+        subprocess.call(["xdg-open", url])
     else:
         webbrowser.open(fileurl)
 


### PR DESCRIPTION
## Description

Follow-up to #8811

Using the previous method to open the fish_config URL on Sailfish OS worked only on 4.4 (and 4.3 IIRC), but not on older OS versions. Opening the URL using `xdg-open` works well with new and ole OS version, and has been tested on

- Sony Xperia 10 II running SFOS 4.4 aarch64
- Sony Xperia XA2 Ultra running SFOS 4.4 armv7hl
- Sony Xperia X running SFOS 4.1 armv7hl
- Jolla Phone running SFOS 3.4 armv7hl

There's no open issue for this, just a straight fix.

Thanks!

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
