### PR TITLE
Print message in set_fish_path -v when a path doesnt exist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,7 @@ Interactive improvements
 - ``ulimit`` learned a number of new options for the resource limits available on Linux, FreeBSD and NetBSD, and returns a specific warning if the limit specified is not available on the active operating system (:issue:`8823`).
 - The ``vared`` command can now successfully edit variables named "tmp" or "prompt" (:issue:`8836`).
 - ``time`` now emits an error if used after the first command in a pipeline (:issue:`8841`).
+- ``fish_add_path`` now prints a message for skipped non-existent paths when using the ``-v`` flag.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/po/en.po
+++ b/po/en.po
@@ -62481,8 +62481,8 @@ msgid "Edit variable value"
 msgstr "Edit variable value"
 
 #: /tmp/fish/implicit/share/functions/fish_add_path.fish:1
-msgid "Skipping non-existent path:"
-msgstr "Skipping non-existent path:"
+msgid "Skipping non-existent path: %s\n"
+msgstr "Skipping non-existent path: %s\n"
 
 #~ msgid "%ls: No function name given\n"
 #~ msgstr "%ls: No function name given\n"

--- a/po/en.po
+++ b/po/en.po
@@ -62480,6 +62480,10 @@ msgstr ""
 msgid "Edit variable value"
 msgstr "Edit variable value"
 
+#: /tmp/fish/implicit/share/functions/fish_add_path.fish:1
+msgid "Skipping non-existent path:"
+msgstr "Skipping non-existent path:"
+
 #~ msgid "%ls: No function name given\n"
 #~ msgstr "%ls: No function name given\n"
 

--- a/share/functions/fish_add_path.fish
+++ b/share/functions/fish_add_path.fish
@@ -47,7 +47,7 @@ function fish_add_path --description "Add paths to the PATH"
         set -l p (builtin realpath -s -- $path 2>/dev/null)
 
         # Ignore non-existing paths
-        if not test -d "$p"; or continue
+        if not test -d "$p"
             # path does not exist
             if set -q _flag_verbose;
                 # print a message in verbose mode

--- a/share/functions/fish_add_path.fish
+++ b/share/functions/fish_add_path.fish
@@ -47,7 +47,14 @@ function fish_add_path --description "Add paths to the PATH"
         set -l p (builtin realpath -s -- $path 2>/dev/null)
 
         # Ignore non-existing paths
-        test -d "$p"; or continue
+        if not test -d "$p"; or continue
+            # path does not exist
+            if set -q _flag_verbose;
+                # print a message in verbose mode
+                echo (_ "Skipping non-existent path:" " $p")
+            end
+            continue
+        end
 
         if set -l ind (contains -i -- $p $$var)
             # In move-mode, we remove it from its current position and add it back.

--- a/share/functions/fish_add_path.fish
+++ b/share/functions/fish_add_path.fish
@@ -51,7 +51,7 @@ function fish_add_path --description "Add paths to the PATH"
             # path does not exist
             if set -q _flag_verbose;
                 # print a message in verbose mode
-                echo (_ "Skipping non-existent path:" " $p")
+                printf (_ "Skipping non-existent path: %s\n") "$p"
             end
             continue
         end


### PR DESCRIPTION
## Description

While debugging something that uses fish_add_path I got confused why it wasn't doing anything, and it turned out to be the path not existing. I figured it should print a message when a path gets skipped when using -v. behavior outside verbose mode is unchanged.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages. (necessary for this?)
- ~~[ ] Tests have been added for regressions fixed~~ N/A
- [x] User-visible changes noted in CHANGELOG.rst
