### PR TITLE
docs/interactive: Document fish_color_history_current variable

### DIFF
--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -125,6 +125,7 @@ Variable                                          Meaning
 .. envvar:: fish_color_status                     the last command's nonzero exit code in the default prompt
 .. envvar:: fish_color_cancel                     the '^C' indicator on a canceled command
 .. envvar:: fish_color_search_match               history search matches and selected pager items (background only)
+.. envvar:: fish_color_history_current            the current position in the history for commands like ``dirh`` and ``cdh``
 
 ==========================================        =====================================================================
 


### PR DESCRIPTION
## Description

All *.theme files set variables documented in the "Syntax highlighting variables" section, and fish_color_history_current was missing.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
