### PR TITLE
`file` completion nuances on macOS

### DIFF
--- a/share/completions/file.fish
+++ b/share/completions/file.fish
@@ -4,7 +4,14 @@ complete -c file -s b -l brief -d 'Do not prepend filenames to output lines'
 complete -c file -s c -l checking-printout -d 'Print the parsed form of the magic file'
 complete -c file -s C -l compile -d 'Write an output file containing a pre-parsed version of file'
 complete -c file -s h -l no-dereference -d 'Do not follow symlinks'
-complete -c file -s i -l mime -d 'Output mime type strings instead human readable strings'
+
+if test (uname) = Darwin
+    complete -c file -s i -d 'Do not classify regular file contents'
+    complete -c file -s I -l mime -d 'Output mime type strings instead human readable strings'
+else
+    complete -c file -s i -l mime -d 'Output mime type strings instead human readable strings'
+end
+
 complete -c file -s k -l keep-going -d 'Don\'t stop at the first match'
 complete -c file -s L -l dereference -d 'Follow symlinks'
 complete -c file -s n -l no-buffer -d 'Flush stdout after checking each file'


### PR DESCRIPTION
## Description

The `file` program coming with macOS 12.4 (21F79) has a slight difference with [vanilla version](https://man.archlinux.org/man/core/file/file.1.en#i) in that it uses uppercase `-I` for `--mime`, and `-i` was assigned another functionality:

```
     -i      If the file is a regular file, do not classify its contents.

     -I, --mime
             Causes the file command to output mime type strings rather than the more
             traditional human readable ones.  Thus it may say ‘text/plain;
             charset=us-ascii’ rather than “ASCII text”.
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
