### PR TITLE
Create funcdel.fish

### DIFF
--- a/share/completions/funcdel.fish
+++ b/share/completions/funcdel.fish
@@ -1,0 +1,2 @@
+complete -c funcdel -s d -l directory -d "dir to remove function(s) from" -a '$fish_function_path' -r
+complete -c funcdel -s q -d "suppress output" -r

--- a/share/completions/wg-quick.fish
+++ b/share/completions/wg-quick.fish
@@ -1,0 +1,12 @@
+set -l valid_subcmds up down strip save
+
+function __fish_wg_complete_interfaces
+    LC_ALL=C wg show 2>| string replace -rf 'Unable to access interface (.*): Operation not permitted' '$1'
+end
+
+complete -c wg-quick -f
+complete -c wg-quick -n "__fish_seen_subcommand_from $valid_subcmds" -a '(__fish_wg_complete_interfaces)'
+complete -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a up -d 'Add and set up an interface'
+complete -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a down -d 'Tear down and remove an interface'
+complete -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a strip -d 'Output config for use with wg'
+complete -c wg-quick -n "not __fish_seen_subcommand_from $valid_subcmds" -a save -d 'Saves the configuration of an existing interface'

--- a/share/functions/funcdel.fish
+++ b/share/functions/funcdel.fish
@@ -11,7 +11,7 @@ function funcdel --description "Remove the current definition of all specified f
     if set -q _flag_directory
         set funcdir $_flag_directory
     else
-        set funcdir $fish_function_path
+        set funcdir $__fish_config_dir/functions
     end
 
     if not set -q argv[1]
@@ -32,7 +32,6 @@ function funcdel --description "Remove the current definition of all specified f
             printf (_ "%s: not defined as a function '%s'\n") funcdel $funcname >&2
             set retval 1
         else if not test -e $funcpath
-            echo "$funcname does not exist as a user function"
             printf (_ "%s: not a saved user function '%s'\n") funcdel $funcname >&2
             set retval 2
         else

--- a/share/functions/funcdel.fish
+++ b/share/functions/funcdel.fish
@@ -1,18 +1,46 @@
-function funcdel -a funcname
+function funcdel --description "Remove the current definition of all specified functions from session and file"
+    set -l options q/quiet h/help d/directory=
+    argparse -n funcdel $options -- $argv
+    or return
 
-    set funcpath $fish_function_path/$funcname.fish
+    if set -q _flag_help
+        __fish_print_help funcdel
+        return 0
+    end
 
-    if not type -q $funcname
-        echo "$funcname is not defined as a function"
+    if set -q _flag_directory
+        set funcdir $_flag_directory
+    else
+        set funcdir $fish_function_path
+    end
+
+    if not set -q argv[1]
+        printf (_ "%ls: Expected at least %d args, got only %d\n") funcdel 1 0 >&2
         return 1
     end
 
-    if not test -e $funcpath
-        echo "$funcname does not exist as a user function"
-        return 2
+    if not test -d $funcdir
+        printf (_ "%s: Configuration directory does not exist '%s'\n") funcdel $funcdir >&2
+        return 1
     end
 
-    functions -e $funcname
-    rm $funcpath
+    set -l retval 0
+    for funcname in $argv
+        set -l funcpath "$funcdir/$funcname.fish"
 
+        if not functions -q -- $funcname
+            printf (_ "%s: not defined as a function '%s'\n") funcdel $funcname >&2
+            set retval 1
+        else if not test -e $funcpath
+            echo "$funcname does not exist as a user function"
+            printf (_ "%s: not a saved user function '%s'\n") funcdel $funcname >&2
+            set retval 2
+        else
+            functions --erase -- $funcname
+            rm $funcpath
+            and set -q _flag_quiet || printf (_ "%s: removed %s\n") funcdel $funcpath
+        end
+    end
+
+    return $retval
 end

--- a/share/functions/funcdel.fish
+++ b/share/functions/funcdel.fish
@@ -1,4 +1,18 @@
 function funcdel -a funcname
+
+    set funcpath $fish_function_path/$funcname.fish
+
+    if not type -q $funcname
+        echo "$funcname is not defined as a function"
+        return 1
+    end
+
+    if not test -e $funcpath
+        echo "$funcname does not exist as a user function"
+        return 2
+    end
+
     functions -e $funcname
-    rm $fish_function_path/$funcname.fish
+    rm $funcpath
+
 end

--- a/share/functions/funcdel.fish
+++ b/share/functions/funcdel.fish
@@ -1,0 +1,4 @@
+function funcdel
+    functions -e $argv
+    rm $__fish_config_dir/functions/$argv.fish
+end

--- a/share/functions/funcdel.fish
+++ b/share/functions/funcdel.fish
@@ -1,4 +1,4 @@
-function funcdel
-    functions -e $argv
-    rm $__fish_config_dir/functions/$argv.fish
+function funcdel -a funcname
+    functions -e $funcname
+    rm $fish_function_path/$funcname.fish
 end


### PR DESCRIPTION
## Description

There does not seem to be a built-in for permanently deleting or renaming user functions. I've been using a variant of this successfully for a few years

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
