### PR TITLE
Be more careful about running git and python3 on macOS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -134,6 +134,8 @@ Fixed Bugs
 - ``printf`` now properly fills extra ``%d`` specifiers with 0 even on macOS and BSD (:issue:`9321`).
 - ``fish_key_reader`` now correctly exits when receiving a SIGHUP (like after closing the terminal) (:issue:`9309`).
 - ``fish_config theme save`` now works as documented instead of erroring out (:issue:`9088`, :issue:`9273`).
+- Fish no longer triggers prompts to install command line tools when first run on macOS (:issue:`9343`).
+- ``fish_git_prompt`` now quietly fails on macOS if the xcrun cache is not yet populated (:issue:`6625`), working around a potential hang.
 
 Completions
 ^^^^^^^^^^^

--- a/share/functions/__fish_anypython.fish
+++ b/share/functions/__fish_anypython.fish
@@ -1,9 +1,18 @@
 function __fish_anypython
     # Try python3 first, because that's usually faster and generally nicer.
+    # Do not consider the stub /usr/bin/python3 that comes installed on Darwin to be Python
+    # unless Xcode reports a real directory path.
     for py in python3 python3.{9,8,7,6,5,4,3} python2 python2.7 python
-        command -sq $py
-        and echo $py
-        and return 0
+        if set -l py_path (command -s $py)
+            if string match -q /usr/bin/python3 -- $py_path
+                and string match -q Darwin -- "$(uname)"
+                and type -q xcode-select
+                and not xcode-select --print-path &>/dev/null
+                continue
+            end
+            echo $py
+            return 0
+        end
     end
     # We have no python.
     return 1


### PR DESCRIPTION
See #9345, this is the same idea but simplified and also addressing python. Credit to @floam for most of this work.

macOS Ventura ships the executables `/usr/bin/git` and `/usr/bin/python3`. These are stubs which attempt to look for the real executables; if they are not found then it pops up a dialog to install command line tools. fish runs python3 to populate manpage completions, and also runs git as part of the default prompt, so this dialog pops up a lot. This makes fish nearly unusable on macOS, unless the command line tools are installed.

Unfortunately I've found no easy way to suppress this dialog, other than avoid running these commands. So that's what this does. The fixes (limited to Darwin only):

1. If `git` is `/usr/bin/git` and `xcode-select --print-path` fails, then do not run git in fish_git_prompt.
2. If `python3` is `/usr/bin/python3` and `xcode-select --print-path` fails, do not consider that python from __fish_anypython.

Lastly we fix the git slowness due to the xcrun cache not-yet existing:

3. If `git` is `/usr/bin/git` and `path is "$(xcrun --show-cache-path)"` fails, then running git may be super-slow; do not run git.

I have tested this on a Ventura VM and it correctly suppresses the dialog on first run, both from git and from python3. I have also tested on a 10.9 VM and it continues to work there.

Fixes #9343 and #6625.