### PR TITLE
completions/git: (git log) show refs before than files

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1400,8 +1400,8 @@ complete -f -c git -n '__fish_git_using_command init' -l bare -d 'Create a bare 
 ### log
 complete -c git -n __fish_git_needs_command -a shortlog -d 'Show commit shortlog'
 complete -c git -n __fish_git_needs_command -a log -d 'Show commit logs'
-complete -c git -n '__fish_git_using_command log' -a '(__fish_git ls-files)'
 complete -c git -n '__fish_git_using_command log' -n 'not contains -- -- (commandline -opc)' -ka '(__fish_git_ranges)'
+complete -c git -n '__fish_git_using_command log' -a '(__fish_git ls-files)'
 complete -c git -n '__fish_git_using_command log' -l follow -d 'Continue listing file history beyond renames'
 complete -c git -n '__fish_git_using_command log' -l no-decorate -d 'Don\'t print ref names'
 complete -f -c git -n '__fish_git_using_command log' -l decorate -d 'Print out ref names' -a "short\t'Hide prefixes'


### PR DESCRIPTION
Signed-off-by: Next Alone <12210746+NextAlone@users.noreply.github.com>

## Description

Show refs before files on git-log completions

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
