### PR TITLE
Update $fish_cursor_selection_mode in vi/default bindings

### DIFF
--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -104,4 +104,6 @@ function fish_default_key_bindings -d "emacs-like key binds"
             # the following to tell a console to paste:
             bind --preset $argv \e\x20ep fish_clipboard_paste
     end
+
+    set -e -g fish_cursor_selection_mode
 end

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -304,6 +304,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # After executing once, this will have defined functions listening for the variable.
     # Therefore it needs to be before setting fish_bind_mode.
     fish_vi_cursor
+    set -g fish_cursor_selection_mode inclusive
 
     set fish_bind_mode $init_mode
 


### PR DESCRIPTION
Introduced with 3.6.0 `fish_cursor_selection_mode` variable breaks existing vi bindings (for example, input sequence `abc<Esc>0vd` doesn't delete the `a` character as would be expected).

This patch fixes it by switching `fish_cursor_selection_mode` to `inclusive` and back.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
