### PR TITLE
completions/git: Allow switch to complete remote branches

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1956,7 +1956,7 @@ complete -F -c git -n '__fish_git_using_command restore' -n '__fish_git_contains
 # switch options
 complete -f -c git -n __fish_git_needs_command -a switch -d 'Switch to a branch'
 complete -f -c git -n '__fish_git_using_command switch' -ka '(__fish_git_unique_remote_branches)' -d 'Unique Remote Branch'
-complete -f -c git -n '__fish_git_using_command switch' -ka '(__fish_git_local_branches)'
+complete -f -c git -n '__fish_git_using_command switch' -ka '(__fish_git_branches)'
 complete -f -c git -n '__fish_git_using_command switch' -s c -l create -d 'Create a new branch'
 complete -f -c git -n '__fish_git_using_command switch' -s C -l force-create -d 'Force create a new branch'
 complete -f -c git -n '__fish_git_using_command switch' -s d -l detach -d 'Switch to a commit for inspection and discardable experiment' -rka '(__fish_git_refs)'


### PR DESCRIPTION
## Description

completions/git: Allow switch to complete remote branches
    
While it is true that `git switch <remote-branch>` errors to disallow a detached
head without the `-d` option, it is valid to use any starting point (commit or
reference) in conjunction with the `-c` option. Additionally, the starting point
can occur before any option.
    
This enables the following completions:
    
* `git switch -c <local-name> <any-branch>`
* `git switch <any-branch> -c <local-name>`
* `git switch -d <any-starting-point>`
* `git switch <any-branch> -d`
    
The trade-off is this does allow for `git switch <remote-branch>` to be
completed with an error.
    
Note that this logically reverts 7e3d3cc30f61d466f450a61ebee7c7fcd264967f.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
