### PR TITLE
rust: fix clippy warnings, doc comments

### DIFF
--- a/fish-rust/build.rs
+++ b/fish-rust/build.rs
@@ -38,7 +38,7 @@ fn main() -> miette::Result<()> {
     // Emit autocxx junk.
     // This allows "C++ to be used from Rust."
     let include_paths = [&fish_src_dir, &fish_build_dir, &cxx_include_dir];
-    let mut b = autocxx_build::Builder::new("src/ffi.rs", &include_paths)
+    let mut b = autocxx_build::Builder::new("src/ffi.rs", include_paths)
         .custom_gendir(autocxx_gen_dir.into())
         .build()?;
     b.flag_if_supported("-std=c++11")

--- a/fish-rust/src/fd_readable_set.rs
+++ b/fish-rust/src/fd_readable_set.rs
@@ -158,7 +158,7 @@ impl fd_readable_set_t {
                 self.pollfds_.insert(
                     pos,
                     libc::pollfd {
-                        fd: fd,
+                        fd,
                         events: libc::POLLIN,
                         revents: 0,
                     },

--- a/fish-rust/src/ffi_tests.rs
+++ b/fish-rust/src/ffi_tests.rs
@@ -7,8 +7,6 @@
 
 #[cfg(all(feature = "fish-ffi-tests", not(test)))]
 mod ffi_tests_impl {
-    use inventory;
-
     /// A test which needs to cross the FFI.
     #[derive(Debug)]
     pub struct FFITest {

--- a/fish-rust/src/ffi_tests.rs
+++ b/fish-rust/src/ffi_tests.rs
@@ -1,9 +1,10 @@
-/// Support for tests which need to cross the FFI.
-/// Because the C++ is not compiled by `cargo test` and there is no natural way to
-/// do it, use the following facilities for tests which need to use C++ types.
-/// This uses the inventory crate to build a custom-test harness
-/// as described at https://www.infinyon.com/blog/2021/04/rust-custom-test-harness/
-/// See smoke.rs add_test for an example of how to use this.
+//! Support for tests which need to cross the FFI.
+//!
+//! Because the C++ is not compiled by `cargo test` and there is no natural way to
+//! do it, use the following facilities for tests which need to use C++ types.
+//! This uses the inventory crate to build a custom-test harness
+//! as described at <https://www.infinyon.com/blog/2021/04/rust-custom-test-harness/>
+//! See smoke.rs add_test for an example of how to use this.
 
 #[cfg(all(feature = "fish-ffi-tests", not(test)))]
 mod ffi_tests_impl {

--- a/fish-rust/src/ffi_tests.rs
+++ b/fish-rust/src/ffi_tests.rs
@@ -53,6 +53,7 @@ mod ffi_tests_impl {
 
 pub(crate) use ffi_tests_impl::*;
 
+#[allow(clippy::module_inception)]
 #[cxx::bridge(namespace = rust)]
 mod ffi_tests {
     extern "Rust" {

--- a/fish-rust/src/flog.rs
+++ b/fish-rust/src/flog.rs
@@ -175,7 +175,7 @@ fn apply_one_wildcard(wc_esc: &wstr, sense: bool) {
         }
     }
     if !match_found {
-        eprintln!("Failed to match debug category: {wc_esc}\n");
+        eprintln!("Failed to match debug category: {wc_esc}");
     }
 }
 

--- a/fish-rust/src/flog.rs
+++ b/fish-rust/src/flog.rs
@@ -169,13 +169,13 @@ fn apply_one_wildcard(wc_esc: &wstr, sense: bool) {
     let wc = parse_util_unescape_wildcards(&wc_esc.to_ffi());
     let mut match_found = false;
     for cat in categories::all_categories() {
-        if wildcard_match(&cat.name.to_ffi(), &*wc, false) {
+        if wildcard_match(&cat.name.to_ffi(), &wc, false) {
             cat.enabled.store(sense, Ordering::Relaxed);
             match_found = true;
         }
     }
     if !match_found {
-        eprintln!("Failed to match debug category: {}\n", wc_esc);
+        eprintln!("Failed to match debug category: {wc_esc}\n");
     }
 }
 

--- a/fish-rust/src/lib.rs
+++ b/fish-rust/src/lib.rs
@@ -8,6 +8,10 @@ extern crate lazy_static;
 
 mod fd_readable_set;
 mod fds;
+#[allow(rustdoc::broken_intra_doc_links)]
+#[allow(clippy::module_inception)]
+#[allow(clippy::new_ret_no_self)]
+#[allow(clippy::wrong_self_convention)]
 mod ffi;
 mod ffi_init;
 mod ffi_tests;

--- a/fish-rust/src/topic_monitor.rs
+++ b/fish-rust/src/topic_monitor.rs
@@ -377,7 +377,7 @@ static mut s_principal: *const topic_monitor_t = std::ptr::null();
 
 /// Create a new topic monitor. Exposed for the FFI.
 pub fn new_topic_monitor() -> Box<topic_monitor_t> {
-    Box::new(topic_monitor_t::default())
+    Box::default()
 }
 
 impl topic_monitor_t {

--- a/fish-rust/src/topic_monitor.rs
+++ b/fish-rust/src/topic_monitor.rs
@@ -1,20 +1,6 @@
-use crate::fd_readable_set::fd_readable_set_t;
-use crate::fds::{self, autoclose_pipes_t};
-use crate::ffi::{self as ffi, c_int};
-use crate::flog::FLOG;
-use crate::wchar::{widestrs, wstr, WString};
-use crate::wchar_ffi::wcharz;
-use nix::errno::Errno;
-use nix::unistd;
-use std::cell::UnsafeCell;
-use std::mem;
-use std::pin::Pin;
-use std::sync::{
-    atomic::{AtomicU8, Ordering},
-    Condvar, Mutex, MutexGuard,
-};
+/*! Topic monitoring support.
 
-/** Topic monitoring support. Topics are conceptually "a thing that can happen." For example,
+Topics are conceptually "a thing that can happen." For example,
 delivery of a SIGINT, a child process exits, etc. It is possible to post to a topic, which means
 that that thing happened.
 
@@ -33,6 +19,22 @@ Tying this all together is the topic_monitor_t. This provides the current topic 
 also provides the ability to perform a blocking wait for any topic to change in a particular topic
 set. This is the real power of topics: you can wait for a sigchld signal OR a thread exit.
 */
+
+use crate::fd_readable_set::fd_readable_set_t;
+use crate::fds::{self, autoclose_pipes_t};
+use crate::ffi::{self as ffi, c_int};
+use crate::flog::FLOG;
+use crate::wchar::{widestrs, wstr, WString};
+use crate::wchar_ffi::wcharz;
+use nix::errno::Errno;
+use nix::unistd;
+use std::cell::UnsafeCell;
+use std::mem;
+use std::pin::Pin;
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Condvar, Mutex, MutexGuard,
+};
 
 #[cxx::bridge]
 mod topic_monitor_ffi {

--- a/fish-rust/src/util.rs
+++ b/fish-rust/src/util.rs
@@ -2,6 +2,7 @@
 
 use crate::ffi::wcharz_t;
 use crate::wchar::wstr;
+use std::cmp::Ordering;
 use std::time;
 
 #[cxx::bridge]
@@ -80,15 +81,19 @@ pub fn wcsfilecmp(a: wcharz_t, b: wcharz_t) -> i32 {
         acl = acl.to_uppercase().next().unwrap();
         bcl = bcl.to_uppercase().next().unwrap();
 
-        if acl < bcl {
-            retval = -1;
-            break;
-        } else if acl > bcl {
-            retval = 1;
-            break;
-        } else {
-            ai += 1;
-            bi += 1;
+        match acl.cmp(&bcl) {
+            Ordering::Less => {
+                retval = -1;
+                break;
+            }
+            Ordering::Equal => {
+                ai += 1;
+                bi += 1;
+            }
+            Ordering::Greater => {
+                retval = 1;
+                break;
+            }
         }
     }
 
@@ -152,15 +157,19 @@ pub fn wcsfilecmp_glob(a: wcharz_t, b: wcharz_t) -> i32 {
         // TODO Compare the tail (enabled by Rust's Unicode support).
         let acl = ac.to_lowercase().next().unwrap();
         let bcl = bc.to_lowercase().next().unwrap();
-        if acl < bcl {
-            retval = -1;
-            break;
-        } else if acl > bcl {
-            retval = 1;
-            break;
-        } else {
-            ai += 1;
-            bi += 1;
+        match acl.cmp(&bcl) {
+            Ordering::Less => {
+                retval = -1;
+                break;
+            }
+            Ordering::Equal => {
+                ai += 1;
+                bi += 1;
+            }
+            Ordering::Greater => {
+                retval = 1;
+                break;
+            }
         }
     }
 

--- a/fish-rust/src/wchar.rs
+++ b/fish-rust/src/wchar.rs
@@ -1,13 +1,14 @@
+//! Support for wide strings.
+//!
+//! There are two wide string types that are commonly used:
+//!   - wstr: a string slice without a nul terminator. Like `&str` but wide chars.
+//!   - WString: an owning string without a nul terminator. Like `String` but wide chars.
+
 use crate::ffi;
 pub use cxx::CxxWString;
 pub use ffi::{wchar_t, wcharz_t};
 pub use widestring::utf32str;
 pub use widestring::{Utf32Str as wstr, Utf32String as WString};
-
-/// Support for wide strings.
-/// There are two wide string types that are commonly used:
-///   - wstr: a string slice without a nul terminator. Like `&str` but wide chars.
-///   - WString: an owning string without a nul terminator. Like `String` but wide chars.
 
 /// Creates a wstr string slice, like the "L" prefix of C++.
 /// The result is of type wstr.

--- a/fish-rust/src/wchar_ext.rs
+++ b/fish-rust/src/wchar_ext.rs
@@ -32,18 +32,18 @@ impl<'a> CharPrefixSuffix for &'a wstr {
 impl<'a> CharPrefixSuffix for &'a WString {
     type Iter = CharsUtf32<'a>;
     fn chars(self) -> Self::Iter {
-        wstr::chars(&*self)
+        wstr::chars(self)
     }
 }
 
 /// \return true if \p prefix is a prefix of \p contents.
-fn iter_prefixes_iter<Prefix, Contents>(mut prefix: Prefix, mut contents: Contents) -> bool
+fn iter_prefixes_iter<Prefix, Contents>(prefix: Prefix, mut contents: Contents) -> bool
 where
     Prefix: Iterator,
     Contents: Iterator,
     Prefix::Item: PartialEq<Contents::Item>,
 {
-    while let Some(c1) = prefix.next() {
+    for c1 in prefix {
         match contents.next() {
             Some(c2) if c1 == c2 => {}
             _ => return false,

--- a/fish-rust/src/wchar_ffi.rs
+++ b/fish-rust/src/wchar_ffi.rs
@@ -121,6 +121,7 @@ impl WCharToFFI for wcharz_t {
 /// Convert from a CxxWString, in preparation for using over FFI.
 pub trait WCharFromFFI<Target> {
     /// Convert from a CxxWString for FFI purposes.
+    #[allow(clippy::wrong_self_convention)]
     fn from_ffi(&self) -> Target;
 }
 

--- a/fish-rust/src/wchar_ffi.rs
+++ b/fish-rust/src/wchar_ffi.rs
@@ -1,15 +1,17 @@
+//! Interfaces for various FFI string types.
+//!
+//! We have the following string types for FFI purposes:
+//!   - CxxWString: the Rust view of a C++ wstring.
+//!   - W0String: an owning string with a nul terminator.
+//!   - wcharz_t: a "newtyped" pointer to a nul-terminated string, implemented in C++.
+//!               This is useful for FFI boundaries, to work around autocxx limitations on pointers.
+
 use crate::ffi;
 pub use cxx::CxxWString;
 pub use ffi::{wchar_t, wcharz_t};
 pub use widestring::U32CString as W0String;
 pub use widestring::{u32cstr, utf32str};
 pub use widestring::{Utf32Str as wstr, Utf32String as WString};
-
-/// We have the following string types for FFI purposes:
-///   - CxxWString: the Rust view of a C++ wstring.
-///   - W0String: an owning string with a nul terminator.
-///   - wcharz_t: a "newtyped" pointer to a nul-terminated string, implemented in C++.
-///               This is useful for FFI boundaries, to work around autocxx limitations on pointers.
 
 /// \return the length of a nul-terminated raw string.
 pub fn wcslen(str: *const wchar_t) -> usize {

--- a/fish-rust/src/wgetopt.rs
+++ b/fish-rust/src/wgetopt.rs
@@ -47,6 +47,7 @@ use crate::wchar::{utf32str, wstr, WExt};
 // `ordering'.  In the case of RETURN_IN_ORDER, only `--' can cause `getopt' to return EOF with
 // `woptind' != ARGC.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::upper_case_acronyms)]
 enum Ordering {
     REQUIRE_ORDER,
     PERMUTE,
@@ -585,6 +586,8 @@ impl<'opts, 'args, 'argarray> wgetopter_t<'opts, 'args, 'argarray> {
         if !self.longopts.is_empty() && self.woptind < self.argc() {
             let arg = self.argv[self.woptind];
 
+            #[allow(clippy::if_same_then_else)]
+            #[allow(clippy::needless_bool)]
             let try_long = if arg.char_at(0) == '-' && arg.char_at(1) == '-' {
                 // Like --foo
                 true

--- a/fish-rust/src/wgetopt.rs
+++ b/fish-rust/src/wgetopt.rs
@@ -1,5 +1,7 @@
-// A version of the getopt library for use with wide character strings.
-//
+//! A version of the getopt library for use with wide character strings.
+//!
+//! Note wgetopter expects an mutable array of const strings. It modifies the order of the
+//! strings, but not their contents.
 /* Declarations for getopt.
    Copyright (C) 1989, 90, 91, 92, 93, 94 Free Software Foundation, Inc.
 
@@ -21,31 +23,29 @@ License along with the GNU C Library; see the file COPYING.LIB.  If
 not, write to the Free Software Foundation, Inc., 675 Mass Ave,
 Cambridge, MA 02139, USA.  */
 
-/// Note wgetopter expects an mutable array of const strings. It modifies the order of the
-/// strings, but not their contents.
 use crate::wchar::{utf32str, wstr, WExt};
 
-// Describe how to deal with options that follow non-option ARGV-elements.
-//
-// If the caller did not specify anything, the default is PERMUTE.
-//
-// REQUIRE_ORDER means don't recognize them as options; stop option processing when the first
-// non-option is seen. This is what Unix does. This mode of operation is selected by using `+'
-// as the first character of the list of option characters.
-//
-// PERMUTE is the default.  We permute the contents of ARGV as we scan, so that eventually all
-// the non-options are at the end.  This allows options to be given in any order, even with
-// programs that were not written to expect this.
-//
-// RETURN_IN_ORDER is an option available to programs that were written to expect options and
-// other ARGV-elements in any order and that care about the ordering of the two.  We describe
-// each non-option ARGV-element as if it were the argument of an option with character code 1.
-// Using `-' as the first character of the list of option characters selects this mode of
-// operation.
-//
-// The special argument `--' forces an end of option-scanning regardless of the value of
-// `ordering'.  In the case of RETURN_IN_ORDER, only `--' can cause `getopt' to return EOF with
-// `woptind' != ARGC.
+/// Describe how to deal with options that follow non-option ARGV-elements.
+///
+/// If the caller did not specify anything, the default is PERMUTE.
+///
+/// REQUIRE_ORDER means don't recognize them as options; stop option processing when the first
+/// non-option is seen. This is what Unix does. This mode of operation is selected by using `+'
+/// as the first character of the list of option characters.
+///
+/// PERMUTE is the default.  We permute the contents of ARGV as we scan, so that eventually all
+/// the non-options are at the end.  This allows options to be given in any order, even with
+/// programs that were not written to expect this.
+///
+/// RETURN_IN_ORDER is an option available to programs that were written to expect options and
+/// other ARGV-elements in any order and that care about the ordering of the two.  We describe
+/// each non-option ARGV-element as if it were the argument of an option with character code 1.
+/// Using `-` as the first character of the list of option characters selects this mode of
+/// operation.
+///
+/// The special argument `--` forces an end of option-scanning regardless of the value of
+/// `ordering`.  In the case of RETURN_IN_ORDER, only `--` can cause `getopt` to return EOF with
+/// `woptind` != ARGC.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 enum Ordering {
@@ -65,47 +65,46 @@ fn empty_wstr() -> &'static wstr {
 }
 
 pub struct wgetopter_t<'opts, 'args, 'argarray> {
-    // Argv.
+    /// Argv.
     argv: &'argarray mut [&'args wstr],
 
-    // For communication from `getopt' to the caller. When `getopt' finds an option that takes an
-    // argument, the argument value is returned here. Also, when `ordering' is RETURN_IN_ORDER, each
-    // non-option ARGV-element is returned here.
+    /// For communication from `getopt` to the caller. When `getopt` finds an option that takes an
+    /// argument, the argument value is returned here. Also, when `ordering` is RETURN_IN_ORDER, each
+    /// non-option ARGV-element is returned here.
     pub woptarg: Option<&'args wstr>,
 
     shortopts: &'opts wstr,
     longopts: &'opts [woption<'opts>],
 
-    // The next char to be scanned in the option-element in which the last option character we
-    // returned was found. This allows us to pick up the scan where we left off.
-    //
-    // If this is empty, it means resume the scan by advancing to the next ARGV-element.
+    /// The next char to be scanned in the option-element in which the last option character we
+    /// returned was found. This allows us to pick up the scan where we left off.
+    ///
+    /// If this is empty, it means resume the scan by advancing to the next ARGV-element.
     nextchar: &'args wstr,
 
-    // Index in ARGV of the next element to be scanned. This is used for communication to and from
-    // the caller and for communication between successive calls to `getopt'.
-    //
-    // On entry to `getopt', zero means this is the first call; initialize.
-    //
-    // When `getopt' returns EOF, this is the index of the first of the non-option elements that the
-    // caller should itself scan.
-    //
-    // Otherwise, `woptind' communicates from one call to the next how much of ARGV has been scanned
-    // so far.
-
+    /// Index in ARGV of the next element to be scanned. This is used for communication to and from
+    /// the caller and for communication between successive calls to `getopt`.
+    ///
+    /// On entry to `getopt`, zero means this is the first call; initialize.
+    ///
+    /// When `getopt` returns EOF, this is the index of the first of the non-option elements that the
+    /// caller should itself scan.
+    ///
+    /// Otherwise, `woptind` communicates from one call to the next how much of ARGV has been scanned
+    /// so far.
     // XXX 1003.2 says this must be 1 before any call.
     pub woptind: usize,
 
-    // Set to an option character which was unrecognized.
+    /// Set to an option character which was unrecognized.
     woptopt: char,
 
-    // Describe how to deal with options that follow non-option ARGV-elements.
+    /// Describe how to deal with options that follow non-option ARGV-elements.
     ordering: Ordering,
 
-    // Handle permutation of arguments.
-
-    // Describe the part of ARGV that contains non-options that have been skipped.  `first_nonopt'
-    // is the index in ARGV of the first of them; `last_nonopt' is the index after the last of them.
+    /// Handle permutation of arguments.
+    ///
+    /// Describe the part of ARGV that contains non-options that have been skipped.  `first_nonopt`
+    /// is the index in ARGV of the first of them; `last_nonopt` is the index after the last of them.
     pub first_nonopt: usize,
     pub last_nonopt: usize,
 
@@ -113,7 +112,7 @@ pub struct wgetopter_t<'opts, 'args, 'argarray> {
     initialized: bool,
 }
 
-// Names for the values of the `has_arg' field of `woption'.
+/// Names for the values of the `has_arg` field of `woption`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum woption_argument_t {
     no_argument,
@@ -125,18 +124,18 @@ pub enum woption_argument_t {
 /// getopt_long or getopt_long_only is a vector of `struct option' terminated by an element
 /// containing a name which is zero.
 ///
-/// The field `has_arg' is:
+/// The field `has_arg` is:
 /// no_argument    (or 0) if the option does not take an argument,
 /// required_argument  (or 1) if the option requires an argument,
 /// optional_argument   (or 2) if the option takes an optional argument.
 ///
-/// If the field `flag' is not NULL, it points to a variable that is set to the value given in the
-/// field `val' when the option is found, but left unchanged if the option is not found.
+/// If the field `flag` is not NULL, it points to a variable that is set to the value given in the
+/// field `val` when the option is found, but left unchanged if the option is not found.
 ///
-/// To have a long-named option do something other than set an `int' to a compiled-in constant, such
-/// as set a value from `optarg', set the option's `flag' field to zero and its `val' field to a
+/// To have a long-named option do something other than set an `int` to a compiled-in constant, such
+/// as set a value from `optarg`, set the option's `flag` field to zero and its `val` field to a
 /// nonzero value (the equivalent single-letter option character, if there is one).  For long
-/// options that have a zero `flag' field, `getopt' returns the contents of the `val' field.
+/// options that have a zero `flag` field, `getopt` returns the contents of the `val` field.
 #[derive(Debug, Clone, Copy)]
 pub struct woption<'a> {
     /// Long name for switch.
@@ -191,13 +190,13 @@ impl<'opts, 'args, 'argarray> wgetopter_t<'opts, 'args, 'argarray> {
         return self.argv.len();
     }
 
-    // Exchange two adjacent subsequences of ARGV. One subsequence is elements
-    // [first_nonopt,last_nonopt) which contains all the non-options that have been skipped so far. The
-    // other is elements [last_nonopt,woptind), which contains all the options processed since those
-    // non-options were skipped.
-    //
-    // `first_nonopt' and `last_nonopt' are relocated so that they describe the new indices of the
-    // non-options in ARGV after they are moved.
+    /// Exchange two adjacent subsequences of ARGV. One subsequence is elements
+    /// [first_nonopt,last_nonopt) which contains all the non-options that have been skipped so far. The
+    /// other is elements [last_nonopt,woptind), which contains all the options processed since those
+    /// non-options were skipped.
+    ///
+    /// `first_nonopt` and `last_nonopt` are relocated so that they describe the new indices of the
+    /// non-options in ARGV after they are moved.
     fn exchange(&mut self) {
         let mut bottom = self.first_nonopt;
         let middle = self.last_nonopt;
@@ -235,7 +234,7 @@ impl<'opts, 'args, 'argarray> wgetopter_t<'opts, 'args, 'argarray> {
         self.last_nonopt = self.woptind;
     }
 
-    // Initialize the internal data when the first call is made.
+    /// Initialize the internal data when the first call is made.
     fn _wgetopt_initialize(&mut self) {
         // Start processing options with ARGV-element 1 (since ARGV-element 0 is the program name); the
         // sequence of previously skipped non-option ARGV-elements is empty.
@@ -266,8 +265,8 @@ impl<'opts, 'args, 'argarray> wgetopter_t<'opts, 'args, 'argarray> {
         self.initialized = true;
     }
 
-    // Advance to the next ARGV-element.
-    // \return Some(\0) on success, or None or another value if we should stop.
+    /// Advance to the next ARGV-element.
+    /// \return Some(\0) on success, or None or another value if we should stop.
     fn _advance_to_next_argv(&mut self) -> Option<char> {
         let argc = self.argc();
         if self.ordering == Ordering::PERMUTE {
@@ -337,7 +336,7 @@ impl<'opts, 'args, 'argarray> wgetopter_t<'opts, 'args, 'argarray> {
         return Some(char::from(0));
     }
 
-    // Check for a matching short opt.
+    /// Check for a matching short opt.
     fn _handle_short_opt(&mut self) -> char {
         // Look at and handle the next short option-character.
         let mut c = self.nextchar.char_at(0);
@@ -439,7 +438,7 @@ impl<'opts, 'args, 'argarray> wgetopter_t<'opts, 'args, 'argarray> {
         *retval = pfound.val;
     }
 
-    // Find a matching long opt.
+    /// Find a matching long opt.
     fn _find_matching_long_opt(
         &self,
         nameend: usize,
@@ -469,7 +468,7 @@ impl<'opts, 'args, 'argarray> wgetopter_t<'opts, 'args, 'argarray> {
         return pfound;
     }
 
-    // Check for a matching long opt.
+    /// Check for a matching long opt.
     fn _handle_long_opt(
         &mut self,
         longind: &mut usize,
@@ -518,45 +517,45 @@ impl<'opts, 'args, 'argarray> wgetopter_t<'opts, 'args, 'argarray> {
         return false;
     }
 
-    // Scan elements of ARGV (whose length is ARGC) for option characters given in OPTSTRING.
-    //
-    // If an element of ARGV starts with '-', and is not exactly "-" or "--", then it is an option
-    // element.  The characters of this element (aside from the initial '-') are option characters.  If
-    // `getopt' is called repeatedly, it returns successively each of the option characters from each of
-    // the option elements.
-    //
-    // If `getopt' finds another option character, it returns that character, updating `woptind' and
-    // `nextchar' so that the next call to `getopt' can resume the scan with the following option
-    // character or ARGV-element.
-    //
-    // If there are no more option characters, `getopt' returns `EOF'. Then `woptind' is the index in
-    // ARGV of the first ARGV-element that is not an option.  (The ARGV-elements have been permuted so
-    // that those that are not options now come last.)
-    //
-    // OPTSTRING is a string containing the legitimate option characters. If an option character is seen
-    // that is not listed in OPTSTRING, return '?'.
-    //
-    // If a char in OPTSTRING is followed by a colon, that means it wants an arg, so the following text
-    // in the same ARGV-element, or the text of the following ARGV-element, is returned in `optarg'.
-    // Two colons mean an option that wants an optional arg; if there is text in the current
-    // ARGV-element, it is returned in `w.woptarg', otherwise `w.woptarg' is set to zero.
-    //
-    // If OPTSTRING starts with `-' or `+', it requests different methods of handling the non-option
-    // ARGV-elements. See the comments about RETURN_IN_ORDER and REQUIRE_ORDER, above.
-    //
-    // Long-named options begin with `--' instead of `-'. Their names may be abbreviated as long as the
-    // abbreviation is unique or is an exact match for some defined option.  If they have an argument,
-    // it follows the option name in the same ARGV-element, separated from the option name by a `=', or
-    // else the in next ARGV-element. When `getopt' finds a long-named option, it returns 0 if that
-    // option's `flag' field is nonzero, the value of the option's `val' field if the `flag' field is
-    // zero.
-    //
-    // LONGOPTS is a vector of `struct option' terminated by an element containing a name which is zero.
-    //
-    // LONGIND returns the index in LONGOPT of the long-named option found. It is only valid when a
-    // long-named option has been found by the most recent call.
-    //
-    // If LONG_ONLY is nonzero, '-' as well as '--' can introduce long-named options.
+    /// Scan elements of ARGV (whose length is ARGC) for option characters given in OPTSTRING.
+    ///
+    /// If an element of ARGV starts with '-', and is not exactly "-" or "--", then it is an option
+    /// element.  The characters of this element (aside from the initial '-') are option characters.  If
+    /// `getopt` is called repeatedly, it returns successively each of the option characters from each of
+    /// the option elements.
+    ///
+    /// If `getopt` finds another option character, it returns that character, updating `woptind` and
+    /// `nextchar` so that the next call to `getopt` can resume the scan with the following option
+    /// character or ARGV-element.
+    ///
+    /// If there are no more option characters, `getopt` returns `EOF`. Then `woptind` is the index in
+    /// ARGV of the first ARGV-element that is not an option.  (The ARGV-elements have been permuted so
+    /// that those that are not options now come last.)
+    ///
+    /// OPTSTRING is a string containing the legitimate option characters. If an option character is seen
+    /// that is not listed in OPTSTRING, return '?'.
+    ///
+    /// If a char in OPTSTRING is followed by a colon, that means it wants an arg, so the following text
+    /// in the same ARGV-element, or the text of the following ARGV-element, is returned in `optarg`.
+    /// Two colons mean an option that wants an optional arg; if there is text in the current
+    /// ARGV-element, it is returned in `w.woptarg`, otherwise `w.woptarg` is set to zero.
+    ///
+    /// If OPTSTRING starts with `-` or `+', it requests different methods of handling the non-option
+    /// ARGV-elements. See the comments about RETURN_IN_ORDER and REQUIRE_ORDER, above.
+    ///
+    /// Long-named options begin with `--` instead of `-`. Their names may be abbreviated as long as the
+    /// abbreviation is unique or is an exact match for some defined option.  If they have an argument,
+    /// it follows the option name in the same ARGV-element, separated from the option name by a `=', or
+    /// else the in next ARGV-element. When `getopt` finds a long-named option, it returns 0 if that
+    /// option's `flag` field is nonzero, the value of the option's `val` field if the `flag` field is
+    /// zero.
+    ///
+    /// LONGOPTS is a vector of `struct option' terminated by an element containing a name which is zero.
+    ///
+    /// LONGIND returns the index in LONGOPT of the long-named option found. It is only valid when a
+    /// long-named option has been found by the most recent call.
+    ///
+    /// If LONG_ONLY is nonzero, '-' as well as '--' can introduce long-named options.
     fn _wgetopt_internal(&mut self, longind: &mut usize, long_only: bool) -> Option<char> {
         if !self.initialized {
             self._wgetopt_initialize();

--- a/fish-rust/src/wutil/format/format.rs
+++ b/fish-rust/src/wutil/format/format.rs
@@ -94,7 +94,7 @@ impl Printf for u64 {
         .try_into()
         .unwrap_or_default();
         let formatted = if spec.left_adj {
-            let mut num_str = prefix.clone();
+            let mut num_str = prefix;
             num_str.extend(rev_num.chars().rev());
             while num_str.len() < width {
                 num_str.push(' ');
@@ -104,11 +104,11 @@ impl Printf for u64 {
             while prefix.len() + rev_num.len() < width {
                 rev_num.push('0');
             }
-            let mut num_str = prefix.clone();
+            let mut num_str = prefix;
             num_str.extend(rev_num.chars().rev());
             num_str
         } else {
-            let mut num_str = prefix.clone();
+            let mut num_str = prefix;
             num_str.extend(rev_num.chars().rev());
             while num_str.len() < width {
                 num_str.insert(0, ' ');
@@ -359,7 +359,7 @@ impl Printf for f64 {
                         rev_tail_str.push((b'0' + (tail % 10) as u8) as char);
                         tail /= 10;
                     }
-                    number.push_str(&format!("{}", int_part));
+                    number.push_str(&int_part.to_string());
                     number.push('.');
                     number.extend(rev_tail_str.chars().rev());
                     if strip_trailing_0s {
@@ -371,35 +371,33 @@ impl Printf for f64 {
                     number.push_str(&format!("{}", normal.round()));
                 }
                 number.push(exp_symb);
-                number.push_str(&format!("{:+03}", exponent));
-            } else {
-                if precision > 0 {
-                    let mut int_part = abs.trunc();
-                    let exp_factor = 10.0_f64.powf(precision as f64);
-                    let mut tail = ((abs - int_part) * exp_factor).round() as u64;
-                    let mut rev_tail_str = WString::new();
-                    if tail >= exp_factor as u64 {
-                        // overflow - we must round up
-                        int_part += 1.0;
-                        tail -= exp_factor as u64;
-                        // no need to change the exponent as we don't have one
-                        // (not scientific notation)
-                    }
-                    for _ in 0..precision {
-                        rev_tail_str.push((b'0' + (tail % 10) as u8) as char);
-                        tail /= 10;
-                    }
-                    number.push_str(&format!("{}", int_part));
-                    number.push('.');
-                    number.extend(rev_tail_str.chars().rev());
-                    if strip_trailing_0s {
-                        while number.ends_with('0') {
-                            number.pop();
-                        }
-                    }
-                } else {
-                    number.push_str(&format!("{}", abs.round()));
+                number.push_str(&format!("{exponent:+03}"));
+            } else if precision > 0 {
+                let mut int_part = abs.trunc();
+                let exp_factor = 10.0_f64.powf(precision as f64);
+                let mut tail = ((abs - int_part) * exp_factor).round() as u64;
+                let mut rev_tail_str = WString::new();
+                if tail >= exp_factor as u64 {
+                    // overflow - we must round up
+                    int_part += 1.0;
+                    tail -= exp_factor as u64;
+                    // no need to change the exponent as we don't have one
+                    // (not scientific notation)
                 }
+                for _ in 0..precision {
+                    rev_tail_str.push((b'0' + (tail % 10) as u8) as char);
+                    tail /= 10;
+                }
+                number.push_str(&int_part.to_string());
+                number.push('.');
+                number.extend(rev_tail_str.chars().rev());
+                if strip_trailing_0s {
+                    while number.ends_with('0') {
+                        number.pop();
+                    }
+                }
+            } else {
+                number.push_str(&format!("{}", abs.round()));
             }
         } else {
             // not finite

--- a/fish-rust/src/wutil/format/mod.rs
+++ b/fish-rust/src/wutil/format/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod format;
 mod parser;
 pub mod printf;

--- a/fish-rust/src/wutil/format/parser.rs
+++ b/fish-rust/src/wutil/format/parser.rs
@@ -57,7 +57,7 @@ pub enum NumericParam {
     Literal(i32),
     /// Get the width from the previous argument
     ///
-    /// This should never be passed to [Printf::format()][crate::Printf::format()].
+    /// This should never be passed to [Printf::format()][super::format::Printf::format()].
     FromArgument,
 }
 

--- a/fish-rust/src/wutil/gettext.rs
+++ b/fish-rust/src/wutil/gettext.rs
@@ -6,10 +6,7 @@ use crate::wchar_ffi::wcslen;
 
 /// Implementation detail for wgettext!.
 pub fn wgettext_impl_do_not_use_directly(text: &[wchar_t]) -> &'static wstr {
-    assert!(
-        text.len() > 0 && text[text.len() - 1] == 0,
-        "should be nul-terminated"
-    );
+    assert_eq!(text.last(), Some(&0), "should be nul-terminated");
     let res: *const wchar_t = ffi::wgettext_ptr(text.as_ptr());
     let slice = unsafe { std::slice::from_raw_parts(res as *const u32, wcslen(res)) };
     wstr::from_slice(slice).expect("Invalid UTF-32")

--- a/fish-rust/src/wutil/wcstoi.rs
+++ b/fish-rust/src/wutil/wcstoi.rs
@@ -35,11 +35,7 @@ where
     Chars: Iterator<Item = char>,
 {
     if let Some(r) = mradix {
-        assert!(
-            (2..=36).contains(&r),
-            "fish_parse_radix: invalid radix {}",
-            r
-        );
+        assert!((2..=36).contains(&r), "fish_parse_radix: invalid radix {r}");
     }
     let chars = &mut ichars.peekable();
 
@@ -63,17 +59,16 @@ where
     }
 
     // Determine the radix.
-    let radix;
-    if mradix.is_some() {
-        radix = mradix.unwrap();
+    let radix = if let Some(radix) = mradix {
+        radix
     } else if current(chars) == '0' {
         chars.next();
         match current(chars) {
             'x' | 'X' => {
                 chars.next();
-                radix = 16;
+                16
             }
-            c if '0' <= c && c <= '9' => radix = 8,
+            c if ('0'..='9').contains(&c) => 8,
             _ => {
                 // Just a 0.
                 return Ok(ParseResult {
@@ -83,8 +78,8 @@ where
             }
         }
     } else {
-        radix = 10;
-    }
+        10
+    };
 
     // Compute as u64.
     let mut consumed1 = false;


### PR DESCRIPTION
## Description

First of all, I really like the direction that fish is taking here! I'd love to contribute to the porting effort; as a way to get myself familiar with the rust codebase so far, I decided to fix the low-hanging fruit reported by clippy. This should also allow developers to use use clippy for their newly written code without being overwhelmed by unrelated warnings.

If you're still too early in development to worry about such small stuff, that's fine too of course.

Is there any interest in running clippy in CI? I could work on that (as well as things like checking rustfmt, running tests on the minimum supported rust version and with the minimum dependency versions).

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst