### PR TITLE
`functions --copy`: store file name and line number

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Scripting improvements
 ----------------------
 - ``abbr --list`` no longer escapes the abbr name, which is necessary to be able to pass it to ``abbr --erase`` (:issue:`9470`).
 - ``read`` will now print an error if told to set a read-only variable instead of silently doing nothing (:issue:`9346`).
+- ``functions`` and ``type`` now show where a function was copied and where it originally was instead of saying ``Defined interactively``.
+- Stack trace now shows line numbers for copied functions.
 
 Interactive improvements
 ------------------------

--- a/doc_src/cmds/functions.rst
+++ b/doc_src/cmds/functions.rst
@@ -34,10 +34,10 @@ The following options are available:
     Causes the specified functions to be erased. This also means that it is prevented from autoloading in the current session. Use :doc:`funcsave <funcsave>` to remove the saved copy.
 
 **-D** or **--details**
-    Reports the path name where the specified function is defined or could be autoloaded, ``stdin`` if the function was defined interactively or on the command line or by reading standard input, **-** if the function was created via :doc:`source <source>`, and ``n/a`` if the function isn't available. (Functions created via :doc:`alias <alias>` will return **-**, because ``alias`` uses ``source`` internally.) If the **--verbose** option is also specified then five lines are written:
+    Reports the path name where the specified function is defined or could be autoloaded, ``stdin`` if the function was defined interactively or on the command line or by reading standard input, **-** if the function was created via :doc:`source <source>`, and ``n/a`` if the function isn't available. (Functions created via :doc:`alias <alias>` will return **-**, because ``alias`` uses ``source`` internally. Copied functions will return where the function was copied.) If the **--verbose** option is also specified then five lines are written:
 
-    - the pathname as already described,
-    - ``autoloaded``, ``not-autoloaded`` or ``n/a``,
+    - the path name as already described,
+    - if the function was copied, the path name to where the function was originally defined, otherwise ``autoloaded``, ``not-autoloaded`` or ``n/a``,
     - the line number within the file or zero if not applicable,
     - ``scope-shadowing`` if the function shadows the vars in the calling function (the normal case if it wasn't defined with **--no-scope-shadowing**), else ``no-scope-shadowing``, or ``n/a`` if the function isn't defined,
     - the function description minimally escaped so it is a single line, or ``n/a`` if the function isn't defined or has no description.

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -231,7 +231,10 @@ void function_set_desc(const wcstring &name, const wcstring &desc, parser_t &par
     }
 }
 
