### PR TITLE
xbps: actually show all packages in `__fish_print_xbps_packages`'s output.

### DIFF
--- a/share/functions/__fish_print_xbps_packages.fish
+++ b/share/functions/__fish_print_xbps_packages.fish
@@ -19,7 +19,7 @@ function __fish_print_xbps_packages
             end
         end
         # prints: <package name>	Package
-        xbps-query -Rsl | sed 's/^... \([^ ]*\)-.* .*/\1/; s/$/\t'Package'/' | tee $cache_file
+        xbps-query -Rs "" | sed 's/^... \([^ ]*\)-.* .*/\1/; s/$/\t'Package'/' | tee $cache_file
         return 0
     else
         xbps-query -l | sed 's/^.. \([^ ]*\)-.* .*/\1/' # TODO: actually put package versions in tab for locally installed packages


### PR DESCRIPTION
## Description

Title. `xbps-query` actually parses `-Rsl` as `-Rs l`, which means that packages without the letter "l" in their names or descriptions are not included in `__fish_print_xbps_packages`'s output.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
