### PR TITLE
added completion for git branch --remotes (-r)

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1166,6 +1166,7 @@ complete -f -c git -n '__fish_git_using_command branch' -s M -d 'Force rename br
 complete -f -c git -n '__fish_git_using_command branch' -s c -l copy -d 'Copy branch'
 complete -f -c git -n '__fish_git_using_command branch' -s C -d 'Force copy branch'
 complete -f -c git -n '__fish_git_using_command branch' -s a -l all -d 'Lists both local and remote branches'
+complete -f -c git -n '__fish_git_using_command branch' -s r -l remotes -d 'List or delete (if used with -d) the remote-tracking branches.'
 complete -f -c git -n '__fish_git_using_command branch' -s t -l track -l track -d 'Track remote branch'
 complete -f -c git -n '__fish_git_using_command branch' -l no-track -d 'Do not track remote branch'
 complete -f -c git -n '__fish_git_using_command branch' -l set-upstream-to -d 'Set remote branch to track'


### PR DESCRIPTION
## Description

The option `--remotes` or `-r` for `git branch` was missing, I added it.

One thing I'm unsure about: If used as `git branch -rd` this will complete to `(__fish_git_local_branches)`, although it might be more helpful to complete it also to the remote branches, e.g. `origin/my-branch-name`. I'm not sure if fish's completion mechanisms support this distinction, and a `(__fish_git_remote_branches)` does not exist anyway, the closest I could find was `__fish_git_unique_remote_branches`, which seems to strip away the remote, which is not what would be helpful in this case.
Still, I guess it's better to add the flag, even if the branch-completion after that does not provide all reasonable results.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
