### PR TITLE
Remove kitty completion in favor of official integration

### DIFF
--- a/share/completions/kitty.fish
+++ b/share/completions/kitty.fish
@@ -1,7 +1,0 @@
-function __ksi_completions
-    set --local ct (commandline --current-token)
-    set --local tokens (commandline --tokenize --cut-at-cursor --current-process)
-    printf "%s\n" $tokens $ct | command kitty +complete fish2
-end
-
-complete -f -c kitty -a "(__ksi_completions)"


### PR DESCRIPTION
## Description

This completion is currently broken with latest kitty (`Error: Invalid shell state specification: fish2`), the latest version lives at https://github.com/kovidgoyal/kitty/blob/master/shell-integration/fish/vendor_completions.d/kitty.fish.

But now kitty's shell integration has been out for a long time, and enabled by default. This means vendoring the completion in fish itself has almost no benefit - it either gets ignored or conflicts with the current version. So I suggest just removing it outright.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
