### PR TITLE
Fix informative vcs to use correct untrackedfiles flag

### DIFF
--- a/share/tools/web_config/sample_prompts/informative_vcs.fish
+++ b/share/tools/web_config/sample_prompts/informative_vcs.fish
@@ -8,8 +8,8 @@ function fish_prompt --description 'Write out the prompt'
     if not set -q __fish_git_prompt_show_informative_status
         set -g __fish_git_prompt_show_informative_status 1
     end
-    if not set -q __fish_git_prompt_hide_untrackedfiles
-        set -g __fish_git_prompt_hide_untrackedfiles 1
+    if not set -q __fish_git_prompt_showuntrackedfiles
+        set -g __fish_git_prompt_showuntrackedfiles 1
     end
     if not set -q __fish_git_prompt_color_branch
         set -g __fish_git_prompt_color_branch magenta --bold


### PR DESCRIPTION
## Description

Dear fish community,
The informative vcs sample stopped showing untracked files a couple of months ago. I investigated a little bit and concluded that the `__fish_git_prompt_hide_untrackedfiles` flag was renamed to `__fish_git_prompt_showuntrackedfiles`.

Tested on my local fish.

Before fix:
<img width="546" alt="image" src="https://user-images.githubusercontent.com/1420513/189505505-5c20e7f5-504e-4ab6-832b-9ac56354d54e.png">

After fix:
<img width="547" alt="image" src="https://user-images.githubusercontent.com/1420513/189505448-0b1d9bd4-7fec-49b1-b848-3849e2206125.png">

Thanks for reviewing this!

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
