### PR TITLE
fix: edit_command_buffer with micro without parsecursor

### DIFF
--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -56,7 +56,7 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
         case subl
             set -a editor $f:$line:$col --wait
         case micro
-            set -a editor $f:$line:$col
+            set -a editor $f +$line:$col
         case '*'
             set -a editor $f
     end


### PR DESCRIPTION
## Description

Micro only parses the [FILE]:LINE:COL syntax if the parsecursor option is enabled.
The +LINE:COL syntax is unambigous and always valid, and thus should be preferred.

I didn't bother opening an issue because it's a single-line fix.
The consequence of not doing this is that `edit_command_buffer` appears to do nothing when micro is used as the editor, and does not have the parsecursor option enabled (as in my case, and the default).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages. *(no changes to fish usage)*
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst *(no user-visible changes)*
