### PR TITLE
docs: clearify global vs universal variable

### DIFF
--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -51,8 +51,8 @@ The following scope control variable scope:
 
 **-g** or **--global**
     Sets a globally-scoped variable.
-    Global variables don't disappear and are available to all functions running in the same shell.
-    They can even be modified.
+    Global variables are available to all functions running in the same shell.
+    They can be modified or erased.
 
 These options modify how variables operate:
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -944,8 +944,8 @@ Variable Scope
 
 There are four kinds of variables in fish: universal, global, function and local variables.
 
-- Universal variables are shared between all fish sessions a user is running on one computer.
-- Global variables are specific to the current fish session, and will never be erased unless explicitly requested by using ``set -e``.
+- Universal variables are shared between all fish sessions a user is running on one computer. They are stored in disk and persist even after reboot.
+- Global variables are specific to the current fish session. They can be erased by explicitly requesting ``set -e``.
 - Function variables are specific to the currently executing function. They are erased ("go out of scope") when the current function ends. Outside of a function, they don't go out of scope.
 - Local variables are specific to the current block of commands, and automatically erased when a specific block goes out of scope. A block of commands is a series of commands that begins with one of the commands ``for``, ``while`` , ``if``, ``function``, ``begin`` or ``switch``, and ends with the command ``end``. Outside of a block, this is the same as the function scope.
 


### PR DESCRIPTION
I got asked about them. It turns out that without much computer knowledge, those sentences are mega confusing. 

The weirdness of the original wording:

> Global variables don't disappear

What does this even mean? If it doesn't disappear, will it exist after the computer shuts down???

> Global variables ....... and will never be erased .....

So there is no difference between Global & Universal since Global never be erased and it also lives forever???

This is wrong. A global variable can be erased by other means (rather than NEVER): quit the current session.