### PR TITLE
Preserve order of completion rules when generating completions

### DIFF
--- a/src/complete.h
+++ b/src/complete.h
@@ -59,6 +59,7 @@ using description_func_t = std::function<wcstring(const wcstring &)>;
 /// Helper to return a description_func_t for a constant string.
 description_func_t const_desc(const wcstring &s);
 
+/// This is an individual completion entry, i.e. the result of an expansion of a completion rule.
 class completion_t {
    private:
     // No public default constructor.
@@ -210,7 +211,7 @@ enum complete_option_type_t {
 void completions_sort_and_prioritize(completion_list_t *comps,
                                      completion_request_options_t flags = {});
 
-/// Add a completion.
+/// Add an unexpanded completion "rule" to generate completions from for a command.
 ///
 /// Examples:
 ///

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -500,6 +500,21 @@ complete -C'oooops '
 echo $oops
 # CHECK: 1
 
+# Validate that completions are generated in the same order as the rules/calls to `complete` were
+# defined.
+
+function foo_to_complete
+end
+
+# Generate completions with `-k` to observe that sort order is preserved
+complete -c foo_to_complete -kf -a "opt_b_2 opt_b_1"
+complete -c foo_to_complete -kf -a "opt_a_1 opt_a_2"
+
+complete -C"foo_to_complete "
+# CHECK: opt_b_2
+# CHECK: opt_b_1
+# CHECK: opt_a_1
+# CHECK: opt_a_2
 
 # See that we load completions only if the command exists in $PATH,
 # as a workaround for #3117.

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -55,8 +55,8 @@ complete
 # CHECK: complete --no-files complete_test_alpha1 -a '(commandline)'
 # CHECK: complete --no-files complete_test_alpha2
 # CHECK: complete --no-files complete_test_alpha3
-# CHECK: complete --force-files t -l fileoption
 # CHECK: complete --no-files t -a '(t)'
+# CHECK: complete --force-files t -l fileoption
 # CHECK: complete -p '/complete test/beta1' -s Z -d 'desc, desc'
 # CHECK: complete --require-parameter 'complete test beta2' -d desc\ \'\ desc2\ \[ -a 'foo bar'
 # CHECK: complete --exclusive complete_test_beta2 -o test -n false
@@ -368,8 +368,8 @@ complete -c banana
 # "-c" is optional
 complete banana -a bar
 complete banana
-#CHECK: complete banana -a bar
 #CHECK: complete banana -a '1 2 3'
+#CHECK: complete banana -a bar
 
 # "-a" ain't
 complete banana bar


### PR DESCRIPTION
This patch forces completions to be generated in the same order that they were declared (only relevant for completions that bypass sort, e.g. declared with the `-k` flag).

The arbitrary (reverse) sort order expected in `checks/complete.fish` when a bare `complete` is executed has been updated and a new test has been added verifying that `-k` completions for the same command with the same conditions respect their order of declaration.

 **If it's desirable for the output of a bare `complete` call (generating a list of all active completions) to be reverse-chronological, it can be iterated in reverse order without backing out this patch.**

As for the order of the completions generated when `tab` completing: IMHO, this is the intent for the majority of completions; I do not think many/most contributors expect that completions (especially those with `-k`) were actually being emitted in _reverse_ declared order.

@faho I've requested a review from you because a) IMHO this is now the correct order for `git checkout ^I` completions with changed files before tags and branches, etc. but I want to make sure that we're on the same page and defer to you here and b) this breaks the test for `checks/git.fish` and I'm not sure if the new output is  incorrect and indicative of something else gone wrong (this patch did change storage from `std::forward_list` to `std::vector`).

In particular, the final check `$fish -c 'complete -C "git diff -c"'` seems to expect no completions but now generates the following (unexpected) completions:

```
    -ca\tTreat all files as text <= no more checks
    -cB\tBreak complete rewrite changes into pairs of delete and create
    -cb\tIgnore changes in amount of whitespace
    -cC\tDetect copies as well as renames
    -cD\tOmit the preimage for deletes
    -cG\tLook for differences where <regex> matches the patch\'s added/removed lines
    -cM\tDetect and report renames
    -cR\tSwap inputs to create a reverse diff
    -cS\tLook for differences that change the number of occurrences of the string
    -cW\tShow whole surrounding functions of changes
    -cw\tIgnore whitespace when comparing lines
    -cz\tUse NULs as output field/commit terminators
    -cO\tControl the order in which files appear in the output
    -cl\tPrevents rename/copy detection when rename/copy targets exceed the given number
    -c1\tCompare the working tree with the \"base\" version
    -c2\tCompare the working tree with the \"our branch\"
    -c3\tCompare the working tree with the \"their branch\"
    -c0\tOmit diff output for unmerged entries and just show \"Unmerged\"
```