### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/lockthreads.yml
+++ b/.github/workflows/lockthreads.yml
@@ -7,8 +7,14 @@ on:
 #   min 0-59 ┘ │  │ │ └ weekday 0-6
 #    hour 0-23 ┘  │ └ month 1-12
 #                 └ day 1-31
+permissions:
+  contents: read
+
 jobs:
   lock:
+    permissions:
+      issues: write  # for dessant/lock-threads to lock issues
+      pull-requests: write  # for dessant/lock-threads to lock PRs
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ env:
   CTEST_PARALLEL_LEVEL: "1"
   CMAKE_BUILD_PARALLEL_LEVEL: "4"
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu:
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
