### PR TITLE
`commandline --selection-start` and `--selection-end` implementation

### DIFF
--- a/doc_src/cmds/commandline.rst
+++ b/doc_src/cmds/commandline.rst
@@ -26,6 +26,12 @@ The following options are available:
     If no argument is given, the current cursor position is printed, otherwise the argument is interpreted as the new cursor position.
     If one of the options **-j**, **-p** or **-t** is given, the position is relative to the respective substring instead of the entire command line buffer.
 
+**-B** or **--selection-start**
+    Get current position of the selection start in the buffer.
+
+**-E** or **--selection-end**
+    Get current position of the selection end in the buffer.
+
 **-f** or **--function**
     Causes any additional arguments to be interpreted as input functions, and puts them into the queue, so that they will be read before any additional actual key presses are.
     This option cannot be combined with any other option.

--- a/share/completions/commandline.fish
+++ b/share/completions/commandline.fish
@@ -16,6 +16,8 @@ complete -c commandline -s o -l tokenize -d "Print each token on a separate line
 
 complete -c commandline -s I -l input -d "Specify command to operate on"
 complete -c commandline -s C -l cursor -d "Set/get cursor position, not buffer contents"
+complete -c commandline -s B -l selection-start -d "Get current selection starting position"
+complete -c commandline -s E -l selection-end -d "Get current selection ending position"
 complete -c commandline -s L -l line -d "Print the line that the cursor is on"
 complete -c commandline -s S -l search-mode -d "Return true if performing a history search"
 complete -c commandline -s P -l paging-mode -d "Return true if showing pager content"


### PR DESCRIPTION
Related to #9197

I figure `selection-start` makes more sense for the left side of the selection, than for the one farther from cursor; also along with naming in code.

Please review. If this is all right, I'll update the docs.