### PR TITLE
Add missing completions for builtins

### DIFF
--- a/share/completions/builtin.fish
+++ b/share/completions/builtin.fish
@@ -1,4 +1,5 @@
 complete -c builtin -n 'test (count (commandline -opc)) -eq 1' -s h -l help -d 'Display help and exit'
 complete -c builtin -n 'test (count (commandline -opc)) -eq 1' -s n -l names -d 'Print names of all existing builtins'
+complete -c builtin -n 'test (count (commandline -opc)) -eq 1' -s q -l query -d 'Tests if builtin exists'
 complete -c builtin -n 'test (count (commandline -opc)) -eq 1' -xa '(builtin -n)'
 complete -c builtin -n 'test (count (commandline -opc)) -ge 2' -xa '(__fish_complete_subcommand)'

--- a/share/completions/command.fish
+++ b/share/completions/command.fish
@@ -1,5 +1,5 @@
 complete -c command -n 'test (count (commandline -opc)) -eq 1' -s h -l help -d 'Display help and exit'
 complete -c command -n 'test (count (commandline -opc)) -eq 1' -s a -l all -d 'Print all external commands by the given name'
 complete -c command -n 'test (count (commandline -opc)) -eq 1' -s q -l quiet -l query -d 'Do not print anything, only set exit status'
-complete -c command -n 'test (count (commandline -opc)) -eq 1' -s s -l search -d 'Print the file that would be executed'
+complete -c command -n 'test (count (commandline -opc)) -eq 1' -s s -s v -l search -d 'Print the file that would be executed'
 complete -c command -xa "(__fish_complete_subcommand)"

--- a/share/completions/contains.fish
+++ b/share/completions/contains.fish
@@ -1,0 +1,2 @@
+complete -c contains -s h -l help -d "Display help"
+complete -c contains -s i -l index -d "Print index of first match"

--- a/share/completions/contains.fish
+++ b/share/completions/contains.fish
@@ -1,2 +1,2 @@
-complete -c contains -s h -l help -d "Display help"
+complete -c contains -s h -l help -d "Display help and exit"
 complete -c contains -s i -l index -d "Print index of first match"

--- a/share/completions/disown.fish
+++ b/share/completions/disown.fish
@@ -1,0 +1,1 @@
+complete -c disown -s h -l help -d "Display help"

--- a/share/completions/disown.fish
+++ b/share/completions/disown.fish
@@ -1,1 +1,1 @@
-complete -c disown -s h -l help -d "Display help"
+complete -c disown -s h -l help -d "Display help and exit"

--- a/share/completions/emit.fish
+++ b/share/completions/emit.fish
@@ -1,1 +1,1 @@
-complete -c emit -s h -l help -d "Display help"
+complete -c emit -s h -l help -d "Display help and exit"

--- a/share/completions/emit.fish
+++ b/share/completions/emit.fish
@@ -1,0 +1,1 @@
+complete -c emit -s h -l help -d "Display help"

--- a/share/completions/pwd.fish
+++ b/share/completions/pwd.fish
@@ -1,0 +1,3 @@
+complete -c pwd -s h -l help -d "Display help"
+complete -c pwd -s L -l logical -d "Print working directory without resolving symlinks"
+complete -c pwd -s P -l physical -d "Print working directory with symlinks resolved"

--- a/share/completions/pwd.fish
+++ b/share/completions/pwd.fish
@@ -1,3 +1,3 @@
-complete -c pwd -s h -l help -d "Display help"
+complete -c pwd -s h -l help -d "Display help and exit"
 complete -c pwd -s L -l logical -d "Print working directory without resolving symlinks"
 complete -c pwd -s P -l physical -d "Print working directory with symlinks resolved"

--- a/share/completions/status.fish
+++ b/share/completions/status.fish
@@ -1,36 +1,34 @@
 # Note that when a completion file is sourced a new block scope is created so `set -l` works.
