### PR TITLE
Make `output_stream_t::append()` fallible and handle SIGINT on append

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -206,9 +206,10 @@ void io_chain_t::push_back(io_data_ref_t element) {
     std::vector<io_data_ref_t>::push_back(std::move(element));
 }
 
-void io_chain_t::append(const io_chain_t &chain) {
+bool io_chain_t::append(const io_chain_t &chain) {
     assert(&chain != this && "Cannot append self to self");
     this->insert(this->end(), chain.begin(), chain.end());
+    return true;
 }
 
 bool io_chain_t::append_from_specs(const redirection_spec_list_t &specs, const wcstring &pwd) {
@@ -308,21 +309,24 @@ shared_ptr<const io_data_t> io_chain_t::io_for_fd(int fd) const {
     return nullptr;
 }
 
-void output_stream_t::append_narrow_buffer(const separated_buffer_t &buffer) {
+bool output_stream_t::append_narrow_buffer(const separated_buffer_t &buffer) {
     for (const auto &rhs_elem : buffer.elements()) {
-        append_with_separation(str2wcstring(rhs_elem.contents), rhs_elem.separation, false);
+        if (!append_with_separation(str2wcstring(rhs_elem.contents), rhs_elem.separation, false)) {
+            return false;
+        }
     }
+    return true;
 }
 
-void output_stream_t::append_with_separation(const wchar_t *s, size_t len, separation_type_t type,
+bool output_stream_t::append_with_separation(const wchar_t *s, size_t len, separation_type_t type,
                                              bool want_newline) {
     if (type == separation_type_t::explicitly && want_newline) {
         // Try calling "append" less - it might write() to an fd
         wcstring buf{s, len};
         buf.push_back(L'\n');
-        append(buf);
+        return append(buf);
     } else {
-        append(s, len);
+        return append(s, len);
     }
 }
 
@@ -330,8 +334,8 @@ const wcstring &output_stream_t::contents() const { return g_empty_string; }
 
 int output_stream_t::flush_and_check_error() { return STATUS_CMD_OK; }
 
-void fd_output_stream_t::append(const wchar_t *s, size_t amt) {
-    if (errored_) return;
+bool fd_output_stream_t::append(const wchar_t *s, size_t amt) {
+    if (errored_) return false;
     int res = wwrite_to_fd(s, amt, this->fd_);
     if (res < 0) {
         // TODO: this error is too aggressive, e.g. if we got SIGINT we should not complain.
@@ -340,6 +344,7 @@ void fd_output_stream_t::append(const wchar_t *s, size_t amt) {
         }
         errored_ = true;
     }
+    return !errored_;
 }
 
 int fd_output_stream_t::flush_and_check_error() {
@@ -347,20 +352,23 @@ int fd_output_stream_t::flush_and_check_error() {
     return errored_ ? STATUS_CMD_ERROR : STATUS_CMD_OK;
 }
 
-void null_output_stream_t::append(const wchar_t *, size_t) {}
+bool null_output_stream_t::append(const wchar_t *, size_t) { return true; }
 
-void string_output_stream_t::append(const wchar_t *s, size_t amt) { contents_.append(s, amt); }
+bool string_output_stream_t::append(const wchar_t *s, size_t amt) {
+    contents_.append(s, amt);
+    return true;
+}
 
 const wcstring &string_output_stream_t::contents() const { return contents_; }
 
-void buffered_output_stream_t::append(const wchar_t *s, size_t amt) {
-    buffer_->append(wcs2string(s, amt));
+bool buffered_output_stream_t::append(const wchar_t *s, size_t amt) {
+    return buffer_->append(wcs2string(s, amt));
 }
 
-void buffered_output_stream_t::append_with_separation(const wchar_t *s, size_t len,
+bool buffered_output_stream_t::append_with_separation(const wchar_t *s, size_t len,
                                                       separation_type_t type, bool want_newline) {
     UNUSED(want_newline);
-    buffer_->append(wcs2string(s, len), type);
+    return buffer_->append(wcs2string(s, len), type);
 }
 
 int buffered_output_stream_t::flush_and_check_error() {


### PR DESCRIPTION
This patch series addresses a long-standing issue (`output_stream_t::append()` is assumed to never fail and returns void) that made it difficult to handle output termination via Ctrl-C (by halting progress and ending early) for various builtins with lots of output, `history` being the best example because it wrote to the pager (giving the user plenty of time and reason to `Ctrl-C` the running process, but to no effect besides an error message).

------

**Make `output_stream_t::append()` fallible**

Allow errors encountered by certain implementations of `output_stream_t` when
writing to the output sink to be bubbled back to the caller.

**Silently handle fd_output_stream_t append errors in case of SIGINT**

If `EINTR` caused by `SIGINT` is encountered while writing to the
`fd_output_stream_t` output fd, mark the output stream as errored and return
false to the caller but do not visibly complain.

Addressing the outstanding TODO notwithstanding, this is needed to avoid
littering the tty with spurious errors when the user hits Ctrl-C to abort a
long-running builtin's output (w/ the primary example being `history`).

**history: Handle Ctrl-C/SIGINT or other errors on output append**

When there are multiple screens worth of output and `history` is writing to the
pager, pressing Ctrl-C at the end of a screen doesn't exit the pager (`q` is
needed for that) but previously caused fish to emit an error ("write:
Interrupted system call) until we started silently handling SIGINT in
`fd_output_stream_t::append()`.

This patch makes `history` detect when the `append()` call returns with an error
and causes it to end early rather than repeatedly trying (and failing) to write
to the output stream.