### PR TITLE
alias can now print the definition of a single alias

### DIFF
--- a/share/functions/alias.fish
+++ b/share/functions/alias.fish
@@ -38,8 +38,25 @@ function alias --description 'Creates a function wrapping a command'
         printf ( _ "%s: name cannot be empty\n") alias >&2
         return 1
     else if test -z "$body"
-        printf ( _ "%s: body cannot be empty\n") alias >&2
-        return 1
+        # if there is no body, try to see if the alias has already been defined
+        set -l found_alias_definition 0
+        for func in (functions -n)
+            set -l output (functions $func | string match -r -- "^function .* --description (?:'alias (.*)'|alias\\\\ (.*))\$")
+            if set -q output[2]
+                if test "$name" = "$func"
+                    # if the alias is found, print it.
+                    set output (string replace -r -- '^'$func'[= ]' '' $output[2])
+                    echo alias $func (string escape -- $output[1])
+                    set found_alias_definition 1
+                end
+            end
+        end
+        if test $found_alias_definition = 1
+            return 0
+        else
+            printf ( _ "%s: body cannot be empty\n") alias >&2
+            return 1
+        end
     end
 
     # Extract the first command from the body.


### PR DESCRIPTION
## Description

It is now possible to use alias to print the definition of a single alias.

usage:
`alias my_alias`
fish.alias will now print out the definition of my_alias

if the given alias is not in the list of functions, the error message "alias: Body cannot be empty" is printed as it was before.



Fixes issue #9686 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Please let me know if this feature will be accepted.  If this feature gets approved, I will make updates to the docs, test, and changelog.

Thanks,
Ryan