### PR TITLE
completions iw: added completions for `iw dev set type` and `set channel`

### DIFF
--- a/share/completions/iw.fish
+++ b/share/completions/iw.fish
@@ -149,6 +149,19 @@ function __fish_complete_iw
                             channel "" \
                             freq "" \
                             power_save "Power save state"
+                    else
+                        switch "$cmd[5]"
+                            case type
+                                if not set -q cmd[6]
+                                    printf '%s\n' managed ibss monitor mesh wds
+                                end
+                            case channel
+                                if not set -q cmd[6]
+                                    # cmd[6] is just the simple channel number
+                                else if not set -q cmd[7]
+                                    printf '%s\n' NOHT HT20 HT40+ HT40- 5MHz 10MHz 80MHz
+                                end
+                        end
                     end
                 case get
                     if not set -q cmd[5]


### PR DESCRIPTION
## Description

Completions for `iw` can now complete the device type (managed, monitor, ...) and the channel width (HT20, 80MHz, ...).


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
