### PR TITLE
Improve math errors

### DIFF
--- a/src/builtins/math.cpp
+++ b/src/builtins/math.cpp
@@ -258,7 +258,12 @@ static int evaluate_expression(const wchar_t *cmd, const parser_t &parser, io_st
     } else {
         streams.err.append_format(L"%ls: Error: %ls\n", cmd, math_describe_error(error));
         streams.err.append_format(L"'%ls'\n", expression.c_str());
-        streams.err.append_format(L"%*ls%ls\n", error.position - 1, L" ", L"^");
+        if (error.len >= 2) {
+            wcstring tildes(error.len - 2, L'~');
+            streams.err.append_format(L"%*ls%ls%ls%ls\n", error.position - 1, L" ", L"^", tildes.c_str(), L"^");
+        } else {
+            streams.err.append_format(L"%*ls%ls\n", error.position - 1, L" ", L"^");
+        }
         retval = STATUS_CMD_ERROR;
     }
     return retval;

--- a/src/builtins/math.cpp
+++ b/src/builtins/math.cpp
@@ -177,6 +177,8 @@ static const wchar_t *math_describe_error(const te_error_t &error) {
             return _(L"Unexpected token");
         case TE_ERROR_LOGICAL_OPERATOR:
             return _(L"Logical operations are not supported, use `test` instead");
+        case TE_ERROR_DIV_BY_ZERO:
+            return _(L"Division by zero");
         case TE_ERROR_UNKNOWN:
             return _(L"Expression is bogus");
         default:

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -383,7 +383,6 @@ double state::base() {
     /* <base>      =    <constant> | <function-0> {"(" ")"} | <function-1> <power> |
      * <function-X> "(" <expr> {"," <expr>} ")" | "(" <list> ")" */
 
-    auto previous = start_;
     auto next = next_;
     switch (type_) {
         case TOK_NUMBER: {
@@ -398,10 +397,10 @@ double state::base() {
                 error_ = TE_ERROR_MISSING_OPERATOR;
                 // The error should be given *between*
                 // the last two tokens.
-                // Since these are two separate numbers there is at least
-                // one space between.
-                start_ = previous;
-                next_ = next + 1;
+                errpos_ = next + 1;
+                // Go to the end of whitespace.
+                while (wcschr(L" \t\n\r", next++[0]));
+                errlen_ = next - errpos_;
             }
             return val;
         }

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -461,7 +461,9 @@ double state::base() {
             if (type_ != TOK_ERROR || error_ == TE_ERROR_UNEXPECTED_TOKEN) {
                 // Otherwise we complain about the number of arguments *first*,
                 // a closing parenthesis should be more obvious.
-                error_ = i < arity ? TE_ERROR_TOO_FEW_ARGS : TE_ERROR_TOO_MANY_ARGS;
+                //
+                // Vararg functions need at least one argument.
+                error_ = (i < arity || (arity == -1 && i == 0)) ? TE_ERROR_TOO_FEW_ARGS : TE_ERROR_TOO_MANY_ARGS;
                 type_ = TOK_ERROR;
                 if (first_err) {
                     errpos_ = first_err;

--- a/src/tinyexpr.cpp
+++ b/src/tinyexpr.cpp
@@ -433,7 +433,9 @@ double state::base() {
 
             std::vector<double> parameters;
             int i;
-            for (i = 0; arity < 0 || i < arity; i++) {
+            const wchar_t *first_err = nullptr;
+            for (i = 0; ; i++) {
+                if (i == arity) first_err = next_;
                 parameters.push_back(expr());
                 if (type_ != TOK_SEP) {
                     break;
@@ -461,6 +463,13 @@ double state::base() {
                 // a closing parenthesis should be more obvious.
                 error_ = i < arity ? TE_ERROR_TOO_FEW_ARGS : TE_ERROR_TOO_MANY_ARGS;
                 type_ = TOK_ERROR;
+                if (first_err) {
+                    errpos_ = first_err;
+                    errlen_ = next_ - first_err;
+                    // TODO: Rationalize where we put the cursor exactly.
+                    // If we have a closing paren it's on it, if we don't it's before the number.
+                    if (type_ != TOK_CLOSE) errlen_++;
+                }
             }
             break;
         }

--- a/src/tinyexpr.h
+++ b/src/tinyexpr.h
@@ -44,6 +44,7 @@ typedef enum {
 typedef struct te_error_t {
     te_error_type_t type;
     int position;
+    int len;
 } te_error_t;
 
 /* Parses the input expression, evaluates it, and frees it. */

--- a/src/tinyexpr.h
+++ b/src/tinyexpr.h
@@ -37,7 +37,8 @@ typedef enum {
     TE_ERROR_MISSING_OPERATOR = 6,
     TE_ERROR_UNEXPECTED_TOKEN = 7,
     TE_ERROR_LOGICAL_OPERATOR = 8,
-    TE_ERROR_UNKNOWN = 9
+    TE_ERROR_DIV_BY_ZERO = 9,
+    TE_ERROR_UNKNOWN = 10
 } te_error_type_t;
 
 typedef struct te_error_t {

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -113,7 +113,7 @@ not math 'ncr(1)'
 not math 'blah()'
 # CHECKERR: math: Error: Unknown function
 # CHECKERR: 'blah()'
-# CHECKERR:    ^
+# CHECKERR:  ^~~^
 
 math n + 4
 # CHECKERR: math: Error: Unknown function
@@ -167,7 +167,7 @@ math 2x 4
 math 2 x4 # ERROR
 # CHECKERR: math: Error: Unknown function
 # CHECKERR: '2 x4'
-# CHECKERR:     ^
+# CHECKERR:    ^^
 math 0x 3
 # CHECK: 2
 # CHECK: 20

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -169,6 +169,10 @@ printf '<%s>\n' (math 1 % 0 - 5 2>&1)
 # CHECK: <math: Error: Division by zero>
 # CHECK: <'1 % 0 - 5'>
 # CHECK: <   ^>
+printf '<%s>\n' (math min 1 / 0, 5 2>&1)
+# CHECK: <math: Error: Division by zero>
+# CHECK: <'min 1 / 0, 5'>
+# CHECK: <       ^>
 
 # Validate "x" as multiplier
 math 0x2 # Hex

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -151,9 +151,14 @@ not math -s 12
 not math 2^999999
 # CHECKERR: math: Error: Result is infinite
 # CHECKERR: '2^999999'
-not math 1 / 0
-# CHECKERR: math: Error: Result is infinite
-# CHECKERR: '1 / 0'
+printf '<%s>\n' (not math 1 / 0 2>&1)
+# CHECK: <math: Error: Division by zero>
+# CHECK: <'1 / 0'>
+# CHECK: <   ^>
+printf '<%s>\n' (math 1 % 0 - 5 2>&1)
+# CHECK: <math: Error: Division by zero>
+# CHECK: <'1 % 0 - 5'>
+# CHECK: <   ^>
 
 # Validate "x" as multiplier
 math 0x2 # Hex
@@ -259,8 +264,9 @@ math pow 2 x cos'(-pi)', 2
 # This used to take ages, see #8170.
 # If this test hangs, that's reintroduced!
 math 'ncr(0/0, 1)'
-# CHECKERR: math: Error: Result is infinite
+# CHECKERR: math: Error: Division by zero
 # CHECKERR: 'ncr(0/0, 1)'
+# CHECKERR:       ^
 
 # Variadic functions require at least one argument
 math min

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -109,6 +109,11 @@ not math 'ncr(1)'
 # CHECKERR: 'ncr(1)'
 # CHECKERR:       ^
 
+math "min()"
+# CHECKERR: math: Error: Too few arguments
+# CHECKERR: 'min()'
+# CHECKERR:      ^
+
 # There is no "blah" function.
 not math 'blah()'
 # CHECKERR: math: Error: Unknown function

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -131,6 +131,11 @@ not math '2 + 2 4'
 # This regex to check whitespace - the error appears between the second 2 and the 4!
 # (right after the 2)
 # CHECKERR: {{^}}      ^
+printf '<%s>\n' (math '2 + 2      4' 2>&1)
+# CHECK: <math: Error: Missing operator>
+# CHECK: <'2 + 2      4'>
+# CHECK: <      ^~~~~^>
+
 not math '(1 2)'
 # CHECKERR: math: Error: Missing operator
 # CHECKERR: '(1 2)'

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -254,6 +254,11 @@ math pow sin 3, 5
 # CHECKERR: 'pow sin 3, 5'
 # CHECKERR: ^
 
+math pow sin 3, 5 + 2
+# CHECKERR: math: Error: Too many arguments
+# CHECKERR: 'pow sin 3, 5 + 2'
+# CHECKERR:             ^~~~^
+
 math sin pow 3, 5
 # CHECK: -0.890009
 


### PR DESCRIPTION
## Description

This introduces a specific error for division/modulo by zero and augments some error reporting with the length of the location.

Examples:

```fish
> math '1 - 1      pi'
math: Error: Missing operator
'1 - 1      pi'
      ^~~~~^
> math '2 + notafunction 5'
math: Error: Unknown function
'2 + notafunction 5'
     ^~~~~~~~~~~^
> math '1 - 1 / (5 - 5)'
math: Error: Division by zero
'1 - 1 / (5 - 5)'
       ^
```

Note: The division-by-zero error *technically* changes behavior, in that it now errors out early instead of carrying on and only complaining at the end that "Result is infinite" or "not a number".

That means something like

```fish
math min 1 / 0, 5
```

will now error out instead of returning 5.

I believe that is the correct choice - division by zero is typically expected to not be defined.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
