### PR TITLE
Reduce write()s for builtins

### DIFF
--- a/src/builtins/builtin.cpp
+++ b/src/builtins/builtin.cpp
@@ -101,11 +101,8 @@ maybe_t<int> builtin_builtin(parser_t &parser, io_streams_t &streams, const wcha
         wcstring_list_t names = builtin_get_names();
         std::sort(names.begin(), names.end());
 
-        for (const auto &name : names) {
-            auto el = name.c_str();
-
-            streams.out.append(el);
-            streams.out.append(L"\n");
+        for (auto &name : names) {
+            streams.out.append(name + L"\n");
         }
     }
 

--- a/src/builtins/complete.cpp
+++ b/src/builtins/complete.cpp
@@ -416,14 +416,14 @@ maybe_t<int> builtin_complete(parser_t &parser, io_streams_t &streams, const wch
                     // we need to unescape the command line. See #1127.
                     unescape_string_in_place(&faux_cmdline_with_completion, UNESCAPE_DEFAULT);
                 }
-                streams.out.append(faux_cmdline_with_completion);
 
                 // Append any description.
                 if (!next.description.empty()) {
-                    streams.out.push_back(L'\t');
-                    streams.out.append(next.description);
+                    faux_cmdline_with_completion.push_back(L'\t');
+                    faux_cmdline_with_completion.append(next.description);
                 }
-                streams.out.push_back(L'\n');
+                faux_cmdline_with_completion.push_back(L'\n');
+                streams.out.append(faux_cmdline_with_completion);
             }
 
             parser.libdata().builtin_complete_current_commandline = false;

