### PR TITLE
Search $__fish_user_data_dir for vendor additions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,7 +83,10 @@ Other improvements
 For distributors
 ----------------
 - libatomic is now correctly detected as necessary when building on RISC-V (:issue:`8850`).
-
+- The paths for completions, functions, and configuration snippets now include
+  subdirectories ``fish/vendor_completions.d``, ``fish/vendor_functions.d``, and
+  ``fish/vendor_conf.d`` (respectively) within ``XDG_DATA_HOME`` (or ``~/.local/share``
+  if not defined) (:issue:`8887`).
 --------------
 
 fish 3.4.1 (released March 25, 2022)

--- a/doc_src/completions.rst
+++ b/doc_src/completions.rst
@@ -111,6 +111,7 @@ By default, Fish searches the following for completions, using the first availab
 
 - A directory for end-users to keep their own completions, usually ``~/.config/fish/completions`` (controlled by the ``XDG_CONFIG_HOME`` environment variable);
 - A directory for systems administrators to install completions for all users on the system, usually ``/etc/fish/completions``;
+- A user-specified directory for third-party vendor completions, usually ``~/.local/share/fish/vendor_completions.d`` (controlled by the ``XDG_DATA_HOME`` environment variable);
 - A directory for third-party software vendors to ship their own completions for their software, usually ``/usr/share/fish/vendor_completions.d``;
 - The completions shipped with fish, usually installed in ``/usr/share/fish/completions``; and
 - Completions automatically generated from the operating system's manual, usually stored in ``~/.local/share/fish/generated_completions``.

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -316,7 +316,7 @@ By default ``$fish_function_path`` contains the following:
 
 - A directory for users to keep their own functions, usually ``~/.config/fish/functions`` (controlled by the ``XDG_CONFIG_HOME`` environment variable).
 - A directory for functions for all users on the system, usually ``/etc/fish/functions`` (really ``$__fish_sysconfdir/functions``).
-- Directories for other software to put their own functions. These are in the directories in the ``XDG_DATA_DIRS`` environment variable, in a subdirectory called ``fish/vendor_functions.d``. The default is usually ``/usr/share/fish/vendor_functions.d`` and ``/usr/local/share/fish/vendor_functions.d``.
+- Directories for other software to put their own functions. These are in the directories under ``$__fish_user_data_dir`` (usually ``~/.local/share/fish``, controlled by the ``XDG_DATA_HOME`` environment variable) and in the ``XDG_DATA_DIRS`` environment variable, in a subdirectory called ``fish/vendor_functions.d``. The default value for ``XDG_DATA_DIRS`` is usually ``/usr/share/fish/vendor_functions.d`` and ``/usr/local/share/fish/vendor_functions.d``.
 - The functions shipped with fish, usually installed in ``/usr/share/fish/functions`` (really ``$__fish_data_dir/functions``).
 
 If you are unsure, your functions probably belong in ``~/.config/fish/functions``.
@@ -1559,7 +1559,7 @@ Configuration files are run in the following order:
 
   - ``$__fish_config_dir/conf.d`` (by default, ``~/.config/fish/conf.d/``)
   - ``$__fish_sysconf_dir/conf.d`` (by default, ``/etc/fish/conf.d/``)
-  - Directories for others to ship configuration snippets for their software. Fish searches the directories in the ``XDG_DATA_DIRS`` environment variable for a ``fish/vendor_conf.d`` directory; if that is not defined, the default is ``/usr/share/fish/vendor_conf.d`` and ``/usr/local/share/fish/vendor_conf.d``, unless your distribution customized this.
+  - Directories for others to ship configuration snippets for their software. Fish searches the directories under ``$__fish_user_data_dir`` (usually ``~/.local/share/fish``, controlled by the ``XDG_DATA_HOME`` environment variable) and in the ``XDG_DATA_DIRS`` environment variable for a ``fish/vendor_conf.d`` directory; if not defined, the default value of ``XDG_DATA_DIRS`` is ``/usr/share/fish/vendor_conf.d`` and ``/usr/local/share/fish/vendor_conf.d``, unless your distribution customized this.
 
   If there are multiple files with the same name in these directories, only the first will be executed.
   They are executed in order of their filename, sorted (like globs) in a natural order (i.e. "01" sorts before "2").

--- a/share/config.fish
+++ b/share/config.fish
@@ -56,9 +56,9 @@ set -l vendor_functionsdirs
 set -l vendor_confdirs
 # Don't load vendor directories when running unit tests
 if not set -q FISH_UNIT_TESTS_RUNNING
-    set vendor_completionsdirs $xdg_data_dirs/vendor_completions.d
-    set vendor_functionsdirs $xdg_data_dirs/vendor_functions.d
-    set vendor_confdirs $xdg_data_dirs/vendor_conf.d
+    set vendor_completionsdirs $__fish_user_data_dir/vendor_completions.d $xdg_data_dirs/vendor_completions.d
+    set vendor_functionsdirs $__fish_user_data_dir/vendor_functions.d $xdg_data_dirs/vendor_functions.d
+    set vendor_confdirs $__fish_user_data_dir/vendor_conf.d $xdg_data_dirs/vendor_conf.d
 
     # Ensure that extra directories are always included.
     if not contains -- $__extra_completionsdir $vendor_completionsdirs


### PR DESCRIPTION
## Description

Add `$__fish_user_data_dir` to the default search paths for vendor completions, functions, and configuration.

This is useful for installing third-party software into a user's home directory.

Fixes issue #7816.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
