### PR TITLE
fix issue#8624 empty case

### DIFF
--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -561,6 +561,10 @@ end_execution_reason_t parse_execution_context_t::run_switch_statement(
             for (const wcstring &arg : case_args) {
                 // Unescape wildcards so they can be expanded again.
                 wcstring unescaped_arg = parse_util_unescape_wildcards(arg);
+                if (arg.empty()) {
+                    wcstring empty_arg = std::to_wstring('*');
+                    wcstring unescaped_arg = parse_util_unescape_wildcards(empty_arg);
+                }
                 bool match = wildcard_match(switch_value_expanded, unescaped_arg);
 
                 // If this matched, we're done.


### PR DESCRIPTION
## Empty case is valid but unreachable #8624

We added a condition to check whether the argument is empty. If the argument is empty, then we attach “*” to the case’s argument to convert it into a default argument. By doing so, the case would be reachable.

Fixes issue #8624 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
