### PR TITLE
Add md-to-clip completion

### DIFF
--- a/share/completions/md-to-clip.fish
+++ b/share/completions/md-to-clip.fish
@@ -1,0 +1,8 @@
+# Source: https://github.com/command-line-interface-pages/v2-tooling/tree/main/md-to-clip
+complete -c md-to-clip -s h -l help -d 'Display help'
+complete -c md-to-clip -s v -l version -d 'Display version'
+complete -c md-to-clip -s a -l author -d 'Display author'
+complete -c md-to-clip -s e -l email -d 'Display author email'
+complete -c md-to-clip -o nfs -l no-file-save -d 'Whether to display conversion result in stdout instead of writing it to a file'
+complete -c md-to-clip -o od -l output-directory -d 'Directory where conversion result will be written'
+complete -c md-to-clip -o spc -l special-placeholder-config -d 'Config with special placeholders'


### PR DESCRIPTION
- https://github.com/command-line-interface-pages/v2-tooling/tree/main/md-to-clip

## Description

Add completion for [converter](https://github.com/command-line-interface-pages/v2-tooling/tree/main/md-to-clip) from TlDr Markdown format to [Command Line Interface Page](https://command-line-interface-pages.github.io/site.github.io/about/)'s format.

Although completion is [presented](https://github.com/command-line-interface-pages/v2-tooling/tree/main/md-to-clip#fish) in the official README, I guess it will be more convenient to have it preinstalled by default.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
