### PR TITLE
Add Control+R incremental history search in pager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Interactive improvements
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - The :kbd:`Alt-H` binding will now show the manpage of the command under cursor instead of the always skipping ``sudo`` and the likes (:issue:`9020`).
+- New special input function ``history-pager`` (:kbd:``Control-R``) opens the command history in the searchable pager (incremental search) (:issue:`602`).
 
 Improved prompts
 ^^^^^^^^^^^^^^^^

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -196,6 +196,9 @@ The following special input functions are available:
     move one word to the right; or if at the end of the commandline, accept one word
     from the current autosuggestion.
 
+``history-pager``
+    invoke the searchable pager on history (incremental search).
+
 ``history-search-backward``
     search the history for the previous match
 

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -197,7 +197,7 @@ The following special input functions are available:
     from the current autosuggestion.
 
 ``history-pager``
-    invoke the searchable pager on history (incremental search).
+    invoke the searchable pager on history (incremental search); or if the history pager is already active, search further backwards in time.
 
 ``history-search-backward``
     search the history for the previous match
@@ -252,7 +252,7 @@ The following special input functions are available:
     only execute the next function if the previous succeeded (note: only some functions report success)
 
 ``pager-toggle-search``
-    toggles the search field if the completions pager is visible.
+    toggles the search field if the completions pager is visible; or if used after ``history-pager``, search forwards in time.
 
 ``prevd-or-backward-word``
     if the commandline is empty, then move backward in the directory history, otherwise move one word to the left

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -85,8 +85,7 @@ function fish_default_key_bindings -d "emacs-like key binds"
 
     bind --preset $argv \ed kill-word
 
-    # Let ctrl+r search history if there is something in the commandline.
-    bind --preset $argv \cr 'commandline | string length -q; and commandline -f history-search-backward'
+    bind --preset $argv \cr history-pager
 
     # term-specific special bindings
     switch "$TERM"

