### PR TITLE
completions/unzip: Silence stderr

### DIFF
--- a/share/completions/unzip.fish
+++ b/share/completions/unzip.fish
@@ -36,7 +36,7 @@ if unzip -v 2>/dev/null | string match -eq Debian
 
     # Files thereafter are either files to include or exclude from the operation
     set -l zipfile
-    complete -c unzip -n 'not __fish_is_nth_token 1' -xa '(unzip -l (eval set zipfile (__fish_first_token); echo $zipfile) | string replace -r --filter ".*:\S+\s+(.*)" "\$1")'
+    complete -c unzip -n 'not __fish_is_nth_token 1' -xa '(unzip -l (eval set zipfile (__fish_first_token); echo $zipfile) 2>/dev/null | string replace -r --filter ".*:\S+\s+(.*)" "\$1")'
 
 else
 


### PR DESCRIPTION
## Description

When fish completes an invalid zip file for `unzip`, an error message is displayed.

```text
touch invalid.zip
unzip invalid.zip <press TAB>
```

```log
PROMPT> unzip invalid.zip   End-of-central-directory signature not found. ...
...
...
PROMPT> unzip invalid.zip
```

To avoid this, redirect `stderr` to `/dev/null` in the completion script.