### PR TITLE
Reset the read byte limit to the default when unset

### DIFF
--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -56,6 +56,12 @@
 #include "trace.h"
 #include "wutil.h"  // IWYU pragma: keep
 
+
+// Limit `read` to 100 MiB (bytes not wide chars) by default. This can be overridden by the
+// fish_read_limit variable.
+constexpr size_t DEFAULT_READ_BYTE_LIMIT = 100 * 1024 * 1024;
+size_t read_byte_limit = DEFAULT_READ_BYTE_LIMIT;
+
 /// List of all locale environment variable names that might trigger (re)initializing the locale
 /// subsystem. These are only the variables we're possibly interested in.
 static const wcstring locale_variables[] = {
@@ -299,6 +305,8 @@ static void handle_read_limit_change(const environment_t &vars) {
         } else {
             read_byte_limit = limit;
         }
+    } else {
+        read_byte_limit = DEFAULT_READ_BYTE_LIMIT;
     }
 }
 
@@ -671,7 +679,3 @@ static void init_locale(const environment_t &vars) {
 
 /// Returns true if we think the terminal supports setting its title.
 bool term_supports_setting_title() { return can_set_term_title; }
-
-// Limit `read` to 100 MiB (bytes not wide chars) by default. This can be overridden by the
-// fish_read_limit variable.
-size_t read_byte_limit = 100 * 1024 * 1024;

--- a/tests/checks/cmdsub-limit.fish
+++ b/tests/checks/cmdsub-limit.fish
@@ -72,3 +72,15 @@ or echo expected status 122, saw $saved_status >&2
 #CHECKERR: {{.*}}: Too much data emitted by command substitution so it was discarded
 #CHECKERR: echo this will fail (string repeat --max 513 b) to output anything
 #CHECKERR:                     ^
+
+
+# Check that it's reset to the default when unset
+begin
+    set -l fish_read_limit 5
+    echo (string repeat -n 10 a)
+    # CHECKERR: {{.*}}cmdsub-limit.fish (line {{\d+}}): Too much data emitted by command substitution so it was discarded
+    # CHECKERR: echo (string repeat -n 10 a)
+    # CHECKERR: ^
+end
+echo (string repeat -n 10 a)
+# CHECK: aaaaaaaaaa


### PR DESCRIPTION
This used to be kept, so e.g. testing it with

    fish_read_limit=5 echo (string repeat -n 10 a)

would cause the prompt and such to error as well.

Also there was no good way to get back to the default value
afterwards.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
