### PR TITLE
Add the possibility to ignore arguments in alliases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,6 +97,7 @@ Other improvements
 ------------------
 - The css for fish's documentation no longer depends on sphinx' stock "classic" theme. This should improve compatibility with sphinx versions and ease upgrading (:issue:`9003`).
 - The web-based configuration tool now works on systems that have ipv6 disabled (:issue:`3857`).
+- Aliases can ignore arguments by ending them with ``#``.
 
 
 For distributors

--- a/share/functions/alias.fish
+++ b/share/functions/alias.fish
@@ -67,7 +67,8 @@ function alias --description 'Creates a function wrapping a command'
         set wraps --wraps (string escape -- $body)
     end
 
-    echo "function $name $wraps --description $cmd_string; $prefix $body \$argv; end" | source
+    echo "function $name $wraps --description $cmd_string; $prefix $body \$argv
+        end" | source # The function definition in split in two lines to ensure that a '#' can be put in the body.
     if set -q _flag_save
         funcsave $name
     end

--- a/tests/checks/alias.fish
+++ b/tests/checks/alias.fish
@@ -29,7 +29,7 @@ alias d "'/mnt/c/Program Files (x86)/devenv.exe' /Edit"
 functions d
 # CHECK: # Defined via `source`
 # CHECK: function d --wraps=\'/mnt/c/Program\ Files\ \(x86\)/devenv.exe\'\ /Edit --description alias\ d\ \'/mnt/c/Program\ Files\ \(x86\)/devenv.exe\'\ /Edit
-# CHECK: '/mnt/c/Program Files (x86)/devenv.exe' /Edit $argv;
+# CHECK: '/mnt/c/Program Files (x86)/devenv.exe' /Edit $argv
 # CHECK: end
 
 # Use "command" to prevent recusion, and don't add --wraps to avoid accidental recursion in completion.
@@ -37,7 +37,7 @@ alias e 'e --option=value'
 functions e
 # CHECK: # Defined via `source`
 # CHECK: function e --description 'alias e e --option=value'
-# CHECK: command e --option=value $argv;
+# CHECK: command e --option=value $argv
 # CHECK: end
 
 # Don't add --wraps if it looks like a wrapper command to avoid accidental recursion in completion.
@@ -45,5 +45,5 @@ alias f 'wrapper around f'
 functions f
 # CHECK: # Defined via `source`
 # CHECK: function f --description 'alias f wrapper around f'
-# CHECK: wrapper around f $argv;
+# CHECK: wrapper around f $argv
 # CHECK: end


### PR DESCRIPTION
In other shells such as Bash, one can end its alias with `#` in order to make the alias ignore additional arguments. Example:

```bash
$ alias test='echo test #'
$ test abcd
test
```

Unfortunately, in Fish, this is not possible yet.

```fish
$ alias test='echo test #'
- (line 1): function: test: cannot use reserved keyword as function name
function test --wraps 'echo test #' --description 'alias test=echo test #';  echo test # $argv
^
from sourcing file -
        called on line 70 of file /usr/local/share/fish/functions/alias.fish
in function 'alias' with arguments 'test=echo\ test\ \#'
```

This PR modifies `alias.fish` to make it possible to create this kind of alias.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages. (Non applicable ?)
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
