### PR TITLE
Add "string shorten" command to shorten strings with an ellipsis

### DIFF
--- a/doc_src/cmds/string-shorten.rst
+++ b/doc_src/cmds/string-shorten.rst
@@ -1,0 +1,89 @@
+string-shorten - shorten strings to a width, with an ellipsis
+===============================================================
+
+Synopsis
+--------
+
+.. BEGIN SYNOPSIS
+
+.. synopsis::
+
+    string shorten [(-c | --char) CHARS] [(-m | --max) INTEGER] [(-N | --no-newline)] [(-l | --left)]
+               [STRING ...]
+
+.. END SYNOPSIS
+
+Description
+-----------
+
+.. BEGIN DESCRIPTION
+
+``string shorten`` truncates each *STRING* to the given visible width and adds an ellipsis to indicate it. "Visible width" means the width of all visible characters added together, excluding escape sequences and accounting for :envvar:`fish_emoji_width` and :envvar:`fish_ambiguous_width`. It is the amount of columns in a terminal the *STRING* occupies.
+
+The escape sequences reflect what fish knows about, and how it computes its output. Your terminal might support more escapes, or not support escape sequences that fish knows about.
+
+If **-m** or **--max** is given, truncate at the given width. Otherwise, the lowest non-zero width of all input strings is used.
+
+If **-N** or **--no-newline** is given, only the first line (or last line with **--left**) of each STRING is used, and an ellipsis is added if it was multiline. This only works for STRINGs being given as arguments, multiple lines given on stdin will be interpreted as separate STRINGs instead.
+
+If **-c** or **--char** is given, add *CHAR* instead of an ellipsis. This can also be empty or more than one character.
+
+If **-l** or **--left** is given, remove text from the left on instead, so this prints the longest *suffix* of the string that fits. With **--no-newline**, this will take from the last line instead of the first.
+
+The default ellipsis is ``…``. If fish thinks your system is incapable because of your locale, it will use ``...`` instead.
+
+.. END DESCRIPTION
+
+Examples
+--------
+
+.. BEGIN EXAMPLES
+
+::
+
+    >_ string shorten foo foobar
+    # No width was given, we infer, and "foo" is the shortest.
+    foo
+    fo…
+
+    >_ string shorten --char="..." foo foobar
+    # The target width is 3 because of "foo",
+    # and our ellipsis is 3 too, so we can't really show anything.
+    # This is the default ellipsis if your locale doesn't allow "…".
+    foo
+    ...
+
+    >_ string shorten --char="" --max 4 abcdef 123456
+    # Leaving the char empty makes us not add an ellipsis
+    # So this truncates at 4 columns:
+    abcd
+    1234
+
+    >_ touch "a multiline"\n"file"
+    >_ for file in *; string shorten -N -- $file; end
+    # Shorten the multiline file so we only show one line per file:
+    a multiline…
+
+    >_ ss -p | string shorten -m$COLUMNS -c ""
+    # `ss` from Linux' iproute2 shows socket information, but prints extremely long lines.
+    # This shortens input so it fits on the screen without overflowing lines.
+
+    >_ git branch | string match -rg '^\* (.*)' | string shorten -m20
+    # Take the current git branch and shorten it at 20 columns.
+    # Here the branch is "builtin-path-with-expand"
+    builtin-path-with-e…
+
+    >_ git branch | string match -rg '^\* (.*)' | string shorten -m20 --left
+    # Taking 20 columns from the right instead:
+    …in-path-with-expand
+
+See Also
+--------
+
+- :ref:`string<cmd-string>`'s ``pad`` subcommand does the inverse of this command, adding padding to a specific width instead.
+  
+- The :ref:`printf <cmd-printf>` command can do simple padding, for example ``printf %10s\n`` works like ``string pad -w10``.
+
+- :ref:`string length <cmd-string-length>` with the ``--visible`` option can be used to show what fish thinks the width is.
+
+.. END EXAMPLES

--- a/doc_src/cmds/string.rst
+++ b/doc_src/cmds/string.rst
@@ -24,6 +24,8 @@ Synopsis
                   [-q | --quiet] [STRING ...]
     string replace [-a | --all] [-f | --filter] [-i | --ignore-case]
                    [-r | --regex] [-q | --quiet] PATTERN REPLACE [STRING ...]
