### PR TITLE
Rebuild terlar git prompt as configuration of fish_git_prompt

### DIFF
--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -80,10 +80,8 @@ A number of variables set characters and color used as indicators. Many of these
 - ``$__fish_git_prompt_color_bare`` - the color to use for a bare repository - one without a working tree
 - ``$__fish_git_prompt_color_merging`` - the color when a merge/rebase/revert/bisect or cherry-pick is in progress
 
-Some variables are only used in some modes, like when informative status is enabled:
-
-- ``$__fish_git_prompt_char_cleanstate`` (✔) - the character to be used when nothing else applies
-- ``$__fish_git_prompt_color_cleanstate``
+- ``$__fish_git_prompt_char_cleanstate`` (✔ in informative mode) - the character to be used when nothing else applies
+- ``$__fish_git_prompt_color_cleanstate`` (no default)
 
 Variables used with ``showdirtystate``:
 

--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -115,8 +115,10 @@ Variables used with ``showupstream`` (also implied by informative status):
 
 Colors used with ``showcolorhints``:
 
-- ``$__fish_git_prompt_color_branch`` (green) - the color of the branch
+- ``$__fish_git_prompt_color_branch`` (green) - the color of the branch if nothing else applies
 - ``$__fish_git_prompt_color_branch_detached`` (red) the color of the branch if it's detached (e.g. a commit is checked out)
+- ``$__fish_git_prompt_color_branch_dirty`` (no default) the color of the branch if it's dirty and not detached
+- ``$__fish_git_prompt_color_branch_staged`` (no default) the color of the branch if it just has something staged and is otherwise clean
 - ``$__fish_git_prompt_color_flags`` (--bold blue) - the default color for dirty/staged/stashed/untracked state
 
 Note that all colors can also have a corresponding ``_done`` color. For example, the contents of ``$__fish_git_prompt_color_upstream_done`` is printed right _after_ the upstream.

--- a/share/functions/__terlar_git_prompt.fish
+++ b/share/functions/__terlar_git_prompt.fish
@@ -34,5 +34,5 @@ function __terlar_git_prompt --description 'Write out the git prompt'
     set -q __fish_git_prompt_char_stateseparator
     or set -g __fish_git_prompt_char_stateseparator '⚡'
 
-    fish_git_prompt $argv
+    fish_git_prompt '|%s'
 end

--- a/share/functions/__terlar_git_prompt.fish
+++ b/share/functions/__terlar_git_prompt.fish
@@ -1,98 +1,38 @@
-set -g fish_color_git_clean green
-set -g fish_color_git_staged yellow
-set -g fish_color_git_dirty red
-
-set -g fish_color_git_added green
-set -g fish_color_git_modified blue
-set -g fish_color_git_renamed magenta
-set -g fish_color_git_copied magenta
-set -g fish_color_git_deleted red
-set -g fish_color_git_untracked yellow
-set -g fish_color_git_unmerged red
-
-set -g fish_prompt_git_status_added '✚'
-set -g fish_prompt_git_status_modified '*'
-set -g fish_prompt_git_status_renamed '➜'
-set -g fish_prompt_git_status_copied '⇒'
-set -g fish_prompt_git_status_deleted '✖'
-set -g fish_prompt_git_status_untracked '?'
-set -g fish_prompt_git_status_unmerged !
-
-set -g fish_prompt_git_status_order added modified renamed copied deleted untracked unmerged
-
 function __terlar_git_prompt --description 'Write out the git prompt'
-    # If git isn't installed, there's nothing we can do
-    # Return 1 so the calling prompt can deal with it
-    if not command -sq git
-        return 1
-    end
-    set -l branch (git rev-parse --abbrev-ref HEAD 2>/dev/null)
-    if test -z $branch
-        return
-    end
-
-    echo -n '|'
-
-    # Ignore untracked files unless we're explicitly asked.
-    # This is dog slow.
-    set -l untr -uno
+    set -q __fish_git_prompt_showdirtystate
+    or set -g __fish_git_prompt_showdirtystate 1
     set -q __fish_git_prompt_showuntrackedfiles
