### PR TITLE
Fix `open` completion for macOS

### DIFF
--- a/share/completions/open.fish
+++ b/share/completions/open.fish
@@ -1,6 +1,6 @@
 if test (uname) = Darwin # OS X
-    complete -c open -s a -d 'specify app name' -r -a "(mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /Developer/Applications 'kMDItemContentType==com.apple.application-*' | string replace -r '.+/(.+).app' '\$1')"
-    complete -c open -s b -d 'specify app bundle id' -x -a "(mdls (mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /Developer/Applications 'kMDItemContentType==com.apple.application-*') -name kMDItemCFBundleIdentifier | string replace -rf 'kMDItemCFBundleIdentifier = \"(.+)\"' '\$1')"
+    complete -c open -s a -d 'specify app name' -r -a "(mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /System/Applications -onlyin /Developer/Applications 'kMDItemContentType==com.apple.application-*' | string replace -r '.+/(.+).app' '\$1')"
+    complete -c open -s b -d 'specify app bundle id' -x -a "(mdls (mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /System/Applications -onlyin /Developer/Applications 'kMDItemContentType==com.apple.application-*') -name kMDItemCFBundleIdentifier | string replace -rf 'kMDItemCFBundleIdentifier = \"(.+)\"' '\$1')"
     complete -c open -s e -d 'open in TextEdit'
     complete -c open -s t -d 'open in default editor'
     complete -c open -s f -d 'open stdin with editor'


### PR DESCRIPTION
macOS 11+ (possibly 12+) has an additional place where certain applications will be installed, `/System/Applications`. This is a sealed system volume and includes the following applications:

- `App Store.app`
- `Automator.app`
- `Books.app`
- `Calculator.app`
- `Calendar.app`
- `Chess.app`
- `Clock.app`
- `Contacts.app`
- `Dictionary.app`
- `FaceTime.app`
- `FindMy.app`
- `Font Book.app`
- `Freeform.app`
- `Home.app`
- `Image Capture.app`
- `Launchpad.app`
- `Mail.app`
- `Maps.app`
- `Messages.app`
- `Mission Control.app`
- `Music.app`
- `News.app`
- `Notes.app`
- `Photo Booth.app`
- `Photos.app`
- `Podcasts.app`
- `Preview.app`
- `QuickTime Player.app`
- `Reminders.app`
- `Shortcuts.app`
- `Siri.app`
- `Stickies.app`
- `Stocks.app`
- `System Settings.app`
- `TextEdit.app`
- `Time Machine.app`
- `TV.app`
- `Utilities`
- `VoiceMemos.app`
- `Weather.app`

The change here adds `/System/Applications` to the search locations for `-a` and `-b` options on the macOS completions for `open`. There are possibly other locations that may be considered (I’m not using `mdls` or `mdfind` in my functions for "reasons"), but this is partially based on https://github.com/halostatue/fish-macos/blob/main/functions/__macos_app_find.fish

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
