### PR TITLE
Update deno task completions to handle deno.jsonc and package.json

### DIFF
--- a/share/completions/deno.fish
+++ b/share/completions/deno.fish
@@ -2,23 +2,18 @@ deno completions fish | source
 
 # complete deno task
 set searchForDenoFilesCode '
+// order matters
 const denoFile = ["deno.json", "deno.jsonc", "package.json"];
 for (const file of denoFile) {
   try {
     Deno.statSync(file);
     // file exists
-    if (file === "package.json") {
-      console.log(
-        Object.keys(JSON.parse(Deno.readTextFileSync(file)).scripts).join("\n"),
-      );
-    } else {
-      console.log(
-        Object.keys(JSON.parse(Deno.readTextFileSync(file)).tasks).join("\n"),
-      );
-    }
+    const props = file === "package.json" ? "scripts" : "tasks";
+    console.log(
+      Object.keys(JSON.parse(Deno.readTextFileSync(file))[props]).join("\n"),
+    );
     break;
-  } catch {
-  }
+  } catch {}
 }
 '
 complete -f -c deno -n "__fish_seen_subcommand_from task" -n "__fish_is_nth_token 2" -a "(deno eval '$searchForDenoFilesCode')"

--- a/share/completions/deno.fish
+++ b/share/completions/deno.fish
@@ -21,4 +21,4 @@ for (const file of denoFile) {
   }
 }
 '
-complete -f -c deno -n "__fish_seen_subcommand_from task" -a "(deno eval '$searchForDenoFilesCode')"
+complete -f -c deno -n "__fish_seen_subcommand_from task" -n "__fish_is_nth_token 2" -a "(deno eval '$searchForDenoFilesCode')"

--- a/share/completions/deno.fish
+++ b/share/completions/deno.fish
@@ -1,2 +1,24 @@
 deno completions fish | source
-complete -f -c deno -n "__fish_seen_subcommand_from task" -a "(deno eval \"try {console.log(Object.keys(JSON.parse(Deno.readTextFileSync('deno.json')).tasks).join('\n'))} catch {} \")"
+
+# complete deno task
+set searchForDenoFilesCode '
+const denoFile = ["deno.json", "deno.jsonc", "package.json"];
+for (const file of denoFile) {
+  try {
+    Deno.statSync(file);
+    // file exists
+    if (file === "package.json") {
+      console.log(
+        Object.keys(JSON.parse(Deno.readTextFileSync(file)).scripts).join("\n"),
+      );
+    } else {
+      console.log(
+        Object.keys(JSON.parse(Deno.readTextFileSync(file)).tasks).join("\n"),
+      );
+    }
+    break;
+  } catch {
+  }
+}
+'
+complete -f -c deno -n "__fish_seen_subcommand_from task" -a "(deno eval '$searchForDenoFilesCode')"


### PR DESCRIPTION
I remembered that deno handles deno.jsonc and recently pacakge.json

I want to specify that deno task only takes one arguemnt so for example `deno task a b` is invalid but `deno task a` is, because currently it keep give the completions after each space, is there a flag for that ?


The second completion should not happen
![image](https://user-images.githubusercontent.com/22427111/226732002-d15b2014-6b3c-4b46-8250-b7692c4997b1.png)
