### PR TITLE
completions wireshark: removed wrong interface completion for -I option

### DIFF
--- a/share/functions/__fish_complete_wireshark.fish
+++ b/share/functions/__fish_complete_wireshark.fish
@@ -62,7 +62,7 @@ packets:\t"Switch to the next file after it contains N packets"'
     complete -c $shark -s i -ra '(__fish_wireshark_interface)'
     complete -c $shark -s i -ra '-\t"Capture from standard input"' \
         -d 'Network interface or pipe to use for live packet capture'
-    complete -c $shark -s I -l monitor-mode -d 'Put the interface in "monitor mode"' -xa '(__fish_wireshark_interface)'
+    complete -c $shark -s I -l monitor-mode -d 'Put the interface in "monitor mode"'
     complete -c $shark -s L -l list-data-link-types -d 'List the data link types supported by the interface and exit'
     complete -c $shark -l list-time-stamp-types -d 'List time stamp types supported for the interface'
     complete -c $shark -s p -l no-promiscuous-mode -d "Don't put the interface into promiscuous mode"


### PR DESCRIPTION
## Description

Wireshark completions for `-I` were wrong, since it doesn't take the network interface directly. It must still be specified with `-i`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
