### PR TITLE
completions: include nologin in useradd/adduser shell options

### DIFF
--- a/share/completions/adduser.fish
+++ b/share/completions/adduser.fish
@@ -15,7 +15,7 @@ complete -c adduser -l gid -d 'When creating a group, force the groupid to be th
 complete -c adduser -l group -d 'Create a group'
 complete -c adduser -l help -d 'Display brief instructions'
 complete -c adduser -l home -d 'Use specified directory as the user\'s home directory' -x -a '(__fish_complete_directories)'
-complete -c adduser -l shell -d 'Use shell as the user\'s login shell, rather than the default' -x -a "(string match --regex '^[^#].*' < /etc/shells)"
+complete -c adduser -l shell -d 'Use shell as the user\'s login shell, rather than the default' -x -a "(string match --regex '^[^#].*' < /etc/shells; type -afp nologin)"
 complete -c adduser -l ingroup -d 'Add the new user to GROUP instead of a usergroup or the default group' -x -a '(cut -d : -f 1 /etc/group)'
 complete -c adduser -l no-create-home -d 'Do not create the home directory'
 complete -c adduser -l quiet -d 'Suppress informational messages, only show warnings and errors'

--- a/share/completions/useradd.fish
+++ b/share/completions/useradd.fish
@@ -19,4 +19,4 @@ complete -c useradd -s b -l base-dir -d 'The initial path prefix for a new user\
 complete -c useradd -s e -l expiredate -d 'The date on which the user account is disabled' -r
 complete -c useradd -s f -l inactive -d 'Number of days to disable account after password expiration' -r
 complete -c useradd -s g -l gid -d 'The group name or ID for a new user\'s initial group' -x -a '(string match -r "^[^#].*" < /etc/group | string split -f1,3 ":" | string join ":" | string replace -a ":" \n)'
-complete -c useradd -s s -l shell -d 'Name of the new user\'s login shell' -x -a '(string match -r "^[^#].*" < /etc/shells)'
+complete -c useradd -s s -l shell -d 'Name of the new user\'s login shell' -x -a '(string match -r "^[^#].*" < /etc/shells; type -afp nologin)'


### PR DESCRIPTION
## Description

`nologin` (located at `/usr/sbin/nologin` and/or `/sbin/nologin`) is a valid option for the login shell of a user, and it can be specified using the `-s` or `--shell` option of `useradd`, and the `--shell` option of `adduser` when creating new users.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
