### PR TITLE
Adds autocomplete for many git commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -99,6 +99,7 @@ Completions
   - tuned-adm (:issue:`8760`)
   - archlinux-java
   - fastboot
+  - various git subcommands (fetch, show-branch, archive (:issue:`8398`), difftool, grep, init, prune, revert, status, rm)
 
 
 Improved terminal support

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1028,6 +1028,15 @@ complete -f -c git -n '__fish_git_using_command show' -l show-signature -d 'Chec
 ### show-branch
 complete -f -c git -n __fish_git_needs_command -a show-branch -d 'Shows the commits on branches'
 complete -f -c git -n '__fish_git_using_command show-branch' -k -a '(__fish_git_refs)' -d Rev
+complete -f -c git -n '__fish_git_using_command show-branch' -s r -l remotes -d "Shows the remote tracking branches"
+complete -f -c git -n '__fish_git_using_command show-branch' -s a -l all -d "Show both remote-tracking branches and local branches"
+complete -f -c git -n '__fish_git_using_command show-branch' -l current -d "Includes the current branch to the list of revs to be shown"
+complete -f -c git -n '__fish_git_using_command show-branch' -l topo-order -d "Makes commits appear in topological order"
+complete -f -c git -n '__fish_git_using_command show-branch' -l date-order -d "Makes commits appear in date order"
+complete -f -c git -n '__fish_git_using_command show-branch' -l sparse -d "Shows merges only reachable from one tip"
+complete -f -c git -n '__fish_git_using_command show-branch' -l no-name -d "Do not show naming strings for each commit"
+complete -f -c git -n '__fish_git_using_command show-branch' -l sha1-name -d "Name commits with unique prefix"
+complete -f -c git -n '__fish_git_using_command show-branch' -l no-color -d "Turn off colored output"
 # TODO options
 
 ### add
@@ -1132,6 +1141,9 @@ complete -f -c git -n '__fish_git_using_command apply' -l unsafe-paths -d 'Allow
 
 ### archive
 complete -f -c git -n __fish_git_needs_command -a archive -d 'Create an archive of files from a named tree'
+complete -f -c git -n '__fish_git_using_command archive' -s l -l list -d "Show all available formats"
+complete -f -c git -n '__fish_git_using_command archive' -s v -l verbose -d "Be verbose"
+complete -f -c git -n '__fish_git_using_command archive' -l worktree-attributes -d "Look for attributes in .gitattributes files in the working tree as well"
 # TODO options
 
 ### bisect

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1405,7 +1405,7 @@ complete -f -c git -n '__fish_git_using_command grep' -l and -d 'Combine pattern
 complete -f -c git -n '__fish_git_using_command grep' -l or -d 'Combine patterns using or'
 complete -f -c git -n '__fish_git_using_command grep' -l not -d 'Combine patterns using not'
 complete -f -c git -n '__fish_git_using_command grep' -l all-match -d 'Only match files that can match all the pattern expressions when giving multiple'
-complete -f -c git -n '__fish_git_using_command grep' -s q -l quiet -d 'just exit with status 0 when there is a match and with non-zero status when there isn’t'
+complete -f -c git -n '__fish_git_using_command grep' -s q -l quiet -d 'Just exit with status 0 when there is a match and with non-zero status when there isn\'t'
 # TODO options, including max-depth, h, open-files-in-pager, contexts, threads, file
 
 ### init

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1387,7 +1387,7 @@ complete -f -c git -n '__fish_git_using_command grep' -l full-name -d 'Forces pa
 complete -f -c git -n '__fish_git_using_command grep' -s E -l extended-regexp -d 'Use POSIX extended regexp for patterns'
 complete -f -c git -n '__fish_git_using_command grep' -s G -l basic-regexp -d 'Use POSIX basic regexp for patterns'
 complete -f -c git -n '__fish_git_using_command grep' -s P -l perl-regexp -d 'Use Perl-compatible regular expressions for patterns.'
