### PR TITLE
Command blocking by preexec handler

### DIFF
--- a/fish-rust/src/ffi.rs
+++ b/fish-rust/src/ffi.rs
@@ -66,6 +66,7 @@ include_cpp! {
 
     generate!("block_t")
     generate!("parser_t")
+    generate!("eval_res_t")
 
     generate!("job_t")
     generate!("process_t")

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -33,8 +33,8 @@ const wchar_t *const event_filter_names[] = {L"signal",       L"variable", L"exi
                                              L"process-exit", L"job-exit", L"caller-exit",
                                              L"generic",      nullptr};
 
-void event_fire_generic(parser_t &parser, const wcstring &name, const std::vector<wcstring> &args) {
+bool event_fire_generic(parser_t &parser, const wcstring &name, const std::vector<wcstring> &args) {
     std::vector<wcharz_t> ffi_args;
     for (const auto &arg : args) ffi_args.push_back(arg.c_str());
-    event_fire_generic_ffi(parser, name, ffi_args);
+    return event_fire_generic_ffi(parser, name, ffi_args);
 }

--- a/src/event.h
+++ b/src/event.h
@@ -30,7 +30,7 @@ extern const wchar_t *const event_filter_names[];
 
 class parser_t;
 
-void event_fire_generic(parser_t &parser, const wcstring &name,
+bool event_fire_generic(parser_t &parser, const wcstring &name,
                         const std::vector<wcstring> &args = g_empty_string_list);
 
 #endif

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -552,6 +552,9 @@ eval_res_t parser_t::eval_with(const wcstring &cmd, const io_chain_t &io,
 }
 
 eval_res_t parser_t::eval_string_ffi1(const wcstring &cmd) { return eval(cmd, io_chain_t()); }
+int parser_t::eval_string_ffi1_status(const wcstring &cmd) {
+    return this->eval_string_ffi1(cmd).status.status_value();
+}
 
 eval_res_t parser_t::eval_parsed_source(const parsed_source_ref_t &ps, const io_chain_t &io,
                                         const job_group_ref_t &job_group,

--- a/src/parser.h
+++ b/src/parser.h
@@ -338,6 +338,7 @@ class parser_t : public std::enable_shared_from_this<parser_t> {
                          const job_group_ref_t &job_group, block_type_t block_type);
 
     eval_res_t eval_string_ffi1(const wcstring &cmd);
+    int eval_string_ffi1_status(const wcstring &cmd);
 
     /// Evaluate the parsed source ps.
     /// Because the source has been parsed, a syntax error is impossible.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -3706,10 +3706,10 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             reader_history_search_t::mode_t mode =
                 (c == rl::history_token_search_backward || c == rl::history_token_search_forward)
                     ? reader_history_search_t::token
-                : (c == rl::history_prefix_search_backward ||
-                   c == rl::history_prefix_search_forward)
-                    ? reader_history_search_t::prefix
-                    : reader_history_search_t::line;
+                    : (c == rl::history_prefix_search_backward ||
+                       c == rl::history_prefix_search_forward)
+                          ? reader_history_search_t::prefix
+                          : reader_history_search_t::line;
 
             bool was_active_before = history_search.active();
 
@@ -3817,10 +3817,11 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
         case rl::backward_kill_path_component:
         case rl::backward_kill_bigword: {
             move_word_style_t style =
-                (c == rl::backward_kill_bigword ? move_word_style_t::move_word_style_whitespace
-                 : c == rl::backward_kill_path_component
-                     ? move_word_style_t::move_word_style_path_components
-                     : move_word_style_t::move_word_style_punctuation);
+                (c == rl::backward_kill_bigword
+                     ? move_word_style_t::move_word_style_whitespace
+                     : c == rl::backward_kill_path_component
+                           ? move_word_style_t::move_word_style_path_components
+                           : move_word_style_t::move_word_style_punctuation);
             // Is this the same killring item as the last kill?
             bool newv = (rls.last_cmd != rl::backward_kill_word &&
                          rls.last_cmd != rl::backward_kill_path_component &&


### PR DESCRIPTION
This PR gives a guard-like functionality to `fish_preexec` event handlers (like pre-push hooks for example). If any of the handlers exit with status code other that zero, then the command will not execute. This example shows how the handler can block the shutdown command

``` fish
function intercept --on-event fish_preexec
    if test $argv[1] = 'shutdown'
        return 1
    end
end
```

## Why adding this?

This is by no means a security feature to prevent certain commands being executed on the machine, but a handy command interceptor which can help to contain harmful effects of unintentional command execution. This is pretty common (at least for me) to just iterate over the shell history to find a command that had been run before and press enter on another command by mistake, which shouldn't have been executed (I have lost my work on a local repo several times just by rerunning `git restore .`)
This can also help to run tests and linting before running publish sub-command of package managers which might not support pre-publish hooks. I'm in need of such functionality badly :)