### PR TITLE
Erase __fish_config_interactive after we run it. 

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -4,17 +4,11 @@
 # This function is called by the __fish_on_interactive function, which is defined in config.fish.
 #
 function __fish_config_interactive -d "Initializations that should be performed when entering interactive mode"
-    # Make sure this function is only run once.
-    if set -q __fish_config_interactive_done
-        return
-    end
-
     # For one-off upgrades of the fish version
     if not set -q __fish_initialized
         set -U __fish_initialized 0
     end
 
-    set -g __fish_config_interactive_done
     set -g __fish_active_key_bindings
 
     # usage: __init_uvar VARIABLE VALUES...
@@ -284,4 +278,6 @@ end" >$__fish_config_dir/config.fish
     # Bump this whenever some code below needs to run once when upgrading to a new version.
     # The universal variable __fish_initialized is initialized in share/config.fish.
     set __fish_initialized 3400
+
+    functions -e __fish_config_interactive
 end


### PR DESCRIPTION
From my experience, the biggest thing that takes up memory per fish instance, that really varies is the parsed_source and wcstrings for functions we have loaded. I curiously went looking for some of our bigger functions:

```
$ for fn in (functions -na); printf "%d %s\n" (functions $fn |wc -c) $fn; end|sort -h|tail -n10
6843 __fish_git_prompt_show_upstream
7324 history
8179 fish_git_prompt
10250 __fish_shared_key_bindings
12279 fish_config
12802 __fish_config_interactive
14747 help
15765 fish_vi_key_bindings
19275 __fish_git_files
37448 __fish_complete_gpg
```
__fish_config_interactive is something *everyone* autoloads, and is somewhat unique in that it actually has a mechanism already to make sure it's never ran more than once, so I **think** it's safe to just yeet it when it's done, but I'm making this PR to check if this might break something I haven't thought of.

12802 * 4 = 51K per fish process. Not like astronomical or anything but it's a little something.