### PR TITLE
abbr: Warn when `-U` is given

### DIFF
--- a/src/builtins/abbr.cpp
+++ b/src/builtins/abbr.cpp
@@ -393,9 +393,15 @@ maybe_t<int> builtin_abbr(parser_t &parser, io_streams_t &streams, const wchar_t
                 opts.list = true;
                 break;
             case 'g':
-            case 'U':
                 // Kept for backwards compatibility but ignored.
+                // This basically does nothing now.
                 break;
+            case 'U': {
+                // Kept and made ineffective, so we warn.
+                streams.err.append_format(_(L"%ls: Warning: Option '%ls' was removed and is now ignored"), cmd, argv[w.woptind - 1]);
+                builtin_print_error_trailer(parser, streams.err, cmd);
+                break;
+            }
             case 'h': {
                 builtin_print_help(parser, streams, cmd);
                 return STATUS_CMD_OK;


### PR DESCRIPTION
This prints a warning to stderr and then still does the thing.

Because of the error trailer, it points to the abbr help page.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
- [ ] Wording? I tried to keep it reasonably general so it stands a chance of being reused, maybe something more specific is useful?
- [ ] This can now warn on every startup, if you have `abbr -U` in your config.fish. I don't believe there's anything better we can do (we don't want to store a universal variable or write a file to mark that we've errored)