### PR TITLE
completions pipenv: updated activation command of built-in completion mechanism

### DIFF
--- a/share/completions/pipenv.fish
+++ b/share/completions/pipenv.fish
@@ -1,7 +1,12 @@
-if command -sq pipenv
-    # pipenv determines which completions to print via some automagic that might not be perfect.
-    # Force it to be correct.
-    _PIPENV_COMPLETE=source-fish pipenv --completion 2>/dev/null | source
+# try new completion generation of click first
+set -l comps (_PIPENV_COMPLETE=fish_source pipenv 2>/dev/null)
+if test -z "$comps" || string match -q 'Usage:*' -- $comps
+    # fall back to older click-completion used in prior versions
+    set comps (_PIPENV_COMPLETE=source-fish pipenv --completion 2>/dev/null)
 end
 
+set -q comps[1] && printf %s\n $comps | source
+
+
+# manual workaround for pipenv run command completion until this is supported by the built-in mechanism
 complete -c pipenv -n "__fish_seen_subcommand_from run" -a "(__fish_complete_subcommand --fcs-skip=2)" -x


### PR DESCRIPTION
## Description

The internal completion mechanism of pipenv has changed. This PR updates the completions to work with the new invocation syntax.

By the way, I removed the `if command -sq pipenv` guard because I can't see where this is good for. The completion file should only be loaded when the command exists anyway? If not I can add that back.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
