### PR TITLE
string repeat: allow omission of -n

### DIFF
--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -418,6 +418,12 @@ string repeat --count 2 foo
 echo foo | string repeat -n 2
 # CHECK: foofoo
 
+echo foo | string repeat 2
+# CHECK: foofoo
+
+string repeat 2 foo
+# CHECK: foofoo
+
 string repeat -n2 -q foo; and echo "exit 0"
 # CHECK: exit 0
 
@@ -486,9 +492,8 @@ string repeat -n notanumber foo; and echo "exit 0"
 string repeat -m notanumber foo; and echo "exit 0"
 # CHECKERR: string repeat: notanumber: invalid integer
 
-# FIXME doesn't error
-#echo stdin | string repeat -n1 "and arg"; and echo "exit 0"
-# DONTCHECKERR: string repeat: too many arguments
+echo stdin | string repeat -n1 "and arg"; and echo "exit 0"
+# CHECKERR: string repeat: too many arguments
 
 string repeat -n; and echo "exit 0"
 # CHECKERR: string repeat: -n: option requires an argument

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -486,8 +486,9 @@ string repeat -n notanumber foo; and echo "exit 0"
 string repeat -m notanumber foo; and echo "exit 0"
 # CHECKERR: string repeat: notanumber: invalid integer
 
-echo stdin | string repeat -n1 "and arg"; and echo "exit 0"
-# CHECKERR: string repeat: too many arguments
+# FIXME doesn't error
+#echo stdin | string repeat -n1 "and arg"; and echo "exit 0"
+# DONTCHECKERR: string repeat: too many arguments
 
 string repeat -n; and echo "exit 0"
 # CHECKERR: string repeat: -n: option requires an argument
@@ -497,8 +498,7 @@ string repeat -n; and echo "exit 0"
 # DONTCHECKERR: string repeat: Unknown option '-l'
 
 string repeat ""
-or echo string repeat empty string failed
-# CHECK: string repeat empty string failed
+# CHECKERR: string repeat: Invalid count value: ''
 
 string repeat -n3 ""
 or echo string repeat empty string failed


### PR DESCRIPTION
This implements https://github.com/fish-shell/fish-shell/issues/9332

the new `string replace` signature is:

<pre class="p1">
<span class="s1"><b>string</b></span><span class="s2"> </span><span class="s1"><b>repeat</b></span><span class="s2"> [</span><span class="s1"><b>-N</b></span><span class="s2"> | </span><span class="s1"><b>--no-newline</b></span><span class="s2">] (</span><span class="s1"><b>-q</b></span><span class="s2"> | </span><span class="s1"><b>--quiet</b></span><span class="s2">] </span><span class="s3"><em>COUNT</em></span><span class="s2"> [</span><span class="s3"><em>STRING</em> …]<br><span class="s1"><b>string</b></span><span class="s2"> </span><span class="s1"><b>repeat</b></span><span class="s2"> [(</span><span class="s1"><b>-n</b></span><span class="s2"> | </span><span class="s1"><b>--count</b></span><span class="s2">) </span><span class="s3"><em>COUNT</em></span><span class="s2">] [(</span><span class="s1"><b>-m</b></span><span class="s2"> | </span><span class="s1"><b>--max</b></span><span class="s2">) </span><span class="s3"><em>MAX</em></span><span class="s2">] [</span><span class="s1"><b>-N</b></span><span class="s2"> | </span><span class="s1"><b>--no-newline</b></span><span class="s2">]</span><br><span class="s1">              [</span><span class="s4"><b>-q</b></span><span class="s1"> | </span><span class="s4"><b>--quiet</b></span><span class="s1">] [</span><span class="s5"><em>STRING</span><span class="s1"> …</em>]</span></pre>

Needs
- [x] Pass tests
- [ ] Add tests
- [ ] Documentation