### PR TITLE
Make history pager use more entries

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1277,9 +1277,13 @@ static history_pager_result_t history_pager_search(const std::shared_ptr<history
                                                    history_search_direction_t direction,
                                                    size_t history_index,
                                                    const wcstring &search_string) {
-    // Use a small page size because we don't always offer practical ways to select a item from
-    // a large page (since we don't support subsequence filtering here).
-    constexpr size_t page_size = 12;
+    // Limit the number of elements to half the screen like we do for completions
+    // Note that this is imperfect because we could have a multi-column layout.
+    //
+    // We can still push fish further upward in case the first entry is multiline,
+    // but that can't really be helped.
+    size_t page_size = std::max(termsize_last().height / 2, 12);
+
     completion_list_t completions;
     history_search_t search{history, search_string, history_search_type_t::contains,
                             smartcase_flags(search_string), history_index};

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1282,7 +1282,8 @@ static history_pager_result_t history_pager_search(const std::shared_ptr<history
     //
     // We can still push fish further upward in case the first entry is multiline,
     // but that can't really be helped.
-    size_t page_size = std::max(termsize_last().height / 2, 12);
+    // (subtract 2 for the search line and the prompt)
+    size_t page_size = std::max(termsize_last().height / 2 - 2, 12);
 
     completion_list_t completions;
     history_search_t search{history, search_string, history_search_type_t::contains,


### PR DESCRIPTION
Like I mentioned in https://github.com/fish-shell/fish-shell/pull/9089, 12 entries is a bit few.

So, instead, we do like we do for completions before disclosing and
pick half the screen (but at least X, in this case 12).

This avoids filling the entire screen, and will avoid an unsightly "X
more entries" (which requires scrolling down to fully disclose)
because it matches what the pager does.

Note: For multiline commands we can be pushed further upwards, and in
case of a multi-column layout we could fit more lines. That would
require asking the pager to fit as many as possible and give us back
the index of the last matching entry and rewinding the history search.

That's gonna be left as an exercise for later if it turns out to be necessary.