### PR TITLE
Highlight shell commands in history pager

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -148,7 +148,9 @@ enum {
     /// string.
     ESCAPE_NO_QUOTED = 1 << 1,
     /// Do not escape tildes.
-    ESCAPE_NO_TILDE = 1 << 2
+    ESCAPE_NO_TILDE = 1 << 2,
+    /// Replace nonprintable control characters with Unicode symbols.
+    ESCAPE_SYMBOLIC = 1 << 3
 };
 typedef unsigned int escape_flags_t;
 

--- a/src/complete.h
+++ b/src/complete.h
@@ -88,6 +88,9 @@ class completion_t {
     /// \return whether this replaces its token.
     bool replaces_token() const { return flags & COMPLETE_REPLACES_TOKEN; }
 
+    /// \return whether this replaces the entire commandline.
+    bool replaces_commandline() const { return flags & COMPLETE_REPLACES_COMMANDLINE; }
+
     /// \return the completion's match rank. Lower ranks are better completions.
     uint32_t rank() const { return match.rank(); }
 

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -313,8 +313,8 @@ static comp_info_list_t process_completions_into_infos(const completion_list_t &
         comp_t *comp_info = &result.at(i);
 
         // Append the single completion string. We may later merge these into multiple.
-        comp_info->comp.push_back(
-            escape_string(comp.completion, ESCAPE_NO_PRINTABLES | ESCAPE_NO_QUOTED));
+        comp_info->comp.push_back(escape_string(
+            comp.completion, ESCAPE_NO_PRINTABLES | ESCAPE_NO_QUOTED | ESCAPE_SYMBOLIC));
 
         // Append the mangled description.
         comp_info->desc = comp.description;

--- a/src/pager.h
+++ b/src/pager.h
@@ -61,6 +61,8 @@ enum class selection_motion_t {
 // How many rows we will show in the "initial" pager.
 #define PAGER_UNDISCLOSED_MAX_ROWS 4
 
+struct highlight_spec_t;
+
 class pager_t {
     size_t available_term_width{0};
     size_t available_term_height{0};
@@ -87,6 +89,8 @@ class pager_t {
         wcstring desc{};
         /// The representative completion.
         completion_t representative{L""};
+        /// The per-character highlighting, used when this is a full shell command.
+        std::vector<highlight_spec_t> colors{};
         /// On-screen width of the completion string.
         size_t comp_width{0};
         /// On-screen width of the description information.


### PR DESCRIPTION
To make this work correctly for multiline commands,  use Unicode symbols
for rendering control characters. For example, the command

	begin
	    echo 123
	end

used to be rendered as

	begin\necho 123\nend

which means we can't use the highlighting of the original command, because
\n has turned into two characters.
This proposed fix just turns \n into a single character, then we can reuse
the same highlighting info for the rendered string.
