### PR TITLE
Update webconfig.py to correctly detect IPv6 support.

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -942,7 +942,7 @@ class FishConfigTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
 
     WHITELIST = set(["::1", "::ffff:127.0.0.1", "127.0.0.1"])
 
-    address_family = socket.AF_INET6 if socket.has_ipv6 else socket.AF_INET
+    address_family = socket.AF_INET6 if socket.has_dualstack_ipv6() else socket.AF_INET
 
     def verify_request(self, request, client_address):
         return client_address[0] in FishConfigTCPServer.WHITELIST
@@ -1664,7 +1664,7 @@ authkey = binascii.b2a_hex(os.urandom(16)).decode("ascii")
 
 # Try to find a suitable port
 PORT = 8000
-HOST = "::" if socket.has_ipv6 else "localhost"
+HOST = "::" if socket.has_dualstack_ipv6() else "localhost"
 while PORT <= 9000:
     try:
         Handler = FishConfigHTTPRequestHandler


### PR DESCRIPTION
## Description

A quick search on the issues shows many users reporting this problem.

Currently the code checks if IPv6 is enabled on the system by using `socket.has_ipv6`. This variable is a compile time constant meaning that Python is compiled with IPv6, **not** that the system currently has support for it.

The common workaround for this was to actually try to bind to an IPv6 access catching the errors. This error checking functionality seems to have been added to python as can be seen [here](https://github.com/python/cpython/blob/b430399d41fa88e9040cd055e55cf9211bf63c61/Lib/socket.py#L870).
My patch simply replaces `socket.has_ipv6` with `socket.has_dualstack_ipv6()`.

A more detailed overview can also be found in https://github.com/urllib3/urllib3/pull/611#issuecomment-100954017.

Fixes issue #3857

## System Info

Latest arch kernel with IPv6 totally disabled (with `ipv6.disable=1`).
Python version 3.10.8

## TODOs:

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
