### PR TITLE
fish_clipboard_copy/paste: Handle redirected stdout/stdin

### DIFF
--- a/doc_src/cmds/fish_clipboard_copy.rst
+++ b/doc_src/cmds/fish_clipboard_copy.rst
@@ -1,0 +1,36 @@
+.. _cmd-fish_clipboard_copy:
+
+fish_clipboard_copy - copy text to the system's clipboard
+==============================================================
+
+Synopsis
+--------
+
+.. synopsis::
+
+    fish_clipboard_copy
+
+    foo | fish_clipboard_copy
+
+Description
+-----------
+
+The ``fish_clipboard_copy`` function copies text to the system clipboard.
+
+If stdin is not a terminal (see :doc:`isatty <isatty>`), it will read all input from there and copy it. If it is, it will use the current commandline, or the current selection if there is one.
+
+It is bound to :kbd:`Control`\ +\ :kbd:`X` by default.
+
+``fish_clipboard_copy`` works by calling a system-specific backend. If it doesn't appear to work you may need to install yours.
+
+Currently supported are:
+
+- ``pbcopy``
+- ``wl-copy`` using wayland
+- ``xsel`` and ``xclip`` for X11
+- ``clip.exe`` on Windows.
+
+See also
+--------
+
+- :doc:`fish_clipboard_paste` which does the inverse.

--- a/doc_src/cmds/fish_clipboard_paste.rst
+++ b/doc_src/cmds/fish_clipboard_paste.rst
@@ -1,0 +1,38 @@
+.. _cmd-fish_clipboard_paste:
+
+fish_clipboard_paste - get text from the system's clipboard
+==============================================================
+
+Synopsis
+--------
+
+.. synopsis::
+
+    fish_clipboard_paste
+
+    fish_clipboard_paste | foo
+
+Description
+-----------
+
+The ``fish_clipboard_paste`` function copies text from the system clipboard.
+
+If its stdout is not a terminal (see :doc:`isatty <isatty>`), it will output everything there, as-is, without any additional newlines. If it is, it will put the text in the commandline instead.
+
+If it outputs to the commandline, it will automatically escape the output if the cursor is currently inside single-quotes so it is suitable for single-quotes (meaning it escapes ``'`` and ``\\``).
+
+It is bound to :kbd:`Control`\ +\ :kbd:`V` by default.
+
+``fish_clipboard_paste`` works by calling a system-specific backend. If it doesn't appear to work you may need to install yours.
+
+Currently supported are:
+
+- ``pbpaste``
+- ``wl-paste`` using wayland
+- ``xsel`` and ``xclip`` for X11
+- ``powershell.exe`` on Windows (this backend has encoding limitations and uses windows line endings that ``fish_clipboard_paste`` undoes)
+
+See also
+--------
+
+- :doc:`fish_clipboard_copy` which does the inverse.

--- a/doc_src/cmds/isatty.rst
+++ b/doc_src/cmds/isatty.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    isatty [FILE DESCRIPTOR]
+    isatty [FILE_DESCRIPTOR]
 
 Description
 -----------

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -303,7 +303,7 @@ Some bindings are common across Emacs and Vi mode, because they aren't text edit
 
 - :kbd:`Control`\ +\ :kbd:`W` moves the previous path component (everything up to the previous "/", ":" or "@") to the :ref:`killring`.
 
-- :kbd:`Control`\ +\ :kbd:`X` copies the current buffer to the system's clipboard, :kbd:`Control`\ +\ :kbd:`V` inserts the clipboard contents.
+- :kbd:`Control`\ +\ :kbd:`X` copies the current buffer to the system's clipboard, :kbd:`Control`\ +\ :kbd:`V` inserts the clipboard contents. (see :doc:`fish_clipboard_copy <cmds/fish_clipboard_copy>` and :doc:`fish_clipboard_paste <cmds/fish_clipboard_paste>`)
 
 - :kbd:`Alt`\ +\ :kbd:`D` moves the next word to the :ref:`killring`.
 

--- a/share/functions/fish_clipboard_copy.fish
+++ b/share/functions/fish_clipboard_copy.fish
@@ -1,7 +1,17 @@
 function fish_clipboard_copy
-    # Copy the current selection, or the entire commandline if that is empty.
-    set -l cmdline (commandline --current-selection | string collect)
-    test -n "$cmdline"; or set cmdline (commandline | string collect)
+    set -l cmdline
+    if isatty stdin
+        # Copy the current selection, or the entire commandline if that is empty.
+        # Don't use `string collect -N` here - `commandline` adds a newline.
+        set cmdline (commandline --current-selection | string collect)
+        test -n "$cmdline"; or set cmdline (commandline | string collect)
+    else
+        # Read from stdin
+        while read -lz line
+            set -a cmdline $line
+        end
+    end
+
     if type -q pbcopy
         printf '%s' $cmdline | pbcopy
     else if set -q WAYLAND_DISPLAY; and type -q wl-copy


### PR DESCRIPTION
## Description

This makes these tools usable in a pipe.

You can run

```fish
some-long-command | fish_clipboard_copy
```

to copy some command's output to your clipboard, and

```fish
fish_clipboard_paste | some-other-command
```

To feed your clipboard to some command.

For instance, let's say I want to insert my patented "commits missing from release X" table.

I've written a function called "gitcomp" to generate the info, and I have another function "mdtable" that transforms it to markdown. But I need it in my clipboard so I can paste it in the browser, and previously I'd use `xsel --clipboard` for that, which is very platform-dependent - if I switched to wayland I'd suddenly have to get used to a different thing!

So now I can instead do:

```fish
LANG=en_US.UTF-8 gitcomp | tail -n 5 | mdtable -d\t release commits percent date | fish_clipboard_copy
```

and paste directly into my browser to get:

|release|commits|percent|date|
|:---|:---|:---|:---|
|3.4.0|1106|5.7%|2022-03-12 22:31:57 +0800 (7 months ago)|
|3.4.1|9|5.7%|2022-03-26 00:27:56 +0800 (7 months ago)|
|3.5.0|433|3%|2022-06-16 21:02:33 +1000 (4 months ago)|
|3.5.1|24|2.9%|2022-07-20 18:15:47 +0800 (3 months ago)|
|HEAD|469|0%||

and if I want to work on something from my clipboard, I can do

```fish
fish_clipboard_paste | something
```

and be reasonably sure it'll work.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
