### PR TITLE
link to faq greeting message

### DIFF
--- a/doc_src/cmds/fish_greeting.rst
+++ b/doc_src/cmds/fish_greeting.rst
@@ -22,7 +22,7 @@ Description
 
 When an interactive fish starts, it executes fish_greeting and displays its output.
 
-The default fish_greeting is a function that prints a variable of the same name (``$fish_greeting``), so you can also just change that if you just want to change the text.
+The default fish_greeting is a function that prints a variable of the same name (``$fish_greeting``), so you can also just change that if you just want to change the text. See also the :ref:`FAQ: change greeting message <faq-fish_greeting>`
 
 While you could also just put ``echo`` calls into config.fish, fish_greeting takes care of only being used in interactive shells, so it won't be used e.g. with ``scp`` (which executes a shell), which prevents some errors.
 


### PR DESCRIPTION
I am not proficient with rst, but I think it would be helpful to link from this cmd to the faq page of the greeting. 
How do find the right :ref: attribute for the faq? couldn't find it in the faq itself. The link to docs
https://fishshell.com/docs/current/faq.html#how-do-i-change-the-greeting-message

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
