### PR TITLE
Remove test for italics_mode and dim_mode on Apple

### DIFF
--- a/src/builtins/set_color.cpp
+++ b/src/builtins/set_color.cpp
@@ -113,17 +113,14 @@ maybe_t<int> builtin_set_color(parser_t &parser, io_streams_t &streams, const wc
 #ifdef __APPLE__
     // Hack in missing italics and dim capabilities omitted from MacOS xterm-256color terminfo
     // Helps Terminal.app/iTerm
-    if ((!enter_italics_mode || enter_italics_mode == "") ||
-        (!enter_dim_mode || enter_dim_mode == "")) {
-        const auto term_prog = parser.vars().get(L"TERM_PROGRAM");
-        if (!term_prog.missing_or_empty() && (term_prog->as_string() == L"Apple_Terminal" ||
-                                              term_prog->as_string() == L"iTerm.app")) {
-            const auto term = parser.vars().get(L"TERM");
-            if (!term.missing_or_empty() && (term->as_string() == L"xterm-256color")) {
-                enter_italics_mode = sitm_esc;
-                exit_italics_mode = ritm_esc;
-                enter_dim_mode = dim_esc;
-            }
+    const auto term_prog = parser.vars().get(L"TERM_PROGRAM");
+    if (!term_prog.missing_or_empty() && (term_prog->as_string() == L"Apple_Terminal" ||
+        term_prog->as_string() == L"iTerm.app")) {
+        const auto term = parser.vars().get(L"TERM");
+        if (!term.missing_or_empty() && (term->as_string() == L"xterm-256color")) {
+            enter_italics_mode = sitm_esc;
+            exit_italics_mode = ritm_esc;
+            enter_dim_mode = dim_esc;
         }
     }
 #endif


### PR DESCRIPTION
This resolves an issue on Apple macOS, where fish crashes with SIGSEGV if the TERM environment
variable is not set.

See:
- https://github.com/fish-shell/fish-shell/issues/8873
- https://github.com/microsoft/vscode/issues/147320

## Description

It appears that the set_color built-in is always called on a normal start-up to the shell, and if the `$TERM` environment variable is not set, we dump core with a SIGSEGV. 

To reproduce:

```sh
$ sh -c 'env -i HOME=$(mktemp -d) /Users/mjarvis/src/github.com/mojotx/fish-shell/build/fish'
```

Fixes issue #8873 

