### PR TITLE
create_manpage_completions.py: Do not overstrip commands with dots

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -929,9 +929,15 @@ def parse_and_output_man_pages(paths, output_directory, show_progress):
     for manpage_path in paths:
         index += 1
 
-        # Get the "base" command, e.g. gcc.1.gz -> gcc
+        # Get the "base" command, e.g. mkfs.xfs.8.gz -> mkfs.xfs
         man_file_name = os.path.basename(manpage_path)
-        CMDNAME = man_file_name.split(".", 1)[0]
+        # 1. strip the optional compressor suffix
+        CMDNAME, extension = os.path.splitext(man_file_name)
+        # 2. strip mandatory section nu:ber
+        if CMDNAME.endswith((".1", ".2", ".3", ".4", ".5", ".6", ".7", ".8", ".9")):
+            CMDNAME, extension = os.path.splitext(CMDNAME)
+        # 3. XXX strip optional version(?) number?
+        # see comment above `already_output_completions = {}` line
 
         # Show progress if we're doing that
         if show_progress:


### PR DESCRIPTION
The best effort parser over-eagerly strips all extensions off a manual
page file's basename, hence commands containing dots will output
completions for a different command.

Prominent examples are the mkfs.*(8) and fsck.*(8) families, e.g.
completions for mkfs.xfs.8.gz are generated for the command `mkfs`
is not only incorrect but can also filename collisions in case .fish
files for multiple commands are put into the same directory.

Thus do not strip everything past the first dot from the left, but
instead merely strip expected extensions from the right.
