### PR TITLE
Disclose pager to half of screen height immediately

### DIFF
--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -424,9 +424,6 @@ bool pager_t::completion_try_print(size_t cols, const wcstring &prefix, const co
     size_t term_height =
         this->available_term_height - 1 -
         (search_field_shown ? 1 : 0);  // we always subtract 1 to make room for a comment row
-    if (!this->fully_disclosed) {
-        term_height = std::min(term_height, static_cast<size_t>(PAGER_UNDISCLOSED_MAX_ROWS));
-    }
 
     size_t row_count = divide_round_up(lst.size(), cols);
 

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -424,6 +424,17 @@ bool pager_t::completion_try_print(size_t cols, const wcstring &prefix, const co
     size_t term_height =
         this->available_term_height - 1 -
         (search_field_shown ? 1 : 0);  // we always subtract 1 to make room for a comment row
+    if (!this->fully_disclosed) {
+        // We disclose between half and the entirety of the terminal height,
+        // but at least 4 rows.
+        //
+        // We do this so we show a useful amount but don't force fish to
+        // THE VERY TOP, which is jarring.
+        term_height = std::min(term_height,
+                               std::max(term_height / 2,
+                                        static_cast<size_t>(PAGER_UNDISCLOSED_MAX_ROWS))
+                               );
+    }
 
     size_t row_count = divide_round_up(lst.size(), cols);
 


### PR DESCRIPTION
This removes that bit where we only show 4 rows at most at first,
instead we disclose between half and up to the full terminal height.

This results in less pressing of tab to get the other results, and
better visibility of results.

However, it also means that it'll push the shell up to the top of the
terminal a lot.

So this is an experiment to see how that works in practice.

Fixes #2698

----

The direct impetus for this is #9089, which creates up to 12 rows. In that case it feels supremely weird to have to disclose "8 more rows", when there's clearly more room.

An alternative is to increase the maximum either up to a constant, or up to half the terminal height.

----

There's some weirdness here where it doesn't *count* the pager as fully disclosed, and so pressing tab again doesn't immediately move down into it, which doesn't actually save any key presses. I'd look into it, but only after we've decided which way to go.

(also the constant here still exists and such)

---

Edit: Originally this went fullscreen immediately. That's awkward because it removes all scrollback.