### PR TITLE
Make doc css not depend on sphinx' css

### DIFF
--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -188,6 +188,11 @@ p.admonition-title {
   font-weight: bold;
 }
 
+div.admonition p.admonition-title + p {
+  display: inline;
+}
+
+
 div.footer {
   padding: 9px 0 9px 0;
   font-size: 75%;
@@ -197,6 +202,19 @@ th, dl.field-list > dt {
   background-color: #ede;
 }
 
+table.docutils {
+  border-collapse: collapse;
+}
+.align-default {
+  text-align: center;
+}
+
+th > :last-child, td > :last-child {
+  margin-bottom: 0px;
+}
+th > :first-child, td > :first-child {
+  margin-top: 0px;
+}
 /* End of SPHINX IMPORT */
 
 div#fmain {
@@ -302,6 +320,15 @@ ul li, div.body li {
     line-height: 2em;
 }
 
+ul.simple p {
+  /* See "special features" list on index.html */
+  margin-bottom: 0;
+}
+
+ul.simple > li:not(:first-child) > p {
+  margin-top: 0;
+}
+
 form.inline-search input,
 div.sphinxsidebar input {
     border: 1px solid #999999;
@@ -329,6 +356,10 @@ div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
     margin: 0;
     border: 0;
     padding: 0.3em 0;
+}
+
+div.body h3 {
+  font-size: 140%;
 }
 
 div.body hr {

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -95,9 +95,6 @@ div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
 
 div.body p, div.body dd, div.body li, div.body blockquote {
   text-align: justify;
-}
-
-div.body p, div.body dd, div.body li, div.body blockquote {
   -moz-hyphens: auto;
   -ms-hyphens: auto;
   -webkit-hyphens: auto;
@@ -187,61 +184,42 @@ a.headerlink {
   visibility: hidden;
 }
 
-h1:hover > a.headerlink, h2:hover > a.headerlink, h3:hover > a.headerlink, h4:hover > a.headerlink, h5:hover > a.headerlink, h6:hover > a.headerlink, dt:hover > a.headerlink, caption:hover > a.headerlink, p.caption:hover > a.headerlink, div.code-block-caption:hover > a.headerlink {
+*:hover > a.headerlink {
   visibility: visible;
 }
+
 a.headerlink:hover {
   background-color: #aaaaaa;
 }
 
-a:hover {
+a:hover, div.footer a {
   text-decoration: underline;
 }
 
-div.sphinxsidebar a {
-  color: #444444;
-}
-div.related a {
+div.related a, div.sphinxsidebar a {
   color: #444444;
 }
 
-div.sidebar::after, aside.sidebar::after, div.topic::after, div.admonition::after, blockquote::after {
-  display: block;
-  content: '';
-  clear: both;
-}
 div.warning {
   border: 1px solid #f66;
 }
+
 div.admonition {
-  margin-top: 10px;
-  margin-bottom: 10px;
   padding: 7px;
 }
-div.admonition, div.topic, blockquote {
-  clear: left;
-}
+
 p.admonition-title::after {
   content: ":";
 }
-div.admonition p {
-  margin-bottom: 5px;
-}
+
 p.admonition-title {
   display: inline;
-}
-p.admonition-title {
-  margin: 0px 10px 5px 0px;
   font-weight: bold;
 }
 
 div.footer {
   padding: 9px 0 9px 0;
   font-size: 75%;
-}
-
-div.footer a {
-  text-decoration: underline;
 }
 
 th, dl.field-list > dt {

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -1,5 +1,3 @@
-/* @import url("classic.css");
- */
 :root {
   color-scheme: light dark; /* both supported */
 }
@@ -29,6 +27,7 @@ body {
 /* SPHINX IMPORT */
 
 body {
+  /* These stay, assuming some browsers pick different defaults */
   font-size: 100%;
   background-color: #eeeefa;
   color: #000;
@@ -41,6 +40,7 @@ div.related ul {
   padding: 0 0 0 10px;
   list-style: none;
 }
+
 div.related {
   line-height: 30px;
   color: #666666;
@@ -49,10 +49,6 @@ div.related {
 
 div.related li {
   display: inline;
-}
-
-a {
-  text-decoration: none;
 }
 
 div.related h3 {
@@ -69,18 +65,8 @@ div.sphinxsidebar {
   overflow-wrap: break-word;
 }
 
-div.documentwrapper {
-  width: 100%;
-  float: none;
-}
-
-div.highlight pre, table.highlighttable pre {
-  margin: 0;
-}
-
 pre {
   padding: 5px;
-  color: unset;
   line-height: 120%;
   overflow: auto;
   overflow-y: hidden;
@@ -89,13 +75,12 @@ pre {
 div.body h1 {
   font-size: 200%;
 }
+
 div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
   font-weight: normal;
 }
 
 div.body p, div.body dd, div.body li, div.body blockquote {
-  text-align: justify;
-  -moz-hyphens: auto;
   -ms-hyphens: auto;
   -webkit-hyphens: auto;
   hyphens: auto;
@@ -104,29 +89,23 @@ div.body p, div.body dd, div.body li, div.body blockquote {
 :not(li) > ol > li:last-child > :last-child, :not(li) > ul > li:last-child > :last-child {
   margin-bottom: 0px;
 }
+
 div.sphinxsidebar ul ul {
   margin-top: 0;
   margin-bottom: 0;
 }
+
 div.sphinxsidebar ul ul, div.sphinxsidebar ul.want-points {
   margin-left: 20px;
   list-style: square;
 }
+
 div.sphinxsidebar ul {
   margin: 10px;
   padding: 0;
   color: #444444;
   margin: 10px;
-  padding: 0;
   list-style: none;
-}
-
-div.sphinxsidebar h3 {
-  font-size: 1.4em;
-  font-weight: normal;
-  margin: 0;
-    margin-top: 0px;
-  padding: 0;
 }
 
 div.sphinxsidebarwrapper {
@@ -137,32 +116,25 @@ div[class*="highlight-"] {
   margin: 1em 0;
 }
 
-dl.footnote > dt, dl.citation > dt {
-  float: left;
-  margin-right: 0.5em;
-}
-
 div.sphinxsidebar #searchbox input[type="text"] {
-    float: left;
     width: 80%;
     padding: 0.25em;
-    box-sizing: border-box;
 }
 
 div.sphinxsidebar #searchbox input[type="submit"] {
-  float: left;
   width: 20%;
-  border-left: none;
   padding: 0.25em;
-  box-sizing: border-box;
 }
 
 div.sphinxsidebar form {
   margin-top: 10px;
 }
 
-div.sphinxsidebar #searchbox form.search {
-  overflow: hidden;
+div.sphinxsidebar h3 {
+  font-size: 1.4em;
+  font-weight: normal;
+  margin: 0;
+  padding: 0;
 }
 
 div.sphinxsidebar h4 {
@@ -177,19 +149,18 @@ div.body h2 {
   font-size: 160%;
 }
 
+a {
+  text-decoration: none;
+}
+
 a.headerlink {
   font-size: 0.8em;
   padding: 0 4px 0 4px;
-  text-decoration: none;
   visibility: hidden;
 }
 
 *:hover > a.headerlink {
   visibility: visible;
-}
-
-a.headerlink:hover {
-  background-color: #aaaaaa;
 }
 
 a:hover, div.footer a {
@@ -246,7 +217,6 @@ div.related {
     padding: 0.5em 0;
     border-top: 1px solid #ccc;
     margin-top: 0;
-    background-color: inherit;
 }
 
 div.section {
@@ -309,15 +279,6 @@ div.sphinxsidebar::-webkit-scrollbar-thumb {
   border-radius: 10px;
 }
 
-div.document {
-    display: block;
-}
-
-div.document, div.body, div.warning {
-    background-color: inherit;
-    color: inherit;
-}
-
 div#searchbox {
     /* Cheesy: The padding is on the sphinxsidebar*wrapper*,
        so if this is the last element the bottom padding won't apply.
@@ -327,7 +288,6 @@ div#searchbox {
 
 div.sphinxsidebar h3, div.sphinxsidebar h4 {
     margin-top: 1em;
-    font-family: inherit;
 }
 
 div.sphinxsidebarwrapper > h3:first-child {
@@ -344,8 +304,6 @@ ul li, div.body li {
 
 form.inline-search input,
 div.sphinxsidebar input {
-    /* Inputs typically have different default fonts, remove that idea */
-    font-family: inherit;
     border: 1px solid #999999;
     font-size: smaller;
     border-radius: 3px;
@@ -371,7 +329,6 @@ div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
     margin: 0;
     border: 0;
     padding: 0.3em 0;
-    font-family: inherit;
 }
 
 div.body hr {
@@ -429,10 +386,6 @@ div.body a:hover {
     color: #00B0E4;
 }
 
-tr, pre {
-    background-color: inherit;
-}
-
 code {
     /* Make inline-code better visible */
     background-color: rgba(20,20,80, .1);
@@ -463,11 +416,6 @@ tt, code, pre, dl > dt span ~ em, #synopsis p, #synopsis code, .command {
 
 #synopsis .line {
     line-height: 1em;
-}
-
-pre, div[class*="highlight-"] {
-    /* For some reason sphinx since 3.1.2 sets "clear: both" here, which breaks in interesting ways */
-    clear: unset;
 }
 
 div.body tt {
@@ -648,14 +596,6 @@ div.body .internal.reference:link {
     font-size: 90%;
 }
 
-.sig-name {
-    font-size: unset;
-}
-
-.sig, dl.envvar {
-    font-family: unset;
-}
-
 @media (prefers-color-scheme: dark) {
     body {
         background: linear-gradient(to top, #1f1f3f 0%,#051f3a 100%);
@@ -664,11 +604,6 @@ div.body .internal.reference:link {
         color: #DDD;
         background-color: #202028;
         box-shadow: 0 0 5px 1px #000;
-    }
-
-    div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
-        background-color: inherit;
-        color: inherit;
     }
 
     div.body pre, code {
@@ -743,9 +678,5 @@ div.body .internal.reference:link {
 
     code {
         background-color: rgba(200, 200, 255, .2);
-    }
-
-    .warning code {
-        background-color: #604040;
     }
 }

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -538,6 +538,15 @@ div.bodywrapper {
     margin-left: 230px;
 }
 
+aside.footnote > .label {
+    display: inline;
+}
+
+aside.footnote > p {
+    display: inline-block;
+    line-height: 1.5em;
+}
+
 /* On screens that are less than 700px wide remove anything non-essential
    - the sidebar, the gradient background, ... */
 @media screen and (max-width: 700px) {

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -1,5 +1,5 @@
-@import url("classic.css");
-
+/* @import url("classic.css");
+ */
 :root {
   color-scheme: light dark; /* both supported */
 }
@@ -25,6 +25,230 @@ body {
     */
     font-family: "Segoe UI", system-ui, sans-serif;
 }
+
+/* SPHINX IMPORT */
+
+body {
+  font-size: 100%;
+  background-color: #eeeefa;
+  color: #000;
+  margin: 0;
+  padding: 0;
+}
+
+div.related ul {
+  margin: 0;
+  padding: 0 0 0 10px;
+  list-style: none;
+}
+div.related {
+  line-height: 30px;
+  color: #666666;
+  font-size: 90%;
+}
+
+div.related li {
+  display: inline;
+}
+
+a {
+  text-decoration: none;
+}
+
+div.related h3 {
+  display: none;
+}
+
+div.related li.right {
+  float: right;
+  margin-right: 5px;
+}
+
+div.sphinxsidebar {
+  width: 230px;
+  overflow-wrap: break-word;
+}
+
+div.documentwrapper {
+  width: 100%;
+  float: none;
+}
+
+div.highlight pre, table.highlighttable pre {
+  margin: 0;
+}
+
+pre {
+  padding: 5px;
+  color: unset;
+  line-height: 120%;
+  overflow: auto;
+  overflow-y: hidden;
+}
+
+div.body h1 {
+  font-size: 200%;
+}
+div.body h1, div.body h2, div.body h3, div.body h4, div.body h5, div.body h6 {
+  font-weight: normal;
+}
+
+div.body p, div.body dd, div.body li, div.body blockquote {
+  text-align: justify;
+}
+
+div.body p, div.body dd, div.body li, div.body blockquote {
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}
+
+:not(li) > ol > li:last-child > :last-child, :not(li) > ul > li:last-child > :last-child {
+  margin-bottom: 0px;
+}
+div.sphinxsidebar ul ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+div.sphinxsidebar ul ul, div.sphinxsidebar ul.want-points {
+  margin-left: 20px;
+  list-style: square;
+}
+div.sphinxsidebar ul {
+  margin: 10px;
+  padding: 0;
+  color: #444444;
+  margin: 10px;
+  padding: 0;
+  list-style: none;
+}
+
+div.sphinxsidebar h3 {
+  font-size: 1.4em;
+  font-weight: normal;
+  margin: 0;
+    margin-top: 0px;
+  padding: 0;
+}
+
+div.sphinxsidebarwrapper {
+  padding: 10px 5px 0 10px;
+}
+
+div[class*="highlight-"] {
+  margin: 1em 0;
+}
+
+dl.footnote > dt, dl.citation > dt {
+  float: left;
+  margin-right: 0.5em;
+}
+
+div.sphinxsidebar #searchbox input[type="text"] {
+    float: left;
+    width: 80%;
+    padding: 0.25em;
+    box-sizing: border-box;
+}
+
+div.sphinxsidebar #searchbox input[type="submit"] {
+  float: left;
+  width: 20%;
+  border-left: none;
+  padding: 0.25em;
+  box-sizing: border-box;
+}
+
+div.sphinxsidebar form {
+  margin-top: 10px;
+}
+
+div.sphinxsidebar #searchbox form.search {
+  overflow: hidden;
+}
+
+div.sphinxsidebar h4 {
+  color: #444444;
+  font-size: 1.3em;
+  font-weight: normal;
+  margin: 5px 0 0 0;
+  padding: 0;
+}
+
+div.body h2 {
+  font-size: 160%;
+}
+
+a.headerlink {
+  font-size: 0.8em;
+  padding: 0 4px 0 4px;
+  text-decoration: none;
+  visibility: hidden;
+}
+
+h1:hover > a.headerlink, h2:hover > a.headerlink, h3:hover > a.headerlink, h4:hover > a.headerlink, h5:hover > a.headerlink, h6:hover > a.headerlink, dt:hover > a.headerlink, caption:hover > a.headerlink, p.caption:hover > a.headerlink, div.code-block-caption:hover > a.headerlink {
+  visibility: visible;
+}
+a.headerlink:hover {
+  background-color: #aaaaaa;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+div.sphinxsidebar a {
+  color: #444444;
+}
+div.related a {
+  color: #444444;
+}
+
+div.sidebar::after, aside.sidebar::after, div.topic::after, div.admonition::after, blockquote::after {
+  display: block;
+  content: '';
+  clear: both;
+}
+div.warning {
+  border: 1px solid #f66;
+}
+div.admonition {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding: 7px;
+}
+div.admonition, div.topic, blockquote {
+  clear: left;
+}
+p.admonition-title::after {
+  content: ":";
+}
+div.admonition p {
+  margin-bottom: 5px;
+}
+p.admonition-title {
+  display: inline;
+}
+p.admonition-title {
+  margin: 0px 10px 5px 0px;
+  font-weight: bold;
+}
+
+div.footer {
+  padding: 9px 0 9px 0;
+  font-size: 75%;
+}
+
+div.footer a {
+  text-decoration: underline;
+}
+
+th, dl.field-list > dt {
+  background-color: #ede;
+}
+
+/* End of SPHINX IMPORT */
 
 div#fmain {
     color: #222;
@@ -107,10 +331,6 @@ div.sphinxsidebar::-webkit-scrollbar-thumb {
   border-radius: 10px;
 }
 
-div.documentwrapper {
-    float: none;
-}
-
 div.document {
     display: block;
 }
@@ -160,7 +380,9 @@ div.sphinxsidebar input[type=text] {
 div.body {
     padding: 10px 0 0 1.2em;
     min-width: 150px;
+    max-width: 800px;
 }
+
 
 div.body p {
     line-height: 2em;


### PR DESCRIPTION
This has required workarounds a few times, plus if it changes it might
break our theme. See e.g.

4712da3eb1d2324e5fc624f77d96b06eb8898930
e27456df2494a238f2a8ba18b4f71cde360daa3f
a6d484836e55a0a1aa1f04c8b59ce4461fc323f4
85522036f5edf985efa92d0127da16dcef4c300f

So we import the rules we *use* and throw away the rest. Note that
this might still have rules that are no longer necessary - e.g. some
that are required to work around sphinx bugs would still be left.

It could benefit from some cleanup and simplification, and from
switching to a flex layout instead of the 230px hardcoded
sidebar - sphinx tried that, but it doesn't really work with our
narrow layout, so we disabled it again.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
