### PR TITLE
Rewrite `wrealpath` from `wutil` in Rust

### DIFF
--- a/fish-rust/src/ffi.rs
+++ b/fish-rust/src/ffi.rs
@@ -90,6 +90,8 @@ include_cpp! {
     generate!("re::regex_t")
     generate!("re::regex_result_ffi")
     generate!("re::try_compile_ffi")
+    generate!("wcs2string")
+    generate!("str2wcstring")
 }
 
 impl parser_t {

--- a/fish-rust/src/wchar_ffi.rs
+++ b/fish-rust/src/wchar_ffi.rs
@@ -143,3 +143,15 @@ impl WCharFromFFI<WString> for cxx::SharedPtr<cxx::CxxWString> {
         WString::from_chars(self.as_chars())
     }
 }
+
+impl WCharFromFFI<Vec<u8>> for cxx::UniquePtr<cxx::CxxString> {
+    fn from_ffi(&self) -> Vec<u8> {
+        self.as_bytes().to_vec()
+    }
+}
+
+impl WCharFromFFI<Vec<u8>> for cxx::SharedPtr<cxx::CxxString> {
+    fn from_ffi(&self) -> Vec<u8> {
+        self.as_bytes().to_vec()
+    }
+}

--- a/fish-rust/src/wutil/mod.rs
+++ b/fish-rust/src/wutil/mod.rs
@@ -1,12 +1,14 @@
 pub mod format;
 pub mod gettext;
 mod wcstoi;
+mod wrealpath;
 
 use std::io::Write;
 
 pub(crate) use format::printf::sprintf;
 pub(crate) use gettext::{wgettext, wgettext_fmt};
 pub use wcstoi::*;
