### PR TITLE
Exclude current directory ('.') from rsync completions

### DIFF
--- a/share/completions/rsync.fish
+++ b/share/completions/rsync.fish
@@ -205,6 +205,7 @@ complete -c rsync -d "Remote path" -n "commandline -ct | string match -q '*:*'" 
 )(
 	# Get the list of remote files from the specified rsync server.
         rsync --list-only (__rsync_remote_target) 2>/dev/null | string replace -r '^d.*' '\$0/' |
-        string replace -r '(\S+\s+){4}' '' $(set -q new_escaping[1]; or echo ' | string escape -n'; echo)
+        string replace -r '(\S+\s+){4}' '' |
+        string match --invert './' $(set -q new_escaping[1]; or echo ' | string escape -n'; echo)
 )
 "


### PR DESCRIPTION
## Description

This is what currently happens when I try to tab complete on a directory with a single file (`file.txt`) in the middle of an `rsync` command:

```shell
$ rsync localhost:~/stuff/<TAB>
…:~/stuff/./  (Remote path)  …:~/stuff/file.txt  (Remote path)
```

The current directory (`.`) shows up as an option and stops rsync from automatically selecting the only file. I can't think of a reason why one would actually want to tab complete to `.` (and even if one did, just typing `.` is a hell of a lot quicker than waiting for a response that probably traverses the network). I couldn't find any `rsync` option to exclude the current directory so I just used `string match` to remove it. Hopefully nothing actually useful gets matched (I tried, for example, creating `file.` and `directory./` and they still show up) but I would appreciate it if someone could double-check.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
