### PR TITLE
Update single layer stripping

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -139,6 +139,14 @@ def escape_fish_cmd(text):
     escaped = text.replace("\\", "\\\\").replace("'", "\\'")
     return "'" + escaped + "'"
 
+def strip_one_layer(text, char):
+    # Strip the text from one layer of a given character
+    if text[-1]==char:
+        text = text[:-1]
+    if text[0]==char:
+        text = text[1:]
+    return text
+
 
 named_colors = {
     "black": "000000",
@@ -1329,8 +1337,8 @@ class FishConfigHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             # Remove one layer of single-quotes because escape_fish_cmd adds them back.
             "abbr --add %s %s"
             % (
-                escape_fish_cmd(abbreviation["word"].strip("'")),
-                escape_fish_cmd(abbreviation["phrase"].strip("'")),
+                escape_fish_cmd(strip_one_layer(abbreviation["word"], "'")),
+                escape_fish_cmd(strip_one_layer(abbreviation["phrase"], "'")),
             )
         )
         if err:

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -141,9 +141,9 @@ def escape_fish_cmd(text):
 
 def strip_one_layer(text, char):
     # Strip the text from one layer of a given character
-    if text[-1]==char:
+    if text[-1] == char:
         text = text[:-1]
-    if text[0]==char:
+    if text[0] == char:
         text = text[1:]
     return text
 


### PR DESCRIPTION
## Description

Fixed words and phrases being stripped of multiple single quotes. As per the comment of the function states, only one layer of single quotas need to be stripped. The `strip` method in python actually removes as many trailing and leading characters as it can.

Fixes issue https://github.com/fish-shell/fish-shell/issues/8917

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