--- a/src/builtins/functions.cpp
+++ b/src/builtins/functions.cpp
@@ -286,9 +286,8 @@ maybe_t<int> builtin_functions(parser_t &parser, io_streams_t &streams, const wc
 
             streams.out.append(reformat_for_screen(buff, termsize_last()));
         } else {
-            for (const auto &name : names) {
-                streams.out.append(name.c_str());
-                streams.out.append(L"\n");
+            for (auto &name : names) {
+                streams.out.append(name + L"\n");
             }
         }
 

--- a/src/builtins/jobs.cpp
+++ b/src/builtins/jobs.cpp
@@ -46,6 +46,7 @@ static void builtin_jobs_print(const job_t *j, int mode, int header, io_streams_
         pgid = *job_pgid;
     }
 
+    wcstring out;
     switch (mode) {
         case JOBS_PRINT_NOTHING: {
             break;
@@ -53,53 +54,57 @@ static void builtin_jobs_print(const job_t *j, int mode, int header, io_streams_
         case JOBS_DEFAULT: {
             if (header) {
                 // Print table header before first job.
-                streams.out.append(_(L"Job\tGroup\t"));
+                out.append(_(L"Job\tGroup\t"));
                 if (have_proc_stat()) {
-                    streams.out.append(_(L"CPU\t"));
+                    out.append(_(L"CPU\t"));
                 }
-                streams.out.append(_(L"State\tCommand\n"));
+                out.append(_(L"State\tCommand\n"));
             }
 
-            streams.out.append_format(L"%d\t%d\t", j->job_id(), pgid);
+            append_format(out, L"%d\t%d\t", j->job_id(), pgid);
 
             if (have_proc_stat()) {
-                streams.out.append_format(L"%.0f%%\t", 100. * cpu_use(j));
+                append_format(out, L"%.0f%%\t", 100. * cpu_use(j));
             }
 
-            streams.out.append(j->is_stopped() ? _(L"stopped") : _(L"running"));
-            streams.out.append(L"\t");
-            streams.out.append(j->command_wcstr());
-            streams.out.append(L"\n");
+            out.append(j->is_stopped() ? _(L"stopped") : _(L"running"));
+            out.append(L"\t");
+            out.append(j->command_wcstr());
+            out.append(L"\n");
+            streams.out.append(out);
             break;
         }
         case JOBS_PRINT_GROUP: {
             if (header) {
                 // Print table header before first job.
-                streams.out.append(_(L"Group\n"));
+                out.append(_(L"Group\n"));
             }
-            streams.out.append_format(L"%d\n", pgid);
+            append_format(out, L"%d\n", pgid);
+            streams.out.append(out);
             break;
         }
         case JOBS_PRINT_PID: {
             if (header) {
                 // Print table header before first job.
-                streams.out.append(_(L"Process\n"));
+                out.append(_(L"Process\n"));
             }
 
             for (const process_ptr_t &p : j->processes) {
-                streams.out.append_format(L"%d\n", p->pid);
+                append_format(out, L"%d\n", p->pid);
             }
+            streams.out.append(out);
             break;
         }
         case JOBS_PRINT_COMMAND: {
             if (header) {
                 // Print table header before first job.
-                streams.out.append(_(L"Command\n"));
+                out.append(_(L"Command\n"));
             }
 
             for (const process_ptr_t &p : j->processes) {
-                streams.out.append_format(L"%ls\n", p->argv0());
+                append_format(out, L"%ls\n", p->argv0());
             }
+            streams.out.append(out);
             break;
         }
         default: {

--- a/src/builtins/math.cpp
+++ b/src/builtins/math.cpp
@@ -252,8 +252,7 @@ static int evaluate_expression(const wchar_t *cmd, const parser_t &parser, io_st
             streams.err.append_format(L"'%ls'\n", expression.c_str());
             retval = STATUS_CMD_ERROR;
         } else {
-            streams.out.append(format_double(v, opts));
-            streams.out.push_back(L'\n');
+            streams.out.append(format_double(v, opts) + L"\n");
         }
     } else {
         streams.err.append_format(L"%ls: Error: %ls\n", cmd, math_describe_error(error));

--- a/src/builtins/path.cpp
+++ b/src/builtins/path.cpp
@@ -201,8 +201,7 @@ static void path_out(io_streams_t &streams, const options_t &opts, const wcstrin
         if (!opts.null_out) {
             streams.out.append_with_separation(str, separation_type_t::explicitly);
         } else {
-            streams.out.append(str);
-            streams.out.push_back(L'\0');
+            streams.out.append(str + L"\0");
         }
     }
 }

--- a/src/builtins/pwd.cpp
+++ b/src/builtins/pwd.cpp
@@ -73,7 +73,6 @@ maybe_t<int> builtin_pwd(parser_t &parser, io_streams_t &streams, const wchar_t 
     if (pwd.empty()) {
         return STATUS_CMD_ERROR;
     }
-    streams.out.append(pwd);
-    streams.out.push_back(L'\n');
+    streams.out.append(pwd + L"\n");
     return STATUS_CMD_OK;
 }

--- a/src/builtins/set.cpp
+++ b/src/builtins/set.cpp
@@ -437,7 +437,8 @@ static int builtin_set_list(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
     sort(names.begin(), names.end());
 
     for (const auto &key : names) {
-        streams.out.append(key);
+        wcstring out;
+        out.append(key);
 
         if (!names_only) {
             wcstring val;
@@ -460,14 +461,15 @@ static int builtin_set_list(const wchar_t *cmd, set_cmd_opts_t &opts, int argc,
                     shorten = true;
                     val.resize(60);
                 }
-                streams.out.append(L" ");
-                streams.out.append(val);
+                out.push_back(L' ');
+                out.append(val);
 
-                if (shorten) streams.out.push_back(get_ellipsis_char());
+                if (shorten) out.push_back(get_ellipsis_char());
             }
         }
 
-        streams.out.append(L"\n");
+        out.push_back(L'\n');
+        streams.out.append(out);
     }
 
     return STATUS_CMD_OK;


### PR DESCRIPTION
## Description

Our io_streams_t is, when it comes to pipes (including the terminal), an extremely thin wrapper over `write(2)`.

Whenever you do `streams.out.append()` or `streams.out.push_back()` that corresponds to one `write(2)`. This means doing something like

```c++
for (wchar_t c : somestring) {
    streams.out.push_back(c);
}
```

is extremely slow. The pattern we see a lot is

```c++
streams.out.append(somestring);
streams.out.push_back(L'\n');
```

So, this PR tries to reduce how often we do that, sometimes by constructing strings on-the-fly like

```c++
streams.out.append(somestring + L"\n");
```

Or doing some buffering.

I'd like to call out one egregious case, which is `printf`. This one would `out.push_back` for every character escape, so

```fish
printf (string repeat -n 200 \\x7f)%s\n (string repeat -n 2000 aaa\n)
```

would issue 400000 (four hundred thousand) `write(2)` calls. Now it has been reduced to 2000 (one per argument excluding the format string - I experimented with doing one big write but that turned out to be slower in some cases and would of course have worse latency and memory requirements). This used to take ~400ms, now it takes 16ms.

The rest of the wins are more modest, ranging from ~1.1x to 1.7x.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
