### PR TITLE
Add placeholder text to silence sphinx-doc warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Other improvements
 
 For distributors
 ----------------
+- *Placeholder text*
 
 --------------
 


### PR DESCRIPTION
## Description

[100%] Building HTML documentation with Sphinx
../CHANGELOG.rst:42: ERROR: Document or section may not begin with a transition.
[100%] Built target sphinx-docs

This is essentially a duplicate of commit cd1f0cc5d  🙂

