### PR TITLE
Fix adb path completion

### DIFF
--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -74,7 +74,7 @@ function __fish_adb_list_files
     end
 
     # Return list of directories suffixed with '/'
-    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type d 2\>/dev/null | awk '{print $1"/"}'
+    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type d 2\>/dev/null | awk '{print $0"/"}'
     # Return list of files
     __fish_adb_run_command find -H "$token*" -maxdepth 0 -type f 2\>/dev/null
 end


### PR DESCRIPTION
## Description

Fixed path completion for adb-connected devices. There was a bug where suffixing paths was done using the first segment of a line (ie up to a separator, here a space) in awk: `$1`. Fixed by taking the whole line instead: `$0`. Is this fix worth mentioning in the changelog? If so, I will add an entry.

### Before

<img width="569" alt="image" src="https://user-images.githubusercontent.com/29288116/229617231-f7e5ba90-4b54-4a29-ad4d-5c5d5b08c182.png">

### After

<img width="675" alt="image" src="https://user-images.githubusercontent.com/29288116/229617188-1e84e772-2537-43b7-b544-37a8e4adf504.png">


## TODOs:

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst