### PR TITLE
docs: bind: explain more fully how modes work

### DIFF
--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -41,7 +41,7 @@ If no ``SEQUENCE`` is provided, all bindings (or just the bindings in the given 
 
 To save custom key bindings, put the ``bind`` statements into :ref:`config.fish <configuration>`. Alternatively, fish also automatically executes a function called ``fish_user_key_bindings`` if it exists.
 
-Key bindings may use "modes", which mimics Vi's modal input behavior. The default mode is "default". Every key binding applies to a single mode; you can specify which one with ``-M MODE``. If the key binding should change the mode, you can specify the new mode with ``-m NEW_MODE``. The mode can be viewed in the ``$fish_bind_mode`` variable. If you want to change the mode from inside a fish function, you can use the fish command `set fish_bind_mode MODE`.
+Key bindings may use "modes", which mimics Vi's modal input behavior. The default mode is "default". Every key binding applies to a single mode; you can specify which one with ``-M MODE``. If the key binding should change the mode, you can specify the new mode with ``-m NEW_MODE``. The mode can be viewed and changed via the ``$fish_bind_mode`` variable. If you want to change the mode from inside a fish function, use ``set fish_bind_mode MODE``.
 
 Options
 -------

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -39,9 +39,9 @@ Note that special input functions cannot be combined with ordinary shell script 
 
 If no ``SEQUENCE`` is provided, all bindings (or just the bindings in the given ``MODE``) are printed. If ``SEQUENCE`` is provided but no ``COMMAND``, just the binding matching that sequence is printed.
 
-To save custom keybindings, put the ``bind`` statements into :ref:`config.fish <configuration>`. Alternatively, fish also automatically executes a function called ``fish_user_key_bindings`` if it exists.
+To save custom key bindings, put the ``bind`` statements into :ref:`config.fish <configuration>`. Alternatively, fish also automatically executes a function called ``fish_user_key_bindings`` if it exists.
 
-Key bindings may use "modes", which mimics Vi's modal input behavior. The default mode is "default", and every bind applies to a single mode. The mode can be viewed/changed with the ``$fish_bind_mode`` variable.
+Key bindings may use "modes", which mimics Vi's modal input behavior. The default mode is "default". Every key binding applies to a single mode; you can specify which one with ``-M MODE``. If the key binding should change the mode, you can specify the new mode with ``-m NEW_MODE``. The mode can be viewed in the ``$fish_bind_mode`` variable. If you want to change the mode from inside a fish function, you can use the fish command `set fish_bind_mode MODE`.
 
 Options
 -------


### PR DESCRIPTION
## Description

In the docs for `bind`, the paragraph on modes previously only suggested using `set fish_bind_mode ...`. Update that paragraph to also explain the `-M MODE` and `-m NEW_MODE` flags.

Fixes issue (no issue number)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [NA] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
- [x] I missed one single-backquotes markdown, change that to double-backquotes ReStructuredText
