### PR TITLE
fix completion, apk {add,manifest} accept files

### DIFF
--- a/share/completions/apk.fish
+++ b/share/completions/apk.fish
@@ -1,8 +1,10 @@
 # Completions for apk (Alpine Package Keeper)
 
 # Package name
-complete -f -c apk -n "__fish_seen_subcommand_from add info fetch dot" -a "(apk search -q)" -d Package
-complete -f -c apk -n "__fish_seen_subcommand_from del fix version manifest" -a "(apk info -q)" -d Package
+complete -c apk -n "__fish_seen_subcommand_from add" -a "(apk search -q)" -d Package
+complete -c apk -n "__fish_seen_subcommand_from manifest" -a "(apk info -q)" -d Package
+complete -f -c apk -n "__fish_seen_subcommand_from info fetch dot" -a "(apk search -q)" -d Package
+complete -f -c apk -n "__fish_seen_subcommand_from del fix version" -a "(apk info -q)" -d Package
 
 # Global options
 complete -f -c apk -s h -l help -d "Show help"


### PR DESCRIPTION
## Description

`apk add` and `apk manifest` accept file arguments to `.apk` file

```
❯ apk manifest ~/packages/community/x86_64/github-cli-2.0.0-r2.apk
sha1:d1c5be0d45525a30e7207f6b53be5e5eade11511  usr/bin/gh
❯ sudo apk add ~/packages/community/x86_64/github-cli-2.0.0-r2.apk
fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
(1/1) Downgrading github-cli (2.8.0-r0 -> 2.0.0-r2)
OK: 2397 MiB in 259 packages
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
