### PR TITLE
Remove str2wcs special case for MB_CUR_MAX

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -303,16 +303,6 @@ static wcstring str2wcs_internal(const char *in, const size_t in_len) {
     wcstring result;
     result.reserve(in_len);
 
-    // In the unlikely event that MB_CUR_MAX is 1, then we are just going to append.
-    if (MB_CUR_MAX == 1) {
-        size_t in_pos = 0;
-        while (in_pos < in_len) {
-            result.push_back(static_cast<unsigned char>(in[in_pos]));
-            in_pos++;
-        }
-        return result;
-    }
-
     size_t in_pos = 0;
     mbstate_t state = {};
     while (in_pos < in_len) {


### PR DESCRIPTION
This meant we didn't actually do our weird en/decoding scheme for e.g. a C locale, which meant that, when you then switch to a proper locale the previous variables were broken.

I don't know how to test this automatically - none of my attempts seem to ever *fail* with the old code, here's what you'd do manually:

- Run fish with an actual C locale (LC_ALL=C fish_allow_singlebyte_locale=1 fish)
- `set -gx foo 💩`
- `set -e LC_ALL`
- `echo $foo` outputs "💩" if it works and "ð⏎" if it's broken.

Fixes #2613

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
