### PR TITLE
Add missing cp completions

### DIFF
--- a/share/completions/cp.fish
+++ b/share/completions/cp.fish
@@ -1,5 +1,6 @@
 if cp --version 2>/dev/null >/dev/null # GNU cp
     complete -c cp -s a -l archive -d "Same as -dpR"
+    complete -c cp -l attributes-only -d "Copy just the attributes"
     complete -c cp -s b -l backup -d "Make backup of each existing destination file" -a "none off numbered t existing nil simple never"
     complete -c cp -l copy-contents -d "Copy contents of special files when recursive"
     complete -c cp -s d -d "Same as --no-dereference --preserve=link"
@@ -15,17 +16,20 @@ if cp --version 2>/dev/null >/dev/null # GNU cp
     complete -c cp -l help -d "Display help and exit"
     complete -c cp -l version -d "Display version and exit"
     complete -c cp -s L -l dereference -d "Always follow symbolic links"
+    complete -c cp -s n -l no-clobber -d "Do not overwrite an existing file"
     complete -c cp -s P -l no-dereference -d "Never follow symbolic links"
     complete -c cp -s p -d "Same as --preserve=mode,ownership,timestamps"
     complete -c cp -f -l preserve -d "Preserve ATTRIBUTES if possible" -xa "mode ownership timestamps links all"
     complete -c cp -f -l no-preserve -r -d "Don't preserve ATTRIBUTES" -xa "mode ownership timestamps links all"
     complete -c cp -l parents -d "Use full source file name under DIRECTORY"
     complete -c cp -s r -s R -l recursive -d "Copy directories recursively"
+    complete -c cp -l reflink -d "Control clone/CoW copies" -xa "always auto never"
     complete -c cp -l remove-destination -d "First remove existing destination files"
     complete -c cp -f -l sparse -r -d "Control creation of sparse files" -xa "always auto never"
     complete -c cp -s s -l symbolic-link -d "Make symbolic links instead of copying"
     complete -c cp -s T -l no-target-directory -d "Treat DEST as a normal file"
     complete -c cp -s x -l one-file-system -d "Stay on this file system"
+    complete -c cp -s Z -d "Set SELinux context of copy to default type"
     complete -c cp -s X -l context -r -d "Set SELinux context of copy to CONTEXT"
 else # BSD/macOS
     set -l uname (uname -s)


### PR DESCRIPTION
## Description

All of the missing options were present in the GNU cp for more than 8 years, so it makes sense to add completions for them.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
