### PR TITLE
Add subsequence search type to `history` command

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -195,6 +195,9 @@ bool history_item_t::matches_search(const wcstring &term, enum history_search_ty
             if (wcpattern2.back() != ANY_STRING) wcpattern2.push_back(ANY_STRING);
             return wildcard_match(content_to_match, wcpattern2);
         }
+        case history_search_type_t::contains_subsequence: {
+            return subsequence_in_string(term, content_to_match);
+        }
         case history_search_type_t::match_everything: {
             return true;
         }

--- a/src/history.h
+++ b/src/history.h
@@ -57,6 +57,8 @@ enum class history_search_type_t {
     contains_glob,
     /// Search for commands starting with the given glob pattern.
     prefix_glob,
+    /// Search for commands containing the given string as a subsequence
+    contains_subsequence,
     /// Matches everything.
     match_everything,
 };

--- a/src/wcstringutil.cpp
+++ b/src/wcstringutil.cpp
@@ -119,7 +119,7 @@ bool string_suffixes_string_case_insensitive(const wcstring &proposed_suffix,
 
 /// Returns true if needle, represented as a subsequence, is contained within haystack.
 /// Note subsequence is not substring: "foo" is a subsequence of "follow" for example.
-static bool subsequence_in_string(const wcstring &needle, const wcstring &haystack) {
+bool subsequence_in_string(const wcstring &needle, const wcstring &haystack) {
     // Impossible if needle is larger than haystack.
     if (needle.size() > haystack.size()) {
         return false;

--- a/src/wcstringutil.h
+++ b/src/wcstringutil.h
@@ -34,6 +34,9 @@ bool string_suffixes_string_case_insensitive(const wcstring &proposed_suffix,
 bool string_prefixes_string_case_insensitive(const wcstring &proposed_prefix,
                                              const wcstring &value);
 
+/// Test if a string matches a subsequence of another.
+bool subsequence_in_string(const wcstring &needle, const wcstring &haystack);
+
 /// Case-insensitive string search, modeled after std::string::find().
 /// \param fuzzy indicates this is being used for fuzzy matching and case insensitivity is
 /// expanded to include symbolic characters (#3584).


### PR DESCRIPTION
## Description

This adds a subsequence search type to the `history` command. It was easier than I expected because wcstringutil already had a `subsequence_in_string()`!

#1874 discussed adding this behavior to `history-pager`, but `history` seemed easier so I figured it was better to start with this. We can do `history-pager` in a followup PR, or add it to this one.

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
