### PR TITLE
fix lsblk column completion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -115,6 +115,8 @@ Completions
   - ``dua``
   - ``clojure``
 
+- Improvements to some completions.
+
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/share/completions/lsblk.fish
+++ b/share/completions/lsblk.fish
@@ -1,6 +1,5 @@
 function __fish_print_lsblk_columns --description 'Print available lsblk columns'
-    lsblk --help | sed '1,/Available columns:/d; /^$/,$d; s/^\s\+//; s/\s/\t/'
-
+    LC_ALL=C lsblk --help | sed '1,/Available .*columns:/d; /^$/,$d; s/^\s\+//; s/\s/\t/'
 end
 
 complete -c lsblk -s a -l all -d "print all devices"


### PR DESCRIPTION
## Description

The current completion of `lsblk -o` has been broken since commit [c3a4cfc](https://github.com/util-linux/util-linux/commit/c3a4cfc5795da0a5f7eb2753aef3f543d12c8341) of util-linux. This PR changes the completion so it works with the current help format.

## TODOs:
- n/a Changes to fish usage are reflected in user documentation/manpages.
- n/a Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
