### PR TITLE
Move POD components of library_data_t to separate struct

### DIFF
--- a/fish-rust/src/builtins/exit.rs
+++ b/fish-rust/src/builtins/exit.rs
@@ -2,7 +2,7 @@ use libc::c_int;
 
 use super::r#return::parse_return_value;
 use super::shared::io_streams_t;
-use crate::ffi::{parser_t, Repin};
+use crate::ffi::parser_t;
 use crate::wchar::wstr;
 
 /// Function for handling the exit builtin.
@@ -20,7 +20,7 @@ pub fn exit(
     // TODO: in concurrent mode this won't successfully exit a pipeline, as there are other parsers
     // involved. That is, `exit | sleep 1000` may not exit as hoped. Need to rationalize what
     // behavior we want here.
-    parser.pin().libdata().set_exit_current_script(true);
+    parser.get_libdata_pod().exit_current_script = true;
 
     return Some(retval);
 }

--- a/fish-rust/src/builtins/return.rs
+++ b/fish-rust/src/builtins/return.rs
@@ -8,7 +8,7 @@ use super::shared::{
     BUILTIN_ERR_NOT_NUMBER, STATUS_CMD_OK, STATUS_INVALID_ARGS,
 };
 use crate::builtins::shared::BUILTIN_ERR_TOO_MANY_ARGUMENTS;
-use crate::ffi::{parser_t, Repin};
+use crate::ffi::parser_t;
 use crate::wchar::{wstr, L};
 use crate::wgetopt::{wgetopter_t, wopt, woption, woption_argument_t};
 use crate::wutil::fish_wcstoi;
@@ -79,14 +79,15 @@ pub fn r#return(
 
     // If we're not in a function, exit the current script (but not an interactive shell).
     if !has_function_block {
-        if !parser.is_interactive() {
-            parser.pin().libdata().set_exit_current_script(true);
+        let ld = parser.get_libdata_pod();
+        if !ld.is_interactive {
+            ld.exit_current_script = true;
         }
         return Some(retval);
     }
 
     // Mark a return in the libdata.
-    parser.pin().libdata().set_returning(true);
+    parser.get_libdata_pod().returning = true;
 
     return Some(retval);
 }

--- a/fish-rust/src/ffi.rs
+++ b/fish-rust/src/ffi.rs
@@ -49,6 +49,7 @@ include_cpp! {
     generate!("job_t")
     generate!("process_t")
     generate!("library_data_t")
+    generate_pod!("library_data_pod")
 
     generate!("proc_wait_any")
 
@@ -79,6 +80,12 @@ impl parser_t {
     pub fn get_jobs(&self) -> &[SharedPtr<job_t>] {
         let ffi_jobs = self.ffi_jobs();
         unsafe { slice::from_raw_parts(ffi_jobs.jobs, ffi_jobs.count) }
+    }
+
+    pub fn get_libdata_pod(&mut self) -> &mut library_data_pod {
+        let libdata = self.pin().ffi_libdata_pod();
+
+        unsafe { &mut *libdata }
     }
 }
 

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -295,7 +295,7 @@ static maybe_t<int> builtin_break_continue(parser_t &parser, io_streams_t &strea
     }
 
     // Mark the status in the libdata.
-    parser.libdata().loop_status = is_break ? loop_status_t::breaks : loop_status_t::continues;
+    parser.libdata().pod.loop_status = is_break ? loop_status_t::breaks : loop_status_t::continues;
     return STATUS_CMD_OK;
 }
 

