### PR TITLE
Add `--no-patch` option to `git show` completion

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -994,6 +994,7 @@ complete -f -c git -n '__fish_git_using_command show' -l expand-tabs -d 'Perform
 complete -f -c git -n '__fish_git_using_command show' -l no-expand-tabs -d 'Do not perform a tab expansion in the log message'
 complete -f -c git -n '__fish_git_using_command show' -l notes -k -a '(__fish_git_refs)' -d 'Show the notes that annotate the commit'
 complete -f -c git -n '__fish_git_using_command show' -l no-notes -d 'Do not show notes'
+complete -f -c git -n '__fish_git_using_command show' -s s -l no-patch -d 'Suppress diff output'
 complete -f -c git -n '__fish_git_using_command show' -l show-signature -d 'Check the validity of a signed commit object'
 
 


### PR DESCRIPTION
## Description

Add `--no-patch` option to `git show` command completions. While this option existed for a long time, it was not reflected in completions.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
