### PR TITLE
functions: list caller-exit handlers correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Notable improvements and fixes
 
   can now be used to clean out all old abbreviations (:issue:`9468`).
 - ``abbr --add --universal`` now warns about --universal being non-functional, to make it easier to detect old-style ``abbr`` calls (:issue:`9475`).
+- ``functions --handlers-type caller-exit`` once again lists functions defined as ``function --on-job-exit caller``, rather than them being listed by ``functions --handlers-type process-exit``.
 
 Deprecations and removed features
 ---------------------------------

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -418,7 +418,7 @@ static bool filter_matches_event(const wcstring &filter, event_type_t type) {
         case event_type_t::job_exit:
             return filter == L"job-exit" || filter == L"exit";
         case event_type_t::caller_exit:
-            return filter == L"process-exit" || filter == L"exit";
+            return filter == L"caller-exit" || filter == L"exit";
         case event_type_t::generic:
             return filter == L"generic";
     }

--- a/tests/checks/caller-exit.fish
+++ b/tests/checks/caller-exit.fish
@@ -1,0 +1,4 @@
+#RUN: %fish %s
+echo (function foo1 --on-job-exit caller; end; functions --handlers-type caller-exit | grep foo)
+# CHECK: caller-exit foo1
+echo (function foo2 --on-job-exit caller; end; functions --handlers-type process-exit | grep foo)


### PR DESCRIPTION
Extracted from #9563.

`functions --handlers-type caller-exit` did not list any functions, while `functions --handlers-type process-exit` listed both process-exit and caller-exit handlers:

```
$ echo (function foo --on-job-exit caller; end; functions --handlers-type caller-exit | grep foo)

$ echo (function foo --on-job-exit caller; end; functions --handlers-type process-exit | grep foo)
caller-exit foo
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst