### PR TITLE
Ansible completion: fix typo in `--limit-hosts`

### DIFF
--- a/share/completions/ansible.fish
+++ b/share/completions/ansible.fish
@@ -8,7 +8,7 @@ complete -c ansible -s f -l forks -a "(seq 0 100)" -d "Number of parallel proces
 complete -c ansible -s h -l help -d "Shows a help message"
 complete -c ansible -s i -l inventory -r -d "Specify inventory host path or comma separated host list"
 complete -c ansible -s l -l limit -r -d "Further limit selected hosts to an additional pattern"
-complete -c ansible -l limit-hosts -r -d "List all matching hosts"
+complete -c ansible -l list-hosts -r -d "List all matching hosts"
 complete -c ansible -s m -l module-name -r -d "Module name to execute (default=command)"
 complete -c ansible -s M -l module-path -r -d "Specify path(s) to module library (default=None)"
 complete -c ansible -l new-vault-password-file -f -d "New vault password file for rekey"


### PR DESCRIPTION
## Description

I believe it's a typo in the Ansible completion file: there's no such option as `--limit-hosts`. The correct option would be `--list-hosts`, which is missing. (The option's description seems to confirm it.)