### PR TITLE
Fix typo in `set` docs

### DIFF
--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -66,7 +66,7 @@ These options modify how variables operate:
     Treat specified variable as a :ref:`path variable <variables-path>`; variable will be split on colons (``:``) and will be displayed joined by colons colons when quoted (``echo "$PATH"``) or exported.
 
 **--unpath**
-     Causes variable to no longer be tred as a :ref:`path variable <variables-path>`.
+     Causes variable to no longer be treated as a :ref:`path variable <variables-path>`.
      Note: variables ending in "PATH" are automatically path variables.
 
 Further options:


### PR DESCRIPTION
## Description
Fix a small typo in the documentation for the `set` command (the word "treated" was misspelled as "tred").

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