-    and set untr -unormal
+    or set -g __fish_git_prompt_showuntrackedfiles 1
+    set -q __fish_git_prompt_showcolorhints
+    or set -g __fish_git_prompt_showcolorhints 1
+    set -q __fish_git_prompt_color_untrackedfiles
+    or set -g __fish_git_prompt_color_untrackedfiles yellow
+    set -q __fish_git_prompt_char_untrackedfiles
+    or set -g __fish_git_prompt_char_untrackedfiles '?'
+    set -q __fish_git_prompt_color_invalidstate
+    or set -g __fish_git_prompt_color_invalidstate red
+    set -q __fish_git_prompt_char_invalidstate
+    or set -g __fish_git_prompt_char_invalidstate '!'
+    set -q __fish_git_prompt_color_dirtystate
+    or set -g __fish_git_prompt_color_dirtystate blue
+    set -q __fish_git_prompt_char_dirtystate
+    or set -g __fish_git_prompt_char_dirtystate '*'
+    set -q __fish_git_prompt_char_stagedstate
+    or set -g __fish_git_prompt_char_stagedstate '✚'
+    set -q __fish_git_prompt_color_cleanstate
+    or set -g __fish_git_prompt_color_cleanstate green
+    set -q __fish_git_prompt_char_cleanstate
+    or set -g __fish_git_prompt_char_cleanstate '✓'
+    set -q __fish_git_prompt_color_stagedstate
+    or set -g __fish_git_prompt_color_stagedstate yellow
+    set -q __fish_git_prompt_color_branch_dirty
+    or set -g __fish_git_prompt_color_branch_dirty red
+    set -q __fish_git_prompt_color_branch_staged
+    or set -g __fish_git_prompt_color_branch_staged yellow
+    set -q __fish_git_prompt_color_branch
+    or set -g __fish_git_prompt_color_branch green
+    set -q __fish_git_prompt_char_stateseparator
+    or set -g __fish_git_prompt_char_stateseparator '⚡'
 
-    set -l index (git -c core.fsmonitor= status --porcelain 2>/dev/null|cut -c 1-2|sort -u)
-
-    if test -z "$index"
-        set_color $fish_color_git_clean
-        echo -n $branch'✓'
-        set_color normal
-        return
-    end
-
-    set -l gs
-    set -l staged
-
-    for i in $index
-        if string match -rq '^[AMRCD]' -- $i
-            set staged 1
-        end
-
-        # HACK: To allow matching a literal `??` both with and without `?` globs.
-        set -l dq '??'
-        switch $i
-            case 'A '
-                set -a gs added
-            case 'M ' ' M'
-                set -a gs modified
-            case 'R '
-                set -a gs renamed
-            case 'C '
-                set -a gs copied
-            case 'D ' ' D'
-                set -a gs deleted
-            case "$dq"
-                set -a gs untracked
-            case 'U*' '*U' DD AA
-                set -a gs unmerged
-        end
-    end
-
-    if set -q staged[1]
-        set_color $fish_color_git_staged
-    else
-        set_color $fish_color_git_dirty
-    end
-
-    echo -n $branch'⚡'
-
-    for i in $fish_prompt_git_status_order
-        if contains $i in $gs
-            set -l color_name fish_color_git_$i
-            set -l status_name fish_prompt_git_status_$i
-
-            set_color $$color_name
-            echo -n $$status_name
-        end
-    end
-
-    set_color normal
+    fish_git_prompt $argv
 end

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -331,6 +331,10 @@ function fish_git_prompt --description "Prompt function for Git"
     end
     if test -n "$b"
         set b "$branch_color$b$branch_done"
+        if test -z "$dirtystate$untrackedfiles$stagedstate"; and test -n "$___fish_git_prompt_char_cleanstate"
+            and not set -q __fish_git_prompt_show_informative_status
+            set b "$b$___fish_git_prompt_color_cleanstate$___fish_git_prompt_char_cleanstate$___fish_git_prompt_color_cleanstate_done"
+        end
     end
     if test -n "$c"
         set c "$___fish_git_prompt_color_bare$c$___fish_git_prompt_color_bare_done"
@@ -528,8 +532,11 @@ function __fish_git_prompt_set_char
 end
 
 function __fish_git_prompt_validate_chars --description "fish_git_prompt helper, checks char variables"
+    # cleanstate is only defined with actual informative status.
+    set -q __fish_git_prompt_show_informative_status
+    and __fish_git_prompt_set_char __fish_git_prompt_char_cleanstate '✔'
+    or __fish_git_prompt_set_char __fish_git_prompt_char_cleanstate ''
 
