### PR TITLE
Port `pwd` builtin to Rust

### DIFF
--- a/fish-rust/src/builtins/mod.rs
+++ b/fish-rust/src/builtins/mod.rs
@@ -3,6 +3,7 @@ pub mod shared;
 pub mod echo;
 pub mod emit;
 mod exit;
+pub mod pwd;
 pub mod random;
 pub mod r#return;
 pub mod wait;

--- a/fish-rust/src/builtins/pwd.rs
+++ b/fish-rust/src/builtins/pwd.rs
@@ -1,0 +1,60 @@
+use libc::c_int;
+
+use crate::builtins::shared::{io_streams_t, BUILTIN_ERR_ARG_COUNT1};
+use crate::ffi::parser_t;
+use crate::wchar::{wstr, WString, L};
+use crate::wgetopt::{wgetopter_t, wopt, woption, woption_argument_t};
+use crate::wutil::wgettext_fmt;
+
+use super::shared::{
+    builtin_print_help, builtin_unknown_option, STATUS_CMD_OK, STATUS_INVALID_ARGS,
+};
+
+const short_options: &wstr = L!("LPh");
+const long_options: &[woption] = &[
+    wopt(L!("help"), woption_argument_t::no_argument, 'h'),
+    wopt(L!("logical"), woption_argument_t::no_argument, 'L'),
+    wopt(L!("physical"), woption_argument_t::no_argument, 'P'),
+];
+
+pub fn pwd(parser: &mut parser_t, streams: &mut io_streams_t, argv: &mut [&wstr]) -> Option<c_int> {
+    let cmd = argv[0];
+    let argc = argv.len();
+    let mut resolve_symlinks = false;
+    let print_hints = false;
+
+    let mut w = wgetopter_t::new(short_options, long_options, argv);
+    while let Some(opt) = w.wgetopt_long() {
+        match opt {
+            'L' => resolve_symlinks = false,
+            'P' => resolve_symlinks = true,
+            'h' => {
+                builtin_print_help(parser, streams, cmd);
+                return STATUS_CMD_OK;
+            }
+            '?' => {
+                builtin_unknown_option(parser, streams, cmd, argv[w.woptind - 1], print_hints);
+                return STATUS_INVALID_ARGS;
+            }
+            _ => panic!("unexpected retval from wgetopt_long"),
+        }
+    }
+
+    if w.woptind != argc {
+        streams
+            .err
+            .append(wgettext_fmt!(BUILTIN_ERR_ARG_COUNT1, cmd, 0, argc - 1));
+        return STATUS_INVALID_ARGS;
+    }
+
+    let mut pwd = WString::new();
+    let raw_pwd = parser.vars1().get_pwd_slash();
+    if !raw_pwd.is_null() {
+        pwd.push_str(&raw_pwd.to_str());
+        pwd.pop();
+    }
+
+    streams.out.append(pwd + L!("\n"));
+
+    return STATUS_CMD_OK;
+}

--- a/fish-rust/src/builtins/shared.rs
+++ b/fish-rust/src/builtins/shared.rs
@@ -37,6 +37,8 @@ pub const BUILTIN_ERR_TOO_MANY_ARGUMENTS: &str = "%ls: too many arguments\n";
 /// Error message when integer expected
 pub const BUILTIN_ERR_NOT_NUMBER: &str = "%ls: %ls: invalid integer\n";
 
+pub const BUILTIN_ERR_ARG_COUNT1: &str = "%ls: expected %d arguments; got %d\n";
+
 /// A handy return value for successful builtins.
 pub const STATUS_CMD_OK: Option<c_int> = Some(0);
 

--- a/fish-rust/src/ffi.rs
+++ b/fish-rust/src/ffi.rs
@@ -23,6 +23,7 @@ include_cpp! {
     #include "builtin.h"
     #include "fallback.h"
     #include "event.h"
+    #include "env.h"
 
     safety!(unsafe_ffi)
 
@@ -44,6 +45,8 @@ include_cpp! {
 
     generate!("wildcard_match")
     generate!("wgettext_ptr")
+
+    generate!("env_stack_t")
 
     generate!("parser_t")
     generate!("job_t")


### PR DESCRIPTION
Reopen of #9566, which was closed because the target branch was merged. This is still a work in progress.
