### PR TITLE
Change Job and Process to use interior mutability and fix fallout

### DIFF
--- a/fish-rust/src/builtins/bg.rs
+++ b/fish-rust/src/builtins/bg.rs
@@ -27,9 +27,9 @@ fn send_to_bg(
     job_pos: usize,
 ) -> Option<c_int> {
     let jobs = parser.jobs();
-    if !jobs[job_pos].read().unwrap().wants_job_control() {
+    if !jobs[job_pos].wants_job_control() {
         let err = {
-            let job = &jobs[job_pos].read().unwrap();
+            let job = &jobs[job_pos];
             wgettext_fmt!(
                 "%ls: Can't put job %d, '%ls' to background because it is not under job control\n",
                 cmd,
@@ -42,7 +42,7 @@ fn send_to_bg(
     }
 
     {
-        let mut job = jobs[job_pos].write().unwrap();
+        let job = &jobs[job_pos];
         streams.err.append(&wgettext_fmt!(
             "Send job %d '%ls' to background\n",
             job.job_id().to_wstring(),
@@ -77,10 +77,9 @@ pub fn bg(parser: &Parser, streams: &mut IoStreams<'_>, args: &mut [WString]) ->
     if opts.optind == args.len() {
         // No jobs were specified so use the most recent (i.e., last) job.
         let jobs = parser.jobs();
-        let job_pos = jobs.iter().position(|job| {
-            let job = job.read().unwrap();
-            job.is_stopped() && job.wants_job_control() && !job.is_completed()
-        });
+        let job_pos = jobs
+            .iter()
+            .position(|job| job.is_stopped() && job.wants_job_control() && !job.is_completed());
 
         let Some(job_pos) = job_pos else {
             streams

--- a/fish-rust/src/builtins/wait.rs
+++ b/fish-rust/src/builtins/wait.rs
@@ -60,13 +60,11 @@ fn find_wait_handles(
 
     // Is there a running job match?
     for j in &*parser.jobs() {
-        let mut j = j.write().unwrap();
         // We want to set 'matched' to true if we could have matched, even if the job was stopped.
         let provide_handle = can_wait_on_job(&j);
         let internal_job_id = j.internal_job_id;
-        for proc in &mut j.processes {
-            let wh = proc.make_wait_handle(internal_job_id);
-            let Some(wh) = wh else {
+        for proc in j.processes().iter() {
+            let Some(wh) = proc.make_wait_handle(internal_job_id) else {
                 continue;
             };
             if wait_handle_matches(query, &wh) {
@@ -86,12 +84,11 @@ fn get_all_wait_handles(parser: &Parser) -> Vec<WaitHandleRef> {
 
     // Get wait handles for running jobs.
     for j in &*parser.jobs() {
-        let mut j = j.write().unwrap();
         if !can_wait_on_job(&j) {
             continue;
         }
         let internal_job_id = j.internal_job_id;
-        for proc in j.processes.iter_mut() {
+        for proc in j.processes().iter() {
             if let Some(wh) = proc.make_wait_handle(internal_job_id) {
                 result.push(wh);
             }

--- a/fish-rust/src/event.rs
+++ b/fish-rust/src/event.rs
@@ -598,7 +598,6 @@ pub fn get_desc(parser: &Parser, evt: &Event) -> WString {
         EventType::ProcessExit { pid } => format!("exit handler for process {pid}"),
         EventType::JobExit { pid, .. } => {
             if let Some(job) = parser.job_get_from_pid(*pid) {
-                let job = job.read().unwrap();
                 format!("exit handler for job {}, '{}'", job.job_id(), job.command())
             } else {
                 format!("exit handler for job with pid {pid}")

--- a/fish-rust/src/exec.rs
+++ b/fish-rust/src/exec.rs
@@ -522,7 +522,7 @@ fn run_internal_process(p: &Process, outdata: Vec<u8>, errdata: Vec<u8>, ios: &I
 
         ios: IoChain,
         dup2s: Dup2List,
-        internal_proc: Arc<InternalProc>,
+        internal_proc: Rc<InternalProc>,
 
         success_status: ProcStatus,
     }
@@ -535,7 +535,7 @@ fn run_internal_process(p: &Process, outdata: Vec<u8>, errdata: Vec<u8>, ios: &I
         }
     }
     // Construct and assign the internal process to the real process.
-    let internal_proc = Arc::new(InternalProc::new());
+    let internal_proc = Rc::new(InternalProc::new());
     let old = p.internal_proc.replace(Some(internal_proc.clone()));
     assert!(
         old.is_none(),

--- a/fish-rust/src/postfork.rs
+++ b/fish-rust/src/postfork.rs
@@ -140,9 +140,9 @@ pub fn report_setpgid_error(
     let mut argv0 = [b'0'; 64];
     let mut command = [b'0'; 64];
 
-    format_llong_safe(&mut pid_buff, p.pid);
+    format_llong_safe(&mut pid_buff, p.pid());
     format_llong_safe(&mut job_id_buff, j.job_id().as_num());
-    format_llong_safe(&mut getpgid_buff, unsafe { libc::getpgid(p.pid) });
+    format_llong_safe(&mut getpgid_buff, unsafe { libc::getpgid(p.pid()) });
     format_llong_safe(&mut job_pgid_buff, desired_pgid);
     narrow_string_safe(&mut argv0, p.argv0().unwrap());
     narrow_string_safe(&mut command, j.command());

--- a/fish-rust/src/proc.rs
+++ b/fish-rust/src/proc.rs
@@ -38,6 +38,7 @@ use std::ffi::CString;
 use std::fs;
 use std::io::{Read, Write};
 use std::os::fd::RawFd;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use widestring_suffix::widestrs;
@@ -549,7 +550,7 @@ pub struct Process {
     pub pid: AtomicI32,
 
     /// If we are an "internal process," that process.
-    pub internal_proc: RefCell<Option<Arc<InternalProc>>>,
+    pub internal_proc: RefCell<Option<Rc<InternalProc>>>,
 
     /// File descriptor that pipe output should bind to.
     pub pipe_write_fd: RawFd,
@@ -578,6 +579,9 @@ pub struct Process {
     // The wait handle. This is constructed lazily, and cached.
     // This may be null.
     wait_handle: RefCell<Option<WaitHandleRef>>,
+
+    /// Prevent `Process` from being `Send` or `Sync`.
+    _marker: std::marker::PhantomData<*const ()>,
 }
 
 #[derive(Default)]
@@ -782,6 +786,9 @@ pub struct Job {
 
     /// Flags associated with the job.
     pub job_flags: RefCell<JobFlags>,
+
+    /// Prevent `Job` from being `Send` or `Sync`.
+    _marker: std::marker::PhantomData<*const ()>,
 }
 
 impl Job {

--- a/fish-rust/src/signal.rs
+++ b/fish-rust/src/signal.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroI32;
 use crate::common::{exit_without_destructors, restore_term_foreground_process_group_for_exit};
 use crate::event::{enqueue_signal, is_signal_observed};
 use crate::termsize::termsize_handle_winch;
-use crate::topic_monitor::{generation_t, invalid_generations, topic_monitor_principal, topic_t};
+use crate::topic_monitor::{generation_t, topic_monitor_principal, topic_t, GenerationsList};
 use crate::wchar::{wstr, WExt, L};
 use crate::wchar_ffi::c_str;
 use crate::wchar_ffi::{AsWstr, WCharToFFI};
@@ -394,8 +394,8 @@ impl SigChecker {
     /// Wait until a sigint is delivered.
     pub fn wait(&self) {
         let tm = topic_monitor_principal();
-        let mut gens = invalid_generations();
-        *gens.at_mut(self.topic) = self.gen;
+        let mut gens = GenerationsList::invalid();
+        gens.set(self.topic, self.gen);
         tm.check(&mut gens, true /* wait */);
     }
 }

--- a/fish-rust/src/topic_monitor.rs
+++ b/fish-rust/src/topic_monitor.rs
@@ -28,93 +28,56 @@ use crate::wchar::{widestrs, wstr, WString};
 use crate::wchar_ffi::wcharz;
 use nix::errno::Errno;
 use nix::unistd;
-use std::cell::UnsafeCell;
+use std::cell::{Cell, UnsafeCell};
 use std::mem;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::{Condvar, Mutex, MutexGuard};
 
 #[cxx::bridge]
-mod topic_monitor_ffi {
-    /// Simple value type containing the values for a topic.
-    /// This should be kept in sync with topic_t.
-    #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
-    pub struct generation_list_t {
-        // TODO: Replace with AtomicU64 for interior mutability
-        pub sighupint: u64,
-        // TODO: Replace with AtomicU64 for interior mutability
-        pub sigchld: u64,
-        // TODO: Replace with AtomicU64 for interior mutability
-        pub internal_exit: u64,
-    }
+mod topic_monitor_ffi {}
 
-    extern "Rust" {
-        fn invalid_generations() -> generation_list_t;
-        fn set_min_from(self: &mut generation_list_t, topic: topic_t, other: &generation_list_t);
-        fn at(self: &generation_list_t, topic: topic_t) -> u64;
-        fn at_mut(self: &mut generation_list_t, topic: topic_t) -> &mut u64;
-        //fn describe(self: &generation_list_t) -> UniquePtr<wcstring>;
-    }
-
-    /// The list of topics which may be observed.
-    #[repr(u8)]
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-    pub enum topic_t {
-        sighupint,     // Corresponds to both SIGHUP and SIGINT signals.
-        sigchld,       // Corresponds to SIGCHLD signal.
-        internal_exit, // Corresponds to an internal process exit.
-    }
-
-    extern "Rust" {
-        type topic_monitor_t;
-        fn new_topic_monitor() -> Box<topic_monitor_t>;
-
-        fn topic_monitor_principal() -> &'static topic_monitor_t;
-        fn post(self: &topic_monitor_t, topic: topic_t);
-        fn current_generations(self: &topic_monitor_t) -> generation_list_t;
-        fn generation_for_topic(self: &topic_monitor_t, topic: topic_t) -> u64;
-        fn check(self: &topic_monitor_t, gens: *mut generation_list_t, wait: bool) -> bool;
-    }
+/// The list of topics which may be observed.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum topic_t {
+    sighupint = 0,     // Corresponds to both SIGHUP and SIGINT signals.
+    sigchld = 1,       // Corresponds to SIGCHLD signal.
+    internal_exit = 2, // Corresponds to an internal process exit.
 }
 
-impl topic_monitor_ffi::generation_list_t {
-    pub fn set_sighupint(&self, value: u64) {
-        let dst: &AtomicU64 = unsafe { std::mem::transmute(&self.sighupint) };
-        dst.store(value, Ordering::Relaxed);
-    }
+// XXX: Is it correct to use the default or should the default be invalid_generation?
+#[derive(Clone, Default, PartialEq, PartialOrd, Eq, Ord)]
+pub struct GenerationsList {
+    pub sighupint: Cell<u64>,
+    pub sigchld: Cell<u64>,
+    pub internal_exit: Cell<u64>,
+}
 
-    pub fn set_sigchld(&self, value: u64) {
-        let dst: &AtomicU64 = unsafe { std::mem::transmute(&self.sigchld) };
-        dst.store(value, Ordering::Relaxed);
-    }
-
-    pub fn set_internal_exit(&self, value: u64) {
-        let dst: &AtomicU64 = unsafe { std::mem::transmute(&self.internal_exit) };
-        dst.store(value, Ordering::Relaxed);
-    }
-
+/// Simple value type containing the values for a topic.
+/// This should be kept in sync with topic_t.
+impl GenerationsList {
     /// Update `self` gen counts to match those of `other`.
     pub fn update(&self, other: &Self) {
-        self.set_sighupint(other.sighupint);
-        self.set_sigchld(other.sigchld);
-        self.set_internal_exit(other.internal_exit);
+        self.sighupint.set(other.sighupint.get());
+        self.sigchld.set(other.sigchld.get());
+        self.internal_exit.set(other.internal_exit.get());
     }
 }
 
-pub use topic_monitor_ffi::{generation_list_t, topic_t};
 pub type generation_t = u64;
 
 impl FloggableDebug for topic_t {}
 
 /// A generation value which indicates the topic is not of interest.
-pub const invalid_generation: generation_t = std::u64::MAX;
+pub const INVALID_GENERATION: generation_t = std::u64::MAX;
 
 pub fn all_topics() -> [topic_t; 3] {
     [topic_t::sighupint, topic_t::sigchld, topic_t::internal_exit]
 }
 
 #[widestrs]
-impl generation_list_t {
+impl GenerationsList {
     pub fn new() -> Self {
         Self::default()
     }
@@ -125,7 +88,7 @@ impl generation_list_t {
             if result.len() > 0 {
                 result.push(',');
             }
-            if gen == invalid_generation {
+            if gen == INVALID_GENERATION {
                 result.push_str("-1");
             } else {
                 result.push_str(&gen.to_string());
@@ -134,48 +97,50 @@ impl generation_list_t {
         return result;
     }
 
-    /// \return the a mutable reference to the value for a topic.
-    pub fn at_mut(&mut self, topic: topic_t) -> &mut generation_t {
+    /// Sets the generation for `topic` to `value`.
+    pub fn set(&self, topic: topic_t, value: generation_t) {
         match topic {
-            topic_t::sighupint => &mut self.sighupint,
-            topic_t::sigchld => &mut self.sigchld,
-            topic_t::internal_exit => &mut self.internal_exit,
-            _ => panic!("invalid topic"),
+            topic_t::sighupint => self.sighupint.set(value),
+            topic_t::sigchld => self.sigchld.set(value),
+            topic_t::internal_exit => self.internal_exit.set(value),
         }
     }
 
     /// \return the value for a topic.
-    pub fn at(&self, topic: topic_t) -> generation_t {
+    pub fn get(&self, topic: topic_t) -> generation_t {
         match topic {
-            topic_t::sighupint => self.sighupint,
-            topic_t::sigchld => self.sigchld,
-            topic_t::internal_exit => self.internal_exit,
-            _ => panic!("invalid topic"),
+            topic_t::sighupint => self.sighupint.get(),
+            topic_t::sigchld => self.sigchld.get(),
+            topic_t::internal_exit => self.internal_exit.get(),
         }
     }
 
     /// \return ourselves as an array.
     pub fn as_array(&self) -> [generation_t; 3] {
-        [self.sighupint, self.sigchld, self.internal_exit]
+        [
+            self.sighupint.get(),
+            self.sigchld.get(),
+            self.internal_exit.get(),
+        ]
     }
 
     /// Set the value of \p topic to the smaller of our value and the value in \p other.
-    pub fn set_min_from(&mut self, topic: topic_t, other: &generation_list_t) {
-        if self.at(topic) > other.at(topic) {
-            *self.at_mut(topic) = other.at(topic);
+    pub fn set_min_from(&mut self, topic: topic_t, other: &Self) {
+        if self.get(topic) > other.get(topic) {
+            self.set(topic, other.get(topic));
         }
     }
 
     /// \return whether a topic is valid.
     pub fn is_valid(&self, topic: topic_t) -> bool {
-        self.at(topic) != invalid_generation
+        self.get(topic) != INVALID_GENERATION
     }
 
     /// \return whether any topic is valid.
     pub fn any_valid(&self) -> bool {
         let mut valid = false;
         for gen in self.as_array() {
-            if gen != invalid_generation {
+            if gen != INVALID_GENERATION {
                 valid = true;
             }
         }
@@ -183,18 +148,13 @@ impl generation_list_t {
     }
 
     /// Generation list containing invalid generations only.
-    pub fn invalids() -> generation_list_t {
-        generation_list_t {
-            sighupint: invalid_generation,
-            sigchld: invalid_generation,
-            internal_exit: invalid_generation,
+    pub fn invalid() -> GenerationsList {
+        GenerationsList {
+            sighupint: INVALID_GENERATION.into(),
+            sigchld: INVALID_GENERATION.into(),
+            internal_exit: INVALID_GENERATION.into(),
         }
     }
-}
-
-/// CXX wrapper as it does not support member functions.
-pub fn invalid_generations() -> generation_list_t {
-    generation_list_t::invalids()
 }
 
 /// A simple binary semaphore.
@@ -233,11 +193,11 @@ impl binary_semaphore_t {
             assert!(pipes.is_some(), "Failed to make pubsub pipes");
             pipes_ = pipes.unwrap();
 
-            // Whoof. Thread Sanitizer swallows signals and replays them at its leisure, at the point
-            // where instrumented code makes certain blocking calls. But tsan cannot interrupt a signal
-            // call, so if we're blocked in read() (like the topic monitor wants to be!), we'll never
-            // receive SIGCHLD and so deadlock. So if tsan is enabled, we mark our fd as non-blocking
-            // (so reads will never block) and use select() to poll it.
+            // Whoof. Thread Sanitizer swallows signals and replays them at its leisure, at the
+            // point where instrumented code makes certain blocking calls. But tsan cannot interrupt
+            // a signal call, so if we're blocked in read() (like the topic monitor wants to be!),
+            // we'll never receive SIGCHLD and so deadlock. So if tsan is enabled, we mark our fd as
+            // non-blocking (so reads will never block) and use select() to poll it.
             if cfg!(feature = "FISH_TSAN_WORKAROUNDS") {
                 ffi::make_fd_nonblocking(c_int(pipes_.read.fd()));
             }
@@ -359,14 +319,14 @@ impl Default for binary_semaphore_t {
 type topic_bitmask_t = u8;
 
 fn topic_to_bit(t: topic_t) -> topic_bitmask_t {
-    1 << t.repr
+    1 << (t as u8)
 }
 
 // Some stuff that needs to be protected by the same lock.
 #[derive(Default)]
 struct data_t {
     /// The current values.
-    current: generation_list_t,
+    current: GenerationsList,
 
     /// A flag indicating that there is a current reader.
     /// The 'reader' is responsible for calling sema_.wait().
@@ -465,7 +425,7 @@ impl topic_monitor_t {
     /// Apply any pending updates to the data.
     /// This accepts data because it must be locked.
     /// \return the updated generation list.
-    fn updated_gens_in_data(&self, data: &mut MutexGuard<data_t>) -> generation_list_t {
+    fn updated_gens_in_data(&self, data: &mut MutexGuard<data_t>) -> GenerationsList {
         // Atomically acquire the pending updates, swapping in 0.
         // If there are no pending updates (likely) or a thread is waiting, just return.
         // Otherwise CAS in 0 and update our topics.
@@ -475,7 +435,7 @@ impl topic_monitor_t {
         while !cas_success {
             changed_topic_bits = self.status_.load(relaxed);
             if changed_topic_bits == 0 || changed_topic_bits == STATUS_NEEDS_WAKEUP {
-                return data.current;
+                return data.current.clone();
             }
             cas_success = self
                 .status_
@@ -490,35 +450,35 @@ impl topic_monitor_t {
         // Update the current generation with our topics and return it.
         for topic in all_topics() {
             if changed_topic_bits & topic_to_bit(topic) != 0 {
-                *data.current.at_mut(topic) += 1;
+                data.current.set(topic, data.current.get(topic) + 1);
                 FLOG!(
                     topic_monitor,
                     "Updating topic",
                     topic,
                     "to",
-                    data.current.at(topic)
+                    data.current.get(topic)
                 );
             }
         }
         // Report our change.
         self.data_notifier_.notify_all();
-        return data.current;
+        return data.current.clone();
     }
 
     /// \return the current generation list, opportunistically applying any pending updates.
-    fn updated_gens(&self) -> generation_list_t {
+    fn updated_gens(&self) -> GenerationsList {
         let mut data = self.data_.lock().unwrap();
         return self.updated_gens_in_data(&mut data);
     }
 
     /// Access the current generations.
-    pub fn current_generations(self: &topic_monitor_t) -> generation_list_t {
+    pub fn current_generations(self: &topic_monitor_t) -> GenerationsList {
         self.updated_gens()
     }
 
     /// Access the generation for a topic.
     pub fn generation_for_topic(self: &topic_monitor_t, topic: topic_t) -> generation_t {
-        self.current_generations().at(topic)
+        self.current_generations().get(topic)
     }
 
     /// Given a list of input generations, attempt to update them to something newer.
@@ -528,7 +488,7 @@ impl topic_monitor_t {
     /// indicating we should become the reader. Now it is our responsibility to wait on the
     /// semaphore and notify on a change via the condition variable. If \p gens is current, and
     /// there is already a reader, then wait until the reader notifies us and try again.
-    fn try_update_gens_maybe_becoming_reader(&self, gens: &mut generation_list_t) -> bool {
+    fn try_update_gens_maybe_becoming_reader(&self, gens: &mut GenerationsList) -> bool {
         let mut become_reader = false;
         let mut data = self.data_.lock().unwrap();
         loop {
@@ -584,9 +544,9 @@ impl topic_monitor_t {
 
     /// Wait for some entry in the list of generations to change.
     /// \return the new gens.
-    fn await_gens(&self, input_gens: &generation_list_t) -> generation_list_t {
-        let mut gens = *input_gens;
-        while gens == *input_gens {
+    fn await_gens(&self, input_gens: &GenerationsList) -> GenerationsList {
+        let mut gens = input_gens.clone();
+        while &gens == input_gens {
             let become_reader = self.try_update_gens_maybe_becoming_reader(&mut gens);
             if become_reader {
                 // Now we are the reader. Read from the pipe, and then update with any changes.
@@ -602,7 +562,7 @@ impl topic_monitor_t {
                 // We are finished waiting. We must stop being the reader, and post on the condition
                 // variable to wake up any other threads waiting for us to finish reading.
                 let mut data = self.data_.lock().unwrap();
-                gens = data.current;
+                gens = data.current.clone();
                 // FLOG(topic_monitor, "TID", thread_id(), "local", input_gens.describe(),
                 //      "read() complete, current is", gens.describe());
                 assert!(data.has_reader, "We should be the reader");
@@ -618,25 +578,23 @@ impl topic_monitor_t {
     /// If \p wait is set, then wait if there are no changes; otherwise return immediately.
     /// \return true if some topic changed, false if none did.
     /// On a true return, this updates the generation list \p gens.
-    pub fn check(&self, gens: *mut generation_list_t, wait: bool) -> bool {
-        assert!(!gens.is_null(), "gens must not be null");
-        let gens = unsafe { &mut *gens };
+    pub fn check(&self, gens: &GenerationsList, wait: bool) -> bool {
         if !gens.any_valid() {
             return false;
         }
 
-        let mut current: generation_list_t = self.updated_gens();
+        let mut current: GenerationsList = self.updated_gens();
         let mut changed = false;
         loop {
             // Load the topic list and see if anything has changed.
             for topic in all_topics() {
                 if gens.is_valid(topic) {
                     assert!(
-                        gens.at(topic) <= current.at(topic),
+                        gens.get(topic) <= current.get(topic),
                         "Incoming gen count exceeded published count"
                     );
-                    if gens.at(topic) < current.at(topic) {
-                        *gens.at_mut(topic) = current.at(topic);
+                    if gens.get(topic) < current.get(topic) {
+                        gens.set(topic, current.get(topic));
                         changed = true;
                     }
                 }


### PR DESCRIPTION
I removed the `RwLock`s but then all the `&T` and `&mut T` lifetimes were conflicting and nothing made sense so I changed to using a bare `&mut Job` and `&mut Process` when they are first created then after mutation has finished switching the `Job` to `Arc<Job>` (well, now it's an `Rc<Job>`). All access to `Job` after it's been handed to the `Parser` and all access to `Process` after it's been added to a `Job` happens through interior mutability.

----

    Use interior mutability for most Job and Process operations

    We only use `&mut Job` from the creation of a new `Job` until we put it in an
    `Arc` and hand it over to the parser. From that point on, all `Job` access must
    be read-only.

    Aside from not needing an `RwLock` because a Job is never sent to another
    thread and is only accessed from the same thread it was created, I believe the
    old code was prone to deadlocks since there were too many read borrows flying
    around at once for us to reliably say that no one will try to get a simultaneous
    write lock.

    The change necessitated the same treatment for `Process`: aside from when it is
    first created, we no longer use `&mut Process` for anything. All methods that
    can be called during the lifetime of a Process now use interior mutability.

    Note that with these changes we need to make sure that Job, JobRef, Process,
    etc. are all !Send and !Sync. Our interior mutability uses atomics but it
    doesn't use locks when updating multiple fields, meaning outside observers from
    another thread would see torn writes to the structs as a whole.

    With this change, the usages of `Parser::jobs_mut()` have been whittled down to
    just two (those that add a new job and those that remove an existing job) - all
    other access can now happen via `&Job` read-only references.

----
    Make Process and Job !Send and !Sync

    They are not intended to be shared across threads and our interior mutability
    functions are only sufficient for same-core access.

    With this change, we can also use Rc<Job> instead of Arc<Job> since there's no
    point to paying the atomic price here.

----

    Use interior mutability in generation_list_t

    The previous approach transmuting the values to `Cell<u64>` was extremely
    unsound since the compiler doesn't treat structs containg `Cell<T>` the same way
    that it treats `T`.

    It wasn't possible with the ffi because `at_mut()` returns a mutable reference
    and we really don't want to use `RefCell` here when the usecase is practically
    crying for `Cell` instead.
