### PR TITLE
builtins: set_color: remove unhandled -v/--version flag

### DIFF
--- a/src/builtins/set_color.cpp
+++ b/src/builtins/set_color.cpp
@@ -90,7 +90,7 @@ static void print_colors(io_streams_t &streams, wcstring_list_t args, bool bold,
     streams.out.append(str2wcstring(outp.contents()));
 }
 
-static const wchar_t *const short_options = L":b:hvoidrcu";
+static const wchar_t *const short_options = L":b:hoidrcu";
 static const struct woption long_options[] = {{L"background", required_argument, 'b'},
                                               {L"help", no_argument, 'h'},
                                               {L"bold", no_argument, 'o'},
@@ -98,7 +98,6 @@ static const struct woption long_options[] = {{L"background", required_argument,
                                               {L"italics", no_argument, 'i'},
                                               {L"dim", no_argument, 'd'},
                                               {L"reverse", no_argument, 'r'},
-                                              {L"version", no_argument, 'v'},
                                               {L"print-colors", no_argument, 'c'},
                                               {}};
 


### PR DESCRIPTION
Invoking `set_color -v` crashes fish. This one goes way back to 2013, when `set_color` was converted to a builtin (8d95d0834d4f327ba2a4d829c64050cda80cb302)!

This was never documented and never did more than crash, so I don't think a changelog entry is required.