--- a/src/complete.h
+++ b/src/complete.h
@@ -45,6 +45,8 @@ enum {
     COMPLETE_DONT_SORT = 1 << 5,
     /// This completion looks to have the same string as an existing argument.
     COMPLETE_DUPLICATES_ARGUMENT = 1 << 6,
+    /// This completes not just a token but replaces the entire commandline.
+    COMPLETE_REPLACES_COMMANDLINE = 1 << 7,
 };
 using complete_flags_t = uint8_t;
 

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3793,7 +3793,7 @@ static void test_autosuggestion_combining() {
 static void test_history_matches(history_search_t &search, const wcstring_list_t &expected,
                                  unsigned from_line) {
     wcstring_list_t found;
-    while (search.go_backwards()) {
+    while (search.go_to_next_match(history_search_direction_t::backward)) {
         found.push_back(search.current_string());
     }
     do_test_from(expected == found, from_line);

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -677,6 +677,8 @@ const history_item_t &history_search_t::current_item() const {
 
 const wcstring &history_search_t::current_string() const { return this->current_item().str(); }
 
+size_t history_search_t::current_index() const { return this->current_index_; }
+
 void history_impl_t::clear_file_state() {
     // Erase everything we know about our file.
     file_contents.reset();

--- a/src/history.h
+++ b/src/history.h
@@ -280,6 +280,9 @@ class history_search_t {
     /// Returns the current search result item contents. asserts if there is no current item.
     const wcstring &current_string() const;
 
+    /// Returns the index of the current history item.
+    size_t current_index() const;
+
     /// return whether we are case insensitive.
     bool ignores_case() const { return flags_ & history_search_ignore_case; }
 
@@ -287,8 +290,13 @@ class history_search_t {
     /// alive.
     history_search_t(history_t *hist, const wcstring &str,
                      enum history_search_type_t type = history_search_type_t::contains,
-                     history_search_flags_t flags = 0)
-        : history_(hist), orig_term_(str), canon_term_(str), search_type_(type), flags_(flags) {
+                     history_search_flags_t flags = 0, size_t starting_index = 0)
+        : history_(hist),
+          orig_term_(str),
+          canon_term_(str),
+          search_type_(type),
+          flags_(flags),
+          current_index_(starting_index) {
         if (ignores_case()) {
             std::transform(canon_term_.begin(), canon_term_.end(), canon_term_.begin(), towlower);
         }
@@ -297,8 +305,8 @@ class history_search_t {
     /// Construct from a shared_ptr. TODO: this should be the only constructor.
     history_search_t(const std::shared_ptr<history_t> &hist, const wcstring &str,
                      enum history_search_type_t type = history_search_type_t::contains,
-                     history_search_flags_t flags = 0)
-        : history_search_t(hist.get(), str, type, flags) {}
+                     history_search_flags_t flags = 0, size_t starting_index = 0)
+        : history_search_t(hist.get(), str, type, flags, starting_index) {}
 
     /** Default constructor. */
     history_search_t() = default;

--- a/src/history.h
+++ b/src/history.h
@@ -129,6 +129,8 @@ using history_item_list_t = std::deque<history_item_t>;
 
 struct history_impl_t;
 
+enum class history_search_direction_t { forward, backward };
+
 class history_t : noncopyable_t, nonmovable_t {
     friend class history_tests_t;
     struct impl_wrapper_t;
@@ -269,8 +271,8 @@ class history_search_t {
     /// Gets the original search term.
     const wcstring &original_term() const { return orig_term_; }
 
-    /// Finds the previous search result (backwards in time). Returns true if one was found.
-    bool go_backwards();
+    // Finds the next search result. Returns true if one was found.
+    bool go_to_next_match(history_search_direction_t direction);
 
     /// Returns the current search result item. asserts if there is no current item.
     const history_item_t &current_item() const;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -130,6 +130,7 @@ static constexpr const input_function_metadata_t input_function_metadata[] = {
     {L"forward-jump-till", readline_cmd_t::forward_jump_till},
     {L"forward-single-char", readline_cmd_t::forward_single_char},
     {L"forward-word", readline_cmd_t::forward_word},
+    {L"history-pager", readline_cmd_t::history_pager},
     {L"history-prefix-search-backward", readline_cmd_t::history_prefix_search_backward},
     {L"history-prefix-search-forward", readline_cmd_t::history_prefix_search_forward},
     {L"history-search-backward", readline_cmd_t::history_search_backward},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -25,6 +25,7 @@ enum class readline_cmd_t {
     history_search_forward,
     history_prefix_search_backward,
     history_prefix_search_forward,
+    history_pager,
     delete_char,
     backward_delete_char,
     kill_line,

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -377,6 +377,7 @@ void pager_t::refilter_completions() {
 }
 
 void pager_t::set_completions(const completion_list_t &raw_completions) {
+    selected_completion_idx = PAGER_SELECTION_NONE;
     // Get completion infos out of it.
     unfiltered_completion_infos = process_completions_into_infos(raw_completions);
 
@@ -498,7 +499,7 @@ bool pager_t::completion_try_print(size_t cols, const wcstring &prefix, const co
         // these are the "past the last value".
         progress_text =
             format_string(_(L"rows %lu to %lu of %lu"), start_row + 1, stop_row, row_count);
-    } else if (completion_infos.empty() && !unfiltered_completion_infos.empty()) {
+    } else if (search_field_shown && completion_infos.empty()) {
         // Everything is filtered.
         progress_text = _(L"(no matches)");
     }

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -388,6 +388,7 @@ void pager_t::set_completions(const completion_list_t &raw_completions) {
 
     // Refilter them.
     this->refilter_completions();
+    have_unrendered_completions = true;
 }
 
 void pager_t::set_prefix(const wcstring &pref) { prefix = pref; }
@@ -575,6 +576,7 @@ page_rendering_t pager_t::render() const {
 }
 
 bool pager_t::rendering_needs_update(const page_rendering_t &rendering) const {
+    if (have_unrendered_completions) return true;
     // Common case is no pager.
     if (this->empty() && rendering.screen_data.empty()) return false;
 
@@ -589,9 +591,10 @@ bool pager_t::rendering_needs_update(const page_rendering_t &rendering) const {
            (rendering.remaining_to_disclose > 0 && this->fully_disclosed);
 }
 
-void pager_t::update_rendering(page_rendering_t *rendering) const {
+void pager_t::update_rendering(page_rendering_t *rendering) {
     if (rendering_needs_update(*rendering)) {
         *rendering = this->render();
+        have_unrendered_completions = false;
     }
 }
 

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -153,7 +153,10 @@ line_t pager_t::completion_print_item(const wcstring &prefix, const comp_t *c, s
 
     highlight_role_t bg_role = modify_role(highlight_role_t::pager_background);
     highlight_spec_t bg = {highlight_role_t::normal, bg_role};
-    highlight_spec_t prefix_col = {modify_role(highlight_role_t::pager_prefix), bg_role};
+    highlight_spec_t prefix_col = {
+        modify_role(highlight_prefix ? highlight_role_t::pager_prefix
+                                     : highlight_role_t::pager_completion),
+        bg_role};
     highlight_spec_t comp_col = {modify_role(highlight_role_t::pager_completion), bg_role};
     highlight_spec_t desc_col = {modify_role(highlight_role_t::pager_description), bg_role};
 
@@ -392,7 +395,10 @@ void pager_t::set_completions(const completion_list_t &raw_completions) {
     have_unrendered_completions = true;
 }
 
-void pager_t::set_prefix(const wcstring &pref) { prefix = pref; }
+void pager_t::set_prefix(const wcstring &pref, bool highlight) {
+    prefix = pref;
+    highlight_prefix = highlight;
+}
 
 void pager_t::set_term_size(termsize_t ts) {
     available_term_width = ts.width > 0 ? ts.width : 0;
@@ -858,6 +864,7 @@ void pager_t::clear() {
     unfiltered_completion_infos.clear();
     completion_infos.clear();
     prefix.clear();
+    highlight_prefix = false;
     selected_completion_idx = PAGER_SELECTION_NONE;
     fully_disclosed = false;
     search_field_shown = false;

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -509,6 +509,12 @@ bool pager_t::completion_try_print(size_t cols, const wcstring &prefix, const co
         // Everything is filtered.
         progress_text = _(L"(no matches)");
     }
+    if (!extra_progress_text.empty()) {
+        if (!progress_text.empty()) {
+            progress_text += L". ";
+        }
+        progress_text += extra_progress_text;
+    }
 
     if (!progress_text.empty()) {
         line_t &line = rendering->screen_data.add_line();
@@ -869,6 +875,7 @@ void pager_t::clear() {
     fully_disclosed = false;
     search_field_shown = false;
     search_field_line.clear();
+    extra_progress_text.clear();
 }
 
 void pager_t::set_search_field_shown(bool flag) { this->search_field_shown = flag; }

--- a/src/pager.h
+++ b/src/pager.h
@@ -121,6 +121,7 @@ class pager_t {
     bool have_unrendered_completions = false;
 
     wcstring prefix;
+    bool highlight_prefix = false;
 
     bool completion_try_print(size_t cols, const wcstring &prefix, const comp_info_list_t &lst,
                               page_rendering_t *rendering, size_t suggested_start_row) const;
@@ -145,7 +146,7 @@ class pager_t {
     void set_completions(const completion_list_t &raw_completions);
 
     // Sets the prefix.
-    void set_prefix(const wcstring &pref);
+    void set_prefix(const wcstring &pref, bool highlight = true);
 
     // Sets the terminal size.
     void set_term_size(termsize_t ts);

--- a/src/pager.h
+++ b/src/pager.h
@@ -116,6 +116,10 @@ class pager_t {
     // The unfiltered list. Note there's a lot of duplication here.
     comp_info_list_t unfiltered_completion_infos;
 
+    // This tracks if the completion list has been changed since we last rendered. If yes,
+    // then we definitely need to re-render.
+    bool have_unrendered_completions = false;
+
     wcstring prefix;
 
     bool completion_try_print(size_t cols, const wcstring &prefix, const comp_info_list_t &lst,
@@ -167,7 +171,7 @@ class pager_t {
     bool rendering_needs_update(const page_rendering_t &rendering) const;
 
     // Updates the rendering.
-    void update_rendering(page_rendering_t *rendering) const;
+    void update_rendering(page_rendering_t *rendering);
 
     // Indicates if there are no completions, and therefore nothing to render.
     bool empty() const;

--- a/src/pager.h
+++ b/src/pager.h
@@ -142,6 +142,9 @@ class pager_t {
     // The text of the search field.
     editable_line_t search_field_line;
 
+    // Extra text to display at the bottom of the pager.
+    wcstring extra_progress_text{};
+
     // Sets the set of completions.
     void set_completions(const completion_list_t &raw_completions);
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -3741,7 +3741,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             this->history_pager_history_index_end = 0;
             // Update the pager data.
             pager.set_search_field_shown(true);
-            pager.set_prefix(L"");
+            pager.set_prefix(MB_CUR_MAX > 1 ? L"► " : L"> ", false /* highlight */);
             // Update the search field, which triggers the actual history search.
             insert_string(&pager.search_field_line, command_line.text());
             break;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -2175,8 +2175,6 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
     // Update the pager data.
     pager.set_prefix(prefix);
     pager.set_completions(surviving_completions);
-    // Invalidate our rendering.
-    current_page_rendering = page_rendering_t();
     // Modify the command line to reflect the new pager.
     pager_selection_changed();
     return false;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -335,6 +335,11 @@ void editable_line_t::end_edit_group() {
     }
 }
 
+// Make the search case-insensitive unless we have an uppercase character.
+static history_search_flags_t smartcase_flags(const wcstring &query) {
+    return query == wcstolower(query) ? history_search_ignore_case : 0;
+}
+
 namespace {
 
 /// Encapsulation of the reader's history search functionality.
@@ -506,10 +511,7 @@ class reader_history_search_t {
         match_index_ = 0;
         mode_ = mode;
         token_offset_ = token_offset;
-        history_search_flags_t flags = history_search_no_dedup;
-        // Make the search case-insensitive unless we have an uppercase character.
-        wcstring low = wcstolower(text);
-        if (low == text) flags |= history_search_ignore_case;
+        history_search_flags_t flags = history_search_no_dedup | smartcase_flags(text);
         // We can skip dedup in history_search_t because we do it ourselves in skips_.
         search_ = history_search_t(
             hist, text,

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -824,6 +824,7 @@ class reader_data_t : public std::enable_shared_from_this<reader_data_t> {
     maybe_t<char_event_t> read_normal_chars(readline_loop_state_t &rls);
     void handle_readline_command(readline_cmd_t cmd, readline_loop_state_t &rls);
 
+    void clear_pager();
     void select_completion_in_direction(selection_motion_t dir);
     void flash();
 
@@ -1904,7 +1905,7 @@ void reader_data_t::update_autosuggestion() {
 void reader_data_t::accept_autosuggestion(bool full, bool single, move_word_style_t style) {
     if (!autosuggestion.empty()) {
         // Accepting an autosuggestion clears the pager.
-        pager.clear();
+        clear_pager();
 
         // Accept the autosuggestion.
         if (full) {
@@ -1927,6 +1928,9 @@ void reader_data_t::accept_autosuggestion(bool full, bool single, move_word_styl
         }
     }
 }
+
+// Ensure we have no pager contents.
+void reader_data_t::clear_pager() { pager.clear(); }
 
 void reader_data_t::select_completion_in_direction(selection_motion_t dir) {
     bool selection_changed = pager.select_next_completion_in_direction(dir, current_page_rendering);
@@ -2810,7 +2814,7 @@ void reader_data_t::apply_commandline_state_changes() {
     if (state.text != this->command_line.text() ||
         state.cursor_pos != this->command_line.position()) {
         // The commandline builtin changed our contents.
-        this->pager.clear();
+        this->clear_pager();
         this->set_buffer_maintaining_pager(state.text, state.cursor_pos);
         this->reset_loop_state = true;
     }
@@ -3163,7 +3167,7 @@ maybe_t<char_event_t> reader_data_t::read_normal_chars(readline_loop_state_t &rl
 
         // End paging upon inserting into the normal command line.
         if (el == &command_line) {
-            pager.clear();
+            clear_pager();
         }
 
         // Since we handled a normal character, we don't have a last command.
@@ -3449,7 +3453,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
         case rl::execute: {
             // If the user hits return while navigating the pager, it only clears the pager.
             if (is_navigating_pager_contents()) {
-                pager.clear();
+                clear_pager();
                 break;
             }
 
@@ -3458,7 +3462,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
 
             // The user may have hit return with pager contents, but while not navigating them.
             // Clear the pager in that event.
-            pager.clear();
+            clear_pager();
 
             // We only execute the command line.
             editable_line_t *el = &command_line;
@@ -4074,7 +4078,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             bool ok = (c == rl::undo) ? el->undo() : el->redo();
             if (ok) {
                 if (el == &command_line) {
-                    pager.clear();
+                    clear_pager();
                 }
                 update_buff_pos(el);
                 maybe_refilter_pager(el);
@@ -4233,7 +4237,7 @@ maybe_t<wcstring> reader_data_t::readline(int nchars_or_0) {
             // Clear the pager if necessary.
             bool focused_on_search_field = (active_edit_line() == &pager.search_field_line);
             if (command_ends_paging(readline_cmd, focused_on_search_field)) {
-                pager.clear();
+                clear_pager();
             }
 
             handle_readline_command(readline_cmd, rls);
@@ -4264,7 +4268,7 @@ maybe_t<wcstring> reader_data_t::readline(int nchars_or_0) {
 
                 // End paging upon inserting into the normal command line.
                 if (el == &command_line) {
-                    pager.clear();
+                    clear_pager();
                 }
             } else {
                 // This can happen if the user presses a control char we don't recognize. No
@@ -4302,7 +4306,7 @@ maybe_t<wcstring> reader_data_t::readline(int nchars_or_0) {
         // Clear to end of screen to erase the pager contents.
         // TODO: this may fail if eos doesn't exist, in which case we should emit newlines.
         screen_force_clear_to_end();
-        pager.clear();
+        clear_pager();
     }
 
     if (s_exit_state != exit_state_t::finished_handlers) {

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -123,8 +123,6 @@ static const size_t TAB_COMPLETE_WILDCARD_MAX_EXPANSION = 256;
 /// current contents of the kill buffer.
 #define KILL_PREPEND 1
 
-enum class history_search_direction_t { forward, backward };
-
 enum class jump_direction_t { forward, backward };
 enum class jump_precision_t { till, to };
 
@@ -445,7 +443,7 @@ class reader_history_search_t {
         }
 
         // Add more items from our search.
-        while (search_.go_backwards()) {
+        while (search_.go_to_next_match(history_search_direction_t::backward)) {
             if (append_matches_from_search()) {
                 match_index_++;
                 assert(match_index_ < matches_.size() && "Should have found more matches");
@@ -1237,7 +1235,8 @@ static history_pager_result_t history_pager_search(const std::shared_ptr<history
     completion_list_t completions;
     history_search_t search{history, search_string, history_search_type_t::contains,
                             smartcase_flags(search_string)};
-    while (completions.size() < page_size && search.go_backwards()) {
+    while (completions.size() < page_size &&
+           search.go_to_next_match(history_search_direction_t::backward)) {
         const history_item_t &item = search.current_item();
         completions.push_back(completion_t{
             item.str(), L"", string_fuzzy_match_t::exact_match(),
@@ -1836,7 +1835,8 @@ static std::function<autosuggestion_t(void)> get_autosuggestion_performer(
         // Search history for a matching item.
         history_search_t searcher(history.get(), search_string, history_search_type_t::prefix,
                                   history_search_flags_t{});
-        while (!ctx.check_cancel() && searcher.go_backwards()) {
+        while (!ctx.check_cancel() &&
+               searcher.go_to_next_match(history_search_direction_t::backward)) {
             const history_item_t &item = searcher.current_item();
 
             // Skip items with newlines because they make terrible autosuggestions.


### PR DESCRIPTION
*This text is wildly outdated, please see the commit messages*

This reimplements [ridiculousfish/control_r](history-search-in-pager) which
is a more future-proof approach than #6686.

I haven't tested this much but it feels good. I wonder though if fuzzy search
(with non-chronological ordering) would be better overall.

Most commits are not very interesting, I'll reintegrate those after a fresh look.
The interesting changes are in the third-to-last and last commits.

A few differences to other shells:

1. Our pager can show multiple results at a time.
2. We use the current token as initial query. This makes it more consistent
with up-arrow search, though I wonder if this is actually useful?
3. We only replace the current token, not the entire commandline. (Does this
make sense?)
4. Other shells allow to use up arrow/down arrow to select adjacent entries
in history. Shouldn't be hard to implement but it might confuse users.
5. In other shells, pressing Return immediately runs the command.
6. We add a space after an accepted completion. This is trivial to change
but the space is harmless since it's trimmed before adding the command
to history.

The pager shows at most 10 history items at a time.  This keeps everything
snappy even with huge histories, though I'm sure there are other solutions
for that.

The UI is a bit arbitrary; we could experiment with using only one column
or allowing multiline commands in pager cells etc.

Closes #602

