### PR TITLE
fix: complete `git rebase` with commits first and keep-order

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1764,8 +1764,8 @@ complete -f -c git -n __fish_git_needs_command -a rebase -d 'Forward-port local 
 complete -f -c git -n '__fish_git_using_command rebase' -a '(__fish_git_remotes)' -d 'Remote alias'
 complete -f -c git -n '__fish_git_using_command rebase' -a '(__fish_git_branches)'
 complete -f -c git -n '__fish_git_using_command rebase' -a '(__fish_git_heads)' -d Head
-complete -f -c git -n '__fish_git_using_command rebase' -a '(__fish_git_recent_commits)'
-complete -f -c git -n '__fish_git_using_command rebase' -a '(__fish_git_tags)' -d Tag
+complete -f -c git -n '__fish_git_using_command rebase' -a '(__fish_git_tags)' -d Tag -k
+complete -f -c git -n '__fish_git_using_command rebase' -a '(__fish_git_recent_commits)' -k
 complete -f -c git -n '__fish_git_using_command rebase; and __fish_git_is_rebasing' -l continue -d 'Restart the rebasing process'
 complete -f -c git -n '__fish_git_using_command rebase; and __fish_git_is_rebasing' -l abort -d 'Abort the rebase operation'
 complete -f -c git -n '__fish_git_using_command rebase; and __fish_git_is_rebasing' -l edit-todo -d 'Edit the todo list'


### PR DESCRIPTION
Because TAGs are easy to type and complete, but commits with its SHA are
difficult to complete manualy. Keep commits and TAGs order to show more recent
commits first.

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
