### PR TITLE
Add `--unset-upstream` to `git branch` completions

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1181,6 +1181,7 @@ complete -f -c git -n '__fish_git_using_command branch' -l no-track -d 'Do not t
 complete -f -c git -n '__fish_git_using_command branch' -l set-upstream-to -d 'Set remote branch to track'
 complete -f -c git -n '__fish_git_using_command branch' -l merged -d 'List branches that have been merged'
 complete -f -c git -n '__fish_git_using_command branch' -l no-merged -d 'List branches that have not been merged'
+complete -f -c git -n '__fish_git_using_command branch' -l unset-upstream -d 'Remove branch upstream information'
 
 ### cherry
 complete -f -c git -n __fish_git_needs_command -a cherry -d 'Find commits yet to be applied to upstream [upstream [head]]'


### PR DESCRIPTION
## Description

Just found a flag that didn't seem to be in the `git branch` completions.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
