### PR TITLE
docs: removed enumeration item from echo docs

### DIFF
--- a/doc_src/cmds/echo.rst
+++ b/doc_src/cmds/echo.rst
@@ -17,7 +17,7 @@ Description
 
 The following options are available:
 
-- **-n**
+**-n**
     Do not output a newline.
 
 **-s**


### PR DESCRIPTION
## Description

There was a single `-` in the documentation of `echo` that made the man page look weird.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
