### PR TITLE
history pager: allow filtering by multiple words

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -184,6 +184,14 @@ bool history_item_t::matches_search(const wcstring &term, enum history_search_ty
         case history_search_type_t::prefix: {
             return string_prefixes_string(term, content_to_match);
         }
+        case history_search_type_t::glob: {
+            wcstring wcpattern = parse_util_unescape_wildcards(term);
+            if (wcpattern.empty())
+                wcpattern = ANY_STRING;
+            else if (wcpattern.front() != ANY_STRING && wcpattern.back() != ANY_STRING)
+                wcpattern.push_back(ANY_STRING);
+            return wildcard_match(content_to_match, wcpattern);
+        }
         case history_search_type_t::contains_glob: {
             wcstring wcpattern1 = parse_util_unescape_wildcards(term);
             if (wcpattern1.front() != ANY_STRING) wcpattern1.insert(0, 1, ANY_STRING);

--- a/src/history.h
+++ b/src/history.h
@@ -53,6 +53,8 @@ enum class history_search_type_t {
     contains,
     /// Search for commands starting with the given string.
     prefix,
+    /// Search for commands matching the given glob pattern.
+    glob,
     /// Search for commands containing the given glob pattern.
     contains_glob,
     /// Search for commands starting with the given glob pattern.

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -386,6 +386,9 @@ bool pager_t::completion_info_passes_filter(const comp_t &info) const {
     // If we have no filter, everything passes.
     if (!search_field_shown || this->search_field_line.empty()) return true;
 
+    // By definition, history pager entries always match.
+    if (info.representative.replaces_commandline()) return true;
+
     const wcstring &needle = this->search_field_line.text();
 
     // Match against the description.

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -483,6 +483,22 @@ void parse_util_token_extent(const wchar_t *buff, size_t cursor_pos, const wchar
     assert(pb <= (buff + bufflen));
 }
 
+wcstring parse_util_escape_wildcards(const wcstring &str) {
+    wcstring result;
+    result.reserve(str.size());
+    bool esc_qmark = !feature_test(features_t::qmark_noglob);
+
+    for (wchar_t c : str) {
+        bool escape = c == L'*' || (esc_qmark && c == L'?') || c == L'\\';
+        if (escape) {
+            result.push_back(L'\\');
+        }
+        result.push_back(c);
+    }
+
+    return result;
+}
+
 wcstring parse_util_unescape_wildcards(const wcstring &str) {
     wcstring result;
     result.reserve(str.size());

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -95,6 +95,9 @@ size_t parse_util_get_offset_from_line(const wcstring &str, int line);
 /// Return the total offset of the buffer for the cursor position nearest to the specified position.
 size_t parse_util_get_offset(const wcstring &str, int line, long line_offset);
 
+/// Return the given string, escaping wildcard characters.
+wcstring parse_util_escape_wildcards(const wcstring &str);
+
 /// Return the given string, unescaping wildcard characters but not performing any other character
 /// transformation.
 wcstring parse_util_unescape_wildcards(const wcstring &str);

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1286,7 +1286,7 @@ static history_pager_result_t history_pager_search(const std::shared_ptr<history
     size_t page_size = std::max(termsize_last().height / 2 - 2, 12);
 
     completion_list_t completions;
-    history_search_t search{history, search_string, history_search_type_t::contains,
+    history_search_t search{history, search_string, history_search_type_t::glob,
                             smartcase_flags(search_string), history_index};
     while (completions.size() < page_size && search.go_to_next_match(direction)) {
         const history_item_t &item = search.current_item();
@@ -3750,7 +3750,9 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             pager.set_search_field_shown(true);
             pager.set_prefix(MB_CUR_MAX > 1 ? L"► " : L"> ", false /* highlight */);
             // Update the search field, which triggers the actual history search.
-            insert_string(&pager.search_field_line, command_line.text());
+            insert_string(&pager.search_field_line,
+                          wcstring{L"*"} + parse_util_escape_wildcards(command_line.text()) + L"*");
+            pager.search_field_line.set_position(pager.search_field_line.size() - 1);
             break;
         }
         case rl::backward_char: {


### PR DESCRIPTION
When using Control-R to search command history, I tend to not navigate the
pager. Instead I like to keep typing the query until my desired command is
on top.

This strategy is awkward when the query is part of a long string that is
shared by many commands.  Let's improve this scenario by allowing arbitrary
gaps in between words in the search string.

This interprets "foo bar" as a glob-search for "foo*bar".  This feels a
bit weird because this syntax has no precedent in fish or other shells. Zsh
supports various globbing syntaxes instead.  We could use globbing syntax too,
but this approach has some upsides:
1. Space is easier to type
2. Space splitting is used in most other search prompts
3. glob syntax would make it awkward to search for actual globs in the
   command history ("to  find `**` type `\*\*`"). I don't think I ever want
   to search for spaces.
