### PR TITLE
Fix compile error on OpenBSD

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -648,6 +648,16 @@ void format_long_safe(wchar_t buff[64], long val) {
     }
 }
 
+void format_llong_safe(wchar_t buff[64], long long val) {
+    unsigned long long uval = absolute_value(val);
+    if (val >= 0) {
+        format_safe_impl(buff, 64, uval);
+    } else {
+        buff[0] = '-';
+        format_safe_impl(buff + 1, 63, uval);
+    }
+}
+
 void format_ullong_safe(wchar_t buff[64], unsigned long long val) {
     return format_safe_impl(buff, 64, val);
 }

--- a/src/common.h
+++ b/src/common.h
@@ -329,6 +329,7 @@ void format_size_safe(char buff[128], unsigned long long sz);
 /// Writes out a long safely.
 void format_long_safe(char buff[64], long val);
 void format_long_safe(wchar_t buff[64], long val);
+void format_llong_safe(wchar_t buff[64], long long val);
 void format_ullong_safe(wchar_t buff[64], unsigned long long val);
 
 /// "Narrows" a wide character string. This just grabs any ASCII characters and trunactes.

--- a/src/wcstringutil.h
+++ b/src/wcstringutil.h
@@ -139,6 +139,12 @@ inline wcstring to_string(long x) {
     return wcstring(buff);
 }
 
+inline wcstring to_string(long long x) {
+    wchar_t buff[64];
+    format_llong_safe(buff, x);
+    return wcstring(buff);
+}
+
 inline wcstring to_string(unsigned long long x) {
     wchar_t buff[64];
     format_ullong_safe(buff, x);


### PR DESCRIPTION
## Description

This fixes a compile error introduced with 5dfb64b5476e16c847b2a385202182b84b86b6fe on OpenBSD.

The error is:
```
fish-shell/src/builtins/path.cpp:618:41: error: call to 'to_string' is ambiguous
                path_out(streams, opts, to_string(ret.change_seconds));
                                        ^~~~~~~~~
fish-shell/src/builtins/../wcstringutil.h:136:17: note: candidate function
inline wcstring to_string(long x) {
                ^
fish-shell/src/builtins/../wcstringutil.h:142:17: note: candidate function
inline wcstring to_string(unsigned long long x) {
                ^
fish-shell/src/builtins/../wcstringutil.h:148:17: note: candidate function
inline wcstring to_string(int x) { return to_string(static_cast<long>(x)); }
                ^
fish-shell/src/builtins/../wcstringutil.h:150:17: note: candidate function
inline wcstring to_string(size_t x) { return to_string(static_cast<unsigned long long>(x)); }
                ^
fish-shell/src/builtins/path.cpp:620:41: error: call to 'to_string' is ambiguous
                path_out(streams, opts, to_string(t - ret.change_seconds));
                                        ^~~~~~~~~
fish-shell/src/builtins/../wcstringutil.h:136:17: note: candidate function
inline wcstring to_string(long x) {
                ^
fish-shell/src/builtins/../wcstringutil.h:142:17: note: candidate function
inline wcstring to_string(unsigned long long x) {
                ^
fish-shell/src/builtins/../wcstringutil.h:148:17: note: candidate function
inline wcstring to_string(int x) { return to_string(static_cast<long>(x)); }
                ^
fish-shell/src/builtins/../wcstringutil.h:150:17: note: candidate function
inline wcstring to_string(size_t x) { return to_string(static_cast<unsigned long long>(x)); }
                ^
2 errors generated.
```

The problem turned out to be that OpenBSD's `time_t` is int64_t - long long.  This fixes the error by adding  a `to_string()` long long variant.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
