### PR TITLE
Run rustfmt and clippy in CI

### DIFF
--- a/.github/workflows/rust_checks.yml
+++ b/.github/workflows/rust_checks.yml
@@ -1,0 +1,42 @@
+name: Rust checks
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: SetupRust
+      uses: ATiltedTree/setup-rust@v1
+      with:
+        rust-version: stable
+    - name: cargo fmt
+      run: |
+        cd fish-rust
+        cargo fmt --check --all
+
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: SetupRust
+      uses: ATiltedTree/setup-rust@v1
+      with:
+        rust-version: stable
+    - name: Install deps
+      run: |
+        sudo apt install gettext libncurses5-dev libpcre2-dev python3-pip tmux
+        sudo pip3 install pexpect
+    - name: cmake
+      run: |
+        cmake -B build
+    - name: cargo clippy
+      run: |
+        cd fish-rust
+        cargo clippy --workspace --all-targets -- --deny=warnings

--- a/doc_internal/rust-devel.md
+++ b/doc_internal/rust-devel.md
@@ -60,6 +60,7 @@ The basic development loop for this port:
 4. Decide whether any existing C++ callers should invoke the Rust implementation, or whether we should keep the C++ one.
    - Utility functions may have both a Rust and C++ implementation. An example is `FLOG` where interop is too hard.
    - Major components (e.g. builtin implementations) should _not_ be duplicated; instead the Rust should call C++ or vice-versa.
+5. Remember to run `cargo fmt` and `cargo clippy` to keep the codebase somewhat clean (otherwise CI will fail). If you use rust-analyzer, you can run clippy automatically by setting `rust-analyzer.checkOnSave.command = "clippy"`.
 
 You will likely run into limitations of [`autocxx`](https://google.github.io/autocxx/) and to a lesser extent [`cxx`](https://cxx.rs/). See the [FFI sections](#ffi) below.
 

--- a/fish-rust/Cargo.toml
+++ b/fish-rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fish-rust"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.67"
 
 
 [dependencies]

--- a/fish-rust/src/common.rs
+++ b/fish-rust/src/common.rs
@@ -112,10 +112,6 @@ pub fn valid_func_name(name: &wstr) -> bool {
     true
 }
 
-pub const fn assert_send<T: Send>() -> () {
-    ()
-}
+pub const fn assert_send<T: Send>() {}
 
-pub const fn assert_sync<T: Sync>() -> () {
-    ()
-}
+pub const fn assert_sync<T: Sync>() {}

--- a/fish-rust/src/job_group.rs
+++ b/fish-rust/src/job_group.rs
@@ -1,4 +1,4 @@
-use self::job_group::pgid_t;
+use self::ffi::pgid_t;
 use crate::common::{assert_send, assert_sync};
 use crate::wchar_ffi::{WCharFromFFI, WCharToFFI};
 use cxx::{CxxWString, UniquePtr};
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 use widestring::WideUtfString;
 
 #[cxx::bridge]
-mod job_group {
+mod ffi {
     // Not only does cxx bridge not recognize libc::pid_t, it doesn't even recognize i32 as a POD
     // type! :sadface:
     struct pgid_t {


### PR DESCRIPTION
## Description

This ensures that master always contains rustfmt and clippy-clean code, allowing contributors to use these tools effectively (without a bunch of false positives in existing code).

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst