### PR TITLE
fish-rust/build.rs: Fix hardcode target_dir

### DIFF
--- a/fish-rust/build.rs
+++ b/fish-rust/build.rs
@@ -1,7 +1,9 @@
 fn main() -> miette::Result<()> {
+    let out_dir =
+        std::path::PathBuf::from(std::env::var("OUT_DIR").expect("Env var OUT_DIR missing"));
     let rust_dir = std::env::var("CARGO_MANIFEST_DIR").expect("Env var CARGO_MANIFEST_DIR missing");
-    let target_dir =
-        std::env::var("FISH_RUST_TARGET_DIR").unwrap_or(format!("{}/{}", rust_dir, "target/"));
+    let target_dir = std::env::var("FISH_RUST_TARGET_DIR")
+        .unwrap_or(out_dir.ancestors().nth(4).unwrap().display().to_string());
     let fish_src_dir = format!("{}/{}", rust_dir, "../src/");
 
     // Where cxx emits its header.


### PR DESCRIPTION
## Description

When `FISH_RUST_TARGET_DIR` is not set, `target_dir` will set to `$CARGO_MANIFEST_DIR/target`. 

But if `build.target-dir` or `CARGO_TARGET_DIR` is set,  the real `target_dir` doesn't at the `$CARGO_MANIFEST_DIR/target`.

It causes failure in cargo test.

Then, I do a magic to get real `target_dir` from `OUT_DIR`.

Fixes issue #9600

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
