### PR TITLE
feat: completions for adb push and pull

### DIFF
--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -75,6 +75,22 @@ function __fish_adb_list_files
     __fish_adb_run_command find -H "$token*" -maxdepth 0 -type f 2\>/dev/null
 end
 
+function __fish_adb_completion_for_pull
+    set -l token (commandline -opc)
+    __fish_adb_list_files
+    if test (count $token) -gt 2
+        __fish_complete_path
+    end
+end
+
+function __fish_adb_completion_for_push
+    set -l token (commandline -opc)
+    __fish_complete_path
+    if test (count $token) -gt 2
+        __fish_adb_list_files
+    end
+end
+
 
 # Generic options, must come before command
 complete -n __fish_adb_no_subcommand -c adb -s s -x -a "(__fish_adb_get_devices)" -d 'Device to communicate with'
@@ -164,4 +180,5 @@ complete -n '__fish_seen_subcommand_from reconnect' -c adb -x -a device -d 'Kick
 
 # commands that accept listing device files
 complete -n '__fish_seen_subcommand_from shell' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'
-complete -n '__fish_seen_subcommand_from pull' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'
+complete -n '__fish_seen_subcommand_from pull' -c adb -f -a "(__fish_adb_completion_for_pull)" -d 'File on device'
+complete -n '__fish_seen_subcommand_from push' -c adb -f -a "(__fish_adb_completion_for_push)" -d 'File on device'


### PR DESCRIPTION
## Description

Optimize completions for `adb push` and `adb pull`.

These two command need to complete both local files and remote files, but the first ones are different. `adb push` needs to complete local first, and then remote. `adb pull` is on the contrary. Adn both allow to transfer multi files one time.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
