### PR TITLE
Document behavior of `set -f` outside a function?

### DIFF
--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -97,6 +97,7 @@ The scoping rules when creating or updating a variable are:
 
 - If a variable's scope is not explicitly set and there is no existing variable by that name, the variable will be local to the currently executing function. Note that this is different from using the ``-l`` or ``--local`` flag, in which case the variable will be local to the most-inner currently executing block, while without them the variable will be local to the function as a whole. If no function is executing, the variable will be set in the global scope.
 
+- Similarly, a variable explicitly set with ``-f`` or ``--function`` outside of any function (a top-level declaration or at the interactive prompt) will be assigned to the global scope instead.
 
 The exporting rules when creating or updating a variable are identical to the scoping rules for variables:
 


### PR DESCRIPTION
We should either document this behavior or emit an error (warning?) when function scope is explicitly requested but no function is executing. I'm leaning more towards the latter, but would like to hear others' thoughts.