### PR TITLE
Port fish_wcstod*() to Rust

### DIFF
--- a/fish-rust/src/wutil/wcstoi.rs
+++ b/fish-rust/src/wutil/wcstoi.rs
@@ -13,6 +13,8 @@ struct ParseResult {
     result: u64,
     negative: bool,
     consumed_all: bool,
+    radix: u32,
+    num_digits: u32,
 }
 
 /// Helper to get the current char, or \0.
@@ -88,7 +90,7 @@ where
         _ => negative = false,
     }
 
-    let mut consumed1 = false;
+    let mut num_digits = 0;
 
     // Determine the radix.
     let radix = match mradix {
@@ -106,12 +108,12 @@ where
                 16
             } else if recognize.octal {
                 // If no more numbers follow, that's fine, then it's just 0.
-                consumed1 = true;
+                num_digits += 1;
                 8
             } else if recognize.decimal {
                 // Octal numbers are not allowed, so this must simply be a leading zero of a decimal
                 // number.
-                consumed1 = true;
+                num_digits += 1;
                 10
             } else {
                 // no prefix, and no (un-prefixed) decimal numbers allowed.
@@ -133,11 +135,11 @@ where
             .and_then(|r| r.checked_add(digit as u64))
             .ok_or(Error::Overflow)?;
         chars.next();
-        consumed1 = true;
+        num_digits += 1;
     }
 
     // Did we consume at least one char?
-    if !consumed1 {
+    if num_digits == 0 {
         return Err(Error::InvalidDigit);
     }
 
@@ -150,6 +152,8 @@ where
         result,
         negative,
         consumed_all,
+        radix,
+        num_digits,
     })
 }
 

--- a/fish-rust/src/wutil/wcstoi.rs
+++ b/fish-rust/src/wutil/wcstoi.rs
@@ -90,7 +90,7 @@ where
 ///   - Otherwise 10.
 /// The parse result contains the number as a u64, and whether it was negative.
 fn fish_parse_radix<Chars>(
-    ichars: Chars,
+    chars: &mut Peekable<Chars>,
     mradix: Radix,
     options: ParseOptions,
 ) -> Result<ParseResult, Error>
@@ -100,9 +100,8 @@ where
     if let Radix::Plain(r) = mradix {
         assert!((2..=36).contains(&r), "fish_parse_radix: invalid radix {r}");
     }
-    let chars = &mut ichars.peekable();
 
-    let skip_underscores = |chars| {
+    let skip_underscores = |chars: &mut _| {
         if options.allow_underscores {
             while current(chars) == '_' {
                 chars.next();
@@ -213,6 +212,8 @@ where
     Chars: Iterator<Item = char>,
     Int: PrimInt,
 {
+    let src = &mut src.peekable();
+
     let bits = Int::zero().count_zeros();
     assert!(bits <= 64, "fish_wcstoi: Int must be <= 64 bits");
     let signed = Int::min_value() < Int::zero();

--- a/fish-rust/src/wutil/wcstoi.rs
+++ b/fish-rust/src/wutil/wcstoi.rs
@@ -62,6 +62,27 @@ struct ParseOptions {
     allow_underscores: bool,
 }
 
+enum Sign {
+    Positive,
+    Negative,
+}
+
+/// Tries to consume a `+` or `-` sign, or returns `None` if no sign prefix is present.
+fn parse_sign<Chars>(chars: &mut Peekable<Chars>) -> Option<Sign>
+where
+    Chars: Iterator<Item = char>,
+{
+    if current(chars) == '+' {
+        chars.next();
+        Some(Sign::Positive)
+    } else if current(chars) == '-' {
+        chars.next();
+        Some(Sign::Negative)
+    } else {
+        None
+    }
+}
+
 /// Parse the given \p src as an integer.
 /// If mradix is not None, it is used as the radix; otherwise the radix is inferred:
 ///   - Leading 0x or 0X means 16.
@@ -105,11 +126,8 @@ where
     // Consume leading +/-.
     let mut negative = false;
     if options.sign_prefix {
-        if current(chars) == '+' {
-            chars.next();
-        } else if current(chars) == '-' {
+        if let Some(Sign::Negative) = parse_sign(chars) {
             negative = true;
-            chars.next();
         }
     }
 

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -3043,6 +3043,7 @@ static void test_fish_wcstod_underscores() {
 
     test_case(L"123", 3);
     test_case(L"1_2.3_4.5_6", 7);
+    test_case(L"_-__1_23e-2.5", 11);
     test_case(L"1_2", 3);
     test_case(L"1_._2", 5);
     test_case(L"1__2", 4);
@@ -3057,6 +3058,7 @@ static void test_fish_wcstod_underscores() {
     test_case(L"1 ", 1);
     test_case(L"infinity_", 8);
     test_case(L" -INFINITY", 10);
+    test_case(L"_-INFINITY", 0);
     test_case(L"_infinity", 0);
     test_case(L"nan(0)", 6);
     test_case(L"nan(0)_", 6);


### PR DESCRIPTION
## Description

Unfortunately the Rust standard library does not offer partial parsing (leaving the unparseable suffix alone), so this reimplements both the C standard library's `wcstod` and fish's modifications in Rust.

There are some differences which I haven't been able to paper over so far, I'm not sure how imporant they are:

- e.g. `0x` is a parse error rather than `(0.0, "x")`; for that one in particular there's even a test for the `math` builtin (`math "0x 3"` should be the same as `0 * 3`, but is an error with the new float parser).
- `nan(foo)` creates platform-specific NAN values. The new parser does not recognize brackets after NAN at all.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
