### PR TITLE
Improve fossil prompt execution time

### DIFF
--- a/share/functions/fish_fossil_prompt.fish
+++ b/share/functions/fish_fossil_prompt.fish
@@ -32,7 +32,7 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
 
     echo -n ' ['
     # Disabling color and pager is always a good idea.
-    set -l repo_status (fossil status --differ 2>/dev/null | grep -v '\w:\|^\s' | awk '{print $1}' | sort -u)
+    set -l repo_status (fossil changes --differ 2>/dev/null | grep -v '\w:\|^\s' | awk '{print $1}' | sort -u)
 
     # Show nice color for a clean repo
     if test -z "$repo_status"

--- a/share/functions/fish_fossil_prompt.fish
+++ b/share/functions/fish_fossil_prompt.fish
@@ -34,9 +34,9 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
     or set -g fish_prompt_fossil_status_modified '*'
     set -q fish_prompt_fossil_status_renamed
     or set -g fish_prompt_fossil_status_renamed '⇒'
-    set -q fish_prompt_fossil_status_deleted '
+    set -q fish_prompt_fossil_status_deleted
     or set -g fish_prompt_fossil_status_deleted '-'
-    set -q fish_prompt_fossil_status_missing '
+    set -q fish_prompt_fossil_status_missing
     or set -g fish_prompt_fossil_status_missing '✖'
     set -q fish_prompt_fossil_status_untracked
     or set -g fish_prompt_fossil_status_untracked '?'
@@ -48,14 +48,18 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
 
 
 
-    echo -n ' ['
+    echo -n ' ('
+	set_color magenta
+	echo -n "$branch"
+	set_color normal
+	echo -n '|'
+	#set -l repo_status (fossil changes --differ 2>/dev/null | string match -rv '\w:|^\s' | string split " " -f1 | sort -u)
 	set -l repo_status (fossil changes --differ 2>/dev/null | string match -rv '\w:|^\s' | string split " " -f1 | path sort -u)
 
     # Show nice color for a clean repo
     if test -z "$repo_status"
         set_color $fish_color_fossil_clean
-        echo -n "($branch)"'✓'
-        set_color normal
+        echo -n '✔'
 
     # Handle modified or dirty (unknown state)
     else
@@ -86,10 +90,11 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
         if string match -qr '^(ADDED|EDITED|DELETED)' $repo_status
             set_color $fish_color_fossil_modified
         else
-            set_color $fish_color_fossil_dirty
+            set_color --bold $fish_color_fossil_dirty
         end
 
-        echo -n "($branch)"'⚡'
+        echo -n '⚡'
+		set_color normal
 
         # Sort status symbols
         for i in $fish_prompt_fossil_status_order
@@ -101,10 +106,8 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
                 echo -n $$status_name
             end
         end
-
-        set_color normal
     end
 
     set_color normal
-    echo -n ']'
+    echo -n ')'
 end

--- a/share/functions/fish_fossil_prompt.fish
+++ b/share/functions/fish_fossil_prompt.fish
@@ -4,48 +4,88 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
         return 1
     end
 
-    # Bail if not a fossil checkout
-    if not fossil ls &> /dev/null
-	return 127
-    end
+    # Read branch and bookmark (bail if not checkout)
+    set -l branch (fossil branch current 2>/dev/null)
+    or return 127
 
-    # Parse fossil info
-    set -l fossil_info (fossil info)
-    string match --regex --quiet \
-        '^project-name:\s*(?<fossil_project_name>.*)$' $fossil_info
-    string match --regex --quiet \
-        '^tags:\s*(?<fossil_tags>.*)$' $fossil_info
+    set -g fish_color_fossil_clean green
+    set -g fish_color_fossil_modified yellow
+    set -g fish_color_fossil_dirty red
+
+    set -g fish_color_fossil_added green
+    set -g fish_color_fossil_renamed magenta
+    set -g fish_color_fossil_missing red
+    set -g fish_color_fossil_deleted red
+    set -g fish_color_fossil_untracked yellow
+    set -g fish_color_fossil_conflict red
+
+    set -g fish_prompt_fossil_status_added '✚'
+    set -g fish_prompt_fossil_status_modified '*'
+    set -g fish_prompt_fossil_status_renamed '⇒'
+    set -g fish_prompt_fossil_status_deleted '-'
+    set -g fish_prompt_fossil_status_missing '✖'
+    set -g fish_prompt_fossil_status_untracked '?'
+    set -g fish_prompt_fossil_status_conflict '×'
+
+    set -g fish_prompt_fossil_status_order added modified renamed deleted missing untracked conflict
+
 
     echo -n ' ['
