### PR TITLE
help: Handle the missing builtin aliases : and [

### DIFF
--- a/doc_src/cmds/true.rst
+++ b/doc_src/cmds/true.rst
@@ -15,6 +15,8 @@ Description
 
 ``true`` sets the exit status to 0.
 
+**:** (a single colon) is an alias for the ``true`` command.
+
 See Also
 --------
 

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -127,6 +127,10 @@ function help --description 'Show help for the fish shell'
     switch "$fish_help_item"
         case "."
             set fish_help_page "cmds/source.html"
+        case ":"
+            set fish_help_page "cmds/true.html"
+        case "["
+            set fish_help_page "cmds/test.html"
         case globbing
             set fish_help_page "language.html#expand"
         case 'completion-*'


### PR DESCRIPTION
## Description

When executing `help :` or `help [`, the opened web page does not exist.
These two should open the corresponding builtin pages.

Do you know why `.` is not listed when auto-completing builtin (`builtin <TAB>`)?

Thanks.

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