-complete -f -c git -n '__fish_git_using_command grep' -s F -l fixed-strings -d 'Don’t interpret pattern as a regex'
+complete -f -c git -n '__fish_git_using_command grep' -s F -l fixed-strings -d 'Don\'t interpret pattern as a regex'
 complete -f -c git -n '__fish_git_using_command grep' -s n -l line-number -d 'Prefix the line number to matching lines'
 complete -f -c git -n '__fish_git_using_command grep' -l column -d 'Prefix the 1-indexed byte-offset of the first match from the start of the matching line'
 complete -f -c git -n '__fish_git_using_command grep' -s l -l files-with-matches -d 'Show only the names of files that contain matches'

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1353,6 +1353,7 @@ complete -f -c git -n '__fish_git_using_command difftool' -s t -l tool -d 'Use t
 complete -f -c git -n '__fish_git_using_command difftool' -l tool-help -d 'Print a list of diff tools that may be used with `--tool`'
 complete -f -c git -n '__fish_git_using_command difftool' -l trust-exit-code -d 'Exit when an invoked diff tool returns a non-zero exit code'
 complete -f -c git -n '__fish_git_using_command difftool' -s x -l extcmd -d 'Specify a custom command for viewing diffs'
+complete -f -c git -n '__fish_git_using_command difftool' -l no-gui -d 'Overrides --gui setting'
 # TODO options
 
 ### gc
@@ -1367,7 +1368,45 @@ complete -f -c git -n '__fish_git_using_command gc' -l keep-largest-pack -d 'Ign
 
 ### grep
 complete -c git -n __fish_git_needs_command -a grep -d 'Print lines matching a pattern'
-# TODO options
+complete -f -c git -n '__fish_git_using_command grep' -l cached -d 'Search blobs registered in the index file'
+complete -f -c git -n '__fish_git_using_command grep' -l no-index -d 'Search files in the current directory not managed by Git'
+complete -f -c git -n '__fish_git_using_command grep' -l untracked -d 'Search also in untracked files'
+complete -f -c git -n '__fish_git_using_command grep' -l no-exclude-standard -d 'Also search in ignored files by not honoring the .gitignore mechanism'
+complete -f -c git -n '__fish_git_using_command grep' -l exclude-standard -d 'Do not pay attention to ignored files specified via the .gitignore mechanism'
+complete -f -c git -n '__fish_git_using_command grep' -l recurse-submodules -d 'Recursively search in each submodule that is active and checked out in the repository'
+complete -f -c git -n '__fish_git_using_command grep' -s a -l text -d 'Process binary files as if they were text'
+complete -f -c git -n '__fish_git_using_command grep' -l textconv -d 'Honor textconv filter settings'
+complete -f -c git -n '__fish_git_using_command grep' -l no-textconv -d 'Do not honor textconv filter settings'
+complete -f -c git -n '__fish_git_using_command grep' -s i -l ignore-case -d 'Ignore case differences between the patterns and the files'
+complete -f -c git -n '__fish_git_using_command grep' -s I -d 'Don’t match the pattern in binary files'
+complete -f -c git -n '__fish_git_using_command grep' -s r -l recursive -d 'Descend into levels of directories endlessly'
+complete -f -c git -n '__fish_git_using_command grep' -l no-recursive -d 'Do not descend into directories'
+complete -f -c git -n '__fish_git_using_command grep' -s w -l word-regexp -d 'Match the pattern only at word boundary'
+complete -f -c git -n '__fish_git_using_command grep' -s v -l invert-match -d 'Select non-matching lines'
+complete -f -c git -n '__fish_git_using_command grep' -l full-name -d 'Forces paths to be output relative to the project top directory'
+complete -f -c git -n '__fish_git_using_command grep' -s E -l extended-regexp -d 'Use POSIX extended regexp for patterns'
+complete -f -c git -n '__fish_git_using_command grep' -s G -l basic-regexp -d 'Use POSIX basic regexp for patterns'
+complete -f -c git -n '__fish_git_using_command grep' -s P -l perl-regexp -d 'Use Perl-compatible regular expressions for patterns. Git must be compiled with support for this'
+complete -f -c git -n '__fish_git_using_command grep' -s F -l fixed-strings -d 'Don’t interpret pattern as a regex'
+complete -f -c git -n '__fish_git_using_command grep' -s n -l line-number -d 'Prefix the line number to matching lines'
+complete -f -c git -n '__fish_git_using_command grep' -l column -d 'Prefix the 1-indexed byte-offset of the first match from the start of the matching line'
+complete -f -c git -n '__fish_git_using_command grep' -s l -l files-with-matches -d 'Show only the names of files that contain matches'
+complete -f -c git -n '__fish_git_using_command grep' -s L -l files-without-match -d 'Show only the names of files that do not contain matches'
+complete -f -c git -n '__fish_git_using_command grep' -s z -l null -d 'Use \\0 as the delimiter for pathnames in the output, and print them verbatim'
+complete -f -c git -n '__fish_git_using_command grep' -s o -l only-matching -d 'Print only the matched parts of a matching line'
+complete -f -c git -n '__fish_git_using_command grep' -s c -l count -d 'Instead of showing every matched line, show the number of lines that match'
+complete -f -c git -n '__fish_git_using_command grep' -l no-color -d 'Turn off match highlighting, even when the configuration file gives the default to color output'
+complete -f -c git -n '__fish_git_using_command grep' -l break -d 'Print an empty line between matches from different files'
+complete -f -c git -n '__fish_git_using_command grep' -l heading -d 'Show the filename above the matches in that file instead of at the start of each shown line'
+complete -f -c git -n '__fish_git_using_command grep' -s p -l show-function -d 'Show the preceding line that contains the function name of the match, unless the matching line is a function name itself'
+complete -f -c git -n '__fish_git_using_command grep' -s W -l function-context -d 'Show the surrounding text from the previous line containing a function name up to the one before the next function name'
+complete -f -c git -n '__fish_git_using_command grep' -s e -d 'The next parameter is the pattern'
+complete -f -c git -n '__fish_git_using_command grep' -l and -d 'Combine patterns using and'
+complete -f -c git -n '__fish_git_using_command grep' -l or -d 'Combine patterns using or'
+complete -f -c git -n '__fish_git_using_command grep' -l not -d 'Combine patterns using not'
+complete -f -c git -n '__fish_git_using_command grep' -l all-match -d 'Limit the match to files that have lines to match all of them when giving multiple pattern expressions combined with --or'
+complete -f -c git -n '__fish_git_using_command grep' -s q -l quiet -d 'exit with status 0 when there is a match and with non-zero status when there isn’t instead of outputting matched lines'
+# TODO options, including max-depth, h, open-files-in-pager, contexts, threads, file
 
 ### init
 complete -f -c git -n __fish_git_needs_command -a init -d 'Create an empty git repository or reinitialize an existing one'

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1926,7 +1926,7 @@ complete -f -c git -n '__fish_git_using_command revert' -l abort -d 'Cancel the 
 complete -f -c git -n '__fish_git_using_command revert' -l skip -d 'Skip the current commit and continue with the rest of the sequence'
 complete -f -c git -n '__fish_git_using_command revert' -l quit -d 'Forget about the current operation in progress'
 complete -f -c git -n '__fish_git_using_command revert' -l no-edit -d 'Do not start the commit message editor'