-    set_color --bold magenta
-    echo -n $fossil_project_name
-    set_color normal
-    echo -n ':'
-    set_color --bold yellow
-    echo -n $fossil_tags
-    set_color normal
+    # Disabling color and pager is always a good idea.
+    set -l repo_status (fossil status --differ 2>/dev/null | grep -v '\w:\|^\s' | awk '{print $1}' | sort -u)
 
-    # Parse fossil status
-    set -l fossil_status (fossil status)
-    if string match --quiet 'ADDED*' $fossil_status
-        set_color --bold green
-        echo -n '+'
-    end
-    if string match --quiet 'DELETED*' $fossil_status
-        set_color --bold red
-        echo -n '-'
-    end
-    if string match --quiet 'MISSING*' $fossil_status
-        set_color --bold red
-        echo -n '!'
-    end
-    if string match --quiet 'RENAMED*' $fossil_status
-        set_color --bold yellow
-        echo -n '→'
-    end
-    if string match --quiet 'CONFLICT*' $fossil_status
-        set_color --bold green
-        echo -n '×'
+    # Show nice color for a clean repo
+    if test -z "$repo_status"
+        set_color $fish_color_fossil_clean
+        echo -n "($branch)"'✓'
+        set_color normal
+
+    # Handle modified or dirty (unknown state)
+    else
+        set -l fossil_statuses
+
+        # Take actions for the statuses of the files in the repo
+        for line in $repo_status
+
+            # Add a character for each file status if we have one
+            switch $line
+                case 'ADDED'
+                    set -a fossil_statuses added
+                case 'EDITED'
+                    set -a fossil_statuses modified
+                case 'EXTRA'
+                    set -a fossil_statuses untracked
+                case 'DELETED'
+                    set -a fossil_statuses deleted
+                case 'MISSING'
+                    set -a fossil_statuses missing
+                case 'RENAMED'
+                    set -a fossil_statuses renamed
+                case 'CONFLICT'
+                    set -a fossil_statuses conflict
+            end
+        end
+
+        if string match -qr '^(ADDED|EDITED|DELETD)' $repo_status
+            set_color $fish_color_fossil_modified
+        else
+            set_color $fish_color_fossil_dirty
+        end
+
+        echo -n "($branch)"'⚡'
+
+        # Sort status symbols
+        for i in $fish_prompt_fossil_status_order
+            if contains -- $i $fossil_statuses
+                set -l color_name fish_color_fossil_$i
+                set -l status_name fish_prompt_fossil_status_$i
+
+                set_color $$color_name
+                echo -n $$status_name
+            end
+        end
+
+        set_color normal
     end
 
     set_color normal

--- a/share/functions/fish_fossil_prompt.fish
+++ b/share/functions/fish_fossil_prompt.fish
@@ -8,31 +8,48 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
     set -l branch (fossil branch current 2>/dev/null)
     or return 127
 
-    set -g fish_color_fossil_clean green
-    set -g fish_color_fossil_modified yellow
-    set -g fish_color_fossil_dirty red
+    set -q fish_color_fossil_clean
+    or set -g fish_color_fossil_clean green
+    set -q fish_color_fossil_modified
+    or set -g fish_color_fossil_modified yellow
+    set -q fish_color_fossil_dirty
+    or set -g fish_color_fossil_dirty red
 
