### PR TITLE
fix trailing comments in __fish_print_hostnames

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -8,13 +8,13 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
     # `/etc/hosts` for portability reasons.
 
     begin
-        test -r /etc/hosts && read -z </etc/hosts
+        test -r /etc/hosts && read -z </etc/hosts | string replace -r '#.*$' ''
         or type -q getent && getent hosts 2>/dev/null
     end |
-        # Ignore comments, own IP addresses (127.*, 0.0[.0[.0]], ::1), non-host IPs (fe00::*, ff00::*),
+        # Ignore own IP addresses (127.*, 0.0[.0[.0]], ::1), non-host IPs (fe00::*, ff00::*),
         # and leading/trailing whitespace. Split results on whitespace to handle multiple aliases for
         # one IP.
-        string replace -irf '^\s*?(?!(?:#|0\.|127\.|ff0|fe0|::1))\S+\s*(.*?)\s*$' '$1' |
+        string replace -irf '^\s*?(?!(?:0\.|127\.|ff0|fe0|::1))\S+\s*(.*?)\s*$' '$1' |
         string split ' '
 
     # Print nfs servers from /etc/fstab


### PR DESCRIPTION
/etc/hosts specifies, that everything after a #-character is to be
treated as a comment. The current __fish_print_hostnames however only
considers #-characters at the beginning of a line.
Thus the comment from following valid hosts-entry would end up in the
completion output:

1.2.3.4  myhost # examplecomment

getent hosts properly handles comments.

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
