### PR TITLE
Return true consistently from all man parsers

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -318,6 +318,8 @@ class Type1ManParser(ManParser):
             options_section = options_section[options_matched.end() - 3 :]
             options_matched = re.search(options_parts_regex, options_section)
 
+        return True
+            
     def fallback(self, options_section):
         add_diagnostic("Trying fallback")
         options_parts_regex = re.compile("\.TP( \d+)?(.*?)\.TP", re.DOTALL)
@@ -423,6 +425,8 @@ class Type2ManParser(ManParser):
             options_section = options_section[options_matched.end() - 3 :]
             options_matched = re.search(options_parts_regex, options_section)
 
+        return True
+
 
 class Type3ManParser(ManParser):
     def is_my_type(self, manpage):
@@ -463,6 +467,8 @@ class Type3ManParser(ManParser):
 
             options_section = options_section[options_matched.end() - 3 :]
             options_matched = re.search(options_parts_regex, options_section)
+
+        return True
 
 
 class Type4ManParser(ManParser):
@@ -506,6 +512,8 @@ class Type4ManParser(ManParser):
 
             options_section = options_section[options_matched.end() - 3 :]
             options_matched = re.search(options_parts_regex, options_section)
+
+        return True
 
 
 class TypeScdocManParser(ManParser):


### PR DESCRIPTION
## Description

Maybe I'm missing something and this is intentional (perhaps best to leave a comment if so), but I've noticed that those few parsers don't have `return True` in the end of respective `parse_man_page` methods.

Due to that, the main loop in `parse_manpage_at_path` assumes that those parsers have failed, and keeps walking and trying to re-parse the man page with other parsers, even though the completions for all the options have been already generated.

Was this an accidental oversight or is it some sort of intentional fallthrough to augment output with results from several parsers at once?

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
