### PR TITLE
Improve newline behavior of `kill-whole-line`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,6 +93,8 @@ Interactive improvements
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Keyboard shortcut :kbd:`Alt-S` (previously: toggle ``sudo`` prepended to current commandline contents) now supports ``doas`` on systems without ``sudo`` (:issue:`8942`).
+- The ``kill-whole-line`` special input function now kills the newline preceeding the last line. This makes ``dd`` in vi-mode clear the last line properly.
+- Introduce the ``kill-inner-line`` special input function, which kills the line without any newlines, allowing ``cc`` in vi-mode to clear the line while preserving newlines.
 
 Improved prompts
 ^^^^^^^^^^^^^^^^

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -230,7 +230,10 @@ The following special input functions are available:
     move the selected text to the killring
 
 ``kill-whole-line``
-    move the line to the killring
+    move the line (including the following newline) to the killring. If the line is the last line, its preceeding newline is also removed
+
+``kill-inner-line``
+    move the line (without the following newline) to the killring
 
 ``kill-word``
     move the next word to the killring

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -153,8 +153,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset 'd,' begin-selection repeat-jump-reverse kill-selection end-selection
 
     bind -s --preset -m insert s delete-char repaint-mode
-    bind -s --preset -m insert S kill-whole-line repaint-mode
-    bind -s --preset -m insert cc kill-whole-line repaint-mode
+    bind -s --preset -m insert S kill-inner-line repaint-mode
+    bind -s --preset -m insert cc kill-inner-line repaint-mode
     bind -s --preset -m insert C kill-line repaint-mode
     bind -s --preset -m insert c\$ kill-line repaint-mode
     bind -s --preset -m insert c\^ backward-kill-line repaint-mode

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -139,6 +139,7 @@ static constexpr const input_function_metadata_t input_function_metadata[] = {
     {L"insert-line-over", readline_cmd_t::insert_line_over},
     {L"insert-line-under", readline_cmd_t::insert_line_under},
     {L"kill-bigword", readline_cmd_t::kill_bigword},
+    {L"kill-inner-line", readline_cmd_t::kill_inner_line},
     {L"kill-line", readline_cmd_t::kill_line},
     {L"kill-selection", readline_cmd_t::kill_selection},
     {L"kill-whole-line", readline_cmd_t::kill_whole_line},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -37,6 +37,7 @@ enum class readline_cmd_t {
     end_of_history,
     backward_kill_line,
     kill_whole_line,
+    kill_inner_line,
     kill_word,
     kill_bigword,
     backward_kill_word,


### PR DESCRIPTION
## Description

Previously, `kill-whole-line` kills the line and its following newline. This is insufficient when we are on the last line, because it would not actually clear the line. The cursor would stay on the line, which is not the correct behavior for bindings like `dd`.

Also, `cc` in vi-mode used `kill-whole-line`, which is not correct because it should not remove any newlines. We have to introduce another special input function (`kill-inner-line`) to fix this.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst
