### PR TITLE
Highlight history searches correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Interactive improvements
 ------------------------
 - Cancelling an initial command via control-C no longer prevents configuration scripts from running (:issue:`9024`).
 - If the terminal definition for $TERM can't be used, fish now tries using the "xterm-256color" and "xterm" definitions before "ansi" and "dumb". As the majority of terminal emulators in common use are now more or less xterm-compatible (often even explicitly claiming the xterm-256color entry), this should often result in a fully or almost fully usable terminal (:issue:`9026`).
+- The history search text for a token search is now highlighted correctly if the line contains multiple instances of that text.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/history.h
+++ b/src/history.h
@@ -262,9 +262,6 @@ class history_search_t {
     /// If deduping, the items we've seen.
     std::unordered_set<wcstring> deduper_;
 
-    /// return whether we are case insensitive.
-    bool ignores_case() const { return flags_ & history_search_ignore_case; }
-
     /// return whether we deduplicate items.
     bool dedup() const { return !(flags_ & history_search_no_dedup); }
 
@@ -280,6 +277,9 @@ class history_search_t {
 
     /// Returns the current search result item contents. asserts if there is no current item.
     const wcstring &current_string() const;
+
+    /// return whether we are case insensitive.
+    bool ignores_case() const { return flags_ & history_search_ignore_case; }
 
     /// Construct from a history pointer; the caller is responsible for ensuring the history stays
     /// alive.

--- a/src/parse_constants.h
+++ b/src/parse_constants.h
@@ -25,6 +25,12 @@ struct source_range_t {
         assert(start + length >= start && "Overflow");
         return start + length;
     }
+
+    bool operator==(const source_range_t &rhs) const {
+        return start == rhs.start && length == rhs.length;
+    }
+
+    bool operator!=(const source_range_t &rhs) const { return !(*this == rhs); }
 };
 
 // IMPORTANT: If the following enum table is modified you must also update token_enum_map below.


### PR DESCRIPTION
## Description

Previously, the search text is used to find out which part of the updated command line should be highlighted during a history search. This approach will cause the incorrect part to be highlighted when the line contains multiple instances of the search text.

For example, if we execute:
```fish
echo hohoho
```
And type this in the command line:
```fish
echo ho
```
Then do a token search on `ho`, we get an unexpected highlight:
```fish
# Expected:
echo hohoho
     ^^
# Actual:
echo hohoho
  ^^
```
That is, the `ho` in `echo` is highlighted instead of `ho` that is the current token.

To address this, we have to find out exactly where to highlight, i.e. the offset of the current token in the command line (0 if not a token search) plus the offset of the search text in the match.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst