### PR TITLE
Fixed escaping in rsync completion

### DIFF
--- a/share/completions/rsync.fish
+++ b/share/completions/rsync.fish
@@ -183,7 +183,6 @@ complete -c rsync -d "Remote path" -n "commandline -ct | string match -q '*:*'" 
 )(
 	# Get the list of remote files from the specified rsync server.
         rsync --list-only (__rsync_remote_target) 2>/dev/null | string replace -r '^d.*' '\$0/' |
-        string replace -r '(\S+\s+){4}' '' | # drop the first four columns
-        string escape -n
+        string replace -r '(\S+\s+){4}' '' # drop the first four columns
 )
 "


### PR DESCRIPTION
## Description

Removing the escape fixes the escaping problem in rsync (no double escaping).

Fixes issue #8895

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst