### PR TITLE
Allow erasing in multiple scopes in one go

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Notable improvements and fixes
     for a,b in y 1 z 3
         ^~^
 - A new helper function ``fish_delta`` can be used to show the difference to fish's stock configuration (:issue:`9255`).
+- It is now possible to specify multiple scopes for ``set -e`` and all of the named variables present in any of the specified scopes will be erased. This makes it possible to remove all instances of a variable in all scopes (``set -efglU foo``) in one go (:issue:`7711`).
+
+=======
 
 Deprecations and removed features
 ---------------------------------

--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -68,7 +68,7 @@ The following other options are available:
     Causes the values to be prepended to the current set of values for the variable. This can be used with **--append** to both append and prepend at the same time. This cannot be used when assigning to a variable slice.
 
 **-e** or **--erase**
-    Causes the specified shell variables to be erased
+    Causes the specified shell variables to be erased. Supports erasing from multiple scopes at once.
 
 **-q** or **--query**
     Test if the specified variable names are defined. Does not output anything, but the builtins exit status is the number of variables specified that were not defined, up to a maximum of 255. If no variable was given, it also returns 255.

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -921,3 +921,23 @@ foo=bar $FISH -c 'set foo 1 2 3; set --show foo'
 # CHECK: $foo[2]: |2|
 # CHECK: $foo[3]: |3|
 # CHECK: $foo: originally inherited as |bar|
+
+# Verify behavior of erasing in multiple scopes simultaneously
+set -U marbles global
+set -g marbles global
+set -l marbles local
+
+set -eUg marbles
+set -ql marbles || echo "erased in more scopes than it should!"
+set -qg marbles && echo "didn't erase from global scope!"
+set -qU marbles && echo "didn't erase from universal scope!"
+
+begin
+    set -l secret local 4 8 15 16 23 42
+    set -g secret global 4 8 15 16 23 42
+    set -egl secret[3..5]
+    echo $secret
+    # CHECK: local 4 23 42
+end
+echo $secret
+# CHECK: global 4 23 42


### PR DESCRIPTION
While I was working on `fish_config` I found myself trying to execute `set -egl ...` a few times, and I couldn't come up with a good reason for why this wasn't allowed.

This patch extends `set -e` to allow unsetting a variable from multiple scopes in one go. (The docs and changelog would also need to be updated.)

Closes #7711.