+    string shorten [(-c | --char) CHARS] [(-m | --max) INTEGER] [(-N | --no-newline)]
+               [STRING ...]
     string split [(-f | --fields) FIELDS] [(-m | --max) MAX] [-n | --no-empty] 
                  [-q | --quiet] [-r | --right] SEP [STRING ...]
     string split0 [(-f | --fields) FIELDS] [(-m | --max) MAX] [-n | --no-empty]
@@ -152,8 +154,8 @@ Examples
    :start-after: BEGIN EXAMPLES
    :end-before: END EXAMPLES
 
-"pad" subcommand
-------------------
+"pad" and "shorten" subcommands
+---------------------------------
 
 .. include:: string-pad.rst
    :start-after: BEGIN SYNOPSIS
@@ -164,6 +166,18 @@ Examples
    :end-before: END DESCRIPTION
 
 .. include:: string-pad.rst
+   :start-after: BEGIN EXAMPLES
+   :end-before: END EXAMPLES
+
+.. include:: string-shorten.rst
+   :start-after: BEGIN SYNOPSIS
+   :end-before: END SYNOPSIS
+
+.. include:: string-shorten.rst
+   :start-after: BEGIN DESCRIPTION
+   :end-before: END DESCRIPTION
+
+.. include:: string-shorten.rst
    :start-after: BEGIN EXAMPLES
    :end-before: END EXAMPLES
 

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -523,14 +523,6 @@ function __fish_git_complete_rev_files
     printf "$rev:%s\n" (__fish_git_rev_files $rev $path)
 end
 
-# This is the same logic used on $LANG in fish_job_summary. Print a pretty ellipse if we can,
-# returns the width.
-function __fish_git_ellipsis
-    string match -iqr 'utf.?8' -- $LANG && set -f str \u2026 || set -f str ..
-    printf %s $str
-    return (string length -V $str)
-end
-
 # Determines whether we can/should complete with __fish_git_rev_files
 function __fish_git_needs_rev_files
     # git (as of 2.20) accepts the rev:path syntax for a number of subcommands,
@@ -615,7 +607,7 @@ function __fish_git_config_keys
     # With -z, key and value are separated by space, not "="
     __fish_git config -lz | while read -lz key value
         # Print only first line of value(with an ellipsis) if multiline
-        printf '%s\t%s\n' $key (string replace \n (__fish_git_ellipsis)\n -- $value)[1]
+        printf '%s\t%s\n' $key (string shorten -N -- $value)
     end
     # Print all recognized config keys; duplicates are not shown twice by fish
     printf '%s\n' (__fish_git help --config)[1..-2] # Last line is a footer; ignore it
@@ -739,10 +731,7 @@ function __fish_git_aliases
     __fish_git config -z --get-regexp '^alias\.' 2>/dev/null | while read -lz key value
         begin
             set -l name (string replace -r '^.*\.' '' -- $key)
-            # Only use the first line of the value as the description.
-            # Also shorten it to 35/36 chars depending on how wide the ellipsis is.
-            set -f ellipsis (__fish_git_ellipsis)
-            set -l val (printf '%s\n' $value | string replace -r "^(.{0,$(math 37 - $status)}).+" '$1'$ellipsis)[1]
+            set -l val (string shorten --no-newline -m 36 -- $value)
             printf "%s\t%s\n" $name "alias: $val"
         end
     end

--- a/share/completions/string.fish
+++ b/share/completions/string.fish
@@ -56,3 +56,8 @@ complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a pad
 complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] pad" -s r -l right -d "Pad right instead of left"
 complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] pad" -s c -l char -x -d "Character to use for padding"
 complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] pad" -s w -l width -x -d "Integer width of the result, default is maximum width of inputs"
+complete -f -c string -n "test (count (commandline -opc)) -lt 2" -a shorten
+complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] shorten" -s l -l left -d "Remove from the left on"
+complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] shorten" -s c -l char -x -d "Characters to use as ellipsis"
+complete -x -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] shorten" -s m -l max -x -d "Integer width of the result, default is minimum non-zero width of inputs"
+complete -f -c string -n "test (count (commandline -opc)) -ge 2" -n "contains -- (commandline -opc)[2] shorten" -s N -l no-newline -d "Only keep one line of each input"

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -324,10 +324,10 @@ function fish_git_prompt --description "Prompt function for Git"
     end
 
     set b (string replace refs/heads/ '' -- $b)