-bool function_copy(const wcstring &name, const wcstring &new_name) {
+bool function_copy(const wcstring &name, const wcstring &new_name, parser_t &parser) {
+    auto filename = parser.current_filename();
+    auto lineno = parser.get_lineno();
+
     auto funcset = function_set.acquire();
     auto props = funcset->get_props(name);
     if (!props) {
@@ -239,11 +242,11 @@ bool function_copy(const wcstring &name, const wcstring &new_name) {
         return false;
     }
     // Copy the function's props.
-    // This new instance of the function shouldn't be tied to the definition file of the
-    // original, so clear the filename, etc.
     auto new_props = copy_props(props);
     new_props->is_autoload = false;
-    new_props->definition_file = nullptr;
+    new_props->is_copy = true;
+    new_props->copy_definition_file = filename;
+    new_props->copy_definition_lineno = lineno;
 
     // Note this will NOT overwrite an existing function with the new name.
     // TODO: rationalize if this behavior is desired.

--- a/src/function.h
+++ b/src/function.h
@@ -46,6 +46,15 @@ struct function_properties_t {
     /// The file from which the function was created, or nullptr if not from a file.
     filename_ref_t definition_file{};
 
+    /// Whether the function was copied.
+    bool is_copy{false};
+
+    /// The file from which the function was copied, or nullptr if not from a file.
+    filename_ref_t copy_definition_file{};
+
+    /// The line number where the specified function was copied.
+    int copy_definition_lineno{};
+
     /// \return the description, localized via _.
     const wchar_t *localized_description() const;
 
@@ -95,7 +104,7 @@ wcstring_list_t function_get_names(bool get_hidden);
 
 /// Creates a new function using the same definition as the specified function. Returns true if copy
 /// is successful.
-bool function_copy(const wcstring &name, const wcstring &new_name);
+bool function_copy(const wcstring &name, const wcstring &new_name, parser_t &parser);
 
 /// Observes that fish_function_path has changed.
 void function_invalidate_path();

--- a/tests/checks/function.fish
+++ b/tests/checks/function.fish
@@ -99,11 +99,25 @@ set -l name1 (functions name1)
 set -l name1a (functions name1a)
 set -l name3 (functions name3)
 set -l name3a (functions name3a)
-# First line for the non-copied function is "# Defined in checks/function.fish" - skip it to work around #6575.
+# First two lines for the copied and non-copied functions are different. Skip it for now.
 test "$name1[3..-1]" = "$name1a[3..-1]"; and echo "1 = 1a"
 #CHECK: 1 = 1a
 test "$name3[3..-1]" = "$name3a[3..-1]"; and echo "3 = 3a"
 #CHECK: 3 = 3a
+
+# Test the first two lines.
+string join \n -- $name1[1..2]
+#CHECK: # Defined in {{(?:(?!, copied).)*}}
+#CHECK: function name1 --argument arg1 arg2
+string join \n -- $name1a[1..2]
+#CHECK: # Defined in {{.*}}, copied in {{.*}}
+#CHECK: function name1a --argument arg1 arg2
+string join \n -- $name3[1..2]
+#CHECK: # Defined in {{(?:(?!, copied).)*}}
+#CHECK: function name3 --argument arg1 arg2
+string join \n -- $name3a[1..2]
+#CHECK: # Defined in {{.*}}, copied in {{.*}}
+#CHECK: function name3a --argument arg1 arg2
 
 function test
     echo banana

--- a/tests/checks/functions.fish
+++ b/tests/checks/functions.fish
@@ -55,6 +55,28 @@ if test $x[5] != 'line 1\\\\n\\nline 2 & more; way more'
 end
 
 # ==========
+# Verify that `functions --details` works as expected when given the name of a
+# function that is copied. (Prints the filename where it was copied.)
+functions -c f1 f1a
+functions -D f1a
+#CHECK: {{.*}}checks/functions.fish
+functions -Dv f1a
+#CHECK: {{.*}}checks/functions.fish
+#CHECK: {{.*}}checks/functions.fish
+#CHECK: {{\d+}}
+#CHECK: scope-shadowing
+#CHECK:
+echo "functions -c f1 f1b" | source
+functions -D f1b
+#CHECK: -
+functions -Dv f1b
+#CHECK: -
+#CHECK: {{.*}}checks/functions.fish
+#CHECK: {{\d+}}
+#CHECK: scope-shadowing
+#CHECK:
+
+# ==========
 # Verify function description setting
 function test_func_desc
 end
@@ -103,6 +125,41 @@ functions t
 
 functions --no-details t
 # CHECK: function t
+# CHECK: echo tttt;
+# CHECK: end
+
+functions -c t t2
+functions t2
+# CHECK: # Defined via `source`, copied in {{.*}}checks/functions.fish @ line {{\d+}}
+# CHECK: function t2
+# CHECK: echo tttt;
+# CHECK: end
+functions -D t2
+#CHECK: {{.*}}checks/functions.fish
+functions -Dv t2
+#CHECK: {{.*}}checks/functions.fish
+#CHECK: -
+#CHECK: {{\d+}}
+#CHECK: scope-shadowing
+#CHECK:
+
+echo "functions -c t t3" | source
+functions t3
+# CHECK: # Defined via `source`, copied via `source`
+# CHECK: function t3
+# CHECK: echo tttt;
+# CHECK: end
+functions -D t3
+#CHECK: -
+functions -Dv t3
+#CHECK: -
+#CHECK: -
+#CHECK: {{\d+}}
+#CHECK: scope-shadowing
+#CHECK:
+
+functions --no-details t2
+# CHECK: function t2
 # CHECK: echo tttt;
 # CHECK: end
 

--- a/tests/checks/status.fish
+++ b/tests/checks/status.fish
@@ -105,3 +105,24 @@ end
 # CHECK: Failed write tests {{finished|skipped}}
 # CHECKERR: write: {{.*}}
 # CHECKERR: write: {{.*}}
+
+function test-stack-trace-main
+    status stack-trace
+end
+
+function test-stack-trace-other
+    test-stack-trace-main
+end
+
+printf "%s\n" (test-stack-trace-other | string replace \t '<TAB>')[1..4]
+# CHECK: in function 'test-stack-trace-main'
+# CHECK: <TAB>called on line {{\d+}} of file {{.*}}/status.fish
+# CHECK: in function 'test-stack-trace-other'
+# CHECK: <TAB>called on line {{\d+}} of file {{.*}}/status.fish
+
+functions -c test-stack-trace-other test-stack-trace-copy
+printf "%s\n" (test-stack-trace-copy | string replace \t '<TAB>')[1..4]
+# CHECK: in function 'test-stack-trace-main'
+# CHECK: <TAB>called on line {{\d+}} of file {{.*}}/status.fish
+# CHECK: in function 'test-stack-trace-copy'
+# CHECK: <TAB>called on line {{\d+}} of file {{.*}}/status.fish

--- a/tests/checks/type.fish
+++ b/tests/checks/type.fish
@@ -61,7 +61,7 @@ type -p alias
 # CHECK: {{.*}}/alias.fish
 
 type -s alias
-# CHECK: alias is a function (defined in {{.*}}/alias.fish)
+# CHECK: alias is a function (Defined in {{.*}}/alias.fish @ line {{\d+}})
 
 function test-type
     echo this is a type test
@@ -76,3 +76,61 @@ type test-type
 
 type -p test-type
 # CHECK: {{.*}}/type.fish
+
+functions -c test-type test-type2
+type test-type2
+# CHECK: test-type2 is a function with definition
+# CHECK: # Defined in {{.*}}/type.fish @ line {{\d+}}, copied in {{.*}}/type.fish @ line {{\d+}}
+# CHECK: function test-type2
+# CHECK: echo this is a type test
+# CHECK: end
+
+type -p test-type2
+# CHECK: {{.*}}/type.fish
+
+type -s test-type2
+# CHECK: test-type2 is a function (Defined in {{.*}}/type.fish @ line {{\d+}}, copied in {{.*}}/type.fish @ line {{\d+}})
+
+echo "functions -c test-type test-type3" | source
+type test-type3
+# CHECK: test-type3 is a function with definition
+# CHECK: # Defined in {{.*}}/type.fish @ line {{\d+}}, copied via `source`
+# CHECK: function test-type3
+# CHECK: echo this is a type test
+# CHECK: end
+
+type -p test-type3
+# CHECK: -
+
+type -s test-type3
+# CHECK: test-type3 is a function (Defined in {{.*}}/type.fish @ line {{\d+}}, copied via `source`)
+
+echo "function other-test-type; echo this is a type test; end" | source
+
+functions -c other-test-type other-test-type2
+type other-test-type2
+# CHECK: other-test-type2 is a function with definition
+# CHECK: # Defined via `source`, copied in {{.*}}/type.fish @ line {{\d+}}
+# CHECK: function other-test-type2
+# CHECK: echo this is a type test;
+# CHECK: end
+
+type -p other-test-type2
+# CHECK: {{.*}}/type.fish
+
+type -s other-test-type2
+# CHECK: other-test-type2 is a function (Defined via `source`, copied in {{.*}}/type.fish @ line {{\d+}})
+
+echo "functions -c other-test-type other-test-type3" | source
+type other-test-type3
+# CHECK: other-test-type3 is a function with definition
+# CHECK: # Defined via `source`, copied via `source`
+# CHECK: function other-test-type3
+# CHECK: echo this is a type test;
+# CHECK: end
+
+type -p other-test-type3
+# CHECK: -
+
+type -s other-test-type3
+# CHECK: other-test-type3 is a function (Defined via `source`, copied via `source`)


### PR DESCRIPTION
## Description

Keeps the location of original function definition, and also stores where it was copied. `functions` and `type` show both locations, instead of none. It also retains the line numbers in the stack trace.

Fixes issue #6575

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