-    set -g fish_color_fossil_added green
-    set -g fish_color_fossil_renamed magenta
-    set -g fish_color_fossil_missing red
-    set -g fish_color_fossil_deleted red
-    set -g fish_color_fossil_untracked yellow
-    set -g fish_color_fossil_conflict red
+    set -q fish_color_fossil_added
+    or set -g fish_color_fossil_added green
+    set -q fish_color_fossil_renamed
+    or set -g fish_color_fossil_renamed magenta
+    set -q fish_color_fossil_missing
+    or set -g fish_color_fossil_missing red
+    set -q fish_color_fossil_deleted
+    or set -g fish_color_fossil_deleted red
+    set -q fish_color_fossil_untracked
+    or set -g fish_color_fossil_untracked yellow
+    set -q fish_color_fossil_conflict
+    or set -g fish_color_fossil_conflict red
 
-    set -g fish_prompt_fossil_status_added '✚'
-    set -g fish_prompt_fossil_status_modified '*'
-    set -g fish_prompt_fossil_status_renamed '⇒'
-    set -g fish_prompt_fossil_status_deleted '-'
-    set -g fish_prompt_fossil_status_missing '✖'
-    set -g fish_prompt_fossil_status_untracked '?'
-    set -g fish_prompt_fossil_status_conflict '×'
+    set -q fish_prompt_fossil_status_added
+    or set -g fish_prompt_fossil_status_added '✚'
+    set -q fish_prompt_fossil_status_modified
+    or set -g fish_prompt_fossil_status_modified '*'
+    set -q fish_prompt_fossil_status_renamed
+    or set -g fish_prompt_fossil_status_renamed '⇒'
+    set -q fish_prompt_fossil_status_deleted '
+    or set -g fish_prompt_fossil_status_deleted '-'
+    set -q fish_prompt_fossil_status_missing '
+    or set -g fish_prompt_fossil_status_missing '✖'
+    set -q fish_prompt_fossil_status_untracked
+    or set -g fish_prompt_fossil_status_untracked '?'
+    set -q fish_prompt_fossil_status_conflict
+    or set -g fish_prompt_fossil_status_conflict '×'
 
-    set -g fish_prompt_fossil_status_order added modified renamed deleted missing untracked conflict
+	set -q fish_prompt_fossil_status_order
+	or set -g fish_prompt_fossil_status_order added modified renamed deleted missing untracked conflict
+
 
 
     echo -n ' ['
-    # Disabling color and pager is always a good idea.
-    set -l repo_status (fossil changes --differ 2>/dev/null | grep -v '\w:\|^\s' | awk '{print $1}' | sort -u)
+	set -l repo_status (fossil changes --differ 2>/dev/null | string match -rv '\w:|^\s' | string split " " -f1 | path sort -u)
 
     # Show nice color for a clean repo
     if test -z "$repo_status"
@@ -66,7 +83,7 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
             end
         end
 
-        if string match -qr '^(ADDED|EDITED|DELETD)' $repo_status
+        if string match -qr '^(ADDED|EDITED|DELETED)' $repo_status
             set_color $fish_color_fossil_modified
         else
             set_color $fish_color_fossil_dirty


### PR DESCRIPTION
## Improve fossil prompt execution time

This PR improves the execution time of the fish_fossil_prompt by up to 70ms.
It has the following changes from the original prompt introduced in #9500.

1. Instead of calling `fossil ls` to check if we are inside a fossil repository, we call `fossil branch` instead and cache the value as the current branch. This saves the need of finding the branch later.
2. It also notifies the user if some files in the folder are not ignored yet not added to the repository. This is done by adding `--differ` flag.
3. It makes use of the `changes` command instead of `status` which is cheaper to compute (~20ms).

# Discussion:
1. This PR removes the tags from the current branch and instead keeps only the branch. This is the same behavior if the commit is not tagged. If this behavior is wanted, we can restore it possibly using `fossil tag list` for checking if we are in a repository. Another option is to use `fossil status --differ` to check if the repository exist. The output from status, while slower, has the tags.
2. It removes the repository name from the prompt. Calling `fossil info` takes 50ms on a clean repository. 
3. Are there fish built-ins that I am not aware of that could replace the calls to `grep` `awk` and `sort`?
4. The call to `grep` is probably not required with the use of `changes` instead of `status` but I haven't verified it yet.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
