### PR TITLE
Rework ASAN integration 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,9 +119,9 @@ jobs:
           # environments. Follow https://github.com/google/sanitizers/issues/1342 and
           # https://github.com/google/sanitizers/issues/1409 to track this issue.
           # UPDATE: this can cause spurious leak reports for __cxa_thread_atexit_impl() under glibc.
-          LSAN_OPTIONS: verbosity=0:log_threads=0:use_tls=1
+          LSAN_OPTIONS: verbosity=0:log_threads=0:use_tls=1:print_suppressions=0
       run: |
-        make test
+        env LSAN_OPTIONS="$LSAN_OPTIONS:suppressions=$PWD/build_tools/lsan_suppressions.txt" make test
 
   # Our clang++ tsan builds are not recognizing safe rust patterns (such as the fact that Drop
   # cannot be called while a thread is using the object in question). Rust has its own way of

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,8 @@ jobs:
           # which seems to be an issue with TLS support in newer glibc versions under virtualized
           # environments. Follow https://github.com/google/sanitizers/issues/1342 and
           # https://github.com/google/sanitizers/issues/1409 to track this issue.
-          LSAN_OPTIONS: verbosity=0:log_threads=0:use_tls=0
+          # UPDATE: this can cause spurious leak reports for __cxa_thread_atexit_impl() under glibc.
+          LSAN_OPTIONS: verbosity=0:log_threads=0:use_tls=1
       run: |
         make test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
     - name: make test
       env:
           FISH_CI_SAN: 1
-          ASAN_OPTIONS: check_initialization_order=1:detect_stack_use_after_return=1:detect_leaks=1
+          ASAN_OPTIONS: check_initialization_order=1:detect_stack_use_after_return=1:detect_leaks=1:fast_unwind_on_malloc=0
           UBSAN_OPTIONS: print_stacktrace=1:report_error_type=1
           # use_tls=0 is a workaround for LSAN crashing with "Tracer caught signal 11" (SIGSEGV),
           # which seems to be an issue with TLS support in newer glibc versions under virtualized

--- a/build_tools/lsan_suppressions.txt
+++ b/build_tools/lsan_suppressions.txt
@@ -1,0 +1,6 @@
+# LSAN can detect leaks tracing back to __asan::AsanThread::ThreadStart (probably caused by our
+# threads not exiting before their TLS dtors are called). Just ignore it.
+leak:AsanThread
+
+# ncurses leaks allocations freely as it assumes it will be running throughout. Ignore these.
+leak:tparm

--- a/cmake/Rust.cmake
+++ b/cmake/Rust.cmake
@@ -25,6 +25,7 @@ set(fish_rust_target "fish-rust")
 
 set(fish_autocxx_gen_dir "${CMAKE_BINARY_DIR}/fish-autocxx-gen/")
 
+set(FISH_CRATE_FEATURES "fish-ffi-tests")
 if(NOT DEFINED CARGO_FLAGS)
     # Corrosion doesn't like an empty string as FLAGS. This is basically a no-op alternative.
     # See https://github.com/corrosion-rs/corrosion/issues/356
@@ -32,11 +33,12 @@ if(NOT DEFINED CARGO_FLAGS)
 endif()
 if(DEFINED ASAN)
     list(APPEND CARGO_FLAGS "-Z" "build-std")
+    list(APPEND FISH_CRATE_FEATURES "asan")
 endif()
 
 corrosion_import_crate(
     MANIFEST_PATH "${CMAKE_SOURCE_DIR}/fish-rust/Cargo.toml"
-    FEATURES "fish-ffi-tests"
+    FEATURES "${FISH_CRATE_FEATURES}"
     FLAGS "${CARGO_FLAGS}"
 )
 

--- a/fish-rust/Cargo.toml
+++ b/fish-rust/Cargo.toml
@@ -44,6 +44,7 @@ default = ["fish-ffi-tests"]
 fish-ffi-tests = ["inventory"]
 
 # The following features are auto-detected by the build-script and should not be enabled manually.
+asan = []
 bsd = []
 
 [patch.crates-io]

--- a/fish-rust/src/re.rs
+++ b/fish-rust/src/re.rs
@@ -4,12 +4,12 @@ use crate::wchar::{wstr, WString, L};
 /// This is a workaround for the fact that PCRE2_ENDANCHORED is unavailable on pre-2017 PCRE2
 /// (e.g. 10.21, on Xenial).
 pub fn regex_make_anchored(pattern: &wstr) -> WString {
-    let mut anchored = pattern.to_owned();
     // PATTERN -> ^(:?PATTERN)$.
     let prefix = L!("^(?:");
     let suffix = L!(")$");
-    anchored.reserve(pattern.len() + prefix.len() + suffix.len());
-    anchored.insert_utfstr(0, prefix);
+    let mut anchored = WString::with_capacity(prefix.len() + pattern.len() + suffix.len());
+    anchored.push_utfstr(prefix);
+    anchored.push_utfstr(pattern);
     anchored.push_utfstr(suffix);
     anchored
 }

--- a/fish-rust/src/threads.rs
+++ b/fish-rust/src/threads.rs
@@ -325,6 +325,13 @@ pub fn asan_maybe_exit(#[allow(unused)] code: i32) {
 pub fn asan_before_exit() {
     #[cfg(feature = "asan")]
     if !is_forked_child() {
+        unsafe {
+            // Free ncurses terminal state
+            extern "C" {
+                fn env_cleanup();
+            }
+            env_cleanup();
+        }
     }
 }
 

--- a/src/fish.cpp
+++ b/src/fish.cpp
@@ -63,6 +63,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "proc.h"
 #include "reader.h"
 #include "signals.h"
+#include "threads.rs.h"
 #include "wcstringutil.h"
 #include "wutil.h"  // IWYU pragma: keep
 
@@ -614,6 +615,7 @@ int main(int argc, char **argv) {
     if (debug_output) {
         fclose(debug_output);
     }
+    asan_maybe_exit(exit_status);
     exit_without_destructors(exit_status);
     return EXIT_FAILURE;  // above line should always exit
 }

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -96,6 +96,7 @@
 #include "signals.h"
 #include "smoke.rs.h"
 #include "termsize.h"
+#include "threads.rs.h"
 #include "tokenizer.h"
 #include "topic_monitor.h"
 #include "utf8.h"
@@ -6513,6 +6514,9 @@ int main(int argc, char **argv) {
 
     say(L"Encountered %d errors in low-level tests", err_count);
     if (s_test_run_count == 0) say(L"*** No Tests Were Actually Run! ***");
+
+    // If under ASAN, reclaim some resources before exiting.
+    asan_before_exit();
 
     if (err_count != 0) {
         return 1;


### PR DESCRIPTION
After fighting with ASAN for three days, I think I have something better. 

* The workaround for the virtualization bug w/ ASAN segfaulting randomly was to use use_tls=0 which didn’t use the ASAN tls interposer. Flipping that makes threads use ASAN for tls management and everything works better (I think ASAN runs after they're killed and reaped?). If ASAN runs again into the `Tracer caught signal 11` error randomly because of this change, well, it's better than it failing every CI run.
* I also tweaked the other ASAN options a bit and added a separate LSAN suppressions list. The individual commits for those explain it. 
* Now the only thing we do differently under ASAN is free the ncurses `TERMINAL` pointer and use `exit()` instead of `_exit()` so LSAN gets a chance to report (this is for `fish.cpp`).
* There was an actual memory leak in `init_curses()` - I’m not sure how many times it could theoretically be called but it is not just once. That’s patched. 