### PR TITLE
bind: port input key binding mappings to rust

### DIFF
--- a/fish-rust/build.rs
+++ b/fish-rust/build.rs
@@ -26,6 +26,7 @@ fn main() -> miette::Result<()> {
         "src/ffi_init.rs",
         "src/ffi_tests.rs",
         "src/future_feature_flags.rs",
+        "src/input_common.rs",
         "src/job_group.rs",
         "src/parse_constants.rs",
         "src/redirection.rs",

--- a/fish-rust/build.rs
+++ b/fish-rust/build.rs
@@ -26,6 +26,7 @@ fn main() -> miette::Result<()> {
         "src/ffi_init.rs",
         "src/ffi_tests.rs",
         "src/future_feature_flags.rs",
+        "src/input.rs",
         "src/input_common.rs",
         "src/job_group.rs",
         "src/parse_constants.rs",

--- a/fish-rust/src/env.rs
+++ b/fish-rust/src/env.rs
@@ -1,30 +1,28 @@
 /// Flags that may be passed as the 'mode' in env_stack_t::set() / environment_t::get().
 pub mod flags {
-    use autocxx::c_int;
-
     /// Default mode. Used with `env_stack_t::get()` to indicate the caller doesn't care what scope
     /// the var is in or whether it is exported or unexported.
-    pub const ENV_DEFAULT: c_int = c_int(0);
+    pub const ENV_DEFAULT: u16 = 0;
     /// Flag for local (to the current block) variable.
-    pub const ENV_LOCAL: c_int = c_int(1 << 0);
-    pub const ENV_FUNCTION: c_int = c_int(1 << 1);
+    pub const ENV_LOCAL: u16 = 1 << 0;
+    pub const ENV_FUNCTION: u16 = 1 << 1;
     /// Flag for global variable.
-    pub const ENV_GLOBAL: c_int = c_int(1 << 2);
+    pub const ENV_GLOBAL: u16 = 1 << 2;
     /// Flag for universal variable.
-    pub const ENV_UNIVERSAL: c_int = c_int(1 << 3);
+    pub const ENV_UNIVERSAL: u16 = 1 << 3;
     /// Flag for exported (to commands) variable.
-    pub const ENV_EXPORT: c_int = c_int(1 << 4);
+    pub const ENV_EXPORT: u16 = 1 << 4;
     /// Flag for unexported variable.
-    pub const ENV_UNEXPORT: c_int = c_int(1 << 5);
+    pub const ENV_UNEXPORT: u16 = 1 << 5;
     /// Flag to mark a variable as a path variable.
-    pub const ENV_PATHVAR: c_int = c_int(1 << 6);
+    pub const ENV_PATHVAR: u16 = 1 << 6;
     /// Flag to unmark a variable as a path variable.
-    pub const ENV_UNPATHVAR: c_int = c_int(1 << 7);
+    pub const ENV_UNPATHVAR: u16 = 1 << 7;
     /// Flag for variable update request from the user. All variable changes that are made directly
     /// by the user, such as those from the `read` and `set` builtin must have this flag set. It
     /// serves one purpose: to indicate that an error should be returned if the user is attempting
     /// to modify a var that should not be modified by direct user action; e.g., a read-only var.
-    pub const ENV_USER: c_int = c_int(1 << 8);
+    pub const ENV_USER: u16 = 1 << 8;
 }
 
 /// Return values for `env_stack_t::set()`.

--- a/fish-rust/src/fds.rs
+++ b/fish-rust/src/fds.rs
@@ -2,6 +2,9 @@ use crate::ffi;
 use nix::unistd;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
+/// A sentinel value indicating no timeout.
+pub const kNoTimeout: u64 = u64::MAX;
+
 /// A helper type for managing and automatically closing a file descriptor
 ///
 /// This was implemented in rust as a port of the existing C++ code but it didn't take its place

--- a/fish-rust/src/ffi.rs
+++ b/fish-rust/src/ffi.rs
@@ -30,6 +30,10 @@ include_cpp! {
     #include "tokenizer.h"
     #include "wildcard.h"
     #include "wutil.h"
+    #include "iothread.h"
+    #include "env_universal_common.h"
+    #include "input_common.h"
+    #include "iothread.h"
 
     safety!(unsafe_ffi)
 
@@ -93,6 +97,16 @@ include_cpp! {
     generate!("re::try_compile_ffi")
     generate!("wcs2string")
     generate!("str2wcstring")
+
+    generate!("iothread_port")
+    generate!("default_notifier_ffi")
+    generate!("universal_notifier_t")
+    generate!("read_blocked")
+    generate!("read_mbtowc_t")
+    generate!("read_mbtowc_t_create")
+    generate!("is_single_byte_locale")
+    generate!("iothread_service_main")
+    generate!("is_windows_subsystem_for_linux")
 }
 
 impl parser_t {
@@ -107,7 +121,7 @@ impl parser_t {
         unsafe { &mut *libdata }
     }
 
-    pub fn remove_var(&mut self, var: &wstr, flags: c_int) -> c_int {
+    pub fn remove_var(&mut self, var: &wstr, flags: u16) -> c_int {
         self.pin().remove_var_ffi(&var.to_ffi(), flags)
     }
 }
@@ -168,16 +182,20 @@ pub trait Repin {
 // Implement Repin for our types.
 impl Repin for block_t {}
 impl Repin for env_stack_t {}
+impl Repin for environment_t {}
 impl Repin for io_streams_t {}
 impl Repin for job_t {}
 impl Repin for output_stream_t {}
 impl Repin for parser_t {}
 impl Repin for process_t {}
 impl Repin for re::regex_result_ffi {}
+impl Repin for universal_notifier_t {}
+impl Repin for read_mbtowc_t {}
 
 unsafe impl Send for re::regex_t {}
 
 pub use autocxx::c_int;
+pub use autocxx::moveit::moveit;
 pub use ffi::*;
 pub use libc::c_char;
 

--- a/fish-rust/src/ffi.rs
+++ b/fish-rust/src/ffi.rs
@@ -1,12 +1,12 @@
 use crate::wchar;
-use crate::wchar_ffi::WCharToFFI;
+use crate::wchar_ffi::{WCharToFFI, WCharFromFFI};
 #[rustfmt::skip]
 use ::std::fmt::{self, Debug, Formatter};
 #[rustfmt::skip]
 use ::std::pin::Pin;
 #[rustfmt::skip]
 use ::std::slice;
-use crate::wchar::wstr;
+use crate::wchar::{wstr, WString};
 use autocxx::prelude::*;
 use cxx::SharedPtr;
 
@@ -34,6 +34,8 @@ include_cpp! {
     #include "env_universal_common.h"
     #include "input_common.h"
     #include "iothread.h"
+    #include "input_common.h"
+    #include "reader.h"
 
     safety!(unsafe_ffi)
 
@@ -107,6 +109,8 @@ include_cpp! {
     generate!("is_single_byte_locale")
     generate!("iothread_service_main")
     generate!("is_windows_subsystem_for_linux")
+
+    generate!("reader_reset_interrupted")
 }
 
 impl parser_t {
@@ -123,6 +127,17 @@ impl parser_t {
 
     pub fn remove_var(&mut self, var: &wstr, flags: u16) -> c_int {
         self.pin().remove_var_ffi(&var.to_ffi(), flags)
+    }
+}
+
+impl env_stack_t {
+    pub fn get_or_default(&mut self, name: &wstr, def: &wstr, flag: u16) -> WString {
+        let val = self.pin().get_or_default_ffi(
+            &name.to_ffi(),
+            &def.to_ffi(),
+            flag,
+        );
+        val.from_ffi()
     }
 }
 

--- a/fish-rust/src/input.rs
+++ b/fish-rust/src/input.rs
@@ -1,23 +1,51 @@
-use crate::wchar::{wstr, WString, L};
+#![allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
+use crate::ffi::{self, parser_t, readline_cmd_t};
+use crate::threads::assert_is_main_thread;
+use crate::wchar_ffi::WCharToFFI;
+use crate::{
+    env::flags,
+    ffi::Repin,
+    wchar::{wstr, WString, L},
+    wutil::wgettext_fmt,
+};
+use errno::set_errno;
+use libc::{EILSEQ, ENOENT};
 use once_cell::sync::Lazy;
 use std::sync::{
     atomic::{AtomicU32, Ordering},
-    Arc, Mutex,
+    Arc, Mutex, MutexGuard,
 };
 
+#[cxx::bridge]
+mod input_ffi {
+    extern "C++" {}
+
+    extern "Rust" {
+        type GlobalMappings<'a>;
+
+        #[cxx_name = "input_mappings"]
+        unsafe fn input_mappings_ffi<'a>() -> Box<GlobalMappings<'a>>;
+    }
+}
+
 const DEFAULT_BIND_MODE: &wstr = L!("default");
+const FISH_BIND_MODE_VAR: &wstr = L!("fish_bind_mode");
+const k_nul_mapping_name: &wstr = L!("nul");
 
-static s_last_input_map_spec_order: AtomicU32 = AtomicU32::new(0);
-static MAPPINGS: Lazy<Mutex<input_mapping_set_t>> = Lazy::new(Default::default);
+const input_function_count: usize = 100; // TODO
+static terminfo_mappings: Lazy<Vec<TermInfoMapping>> = Lazy::new(|| Vec::new());
+static last_input_map_spec_order: AtomicU32 = AtomicU32::new(0);
+static MAPPINGS: Lazy<Arc<Mutex<MappingsSet>>> = Lazy::new(Default::default);
+const input_function_metadata: [FuntionMetadata; 0] = [];
 
-pub fn with_mappings_mut<R>(cb: impl FnOnce(&mut input_mapping_set_t) -> R) -> R {
+pub fn with_mappings_mut<R>(cb: impl FnOnce(&mut MappingsSet) -> R) -> R {
     let mut mappings = MAPPINGS.lock().unwrap();
     cb(&mut mappings)
 }
 
 /// Struct representing a keybinding. Returned by input_get_mappings.
 #[derive(Default, Clone)]
-pub struct input_mapping_t {
+pub struct Mapping {
     /// Character sequence which generates this event.
     seq: WString,
     /// Commands that should be evaluated by this mapping.
@@ -29,10 +57,11 @@ pub struct input_mapping_t {
     /// New mode that should be switched to after command evaluation.
     sets_mode: WString,
 }
+pub type MappingList = Vec<Mapping>;
 
-impl input_mapping_t {
+impl Mapping {
     fn new(seq: WString, commands: Vec<WString>, mode: WString, sets_mode: WString) -> Self {
-        let specification_order = s_last_input_map_spec_order.fetch_add(1, Ordering::SeqCst);
+        let specification_order = last_input_map_spec_order.fetch_add(1, Ordering::SeqCst);
 
         Self {
             seq,
@@ -49,45 +78,21 @@ impl input_mapping_t {
     }
 }
 
-/// A struct representing the mapping from a terminfo key name to a terminfo character sequence.
-struct terminfo_mapping_t {
-    // name of key
-    name: WString,
-
-    // character sequence generated on keypress, or none if there was no mapping.
-    seq: Option<String>,
-}
-
-impl terminfo_mapping_t {
-    fn new(name: WString) -> Self {
-        Self { name, seq: None }
-    }
-
-    fn new_with_seq(name: WString, seq: String) -> Self {
-        Self {
-            name,
-            seq: Some(seq),
-        }
-    }
-}
-
 #[derive(Default)]
-pub struct input_mapping_name_t {
+pub struct MappingName {
     seq: WString,
     mode: WString,
 }
 
-pub type MappingList = Vec<input_mapping_t>;
-
 /// The input mapping set is the set of mappings from character sequences to commands.
 #[derive(Default)]
-pub struct input_mapping_set_t {
+pub struct MappingsSet {
     mappings: MappingList,
     preset_mappings: MappingList,
     all_mappings_cache: Option<Arc<MappingList>>,
 }
 
-impl input_mapping_set_t {
+impl MappingsSet {
     /// Erase all bindings with matching mode.
     fn clear(&mut self, mode: WString, user: bool) {
         self.all_mappings_cache = Default::default();
@@ -155,7 +160,7 @@ impl input_mapping_set_t {
     }
 
     /// Returns all mapping names and modes.
-    pub fn get_names(&self, user: bool) -> Vec<input_mapping_name_t> {
+    pub fn get_names(&self, user: bool) -> Vec<MappingName> {
         // Sort the mappings by the user specification order, so we can return them in the same order
         // that the user specified them in.
         let mut local_list = if user {
@@ -169,7 +174,7 @@ impl input_mapping_set_t {
         let mut result = Vec::with_capacity(local_list.len());
 
         for m in local_list {
-            result.push(input_mapping_name_t {
+            result.push(MappingName {
                 seq: m.seq.clone(),
                 mode: m.mode.clone(),
             });
@@ -209,7 +214,7 @@ impl input_mapping_set_t {
         }
 
         // Add a new mapping, using the next order.
-        let new_mapping = input_mapping_t::new(sequence, commands, mode, sets_mode);
+        let new_mapping = Mapping::new(sequence, commands, mode, sets_mode);
         input_mapping_insert_sorted(ml, new_mapping);
     }
 
@@ -237,14 +242,31 @@ impl input_mapping_set_t {
     }
 }
 
+/// A struct representing the mapping from a terminfo key name to a terminfo character sequence.
+#[derive(Debug)]
+struct TermInfoMapping {
+    // name of key
+    name: WString,
+
+    // character sequence generated on keypress, or none if there was no mapping.
+    seq: Option<WString>,
+}
+
+/// Input function metadata. This list should be kept in sync with the key code list in
+/// input_common.h.
+struct FuntionMetadata {
+    name: WString,
+    code: readline_cmd_t,
+}
+
 /// Helper function to compare the lengths of sequences.
-fn length_is_greater_than(m1: &input_mapping_t, m2: &input_mapping_t) -> bool {
+fn length_is_greater_than(m1: &Mapping, m2: &Mapping) -> bool {
     return m1.seq.len() > m2.seq.len();
 }
 
 /// Inserts an input mapping at the correct position. We sort them in descending order by length, so
 /// that we test longer sequences first.
-pub fn input_mapping_insert_sorted(ml: &mut MappingList, new_mapping: input_mapping_t) {
+pub fn input_mapping_insert_sorted(ml: &mut MappingList, new_mapping: Mapping) {
     let mut loc = 0usize;
     for m in ml.iter() {
         if m.seq.len() > new_mapping.seq.len() {
@@ -255,7 +277,13 @@ pub fn input_mapping_insert_sorted(ml: &mut MappingList, new_mapping: input_mapp
     ml.insert(loc, new_mapping);
 }
 
-pub fn init_mappings() {
+/// Set up arrays used by readch to detect escape sequences for special keys and perform related
+/// initializations for our input subsystem.
+pub fn init_input() {
+    assert_is_main_thread();
+    // if (s_terminfo_mappings.is_set()) return;
+    // s_terminfo_mappings = create_input_terminfo();
+
     with_mappings_mut(|input_mapping| {
         // If we have no keybindings, add a few simple defaults.
         if input_mapping.preset_mappings.is_empty() {
@@ -393,3 +421,191 @@ pub fn init_mappings() {
         }
     });
 }
+
+fn describe_char(c: usize) -> WString {
+    if c < input_function_count {
+        return wgettext_fmt!("%02x (%ls)", c, input_function_metadata[c].name);
+    }
+    return wgettext_fmt!("%02x", c);
+}
+
+pub struct Inputter{
+}
+
+impl Inputter {
+    // /// Construct from a parser, and the fd from which to read.
+    // explicit inputter_t(parser_t &parser, int in = STDIN_FILENO);
+
+    /// Read a character from stdin. Try to convert some escape sequences into character constants,
+    /// but do not permanently block the escape character.
+    ///
+    /// This is performed in the same way vim does it, i.e. if an escape character is read, wait for
+    /// more input for a short time (a few milliseconds). If more input is available, it is assumed
+    /// to be an escape sequence for a special character (such as an arrow key), and readch attempts
+    /// to parse it. If no more input follows after the escape key, it is assumed to be an actual
+    /// escape key press, and is returned as such.
+    ///
+    /// \p command_handler is used to run commands. If empty (in the std::function sense), when a
+    /// character is encountered that would invoke a fish command, it is unread and
+    /// char_event_type_t::check_exit is returned. Note the handler is not stored.
+     fn read_char() {
+        // Clear the interrupted flag.
+        ffi::reader_reset_interrupted();
+    // Search for sequence in mapping tables.
+
+    }
+
+    /// Enqueue a char event to the queue of unread characters that input_readch will return before
+    /// actually reading from fd 0.
+    // void queue_char(const char_event_t &ch);
+
+    /// Sets the return status of the most recently executed input function.
+    // void function_set_status(bool status) { function_status_ = status; }
+
+    /// Pop an argument from the function argument stack.
+    // wchar_t function_pop_arg();
+
+    // Called right before potentially blocking in select().
+    // void prepare_to_select() override;
+
+    // Called when select() is interrupted by a signal.
+    // void select_interrupted() override;
+
+    // Called when we are notified of a uvar change.
+    // void uvar_change_notified() override;
+
+    // void function_push_arg(wchar_t arg);
+    // void function_push_args(readline_cmd_t code);
+    // void mapping_execute(const input_mapping_t &m, const command_handler_t &command_handler);
+    // void mapping_execute_matching_or_generic(const command_handler_t &command_handler);
+    // maybe_t<input_mapping_t> find_mapping(event_queue_peeker_t *peeker);
+    // char_event_t read_characters_no_readline();
+
+    // We need a parser to evaluate bindings.
+    // const std::shared_ptr<parser_t> parser_;
+
+    // std::vector<wchar_t> input_function_args_{};
+    // bool function_status_{false};
+
+    // Transient storage to avoid repeated allocations.
+    // std::vector<char_event_t> event_storage_{};
+}
+
+/// Return the current bind mode.
+fn get_bind_mode(parser: &mut parser_t) -> WString {
+    parser.pin().vars().unpin().get_or_default(
+        FISH_BIND_MODE_VAR,
+        DEFAULT_BIND_MODE,
+        flags::ENV_DEFAULT,
+    )
+}
+
+/// Set the current bind mode.
+fn input_set_bind_mode(parser: &mut parser_t, bm: &wstr) {
+    // Only set this if it differs to not execute variable handlers all the time.
+    // modes may not be empty - empty is a sentinel value meaning to not change the mode
+    assert!(!bm.is_empty());
+
+    if get_bind_mode(parser) != bm {
+        // Must send events here - see #6653.
+        parser
+            .pin()
+            .set_var_and_fire(&FISH_BIND_MODE_VAR.to_ffi(), flags::ENV_GLOBAL, bm.to_ffi());
+    }
+}
+
+fn input_mappings_ffi<'a>() -> Box<GlobalMappings<'a>> {
+    let mappings = MAPPINGS.lock().unwrap();
+    Box::new(GlobalMappings { g: mappings })
+}
+
+/// Returns the arity of a given input function.
+fn input_function_arity(function: readline_cmd_t) -> i32 {
+    match function {
+        readline_cmd_t::forward_jump
+        | readline_cmd_t::backward_jump
+        | readline_cmd_t::forward_jump_till
+        | readline_cmd_t::backward_jump_till => 1,
+        _ => 0,
+    }
+}
+
+/// Return the sequence for the terminfo variable of the specified name.
+///
+/// If no terminfo variable of the specified name could be found, return false and set errno to
+/// ENOENT. If the terminfo variable does not have a value, return false and set errno to EILSEQ.
+fn input_terminfo_get_sequence(name: &wstr) -> Option<WString> {
+    // assert(s_terminfo_mappings.is_set());
+    for m in terminfo_mappings.iter() {
+        if name == m.name {
+            // Found the mapping.
+            if let Some(ref seq) = m.seq {
+                return Some(seq.clone());
+            } else {
+                set_errno(EILSEQ);
+                return None;
+            }
+        }
+    }
+    set_errno(ENOENT);
+    None
+}
+
+/// Return the name of the terminfo variable with the specified sequence, in out_name. Returns true
+/// if found, false if not found.
+fn input_terminfo_get_name(seq: &wstr) -> Option<WString> {
+    // assert(terminfo_mappings.is_set());
+    for m in terminfo_mappings.iter() {
+        if let Some(ref m_seq) = m.seq {
+            if m_seq == seq {
+                return Some(m.name.clone());
+            }
+        }
+    }
+
+    None
+}
+
+/// Return a list of all known terminfo names.
+fn input_terminfo_get_names(skip_null: bool) -> Vec<WString> {
+    // assert!(s_terminfo_mappings.is_set()); // TODO
+    let mut result = Vec::with_capacity(terminfo_mappings.len());
+    for m in terminfo_mappings.iter() {
+        if (skip_null && m.seq.is_none()) {
+            continue;
+        }
+        result.push(m.name.clone());
+    }
+    result
+}
+
+/// Returns the input function code for the given input function name.
+fn input_function_get_names() -> Vec<WString> {
+    // The list and names of input functions are hard-coded and never change
+    let mut result = Vec::new();
+    for md in &input_function_metadata {
+        if !md.name.is_empty() {
+            result.push(md.name.clone());
+        }
+    }
+
+    result
+}
+
+/// Returns a list of all existing input function names.
+fn input_function_get_code(name: &wstr) -> Option<readline_cmd_t> {
+    // `input_function_metadata` is required to be kept in asciibetical order, making it OK to do
+    // a binary search for the matching name.
+    return input_function_metadata
+        .as_slice()
+        .binary_search_by(|md| md.name.as_utfstr().cmp(name))
+        .ok()
+        .map(|i| &input_function_metadata[i])
+        .map(|md| md.code.clone());
+}
+
+pub struct GlobalMappings<'a> {
+    g: MutexGuard<'a, MappingsSet>,
+}
+
+impl<'a> GlobalMappings<'a> {}

--- a/fish-rust/src/input.rs
+++ b/fish-rust/src/input.rs
@@ -1,0 +1,395 @@
+use crate::wchar::{wstr, WString, L};
+use once_cell::sync::Lazy;
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc, Mutex,
+};
+
+const DEFAULT_BIND_MODE: &wstr = L!("default");
+
+static s_last_input_map_spec_order: AtomicU32 = AtomicU32::new(0);
+static MAPPINGS: Lazy<Mutex<input_mapping_set_t>> = Lazy::new(Default::default);
+
+pub fn with_mappings_mut<R>(cb: impl FnOnce(&mut input_mapping_set_t) -> R) -> R {
+    let mut mappings = MAPPINGS.lock().unwrap();
+    cb(&mut mappings)
+}
+
+/// Struct representing a keybinding. Returned by input_get_mappings.
+#[derive(Default, Clone)]
+pub struct input_mapping_t {
+    /// Character sequence which generates this event.
+    seq: WString,
+    /// Commands that should be evaluated by this mapping.
+    commands: Vec<WString>,
+    /// We wish to preserve the user-specified order. This is just an incrementing value.
+    specification_order: u32,
+    /// Mode in which this command should be evaluated.
+    mode: WString,
+    /// New mode that should be switched to after command evaluation.
+    sets_mode: WString,
+}
+
+impl input_mapping_t {
+    fn new(seq: WString, commands: Vec<WString>, mode: WString, sets_mode: WString) -> Self {
+        let specification_order = s_last_input_map_spec_order.fetch_add(1, Ordering::SeqCst);
+
+        Self {
+            seq,
+            commands,
+            specification_order,
+            mode,
+            sets_mode,
+        }
+    }
+
+    /// \return true if this is a generic mapping, i.e. acts as a fallback.
+    fn is_generic(&self) -> bool {
+        self.seq.is_empty()
+    }
+}
+
+/// A struct representing the mapping from a terminfo key name to a terminfo character sequence.
+struct terminfo_mapping_t {
+    // name of key
+    name: WString,
+
+    // character sequence generated on keypress, or none if there was no mapping.
+    seq: Option<String>,
+}
+
+impl terminfo_mapping_t {
+    fn new(name: WString) -> Self {
+        Self { name, seq: None }
+    }
+
+    fn new_with_seq(name: WString, seq: String) -> Self {
+        Self {
+            name,
+            seq: Some(seq),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct input_mapping_name_t {
+    seq: WString,
+    mode: WString,
+}
+
+pub type MappingList = Vec<input_mapping_t>;
+
+/// The input mapping set is the set of mappings from character sequences to commands.
+#[derive(Default)]
+pub struct input_mapping_set_t {
+    mappings: MappingList,
+    preset_mappings: MappingList,
+    all_mappings_cache: Option<Arc<MappingList>>,
+}
+
+impl input_mapping_set_t {
+    /// Erase all bindings with matching mode.
+    fn clear(&mut self, mode: WString, user: bool) {
+        self.all_mappings_cache = Default::default();
+        let ml = if user {
+            &mut self.mappings
+        } else {
+            &mut self.preset_mappings
+        };
+
+        ml.retain(|m| mode != m.mode);
+    }
+
+    /// Erase all bindings.
+    fn clear_all(&mut self, user: bool) {
+        self.all_mappings_cache = Default::default();
+        let ml = if user {
+            &mut self.mappings
+        } else {
+            &mut self.preset_mappings
+        };
+        ml.clear();
+    }
+
+    /// Erase binding for specified key sequence.
+    fn erase(&mut self, sequence: WString, mode: WString, user: bool) -> bool {
+        // Clear cached mappings.
+        self.all_mappings_cache = Default::default();
+
+        let mut result = false;
+        let ml = if user {
+            &mut self.mappings
+        } else {
+            &mut self.preset_mappings
+        };
+
+        for (i, it) in ml.iter().enumerate() {
+            if sequence == it.seq && mode == it.mode {
+                ml.remove(i);
+                result = true;
+                break;
+            }
+        }
+
+        result
+    }
+
+    /// Gets the command bound to the specified key sequence in the specified mode. Returns true if
+    /// it exists, false if not.
+    fn get(&self, sequence: WString, mode: WString, user: bool) -> bool {
+        let mut result = false;
+        let ml = if user {
+            &self.mappings
+        } else {
+            &self.preset_mappings
+        };
+        for m in ml {
+            if sequence == m.seq && mode == m.mode {
+                // *out_cmds = m.commands;
+                // *out_sets_mode = m.sets_mode;
+                result = true;
+                break;
+            }
+        }
+        return result;
+    }
+
+    /// Returns all mapping names and modes.
+    pub fn get_names(&self, user: bool) -> Vec<input_mapping_name_t> {
+        // Sort the mappings by the user specification order, so we can return them in the same order
+        // that the user specified them in.
+        let mut local_list = if user {
+            self.mappings.clone()
+        } else {
+            self.preset_mappings.clone()
+        };
+
+        local_list.sort_by_key(|a| a.specification_order);
+
+        let mut result = Vec::with_capacity(local_list.len());
+
+        for m in local_list {
+            result.push(input_mapping_name_t {
+                seq: m.seq.clone(),
+                mode: m.mode.clone(),
+            });
+        }
+
+        result
+    }
+
+    /// Add a key mapping from the specified sequence to the specified command.
+    ///
+    /// \param sequence the sequence to bind
+    /// \param command an input function that will be run whenever the key sequence occurs
+    fn add(
+        &mut self,
+        sequence: WString,
+        commands: Vec<WString>,
+        mode: WString,
+        sets_mode: WString,
+        user: bool,
+    ) {
+        // Clear cached mappings.
+        self.all_mappings_cache = Default::default();
+
+        // Remove existing mappings with this sequence.
+        let ml = if user {
+            &mut self.mappings
+        } else {
+            &mut self.preset_mappings
+        };
+
+        for m in ml.iter_mut() {
+            if m.seq == sequence && m.mode == mode {
+                m.commands = commands;
+                m.sets_mode = sets_mode;
+                return;
+            }
+        }
+
+        // Add a new mapping, using the next order.
+        let new_mapping = input_mapping_t::new(sequence, commands, mode, sets_mode);
+        input_mapping_insert_sorted(ml, new_mapping);
+    }
+
+    fn add_command(
+        &mut self,
+        sequence: WString,
+        command: WString,
+        mode: WString,
+        sets_mode: WString,
+        user: bool,
+    ) {
+        self.add(sequence, vec![command], mode, sets_mode, user);
+    }
+
+    /// \return a snapshot of the list of input mappings.
+    pub fn all_mappings(&mut self) -> Arc<MappingList> {
+        // Populate the cache if needed.
+        if let Some(ref all_mappings_cache) = self.all_mappings_cache {
+            Arc::clone(all_mappings_cache)
+        } else {
+            let all_mappings = Arc::new(self.preset_mappings.clone());
+            self.all_mappings_cache = Some(Arc::clone(&all_mappings));
+            Arc::clone(&all_mappings)
+        }
+    }
+}
+
+/// Helper function to compare the lengths of sequences.
+fn length_is_greater_than(m1: &input_mapping_t, m2: &input_mapping_t) -> bool {
+    return m1.seq.len() > m2.seq.len();
+}
+
+/// Inserts an input mapping at the correct position. We sort them in descending order by length, so
+/// that we test longer sequences first.
+pub fn input_mapping_insert_sorted(ml: &mut MappingList, new_mapping: input_mapping_t) {
+    let mut loc = 0usize;
+    for m in ml.iter() {
+        if m.seq.len() > new_mapping.seq.len() {
+            loc += 1;
+        }
+    }
+
+    ml.insert(loc, new_mapping);
+}
+
+pub fn init_mappings() {
+    with_mappings_mut(|input_mapping| {
+        // If we have no keybindings, add a few simple defaults.
+        if input_mapping.preset_mappings.is_empty() {
+            input_mapping.add_command(
+                WString::from_str(""),
+                WString::from_str("self-insert"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\n"),
+                WString::from_str("execute"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\r"),
+                WString::from_str("execute"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\t"),
+                WString::from_str("complete"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\x03"),
+                WString::from_str("cancel-commandline"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\x04"),
+                WString::from_str("exit"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\x05"),
+                WString::from_str("bind"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            // ctrl-s
+            input_mapping.add_command(
+                WString::from_str("\x13"),
+                WString::from_str("pager-toggle-search"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            // ctrl-u
+            input_mapping.add_command(
+                WString::from_str("\x15"),
+                WString::from_str("backward-kill-line"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            // del/backspace
+            input_mapping.add_command(
+                WString::from_str("\x7f"),
+                WString::from_str("backward-delete-char"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            // Arrows - can't have functions, so *-or-search isn't available.
+            input_mapping.add_command(
+                WString::from_str("\x1B[A"),
+                WString::from_str("up-line"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\x1B[B"),
+                WString::from_str("down-line"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\x1B[C"),
+                WString::from_str("forward-char"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\x1B[D"),
+                WString::from_str("backward-char"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            // emacs-style ctrl-p/n/b/f
+            input_mapping.add_command(
+                WString::from_str("\x10"),
+                WString::from_str("up-line"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\x0e"),
+                WString::from_str("down-line"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\x02"),
+                WString::from_str("backward-char"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+            input_mapping.add_command(
+                WString::from_str("\x06"),
+                WString::from_str("forward-char"),
+                DEFAULT_BIND_MODE.into(),
+                DEFAULT_BIND_MODE.into(),
+                false,
+            );
+        }
+    });
+}

--- a/fish-rust/src/input_common.rs
+++ b/fish-rust/src/input_common.rs
@@ -1,0 +1,543 @@
+#![allow(unused_imports)]
+use crate::wchar_ffi::{WCharFromFFI, WCharToFFI};
+use crate::{
+    env::flags,
+    fd_readable_set::{self, new_fd_readable_set},
+    fds::kNoTimeout,
+    ffi::{self, moveit, Repin},
+    flog::{categories::iothread, FLOG},
+    wchar::{wchar_t, WString, L},
+    wutil::{fish_wcstoi, format::printf, wgettext, wgettext_fmt},
+};
+use autocxx::WithinUniquePtr;
+use cxx::{CxxWString, UniquePtr};
+use errno::errno;
+use libc::{sigset_t, EAGAIN, EINTR};
+use std::pin::Pin;
+use std::{
+    collections::VecDeque,
+    ffi::c_int,
+    fmt::Debug,
+    io::{self, Read},
+    mem,
+    os::fd::RawFd,
+    ptr::{null, null_mut},
+};
+use widestring::WideChar;
+
+#[cxx::bridge]
+mod input_common_ffi {
+    extern "Rust" {
+        fn update_wait_on_escape_ms_ffi(escape_time_ms: &CxxWString);
+    }
+}
+
+/// Time in milliseconds to wait for another byte to be available for reading
+/// after \x1B is read before assuming that escape key was pressed, and not an
+/// escape sequence.
+const WAIT_ON_ESCAPE_DEFAULT: i64 = 30;
+static mut wait_on_escape_ms: i64 = WAIT_ON_ESCAPE_DEFAULT;
+
+/// The range of key codes for inputrc-style keyboard functions.
+const R_END_INPUT_FUNCTIONS: u16 = ReadlineCmd::reverse_repeat_jump as u16 + 1;
+
+/// Internal function used by readch to read one byte.
+/// This calls select() on three fds: input (e.g. stdin), the ioport notifier fd (for main thread
+/// requests), and the uvar notifier. This returns either the byte which was read, or one of the
+/// special values below.
+mod readb_result {
+    // The in fd has been closed.
+    pub const readb_eof: i32 = -1;
+
+    // select() was interrupted by a signal.
+    pub const readb_interrupted: i32 = -2;
+
+    // Our uvar notifier reported a change (either through poll() or its fd).
+    pub const readb_uvar_notified: i32 = -3;
+
+    // Our ioport reported a change, so service main thread requests.
+    pub const readb_ioport_notified: i32 = -4;
+}
+
+fn readb(in_fd: RawFd) -> i32 {
+    assert!(in_fd >= 0, "Invalid in fd");
+    let notifier = unsafe { &mut *ffi::default_notifier_ffi() };
+    let mut fdset = new_fd_readable_set();
+    loop {
+        fdset.clear();
+        fdset.add(in_fd);
+
+        // Add the completion ioport.
+        let ioport_fd = ffi::iothread_port().into();
+        fdset.add(ioport_fd);
+
+        // Get the uvar notifier fd (possibly none).
+        let notifier_fd = notifier.notification_fd().into();
+        fdset.add(notifier_fd);
+
+        // Get its suggested delay (possibly none).
+        // Note a 0 here means do not poll.
+        let mut timeout = kNoTimeout;
+        let usecs_delay = notifier.usec_delay_between_polls().into();
+        if usecs_delay > 0 {
+            timeout = usecs_delay;
+        }
+
+        // Here's where we call select().
+        let select_res = fdset.check_readable(timeout);
+        if select_res < 0 {
+            let err: i32 = errno().into();
+            if err == EINTR || err == EAGAIN {
+                // A signal.
+                return readb_result::readb_interrupted;
+            } else {
+                // Some fd was invalid, so probably the tty has been closed.
+                return readb_result::readb_eof;
+            }
+        }
+
+        // select() did not return an error, so we may have a readable fd.
+        // The priority order is: uvars, stdin, ioport.
+        // Check to see if we want a universal variable barrier.
+        // This may come about through readability, or through a call to poll().
+        if (fdset.test(notifier_fd)
+            && notifier
+                .pin()
+                .notification_fd_became_readable(notifier_fd.into()))
+            || notifier.pin().poll()
+        {
+            return readb_result::readb_uvar_notified;
+        }
+
+        // Check stdin.
+        if fdset.test(in_fd) {
+            let mut arr = [0 as u8];
+            if ffi::read_blocked(in_fd.into(), arr.as_mut_ptr() as *mut autocxx::c_void, 1)
+                != 1.into()
+            {
+                // The terminal has been closed.
+                return readb_result::readb_eof;
+            }
+            // The common path is to return a (non-negative) char.
+            return arr[0] as i32;
+        }
+
+        // Check for iothread completions only if there is no data to be read from the stdin.
+        // This gives priority to the foreground.
+        if fdset.test(ioport_fd) {
+            return readb_result::readb_ioport_notified;
+        }
+    }
+}
+
+#[repr(u16)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum ReadlineCmd {
+    beginning_of_line,
+    end_of_line,
+    forward_char,
+    backward_char,
+    forward_single_char,
+    forward_word,
+    backward_word,
+    forward_bigword,
+    backward_bigword,
+    nextd_or_forward_word,
+    prevd_or_backward_word,
+    history_search_backward,
+    history_search_forward,
+    history_prefix_search_backward,
+    history_prefix_search_forward,
+    history_pager,
+    delete_char,
+    backward_delete_char,
+    kill_line,
+    yank,
+    yank_pop,
+    complete,
+    complete_and_search,
+    pager_toggle_search,
+    beginning_of_history,
+    end_of_history,
+    backward_kill_line,
+    kill_whole_line,
+    kill_inner_line,
+    kill_word,
+    kill_bigword,
+    backward_kill_word,
+    backward_kill_path_component,
+    backward_kill_bigword,
+    history_token_search_backward,
+    history_token_search_forward,
+    self_insert,
+    self_insert_notfirst,
+    transpose_chars,
+    transpose_words,
+    upcase_word,
+    downcase_word,
+    capitalize_word,
+    togglecase_char,
+    togglecase_selection,
+    execute,
+    beginning_of_buffer,
+    end_of_buffer,
+    repaint_mode,
+    repaint,
+    force_repaint,
+    up_line,
+    down_line,
+    suppress_autosuggestion,
+    accept_autosuggestion,
+    begin_selection,
+    swap_selection_start_stop,
+    end_selection,
+    kill_selection,
+    insert_line_under,
+    insert_line_over,
+    forward_jump,
+    backward_jump,
+    forward_jump_till,
+    backward_jump_till,
+    func_and,
+    func_or,
+    expand_abbr,
+    delete_or_exit,
+    exit,
+    cancel_commandline,
+    cancel,
+    undo,
+    redo,
+    begin_undo_group,
+    end_undo_group,
+    repeat_jump,
+    disable_mouse_tracking,
+    // NOTE: This one has to be last.
+    reverse_repeat_jump,
+}
+
+/// Represents an event on the character input stream.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum CharEventType {
+    /// A character was entered.
+    charc(wchar_t),
+
+    /// A readline event.
+    readline(ReadlineCmd),
+
+    /// end-of-file was reached.
+    eof,
+
+    /// An event was handled internally, or an interrupt was received. Check to see if the reader
+    /// loop should exit.
+    check_exit,
+}
+
+/// Hackish: the input style, which describes how char events (only) are applied to the command
+/// line. Note this is set only after applying bindings; it is not set from readb().
+#[repr(u8)]
+#[derive(Debug, Clone, Copy)]
+enum CharInputStyle {
+    // Insert characters normally.
+    normal,
+
+    // Insert characters only if the cursor is not at the beginning. Otherwise, discard them.
+    notfirst,
+}
+
+#[derive(Debug, Clone)]
+struct CharEvent {
+    /// The type of event.
+    event_type: CharEventType,
+
+    /// The style to use when inserting characters into the command line.
+    input_style: CharInputStyle,
+
+    /// The sequence of characters in the input mapping which generated this event.
+    /// Note that the generic self-insert case does not have any characters, so this would be empty.
+    seq: WString,
+}
+
+impl CharEvent {
+    fn is_char(&self) -> bool {
+        matches!(self.event_type, CharEventType::charc(_))
+    }
+
+    fn is_eof(&self) -> bool {
+        self.event_type == CharEventType::eof
+    }
+
+    fn is_check_exit(&self) -> bool {
+        self.event_type == CharEventType::check_exit
+    }
+
+    fn is_readline(&self) -> bool {
+        matches!(self.event_type, CharEventType::readline(_))
+    }
+
+    fn get_char(&self) -> wchar_t {
+        match self.event_type {
+            CharEventType::charc(c) => c,
+            _ => panic!("Not a char type"),
+        }
+    }
+
+    fn maybe_char(&self) -> Option<wchar_t> {
+        match self.event_type {
+            CharEventType::charc(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    fn get_readline(&self) -> ReadlineCmd {
+        match self.event_type {
+            CharEventType::readline(c) => c,
+            _ => panic!("Not a readline type"),
+        }
+    }
+
+    fn new(event_type: CharEventType) -> Self {
+        Self {
+            event_type,
+            input_style: CharInputStyle::normal,
+            seq: Default::default(),
+        }
+    }
+    fn new_with_seq(event_type: CharEventType, seq: WString) -> Self {
+        Self {
+            event_type,
+            input_style: CharInputStyle::normal,
+            seq,
+        }
+    }
+}
+
+/// Adjust the escape timeout.
+/// Update the wait_on_escape_ms value in response to the fish_escape_delay_ms
+/// user variable being set.
+fn update_wait_on_escape_ms_ffi(escape_time_ms: &CxxWString) {
+    let escape_time_ms = escape_time_ms.from_ffi();
+
+    if escape_time_ms.is_empty() {
+        unsafe {
+            wait_on_escape_ms = WAIT_ON_ESCAPE_DEFAULT;
+        }
+        return;
+    }
+
+    let tmp = fish_wcstoi(escape_time_ms.chars());
+    match tmp {
+        Ok(n) if n >= 10 || n < 5000 => unsafe { wait_on_escape_ms = n },
+        _ => {
+            eprint!("{}", wgettext_fmt!("ignoring fish_escape_delay_ms: value '%ls' is not an integer or is < 10 or >= 5000 ms\n", escape_time_ms))
+        }
+    }
+}
+
+/// A class which knows how to produce a stream of input events.
+/// This is a base class; you may subclass it for its override points.
+struct InputEventQueue {
+    input: RawFd,
+    queue: VecDeque<CharEvent>,
+    hooks: Box<dyn InputEventQueueHooks + 'static>,
+}
+
+impl InputEventQueue {
+    /// Construct from a file descriptor \p in, and an interrupt handler \p handler.
+    pub fn new_stdin() -> Self {
+        Self {
+            input: 0,
+            queue: Default::default(),
+            hooks: DefaultInputEventQueueHooks::new(),
+        }
+    }
+
+    /// Function used by input_readch to read bytes from stdin until enough bytes have been read to
+    /// convert them to a wchar_t. Conversion is done using mbrtowc. If a character has previously
+    /// been read and then 'unread' using \c input_common_unreadch, that character is returned.
+    pub fn readch(&mut self) -> CharEvent {
+        moveit! {
+            let mut state = ffi::read_mbtowc_t_create();
+        }
+
+        loop {
+            // Do we have something enqueued already?
+            // Note this may be initially true, or it may become true through calls to
+            // iothread_service_main() or env_universal_barrier() below.
+            if let Some(mevt) = self.try_pop() {
+                return mevt;
+            }
+
+            // We are going to block; but first allow any override to inject events.
+            self.hooks.prepare_to_select();
+            if let Some(mevt) = self.try_pop() {
+                return mevt;
+            }
+
+            let rr = readb(self.input);
+            match rr {
+                readb_result::readb_eof => return CharEvent::new(CharEventType::eof),
+
+                // FIXME: here signals may break multibyte sequences.
+                readb_result::readb_interrupted => self.hooks.select_interrupted(),
+
+                readb_result::readb_uvar_notified => {
+                    self.hooks.uvar_change_notified();
+                }
+
+                readb_result::readb_ioport_notified => ffi::iothread_service_main(),
+
+                _ => {
+                    let read_byte: u8 = rr
+                        .try_into()
+                        .expect("Read byte out of bounds - missing error case?");
+
+                    if ffi::is_single_byte_locale() {
+                        // single-byte locale, all values are legal
+                        return CharEvent::new(CharEventType::charc(read_byte as wchar_t));
+                    }
+
+                    let sz = state.as_mut().read_mbtowc(read_byte as i8);
+                    match sz.0 {
+                        -1 => {
+                            FLOG!(reader, "Illegal input");
+                            return CharEvent::new(CharEventType::check_exit);
+                        }
+                        // Sequence not yet complete.
+                        -2 => {}
+                        // Actual nul char.
+                        0 => return CharEvent::new(CharEventType::charc(0)),
+
+                        // Sequence complete.
+                        _ => return CharEvent::new(CharEventType::charc(state.get_char())),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Like readch(), except it will wait at most WAIT_ON_ESCAPE milliseconds for a
+    /// character to be available for reading.
+    /// \return none on timeout, the event on success.
+    fn readch_timed(&mut self) -> Option<CharEvent> {
+        if let Some(mevt) = self.try_pop() {
+            return Some(mevt);
+        }
+        // We are not prepared to handle a signal immediately; we only want to know if we get input on
+        // our fd before the timeout. Use pselect to block all signals; we will handle signals
+        // before the next call to readch().
+        let mut sigs = sigset_t::default();
+        unsafe { libc::sigfillset(&mut sigs) };
+
+        // pselect expects timeouts in nanoseconds.
+        let nsec_per_msec: i64 = 1000 * 1000;
+        let nsec_per_sec = nsec_per_msec * 1000;
+        let wait_nsec = unsafe { wait_on_escape_ms } * nsec_per_msec;
+        let timeout = libc::timespec {
+            tv_sec: (wait_nsec) / nsec_per_sec,
+            tv_nsec: (wait_nsec) % nsec_per_sec,
+        };
+        unsafe {
+            let mut fdset: libc::fd_set = std::mem::zeroed();
+            // We have one fd of interest.
+
+            libc::FD_ZERO(&mut fdset);
+            libc::FD_SET(self.input, &mut fdset);
+
+            let res = libc::pselect(
+                self.input + 1,
+                &mut fdset,
+                null_mut(),
+                null_mut(),
+                &timeout,
+                &sigs,
+            );
+
+            // Prevent signal starvation on WSL causing the `torn_escapes.py` test to fail
+            if ffi::is_windows_subsystem_for_linux() {
+                // Merely querying the current thread's sigmask is sufficient to deliver a pending signal
+                libc::pthread_sigmask(0, null(), &mut sigs);
+            }
+
+            if res > 0 {
+                return Some(self.readch());
+            }
+            return None;
+        }
+    }
+
+    /// Enqueue a character or a readline function to the queue of unread characters that
+    /// readch will return before actually reading from fd 0.
+    fn push_back(&mut self, ch: CharEvent) {
+        self.queue.push_back(ch);
+    }
+
+    /// Add a character or a readline function to the front of the queue of unread characters.  This
+    /// will be the next character returned by readch.
+    fn push_front(&mut self, ch: CharEvent) {
+        self.queue.push_front(ch);
+    }
+
+    /// Find the first sequence of non-char events, and promote them to the front.
+    fn promote_interruptions_to_front(&mut self) {
+        // Find the first sequence of non-char events.
+        // EOF is considered a char: we don't want to pull EOF in front of real chars.
+        let is_char = |ch: &CharEvent| ch.is_char() || ch.is_eof();
+
+        let first = self.queue.iter().position(|ch| !is_char(ch));
+        let first = match first {
+            Some(i) if i > 0 => i,
+            _ => return,
+        };
+
+        let last = self
+            .queue
+            .iter()
+            .skip(first)
+            .position(is_char)
+            .map(|i| i + first)
+            .unwrap_or(self.queue.len());
+
+        println!("{}, {}", first, last);
+        for _ in first..last {
+            if let Some(e) = self.queue.remove(last - 1) {
+                self.queue.push_front(e);
+            }
+        }
+    }
+
+    /// Add multiple characters or readline events to the front of the queue of unread characters.
+    /// The order of the provided events is not changed, i.e. they are not inserted in reverse
+    /// order.
+    fn insert_front(&mut self, i: impl Iterator<Item = CharEvent>) {
+        for c in i {
+            self.queue.push_front(c);
+        }
+    }
+
+    /// \return the next event in the queue, or none if the queue is empty.
+    fn try_pop(&mut self) -> Option<CharEvent> {
+        self.queue.pop_front()
+    }
+}
+
+pub trait InputEventQueueHooks {
+    /// Override point for when we are about to (potentially) block in select().
+    /// The default does nothing.
+    fn prepare_to_select(&self) {}
+
+    /// Override point for when when select() is interrupted by a signal. The default does nothing.
+    fn select_interrupted(&self) {}
+
+    /// Override point for when when select() is interrupted by the universal variable notifier.
+    /// The default does nothing.
+    fn uvar_change_notified(&self) {}
+}
+
+struct DefaultInputEventQueueHooks;
+impl DefaultInputEventQueueHooks {
+    fn new() -> Box<dyn InputEventQueueHooks> {
+        Box::new(DefaultInputEventQueueHooks)
+    }
+}
+
+impl InputEventQueueHooks for DefaultInputEventQueueHooks {}

--- a/fish-rust/src/lib.rs
+++ b/fish-rust/src/lib.rs
@@ -40,3 +40,4 @@ mod builtins;
 mod env;
 mod input_common;
 mod re;
+mod input;

--- a/fish-rust/src/lib.rs
+++ b/fish-rust/src/lib.rs
@@ -38,4 +38,5 @@ mod wutil;
 mod abbrs;
 mod builtins;
 mod env;
+mod input_common;
 mod re;

--- a/fish-rust/src/lib.rs
+++ b/fish-rust/src/lib.rs
@@ -38,6 +38,6 @@ mod wutil;
 mod abbrs;
 mod builtins;
 mod env;
+mod input;
 mod input_common;
 mod re;
-mod input;

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -1371,6 +1371,15 @@ maybe_t<env_var_t> env_stack_t::get(const wcstring &key, env_mode_flags_t mode) 
     return acquire_impl()->get(key, mode);
 }
 
+wcstring env_stack_t::get_or_default_ffi(const wcstring &key, const wcstring &def,
+                                         env_mode_flags_t mode) const {
+    auto var = acquire_impl()->get(key, mode);
+    if (var) {
+        return var->as_string();
+    }
+    return def;
+}
+
 wcstring_list_t env_stack_t::get_names(env_mode_flags_t flags) const {
     return acquire_impl()->get_names(flags);
 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -942,7 +942,7 @@ class env_stack_impl_t final : public env_scoped_impl_t {
     mod_result_t set(const wcstring &key, env_mode_flags_t mode, wcstring_list_t val);
 
     /// Remove a variable under the name \p key.
-    mod_result_t remove(const wcstring &key, int var_mode);
+    mod_result_t remove(const wcstring &key, env_mode_flags_t var_mode);
 
     /// Push a new shadowing local scope.
     void push_shadowing();
@@ -1274,7 +1274,7 @@ mod_result_t env_stack_impl_t::set(const wcstring &key, env_mode_flags_t mode,
     return result;
 }
 
-mod_result_t env_stack_impl_t::remove(const wcstring &key, int mode) {
+mod_result_t env_stack_impl_t::remove(const wcstring &key, env_mode_flags_t mode) {
     const query_t query(mode);
 
     // Users can't remove read-only keys.
@@ -1415,7 +1415,7 @@ int env_stack_t::set_empty(const wcstring &key, env_mode_flags_t mode) {
     return set(key, mode, {});
 }
 
-int env_stack_t::remove(const wcstring &key, int mode) {
+int env_stack_t::remove(const wcstring &key, env_mode_flags_t mode) {
     mod_result_t ret = acquire_impl()->remove(key, mode);
     if (ret.status == ENV_OK) {
         if (ret.global_modified || is_principal()) {

--- a/src/env.h
+++ b/src/env.h
@@ -254,7 +254,7 @@ class env_stack_t final : public environment_t {
     /// the scope of the variable that should be erased.
     ///
     /// \return zero if the variable existed, and non-zero if the variable did not exist
-    int remove(const wcstring &key, int mode);
+    int remove(const wcstring &key, env_mode_flags_t mode);
 
     /// Push the variable stack. Used for implementing local variables for functions and for-loops.
     void push(bool new_scope);

--- a/src/env.h
+++ b/src/env.h
@@ -232,6 +232,11 @@ class env_stack_t final : public environment_t {
     maybe_t<env_var_t> get(const wcstring &key, env_mode_flags_t mode = ENV_DEFAULT) const override;
 
     /// Implementation of environment_t.
+    wcstring get_or_default_ffi(const wcstring &key,
+                                const wcstring &def,
+                                env_mode_flags_t mode) const;
+
+    /// Implementation of environment_t.
     wcstring_list_t get_names(env_mode_flags_t flags) const override;
 
     /// Sets the variable with the specified name to the given values.

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -1388,6 +1388,8 @@ universal_notifier_t::notifier_strategy_t universal_notifier_t::resolve_default_
 #endif
 }
 
+universal_notifier_t *default_notifier_ffi() { return &universal_notifier_t::default_notifier(); }
+
 universal_notifier_t &universal_notifier_t::default_notifier() {
     static std::unique_ptr<universal_notifier_t> result =
         new_notifier_for_strategy(universal_notifier_t::resolve_default_strategy());

--- a/src/env_universal_common.h
+++ b/src/env_universal_common.h
@@ -218,4 +218,6 @@ class universal_notifier_t {
 
 wcstring get_runtime_path();
 
+universal_notifier_t *default_notifier_ffi();
+
 #endif

--- a/src/input.h
+++ b/src/input.h
@@ -84,60 +84,6 @@ class inputter_t final : private input_event_queue_t {
     std::vector<char_event_t> event_storage_{};
 };
 
-struct input_mapping_name_t {
-    wcstring seq;
-    wcstring mode;
-};
-
-/// The input mapping set is the set of mappings from character sequences to commands.
-class input_mapping_set_t {
-    friend acquired_lock<input_mapping_set_t> input_mappings();
-    friend void init_input();
-
-    using mapping_list_t = std::vector<input_mapping_t>;
-
-    mapping_list_t mapping_list_;
-    mapping_list_t preset_mapping_list_;
-    std::shared_ptr<const mapping_list_t> all_mappings_cache_;
-
-    input_mapping_set_t();
-
-   public:
-    ~input_mapping_set_t();
-
-    /// Erase all bindings.
-    void clear(const wchar_t *mode = nullptr, bool user = true);
-
-    /// Erase binding for specified key sequence.
-    bool erase(const wcstring &sequence, const wcstring &mode = DEFAULT_BIND_MODE,
-               bool user = true);
-
-    /// Gets the command bound to the specified key sequence in the specified mode. Returns true if
-    /// it exists, false if not.
-    bool get(const wcstring &sequence, const wcstring &mode, wcstring_list_t *out_cmds, bool user,
-             wcstring *out_sets_mode) const;
-
-    /// Returns all mapping names and modes.
-    std::vector<input_mapping_name_t> get_names(bool user = true) const;
-
-    /// Add a key mapping from the specified sequence to the specified command.
-    ///
-    /// \param sequence the sequence to bind
-    /// \param command an input function that will be run whenever the key sequence occurs
-    void add(wcstring sequence, const wchar_t *command, const wchar_t *mode = DEFAULT_BIND_MODE,
-             const wchar_t *sets_mode = DEFAULT_BIND_MODE, bool user = true);
-
-    void add(wcstring sequence, const wchar_t *const *commands, size_t commands_len,
-             const wchar_t *mode = DEFAULT_BIND_MODE, const wchar_t *sets_mode = DEFAULT_BIND_MODE,
-             bool user = true);
-
-    /// \return a snapshot of the list of input mappings.
-    std::shared_ptr<const mapping_list_t> all_mappings();
-};
-
-/// Access the singleton input mapping set.
-acquired_lock<input_mapping_set_t> input_mappings();
-
 /// Return the sequence for the terminfo variable of the specified name.
 ///
 /// If no terminfo variable of the specified name could be found, return false and set errno to

--- a/src/input.h
+++ b/src/input.h
@@ -14,6 +14,13 @@
 #include "input_common.h"
 #include "maybe.h"
 
+#if INCLUDE_RUST_HEADERS
+#include "input.rs.h"
+#else
+// Hacks to allow us to compile without Rust headers.
+
+#endif
+
 #define FISH_BIND_MODE_VAR L"fish_bind_mode"
 #define DEFAULT_BIND_MODE L"default"
 
@@ -26,7 +33,6 @@ wcstring describe_char(wint_t c);
 /// initializations for our input subsystem.
 void init_input();
 
-struct input_mapping_t;
 class inputter_t final : private input_event_queue_t {
    public:
     /// Construct from a parser, and the fd from which to read.
@@ -83,24 +89,5 @@ class inputter_t final : private input_event_queue_t {
     // Transient storage to avoid repeated allocations.
     std::vector<char_event_t> event_storage_{};
 };
-
-/// Return the sequence for the terminfo variable of the specified name.
-///
-/// If no terminfo variable of the specified name could be found, return false and set errno to
-/// ENOENT. If the terminfo variable does not have a value, return false and set errno to EILSEQ.
-bool input_terminfo_get_sequence(const wcstring &name, wcstring *out_seq);
-
-/// Return the name of the terminfo variable with the specified sequence, in out_name. Returns true
-/// if found, false if not found.
-bool input_terminfo_get_name(const wcstring &seq, wcstring *out_name);
-
-/// Return a list of all known terminfo names.
-wcstring_list_t input_terminfo_get_names(bool skip_null);
-
-/// Returns the input function code for the given input function name.
-maybe_t<readline_cmd_t> input_function_get_code(const wcstring &name);
-
-/// Returns a list of all existing input function names.
-const wcstring_list_t &input_function_get_names(void);
 
 #endif

--- a/src/input_common.cpp
+++ b/src/input_common.cpp
@@ -120,26 +120,6 @@ static readb_result_t readb(int in_fd) {
     }
 }
 
-// Update the wait_on_escape_ms value in response to the fish_escape_delay_ms user variable being
-// set.
-void update_wait_on_escape_ms(const environment_t& vars) {
-    auto escape_time_ms = vars.get(L"fish_escape_delay_ms");
-    if (escape_time_ms.missing_or_empty()) {
-        wait_on_escape_ms = WAIT_ON_ESCAPE_DEFAULT;
-        return;
-    }
-
-    long tmp = fish_wcstol(escape_time_ms->as_string().c_str());
-    if (errno || tmp < 10 || tmp >= 5000) {
-        std::fwprintf(stderr,
-                      L"ignoring fish_escape_delay_ms: value '%ls' "
-                      L"is not an integer or is < 10 or >= 5000 ms\n",
-                      escape_time_ms->as_string().c_str());
-    } else {
-        wait_on_escape_ms = static_cast<int>(tmp);
-    }
-}
-
 maybe_t<char_event_t> input_event_queue_t::try_pop() {
     if (queue_.empty()) {
         return none();
@@ -272,3 +252,39 @@ void input_event_queue_t::prepare_to_select() {}
 void input_event_queue_t::select_interrupted() {}
 void input_event_queue_t::uvar_change_notified() {}
 input_event_queue_t::~input_event_queue_t() = default;
+
+// Update the wait_on_escape_ms value in response to the fish_escape_delay_ms user variable being
+// set.
+void update_wait_on_escape_ms(const environment_t& vars) {
+    wcstring escape_time_val;
+    auto escape_time_ms = vars.get(L"fish_escape_delay_ms");
+    if (!escape_time_ms.missing_or_empty()) {
+        escape_time_val = escape_time_ms->as_string();
+    }
+    update_wait_on_escape_ms_ffi(escape_time_val);
+}
+
+bool is_single_byte_locale() { return MB_CUR_MAX == 1; }
+
+int read_mbtowc_t::read_mbtowc(char rb) {
+    size_t sz = std::mbrtowc(&res, &rb, 1, &inner);
+    switch (sz) {
+        case static_cast<size_t>(-1):
+            std::memset(&inner, '\0', sizeof(inner));
+            return -1;
+
+        case static_cast<size_t>(-2):
+            // Sequence not yet complete.
+            return -2;
+
+        case 0:
+            // Actual nul char.
+            return 0;
+
+        default:
+            // Sequence complete.
+            return 1;
+    }
+}
+
+read_mbtowc_t read_mbtowc_t_create() { return read_mbtowc_t{}; }

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -11,6 +11,9 @@
 
 #include "common.h"
 #include "maybe.h"
+#if INCLUDE_RUST_HEADERS
+#include "input_common.rs.h"
+#endif
 
 enum class readline_cmd_t {
     beginning_of_line,
@@ -183,10 +186,6 @@ class char_event_t {
     }
 };
 
-/// Adjust the escape timeout.
-class environment_t;
-void update_wait_on_escape_ms(const environment_t &vars);
-
 /// A class which knows how to produce a stream of input events.
 /// This is a base class; you may subclass it for its override points.
 class input_event_queue_t {
@@ -246,5 +245,20 @@ class input_event_queue_t {
     int in_{0};
     std::deque<char_event_t> queue_;
 };
+
+/// Adjust the escape timeout.
+class environment_t;
+void update_wait_on_escape_ms(const environment_t &vars);
+
+bool is_single_byte_locale();
+
+struct read_mbtowc_t {
+    wchar_t res{};
+    mbstate_t inner = {};
+    int read_mbtowc(char rb);
+    wchar_t get_char() const { return res; };
+};
+
+read_mbtowc_t read_mbtowc_t_create();
 
 #endif

--- a/src/parser.h
+++ b/src/parser.h
@@ -386,7 +386,7 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     env_stack_t &vars() { return *variables; }
     const env_stack_t &vars() const { return *variables; }
 
-    int remove_var_ffi(const wcstring &key, int mode) { return vars().remove(key, mode); }
+    int remove_var_ffi(const wcstring &key, env_mode_flags_t mode) { return vars().remove(key, mode); }
 
     /// Get the library data.
     library_data_t &libdata() { return library_data; }

--- a/src/parser.h
+++ b/src/parser.h
@@ -386,7 +386,9 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     env_stack_t &vars() { return *variables; }
     const env_stack_t &vars() const { return *variables; }
 
-    int remove_var_ffi(const wcstring &key, env_mode_flags_t mode) { return vars().remove(key, mode); }
+    int remove_var_ffi(const wcstring &key, env_mode_flags_t mode) {
+        return vars().remove(key, mode);
+    }
 
     /// Get the library data.
     library_data_t &libdata() { return library_data; }
@@ -433,7 +435,7 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
     job_t *job_get_from_pid(pid_t pid) const;
 
     /// Returns the job and position with the given pid.
-    job_t *job_get_from_pid(int64_t pid, size_t& job_pos) const;
+    job_t *job_get_from_pid(int64_t pid, size_t &job_pos) const;
 
     /// Returns a new profile item if profiling is active. The caller should fill it in.
     /// The parser_t will deallocate it.


### PR DESCRIPTION
## Description

Porting bind builtin with global input mappings to rust

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
