### PR TITLE
Add powershell support to suppress UNC path error

### DIFF
--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -48,7 +48,7 @@ function help --description 'Show help for the fish shell'
 
             # If we are in a graphical environment, check if there is a graphical
             # browser to use instead.
-            if test -n "$DISPLAY" -a \( "$XAUTHORITY" = "$HOME/.Xauthority" -o -z "$XAUTHORITY"\)
+            if test -n "$DISPLAY" -a \( "$XAUTHORITY" = "$HOME/.Xauthority" -o "$XAUTHORITY" = "" \)
                 for i in $graphical_browsers
                     if type -q -f $i
                         set fish_browser $i

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -89,7 +89,9 @@ function help --description 'Show help for the fish shell'
             # Try and see if powershell.exe is an option to avoid UNC path error
             # https://ss64.com/nt/cmd.html Launching CMD/batch files from a UNC path
             if type -q powershell.exe
-                set fish_browser powershell.exe
+                and set -l cmd (command -s powershell.exe cmd.exe /mnt/c/Windows/System32/cmd.exe)
+                # Use the first of these.
+                set fish_browser $cmd[1]
             end
 
             if type -q wsl-open
@@ -231,13 +233,9 @@ function help --description 'Show help for the fish shell'
     end
 
     # cmd.exe and powershell needs more coaxing.
-    if string match -qr 'cmd\.exe$' -- $fish_browser[1]
+    if string match -qr 'powershell\.exe$|cmd\.exe$' -- $fish_browser[1]
         # The space before the /c is to prevent msys2 from expanding it to a path
         $fish_browser " /c" start $page_url
-    else if string match -qr 'powershell\.exe$' -- $fish_browser[1]
-        # The space before the /c is to prevent msys2 from expanding it to a path
-        $fish_browser " /c" start $page_url
-        # If browser is known to be graphical, put into background
     else if contains -- $fish_browser[1] $graphical_browsers
         switch $fish_browser[1]
             case htmlview x-www-browser

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -86,6 +86,12 @@ function help --description 'Show help for the fish shell'
                 set fish_browser $cmd[1]
             end
 
+            # Try and see if powershell.exe is an option to avoid UNC path error
+            # https://ss64.com/nt/cmd.html Launching CMD/batch files from a UNC path
+            if type -q powershell.exe
+                set fish_browser powershell.exe
+            end
+
             if type -q wsl-open
                 set fish_browser wsl-open
             end
@@ -224,8 +230,11 @@ function help --description 'Show help for the fish shell'
         end
     end
 
-    # cmd.exe needs more coaxing.
+    # cmd.exe and powershell needs more coaxing.
     if string match -qr 'cmd\.exe$' -- $fish_browser[1]
+        # The space before the /c is to prevent msys2 from expanding it to a path
+        $fish_browser " /c" start $page_url
+    else if string match -qr 'powershell\.exe$' -- $fish_browser[1]
         # The space before the /c is to prevent msys2 from expanding it to a path
         $fish_browser " /c" start $page_url
         # If browser is known to be graphical, put into background

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -81,14 +81,6 @@ function help --description 'Show help for the fish shell'
             # like wsl-open which we'll check in a minute.
             if test -f /proc/version
                 and string match -riq 'Microsoft|WSL|MSYS|MINGW' </proc/version
-                and set -l cmd (command -s cmd.exe /mnt/c/Windows/System32/cmd.exe)
-                # Use the first of these.
-                set fish_browser $cmd[1]
-            end
-
-            # Try and see if powershell.exe is an option to avoid UNC path error
-            # https://ss64.com/nt/cmd.html Launching CMD/batch files from a UNC path
-            if type -q powershell.exe
                 and set -l cmd (command -s powershell.exe cmd.exe /mnt/c/Windows/System32/cmd.exe)
                 # Use the first of these.
                 set fish_browser $cmd[1]

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -48,7 +48,7 @@ function help --description 'Show help for the fish shell'
 
             # If we are in a graphical environment, check if there is a graphical
             # browser to use instead.
-            if test -n "$DISPLAY" -a \( "$XAUTHORITY" = "$HOME/.Xauthority" -o "$XAUTHORITY" = "" \)
+            if test -n "$DISPLAY" -a \( "$XAUTHORITY" = "$HOME/.Xauthority" -o -z "$XAUTHORITY" \)
                 for i in $graphical_browsers
                     if type -q -f $i
                         set fish_browser $i


### PR DESCRIPTION
## Description

1) Prefer using `powershell.exe` over `cmd.exe` on wsl to supress terminal error:
`CMD.EXE was started with the above path as the current directory`

Follow up to issue #6338

Before:
![image](https://user-images.githubusercontent.com/32073428/183260006-5d001faa-30fe-40b3-bc6a-75543b0b55ea.png)

After:
![image](https://user-images.githubusercontent.com/32073428/183260299-cf09936f-fe8b-4845-84c4-9438608555b3.png)


2) Add space for "-z" flag in help.fish. The new flag was causing the following error:
![image](https://user-images.githubusercontent.com/32073428/183260448-a3119dfa-5138-4f3d-8a5b-3dfac5967024.png)

Previous change that caused the `missing close paren` error linked here
https://github.com/fish-shell/fish-shell/commit/ff2999ef2bc0b416e278f0cf8e975fd77457eaa8
  
## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