-complete -f -c git -n '__fish_git_using_command revert' -s n -l no-commit -d 'Applies the changes necessary to revert the named commits to your working tree and the index, but does not make the commits'
+complete -f -c git -n '__fish_git_using_command revert' -s n -l no-commit -d 'Apply changes to index but don't create a commit'
 complete -f -c git -n '__fish_git_using_command revert' -s s -l signoff -d 'Add a Signed-off-by trailer at the end of the commit message'
 complete -f -c git -n '__fish_git_using_command revert' -l rerere-autoupdate -d 'Allow the rerere mechanism to update the index with the result of auto-conflict resolution if possible'
 complete -f -c git -n '__fish_git_using_command revert' -l no-rerere-autoupdate -d 'Does not allow the rerere mechanism to update the index with the result of auto-conflict resolution if possible'

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1386,7 +1386,7 @@ complete -f -c git -n '__fish_git_using_command grep' -s v -l invert-match -d 'S
 complete -f -c git -n '__fish_git_using_command grep' -l full-name -d 'Forces paths to be output relative to the project top directory'
 complete -f -c git -n '__fish_git_using_command grep' -s E -l extended-regexp -d 'Use POSIX extended regexp for patterns'
 complete -f -c git -n '__fish_git_using_command grep' -s G -l basic-regexp -d 'Use POSIX basic regexp for patterns'
