### PR TITLE
Fix NetBSD executable path to not use procfs

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1865,7 +1865,11 @@ std::string get_executable_path(const char *argv0) {
     //
     // (this is broken on NetBSD, while /proc works, so we use that)
     size_t buff_size = sizeof buff;
+    #if defined(__NetBSD__)
+    int name[] = {CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_PATHNAME};
+    #else
     int name[] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+    #endif
     int result = sysctl(name, sizeof(name) / sizeof(int), buff, &buff_size, nullptr, 0);
     if (result != 0) {
         wperror(L"sysctl KERN_PROC_PATHNAME");

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1858,12 +1858,10 @@ std::string get_executable_path(const char *argv0) {
     // https://opensource.apple.com/source/adv_cmds/adv_cmds-163/ps/print.c
     uint32_t buffSize = sizeof buff;
     if (_NSGetExecutablePath(buff, &buffSize) == 0) return std::string(buff);
-#elif defined(__BSD__) && defined(KERN_PROC_PATHNAME) && !defined(__NetBSD__)
+#elif defined(__BSD__) && defined(KERN_PROC_PATHNAME)
     // BSDs do not have /proc by default, (although it can be mounted as procfs via the Linux
     // compatibility layer). We can use sysctl instead: per sysctl(3), passing in a process ID of -1
     // returns the value for the current process.
-    //
-    // (this is broken on NetBSD, while /proc works, so we use that)
     size_t buff_size = sizeof buff;
     #if defined(__NetBSD__)
     int name[] = {CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_PATHNAME};


### PR DESCRIPTION
## Description

NetBSD can sometimes give an absolute path but with an odd period and extra slash, for example:

"/path/to/./executable"

to fix this, i would recommend using realpath, or writing your own realpath implementation based on the one NetBSD uses in its source code, but without the PATH_MAX limitation. Let me know what your thoughts are on this.