### PR TITLE
fish_clipboard_copy: use OSC 52 when running inside SSH

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,6 +83,7 @@ Interactive improvements
 - Fish now disables the QUIT terminal sequence when it has the terminal. This frees up a key combination, often ctrl-backslash (``\x1c``) (:issue:`9234`).
 - Fish's vi mode no longer uses iTerm's proprietary escape sequences to signal cursor change, instead using the normal xterm-style sequences. This allows for a blinking cursor and makes it work in complicated scenarios with nested terminals. (:issue:`3741`, :issue:`9172`)
 - Generating descriptions for commands now uses ``manpath`` instead of ``man --path`` on macOS, as that has been removed in macOS Ventura.
+- When running fish on a remote system (e.g. inside SSH or a container), :kbd:`Control-X` now copies to the local client system's clipboard if the terminal supports OSC 52.
 
 
 Fixed Bugs

--- a/share/functions/fish_clipboard_copy.fish
+++ b/share/functions/fish_clipboard_copy.fish
@@ -23,4 +23,15 @@ function fish_clipboard_copy
     else if type -q clip.exe
         printf '%s' $cmdline | clip.exe
     end
+
+    # Copy with OSC 52; useful if we are running in an SSH session or in
+    # a container.
+    if type -q base64
+        if not isatty stdout
+            echo "fish_clipboard_copy: stdout is not a terminal" >&2
+            return 1
+        end
+        set -l encoded (printf %s $cmdline | base64 | string join '')
+        printf '\e]52;c;%s\a' "$encoded"
+    end
 end


### PR DESCRIPTION
When connecting to a remote system via SSH, Control-X either does nothing,
or if a clipboard-copying program is installed, tries to copy into the remote
system's clipboard, which often fails.

Modern terminal emulators implement the OSC 52 escape sequence for setting
the clipboard of the terminal host system. Use OSC 52 in fish_clipboard_copy
when running inside SSH.  Give it precedence over all other cases since that
behavior is probably better than setting the clipboard of the remote system.

Tested on foot, iTerm2, kitty, [tmux] and xterm (which requires
"XTerm.vt100.allowWindowOps: true").

Should also work in screen and Windows Terminal. On terminals that don't
support OSC 52 (like Gnome Terminal or Konsole), it seems to do nothing (but
with this patch we also don't delegate to pbcopy and friends, so I hope no
one relies on that).

I think there is also an escape sequence to request pasting the system
clipboard but that's less important and less popular, possibly due to
security concerns.

[tmux]: https://github.com/tmux/tmux/wiki/Clipboard
