### PR TITLE
Port most of env to Rust

### DIFF
--- a/fish-rust/build.rs
+++ b/fish-rust/build.rs
@@ -25,6 +25,7 @@ fn main() -> miette::Result<()> {
     let source_files = vec![
         "src/abbrs.rs",
         "src/ast.rs",
+        "src/env/env_ffi.rs",
         "src/event.rs",
         "src/common.rs",
         "src/fd_monitor.rs",

--- a/fish-rust/build.rs
+++ b/fish-rust/build.rs
@@ -36,6 +36,7 @@ fn main() -> miette::Result<()> {
         "src/future_feature_flags.rs",
         "src/highlight.rs",
         "src/job_group.rs",
+        "src/null_terminated_array.rs",
         "src/parse_constants.rs",
         "src/parse_tree.rs",
         "src/parse_util.rs",

--- a/fish-rust/src/abbrs.rs
+++ b/fish-rust/src/abbrs.rs
@@ -96,6 +96,10 @@ pub fn with_abbrs_mut<R>(cb: impl FnOnce(&mut AbbreviationSet) -> R) -> R {
     cb(&mut abbrs_g)
 }
 
+pub fn abbrs_get_set() -> MutexGuard<'static, AbbreviationSet> {
+    abbrs.lock().unwrap()
+}
+
 /// Controls where in the command line abbreviations may expand.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Position {

--- a/fish-rust/src/env/env_ffi.rs
+++ b/fish-rust/src/env/env_ffi.rs
@@ -1,0 +1,119 @@
+use super::var::{EnvVar, EnvVarFlags};
+use crate::ffi::{wchar_t, wcharz_t, wcstring_list_ffi_t};
+use crate::wchar_ffi::WCharToFFI;
+use crate::wchar_ffi::{AsWstr, WCharFromFFI};
+use cxx::{CxxWString, UniquePtr};
+use std::pin::Pin;
+
+#[allow(clippy::module_inception)]
+#[cxx::bridge]
+mod env_ffi {
+    /// Return values for `EnvStack::set()`.
+    #[repr(u8)]
+    #[cxx_name = "env_stack_set_result_t"]
+    enum EnvStackSetResult {
+        ENV_OK,
+        ENV_PERM,
+        ENV_SCOPE,
+        ENV_INVALID,
+        ENV_NOT_FOUND,
+    }
+
+    extern "C++" {
+        include!("wutil.h");
+        type wcstring_list_ffi_t = super::wcstring_list_ffi_t;
+        type wcharz_t = super::wcharz_t;
+    }
+
+    extern "Rust" {
+        type EnvVar;
+
+        fn is_empty(&self) -> bool;
+
+        fn exports(&self) -> bool;
+        fn is_read_only(&self) -> bool;
+        fn is_pathvar(&self) -> bool;
+
+        #[cxx_name = "equals"]
+        fn equals_ffi(&self, rhs: &EnvVar) -> bool;
+
+        #[cxx_name = "as_string"]
+        fn as_string_ffi(&self) -> UniquePtr<CxxWString>;
+
+        #[cxx_name = "as_list"]
+        fn as_list_ffi(&self) -> UniquePtr<wcstring_list_ffi_t>;
+
+        #[cxx_name = "to_list"]
+        fn to_list_ffi(&self, out: Pin<&mut wcstring_list_ffi_t>);
+
+        #[cxx_name = "get_delimiter"]
+        fn get_delimiter_ffi(&self) -> wchar_t;
+
+        #[cxx_name = "get_flags"]
+        fn get_flags_ffi(&self) -> u8;
+
+        #[cxx_name = "clone_box"]
+        fn clone_box_ffi(&self) -> Box<EnvVar>;
+
+        #[cxx_name = "env_var_create"]
+        fn env_var_create_ffi(vals: &wcstring_list_ffi_t, flags: u8) -> Box<EnvVar>;
+
+        #[cxx_name = "env_var_create_from_name"]
+        fn env_var_create_from_name_ffi(
+            name: wcharz_t,
+            values: &wcstring_list_ffi_t,
+        ) -> Box<EnvVar>;
+    }
+}
+pub use env_ffi::EnvStackSetResult;
+
+impl Default for EnvStackSetResult {
+    fn default() -> Self {
+        EnvStackSetResult::ENV_OK
+    }
+}
+
+/// FFI bits.
+impl EnvVar {
+    pub fn equals_ffi(&self, rhs: &EnvVar) -> bool {
+        self == rhs
+    }
+
+    pub fn as_string_ffi(&self) -> UniquePtr<CxxWString> {
+        self.as_string().to_ffi()
+    }
+
+    pub fn as_list_ffi(&self) -> UniquePtr<wcstring_list_ffi_t> {
+        self.as_list().to_ffi()
+    }
+
+    pub fn to_list_ffi(&self, mut out: Pin<&mut wcstring_list_ffi_t>) {
+        out.as_mut().clear();
+        for val in self.as_list() {
+            out.as_mut().push(val);
+        }
+    }
+
+    pub fn clone_box_ffi(&self) -> Box<Self> {
+        Box::new(self.clone())
+    }
+
+    pub fn get_flags_ffi(&self) -> u8 {
+        self.get_flags().bits()
+    }
+
+    pub fn get_delimiter_ffi(self: &EnvVar) -> wchar_t {
+        self.get_delimiter().into()
+    }
+}
+
+fn env_var_create_ffi(vals: &wcstring_list_ffi_t, flags: u8) -> Box<EnvVar> {
+    Box::new(EnvVar::new_vec(
+        vals.from_ffi(),
+        EnvVarFlags::from_bits(flags).expect("invalid flags"),
+    ))
+}
+
+pub fn env_var_create_from_name_ffi(name: wcharz_t, values: &wcstring_list_ffi_t) -> Box<EnvVar> {
+    Box::new(EnvVar::new_from_name_vec(name.as_wstr(), values.from_ffi()))
+}

--- a/fish-rust/src/env/env_ffi.rs
+++ b/fish-rust/src/env/env_ffi.rs
@@ -1,8 +1,13 @@
-use super::var::{EnvVar, EnvVarFlags};
-use crate::ffi::{wchar_t, wcharz_t, wcstring_list_ffi_t};
+use super::environment::{self, EnvNull, EnvStack, EnvStackRef, Environment};
+use super::var::{ElectricVar, EnvVar, EnvVarFlags, Statuses};
+use crate::env::EnvMode;
+use crate::event::Event;
+use crate::ffi::{event_list_ffi_t, wchar_t, wcharz_t, wcstring_list_ffi_t};
+use crate::null_terminated_array::OwningNullTerminatedArrayRefFFI;
+use crate::signal::Signal;
 use crate::wchar_ffi::WCharToFFI;
 use crate::wchar_ffi::{AsWstr, WCharFromFFI};
-use cxx::{CxxWString, UniquePtr};
+use cxx::{CxxVector, CxxWString, UniquePtr};
 use std::pin::Pin;
 
 #[allow(clippy::module_inception)]
@@ -20,9 +25,15 @@ mod env_ffi {
     }
 
     extern "C++" {
+        include!("env.h");
+        include!("null_terminated_array.h");
         include!("wutil.h");
+        type event_list_ffi_t = super::event_list_ffi_t;
         type wcstring_list_ffi_t = super::wcstring_list_ffi_t;
         type wcharz_t = super::wcharz_t;
+
+        type OwningNullTerminatedArrayRefFFI =
+            crate::null_terminated_array::OwningNullTerminatedArrayRefFFI;
     }
 
     extern "Rust" {
@@ -63,6 +74,81 @@ mod env_ffi {
             name: wcharz_t,
             values: &wcstring_list_ffi_t,
         ) -> Box<EnvVar>;
+    }
+    extern "Rust" {
+        type EnvNull;
+        #[cxx_name = "getf"]
+        fn getf_ffi(&self, name: &CxxWString, mode: u16) -> *mut EnvVar;
+        #[cxx_name = "get_names"]
+        fn get_names_ffi(&self, flags: u16, out: Pin<&mut wcstring_list_ffi_t>);
+        #[cxx_name = "env_null_create"]
+        fn env_null_create_ffi() -> Box<EnvNull>;
+    }
+
+    extern "Rust" {
+        type Statuses;
+        #[cxx_name = "get_status"]
+        fn get_status_ffi(&self) -> i32;
+
+        #[cxx_name = "get_pipestatus"]
+        fn get_pipestatus_ffi(&self) -> &Vec<i32>;
+
+        #[cxx_name = "get_kill_signal"]
+        fn get_kill_signal_ffi(&self) -> i32;
+    }
+
+    extern "Rust" {
+        #[cxx_name = "EnvDyn"]
+        type EnvDynFFI;
+        fn getf(&self, name: &CxxWString, mode: u16) -> *mut EnvVar;
+        fn get_names(&self, flags: u16, out: Pin<&mut wcstring_list_ffi_t>);
+    }
+
+    extern "Rust" {
+        #[cxx_name = "EnvStackRef"]
+        type EnvStackRefFFI;
+        fn getf(&self, name: &CxxWString, mode: u16) -> *mut EnvVar;
+        fn get_names(&self, flags: u16, out: Pin<&mut wcstring_list_ffi_t>);
+        fn is_principal(&self) -> bool;
+        fn get_last_statuses(&self) -> Box<Statuses>;
+        fn set_last_statuses(&self, status: i32, kill_signal: i32, pipestatus: &CxxVector<i32>);
+        fn set(
+            &self,
+            name: &CxxWString,
+            flags: u16,
+            vals: &wcstring_list_ffi_t,
+        ) -> EnvStackSetResult;
+        fn remove(&self, name: &CxxWString, flags: u16) -> EnvStackSetResult;
+        fn get_pwd_slash(&self) -> UniquePtr<CxxWString>;
+        fn set_pwd_from_getcwd(&self);
+
+        fn push(&mut self, new_scope: bool);
+        fn pop(&mut self);
+
+        // Returns a ``Box<OwningNullTerminatedArrayRefFFI>.into_raw()``.
+        fn export_array(&self) -> *mut OwningNullTerminatedArrayRefFFI;
+
+        fn snapshot(&self) -> Box<EnvDynFFI>;
+
+        // Access a variable stack that only represents globals.
+        // Do not push or pop from this.
+        fn env_get_globals_ffi() -> Box<EnvStackRefFFI>;
+
+        // Access the principal variable stack.
+        fn env_get_principal_ffi() -> Box<EnvStackRefFFI>;
+
+        fn universal_sync(&self, always: bool, out_events: Pin<&mut event_list_ffi_t>);
+    }
+
+    extern "Rust" {
+        #[cxx_name = "var_is_electric"]
+        fn var_is_electric_ffi(name: &CxxWString) -> bool;
+
+        #[cxx_name = "rust_env_init"]
+        fn rust_env_init_ffi(do_uvars: bool);
+
+        #[cxx_name = "env_flags_for"]
+        fn env_flags_for_ffi(name: wcharz_t) -> u8;
     }
 }
 pub use env_ffi::EnvStackSetResult;
@@ -116,4 +202,168 @@ fn env_var_create_ffi(vals: &wcstring_list_ffi_t, flags: u8) -> Box<EnvVar> {
 
 pub fn env_var_create_from_name_ffi(name: wcharz_t, values: &wcstring_list_ffi_t) -> Box<EnvVar> {
     Box::new(EnvVar::new_from_name_vec(name.as_wstr(), values.from_ffi()))
+}
+
+fn env_null_create_ffi() -> Box<EnvNull> {
+    Box::new(EnvNull::new())
+}
+
+/// FFI wrapper around dyn Environment.
+pub struct EnvDynFFI(Box<dyn Environment>);
+impl EnvDynFFI {
+    fn getf(&self, name: &CxxWString, mode: u16) -> *mut EnvVar {
+        EnvironmentFFI::getf_ffi(&*self.0, name, mode)
+    }
+    fn get_names(&self, flags: u16, out: Pin<&mut wcstring_list_ffi_t>) {
+        EnvironmentFFI::get_names_ffi(&*self.0, flags, out)
+    }
+}
+
+/// FFI wrapper around EnvStackRef.
+pub struct EnvStackRefFFI(EnvStackRef);
+
+impl EnvStackRefFFI {
+    fn getf(&self, name: &CxxWString, mode: u16) -> *mut EnvVar {
+        EnvironmentFFI::getf_ffi(&*self.0, name, mode)
+    }
+    fn get_names(&self, flags: u16, out: Pin<&mut wcstring_list_ffi_t>) {
+        EnvironmentFFI::get_names_ffi(&*self.0, flags, out)
+    }
+    fn is_principal(&self) -> bool {
+        self.0.is_principal()
+    }
+
+    fn get_pwd_slash(&self) -> UniquePtr<CxxWString> {
+        self.0.get_pwd_slash().to_ffi()
+    }
+
+    fn push(&self, new_scope: bool) {
+        self.0.push(new_scope)
+    }
+
+    fn pop(&self) {
+        self.0.pop()
+    }
+
+    fn get_last_statuses(&self) -> Box<Statuses> {
+        Box::new(self.0.get_last_statuses())
+    }
+
+    fn set_last_statuses(&self, status: i32, kill_signal: i32, pipestatus: &CxxVector<i32>) {
+        let statuses = Statuses {
+            status,
+            kill_signal: if kill_signal == 0 {
+                None
+            } else {
+                Some(Signal::new(kill_signal))
+            },
+            pipestatus: pipestatus.as_slice().to_vec(),
+        };
+        self.0.set_last_statuses(statuses)
+    }
+
+    fn set_pwd_from_getcwd(&self) {
+        self.0.set_pwd_from_getcwd()
+    }
+
+    fn set(&self, name: &CxxWString, flags: u16, vals: &wcstring_list_ffi_t) -> EnvStackSetResult {
+        let mode = EnvMode::from_bits(flags).expect("Invalid mode bits");
+        self.0.set(name.as_wstr(), mode, vals.from_ffi())
+    }
+
+    fn remove(&self, name: &CxxWString, flags: u16) -> EnvStackSetResult {
+        let mode = EnvMode::from_bits(flags).expect("Invalid mode bits");
+        self.0.remove(name.as_wstr(), mode)
+    }
+
+    fn export_array(&self) -> *mut OwningNullTerminatedArrayRefFFI {
+        Box::into_raw(Box::new(OwningNullTerminatedArrayRefFFI(
+            self.0.export_array(),
+        )))
+    }
+
+    fn snapshot(&self) -> Box<EnvDynFFI> {
+        Box::new(EnvDynFFI(self.0.snapshot()))
+    }
+
+    fn universal_sync(
+        self: &EnvStackRefFFI,
+        always: bool,
+        mut out_events: Pin<&mut event_list_ffi_t>,
+    ) {
+        let events: Vec<Box<Event>> = self.0.universal_sync(always);
+        for event in events {
+            out_events.as_mut().push(Box::into_raw(event).cast());
+        }
+    }
+}
+
+impl Statuses {
+    fn get_status_ffi(&self) -> i32 {
+        self.status
+    }
+
+    fn get_pipestatus_ffi(&self) -> &Vec<i32> {
+        &self.pipestatus
+    }
+
+    fn get_kill_signal_ffi(&self) -> i32 {
+        match self.kill_signal {
+            Some(sig) => sig.code(),
+            None => 0,
+        }
+    }
+}
+
+fn env_get_globals_ffi() -> Box<EnvStackRefFFI> {
+    Box::new(EnvStackRefFFI(EnvStack::globals().clone()))
+}
+
+fn env_get_principal_ffi() -> Box<EnvStackRefFFI> {
+    Box::new(EnvStackRefFFI(EnvStack::principal().clone()))
+}
+
+// We have to implement these directly to make cxx happy, even though they're implemented in the EnvironmentFFI trait.
+impl EnvNull {
+    pub fn getf_ffi(&self, name: &CxxWString, mode: u16) -> *mut EnvVar {
+        EnvironmentFFI::getf_ffi(self, name, mode)
+    }
+    pub fn get_names_ffi(&self, flags: u16, out: Pin<&mut wcstring_list_ffi_t>) {
+        EnvironmentFFI::get_names_ffi(self, flags, out)
+    }
+}
+
+trait EnvironmentFFI: Environment {
+    /// FFI helper.
+    /// This returns either null, or the result of Box.into_raw().
+    /// This is a workaround for the difficulty of passing an Option through FFI.
+    fn getf_ffi(&self, name: &CxxWString, mode: u16) -> *mut EnvVar {
+        match self.getf(
+            name.as_wstr(),
+            EnvMode::from_bits(mode).expect("Invalid mode bits"),
+        ) {
+            None => std::ptr::null_mut(),
+            Some(var) => Box::into_raw(Box::new(var)),
+        }
+    }
+    fn get_names_ffi(&self, mode: u16, mut out: Pin<&mut wcstring_list_ffi_t>) {
+        let names = self.get_names(EnvMode::from_bits(mode).expect("Invalid mode bits"));
+        for name in names {
+            out.as_mut().push(name.to_ffi());
+        }
+    }
+}
+
+impl<T: Environment + ?Sized> EnvironmentFFI for T {}
+
+fn var_is_electric_ffi(name: &CxxWString) -> bool {
+    ElectricVar::for_name(name.as_wstr()).is_some()
+}
+
+fn rust_env_init_ffi(do_uvars: bool) {
+    environment::env_init(do_uvars);
+}
+
+fn env_flags_for_ffi(name: wcharz_t) -> u8 {
+    EnvVar::flags_for(name.as_wstr()).bits()
 }

--- a/fish-rust/src/env/environment.rs
+++ b/fish-rust/src/env/environment.rs
@@ -1,44 +1,435 @@
-#![allow(unused_variables)]
-//! Prototypes for functions for manipulating fish script variables.
+use super::environment_impl::{
+    colon_split, uvars, EnvMutex, EnvMutexGuard, EnvScopedImpl, EnvStackImpl, ModResult,
+    UVAR_SCOPE_IS_GLOBAL,
+};
+use crate::abbrs::{abbrs_get_set, Abbreviation, Position};
+use crate::common::{unescape_string, UnescapeStringStyle};
+use crate::env::{EnvMode, EnvStackSetResult, EnvVar, Statuses};
+use crate::event::Event;
+use crate::ffi::{self, env_universal_t, universal_notifier_t};
+use crate::flog::FLOG;
+use crate::global_safety::RelaxedAtomicBool;
+use crate::null_terminated_array::OwningNullTerminatedArray;
+use crate::path::path_make_canonical;
+use crate::wchar::{wstr, WExt, WString, L};
+use crate::wchar_ffi::{AsWstr, WCharFromFFI, WCharToFFI};
+use crate::wcstringutil::join_strings;
+use crate::wutil::{wgetcwd, wgettext};
 
-use crate::env::{EnvMode, EnvVar};
-use crate::wchar::{wstr, WString};
+use autocxx::WithinUniquePtr;
+use cxx::UniquePtr;
+use lazy_static::lazy_static;
+use libc::c_int;
+use std::sync::{Arc, Mutex};
 
-// Limit `read` to 100 MiB (bytes not wide chars) by default. This can be overridden by the
-// fish_read_limit variable.
-const DEFAULT_READ_BYTE_LIMIT: usize = 100 * 1024 * 1024;
-pub static mut read_byte_limit: usize = DEFAULT_READ_BYTE_LIMIT;
-pub static mut curses_initialized: bool = true;
+/// TODO: migrate to history once ported.
+const DFLT_FISH_HISTORY_SESSION_ID: &wstr = L!("fish");
 
+// Universal variables instance.
+lazy_static! {
+    static ref UVARS: Mutex<UniquePtr<env_universal_t>> = Mutex::new(env_universal_t::new_unique());
+}
+
+/// Set when a universal variable has been modified but not yet been written to disk via sync().
+static UVARS_LOCALLY_MODIFIED: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
+
+/// Convert an EnvVar to an FFI env_var_t.
+fn env_var_to_ffi(var: EnvVar) -> cxx::UniquePtr<ffi::env_var_t> {
+    ffi::env_var_t::new_ffi(Box::into_raw(Box::from(var)).cast()).within_unique_ptr()
+}
+
+/// An environment is read-only access to variable values.
 pub trait Environment {
+    /// Get a variable by name using default flags.
     fn get(&self, name: &wstr) -> Option<EnvVar> {
-        todo!()
+        self.getf(name, EnvMode::DEFAULT)
     }
-    fn getf(&self, name: &wstr, mode: EnvMode) -> Option<EnvVar> {
-        todo!()
+
+    /// Get a variable by name using the specified flags.
+    fn getf(&self, name: &wstr, mode: EnvMode) -> Option<EnvVar>;
+
+    /// Return the list of variable names.
+    fn get_names(&self, flags: EnvMode) -> Vec<WString>;
+
+    /// Returns PWD with a terminating slash.
+    fn get_pwd_slash(&self) -> WString {
+        // Return "/" if PWD is missing.
+        // See https://github.com/fish-shell/fish-shell/issues/5080
+        let Some(var) = self.get(L!("PWD")) else {
+            return WString::from("/");
+        };
+        let mut pwd = WString::new();
+        if var.is_empty() {
+            pwd = var.as_string();
+        }
+        if !pwd.ends_with('/') {
+            pwd.push('/');
+        }
+        pwd
     }
+
+    /// Get a variable by name using default flags, unless it is empty.
     fn get_unless_empty(&self, name: &wstr) -> Option<EnvVar> {
-        todo!()
+        self.getf_unless_empty(name, EnvMode::DEFAULT)
     }
+
+    /// Get a variable by name using the given flags, unless it is empty.
     fn getf_unless_empty(&self, name: &wstr, mode: EnvMode) -> Option<EnvVar> {
-        todo!()
+        let var = self.getf(name, mode)?;
+        if !var.is_empty() {
+            return Some(var);
+        }
+        None
     }
 }
 
-pub enum EnvStackSetResult {
-    ENV_OK,
+/// The null environment contains nothing.
+pub struct EnvNull;
+
+impl EnvNull {
+    pub fn new() -> EnvNull {
+        EnvNull
+    }
 }
 
-pub struct EnvStack {}
-impl Environment for EnvStack {}
+impl Environment for EnvNull {
+    fn getf(&self, _name: &wstr, _mode: EnvMode) -> Option<EnvVar> {
+        None
+    }
+
+    fn get_names(&self, _flags: EnvMode) -> Vec<WString> {
+        Vec::new()
+    }
+}
+
+/// An immutable environment, used in snapshots.
+pub struct EnvScoped {
+    inner: EnvMutex<EnvScopedImpl>,
+}
+
+impl EnvScoped {
+    fn from_impl(inner: EnvMutex<EnvScopedImpl>) -> EnvScoped {
+        EnvScoped { inner }
+    }
+
+    fn lock(&self) -> EnvMutexGuard<EnvScopedImpl> {
+        self.inner.lock()
+    }
+}
+
+/// A mutable environment which allows scopes to be pushed and popped.
+/// This backs the parser's "vars".
+pub struct EnvStack {
+    inner: EnvMutex<EnvStackImpl>,
+}
+
 impl EnvStack {
+    fn new() -> EnvStack {
+        EnvStack {
+            inner: EnvStackImpl::new(),
+        }
+    }
+
+    fn lock(&self) -> EnvMutexGuard<EnvStackImpl> {
+        self.inner.lock()
+    }
+
+    /// \return whether we are the principal stack.
+    pub fn is_principal(&self) -> bool {
+        self as *const Self == Arc::as_ptr(&*PRINCIPAL_STACK)
+    }
+
+    /// Helpers to get and set the proc statuses.
+    /// These correspond to $status and $pipestatus.
+    pub fn get_last_statuses(&self) -> Statuses {
+        self.lock().base.get_last_statuses().clone()
+    }
+
+    pub fn get_last_status(&self) -> c_int {
+        self.lock().base.get_last_statuses().status
+    }
+
+    pub fn set_last_statuses(&self, statuses: Statuses) {
+        self.lock().base.set_last_statuses(statuses);
+    }
+
+    /// Sets the variable with the specified name to the given values.
+    pub fn set(&self, key: &wstr, mode: EnvMode, mut vals: Vec<WString>) -> EnvStackSetResult {
+        // Historical behavior.
+        if vals.len() == 1 && (key == "PWD" || key == "HOME") {
+            path_make_canonical(vals.first_mut().unwrap());
+        }
+
+        // Hacky stuff around PATH and CDPATH: #3914.
+        // Not MANPATH; see #4158.
+        // Replace empties with dot. Note we ignore pathvar here.
+        if key == "PATH" || key == "CDPATH" {
+            // Split on colons.
+            let mut munged_vals = colon_split(&vals);
+            // Replace empties with dots.
+            for val in munged_vals.iter_mut() {
+                if val.is_empty() {
+                    val.push('.');
+                }
+            }
+            vals = munged_vals;
+        }
+
+        let ret: ModResult = self.lock().set(key, mode, vals);
+        if ret.status == EnvStackSetResult::ENV_OK {
+            // If we modified the global state, or we are principal, then dispatch changes.
+            // Important to not hold the lock here.
+            if ret.global_modified || self.is_principal() {
+                ffi::env_dispatch_var_change_ffi(&key.to_ffi() /* , self */);
+            }
+        }
+        // Mark if we modified a uvar.
+        if ret.uvar_modified {
+            UVARS_LOCALLY_MODIFIED.store(true);
+        }
+        ret.status
+    }
+
+    /// Sets the variable with the specified name to a single value.
     pub fn set_one(&self, key: &wstr, mode: EnvMode, val: WString) -> EnvStackSetResult {
-        todo!()
+        self.set(key, mode, vec![val])
+    }
+
+    /// Sets the variable with the specified name to no values.
+    pub fn set_empty(&self, key: &wstr, mode: EnvMode) -> EnvStackSetResult {
+        self.set(key, mode, Vec::new())
+    }
+
+    /// Update the PWD variable based on the result of getcwd.
+    pub fn set_pwd_from_getcwd(&self) {
+        let cwd = wgetcwd();
+        if cwd.is_empty() {
+            FLOG!(
+                error,
+                wgettext!(
+                    "Could not determine current working directory. Is your locale set correctly?"
+                )
+            );
+        }
+        self.set_one(L!("PWD"), EnvMode::EXPORT | EnvMode::GLOBAL, cwd);
+    }
+
+    /// Remove environment variable.
+    ///
+    /// \param key The name of the variable to remove
+    /// \param mode should be ENV_USER if this is a remove request from the user, 0 otherwise. If
+    /// this is a user request, read-only variables can not be removed. The mode may also specify
+    /// the scope of the variable that should be erased.
+    ///
+    /// \return the set result.
+    pub fn remove(&self, key: &wstr, mode: EnvMode) -> EnvStackSetResult {
+        let ret = self.lock().remove(key, mode);
+        #[allow(clippy::collapsible_if)]
+        if ret.status == EnvStackSetResult::ENV_OK {
+            if ret.global_modified || self.is_principal() {
+                // Important to not hold the lock here.
+                ffi::env_dispatch_var_change_ffi(&key.to_ffi() /*,  self */);
+            }
+        }
+        if ret.uvar_modified {
+            UVARS_LOCALLY_MODIFIED.store(true);
+        }
+        ret.status
+    }
+
+    /// Push the variable stack. Used for implementing local variables for functions and for-loops.
+    pub fn push(&self, new_scope: bool) {
+        let mut imp = self.lock();
+        if new_scope {
+            imp.push_shadowing();
+        } else {
+            imp.push_nonshadowing();
+        }
+    }
+
+    /// Pop the variable stack. Used for implementing local variables for functions and for-loops.
+    pub fn pop(&self) {
+        let popped = self.lock().pop();
+        // Only dispatch variable changes if we are the principal environment.
+        if self.is_principal() {
+            // TODO: we would like to coalesce locale / curses changes, so that we only re-initialize
+            // once.
+            for key in popped {
+                ffi::env_dispatch_var_change_ffi(&key.to_ffi() /*, self */);
+            }
+        }
+    }
+
+    /// Returns an array containing all exported variables in a format suitable for execv.
+    pub fn export_array(&self) -> Arc<OwningNullTerminatedArray> {
+        self.lock().base.export_array()
+    }
+
+    /// Snapshot this environment. This means returning a read-only copy. Local variables are copied
+    /// but globals are shared (i.e. changes to global will be visible to this snapshot).
+    pub fn snapshot(&self) -> Box<dyn Environment> {
+        let scoped = EnvScoped::from_impl(self.lock().base.snapshot());
+        Box::new(scoped)
+    }
+
+    /// Synchronizes universal variable changes.
+    /// If \p always is set, perform synchronization even if there's no pending changes from this
+    /// instance (that is, look for changes from other fish instances).
+    /// \return a list of events for changed variables.
+    #[allow(clippy::vec_box)]
+    pub fn universal_sync(&self, always: bool) -> Vec<Box<Event>> {
+        if UVAR_SCOPE_IS_GLOBAL.load() {
+            return Vec::new();
+        }
+        if !always && !UVARS_LOCALLY_MODIFIED.load() {
+            return Vec::new();
+        }
+        UVARS_LOCALLY_MODIFIED.store(false);
+
+        let mut unused = autocxx::c_int(0);
+        let sync_res_ptr = uvars().as_mut().unwrap().sync_ffi().within_unique_ptr();
+        let sync_res = sync_res_ptr.as_ref().unwrap();
+        if sync_res.get_changed() {
+            universal_notifier_t::default_notifier_ffi(std::pin::Pin::new(&mut unused))
+                .post_notification();
+        }
+        // React internally to changes to special variables like LANG, and populate on-variable events.
+        let mut result = Vec::new();
+        #[allow(unreachable_code)]
+        for idx in 0..sync_res.count() {
+            let name = sync_res.get_key(idx).from_ffi();
+            ffi::env_dispatch_var_change_ffi(&name.to_ffi() /* , self */);
+            let evt = if sync_res.get_is_erase(idx) {
+                Event::variable_erase(name)
+            } else {
+                Event::variable_set(name)
+            };
+            result.push(Box::new(evt));
+        }
+        result
+    }
+
+    /// A variable stack that only represents globals.
+    /// Do not push or pop from this.
+    pub fn globals() -> &'static EnvStackRef {
+        &GLOBALS
+    }
+
+    /// Access the principal variable stack, associated with the principal parser.
+    pub fn principal() -> &'static EnvStackRef {
+        &PRINCIPAL_STACK
     }
 }
 
-impl EnvStack {
-    pub fn globals() -> &'static dyn Environment {
-        todo!()
+impl Environment for EnvScoped {
+    fn getf(&self, key: &wstr, mode: EnvMode) -> Option<EnvVar> {
+        self.lock().getf(key, mode)
+    }
+
+    fn get_names(&self, flags: EnvMode) -> Vec<WString> {
+        self.lock().get_names(flags)
+    }
+
+    fn get_pwd_slash(&self) -> WString {
+        self.lock().get_pwd_slash()
+    }
+}
+
+/// Necessary for Arc<EnvStack> to be sync.
+/// Safety: again, the global lock.
+unsafe impl Send for EnvStack {}
+
+impl Environment for EnvStack {
+    fn getf(&self, key: &wstr, mode: EnvMode) -> Option<EnvVar> {
+        self.lock().getf(key, mode)
+    }
+
+    fn get_names(&self, flags: EnvMode) -> Vec<WString> {
+        self.lock().get_names(flags)
+    }
+
+    fn get_pwd_slash(&self) -> WString {
+        self.lock().get_pwd_slash()
+    }
+}
+
+pub type EnvStackRef = Arc<EnvStack>;
+
+// A variable stack that only represents globals.
+// Do not push or pop from this.
+lazy_static! {
+    static ref GLOBALS: EnvStackRef = Arc::new(EnvStack::new());
+}
+
+// Our singleton "principal" stack.
+lazy_static! {
+    static ref PRINCIPAL_STACK: EnvStackRef = Arc::new(EnvStack::new());
+}
+
+// Note: this is an incomplete port of env_init(); the rest remains in C++.
+pub fn env_init(do_uvars: bool) {
+    if !do_uvars {
+        UVAR_SCOPE_IS_GLOBAL.store(true);
+    } else {
+        // let vars = EnvStack::principal();
+
+        // Set up universal variables using the default path.
+        let callbacks = uvars()
+            .as_mut()
+            .unwrap()
+            .initialize_ffi()
+            .within_unique_ptr();
+        let callbacks = callbacks.as_ref().unwrap();
+        for idx in 0..callbacks.count() {
+            ffi::env_dispatch_var_change_ffi(callbacks.get_key(idx) /* , vars */);
+        }
+
+        // Do not import variables that have the same name and value as
+        // an exported universal variable. See issues #5258 and #5348.
+        let mut table = uvars()
+            .as_ref()
+            .unwrap()
+            .get_table_ffi()
+            .within_unique_ptr();
+        for idx in 0..table.count() {
+            // autocxx gets confused when a value goes Rust -> Cxx -> Rust.
+            let uvar = table.as_mut().unwrap().get_var(idx).from_ffi();
+            if !uvar.exports() {
+                continue;
+            }
+            let name: &wstr = table.get_name(idx).as_wstr();
+
+            // Look for a global exported variable with the same name.
+            let global = EnvStack::globals().getf(name, EnvMode::GLOBAL | EnvMode::EXPORT);
+            if global.is_some() && global.unwrap().as_string() == uvar.as_string() {
+                EnvStack::globals().remove(name, EnvMode::GLOBAL | EnvMode::EXPORT);
+            }
+        }
+
+        // Import any abbreviations from uvars.
+        // Note we do not dynamically react to changes.
+        let prefix = L!("_fish_abbr_");
+        let prefix_len = prefix.char_count();
+        let from_universal = true;
+        let mut abbrs = abbrs_get_set();
+        for idx in 0..table.count() {
+            let name: &wstr = table.get_name(idx).as_wstr();
+            if !name.starts_with(prefix) {
+                continue;
+            }
+            let escaped_name = name.slice_from(prefix_len);
+            if let Some(name) = unescape_string(escaped_name, UnescapeStringStyle::Var) {
+                let key = name.clone();
+                let uvar = table.get_var(idx).from_ffi();
+                let replacement: WString = join_strings(uvar.as_list(), ' ');
+                abbrs.add(Abbreviation::new(
+                    name,
+                    key,
+                    replacement,
+                    Position::Command,
+                    from_universal,
+                ));
+            }
+        }
     }
 }

--- a/fish-rust/src/env/environment_impl.rs
+++ b/fish-rust/src/env/environment_impl.rs
@@ -1,0 +1,1226 @@
+use crate::common::wcs2zstring;
+use crate::env::{
+    is_read_only, ElectricVar, EnvMode, EnvStackSetResult, EnvVar, EnvVarFlags, Statuses, VarTable,
+    ELECTRIC_VARIABLES, PATH_ARRAY_SEP,
+};
+use crate::ffi::{self, env_universal_t};
+use crate::flog::FLOG;
+use crate::global_safety::RelaxedAtomicBool;
+use crate::null_terminated_array::OwningNullTerminatedArray;
+use crate::threads::{is_forked_child, is_main_thread};
+use crate::wchar::{widestrs, wstr, WExt, WString, L};
+use crate::wchar_ext::ToWString;
+use crate::wchar_ffi::{WCharFromFFI, WCharToFFI};
+use crate::wutil::{fish_wcstoi_opts, sprintf, Options};
+
+use autocxx::WithinUniquePtr;
+use cxx::UniquePtr;
+use lazy_static::lazy_static;
+use std::cell::{RefCell, UnsafeCell};
+use std::collections::HashSet;
+use std::ffi::CString;
+use std::marker::PhantomData;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+
+use std::sync::{atomic::AtomicU64, atomic::Ordering, Arc, Mutex, MutexGuard};
+
+/// TODO: migrate to history once ported.
+const DFLT_FISH_HISTORY_SESSION_ID: &wstr = L!("fish");
+
+// Universal variables instance.
+lazy_static! {
+    static ref UVARS: Mutex<UniquePtr<env_universal_t>> = Mutex::new(env_universal_t::new_unique());
+}
+
+/// Getter for universal variables.
+/// This is typically initialized in env_init(), and is considered empty before then.
+pub fn uvars() -> MutexGuard<'static, UniquePtr<env_universal_t>> {
+    UVARS.lock().unwrap()
+}
+
+/// Whether we were launched with no_config; in this case setting a uvar instead sets a global.
+pub static UVAR_SCOPE_IS_GLOBAL: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
+
+/// Helper to get the kill ring.
+fn get_kill_ring_entries() -> Vec<WString> {
+    ffi::kill_entries_ffi().from_ffi()
+}
+
+/// Helper to get the history for a session ID.
+fn get_history_var_text(history_session_id: &wstr) -> Vec<WString> {
+    ffi::get_history_variable_text_ffi(&history_session_id.to_ffi()).from_ffi()
+}
+
+/// Convert an FFI env_var_t to our EnvVar.
+impl ffi::env_var_t {
+    #[allow(clippy::wrong_self_convention)]
+    pub fn from_ffi(&self) -> EnvVar {
+        let var_ptr: *const EnvVar = self.ffi_ptr().cast();
+        let var: &EnvVar = unsafe { &*var_ptr };
+        var.clone()
+    }
+}
+
+/// Apply the pathvar behavior, splitting about colons.
+pub fn colon_split<T: AsRef<wstr>>(val: &[T]) -> Vec<WString> {
+    let mut split_val = Vec::new();
+    for str in val.iter() {
+        split_val.extend(str.as_ref().split(PATH_ARRAY_SEP).map(|s| s.to_owned()));
+    }
+    split_val
+}
+
+/// Convert an EnvVar to an FFI env_var_t.
+fn env_var_to_ffi(var: EnvVar) -> cxx::UniquePtr<ffi::env_var_t> {
+    ffi::env_var_t::new_ffi(Box::into_raw(Box::from(var)).cast()).within_unique_ptr()
+}
+
+/// Return true if a variable should become a path variable by default. See #436.
+fn variable_should_auto_pathvar(name: &wstr) -> bool {
+    name.ends_with("PATH")
+}
+
+/// We cache our null-terminated export list. However an exported variable may change for lots of
+/// reasons: popping a scope, a modified universal variable, etc. We thus have a monotone counter.
+/// Every time an exported variable changes in a node, it acquires the next generation. 0 is a
+/// sentinel that indicates that the node contains no exported variables.
+type ExportGeneration = u64;
+fn next_export_generation() -> ExportGeneration {
+    static GEN: AtomicU64 = AtomicU64::new(0);
+    1 + GEN.fetch_add(1, Ordering::Relaxed)
+}
+
+fn set_umask(list_val: &Vec<WString>) -> EnvStackSetResult {
+    if list_val.len() != 1 || list_val[0].is_empty() {
+        return EnvStackSetResult::ENV_INVALID;
+    }
+    let opts = Options {
+        wrap_negatives: false,
+        consume_all: false,
+        mradix: Some(8),
+    };
+    let Ok(mask) = fish_wcstoi_opts(&list_val[0], opts) else {
+            return EnvStackSetResult::ENV_INVALID;
+        };
+
+    #[allow(
+        unused_comparisons,
+        clippy::manual_range_contains,
+        clippy::absurd_extreme_comparisons
+    )]
+    if mask > 0o777 || mask < 0 {
+        return EnvStackSetResult::ENV_INVALID;
+    }
+    // Do not actually create a umask variable. On env_stack_t::get() it will be calculated.
+    // SAFETY: umask cannot fail.
+    unsafe { libc::umask(mask) };
+    EnvStackSetResult::ENV_OK
+}
+
+/// A query for environment variables.
+struct Query {
+    /// Whether any scopes were specified.
+    pub has_scope: bool,
+
+    /// Whether to search local, function, global, universal scopes.
+    pub local: bool,
+    pub function: bool,
+    pub global: bool,
+    pub universal: bool,
+
+    /// Whether export or unexport was specified.
+    pub has_export_unexport: bool,
+
+    /// Whether to search exported and unexported variables.
+    pub exports: bool,
+    pub unexports: bool,
+
+    /// Whether pathvar or unpathvar was set.
+    pub has_pathvar_unpathvar: bool,
+    pub pathvar: bool,
+    pub unpathvar: bool,
+
+    /// Whether this is a "user" set.
+    pub user: bool,
+}
+
+impl Query {
+    /// Creates a `Query` from env mode flags.
+    fn new(mode: EnvMode) -> Self {
+        let has_scope = mode
+            .intersects(EnvMode::LOCAL | EnvMode::FUNCTION | EnvMode::GLOBAL | EnvMode::UNIVERSAL);
+        let has_export_unexport = mode.intersects(EnvMode::EXPORT | EnvMode::UNEXPORT);
+        Query {
+            has_scope,
+            local: !has_scope || mode.contains(EnvMode::LOCAL),
+            function: !has_scope || mode.contains(EnvMode::FUNCTION),
+            global: !has_scope || mode.contains(EnvMode::GLOBAL),
+            universal: !has_scope || mode.contains(EnvMode::UNIVERSAL),
+
+            has_export_unexport,
+            exports: !has_export_unexport || mode.contains(EnvMode::EXPORT),
+            unexports: !has_export_unexport || mode.contains(EnvMode::UNEXPORT),
+
+            // note we don't use pathvar for searches, so these don't default to true if unspecified.
+            has_pathvar_unpathvar: mode.intersects(EnvMode::PATHVAR | EnvMode::UNPATHVAR),
+            pathvar: mode.contains(EnvMode::PATHVAR),
+            unpathvar: mode.contains(EnvMode::UNPATHVAR),
+
+            user: mode.contains(EnvMode::USER),
+        }
+    }
+
+    /// Returns whether an environment variable matches the query's export criteria.
+    fn export_matches(&self, var: &EnvVar) -> bool {
+        if self.has_export_unexport {
+            if var.exports() {
+                self.exports
+            } else {
+                self.unexports
+            }
+        } else {
+            true
+        }
+    }
+
+    /// Returns whether an environment variable matches the query's path variable criteria.
+    fn pathvar_matches(&self, var: &EnvVar) -> bool {
+        if self.has_pathvar_unpathvar {
+            if var.is_pathvar() {
+                self.pathvar
+            } else {
+                self.unpathvar
+            }
+        } else {
+            true
+        }
+    }
+}
+
+// Struct representing one level in the function variable stack.
+struct EnvNode {
+    // Variable table.
+    env: VarTable,
+
+    /// Does this node imply a new variable scope? If yes, all non-global variables below this one
+    /// in the stack are invisible. If new_scope is set for the global variable node, the universe
+    /// will explode.
+    new_scope: bool,
+
+    /// The export generation. If this is nonzero, then we contain a variable that is exported to
+    /// subshells, or redefines a variable to not be exported.
+    export_gen: ExportGeneration,
+
+    /// Next scope to search. This is None if this node establishes a new scope.
+    next: Option<EnvNodeRef>,
+}
+
+impl EnvNode {
+    fn find_entry(&self, key: &wstr) -> Option<EnvVar> {
+        self.env.get(key).cloned()
+    }
+
+    fn exports(&self) -> bool {
+        self.export_gen > 0
+    }
+
+    fn changed_exported(&mut self) {
+        self.export_gen = next_export_generation();
+    }
+}
+
+/// EnvNodeRef is a reference to an EnvNode. It may be shared between different environments.
+/// Locking uses
+#[derive(Clone)]
+struct EnvNodeRef(Arc<RefCell<EnvNode>>);
+
+impl Deref for EnvNodeRef {
+    type Target = RefCell<EnvNode>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl EnvNodeRef {
+    fn new(is_new_scope: bool, next: Option<EnvNodeRef>) -> EnvNodeRef {
+        EnvNodeRef(Arc::new(RefCell::new(EnvNode {
+            env: VarTable::new(),
+            new_scope: is_new_scope,
+            export_gen: 0,
+            next,
+        })))
+    }
+
+    /// Return whether this points at the same value as another node.
+    fn ptr_eq(&self, other: &EnvNodeRef) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+
+    /// Cover over find_entry.
+    fn find_entry(&self, key: &wstr) -> Option<EnvVar> {
+        self.borrow().find_entry(key)
+    }
+
+    /// Cover over next.
+    fn next(&self) -> Option<EnvNodeRef> {
+        self.borrow().next.clone()
+    }
+
+    /// Helper to get an iterator over the chain of EnvNodeRefs.
+    fn iter(&self) -> EnvNodeIter {
+        EnvNodeIter::new(self.clone())
+    }
+}
+
+// Safety: in order to do anything with an EnvNodeRef, the caller must be holding ENV_LOCK.
+unsafe impl Sync for EnvNodeRef {}
+
+/// Helper to iterate over a chain of EnvNodeRefs.
+struct EnvNodeIter {
+    current: Option<EnvNodeRef>,
+}
+
+impl EnvNodeIter {
+    fn new(start: EnvNodeRef) -> EnvNodeIter {
+        EnvNodeIter {
+            current: Some(start),
+        }
+    }
+}
+
+impl Iterator for EnvNodeIter {
+    type Item = EnvNodeRef;
+
+    fn next(&mut self) -> Option<EnvNodeRef> {
+        let current: Option<EnvNodeRef> = self.current.take();
+        if let Some(ref current) = current {
+            self.current = current.next();
+        }
+        current
+    }
+}
+
+lazy_static! {
+    static ref GLOBAL_NODE: EnvNodeRef = EnvNodeRef::new(false, None);
+}
+
+/// Recursive helper to snapshot a series of nodes.
+fn copy_node_chain(node: &EnvNodeRef) -> EnvNodeRef {
+    let next = node.next().as_ref().map(copy_node_chain);
+    let node = node.borrow();
+    let new_node = EnvNode {
+        env: node.env.clone(),
+        export_gen: node.export_gen,
+        new_scope: node.new_scope,
+        next,
+    };
+    EnvNodeRef(Arc::new(RefCell::new(new_node)))
+}
+
+/// A struct wrapping up parser-local variables. These are conceptually variables that differ in
+/// different fish internal processes.
+#[derive(Default, Clone)]
+struct PerprocData {
+    pwd: WString,
+    statuses: Statuses,
+}
+
+pub struct EnvScopedImpl {
+    // A linked list of scopes.
+    locals: EnvNodeRef,
+
+    // Global scopes. There is no parent here.
+    globals: EnvNodeRef,
+
+    // Per process data.
+    perproc_data: PerprocData,
+
+    // Exported variable array used by execv.
+    export_array: Option<Arc<OwningNullTerminatedArray>>,
+
+    // Cached list of export generations corresponding to the above export_array.
+    // If this differs from the current export generations then we need to regenerate the array.
+    export_array_generations: Vec<ExportGeneration>,
+}
+
+impl EnvScopedImpl {
+    /// Creates a new `EnvScopedImpl` with the specified local and global scopes.
+    fn new(locals: EnvNodeRef, globals: EnvNodeRef) -> Self {
+        EnvScopedImpl {
+            locals,
+            globals,
+            perproc_data: PerprocData::default(),
+            export_array: None,
+            export_array_generations: Vec::new(),
+        }
+    }
+
+    pub fn get_last_statuses(&self) -> &Statuses {
+        &self.perproc_data.statuses
+    }
+
+    pub fn set_last_statuses(&mut self, s: Statuses) {
+        self.perproc_data.statuses = s;
+    }
+
+    #[widestrs]
+    fn try_get_computed(&self, key: &wstr) -> Option<EnvVar> {
+        let ev = ElectricVar::for_name(key);
+        if ev.is_none() || !ev.unwrap().computed() {
+            return None;
+        }
+
+        if key == "PWD"L {
+            Some(EnvVar::new(
+                self.perproc_data.pwd.clone(),
+                EnvVarFlags::EXPORT,
+            ))
+        } else if key == "history"L {
+            // Big hack. We only allow getting the history on the main thread. Note that history_t
+            // may ask for an environment variable, so don't take the lock here (we don't need it).
+            if (!is_main_thread()) {
+                return None;
+            }
+            let fish_history_var = self
+                .getf(L!("fish_history"), EnvMode::DEFAULT)
+                .map(|v| v.as_string());
+            let history_session_id = fish_history_var
+                .as_ref()
+                .map(WString::as_utfstr)
+                .unwrap_or(DFLT_FISH_HISTORY_SESSION_ID);
+            let vals = get_history_var_text(history_session_id);
+            return Some(EnvVar::new_from_name_vec("history"L, vals));
+        } else if key == "fish_killring"L {
+            Some(EnvVar::new_from_name_vec(
+                "fish_killring"L,
+                get_kill_ring_entries(),
+            ))
+        } else if key == "pipestatus"L {
+            let js = &self.perproc_data.statuses;
+            let mut result = Vec::new();
+            result.reserve(js.pipestatus.len());
+            for i in &js.pipestatus {
+                result.push(i.to_wstring());
+            }
+            Some(EnvVar::new_from_name_vec("pipestatus"L, result))
+        } else if key == "status"L {
+            let js = &self.perproc_data.statuses;
+            Some(EnvVar::new_from_name("status"L, js.status.to_wstring()))
+        } else if key == "status_generation"L {
+            let status_generation = ffi::reader_status_count();
+            Some(EnvVar::new_from_name(
+                "status_generation"L,
+                status_generation.to_wstring(),
+            ))
+        } else if key == "fish_kill_signal"L {
+            let js = &self.perproc_data.statuses;
+            let signal = js.kill_signal.map_or(0, |ks| ks.code());
+            Some(EnvVar::new_from_name(
+                "fish_kill_signal"L,
+                signal.to_wstring(),
+            ))
+        } else if key == "umask"L {
+            // note umask() is an absurd API: you call it to set the value and it returns the old
+            // value. Thus we have to call it twice, to reset the value. The env_lock protects
+            // against races. Guess what the umask is; if we guess right we don't need to reset it.
+            let guess: libc::mode_t = 0o022;
+            // Safety: umask cannot error.
+            let res: libc::mode_t = unsafe { libc::umask(guess) };
+            if res != guess {
+                unsafe { libc::umask(res) };
+            }
+            Some(EnvVar::new_from_name("umask"L, sprintf!("0%0.3o", res)))
+        } else {
+            // We should never get here unless the electric var list is out of sync with the above code.
+            panic!("Unrecognized computed var name {}", key);
+        }
+    }
+
+    fn try_get_local(&self, key: &wstr) -> Option<EnvVar> {
+        for cur in self.locals.iter() {
+            let entry = cur.find_entry(key);
+            if entry.is_some() {
+                return entry;
+            }
+        }
+        None
+    }
+
+    fn try_get_function(&self, key: &wstr) -> Option<EnvVar> {
+        let mut entry = None;
+        let mut node = self.locals.clone();
+        while let Some(next_node) = node.next() {
+            node = next_node;
+            // The first node that introduces a new scope is ours.
+            // If this doesn't happen, we go on until we've reached the
+            // topmost local scope.
+            if node.borrow().new_scope {
+                break;
+            }
+        }
+        for cur in node.iter() {
+            entry = cur.find_entry(key);
+            if entry.is_some() {
+                break;
+            }
+        }
+        entry
+    }
+
+    fn try_get_global(&self, key: &wstr) -> Option<EnvVar> {
+        self.globals.find_entry(key)
+    }
+
+    fn try_get_universal(&self, key: &wstr) -> Option<EnvVar> {
+        return uvars()
+            .as_ref()
+            .expect("Should have non-null uvars in this function")
+            .get_ffi(&key.to_ffi())
+            .as_ref()
+            .map(|v| v.from_ffi());
+    }
+
+    pub fn getf(&self, key: &wstr, mode: EnvMode) -> Option<EnvVar> {
+        let query = Query::new(mode);
+        let mut result: Option<EnvVar> = None;
+        // Computed variables are effectively global and can't be shadowed.
+        if query.global {
+            result = self.try_get_computed(key);
+        }
+        if result.is_none() && query.local {
+            result = self.try_get_local(key);
+        }
+        if result.is_none() && query.function {
+            result = self.try_get_function(key);
+        }
+        if result.is_none() && query.global {
+            result = self.try_get_global(key);
+        }
+        if result.is_none() && query.universal {
+            result = self.try_get_universal(key);
+        }
+        // If the user requested only exported or unexported variables, enforce that here.
+        if result.is_some() && !query.export_matches(result.as_ref().unwrap()) {
+            result = None;
+        }
+        // Same for pathvars
+        if result.is_some() && !query.pathvar_matches(result.as_ref().unwrap()) {
+            result = None;
+        }
+        result
+    }
+
+    pub fn get_names(&self, flags: EnvMode) -> Vec<WString> {
+        let query = Query::new(flags);
+        let mut names: HashSet<WString> = HashSet::new();
+
+        // Helper to add the names of variables from \p envs to names, respecting show_exported and
+        // show_unexported.
+        let add_keys = |envs: &VarTable, names: &mut HashSet<WString>| {
+            for (key, val) in envs.iter() {
+                if query.export_matches(val) {
+                    names.insert(key.clone());
+                }
+            }
+        };
+
+        if query.local {
+            for cur in self.locals.iter() {
+                add_keys(&cur.borrow().env, &mut names);
+            }
+        }
+
+        if query.global {
+            add_keys(&self.globals.borrow().env, &mut names);
+            // Add electrics.
+            for ev in ELECTRIC_VARIABLES {
+                let matches = if ev.exports() {
+                    query.exports
+                } else {
+                    query.unexports
+                };
+                if matches {
+                    names.insert(WString::from(ev.name));
+                }
+            }
+        }
+
+        if query.universal {
+            let uni_list = uvars()
+                .as_ref()
+                .expect("Should have non-null uvars in this function")
+                .get_names_ffi(query.exports, query.unexports)
+                .from_ffi();
+            names.extend(uni_list.into_iter());
+        }
+        names.into_iter().collect()
+    }
+
+    /// Slightly optimized implementation.
+    pub fn get_pwd_slash(&self) -> WString {
+        let mut pwd = self.perproc_data.pwd.clone();
+        if !pwd.ends_with('/') {
+            pwd.push('/');
+        }
+        pwd
+    }
+
+    /// Return a copy of self, with copied locals but shared globals.
+    pub fn snapshot(&self) -> EnvMutex<Self> {
+        EnvMutex::new(EnvScopedImpl {
+            locals: copy_node_chain(&self.locals),
+            globals: self.globals.clone(),
+            perproc_data: self.perproc_data.clone(),
+            export_array: None,
+            export_array_generations: Vec::new(),
+        })
+    }
+}
+
+/// Export array implementations.
+impl EnvScopedImpl {
+    /// Invoke a function on the current (nonzero) export generations, in order.
+    fn enumerate_generations<F>(&self, mut func: F)
+    where
+        F: FnMut(u64),
+    {
+        // Our uvars generation count doesn't come from next_export_generation(), so always supply
+        // it even if it's 0.
+        func(uvars().as_ref().unwrap().get_export_generation());
+        if self.globals.borrow().exports() {
+            func(self.globals.borrow().export_gen);
+        }
+        for node in self.locals.iter() {
+            if node.borrow().exports() {
+                func(node.borrow().export_gen);
+            }
+        }
+    }
+
+    /// Return whether the current export array is empty or out-of-date.
+    fn export_array_needs_regeneration(&self) -> bool {
+        // Check if our export array is stale. If we don't have one, it's obviously stale. Otherwise,
+        // compare our cached generations with the current generations. If they don't match exactly then
+        // our generation list is stale.
+        if self.export_array.is_none() {
+            return true;
+        }
+
+        let mut cursor = self.export_array_generations.iter().fuse();
+        let mut mismatch = true;
+        self.enumerate_generations(|gen| {
+            if cursor.next().cloned() != Some(gen) {
+                mismatch = true;
+            }
+        });
+        if cursor.next().is_some() {
+            mismatch = true;
+        }
+        return mismatch;
+    }
+
+    /// Get the exported variables into a variable table.
+    fn get_exported(n: &EnvNodeRef, table: &mut VarTable) {
+        let n = n.borrow();
+
+        // Allow parent scopes to populate first, since we may want to overwrite those results.
+        if let Some(next) = n.next.as_ref() {
+            Self::get_exported(next, table);
+        }
+
+        for (key, var) in n.env.iter() {
+            if var.exports() {
+                // Export the variable. Note this overwrites existing values from previous scopes.
+                table.insert(key.clone(), var.clone());
+            } else {
+                // We need to erase from the map if we are not exporting, since a lower scope may have
+                // exported. See #2132.
+                table.remove(key);
+            }
+        }
+    }
+
+    /// Return a newly allocated export array.
+    fn create_export_array(&self) -> Arc<OwningNullTerminatedArray> {
+        FLOG!(env_export, "create_export_array() recalc");
+        let mut vals = VarTable::new();
+        Self::get_exported(&self.globals, &mut vals);
+        Self::get_exported(&self.locals, &mut vals);
+
+        let uni = uvars()
+            .as_ref()
+            .unwrap()
+            .get_names_ffi(true, false)
+            .from_ffi();
+        for key in uni {
+            let var = uvars()
+                .as_ref()
+                .unwrap()
+                .get_ffi(&key.to_ffi())
+                .as_ref()
+                .map(|v| v.from_ffi())
+                .expect("Variable should be present in uvars");
+            // Only insert if not already present, as uvars have lowest precedence.
+            // TODO: a longstanding bug is that an unexported local variable will not mask an exported uvar.
+            vals.entry(key).or_insert(var);
+        }
+
+        // Dorky way to add our single exported computed variable.
+        vals.insert(
+            L!("PWD").to_owned(),
+            EnvVar::new_from_name(L!("PWD"), self.perproc_data.pwd.clone()),
+        );
+
+        // Construct the export list: a list of strings of the form key=value.
+        let mut export_list: Vec<CString> = Vec::new();
+        export_list.reserve(vals.len());
+        for (key, val) in vals.into_iter() {
+            let mut str = key;
+            str.push('=');
+            str.push_utfstr(&val.as_string());
+            export_list.push(wcs2zstring(&str));
+        }
+        return Arc::new(OwningNullTerminatedArray::new(export_list));
+    }
+
+    // Exported variable array used by execv.
+    pub fn export_array(&mut self) -> Arc<OwningNullTerminatedArray> {
+        assert!(!is_forked_child());
+        if self.export_array_needs_regeneration() {
+            self.export_array = Some(self.create_export_array());
+
+            // Have to pull this into a local to satisfy the borrow checker.
+            let mut generations = std::mem::take(&mut self.export_array_generations);
+            generations.clear();
+            self.enumerate_generations(|gen| generations.push(gen));
+            self.export_array_generations = generations;
+        }
+        return self.export_array.as_ref().unwrap().clone();
+    }
+}
+
+#[derive(Copy, Clone, Default)]
+/// A restricted set of variable flags.
+struct VarFlags {
+    /// If set, whether the variable should be a path variable; otherwise guess based on the name.
+    pub pathvar: Option<bool>,
+
+    /// If set, the new export value; otherwise inherit any existing export value.
+    pub exports: Option<bool>,
+
+    /// Whether the variable is exported by some parent.
+    pub parent_exports: bool,
+}
+
+#[derive(Copy, Clone, Default)]
+pub struct ModResult {
+    /// The publicly visible status of the set call.
+    pub status: EnvStackSetResult,
+
+    /// Whether the global scope was modified.
+    pub global_modified: bool,
+
+    /// Whether universal variables were modified.
+    pub uvar_modified: bool,
+}
+
+impl ModResult {
+    /// Creates a `ModResult` with a given status.
+    fn new(status: EnvStackSetResult) -> Self {
+        ModResult {
+            status,
+            ..Default::default()
+        }
+    }
+}
+
+/// A mutable "subclass" of EnvScopedImpl.
+pub struct EnvStackImpl {
+    pub base: EnvScopedImpl,
+
+    /// The scopes of caller functions, which are currently shadowed.
+    shadowed_locals: Vec<EnvNodeRef>,
+}
+
+impl EnvStackImpl {
+    /// \return a new impl representing global variables, with a single local scope.
+    pub fn new() -> EnvMutex<EnvStackImpl> {
+        let globals = GLOBAL_NODE.clone();
+        let locals = EnvNodeRef::new(false, None);
+        let base = EnvScopedImpl::new(locals, globals);
+        EnvMutex::new(EnvStackImpl {
+            base,
+            shadowed_locals: Vec::new(),
+        })
+    }
+
+    /// Set a variable under the name \p key, using the given \p mode, setting its value to \p val.
+    pub fn set(&mut self, key: &wstr, mode: EnvMode, mut val: Vec<WString>) -> ModResult {
+        let query = Query::new(mode);
+        // Handle electric and read-only variables.
+        if let Some(ret) = self.try_set_electric(key, &query, &mut val) {
+            return ModResult::new(ret);
+        }
+
+        // Resolve as much of our flags as we can. Note these contain maybes, and we may defer the final
+        // decision until the set_in_node call. Also note that we only inherit pathvar, not export. For
+        // example, if you have a global exported variable, a local variable with the same name will not
+        // automatically be exported. But if you have a global pathvar, a local variable with the same
+        // name will be a pathvar. This is historical.
+        let mut flags = VarFlags::default();
+        if let Some(existing) = self.find_variable(key) {
+            flags.pathvar = Some(existing.is_pathvar());
+            flags.parent_exports = existing.exports();
+        }
+        if query.has_export_unexport {
+            flags.exports = Some(query.exports);
+        }
+        if query.has_pathvar_unpathvar {
+            flags.pathvar = Some(query.pathvar);
+        }
+
+        let mut result = ModResult::new(EnvStackSetResult::ENV_OK);
+        if query.has_scope {
+            // The user requested a particular scope.
+            // If we don't have uvars, fall back to using globals.
+            if query.universal && !UVAR_SCOPE_IS_GLOBAL.load() {
+                self.set_universal(key, val, query);
+                result.uvar_modified = true;
+            } else if query.global || (query.universal && UVAR_SCOPE_IS_GLOBAL.load()) {
+                Self::set_in_node(&mut self.base.globals, key, val, flags);
+                result.global_modified = true;
+            } else if query.local {
+                assert!(
+                    !self.base.locals.ptr_eq(&self.base.globals),
+                    "Locals should not be globals"
+                );
+                Self::set_in_node(&mut self.base.locals, key, val, flags);
+            } else if query.function {
+                // "Function" scope is:
+                // Either the topmost local scope of the nearest function,
+                // or the top-level local scope if no function exists.
+                //
+                // This is distinct from the unspecified scope,
+                // which is the global scope if no function exists.
+                let mut node = self.base.locals.clone();
+                while node.next().is_some() {
+                    node = node.next().unwrap();
+                    // The first node that introduces a new scope is ours.
+                    // If this doesn't happen, we go on until we've reached the
+                    // topmost local scope.
+                    if node.borrow().new_scope {
+                        break;
+                    }
+                }
+                Self::set_in_node(&mut node, key, val, flags);
+            } else {
+                panic!("Unknown scope");
+            }
+        } else if let Some(mut node) = Self::find_in_chain(&self.base.locals, key) {
+            // Existing local variable.
+            Self::set_in_node(&mut node, key, val, flags);
+        } else if let Some(mut node) = Self::find_in_chain(&self.base.globals, key) {
+            // Existing global variable.
+            Self::set_in_node(&mut node, key, val, flags);
+            result.global_modified = true;
+        } else if uvars()
+            .as_ref()
+            .unwrap()
+            .get_ffi(&key.to_ffi())
+            .as_ref()
+            .is_some()
+        {
+            // Existing universal variable.
+            self.set_universal(key, val, query);
+            result.uvar_modified = true;
+        } else {
+            // Unspecified scope with no existing variables.
+            let mut node = self.resolve_unspecified_scope();
+            Self::set_in_node(&mut node, key, val, flags);
+            result.global_modified = node.ptr_eq(&self.base.globals);
+        }
+        result
+    }
+
+    /// Remove a variable under the name \p key.
+    pub fn remove(&mut self, key: &wstr, mode: EnvMode) -> ModResult {
+        let query = Query::new(mode);
+        // Users can't remove read-only keys.
+        if query.user && is_read_only(key) {
+            return ModResult::new(EnvStackSetResult::ENV_SCOPE);
+        }
+
+        // Helper to invoke remove_from_chain and map a false return to not found.
+        fn remove_from_chain(node: &mut EnvNodeRef, key: &wstr) -> EnvStackSetResult {
+            if EnvStackImpl::remove_from_chain(node, key) {
+                EnvStackSetResult::ENV_OK
+            } else {
+                EnvStackSetResult::ENV_NOT_FOUND
+            }
+        }
+
+        let mut result = ModResult::new(EnvStackSetResult::ENV_OK);
+        if query.has_scope {
+            // The user requested erasing from a particular scope.
+            if query.universal {
+                if uvars().as_mut().unwrap().remove(&key.to_ffi()) {
+                    result.status = EnvStackSetResult::ENV_OK;
+                } else {
+                    result.status = EnvStackSetResult::ENV_NOT_FOUND;
+                }
+                // Note we have historically set this even if the uvar is not found.
+                result.uvar_modified = true;
+            } else if query.global {
+                result.status = remove_from_chain(&mut self.base.globals, key);
+                result.global_modified = true;
+            } else if query.local {
+                result.status = remove_from_chain(&mut self.base.locals, key);
+            } else if query.function {
+                let mut node = self.base.locals.clone();
+                while node.next().is_some() {
+                    node = node.next().unwrap();
+                    if node.borrow().new_scope {
+                        break;
+                    }
+                }
+                result.status = remove_from_chain(&mut node, key);
+            } else {
+                panic!("Unknown scope");
+            }
+        } else if Self::remove_from_chain(&mut self.base.locals, key) {
+            // pass
+        } else if Self::remove_from_chain(&mut self.base.globals, key) {
+            result.global_modified = true;
+        } else if uvars()
+            .as_mut()
+            .expect("Should have non-null uvars in this function")
+            .remove(&key.to_ffi())
+        {
+            result.uvar_modified = true;
+        } else {
+            result.status = EnvStackSetResult::ENV_NOT_FOUND;
+        }
+        result
+    }
+
+    /// Push a new shadowing local scope.
+    pub fn push_shadowing(&mut self) {
+        // Propagate local exported variables.
+        let node = EnvNodeRef::new(true, None);
+        for cursor in self.base.locals.iter() {
+            for (key, val) in cursor.borrow().env.iter() {
+                if val.exports() {
+                    let mut node_ref = node.borrow_mut();
+                    // Do NOT overwrite existing values, since we go from inner scopes outwards.
+                    if node_ref.env.get(key).is_none() {
+                        node_ref.env.insert(key.clone(), val.clone());
+                    }
+                    node_ref.changed_exported();
+                }
+            }
+        }
+        let old_locals = mem::replace(&mut self.base.locals, node);
+        self.shadowed_locals.push(old_locals);
+    }
+
+    /// Push a new non-shadowing (inner) local scope.
+    pub fn push_nonshadowing(&mut self) {
+        self.base.locals = EnvNodeRef::new(false, Some(self.base.locals.clone()));
+    }
+
+    /// Pop the variable stack.
+    /// Return a list of the names of variables which were modified.
+    /// TODO: We return the variable names because we may need to dispatch changes,
+    /// for example if there is a local change to LC_ALL; but that is rare. How can
+    /// we avoid these copies in the common case?
+    pub fn pop(&mut self) -> Vec<WString> {
+        let popped: EnvNodeRef;
+        if let Some(next) = self.base.locals.next() {
+            popped = mem::replace(&mut self.base.locals, next);
+        } else {
+            // Exhausted the inner scopes, put back a shadowing scope.
+            if let Some(shadowed) = self.shadowed_locals.pop() {
+                popped = mem::replace(&mut self.base.locals, shadowed);
+            } else {
+                panic!("Attempt to pop last local scope")
+            }
+        }
+        let var_names = popped.borrow().env.keys().cloned().collect();
+        var_names
+    }
+
+    /// Find the first node in the chain starting at \p node which contains the given key \p key.
+    fn find_in_chain(node: &EnvNodeRef, key: &wstr) -> Option<EnvNodeRef> {
+        #[allow(clippy::manual_find)]
+        for cur in node.iter() {
+            if cur.borrow().env.contains_key(key) {
+                return Some(cur);
+            }
+        }
+        None
+    }
+
+    /// Remove a variable from the chain \p node.
+    /// Return true if the variable was found and removed.
+    fn remove_from_chain(node: &mut EnvNodeRef, key: &wstr) -> bool {
+        for cur in node.iter() {
+            let mut cur_ref = cur.borrow_mut();
+            if let Some(var) = cur_ref.env.remove(key) {
+                if var.exports() {
+                    cur_ref.changed_exported();
+                }
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Try setting \p key as an electric or readonly variable, whose value is provided by reference in \p val.
+    /// Return an error code, or NOne if not an electric or readonly variable.
+    /// \p val will not be modified upon a None return.
+    fn try_set_electric(
+        &mut self,
+        key: &wstr,
+        query: &Query,
+        val: &mut Vec<WString>,
+    ) -> Option<EnvStackSetResult> {
+        // Do nothing if not electric.
+        let ev = ElectricVar::for_name(key)?;
+
+        // If a variable is electric, it may only be set in the global scope.
+        if query.has_scope && !query.global {
+            return Some(EnvStackSetResult::ENV_SCOPE);
+        }
+
+        // If the variable is read-only, the user may not set it.
+        if query.user && ev.readonly() {
+            return Some(EnvStackSetResult::ENV_PERM);
+        }
+
+        // Be picky about exporting.
+        if query.has_export_unexport {
+            let matches = if ev.exports() {
+                query.exports
+            } else {
+                query.unexports
+            };
+            if !matches {
+                return Some(EnvStackSetResult::ENV_SCOPE);
+            }
+        }
+
+        // Handle computed mutable electric variables.
+        if key == "umask" {
+            return Some(set_umask(val));
+        } else if key == "PWD" {
+            assert!(val.len() == 1, "Should have exactly one element in PWD");
+            let pwd = val.pop().unwrap();
+            if pwd != self.base.perproc_data.pwd {
+                self.base.perproc_data.pwd = pwd;
+                self.base.globals.borrow_mut().changed_exported();
+            }
+            return Some(EnvStackSetResult::ENV_OK);
+        }
+        // Claim the value.
+        let val = std::mem::take(val);
+
+        // Decide on the mode and set it in the global scope.
+        let flags = VarFlags {
+            exports: Some(ev.exports()),
+            parent_exports: ev.exports(),
+            pathvar: Some(false),
+        };
+        Self::set_in_node(&mut self.base.globals, key, val, flags);
+        return Some(EnvStackSetResult::ENV_OK);
+    }
+
+    /// Set a universal variable, inheriting as applicable from the given old variable.
+    fn set_universal(&mut self, key: &wstr, mut val: Vec<WString>, query: Query) {
+        let mut locked_uvars = uvars();
+        let uv = locked_uvars
+            .as_mut()
+            .expect("Should have non-null uvars in this function");
+        let oldvar = uv.get_ffi(&key.to_ffi()).as_ref().map(|v| v.from_ffi());
+        let oldvar = oldvar.as_ref();
+
+        // Resolve whether or not to export.
+        let mut exports = false;
+        if query.has_export_unexport {
+            exports = query.exports;
+        } else if oldvar.is_some() {
+            exports = oldvar.unwrap().exports();
+        }
+
+        // Resolve whether to be a path variable.
+        // Here we fall back to the auto-pathvar behavior.
+        let pathvar;
+        if query.has_pathvar_unpathvar {
+            pathvar = query.pathvar;
+        } else if oldvar.is_some() {
+            pathvar = oldvar.unwrap().is_pathvar();
+        } else {
+            pathvar = variable_should_auto_pathvar(key);
+        }
+
+        // Split about ':' if it's a path variable.
+        if pathvar {
+            val = colon_split(&val);
+        }
+
+        // Construct and set the new variable.
+        let mut varflags = EnvVarFlags::empty();
+        varflags.set(EnvVarFlags::EXPORT, exports);
+        varflags.set(EnvVarFlags::PATHVAR, pathvar);
+        let new_var = EnvVar::new_vec(val, varflags);
+
+        uv.set(&key.to_ffi(), &env_var_to_ffi(new_var));
+    }
+
+    /// Set a variable in a given node \p node.
+    fn set_in_node(node: &mut EnvNodeRef, key: &wstr, mut val: Vec<WString>, flags: VarFlags) {
+        // Read the var from the node. In C++ this was node->env[key] which establishes a default.
+        let mut node_ref = node.borrow_mut();
+        let var = node_ref.env.entry(key.to_owned()).or_default();
+
+        // Use an explicit exports, or inherit from the existing variable.
+        let res_exports = match flags.exports {
+            Some(exports) => exports,
+            None => var.exports(),
+        };
+
+        // Pathvar is inferred from the name. If set, split our entry about colons.
+        let res_pathvar = match flags.pathvar {
+            Some(pathvar) => pathvar,
+            None => variable_should_auto_pathvar(key),
+        };
+        if res_pathvar {
+            val = colon_split(&val);
+        }
+
+        *var = var
+            .setting_vals(val)
+            .setting_exports(res_exports)
+            .setting_pathvar(res_pathvar);
+
+        // Perhaps mark that this node contains an exported variable, or shadows an exported variable.
+        // If so regenerate the export list.
+        if res_exports || flags.parent_exports {
+            node_ref.changed_exported();
+        }
+    }
+
+    // Implement the default behavior of 'set' by finding the node for an unspecified scope.
+    fn resolve_unspecified_scope(&mut self) -> EnvNodeRef {
+        for cursor in self.base.locals.iter() {
+            if cursor.borrow().new_scope {
+                return cursor;
+            }
+        }
+        return self.base.globals.clone();
+    }
+
+    /// Get an existing variable, or None.
+    /// This is used for inheriting pathvar and export status.
+    fn find_variable(&self, key: &wstr) -> Option<EnvVar> {
+        let mut node = Self::find_in_chain(&self.base.locals, key);
+        if node.is_none() {
+            node = Self::find_in_chain(&self.base.globals, key);
+        }
+        if let Some(node) = node {
+            let iter = node.borrow().env.get(key).cloned();
+            assert!(iter.is_some(), "Node should contain key");
+            return iter;
+        }
+        None
+    }
+
+    pub fn getf(&self, key: &wstr, mode: EnvMode) -> Option<EnvVar> {
+        self.base.getf(key, mode)
+    }
+
+    pub fn get_names(&self, flags: EnvMode) -> Vec<WString> {
+        self.base.get_names(flags)
+    }
+
+    pub fn get_pwd_slash(&self) -> WString {
+        self.base.get_pwd_slash()
+    }
+}
+
+// This is a big dorky lock we take around everything. Everything exported from this module should be
+// wrapped in an EnvMutexGurad using this lock.
+// Fine grained locking is annoying here because nodes may be shared between stacks, so each
+// node would need its own lock, and each stack would need to take all the locks before any operation.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Like MutexGuard but for our global lock.
+pub struct EnvMutexGuard<'a, T: 'a> {
+    guard: MutexGuard<'static, ()>,
+    value: *mut T,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T: 'a> Deref for EnvMutexGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &'a T {
+        // Safety: we hold the global lock.
+        unsafe { &*self.value }
+    }
+}
+
+impl<'a, T: 'a> DerefMut for EnvMutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &'a mut T {
+        // Safety: we hold the global lock.
+        unsafe { &mut *self.value }
+    }
+}
+
+// Like Mutex, but references the global lock.\
+pub struct EnvMutex<T> {
+    inner: UnsafeCell<T>,
+}
+
+impl<T> EnvMutex<T> {
+    fn new(inner: T) -> Self {
+        Self {
+            inner: UnsafeCell::new(inner),
+        }
+    }
+
+    pub fn lock(&self) -> EnvMutexGuard<T> {
+        let guard = ENV_LOCK.lock().unwrap();
+        // Safety: we have the global lock.
+        let value = unsafe { &mut *self.inner.get() };
+        EnvMutexGuard {
+            guard,
+            value,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+// Safety: we use a global lock.
+unsafe impl<T> Sync for EnvMutex<T> {}
+
+#[test]
+fn test_colon_split() {
+    assert_eq!(colon_split(&[L!("foo")]), &[L!("foo")]);
+    assert_eq!(
+        colon_split(&[L!("foo:bar:baz")]),
+        &[L!("foo"), L!("bar"), L!("baz")]
+    );
+    assert_eq!(
+        colon_split(&[L!("foo:bar"), L!("baz")]),
+        &[L!("foo"), L!("bar"), L!("baz")]
+    );
+    assert_eq!(
+        colon_split(&[L!("foo:bar"), L!("baz")]),
+        &[L!("foo"), L!("bar"), L!("baz")]
+    );
+    assert_eq!(
+        colon_split(&[L!("1:"), L!("2:"), L!(":3:")]),
+        &[L!("1"), L!(""), L!("2"), L!(""), L!(""), L!("3"), L!("")]
+    );
+}

--- a/fish-rust/src/env/mod.rs
+++ b/fish-rust/src/env/mod.rs
@@ -1,6 +1,8 @@
 mod env_ffi;
 pub mod environment;
+mod environment_impl;
 pub mod var;
 
+pub use env_ffi::EnvStackSetResult;
 pub use environment::*;
 pub use var::*;

--- a/fish-rust/src/env/mod.rs
+++ b/fish-rust/src/env/mod.rs
@@ -1,3 +1,4 @@
+mod env_ffi;
 pub mod environment;
 pub mod var;
 

--- a/fish-rust/src/env/var.rs
+++ b/fish-rust/src/env/var.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 pub const PATH_ARRAY_SEP: char = ':';
 pub const NONPATH_ARRAY_SEP: char = ' ';
 
-// Flags that may be passed as the 'mode' in env_stack_t::set() / environment_t::get().
 bitflags! {
     /// Flags that may be passed as the 'mode' in env_stack_t::set() / environment_t::get().
     #[repr(C)]
@@ -69,6 +68,12 @@ pub enum EnvStackSetResult {
     ENV_SCOPE,
     ENV_INVALID,
     ENV_NOT_FOUND,
+}
+
+impl Default for EnvStackSetResult {
+    fn default() -> Self {
+        EnvStackSetResult::ENV_OK
+    }
 }
 
 /// A struct of configuration directories, determined in main() that fish will optionally pass to
@@ -213,7 +218,7 @@ impl EnvVar {
     }
 
     /// Returns the delimiter character used when converting from a list to a string.
-    fn get_delimiter(&self) -> char {
+    pub fn get_delimiter(&self) -> char {
         if self.is_pathvar() {
             PATH_ARRAY_SEP
         } else {
@@ -250,7 +255,7 @@ impl EnvVar {
     }
 
     /// Returns flags for a variable with the given name.
-    fn flags_for(name: &wstr) -> EnvVarFlags {
+    pub fn flags_for(name: &wstr) -> EnvVarFlags {
         let mut result = EnvVarFlags::empty();
         if is_read_only(name) {
             result.insert(EnvVarFlags::READ_ONLY);

--- a/fish-rust/src/ffi.rs
+++ b/fish-rust/src/ffi.rs
@@ -21,6 +21,8 @@ include_cpp! {
     #include "builtin.h"
     #include "common.h"
     #include "env.h"
+    #include "env_dispatch.h"
+    #include "env_universal_common.h"
     #include "event.h"
     #include "fallback.h"
     #include "fds.h"
@@ -29,11 +31,13 @@ include_cpp! {
     #include "function.h"
     #include "highlight.h"
     #include "io.h"
+    #include "kill.h"
     #include "parse_constants.h"
     #include "parser.h"
     #include "parse_util.h"
     #include "path.h"
     #include "proc.h"
+    #include "reader.h"
     #include "tokenizer.h"
     #include "wildcard.h"
     #include "wutil.h"
@@ -51,8 +55,17 @@ include_cpp! {
 
     generate_pod!("pipes_ffi_t")
     generate!("environment_t")
+    generate!("env_dispatch_var_change_ffi")
     generate!("env_stack_t")
     generate!("env_var_t")
+    generate!("env_universal_t")
+    generate!("env_universal_sync_result_t")
+    generate!("callback_data_t")
+    generate!("universal_notifier_t")
+    generate!("var_table_ffi_t")
+
+    generate!("event_list_ffi_t")
+
     generate!("make_pipes_ffi")
 
     generate!("get_flog_file_fd")
@@ -116,6 +129,10 @@ include_cpp! {
     generate!("path_get_paths_ffi")
 
     generate!("colorize_shell")
+    generate!("reader_status_count")
+    generate!("kill_entries_ffi")
+
+    generate!("get_history_variable_text_ffi")
 }
 
 impl parser_t {
@@ -173,6 +190,8 @@ impl parser_t {
         self.get_var_stack().set_var(name, value, flags)
     }
 }
+
+unsafe impl Send for env_universal_t {}
 
 impl environment_t {
     /// Helper to get a variable as a string, using the default flags.
@@ -287,6 +306,7 @@ pub trait Repin {
 // Implement Repin for our types.
 impl Repin for block_t {}
 impl Repin for env_stack_t {}
+impl Repin for env_universal_t {}
 impl Repin for io_streams_t {}
 impl Repin for job_t {}
 impl Repin for output_stream_t {}

--- a/fish-rust/src/null_terminated_array.rs
+++ b/fish-rust/src/null_terminated_array.rs
@@ -2,6 +2,7 @@ use std::ffi::{c_char, CStr, CString};
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::ptr;
+use std::sync::Arc;
 
 pub trait NulTerminatedString {
     type CharType: Copy;
@@ -21,9 +22,6 @@ impl NulTerminatedString for CStr {
 /// This supports the null-terminated array of NUL-terminated strings consumed by exec.
 /// Given a list of strings, construct a vector of pointers to those strings contents.
 /// This is used for building null-terminated arrays of null-terminated strings.
-/// *Important*: the vector stores pointers into the interior of the input strings, which may be
-/// subject to the small-string optimization. This means that pointers will be left dangling if any
-/// input string is deallocated *or moved*. This class should only be used in transient calls.
 pub struct NullTerminatedArray<'p, T: NulTerminatedString + ?Sized> {
     pointers: Vec<*const T::CharType>,
     _phantom: PhantomData<&'p T>,
@@ -98,6 +96,53 @@ pub fn null_terminated_array_length<T>(mut arr: *const *const T) -> usize {
         }
     }
     len
+}
+
+/// FFI bits.
+/// We often work in Arc<OwningNullTerminatedArray>.
+/// Expose this to C++.
+pub struct OwningNullTerminatedArrayRefFFI(pub Arc<OwningNullTerminatedArray>);
+impl OwningNullTerminatedArrayRefFFI {
+    fn get(&self) -> *mut *const c_char {
+        self.0.get()
+    }
+}
+
+unsafe impl cxx::ExternType for OwningNullTerminatedArrayRefFFI {
+    type Id = cxx::type_id!("OwningNullTerminatedArrayRefFFI");
+    type Kind = cxx::kind::Opaque;
+}
+
+/// Convert a CxxString to a CString, truncating at the first NUL.
+use cxx::{CxxString, CxxVector};
+fn cxxstring_to_cstring(s: &CxxString) -> CString {
+    let bytes: &[u8] = s.as_bytes();
+    let nul_pos = bytes.iter().position(|&b| b == 0);
+    let slice = &bytes[..nul_pos.unwrap_or(bytes.len())];
+    CString::new(slice).unwrap()
+}
+
+fn new_owning_null_terminated_array_ffi(
+    strs: &CxxVector<CxxString>,
+) -> Box<OwningNullTerminatedArrayRefFFI> {
+    let cstrs = strs.iter().map(cxxstring_to_cstring).collect();
+    Box::new(OwningNullTerminatedArrayRefFFI(Arc::new(
+        OwningNullTerminatedArray::new(cstrs),
+    )))
+}
+
+#[cxx::bridge]
+mod null_terminated_array_ffi {
+    extern "Rust" {
+        type OwningNullTerminatedArrayRefFFI;
+
+        fn get(&self) -> *mut *const c_char;
+
+        #[cxx_name = "new_owning_null_terminated_array"]
+        fn new_owning_null_terminated_array_ffi(
+            strs: &CxxVector<CxxString>,
+        ) -> Box<OwningNullTerminatedArrayRefFFI>;
+    }
 }
 
 #[test]

--- a/fish-rust/src/wchar_ffi.rs
+++ b/fish-rust/src/wchar_ffi.rs
@@ -104,6 +104,18 @@ impl ToCppWString for &wstr {
     }
 }
 
+impl ToCppWString for WString {
+    fn into_cpp(self) -> cxx::UniquePtr<cxx::CxxWString> {
+        self.to_ffi()
+    }
+}
+
+impl ToCppWString for &WString {
+    fn into_cpp(self) -> cxx::UniquePtr<cxx::CxxWString> {
+        self.to_ffi()
+    }
+}
+
 /// WString may be converted to CxxWString.
 impl WCharToFFI for WString {
     type Target = cxx::UniquePtr<cxx::CxxWString>;
@@ -210,6 +222,12 @@ impl<'a> AsWstr<'a> for cxx::UniquePtr<cxx::CxxWString> {
 impl<'a> AsWstr<'a> for cxx::CxxWString {
     fn as_wstr(&'a self) -> &'a wstr {
         wstr::from_char_slice(self.as_chars())
+    }
+}
+
+impl AsWstr<'_> for wcharz_t {
+    fn as_wstr(&self) -> &wstr {
+        wstr::from_char_slice(self.chars())
     }
 }
 

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -50,105 +50,10 @@
 /// At init, we read all the environment variables from this array.
 extern char **environ;
 
-/// The character used to delimit path variables in exporting and in string expansion.
-static constexpr wchar_t PATH_ARRAY_SEP = L':';
-
 bool curses_initialized = false;
 
 /// Does the terminal have the "eat_newline_glitch".
 bool term_has_xn = false;
-
-/// Getter for universal variables.
-/// This is typically initialized in env_init(), and is considered empty before then.
-static acquired_lock<env_universal_t> uvars() {
-    // Leaked to avoid shutdown dtor registration.
-    static auto const s_universal_variables = new owning_lock<env_universal_t>();
-    return s_universal_variables->acquire();
-}
-
-/// Set when a universal variable has been modified but not yet been written to disk via sync().
-static relaxed_atomic_bool_t s_uvars_locally_modified{false};
-
-/// Whether we were launched with no_config; in this case setting a uvar instead sets a global.
-static relaxed_atomic_bool_t s_uvar_scope_is_global{false};
-
-namespace {
-struct electric_var_t {
-    enum {
-        freadonly = 1 << 0,  // May not be modified by the user.
-        fcomputed = 1 << 1,  // Value is dynamically computed.
-        fexports = 1 << 2,   // Exported to child processes.
-    };
-    const wchar_t *name;
-    uint32_t flags;
-
-    bool readonly() const { return flags & freadonly; }
-
-    bool computed() const { return flags & fcomputed; }
-
-    bool exports() const { return flags & fexports; }
-
-    static const electric_var_t *for_name(const wchar_t *name);
-    static const electric_var_t *for_name(const wcstring &name);
-};
-
-// Keep sorted alphabetically
-static constexpr const electric_var_t electric_variables[] = {
-    {L"FISH_VERSION", electric_var_t::freadonly},
-    {L"PWD", electric_var_t::freadonly | electric_var_t::fcomputed | electric_var_t::fexports},
-    {L"SHLVL", electric_var_t::freadonly | electric_var_t::fexports},
-    {L"_", electric_var_t::freadonly},
-    {L"fish_kill_signal", electric_var_t::freadonly | electric_var_t::fcomputed},
-    {L"fish_killring", electric_var_t::freadonly | electric_var_t::fcomputed},
-    {L"fish_pid", electric_var_t::freadonly},
-    {L"history", electric_var_t::freadonly | electric_var_t::fcomputed},
-    {L"hostname", electric_var_t::freadonly},
-    {L"pipestatus", electric_var_t::freadonly | electric_var_t::fcomputed},
-    {L"status", electric_var_t::freadonly | electric_var_t::fcomputed},
-    {L"status_generation", electric_var_t::freadonly | electric_var_t::fcomputed},
-    {L"umask", electric_var_t::fcomputed},
-    {L"version", electric_var_t::freadonly},
-};
-ASSERT_SORTED_BY_NAME(electric_variables);
-
-const electric_var_t *electric_var_t::for_name(const wchar_t *name) {
-    return get_by_sorted_name(name, electric_variables);
-}
-
-const electric_var_t *electric_var_t::for_name(const wcstring &name) {
-    return electric_var_t::for_name(name.c_str());
-}
-}  // namespace
-
-/// Check if a variable may not be set using the set command.
-static bool is_read_only(const wchar_t *key) {
-    if (auto ev = electric_var_t::for_name(key)) {
-        return ev->readonly();
-    }
-    return false;
-}
-
-static bool is_read_only(const wcstring &key) { return is_read_only(key.c_str()); }
-
-/// Return true if a variable should become a path variable by default. See #436.
-static bool variable_should_auto_pathvar(const wcstring &name) {
-    return string_suffixes_string(L"PATH", name);
-}
-// This is a big dorky lock we take around everything that might read from or modify an env_node_t.
-// Fine grained locking is annoying here because env_nodes may be shared between env_stacks, so each
-// node would need its own lock.
-static std::mutex env_lock;
-
-/// We cache our null-terminated export list. However an exported variable may change for lots of
-/// reasons: popping a scope, a modified universal variable, etc. We thus have a monotone counter.
-/// Every time an exported variable changes in a node, it acquires the next generation. 0 is a
-/// sentinel that indicates that the node contains no exported variables.
-using export_generation_t = uint64_t;
-static export_generation_t next_export_generation() {
-    static owning_lock<export_generation_t> s_gen;
-    auto val = s_gen.acquire();
-    return ++*val;
-}
 
 // static
 env_var_t env_var_t::new_ffi(EnvVar *ptr) {
@@ -185,29 +90,16 @@ env_var_t &env_var_t::operator=(const env_var_t &rhs) {
     return *this;
 }
 
-env_var_t::env_var_flags_t env_var_t::flags_for(const wchar_t *name) {
-    env_var_flags_t result = 0;
-    if (::is_read_only(name)) result |= flag_read_only;
-    return result;
-}
+env_var_t::env_var_t(const wcstring_list_ffi_t &vals, uint8_t flags)
+    : impl_(env_var_create(vals, flags)) {}
 
 env_var_t::env_var_t(const env_var_t &rhs) : impl_(rhs.impl_->clone_box()) {}
 
-env_var_t::env_var_t(std::vector<wcstring> vals, env_var_flags_t flags)
-    : impl_(env_var_create(std::move(vals), flags)) {}
-
-env_var_t::env_var_t(const wchar_t *name, std::vector<wcstring> vals)
-    : impl_(env_var_create_from_name(name, std::move(vals))) {}
-
 bool env_var_t::operator==(const env_var_t &rhs) const { return impl_->equals(*rhs.impl_); }
 
-/// \return a singleton empty list, to avoid unnecessary allocations in env_var_t.
-std::shared_ptr<const std::vector<wcstring>> env_var_t::empty_list() {
-    static const auto s_empty_result = std::make_shared<const std::vector<wcstring>>();
-    return s_empty_result;
-}
-
 environment_t::~environment_t() = default;
+
+env_var_t::env_var_flags_t env_var_t::flags_for(const wchar_t *name) { return env_flags_for(name); }
 
 wcstring environment_t::get_pwd_slash() const {
     // Return "/" if PWD is missing.
@@ -242,15 +134,20 @@ std::unique_ptr<env_var_t> environment_t::get_or_null(wcstring const &key,
     return make_unique<env_var_t>(variable.acquire());
 }
 
+null_environment_t::null_environment_t() : impl_(env_null_create()) {}
 null_environment_t::~null_environment_t() = default;
+
 maybe_t<env_var_t> null_environment_t::get(const wcstring &key, env_mode_flags_t mode) const {
-    UNUSED(key);
-    UNUSED(mode);
+    if (auto *ptr = impl_->getf(key, mode)) {
+        return env_var_t::new_ffi(ptr);
+    }
     return none();
 }
+
 std::vector<wcstring> null_environment_t::get_names(env_mode_flags_t flags) const {
-    UNUSED(flags);
-    return {};
+    wcstring_list_ffi_t names;
+    impl_->get_names(flags, names);
+    return std::move(names.vals);
 }
 
 /// Set up the USER and HOME variable.
@@ -355,7 +252,7 @@ void env_init(const struct config_paths_t *paths, bool do_uvars, bool default_pa
         size_t eql = key_and_val.find(L'=');
         if (eql == wcstring::npos) {
             // No equal-sign found so treat it as a defined var that has no value(s).
-            if (!electric_var_t::for_name(key_and_val)) {
+            if (!var_is_electric(key_and_val)) {
                 vars.set_empty(key_and_val, ENV_EXPORT | ENV_GLOBAL);
             }
             inheriteds[key] = L"";
@@ -363,7 +260,7 @@ void env_init(const struct config_paths_t *paths, bool do_uvars, bool default_pa
             key.assign(key_and_val, 0, eql);
             val.assign(key_and_val, eql + 1, wcstring::npos);
             inheriteds[key] = val;
-            if (!electric_var_t::for_name(key)) {
+            if (!var_is_electric(key)) {
                 // fish_user_paths should not be exported; attempting to re-import it from
                 // a value we previously (due to user error) exported will cause impossibly
                 // difficult to debug PATH problems.
@@ -482,982 +379,51 @@ void env_init(const struct config_paths_t *paths, bool do_uvars, bool default_pa
         path_emit_config_directory_messages(vars);
     }
 
-    // Initialize our uvars if requested.
-    if (!do_uvars) {
-        s_uvar_scope_is_global = true;
-    } else {
-        // Set up universal variables using the default path.
-        callback_data_list_t callbacks;
-        uvars()->initialize(callbacks);
-        for (const callback_data_t &cb : callbacks) {
-            env_dispatch_var_change(cb.key, vars);
-        }
-
-        // Do not import variables that have the same name and value as
-        // an exported universal variable. See issues #5258 and #5348.
-        var_table_t table = uvars()->get_table();
-        for (const auto &kv : table) {
-            const wcstring &name = kv.first;
-            const env_var_t &uvar = kv.second;
-            if (!uvar.exports()) continue;
-            // Look for a global exported variable with the same name.
-            maybe_t<env_var_t> global = vars.globals().get(name, ENV_GLOBAL | ENV_EXPORT);
-            if (global && uvar.as_string() == global->as_string()) {
-                vars.globals().remove(name, ENV_GLOBAL | ENV_EXPORT);
-            }
-        }
-
-        // Import any abbreviations from uvars.
-        // Note we do not dynamically react to changes.
-        const wchar_t *const prefix = L"_fish_abbr_";
-        size_t prefix_len = wcslen(prefix);
-        const bool from_universal = true;
-        auto abbrs = abbrs_get_set();
-        for (const auto &kv : table) {
-            if (string_prefixes_string(prefix, kv.first)) {
-                wcstring escaped_name = kv.first.substr(prefix_len);
-                if (auto name =
-                        unescape_string(escaped_name, unescape_flags_t{}, STRING_STYLE_VAR)) {
-                    wcstring key = *name;
-                    wcstring replacement = join_strings(kv.second.as_list(), L' ');
-                    abbrs->add(std::move(*name), std::move(key), std::move(replacement),
-                               abbrs_position_t::command, from_universal);
-                }
-            }
-        }
-    }
+    rust_env_init(do_uvars);
 }
 
-static int set_umask(const std::vector<wcstring> &list_val) {
-    long mask = -1;
-    if (list_val.size() == 1 && !list_val.front().empty()) {
-        mask = fish_wcstol(list_val.front().c_str(), nullptr, 8);
-    }
-
-    if (errno || mask > 0777 || mask < 0) return ENV_INVALID;
-    // Do not actually create a umask variable. On env_stack_t::get() it will be calculated.
-    umask(mask);
-    return ENV_OK;
-}
-
-namespace {
-struct query_t {
-    // Whether any scopes were specified.
-    bool has_scope;
-
-    // Whether to search local, function, global, universal scopes.
-    bool local;
-    bool function;
-    bool global;
-    bool universal;
-
-    // Whether export or unexport was specified.
-    bool has_export_unexport;
-
-    // Whether to search exported and unexported variables.
-    bool exports;
-    bool unexports;
-
-    // Whether pathvar or unpathvar was set.
-    bool has_pathvar_unpathvar;
-    bool pathvar;
-    bool unpathvar;
-
-    // Whether this is a "user" set.
-    bool user;
-
-    explicit query_t(env_mode_flags_t mode) {
-        has_scope = mode & (ENV_LOCAL | ENV_FUNCTION | ENV_GLOBAL | ENV_UNIVERSAL);
-        local = !has_scope || (mode & ENV_LOCAL);
-        function = !has_scope || (mode & ENV_FUNCTION);
-        global = !has_scope || (mode & ENV_GLOBAL);
-        universal = !has_scope || (mode & ENV_UNIVERSAL);
-
-        has_export_unexport = mode & (ENV_EXPORT | ENV_UNEXPORT);
-        exports = !has_export_unexport || (mode & ENV_EXPORT);
-        unexports = !has_export_unexport || (mode & ENV_UNEXPORT);
-
-        // note we don't use pathvar for searches, so these don't default to true if unspecified.
-        has_pathvar_unpathvar = mode & (ENV_PATHVAR | ENV_UNPATHVAR);
-        pathvar = mode & ENV_PATHVAR;
-        unpathvar = mode & ENV_UNPATHVAR;
-
-        user = mode & ENV_USER;
-    }
-
-    bool export_matches(const env_var_t &var) const {
-        if (has_export_unexport) {
-            return var.exports() ? exports : unexports;
-        } else {
-            return true;
-        }
-    }
-
-    bool pathvar_matches(const env_var_t &var) const {
-        if (has_pathvar_unpathvar) {
-            return var.is_pathvar() ? pathvar : unpathvar;
-        } else {
-            return true;
-        }
-    }
-};
-
-// Struct representing one level in the function variable stack.
-class env_node_t {
-   public:
-    /// Variable table.
-    var_table_t env;
-    /// Does this node imply a new variable scope? If yes, all non-global variables below this one
-    /// in the stack are invisible. If new_scope is set for the global variable node, the universe
-    /// will explode.
-    const bool new_scope;
-    /// The export generation. If this is nonzero, then we contain a variable that is exported to
-    /// subshells, or redefines a variable to not be exported.
-    export_generation_t export_gen = 0;
-    /// Pointer to next level.
-    const std::shared_ptr<env_node_t> next;
-
-    env_node_t(bool is_new_scope, std::shared_ptr<env_node_t> next_scope)
-        : new_scope(is_new_scope), next(std::move(next_scope)) {}
-
-    maybe_t<env_var_t> find_entry(const wcstring &key) {
-        auto it = env.find(key);
-        if (it != env.end()) return it->second;
-        return none();
-    }
-
-    bool exports() const { return export_gen > 0; }
-
-    void changed_exported() { export_gen = next_export_generation(); }
-};
-}  // namespace
-
-using env_node_ref_t = std::shared_ptr<env_node_t>;
-class env_scoped_impl_t : public environment_t, noncopyable_t {
-    /// A struct wrapping up parser-local variables. These are conceptually variables that differ in
-    /// different fish internal processes.
-    struct perproc_data_t {
-        wcstring pwd{};
-        statuses_t statuses{statuses_t::just(0)};
-    };
-
-   public:
-    env_scoped_impl_t(env_node_ref_t locals, env_node_ref_t globals)
-        : locals_(std::move(locals)), globals_(std::move(globals)) {
-        assert(locals_ && globals_ && "Nodes cannot be null");
-    }
-
-    maybe_t<env_var_t> get(const wcstring &key, env_mode_flags_t mode = ENV_DEFAULT) const override;
-    std::vector<wcstring> get_names(env_mode_flags_t flags) const override;
-
-    perproc_data_t &perproc_data() { return perproc_data_; }
-    const perproc_data_t &perproc_data() const { return perproc_data_; }
-
-    std::shared_ptr<environment_t> snapshot() const;
-
-    ~env_scoped_impl_t() override = default;
-
-    std::shared_ptr<owning_null_terminated_array_t> export_array();
-
-   protected:
-    // A linked list of scopes.
-    env_node_ref_t locals_{};
-
-    // Global scopes. There is no parent here.
-    env_node_ref_t globals_{};
-
-    // Per process data.
-    perproc_data_t perproc_data_{};
-
-    // Exported variable array used by execv.
-    std::shared_ptr<owning_null_terminated_array_t> export_array_{};
-
-    // Cached list of export generations corresponding to the above export_array_.
-    // If this differs from the current export generations then we need to regenerate the array.
-    std::vector<export_generation_t> export_array_generations_{};
-
-   private:
-    // These "try" methods return true on success, false on failure. On a true return, \p result is
-    // populated. A maybe_t<maybe_t<...>> is a bridge too far.
-    // These may populate result with none() if a variable is present which does not match the
-    // query.
-    maybe_t<env_var_t> try_get_computed(const wcstring &key) const;
-    maybe_t<env_var_t> try_get_local(const wcstring &key) const;
-    maybe_t<env_var_t> try_get_function(const wcstring &key) const;
-    maybe_t<env_var_t> try_get_global(const wcstring &key) const;
-    maybe_t<env_var_t> try_get_universal(const wcstring &key) const;
-
-    /// Invoke a function on the current (nonzero) export generations, in order.
-    template <typename Func>
-    void enumerate_generations(const Func &func) const {
-        // Our uvars generation count doesn't come from next_export_generation(), so always supply
-        // it even if it's 0.
-        func(uvars()->get_export_generation());
-        if (globals_->exports()) func(globals_->export_gen);
-        for (auto node = locals_; node; node = node->next) {
-            if (node->exports()) func(node->export_gen);
-        }
-    }
-
-    /// \return whether the current export array is empty or out-of-date.
-    bool export_array_needs_regeneration() const;
-
-    /// \return a newly allocated export array.
-    std::shared_ptr<owning_null_terminated_array_t> create_export_array() const;
-};
-
-/// Get the exported variables into a variable table.
-static void get_exported(const env_node_ref_t &n, var_table_t &table) {
-    if (!n) return;
-
-    // Allow parent scopes to populate first, since we may want to overwrite those results.
-    get_exported(n->next, table);
-
-    for (const auto &kv : n->env) {
-        const wcstring &key = kv.first;
-        const env_var_t &var = kv.second;
-        if (var.exports()) {
-            // Export the variable. Don't use std::map::insert here, since we need to overwrite
-            // existing values from previous scopes.
-            table[key] = var;
-        } else {
-            // We need to erase from the map if we are not exporting, since a lower scope may have
-            // exported. See #2132.
-            table.erase(key);
-        }
-    }
-}
-
-bool env_scoped_impl_t::export_array_needs_regeneration() const {
-    // Check if our export array is stale. If we don't have one, it's obviously stale. Otherwise,
-    // compare our cached generations with the current generations. If they don't match exactly then
-    // our generation list is stale.
-    if (!export_array_) return true;
-
-    bool mismatch = false;
-    auto cursor = export_array_generations_.begin();
-    auto end = export_array_generations_.end();
-    enumerate_generations([&](export_generation_t gen) {
-        if (cursor != end && *cursor == gen) {
-            ++cursor;
-        } else {
-            mismatch = true;
-        }
-    });
-    if (cursor != end) {
-        mismatch = true;
-    }
-    return mismatch;
-}
-
-std::shared_ptr<owning_null_terminated_array_t> env_scoped_impl_t::create_export_array() const {
-    FLOG(env_export, L"create_export_array() recalc");
-    var_table_t vals;
-    get_exported(this->globals_, vals);
-    get_exported(this->locals_, vals);
-
-    const std::vector<wcstring> uni = uvars()->get_names(true, false);
-    for (const wcstring &key : uni) {
-        auto var = uvars()->get(key);
-        assert(var && "Variable should be present in uvars");
-        // Note that std::map::insert does NOT overwrite a value already in the map,
-        // which we depend on here.
-        // Note: Using std::move around emplace prevents the compiler from implementing
-        // copy elision.
-        vals.emplace(key, std::move(*var));
-    }
-
-    // Dorky way to add our single exported computed variable.
-    vals[L"PWD"] = env_var_t(L"PWD", perproc_data().pwd);
-
-    // Construct the export list: a list of strings of the form key=value.
-    std::vector<std::string> export_list;
-    export_list.reserve(vals.size());
-    for (const auto &kv : vals) {
-        std::string str = wcs2zstring(kv.first);
-        str.push_back('=');
-        str.append(wcs2zstring(kv.second.as_string()));
-        export_list.push_back(std::move(str));
-    }
-    return std::make_shared<owning_null_terminated_array_t>(std::move(export_list));
-}
-
-std::shared_ptr<owning_null_terminated_array_t> env_scoped_impl_t::export_array() {
-    ASSERT_IS_NOT_FORKED_CHILD();
-    if (export_array_needs_regeneration()) {
-        export_array_ = create_export_array();
-
-        // Update our export array generations.
-        export_array_generations_.clear();
-        enumerate_generations(
-            [this](export_generation_t gen) { export_array_generations_.push_back(gen); });
-    }
-    return export_array_;
-}
-
-maybe_t<env_var_t> env_scoped_impl_t::try_get_computed(const wcstring &key) const {
-    const electric_var_t *ev = electric_var_t::for_name(key);
-    if (!(ev && ev->computed())) {
-        return none();
-    }
-    if (key == L"PWD") {
-        return env_var_t(perproc_data().pwd, env_var_t::flag_export);
-    } else if (key == L"history") {
-        // Big hack. We only allow getting the history on the main thread. Note that history_t
-        // may ask for an environment variable, so don't take the lock here (we don't need it).
-        if (!is_main_thread()) {
-            return none();
-        }
-
-        std::shared_ptr<history_t> history = commandline_get_state().history;
-        if (!history) {
-            history = history_t::with_name(history_session_id(*this));
-        }
-        std::vector<wcstring> result;
-        if (history) history->get_history(result);
-        return env_var_t(L"history", std::move(result));
-    } else if (key == L"fish_killring") {
-        return env_var_t(L"fish_killring", kill_entries());
-    } else if (key == L"pipestatus") {
-        const auto &js = perproc_data().statuses;
-        std::vector<wcstring> result;
-        result.reserve(js.pipestatus.size());
-        for (int i : js.pipestatus) {
-            result.push_back(to_string(i));
-        }
-        return env_var_t(L"pipestatus", std::move(result));
-    } else if (key == L"status") {
-        const auto &js = perproc_data().statuses;
-        return env_var_t(L"status", to_string(js.status));
-    } else if (key == L"status_generation") {
-        auto status_generation = reader_status_count();
-        return env_var_t(L"status_generation", to_string(status_generation));
-    } else if (key == L"fish_kill_signal") {
-        const auto &js = perproc_data().statuses;
-        return env_var_t(L"fish_kill_signal", to_string(js.kill_signal));
-    } else if (key == L"umask") {
-        // note umask() is an absurd API: you call it to set the value and it returns the old
-        // value. Thus we have to call it twice, to reset the value. The env_lock protects
-        // against races. Guess what the umask is; if we guess right we don't need to reset it.
-        mode_t guess = 022;
-        mode_t res = umask(guess);
-        if (res != guess) umask(res);
-        return env_var_t(L"umask", format_string(L"0%0.3o", res));
-    }
-    // We should never get here unless the electric var list is out of sync with the above code.
-    DIE("unrecognized computed var name");
-}
-
-maybe_t<env_var_t> env_scoped_impl_t::try_get_local(const wcstring &key) const {
-    maybe_t<env_var_t> entry;
-    for (auto cur = locals_; cur; cur = cur->next) {
-        if ((entry = cur->find_entry(key))) break;
-    }
-    return entry;  // this is either the entry or none() from find_entry
-}
-
-maybe_t<env_var_t> env_scoped_impl_t::try_get_function(const wcstring &key) const {
-    maybe_t<env_var_t> entry;
-    auto node = locals_;
-    while (node->next) {
-        node = node->next;
-        // The first node that introduces a new scope is ours.
-        // If this doesn't happen, we go on until we've reached the
-        // topmost local scope.
-        if (node->new_scope) break;
-    }
-    for (auto cur = node; cur; cur = cur->next) {
-        if ((entry = cur->find_entry(key))) break;
-    }
-    return entry;  // this is either the entry or none() from find_entry
-}
-
-maybe_t<env_var_t> env_scoped_impl_t::try_get_global(const wcstring &key) const {
-    return globals_->find_entry(key);
-}
-
-maybe_t<env_var_t> env_scoped_impl_t::try_get_universal(const wcstring &key) const {
-    return uvars()->get(key);
-}
-
-maybe_t<env_var_t> env_scoped_impl_t::get(const wcstring &key, env_mode_flags_t mode) const {
-    const query_t query(mode);
-
-    maybe_t<env_var_t> result;
-    // Computed variables are effectively global and can't be shadowed.
-    if (query.global) {
-        result = try_get_computed(key);
-    }
-
-    if (!result && query.local) {
-        result = try_get_local(key);
-    }
-    if (!result && query.function) {
-        result = try_get_function(key);
-    }
-    if (!result && query.global) {
-        result = try_get_global(key);
-    }
-    if (!result && query.universal) {
-        result = try_get_universal(key);
-    }
-    // If the user requested only exported or unexported variables, enforce that here.
-    if (result && !query.export_matches(*result)) {
-        result = none();
-    }
-    // Same for pathvars
-    if (result && !query.pathvar_matches(*result)) {
-        result = none();
-    }
-    return result;
-}
-
-std::vector<wcstring> env_scoped_impl_t::get_names(env_mode_flags_t flags) const {
-    const query_t query(flags);
-    std::set<wcstring> names;
-
-    // Helper to add the names of variables from \p envs to names, respecting show_exported and
-    // show_unexported.
-    auto add_keys = [&](const var_table_t &envs) {
-        for (const auto &kv : envs) {
-            if (query.export_matches(kv.second)) {
-                names.insert(kv.first);
-            }
-        }
-    };
-
-    if (query.local) {
-        for (auto cursor = locals_; cursor != nullptr; cursor = cursor->next) {
-            add_keys(cursor->env);
-        }
-    }
-
-    if (query.global) {
-        add_keys(globals_->env);
-        // Add electrics.
-        for (const auto &ev : electric_variables) {
-            if (ev.exports() ? query.exports : query.unexports) {
-                names.insert(ev.name);
-            }
-        }
-    }
-
-    if (query.universal) {
-        const std::vector<wcstring> uni_list = uvars()->get_names(query.exports, query.unexports);
-        names.insert(uni_list.begin(), uni_list.end());
-    }
-
-    return {names.begin(), names.end()};
-}
-
-/// Recursive helper to snapshot a series of nodes.
-static env_node_ref_t copy_node_chain(const env_node_ref_t &node) {
-    if (node == nullptr) {
-        return nullptr;
-    }
-
-    auto next = copy_node_chain(node->next);
-    auto result = std::make_shared<env_node_t>(node->new_scope, next);
-    // Copy over variables.
-    // Note assigning env is a potentially big copy.
-    result->export_gen = node->export_gen;
-    result->env = node->env;
-    return result;
-}
-
-std::shared_ptr<environment_t> env_scoped_impl_t::snapshot() const {
-    auto ret = std::make_shared<env_scoped_impl_t>(copy_node_chain(locals_), globals_);
-    ret->perproc_data_ = this->perproc_data_;
-    return ret;
-}
-
-// A struct that wraps up the result of setting or removing a variable.
-namespace {
-struct mod_result_t {
-    // The publicly visible status of the set call.
-    int status{ENV_OK};
-
-    // Whether we modified the global scope.
-    bool global_modified{false};
-
-    // Whether we modified universal variables.
-    bool uvar_modified{false};
-
-    explicit mod_result_t(int status) : status(status) {}
-};
-}  // namespace
-
-/// A mutable subclass of env_scoped_impl_t.
-class env_stack_impl_t final : public env_scoped_impl_t {
-   public:
-    using env_scoped_impl_t::env_scoped_impl_t;
-
-    /// Set a variable under the name \p key, using the given \p mode, setting its value to \p val.
-    mod_result_t set(const wcstring &key, env_mode_flags_t mode, std::vector<wcstring> val);
-
-    /// Remove a variable under the name \p key.
-    mod_result_t remove(const wcstring &key, int var_mode);
-
-    /// Push a new shadowing local scope.
-    void push_shadowing();
-
-    /// Push a new non-shadowing (inner) local scope.
-    void push_nonshadowing();
-
-    /// Pop the variable stack.
-    /// \return the popped node.
-    env_node_ref_t pop();
-
-    /// \return a new impl representing global variables, with a single local scope.
-    static std::unique_ptr<env_stack_impl_t> create() {
-        static const auto s_global_node = std::make_shared<env_node_t>(false, nullptr);
-        auto local = std::make_shared<env_node_t>(false, nullptr);
-        return make_unique<env_stack_impl_t>(std::move(local), s_global_node);
-    }
-
-    ~env_stack_impl_t() override = default;
-
-   private:
-    /// The scopes of caller functions, which are currently shadowed.
-    std::vector<env_node_ref_t> shadowed_locals_;
-
-    /// A restricted set of variable flags.
-    struct var_flags_t {
-        // if set, whether we should become a path variable; otherwise guess based on the name.
-        maybe_t<bool> pathvar{};
-
-        // if set, the new export value; otherwise inherit any existing export value.
-        maybe_t<bool> exports{};
-
-        // whether the variable is exported by some parent.
-        bool parent_exports{};
-    };
-
-    /// Find the first node in the chain starting at \p node which contains the given key \p key.
-    static env_node_ref_t find_in_chain(const env_node_ref_t &node, const wcstring &key) {
-        for (auto cursor = node; cursor; cursor = cursor->next) {
-            if (cursor->env.count(key)) {
-                return cursor;
-            }
-        }
-        return nullptr;
-    }
-
-    /// Remove a variable from the chain \p node.
-    /// \return true if the variable was found and removed.
-    bool remove_from_chain(const env_node_ref_t &node, const wcstring &key) const {
-        for (auto cursor = node; cursor; cursor = cursor->next) {
-            auto iter = cursor->env.find(key);
-            if (iter != cursor->env.end()) {
-                if (iter->second.exports()) {
-                    node->changed_exported();
-                }
-                cursor->env.erase(iter);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /// Try setting\p key as an electric or readonly variable.
-    /// \return an error code, or none() if not an electric or readonly variable.
-    /// \p val will not be modified upon a none() return.
-    maybe_t<int> try_set_electric(const wcstring &key, const query_t &query,
-                                  std::vector<wcstring> &val);
-
-    /// Set a universal value.
-    void set_universal(const wcstring &key, std::vector<wcstring> val, const query_t &query);
-
-    /// Set a variable in a given node \p node.
-    void set_in_node(const env_node_ref_t &node, const wcstring &key, std::vector<wcstring> &&val,
-                     const var_flags_t &flags);
-
-    // Implement the default behavior of 'set' by finding the node for an unspecified scope.
-    env_node_ref_t resolve_unspecified_scope() {
-        for (auto cursor = locals_; cursor; cursor = cursor->next) {
-            if (cursor->new_scope) return cursor;
-        }
-        return globals_;
-    }
-
-    /// Get a pointer to an existing variable, or nullptr.
-    /// This is used for inheriting pathvar and export status.
-    const env_var_t *find_variable(const wcstring &key) const {
-        env_node_ref_t node = find_in_chain(locals_, key);
-        if (!node) node = find_in_chain(globals_, key);
-        if (node) {
-            auto iter = node->env.find(key);
-            assert(iter != node->env.end() && "Node should contain key");
-            return &iter->second;
-        }
-        return nullptr;
-    }
-};
-
-void env_stack_impl_t::push_nonshadowing() {
-    locals_ = std::make_shared<env_node_t>(false, locals_);
-}
-
-void env_stack_impl_t::push_shadowing() {
-    // Propagate local exported variables.
-    auto node = std::make_shared<env_node_t>(true, nullptr);
-    for (auto cursor = locals_; cursor; cursor = cursor->next) {
-        for (const auto &var : cursor->env) {
-            if (var.second.exports()) {
-                node->env.insert(var);
-                node->changed_exported();
-            }
-        }
-    }
-    this->shadowed_locals_.push_back(std::move(locals_));
-    this->locals_ = std::move(node);
-}
-
-env_node_ref_t env_stack_impl_t::pop() {
-    auto popped = std::move(locals_);
-    if (popped->next) {
-        // Pop the inner scope.
-        locals_ = popped->next;
-    } else {
-        // Exhausted the inner scopes, put back a shadowing scope.
-        assert(!shadowed_locals_.empty() && "Attempt to pop last local scope");
-        locals_ = std::move(shadowed_locals_.back());
-        shadowed_locals_.pop_back();
-    }
-    assert(locals_ && "Attempt to pop first local scope");
-    return popped;
-}
-
-/// Apply the pathvar behavior, splitting about colons.
-static std::vector<wcstring> colon_split(const std::vector<wcstring> &val) {
-    std::vector<wcstring> split_val;
-    split_val.reserve(val.size());
-    for (const wcstring &str : val) {
-        vec_append(split_val, split_string(str, PATH_ARRAY_SEP));
-    }
-    return split_val;
-}
-
-void env_stack_impl_t::set_in_node(const env_node_ref_t &node, const wcstring &key,
-                                   std::vector<wcstring> &&val, const var_flags_t &flags) {
-    env_var_t &var = node->env[key];
-
-    // Use an explicit exports, or inherit from the existing variable.
-    bool res_exports = flags.exports.has_value() ? *flags.exports : var.exports();
-
-    // Pathvar is inferred from the name. If set, split our entry about colons.
-    bool res_pathvar =
-        flags.pathvar.has_value() ? *flags.pathvar : variable_should_auto_pathvar(key);
-    if (res_pathvar) {
-        val = colon_split(val);
-    }
-
-    var =
-        var.setting_vals(std::move(val)).setting_exports(res_exports).setting_pathvar(res_pathvar);
-
-    // Perhaps mark that this node contains an exported variable, or shadows an exported variable.
-    // If so regenerate the export list.
-    if (res_exports || flags.parent_exports) {
-        node->changed_exported();
-    }
-}
-
-maybe_t<int> env_stack_impl_t::try_set_electric(const wcstring &key, const query_t &query,
-                                                std::vector<wcstring> &val) {
-    const electric_var_t *ev = electric_var_t::for_name(key);
-    if (!ev) {
-        return none();
-    }
-
-    // If a variable is electric, it may only be set in the global scope.
-    if (query.has_scope && !query.global) {
-        return ENV_SCOPE;
-    }
-
-    // If the variable is read-only, the user may not set it.
-    if (query.user && ev->readonly()) {
-        return ENV_PERM;
-    }
-
-    // Be picky about exporting.
-    if (query.has_export_unexport) {
-        if (ev->exports() ? query.unexports : query.exports) {
-            return ENV_SCOPE;
-        }
-    }
-
-    // Handle computed mutable electric variables.
-    if (key == L"umask") {
-        return set_umask(val);
-    } else if (key == L"PWD") {
-        assert(val.size() == 1 && "Should have exactly one element in PWD");
-        wcstring &pwd = val.front();
-        if (pwd != perproc_data().pwd) {
-            perproc_data().pwd = std::move(pwd);
-            globals_->changed_exported();
-        }
-        return ENV_OK;
-    }
-
-    // Decide on the mode and set it in the global scope.
-    var_flags_t flags{};
-    flags.exports = ev->exports();
-    flags.parent_exports = ev->exports();
-    flags.pathvar = false;
-    set_in_node(globals_, key, std::move(val), flags);
-    return ENV_OK;
-}
-
-/// Set a universal variable, inheriting as applicable from the given old variable.
-void env_stack_impl_t::set_universal(const wcstring &key, std::vector<wcstring> val,
-                                     const query_t &query) {
-    auto oldvar = uvars()->get(key);
-    // Resolve whether or not to export.
-    bool exports = false;
-    if (query.has_export_unexport) {
-        exports = query.exports;
-    } else if (oldvar) {
-        exports = oldvar->exports();
-    }
-
-    // Resolve whether to be a path variable.
-    // Here we fall back to the auto-pathvar behavior.
-    bool pathvar = false;
-    if (query.has_pathvar_unpathvar) {
-        pathvar = query.pathvar;
-    } else if (oldvar) {
-        pathvar = oldvar->is_pathvar();
-    } else {
-        pathvar = variable_should_auto_pathvar(key);
-    }
-
-    // Split about ':' if it's a path variable.
-    if (pathvar) {
-        std::vector<wcstring> split_val;
-        for (const wcstring &str : val) {
-            vec_append(split_val, split_string(str, PATH_ARRAY_SEP));
-        }
-        val = std::move(split_val);
-    }
-
-    // Construct and set the new variable.
-    env_var_t::env_var_flags_t varflags = 0;
-    if (exports) varflags |= env_var_t::flag_export;
-    if (pathvar) varflags |= env_var_t::flag_pathvar;
-    env_var_t new_var{val, varflags};
-
-    uvars()->set(key, new_var);
-}
-
-mod_result_t env_stack_impl_t::set(const wcstring &key, env_mode_flags_t mode,
-                                   std::vector<wcstring> val) {
-    const query_t query(mode);
-    // Handle electric and read-only variables.
-    auto ret = try_set_electric(key, query, val);
-    if (ret.has_value()) {
-        return mod_result_t{*ret};
-    }
-
-    // Resolve as much of our flags as we can. Note these contain maybes, and we may defer the final
-    // decision until the set_in_node call. Also note that we only inherit pathvar, not export. For
-    // example, if you have a global exported variable, a local variable with the same name will not
-    // automatically be exported. But if you have a global pathvar, a local variable with the same
-    // name will be a pathvar. This is historical.
-    var_flags_t flags{};
-    if (const env_var_t *existing = find_variable(key)) {
-        flags.pathvar = existing->is_pathvar();
-        flags.parent_exports = existing->exports();
-    }
-    if (query.has_export_unexport) {
-        flags.exports = query.exports;
-    }
-    if (query.has_pathvar_unpathvar) {
-        flags.pathvar = query.pathvar;
-    }
-
-    mod_result_t result{ENV_OK};
-    if (query.has_scope) {
-        // The user requested a particular scope.
-        //
-        // If we don't have uvars, fall back to using globals
-        if (query.universal && !s_uvar_scope_is_global) {
-            set_universal(key, std::move(val), query);
-            result.uvar_modified = true;
-        } else if (query.global || (query.universal && s_uvar_scope_is_global)) {
-            set_in_node(globals_, key, std::move(val), flags);
-            result.global_modified = true;
-        } else if (query.local) {
-            assert(locals_ != globals_ && "Locals should not be globals");
-            set_in_node(locals_, key, std::move(val), flags);
-        } else if (query.function) {
-            // "Function" scope is:
-            // Either the topmost local scope of the nearest function,
-            // or the top-level local scope if no function exists.
-            //
-            // This is distinct from the unspecified scope,
-            // which is the global scope if no function exists.
-            auto node = locals_;
-            while (node->next) {
-                node = node->next;
-                // The first node that introduces a new scope is ours.
-                // If this doesn't happen, we go on until we've reached the
-                // topmost local scope.
-                if (node->new_scope) break;
-            }
-            set_in_node(node, key, std::move(val), flags);
-        } else {
-            DIE("Unknown scope");
-        }
-    } else if (env_node_ref_t node = find_in_chain(locals_, key)) {
-        // Existing local variable.
-        set_in_node(node, key, std::move(val), flags);
-    } else if (env_node_ref_t node = find_in_chain(globals_, key)) {
-        // Existing global variable.
-        set_in_node(node, key, std::move(val), flags);
-        result.global_modified = true;
-    } else if (uvars()->get(key)) {
-        // Existing universal variable.
-        set_universal(key, std::move(val), query);
-        result.uvar_modified = true;
-    } else {
-        // Unspecified scope with no existing variables.
-        node = resolve_unspecified_scope();
-        assert(node && "Should always resolve some scope");
-        set_in_node(node, key, std::move(val), flags);
-        result.global_modified = (node == globals_);
-    }
-    return result;
-}
-
-mod_result_t env_stack_impl_t::remove(const wcstring &key, int mode) {
-    const query_t query(mode);
-
-    // Users can't remove read-only keys.
-    if (query.user && is_read_only(key)) {
-        return mod_result_t{ENV_SCOPE};
-    }
-
-    mod_result_t result{ENV_OK};
-    if (query.has_scope) {
-        // The user requested erasing from a particular scope.
-        if (query.universal) {
-            result.status = uvars()->remove(key) ? ENV_OK : ENV_NOT_FOUND;
-            result.uvar_modified = true;
-        } else if (query.global) {
-            result.status = remove_from_chain(globals_, key) ? ENV_OK : ENV_NOT_FOUND;
-            result.global_modified = true;
-        } else if (query.local) {
-            result.status = remove_from_chain(locals_, key) ? ENV_OK : ENV_NOT_FOUND;
-        } else if (query.function) {
-            auto node = locals_;
-            while (node->next) {
-                node = node->next;
-                if (node->new_scope) break;
-            }
-            result.status = remove_from_chain(node, key) ? ENV_OK : ENV_NOT_FOUND;
-        } else {
-            DIE("Unknown scope");
-        }
-    } else if (remove_from_chain(locals_, key)) {
-        // pass
-    } else if (remove_from_chain(globals_, key)) {
-        result.global_modified = true;
-    } else if (uvars()->remove(key)) {
-        result.uvar_modified = true;
-    } else {
-        result.status = ENV_NOT_FOUND;
-    }
-    return result;
-}
+bool env_stack_t::is_principal() const { return impl_->is_principal(); }
 
 std::vector<rust::Box<Event>> env_stack_t::universal_sync(bool always) {
-    if (s_uvar_scope_is_global) return {};
-    if (!always && !s_uvars_locally_modified) return {};
-    s_uvars_locally_modified = false;
-
-    callback_data_list_t callbacks;
-    bool changed = uvars()->sync(callbacks);
-    if (changed) {
-        universal_notifier_t::default_notifier().post_notification();
-    }
-    // React internally to changes to special variables like LANG, and populate on-variable events.
-    std::vector<rust::Box<Event>> result;
-    for (const callback_data_t &cb : callbacks) {
-        env_dispatch_var_change(cb.key, *this);
-        auto evt =
-            cb.is_erase() ? new_event_variable_erase(cb.key) : new_event_variable_set(cb.key);
-        result.push_back(std::move(evt));
-    }
-    return result;
+    event_list_ffi_t result;
+    impl_->universal_sync(always, result);
+    return std::move(result.events);
 }
 
 statuses_t env_stack_t::get_last_statuses() const {
-    return acquire_impl()->perproc_data().statuses;
+    auto statuses_ffi = impl_->get_last_statuses();
+    statuses_t res{};
+    res.status = statuses_ffi->get_status();
+    res.kill_signal = statuses_ffi->get_kill_signal();
+    auto &pipestatus = statuses_ffi->get_pipestatus();
+    res.pipestatus.assign(pipestatus.begin(), pipestatus.end());
+    return res;
 }
 
-int env_stack_t::get_last_status() const { return acquire_impl()->perproc_data().statuses.status; }
+int env_stack_t::get_last_status() const { return get_last_statuses().status; }
 
 void env_stack_t::set_last_statuses(statuses_t s) {
-    acquire_impl()->perproc_data().statuses = std::move(s);
+    return impl_->set_last_statuses(s.status, s.kill_signal, s.pipestatus);
 }
 
 /// Update the PWD variable directory from the result of getcwd().
-void env_stack_t::set_pwd_from_getcwd() {
-    wcstring cwd = wgetcwd();
-    if (cwd.empty()) {
-        FLOG(error,
-             _(L"Could not determine current working directory. Is your locale set correctly?"));
-        return;
-    }
-    set_one(L"PWD", ENV_EXPORT | ENV_GLOBAL, cwd);
-}
-
-env_stack_t::env_stack_t(std::unique_ptr<env_stack_impl_t> impl) : impl_(std::move(impl)) {}
-
-acquired_lock<env_stack_impl_t> env_stack_t::acquire_impl() {
-    return acquired_lock<env_stack_impl_t>::from_global(env_lock, impl_.get());
-}
-
-acquired_lock<const env_stack_impl_t> env_stack_t::acquire_impl() const {
-    return acquired_lock<const env_stack_impl_t>::from_global(env_lock, impl_.get());
-}
+void env_stack_t::set_pwd_from_getcwd() { impl_->set_pwd_from_getcwd(); }
 
 maybe_t<env_var_t> env_stack_t::get(const wcstring &key, env_mode_flags_t mode) const {
-    return acquire_impl()->get(key, mode);
+    if (auto *ptr = impl_->getf(key, mode)) {
+        return env_var_t::new_ffi(ptr);
+    }
+    return none();
 }
 
 std::vector<wcstring> env_stack_t::get_names(env_mode_flags_t flags) const {
-    return acquire_impl()->get_names(flags);
+    wcstring_list_ffi_t names;
+    impl_->get_names(flags, names);
+    return std::move(names.vals);
 }
 
 int env_stack_t::set(const wcstring &key, env_mode_flags_t mode, std::vector<wcstring> vals) {
-    // Historical behavior.
-    if (vals.size() == 1 && (key == L"PWD" || key == L"HOME")) {
-        path_make_canonical(vals.front());
-    }
-
-    // Hacky stuff around PATH and CDPATH: #3914.
-    // Not MANPATH; see #4158.
-    // Replace empties with dot. Note we ignore pathvar here.
-    if (key == L"PATH" || key == L"CDPATH") {
-        auto munged_vals = colon_split(vals);
-        std::replace(munged_vals.begin(), munged_vals.end(), wcstring(L""), wcstring(L"."));
-        vals = std::move(munged_vals);
-    }
-
-    mod_result_t ret = acquire_impl()->set(key, mode, std::move(vals));
-    if (ret.status == ENV_OK) {
-        // If we modified the global state, or we are principal, then dispatch changes.
-        // Important to not hold the lock here.
-        if (ret.global_modified || is_principal()) {
-            env_dispatch_var_change(key, *this);
-        }
-    }
-    // Mark if we modified a uvar.
-    if (ret.uvar_modified) {
-        s_uvars_locally_modified = true;
-    }
-    return ret.status;
+    return static_cast<int>(impl_->set(key, mode, std::move(vals)));
 }
 
 int env_stack_t::set_ffi(const wcstring &key, env_mode_flags_t mode, const void *vals,
@@ -1477,70 +443,69 @@ int env_stack_t::set_empty(const wcstring &key, env_mode_flags_t mode) {
 }
 
 int env_stack_t::remove(const wcstring &key, int mode) {
-    mod_result_t ret = acquire_impl()->remove(key, mode);
-    if (ret.status == ENV_OK) {
-        if (ret.global_modified || is_principal()) {
-            // Important to not hold the lock here.
-            env_dispatch_var_change(key, *this);
-        }
-    }
-    if (ret.uvar_modified) {
-        s_uvars_locally_modified = true;
-    }
-    return ret.status;
+    return static_cast<int>(impl_->remove(key, mode));
 }
 
 std::shared_ptr<owning_null_terminated_array_t> env_stack_t::export_arr() {
-    return acquire_impl()->export_array();
+    // export_array() returns a rust::Box<OwningNullTerminatedArrayRefFFI>.
+    // Acquire ownership.
+    OwningNullTerminatedArrayRefFFI *ptr = impl_->export_array();
+    assert(ptr && "Null pointer");
+    return std::make_shared<owning_null_terminated_array_t>(
+        rust::Box<OwningNullTerminatedArrayRefFFI>::from_raw(ptr));
 }
 
-std::shared_ptr<environment_t> env_stack_t::snapshot() const { return acquire_impl()->snapshot(); }
+/// Wrapper around a EnvDyn.
+class env_dyn_t final : public environment_t {
+   public:
+    env_dyn_t(rust::Box<EnvDyn> impl) : impl_(std::move(impl)) {}
+
+    maybe_t<env_var_t> get(const wcstring &key, env_mode_flags_t mode) const {
+        if (auto *ptr = impl_->getf(key, mode)) {
+            return env_var_t::new_ffi(ptr);
+        }
+        return none();
+    }
+
+    std::vector<wcstring> get_names(env_mode_flags_t flags) const {
+        wcstring_list_ffi_t names;
+        impl_->get_names(flags, names);
+        return std::move(names.vals);
+    }
+
+   private:
+    rust::Box<EnvDyn> impl_;
+};
+
+std::shared_ptr<environment_t> env_stack_t::snapshot() const {
+    auto res = std::make_shared<env_dyn_t>(impl_->snapshot());
+    return std::static_pointer_cast<environment_t>(res);
+}
 
 void env_stack_t::set_argv(std::vector<wcstring> argv) { set(L"argv", ENV_LOCAL, std::move(argv)); }
 
 wcstring env_stack_t::get_pwd_slash() const {
-    wcstring pwd = acquire_impl()->perproc_data().pwd;
-    if (!string_suffixes_string(L"/", pwd)) {
-        pwd.push_back(L'/');
-    }
-    return pwd;
+    std::unique_ptr<wcstring> res = impl_->get_pwd_slash();
+    return std::move(*res);
 }
 
-void env_stack_t::push(bool new_scope) {
-    auto impl = acquire_impl();
-    if (new_scope) {
-        impl->push_shadowing();
-    } else {
-        impl->push_nonshadowing();
-    }
-}
+void env_stack_t::push(bool new_scope) { impl_->push(new_scope); }
 
-void env_stack_t::pop() {
-    auto popped = acquire_impl()->pop();
-    // Only dispatch variable changes if we are the principal environment.
-    if (this == principal_ref().get()) {
-        // TODO: we would like to coalesce locale / curses changes, so that we only re-initialize
-        // once.
-        for (const auto &kv : popped->env) {
-            env_dispatch_var_change(kv.first, *this);
-        }
-    }
-}
+void env_stack_t::pop() { impl_->pop(); }
 
 env_stack_t &env_stack_t::globals() {
-    static env_stack_t s_globals(env_stack_impl_t::create());
+    static env_stack_t s_globals(env_get_globals_ffi());
     return s_globals;
 }
 
 const std::shared_ptr<env_stack_t> &env_stack_t::principal_ref() {
-    static const std::shared_ptr<env_stack_t> s_principal{
-        new env_stack_t(env_stack_impl_t::create())};
+    static const std::shared_ptr<env_stack_t> s_principal{new env_stack_t(env_get_principal_ffi())};
     return s_principal;
 }
 
 env_stack_t::~env_stack_t() = default;
-
 env_stack_t::env_stack_t(env_stack_t &&) = default;
+env_stack_t::env_stack_t(rust::Box<EnvStackRef> imp) : impl_(std::move(imp)) {}
 
 #if defined(__APPLE__) || defined(__CYGWIN__)
 static int check_runtime_path(const char *path) {

--- a/src/env.h
+++ b/src/env.h
@@ -23,6 +23,20 @@
 struct EnvVar;
 #endif
 
+/// FFI helper for events.
+struct Event;
+struct event_list_ffi_t {
+    event_list_ffi_t(const event_list_ffi_t &) = delete;
+    event_list_ffi_t &operator=(const event_list_ffi_t &) = delete;
+    event_list_ffi_t();
+#if INCLUDE_RUST_HEADERS
+    std::vector<rust::Box<Event>> events{};
+#endif
+
+    // Append an Event pointer, which came from Box::into_raw().
+    void push(void *event);
+};
+
 struct owning_null_terminated_array_t;
 
 extern size_t read_byte_limit;
@@ -341,5 +355,9 @@ void unsetenv_lock(const char *name);
 /// Returns the originally inherited variables and their values.
 /// This is a simple key->value map and not e.g. cut into paths.
 const std::map<wcstring, wcstring> &env_get_inherited();
+
+/// Populate the values in the "$history" variable.
+/// fish_history_val is the value of the "$fish_history" variable, or "fish" if not set.
+wcstring_list_ffi_t get_history_variable_text_ffi(const wcstring &fish_history_val);
 
 #endif

--- a/src/env.h
+++ b/src/env.h
@@ -16,7 +16,7 @@
 #include "cxx.h"
 #include "maybe.h"
 
-class owning_null_terminated_array_t;
+struct owning_null_terminated_array_t;
 
 extern size_t read_byte_limit;
 extern bool curses_initialized;

--- a/src/env_dispatch.cpp
+++ b/src/env_dispatch.cpp
@@ -195,6 +195,10 @@ void env_dispatch_var_change(const wcstring &key, env_stack_t &vars) {
     s_var_dispatch_table->dispatch(key, vars);
 }
 
+void env_dispatch_var_change_ffi(const wcstring &key) {
+    return env_dispatch_var_change(key, env_stack_t::principal());
+}
+
 static void handle_fish_term_change(const env_stack_t &vars) {
     update_fish_color_support(vars);
     reader_schedule_prompt_repaint();

--- a/src/env_dispatch.h
+++ b/src/env_dispatch.h
@@ -15,4 +15,8 @@ void env_dispatch_init(const environment_t &vars);
 /// React to changes in variables like LANG which require running some code.
 void env_dispatch_var_change(const wcstring &key, env_stack_t &vars);
 
+/// FFI wrapper which always uses the principal stack.
+/// TODO: pass in the variables directly.
+void env_dispatch_var_change_ffi(const wcstring &key /*, env_stack_t &vars */);
+
 #endif

--- a/src/env_universal_common.cpp
+++ b/src/env_universal_common.cpp
@@ -236,6 +236,14 @@ maybe_t<env_var_t> env_universal_t::get(const wcstring &name) const {
     return none();
 }
 
+std::unique_ptr<env_var_t> env_universal_t::get_ffi(const wcstring &name) const {
+    if (auto var = this->get(name)) {
+        return make_unique<env_var_t>(var.acquire());
+    } else {
+        return nullptr;
+    }
+}
+
 maybe_t<env_var_t::env_var_flags_t> env_universal_t::get_flags(const wcstring &name) const {
     auto where = vars.find(name);
     if (where != vars.end()) {
@@ -1430,3 +1438,11 @@ bool universal_notifier_t::notification_fd_became_readable(int fd) {
     UNUSED(fd);
     return false;
 }
+
+var_table_ffi_t::var_table_ffi_t(const var_table_t &table) {
+    for (const auto &kv : table) {
+        this->names.push_back(kv.first);
+        this->vars.push_back(kv.second);
+    }
+}
+var_table_ffi_t::~var_table_ffi_t() = default;

--- a/src/event.h
+++ b/src/event.h
@@ -2,7 +2,6 @@
 // replacement. There is no logic still in here that needs to be ported to rust.
 
 #ifndef FISH_EVENT_H
-#ifdef INCLUDE_RUST_HEADERS
 #define FISH_EVENT_H
 
 #include <unistd.h>
@@ -13,11 +12,16 @@
 #include <vector>
 
 #include "common.h"
+#include "cxx.h"
 #include "global_safety.h"
 #include "wutil.h"
 
 class parser_t;
+#if INCLUDE_RUST_HEADERS
 #include "event.rs.h"
+#else
+struct Event;
+#endif
 
 /// The process id that is used to match any process id.
 // TODO: Remove after porting functions.cpp
@@ -33,5 +37,4 @@ class parser_t;
 void event_fire_generic(parser_t &parser, const wcstring &name,
                         const std::vector<wcstring> &args = g_empty_string_list);
 
-#endif
 #endif

--- a/src/kill.cpp
+++ b/src/kill.cpp
@@ -57,3 +57,5 @@ std::vector<wcstring> kill_entries() {
     auto kill_list = s_kill_list.acquire();
     return std::vector<wcstring>{kill_list->begin(), kill_list->end()};
 }
+
+wcstring_list_ffi_t kill_entries_ffi() { return kill_entries(); }

--- a/src/kill.h
+++ b/src/kill.h
@@ -6,6 +6,7 @@
 #define FISH_KILL_H
 
 #include "common.h"
+#include "wutil.h"
 
 /// Replace the specified string in the killring.
 void kill_replace(const wcstring &old, const wcstring &newv);
@@ -21,5 +22,8 @@ wcstring kill_yank();
 
 /// Get copy of kill ring as vector of strings
 std::vector<wcstring> kill_entries();
+
+/// Rust-friendly kill entries.
+wcstring_list_ffi_t kill_entries_ffi();
 
 #endif

--- a/src/null_terminated_array.cpp
+++ b/src/null_terminated_array.cpp
@@ -8,3 +8,12 @@ std::vector<std::string> wide_string_list_to_narrow(const std::vector<wcstring> 
     }
     return res;
 }
+
+const char **owning_null_terminated_array_t::get() { return impl_->get(); }
+
+owning_null_terminated_array_t::owning_null_terminated_array_t(std::vector<std::string> &&strings)
+    : impl_(new_owning_null_terminated_array(strings)) {}
+
+owning_null_terminated_array_t::owning_null_terminated_array_t(
+    rust::Box<OwningNullTerminatedArrayRefFFI> impl)
+    : impl_(std::move(impl)) {}

--- a/src/null_terminated_array.h
+++ b/src/null_terminated_array.h
@@ -10,6 +10,12 @@
 #include <vector>
 
 #include "common.h"
+#include "cxx.h"
+
+struct OwningNullTerminatedArrayRefFFI;
+#if INCLUDE_RUST_HEADERS
+#include "null_terminated_array.rs.h"
+#endif
 
 /// This supports the null-terminated array of NUL-terminated strings consumed by exec.
 /// Given a list of strings, construct a vector of pointers to those strings contents.
@@ -46,18 +52,19 @@ class null_terminated_array_t : noncopyable_t, nonmovable_t {
 /// This is useful for persisted null-terminated arrays, e.g. the exported environment variable
 /// list. This assumes char, since we don't need this for wchar_t.
 /// Note this class is not movable or copyable as it embeds a null_terminated_array_t.
-class owning_null_terminated_array_t {
+struct owning_null_terminated_array_t {
    public:
     // Access the null-terminated array of nul-terminated strings, appropriate for execv().
-    const char **get() { return pointers_.get(); }
+    const char **get();
 
     // Construct, taking ownership of a list of strings.
-    explicit owning_null_terminated_array_t(std::vector<std::string> &&strings)
-        : strings_(std::move(strings)), pointers_(strings_) {}
+    explicit owning_null_terminated_array_t(std::vector<std::string> &&strings);
+
+    // Construct from the FFI side.
+    explicit owning_null_terminated_array_t(rust::Box<OwningNullTerminatedArrayRefFFI> impl);
 
    private:
-    const std::vector<std::string> strings_;
-    null_terminated_array_t<char> pointers_;
+    const rust::Box<OwningNullTerminatedArrayRefFFI> impl_;
 };
 
 /// Helper to convert a list of wcstring to a list of std::string.

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -47,6 +47,7 @@ struct wcstring_list_ffi_t {
 
     size_t size() const { return vals.size(); }
     const wcstring &at(size_t idx) const { return vals.at(idx); }
+    void clear() { vals.clear(); }
 
     /// Helper to construct one.
     static std::unique_ptr<wcstring_list_ffi_t> create() {


### PR DESCRIPTION
This reimplements variables in Rust (`env_var_t` -> `EnvVar`) and also the environment stack, and other environments.

We retain the C++ classes, but both now wrap Rust implementations.

There's still a lot of initialization code in env.cpp which will be migrated to Rust later, but this is a good milestone.