### PR TITLE
Make __fish_print_rpm_packages work on macOS

### DIFF
--- a/share/functions/__fish_print_rpm_packages.fish
+++ b/share/functions/__fish_print_rpm_packages.fish
@@ -8,12 +8,20 @@ function __fish_print_rpm_packages
     set -l xdg_cache_home (__fish_make_cache_dir)
     or return
 
+    set -l fmt_mtime (
+        if stat --version 2>/dev/null >/dev/null
+            echo -- -c%Y  # GNU
+        else
+            echo -- -f%m  # BSD
+        end
+    )
+
     if type -q -f /usr/share/yum-cli/completion-helper.py
         # If the cache is less than six hours old, we do not recalculate it
         set -l cache_file $xdg_cache_home/.yum-cache.$USER
         if test -f $cache_file
             cat $cache_file
-            set -l age (math (date +%s) - (stat -c '%Y' $cache_file))
+            set -l age (math (date +%s) - (stat $fmt_mtime $cache_file))
             set -l max_age 21600
             if test $age -lt $max_age
                 return
@@ -32,7 +40,7 @@ function __fish_print_rpm_packages
         set -l cache_file $xdg_cache_home/.rpm-cache.$USER
         if test -f $cache_file
             cat $cache_file
-            set -l age (math (date +%s) - (stat -c '%Y' $cache_file))
+            set -l age (math (date +%s) - (stat $fmt_mtime $cache_file))
             set -l max_age 250
             if test $age -lt $max_age
                 return


### PR DESCRIPTION
## Description

I use `rpm` installed by Homebrew to inspect RPM package files, and currently completion produces an error,

```
[...] ~/D/M/RPMS> rpm -ql kmstat: illegal option -- c5.4.3.0.7.1.rhel8u5.x86_64.rpm r
usage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]
math: Error: Too few arguments
'1650398323 -'
            ^
test: Missing argument at index 3
-lt 250
        ^
/usr/local/Cellar/fish/3.4.1/share/fish/functions/__fish_print_rpm_packages.fish (line 37): 
            if test $age -lt $max_age
               ^
in function '__fish_print_rpm_packages'
in command substitution
[...] ~/D/M/RPMS>
```

so the patch just varies the formatting flag and sequence based on the check used in Fish's `stat` completion.  The current completion doesn't error if you add `-p` but that flag is no longer required to query an uninstalled package.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
