### PR TITLE
cmake/Tests.cmake: Fix failure in cargo test

### DIFF
--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -179,7 +179,7 @@ endforeach(PEXPECT)
 # Rust stuff.
 add_test(
     NAME "cargo-test"
-    COMMAND cargo test
+    COMMAND cargo test --target-dir target
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/fish-rust"
 )
 set_tests_properties("cargo-test" PROPERTIES SKIP_RETURN_CODE ${SKIP_RETURN_CODE})
@@ -187,7 +187,7 @@ add_test_target("cargo-test")
 
 add_test(
     NAME "cargo-test-widestring"
-    COMMAND cargo test
+    COMMAND cargo test --target-dir target
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/fish-rust/widestring-suffix/"
 )
 add_test_target("cargo-test-widestring")


### PR DESCRIPTION
## Description

The `FISH_RUST_TARGET_DIR` is not set for `Tests.cmake`, the `target_dir` will set to `$CARGO_MANIFEST_DIR/target`.

But if `build.target-dir` or `CARGO_TARGET_DIR` is set, the real `target_dir` doesn't at the `$CARGO_MANIFEST_DIR/target`.

It causes failure in cargo test.

Then, set `--target-dir` for cargo test.

Fixes issue #9600

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