-complete -f -c git -n '__fish_git_using_command grep' -s P -l perl-regexp -d 'Use Perl-compatible regular expressions for patterns. Git must be compiled with support for this'
+complete -f -c git -n '__fish_git_using_command grep' -s P -l perl-regexp -d 'Use Perl-compatible regular expressions for patterns.'
 complete -f -c git -n '__fish_git_using_command grep' -s F -l fixed-strings -d 'Don’t interpret pattern as a regex'
 complete -f -c git -n '__fish_git_using_command grep' -s n -l line-number -d 'Prefix the line number to matching lines'
 complete -f -c git -n '__fish_git_using_command grep' -l column -d 'Prefix the 1-indexed byte-offset of the first match from the start of the matching line'
@@ -1398,14 +1398,14 @@ complete -f -c git -n '__fish_git_using_command grep' -s c -l count -d 'Instead 
 complete -f -c git -n '__fish_git_using_command grep' -l no-color -d 'Turn off match highlighting, even when the configuration file gives the default to color output'
 complete -f -c git -n '__fish_git_using_command grep' -l break -d 'Print an empty line between matches from different files'
 complete -f -c git -n '__fish_git_using_command grep' -l heading -d 'Show the filename above the matches in that file instead of at the start of each shown line'
-complete -f -c git -n '__fish_git_using_command grep' -s p -l show-function -d 'Show the preceding line that contains the function name of the match, unless the matching line is a function name itself'
-complete -f -c git -n '__fish_git_using_command grep' -s W -l function-context -d 'Show the surrounding text from the previous line containing a function name up to the one before the next function name'
+complete -f -c git -n '__fish_git_using_command grep' -s p -l show-function -d 'Show the line that contains the function name of the match, unless the match is a function name itself'
+complete -f -c git -n '__fish_git_using_command grep' -s W -l function-context -d 'Show the surrounding text from the line containing a function name up to the one before the next function name'
 complete -f -c git -n '__fish_git_using_command grep' -s e -d 'The next parameter is the pattern'
 complete -f -c git -n '__fish_git_using_command grep' -l and -d 'Combine patterns using and'
 complete -f -c git -n '__fish_git_using_command grep' -l or -d 'Combine patterns using or'
 complete -f -c git -n '__fish_git_using_command grep' -l not -d 'Combine patterns using not'
-complete -f -c git -n '__fish_git_using_command grep' -l all-match -d 'Limit the match to files that have lines to match all of them when giving multiple pattern expressions combined with --or'
-complete -f -c git -n '__fish_git_using_command grep' -s q -l quiet -d 'exit with status 0 when there is a match and with non-zero status when there isn’t instead of outputting matched lines'
+complete -f -c git -n '__fish_git_using_command grep' -l all-match -d 'Only match files that can match all the pattern expressions when giving multiple'
+complete -f -c git -n '__fish_git_using_command grep' -s q -l quiet -d 'just exit with status 0 when there is a match and with non-zero status when there isn’t'
 # TODO options, including max-depth, h, open-files-in-pager, contexts, threads, file
 
 ### init
@@ -1928,8 +1928,8 @@ complete -f -c git -n '__fish_git_using_command revert' -l quit -d 'Forget about
 complete -f -c git -n '__fish_git_using_command revert' -l no-edit -d 'Do not start the commit message editor'
 complete -f -c git -n '__fish_git_using_command revert' -s n -l no-commit -d 'Apply changes to index but don't create a commit'
 complete -f -c git -n '__fish_git_using_command revert' -s s -l signoff -d 'Add a Signed-off-by trailer at the end of the commit message'
-complete -f -c git -n '__fish_git_using_command revert' -l rerere-autoupdate -d 'Allow the rerere mechanism to update the index with the result of auto-conflict resolution if possible'
-complete -f -c git -n '__fish_git_using_command revert' -l no-rerere-autoupdate -d 'Does not allow the rerere mechanism to update the index with the result of auto-conflict resolution if possible'
+complete -f -c git -n '__fish_git_using_command revert' -l rerere-autoupdate -d 'Allow the rerere mechanism to update the index with the result of auto-conflict resolution'
+complete -f -c git -n '__fish_git_using_command revert' -l no-rerere-autoupdate -d 'Does not allow the rerere mechanism to update the index with auto-conflict resolution'
 # TODO options
 
 ### rm

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1378,7 +1378,7 @@ complete -f -c git -n '__fish_git_using_command grep' -s a -l text -d 'Process b
 complete -f -c git -n '__fish_git_using_command grep' -l textconv -d 'Honor textconv filter settings'
 complete -f -c git -n '__fish_git_using_command grep' -l no-textconv -d 'Do not honor textconv filter settings'
 complete -f -c git -n '__fish_git_using_command grep' -s i -l ignore-case -d 'Ignore case differences between the patterns and the files'
