### PR TITLE
Add `history-backward` and `history-forward` input functions (fixes #1671)

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -127,6 +127,8 @@ static constexpr const input_function_metadata_t input_function_metadata[] = {
     {L"forward-jump-till", readline_cmd_t::forward_jump_till},
     {L"forward-single-char", readline_cmd_t::forward_single_char},
     {L"forward-word", readline_cmd_t::forward_word},
+    {L"history-backward", readline_cmd_t::history_backward},
+    {L"history-forward", readline_cmd_t::history_forward},
     {L"history-pager", readline_cmd_t::history_pager},
     {L"history-prefix-search-backward", readline_cmd_t::history_prefix_search_backward},
     {L"history-prefix-search-forward", readline_cmd_t::history_prefix_search_forward},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -28,6 +28,8 @@ enum class readline_cmd_t {
     history_search_forward,
     history_prefix_search_backward,
     history_prefix_search_forward,
+    history_backward,
+    history_forward,
     history_pager,
     delete_char,
     backward_delete_char,


### PR DESCRIPTION
## Description

This attempts the solution described at https://github.com/fish-shell/fish-shell/issues/1671#issuecomment-555080883. It is not quite working currently.

Fixes issue #1671

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst