### PR TITLE
git_prompt: Only show untracked files in informative mode if asked

### DIFF
--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -26,7 +26,10 @@ The ``fish_git_prompt`` function displays information about the current git repo
 
 There are numerous customization options, which can be controlled with git options or fish variables. git options, where available, take precedence over the fish variable with the same function. git options can be set on a per-repository or global basis. git options can be set with the ``git config`` command, while fish variables can be set as usual with the :ref:`set <cmd-set>` command.
 
-- ``$__fish_git_prompt_show_informative_status`` or the git option ``bash.showInformativeStatus`` can be set to enable the "informative" display, which will show a large amount of information - the number of untracked files, dirty files, unpushed/unpulled commits, and more. In large repositories, this can take a lot of time, so it you may wish to disable it in these repositories with  ``git config --local bash.showInformativeStatus false``. It also changes the characters the prompt uses to less plain ones (``✚`` instead of ``*`` for the dirty state for example) , and if you are only interested in that, set ``$__fish_git_prompt_use_informative_chars`` instead.
+- ``$__fish_git_prompt_show_informative_status`` or the git option ``bash.showInformativeStatus`` can be set to enable the "informative" display, which will show a large amount of information - the number of dirty files, unpushed/unpulled commits, and more.
+  In large repositories, this can take a lot of time, so it you may wish to disable it in these repositories with  ``git config --local bash.showInformativeStatus false``. It also changes the characters the prompt uses to less plain ones (``✚`` instead of ``*`` for the dirty state for example) , and if you are only interested in that, set ``$__fish_git_prompt_use_informative_chars`` instead.
+
+  Because counting untracked files requires a lot of time, the number of untracked files is only shown if enabled via ``$__fish_git_prompt_showuntrackedfiles`` or the git option ``bash.showUntrackedFiles``.
 
 - ``$__fish_git_prompt_showdirtystate`` or the git option ``bash.showDirtyState`` can be set to show if the repository is "dirty", i.e. has uncommitted changes.
 

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -251,9 +251,8 @@ function fish_git_prompt --description "Prompt function for Git"
             or begin
                 set -q __fish_git_prompt_show_informative_status
                 and test "$dirty" != false
-                and test "$untracked" != false
             end
-            set informative_status (__fish_git_prompt_informative_status $git_dir)
+            set informative_status (untracked=$untracked __fish_git_prompt_informative_status $git_dir)
             if test -n "$informative_status"
                 set informative_status "$space$informative_status"
             end
@@ -356,12 +355,17 @@ function __fish_git_prompt_informative_status
         set stashstate (count < $stashfile)
     end
 
-    # Use git status --porcelain.
-    # This uses the "normal" untracked mode so untracked directories are considered as 1 entry.
-    # It's quite a bit faster and unlikely anyone cares about the number of files if it's *all* of the files
+    # If we're not told to show untracked files, we don't.
+    # If we are, we still use the "normal" mode because it's a lot faster,
+    # and it's unlikely anyone cares about the number of files if it's *all* of the files
     # in that directory.
+    set -l untr -uno
+    test "$untracked" = true
+    and set untr -unormal
+
+    # Use git status --porcelain.
     # The v2 format is better, but we don't actually care in this case.
-    set -l stats (string sub -l 2 (git -c core.fsmonitor= status --porcelain -z -unormal | string split0))
+    set -l stats (string sub -l 2 (git -c core.fsmonitor= status --porcelain -z $untr | string split0))
     set -l invalidstate (string match -r '^UU' $stats | count)
     set -l stagedstate (string match -r '^[ACDMR].' $stats | count)
     set -l dirtystate (string match -r '^.[ACDMR]' $stats | count)

--- a/tests/checks/git.fish
+++ b/tests/checks/git.fish
@@ -54,8 +54,15 @@ echo # the git prompt doesn't print a newline
 set -g __fish_git_prompt_show_informative_status 1
 fish_git_prompt
 echo
+#CHECK: (newbranch|✔)
+
+# Informative mode only shows untracked files if explicitly told.
+set -g __fish_git_prompt_showuntrackedfiles 1
+fish_git_prompt
+echo
 #CHECK: (newbranch|…1)
 set -e __fish_git_prompt_show_informative_status
+set -e __fish_git_prompt_showuntrackedfiles
 
 # Confirm the mode changes back
 fish_git_prompt


### PR DESCRIPTION
This makes it so

1. The informative status can work without showing untracked
files (previously it was disabled if bash.showUntrackedFiles was
false)
2. If untrackedfiles isn't explicitly enabled, we use -uno, so git
doesn't have to scan all the files.

In a large repository (like the FreeBSD ports repo), this can improve
performance by a factor of 5 or up.

----

The impetus for this is that our informative+vcs prompt already tries to disable untracked file display via the (undocumented) __fish_git_prompt_hide_untrackedfiles variable, so in that case we're just wasting time.

We *could* also make it so we recognize that option and skip untracked display (or make it use $__fish_git_prompt_status_order without untrackedfiles), but:

1. We've decided that it's not useful there, so we apparently don't like it in the prompt meant to showcase the informative git prompt!
2. This can be *very* costly and so should probably be enabled explicitly.

Part of #8979 (well, except for the terlar bit)

(we probably also want to make it so you can set $__fish_git_prompt_showuntrackedfiles to 0 to explicitly *disable* it)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
