### PR TITLE
builtin commandline: use readline

### DIFF
--- a/src/builtins/commandline.cpp
+++ b/src/builtins/commandline.cpp
@@ -24,9 +24,6 @@
 #include "../wgetopt.h"
 #include "../wutil.h"  // IWYU pragma: keep
 
-/// Handle a single readline_cmd_t command out-of-band.
-void reader_handle_command(readline_cmd_t cmd);
-
 /// Get the bounds of a part of the command line
 void commandline_get_part(const wchar_t *current_buffer, size_t current_cursor_pos,
                           commandline_part_t buffer_part, const wchar_t **begin,
@@ -252,17 +249,8 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
                     if (ld.is_repaint) continue;
                 }
 
-                // HACK: Execute these right here and now so they can affect any insertions/changes
-                // made via bindings. The correct solution is to change all `commandline`
-                // insert/replace operations into readline functions with associated data, so that
-                // all queued `commandline` operations - including buffer modifications - are
-                // executed in order
-                if (mc == rl::begin_undo_group || mc == rl::end_undo_group) {
-                    reader_handle_command(*mc);
-                } else {
-                    // Inserts the readline function at the back of the queue.
-                    reader_queue_ch(readline_cmd_t(*mc));
-                }
+                // Inserts the readline function at the back of the queue.
+                reader_queue_ch(readline_cmd_t(*mc));
             } else {
                 streams.err.append_format(_(L"%ls: Unknown input function '%ls'"), cmd, argv[i]);
                 builtin_print_error_trailer(parser, streams.err, cmd);

--- a/src/builtins/commandline.cpp
+++ b/src/builtins/commandline.cpp
@@ -450,26 +450,24 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
         return res & PARSER_TEST_ERROR ? STATUS_CMD_ERROR : STATUS_CMD_OK;
     }
 
-    commandline_get_part(current_buffer, current_cursor_pos, *buffer_part, &begin, &end);
-
     if (cursor_mode) {
         if (argc - w.woptind) {
-            long new_pos = fish_wcstol(argv[w.woptind]) + (begin - current_buffer);
+            long new_pos = fish_wcstol(argv[w.woptind]);
             if (errno) {
                 streams.err.append_format(BUILTIN_ERR_NOT_NUMBER, cmd, argv[w.woptind]);
                 builtin_print_error_trailer(parser, streams.err, cmd);
             }
 
-            new_pos =
-                std::max(0L, std::min(new_pos, static_cast<long>(std::wcslen(current_buffer))));
-            commandline_set_buffer(current_buffer, static_cast<size_t>(new_pos));
+            reader_queue_ch(readline_cmd_t(commandline_cursor_pos_t(*buffer_part, new_pos)));
         } else {
+            commandline_get_part(current_buffer, current_cursor_pos, *buffer_part, &begin, &end);
             size_t pos = current_cursor_pos - (begin - current_buffer);
             streams.out.append_format(L"%lu\n", static_cast<unsigned long>(pos));
         }
         return STATUS_CMD_OK;
     }
 
