### PR TITLE
completions/systemctl: add import-environment command

### DIFF
--- a/share/completions/systemctl.fish
+++ b/share/completions/systemctl.fish
@@ -4,7 +4,7 @@ set -l commands list-units list-sockets start stop reload restart try-restart re
     reset-failed list-unit-files enable disable is-enabled reenable preset mask unmask link load list-jobs cancel dump \
     list-dependencies snapshot delete daemon-reload daemon-reexec show-environment set-environment unset-environment \
     default rescue emergency halt poweroff reboot kexec exit suspend hibernate hybrid-sleep switch-root list-timers \
-    set-property
+    set-property import-environment
 if test $systemd_version -gt 208 2>/dev/null
     set commands $commands cat
     if test $systemd_version -gt 217 2>/dev/null


### PR DESCRIPTION
## Description

Hi

This commit introduces the missing `systemctl import-environment`

Man page reference:
https://man.archlinux.org/man/systemctl.1#Environment_Commands

Note: I added it at the end of the list, to avoid shifting all other commands and introduce noise in the review.

Thanks

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
