### PR TITLE
fish_should_add_history function

### DIFF
--- a/doc_src/cmds/fish_should_add_history.rst
+++ b/doc_src/cmds/fish_should_add_history.rst
@@ -1,0 +1,45 @@
+.. _cmd-fish_should_add_history:
+
+fish_should_add_history - decide whether a command should be added to the history
+==============================================================
+
+Synopsis
+--------
+
+.. synopsis::
+
+    fish_should_add_history
+
+::
+
+  function fish_should_add_history
+      ...
+  end
+
+
+Description
+-----------
+
+The ``fish_should_add_history`` function is executed after every command that would normaly be saved to the disk. It is used to decide whether the command should be saved to the history or not.
+
+The function is executed with the command as its first argument. If the function returns a status of 0, the command is saved to the history. If the function returns a status of 255, the command is not saved to the history.
+
+The function can also return a status of 1 or 2, to save the command in ephemeral or memory mode respectively. This is useful for commands that should not be saved to the history file, but should be available for the up and down arrow keys.
+
+Example
+-------
+
+A simple example:
+
+
+
+::
+
+    function fish_should_add_history
+        for cmd in clear
+        string match -qr "^$cmd" -- $argv; and return 255
+        end
+        return 0
+    end
+
+

--- a/doc_src/commands.rst
+++ b/doc_src/commands.rst
@@ -60,6 +60,7 @@ Known functions are a customization point. You can change them to change how you
 - :doc:`fish_command_not_found <cmds/fish_command_not_found>` to tell fish what to do when a command is not found.
 - :doc:`fish_title <cmds/fish_title>` to change the terminal's title.
 - :doc:`fish_greeting <cmds/fish_greeting>` to show a greeting when fish starts.
+- :doc:`fish_should_add_history <cmd/fish_should_add_history>` to decide whether a command should be added to the history.
 
 Helper functions
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

Adding a function `fish_should_add_history` to check if an item should be added to the history. I think that there need to be alot more discussion on how this feature should work. I would also welcome feedback on hope I implemented the feature.

Fixes issue #5924

## TODOs:
- [ x ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
