### PR TITLE
Add feature to fish_commandline_prepend and fix minor issue

### DIFF
--- a/share/functions/fish_commandline_prepend.fish
+++ b/share/functions/fish_commandline_prepend.fish
@@ -3,14 +3,24 @@ function fish_commandline_prepend --description "Prepend the given string to the
         commandline -r $history[1]
     end
 
-    set -l escaped (string escape --style=regex -- $argv[1])
     set -l process (commandline -p | string collect)
-    if set process (string replace -r -- "^$escaped " "" $process)
-        commandline --replace -p -- $process
-    else
-        set -l cursor (commandline -C)
-        commandline -C 0 -p
-        commandline -i -- "$argv[1] "
-        commandline -C (math $cursor + (string length -- "$argv[1] "))
+
+    set -l to_prepend "$argv[1] "
+    if string match -qr '^ ' "$process"
+        set to_prepend " $argv[1]"
     end
+
+    set -l length_diff (string length -- "$to_prepend")
+    set -l cursor_location (commandline -pC)
+
+    set -l escaped "$(string escape --style=regex -- $to_prepend)"
+    if set process (string replace -r -- "^$escaped" "" $process)
+        commandline --replace -p -- $process
+        set length_diff "-$length_diff"
+    else
+        commandline -pC 0
+        commandline -pi -- "$to_prepend"
+    end
+
+    commandline -pC (math "max 0,($cursor_location + $length_diff)")
 end


### PR DESCRIPTION
## Description

Prepending will now respect leading spaces instead of doubling it up, and removing a prefix no longer sends the cursor to the end of the line.

```sh
# new feature:
~>  vi /etc/fstab
#  ^ one leading space

# press <alt+s>

# before this change
~> sudo  vi /etc/fstab
#      ^^ two spaces

# after
~>  sudo vi /etc/fstab
#  ^    ^ one space either side

## fixed issue:
~> sudo systemctl status
#                ^ cursor location

# press <alt+s>

# before
~> systemctl status
#                  ^ cursor location
# always moved to the end

# after
~> systemctl status
#           ^ cursor location
# same relative placement
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
