### PR TITLE
git prompt: Interpret values as true for bools instead of relying on defined-or-not

### DIFF
--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -28,14 +28,14 @@ There are numerous customization options, which can be controlled with git optio
 
 Boolean options (those which enable or disable something) understand "1", "yes" or "true" to mean true and every other value to mean false.
 
-- ``$__fish_git_prompt_show_informative_status`` or the git option ``bash.showInformativeStatus`` can be set to enable the "informative" display, which will show a large amount of information - the number of dirty files, unpushed/unpulled commits, and more.
+- ``$__fish_git_prompt_show_informative_status`` or the git option ``bash.showInformativeStatus`` can be set to 1, true or yes to enable the "informative" display, which will show a large amount of information - the number of dirty files, unpushed/unpulled commits, and more.
   In large repositories, this can take a lot of time, so you may wish to disable it in these repositories with  ``git config --local bash.showInformativeStatus false``. It also changes the characters the prompt uses to less plain ones (``✚`` instead of ``*`` for the dirty state for example) , and if you are only interested in that, set ``$__fish_git_prompt_use_informative_chars`` instead.
 
   Because counting untracked files requires a lot of time, the number of untracked files is only shown if enabled via ``$__fish_git_prompt_showuntrackedfiles`` or the git option ``bash.showUntrackedFiles``.
 
-- ``$__fish_git_prompt_showdirtystate`` or the git option ``bash.showDirtyState`` can be set to show if the repository is "dirty", i.e. has uncommitted changes.
+- ``$__fish_git_prompt_showdirtystate`` or the git option ``bash.showDirtyState`` can be set to 1, true or yes to show if the repository is "dirty", i.e. has uncommitted changes.
 
