### PR TITLE
Fixed problem where fish would escape '~' when completing an unescaped '['

### DIFF
--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -1435,6 +1435,8 @@ void completer_t::escape_opening_brackets(const wcstring &argument) {
     for (completion_t &comp : completions.get_list()) {
         if (comp.flags & COMPLETE_REPLACES_TOKEN) continue;
         comp.flags |= COMPLETE_REPLACES_TOKEN;
+        // if path contains tilde and the bracket is unescaped. Don't escape the tilde.
+        comp.flags |= COMPLETE_DONT_ESCAPE_TILDES;
         if (comp.flags & COMPLETE_DONT_ESCAPE) {
             // If the completion won't be escaped, we need to do it here.
             // Currently, this will probably never happen since COMPLETE_DONT_ESCAPE


### PR DESCRIPTION
## Description

 Due to the bracket special case when it comes to completion. The #4570 bug occurs when an unescaped bracket is used in the path.
For example, completing  `~/fish_bug/[` will result in `\~/fish_bug/[` this will cause fish to use an incorrect path. 
As a solution, the `COMPLETE_DONT_ESCAPE_TILDES` was used to ensure we don't escape tildes in the path while completing the unescaped bracket. 

Fixed issue #9073 .


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
