### PR TITLE
docs: remove redundant '$' in `read.rst`

### DIFF
--- a/doc_src/cmds/read.rst
+++ b/doc_src/cmds/read.rst
@@ -100,7 +100,7 @@ Example
 
 ``read`` has a few separate uses.
 
-The following code stores the value 'hello' in the shell variable :envvar:`$foo`.
+The following code stores the value 'hello' in the shell variable :envvar:`foo`.
 
 ::
 


### PR DESCRIPTION
## Description

Remove redundant `$` in the `read` function doc file

| Before | After |
|----------|--------|
|![image](https://user-images.githubusercontent.com/68606322/194246376-b5fa98ed-638d-4256-9d18-4d4f48b147ee.png)|![image](https://user-images.githubusercontent.com/68606322/194246440-8fc2cf0e-300d-4753-bc4c-03fd699c2aa4.png)|

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
