### PR TITLE
Document that break cannot be used in switch

### DIFF
--- a/doc_src/cmds/break.rst
+++ b/doc_src/cmds/break.rst
@@ -17,7 +17,7 @@ Synopsis
 Description
 -----------
 
-``break`` halts a currently running loop (*LOOP_CONSTRUCT*), such as a :ref:`switch <cmd-switch>`, :ref:`for <cmd-for>` or :ref:`while <cmd-while>` loop. It is usually added inside of a conditional block such as an :ref:`if <cmd-if>` block.
+``break`` halts a currently running loop (*LOOP_CONSTRUCT*), such as a :ref:`for <cmd-for>` or :ref:`while <cmd-while>` loop. It is usually added inside of a conditional block such as an :ref:`if <cmd-if>` block.
 
 There are no parameters for ``break``.
 

--- a/doc_src/cmds/switch.rst
+++ b/doc_src/cmds/switch.rst
@@ -19,7 +19,7 @@ Each ``case`` command is given one or more parameters. The first ``case`` comman
 
 Note that fish does not fall through on case statements. Only the first matching case is executed.
 
-Note that :ref:`break <cmd-break>` cannot be used to exit a case statement early like in other languages. It can only be used in loops.
+Note that :ref:`break <cmd-break>` cannot be used to exit a case/switch block early like in other languages. It can only be used in loops.
 
 Note that command substitutions in a case statement will be evaluated even if its body is not taken. All substitutions, including command substitutions, must be performed before the value can be compared against the parameter.
 

--- a/doc_src/cmds/switch.rst
+++ b/doc_src/cmds/switch.rst
@@ -19,6 +19,8 @@ Each ``case`` command is given one or more parameters. The first ``case`` comman
 
 Note that fish does not fall through on case statements. Only the first matching case is executed.
 
+Note that :ref:`break <cmd-break>` cannot be used to exit a case statement early like in other languages. It can only be used in loops.
+
 Note that command substitutions in a case statement will be evaluated even if its body is not taken. All substitutions, including command substitutions, must be performed before the value can be compared against the parameter.
 
 


### PR DESCRIPTION
Fixed the docs for `break` which incorrectly stated it can be used in `switch`. Also clarified this in the docs for `switch`.
