### PR TITLE
Add --remove to fish_add_path

### DIFF
--- a/doc_src/cmds/fish_add_path.rst
+++ b/doc_src/cmds/fish_add_path.rst
@@ -10,7 +10,7 @@ Synopsis
 .. synopsis::
 
     fish_add_path path ...
-    fish_add_path [(-g | --global) | (-U | --universal) | (-P | --path)] [(-m | --move)] [(-a | --append) | (-p | --prepend)] [(-v | --verbose) | (-n | --dry-run)] PATHS ...
+    fish_add_path [(-g | --global) | (-U | --universal) | (-P | --path)] [(-m | --move) | (-r | --remove)] [(-a | --append) | (-p | --prepend)] [(-v | --verbose) | (-n | --dry-run)] PATHS ...
 
 
 Description
@@ -51,6 +51,9 @@ Options
 **-m** or **--move**
     Move already-existing components to the place they would be added - by default they would be left in place and not added again.
 
+**-r** or **--remove**
+    Remove existing components. This option is a footgun for anything other than cleaning :envvar:`fish_user_paths`.
+
 **-v** or **--verbose**
     Print the :doc:`set <set>` command used.
 
@@ -73,6 +76,11 @@ Example
    # It is at /opt/mycoolthing/bin/mycoolthing,
    # so let's add the directory: /opt/mycoolthing/bin.
    > fish_add_path /opt/mycoolthing/bin
+
+   # I want to remove the path to mycoolthing.
+   # This is the only sensible use case of -r,
+   # because removing paths from an inherited $PATH is an anti-pattern.
+   > fish_add_path -r /opt/mycoolthing/bin
 
    # I want my ~/.local/bin to be checked first,
    # even if it was already added.

--- a/tests/checks/fish_add_path.fish
+++ b/tests/checks/fish_add_path.fish
@@ -61,4 +61,8 @@ PATH=$tmpdir/{bin,etc,link,sbin} fish_add_path -nPpm $tmpdir/{link,sbin} | strin
 # See that trying to add a path twice doesn't duplicate it
 PATH=$tmpdir/{bin,etc,link,sbin} fish_add_path -nPpm $tmpdir/sbin{,} | string replace -a $tmpdir ''
 # CHECK: set -g PATH /sbin /bin /etc /link
+
+# Remove existing and non-existent paths.
+PATH=$tmpdir/{bin,etc,link,fish} fish_add_path -nPr $tmpdir/{etc,sbin,fish,cat} | string replace -a $tmpdir ''
+# CHECK: set -g PATH /bin /link
 exit 0


### PR DESCRIPTION
## Description

A new option for cleaning $fish_user_paths with some warnings.
This change makes maintaining $fish_user_path easier for beginners without introducing a stand-alone footgun fish_remove_path function.

Fixes issue #8604 #9147

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
