### PR TITLE
completions: fix qdbus property completion

### DIFF
--- a/share/completions/qdbus.fish
+++ b/share/completions/qdbus.fish
@@ -11,7 +11,7 @@ function __fish_qdbus_complete
     set argc (count $argv)
     if test $argc -le 3
         # avoid completion of property value
-        qdbus $qdbus_flags $argv[2] $argv[3] | string replace --regex '^(property(\ read)?|signal|method) ((\{.+\})|([^\ ]+)) ([^\(]+)(\(.+?\))?' '$6\t$1 $3 $7' | string trim
+        qdbus $qdbus_flags $argv[2] $argv[3] | string replace --regex '^(?<kind>property\ (read)?(write)?|signal|method) (?<type>(\{.+\})|([^\ ]+)) (?<name>[^\(]+)(?<arguments>\(.+?\))?' '$name\t$kind $type $arguments' | string trim
     end
 end
 


### PR DESCRIPTION
## Description

Improvements upon #9031 :

`qdbus` can print property as `read` `write` or `readwrite` [^1], this PR covers that.

Use named capturing group to improve readability.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst


[^1]: https://github.com/qt/qttools/blob/5.15.2/src/qdbus/qdbus/qdbus.cpp#L164-L172