+    commandline_get_part(current_buffer, current_cursor_pos, *buffer_part, &begin, &end);
     int arg_count = argc - w.woptind;
     if (arg_count == 0) {
         write_part(begin, end, cut_at_cursor, tokenize, current_buffer, current_cursor_pos,

--- a/src/builtins/commandline.cpp
+++ b/src/builtins/commandline.cpp
@@ -297,7 +297,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
             return STATUS_INVALID_ARGS;
         }
 
-        using rl = readline_cmd_t;
+        using rl = readline_cmd_t::id_t;
         for (i = w.woptind; i < argc; i++) {
             if (auto mc = input_function_get_code(argv[i])) {
                 // Don't enqueue a repaint if we're currently in the middle of one,
@@ -315,7 +315,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
                     reader_handle_command(*mc);
                 } else {
                     // Inserts the readline function at the back of the queue.
-                    reader_queue_ch(*mc);
+                    reader_queue_ch(readline_cmd_t(*mc));
                 }
             } else {
                 streams.err.append_format(_(L"%ls: Unknown input function '%ls'"), cmd, argv[i]);

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3948,7 +3948,7 @@ static void test_input() {
     auto evt = input.read_char();
     if (!evt.is_readline()) {
         err(L"Event is not a readline");
-    } else if (evt.get_readline() != readline_cmd_t::down_line) {
+    } else if (evt.get_readline().id() != readline_cmd_t::id_t::down_line) {
         err(L"Expected to read char down_line");
     }
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -88,6 +88,8 @@ static constexpr const input_function_metadata_t input_function_metadata[] = {
     {L"", readline_cmd_t::id_t::disable_mouse_tracking},
     // Cannot be bound to a key, used by `commandline --cursor <pos>`
     {L"", readline_cmd_t::id_t::set_cursor},
+    // Cannot be bound to a key, used by `commandline --insert` etc.
+    {L"", readline_cmd_t::id_t::insert_chars},
     {L"accept-autosuggestion", readline_cmd_t::id_t::accept_autosuggestion},
     {L"and", readline_cmd_t::id_t::func_and},
     {L"backward-bigword", readline_cmd_t::id_t::backward_bigword},

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -78,92 +78,92 @@ static constexpr size_t input_function_count = R_END_INPUT_FUNCTIONS;
 /// input_common.h.
 struct input_function_metadata_t {
     const wchar_t *name;
-    readline_cmd_t code;
+    readline_cmd_t::id_t code;
 };
 
 /// A static mapping of all readline commands as strings to their readline_cmd_t equivalent.
 /// Keep this list sorted alphabetically!
 static constexpr const input_function_metadata_t input_function_metadata[] = {
     // NULL makes it unusable - this is specially inserted when we detect mouse input
-    {L"", readline_cmd_t::disable_mouse_tracking},
-    {L"accept-autosuggestion", readline_cmd_t::accept_autosuggestion},
-    {L"and", readline_cmd_t::func_and},
-    {L"backward-bigword", readline_cmd_t::backward_bigword},
-    {L"backward-char", readline_cmd_t::backward_char},
-    {L"backward-delete-char", readline_cmd_t::backward_delete_char},
-    {L"backward-jump", readline_cmd_t::backward_jump},
-    {L"backward-jump-till", readline_cmd_t::backward_jump_till},
-    {L"backward-kill-bigword", readline_cmd_t::backward_kill_bigword},
-    {L"backward-kill-line", readline_cmd_t::backward_kill_line},
-    {L"backward-kill-path-component", readline_cmd_t::backward_kill_path_component},
-    {L"backward-kill-word", readline_cmd_t::backward_kill_word},
-    {L"backward-word", readline_cmd_t::backward_word},
-    {L"begin-selection", readline_cmd_t::begin_selection},
-    {L"begin-undo-group", readline_cmd_t::begin_undo_group},
-    {L"beginning-of-buffer", readline_cmd_t::beginning_of_buffer},
-    {L"beginning-of-history", readline_cmd_t::beginning_of_history},
-    {L"beginning-of-line", readline_cmd_t::beginning_of_line},
-    {L"cancel", readline_cmd_t::cancel},
-    {L"cancel-commandline", readline_cmd_t::cancel_commandline},
-    {L"capitalize-word", readline_cmd_t::capitalize_word},
-    {L"complete", readline_cmd_t::complete},
-    {L"complete-and-search", readline_cmd_t::complete_and_search},
-    {L"delete-char", readline_cmd_t::delete_char},
-    {L"delete-or-exit", readline_cmd_t::delete_or_exit},
-    {L"down-line", readline_cmd_t::down_line},
-    {L"downcase-word", readline_cmd_t::downcase_word},
-    {L"end-of-buffer", readline_cmd_t::end_of_buffer},
-    {L"end-of-history", readline_cmd_t::end_of_history},
-    {L"end-of-line", readline_cmd_t::end_of_line},
-    {L"end-selection", readline_cmd_t::end_selection},
-    {L"end-undo-group", readline_cmd_t::end_undo_group},
-    {L"execute", readline_cmd_t::execute},
-    {L"exit", readline_cmd_t::exit},
-    {L"expand-abbr", readline_cmd_t::expand_abbr},
-    {L"force-repaint", readline_cmd_t::force_repaint},
-    {L"forward-bigword", readline_cmd_t::forward_bigword},
-    {L"forward-char", readline_cmd_t::forward_char},
-    {L"forward-jump", readline_cmd_t::forward_jump},
-    {L"forward-jump-till", readline_cmd_t::forward_jump_till},
-    {L"forward-single-char", readline_cmd_t::forward_single_char},
-    {L"forward-word", readline_cmd_t::forward_word},
-    {L"history-pager", readline_cmd_t::history_pager},
-    {L"history-prefix-search-backward", readline_cmd_t::history_prefix_search_backward},
-    {L"history-prefix-search-forward", readline_cmd_t::history_prefix_search_forward},
-    {L"history-search-backward", readline_cmd_t::history_search_backward},
-    {L"history-search-forward", readline_cmd_t::history_search_forward},
-    {L"history-token-search-backward", readline_cmd_t::history_token_search_backward},
-    {L"history-token-search-forward", readline_cmd_t::history_token_search_forward},
-    {L"insert-line-over", readline_cmd_t::insert_line_over},
-    {L"insert-line-under", readline_cmd_t::insert_line_under},
-    {L"kill-bigword", readline_cmd_t::kill_bigword},
-    {L"kill-inner-line", readline_cmd_t::kill_inner_line},
-    {L"kill-line", readline_cmd_t::kill_line},
-    {L"kill-selection", readline_cmd_t::kill_selection},
-    {L"kill-whole-line", readline_cmd_t::kill_whole_line},
-    {L"kill-word", readline_cmd_t::kill_word},
-    {L"nextd-or-forward-word", readline_cmd_t::nextd_or_forward_word},
-    {L"or", readline_cmd_t::func_or},
-    {L"pager-toggle-search", readline_cmd_t::pager_toggle_search},
-    {L"prevd-or-backward-word", readline_cmd_t::prevd_or_backward_word},
-    {L"redo", readline_cmd_t::redo},
-    {L"repaint", readline_cmd_t::repaint},
-    {L"repaint-mode", readline_cmd_t::repaint_mode},
-    {L"repeat-jump", readline_cmd_t::repeat_jump},
-    {L"repeat-jump-reverse", readline_cmd_t::reverse_repeat_jump},
-    {L"self-insert", readline_cmd_t::self_insert},
-    {L"self-insert-notfirst", readline_cmd_t::self_insert_notfirst},
-    {L"suppress-autosuggestion", readline_cmd_t::suppress_autosuggestion},
-    {L"swap-selection-start-stop", readline_cmd_t::swap_selection_start_stop},
-    {L"togglecase-char", readline_cmd_t::togglecase_char},
-    {L"togglecase-selection", readline_cmd_t::togglecase_selection},
-    {L"transpose-chars", readline_cmd_t::transpose_chars},
-    {L"transpose-words", readline_cmd_t::transpose_words},
-    {L"undo", readline_cmd_t::undo},
-    {L"up-line", readline_cmd_t::up_line},
-    {L"upcase-word", readline_cmd_t::upcase_word},
-    {L"yank", readline_cmd_t::yank},
-    {L"yank-pop", readline_cmd_t::yank_pop},
+    {L"", readline_cmd_t::id_t::disable_mouse_tracking},
+    {L"accept-autosuggestion", readline_cmd_t::id_t::accept_autosuggestion},
+    {L"and", readline_cmd_t::id_t::func_and},
+    {L"backward-bigword", readline_cmd_t::id_t::backward_bigword},
+    {L"backward-char", readline_cmd_t::id_t::backward_char},
+    {L"backward-delete-char", readline_cmd_t::id_t::backward_delete_char},
+    {L"backward-jump", readline_cmd_t::id_t::backward_jump},
+    {L"backward-jump-till", readline_cmd_t::id_t::backward_jump_till},
+    {L"backward-kill-bigword", readline_cmd_t::id_t::backward_kill_bigword},
+    {L"backward-kill-line", readline_cmd_t::id_t::backward_kill_line},
+    {L"backward-kill-path-component", readline_cmd_t::id_t::backward_kill_path_component},
+    {L"backward-kill-word", readline_cmd_t::id_t::backward_kill_word},
+    {L"backward-word", readline_cmd_t::id_t::backward_word},
+    {L"begin-selection", readline_cmd_t::id_t::begin_selection},
+    {L"begin-undo-group", readline_cmd_t::id_t::begin_undo_group},
+    {L"beginning-of-buffer", readline_cmd_t::id_t::beginning_of_buffer},
+    {L"beginning-of-history", readline_cmd_t::id_t::beginning_of_history},
+    {L"beginning-of-line", readline_cmd_t::id_t::beginning_of_line},
+    {L"cancel", readline_cmd_t::id_t::cancel},
+    {L"cancel-commandline", readline_cmd_t::id_t::cancel_commandline},
+    {L"capitalize-word", readline_cmd_t::id_t::capitalize_word},
+    {L"complete", readline_cmd_t::id_t::complete},
+    {L"complete-and-search", readline_cmd_t::id_t::complete_and_search},
+    {L"delete-char", readline_cmd_t::id_t::delete_char},
+    {L"delete-or-exit", readline_cmd_t::id_t::delete_or_exit},
+    {L"down-line", readline_cmd_t::id_t::down_line},
+    {L"downcase-word", readline_cmd_t::id_t::downcase_word},
+    {L"end-of-buffer", readline_cmd_t::id_t::end_of_buffer},
+    {L"end-of-history", readline_cmd_t::id_t::end_of_history},
+    {L"end-of-line", readline_cmd_t::id_t::end_of_line},
+    {L"end-selection", readline_cmd_t::id_t::end_selection},
+    {L"end-undo-group", readline_cmd_t::id_t::end_undo_group},
+    {L"execute", readline_cmd_t::id_t::execute},
+    {L"exit", readline_cmd_t::id_t::exit},
+    {L"expand-abbr", readline_cmd_t::id_t::expand_abbr},
+    {L"force-repaint", readline_cmd_t::id_t::force_repaint},
+    {L"forward-bigword", readline_cmd_t::id_t::forward_bigword},
+    {L"forward-char", readline_cmd_t::id_t::forward_char},
+    {L"forward-jump", readline_cmd_t::id_t::forward_jump},
+    {L"forward-jump-till", readline_cmd_t::id_t::forward_jump_till},
+    {L"forward-single-char", readline_cmd_t::id_t::forward_single_char},
+    {L"forward-word", readline_cmd_t::id_t::forward_word},
+    {L"history-pager", readline_cmd_t::id_t::history_pager},
+    {L"history-prefix-search-backward", readline_cmd_t::id_t::history_prefix_search_backward},
+    {L"history-prefix-search-forward", readline_cmd_t::id_t::history_prefix_search_forward},
+    {L"history-search-backward", readline_cmd_t::id_t::history_search_backward},
+    {L"history-search-forward", readline_cmd_t::id_t::history_search_forward},
+    {L"history-token-search-backward", readline_cmd_t::id_t::history_token_search_backward},
+    {L"history-token-search-forward", readline_cmd_t::id_t::history_token_search_forward},
+    {L"insert-line-over", readline_cmd_t::id_t::insert_line_over},
+    {L"insert-line-under", readline_cmd_t::id_t::insert_line_under},
+    {L"kill-bigword", readline_cmd_t::id_t::kill_bigword},
+    {L"kill-inner-line", readline_cmd_t::id_t::kill_inner_line},
+    {L"kill-line", readline_cmd_t::id_t::kill_line},
+    {L"kill-selection", readline_cmd_t::id_t::kill_selection},
+    {L"kill-whole-line", readline_cmd_t::id_t::kill_whole_line},
+    {L"kill-word", readline_cmd_t::id_t::kill_word},
+    {L"nextd-or-forward-word", readline_cmd_t::id_t::nextd_or_forward_word},
+    {L"or", readline_cmd_t::id_t::func_or},
+    {L"pager-toggle-search", readline_cmd_t::id_t::pager_toggle_search},
+    {L"prevd-or-backward-word", readline_cmd_t::id_t::prevd_or_backward_word},
+    {L"redo", readline_cmd_t::id_t::redo},
+    {L"repaint", readline_cmd_t::id_t::repaint},
+    {L"repaint-mode", readline_cmd_t::id_t::repaint_mode},
+    {L"repeat-jump", readline_cmd_t::id_t::repeat_jump},
+    {L"repeat-jump-reverse", readline_cmd_t::id_t::reverse_repeat_jump},
+    {L"self-insert", readline_cmd_t::id_t::self_insert},
+    {L"self-insert-notfirst", readline_cmd_t::id_t::self_insert_notfirst},
+    {L"suppress-autosuggestion", readline_cmd_t::id_t::suppress_autosuggestion},
+    {L"swap-selection-start-stop", readline_cmd_t::id_t::swap_selection_start_stop},
+    {L"togglecase-char", readline_cmd_t::id_t::togglecase_char},
+    {L"togglecase-selection", readline_cmd_t::id_t::togglecase_selection},
+    {L"transpose-chars", readline_cmd_t::id_t::transpose_chars},
+    {L"transpose-words", readline_cmd_t::id_t::transpose_words},
+    {L"undo", readline_cmd_t::id_t::undo},
+    {L"up-line", readline_cmd_t::id_t::up_line},
+    {L"upcase-word", readline_cmd_t::id_t::upcase_word},
+    {L"yank", readline_cmd_t::id_t::yank},
+    {L"yank-pop", readline_cmd_t::id_t::yank_pop},
 };
 
 ASSERT_SORTED_BY_NAME(input_function_metadata);
@@ -212,12 +212,12 @@ static void input_set_bind_mode(parser_t &parser, const wcstring &bm) {
 }
 
 /// Returns the arity of a given input function.
-static int input_function_arity(readline_cmd_t function) {
-    switch (function) {
-        case readline_cmd_t::forward_jump:
-        case readline_cmd_t::backward_jump:
-        case readline_cmd_t::forward_jump_till:
-        case readline_cmd_t::backward_jump_till:
+static int input_function_arity(const readline_cmd_t& function) {
+    switch (function.id()) {
+        case readline_cmd_t::id_t::forward_jump:
+        case readline_cmd_t::id_t::backward_jump:
+        case readline_cmd_t::id_t::forward_jump_till:
+        case readline_cmd_t::id_t::backward_jump_till:
             return 1;
         default:
             return 0;
@@ -360,7 +360,7 @@ wchar_t inputter_t::function_pop_arg() {
     return result;
 }
 
-void inputter_t::function_push_args(readline_cmd_t code) {
+void inputter_t::function_push_args(const readline_cmd_t& code) {
     int arity = input_function_arity(code);
     assert(event_storage_.empty() && "event_storage_ should be empty");
     auto &skipped = event_storage_;
@@ -418,7 +418,7 @@ void inputter_t::mapping_execute(const input_mapping_t &m,
     } else if (has_functions && !has_commands) {
         // Functions are added at the head of the input queue.
         for (auto it = m.commands.rbegin(), end = m.commands.rend(); it != end; ++it) {
-            readline_cmd_t code = input_function_get_code(*it).value();
+            readline_cmd_t::id_t code = input_function_get_code(*it).value();
             function_push_args(code);
             this->push_front(char_event_t(code, m.seq));
         }
@@ -674,7 +674,7 @@ void inputter_t::mapping_execute_matching_or_generic(const command_handler_t &co
         // of a helper function to disable mouse tracking.
         // writembs(outputter_t::stdoutput(), "\x1B[?1000l");
         peeker.consume();
-        this->push_front(char_event_t(readline_cmd_t::disable_mouse_tracking, L""));
+        this->push_front(char_event_t(readline_cmd_t::id_t::disable_mouse_tracking, L""));
         return;
     }
     peeker.restart();
@@ -732,9 +732,9 @@ char_event_t inputter_t::read_char(const command_handler_t &command_handler) {
         auto evt = this->readch();
 
         if (evt.is_readline()) {
-            switch (evt.get_readline()) {
-                case readline_cmd_t::self_insert:
-                case readline_cmd_t::self_insert_notfirst: {
+            switch (evt.get_readline().id()) {
+                case readline_cmd_t::id_t::self_insert:
+                case readline_cmd_t::id_t::self_insert_notfirst: {
                     // Typically self-insert is generated by the generic (empty) binding.
                     // However if it is generated by a real sequence, then insert that sequence.
                     this->insert_front(evt.seq.cbegin(), evt.seq.cend());
@@ -743,15 +743,16 @@ char_event_t inputter_t::read_char(const command_handler_t &command_handler) {
                     char_event_t res = read_characters_no_readline();
 
                     // Hackish: mark the input style.
-                    res.input_style = evt.get_readline() == readline_cmd_t::self_insert_notfirst
-                                          ? char_input_style_t::notfirst
-                                          : char_input_style_t::normal;
+                    res.input_style =
+                        evt.get_readline().id() == readline_cmd_t::id_t::self_insert_notfirst
+                            ? char_input_style_t::notfirst
+                            : char_input_style_t::normal;
                     return res;
                 }
-                case readline_cmd_t::func_and:
-                case readline_cmd_t::func_or: {
+                case readline_cmd_t::id_t::func_and:
+                case readline_cmd_t::id_t::func_or: {
                     // If previous function has correct status, we keep reading tokens
-                    if (evt.get_readline() == readline_cmd_t::func_and) {
+                    if (evt.get_readline().id() == readline_cmd_t::id_t::func_and) {
                         // Don't return immediately, we might need to handle it here - like
                         // self-insert.
                         if (function_status_) continue;
@@ -960,7 +961,7 @@ const wcstring_list_t &input_function_get_names() {
     return result;
 }
 
-maybe_t<readline_cmd_t> input_function_get_code(const wcstring &name) {
+maybe_t<readline_cmd_t::id_t> input_function_get_code(const wcstring &name) {
     // `input_function_metadata` is required to be kept in asciibetical order, making it OK to do
     // a binary search for the matching name.
     if (const input_function_metadata_t *md = get_by_sorted_name(name, input_function_metadata)) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -86,6 +86,8 @@ struct input_function_metadata_t {
 static constexpr const input_function_metadata_t input_function_metadata[] = {
     // NULL makes it unusable - this is specially inserted when we detect mouse input
     {L"", readline_cmd_t::id_t::disable_mouse_tracking},
+    // Cannot be bound to a key, used by `commandline --cursor <pos>`
+    {L"", readline_cmd_t::id_t::set_cursor},
     {L"accept-autosuggestion", readline_cmd_t::id_t::accept_autosuggestion},
     {L"and", readline_cmd_t::id_t::func_and},
     {L"backward-bigword", readline_cmd_t::id_t::backward_bigword},

--- a/src/input.h
+++ b/src/input.h
@@ -68,7 +68,7 @@ class inputter_t final : private input_event_queue_t {
     void uvar_change_notified() override;
 
     void function_push_arg(wchar_t arg);
-    void function_push_args(readline_cmd_t code);
+    void function_push_args(const readline_cmd_t& code);
     void mapping_execute(const input_mapping_t &m, const command_handler_t &command_handler);
     void mapping_execute_matching_or_generic(const command_handler_t &command_handler);
     maybe_t<input_mapping_t> find_mapping(event_queue_peeker_t *peeker);
@@ -152,7 +152,7 @@ bool input_terminfo_get_name(const wcstring &seq, wcstring *out_name);
 wcstring_list_t input_terminfo_get_names(bool skip_null);
 
 /// Returns the input function code for the given input function name.
-maybe_t<readline_cmd_t> input_function_get_code(const wcstring &name);
+maybe_t<readline_cmd_t::id_t> input_function_get_code(const wcstring &name);
 
 /// Returns a list of all existing input function names.
 const wcstring_list_t &input_function_get_names(void);

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -12,91 +12,103 @@
 #include "common.h"
 #include "maybe.h"
 
-enum class readline_cmd_t {
-    beginning_of_line,
-    end_of_line,
-    forward_char,
-    backward_char,
-    forward_single_char,
-    forward_word,
-    backward_word,
-    forward_bigword,
-    backward_bigword,
-    nextd_or_forward_word,
-    prevd_or_backward_word,
-    history_search_backward,
-    history_search_forward,
-    history_prefix_search_backward,
-    history_prefix_search_forward,
-    history_pager,
-    delete_char,
-    backward_delete_char,
-    kill_line,
-    yank,
-    yank_pop,
-    complete,
-    complete_and_search,
-    pager_toggle_search,
-    beginning_of_history,
-    end_of_history,
-    backward_kill_line,
-    kill_whole_line,
-    kill_inner_line,
-    kill_word,
-    kill_bigword,
-    backward_kill_word,
-    backward_kill_path_component,
-    backward_kill_bigword,
-    history_token_search_backward,
-    history_token_search_forward,
-    self_insert,
-    self_insert_notfirst,
-    transpose_chars,
-    transpose_words,
-    upcase_word,
-    downcase_word,
-    capitalize_word,
-    togglecase_char,
-    togglecase_selection,
-    execute,
-    beginning_of_buffer,
-    end_of_buffer,
-    repaint_mode,
-    repaint,
-    force_repaint,
-    up_line,
-    down_line,
-    suppress_autosuggestion,
-    accept_autosuggestion,
-    begin_selection,
-    swap_selection_start_stop,
-    end_selection,
-    kill_selection,
-    insert_line_under,
-    insert_line_over,
-    forward_jump,
-    backward_jump,
-    forward_jump_till,
-    backward_jump_till,
-    func_and,
-    func_or,
-    expand_abbr,
-    delete_or_exit,
-    exit,
-    cancel_commandline,
-    cancel,
-    undo,
-    redo,
-    begin_undo_group,
-    end_undo_group,
-    repeat_jump,
-    disable_mouse_tracking,
-    // NOTE: This one has to be last.
-    reverse_repeat_jump
+class readline_cmd_t {
+   public:
+    enum class id_t {
+        beginning_of_line,
+        end_of_line,
+        forward_char,
+        backward_char,
+        forward_single_char,
+        forward_word,
+        backward_word,
+        forward_bigword,
+        backward_bigword,
+        nextd_or_forward_word,
+        prevd_or_backward_word,
+        history_search_backward,
+        history_search_forward,
+        history_prefix_search_backward,
+        history_prefix_search_forward,
+        history_pager,
+        delete_char,
+        backward_delete_char,
+        kill_line,
+        yank,
+        yank_pop,
+        complete,
+        complete_and_search,
+        pager_toggle_search,
+        beginning_of_history,
+        end_of_history,
+        backward_kill_line,
+        kill_whole_line,
+        kill_inner_line,
+        kill_word,
+        kill_bigword,
+        backward_kill_word,
+        backward_kill_path_component,
+        backward_kill_bigword,
+        history_token_search_backward,
+        history_token_search_forward,
+        self_insert,
+        self_insert_notfirst,
+        transpose_chars,
+        transpose_words,
+        upcase_word,
+        downcase_word,
+        capitalize_word,
+        togglecase_char,
+        togglecase_selection,
+        execute,
+        beginning_of_buffer,
+        end_of_buffer,
+        repaint_mode,
+        repaint,
+        force_repaint,
+        up_line,
+        down_line,
+        suppress_autosuggestion,
+        accept_autosuggestion,
+        begin_selection,
+        swap_selection_start_stop,
+        end_selection,
+        kill_selection,
+        insert_line_under,
+        insert_line_over,
+        forward_jump,
+        backward_jump,
+        forward_jump_till,
+        backward_jump_till,
+        func_and,
+        func_or,
+        expand_abbr,
+        delete_or_exit,
+        exit,
+        cancel_commandline,
+        cancel,
+        undo,
+        redo,
+        begin_undo_group,
+        end_undo_group,
+        repeat_jump,
+        disable_mouse_tracking,
+        // NOTE: This one has to be last.
+        reverse_repeat_jump
+    };
+
+    /// Get the command this instance represents
+    id_t id() const { return id_; }
+
+    /// Create a command without data.
+    /* implicit */ readline_cmd_t(readline_cmd_t::id_t id) : id_(id){};
+
+   private:
+    id_t id_;
 };
 
 // The range of key codes for inputrc-style keyboard functions.
-enum { R_END_INPUT_FUNCTIONS = static_cast<int>(readline_cmd_t::reverse_repeat_jump) + 1 };
+enum { R_END_INPUT_FUNCTIONS = static_cast<int>(readline_cmd_t::id_t::reverse_repeat_jump) + 1 };
 
 /// Represents an event on the character input stream.
 enum class char_event_type_t : uint8_t {
@@ -165,7 +177,7 @@ class char_event_t {
         }
     }
 
-    readline_cmd_t get_readline() const {
+    const readline_cmd_t& get_readline() const {
         assert(type == char_event_type_t::readline && "Not a readline type");
         return v_.rl;
     }

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -12,6 +12,14 @@
 #include "common.h"
 #include "maybe.h"
 
+/// Which part of the commandline buffer are we operating on.
+enum class commandline_part_t {
+    buffer,   // operate on entire buffer
+    job,      // operate on job under cursor
+    process,  // operate on process under cursor
+    token     // operate on token under cursor
+};
+
 class readline_cmd_t {
    public:
     enum class id_t {

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -20,6 +20,18 @@ enum class commandline_part_t {
     token     // operate on token under cursor
 };
 
+/// Data for set_cursor command.
+struct commandline_cursor_pos_t {
+    commandline_part_t part;
+    long pos;
+
+    // Hack for default initialization for commands other than
+    // set_cursor. Will be removed in the next commit.
+    commandline_cursor_pos_t() {}
+
+    commandline_cursor_pos_t(commandline_part_t part, long pos) : part(part), pos(pos) {}
+};
+
 class readline_cmd_t {
    public:
     enum class id_t {
@@ -101,6 +113,7 @@ class readline_cmd_t {
         end_undo_group,
         repeat_jump,
         disable_mouse_tracking,
+        set_cursor,
         // NOTE: This one has to be last.
         reverse_repeat_jump
     };
@@ -108,11 +121,26 @@ class readline_cmd_t {
     /// Get the command this instance represents
     id_t id() const { return id_; }
 
+    /// Get the data associated with set_cursor command.
+    const commandline_cursor_pos_t& get_cursor_pos() const {
+        assert(id_ == id_t::set_cursor && "Only valid for set_cursor");
+        return cursor_pos_;
+    }
+
     /// Create a command without data.
-    /* implicit */ readline_cmd_t(readline_cmd_t::id_t id) : id_(id){};
+    /* implicit */ readline_cmd_t(readline_cmd_t::id_t id) : id_(id) {
+        assert(id_ != id_t::set_cursor && "Cannot create set_cursor command with this constructor");
+    }
+
+    /// Create set_cursor command.
+    /* implicit */ readline_cmd_t(commandline_cursor_pos_t pos)
+        : id_(id_t::set_cursor), cursor_pos_(pos) {}
 
    private:
     id_t id_;
+
+    /// Only used by set_cursor command
+    commandline_cursor_pos_t cursor_pos_;
 };
 
 // The range of key codes for inputrc-style keyboard functions.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -138,6 +138,34 @@ static acquired_lock<commandline_state_t> commandline_state_snapshot() {
 
 commandline_state_t commandline_get_state() { return *commandline_state_snapshot(); }
 
+void commandline_get_part(const wchar_t *current_buffer, size_t current_cursor_pos,
+                          commandline_part_t buffer_part, const wchar_t **begin,
+                          const wchar_t **end) {
+    switch (buffer_part) {
+        case commandline_part_t::buffer: {
+            *begin = current_buffer;
+            *end = *begin + std::wcslen(*begin);
+            break;
+        }
+        case commandline_part_t::process: {
+            parse_util_process_extent(current_buffer, current_cursor_pos, begin, end, nullptr);
+            break;
+        }
+        case commandline_part_t::job: {
+            parse_util_job_extent(current_buffer, current_cursor_pos, begin, end);
+            break;
+        }
+        case commandline_part_t::token: {
+            parse_util_token_extent(current_buffer, current_cursor_pos, begin, end, nullptr,
+                                    nullptr);
+            break;
+        }
+        default: {
+            DIE("unexpected buffer_part");
+        }
+    }
+}
+
 void commandline_set_buffer(wcstring text, size_t cursor_pos) {
     auto state = commandline_state_snapshot();
     state->cursor_pos = std::min(cursor_pos, text.size());

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -4199,6 +4199,27 @@ void reader_data_t::handle_readline_command(const readline_cmd_t& c, readline_lo
             update_buff_pos(el, static_cast<size_t>(pos));
             break;
         }
+        case rl::insert_chars: {
+            auto el = active_edit_line();
+            auto ins = c.get_insertion();
+            if (ins.mode == commandline_insertion_mode_t::insert) {
+                insert_string(el, ins.str);
+            } else {
+                const wchar_t *begin;
+                const wchar_t *end;
+                const wchar_t *buffer = el->text().c_str();
+                commandline_get_part(buffer, el->position(), ins.part, &begin, &end);
+                if (ins.mode == commandline_insertion_mode_t::replace) {
+                    replace_substring(el, begin - buffer, end - begin, ins.str);
+                } else {
+                    auto current_pos = el->position();
+                    update_buff_pos(el, end - buffer);
+                    insert_string(el, ins.str);
+                    update_buff_pos(el, current_pos);
+                }
+            }
+            break;
+        }
         // Some commands should have been handled internally by inputter_t::readch().
         case rl::self_insert:
         case rl::self_insert_notfirst:

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -4626,13 +4626,6 @@ void reader_schedule_prompt_repaint() {
     }
 }
 
-void reader_handle_command(readline_cmd_t cmd) {
-    if (reader_data_t *data = current_data_or_null()) {
-        readline_loop_state_t rls{};
-        data->handle_readline_command(cmd, rls);
-    }
-}
-
 void reader_queue_ch(const char_event_t &ch) {
     if (reader_data_t *data = current_data_or_null()) {
         data->inputter.queue_char(ch);

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -4187,6 +4187,18 @@ void reader_data_t::handle_readline_command(const readline_cmd_t& c, readline_lo
             outp.writestr(L"\x1B[?1000l");
             break;
         }
+        case rl::set_cursor: {
+            auto cursor_pos = c.get_cursor_pos();
+            const wchar_t *begin;
+            const wchar_t *end;
+            auto el = active_edit_line();
+            const wchar_t *buffer = el->text().c_str();
+            commandline_get_part(buffer, el->position(), cursor_pos.part, &begin, &end);
+            long pos = cursor_pos.pos + (begin - buffer);
+            pos = std::max(0L, std::min(pos, static_cast<long>(el->size())));
+            update_buff_pos(el, static_cast<size_t>(pos));
+            break;
+        }
         // Some commands should have been handled internally by inputter_t::readch().
         case rl::self_insert:
         case rl::self_insert_notfirst:

--- a/tests/pexpects/commandline.py
+++ b/tests/pexpects/commandline.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from pexpect_helper import SpawnedProc, control
+from re import escape
 
 sp = SpawnedProc()
 send, sendline, sleep, expect_prompt, expect_re, expect_str = (
@@ -11,6 +12,72 @@ send, sendline, sleep, expect_prompt, expect_re, expect_str = (
     sp.expect_str,
 )
 expect_prompt()
+
+# Setup commandline test bindings
+sendline(r"""function query_commandline;\
+                 printf '\n%s ' (commandline --cursor); commandline;\
+                 commandline -f cancel-commandline;\
+             end;\
+             bind \eQ query_commandline;\
+             bind \eT test_commandline;""")
+expect_prompt()
+
+# Run a commandline test
+#   commandline is the command line text
+#   binding is the function body for test_commandline
+#   expect is the expected value of $result (see query_commandline above)
+def t(commandline, binding, expect):
+    sendline(f"function test_commandline; {binding}; end")
+    expect_prompt()
+    sendline(f"{commandline}\x1bT\x1bQ")
+    expect_prompt(escape(f"\r\n{expect}\r\n"))
+
+# commandline --cursor
+t("abcdef", "commandline --cursor 3", "3 abcdef")
+t("abc defghi jkl",
+  "commandline --cursor 8; commandline --current-token --cursor 1",
+  "5 abc defghi jkl")
+t("abc def", "commandline --current-token --cursor -- -3", "1 abc def")
+t("abc def", "commandline --current-token --cursor -- -100", "0 abc def")
+t("abc def",
+  "commandline --current-token --cursor 0; commandline --insert x",
+  "5 abc xdef")
+t("echo ===; echo hello | echo there",
+  "commandline --current-job --cursor 5",
+  "14 echo ===; echo hello | echo there" )
+t("echo hello | echo there",
+  "commandline --current-process --cursor 4",
+  "16 echo hello | echo there")
+
+# commandline --insert
+t("abc", "commandline --cursor 2; commandline --insert x", "3 abxc")
+t("abc defghi jkl",
+  "commandline --cursor 8; commandline --current-token --insert x",
+  "9 abc defgxhi jkl")
+
+# commandline --append
+t("abc def; ghi", "commandline --append x", "12 abc def; ghix")
+t("abc def ghi",
+  "commandline --cursor 5; commandline --current-token --append x",
+  "5 abc defx ghi")
+t("abc def | efg hij",
+  "commandline --cursor 1; commandline --current-process --append x",
+  "1 abc def x| efg hij")
+t("echo ===; echo hello | echo there; echo bye",
+  "commandline --cursor 12; commandline --current-job --append x",
+  "12 echo ===; echo hello | echo therex; echo bye")
+
+# commandline --replace
+t("abc def; ghi", "commandline --replace 'hello'", "5 hello")
+t("abc def ghi",
+  "commandline --cursor 5; commandline --current-token --replace xxx",
+  "7 abc xxx ghi")
+t("abc def | efg hij",
+  "commandline --cursor 2; commandline --current-process --replace xxx",
+  "3 xxx| efg hij")
+t("echo ===; echo hello | echo there; echo bye",
+  "commandline --cursor 12; commandline --current-job --replace xxx",
+  "12 echo ===;xxx; echo bye")
 
 sendline("bind '~' 'handle_tilde'")
 expect_prompt()

--- a/tests/pexpects/commandline.py
+++ b/tests/pexpects/commandline.py
@@ -92,6 +92,13 @@ t("abc def ghi",
    commandline --insert x",
   "9 abc def xghi")
 
+#commandline -f begin/end_undo_group
+t("abc def ghi",
+  "commandline -f begin-undo-group;\
+   commandline -f backward-delete-char backward-delete-char;\
+   commandline -f end-undo-group undo",
+  "11 abc def ghi")
+
 sendline("bind '~' 'handle_tilde'")
 expect_prompt()
 

--- a/tests/pexpects/commandline.py
+++ b/tests/pexpects/commandline.py
@@ -39,9 +39,11 @@ t("abc defghi jkl",
   "5 abc defghi jkl")
 t("abc def", "commandline --current-token --cursor -- -3", "1 abc def")
 t("abc def", "commandline --current-token --cursor -- -100", "0 abc def")
-t("abc def",
-  "commandline --current-token --cursor 0; commandline --insert x",
-  "5 abc xdef")
+# temporarily broken as `commandline --insert` now happens before `commandline --cursor`
+# fixed in the next commit
+#t("abc def",
+#  "commandline --current-token --cursor 0; commandline --insert x",
+#  "5 abc xdef")
 t("echo ===; echo hello | echo there",
   "commandline --current-job --cursor 5",
   "14 echo ===; echo hello | echo there" )
@@ -50,34 +52,47 @@ t("echo hello | echo there",
   "16 echo hello | echo there")
 
 # commandline --insert
-t("abc", "commandline --cursor 2; commandline --insert x", "3 abxc")
-t("abc defghi jkl",
-  "commandline --cursor 8; commandline --current-token --insert x",
-  "9 abc defgxhi jkl")
+# temporarily broken as `commandline --insert` now happens before `commandline --cursor`
+# fixed in the next commit
+#t("abc", "commandline --cursor 2; commandline --insert x", "3 abxc")
+#t("abc defghi jkl",
+#  "commandline --cursor 8; commandline --current-token --insert x",
+#  "9 abc defgxhi jkl")
 
 # commandline --append
 t("abc def; ghi", "commandline --append x", "12 abc def; ghix")
-t("abc def ghi",
-  "commandline --cursor 5; commandline --current-token --append x",
-  "5 abc defx ghi")
-t("abc def | efg hij",
-  "commandline --cursor 1; commandline --current-process --append x",
-  "1 abc def x| efg hij")
-t("echo ===; echo hello | echo there; echo bye",
-  "commandline --cursor 12; commandline --current-job --append x",
-  "12 echo ===; echo hello | echo therex; echo bye")
+# temporarily broken as `commandline --append` now happens before `commandline --cursor`
+# fixed in the next commit
+#t("abc def ghi",
+#  "commandline --cursor 5; commandline --current-token --append x",
+#  "5 abc defx ghi")
+#t("abc def | efg hij",
+#  "commandline --cursor 1; commandline --current-process --append x",
+#  "1 abc def x| efg hij")
+#t("echo ===; echo hello | echo there; echo bye",
+#  "commandline --cursor 12; commandline --current-job --append x",
+#  "12 echo ===; echo hello | echo therex; echo bye")
 
 # commandline --replace
 t("abc def; ghi", "commandline --replace 'hello'", "5 hello")
+# temporarily broken as `commandline --replace` now happens before `commandline --cursor`
+# fixed in the next commit
+#t("abc def ghi",
+#  "commandline --cursor 5; commandline --current-token --replace xxx",
+#  "7 abc xxx ghi")
+#t("abc def | efg hij",
+#  "commandline --cursor 2; commandline --current-process --replace xxx",
+#  "3 xxx| efg hij")
+#t("echo ===; echo hello | echo there; echo bye",
+#  "commandline --cursor 12; commandline --current-job --replace xxx",
+#  "12 echo ===;xxx; echo bye")
+
+# commandline -f followed by commandline --cursor
 t("abc def ghi",
-  "commandline --cursor 5; commandline --current-token --replace xxx",
-  "7 abc xxx ghi")
-t("abc def | efg hij",
-  "commandline --cursor 2; commandline --current-process --replace xxx",
-  "3 xxx| efg hij")
-t("echo ===; echo hello | echo there; echo bye",
-  "commandline --cursor 12; commandline --current-job --replace xxx",
-  "12 echo ===;xxx; echo bye")
+  "commandline -f backward-char begin-selection;\
+   commandline --cursor 4;\
+   commandline -f kill-selection end-selection",
+  "4 abc i")
 
 sendline("bind '~' 'handle_tilde'")
 expect_prompt()

--- a/tests/pexpects/commandline.py
+++ b/tests/pexpects/commandline.py
@@ -39,11 +39,9 @@ t("abc defghi jkl",
   "5 abc defghi jkl")
 t("abc def", "commandline --current-token --cursor -- -3", "1 abc def")
 t("abc def", "commandline --current-token --cursor -- -100", "0 abc def")
-# temporarily broken as `commandline --insert` now happens before `commandline --cursor`
-# fixed in the next commit
-#t("abc def",
-#  "commandline --current-token --cursor 0; commandline --insert x",
-#  "5 abc xdef")
+t("abc def",
+  "commandline --current-token --cursor 0; commandline --insert x",
+  "5 abc xdef")
 t("echo ===; echo hello | echo there",
   "commandline --current-job --cursor 5",
   "14 echo ===; echo hello | echo there" )
@@ -52,40 +50,34 @@ t("echo hello | echo there",
   "16 echo hello | echo there")
 
 # commandline --insert
-# temporarily broken as `commandline --insert` now happens before `commandline --cursor`
-# fixed in the next commit
-#t("abc", "commandline --cursor 2; commandline --insert x", "3 abxc")
-#t("abc defghi jkl",
-#  "commandline --cursor 8; commandline --current-token --insert x",
-#  "9 abc defgxhi jkl")
+t("abc", "commandline --cursor 2; commandline --insert x", "3 abxc")
+t("abc defghi jkl",
+  "commandline --cursor 8; commandline --current-token --insert x",
+  "9 abc defgxhi jkl")
 
 # commandline --append
 t("abc def; ghi", "commandline --append x", "12 abc def; ghix")
-# temporarily broken as `commandline --append` now happens before `commandline --cursor`
-# fixed in the next commit
-#t("abc def ghi",
-#  "commandline --cursor 5; commandline --current-token --append x",
-#  "5 abc defx ghi")
-#t("abc def | efg hij",
-#  "commandline --cursor 1; commandline --current-process --append x",
-#  "1 abc def x| efg hij")
-#t("echo ===; echo hello | echo there; echo bye",
-#  "commandline --cursor 12; commandline --current-job --append x",
-#  "12 echo ===; echo hello | echo therex; echo bye")
+t("abc def ghi",
+  "commandline --cursor 5; commandline --current-token --append x",
+  "5 abc defx ghi")
+t("abc def | efg hij",
+  "commandline --cursor 1; commandline --current-process --append x",
+  "1 abc def x| efg hij")
+t("echo ===; echo hello | echo there; echo bye",
+  "commandline --cursor 12; commandline --current-job --append x",
+  "12 echo ===; echo hello | echo therex; echo bye")
 
 # commandline --replace
 t("abc def; ghi", "commandline --replace 'hello'", "5 hello")
-# temporarily broken as `commandline --replace` now happens before `commandline --cursor`
-# fixed in the next commit
-#t("abc def ghi",
-#  "commandline --cursor 5; commandline --current-token --replace xxx",
-#  "7 abc xxx ghi")
-#t("abc def | efg hij",
-#  "commandline --cursor 2; commandline --current-process --replace xxx",
-#  "3 xxx| efg hij")
-#t("echo ===; echo hello | echo there; echo bye",
-#  "commandline --cursor 12; commandline --current-job --replace xxx",
-#  "12 echo ===;xxx; echo bye")
+t("abc def ghi",
+  "commandline --cursor 5; commandline --current-token --replace xxx",
+  "7 abc xxx ghi")
+t("abc def | efg hij",
+  "commandline --cursor 2; commandline --current-process --replace xxx",
+  "3 xxx| efg hij")
+t("echo ===; echo hello | echo there; echo bye",
+  "commandline --cursor 12; commandline --current-job --replace xxx",
+  "12 echo ===;xxx; echo bye")
 
 # commandline -f followed by commandline --cursor
 t("abc def ghi",
@@ -93,6 +85,12 @@ t("abc def ghi",
    commandline --cursor 4;\
    commandline -f kill-selection end-selection",
   "4 abc i")
+
+# commandline -f followed by commandline --insert
+t("abc def ghi",
+  "commandline -f backward-word;\
+   commandline --insert x",
+  "9 abc def xghi")
 
 sendline("bind '~' 'handle_tilde'")
 expect_prompt()


### PR DESCRIPTION
## Description

Currently in a key-binding `commandline --insert` and `commandline --cursor` are always be executed before `commandline -f`. To work around this `commandline -f` special cases `begin-undo-group` and `end-undo-group` so they work when combined with text insertion but that means they do not work with `delete-char` or `kill-word` etc. This PR uses the suggestion in src/builtin/commandline.cpp to try and fix that. It converts the builtin `commandline` function to use readline functions for moving the cursor and inserting text. This has the advantage that `commandline --insert` and `commandline --cursor` can be freely mixed with `commandline -f` and they are executed in the order that they are written.

### Some notes on the commits:

 - The second commit is larger than I'd like, it would be smaller if we could avoid renaming `enum readline_cmd_t` by choosing a different name for the class but I failed to come up with a good name.

 - The fourth commit should perhaps be squashed into the fifth to avoid having to comment out the temporary test failures

 - The fifth commit would benefit from using `std::variant` but that is not an option in C++11. I did look at some C++11 implementations with a view to importing one but they were all huge.

Fixes #3031

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