-complete -f -c git -n '__fish_git_using_command grep' -s I -d 'Don’t match the pattern in binary files'
+complete -f -c git -n '__fish_git_using_command grep' -s I -d 'Don\'t match the pattern in binary files'
 complete -f -c git -n '__fish_git_using_command grep' -s r -l recursive -d 'Descend into levels of directories endlessly'
 complete -f -c git -n '__fish_git_using_command grep' -l no-recursive -d 'Do not descend into directories'
 complete -f -c git -n '__fish_git_using_command grep' -s w -l word-regexp -d 'Match the pattern only at word boundary'

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1926,7 +1926,7 @@ complete -f -c git -n '__fish_git_using_command revert' -l abort -d 'Cancel the 
 complete -f -c git -n '__fish_git_using_command revert' -l skip -d 'Skip the current commit and continue with the rest of the sequence'
 complete -f -c git -n '__fish_git_using_command revert' -l quit -d 'Forget about the current operation in progress'
 complete -f -c git -n '__fish_git_using_command revert' -l no-edit -d 'Do not start the commit message editor'
-complete -f -c git -n '__fish_git_using_command revert' -s n -l no-commit -d 'Apply changes to index but don't create a commit'
+complete -f -c git -n '__fish_git_using_command revert' -s n -l no-commit -d 'Apply changes to index but don\'t create a commit'
 complete -f -c git -n '__fish_git_using_command revert' -s s -l signoff -d 'Add a Signed-off-by trailer at the end of the commit message'
 complete -f -c git -n '__fish_git_using_command revert' -l rerere-autoupdate -d 'Allow the rerere mechanism to update the index with the result of auto-conflict resolution'
 complete -f -c git -n '__fish_git_using_command revert' -l no-rerere-autoupdate -d 'Does not allow the rerere mechanism to update the index with auto-conflict resolution'

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1372,7 +1372,7 @@ complete -f -c git -n '__fish_git_using_command grep' -l cached -d 'Search blobs
 complete -f -c git -n '__fish_git_using_command grep' -l no-index -d 'Search files in the current directory not managed by Git'
 complete -f -c git -n '__fish_git_using_command grep' -l untracked -d 'Search also in untracked files'
 complete -f -c git -n '__fish_git_using_command grep' -l no-exclude-standard -d 'Also search in ignored files by not honoring the .gitignore mechanism'
-complete -f -c git -n '__fish_git_using_command grep' -l exclude-standard -d 'Do not pay attention to ignored files specified via the .gitignore mechanism'
+complete -f -c git -n '__fish_git_using_command grep' -l exclude-standard -d 'Do not search ignored files specified via the .gitignore mechanism'
 complete -f -c git -n '__fish_git_using_command grep' -l recurse-submodules -d 'Recursively search in each submodule that is active and checked out in the repository'
 complete -f -c git -n '__fish_git_using_command grep' -s a -l text -d 'Process binary files as if they were text'
 complete -f -c git -n '__fish_git_using_command grep' -l textconv -d 'Honor textconv filter settings'

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1410,13 +1410,14 @@ complete -f -c git -n '__fish_git_using_command grep' -s q -l quiet -d 'exit wit
 
 ### init
 complete -f -c git -n __fish_git_needs_command -a init -d 'Create an empty git repository or reinitialize an existing one'
+complete -f -c git -n '__fish_git_using_command init' -s q -l quiet -d 'Only print error and warning messages'
+complete -f -c git -n '__fish_git_using_command init' -l bare -d 'Create a bare repository'
 # TODO options
 
 ### log
 complete -c git -n __fish_git_needs_command -a shortlog -d 'Show commit shortlog'
 complete -c git -n __fish_git_needs_command -a log -d 'Show commit logs'
 complete -c git -n '__fish_git_using_command log; and not contains -- -- (commandline -opc)' -k -a '(__fish_git_ranges)'
-
 complete -c git -n '__fish_git_using_command log' -l follow -d 'Continue listing file history beyond renames'
 complete -c git -n '__fish_git_using_command log' -l no-decorate -d 'Don\'t print ref names'
 complete -f -c git -n '__fish_git_using_command log' -l decorate -a 'short\tHide\ prefixes full\tShow\ full\ ref\ names auto\tHide\ prefixes\ if\ printed\ to\ terminal no\tDon\\\'t\ display\ ref' -d 'Print out ref names'
