### PR TITLE
Show manpage for command under cursor in `__fish_man_page`

### DIFF
--- a/share/functions/__fish_man_page.fish
+++ b/share/functions/__fish_man_page.fish
@@ -1,6 +1,6 @@
 function __fish_man_page
-    # Get all commandline tokens not starting with "-"
-    set -l args (commandline -po | string match -rv '^-')
+    # Get all commandline tokens not starting with "-", up to and including the cursor's
+    set -l args (string match -rv '^-|^$' -- (commandline -cpo && commandline -t))
 
     # If commandline is empty, exit.
     if not set -q args[1]


### PR DESCRIPTION
## Description

This lets you check the manpage for a leading command by moving
the cursor over it, matching the behavior of tab complete.

It also lets you select the man page for the base of a two-part command
like `string match`.

I added the additional regex case because
`commandline -t` returns an empty string when the cursor is after a
space, e.g. at the end of 'sudo ', which the later checks don't handle.

This diagram shows the manpage picked for different cursor positions:

    > sudo -Es time git commit -m foo
      +-------++---++--++------------+
      |       ||   ||  ||            |
      |       ||   ||  |+------------+
      |       ||   ||  |  git-commit
      |       ||   |+--+
      |       ||   | git
      |       |+---+
      |       | time
      +-------+
         sudo

[![asciicast](https://asciinema.org/a/502248.svg)](https://asciinema.org/a/502248)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
