### PR TITLE
Remove invalid trailing period in CSI u shift-space binding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Interactive improvements
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - The :kbd:`Alt-H` binding will now show the manpage of the command under cursor instead of the always skipping ``sudo`` and the likes (:issue:`9020`).
+- The :kbd:`Shift-Space` binding for CSI u now works correctly (:issue:`9054`).
 
 Improved prompts
 ^^^^^^^^^^^^^^^^

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -188,7 +188,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
         # Ctrl-space inserts space without expanding abbrs
         bind --preset $argv -k nul 'test -n "$(commandline)" && commandline -i " "'
         # Shift-space (CSI u escape sequence) behaves like space because it's easy to mistype.
-        bind --preset $argv \e\[32\;2u 'commandline -i " "; commandline -f expand-abbr'.
+        bind --preset $argv \e\[32\;2u 'commandline -i " "; commandline -f expand-abbr'
 
 
         bind --preset $argv \n execute


### PR DESCRIPTION
## Description

Removes a trailing period that resulted in the following error:

```
commandline: Unknown input function 'expand-abbr.'
(Type 'help commandline' for related documentation)
```

...when typing shift-space.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
