### PR TITLE
abbr: Let --function use a mandatory argument

### DIFF
--- a/doc_src/cmds/abbr.rst
+++ b/doc_src/cmds/abbr.rst
@@ -9,8 +9,7 @@ Synopsis
 .. synopsis::
 
     abbr --add NAME [--position command | anywhere] [-r | --regex PATTERN]
-                    [--set-cursor[=MARKER]]
-                    [-f | --function] EXPANSION
+                    [--set-cursor[=MARKER]] ([-f | --function FUNCTION] | EXPANSION)
     abbr --erase NAME ...
     abbr --rename OLD_WORD NEW_WORD
     abbr --show
@@ -43,7 +42,7 @@ Abbreviations may be added to :ref:`config.fish <configuration>`.
 .. synopsis::
 
     abbr [-a | --add] NAME [--position command | anywhere] [-r | --regex PATTERN]
-         [--set-cursor[=MARKER]] [-f | --function] EXPANSION
+         [--set-cursor[=MARKER]] ([-f | --function FUNCTION] | EXPANSION)
 
 ``abbr --add`` creates a new abbreviation. With no other options, the string **NAME** is replaced by **EXPANSION**.
 
@@ -53,7 +52,7 @@ With **--regex**, the abbreviation matches using the regular expression given by
 
 With **--set-cursor=MARKER**, the cursor is moved to the first occurrence of **MARKER** in the expansion. The **MARKER** value is erased. The **MARKER** may be omitted (i.e. simply ``--set-cursor``), in which case it defaults to ``%``.
 
-With **-f** or **--function**, **EXPANSION** is treated as the name of a fish function instead of a literal replacement. When the abbreviation matches, the function will be called with the matching token as an argument. If the function's exit status is 0 (success), the token will be replaced by the function's output; otherwise the token will be left unchanged.
+With **-f FUNCTION** or **--function FUNCTION**, **FUNCTION** is treated as the name of a fish function instead of a literal replacement. When the abbreviation matches, the function will be called with the matching token as an argument. If the function's exit status is 0 (success), the token will be replaced by the function's output; otherwise the token will be left unchanged. No **EXPANSION** may be given separately.
 
 
 Examples

--- a/tests/checks/abbr.fish
+++ b/tests/checks/abbr.fish
@@ -133,9 +133,18 @@ echo $status
 # CHECKERR: abbr: --position option requires --add
 # CHECK: 2
 
-abbr --query banana --function
+abbr --query banana --function foo
 echo $status
 # CHECKERR: abbr: --function option requires --add
+# CHECK: 2
+
+abbr --query banana --function
+echo $status
+# CHECKERR: abbr: --function: option requires an argument
+# CHECKERR: checks/abbr.fish (line 141):
+# CHECKERR: abbr --query banana --function
+# CHECKERR: ^
+# CHECKERR: (Type 'help abbr' for related documentation)
 # CHECK: 2
 
 abbr --add peach --function invalid/function/name
@@ -160,7 +169,7 @@ abbr --add !! --position anywhere --function replace_history
 abbr --show
 # CHECK: abbr -a -- nonregex_name foo
 # CHECK: abbr -a --regex 'A[0-9]B' -- regex_name bar
-# CHECK: abbr -a --position anywhere --function -- !! replace_history
+# CHECK: abbr -a --position anywhere --function replace_history -- !!
 abbr --erase (abbr --list)
 
 abbr --add bogus --position never stuff


### PR DESCRIPTION
This now means `abbr --add` has two modes:

```fish
abbr --add name --function foo --regex regex
```

```fish
abbr --add name --regex regex replacement
```

This is because `--function` was seen to be confusing as a boolean flag.

Note: I am not sure this is a good idea. I think the example of

```fish
abbr -a --position anywhere --function replace_history -- !!
```

is sufficiently awkward that I think this might just be fixable with documentation changes instead.

Basically, instead of documenting `abbr -a !! --position anywhere --function last_history_item`, document `abbr -a !! --function --position anywhere  last_history_item` or `abbr -fa !! --position anywhere last_history_item`

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst
