### PR TITLE
Fix wg-quick completion running from root

### DIFF
--- a/share/completions/wg-quick.fish
+++ b/share/completions/wg-quick.fish
@@ -1,7 +1,7 @@
 set -l valid_subcmds up down strip save
 
 function __fish_wg_complete_interfaces
-    LC_ALL=C wg show 2>| string replace -rf 'Unable to access interface (.*): Operation not permitted' '$1'
+    wg show interfaces
 end
 
 complete -c wg-quick -f


### PR DESCRIPTION
## Description

`wg show` command shows entire interfaces configuration, not just the
list. This breaks completion when running fish from root, because
command output looks like this:

    interface: wg0
      public key: fred2rX85AxpcTObLuiWTzkRPZaXjnhd1C4XOdZOGWs=
      private key: (hidden)
      listening port: 12345
      fwmark: 0xca6c

    peer: g2YHHDkxmgoT9EV0TxKtq556WLXpaOh4zgC5L7EAGTQ=
      endpoint: 192.168.88.50:54321
      allowed ips: 0.0.0.0/0, ::/0
      latest handshake: 1 minute, 37 seconds ago
      transfer: 1.83 MiB received, 927.19 KiB sent

To show just the list of active interfaces, `wg show interfaces` should
be used instead.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
