### PR TITLE
Upgrade GitHub action `dessant/lock-threads` to v4

### DIFF
--- a/.github/workflows/lockthreads.yml
+++ b/.github/workflows/lockthreads.yml
@@ -17,9 +17,9 @@ jobs:
       pull-requests: write  # for dessant/lock-threads to lock PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v4
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: '365'
-          pr-lock-inactive-days: '365'
-          issue-exclude-labels: 'question, needs more info'
+          issue-inactive-days: '365'
+          pr-inactive-days: '365'
+          exclude-any-issue-labels: 'question, needs more info'


### PR DESCRIPTION
In v3 several input parameters where renamed and since v4 it requires Node.js 16.

This resolves warnings about Node.js 12 and `set-output` being deprecated and slated for removal in the `Lock threads` workflow.
