### PR TITLE
Try to use xterm{-256color,} if $TERM could not be used

### DIFF
--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -438,21 +438,24 @@ static void update_fish_color_support(const environment_t &vars) {
 }
 
 // Try to initialize the terminfo/curses subsystem using our fallback terminal name. Do not set
-// `TERM` to our fallback. We're only doing this in the hope of getting a minimally functional
+// `TERM` to our fallback. We're only doing this in the hope of getting a functional
 // shell. If we launch an external command that uses TERM it should get the same value we were
 // given, if any.
 static void initialize_curses_using_fallbacks(const environment_t &vars) {
-    const wchar_t *const fallbacks[] = {L"ansi", L"dumb"};
+    // xterm-256color is the most used terminal type by a massive margin,
+    // especially counting terminals that are mostly compatible.
+    const wchar_t *const fallbacks[] = {L"xterm-256color", L"xterm", L"ansi", L"dumb"};
 
+    wcstring termstr = L"";
     auto term_var = vars.get(L"TERM");
-    if (term_var.missing_or_empty()) {
-        return;
+    if (!term_var.missing_or_empty()) {
+        termstr = term_var->as_string();
     }
 
     for (const wchar_t *fallback : fallbacks) {
         // If $TERM is already set to the fallback name we're about to use there isn't any point in
         // seeing if the fallback name can be used.
-        if (term_var->as_string() == fallback) {
+        if (termstr == fallback) {
             continue;
         }
 


### PR DESCRIPTION
This is very very very likely to result in an almost fully functional
terminal, as opposed to a "minimally functional" one.

Xterm isn't *entirely* a superset of ansi, but where it isn't it's likely that the running terminal behaves like xterm and not like ansi.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
