### PR TITLE
Fix `composer require` completion

### DIFF
--- a/share/completions/composer.fish
+++ b/share/completions/composer.fish
@@ -29,7 +29,7 @@ import json
 json_data = open('composer.json')
 data = json.load(json_data)
 json_data.close()
-packages = itertools.chain(data['require'].keys(), data['require-dev'].keys())
+packages = itertools.chain(data.get('require', {}).keys(), data.get('require-dev', {}).keys())
 print(\"\n\".join(packages))
       " | $python -S
 end


### PR DESCRIPTION
When no development dependencies are installed, the completion would crash with:

    KeyError: 'require-dev'