### PR TITLE
Decode `\X` escapes immediately

### DIFF
--- a/tests/checks/locale.fish
+++ b/tests/checks/locale.fish
@@ -88,3 +88,12 @@ env LC_ALL=C $fish -c 'echo -n Y\u00FCY' | display_bytes
 env LC_ALL=C $fish -c 'echo -n T\u01FDT' | display_bytes
 #CHECK: 0000000 124 077 124
 #CHECK: 0000003
+
+string match ö \Xc3\Xb6
+#CHECK: ö
+
+math 5 \X2b 5
+#CHECK: 10
+
+math 7 \x2b 7
+#CHECK: 14


### PR DESCRIPTION
We forgot to decode (i.e. turn into nice wchar_t codepoints) "byte_literal" escape sequences. This meant that e.g.

```fish
string match ö \Xc3\Xb6

math 5 \X2b 5
```

didn't work, and the latter would print the wonderful error:

```
math: Error: Missing operator
'5 + 5'
   ^
```

In contrast, `math 5 \x2b 5` works because `\x` is currently not "byte_literal" - it's seen as a codepoint number.

So, instead, we decode eagerly.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst


----

Sidenote: The diff is an absolute mess - what I did was:

1. Pack the switch/case into a `while` loop so we can `continue`
2. Add a std::string buffer for multiple `\X` escaped values
3. Move an early `if (errored) return none()` into the loop
4. Make the path for "byte_literal" (currently that's only `\X`) put the value into the buffer and `continue` if there's another `\X` following.

A reasonably simple change, but because of the additional indentation this touched most of `read_unquoted_escape`. Sorry about that!