### PR TITLE
fix missing required parameter in terraform completions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,7 @@ Completions
   - ``otool``
 - git's completion for ``git-foo``-style commands was fixed (:issue:`9457`)
 - File completion now offers ``../`` and ``./`` again (:issue:`9477`)
-
+- Completion for ``terraform`` now asks for a parameter after ``terraform init -backend-config``. (:issue:`9498`)
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -81,7 +81,7 @@ complete -r -c terraform -n "__fish_seen_subcommand_from import" -o var-file -d 
 complete -f -c terraform -n __fish_terraform_needs_command -a init -d "Initialize a new or existing Terraform configuration"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o backend=false -d "Disable backend initialization"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o cloud=false -d "Disable backend initialization"
-complete -f -c terraform -n "__fish_seen_subcommand_from init" -o backend-config -d "Backend configuration"
+complete -r -c terraform -n "__fish_seen_subcommand_from init" -o backend-config -d "Backend configuration"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o force-copy -d "Suppress prompts about copying state data"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o from-module -d "Copy the module into target directory before init"
 complete -f -c terraform -n "__fish_seen_subcommand_from init" -o get=false -d "Disable downloading modules for this configuration"


### PR DESCRIPTION
## Description

This PR fixes an issue where the completions for terraform would not ask for a file parameter with `terraform init -backend-config`.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
