### PR TITLE
ScopeGuard: remove potential memory leak

### DIFF
--- a/fish-rust/src/common.rs
+++ b/fish-rust/src/common.rs
@@ -65,7 +65,7 @@ impl<T, F: FnOnce(&mut T)> ScopeGuard<T, F> {
     /// Cancels the unwind operation like [`ScopeGuard::cancel()`] but also returns the captured
     /// value (consuming the `ScopeGuard` in the process).
     pub fn rollback(mut guard: Self) -> T {
-        let _ = guard.on_drop;
+        guard.on_drop.take();
         // Safety: we're about to forget the guard altogether
         let value = unsafe { ManuallyDrop::take(&mut guard.captured) };
         std::mem::forget(guard);


### PR DESCRIPTION
Calling `ScopeGuard::rollback()` would leak the `on_drop` callable; this is a problem for `Box<dyn FnOnce>` or closures containing `Drop` data. I [originally suggested](https://github.com/fish-shell/fish-shell/pull/9653/commits/992480b1a0d0f108c25038c9d3e7bb919cc09e8c#r1133321862) `let _ = self.on_drop;` as a fix for this, but that's actually a no-op; using a named binding instead shows that this can't possibly work because you can't move out of a type implementing `Drop`. `Option::take()` replaces the field with `None` instead.