### PR TITLE
fix: `git remote` only complete remotes when seen command

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -979,7 +979,7 @@ complete -c git -n '__fish_git_using_command filter-branch' -s f -l force -d 'Fi
 ### remote
 set -l remotecommands add rm remove show prune update rename set-head set-url set-branches get-url
 complete -f -c git -n __fish_git_needs_command -a remote -d 'Manage set of tracked repositories'
-complete -f -c git -n '__fish_git_using_command remote' -a '(__fish_git_remotes)'
+complete -f -c git -n "__fish_git_using_command remote; and __fish_seen_subcommand_from $remotecommands" -a '(__fish_git_remotes)'
 complete -f -c git -n "__fish_git_using_command remote; and not __fish_seen_subcommand_from $remotecommands" -s v -l verbose -d 'Be verbose'
 complete -f -c git -n "__fish_git_using_command remote; and not __fish_seen_subcommand_from $remotecommands" -a add -d 'Adds a new remote'
 complete -f -c git -n "__fish_git_using_command remote; and not __fish_seen_subcommand_from $remotecommands" -a rm -d 'Removes a remote'


### PR DESCRIPTION
## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
