### PR TITLE
updated function __fish_print_portage_repository_paths.fish

### DIFF
--- a/share/functions/__fish_print_portage_repository_paths.fish
+++ b/share/functions/__fish_print_portage_repository_paths.fish
@@ -6,9 +6,9 @@ function __fish_print_portage_repository_paths --description 'Print the paths of
     and set b (find $a -type f )
     test -f $a
     and set b $a
-    test -n (echo $b)
-    and string match -q "[gentoo]" (cat $b)
+    test -n "$b"
+    and string match -q "[gentoo]" -- (cat $b)
     and set c $b
     or set -a c $b
-    cat $c | string match -g -r 'location = (.*$)'
+    cat $c | string match -g -r '^location = (.*$)'
 end

--- a/share/functions/__fish_print_portage_repository_paths.fish
+++ b/share/functions/__fish_print_portage_repository_paths.fish
@@ -1,18 +1,14 @@
 function __fish_print_portage_repository_paths --description 'Print the paths of all configured repositories'
-    set a /etc/portage/repos.conf
-    set default /usr/share/portage/config/repos.conf
-    set confs
-    if test -f $a
-        set confs $a
-    else if test -d $a
-        set -p confs (find $a -type f -name '*.conf')
-        if not contains "$a/gentoo.conf" $confs
-            set -p confs $default
-        end
-    else
-        set confs $default
-    end
-    for b in $confs
-        cat $b | string match -g -r 'location = (.*$)'
-    end
+    set -l a /etc/portage/repos.conf
+    set -l b
+    set -l c /usr/share/portage/config/repos.conf
+    test -d $a
+    and set b (find $a -type f )
+    test -f $a
+    and set b $a
+    test -n (echo $b)
+    and string match -q "[gentoo]" (cat $b)
+    and set c $b
+    or set -a c $b
+    cat $c | string match -g -r 'location = (.*$)'
 end

--- a/share/functions/__fish_print_portage_repository_paths.fish
+++ b/share/functions/__fish_print_portage_repository_paths.fish
@@ -1,4 +1,18 @@
 function __fish_print_portage_repository_paths --description 'Print the paths of all configured repositories'
-    # repos.conf may be a file or a directory
-    find /etc/portage/repos.conf -type f -exec cat '{}' + | string replace -r --filter '^\s*location\s*=\s*(\S+)' '$1'
+    set a /etc/portage/repos.conf
+    set default /usr/share/portage/config/repos.conf
+    set confs
+    if test -f $a
+        set confs $a
+    else if test -d $a
+        set -p confs (find $a -type f -name '*.conf')
+        if not contains "$a/gentoo.conf" $confs
+            set -p confs $default
+        end
+    else
+        set confs $default
+    end
+    for b in $confs
+        cat $b | string match -g -r 'location = (.*$)'
+    end
 end


### PR DESCRIPTION
I've updated this function to cover the main ways repos.conf can end up and tested them on my system.

-no file or dir, so just use default
-repos.conf as a file
-repos.conf as a dir containing .conf files
-adds the default if gentoo.conf is not present

There are a couple of ways a you can have a working Portage but not get a full list of completions just like the previous version, but being off-docs or not recommended I didn't want to make the whole function about checking strings just for them.

