### PR TITLE
scp completions: added new options

### DIFF
--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -59,9 +59,12 @@ complete -c scp -d "Remote Path" -f -n "commandline -ct | string match -e ':'" -
 "
 complete -c scp -s 3 -d "Copies between two remote hosts are transferred through the local host"
 complete -c scp -s B -d "Batch mode"
+complete -c scp -s D -x -d "Connect directly to a local SFTP server"
 complete -c scp -s l -x -d "Bandwidth limit"
+complete -c scp -s O -d "Use original SCP protocol instead of SFTP"
 complete -c scp -s P -x -d Port
 complete -c scp -s p -d "Preserves modification times, access times, and modes from the original file"
+complete -c scp -s R -d "Copies between two remote hosts are performed by executing scp on the origin host"
 complete -c scp -s r -d "Recursively copy"
 complete -c scp -s S -d "Encryption program"
 complete -c scp -s T -d "Disable strict filename checking"


### PR DESCRIPTION
## Description

Added some newer options for `scp`. Especially because recent OpenSSH uses SFTP under the hood when running `scp`. So a special option is required when the original scp protocol is required.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