@@ -1729,6 +1730,9 @@ complete -f -c git -n "__fish_git_using_command notes; and __fish_seen_subcomman
 
 ### prune
 complete -f -c git -n __fish_git_needs_command -a prune -d 'Prune all unreachable objects from the object database'
+complete -f -c git -n '__fish_git_using_command prune' -s n -l dry-run -d 'Just report what it would remove'
+complete -f -c git -n '__fish_git_using_command prune' -s v -l verbose -d 'Report all removed objects'
+complete -f -c git -n '__fish_git_using_command prune' -l progress -d 'Show progress'
 # TODO options
 
 ### pull
@@ -1920,6 +1924,12 @@ complete -f -c git -n '__fish_git_using_command revert' -ka '(__fish_git_commits
 complete -f -c git -n '__fish_git_using_command revert' -l continue -d 'Continue the operation in progress'
 complete -f -c git -n '__fish_git_using_command revert' -l abort -d 'Cancel the operation'
 complete -f -c git -n '__fish_git_using_command revert' -l skip -d 'Skip the current commit and continue with the rest of the sequence'
+complete -f -c git -n '__fish_git_using_command revert' -l quit -d 'Forget about the current operation in progress'
+complete -f -c git -n '__fish_git_using_command revert' -l no-edit -d 'Do not start the commit message editor'
+complete -f -c git -n '__fish_git_using_command revert' -s n -l no-commit -d 'Applies the changes necessary to revert the named commits to your working tree and the index, but does not make the commits'
+complete -f -c git -n '__fish_git_using_command revert' -s s -l signoff -d 'Add a Signed-off-by trailer at the end of the commit message'
+complete -f -c git -n '__fish_git_using_command revert' -l rerere-autoupdate -d 'Allow the rerere mechanism to update the index with the result of auto-conflict resolution if possible'
+complete -f -c git -n '__fish_git_using_command revert' -l no-rerere-autoupdate -d 'Does not allow the rerere mechanism to update the index with the result of auto-conflict resolution if possible'
 # TODO options
 
 ### rm
@@ -1931,6 +1941,7 @@ complete -c git -n '__fish_git_using_command rm' -s r -d 'Allow recursive remova
 complete -c git -n '__fish_git_using_command rm' -s q -l quiet -d 'Be quiet'
 complete -c git -n '__fish_git_using_command rm' -s f -l force -d 'Override the up-to-date check'
 complete -c git -n '__fish_git_using_command rm' -s n -l dry-run -d 'Dry run'
+complete -c git -n '__fish_git_using_command rm' -l sparse -d 'Allow updating index entries outside of the sparse-checkout cone'
 # TODO options
 
 ### status
@@ -1941,6 +1952,10 @@ complete -f -c git -n '__fish_git_using_command status' -l porcelain -d 'Give th
 complete -f -c git -n '__fish_git_using_command status' -s z -d 'Terminate entries with null character'
 complete -f -c git -n '__fish_git_using_command status' -s u -l untracked-files -x -a 'no normal all' -d 'The untracked files handling mode'
 complete -f -c git -n '__fish_git_using_command status' -l ignore-submodules -x -a 'none untracked dirty all' -d 'Ignore changes to submodules'
+complete -f -c git -n '__fish_git_using_command status' -s v -l verbose -d 'Also show the textual changes that are staged to be committed'
+complete -f -c git -n '__fish_git_using_command status' -l no-ahead-behind -d 'Do not display detailed ahead/behind counts for the branch relative to its upstream branch'
+complete -f -c git -n '__fish_git_using_command status' -l renames -d 'Turn on rename detection regardless of user configuration'
+complete -f -c git -n '__fish_git_using_command status' -l no-renames -d 'Turn off rename detection regardless of user configuration'
 # TODO options
 
 ### stripspace


### PR DESCRIPTION
## Description

Adds limited autocomplete for git commands fetch, show-branch, archive, difftool, grep, init, prune, revert, rm and status. Incomplete, I didn't touch the flags I didn't understand or didn't know how to implement.

Fixes issue #
#8398 
... but only partially.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst (I don't think this really counts as 'notable' or 'user-visible', given autocomplete was meant to be there already)
