### PR TITLE
use default trait for enum

### DIFF
--- a/fish-rust/src/parse_constants.rs
+++ b/fish-rust/src/parse_constants.rs
@@ -90,8 +90,9 @@ mod parse_constants_ffi {
 
     /// IMPORTANT: If the following enum table is modified you must also update token_type_description below.
     /// TODO above comment can be removed when we drop the FFI and get real enums.
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Default)]
     enum ParseTokenType {
+        #[default]
         invalid = 1,
 
         // Terminal types.
@@ -111,9 +112,10 @@ mod parse_constants_ffi {
     }
 
     #[repr(u8)]
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Default)]
     enum ParseKeyword {
         // 'none' is not a keyword, it is a sentinel indicating nothing.
+        #[default]
         none,
 
         kw_and,
@@ -151,7 +153,9 @@ mod parse_constants_ffi {
     }
 
     // Parse error code list.
+    #[derive(Default)]
     pub enum ParseErrorCode {
+        #[default]
         none,
 
         // Matching values from enum parser_error.
@@ -257,12 +261,6 @@ impl SourceRange {
     }
 }
 
-impl Default for ParseTokenType {
-    fn default() -> Self {
-        ParseTokenType::invalid
-    }
-}
-
 impl From<ParseTokenType> for &'static wstr {
     #[widestrs]
     fn from(token_type: ParseTokenType) -> Self {
@@ -287,12 +285,6 @@ impl From<ParseTokenType> for &'static wstr {
 fn token_type_description(token_type: ParseTokenType) -> wcharz_t {
     let s: &'static wstr = token_type.into();
     wcharz!(s)
-}
-
-impl Default for ParseKeyword {
-    fn default() -> Self {
-        ParseKeyword::none
-    }
 }
 
 impl From<ParseKeyword> for &'static wstr {
@@ -359,7 +351,7 @@ fn keyword_from_string<'a>(s: impl Into<&'a wstr>) -> ParseKeyword {
     ParseKeyword::from(s)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct ParseError {
     /// Text of the error.
     pub text: WString,
@@ -368,17 +360,6 @@ pub struct ParseError {
     /// Offset and length of the token in the source code that triggered this error.
     pub source_start: usize,
     pub source_length: usize,
-}
-
-impl Default for ParseError {
-    fn default() -> ParseError {
-        ParseError {
-            text: L!("").to_owned(),
-            code: ParseErrorCode::none,
-            source_start: 0,
-            source_length: 0,
-        }
-    }
 }
 
 impl ParseError {

--- a/fish-rust/src/parse_constants.rs
+++ b/fish-rust/src/parse_constants.rs
@@ -90,9 +90,7 @@ mod parse_constants_ffi {
 
     /// IMPORTANT: If the following enum table is modified you must also update token_type_description below.
     /// TODO above comment can be removed when we drop the FFI and get real enums.
-    #[derive(Clone, Copy, Default)]
     enum ParseTokenType {
-        #[default]
         invalid = 1,
 
         // Terminal types.
@@ -112,10 +110,8 @@ mod parse_constants_ffi {
     }
 
     #[repr(u8)]
-    #[derive(Clone, Copy, Default)]
     enum ParseKeyword {
         // 'none' is not a keyword, it is a sentinel indicating nothing.
-        #[default]
         none,
 
         kw_and,
@@ -153,9 +149,7 @@ mod parse_constants_ffi {
     }
 
     // Parse error code list.
-    #[derive(Default)]
     pub enum ParseErrorCode {
-        #[default]
         none,
 
         // Matching values from enum parser_error.
@@ -261,6 +255,12 @@ impl SourceRange {
     }
 }
 
+impl Default for ParseTokenType {
+    fn default() -> Self {
+        ParseTokenType::invalid
+    }
+}
+
 impl From<ParseTokenType> for &'static wstr {
     #[widestrs]
     fn from(token_type: ParseTokenType) -> Self {
@@ -285,6 +285,12 @@ impl From<ParseTokenType> for &'static wstr {
 fn token_type_description(token_type: ParseTokenType) -> wcharz_t {
     let s: &'static wstr = token_type.into();
     wcharz!(s)
+}
+
+impl Default for ParseKeyword {
+    fn default() -> Self {
+        ParseKeyword::none
+    }
 }
 
 impl From<ParseKeyword> for &'static wstr {
@@ -349,6 +355,14 @@ impl From<&wstr> for ParseKeyword {
 fn keyword_from_string<'a>(s: impl Into<&'a wstr>) -> ParseKeyword {
     let s: &wstr = s.into();
     ParseKeyword::from(s)
+}
+
+impl Default for ParseErrorCode {
+    fn default() -> Self {
+        Self {
+            ParseErrorCode::none
+        }
+    }
 }
 
 #[derive(Clone, Default)]

--- a/fish-rust/src/parse_constants.rs
+++ b/fish-rust/src/parse_constants.rs
@@ -359,9 +359,7 @@ fn keyword_from_string<'a>(s: impl Into<&'a wstr>) -> ParseKeyword {
 
 impl Default for ParseErrorCode {
     fn default() -> Self {
-        Self {
-            ParseErrorCode::none
-        }
+        ParseErrorCode::none
     }
 }
 


### PR DESCRIPTION
the default for enum and some other types.

## Description

Use builtin default to shorten the code.

> Note that shared enums automatically always come with impls of Copy, Clone, Eq, and PartialEq, so you're free to omit those derives on an enum.

https://cxx.rs/shared.html

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