-- ``$__fish_git_prompt_showuntrackedfiles`` or the git option ``bash.showUntrackedFiles`` can be set to show if the repository has untracked files (that aren't ignored).
+- ``$__fish_git_prompt_showuntrackedfiles`` or the git option ``bash.showUntrackedFiles`` can be set to 1, true or yes to show if the repository has untracked files (that aren't ignored).
 
 - ``$__fish_git_prompt_showupstream`` can be set to a list of values to determine how changes between HEAD and upstream are shown:
 
@@ -54,7 +54,7 @@ Boolean options (those which enable or disable something) understand "1", "yes" 
      ``none``
           disables (useful with informative status)
 
-- ``$__fish_git_prompt_showstashstate`` can be set to 1 to display the state of the stash.
+- ``$__fish_git_prompt_showstashstate`` can be set to 1, true or yes to display the state of the stash.
 
 - ``$__fish_git_prompt_shorten_branch_len`` can be set to the number of characters that the branch name will be shortened to.
 
@@ -71,7 +71,7 @@ Boolean options (those which enable or disable something) understand "1", "yes" 
 
      If none of these apply, the commit SHA shortened to 8 characters is used.
 
-- ``$__fish_git_prompt_showcolorhints`` can be set to 1 to enable coloring for the branch name and status symbols.
+- ``$__fish_git_prompt_showcolorhints`` can be set to 1, true or yes to enable coloring for the branch name and status symbols.
 
 A number of variables set characters and color used as indicators. Many of these have a different default if used with informative status enabled, or ``$__fish_git_prompt_use_informative_chars`` set. The usual default is given first, then the informative default (if it is different). If no default for the colors is given, they default to ``$__fish_git_prompt_color``.
 

--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -26,7 +26,7 @@ The ``fish_git_prompt`` function displays information about the current git repo
 
 There are numerous customization options, which can be controlled with git options or fish variables. git options, where available, take precedence over the fish variable with the same function. git options can be set on a per-repository or global basis. git options can be set with the ``git config`` command, while fish variables can be set as usual with the :doc:`set <set>` command.
 
-For the boolean options (those which enable or disable something), the fish variables understands "1" to mean true and every other value to mean false, the git settings need to be set to "true" or "false".
+Boolean options (those which enable or disable something) understand "1", "yes" or "true" to mean true and every other value to mean false.
 
 - ``$__fish_git_prompt_show_informative_status`` or the git option ``bash.showInformativeStatus`` can be set to enable the "informative" display, which will show a large amount of information - the number of dirty files, unpushed/unpulled commits, and more.
   In large repositories, this can take a lot of time, so you may wish to disable it in these repositories with  ``git config --local bash.showInformativeStatus false``. It also changes the characters the prompt uses to less plain ones (``✚`` instead of ``*`` for the dirty state for example) , and if you are only interested in that, set ``$__fish_git_prompt_use_informative_chars`` instead.

--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -26,6 +26,8 @@ The ``fish_git_prompt`` function displays information about the current git repo
 
 There are numerous customization options, which can be controlled with git options or fish variables. git options, where available, take precedence over the fish variable with the same function. git options can be set on a per-repository or global basis. git options can be set with the ``git config`` command, while fish variables can be set as usual with the :doc:`set <set>` command.
 
+For the boolean options (those which enable or disable something), the fish variables understands "1" to mean true and every other value to mean false, the git settings need to be set to "true" or "false".
+
 - ``$__fish_git_prompt_show_informative_status`` or the git option ``bash.showInformativeStatus`` can be set to enable the "informative" display, which will show a large amount of information - the number of dirty files, unpushed/unpulled commits, and more.
   In large repositories, this can take a lot of time, so you may wish to disable it in these repositories with  ``git config --local bash.showInformativeStatus false``. It also changes the characters the prompt uses to less plain ones (``✚`` instead of ``*`` for the dirty state for example) , and if you are only interested in that, set ``$__fish_git_prompt_use_informative_chars`` instead.
 
@@ -52,7 +54,7 @@ There are numerous customization options, which can be controlled with git optio
      ``none``
           disables (useful with informative status)
 
-- ``$__fish_git_prompt_showstashstate`` can be set to display the state of the stash.
+- ``$__fish_git_prompt_showstashstate`` can be set to 1 to display the state of the stash.
 
 - ``$__fish_git_prompt_shorten_branch_len`` can be set to the number of characters that the branch name will be shortened to.
 
@@ -69,7 +71,7 @@ There are numerous customization options, which can be controlled with git optio
 
      If none of these apply, the commit SHA shortened to 8 characters is used.
 
-- ``$__fish_git_prompt_showcolorhints`` can be set to enable coloring for the branch name and status symbols.
+- ``$__fish_git_prompt_showcolorhints`` can be set to 1 to enable coloring for the branch name and status symbols.
 
 A number of variables set characters and color used as indicators. Many of these have a different default if used with informative status enabled, or ``$__fish_git_prompt_use_informative_chars`` set. The usual default is given first, then the informative default (if it is different). If no default for the colors is given, they default to ``$__fish_git_prompt_color``.
 

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -18,7 +18,7 @@ function __fish_git_prompt_show_upstream --description "Helper function for fish
     set -l name
 
     # Default to informative if __fish_git_prompt_show_informative_status is set
-    if set -q __fish_git_prompt_show_informative_status
+    if test "$__fish_git_prompt_show_informative_status" = 1
         set informative 1
     end
 
@@ -230,14 +230,16 @@ function fish_git_prompt --description "Prompt function for Git"
     end
 
     # If we don't print these, there is no need to compute them. Note: For now, staged and dirty are coupled.
-    if not set -q dirty[1] && set -q __fish_git_prompt_showdirtystate
-        set dirty true
+    if not set -q dirty[1]
+        test "$__fish_git_prompt_showdirtystate" = 1
+        and set dirty true
     end
     contains dirtystate $__fish_git_prompt_status_order || contains stagedstate $__fish_git_prompt_status_order
     or set dirty false
 
-    if not set -q untracked[1] && set -q __fish_git_prompt_showuntrackedfiles
-        set untracked true
+    if not set -q untracked[1]
+        test "$__fish_git_prompt_showuntrackedfiles" = 1
+        and set untracked true
     end
     contains untrackedfiles $__fish_git_prompt_status_order
     or set untracked false
@@ -249,7 +251,7 @@ function fish_git_prompt --description "Prompt function for Git"
         # This is to allow overrides for the repository.
         if test "$informative" = true
             or begin
-                set -q __fish_git_prompt_show_informative_status
+                test "$__fish_git_prompt_show_informative_status" = 1
                 and test "$dirty" != false
             end
             set informative_status (untracked=$untracked __fish_git_prompt_informative_status $git_dir)
@@ -281,21 +283,21 @@ function fish_git_prompt --description "Prompt function for Git"
                 and set untrackedfiles (string match -qr '\?\?' -- $stat; and echo 1)
             end
 
-            if set -q __fish_git_prompt_showstashstate
+            if test "$__fish_git_prompt_showstashstate" = 1
                 and test -r $git_dir/logs/refs/stash
                 set stashstate 1
             end
         end
 
-        if set -q __fish_git_prompt_showupstream
-            or set -q __fish_git_prompt_show_informative_status
+        if test "$__fish_git_prompt_showupstream" = 1
+            or test "$__fish_git_prompt_show_informative_status" = 1
             set p (__fish_git_prompt_show_upstream)
         end
     end
 
     set -l branch_color $___fish_git_prompt_color_branch
     set -l branch_done $___fish_git_prompt_color_branch_done
-    if set -q __fish_git_prompt_showcolorhints
+    if test "$__fish_git_prompt_showcolorhints" = 1
         if test $detached = yes
             set branch_color $___fish_git_prompt_color_branch_detached
             set branch_done $___fish_git_prompt_color_branch_detached_done
@@ -332,7 +334,7 @@ function fish_git_prompt --description "Prompt function for Git"
     if test -n "$b"
         set b "$branch_color$b$branch_done"
         if test -z "$dirtystate$untrackedfiles$stagedstate"; and test -n "$___fish_git_prompt_char_cleanstate"
-            and not set -q __fish_git_prompt_show_informative_status
+            and not test "$__fish_git_prompt_show_informative_status" = 1
             set b "$b$___fish_git_prompt_color_cleanstate$___fish_git_prompt_char_cleanstate$___fish_git_prompt_color_cleanstate_done"
         end
     end
@@ -363,7 +365,7 @@ end
 function __fish_git_prompt_informative_status
     set -l stashstate 0
     set -l stashfile "$argv[1]/logs/refs/stash"
-    if set -q __fish_git_prompt_showstashstate; and test -e "$stashfile"
+    if test "$__fish_git_prompt_showstashstate" = 1; and test -e "$stashfile"
         set stashstate (count < $stashfile)
     end
 
@@ -518,8 +520,8 @@ function __fish_git_prompt_set_char
 
     if set -q argv[3]
         and begin
-            set -q __fish_git_prompt_show_informative_status
-            or set -q __fish_git_prompt_use_informative_chars
+            test "$__fish_git_prompt_show_informative_status" = 1
+            or test "$__fish_git_prompt_use_informative_chars" = 1
         end
         set char $argv[3]
     end
@@ -534,7 +536,7 @@ end
 
 function __fish_git_prompt_validate_chars --description "fish_git_prompt helper, checks char variables"
     # cleanstate is only defined with actual informative status.
-    set -q __fish_git_prompt_show_informative_status
+    test "$__fish_git_prompt_show_informative_status" = 1
     and __fish_git_prompt_set_char __fish_git_prompt_char_cleanstate '✔'
     or __fish_git_prompt_set_char __fish_git_prompt_char_cleanstate ''
 
@@ -598,7 +600,7 @@ function __fish_git_prompt_validate_colors --description "fish_git_prompt helper
     __fish_git_prompt_set_color __fish_git_prompt_color_upstream
 
     # Colors with defaults with showcolorhints
-    if set -q __fish_git_prompt_showcolorhints
+    if test "$__fish_git_prompt_showcolorhints" = 1
         __fish_git_prompt_set_color __fish_git_prompt_color_flags (set_color --bold blue)
         __fish_git_prompt_set_color __fish_git_prompt_color_branch (set_color green)
         __fish_git_prompt_set_color __fish_git_prompt_color_dirtystate (set_color red)

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -18,7 +18,7 @@ function __fish_git_prompt_show_upstream --description "Helper function for fish
     set -l name
 
     # Default to informative if __fish_git_prompt_show_informative_status is set
-    if test "$__fish_git_prompt_show_informative_status" = 1
+    if contains -- "$__fish_git_prompt_show_informative_status" yes true 1
         set informative 1
     end
 
@@ -231,14 +231,14 @@ function fish_git_prompt --description "Prompt function for Git"
 
     # If we don't print these, there is no need to compute them. Note: For now, staged and dirty are coupled.
     if not set -q dirty[1]
-        test "$__fish_git_prompt_showdirtystate" = 1
+        contains -- "$__fish_git_prompt_showdirtystate" yes true 1
         and set dirty true
     end
     contains dirtystate $__fish_git_prompt_status_order || contains stagedstate $__fish_git_prompt_status_order
     or set dirty false
 
     if not set -q untracked[1]
-        test "$__fish_git_prompt_showuntrackedfiles" = 1
+        contains -- "$__fish_git_prompt_showuntrackedfiles" yes true 1
         and set untracked true
     end
     contains untrackedfiles $__fish_git_prompt_status_order
@@ -251,7 +251,7 @@ function fish_git_prompt --description "Prompt function for Git"
         # This is to allow overrides for the repository.
         if test "$informative" = true
             or begin
-                test "$__fish_git_prompt_show_informative_status" = 1
+                contains -- "$__fish_git_prompt_show_informative_status" yes true 1
                 and test "$dirty" != false
             end
             set informative_status (untracked=$untracked __fish_git_prompt_informative_status $git_dir)
@@ -283,21 +283,21 @@ function fish_git_prompt --description "Prompt function for Git"
                 and set untrackedfiles (string match -qr '\?\?' -- $stat; and echo 1)
             end
 
-            if test "$__fish_git_prompt_showstashstate" = 1
+            if contains -- "$__fish_git_prompt_showstashstate" yes true 1
                 and test -r $git_dir/logs/refs/stash
                 set stashstate 1
             end
         end
 
-        if test "$__fish_git_prompt_showupstream" = 1
-            or test "$__fish_git_prompt_show_informative_status" = 1
+        if contains -- "$__fish_git_prompt_showupstream" yes true 1
+            or contains -- "$__fish_git_prompt_show_informative_status" yes true 1
             set p (__fish_git_prompt_show_upstream)
         end
     end
 
     set -l branch_color $___fish_git_prompt_color_branch
     set -l branch_done $___fish_git_prompt_color_branch_done
-    if test "$__fish_git_prompt_showcolorhints" = 1
+    if contains -- "$__fish_git_prompt_showcolorhints" yes true 1
         if test $detached = yes
             set branch_color $___fish_git_prompt_color_branch_detached
             set branch_done $___fish_git_prompt_color_branch_detached_done
@@ -334,7 +334,7 @@ function fish_git_prompt --description "Prompt function for Git"
     if test -n "$b"
         set b "$branch_color$b$branch_done"
         if test -z "$dirtystate$untrackedfiles$stagedstate"; and test -n "$___fish_git_prompt_char_cleanstate"
-            and not test "$__fish_git_prompt_show_informative_status" = 1
+            and not contains -- "$__fish_git_prompt_show_informative_status" yes true 1
             set b "$b$___fish_git_prompt_color_cleanstate$___fish_git_prompt_char_cleanstate$___fish_git_prompt_color_cleanstate_done"
         end
     end
@@ -365,7 +365,7 @@ end
 function __fish_git_prompt_informative_status
     set -l stashstate 0
     set -l stashfile "$argv[1]/logs/refs/stash"
-    if test "$__fish_git_prompt_showstashstate" = 1; and test -e "$stashfile"
+    if contains -- "$__fish_git_prompt_showstashstate" yes true 1; and test -e "$stashfile"
         set stashstate (count < $stashfile)
     end
 
@@ -520,8 +520,8 @@ function __fish_git_prompt_set_char
 
     if set -q argv[3]
         and begin
-            test "$__fish_git_prompt_show_informative_status" = 1
-            or test "$__fish_git_prompt_use_informative_chars" = 1
+            contains -- "$__fish_git_prompt_show_informative_status" yes true 1
+            or contains -- "$__fish_git_prompt_use_informative_chars" yes true 1
         end
         set char $argv[3]
     end
@@ -536,7 +536,7 @@ end
 
 function __fish_git_prompt_validate_chars --description "fish_git_prompt helper, checks char variables"
     # cleanstate is only defined with actual informative status.
-    test "$__fish_git_prompt_show_informative_status" = 1
+    contains -- "$__fish_git_prompt_show_informative_status" yes true 1
     and __fish_git_prompt_set_char __fish_git_prompt_char_cleanstate '✔'
     or __fish_git_prompt_set_char __fish_git_prompt_char_cleanstate ''
 
@@ -600,7 +600,7 @@ function __fish_git_prompt_validate_colors --description "fish_git_prompt helper
     __fish_git_prompt_set_color __fish_git_prompt_color_upstream
 
     # Colors with defaults with showcolorhints
-    if test "$__fish_git_prompt_showcolorhints" = 1
+    if contains -- "$__fish_git_prompt_showcolorhints" yes true 1
         __fish_git_prompt_set_color __fish_git_prompt_color_flags (set_color --bold blue)
         __fish_git_prompt_set_color __fish_git_prompt_color_branch (set_color green)
         __fish_git_prompt_set_color __fish_git_prompt_color_dirtystate (set_color red)

--- a/tests/checks/git.fish
+++ b/tests/checks/git.fish
@@ -61,6 +61,12 @@ fish_git_prompt
 echo
 #CHECK: (newbranch|✔)
 
+set -g __fish_git_prompt_show_informative_status 0
+fish_git_prompt
+echo # the git prompt doesn't print a newline
+#CHECK: (newbranch)
+set -g __fish_git_prompt_show_informative_status 1
+
 # Informative mode only shows untracked files if explicitly told.
 set -g __fish_git_prompt_showuntrackedfiles 1
 fish_git_prompt
@@ -80,12 +86,22 @@ git add foo
 fish_git_prompt
 echo
 #CHECK: (newbranch +)
+set -g __fish_git_prompt_showdirtystate 0
+fish_git_prompt
+echo
+#CHECK: (newbranch)
+set -g __fish_git_prompt_showdirtystate 1
 
 set -g __fish_git_prompt_showuntrackedfiles 1
 touch bananan
 fish_git_prompt
 echo
 #CHECK: (newbranch +%)
+set -g __fish_git_prompt_showuntrackedfiles 0
+fish_git_prompt
+echo
+#CHECK: (newbranch +)
+set -g __fish_git_prompt_showuntrackedfiles 1
 
 set -g __fish_git_prompt_status_order untrackedfiles stagedstate
 fish_git_prompt


### PR DESCRIPTION
This allows explicitly turning these settings off by setting the variable to e.g. 0.

See #7120

This is technically a change in behavior iff you set these variables to anything *but* "1". I don't think I've ever seen that, and it's easy enough to fix.

Note: This lacks the "hide" stuff (`__fish_git_prompt_hide_stagedstate` and friends), it's not documented, nigh-useless now that we properly look at the status order. I want to remove it.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
