### PR TITLE
ark: add completion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -115,6 +115,7 @@ Completions
   - ``dua``
   - ``clojure``
   - ``loadkeys``
+  - ``ark``
 
 - Improvements to some completions.
 

--- a/share/completions/ark.fish
+++ b/share/completions/ark.fish
@@ -1,0 +1,13 @@
+complete -c ark -s d -l dialog -d 'Show a dialog with options'
+complete -c ark -s m -l mimetypes -d 'List all supported MIME types'
+complete -c ark -s o -l destination -d 'Specify an extraction directory'
+
+complete -c ark -s c -l add -d 'Add files and directories to an archive interactively'
+complete -c ark -s t -l add-to -d 'Add files and directories to an archive'
+complete -c ark -s p -l changetofirstpath -d 'Use a first argument as input path'
+complete -c ark -s f -l autofilename -d 'Specify suffix for automatically choosen filename'
+
+complete -c ark -s b -l batch -d 'Use a batch interface'
+complete -c ark -s e -l autodestination -d 'Use a first argument as output path'
+complete -c ark -s a -l autosubfolder -d 'Create subfolder automatically for multiple archives'
+complete -c ark -s O -l opendestination -d 'Open upon extraction completion'


### PR DESCRIPTION
## Description

Add simple completion for [`ark`](https://apps.kde.org/ark/).

Note: please check option descriptions carefully, I am not sure that I've written them correctly.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
