### PR TITLE
`set --show`: Show the originally inherited value, if any

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <map>
 #include <mutex>
 #include <set>
 #include <utility>
@@ -284,6 +285,12 @@ static void setup_path() {
     }
 }
 
+static std::map<wcstring, wcstring> inheriteds;
+
+const std::map<wcstring, wcstring> &env_get_inherited() {
+    return inheriteds;
+}
+
 void env_init(const struct config_paths_t *paths, bool do_uvars, bool default_paths) {
     env_stack_t &vars = env_stack_t::principal();
     // Import environment variables. Walk backwards so that the first one out of any duplicates wins
@@ -300,9 +307,11 @@ void env_init(const struct config_paths_t *paths, bool do_uvars, bool default_pa
             if (!electric_var_t::for_name(key_and_val)) {
                 vars.set_empty(key_and_val, ENV_EXPORT | ENV_GLOBAL);
             }
+            inheriteds[key] = L"";
         } else {
             key.assign(key_and_val, 0, eql);
             val.assign(key_and_val, eql + 1, wcstring::npos);
+            inheriteds[key] = val;
             if (!electric_var_t::for_name(key)) {
                 // fish_user_paths should not be exported; attempting to re-import it from
                 // a value we previously (due to user error) exported will cause impossibly

--- a/src/env.h
+++ b/src/env.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -311,4 +312,7 @@ wcstring env_get_runtime_path();
 void setenv_lock(const char *name, const char *value, int overwrite);
 void unsetenv_lock(const char *name);
 
+/// Returns the originally inherited variables and their values.
+/// This is a simple key->value map and not e.g. cut into paths.
+const std::map<wcstring, wcstring> &env_get_inherited();
 #endif

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -719,6 +719,7 @@ set -S PWD
 #CHECK: $PWD: set in global scope, exported, with 1 elements
 #CHECK: Variable is read-only
 #CHECK: $PWD[1]: |{{.*}}|
+#CHECK: $PWD: originally inherited as |{{.*}}|
 
 set -ql history
 echo $status
@@ -913,3 +914,10 @@ set -S status
 # CHECK: Variable is read-only
 # CHECK: $status[1]: |2|
 
+# See that we show inherited variables correctly:
+foo=bar $FISH -c 'set foo 1 2 3; set --show foo'
+# CHECK: $foo: set in global scope, exported, with 3 elements
+# CHECK: $foo[1]: |1|
+# CHECK: $foo[2]: |2|
+# CHECK: $foo[3]: |3|
+# CHECK: $foo: originally inherited as |bar|


### PR DESCRIPTION
This adds a line to `set --show`s output like

```
$PATH: originally inherited as |/home/alfa/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/var/lib/flatpak/exports/bin|
```

to help with debugging.

Note that this means keeping an additional copy of the original
environment around. At most this would be one ARG_MAX's worth, which
is typically about 2M on linux and typically less elsewhere.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

This is a quick implementation that might not be ideal, I'm not sure if there isn't some better way to implement it, or if storing the entire environment is seen as too wasteful - an alternative would be to just store the variable *names* so we can say "was originally inherited" but not with what value.