-    set -q __fish_git_prompt_shorten_branch_char_suffix
-    or set -l __fish_git_prompt_shorten_branch_char_suffix "…"
-    if string match -qr '^\d+$' "$__fish_git_prompt_shorten_branch_len"; and test (string length "$b") -gt $__fish_git_prompt_shorten_branch_len
-        set b (string sub -l "$__fish_git_prompt_shorten_branch_len" "$b")"$__fish_git_prompt_shorten_branch_char_suffix"
+    if string match -qr '^\d+$' "$__fish_git_prompt_shorten_branch_len"
+        set -q __fish_git_prompt_shorten_branch_char_suffix
+        and set -l char -c "$__fish_git_prompt_shorten_branch_char_suffix"
+        set b (string shorten -m "$__fish_git_prompt_shorten_branch_len" $char -- "$b")
     end
     if test -n "$b"
         set b "$branch_color$b$branch_done"
@@ -486,8 +486,9 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
             if test $status -ne 0
                 # Shorten the sha ourselves to 8 characters - this should be good for most repositories,
                 # and even for large ones it should be good for most commits
+                # No need for an ellipsis.
                 if set -q sha
-                    set branch (string match -r '^.{8}' -- $sha)…
+                    set branch (string shorten -m8 -c "" -- $sha)
                 else
                     set branch unknown
                 end

--- a/share/functions/fish_job_summary.fish
+++ b/share/functions/fish_job_summary.fish
@@ -24,16 +24,8 @@ function fish_job_summary -a job_id is_foreground cmd_line signal_or_end_name si
         return
     end
 
-    set -l ellipsis '...'
-    if string match -iqr 'utf.?8' -- $LANG
-        set ellipsis \u2026
-    end
-
     set -l max_cmd_len 32
-    if test (string length $cmd_line) -gt $max_cmd_len
-        set -l truncated_len (math $max_cmd_len - (string length $ellipsis))
-        set cmd_line (string trim (string sub -l $truncated_len $cmd_line))$ellipsis
-    end
+    set cmd_line (string shorten -m$max_cmd_len -- $cmd_line)
 
     if test $is_foreground -eq 0; and test $signal_or_end_name != STOPPED
         # Add a newline *before* our message so we get the message after the commandline.


### PR DESCRIPTION
## Description

This is essentially the inverse of `string pad`.
Where that adds characters to get up to the specified width,
this adds an ellipsis to a string if it goes over a specific maximum width.
The char can be given, but defaults to our ellipsis string.
("…" if the locale can handle it and "..." otherwise)

If the ellipsis string is empty, it just truncates.

For arguments given via argv, it goes line-by-line,
because otherwise visible length makes no sense.

If "--no-newline" is given, it adds an ellipsis instead and removes all subsequent lines.

Like pad and `length --visible`, it goes by visible width,
skipping recognized escape sequences, as those have no influence on width.

The default target width is the shortest of the given widths that is non-zero.

If the ellipsis is already wider than the target width,
we truncate instead. This is safer overall, so we don't e.g. move into a new line.
This is especially important given our default ellipsis might be width 3.

We use this in numerous places including fish_job_summary and the git prompt and completions, but we do that in a fundamentally broken way, and it's already a bit complicated:

- We only check $LANG, where we would have to check $LC_ALL and $LC_CTYPE first
- We have no idea if that locale actually *exists* or is used (we set $LC_CTYPE internally!)
- We need to redo it over and over again
- We go by number of codepoints, not width

This already adopts it in those places. It mostly behaves the same, except for one difference in the git prompt when shortening the branch. The original code took $len chars and then added the ellipsis, so a length of 8 could end up printing a length of 10 (and a width of potentially 8*2 + 2 = 18). This takes as many chars as we can so that we can add the ellipsis and keep under the target width. So people will potentially see their git branch names shortened more - typically 1 char so the unicode ellipsis fits.

It also uses "..." as the ellipsis string on singlebyte systems instead of "..". I'd argue that we should probably change our default fallback ellipsis string to "..", but that's a separate change.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Potential questions:

- [x] Is "ellipsize" the right name? I've also thought of "shorten" and "truncate"
- [ ] Are the options right or do we need to add new options, because e.g. `--char` actually takes a string (unlike `string pad`, which really just allows a single codepoint)
- [ ] Do we need a "--exclusive" mode to add the ellipsis on top of the target width?
- [ ] To support shortening to the lowest width, this needs to read all input in before acting on it. That's potentially costly with big inputs in terms of memory, but it has a nice symmetry with `string pad`.