### PR TITLE
fish_git_prompt: drop --ignored flag in git status

### DIFF
--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -267,7 +267,9 @@ function fish_git_prompt --description "Prompt function for Git"
                 # With just dirty, it's ~20%.
                 set -l opt -uno
                 test "$untracked" = true; and set opt -unormal
-                set -l stat (command git -c core.fsmonitor= status --porcelain -z --ignored=no $opt | string split0)
+                # Don't use `--ignored=no`; it was introduced in Git 2.16, from January 2018
+                # Ignored files are omitted by default
+                set -l stat (command git -c core.fsmonitor= status --porcelain -z $opt | string split0)
 
                 set dirtystate (string match -qr '^.[ACDMR]' -- $stat; and echo 1)
                 if test -n "$sha"


### PR DESCRIPTION
The git prompt tests are failing on CentOS 7, because it only has git 1.8. The
git prompt uses `git status --ignored=no`, which only started to work in 2.16.

This was introduced in 542a78a4c3 which has not been released, so no need to add
it to the CHANGELOG.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