--- a/src/builtins/commandline.cpp
+++ b/src/builtins/commandline.cpp
@@ -303,7 +303,7 @@ maybe_t<int> builtin_commandline(parser_t &parser, io_streams_t &streams, const 
                 // Don't enqueue a repaint if we're currently in the middle of one,
                 // because that's an infinite loop.
                 if (mc == rl::repaint_mode || mc == rl::force_repaint || mc == rl::repaint) {
-                    if (ld.is_repaint) continue;
+                    if (ld.pod.is_repaint) continue;
                 }
 
                 // HACK: Execute these right here and now so they can affect any insertions/changes

--- a/src/builtins/complete.cpp
+++ b/src/builtins/complete.cpp
@@ -385,9 +385,9 @@ maybe_t<int> builtin_complete(parser_t &parser, io_streams_t &streams, const wch
         cleanup_t remove_transient([&] { parser.libdata().transient_commandlines.pop_back(); });
 
         // Prevent accidental recursion (see #6171).
-        if (!parser.libdata().builtin_complete_current_commandline) {
+        if (!parser.libdata().pod.builtin_complete_current_commandline) {
             if (!have_do_complete_param) {
-                parser.libdata().builtin_complete_current_commandline = true;
+                parser.libdata().pod.builtin_complete_current_commandline = true;
             }
 
             completion_list_t comp = complete(
@@ -430,7 +430,7 @@ maybe_t<int> builtin_complete(parser_t &parser, io_streams_t &streams, const wch
                 streams.out.append(faux_cmdline_with_completion);
             }
 
-            parser.libdata().builtin_complete_current_commandline = false;
+            parser.libdata().pod.builtin_complete_current_commandline = false;
         }
     } else if (path.empty() && gnu_opt.empty() && short_opt.empty() && old_opt.empty() && !remove &&
                !*comp && !*desc && condition.empty() && wrap_targets.empty() &&

--- a/src/builtins/eval.cpp
+++ b/src/builtins/eval.cpp
@@ -39,7 +39,7 @@ maybe_t<int> builtin_eval(parser_t &parser, io_streams_t &streams, const wchar_t
     // buffer in that case.
     shared_ptr<io_bufferfill_t> stdout_fill{};
     if (streams.out_is_piped) {
-        stdout_fill = io_bufferfill_t::create(parser.libdata().read_limit, STDOUT_FILENO);
+        stdout_fill = io_bufferfill_t::create(parser.libdata().pod.read_limit, STDOUT_FILENO);
         if (!stdout_fill) {
             // We were unable to create a pipe, probably fd exhaustion.
             return STATUS_CMD_ERROR;
@@ -50,7 +50,7 @@ maybe_t<int> builtin_eval(parser_t &parser, io_streams_t &streams, const wchar_t
     // Of course the same applies to stderr.
     shared_ptr<io_bufferfill_t> stderr_fill{};
     if (streams.err_is_piped) {
-        stderr_fill = io_bufferfill_t::create(parser.libdata().read_limit, STDERR_FILENO);
+        stderr_fill = io_bufferfill_t::create(parser.libdata().pod.read_limit, STDERR_FILENO);
         if (!stderr_fill) {
             return STATUS_CMD_ERROR;
         }

--- a/src/builtins/function.cpp
+++ b/src/builtins/function.cpp
@@ -123,7 +123,7 @@ static int parse_cmd_opts(function_cmd_opts_t &opts, int *optind,  //!OCLINT(hig
 
                 if ((opt == 'j') && (wcscasecmp(w.woptarg, L"caller") == 0)) {
                     internal_job_id_t caller_id =
-                        parser.libdata().is_subshell ? parser.libdata().caller_id : 0;
+                        parser.libdata().pod.is_subshell ? parser.libdata().pod.caller_id : 0;
                     if (caller_id == 0) {
                         streams.err.append_format(
                             _(L"%ls: calling job for event handler not found"), cmd);

--- a/src/builtins/read.cpp
+++ b/src/builtins/read.cpp
@@ -224,7 +224,7 @@ static int read_interactive(parser_t &parser, wcstring &buff, int nchars, bool s
     reader_push(parser, wcstring{}, std::move(conf));
 
     commandline_set_buffer(commandline, std::wcslen(commandline));
-    scoped_push<bool> interactive{&parser.libdata().is_interactive, true};
+    scoped_push<bool> interactive{&parser.libdata().pod.is_interactive, true};
 
     auto mline = reader_readline(nchars);
     interactive.restore();

--- a/src/builtins/status.cpp
+++ b/src/builtins/status.cpp
@@ -411,7 +411,7 @@ maybe_t<int> builtin_status(parser_t &parser, io_streams_t &streams, const wchar
         }
         case STATUS_IS_COMMAND_SUB: {
             CHECK_FOR_UNEXPECTED_STATUS_ARGS(opts.status_cmd)
-            retval = parser.libdata().is_subshell ? 0 : 1;
+            retval = parser.libdata().pod.is_subshell ? 0 : 1;
             break;
         }
         case STATUS_IS_BLOCK: {

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -713,8 +713,8 @@ void completer_t::complete_from_args(const wcstring &str, const wcstring &args,
     bool saved_interactive = false;
     statuses_t status;
     if (ctx.parser) {
-        saved_interactive = ctx.parser->libdata().is_interactive;
-        ctx.parser->libdata().is_interactive = false;
+        saved_interactive = ctx.parser->libdata().pod.is_interactive;
+        ctx.parser->libdata().pod.is_interactive = false;
         status = ctx.parser->get_last_statuses();
     }
 
@@ -726,7 +726,7 @@ void completer_t::complete_from_args(const wcstring &str, const wcstring &args,
     completion_list_t possible_comp = parser_t::expand_argument_list(args, eflags, ctx);
 
     if (ctx.parser) {
-        ctx.parser->libdata().is_interactive = saved_interactive;
+        ctx.parser->libdata().pod.is_interactive = saved_interactive;
         ctx.parser->set_last_statuses(status);
     }
 
@@ -1511,15 +1511,15 @@ void completer_t::perform_for_commandline(wcstring cmdline) {
     // wraps "A=B x" (#3474, #7344).  No need to do that when there is no parser: this happens only
     // for autosuggestions where we don't evaluate command substitutions or variable assignments.
     if (ctx.parser) {
-        if (ctx.parser->libdata().complete_recursion_level >= 24) {
+        if (ctx.parser->libdata().pod.complete_recursion_level >= 24) {
             FLOGF(error, _(L"completion reached maximum recursion depth, possible cycle?"),
                   cmdline.c_str());
             return;
         }
-        ++ctx.parser->libdata().complete_recursion_level;
+        ++ctx.parser->libdata().pod.complete_recursion_level;
     };
     cleanup_t decrement{[this]() {
-        if (ctx.parser) --ctx.parser->libdata().complete_recursion_level;
+        if (ctx.parser) --ctx.parser->libdata().pod.complete_recursion_level;
     }};
 
     const size_t cursor_pos = cmdline.size();

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -269,11 +269,11 @@ event_handler_list_t event_get_function_handlers(const wcstring &name) {
 /// allocated/initialized unless needed.
 static void event_fire_internal(parser_t &parser, const event_t &event) {
     auto &ld = parser.libdata();
-    assert(ld.is_event >= 0 && "is_event should not be negative");
-    scoped_push<decltype(ld.is_event)> inc_event{&ld.is_event, ld.is_event + 1};
+    assert(ld.pod.is_event >= 0 && "is_event should not be negative");
+    scoped_push<decltype(ld.pod.is_event)> inc_event{&ld.pod.is_event, ld.pod.is_event + 1};
 
     // Suppress fish_trace during events.
-    scoped_push<bool> suppress_trace{&ld.suppress_fish_trace, true};
+    scoped_push<bool> suppress_trace{&ld.pod.suppress_fish_trace, true};
 
     // Capture the event handlers that match this event.
     std::vector<std::shared_ptr<event_handler_t>> fire;
@@ -302,7 +302,7 @@ static void event_fire_internal(parser_t &parser, const event_t &event) {
 
         // Event handlers are not part of the main flow of code, so they are marked as
         // non-interactive.
-        scoped_push<bool> interactive{&ld.is_interactive, false};
+        scoped_push<bool> interactive{&ld.pod.is_interactive, false};
         auto prev_statuses = parser.get_last_statuses();
 
         FLOGF(event, L"Firing event '%ls' to handler '%ls'", event.desc.str_param1.c_str(),
@@ -328,7 +328,7 @@ static void event_fire_internal(parser_t &parser, const event_t &event) {
 void event_fire_delayed(parser_t &parser) {
     auto &ld = parser.libdata();
     // Do not invoke new event handlers from within event handlers.
-    if (ld.is_event) return;
+    if (ld.pod.is_event) return;
     // Do not invoke new event handlers if we are unwinding (#6649).
     if (signal_check_cancel()) return;
 

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -239,9 +239,9 @@ static void source_config_in_directory(parser_t &parser, const wcstring &dir) {
 
     const wcstring cmd = L"builtin source " + escaped_pathname;
 
-    parser.libdata().within_fish_init = true;
+    parser.libdata().pod.within_fish_init = true;
     parser.eval(cmd, io_chain_t());
-    parser.libdata().within_fish_init = false;
+    parser.libdata().pod.within_fish_init = false;
 }
 
 /// Parse init files. exec_path is the path of fish executable as determined by argv[0].
@@ -565,7 +565,7 @@ int main(int argc, char **argv) {
         }
         parser.vars().set(L"argv", ENV_DEFAULT, std::move(list));
         res = run_command_list(parser, opts.batch_cmds, {});
-        parser.libdata().exit_current_script = false;
+        parser.libdata().pod.exit_current_script = false;
     } else if (my_optind == argc) {
         // Implicitly interactive mode.
         if (opts.no_exec && isatty(STDIN_FILENO)) {

--- a/src/fish_key_reader.cpp
+++ b/src/fish_key_reader.cpp
@@ -277,7 +277,7 @@ static void process_input(bool continuous_mode, bool verbose) {
     env_init();
     reader_init();
     parser_t &parser = parser_t::principal_parser();
-    scoped_push<bool> interactive{&parser.libdata().is_interactive, true};
+    scoped_push<bool> interactive{&parser.libdata().pod.is_interactive, true};
     signal_set_handlers(true);
     // We need to set the shell-modes for ICRNL,
     // in fish-proper this is done once a command is run.

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -653,10 +653,10 @@ static bool process_clean_after_marking(parser_t &parser, bool allow_interactive
 
     // This function may fire an event handler, we do not want to call ourselves recursively (to
     // avoid infinite recursion).
-    if (parser.libdata().is_cleaning_procs) {
+    if (parser.libdata().pod.is_cleaning_procs) {
         return false;
     }
-    const scoped_push<bool> cleaning(&parser.libdata().is_cleaning_procs, true);
+    const scoped_push<bool> cleaning(&parser.libdata().pod.is_cleaning_procs, true);
 
     // This may be invoked in an exit handler, after the TERM has been torn down
     // Don't try to print in that case (#3222)
@@ -955,7 +955,7 @@ bool job_t::resume() {
 void job_t::continue_job(parser_t &parser) {
     FLOGF(proc_job_run, L"Run job %d (%ls), %ls, %ls", job_id(), command_wcstr(),
           is_completed() ? L"COMPLETED" : L"UNCOMPLETED",
-          parser.libdata().is_interactive ? L"INTERACTIVE" : L"NON-INTERACTIVE");
+          parser.libdata().pod.is_interactive ? L"INTERACTIVE" : L"NON-INTERACTIVE");
 
     // Wait for the status of our own job to change.
     while (!fish_is_unwinding_for_exit() && !is_stopped() && !is_completed()) {
@@ -969,7 +969,7 @@ void job_t::continue_job(parser_t &parser) {
             auto statuses = get_statuses();
             if (statuses) {
                 parser.set_last_statuses(statuses.value());
-                parser.libdata().status_count++;
+                parser.libdata().pod.status_count++;
             }
         }
     }
@@ -977,7 +977,7 @@ void job_t::continue_job(parser_t &parser) {
 
 void proc_wait_any(parser_t &parser) {
     process_mark_finished_children(parser, true /* block_ok */);
-    process_clean_after_marking(parser, parser.libdata().is_interactive);
+    process_clean_after_marking(parser, parser.libdata().pod.is_interactive);
 }
 
 void hup_jobs(const job_list_t &jobs) {

--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -15,7 +15,7 @@ void trace_set_enabled(bool do_enable) { do_trace = do_enable; }
 
 bool trace_enabled(const parser_t &parser) {
     const auto &ld = parser.libdata();
-    if (ld.suppress_fish_trace) return false;
+    if (ld.pod.suppress_fish_trace) return false;
     return do_trace;
 }
 


### PR DESCRIPTION
This allows them to be accessed as regular fields from Rust, rather than having to create setter/getter methods for each of them.