+pub use wrealpath::*;
 
 /// Port of the wide-string wperror from `src/wutil.cpp` but for rust `&str`.
 pub fn perror(s: &str) {

--- a/fish-rust/src/wutil/wrealpath.rs
+++ b/fish-rust/src/wutil/wrealpath.rs
@@ -37,7 +37,7 @@ pub fn wrealpath(pathname: &wstr) -> Option<WString> {
         // Check if everything up to the last path component is valid.
         let pathsep_idx = narrow_path.iter().rposition(|&c| c == b'/');
 
-        if let Some(0) = pathsep_idx {
+        if pathsep_idx == Some(0) {
             // If the only pathsep is the first character then it's an absolute path with a
             // single path component and thus doesn't need conversion.
             narrow_path

--- a/fish-rust/src/wutil/wrealpath.rs
+++ b/fish-rust/src/wutil/wrealpath.rs
@@ -1,0 +1,72 @@
+use std::{ffi::OsStr, fs::canonicalize, os::unix::prelude::OsStrExt};
+
+use cxx::{CxxString, UniquePtr};
+
+use crate::{
+    ffi::{make_string, str2wcstring, wcs2string},
+    wchar::{wstr, WString},
+    wchar_ffi::{WCharFromFFI, WCharToFFI},
+};
+
+pub fn wrealpath(pathname: &wstr) -> Option<WString> {
+    if pathname.is_empty() {
+        return None;
+    }
+
+    let mut real_path: UniquePtr<CxxString> = make_string("");
+    let narrow_path_ptr: UniquePtr<CxxString> = wcs2string(&pathname.to_ffi());
+    // We can't `pop` from a `UniquePtr<CxxString>` so we copy it into a vector
+    let mut narrow_path = narrow_path_ptr.as_bytes().to_vec();
+
+    // Strip trailing slashes. This is treats "/a//" as equivalent to "/a" if /a is a non-directory.
+    while narrow_path.len() > 1 && narrow_path[narrow_path.len() - 1] as char == '/' {
+        narrow_path.pop();
+    }
+
+    // `from_bytes` is Unix specific but there isn't really any other way to do this
+    // since `libc::realpath` is also Unix specific. I also don't think we support Windows
+    // outside of WSL + Cygwin (which should be fairly Unix-like anyways)
+    let narrow_res = canonicalize(OsStr::from_bytes(&narrow_path));
+
+    if let Ok(result) = narrow_res {
+        real_path
+            .pin_mut()
+            .push_bytes(result.as_os_str().as_bytes());
+    } else {
+        // Check if everything up to the last path component is valid.
+        let pathsep_idx = narrow_path.iter().rposition(|&c| c as char == '/');
+
+        if let Some(0) = pathsep_idx {
+            // If the only pathsep is the first character then it's an absolute path with a
+            // single path component and thus doesn't need conversion.
+            real_path.pin_mut().clear();
+            real_path.pin_mut().push_bytes(&narrow_path);
+        } else {
+            // Only call realpath() on the portion up to the last component.
+            let narrow_res = if let Some(pathsep_idx) = pathsep_idx {
+                // Only call realpath() on the portion up to the last component.
+                canonicalize(OsStr::from_bytes(&narrow_path[0..pathsep_idx]))
+            } else {
+                // If there is no "/", this is a file in $PWD, so give the realpath to that.
+                canonicalize(".")
+            };
+
+            let Ok(narrow_result) = narrow_res else { return None; };
+
+            let pathsep_idx = pathsep_idx.map_or(0, |idx| idx + 1);
+
+            real_path
+                .pin_mut()
+                .push_bytes(narrow_result.as_os_str().as_bytes());
+
+            // This test is to deal with cases such as /../../x => //x.
+            if real_path.len() > 1 {
+                real_path.pin_mut().push_str("/");
+            }
+
+            real_path.pin_mut().push_bytes(&narrow_path[pathsep_idx..]);
+        }
+    }
+
+    Some(str2wcstring(real_path.as_ref()?).from_ffi())
+}

--- a/fish-rust/src/wutil/wrealpath.rs
+++ b/fish-rust/src/wutil/wrealpath.rs
@@ -1,4 +1,8 @@
-use std::{ffi::OsStr, fs::canonicalize, os::unix::prelude::OsStrExt};
+use std::{
+    ffi::OsStr,
+    fs::canonicalize,
+    os::unix::prelude::{OsStrExt, OsStringExt},
+};
 
 use cxx::let_cxx_string;
 
@@ -15,7 +19,6 @@ pub fn wrealpath(pathname: &wstr) -> Option<WString> {
         return None;
     }
 
-    let mut real_path = Vec::new();
     let mut narrow_path: Vec<u8> = wcs2string(&pathname.to_ffi()).from_ffi();
 
     // Strip trailing slashes. This is treats "/a//" as equivalent to "/a" if /a is a non-directory.
@@ -28,8 +31,8 @@ pub fn wrealpath(pathname: &wstr) -> Option<WString> {
     // outside of WSL + Cygwin (which should be fairly Unix-like anyways)
     let narrow_res = canonicalize(OsStr::from_bytes(&narrow_path));
 
-    if let Ok(result) = narrow_res {
-        real_path.extend_from_slice(result.as_os_str().as_bytes());
+    let real_path = if let Ok(result) = narrow_res {
+        result.into_os_string().into_vec()
     } else {
         // Check if everything up to the last path component is valid.
         let pathsep_idx = narrow_path.iter().rposition(|&c| c == b'/');
@@ -37,8 +40,7 @@ pub fn wrealpath(pathname: &wstr) -> Option<WString> {
         if let Some(0) = pathsep_idx {
             // If the only pathsep is the first character then it's an absolute path with a
             // single path component and thus doesn't need conversion.
-            real_path.clear();
-            real_path.extend(narrow_path);
+            narrow_path
         } else {
             // Only call realpath() on the portion up to the last component.
             let narrow_res = if let Some(pathsep_idx) = pathsep_idx {
@@ -53,7 +55,7 @@ pub fn wrealpath(pathname: &wstr) -> Option<WString> {
 
             let pathsep_idx = pathsep_idx.map_or(0, |idx| idx + 1);
 
-            real_path.extend_from_slice(narrow_result.as_os_str().as_bytes());
+            let mut real_path = narrow_result.into_os_string().into_vec();
 
             // This test is to deal with cases such as /../../x => //x.
             if real_path.len() > 1 {
@@ -61,8 +63,10 @@ pub fn wrealpath(pathname: &wstr) -> Option<WString> {
             }
 
             real_path.extend_from_slice(&narrow_path[pathsep_idx..]);
+
+            real_path
         }
-    }
+    };
 
     let_cxx_string!(s = real_path);
 

--- a/src/common.h
+++ b/src/common.h
@@ -289,10 +289,10 @@ void show_stackframe(int frame_count = 100, int skip_levels = 0);
 ///
 /// This function encodes illegal character sequences in a reversible way using the private use
 /// area.
-wcstring str2wcstring(const char *in);
-wcstring str2wcstring(const char *in, size_t len);
 wcstring str2wcstring(const std::string &in);
 wcstring str2wcstring(const std::string &in, size_t len);
+wcstring str2wcstring(const char *in);
+wcstring str2wcstring(const char *in, size_t len);
 
 /// Returns a newly allocated multibyte character string equivalent of the specified wide character
 /// string.


### PR DESCRIPTION
Reopen of #9567, which was closed because the target branch was merged. This is needed for a number of other builtins. `autocxx` didn't generate the overloads for `str2wcstring` so I had to change the order of declaration to make it generate the "right" one.
