### PR TITLE
Port `pwd` builtin to Rust

### DIFF
--- a/fish-rust/src/builtins/mod.rs
+++ b/fish-rust/src/builtins/mod.rs
@@ -2,4 +2,5 @@ pub mod shared;
 
 pub mod echo;
 pub mod emit;
+pub mod pwd;
 pub mod wait;

--- a/fish-rust/src/builtins/pwd.rs
+++ b/fish-rust/src/builtins/pwd.rs
@@ -1,0 +1,57 @@
+use autocxx::PinMut;
+use libc::c_int;
+
+use crate::builtins::shared::io_streams_t;
+use crate::ffi::{parser_t, Repin};
+use crate::wchar::{wstr, L, WString};
+use crate::wgetopt::{wgetopter_t, wopt, woption, woption_argument_t};
+use crate::wutil::wgettext_fmt;
+
+use super::shared::{builtin_print_help, builtin_unknown_option, STATUS_CMD_OK, STATUS_INVALID_ARGS};
+
+const short_options: &wstr = L!("LPh");
+const long_options: &[woption] = &[
+    wopt(L!("help"), woption_argument_t::no_argument, 'h'),
+    wopt(L!("logical"), woption_argument_t::no_argument, 'L'),
+    wopt(L!("physical"), woption_argument_t::no_argument, 'P'),
+];
+
+pub fn pwd(parser: &mut parser_t, streams: &mut io_streams_t, argv: &mut [&wstr]) -> Option<c_int> {
+    let cmd = argv[0];
+    let argc = argv.len();
+    let mut resolve_symlinks = false;
+    let print_hints = false;
+
+    let mut w = wgetopter_t::new(short_options, long_options, argv);
+    while let Some(opt) = w.wgetopt_long() {
+        match opt {
+            'L' => resolve_symlinks = false,
+            'P' => resolve_symlinks = true,
+            'h' => {
+                builtin_print_help(parser, streams, cmd);
+                return STATUS_CMD_OK;
+            }
+            '?' => {
+                builtin_unknown_option(parser, streams, cmd, argv[w.woptind - 1], print_hints);
+            }
+            _ => panic!("unexpected retval from wgetopt_long"),
+        }
+    }
+
+    if w.woptind != argc {
+        streams.err.append(wgettext_fmt!(
+            "%ls: expected %d arguments; got %d\n",
+            cmd,
+            0,
+            argc - 1
+        ));
+        return STATUS_INVALID_ARGS;
+    }
+
+    let mut pwd = WString::new();
+    if resolve_symlinks {
+        
+    }
+
+    return STATUS_CMD_OK;
+}


### PR DESCRIPTION
## Description

Port the `pwd` builtin to Rust. I'm unsure about a lot of the FFI stuff, especially related to the parser so extra eyes would be greatly appreciated. This is very much a work in progress.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