-    __fish_git_prompt_set_char __fish_git_prompt_char_cleanstate '✔'
     __fish_git_prompt_set_char __fish_git_prompt_char_dirtystate '*' '✚'
     __fish_git_prompt_set_char __fish_git_prompt_char_invalidstate '#' '✖'
     __fish_git_prompt_set_char __fish_git_prompt_char_stagedstate '+' '●'

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -299,6 +299,12 @@ function fish_git_prompt --description "Prompt function for Git"
         if test $detached = yes
             set branch_color $___fish_git_prompt_color_branch_detached
             set branch_done $___fish_git_prompt_color_branch_detached_done
+        else if test -n "$dirtystate$untrackedfiles"; and set -q __fish_git_prompt_color_branch_dirty
+            set branch_color (set_color $__fish_git_prompt_color_branch_dirty)
+            set branch_done (set_color $__fish_git_prompt_color_branch_dirty_done)
+        else if test -n "$stagedstate"; and set -q __fish_git_prompt_color_branch_staged
+            set branch_color (set_color $__fish_git_prompt_color_branch_staged)
+            set branch_done (set_color $__fish_git_prompt_color_branch_staged_done)
         end
     end
 

--- a/share/tools/web_config/sample_prompts/terlar.fish
+++ b/share/tools/web_config/sample_prompts/terlar.fish
@@ -13,8 +13,41 @@ function fish_prompt --description 'Write out the prompt'
     echo -n (prompt_pwd)
     set_color normal
 
-    __terlar_git_prompt
-    fish_hg_prompt
+    set -q __fish_git_prompt_showdirtystate
+    or set -g __fish_git_prompt_showdirtystate 1
+    set -q __fish_git_prompt_showuntrackedfiles
+    or set -g __fish_git_prompt_showuntrackedfiles 1
+    set -q __fish_git_prompt_showcolorhints
+    or set -g __fish_git_prompt_showcolorhints 1
+    set -q __fish_git_prompt_color_untrackedfiles
+    or set -g __fish_git_prompt_color_untrackedfiles yellow
+    set -q __fish_git_prompt_char_untrackedfiles
+    or set -g __fish_git_prompt_char_untrackedfiles '?'
+    set -q __fish_git_prompt_color_invalidstate
+    or set -g __fish_git_prompt_color_invalidstate red
+    set -q __fish_git_prompt_char_invalidstate
+    or set -g __fish_git_prompt_char_invalidstate '!'
+    set -q __fish_git_prompt_color_dirtystate
+    or set -g __fish_git_prompt_color_dirtystate blue
+    set -q __fish_git_prompt_char_dirtystate
+    or set -g __fish_git_prompt_char_dirtystate '*'
+    set -q __fish_git_prompt_char_stagedstate
+    or set -g __fish_git_prompt_char_stagedstate '✚'
+    set -q __fish_git_prompt_color_cleanstate
+    or set -g __fish_git_prompt_color_cleanstate green
+    set -q __fish_git_prompt_char_cleanstate
+    or set -g __fish_git_prompt_char_cleanstate '✓'
+    set -q __fish_git_prompt_color_stagedstate
+    or set -g __fish_git_prompt_color_stagedstate yellow
+    set -q __fish_git_prompt_color_branch_dirty
+    or set -g __fish_git_prompt_color_branch_dirty red
+    set -q __fish_git_prompt_color_branch_staged
+    or set -g __fish_git_prompt_color_branch_staged yellow
+    set -q __fish_git_prompt_color_branch
+    or set -g __fish_git_prompt_color_branch green
+    set -q __fish_git_prompt_char_stateseparator
+    or set -g __fish_git_prompt_char_stateseparator '⚡'
+    fish_vcs_prompt
     echo
 
     if not test $last_status -eq 0

--- a/share/tools/web_config/sample_prompts/terlar.fish
+++ b/share/tools/web_config/sample_prompts/terlar.fish
@@ -47,7 +47,7 @@ function fish_prompt --description 'Write out the prompt'
     or set -g __fish_git_prompt_color_branch green
     set -q __fish_git_prompt_char_stateseparator
     or set -g __fish_git_prompt_char_stateseparator '⚡'
-    fish_vcs_prompt
+    fish_vcs_prompt '|%s'
     echo
 
     if not test $last_status -eq 0


### PR DESCRIPTION
## Description

Rerun of #7918. This removes a second git prompt implementation that's not pulling its weight. It's slower than it needs to be.

There are some minor differences in behavior. Users who are interested in those can copy the old function.

Fixes issue #8979 

