### PR TITLE
Simplified string match.

### DIFF
--- a/share/functions/__fish_make_completion_signals.fish
+++ b/share/functions/__fish_make_completion_signals.fish
@@ -7,9 +7,7 @@ function __fish_make_completion_signals --description 'Make list of kill signals
     # Cygwin's kill is special, and the documentation lies.
     # Just hardcode the signals.
     set -l os (uname)
-    if string match -q 'CYGWIN*' -- $os
-        or string match -eiq Msys -- $os
-        or string match -eiq mingw -- $os
+    if string match -irq '^CYGWIN|^MSYS|^MINGW' -- $os
         set -a __kill_signals "1 HUP" "2 INT" "3 QUIT" "4 ILL" "5 TRAP" "6 ABRT" \
             "6 IOT" "7 BUS" "8 FPE" "9 KILL" "10 USR1" "11 SEGV" \
             "12 USR2" "13 PIPE" "14 ALRM" "15 TERM" "16 STKFLT" "17 CHLD" \


### PR DESCRIPTION
My Msys fish broke, but when I wanted to write a patch I realised the
version of fish I was using was old and the problem was already fixed.

I did, however, simplify the solution and thought I'd share the patch
as a suggestion anyway.

## Description

A single string match finds all the problematic kill environments.

Re-fixes issue #8046

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
