### PR TITLE
completions: fix qdbus Q_NOREPLY method completion

### DIFF
--- a/share/completions/qdbus.fish
+++ b/share/completions/qdbus.fish
@@ -11,7 +11,7 @@ function __fish_qdbus_complete
     set argc (count $argv)
     if test $argc -le 3
         # avoid completion of property value
-        qdbus $qdbus_flags $argv[2] $argv[3] | string replace --regex '^(?<kind>property\ (read)?(write)?|signal|method) (?<type>(\{.+\})|([^\ ]+)) (?<name>[^\(]+)(?<arguments>\(.+?\))?' '$name\t$kind $type $arguments' | string trim
+        qdbus $qdbus_flags $argv[2] $argv[3] | string replace --regex '^(?<kind>property\ (read)?(write)?|signal|method( Q_NOREPLY)?) (?<type>(\{.+\})|([^\ ]+)) (?<name>[^\(]+)(?<arguments>\(.+?\))?' '$name\t$kind $type $arguments' | string trim
     end
 end
 


### PR DESCRIPTION
## Description

`qdbus` may print method ["tag"](https://doc.qt.io/qt-5/qmetamethod.html#tag) as `Q_NOREPLY`[^1] when it has annotation `org.freedesktop.DBus.Method.NoReply`[^2], and this is the only "tag" value it can be[^3]. This PR just adds optional `Q_NOREPLY` to the regex.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst


[^1]: https://github.com/qt/qttools/blob/v5.15.9-lts-lgpl/src/qdbus/qdbus/qdbus.cpp#L185
[^2]: https://github.com/qt/qtbase/blob/v5.15.9-lts-lgpl/src/dbus/qdbusabstractinterface_p.h#L63
[^3]: https://github.com/qt/qtbase/blob/v5.15.9-lts-lgpl/src/dbus/qdbusmetaobject.cpp#L294-L296
