### PR TITLE
reader: Apply fish_color_selection fg color and options in vi visual mode

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1214,7 +1214,7 @@ void reader_data_t::paint_layout(const wchar_t *reason) {
 
     // Apply any selection.
     if (data.selection.has_value()) {
-        highlight_spec_t selection_color = {highlight_role_t::normal, highlight_role_t::selection};
+        highlight_spec_t selection_color = {highlight_role_t::selection, highlight_role_t::selection};
         auto end = std::min(selection->stop, colors.size());
         for (size_t i = data.selection->start; i < end; i++) {
             colors.at(i) = selection_color;


### PR DESCRIPTION
## Description

Vi visual mode selection highlighting behaves unexpectedly when the selection
foreground and background in the highlight spec don't match. The following
unexpected behaviors are:

*  The foreground color is not being applied when defined by the
   `fish_color_selection` variable.
* `set_color` options (e.g., `--bold`) would not be applied under the cursor
  when selection begins in the middle of the command line or when the cursor
  moves forward after visually selecting text backward.

With this change, visual selection respects the foreground color and any
`set_color` options are applied consistently regardless of where visual
selection begins and the position of the cursor during selection.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
