### PR TITLE
Detect `rust-analyzer` in build script to enable `autocxx` completions

### DIFF
--- a/fish-rust/build.rs
+++ b/fish-rust/build.rs
@@ -50,7 +50,9 @@ fn main() -> miette::Result<()> {
     let include_paths = [&fish_src_dir, &fish_build_dir, &cxx_include_dir];
     let mut builder = autocxx_build::Builder::new("src/ffi.rs", include_paths);
     // Detect `rust-analyzer` and output the autocxx stuff into `target` so we get code intelligence on it
-    if std::env::var("RUSTC_WRAPPER").map_or(true, |wrapper| !wrapper.contains("rust-analyzer")) {
+    if std::env::var("RUSTC_WRAPPER").map_or(true, |wrapper| {
+        !(wrapper.contains("rust-analyzer") || wrapper.contains("intellij-rust-native-helper"))
+    }) {
         // We need this reassignment because of how the builder pattern works
         builder = builder.custom_gendir(autocxx_gen_dir.into());
     }

--- a/fish-rust/build.rs
+++ b/fish-rust/build.rs
@@ -50,7 +50,7 @@ fn main() -> miette::Result<()> {
     let include_paths = [&fish_src_dir, &fish_build_dir, &cxx_include_dir];
     let mut builder = autocxx_build::Builder::new("src/ffi.rs", include_paths);
     // Detect `rust-analyzer` and output the autocxx stuff into `target` so we get code intelligence on it
-    if std::env::var("RUSTC_WRAPPER").as_deref() != Ok("rust-analyzer") {
+    if std::env::var("RUSTC_WRAPPER").map_or(true, |wrapper| !wrapper.contains("rust-analyzer")) {
         // We need this reassignment because of how the builder pattern works
         builder = builder.custom_gendir(autocxx_gen_dir.into());
     }


### PR DESCRIPTION
Currently the `autocxx` generated code does not produce any code intelligence because `rust-analyzer` can't find the generated code since it's not in the workspace. Here, we detect `rust-analyzer` by checking for `RUSTC_WRAPPER=rust-analyzer` and changing the output directory accordingly.

The style of the `if`-statement I added is not super canonical Rust but I believe this is easier to read than the alternatives I considered.