### PR TITLE
Move thread stuff out of common.rs

### DIFF
--- a/fish-rust/src/common.rs
+++ b/fish-rust/src/common.rs
@@ -1205,23 +1205,6 @@ pub fn assert_is_background_thread() {
     crate::threads::assert_is_background_thread()
 }
 
-/// Converts the native rust [`ThreadId`](std::thread::ThreadId) to a `u64` for legacy interop
-/// purposes - this is the same type used by `is_main_thread()` and co.
-///
-/// Prefer to use the native type where possible.
-#[deprecated(note = "Use std::thread::current().id() instead")]
-pub fn thread_id() -> u64 {
-    // Check if we can safely transmute. ThreadId should be 64 bytes regardless of target/usize.
-    const _: () = if std::mem::size_of::<std::thread::ThreadId>() == std::mem::size_of::<u64>()
-        && std::mem::align_of::<std::thread::ThreadId>() == std::mem::align_of::<u64>()
-    {
-    } else {
-        panic!("ThreadId size/alignment assumption does not hold!");
-    };
-
-    unsafe { std::mem::transmute(std::thread::current().id()) }
-}
-
 /// Format the specified size (in bytes, kilobytes, etc.) into the specified stringbuffer.
 #[widestrs]
 fn format_size(mut sz: i64) -> WString {


### PR DESCRIPTION
is_main_thread() and co were previously ported to threads.rs, so remove the duplicate code and move everything else related to threads there as well. No need for common.rs to be as long as our old common.cpp!

I left #[deprecated] stubs in common.rs to help redirect anyone porting code over that we can remove after the port has finished.

Additionally, the fork guards had previously been left as a todo!() item but I ported that over. They're all called from the now-central threads::init() function so there isn't a need to call each individual thread-management-fn manually.

The decision was made a while back to try and embrace/use the native rust thread functionality and utilities so the manual thread management code has been ripped out and was replaced with code that marshals the native rust values instead. The values won't line up with what the C++ code sees, but it never lined up anyway since each was using a separate counter to keep track of the values.