### PR TITLE
abbr: Allow filtering by command

### DIFF
--- a/doc_src/cmds/abbr.rst
+++ b/doc_src/cmds/abbr.rst
@@ -9,7 +9,7 @@ Synopsis
 .. synopsis::
 
     abbr --add NAME [--position command | anywhere] [-r | --regex PATTERN]
-                    [--set-cursor[=MARKER]]
+                    [--set-cursor[=MARKER]] [-c | --command COMMAND]
                     [-f | --function] EXPANSION
     abbr --erase NAME ...
     abbr --rename OLD_WORD NEW_WORD
@@ -47,6 +47,8 @@ Abbreviations may be added to :ref:`config.fish <configuration>`.
 ``abbr --add`` creates a new abbreviation. With no other options, the string **NAME** is replaced by **EXPANSION**.
 
 With **--position command**, the abbreviation will only expand when it is positioned as a command, not as an argument to another command. With **--position anywhere** the abbreviation may expand anywhere in the command line. The default is **command**.
+
+With **--command COMMAND**, the abbreviation will only expand when positioned as an argument to the given command. This allows adding abbreviations e.g. for specific subcommands.
 
 With **--regex**, the abbreviation matches using the regular expression given by **PATTERN**, instead of the literal **NAME**. The pattern is interpreted using PCRE2 syntax and must match the entire token. If multiple abbreviations match the same token, the last abbreviation added is used.
 
@@ -100,6 +102,12 @@ This first creates a function ``vim_edit`` which prepends ``vim`` before its arg
     abbr 4DIRS --set-cursor ! "$(string join \n -- 'for dir in */' 'cd $dir' '!' 'cd ..' 'end')"
 
 This creates an abbreviation "4DIRS" which expands to a multi-line loop "template." The template enters each directory and then leaves it. The cursor is positioned ready to enter the command to run in each directory, at the location of the ``!``, which is itself erased.
+
+::
+
+    abbr --command git c checkout
+
+This creates an abbreviation "c" that expands to "checkout", but only when the current command is "git". It will expand for ``git c`` and ``git show c``, but not for ``echo c``.
 
 Other subcommands
 --------------------

--- a/src/abbrs.h
+++ b/src/abbrs.h
@@ -33,6 +33,10 @@ struct abbreviation_t {
     /// we accomplish this by surrounding the regex in ^ and $.
     maybe_t<re::regex_t> regex{};
 
+    /// If set, this abbr is only valid for a specific command's arguments.
+    /// Note that this implies position != command.
+    maybe_t<wcstring> command{};
+
     /// Replacement string.
     wcstring replacement{};
 
@@ -51,8 +55,10 @@ struct abbreviation_t {
     // \return true if this is a regex abbreviation.
     bool is_regex() const { return this->regex.has_value(); }
 
+    bool is_command() const { return this->command.has_value(); }
+
     // \return true if we match a token at a given position.
-    bool matches(const wcstring &token, abbrs_position_t position) const;
+    bool matches(const wcstring &token, abbrs_position_t position, const wcstring &command) const;
 
     // Construct from a name, a key which matches a token, a replacement token, a position, and
     // whether we are derived from a universal variable.
@@ -103,10 +109,10 @@ class abbrs_set_t {
    public:
     /// \return the list of replacers for an input token, in priority order.
     /// The \p position is given to describe where the token was found.
-    abbrs_replacer_list_t match(const wcstring &token, abbrs_position_t position) const;
+    abbrs_replacer_list_t match(const wcstring &token, abbrs_position_t position, const wcstring &command) const;
 
     /// \return whether we would have at least one replacer for a given token.
-    bool has_match(const wcstring &token, abbrs_position_t position) const;
+    bool has_match(const wcstring &token, abbrs_position_t position, const wcstring &command) const;
 
     /// Add an abbreviation. Any abbreviation with the same name is replaced.
     void add(abbreviation_t &&abbr);
@@ -142,8 +148,8 @@ acquired_lock<abbrs_set_t> abbrs_get_set();
 
 /// \return the list of replacers for an input token, in priority order, using the global set.
 /// The \p position is given to describe where the token was found.
-inline abbrs_replacer_list_t abbrs_match(const wcstring &token, abbrs_position_t position) {
-    return abbrs_get_set()->match(token, position);
+inline abbrs_replacer_list_t abbrs_match(const wcstring &token, abbrs_position_t position, const wcstring &command) {
+    return abbrs_get_set()->match(token, position, command);
 }
 
 #endif

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -2481,7 +2481,8 @@ static void test_abbreviations() {
 
     // Helper to expand an abbreviation, enforcing we have no more than one result.
     auto abbr_expand_1 = [](const wcstring &token, abbrs_position_t pos) -> maybe_t<wcstring> {
-        auto result = abbrs_match(token, pos);
+        // (we're not testing command matches here)
+        auto result = abbrs_match(token, pos, L"");
         if (result.size() > 1) {
             err(L"abbreviation expansion for %ls returned more than 1 result", token.c_str());
         }

--- a/src/highlight.cpp
+++ b/src/highlight.cpp
@@ -1336,7 +1336,7 @@ static bool command_is_valid(const wcstring &cmd, enum statement_decoration_t de
 
     // Abbreviations
     if (!is_valid && abbreviation_ok)
-        is_valid = abbrs_get_set()->has_match(cmd, abbrs_position_t::command);
+        is_valid = abbrs_get_set()->has_match(cmd, abbrs_position_t::command, cmd);
 
     // Regular commands
     if (!is_valid && command_ok) is_valid = path_get_path(cmd, vars).has_value();

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1462,7 +1462,9 @@ maybe_t<abbrs_replacement_t> reader_expand_abbreviation_at_cursor(const wcstring
         iter->is_cmd ? abbrs_position_t::command : abbrs_position_t::anywhere;
 
     wcstring token_str = cmdline.substr(range.start, range.length);
-    auto replacers = abbrs_match(token_str, position);
+    wcstring command = tok_command(cmdline);
+
+    auto replacers = abbrs_match(token_str, position, command);
     for (const auto &replacer : replacers) {
         if (auto replacement = expand_replacer(range, token_str, replacer, parser)) {
             return replacement;

--- a/tests/pexpects/abbrs.py
+++ b/tests/pexpects/abbrs.py
@@ -120,6 +120,14 @@ expect_prompt(r"1 2 3 4 5")
 sendline(r"echo openparen seq 5 closeparen ")  # expands on space
 expect_prompt(r"1 2 3 4 5")
 
+sendline(r"""abbr --add c --command echo checkout""")
+expect_prompt(r"")
+sendline(r"echo c")
+expect_prompt(r"echo checkout")
+sendline(r"printf %s\n c")
+expect_prompt("c")
+sendline("abbr --erase c")
+expect_prompt("")
 
 # Verify that 'commandline' is accurate.
 # Abbreviation functions cannot usefully change the command line, but they can read it.


### PR DESCRIPTION
This allows specifying an abbreviation e.g. just for git:

```fish
abbr --command git c checkout
```

will expand `git c ` to `git checkout `, but not `echo c ` to `echo checkout`, without using regexes.

Fixes #9411.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

This is *not* necessary for 3.6.0, unless we can quickly come to an agreement that it's working and good.