-set -l __fish_status_all_commands current-command current-filename current-function current-line-number features filename fish-path function is-block is-breakpoint is-command-substitution is-full-job-control is-interactive is-interactive-job-control is-login is-no-job-control job-control line-number print-stack-trace stack-trace test-feature
+set -l __fish_status_all_commands basename current-command {,--}current-filename current-function {,--}current-line-number dirname features filename fish-path function {,--}is-block is-breakpoint {,--}is-command-substitution {,--}is-full-job-control {,--}is-interactive {,--}is-interactive-job-control {,--}is-login {,--}is-no-job-control {,--}job-control line-number {,--}print-stack-trace stack-trace test-feature -b -c -f -h -i -j -l -n -t
 
 # These are the recognized flags.
 complete -c status -s h -l help -d "Display help and exit"
 
 # The "is-something" subcommands.
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-login -d "Test if this is a login shell"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-interactive -d "Test if this is an interactive shell"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-command-substitution -d "Test if a command substitution is currently evaluated"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-block -d "Test if a code block is currently evaluated"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "is-login -l --is-login" -d "Test if this is a login shell"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "is-interactive -i --is-interactive" -d "Test if this is an interactive shell"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "is-command-substitution -c --is-command-substitution" -d "Test if a command substitution is currently evaluated"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "is-block -b --is-block" -d "Test if a code block is currently evaluated"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-breakpoint -d "Test if a breakpoint is currently in effect"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-no-job-control -d "Test if new jobs are never put under job control"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-interactive-job-control -d "Test if only interactive new jobs are put under job control"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-full-job-control -d "Test if all new jobs are put under job control"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "is-no-job-control --is-no-job-control" -d "Test if new jobs are never put under job control"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "is-interactive-job-control --is-interactive-job-control" -d "Test if only interactive new jobs are put under job control"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "is-full-job-control --is-full-job-control" -d "Test if all new jobs are put under job control"
 
 # The subcommands that are not "is-something" which don't change the fish state.
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a current-command -d "Print the name of the currently running command or function"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a current-filename -d "Print the filename of the currently running script"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a filename -d "Print the filename of the currently running script"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a current-function -d "Print the name of the current function"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a function -d "Print the name of the current function"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a current-line-number -d "Print the line number of the currently running script"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a line-number -d "Print the line number of the currently running script"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a print-stack-trace -d "Print a list of all function calls leading up to running the current command"
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a stack-trace -d "Print a list of all function calls leading up to running the current command"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "filename current-filename -f --current-filename" -d "Print the filename of the currently running script"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a basename -d "Print filename of running script without parent directories"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a dirname -d "Print path to running script without filename"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "function current-function" -d "Print the name of the current function"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "line-number current-line-number -n --current-line-number" -d "Print the line number of the currently running script"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "stack-trace print-stack-trace -t --print-stack-trace" -d "Print a list of all function calls leading up to running the current command"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a features -d "List all feature flags"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a test-feature -d "Test if a feature flag is enabled"
-complete -f -c status -n "__fish_seen_subcommand_from test-feature" -a '(status features | sed "s/\s\+\S*\s\+\S*/\t/")'
+complete -f -c status -n "__fish_seen_subcommand_from test-feature" -a '(status features | string split -f 1 " ")'
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a fish-path -d "Print the path to the current instance of fish"
 
 # The job-control command changes fish state.
-complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a job-control -d "Set which jobs are under job control"
-complete -f -c status -n "__fish_seen_subcommand_from job-control" -a full -d "Set all jobs under job control"
-complete -f -c status -n "__fish_seen_subcommand_from job-control" -a interactive -d "Set only interactive jobs under job control"
-complete -f -c status -n "__fish_seen_subcommand_from job-control" -a none -d "Set no jobs under job control"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a "job-control -j --job-control" -d "Set which jobs are under job control"
+complete -f -c status -n "__fish_seen_subcommand_from job-control -j --job-control" -a full -d "Set all jobs under job control"
+complete -f -c status -n "__fish_seen_subcommand_from job-control -j --job-control" -a interactive -d "Set only interactive jobs under job control"
+complete -f -c status -n "__fish_seen_subcommand_from job-control -j --job-control" -a none -d "Set no jobs under job control"

--- a/share/completions/string.fish
+++ b/share/completions/string.fish
@@ -8,9 +8,9 @@ complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a upper
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a length
 complete -f -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] length" -s V -l visible -d "Use the visible width, excluding escape sequences"
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a sub
-complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] sub" -s s -l start -xa "(seq 1 10)"
-complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] sub" -s e -l end -xa "(seq 1 10)"
-complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] sub" -s l -l length -xa "(seq 1 10)"
+complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] sub" -s s -l start -xa "(seq 1 10)" -d "Sepcify start index"
+complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] sub" -s e -l end -xa "(seq 1 10)" -d "Sepcify end index"
+complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] sub" -s l -l length -xa "(seq 1 10)" -d "Sepcify substring length"
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a split
 complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a split0
 complete -x -c string -n 'test (count (commandline -opc)) -ge 2' -n 'string match -qr split0\?\$ -- (commandline -opc)[2]' -s m -l max -a "(seq 1 10)" -d "Specify maximum number of splits"


### PR DESCRIPTION
## Description

Regarding `status` flags, despite the manpage stating they are deprecated, I think it's still useful to provide completions for them until they are truly removed.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
