### PR TITLE
Fix typo for `or` input function

### DIFF
--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -249,7 +249,7 @@ The following special input functions are available:
     or if at the end of the commandline, accept one word from the current autosuggestion.
 
 ``or``
-    only execute the next function if the previous succeeded (note: only some functions report success)
+    only execute the next function if the previous did not succeed (note: only some functions report failure)
 
 ``pager-toggle-search``
     toggles the search field if the completions pager is visible; or if used after ``history-pager``, search forwards in time.


### PR DESCRIPTION
## Description

Fix typo for `or` input function.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
