### PR TITLE
Fix sphinx-doc warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -120,6 +120,7 @@ For distributors
   subdirectories ``fish/vendor_completions.d``, ``fish/vendor_functions.d``, and
   ``fish/vendor_conf.d`` (respectively) within ``XDG_DATA_HOME`` (or ``~/.local/share``
   if not defined) (:issue:`8887`).
+
 --------------
 
 fish 3.4.1 (released March 25, 2022)


### PR DESCRIPTION
## Description

This fixes a minor warning.

```
[ 97%] Building man pages with Sphinx
../CHANGELOG.rst:123: WARNING: Bullet list ends without a blank line; unexpected unindent.
[ 97%] Built target sphinx-manpages
[ 98%] Building HTML documentation with Sphinx
../CHANGELOG.rst:123: WARNING: Bullet list ends without a blank line; unexpected unindent.
```

