### PR TITLE
Mark error location across the entire length

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -188,7 +188,7 @@ class token_stream_t {
             // Skip invalid tokens that have a zero length, especially if they are at EOF.
             if (subtoken_offset < result.source_length) {
                 result.source_start += subtoken_offset;
-                result.source_length -= subtoken_offset;
+                result.source_length = token.error_length;
             }
         }
 

--- a/src/parse_execution.cpp
+++ b/src/parse_execution.cpp
@@ -736,7 +736,7 @@ end_execution_reason_t parse_execution_context_t::handle_command_not_found(
         // ELOOP
         // ENAMETOOLONG
         return this->report_error(
-            STATUS_NOT_EXECUTABLE, statement,
+            STATUS_NOT_EXECUTABLE, statement.command,
             _(L"Unknown command. '%ls' exists but is not an executable file."), cmd);
     }
 
@@ -791,7 +791,7 @@ end_execution_reason_t parse_execution_context_t::handle_command_not_found(
 
     // Here we want to report an error (so it shows a backtrace).
     // If the handler printed text, that's already shown, so error will be empty.
-    return this->report_error(STATUS_CMD_UNKNOWN, statement, error.c_str());
+    return this->report_error(STATUS_CMD_UNKNOWN, statement.command, error.c_str());
 }
 
 end_execution_reason_t parse_execution_context_t::expand_command(
@@ -825,7 +825,7 @@ end_execution_reason_t parse_execution_context_t::expand_command(
     // Complain if the resulting expansion was empty, or expanded to an empty string.
     // For no-exec it's okay, as we can't really perform the expansion.
     if (out_cmd->empty() && !no_exec()) {
-        return this->report_error(STATUS_ILLEGAL_CMD, statement,
+        return this->report_error(STATUS_ILLEGAL_CMD, statement.command,
                                   _(L"The expanded command was empty."));
     }
     return end_execution_reason_t::ok;

--- a/src/parse_tree.cpp
+++ b/src/parse_tree.cpp
@@ -126,6 +126,19 @@ wcstring parse_error_t::describe_with_prefix(const wcstring &src, const wcstring
     result.push_back(L'\n');
     result.append(caret_space_line);
     result.push_back(L'^');
+    if (source_length > 1) {
+        // Add a squiggle under the error location.
+        // We do it like this
+        //               ^~~^
+        // With a "^" under the start and end, and squiggles in-between.
+        auto width = fish_wcswidth(src.c_str() + source_start, source_length);
+        if (width > 2) {
+            // Subtract one for each of the carets - this is important in case
+            // the starting char has a width of > 1.
+            result.append(width - 2, L'~');
+            result.push_back(L'^');
+        }
+    }
     return result;
 }
 

--- a/src/parse_tree.cpp
+++ b/src/parse_tree.cpp
@@ -132,7 +132,7 @@ wcstring parse_error_t::describe_with_prefix(const wcstring &src, const wcstring
         //               ^~~^
         // With a "^" under the start and end, and squiggles in-between.
         auto width = fish_wcswidth(src.c_str() + source_start, source_length);
-        if (width > 2) {
+        if (width >= 2) {
             // Subtract one for each of the carets - this is important in case
             // the starting char has a width of > 1.
             result.append(width - 2, L'~');

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -1225,7 +1225,10 @@ static bool detect_errors_in_decorated_statement(const wcstring &buff_src,
         }
 
         if (parse_errors) {
-            parse_error_offset_source_start(&new_errors, source_start);
+            // The expansion errors here go from the *command* onwards,
+            // so we need to offset them by the *command* offset,
+            // excluding the decoration.
+            parse_error_offset_source_start(&new_errors, dst.command.source_range().start);
             vec_append(*parse_errors, std::move(new_errors));
         }
     }

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -68,6 +68,7 @@ struct tok_t {
     // If an error, this is the offset of the error within the token. A value of 0 means it occurred
     // at 'offset'.
     source_offset_t error_offset_within_token{SOURCE_OFFSET_INVALID};
+    source_offset_t error_length{0};
 
     // If an error, this is the error code.
     tokenizer_error_t error{tokenizer_error_t::none};
@@ -107,7 +108,7 @@ class tokenizer_t : noncopyable_t {
     bool continue_line_after_comment{false};
 
     tok_t call_error(tokenizer_error_t error_type, const wchar_t *token_start,
-                     const wchar_t *error_loc, maybe_t<size_t> token_length = {});
+                     const wchar_t *error_loc, maybe_t<size_t> token_length = {}, size_t error_len = 0);
     tok_t read_string();
 
    public:

--- a/tests/checks/andor.fish
+++ b/tests/checks/andor.fish
@@ -4,9 +4,13 @@ set -xl LANG C # uniform quotes
 
 eval 'true | and'
 # CHECKERR: {{.*}}: The 'and' command can not be used in a pipeline
+# CHECKERR: true | and
+# CHECKERR:        ^~^
 
 eval 'true | or'
 # CHECKERR: {{.*}}: The 'or' command can not be used in a pipeline
+# CHECKERR: true | or
+# CHECKERR:        ^^
 
 # Verify and/or behavior with if and while
 if false; or true

--- a/tests/checks/basic.fish
+++ b/tests/checks/basic.fish
@@ -562,9 +562,9 @@ end
 $fish -c 'echo \xtest'
 # CHECKERR: fish: Invalid token '\xtest'
 # CHECKERR: echo \xtest
-# CHECKERR: ^
+# CHECKERR:      ^~~~~^
 
 $fish -c 'echo \utest'
 # CHECKERR: fish: Invalid token '\utest'
 # CHECKERR: echo \utest
-# CHECKERR: ^
+# CHECKERR:      ^~~~~^

--- a/tests/checks/basic.fish
+++ b/tests/checks/basic.fish
@@ -556,7 +556,7 @@ for PWD in foo bar
 end
 # CHECKERR: {{.*}}/basic.fish (line {{\d+}}): for: PWD: cannot overwrite read-only variable
 # CHECKERR: for PWD in foo bar
-# CHECKERR: ^
+# CHECKERR:     ^~^
 # XXX FIXME carat should point at PWD
 
 $fish -c 'echo \xtest'

--- a/tests/checks/broken-config.fish
+++ b/tests/checks/broken-config.fish
@@ -9,7 +9,7 @@ begin
     # CHECKERR: fish: Unknown command: syntax-error
     # CHECKERR: ~//fish/config.fish (line {{\d+}}):
     # CHECKERR: syntax-error
-    # CHECKERR: ^
+    # CHECKERR: ^~~~~~~~~~~^
     # CHECKERR: from sourcing file ~//fish/config.fish
     # CHECKERR: called during startup
 

--- a/tests/checks/cmdsub-limit.fish
+++ b/tests/checks/cmdsub-limit.fish
@@ -42,7 +42,7 @@ set --show b
 
 #CHECKERR: {{.*}}: Too much data emitted by command substitution so it was discarded
 #CHECKERR: set b (string repeat -n 512 x)
-#CHECKERR:       ^
+#CHECKERR:       ^~~~~~~~~~~~~~~~~~~~~~~^
 
 
 # Command sub over the limit should fail
@@ -53,7 +53,7 @@ set --show c
 #CHECK: $c[1]: ||
 #CHECKERR: {{.*}}: Too much data emitted by command substitution so it was discarded
 #CHECKERR:     set -l x (string repeat -n $argv x)
-#CHECKERR:              ^
+#CHECKERR:              ^~~~~~~~~~~~~~~~~~~~~~~~~^
 #CHECKERR: in function 'subme' with arguments '513'
 #CHECKERR: called on line {{.*}}
 #CHECKERR: in command substitution
@@ -71,7 +71,7 @@ or echo expected status 122, saw $saved_status >&2
 
 #CHECKERR: {{.*}}: Too much data emitted by command substitution so it was discarded
 #CHECKERR: echo this will fail (string repeat --max 513 b) to output anything
-#CHECKERR:                     ^
+#CHECKERR:                     ^~~~~~~~~~~~~~~~~~~~~~~~~~^
 
 
 # Check that it's reset to the default when unset
@@ -80,7 +80,7 @@ begin
     echo (string repeat -n 10 a)
     # CHECKERR: {{.*}}cmdsub-limit.fish (line {{\d+}}): Too much data emitted by command substitution so it was discarded
     # CHECKERR: echo (string repeat -n 10 a)
-    # CHECKERR: ^
+    # CHECKERR:      ^~~~~~~~~~~~~~~~~~~~~~^
 end
 echo (string repeat -n 10 a)
 # CHECK: aaaaaaaaaa

--- a/tests/checks/command-not-found.fish
+++ b/tests/checks/command-not-found.fish
@@ -4,22 +4,22 @@ $fish -c "nonexistent-command-1234 banana rama"
 #CHECKERR: fish: Unknown command: nonexistent-command-1234
 #CHECKERR: fish: 
 #CHECKERR: nonexistent-command-1234 banana rama
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~~~~~~~~~~~~^
 $fish -C 'function fish_command_not_found; echo cmd-not-found; end' -ic "nonexistent-command-1234 1 2 3 4"
 #CHECKERR: cmd-not-found
 #CHECKERR: fish: 
 #CHECKERR: nonexistent-command-1234 1 2 3 4
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~~~~~~~~~~~~^
 $fish -C 'function fish_command_not_found; echo command-not-found $argv; end' -c "nonexistent-command-abcd foo bar baz"
 #CHECKERR: command-not-found nonexistent-command-abcd foo bar baz
 #CHECKERR: fish: 
 #CHECKERR: nonexistent-command-abcd foo bar baz
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~~~~~~~~~~~~^
 
 $fish -C 'functions --erase fish_command_not_found' -c 'nonexistent-command apple friday'
 #CHECKERR: fish: Unknown command: nonexistent-command
 #CHECKERR: nonexistent-command apple friday
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~~~~~~~^
 
 command -v nonexistent-command-1234
 echo $status
@@ -30,14 +30,14 @@ echo $status
 # CHECKERR: {{.*}}: Unknown command: '{ echo; echo }'
 # CHECKERR: {{.*}}: '{ ... }' is not supported for grouping commands. Please use 'begin; ...; end'
 # CHECKERR: { echo; echo }
-# CHECKERR: ^
+# CHECKERR: ^~~~~~~~~~~~~^
 
 set -g PATH .
 echo banana > foobar
 foobar --banana
 # CHECKERR: checks/command-not-found.fish (line {{\d+}}): Unknown command. './foobar' exists but is not an executable file.
 # CHECKERR: foobar --banana
-# CHECKERR: ^
+# CHECKERR: ^~~~~^
 
 
 exit 0

--- a/tests/checks/eval.fish
+++ b/tests/checks/eval.fish
@@ -31,7 +31,7 @@ echo $status
 # CHECK: 123
 # CHECKERR: {{.*}}checks/eval.fish (line {{\d+}}): The expanded command was empty.
 # CHECKERR: ""
-# CHECKERR: ^
+# CHECKERR: ^^
 
 function empty
 end

--- a/tests/checks/expansion.fish
+++ b/tests/checks/expansion.fish
@@ -324,8 +324,8 @@ $fish -c 'echo {}}'
 #CHECKERR: fish: Unexpected '}' for unopened brace expansion
 #CHECKERR: echo {}}
 #CHECKERR: ^
-$fish -c 'command (asd)'
-#CHECKERR: fish: Command substitutions not allowed
-#CHECKERR: command (asd)
-#CHECKERR: ^
+printf '<%s>\n' ($fish -c 'command (asd)' 2>&1)
+#CHECK: <fish: Command substitutions not allowed>
+#CHECK: <command (asd)>
+#CHECK: <        ^~~~^>
 true

--- a/tests/checks/expansion.fish
+++ b/tests/checks/expansion.fish
@@ -329,3 +329,8 @@ printf '<%s>\n' ($fish -c 'command (asd)' 2>&1)
 #CHECK: <command (asd)>
 #CHECK: <        ^~~~^>
 true
+
+printf '<%s>\n' ($fish -c 'echo "$abc["' 2>&1)
+#CHECK: <fish: Invalid index value>
+#CHECK: <echo "$abc[">
+#CHECK: <           ^>

--- a/tests/checks/invocation.fish
+++ b/tests/checks/invocation.fish
@@ -94,3 +94,14 @@ $fish --no-config -c 'echo $$ oh no syntax error' -c 'echo this works'
 $fish --no-config .
 # CHECKERR: error: Unable to read input file: Is a directory
 # CHECKERR: warning: Error while reading file .
+
+$fish --no-config -c 'echo notprinted; echo foo; a=b'
+# CHECKERR: fish: Unsupported use of '='. In fish, please use 'set a b'.
+# CHECKERR: echo notprinted; echo foo; a=b
+# CHECKERR:                            ^~^
+
+$fish --no-config -c 'echo notprinted | and true'
+# CHECKERR: fish: The 'and' command can not be used in a pipeline
+# CHECKERR: echo notprinted | and true
+# CHECKERR:                   ^~^
+

--- a/tests/checks/invocation.fish
+++ b/tests/checks/invocation.fish
@@ -82,7 +82,7 @@ and echo matched
 $fish --no-config -c 'echo notprinted; echo foo | exec true; echo banana'
 # CHECKERR: fish: The 'exec' command can not be used in a pipeline
 # CHECKERR: echo notprinted; echo foo | exec true; echo banana
-# CHECKERR: ^
+# CHECKERR:                             ^~~~~~~~^
 
 # Running multiple command lists continues even if one has a syntax error.
 $fish --no-config -c 'echo $$ oh no syntax error' -c 'echo this works'

--- a/tests/checks/loops.fish
+++ b/tests/checks/loops.fish
@@ -109,8 +109,7 @@ for status in a b c
 end
 #CHECKERR: {{.*}}loops.fish (line {{\d+}}): for: status: cannot overwrite read-only variable
 #CHECKERR: for status in a b c
-#CHECKERR: ^
-# XXX FIXME this should point at `status`
+#CHECKERR:     ^~~~~^
 
 # "That goes for non-electric ones as well (#5548)"
 for hostname in a b c
@@ -118,8 +117,7 @@ for hostname in a b c
 end
 #CHECKERR: {{.*}}loops.fish (line {{\d+}}): for: hostname: cannot overwrite read-only variable
 #CHECKERR: for hostname in a b c
-#CHECKERR: ^
-# XXX FIXME this should point at `for`
+#CHECKERR:     ^~~~~~~^
 
 # For loop control vars available outside the for block
 begin

--- a/tests/checks/no-execute.fish
+++ b/tests/checks/no-execute.fish
@@ -19,7 +19,7 @@ echo $status
 echo "begin; echo oops" | $fish -n
 #CHECKERR: fish: Missing end to balance this begin
 #CHECKERR: begin; echo oops
-#CHECKERR: ^
+#CHECKERR: ^~~~^
 echo $status
 #CHECK: 127
 

--- a/tests/checks/redirect.fish
+++ b/tests/checks/redirect.fish
@@ -32,7 +32,7 @@ echo noclobber &>>?$tmpdir/file.txt
 eval "echo foo |& false"
 #CHECKERR: {{.*}} |& is not valid. In fish, use &| to pipe both stdout and stderr.
 #CHECKERR: echo foo |& false
-#CHECKERR:          ^
+#CHECKERR:          ^^
 
 # Ensure that redirection empty data still creates the file.
 rm -f $tmpdir/file.txt

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -473,7 +473,7 @@ for a,b in y 1 z 3
 end
 # CHECKERR: {{.*}} for: a,b: invalid variable name. See `help identifiers`
 # CHECKERR: for a,b in y 1 z 3
-# CHECKERR:     ^
+# CHECKERR:     ^~^
 
 # Global vs Universal Unspecified Scopes
 set -U __fish_test_global_vs_universal universal

--- a/tests/checks/status-value.fish
+++ b/tests/checks/status-value.fish
@@ -23,4 +23,4 @@ echo $status
 # CHECK: 124
 # CHECKERR: {{.*}} No matches for wildcard '*gibberishgibberishgibberish*'. {{.*}}
 # CHECKERR: echo *gibberishgibberishgibberish*
-# CHECKERR:      ^
+# CHECKERR:      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~^

--- a/tests/checks/status-value.fish
+++ b/tests/checks/status-value.fish
@@ -7,7 +7,7 @@ echo $status
 # CHECK: 123
 # CHECKERR: {{.*}} The expanded command was empty.
 # CHECKERR: $empty_var
-# CHECKERR: ^
+# CHECKERR: ^~~~~~~~~^
 
 # Failed expansions
 echo "$abc["

--- a/tests/checks/status-value.fish
+++ b/tests/checks/status-value.fish
@@ -15,7 +15,7 @@ echo $status
 # CHECK: 121
 # CHECKERR: {{.*}} Invalid index value
 # CHECKERR: echo "$abc["
-# CHECKERR:             ^
+# CHECKERR:            ^
 
 # Failed wildcards
 echo *gibberishgibberishgibberish*

--- a/tests/checks/switch.fish
+++ b/tests/checks/switch.fish
@@ -50,7 +50,7 @@ end
 #CHECKERR: {{.*/?}}switch.fish (line {{\d+}}): switch: Expected at most one argument, got 3
 #CHECKERR:
 #CHECKERR: switch (echo; echo; echo)
-#CHECKERR:       ^
+#CHECKERR:        ^~~~~~~~~~~~~~~~~^
 
 # As is no argument at all.
 # Because this is a syntax error, we need to start a sub-fish or we wouldn't execute anything else.
@@ -68,7 +68,7 @@ end
 '
 #CHECKERR: fish: 'case' builtin not inside of switch block
 #CHECKERR:      case a
-#CHECKERR:           ^
+#CHECKERR:      ^~~^
 
 set smurf green
 
@@ -90,7 +90,7 @@ switch $smurf
 end
 #CHECKERR: {{.*}}switch.fish (line {{\d+}}): No matches for wildcard '*ee*'. See `help wildcards-globbing`.
 #CHECKERR: case *ee*
-#CHECKERR: ^
+#CHECKERR:      ^~~^
 #CHECK: Test 2 pass
 
 switch $smurf
@@ -110,10 +110,10 @@ begin
     # CHECKERR: fish: Unknown command: doesnotexist
     # CHECKERR: checks/switch.fish (line {{\d+}}):
     # CHECKERR: doesnotexist
-    # CHECKERR: ^
+    # CHECKERR: ^~~~~~~~~~~^
     # CHECKERR: in command substitution
     # CHECKERR: {{\t}}called on line {{\d+}} of file checks/switch.fish
     # CHECKERR: checks/switch.fish (line {{\d+}}): Unknown command
     # CHECKERR: switch (doesnotexist)
-    # CHECKERR: ^
+    # CHECKERR:        ^~~~~~~~~~~~~^
 end

--- a/tests/checks/syntax-error-location.fish
+++ b/tests/checks/syntax-error-location.fish
@@ -27,7 +27,7 @@ echo '
 
 # CHECK: <fish: Command substitutions not allowed>
 # CHECK: <(true one)>
-# CHECK: <^>
+# CHECK: <^~~~~~~~~^>
 
 $fish -c 'echo "unfinished "(subshell' 2>| string replace -r '.*' '<$0>'
 # CHECK: <fish: Unexpected end of string, expecting ')'>
@@ -48,10 +48,10 @@ echo "function this_should_be_an_error" >$TMPDIR/this_should_be_an_error.fish
 $fish -c "set -g fish_function_path $(string escape $TMPDIR); this_should_be_an_error"
 # CHECKERR: ~/temp/this_should_be_an_error.fish (line 1): Missing end to balance this function definition
 # CHECKERR: function this_should_be_an_error
-# CHECKERR: ^
+# CHECKERR: ^~~~~~~^
 # CHECKERR: from sourcing file ~/temp/this_should_be_an_error.fish
 # CHECKERR: source: Error while reading file '{{.*}}/this_should_be_an_error.fish'
 # CHECKERR: fish: Unknown command: this_should_be_an_error
 # CHECKERR: fish:
 # CHECKERR: set -g fish_function_path {{.*}}; this_should_be_an_error
-# CHECKERR: ^
+# CHECKERR:                                   ^~~~~~~~~~~~~~~~~~~~~~^

--- a/tests/checks/syntax-error-location.fish
+++ b/tests/checks/syntax-error-location.fish
@@ -9,12 +9,12 @@ $status
 
 # CHECK: <fish: The 'exec' command can not be used in a pipeline>
 # CHECK: <echo foo | exec grep # this exec is not allowed!>
-# CHECK: <           ^>
+# CHECK: <           ^~~~~~~~^>
 
 echo 'true | time false' | $fish 2>| string replace -r '(.*)' '<$1>'
 # CHECK: <fish: The 'time' command may only be at the beginning of a pipeline>
 # CHECK: <true | time false>
-# CHECK: <       ^>
+# CHECK: <       ^~~~~~~~~^>
 
 
 echo '
@@ -42,7 +42,7 @@ $fish -c 'echo "unfinished "$(subshell' 2>| string replace -r '.*' '<$0>'
 $fish -c 'echo "ok $(echo still ok)syntax error: \x"' 2>| string replace -r '.*' '<$0>'
 # CHECK: <fish: Invalid token '"ok $(echo still ok)syntax error: \x"'>
 # CHECK: <echo "ok $(echo still ok)syntax error: \x">
-# CHECK: <                         ^>
+# CHECK: <                         ^~~~~~~~~~~~~~~~^>
 
 echo "function this_should_be_an_error" >$TMPDIR/this_should_be_an_error.fish
 $fish -c "set -g fish_function_path $(string escape $TMPDIR); this_should_be_an_error"

--- a/tests/checks/time.fish
+++ b/tests/checks/time.fish
@@ -41,7 +41,7 @@ not time true
 $fish -c 'time true&'
 #CHECKERR: fish: {{.*}}
 #CHECKERR: time true&
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~^
 
 $fish -c 'not time true&'
 #CHECKERR: fish: {{.*}}

--- a/tests/checks/time.fish
+++ b/tests/checks/time.fish
@@ -46,4 +46,5 @@ $fish -c 'time true&'
 $fish -c 'not time true&'
 #CHECKERR: fish: {{.*}}
 #CHECKERR: not time true&
-#CHECKERR: ^
+#FIXME: This error marks the entire statement. Would be cool to mark just `time true&`.
+#CHECKERR: ^~~~~~~~~~~~~^

--- a/tests/checks/variable-assignment.fish
+++ b/tests/checks/variable-assignment.fish
@@ -87,10 +87,16 @@ complete -C'a=b envxalias '
 # Eval invalid grammar to allow fish to parse this file
 eval 'a=(echo b)'
 # CHECKERR: {{.*}}: Unsupported use of '='. In fish, please use 'set a (echo b)'.
+# CHECKERR: a=(echo b)
+# CHECKERR: ^~~~~~~~~^
 eval ': | a=b'
 # CHECKERR: {{.*}}: Unsupported use of '='. In fish, please use 'set a b'.
+# CHECKERR: : | a=b
+# CHECKERR:     ^~^
 eval 'not a=b'
 # CHECKERR: {{.*}}: Unsupported use of '='. In fish, please use 'set a b'.
+# CHECKERR: not a=b
+# CHECKERR:     ^~^
 
 complete -c foo -xa '$a'
 a=b complete -C'foo '

--- a/tests/checks/vars_as_commands.fish
+++ b/tests/checks/vars_as_commands.fish
@@ -4,11 +4,11 @@
 $EMPTY_VARIABLE
 #CHECKERR: {{.*}}checks/vars_as_commands.fish (line {{\d+}}): The expanded command was empty.
 #CHECKERR: $EMPTY_VARIABLE
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~~~^
 "$EMPTY_VARIABLE"
 #CHECKERR: {{.*}}checks/vars_as_commands.fish (line {{\d+}}): The expanded command was empty.
 #CHECKERR: "$EMPTY_VARIABLE"
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~~~~~^
 
 set CMD1 echo basic command as variable
 $CMD1

--- a/tests/checks/vars_as_commands.fish
+++ b/tests/checks/vars_as_commands.fish
@@ -32,17 +32,17 @@ $CMD3 && echo $PWD
 echo 'if $status; echo foo; end' | $fish --no-config
 #CHECKERR: fish: $status is not valid as a command. See `help conditions`
 #CHECKERR: if $status; echo foo; end
-#CHECKERR: ^
+#CHECKERR:    ^~~~~~^
 echo 'not $status' | $fish --no-config
 #CHECKERR: fish: $status is not valid as a command. See `help conditions`
 #CHECKERR: not $status
-#CHECKERR: ^
+#CHECKERR:     ^~~~~~^
 
 # Script doesn't run at all.
 echo 'echo foo; and $status' | $fish --no-config
 #CHECKERR: fish: $status is not valid as a command. See `help conditions`
 #CHECKERR: echo foo; and $status
-#CHECKERR: ^
+#CHECKERR:               ^~~~~~^
 
 echo 'set -l status_cmd true; if $status_cmd; echo Heck yes this is true; end' | $fish --no-config
 #CHECK: Heck yes this is true

--- a/tests/checks/vars_as_commands.fish
+++ b/tests/checks/vars_as_commands.fish
@@ -47,4 +47,9 @@ echo 'echo foo; and $status' | $fish --no-config
 echo 'set -l status_cmd true; if $status_cmd; echo Heck yes this is true; end' | $fish --no-config
 #CHECK: Heck yes this is true
 
+foo=bar $NONEXISTENT -c 'set foo 1 2 3; set --show foo'
+#CHECKERR: {{.*}}checks/vars_as_commands.fish (line {{\d+}}): The expanded command was empty.
+#CHECKERR: foo=bar $NONEXISTENT -c 'set foo 1 2 3; set --show foo'
+#CHECKERR:         ^~~~~~~~~~~^
+
 exit 0


### PR DESCRIPTION
## Description

We currently only mark the start of errors with a `^` caret. This changes it so that we mark the start and end with a caret, with a run of `~` tildes in between.

That makes it easier to see the extent of the erroneous syntax, and is familiar from e.g. gcc.

The output looks like

```
checks/set.fish (line 471): for: a,b: invalid variable name. See `help identifiers`
    for a,b in y 1 z 3
        ^~^

checks/cmdsub-limit.fish (line 67): Too much data emitted by command substitution so it was discarded
    echo this will fail (string repeat --max 513 b) to output anything
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~^
```

Note that this exposes the error location in a way that it wasn't before, so it's likely to shake out mistakes and weirdnesses. This is why I've elected to keep the tests broken for now, so we can easily see what's changed and what needs improvement.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
