### PR TITLE
Fix the completions of tox

### DIFF
--- a/share/completions/tox.fish
+++ b/share/completions/tox.fish
@@ -1,4 +1,4 @@
-function ___fish_toxenvs
+function __fish_toxenvs
     echo ALL
     tox --listenvs-all 2>/dev/null
 end


### PR DESCRIPTION
## Description

This is related to #9078 .
Unfortunately, that patch has a typo and does not work as intended.

The number of `_` should be 2, but the 3 in the definition. Therefore the patch does not work.

Thanks.

## TODOs:
<!-- Just check off what we know has been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
