### PR TITLE
completions: Offer ../ and ./ again

### DIFF
--- a/src/wildcard.cpp
+++ b/src/wildcard.cpp
@@ -858,6 +858,16 @@ void wildcard_expander_t::expand_last_segment(const wcstring &base_dir, dir_iter
     bool is_dir = false;
     bool need_dir = flags & expand_flag::directories_only;
 
+    if (prefix.empty() && flags & expand_flag::for_completions) {
+        // Add the special dot-paths.
+        // dir_iter ordinarily skips these, for good reason,
+        // but here we need them.
+        this->try_add_completion_result(base_dir + L"..", L"..", wc, prefix,
+                                            is_dir);
+        this->try_add_completion_result(base_dir + L".", L".", wc, prefix,
+                                            is_dir);
+    }
+
     const dir_iter_t::entry_t *entry{};
     while (!interrupted_or_overflowed() && (entry = base_dir_iter.next())) {
         if (need_dir && !entry->is_dir()) continue;

--- a/tests/checks/cd.fish
+++ b/tests/checks/cd.fish
@@ -267,3 +267,7 @@ begin
     # CHECK: $PWD is absolute
     cd ../../..
 end
+
+complete -C'cd .'
+# CHECK: ../
+# CHECK: ./


### PR DESCRIPTION
Inadvertently broken in a2d816710fc336e0a964e11b798cd5fb19043760, this made `cd .` no longer offer `cd ../` (same for file completions like `ls .`, which only offers dot-files but no more `ls ../` for `ls ../foo`)

This adds these paths in one specific case rather than changing dir_iter to always go through them. That should be okay.

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [n/a] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
