### PR TITLE
Create fish_[default|vi]_key_bindings documentation

### DIFF
--- a/doc_src/cmds/fish_default_key_bindings.rst
+++ b/doc_src/cmds/fish_default_key_bindings.rst
@@ -1,0 +1,27 @@
+.. _cmd-fish_default_key_bindings:
+
+fish_default_key_bindings - set emacs key bindings for fish
+===============================================================
+
+Synopsis
+--------
+
+.. synopsis::
+
+    fish_default_key_bindings
+
+Description
+-----------
+
+``fish_default_key_bindings`` sets the emacs key bindings for ``fish`` shell.
+
+Some of the Emacs key bindings are defined :ref:`here <emacs-mode>`.
+
+There are no parameters for ``fish_default_key_bindings``.
+
+Examples
+--------
+
+To start using vi key bindings::
+
+  fish_default_key_bindings

--- a/doc_src/cmds/fish_vi_key_bindings.rst
+++ b/doc_src/cmds/fish_vi_key_bindings.rst
@@ -1,0 +1,36 @@
+.. _cmd-fish_vi_key_bindings:
+
+fish_vi_key_bindings - set vi key bindings for fish
+===============================================================
+
+Synopsis
+--------
+
+.. synopsis::
+
+    fish_vi_key_bindings
+    fish_vi_key_bindings [--no-erase] [INIT_MODE]
+
+Description
+-----------
+
+``fish_vi_key_bindings`` sets the vi key bindings for ``fish`` shell.
+
+If a valid *INIT_MODE* is provided (insert, default, visual), then that mode will become the default
+. If no *INIT_MODE* is given, the mode defaults to insert mode.
+
+The following parameters are available:
+
+**--no-erase**
+    Does not clear previous set bindings
+
+Further information on how to use :ref:`vi-mode <vi-mode>`.
+
+Examples
+--------
+
+To start using vi key bindings::
+
+  fish_vi_key_bindings
+
+or ``set -g fish_key_bindings fish_vi_key_bindings`` in :ref:`config.fish <configuration>`.

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -270,7 +270,7 @@ Command line editor
 
 The fish editor features copy and paste, a :ref:`searchable history <history-search>` and many editor functions that can be bound to special keyboard shortcuts.
 
-Like bash and other shells, fish includes two sets of keyboard shortcuts (or key bindings): one inspired by the Emacs text editor, and one by the Vi text editor. The default editing mode is Emacs. You can switch to Vi mode by running ``fish_vi_key_bindings`` and switch back with ``fish_default_key_bindings``. You can also make your own key bindings by creating a function and setting the ``fish_key_bindings`` variable to its name. For example::
+Like bash and other shells, fish includes two sets of keyboard shortcuts (or key bindings): one inspired by the Emacs text editor, and one by the Vi text editor. The default editing mode is Emacs. You can switch to Vi mode by running :doc:`fish_vi_key_bindings <cmds/fish_vi_key_bindings>` and switch back with :doc:`fish_default_key_bindings <cmds/fish_default_key_bindings>`. You can also make your own key bindings by creating a function and setting the ``fish_key_bindings`` variable to its name. For example::
 
 
     function fish_hybrid_key_bindings --description \
@@ -346,7 +346,7 @@ Some bindings are common across Emacs and Vi mode, because they aren't text edit
 Emacs mode commands
 ^^^^^^^^^^^^^^^^^^^
 
-To enable emacs mode, use ``fish_default_key_bindings``. This is also the default.
+To enable emacs mode, use :doc:`fish_default_key_bindings <cmds/fish_default_key_bindings>`. This is also the default.
 
 - :kbd:`Home` or :kbd:`Control`\ +\ :kbd:`A` moves the cursor to the beginning of the line.
 
@@ -391,8 +391,7 @@ Vi mode commands
 
 Vi mode allows for the use of Vi-like commands at the prompt. Initially, :ref:`insert mode <vi-mode-insert>` is active. :kbd:`Escape` enters :ref:`command mode <vi-mode-command>`. The commands available in command, insert and visual mode are described below. Vi mode shares :ref:`some bindings <shared-binds>` with :ref:`Emacs mode <emacs-mode>`.
 
-To enable vi mode, use ``fish_vi_key_bindings``.
-
+To enable vi mode, use :doc:`fish_vi_key_bindings <cmds/fish_vi_key_bindings>`.
 It is also possible to add all emacs-mode bindings to vi-mode by using something like::
 
 


### PR DESCRIPTION
## Description

- Create docs file for both vi and default key bindings
- Exchange `interactive.rst` mention to function to real documentation pages to make things clearer

Fixes issue #6695 (partialy)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.rst
