### PR TITLE
fix 3 instances of old command substitution `$()`

### DIFF
--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -170,7 +170,7 @@ end
 
 # Decide if git is safe to run.
 # On Darwin, git is pre-installed as a stub, which will pop a dialog if you run it.
-if string match -q Darwin -- "$(uname)" && string match -q /usr/bin/git -- "$(command -s git)" && type -q xcode-select && type -q xcrun
+if string match -q Darwin -- (uname) && string match -q /usr/bin/git -- (command -s git) && type -q xcode-select && type -q xcrun
     if not xcode-select --print-path &>/dev/null
         # Only the stub git is installed.
         # Do not try to run it.
@@ -183,7 +183,7 @@ if string match -q Darwin -- "$(uname)" && string match -q /usr/bin/git -- "$(co
         command git --version &>/dev/null &
         disown $last_pid &>/dev/null
         function __fish_git_prompt_ready
-            path is "$(xcrun --show-cache-path 2>/dev/null)" || return 1
+            path is (xcrun --show-cache-path 2>/dev/null) || return 1
             # git is ready, erase the function.
             functions -e __fish_git_prompt_ready
             return 0


### PR DESCRIPTION
## Description

On installation of fish 3.6.0 on Linux, every prompt fails with a syntax error

```
/usr/share/fish/functions/fish_git_prompt.fish (line 173): $(...) is not supported. In fish, please use '(uname)'.
if string match -q Darwin -- "$(uname)" && string match -q /usr/bin/git -- "$(command -s git)" && type -q xcode-select && type -q xcrun
                              ^
from sourcing file /usr/share/fish/functions/fish_git_prompt.fish
        called on line 1 of file ~/.config/fish/functions/fish_prompt.fish
in command substitution
        called on line 1 of file ~/.config/fish/functions/fish_prompt.fish
in command substitution
        called on line 28 of file ~/.config/fish/functions/fish_prompt.fish
in function 'fish_prompt'
in command substitution
```

The commit a77bc70defd47db9c401127465d7e71d05184200 added those old-style substitutions.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
