### PR TITLE
Improve get executable path() Function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,10 +167,12 @@ endfunction(FISH_LINK_DEPS_AND_SIGN)
 
 # Define libfish.a.
 add_library(fishlib STATIC ${FISH_SRCS} ${FISH_BUILTIN_SRCS})
+execute_process(COMMAND sh "-c" "find /usr/lib/libkvm.a 2> /dev/null" OUTPUT_VARIABLE KVM_LIBRARY)
+string(REPLACE "\n" "" KVM_LIB "${KVM_LIBRARY}")
 target_sources(fishlib PRIVATE ${FISH_HEADERS})
 target_link_libraries(fishlib
   ${CURSES_LIBRARY} ${CURSES_EXTRA_LIBRARY} Threads::Threads ${CMAKE_DL_LIBS}
-  ${PCRE2_LIB} ${Intl_LIBRARIES} ${ATOMIC_LIBRARY})
+  ${PCRE2_LIB} ${Intl_LIBRARIES} ${ATOMIC_LIBRARY} ${KVM_LIB})
 target_include_directories(fishlib PRIVATE
   ${CURSES_INCLUDE_DIRS})
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -71,7 +71,6 @@
 
 struct termios shell_modes;
 
-extern 
 const wcstring g_empty_string{};
 
 /// This allows us to notice when we've forked.

--- a/src/wcstringutil.cpp
+++ b/src/wcstringutil.cpp
@@ -256,6 +256,20 @@ wcstring_list_t split_string(const wcstring &val, wchar_t sep) {
     return out;
 }
 
+std::vector<std::string> split_string(const std::string &val, char sep) {
+    std::vector<std::string> out;
+    size_t pos = 0, end = val.size();
+    while (pos <= end) {
+        size_t next_pos = val.find(sep, pos);
+        if (next_pos == wcstring::npos) {
+            next_pos = end;
+        }
+        out.emplace_back(val, pos, next_pos - pos);
+        pos = next_pos + 1;  // skip the separator, or skip past the end
+    }
+    return out;
+}
+
 wcstring_list_t split_string_tok(const wcstring &val, const wcstring &seps, size_t max_results) {
     wcstring_list_t out;
     size_t end = val.size();

--- a/src/wcstringutil.h
+++ b/src/wcstringutil.h
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "common.h"
 #include "expand.h"

--- a/src/wcstringutil.h
+++ b/src/wcstringutil.h
@@ -119,6 +119,7 @@ inline maybe_t<string_fuzzy_match_t> string_fuzzy_match_string(const wcstring &s
 
 /// Split a string by a separator character.
 wcstring_list_t split_string(const wcstring &val, wchar_t sep);
+std::vector<std::string> split_string(const std::string &val, char sep);
 
 /// Split a string by runs of any of the separator characters provided in \p seps.
 /// Note the delimiters are the characters in \p seps, not \p seps itself.


### PR DESCRIPTION
## Description

- macOS API _NSGetExecutablePath() can sometimes return a symbollic link; added realpath to resolve potential symlinks.
- NetBSD API sysctl() / KERN_PROC_PATHNAME can sometimes return an un-normalized path; added realpath to resolve that.
- Unlike FreeBSD, it is not documented for NetBSD, but you can use a -1 instead of getpid() for the current executable path.
- Added new fallback solution which should work on all POSIX-compliant Unix likes. OpenBSD verifies the correct dev / inode.
- Added std::string split_string() overloads.

Fixes issue #9086
