### PR TITLE
update npm completions

### DIFF
--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -127,11 +127,18 @@ complete -f -c npm -n __fish_npm_needs_command -a get -d 'Echo the config value 
 complete -f -c npm -n __fish_npm_needs_command -a set -d 'Sets the config key to the value'
 
 # install
-for c in install isntall i
-    complete -c npm -n __fish_npm_needs_command -a "$c" -d 'install a package'
-    complete -c npm -n "__fish_npm_using_command $c" -l save-dev -d 'Save to devDependencies in package.json'
-    complete -c npm -n "__fish_npm_using_command $c" -l save -d 'Save to dependencies in package.json'
-    complete -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Install package globally'
+for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
+    complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Install a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s B -l save-bundle -d 'Also save to bundleDependencies in package.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s E -l save-exact -d 'Save dependency with exact version rather than a semver range'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Prevents saving to dependencies in package.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s O -l save-optional -d 'Save to optionalDependencies in package.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s P -l save-prod -d 'Save to dependencies in package.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s D -l save-dev -d 'Save to devDependencies in package.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Install package globally'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d 'Do not run scripts specified in package.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Pack and install file: protocol dependences as regular dependencies instead of symlinks'
 end
 
 # list

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -129,6 +129,12 @@ end
 complete -f -c npm -n __fish_npm_needs_command -a get -d 'Echo the config value to stdout'
 complete -f -c npm -n __fish_npm_needs_command -a set -d 'Sets the config key to the value'
 
+# init
+for c in init create innit
+    complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Create a package.json file'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s y -l yes -d 'Automatically answer "yes" to all prompts'
+end
+
 # install
 for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
     complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Install a package'

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -162,8 +162,7 @@ for c in r remove rm un uninstall unlink
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'remove package' -xa '(__yarn_installed_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'remove global package'
     complete -x -c npm -n "__fish_npm_using_command $c" -l save -d 'Package will be removed from your dependencies'
-    complete -x -c npm -n "__fish_npm_using_command $c" -l save-dev -d 'Package will be removed from your devDependencies'
-    complete -x -c npm -n "__fish_npm_using_command $c" -l save-optional -d 'Package will be removed from your optionalDependencies'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
 end
 
 # search

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -196,7 +196,7 @@ complete -x -c npm -n '__fish_npm_using_command publish' -l otp -d '2FA one-time
 # remove
 for c in uninstall unlink remove rm r un
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Remove a package'
-    complete -x -c npm -n "__fish_npm_using_command $c" -d 'remove package' -a '(__yarn_installed_local_packages)'
+    complete -x -c npm -n "__fish_npm_using_command $c" -d 'remove package' -a '(__npm_installed_local_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'remove global package' -a '(__npm_installed_global_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -l save -d 'Package will be removed from your dependencies'
     complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
@@ -262,4 +262,4 @@ complete -f -c npm -n __fish_npm_needs_command -a unstar -d 'Remove star from a 
 complete -f -c npm -n __fish_npm_needs_command -a 'version verison' -d 'Bump a package version'
 complete -f -c npm -n __fish_npm_needs_command -a 'view info v show' -d 'View registry info'
 complete -f -c npm -n __fish_npm_needs_command -a whoami -d 'Display npm username'
-complete -f -c npm -n '__fish_seen_subcommand_from add i install; and not __fish_is_switch' -a "(__yarn_filtered_list_packages \"$npm_install\")"
+complete -f -c npm -n '__fish_seen_subcommand_from add i install; and not __fish_is_switch' -a "(__npm_filtered_list_packages \"$npm_install\")"

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -166,6 +166,14 @@ complete -f -c npm -n '__fish_npm_using_command pack' -l dry-run -d 'Only report
 complete -f -c npm -n '__fish_npm_using_command pack' -l json -d 'Output JSON data'
 complete -c npm -n '__fish_npm_using_command pack' -l pack-destination -d 'Tarball destination directory'
 
+# publish
+complete -f -c npm -n __fish_npm_needs_command -a publish -d 'Publish a package'
+complete -x -c npm -n '__fish_npm_using_command publish' -l tag -d 'Upload to tag'
+complete -x -c npm -n '__fish_npm_using_command publish' -l access -d 'Restrict access' -a "public\t'Publicly viewable' restricted\t'Restricted access (scoped packages only)'"
+complete -f -c npm -n '__fish_npm_using_command publish' -l dry-run -d 'Only report what it would have done'
+complete -x -c npm -n '__fish_npm_using_command publish' -l otp -d '2FA one-time password'
+## todo provenance ?
+
 # remove
 for c in r remove rm un uninstall unlink
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Remove a package'
@@ -204,7 +212,6 @@ complete -f -c npm -n __fish_npm_needs_command -a 'link ln' -d 'Symlink a packag
 complete -f -c npm -n __fish_npm_needs_command -a outdated -d 'Check for outdated packages'
 complete -f -c npm -n __fish_npm_needs_command -a prefix -d 'Display NPM prefix'
 complete -f -c npm -n __fish_npm_needs_command -a prune -d 'Remove extraneous packages'
-complete -c npm -n __fish_npm_needs_command -a publish -d 'Publish a package'
 complete -f -c npm -n __fish_npm_needs_command -a 'rb rebuild' -d 'Rebuild a package'
 complete -f -c npm -n __fish_npm_needs_command -a 'root ' -d 'Display npm root'
 complete -f -c npm -n __fish_npm_needs_command -a 'run-script run' -d 'Run arbitrary package scripts'

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -115,11 +115,11 @@ end
 # access
 set -l access_commands 'list get set grant revoke'
 complete -f -c npm -n __fish_npm_needs_command -a access -d 'Set access level on published packages'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a list -d 'List access info'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a get -d 'Get access level'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a grant -d 'Grant access to users'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a revoke -d 'Revoke access from users'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a set -d 'Set access level'
+complete -x -c npm -n '__fish_npm_using_command access' -n "not __fish_seen_subcommand_from $access_commands" -a list -d 'List access info'
+complete -x -c npm -n '__fish_npm_using_command access' -n "not __fish_seen_subcommand_from $access_commands" -a get -d 'Get access level'
+complete -x -c npm -n '__fish_npm_using_command access' -n "not __fish_seen_subcommand_from $access_commands" -a grant -d 'Grant access to users'
+complete -x -c npm -n '__fish_npm_using_command access' -n "not __fish_seen_subcommand_from $access_commands" -a revoke -d 'Revoke access from users'
+complete -x -c npm -n '__fish_npm_using_command access' -n "not __fish_seen_subcommand_from $access_commands" -a set -d 'Set access level'
 complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from list' -a 'packages collaborators'
 complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from get' -a status
 complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from grant' -a 'read-only read-write'
@@ -145,7 +145,7 @@ complete -f -c npm -n '__fish_npm_using_command audit' -a signatures -d 'Verify 
 complete -f -c npm -n '__fish_npm_using_command audit' -a fix -d 'Install compatible updates to vulnerable deps'
 complete -x -c npm -n '__fish_npm_using_command audit' -l audit-level -a 'info low moderate high critical none' -d 'Audit level'
 complete -f -c npm -n '__fish_npm_using_command audit' -l dry-run -d 'Do not make any changes'
-complete -f -c npm -n '__fish_npm_using_command audit' -l force -d 'Removes various protections'
+complete -f -c npm -n '__fish_npm_using_command audit' -s f -l force -d 'Removes various protections'
 complete -f -c npm -n '__fish_npm_using_command audit' -l json -d 'Output JSON'
 complete -f -c npm -n '__fish_npm_using_command audit' -l package-lock-only -d 'Only use package-lock.json, ignore node_modules'
 complete -x -c npm -n '__fish_npm_using_command audit' -l omit -a 'dev optional peer' -d 'Omit dependency type'
@@ -197,6 +197,11 @@ for c in config c
     complete -f -c npm -n "__fish_npm_using_command $c" -a edit -d 'Opens the config file in an editor'
     complete -f -c npm -n "__fish_npm_using_command $c" -a fix -d 'Attempts to repair invalid configuration items'
     complete -f -c npm -n "__fish_npm_using_command $c" -a fix -d 'Attempts to repair invalid configuration items'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Edit global config'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l editor -d 'Specify the editor'
+    complete -x -c npm -n "__fish_npm_using_command $c" -s L -l location -a 'global user project' -d 'Which config file'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s l -l long -d 'Show extended information'
 end
 # get, set also exist as shorthands
 complete -f -c npm -n __fish_npm_needs_command -a get -d 'Get a value from the npm configuration'
@@ -265,7 +270,7 @@ complete -f -c npm -n '__fish_npm_using_command doctor' -a cache -d 'Verify cach
 
 # edit
 complete -f -c npm -n __fish_npm_needs_command -a edit -d 'Edit an installed package'
-complete -f -c npm -n '__fish_npm_using_command edit' -a editor -d 'Specify the editor'
+complete -f -c npm -n '__fish_npm_using_command edit' -l editor -d 'Specify the editor'
 
 # exec
 complete -f -c npm -n __fish_npm_needs_command -a exec -d 'Run a command from a local or remote npm package'
@@ -298,12 +303,13 @@ complete -f -c npm -n __fish_npm_needs_command -a help-search -d 'Search npm hel
 complete -f -c npm -n '__fish_npm_using_command help-search' -s l -l long -d 'Show extended information'
 
 # hook
+set -l hook_commands 'add ls update rm'
 complete -f -c npm -n __fish_npm_needs_command -a hook -d 'Manage registry hooks'
-complete -f -c npm -n '__fish_npm_using_command hook' -a add -d 'Add a hook'
-complete -f -c npm -n '__fish_npm_using_command hook; and __fish_seen_subcommand_from add' -l type -d 'Hook type'
-complete -f -c npm -n '__fish_npm_using_command hook' -a ls -d 'List all active hooks'
-complete -f -c npm -n '__fish_npm_using_command hook' -a update -d 'Update an existing hook'
-complete -f -c npm -n '__fish_npm_using_command hook' -a rm -d 'Remove a hook'
+complete -f -c npm -n '__fish_npm_using_command hook' -n "not __fish_seen_subcommand_from $hook_commands" -a add -d 'Add a hook'
+complete -f -c npm -n '__fish_npm_using_command hook' -n "not __fish_seen_subcommand_from $hook_commands" -a ls -d 'List all active hooks'
+complete -f -c npm -n '__fish_npm_using_command hook' -n "not __fish_seen_subcommand_from $hook_commands" -a update -d 'Update an existing hook'
+complete -f -c npm -n '__fish_npm_using_command hook' -n "not __fish_seen_subcommand_from $hook_commands" -a rm -d 'Remove a hook'
+complete -f -c npm -n '__fish_npm_using_command hook' -n '__fish_seen_subcommand_from add' -l type -d 'Hook type'
 complete -x -c npm -n '__fish_npm_using_command hook' -l registry -d 'Registry base URL'
 complete -x -c npm -n '__fish_npm_using_command hook' -l otp -d '2FA one-time password'
 
@@ -311,15 +317,18 @@ complete -x -c npm -n '__fish_npm_using_command hook' -l otp -d '2FA one-time pa
 complete -c npm -n __fish_npm_needs_command -a 'init create' -d 'Create a package.json file'
 for c in init create innit
     complete -f -c npm -n "__fish_npm_using_command $c" -s y -l yes -d 'Automatically answer "yes" to all prompts'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l force -d 'Removes various protections'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s f -l force -d 'Removes various protections'
     complete -x -c npm -n "__fish_npm_using_command $c" -l scope -d 'Create a scoped package'
 end
 
 # install
 # install-test
+# link
 complete -c npm -n __fish_npm_needs_command -a 'install add i' -d 'Install a package'
 complete -f -c npm -n __fish_npm_needs_command -a 'install-test it' -d 'Install package(s) and run tests'
-for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall install-test it
+complete -f -c npm -n __fish_npm_needs_command -a 'link ln' -d 'Symlink a package folder'
+for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall install-test it link ln
+    complete -f -c npm -n "__fish_npm_using_command $c" -s S -l save -d 'Save to dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Prevents saving to dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s P -l save-prod -d 'Save to dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s D -l save-dev -d 'Save to devDependencies'
@@ -374,13 +383,13 @@ complete -f -c npm -n '__fish_npm_using_command outdated' -s g -l global -d 'Che
 # org
 complete -f -c npm -n __fish_npm_needs_command -a org -d 'Manage orgs'
 for c in org ogr
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2" -a set -d 'Add a new user'
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2" -a rm -d 'Remove a user'
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2" -a ls -d 'List all users'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 2' -a set -d 'Add a new user'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 2' -a rm -d 'Remove a user'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 2' -a ls -d 'List all users'
 
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 5" -n '__fish_seen_subcommand_from set' -a admin -d 'Add admin'
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 5" -n '__fish_seen_subcommand_from set' -a developer -d 'Add developer'
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 5" -n '__fish_seen_subcommand_from set' -a owner -d 'Add owner'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 5' -n '__fish_seen_subcommand_from set' -a admin -d 'Add admin'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 5' -n '__fish_seen_subcommand_from set' -a developer -d 'Add developer'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 5' -n '__fish_seen_subcommand_from set' -a owner -d 'Add owner'
 end
 
 # owner
@@ -408,12 +417,31 @@ complete -f -c npm -n __fish_npm_needs_command -a pkg -d 'Manages your package.j
 complete -x -c npm -n '__fish_npm_using_command pkg' -a set -d 'Sets a value'
 complete -x -c npm -n '__fish_npm_using_command pkg' -a get -d 'Retrieves a value'
 complete -x -c npm -n '__fish_npm_using_command pkg' -a delete -d 'Deletes a key'
-complete -f -c npm -n '__fish_npm_using_command pkg' -l force -d 'Removes various protections'
+complete -f -c npm -n '__fish_npm_using_command pkg' -s f -l force -d 'Removes various protections'
 complete -f -c npm -n '__fish_npm_using_command pkg' -l json -d 'Parse values with JSON.parse()'
 
 # prefix
 complete -f -c npm -n __fish_npm_needs_command -a prefix -d 'Display npm prefix'
 complete -f -c npm -n '__fish_npm_using_command prefix' -s g -l global -d 'Display global prefix'
+
+# profile
+set -l profile_commands 'enable-2fa disable-2fa get set'
+complete -f -c npm -n __fish_npm_needs_command -a profile -d 'Change settings on your registry profile'
+complete -x -c npm -n '__fish_npm_using_command profile' -n "not __fish_seen_subcommand_from $profile_commands" -a enable-2fa -d 'Enables two-factor authentication'
+complete -x -c npm -n '__fish_npm_using_command profile' -n "not __fish_seen_subcommand_from $profile_commands" -a disable-2fa -d 'Disables two-factor authentication'
+complete -x -c npm -n '__fish_npm_using_command profile' -n "not __fish_seen_subcommand_from $profile_commands" -a get -d 'Display profile properties'
+complete -x -c npm -n '__fish_npm_using_command profile' -n "not __fish_seen_subcommand_from $profile_commands" -a set -d 'Set the value of a profile property'
+complete -x -c npm -n '__fish_npm_using_command profile' -n '__fish_seen_subcommand_from enable-2fa' -a 'auth-only' -d 'Requiere an OTP on profile changes'
+complete -x -c npm -n '__fish_npm_using_command profile' -n '__fish_seen_subcommand_from enable-2fa' -a 'auth-and-writes' -d 'Also requiere an OTP on package changes'
+
+# prune
+complete -f -c npm -n __fish_npm_needs_command -a prune -d 'Remove extraneous packages'
+complete -x -c npm -n '__fish_npm_using_command prune' -l omit -a 'dev optional peer' -d 'Omit dependency type'
+complete -f -c npm -n '__fish_npm_using_command prune' -l dry-run -d 'Do not make any changes'
+complete -f -c npm -n '__fish_npm_using_command prune' -l json -d 'Output JSON'
+complete -f -c npm -n '__fish_npm_using_command prune' -l foreground-scripts -d 'Run all build scripts in the foreground'
+complete -f -c npm -n '__fish_npm_using_command prune' -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
+complete -f -c npm -n '__fish_npm_using_command prune' -l install-links -d 'Install file: protocol deps as regular deps'
 
 # publish
 complete -f -c npm -n __fish_npm_needs_command -a publish -d 'Publish a package'
@@ -427,12 +455,14 @@ complete -f -c npm -n '__fish_npm_using_command publish' -l provenance -d 'Link 
 complete -f -c npm -n __fish_npm_needs_command -a query -d 'Dependency selector query'
 complete -f -c npm -n '__fish_npm_using_command query' -s g -l global -d 'Query global packages'
 
-# remove
-complete -f -c npm -n __fish_npm_needs_command -a 'uninstall remove un' -d 'Remove a package'
-for c in uninstall unlink remove rm r un
-    complete -x -c npm -n "__fish_npm_using_command $c" -d 'Remove package' -a '(__npm_installed_local_packages)'
-    complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Remove global package' -a '(__npm_installed_global_packages)'
-    complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
+# rebuild
+complete -f -c npm -n __fish_npm_needs_command -a rebuild -d 'Rebuild a package'
+for c in rebuild rb
+    complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Rebuild global package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l foreground-scripts -d 'Run all build scripts in the foreground'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
 end
 
 # repo
@@ -465,6 +495,8 @@ for c in search find s se
     complete -f -c npm -n "__fish_npm_using_command $c" -s l -l long -d 'Show extended information'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON data'
     complete -f -c npm -n "__fish_npm_using_command $c" -l color -a always -d 'Print color'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l color -a always -d 'Print color'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-color -d "Don't print color"
     complete -f -c npm -n "__fish_npm_using_command $c" -s p -l parseable -d 'Output parseable results'
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-description -d "Don't show the description"
     complete -x -c npm -n "__fish_npm_using_command $c" -l searchopts -d 'Space-separated search options'
@@ -486,11 +518,63 @@ complete -x -c npm -n '__fish_npm_using_command star' -l otp -d '2FA one-time pa
 complete -f -c npm -n __fish_npm_needs_command -a stars -d 'View packages marked as favorites'
 complete -x -c npm -n '__fish_npm_using_command stars' -l registry -d 'Registry base URL'
 
+# team
+set -l team_commands 'create destroy add rm ls'
+complete -f -c npm -n __fish_npm_needs_command -a team -d 'Manage organization teams and team memberships'
+complete -x -c npm -n '__fish_npm_using_command team' -n "not __fish_seen_subcommand_from $team_commands" -a create -d 'Create a new team'
+complete -x -c npm -n '__fish_npm_using_command team' -n "not __fish_seen_subcommand_from $team_commands" -a destroy -d 'Destroy an existing team'
+complete -x -c npm -n '__fish_npm_using_command team' -n "not __fish_seen_subcommand_from $team_commands" -a add -d 'Add a user to an existing team'
+complete -x -c npm -n '__fish_npm_using_command team' -n "not __fish_seen_subcommand_from $team_commands" -a rm -d 'Remove users from a team'
+complete -x -c npm -n '__fish_npm_using_command team' -n "not __fish_seen_subcommand_from $team_commands" -a ls -d 'List teams or team members'
+complete -x -c npm -n '__fish_npm_using_command team' -n 'not __fish_seen_subcommand_from ls' -l otp -d '2FA one-time password'
+complete -x -c npm -n '__fish_npm_using_command team' -l registry -d 'Registry base URL'
+complete -f -c npm -n '__fish_npm_using_command team' -s p -l parseable -d 'Output parseable results'
+complete -f -c npm -n '__fish_npm_using_command team' -l json -d 'Output JSON'
+
+# token
+set -l token_commands 'create destroy add rm ls'
+complete -f -c npm -n __fish_npm_needs_command -a token -d 'Manage your authentication tokens'
+complete -x -c npm -n '__fish_npm_using_command token' -n "not __fish_seen_subcommand_from $token_commands" -a list -d 'Shows active authentication tokens'
+complete -x -c npm -n '__fish_npm_using_command token' -n "not __fish_seen_subcommand_from $token_commands" -a revoke -d 'Revokes an authentication token'
+complete -x -c npm -n '__fish_npm_using_command token' -n "not __fish_seen_subcommand_from $token_commands" -a create -d 'Create a new authentication token'
+complete -f -c npm -n '__fish_npm_using_command token' -n '__fish_seen_subcommand_from create' -l read-only -d 'Mark a token as unable to publish'
+complete -x -c npm -n '__fish_npm_using_command token' -n '__fish_seen_subcommand_from create' -l cidr -d 'List of CIDR address'
+complete -x -c npm -n '__fish_npm_using_command token' -l registry -d 'Registry base URL'
+complete -x -c npm -n '__fish_npm_using_command token' -l otp -d '2FA one-time password'
+
 # update
 complete -f -c npm -n __fish_npm_needs_command -a 'update up upgrade' -d 'Update package(s)'
 for c in update up upgrade udpate
+    complete -f -c npm -n "__fish_npm_using_command $c" -s S -l save -d 'Save to dependencies'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Update global package(s)'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l install-strategy -a 'hoisted nested shallow linked' -d 'Install strategy'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l strict-peer-deps -d 'Treat conflicting peerDependencies as failure'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l no-package-lock -d 'Ignore package-lock.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l foreground-scripts -d 'Run all build scripts in the foreground'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-audit -d "Don't submit audit reports"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d 'Do not make any changes'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
 end
+
+# uninstall
+complete -f -c npm -n __fish_npm_needs_command -a 'uninstall remove un' -d 'Remove a package'
+for c in uninstall unlink remove rm r un
+    complete -x -c npm -n "__fish_npm_using_command $c" -d 'Remove package' -a '(__npm_installed_local_packages)'
+    complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Remove global package' -a '(__npm_installed_global_packages)'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s S -l save -d 'Save to dependencies'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+end
+
+# unpublish
+complete -f -c npm -n __fish_npm_needs_command -a unpublish -d 'Remove a package from the registry'
+complete -x -c npm -n '__fish_npm_using_command unpublish' -l dry-run -d 'Do not make any changes'
+complete -x -c npm -n '__fish_npm_using_command unpublish' -s f -l force -d 'Removes various protections'
 
 # unstar
 complete -f -c npm -n __fish_npm_needs_command -a unstar -d 'Remove star from a package'
@@ -514,10 +598,10 @@ end
 # view
 complete -f -c npm -n __fish_npm_needs_command -a 'view info' -d 'View registry info'
 for c in view info v show
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2"
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'author bin bugs description engines exports homepage keywords license main name repository scripts type types'
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'dependencies devDependencies optionalDependencies peerDependencies'
-    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'directories dist dist-tags gitHead maintainers readme time users version versions'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 2'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 3' -a 'author bin bugs description engines exports homepage keywords license main name repository scripts type types'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 3' -a 'dependencies devDependencies optionalDependencies peerDependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 3' -a 'directories dist dist-tags gitHead maintainers readme time users version versions'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
 end
 
@@ -529,12 +613,4 @@ complete -f -c npm -n '__fish_npm_using_command whoami' -a registry -d 'Check re
 complete -f -c npm -n __fish_npm_needs_command -a completion -d 'Tab Completion for npm'
 complete -f -c npm -n __fish_npm_needs_command -a 'help hlep' -d 'Get help on npm'
 complete -f -c npm -n __fish_npm_needs_command -a shrinkwrap -d 'Lock down dependency versions'
-
-complete -f -c npm -n __fish_npm_needs_command -a 'link ln' -d 'Symlink a package folder'
-complete -f -c npm -n __fish_npm_needs_command -a profile -d 'Change settings on your registry profile'
-complete -f -c npm -n __fish_npm_needs_command -a prune -d 'Remove extraneous packages'
-complete -f -c npm -n __fish_npm_needs_command -a 'rebuild rb' -d 'Rebuild a package'
-complete -f -c npm -n __fish_npm_needs_command -a team -d 'Manage organization teams and team memberships'
-complete -f -c npm -n __fish_npm_needs_command -a token -d 'Manage your authentication tokens'
-complete -f -c npm -n __fish_npm_needs_command -a unpublish -d 'Remove a package from the registry'
 complete -f -c npm -n '__fish_seen_subcommand_from add i in ins inst insta instal isnt isnta isntal isntall; and not __fish_is_switch' -a "(__npm_filtered_list_packages \"$npm_install\")"

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -72,7 +72,7 @@ end
 # and uninstall (reading dependencies is faster and more robust and yarn needs the functions anyways)
 # see: https://github.com/npm/npm/issues/9524
 # and: https://github.com/fish-shell/fish-shell/pull/2366
-complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run run-script audit r remove rm un uninstall unlink' -a "(__fish_complete_npm)"
+complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run-script run rum urn audit uninstall unlink remove rm r un' -a "(__fish_complete_npm)"
 
 # list available npm scripts and their parial content
 function __fish_parse_npm_run_completions
@@ -174,10 +174,12 @@ for c in ls list ll la
 end
 
 # owner
-complete -f -c npm -n __fish_npm_needs_command -a owner -d 'Manage package owners'
-complete -f -c npm -n '__fish_npm_using_command owner' -a ls -d 'List package owners'
-complete -f -c npm -n '__fish_npm_using_command owner' -a add -d 'Add a new owner to package'
-complete -f -c npm -n '__fish_npm_using_command owner' -a rm -d 'Remove an owner from package'
+for c in owner author
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Manage package owners'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a ls -d 'List package owners'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a add -d 'Add a new owner to package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a rm -d 'Remove an owner from package'
+end
 
 # pack
 complete -f -c npm -n __fish_npm_needs_command -a pack -d 'Create a tarball from a package'
@@ -218,6 +220,7 @@ end
 complete -f -c npm -n __fish_npm_needs_command -a 'adduser add-user login' -d 'Add a registry user account'
 complete -f -c npm -n __fish_npm_needs_command -a 'bugs issues' -d 'Bugs for a package in a web browser maybe'
 complete -f -c npm -n __fish_npm_needs_command -a 'ci clean-install ic install-clean isntall-clean' -d 'Clean install a project'
+complete -f -c npm -n __fish_npm_needs_command -a completion -d 'Tab Completion for npm'
 complete -f -c npm -n __fish_npm_needs_command -a 'dedupe ddp find-dupes' -d 'Reduce duplication'
 complete -f -c npm -n __fish_npm_needs_command -a deprecate -d 'Deprecate a version of a package'
 complete -f -c npm -n __fish_npm_needs_command -a diff -d 'The registry diff command'
@@ -262,4 +265,4 @@ complete -f -c npm -n __fish_npm_needs_command -a unstar -d 'Remove star from a 
 complete -f -c npm -n __fish_npm_needs_command -a 'version verison' -d 'Bump a package version'
 complete -f -c npm -n __fish_npm_needs_command -a 'view info v show' -d 'View registry info'
 complete -f -c npm -n __fish_npm_needs_command -a whoami -d 'Display npm username'
-complete -f -c npm -n '__fish_seen_subcommand_from add i install; and not __fish_is_switch' -a "(__npm_filtered_list_packages \"$npm_install\")"
+complete -f -c npm -n '__fish_seen_subcommand_from add i in ins inst insta instal isnt isnta isntal isntall; and not __fish_is_switch' -a "(__npm_filtered_list_packages \"$npm_install\")"

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -103,8 +103,8 @@ for k,v in data["scripts"].items(): print(k + "\t" + v[:18])' <package.json 2>/d
 end
 
 # run
+complete -f -c npm -n __fish_npm_needs_command -a 'run-script run' -d 'Run arbitrary package scripts'
 for c in run-script run rum urn
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Run arbitrary package scripts'
     complete -f -c npm -n "__fish_npm_using_command $c" -a "(__fish_npm_run)"
     complete -f -c npm -n "__fish_npm_using_command $c" -l if-present -d "Don't error on nonexistant script"
     complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
@@ -131,7 +131,7 @@ complete -x -c npm -n '__fish_npm_using_command access' -l otp -d '2FA one-time 
 complete -x -c npm -n '__fish_npm_using_command access' -l registry -d 'Registry base URL'
 
 # adduser
-complete -f -c npm -n __fish_npm_needs_command -a "adduser add-user" -d 'Add a registry user account'
+complete -f -c npm -n __fish_npm_needs_command -a adduser -d 'Add a registry user account'
 complete -f -c npm -n __fish_npm_needs_command -a login -d 'Login to a registry user account'
 for c in adduser add-user login
     complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
@@ -171,8 +171,8 @@ complete -x -c npm -n '__fish_npm_using_command cache' -l cache -a '(__fish_comp
 
 # ci
 # install-ci-test
-complete -f -c npm -n __fish_npm_needs_command -a 'ci clean-install ic install-clean isntall-clean' -d 'Clean install a project'
-complete -f -c npm -n __fish_npm_needs_command -a 'install-ci-test cit clean-install-test sit' -d 'Install a project with a clean slate and run tests'
+complete -f -c npm -n __fish_npm_needs_command -a 'ci clean-install' -d 'Clean install a project'
+complete -f -c npm -n __fish_npm_needs_command -a 'install-ci-test cit' -d 'Install a project with a clean slate and run tests'
 for c in ci clean-install ic install-clean isntall-clean install-ci-test cit clean-install-test sit
     complete -x -c npm -n "__fish_npm_using_command $c" -l install-strategy -a 'hoisted nested shallow linked' -d 'Install strategy'
     complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
@@ -187,8 +187,8 @@ for c in ci clean-install ic install-clean isntall-clean install-ci-test cit cle
 end
 
 # config
+complete -f -c npm -n __fish_npm_needs_command -a config -d 'Manage the npm configuration files'
 for c in config c
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Manage the npm configuration files'
     complete -f -c npm -n "__fish_npm_using_command $c" -a set -d 'Sets the config keys to the values'
     complete -f -c npm -n "__fish_npm_using_command $c" -a get -d 'Echo the config value(s) to stdout'
     complete -f -c npm -n "__fish_npm_using_command $c" -a delete -d 'Deletes the key from all configuration files'
@@ -203,7 +203,7 @@ complete -f -c npm -n __fish_npm_needs_command -a get -d 'Get a value from the n
 complete -f -c npm -n __fish_npm_needs_command -a set -d 'Set a value in the npm configuration'
 
 # dedupe
-complete -f -c npm -n __fish_npm_needs_command -a 'dedupe ddp' -d 'Reduce duplication'
+complete -f -c npm -n __fish_npm_needs_command -a dedupe -d 'Reduce duplication'
 complete -f -c npm -n __fish_npm_needs_command -a find-dupes -d 'Find duplication'
 for c in dedupe ddp find-dupes
     complete -x -c npm -n "__fish_npm_using_command $c" -l install-strategy -a 'hoisted nested shallow linked' -d 'Install strategy'
@@ -240,16 +240,16 @@ complete -f -c npm -n '__fish_npm_using_command diff' -s g -l global -d 'Operate
 complete -x -c npm -n '__fish_npm_using_command diff' -l tag -d 'The tag used to fetch the tarball'
 
 # dist-tag
+complete -f -c npm -n __fish_npm_needs_command -a dist-tag -d 'Modify package distribution tags'
 for c in dist-tag dist-tags
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Modify package distribution tags'
     complete -f -c npm -n "__fish_npm_using_command $c" -a add -d 'Tag the package'
     complete -f -c npm -n "__fish_npm_using_command $c" -a rm -d 'Clear a tag from the package'
     complete -f -c npm -n "__fish_npm_using_command $c" -a ls -d 'List all dist-tags'
 end
 
 # docs
+complete -f -c npm -n __fish_npm_needs_command -a docs -d 'Open docs for a package in a web browser'
 for c in docs home
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Open docs for a package in a web browser'
     complete -x -c npm -n "__fish_npm_using_command $c" -l browser -d 'Set browser'
     complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
 end
@@ -268,8 +268,8 @@ complete -f -c npm -n __fish_npm_needs_command -a edit -d 'Edit an installed pac
 complete -f -c npm -n '__fish_npm_using_command edit' -a editor -d 'Specify the editor'
 
 # exec
+complete -f -c npm -n __fish_npm_needs_command -a exec -d 'Run a command from a local or remote npm package'
 for c in exec x
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Run a command from a local or remote npm package'
     complete -x -c npm -n "__fish_npm_using_command $c" -l package -d 'The package(s) to install'
     complete -x -c npm -n "__fish_npm_using_command $c" -l call -d 'Specify a custom command'
 end
@@ -308,8 +308,8 @@ complete -x -c npm -n '__fish_npm_using_command hook' -l registry -d 'Registry b
 complete -x -c npm -n '__fish_npm_using_command hook' -l otp -d '2FA one-time password'
 
 # init
+complete -c npm -n __fish_npm_needs_command -a 'init create' -d 'Create a package.json file'
 for c in init create innit
-    complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Create a package.json file'
     complete -f -c npm -n "__fish_npm_using_command $c" -s y -l yes -d 'Automatically answer "yes" to all prompts'
     complete -f -c npm -n "__fish_npm_using_command $c" -l force -d 'Removes various protections'
     complete -x -c npm -n "__fish_npm_using_command $c" -l scope -d 'Create a scoped package'
@@ -317,7 +317,7 @@ end
 
 # install
 # install-test
-complete -c npm -n __fish_npm_needs_command -a 'install add i in ins inst insta instal isnt isnta isntal isntall' -d 'Install a package'
+complete -c npm -n __fish_npm_needs_command -a 'install add i' -d 'Install a package'
 complete -f -c npm -n __fish_npm_needs_command -a 'install-test it' -d 'Install package(s) and run tests'
 for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall install-test it
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Prevents saving to dependencies'
@@ -347,8 +347,8 @@ complete -x -c npm -n '__fish_npm_using_command logout' -l scope -d 'Log out of 
 
 # ls
 # ll, la
+complete -f -c npm -n __fish_npm_needs_command -a 'ls list ll' -d 'List installed packages'
 for c in ls list ll la
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'List installed packages'
     complete -f -c npm -n "__fish_npm_using_command $c" -s a -l all -d 'Also show indirect dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
     complete -f -c npm -n "__fish_npm_using_command $c" -s l -l long -d 'Show extended information'
@@ -372,8 +372,8 @@ complete -f -c npm -n '__fish_npm_using_command outdated' -l parseable -d 'Outpu
 complete -f -c npm -n '__fish_npm_using_command outdated' -s g -l global -d 'Check global packages'
 
 # org
+complete -f -c npm -n __fish_npm_needs_command -a org -d 'Manage orgs'
 for c in org ogr
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Manage orgs'
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2" -a set -d 'Add a new user'
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2" -a rm -d 'Remove a user'
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2" -a ls -d 'List all users'
@@ -428,8 +428,8 @@ complete -f -c npm -n __fish_npm_needs_command -a query -d 'Dependency selector 
 complete -f -c npm -n '__fish_npm_using_command query' -s g -l global -d 'Query global packages'
 
 # remove
+complete -f -c npm -n __fish_npm_needs_command -a 'uninstall remove un' -d 'Remove a package'
 for c in uninstall unlink remove rm r un
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Remove a package'
     complete -x -c npm -n "__fish_npm_using_command $c" -d 'Remove package' -a '(__npm_installed_local_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Remove global package' -a '(__npm_installed_global_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
@@ -446,8 +446,11 @@ complete -x -c npm -n '__fish_npm_using_command repo' -l registry -d 'Registry b
 # start
 # stop
 # test
+complete -f -c npm -n __fish_npm_needs_command -a 'restart' -d 'Restart a package'
+complete -f -c npm -n __fish_npm_needs_command -a 'start' -d 'Start a package'
+complete -f -c npm -n __fish_npm_needs_command -a 'stop' -d 'Stop a package'
+complete -f -c npm -n __fish_npm_needs_command -a 'test' -d 'Test a package'
 for c in restart start stop test tst t
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Test a package'
     complete -f -c npm -n "__fish_npm_using_command $c" -s ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
     complete -x -c npm -n "__fish_npm_using_command $c" -s script-shell -d 'The shell to use for scripts'
 end
@@ -457,8 +460,8 @@ complete -f -c npm -n __fish_npm_needs_command -a root -d 'Display npm root'
 complete -f -c npm -n '__fish_npm_using_command root' -s g -l global -d 'Display global root'
 
 # search
+complete -f -c npm -n __fish_npm_needs_command -a 'search find' -d 'Search for packages'
 for c in search find s se
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Search for packages'
     complete -f -c npm -n "__fish_npm_using_command $c" -s l -l long -d 'Show extended information'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON data'
     complete -f -c npm -n "__fish_npm_using_command $c" -l color -a always -d 'Print color'
@@ -484,8 +487,8 @@ complete -f -c npm -n __fish_npm_needs_command -a stars -d 'View packages marked
 complete -x -c npm -n '__fish_npm_using_command stars' -l registry -d 'Registry base URL'
 
 # update
+complete -f -c npm -n __fish_npm_needs_command -a 'update up upgrade' -d 'Update package(s)'
 for c in update up upgrade udpate
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Update package(s)'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Update global package(s)'
 end
 
@@ -497,8 +500,8 @@ complete -f -c npm -n '__fish_npm_using_command unstar' -l no-unicode -d 'Use as
 complete -x -c npm -n '__fish_npm_using_command unstar' -l otp -d '2FA one-time password'
 
 # version
+complete -f -c npm -n __fish_npm_needs_command -a version -d 'Bump a package version'
 for c in version verison
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Bump a package version'
     complete -x -c npm -n "__fish_npm_using_command $c" -a 'major minor patch premajor preminor prepatch prerelease'
     complete -f -c npm -n "__fish_npm_using_command $c" -l allow-same-version -d 'Allow same version'
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-commit-hooks -d "Don't run git commit hooks"
@@ -509,8 +512,8 @@ for c in version verison
 end
 
 # view
+complete -f -c npm -n __fish_npm_needs_command -a 'view info' -d 'View registry info'
 for c in view info v show
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'View registry info'
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2"
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'author bin bugs description engines exports homepage keywords license main name repository scripts type types'
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'dependencies devDependencies optionalDependencies peerDependencies'

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -21,7 +21,7 @@ function __fish_npm_using_command
     set -l cmd (commandline -opc)
 
     if test (count $cmd) -gt 1
-        if test $argv[1] = $cmd[2]
+        if contains -- $cmd[2] $argv
             return 0
         end
     end
@@ -72,10 +72,7 @@ end
 # and uninstall (reading dependencies is faster and more robust and yarn needs the functions anyways)
 # see: https://github.com/npm/npm/issues/9524
 # and: https://github.com/fish-shell/fish-shell/pull/2366
-complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run; and not __fish_npm_using_command run-script;
-and not __fish_npm_using_command audit;
-and not __fish_npm_using_command r; and not __fish_npm_using_command remove; and not __fish_npm_using_command rm; and not __fish_npm_using_command un;
-and not __fish_npm_using_command uninstall; and not __fish_npm_using_command unlink' -a "(__fish_complete_npm)"
+complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run run-script audit r remove rm un uninstall unlink' -a "(__fish_complete_npm)"
 
 # list available npm scripts and their parial content
 function __fish_parse_npm_run_completions
@@ -114,11 +111,11 @@ end
 # audit
 complete -f -c npm -n __fish_npm_needs_command -a audit -d 'Run a security audit'
 complete -f -c npm -n '__fish_npm_using_command audit' -a signatures -d 'Verify registry signatures'
-complete -f -c npm -n '__fish_npm_using_command audit' -a fix -d 'Automatically install any compatible updates to vulnerable dependencies'
+complete -f -c npm -n '__fish_npm_using_command audit' -a fix -d 'Install compatible updates to vulnerable deps'
 complete -x -c npm -n '__fish_npm_using_command audit' -l audit-level -a 'info low moderate high critical none' -d 'Audit level'
 complete -f -c npm -n '__fish_npm_using_command audit' -l dry-run -d 'Only report what it would have done'
-complete -f -c npm -n '__fish_npm_using_command audit' -l force -d 'Removes various protections against unfortunate side effects, common mistakes, and malicious input'
-complete -f -c npm -n '__fish_npm_using_command audit' -l json -d 'Show information in JSON format'
+complete -f -c npm -n '__fish_npm_using_command audit' -l force -d 'Removes various protections'
+complete -f -c npm -n '__fish_npm_using_command audit' -l json -d 'Output JSON'
 complete -f -c npm -n '__fish_npm_using_command audit' -l package-lock-only -d 'Only use the package-lock.json, ignore node_modules'
 complete -x -c npm -n '__fish_npm_using_command audit' -l omit -a 'dev optional peer' -d 'Omit dependency type'
 complete -f -c npm -n '__fish_npm_using_command audit' -l foreground-scripts -d 'Run all build scripts in the foreground process'
@@ -170,7 +167,7 @@ end
 for c in ls list ll la
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'List installed packages'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'List packages in the global install prefix instead of in the current project'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Show information in JSON format'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
     complete -f -c npm -n "__fish_npm_using_command $c" -l long -d 'Show extended information'
     complete -f -c npm -n "__fish_npm_using_command $c" -l parseable -d 'Show parseable output instead of tree view'
     complete -x -c npm -n "__fish_npm_using_command $c" -l depth -d 'Max display depth of the dependency tree'
@@ -185,7 +182,7 @@ complete -f -c npm -n '__fish_npm_using_command owner' -a rm -d 'Remove an owner
 # pack
 complete -f -c npm -n __fish_npm_needs_command -a pack -d 'Create a tarball from a package'
 complete -f -c npm -n '__fish_npm_using_command pack' -l dry-run -d 'Only report what it would have done'
-complete -f -c npm -n '__fish_npm_using_command pack' -l json -d 'Output JSON data'
+complete -f -c npm -n '__fish_npm_using_command pack' -l json -d 'Output JSON'
 complete -c npm -n '__fish_npm_using_command pack' -l pack-destination -d 'Tarball destination directory'
 
 # publish

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -69,9 +69,12 @@ end
 # use npm completion for most of the things,
 # except options completion (because it sucks at it)
 # and run-script completion (reading package.json is faster).
+# and uninstall (reading dependencies is faster and more robust and yarn needs the functions anyways)
 # see: https://github.com/npm/npm/issues/9524
 # and: https://github.com/fish-shell/fish-shell/pull/2366
-complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run; and not __fish_npm_using_command run-script' -a "(__fish_complete_npm)"
+complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run; and not __fish_npm_using_command run-script;
+and not __fish_npm_using_command r; and not __fish_npm_using_command remove; and not __fish_npm_using_command rm; and not __fish_npm_using_command un;
+and not __fish_npm_using_command uninstall; and not __fish_npm_using_command unlink' -a "(__fish_complete_npm)"
 
 # list available npm scripts and their parial content
 function __fish_parse_npm_run_completions
@@ -159,8 +162,9 @@ complete -f -c npm -n '__fish_npm_using_command owner' -a rm -d 'Remove an owner
 
 # remove
 for c in r remove rm un uninstall unlink
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'remove package' -xa '(__yarn_installed_packages)'
-    complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'remove global package'
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Remove a package'
+    complete -x -c npm -n "__fish_npm_using_command $c" -d 'remove package' -a '(__yarn_installed_local_packages)'
+    complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'remove global package' -a '(__yarn_installed_local_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -l save -d 'Package will be removed from your dependencies'
     complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
 end

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -73,6 +73,7 @@ end
 # see: https://github.com/npm/npm/issues/9524
 # and: https://github.com/fish-shell/fish-shell/pull/2366
 complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run; and not __fish_npm_using_command run-script;
+and not __fish_npm_using_command audit;
 and not __fish_npm_using_command r; and not __fish_npm_using_command remove; and not __fish_npm_using_command rm; and not __fish_npm_using_command un;
 and not __fish_npm_using_command uninstall; and not __fish_npm_using_command unlink' -a "(__fish_complete_npm)"
 
@@ -109,6 +110,20 @@ for c in run-script run rum urn
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Run arbitrary package scripts'
     complete -f -c npm -n "__fish_npm_using_command $c" -a "(__fish_npm_run)"
 end
+
+# audit
+complete -f -c npm -n __fish_npm_needs_command -a audit -d 'Run a security audit'
+complete -f -c npm -n '__fish_npm_using_command audit' -a signatures -d 'Verify registry signatures'
+complete -f -c npm -n '__fish_npm_using_command audit' -a fix -d 'Automatically install any compatible updates to vulnerable dependencies'
+complete -x -c npm -n '__fish_npm_using_command audit' -l audit-level -a 'info low moderate high critical none' -d 'Audit level'
+complete -f -c npm -n '__fish_npm_using_command audit' -l dry-run -d 'Only report what it would have done'
+complete -f -c npm -n '__fish_npm_using_command audit' -l force -d 'Removes various protections against unfortunate side effects, common mistakes, and malicious input'
+complete -f -c npm -n '__fish_npm_using_command audit' -l json -d 'Show information in JSON format'
+complete -f -c npm -n '__fish_npm_using_command audit' -l package-lock-only -d 'Only use the package-lock.json, ignore node_modules'
+complete -x -c npm -n '__fish_npm_using_command audit' -l omit -a 'dev optional peer' -d 'Omit dependency type'
+complete -f -c npm -n '__fish_npm_using_command audit' -l foreground-scripts -d 'Run all build scripts in the foreground process'
+complete -f -c npm -n '__fish_npm_using_command audit' -l ignore-scripts -d 'Do not run scripts specified in package.json'
+complete -f -c npm -n '__fish_npm_using_command audit' -l install-links -d 'Pack and install file: protocol dependences as regular dependencies instead of symlinks'
 
 # cache
 complete -f -c npm -n __fish_npm_needs_command -a cache -d "Manipulates package's cache"
@@ -204,7 +219,6 @@ end
 
 # misc shorter explanations
 complete -f -c npm -n __fish_npm_needs_command -a 'adduser add-user login' -d 'Add a registry user account'
-complete -f -c npm -n __fish_npm_needs_command -a audit -d 'Run a security audit'
 complete -f -c npm -n __fish_npm_needs_command -a 'bugs issues' -d 'Bugs for a package in a web browser maybe'
 complete -f -c npm -n __fish_npm_needs_command -a 'ci clean-install ic install-clean isntall-clean' -d 'Clean install a project'
 complete -f -c npm -n __fish_npm_needs_command -a 'dedupe ddp find-dupes' -d 'Reduce duplication'

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -1,4 +1,4 @@
-# NPM (https://npmjs.org) completions for Fish shell
+# npm (https://npmjs.org) completions for Fish shell
 # __fish_npm_needs_* and __fish_npm_using_* taken from:
 # https://stackoverflow.com/questions/16657803/creating-autocomplete-script-with-sub-commands
 # see also Fish's large set of completions for examples:
@@ -106,6 +106,10 @@ end
 for c in run-script run rum urn
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Run arbitrary package scripts'
     complete -f -c npm -n "__fish_npm_using_command $c" -a "(__fish_npm_run)"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l 'if-present' -d "Don't error on nonexistant script"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
+    complete -x -c npm -n "__fish_npm_using_command $c" -s script-shell -d 'The shell to use for scripts'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l foreground-scripts -d 'Run all build scripts in the foreground'
 end
 
 # access
@@ -127,8 +131,9 @@ complete -x -c npm -n '__fish_npm_using_command access' -l otp -d '2FA one-time 
 complete -x -c npm -n '__fish_npm_using_command access' -l registry -d 'Registry base URL'
 
 # adduser
-for c in adduser add-user
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Add a registry user account'
+complete -f -c npm -n __fish_npm_needs_command -a "adduser add-user" -d 'Add a registry user account'
+complete -f -c npm -n __fish_npm_needs_command -a login -d 'Login to a registry user account'
+for c in adduser add-user login
     complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
     complete -x -c npm -n "__fish_npm_using_command $c" -l scope -d 'Log into a private repository'
     complete -x -c npm -n "__fish_npm_using_command $c" -l auth-type -a 'legacy web' -d 'Authentication strategy'
@@ -145,7 +150,7 @@ complete -f -c npm -n '__fish_npm_using_command audit' -l json -d 'Output JSON'
 complete -f -c npm -n '__fish_npm_using_command audit' -l package-lock-only -d 'Only use package-lock.json, ignore node_modules'
 complete -x -c npm -n '__fish_npm_using_command audit' -l omit -a 'dev optional peer' -d 'Omit dependency type'
 complete -f -c npm -n '__fish_npm_using_command audit' -l foreground-scripts -d 'Run all build scripts in the foreground'
-complete -f -c npm -n '__fish_npm_using_command audit' -l ignore-scripts -d 'Do not run scripts specified in package.json'
+complete -f -c npm -n '__fish_npm_using_command audit' -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
 complete -f -c npm -n '__fish_npm_using_command audit' -l install-links -d 'Install file: protocol deps as regular deps'
 
 # bugs
@@ -162,15 +167,18 @@ complete -f -c npm -n '__fish_npm_using_command cache' -a add -d 'Add the specif
 complete -f -c npm -n '__fish_npm_using_command cache' -a clean -d 'Delete data out of the cache folder'
 complete -f -c npm -n '__fish_npm_using_command cache' -a ls -d 'Show the data in the cache'
 complete -f -c npm -n '__fish_npm_using_command cache' -a verify -d 'Verify the contents of the cache folder'
+complete -x -c npm -n '__fish_npm_using_command cache' -l cache -a '(__fish_complete_directories)' -d 'Cache location'
 
 # ci
-for c in ci clean-install ic install-clean isntall-clean
-    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Clean install a project'
+# install-ci-test
+complete -f -c npm -n __fish_npm_needs_command -a 'ci clean-install ic install-clean isntall-clean' -d 'Clean install a project'
+complete -f -c npm -n __fish_npm_needs_command -a 'install-ci-test cit clean-install-test sit' -d 'Install a project with a clean slate and run tests'
+for c in ci clean-install ic install-clean isntall-clean install-ci-test cit clean-install-test sit
     complete -x -c npm -n "__fish_npm_using_command $c" -l install-strategy -a 'hoisted nested shallow linked' -d 'Install strategy'
     complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
     complete -x -c npm -n "__fish_npm_using_command $c" -l strict-peer-deps -d 'Treat conflicting peerDependencies as failure'
     complete -f -c npm -n "__fish_npm_using_command $c" -l foreground-scripts -d 'Run all build scripts in the foreground'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run scripts specified in package.json"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-audit -d "Don't submit audit reports"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
@@ -202,15 +210,15 @@ for c in dedupe ddp find-dupes
     complete -x -c npm -n "__fish_npm_using_command $c" -l strict-peer-deps -d 'Treat conflicting peerDependencies as failure'
     complete -x -c npm -n "__fish_npm_using_command $c" -l no-package-lock -d 'Ignore package-lock.json'
     complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run scripts specified in package.json"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-audit -d "Don't submit audit reports"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
     complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
 
-	if test $c != find-dupes
-		complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d "Don't display funding info"
-	end
+    if test $c != find-dupes
+        complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d "Don't display funding info"
+    end
 end
 
 # deprecate
@@ -242,7 +250,7 @@ end
 # docs
 for c in docs home
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Open docs for a package in a web browser'
-	complete -x -c npm -n "__fish_npm_using_command $c" -l browser -d 'Set browser'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l browser -d 'Set browser'
     complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
 end
 
@@ -278,12 +286,12 @@ complete -f -c npm -n '__fish_npm_using_command explore' -a shell -d 'The shell 
 
 # fund
 complete -f -c npm -n __fish_npm_needs_command -a fund -d 'Retrieve funding information'
-complete -f -c npm -n "__fish_npm_using_command fund" -l json -d 'Output JSON'
-complete -x -c npm -n "__fish_npm_using_command fund" -l browser -d 'Set browser'
-complete -f -c npm -n "__fish_npm_using_command fund" -l no-browser -d 'Print to stdout'
-complete -f -c npm -n "__fish_npm_using_command fund" -l unicode -d 'Use unicode characters in the output'
-complete -f -c npm -n "__fish_npm_using_command fund" -l no-unicode -d 'Use ascii characters over unicode glyphs'
-complete -x -c npm -n "__fish_npm_using_command fund" -l which -d 'Which source URL to open (1-indexed)'
+complete -f -c npm -n '__fish_npm_using_command fund' -l json -d 'Output JSON'
+complete -x -c npm -n '__fish_npm_using_command fund' -l browser -d 'Set browser'
+complete -f -c npm -n '__fish_npm_using_command fund' -l no-browser -d 'Print to stdout'
+complete -f -c npm -n '__fish_npm_using_command fund' -l unicode -d 'Use unicode characters in the output'
+complete -f -c npm -n '__fish_npm_using_command fund' -l no-unicode -d 'Use ascii characters over unicode glyphs'
+complete -x -c npm -n '__fish_npm_using_command fund' -l which -d 'Which source URL to open (1-indexed)'
 
 # help-search
 complete -f -c npm -n __fish_npm_needs_command -a help-search -d 'Search npm help documentation'
@@ -303,11 +311,15 @@ complete -x -c npm -n '__fish_npm_using_command hook' -l otp -d '2FA one-time pa
 for c in init create innit
     complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Create a package.json file'
     complete -f -c npm -n "__fish_npm_using_command $c" -s y -l yes -d 'Automatically answer "yes" to all prompts'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l force -d 'Removes various protections'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l scope -d 'Create a scoped package'
 end
 
 # install
-for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
-    complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Install a package'
+# install-test
+complete -c npm -n __fish_npm_needs_command -a 'install add i in ins inst insta instal isnt isnta isntal isntall' -d 'Install a package'
+complete -f -c npm -n __fish_npm_needs_command -a 'install-test it' -d 'Install package(s) and run tests'
+for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall install-test it
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Prevents saving to dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s P -l save-prod -d 'Save to dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s D -l save-dev -d 'Save to devDependencies'
@@ -320,7 +332,7 @@ for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
     complete -x -c npm -n "__fish_npm_using_command $c" -l strict-peer-deps -d 'Treat conflicting peerDependencies as failure'
     complete -x -c npm -n "__fish_npm_using_command $c" -l no-package-lock -d 'Ignore package-lock.json'
     complete -f -c npm -n "__fish_npm_using_command $c" -l foreground-scripts -d 'Run all build scripts in the foreground'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run scripts specified in package.json"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-audit -d "Don't submit audit reports"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
@@ -328,14 +340,47 @@ for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
     complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
 end
 
-# list
+# logout
+complete -f -c npm -n __fish_npm_needs_command -a logout -d 'Log out of the registry'
+complete -x -c npm -n '__fish_npm_using_command logout' -l registry -d 'Registry base URL'
+complete -x -c npm -n '__fish_npm_using_command logout' -l scope -d 'Log out of private repository'
+
+# ls
+# ll, la
 for c in ls list ll la
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'List installed packages'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'List packages in the global install prefix instead of in the current project'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s a -l all -d 'Also show indirect dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
     complete -f -c npm -n "__fish_npm_using_command $c" -s l -l long -d 'Show extended information'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l parseable -d 'Show parseable output instead of tree view'
-    complete -x -c npm -n "__fish_npm_using_command $c" -l depth -d 'Max display depth of the dependency tree'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s p -l parseable -d 'Output parseable results'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'List global packages'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l depth -d 'Dependency recursion depth'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l linked -d 'Only show linked packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l package-lock-only -d 'Only use package-lock.json, ignore node_modules'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l unicode -d 'Use unicode characters in the output'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-unicode -d 'Use ascii characters over unicode glyphs'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+end
+
+# outdated
+complete -f -c npm -n __fish_npm_needs_command -a outdated -d 'Check for outdated packages'
+complete -f -c npm -n '__fish_npm_using_command outdated' -s a -l all -d 'Also show indirect dependencies'
+complete -f -c npm -n '__fish_npm_using_command outdated' -l json -d 'Output JSON'
+complete -f -c npm -n '__fish_npm_using_command outdated' -s l -l long -d 'Show extended information'
+complete -f -c npm -n '__fish_npm_using_command outdated' -l parseable -d 'Output parseable results'
+complete -f -c npm -n '__fish_npm_using_command outdated' -s g -l global -d 'Check global packages'
+
+# org
+for c in org ogr
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Manage orgs'
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2" -a set -d 'Add a new user'
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2" -a rm -d 'Remove a user'
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2" -a ls -d 'List all users'
+
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 5" -n '__fish_seen_subcommand_from set' -a admin -d 'Add admin'
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 5" -n '__fish_seen_subcommand_from set' -a developer -d 'Add developer'
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 5" -n '__fish_seen_subcommand_from set' -a owner -d 'Add owner'
 end
 
 # owner
@@ -354,6 +399,22 @@ complete -f -c npm -n '__fish_npm_using_command pack' -l dry-run -d 'Do not make
 complete -f -c npm -n '__fish_npm_using_command pack' -l json -d 'Output JSON'
 complete -x -c npm -n '__fish_npm_using_command pack' -l pack-destination -a '(__fish_complete_directories)' -d 'Tarball destination directory'
 
+# ping
+complete -f -c npm -n __fish_npm_needs_command -a ping -d 'Ping npm registry'
+complete -x -c npm -n '__fish_npm_using_command ping' -l registry -d 'Registry base URL'
+
+# pkg
+complete -f -c npm -n __fish_npm_needs_command -a pkg -d 'Manages your package.json'
+complete -x -c npm -n '__fish_npm_using_command pkg' -a set -d 'Sets a value'
+complete -x -c npm -n '__fish_npm_using_command pkg' -a get -d 'Retrieves a value'
+complete -x -c npm -n '__fish_npm_using_command pkg' -a delete -d 'Deletes a key'
+complete -f -c npm -n '__fish_npm_using_command pkg' -l force -d 'Removes various protections'
+complete -f -c npm -n '__fish_npm_using_command pkg' -l json -d 'Parse values with JSON.parse()'
+
+# prefix
+complete -f -c npm -n __fish_npm_needs_command -a prefix -d 'Display npm prefix'
+complete -f -c npm -n '__fish_npm_using_command prefix' -s g -l global -d 'Display global prefix'
+
 # publish
 complete -f -c npm -n __fish_npm_needs_command -a publish -d 'Publish a package'
 complete -x -c npm -n '__fish_npm_using_command publish' -l tag -d 'Upload to tag'
@@ -362,6 +423,10 @@ complete -f -c npm -n '__fish_npm_using_command publish' -l dry-run -d 'Do not m
 complete -x -c npm -n '__fish_npm_using_command publish' -l otp -d '2FA one-time password'
 complete -f -c npm -n '__fish_npm_using_command publish' -l provenance -d 'Link to build location when publishing from CI/CD'
 
+# query
+complete -f -c npm -n __fish_npm_needs_command -a query -d 'Dependency selector query'
+complete -f -c npm -n '__fish_npm_using_command query' -s g -l global -d 'Query global packages'
+
 # remove
 for c in uninstall unlink remove rm r un
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Remove a package'
@@ -369,6 +434,27 @@ for c in uninstall unlink remove rm r un
     complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Remove global package' -a '(__npm_installed_global_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
 end
+
+# repo
+complete -f -c npm -n __fish_npm_needs_command -a repo -d 'Open package repository page in the browser'
+complete -f -c npm -n '__fish_npm_using_command repo' -s g -l global -d 'Display global root'
+complete -x -c npm -n '__fish_npm_using_command repo' -l browser -d 'Set browser'
+complete -x -c npm -n '__fish_npm_using_command repo' -l no-browser -d 'Print to stdout'
+complete -x -c npm -n '__fish_npm_using_command repo' -l registry -d 'Registry base URL'
+
+# restart
+# start
+# stop
+# test
+for c in restart start stop test tst t
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Test a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
+    complete -x -c npm -n "__fish_npm_using_command $c" -s script-shell -d 'The shell to use for scripts'
+end
+
+# root
+complete -f -c npm -n __fish_npm_needs_command -a root -d 'Display npm root'
+complete -f -c npm -n '__fish_npm_using_command root' -s g -l global -d 'Display global root'
 
 # search
 for c in search find s se
@@ -386,11 +472,29 @@ for c in search find s se
     complete -f -c npm -n "__fish_npm_using_command $c" -l offline -d 'Force offline mode'
 end
 
+# star
+complete -f -c npm -n __fish_npm_needs_command -a star -d 'Mark your favorite packages'
+complete -x -c npm -n '__fish_npm_using_command star' -l registry -d 'Registry base URL'
+complete -f -c npm -n '__fish_npm_using_command star' -l unicode -d 'Use unicode characters in the output'
+complete -f -c npm -n '__fish_npm_using_command star' -l no-unicode -d 'Use ascii characters over unicode glyphs'
+complete -x -c npm -n '__fish_npm_using_command star' -l otp -d '2FA one-time password'
+
+# stars
+complete -f -c npm -n __fish_npm_needs_command -a stars -d 'View packages marked as favorites'
+complete -x -c npm -n '__fish_npm_using_command stars' -l registry -d 'Registry base URL'
+
 # update
 for c in update up upgrade udpate
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Update package(s)'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Update global package(s)'
 end
+
+# unstar
+complete -f -c npm -n __fish_npm_needs_command -a unstar -d 'Remove star from a package'
+complete -x -c npm -n '__fish_npm_using_command unstar' -l registry -d 'Registry base URL'
+complete -f -c npm -n '__fish_npm_using_command unstar' -l unicode -d 'Use unicode characters in the output'
+complete -f -c npm -n '__fish_npm_using_command unstar' -l no-unicode -d 'Use ascii characters over unicode glyphs'
+complete -x -c npm -n '__fish_npm_using_command unstar' -l otp -d '2FA one-time password'
 
 # version
 for c in version verison
@@ -407,42 +511,27 @@ end
 # view
 for c in view info v show
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'View registry info'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2"
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'author bin bugs description engines exports homepage keywords license main name repository scripts type types'
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'dependencies devDependencies optionalDependencies peerDependencies'
     complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'directories dist dist-tags gitHead maintainers readme time users version versions'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
 end
+
+# whoami
+complete -f -c npm -n __fish_npm_needs_command -a whoami -d 'Display npm username'
+complete -f -c npm -n '__fish_npm_using_command whoami' -a registry -d 'Check registry'
 
 # misc shorter explanations
 complete -f -c npm -n __fish_npm_needs_command -a completion -d 'Tab Completion for npm'
 complete -f -c npm -n __fish_npm_needs_command -a 'help hlep' -d 'Get help on npm'
-complete -f -c npm -n __fish_npm_needs_command -a 'install-ci-test cit clean-install-test sit' -d 'Install a project with a clean slate and run tests'
-complete -f -c npm -n __fish_npm_needs_command -a 'install-test it' -d 'Install package(s) and run tests'
+complete -f -c npm -n __fish_npm_needs_command -a shrinkwrap -d 'Lock down dependency versions'
+
 complete -f -c npm -n __fish_npm_needs_command -a 'link ln' -d 'Symlink a package folder'
-complete -f -c npm -n __fish_npm_needs_command -a login -d 'Login to a registry user account'
-complete -f -c npm -n __fish_npm_needs_command -a logout -d 'Log out of the registry'
-complete -f -c npm -n __fish_npm_needs_command -a 'org ogr' -d 'Manage orgs'
-complete -f -c npm -n __fish_npm_needs_command -a outdated -d 'Check for outdated packages'
-complete -f -c npm -n __fish_npm_needs_command -a ping -d 'Ping npm registry'
-complete -f -c npm -n __fish_npm_needs_command -a pkg -d 'Manages your package.json'
-complete -f -c npm -n __fish_npm_needs_command -a prefix -d 'Display npm prefix'
 complete -f -c npm -n __fish_npm_needs_command -a profile -d 'Change settings on your registry profile'
 complete -f -c npm -n __fish_npm_needs_command -a prune -d 'Remove extraneous packages'
-complete -f -c npm -n __fish_npm_needs_command -a query -d 'Dependency selector query'
 complete -f -c npm -n __fish_npm_needs_command -a 'rebuild rb' -d 'Rebuild a package'
-complete -f -c npm -n __fish_npm_needs_command -a repo -d 'Open package repository page in the browser'
-complete -f -c npm -n __fish_npm_needs_command -a restart -d 'Restart a package'
-complete -f -c npm -n __fish_npm_needs_command -a root -d 'Display npm root'
-complete -f -c npm -n __fish_npm_needs_command -a shrinkwrap -d 'Lock down dependency versions'
-complete -f -c npm -n __fish_npm_needs_command -a star -d 'Mark your favorite packages'
-complete -f -c npm -n __fish_npm_needs_command -a stars -d 'View packages marked as favorites'
-complete -f -c npm -n __fish_npm_needs_command -a start -d 'Start a package'
-complete -f -c npm -n __fish_npm_needs_command -a stop -d 'Stop a package'
 complete -f -c npm -n __fish_npm_needs_command -a team -d 'Manage organization teams and team memberships'
-complete -f -c npm -n __fish_npm_needs_command -a 'test tst t' -d 'Test a package'
 complete -f -c npm -n __fish_npm_needs_command -a token -d 'Manage your authentication tokens'
 complete -f -c npm -n __fish_npm_needs_command -a unpublish -d 'Remove a package from the registry'
-complete -f -c npm -n __fish_npm_needs_command -a unstar -d 'Remove star from a package'
-complete -f -c npm -n __fish_npm_needs_command -a whoami -d 'Display npm username'
 complete -f -c npm -n '__fish_seen_subcommand_from add i in ins inst insta instal isnt isnta isntal isntall; and not __fish_is_switch' -a "(__npm_filtered_list_packages \"$npm_install\")"

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -72,7 +72,7 @@ end
 # and uninstall (reading dependencies is faster and more robust and yarn needs the functions anyways)
 # see: https://github.com/npm/npm/issues/9524
 # and: https://github.com/fish-shell/fish-shell/pull/2366
-complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run-script run rum urn audit uninstall unlink remove rm r un' -a "(__fish_complete_npm)"
+complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run-script run rum urn audit cache uninstall unlink remove rm r un' -a "(__fish_complete_npm)"
 
 # list available npm scripts and their parial content
 function __fish_parse_npm_run_completions
@@ -113,14 +113,14 @@ complete -f -c npm -n __fish_npm_needs_command -a audit -d 'Run a security audit
 complete -f -c npm -n '__fish_npm_using_command audit' -a signatures -d 'Verify registry signatures'
 complete -f -c npm -n '__fish_npm_using_command audit' -a fix -d 'Install compatible updates to vulnerable deps'
 complete -x -c npm -n '__fish_npm_using_command audit' -l audit-level -a 'info low moderate high critical none' -d 'Audit level'
-complete -f -c npm -n '__fish_npm_using_command audit' -l dry-run -d 'Do not modify'
+complete -f -c npm -n '__fish_npm_using_command audit' -l dry-run -d 'Do not make any changes'
 complete -f -c npm -n '__fish_npm_using_command audit' -l force -d 'Removes various protections'
 complete -f -c npm -n '__fish_npm_using_command audit' -l json -d 'Output JSON'
 complete -f -c npm -n '__fish_npm_using_command audit' -l package-lock-only -d 'Only use package-lock.json, ignore node_modules'
 complete -x -c npm -n '__fish_npm_using_command audit' -l omit -a 'dev optional peer' -d 'Omit dependency type'
 complete -f -c npm -n '__fish_npm_using_command audit' -l foreground-scripts -d 'Run all build scripts in the foreground'
 complete -f -c npm -n '__fish_npm_using_command audit' -l ignore-scripts -d 'Do not run scripts specified in package.json'
-complete -f -c npm -n '__fish_npm_using_command audit' -l install-links -d 'Install file: protocol dependencies as regular dependencies instead of symlinks'
+complete -f -c npm -n '__fish_npm_using_command audit' -l install-links -d 'Install file: protocol deps as regular deps instead of symlinks'
 
 # cache
 complete -f -c npm -n __fish_npm_needs_command -a cache -d "Manipulates package's cache"
@@ -142,6 +142,10 @@ end
 complete -f -c npm -n __fish_npm_needs_command -a get -d 'Echo the config value to stdout'
 complete -f -c npm -n __fish_npm_needs_command -a set -d 'Sets the config key to the value'
 
+# help-search
+complete -f -c npm -n __fish_npm_needs_command -a help-search -d 'Search npm help documentation'
+complete -f -c npm -n '__fish_npm_using_command help-search' -l long -d 'Show extended information'
+
 # init
 for c in init create innit
     complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Create a package.json file'
@@ -151,8 +155,8 @@ end
 # install
 for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
     complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Install a package'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s B -l save-bundle -d 'Also save to bundleDependencies in'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s E -l save-exact -d 'Save dependency with exact version rather than a semver range'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s B -l save-bundle -d 'Also save to bundleDependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s E -l save-exact -d 'Save dependency with exact version'
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Prevents saving to dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s O -l save-optional -d 'Save to optionalDependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s P -l save-prod -d 'Save to dependencies'
@@ -160,7 +164,7 @@ for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Install package globally'
     complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
     complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d 'Do not run scripts specified in package.json'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Pack and install file: protocol dependences as regular dependencies instead of symlinks'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps instead of symlinks'
 end
 
 # list
@@ -179,28 +183,29 @@ for c in owner author
     complete -f -c npm -n "__fish_npm_using_command $c" -a ls -d 'List package owners'
     complete -f -c npm -n "__fish_npm_using_command $c" -a add -d 'Add a new owner to package'
     complete -f -c npm -n "__fish_npm_using_command $c" -a rm -d 'Remove an owner from package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l otp -d '2FA one-time password'
 end
 
 # pack
 complete -f -c npm -n __fish_npm_needs_command -a pack -d 'Create a tarball from a package'
-complete -f -c npm -n '__fish_npm_using_command pack' -l dry-run -d 'Do not modify'
+complete -f -c npm -n '__fish_npm_using_command pack' -l dry-run -d 'Do not make any changes'
 complete -f -c npm -n '__fish_npm_using_command pack' -l json -d 'Output JSON'
-complete -c npm -n '__fish_npm_using_command pack' -l pack-destination -d 'Tarball destination directory'
+complete -x -c npm -n '__fish_npm_using_command pack' -l pack-destination -a '(__fish_complete_directories)' -d 'Tarball destination directory'
 
 # publish
 complete -f -c npm -n __fish_npm_needs_command -a publish -d 'Publish a package'
 complete -x -c npm -n '__fish_npm_using_command publish' -l tag -d 'Upload to tag'
 complete -x -c npm -n '__fish_npm_using_command publish' -l access -d 'Restrict access' -a "public\t'Publicly viewable' restricted\t'Restricted access (scoped packages only)'"
-complete -f -c npm -n '__fish_npm_using_command publish' -l dry-run -d 'Do not modify'
+complete -f -c npm -n '__fish_npm_using_command publish' -l dry-run -d 'Do not make any changes'
 complete -x -c npm -n '__fish_npm_using_command publish' -l otp -d '2FA one-time password'
-## todo provenance ?
+complete -x -c npm -n '__fish_npm_using_command publish' -l provenance -d 'Link to build location when publishing from CI/CD'
 
 # remove
 for c in uninstall unlink remove rm r un
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Remove a package'
-    complete -x -c npm -n "__fish_npm_using_command $c" -d 'remove package' -a '(__npm_installed_local_packages)'
-    complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'remove global package' -a '(__npm_installed_global_packages)'
-    complete -x -c npm -n "__fish_npm_using_command $c" -l save -d 'Package will be removed from your dependencies'
+    complete -x -c npm -n "__fish_npm_using_command $c" -d 'Remove package' -a '(__npm_installed_local_packages)'
+    complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Remove global package' -a '(__npm_installed_global_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
 end
 
@@ -217,28 +222,29 @@ for c in update up upgrade udpate
 end
 
 # misc shorter explanations
-complete -f -c npm -n __fish_npm_needs_command -a 'adduser add-user login' -d 'Add a registry user account'
-complete -f -c npm -n __fish_npm_needs_command -a 'bugs issues' -d 'Bugs for a package in a web browser maybe'
+complete -f -c npm -n __fish_npm_needs_command -a access -d 'Set access level on published packages'
+complete -f -c npm -n __fish_npm_needs_command -a 'adduser add-user' -d 'Add a registry user account'
+complete -f -c npm -n __fish_npm_needs_command -a 'bugs issues' -d 'Report bugs for a package in a web browser'
 complete -f -c npm -n __fish_npm_needs_command -a 'ci clean-install ic install-clean isntall-clean' -d 'Clean install a project'
 complete -f -c npm -n __fish_npm_needs_command -a completion -d 'Tab Completion for npm'
-complete -f -c npm -n __fish_npm_needs_command -a 'dedupe ddp find-dupes' -d 'Reduce duplication'
+complete -f -c npm -n __fish_npm_needs_command -a 'dedupe ddp' -d 'Reduce duplication'
 complete -f -c npm -n __fish_npm_needs_command -a deprecate -d 'Deprecate a version of a package'
 complete -f -c npm -n __fish_npm_needs_command -a diff -d 'The registry diff command'
 complete -f -c npm -n __fish_npm_needs_command -a 'dist-tag dist-tags' -d 'Modify package distribution tags'
 complete -f -c npm -n __fish_npm_needs_command -a 'docs home' -d 'Docs for a package in a web browser maybe'
 complete -f -c npm -n __fish_npm_needs_command -a doctor -d 'Check your npm environment'
 complete -f -c npm -n __fish_npm_needs_command -a edit -d 'Edit an installed package'
-complete -f -c npm -n __fish_npm_needs_command -a exec -d 'Run a command from a local or remote npm package'
+complete -f -c npm -n __fish_npm_needs_command -a 'exec x' -d 'Run a command from a local or remote npm package'
 complete -f -c npm -n __fish_npm_needs_command -a 'explain why' -d 'Explain installed packages'
 complete -f -c npm -n __fish_npm_needs_command -a explore -d 'Browse an installed package'
+complete -f -c npm -n __fish_npm_needs_command -a find-dupes -d 'Find duplication'
 complete -f -c npm -n __fish_npm_needs_command -a fund -d 'Retrieve funding information'
 complete -f -c npm -n __fish_npm_needs_command -a 'help hlep' -d 'Get help on npm'
-complete -f -c npm -n __fish_npm_needs_command -a help-search -d 'Search npm help documentation'
-complete -f -c npm -n '__fish_npm_using_command help-search' -l long -d 'Display full package descriptions and other long text across multiple lines'
 complete -f -c npm -n __fish_npm_needs_command -a hook -d 'Manage registry hooks'
 complete -f -c npm -n __fish_npm_needs_command -a 'install-ci-test cit clean-install-test sit' -d 'Install a project with a clean slate and run tests'
 complete -f -c npm -n __fish_npm_needs_command -a 'install-test it' -d 'Install package(s) and run tests'
 complete -f -c npm -n __fish_npm_needs_command -a 'link ln' -d 'Symlink a package folder'
+complete -f -c npm -n __fish_npm_needs_command -a login -d 'Login to a registry user account'
 complete -f -c npm -n __fish_npm_needs_command -a logout -d 'Log out of the registry'
 complete -f -c npm -n __fish_npm_needs_command -a 'org ogr' -d 'Manage orgs'
 complete -f -c npm -n __fish_npm_needs_command -a outdated -d 'Check for outdated packages'

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -160,6 +160,12 @@ complete -f -c npm -n '__fish_npm_using_command owner' -a ls -d 'List package ow
 complete -f -c npm -n '__fish_npm_using_command owner' -a add -d 'Add a new owner to package'
 complete -f -c npm -n '__fish_npm_using_command owner' -a rm -d 'Remove an owner from package'
 
+# pack
+complete -f -c npm -n __fish_npm_needs_command -a pack -d 'Create a tarball from a package'
+complete -f -c npm -n '__fish_npm_using_command pack' -l dry-run -d 'Only report what it would have done'
+complete -f -c npm -n '__fish_npm_using_command pack' -l json -d 'Output JSON data'
+complete -c npm -n '__fish_npm_using_command pack' -l pack-destination -d 'Tarball destination directory'
+
 # remove
 for c in r remove rm un uninstall unlink
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Remove a package'
@@ -196,7 +202,6 @@ complete -f -c npm -n '__fish_npm_using_command help-search' -l long -d 'Display
 complete -f -c npm -n __fish_npm_needs_command -a 'info v view' -d 'View registry info'
 complete -f -c npm -n __fish_npm_needs_command -a 'link ln' -d 'Symlink a package folder'
 complete -f -c npm -n __fish_npm_needs_command -a outdated -d 'Check for outdated packages'
-complete -f -c npm -n __fish_npm_needs_command -a pack -d 'Create a tarball from a package'
 complete -f -c npm -n __fish_npm_needs_command -a prefix -d 'Display NPM prefix'
 complete -f -c npm -n __fish_npm_needs_command -a prune -d 'Remove extraneous packages'
 complete -c npm -n __fish_npm_needs_command -a publish -d 'Publish a package'

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -178,8 +178,12 @@ for c in config c
 end
 # get, set also exist as shorthands
 complete -f -c npm -n __fish_npm_needs_command -a get -d 'Get a value from the npm configuration'
+complete -f -c npm -n '__fish_npm_using_command get' -s l -l long -d 'Show extended information'
 complete -f -c npm -n '__fish_npm_using_command get' -s h -l help -d 'Display help'
+# set
 complete -f -c npm -n __fish_npm_needs_command -a set -d 'Set a value in the npm configuration'
+complete -x -c npm -n '__fish_npm_using_command set' -s L -l location -a 'global user project' -d 'Which config file'
+complete -f -c npm -n '__fish_npm_using_command set' -s g -l global -d 'Edit global config'
 complete -f -c npm -n '__fish_npm_using_command set' -s h -l help -d 'Display help'
 
 # dedupe

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -192,17 +192,20 @@ for c in ci clean-install ic install-clean isntall-clean install-ci-test cit cle
     complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
+# completion
+complete -f -c npm -n __fish_npm_needs_command -a completion -d 'Tab Completion for npm'
+complete -f -c npm -n '__fish_npm_using_command completion' -s h -l help -d 'Display help'
+
 # config
 complete -f -c npm -n __fish_npm_needs_command -a config -d 'Manage the npm configuration files'
 for c in config c
-    complete -f -c npm -n "__fish_npm_using_command $c" -a set -d 'Sets the config keys to the values'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a get -d 'Echo the config value(s) to stdout'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a delete -d 'Deletes the key from all configuration files'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a list -d 'Show all the config settings'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a ls -d 'Show all the config settings'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a edit -d 'Opens the config file in an editor'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a fix -d 'Attempts to repair invalid configuration items'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a fix -d 'Attempts to repair invalid configuration items'
+    set -l config_commands 'set get delete list edit fix'
+    complete -x -c npm -n "__fish_npm_using_command $c" -n "not __fish_seen_subcommand_from $config_commands" -a set -d 'Sets the config keys to the values'
+    complete -x -c npm -n "__fish_npm_using_command $c" -n "not __fish_seen_subcommand_from $config_commands" -a get -d 'Echo the config value(s) to stdout'
+    complete -x -c npm -n "__fish_npm_using_command $c" -n "not __fish_seen_subcommand_from $config_commands" -a delete -d 'Deletes the key from all config files'
+    complete -x -c npm -n "__fish_npm_using_command $c" -n "not __fish_seen_subcommand_from $config_commands" -a list -d 'Show all config settings'
+    complete -x -c npm -n "__fish_npm_using_command $c" -n "not __fish_seen_subcommand_from $config_commands" -a edit -d 'Opens the config file in an editor'
+    complete -x -c npm -n "__fish_npm_using_command $c" -n "not __fish_seen_subcommand_from $config_commands" -a fix -d 'Attempts to repair invalid config items'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Edit global config'
     complete -x -c npm -n "__fish_npm_using_command $c" -l editor -d 'Specify the editor'
@@ -349,8 +352,6 @@ for c in help hlep
     complete -f -c npm -n "__fish_npm_using_command $c" -a 'ci clean-install' -d 'Clean install a project'
     complete -f -c npm -n "__fish_npm_using_command $c" -a 'install-ci-test cit' -d 'Install a project with a clean slate and run tests'
     complete -f -c npm -n "__fish_npm_using_command $c" -a config -d 'Manage the npm configuration files'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a get -d 'Get a value from the npm configuration'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a set -d 'Set a value in the npm configuration'
     complete -f -c npm -n "__fish_npm_using_command $c" -a dedupe -d 'Reduce duplication'
     complete -f -c npm -n "__fish_npm_using_command $c" -a find-dupes -d 'Find duplication'
     complete -f -c npm -n "__fish_npm_using_command $c" -a deprecate -d 'Deprecate a version of a package'
@@ -370,7 +371,7 @@ for c in help hlep
     complete -f -c npm -n "__fish_npm_using_command $c" -a 'install add i' -d 'Install a package'
     complete -f -c npm -n "__fish_npm_using_command $c" -a 'install-test it' -d 'Install package(s) and run tests'
     complete -f -c npm -n "__fish_npm_using_command $c" -a logout -d 'Log out of the registry'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a 'ls list ll' -d 'List installed packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'ls list' -d 'List installed packages'
     complete -f -c npm -n "__fish_npm_using_command $c" -a outdated -d 'Check for outdated packages'
     complete -f -c npm -n "__fish_npm_using_command $c" -a org -d 'Manage orgs'
     complete -f -c npm -n "__fish_npm_using_command $c" -a 'owner author' -d 'Manage package owners'
@@ -637,6 +638,10 @@ for c in search find s se
     complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
+# shrinkwrap
+complete -f -c npm -n __fish_npm_needs_command -a shrinkwrap -d 'Lock down dependency versions'
+complete -f -c npm -n '__fish_npm_using_command shrinkwrap' -s h -l help -d 'Display help'
+
 # star
 complete -f -c npm -n __fish_npm_needs_command -a star -d 'Mark your favorite packages'
 complete -x -c npm -n '__fish_npm_using_command star' -l registry -d 'Registry base URL'
@@ -749,7 +754,5 @@ complete -f -c npm -n __fish_npm_needs_command -a whoami -d 'Display npm usernam
 complete -f -c npm -n '__fish_npm_using_command whoami' -a registry -d 'Check registry'
 complete -f -c npm -n '__fish_npm_using_command whoami' -s h -l help -d 'Display help'
 
-# misc shorter explanations
-complete -f -c npm -n __fish_npm_needs_command -a completion -d 'Tab Completion for npm'
-complete -f -c npm -n __fish_npm_needs_command -a shrinkwrap -d 'Lock down dependency versions'
+# misc
 complete -f -c npm -n '__fish_seen_subcommand_from add i in ins inst insta instal isnt isnta isntal isntall; and not __fish_is_switch' -a "(__npm_filtered_list_packages \"$npm_install\")"

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -105,7 +105,8 @@ for k,v in data["scripts"].items(): print(k + "\t" + v[:18])' <package.json 2>/d
 end
 
 # run
-for c in run run-script
+for c in run-script run rum urn
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Run arbitrary package scripts'
     complete -f -c npm -n "__fish_npm_using_command $c" -a "(__fish_npm_run)"
 end
 
@@ -116,7 +117,7 @@ complete -f -c npm -n '__fish_npm_using_command cache' -a clean -d 'Delete  data
 complete -f -c npm -n '__fish_npm_using_command cache' -a ls -d 'Show the data in the cache'
 
 # config
-for c in c config
+for c in config c
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Manage the npm configuration files'
     complete -f -c npm -n "__fish_npm_using_command $c" -a set -d 'Sets the config key to the value'
     complete -f -c npm -n "__fish_npm_using_command $c" -a get -d 'Echo the config value to stdout'
@@ -151,7 +152,7 @@ for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
 end
 
 # list
-for c in la list ll ls
+for c in ls list ll la
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'List installed packages'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'List packages in the global install prefix instead of in the current project'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Show information in JSON format'
@@ -181,7 +182,7 @@ complete -x -c npm -n '__fish_npm_using_command publish' -l otp -d '2FA one-time
 ## todo provenance ?
 
 # remove
-for c in r remove rm un uninstall unlink
+for c in uninstall unlink remove rm r un
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Remove a package'
     complete -x -c npm -n "__fish_npm_using_command $c" -d 'remove package' -a '(__yarn_installed_local_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'remove global package' -a '(__npm_installed_global_packages)'
@@ -190,46 +191,64 @@ for c in r remove rm un uninstall unlink
 end
 
 # search
-for c in find s se search
+for c in search find s se
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Search for packages'
     complete -x -c npm -n "__fish_npm_using_command $c" -l long -d 'Display full package descriptions and other long text across multiple lines'
 end
 
 # update
-for c in up update
+for c in update up upgrade udpate
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Update package(s)'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Update global package(s)'
 end
 
 # misc shorter explanations
 complete -f -c npm -n __fish_npm_needs_command -a 'adduser add-user login' -d 'Add a registry user account'
-complete -f -c npm -n __fish_npm_needs_command -a bin -d 'Display npm bin folder'
+complete -f -c npm -n __fish_npm_needs_command -a audit -d 'Run a security audit'
 complete -f -c npm -n __fish_npm_needs_command -a 'bugs issues' -d 'Bugs for a package in a web browser maybe'
-complete -f -c npm -n __fish_npm_needs_command -a 'ddp dedupe find-dupes' -d 'Reduce duplication'
+complete -f -c npm -n __fish_npm_needs_command -a 'ci clean-install ic install-clean isntall-clean' -d 'Clean install a project'
+complete -f -c npm -n __fish_npm_needs_command -a 'dedupe ddp find-dupes' -d 'Reduce duplication'
 complete -f -c npm -n __fish_npm_needs_command -a deprecate -d 'Deprecate a version of a package'
+complete -f -c npm -n __fish_npm_needs_command -a diff -d 'The registry diff command'
+complete -f -c npm -n __fish_npm_needs_command -a 'dist-tag dist-tags' -d 'Modify package distribution tags'
 complete -f -c npm -n __fish_npm_needs_command -a 'docs home' -d 'Docs for a package in a web browser maybe'
+complete -f -c npm -n __fish_npm_needs_command -a doctor -d 'Check your npm environment'
 complete -f -c npm -n __fish_npm_needs_command -a edit -d 'Edit an installed package'
+complete -f -c npm -n __fish_npm_needs_command -a exec -d 'Run a command from a local or remote npm package'
+complete -f -c npm -n __fish_npm_needs_command -a 'explain why' -d 'Explain installed packages'
 complete -f -c npm -n __fish_npm_needs_command -a explore -d 'Browse an installed package'
-complete -f -c npm -n __fish_npm_needs_command -a faq -d 'Frequently Asked Questions'
+complete -f -c npm -n __fish_npm_needs_command -a fund -d 'Retrieve funding information'
+complete -f -c npm -n __fish_npm_needs_command -a 'help hlep' -d 'Get help on npm'
 complete -f -c npm -n __fish_npm_needs_command -a help-search -d 'Search npm help documentation'
 complete -f -c npm -n '__fish_npm_using_command help-search' -l long -d 'Display full package descriptions and other long text across multiple lines'
-complete -f -c npm -n __fish_npm_needs_command -a 'info v view' -d 'View registry info'
+complete -f -c npm -n __fish_npm_needs_command -a hook -d 'Manage registry hooks'
+complete -f -c npm -n __fish_npm_needs_command -a 'install-ci-test cit clean-install-test sit' -d 'Install a project with a clean slate and run tests'
+complete -f -c npm -n __fish_npm_needs_command -a 'install-test it' -d 'Install package(s) and run tests'
 complete -f -c npm -n __fish_npm_needs_command -a 'link ln' -d 'Symlink a package folder'
+complete -f -c npm -n __fish_npm_needs_command -a logout -d 'Log out of the registry'
+complete -f -c npm -n __fish_npm_needs_command -a 'org ogr' -d 'Manage orgs'
 complete -f -c npm -n __fish_npm_needs_command -a outdated -d 'Check for outdated packages'
-complete -f -c npm -n __fish_npm_needs_command -a prefix -d 'Display NPM prefix'
+complete -f -c npm -n __fish_npm_needs_command -a ping -d 'Ping npm registry'
+complete -f -c npm -n __fish_npm_needs_command -a pkg -d 'Manages your package.json'
+complete -f -c npm -n __fish_npm_needs_command -a prefix -d 'Display npm prefix'
+complete -f -c npm -n __fish_npm_needs_command -a profile -d 'Change settings on your registry profile'
 complete -f -c npm -n __fish_npm_needs_command -a prune -d 'Remove extraneous packages'
-complete -f -c npm -n __fish_npm_needs_command -a 'rb rebuild' -d 'Rebuild a package'
-complete -f -c npm -n __fish_npm_needs_command -a 'root ' -d 'Display npm root'
-complete -f -c npm -n __fish_npm_needs_command -a 'run-script run' -d 'Run arbitrary package scripts'
+complete -f -c npm -n __fish_npm_needs_command -a query -d 'Dependency selector query'
+complete -f -c npm -n __fish_npm_needs_command -a 'rebuild rb' -d 'Rebuild a package'
+complete -f -c npm -n __fish_npm_needs_command -a repo -d 'Open package repository page in the browser'
+complete -f -c npm -n __fish_npm_needs_command -a restart -d 'Restart a package'
+complete -f -c npm -n __fish_npm_needs_command -a root -d 'Display npm root'
 complete -f -c npm -n __fish_npm_needs_command -a shrinkwrap -d 'Lock down dependency versions'
 complete -f -c npm -n __fish_npm_needs_command -a star -d 'Mark your favorite packages'
 complete -f -c npm -n __fish_npm_needs_command -a stars -d 'View packages marked as favorites'
 complete -f -c npm -n __fish_npm_needs_command -a start -d 'Start a package'
 complete -f -c npm -n __fish_npm_needs_command -a stop -d 'Stop a package'
-complete -f -c npm -n __fish_npm_needs_command -a submodule -d 'Add a package as a git submodule'
-complete -f -c npm -n __fish_npm_needs_command -a 't tst test' -d 'Test a package'
+complete -f -c npm -n __fish_npm_needs_command -a team -d 'Manage organization teams and team memberships'
+complete -f -c npm -n __fish_npm_needs_command -a 'test tst t' -d 'Test a package'
+complete -f -c npm -n __fish_npm_needs_command -a token -d 'Manage your authentication tokens'
 complete -f -c npm -n __fish_npm_needs_command -a unpublish -d 'Remove a package from the registry'
 complete -f -c npm -n __fish_npm_needs_command -a unstar -d 'Remove star from a package'
-complete -f -c npm -n __fish_npm_needs_command -a version -d 'Bump a package version'
+complete -f -c npm -n __fish_npm_needs_command -a 'version verison' -d 'Bump a package version'
+complete -f -c npm -n __fish_npm_needs_command -a 'view info v show' -d 'View registry info'
 complete -f -c npm -n __fish_npm_needs_command -a whoami -d 'Display npm username'
 complete -f -c npm -n '__fish_seen_subcommand_from add i install; and not __fish_is_switch' -a "(__yarn_filtered_list_packages \"$npm_install\")"

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -113,14 +113,14 @@ complete -f -c npm -n __fish_npm_needs_command -a audit -d 'Run a security audit
 complete -f -c npm -n '__fish_npm_using_command audit' -a signatures -d 'Verify registry signatures'
 complete -f -c npm -n '__fish_npm_using_command audit' -a fix -d 'Install compatible updates to vulnerable deps'
 complete -x -c npm -n '__fish_npm_using_command audit' -l audit-level -a 'info low moderate high critical none' -d 'Audit level'
-complete -f -c npm -n '__fish_npm_using_command audit' -l dry-run -d 'Only report what it would have done'
+complete -f -c npm -n '__fish_npm_using_command audit' -l dry-run -d 'Do not modify'
 complete -f -c npm -n '__fish_npm_using_command audit' -l force -d 'Removes various protections'
 complete -f -c npm -n '__fish_npm_using_command audit' -l json -d 'Output JSON'
-complete -f -c npm -n '__fish_npm_using_command audit' -l package-lock-only -d 'Only use the package-lock.json, ignore node_modules'
+complete -f -c npm -n '__fish_npm_using_command audit' -l package-lock-only -d 'Only use package-lock.json, ignore node_modules'
 complete -x -c npm -n '__fish_npm_using_command audit' -l omit -a 'dev optional peer' -d 'Omit dependency type'
-complete -f -c npm -n '__fish_npm_using_command audit' -l foreground-scripts -d 'Run all build scripts in the foreground process'
+complete -f -c npm -n '__fish_npm_using_command audit' -l foreground-scripts -d 'Run all build scripts in the foreground'
 complete -f -c npm -n '__fish_npm_using_command audit' -l ignore-scripts -d 'Do not run scripts specified in package.json'
-complete -f -c npm -n '__fish_npm_using_command audit' -l install-links -d 'Pack and install file: protocol dependences as regular dependencies instead of symlinks'
+complete -f -c npm -n '__fish_npm_using_command audit' -l install-links -d 'Install file: protocol dependencies as regular dependencies instead of symlinks'
 
 # cache
 complete -f -c npm -n __fish_npm_needs_command -a cache -d "Manipulates package's cache"
@@ -151,12 +151,12 @@ end
 # install
 for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
     complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Install a package'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s B -l save-bundle -d 'Also save to bundleDependencies in package.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s B -l save-bundle -d 'Also save to bundleDependencies in'
     complete -f -c npm -n "__fish_npm_using_command $c" -s E -l save-exact -d 'Save dependency with exact version rather than a semver range'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Prevents saving to dependencies in package.json'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s O -l save-optional -d 'Save to optionalDependencies in package.json'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s P -l save-prod -d 'Save to dependencies in package.json'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s D -l save-dev -d 'Save to devDependencies in package.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Prevents saving to dependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s O -l save-optional -d 'Save to optionalDependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s P -l save-prod -d 'Save to dependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s D -l save-dev -d 'Save to devDependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Install package globally'
     complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
     complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d 'Do not run scripts specified in package.json'
@@ -183,7 +183,7 @@ end
 
 # pack
 complete -f -c npm -n __fish_npm_needs_command -a pack -d 'Create a tarball from a package'
-complete -f -c npm -n '__fish_npm_using_command pack' -l dry-run -d 'Only report what it would have done'
+complete -f -c npm -n '__fish_npm_using_command pack' -l dry-run -d 'Do not modify'
 complete -f -c npm -n '__fish_npm_using_command pack' -l json -d 'Output JSON'
 complete -c npm -n '__fish_npm_using_command pack' -l pack-destination -d 'Tarball destination directory'
 
@@ -191,7 +191,7 @@ complete -c npm -n '__fish_npm_using_command pack' -l pack-destination -d 'Tarba
 complete -f -c npm -n __fish_npm_needs_command -a publish -d 'Publish a package'
 complete -x -c npm -n '__fish_npm_using_command publish' -l tag -d 'Upload to tag'
 complete -x -c npm -n '__fish_npm_using_command publish' -l access -d 'Restrict access' -a "public\t'Publicly viewable' restricted\t'Restricted access (scoped packages only)'"
-complete -f -c npm -n '__fish_npm_using_command publish' -l dry-run -d 'Only report what it would have done'
+complete -f -c npm -n '__fish_npm_using_command publish' -l dry-run -d 'Do not modify'
 complete -x -c npm -n '__fish_npm_using_command publish' -l otp -d '2FA one-time password'
 ## todo provenance ?
 

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -129,6 +129,7 @@ complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcomma
 complete -f -c npm -n '__fish_npm_using_command access' -l json -d 'Output JSON'
 complete -x -c npm -n '__fish_npm_using_command access' -l otp -d '2FA one-time password'
 complete -x -c npm -n '__fish_npm_using_command access' -l registry -d 'Registry base URL'
+complete -f -c npm -n '__fish_npm_using_command access' -s h -l help -d 'Display help'
 
 # adduser
 complete -f -c npm -n __fish_npm_needs_command -a adduser -d 'Add a registry user account'
@@ -137,6 +138,7 @@ for c in adduser add-user login
     complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
     complete -x -c npm -n "__fish_npm_using_command $c" -l scope -d 'Log into a private repository'
     complete -x -c npm -n "__fish_npm_using_command $c" -l auth-type -a 'legacy web' -d 'Authentication strategy'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # audit
@@ -152,6 +154,7 @@ complete -x -c npm -n '__fish_npm_using_command audit' -l omit -a 'dev optional 
 complete -f -c npm -n '__fish_npm_using_command audit' -l foreground-scripts -d 'Run all build scripts in the foreground'
 complete -f -c npm -n '__fish_npm_using_command audit' -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
 complete -f -c npm -n '__fish_npm_using_command audit' -l install-links -d 'Install file: protocol deps as regular deps'
+complete -f -c npm -n '__fish_npm_using_command audit' -s h -l help -d 'Display help'
 
 # bugs
 for c in bugs issues
@@ -159,6 +162,7 @@ for c in bugs issues
     complete -x -c npm -n "__fish_npm_using_command $c" -l browser -d 'Set browser'
     complete -x -c npm -n "__fish_npm_using_command $c" -l no-browser -d 'Print to stdout'
     complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # cache
@@ -168,6 +172,7 @@ complete -f -c npm -n '__fish_npm_using_command cache' -a clean -d 'Delete data 
 complete -f -c npm -n '__fish_npm_using_command cache' -a ls -d 'Show the data in the cache'
 complete -f -c npm -n '__fish_npm_using_command cache' -a verify -d 'Verify the contents of the cache folder'
 complete -x -c npm -n '__fish_npm_using_command cache' -l cache -a '(__fish_complete_directories)' -d 'Cache location'
+complete -f -c npm -n '__fish_npm_using_command cache' -s h -l help -d 'Display help'
 
 # ci
 # install-ci-test
@@ -184,6 +189,7 @@ for c in ci clean-install ic install-clean isntall-clean install-ci-test cit cle
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
     complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d 'Do not make any changes'
     complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # config
@@ -202,10 +208,13 @@ for c in config c
     complete -x -c npm -n "__fish_npm_using_command $c" -l editor -d 'Specify the editor'
     complete -x -c npm -n "__fish_npm_using_command $c" -s L -l location -a 'global user project' -d 'Which config file'
     complete -f -c npm -n "__fish_npm_using_command $c" -s l -l long -d 'Show extended information'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 # get, set also exist as shorthands
 complete -f -c npm -n __fish_npm_needs_command -a get -d 'Get a value from the npm configuration'
+complete -f -c npm -n '__fish_npm_using_command get' -s h -l help -d 'Display help'
 complete -f -c npm -n __fish_npm_needs_command -a set -d 'Set a value in the npm configuration'
+complete -f -c npm -n '__fish_npm_using_command set' -s h -l help -d 'Display help'
 
 # dedupe
 complete -f -c npm -n __fish_npm_needs_command -a dedupe -d 'Reduce duplication'
@@ -220,6 +229,7 @@ for c in dedupe ddp find-dupes
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
     complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 
     if test $c != find-dupes
         complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d "Don't display funding info"
@@ -230,6 +240,7 @@ end
 complete -f -c npm -n __fish_npm_needs_command -a deprecate -d 'Deprecate a version of a package'
 complete -x -c npm -n '__fish_npm_using_command deprecate' -l registry -d 'Registry base URL'
 complete -x -c npm -n '__fish_npm_using_command deprecate' -l otp -d '2FA one-time password'
+complete -f -c npm -n '__fish_npm_using_command deprecate' -s h -l help -d 'Display help'
 
 # diff
 complete -f -c npm -n __fish_npm_needs_command -a diff -d 'The registry diff command'
@@ -243,6 +254,7 @@ complete -x -c npm -n '__fish_npm_using_command diff' -l diff-dst-prefix -d 'Des
 complete -f -c npm -n '__fish_npm_using_command diff' -l diff-text -d 'Treat all files as text'
 complete -f -c npm -n '__fish_npm_using_command diff' -s g -l global -d 'Operates in "global" mode'
 complete -x -c npm -n '__fish_npm_using_command diff' -l tag -d 'The tag used to fetch the tarball'
+complete -f -c npm -n '__fish_npm_using_command diff' -s h -l help -d 'Display help'
 
 # dist-tag
 complete -f -c npm -n __fish_npm_needs_command -a dist-tag -d 'Modify package distribution tags'
@@ -250,6 +262,7 @@ for c in dist-tag dist-tags
     complete -f -c npm -n "__fish_npm_using_command $c" -a add -d 'Tag the package'
     complete -f -c npm -n "__fish_npm_using_command $c" -a rm -d 'Clear a tag from the package'
     complete -f -c npm -n "__fish_npm_using_command $c" -a ls -d 'List all dist-tags'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # docs
@@ -257,6 +270,7 @@ complete -f -c npm -n __fish_npm_needs_command -a docs -d 'Open docs for a packa
 for c in docs home
     complete -x -c npm -n "__fish_npm_using_command $c" -l browser -d 'Set browser'
     complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # doctor
@@ -267,27 +281,32 @@ complete -f -c npm -n '__fish_npm_using_command doctor' -a versions -d 'Check in
 complete -f -c npm -n '__fish_npm_using_command doctor' -a environment -d 'Check PATH'
 complete -f -c npm -n '__fish_npm_using_command doctor' -a permissions -d 'Check file permissions'
 complete -f -c npm -n '__fish_npm_using_command doctor' -a cache -d 'Verify cache'
+complete -f -c npm -n '__fish_npm_using_command doctor' -s h -l help -d 'Display help'
 
 # edit
 complete -f -c npm -n __fish_npm_needs_command -a edit -d 'Edit an installed package'
 complete -f -c npm -n '__fish_npm_using_command edit' -l editor -d 'Specify the editor'
+complete -f -c npm -n '__fish_npm_using_command edit' -s h -l help -d 'Display help'
 
 # exec
 complete -f -c npm -n __fish_npm_needs_command -a exec -d 'Run a command from a local or remote npm package'
 for c in exec x
     complete -x -c npm -n "__fish_npm_using_command $c" -l package -d 'The package(s) to install'
     complete -x -c npm -n "__fish_npm_using_command $c" -l call -d 'Specify a custom command'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # explain
 for c in explain why
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Explain installed packages'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # explore
 complete -f -c npm -n __fish_npm_needs_command -a explore -d 'Browse an installed package'
 complete -f -c npm -n '__fish_npm_using_command explore' -a shell -d 'The shell to open'
+complete -f -c npm -n '__fish_npm_using_command explore' -s h -l help -d 'Display help'
 
 # fund
 complete -f -c npm -n __fish_npm_needs_command -a fund -d 'Retrieve funding information'
@@ -297,10 +316,100 @@ complete -f -c npm -n '__fish_npm_using_command fund' -l no-browser -d 'Print to
 complete -f -c npm -n '__fish_npm_using_command fund' -l unicode -d 'Use unicode characters in the output'
 complete -f -c npm -n '__fish_npm_using_command fund' -l no-unicode -d 'Use ascii characters over unicode glyphs'
 complete -x -c npm -n '__fish_npm_using_command fund' -l which -d 'Which source URL to open (1-indexed)'
+complete -f -c npm -n '__fish_npm_using_command fund' -s h -l help -d 'Display help'
+
+# help
+complete -f -c npm -n __fish_npm_needs_command -a help -d 'Get help on npm'
+for c in help hlep
+    complete -f -c npm -n "__fish_npm_using_command $c" -l viewer -a 'browser man' -d 'Program to view content'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a registry -d 'The JavaScript Package Registry'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a removal -d 'Cleaning the Slate'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a logging -d 'Why, What & How We Log'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a scope -d 'How npm handles the "scripts" field'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a dependency-selectors -d 'Dependency Selector Syntax & Querying'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a npm -d 'javascript package manager'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a npmrc -d 'The npm config files'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a shrinkwrap -d 'A publishable lockfile'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a developers -d 'Developer Guide'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a npx -d 'Run a command from a local or remote npm package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a package-json -d "Specifics of npm's package.json handling"
+    complete -f -c npm -n "__fish_npm_using_command $c" -a package-lock-json -d 'A manifestation of the manifest'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a package-spec -d 'Package name specifier'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a folders -d 'Folder Structures Used by npm'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a global -d 'Folder Structures Used by npm'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a workspaces -d 'FolderWorking with workspaces'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'run-script run' -d 'Run arbitrary package scripts'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a access -d 'Set access level on published packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a adduser -d 'Add a registry user account'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a login -d 'Login to a registry user account'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a audit -d 'Run a security audit'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'bugs issues' -d 'Report bugs for a package in a web browser'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a cache -d "Manipulates package's cache"
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'ci clean-install' -d 'Clean install a project'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'install-ci-test cit' -d 'Install a project with a clean slate and run tests'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a config -d 'Manage the npm configuration files'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a get -d 'Get a value from the npm configuration'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a set -d 'Set a value in the npm configuration'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a dedupe -d 'Reduce duplication'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a find-dupes -d 'Find duplication'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a deprecate -d 'Deprecate a version of a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a diff -d 'The registry diff command'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a dist-tag -d 'Modify package distribution tags'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a docs -d 'Open docs for a package in a web browser'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a doctor -d 'Check your npm environment'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a edit -d 'Edit an installed package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a exec -d 'Run a command from a local or remote npm package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'explaiin why' -d 'Explain installed packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a explore -d 'Browse an installed package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a fund -d 'Retrieve funding information'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a help -d 'Get help on npm'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a help-search -d 'Search npm help documentation'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a hook -d 'Manage registry hooks'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'init create' -d 'Create a package.json file'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'install add i' -d 'Install a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'install-test it' -d 'Install package(s) and run tests'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a logout -d 'Log out of the registry'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'ls list ll' -d 'List installed packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a outdated -d 'Check for outdated packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a org -d 'Manage orgs'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'owner author' -d 'Manage package owners'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a pack -d 'Create a tarball from a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a ping -d 'Ping npm registry'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a pkg -d 'Manages your package.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a prefix -d 'Display npm prefix'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a publish -d 'Publish a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a query -d 'Dependency selector query'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'uninstall remove un' -d 'Remove a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a repo -d 'Open package repository page in the browser'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'restart' -d 'Restart a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'start' -d 'Start a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'stop' -d 'Stop a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'test' -d 'Test a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a root -d 'Display npm root'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'search find' -d 'Search for packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a star -d 'Mark your favorite packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a stars -d 'View packages marked as favorites'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'update up upgrade' -d 'Update package(s)'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a unstar -d 'Remove star from a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a version -d 'Bump a package version'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'view info' -d 'View registry info'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a whoami -d 'Display npm username'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a 'link ln' -d 'Symlink a package folder'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a profile -d 'Change settings on your registry profile'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a prune -d 'Remove extraneous packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a rebuild -d 'Rebuild a package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a team -d 'Manage organization teams and team memberships'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a token -d 'Manage your authentication tokens'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a unpublish -d 'Remove a package from the registry'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a completion -d 'Tab Completion for npm'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a shrinkwrap -d 'Lock down dependency versions'
+end
 
 # help-search
 complete -f -c npm -n __fish_npm_needs_command -a help-search -d 'Search npm help documentation'
 complete -f -c npm -n '__fish_npm_using_command help-search' -s l -l long -d 'Show extended information'
+complete -f -c npm -n '__fish_npm_using_command help-search' -s h -l help -d 'Display help'
 
 # hook
 set -l hook_commands 'add ls update rm'
@@ -312,6 +421,7 @@ complete -f -c npm -n '__fish_npm_using_command hook' -n "not __fish_seen_subcom
 complete -f -c npm -n '__fish_npm_using_command hook' -n '__fish_seen_subcommand_from add' -l type -d 'Hook type'
 complete -x -c npm -n '__fish_npm_using_command hook' -l registry -d 'Registry base URL'
 complete -x -c npm -n '__fish_npm_using_command hook' -l otp -d '2FA one-time password'
+complete -f -c npm -n '__fish_npm_using_command hook' -s h -l help -d 'Display help'
 
 # init
 complete -c npm -n __fish_npm_needs_command -a 'init create' -d 'Create a package.json file'
@@ -319,6 +429,7 @@ for c in init create innit
     complete -f -c npm -n "__fish_npm_using_command $c" -s y -l yes -d 'Automatically answer "yes" to all prompts'
     complete -f -c npm -n "__fish_npm_using_command $c" -s f -l force -d 'Removes various protections'
     complete -x -c npm -n "__fish_npm_using_command $c" -l scope -d 'Create a scoped package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # install
@@ -347,12 +458,14 @@ for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall inst
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
     complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d 'Do not make any changes'
     complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # logout
 complete -f -c npm -n __fish_npm_needs_command -a logout -d 'Log out of the registry'
 complete -x -c npm -n '__fish_npm_using_command logout' -l registry -d 'Registry base URL'
 complete -x -c npm -n '__fish_npm_using_command logout' -l scope -d 'Log out of private repository'
+complete -f -c npm -n '__fish_npm_using_command logout' -s h -l help -d 'Display help'
 
 # ls
 # ll, la
@@ -370,6 +483,7 @@ for c in ls list ll la
     complete -f -c npm -n "__fish_npm_using_command $c" -l unicode -d 'Use unicode characters in the output'
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-unicode -d 'Use ascii characters over unicode glyphs'
     complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # outdated
@@ -379,6 +493,7 @@ complete -f -c npm -n '__fish_npm_using_command outdated' -l json -d 'Output JSO
 complete -f -c npm -n '__fish_npm_using_command outdated' -s l -l long -d 'Show extended information'
 complete -f -c npm -n '__fish_npm_using_command outdated' -l parseable -d 'Output parseable results'
 complete -f -c npm -n '__fish_npm_using_command outdated' -s g -l global -d 'Check global packages'
+complete -f -c npm -n '__fish_npm_using_command outdated' -s h -l help -d 'Display help'
 
 # org
 complete -f -c npm -n __fish_npm_needs_command -a org -d 'Manage orgs'
@@ -390,6 +505,7 @@ for c in org ogr
     complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 5' -n '__fish_seen_subcommand_from set' -a admin -d 'Add admin'
     complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 5' -n '__fish_seen_subcommand_from set' -a developer -d 'Add developer'
     complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 5' -n '__fish_seen_subcommand_from set' -a owner -d 'Add owner'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # owner
@@ -400,6 +516,7 @@ for c in owner author
     complete -f -c npm -n "__fish_npm_using_command $c" -a rm -d 'Remove an owner from package'
     complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
     complete -x -c npm -n "__fish_npm_using_command $c" -l otp -d '2FA one-time password'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # pack
@@ -407,10 +524,12 @@ complete -f -c npm -n __fish_npm_needs_command -a pack -d 'Create a tarball from
 complete -f -c npm -n '__fish_npm_using_command pack' -l dry-run -d 'Do not make any changes'
 complete -f -c npm -n '__fish_npm_using_command pack' -l json -d 'Output JSON'
 complete -x -c npm -n '__fish_npm_using_command pack' -l pack-destination -a '(__fish_complete_directories)' -d 'Tarball destination directory'
+complete -f -c npm -n '__fish_npm_using_command pack' -s h -l help -d 'Display help'
 
 # ping
 complete -f -c npm -n __fish_npm_needs_command -a ping -d 'Ping npm registry'
 complete -x -c npm -n '__fish_npm_using_command ping' -l registry -d 'Registry base URL'
+complete -f -c npm -n '__fish_npm_using_command ping' -s h -l help -d 'Display help'
 
 # pkg
 complete -f -c npm -n __fish_npm_needs_command -a pkg -d 'Manages your package.json'
@@ -419,10 +538,12 @@ complete -x -c npm -n '__fish_npm_using_command pkg' -a get -d 'Retrieves a valu
 complete -x -c npm -n '__fish_npm_using_command pkg' -a delete -d 'Deletes a key'
 complete -f -c npm -n '__fish_npm_using_command pkg' -s f -l force -d 'Removes various protections'
 complete -f -c npm -n '__fish_npm_using_command pkg' -l json -d 'Parse values with JSON.parse()'
+complete -f -c npm -n '__fish_npm_using_command pkg' -s h -l help -d 'Display help'
 
 # prefix
 complete -f -c npm -n __fish_npm_needs_command -a prefix -d 'Display npm prefix'
 complete -f -c npm -n '__fish_npm_using_command prefix' -s g -l global -d 'Display global prefix'
+complete -f -c npm -n '__fish_npm_using_command prefix' -s h -l help -d 'Display help'
 
 # profile
 set -l profile_commands 'enable-2fa disable-2fa get set'
@@ -433,6 +554,7 @@ complete -x -c npm -n '__fish_npm_using_command profile' -n "not __fish_seen_sub
 complete -x -c npm -n '__fish_npm_using_command profile' -n "not __fish_seen_subcommand_from $profile_commands" -a set -d 'Set the value of a profile property'
 complete -x -c npm -n '__fish_npm_using_command profile' -n '__fish_seen_subcommand_from enable-2fa' -a 'auth-only' -d 'Requiere an OTP on profile changes'
 complete -x -c npm -n '__fish_npm_using_command profile' -n '__fish_seen_subcommand_from enable-2fa' -a 'auth-and-writes' -d 'Also requiere an OTP on package changes'
+complete -f -c npm -n '__fish_npm_using_command profile' -s h -l help -d 'Display help'
 
 # prune
 complete -f -c npm -n __fish_npm_needs_command -a prune -d 'Remove extraneous packages'
@@ -442,6 +564,7 @@ complete -f -c npm -n '__fish_npm_using_command prune' -l json -d 'Output JSON'
 complete -f -c npm -n '__fish_npm_using_command prune' -l foreground-scripts -d 'Run all build scripts in the foreground'
 complete -f -c npm -n '__fish_npm_using_command prune' -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
 complete -f -c npm -n '__fish_npm_using_command prune' -l install-links -d 'Install file: protocol deps as regular deps'
+complete -f -c npm -n '__fish_npm_using_command prune' -s h -l help -d 'Display help'
 
 # publish
 complete -f -c npm -n __fish_npm_needs_command -a publish -d 'Publish a package'
@@ -450,10 +573,12 @@ complete -x -c npm -n '__fish_npm_using_command publish' -l access -d 'Restrict 
 complete -f -c npm -n '__fish_npm_using_command publish' -l dry-run -d 'Do not make any changes'
 complete -x -c npm -n '__fish_npm_using_command publish' -l otp -d '2FA one-time password'
 complete -f -c npm -n '__fish_npm_using_command publish' -l provenance -d 'Link to build location when publishing from CI/CD'
+complete -f -c npm -n '__fish_npm_using_command publish' -s h -l help -d 'Display help'
 
 # query
 complete -f -c npm -n __fish_npm_needs_command -a query -d 'Dependency selector query'
 complete -f -c npm -n '__fish_npm_using_command query' -s g -l global -d 'Query global packages'
+complete -f -c npm -n '__fish_npm_using_command query' -s h -l help -d 'Display help'
 
 # rebuild
 complete -f -c npm -n __fish_npm_needs_command -a rebuild -d 'Rebuild a package'
@@ -463,6 +588,7 @@ for c in rebuild rb
     complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
     complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # repo
@@ -471,6 +597,7 @@ complete -f -c npm -n '__fish_npm_using_command repo' -s g -l global -d 'Display
 complete -x -c npm -n '__fish_npm_using_command repo' -l browser -d 'Set browser'
 complete -x -c npm -n '__fish_npm_using_command repo' -l no-browser -d 'Print to stdout'
 complete -x -c npm -n '__fish_npm_using_command repo' -l registry -d 'Registry base URL'
+complete -f -c npm -n '__fish_npm_using_command repo' -s h -l help -d 'Display help'
 
 # restart
 # start
@@ -483,11 +610,13 @@ complete -f -c npm -n __fish_npm_needs_command -a 'test' -d 'Test a package'
 for c in restart start stop test tst t
     complete -f -c npm -n "__fish_npm_using_command $c" -s ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
     complete -x -c npm -n "__fish_npm_using_command $c" -s script-shell -d 'The shell to use for scripts'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # root
 complete -f -c npm -n __fish_npm_needs_command -a root -d 'Display npm root'
 complete -f -c npm -n '__fish_npm_using_command root' -s g -l global -d 'Display global root'
+complete -f -c npm -n '__fish_npm_using_command root' -s h -l help -d 'Display help'
 
 # search
 complete -f -c npm -n __fish_npm_needs_command -a 'search find' -d 'Search for packages'
@@ -505,6 +634,7 @@ for c in search find s se
     complete -f -c npm -n "__fish_npm_using_command $c" -l prefer-online -d 'Force staleness checks for cached data'
     complete -f -c npm -n "__fish_npm_using_command $c" -l prefer-offline -d 'Bypass staleness checks for cached data'
     complete -f -c npm -n "__fish_npm_using_command $c" -l offline -d 'Force offline mode'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # star
@@ -513,10 +643,12 @@ complete -x -c npm -n '__fish_npm_using_command star' -l registry -d 'Registry b
 complete -f -c npm -n '__fish_npm_using_command star' -l unicode -d 'Use unicode characters in the output'
 complete -f -c npm -n '__fish_npm_using_command star' -l no-unicode -d 'Use ascii characters over unicode glyphs'
 complete -x -c npm -n '__fish_npm_using_command star' -l otp -d '2FA one-time password'
+complete -f -c npm -n '__fish_npm_using_command star' -s h -l help -d 'Display help'
 
 # stars
 complete -f -c npm -n __fish_npm_needs_command -a stars -d 'View packages marked as favorites'
 complete -x -c npm -n '__fish_npm_using_command stars' -l registry -d 'Registry base URL'
+complete -f -c npm -n '__fish_npm_using_command stars' -s h -l help -d 'Display help'
 
 # team
 set -l team_commands 'create destroy add rm ls'
@@ -530,6 +662,7 @@ complete -x -c npm -n '__fish_npm_using_command team' -n 'not __fish_seen_subcom
 complete -x -c npm -n '__fish_npm_using_command team' -l registry -d 'Registry base URL'
 complete -f -c npm -n '__fish_npm_using_command team' -s p -l parseable -d 'Output parseable results'
 complete -f -c npm -n '__fish_npm_using_command team' -l json -d 'Output JSON'
+complete -f -c npm -n '__fish_npm_using_command team' -s h -l help -d 'Display help'
 
 # token
 set -l token_commands 'create destroy add rm ls'
@@ -541,6 +674,7 @@ complete -f -c npm -n '__fish_npm_using_command token' -n '__fish_seen_subcomman
 complete -x -c npm -n '__fish_npm_using_command token' -n '__fish_seen_subcommand_from create' -l cidr -d 'List of CIDR address'
 complete -x -c npm -n '__fish_npm_using_command token' -l registry -d 'Registry base URL'
 complete -x -c npm -n '__fish_npm_using_command token' -l otp -d '2FA one-time password'
+complete -f -c npm -n '__fish_npm_using_command token' -s h -l help -d 'Display help'
 
 # update
 complete -f -c npm -n __fish_npm_needs_command -a 'update up upgrade' -d 'Update package(s)'
@@ -559,6 +693,7 @@ for c in update up upgrade udpate
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
     complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d 'Do not make any changes'
     complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # uninstall
@@ -575,6 +710,7 @@ end
 complete -f -c npm -n __fish_npm_needs_command -a unpublish -d 'Remove a package from the registry'
 complete -x -c npm -n '__fish_npm_using_command unpublish' -l dry-run -d 'Do not make any changes'
 complete -x -c npm -n '__fish_npm_using_command unpublish' -s f -l force -d 'Removes various protections'
+complete -f -c npm -n '__fish_npm_using_command unpublish' -s h -l help -d 'Display help'
 
 # unstar
 complete -f -c npm -n __fish_npm_needs_command -a unstar -d 'Remove star from a package'
@@ -582,6 +718,7 @@ complete -x -c npm -n '__fish_npm_using_command unstar' -l registry -d 'Registry
 complete -f -c npm -n '__fish_npm_using_command unstar' -l unicode -d 'Use unicode characters in the output'
 complete -f -c npm -n '__fish_npm_using_command unstar' -l no-unicode -d 'Use ascii characters over unicode glyphs'
 complete -x -c npm -n '__fish_npm_using_command unstar' -l otp -d '2FA one-time password'
+complete -f -c npm -n '__fish_npm_using_command unstar' -s h -l help -d 'Display help'
 
 # version
 complete -f -c npm -n __fish_npm_needs_command -a version -d 'Bump a package version'
@@ -593,6 +730,7 @@ for c in version verison
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
     complete -x -c npm -n "__fish_npm_using_command $c" -l preid -d 'The prerelease identifier'
     complete -f -c npm -n "__fish_npm_using_command $c" -l sign-git-tag -d 'Sign the version tag'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # view
@@ -603,14 +741,15 @@ for c in view info v show
     complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 3' -a 'dependencies devDependencies optionalDependencies peerDependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -n '__fish_is_nth_token 3' -a 'directories dist dist-tags gitHead maintainers readme time users version versions'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s h -l help -d 'Display help'
 end
 
 # whoami
 complete -f -c npm -n __fish_npm_needs_command -a whoami -d 'Display npm username'
 complete -f -c npm -n '__fish_npm_using_command whoami' -a registry -d 'Check registry'
+complete -f -c npm -n '__fish_npm_using_command whoami' -s h -l help -d 'Display help'
 
 # misc shorter explanations
 complete -f -c npm -n __fish_npm_needs_command -a completion -d 'Tab Completion for npm'
-complete -f -c npm -n __fish_npm_needs_command -a 'help hlep' -d 'Get help on npm'
 complete -f -c npm -n __fish_npm_needs_command -a shrinkwrap -d 'Lock down dependency versions'
 complete -f -c npm -n '__fish_seen_subcommand_from add i in ins inst insta instal isnt isnta isntal isntall; and not __fish_is_switch' -a "(__npm_filtered_list_packages \"$npm_install\")"

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -106,7 +106,7 @@ end
 for c in run-script run rum urn
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Run arbitrary package scripts'
     complete -f -c npm -n "__fish_npm_using_command $c" -a "(__fish_npm_run)"
-    complete -f -c npm -n "__fish_npm_using_command $c" -l 'if-present' -d "Don't error on nonexistant script"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l if-present -d "Don't error on nonexistant script"
     complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run pre-, post- and life-cycle scripts"
     complete -x -c npm -n "__fish_npm_using_command $c" -s script-shell -d 'The shell to use for scripts'
     complete -f -c npm -n "__fish_npm_using_command $c" -l foreground-scripts -d 'Run all build scripts in the foreground'
@@ -115,13 +115,13 @@ end
 # access
 set -l access_commands 'list get set grant revoke'
 complete -f -c npm -n __fish_npm_needs_command -a access -d 'Set access level on published packages'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'list' -d 'List access info'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'get' -d 'Get access level'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'grant' -d 'Grant access to users'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'revoke' -d 'Revoke access from users'
-complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'set' -d 'Set access level'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a list -d 'List access info'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a get -d 'Get access level'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a grant -d 'Grant access to users'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a revoke -d 'Revoke access from users'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a set -d 'Set access level'
 complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from list' -a 'packages collaborators'
-complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from get' -a 'status'
+complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from get' -a status
 complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from grant' -a 'read-only read-write'
 complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from set' -a 'status=public status=private' -d 'Set package status'
 complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from set' -a 'mfa=none mfa=publish mfa=automation' -d 'Set package MFA'
@@ -204,7 +204,7 @@ complete -f -c npm -n __fish_npm_needs_command -a set -d 'Set a value in the npm
 
 # dedupe
 complete -f -c npm -n __fish_npm_needs_command -a 'dedupe ddp' -d 'Reduce duplication'
-complete -f -c npm -n __fish_npm_needs_command -a 'find-dupes' -d 'Find duplication'
+complete -f -c npm -n __fish_npm_needs_command -a find-dupes -d 'Find duplication'
 for c in dedupe ddp find-dupes
     complete -x -c npm -n "__fish_npm_using_command $c" -l install-strategy -a 'hoisted nested shallow linked' -d 'Install strategy'
     complete -x -c npm -n "__fish_npm_using_command $c" -l strict-peer-deps -d 'Treat conflicting peerDependencies as failure'
@@ -461,7 +461,7 @@ for c in search find s se
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Search for packages'
     complete -f -c npm -n "__fish_npm_using_command $c" -s l -l long -d 'Show extended information'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON data'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l color -a 'always' -d 'Print color'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l color -a always -d 'Print color'
     complete -f -c npm -n "__fish_npm_using_command $c" -s p -l parseable -d 'Output parseable results'
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-description -d "Don't show the description"
     complete -x -c npm -n "__fish_npm_using_command $c" -l searchopts -d 'Space-separated search options'

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -164,7 +164,7 @@ complete -f -c npm -n '__fish_npm_using_command owner' -a rm -d 'Remove an owner
 for c in r remove rm un uninstall unlink
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Remove a package'
     complete -x -c npm -n "__fish_npm_using_command $c" -d 'remove package' -a '(__yarn_installed_local_packages)'
-    complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'remove global package' -a '(__yarn_installed_local_packages)'
+    complete -x -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'remove global package' -a '(__npm_installed_global_packages)'
     complete -x -c npm -n "__fish_npm_using_command $c" -l save -d 'Package will be removed from your dependencies'
     complete -x -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Do not remove package from your dependencies'
 end

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -72,7 +72,7 @@ end
 # and uninstall (reading dependencies is faster and more robust and yarn needs the functions anyways)
 # see: https://github.com/npm/npm/issues/9524
 # and: https://github.com/fish-shell/fish-shell/pull/2366
-complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run-script run rum urn audit cache uninstall unlink remove rm r un' -a "(__fish_complete_npm)"
+complete -f -c npm -n 'not __fish_npm_needs_option; and not __fish_npm_using_command run-script run rum urn access audit cache uninstall unlink remove rm r un version verison view info show v' -a "(__fish_complete_npm)"
 
 # list available npm scripts and their parial content
 function __fish_parse_npm_run_completions
@@ -108,6 +108,32 @@ for c in run-script run rum urn
     complete -f -c npm -n "__fish_npm_using_command $c" -a "(__fish_npm_run)"
 end
 
+# access
+set -l access_commands 'list get set grant revoke'
+complete -f -c npm -n __fish_npm_needs_command -a access -d 'Set access level on published packages'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'list' -d 'List access info'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'get' -d 'Get access level'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'grant' -d 'Grant access to users'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'revoke' -d 'Revoke access from users'
+complete -x -c npm -n "__fish_npm_using_command access; and not __fish_seen_subcommand_from $access_commands" -a 'set' -d 'Set access level'
+complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from list' -a 'packages collaborators'
+complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from get' -a 'status'
+complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from grant' -a 'read-only read-write'
+complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from set' -a 'status=public status=private' -d 'Set package status'
+complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from set' -a 'mfa=none mfa=publish mfa=automation' -d 'Set package MFA'
+complete -x -c npm -n '__fish_npm_using_command access' -n '__fish_seen_subcommand_from set' -a '2fa=none 2fa=publish 2fa=automation' -d 'Set package MFA'
+complete -f -c npm -n '__fish_npm_using_command access' -l json -d 'Output JSON'
+complete -x -c npm -n '__fish_npm_using_command access' -l otp -d '2FA one-time password'
+complete -x -c npm -n '__fish_npm_using_command access' -l registry -d 'Registry base URL'
+
+# adduser
+for c in adduser add-user
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Add a registry user account'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l scope -d 'Log into a private repository'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l auth-type -a 'legacy web' -d 'Authentication strategy'
+end
+
 # audit
 complete -f -c npm -n __fish_npm_needs_command -a audit -d 'Run a security audit'
 complete -f -c npm -n '__fish_npm_using_command audit' -a signatures -d 'Verify registry signatures'
@@ -120,31 +146,158 @@ complete -f -c npm -n '__fish_npm_using_command audit' -l package-lock-only -d '
 complete -x -c npm -n '__fish_npm_using_command audit' -l omit -a 'dev optional peer' -d 'Omit dependency type'
 complete -f -c npm -n '__fish_npm_using_command audit' -l foreground-scripts -d 'Run all build scripts in the foreground'
 complete -f -c npm -n '__fish_npm_using_command audit' -l ignore-scripts -d 'Do not run scripts specified in package.json'
-complete -f -c npm -n '__fish_npm_using_command audit' -l install-links -d 'Install file: protocol deps as regular deps instead of symlinks'
+complete -f -c npm -n '__fish_npm_using_command audit' -l install-links -d 'Install file: protocol deps as regular deps'
+
+# bugs
+for c in bugs issues
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Report bugs for a package in a web browser'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l browser -d 'Set browser'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l no-browser -d 'Print to stdout'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
+end
 
 # cache
 complete -f -c npm -n __fish_npm_needs_command -a cache -d "Manipulates package's cache"
 complete -f -c npm -n '__fish_npm_using_command cache' -a add -d 'Add the specified package to the local cache'
-complete -f -c npm -n '__fish_npm_using_command cache' -a clean -d 'Delete  data  out of the cache folder'
+complete -f -c npm -n '__fish_npm_using_command cache' -a clean -d 'Delete data out of the cache folder'
 complete -f -c npm -n '__fish_npm_using_command cache' -a ls -d 'Show the data in the cache'
+complete -f -c npm -n '__fish_npm_using_command cache' -a verify -d 'Verify the contents of the cache folder'
+
+# ci
+for c in ci clean-install ic install-clean isntall-clean
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Clean install a project'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l install-strategy -a 'hoisted nested shallow linked' -d 'Install strategy'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l strict-peer-deps -d 'Treat conflicting peerDependencies as failure'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l foreground-scripts -d 'Run all build scripts in the foreground'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run scripts specified in package.json"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-audit -d "Don't submit audit reports"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d 'Do not make any changes'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+end
 
 # config
 for c in config c
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Manage the npm configuration files'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a set -d 'Sets the config key to the value'
-    complete -f -c npm -n "__fish_npm_using_command $c" -a get -d 'Echo the config value to stdout'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a set -d 'Sets the config keys to the values'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a get -d 'Echo the config value(s) to stdout'
     complete -f -c npm -n "__fish_npm_using_command $c" -a delete -d 'Deletes the key from all configuration files'
     complete -f -c npm -n "__fish_npm_using_command $c" -a list -d 'Show all the config settings'
     complete -f -c npm -n "__fish_npm_using_command $c" -a ls -d 'Show all the config settings'
     complete -f -c npm -n "__fish_npm_using_command $c" -a edit -d 'Opens the config file in an editor'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a fix -d 'Attempts to repair invalid configuration items'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a fix -d 'Attempts to repair invalid configuration items'
 end
 # get, set also exist as shorthands
-complete -f -c npm -n __fish_npm_needs_command -a get -d 'Echo the config value to stdout'
-complete -f -c npm -n __fish_npm_needs_command -a set -d 'Sets the config key to the value'
+complete -f -c npm -n __fish_npm_needs_command -a get -d 'Get a value from the npm configuration'
+complete -f -c npm -n __fish_npm_needs_command -a set -d 'Set a value in the npm configuration'
+
+# dedupe
+complete -f -c npm -n __fish_npm_needs_command -a 'dedupe ddp' -d 'Reduce duplication'
+complete -f -c npm -n __fish_npm_needs_command -a 'find-dupes' -d 'Find duplication'
+for c in dedupe ddp find-dupes
+    complete -x -c npm -n "__fish_npm_using_command $c" -l install-strategy -a 'hoisted nested shallow linked' -d 'Install strategy'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l strict-peer-deps -d 'Treat conflicting peerDependencies as failure'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l no-package-lock -d 'Ignore package-lock.json'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run scripts specified in package.json"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-audit -d "Don't submit audit reports"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
+
+	if test $c != find-dupes
+		complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d "Don't display funding info"
+	end
+end
+
+# deprecate
+complete -f -c npm -n __fish_npm_needs_command -a deprecate -d 'Deprecate a version of a package'
+complete -x -c npm -n '__fish_npm_using_command deprecate' -l registry -d 'Registry base URL'
+complete -x -c npm -n '__fish_npm_using_command deprecate' -l otp -d '2FA one-time password'
+
+# diff
+complete -f -c npm -n __fish_npm_needs_command -a diff -d 'The registry diff command'
+complete -x -c npm -n '__fish_npm_using_command diff' -l diff -d 'Arguments to compare'
+complete -f -c npm -n '__fish_npm_using_command diff' -l diff-name-only -d 'Prints only filenames'
+complete -x -c npm -n '__fish_npm_using_command diff' -l diff-unified -d 'The number of lines to print'
+complete -f -c npm -n '__fish_npm_using_command diff' -l diff-ignore-all-space -d 'Ignore whitespace'
+complete -f -c npm -n '__fish_npm_using_command diff' -l diff-no-prefix -d 'Do not show any prefix'
+complete -x -c npm -n '__fish_npm_using_command diff' -l diff-src-prefix -d 'Source prefix'
+complete -x -c npm -n '__fish_npm_using_command diff' -l diff-dst-prefix -d 'Destination prefix'
+complete -f -c npm -n '__fish_npm_using_command diff' -l diff-text -d 'Treat all files as text'
+complete -f -c npm -n '__fish_npm_using_command diff' -s g -l global -d 'Operates in "global" mode'
+complete -x -c npm -n '__fish_npm_using_command diff' -l tag -d 'The tag used to fetch the tarball'
+
+# dist-tag
+for c in dist-tag dist-tags
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Modify package distribution tags'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a add -d 'Tag the package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a rm -d 'Clear a tag from the package'
+    complete -f -c npm -n "__fish_npm_using_command $c" -a ls -d 'List all dist-tags'
+end
+
+# docs
+for c in docs home
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Open docs for a package in a web browser'
+	complete -x -c npm -n "__fish_npm_using_command $c" -l browser -d 'Set browser'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
+end
+
+# doctor
+complete -f -c npm -n __fish_npm_needs_command -a doctor -d 'Check your npm environment'
+complete -f -c npm -n '__fish_npm_using_command doctor' -a ping -d 'Check npm ping'
+complete -f -c npm -n '__fish_npm_using_command doctor' -a registry -d 'Check registry'
+complete -f -c npm -n '__fish_npm_using_command doctor' -a versions -d 'Check installed versions'
+complete -f -c npm -n '__fish_npm_using_command doctor' -a environment -d 'Check PATH'
+complete -f -c npm -n '__fish_npm_using_command doctor' -a permissions -d 'Check file permissions'
+complete -f -c npm -n '__fish_npm_using_command doctor' -a cache -d 'Verify cache'
+
+# edit
+complete -f -c npm -n __fish_npm_needs_command -a edit -d 'Edit an installed package'
+complete -f -c npm -n '__fish_npm_using_command edit' -a editor -d 'Specify the editor'
+
+# exec
+for c in exec x
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Run a command from a local or remote npm package'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l package -d 'The package(s) to install'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l call -d 'Specify a custom command'
+end
+
+# explain
+for c in explain why
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Explain installed packages'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
+end
+
+# explore
+complete -f -c npm -n __fish_npm_needs_command -a explore -d 'Browse an installed package'
+complete -f -c npm -n '__fish_npm_using_command explore' -a shell -d 'The shell to open'
+
+# fund
+complete -f -c npm -n __fish_npm_needs_command -a fund -d 'Retrieve funding information'
+complete -f -c npm -n "__fish_npm_using_command fund" -l json -d 'Output JSON'
+complete -x -c npm -n "__fish_npm_using_command fund" -l browser -d 'Set browser'
+complete -f -c npm -n "__fish_npm_using_command fund" -l no-browser -d 'Print to stdout'
+complete -f -c npm -n "__fish_npm_using_command fund" -l unicode -d 'Use unicode characters in the output'
+complete -f -c npm -n "__fish_npm_using_command fund" -l no-unicode -d 'Use ascii characters over unicode glyphs'
+complete -x -c npm -n "__fish_npm_using_command fund" -l which -d 'Which source URL to open (1-indexed)'
 
 # help-search
 complete -f -c npm -n __fish_npm_needs_command -a help-search -d 'Search npm help documentation'
-complete -f -c npm -n '__fish_npm_using_command help-search' -l long -d 'Show extended information'
+complete -f -c npm -n '__fish_npm_using_command help-search' -s l -l long -d 'Show extended information'
+
+# hook
+complete -f -c npm -n __fish_npm_needs_command -a hook -d 'Manage registry hooks'
+complete -f -c npm -n '__fish_npm_using_command hook' -a add -d 'Add a hook'
+complete -f -c npm -n '__fish_npm_using_command hook; and __fish_seen_subcommand_from add' -l type -d 'Hook type'
+complete -f -c npm -n '__fish_npm_using_command hook' -a ls -d 'List all active hooks'
+complete -f -c npm -n '__fish_npm_using_command hook' -a update -d 'Update an existing hook'
+complete -f -c npm -n '__fish_npm_using_command hook' -a rm -d 'Remove a hook'
+complete -x -c npm -n '__fish_npm_using_command hook' -l registry -d 'Registry base URL'
+complete -x -c npm -n '__fish_npm_using_command hook' -l otp -d '2FA one-time password'
 
 # init
 for c in init create innit
@@ -155,16 +308,24 @@ end
 # install
 for c in install add i 'in' ins inst insta instal isnt isnta isntal isntall
     complete -c npm -n __fish_npm_needs_command -a "$c" -d 'Install a package'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s B -l save-bundle -d 'Also save to bundleDependencies'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s E -l save-exact -d 'Save dependency with exact version'
     complete -f -c npm -n "__fish_npm_using_command $c" -l no-save -d 'Prevents saving to dependencies'
-    complete -f -c npm -n "__fish_npm_using_command $c" -s O -l save-optional -d 'Save to optionalDependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s P -l save-prod -d 'Save to dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s D -l save-dev -d 'Save to devDependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s O -l save-optional -d 'Save to optionalDependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s B -l save-bundle -d 'Also save to bundleDependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s E -l save-exact -d 'Save dependency with exact version'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Install package globally'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l install-strategy -a 'hoisted nested shallow linked' -d 'Install strategy'
     complete -x -c npm -n "__fish_npm_using_command $c" -l omit -a 'dev optional peer' -d 'Omit dependency type'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d 'Do not run scripts specified in package.json'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps instead of symlinks'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l strict-peer-deps -d 'Treat conflicting peerDependencies as failure'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l no-package-lock -d 'Ignore package-lock.json'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l foreground-scripts -d 'Run all build scripts in the foreground'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l ignore-scripts -d "Don't run scripts specified in package.json"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-audit -d "Don't submit audit reports"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-bin-links -d "Don't symblink package executables"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-fund -d "Don't display funding info"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l dry-run -d 'Do not make any changes'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l install-links -d 'Install file: protocol deps as regular deps'
 end
 
 # list
@@ -172,7 +333,7 @@ for c in ls list ll la
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'List installed packages'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'List packages in the global install prefix instead of in the current project'
     complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l long -d 'Show extended information'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s l -l long -d 'Show extended information'
     complete -f -c npm -n "__fish_npm_using_command $c" -l parseable -d 'Show parseable output instead of tree view'
     complete -x -c npm -n "__fish_npm_using_command $c" -l depth -d 'Max display depth of the dependency tree'
 end
@@ -183,7 +344,7 @@ for c in owner author
     complete -f -c npm -n "__fish_npm_using_command $c" -a ls -d 'List package owners'
     complete -f -c npm -n "__fish_npm_using_command $c" -a add -d 'Add a new owner to package'
     complete -f -c npm -n "__fish_npm_using_command $c" -a rm -d 'Remove an owner from package'
-    complete -f -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
     complete -x -c npm -n "__fish_npm_using_command $c" -l otp -d '2FA one-time password'
 end
 
@@ -199,7 +360,7 @@ complete -x -c npm -n '__fish_npm_using_command publish' -l tag -d 'Upload to ta
 complete -x -c npm -n '__fish_npm_using_command publish' -l access -d 'Restrict access' -a "public\t'Publicly viewable' restricted\t'Restricted access (scoped packages only)'"
 complete -f -c npm -n '__fish_npm_using_command publish' -l dry-run -d 'Do not make any changes'
 complete -x -c npm -n '__fish_npm_using_command publish' -l otp -d '2FA one-time password'
-complete -x -c npm -n '__fish_npm_using_command publish' -l provenance -d 'Link to build location when publishing from CI/CD'
+complete -f -c npm -n '__fish_npm_using_command publish' -l provenance -d 'Link to build location when publishing from CI/CD'
 
 # remove
 for c in uninstall unlink remove rm r un
@@ -212,7 +373,17 @@ end
 # search
 for c in search find s se
     complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Search for packages'
-    complete -x -c npm -n "__fish_npm_using_command $c" -l long -d 'Display full package descriptions and other long text across multiple lines'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s l -l long -d 'Show extended information'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON data'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l color -a 'always' -d 'Print color'
+    complete -f -c npm -n "__fish_npm_using_command $c" -s p -l parseable -d 'Output parseable results'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-description -d "Don't show the description"
+    complete -x -c npm -n "__fish_npm_using_command $c" -l searchopts -d 'Space-separated search options'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l searchexclude -d 'Space-separated options to exclude from search'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l registry -d 'Registry base URL'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l prefer-online -d 'Force staleness checks for cached data'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l prefer-offline -d 'Bypass staleness checks for cached data'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l offline -d 'Force offline mode'
 end
 
 # update
@@ -221,26 +392,31 @@ for c in update up upgrade udpate
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Update global package(s)'
 end
 
+# version
+for c in version verison
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'Bump a package version'
+    complete -x -c npm -n "__fish_npm_using_command $c" -a 'major minor patch premajor preminor prepatch prerelease'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l allow-same-version -d 'Allow same version'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-commit-hooks -d "Don't run git commit hooks"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l no-git-tag-version -d "Don't tag the commit"
+    complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
+    complete -x -c npm -n "__fish_npm_using_command $c" -l preid -d 'The prerelease identifier'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l sign-git-tag -d 'Sign the version tag'
+end
+
+# view
+for c in view info v show
+    complete -f -c npm -n __fish_npm_needs_command -a "$c" -d 'View registry info'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l json -d 'Output JSON'
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 2"
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'author bin bugs description engines exports homepage keywords license main name repository scripts type types'
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'dependencies devDependencies optionalDependencies peerDependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c; and __fish_is_nth_token 3" -a 'directories dist dist-tags gitHead maintainers readme time users version versions'
+end
+
 # misc shorter explanations
-complete -f -c npm -n __fish_npm_needs_command -a access -d 'Set access level on published packages'
-complete -f -c npm -n __fish_npm_needs_command -a 'adduser add-user' -d 'Add a registry user account'
-complete -f -c npm -n __fish_npm_needs_command -a 'bugs issues' -d 'Report bugs for a package in a web browser'
-complete -f -c npm -n __fish_npm_needs_command -a 'ci clean-install ic install-clean isntall-clean' -d 'Clean install a project'
 complete -f -c npm -n __fish_npm_needs_command -a completion -d 'Tab Completion for npm'
-complete -f -c npm -n __fish_npm_needs_command -a 'dedupe ddp' -d 'Reduce duplication'
-complete -f -c npm -n __fish_npm_needs_command -a deprecate -d 'Deprecate a version of a package'
-complete -f -c npm -n __fish_npm_needs_command -a diff -d 'The registry diff command'
-complete -f -c npm -n __fish_npm_needs_command -a 'dist-tag dist-tags' -d 'Modify package distribution tags'
-complete -f -c npm -n __fish_npm_needs_command -a 'docs home' -d 'Docs for a package in a web browser maybe'
-complete -f -c npm -n __fish_npm_needs_command -a doctor -d 'Check your npm environment'
-complete -f -c npm -n __fish_npm_needs_command -a edit -d 'Edit an installed package'
-complete -f -c npm -n __fish_npm_needs_command -a 'exec x' -d 'Run a command from a local or remote npm package'
-complete -f -c npm -n __fish_npm_needs_command -a 'explain why' -d 'Explain installed packages'
-complete -f -c npm -n __fish_npm_needs_command -a explore -d 'Browse an installed package'
-complete -f -c npm -n __fish_npm_needs_command -a find-dupes -d 'Find duplication'
-complete -f -c npm -n __fish_npm_needs_command -a fund -d 'Retrieve funding information'
 complete -f -c npm -n __fish_npm_needs_command -a 'help hlep' -d 'Get help on npm'
-complete -f -c npm -n __fish_npm_needs_command -a hook -d 'Manage registry hooks'
 complete -f -c npm -n __fish_npm_needs_command -a 'install-ci-test cit clean-install-test sit' -d 'Install a project with a clean slate and run tests'
 complete -f -c npm -n __fish_npm_needs_command -a 'install-test it' -d 'Install package(s) and run tests'
 complete -f -c npm -n __fish_npm_needs_command -a 'link ln' -d 'Symlink a package folder'
@@ -268,7 +444,5 @@ complete -f -c npm -n __fish_npm_needs_command -a 'test tst t' -d 'Test a packag
 complete -f -c npm -n __fish_npm_needs_command -a token -d 'Manage your authentication tokens'
 complete -f -c npm -n __fish_npm_needs_command -a unpublish -d 'Remove a package from the registry'
 complete -f -c npm -n __fish_npm_needs_command -a unstar -d 'Remove star from a package'
-complete -f -c npm -n __fish_npm_needs_command -a 'version verison' -d 'Bump a package version'
-complete -f -c npm -n __fish_npm_needs_command -a 'view info v show' -d 'View registry info'
 complete -f -c npm -n __fish_npm_needs_command -a whoami -d 'Display npm username'
 complete -f -c npm -n '__fish_seen_subcommand_from add i in ins inst insta instal isnt isnta isntal isntall; and not __fish_is_switch' -a "(__npm_filtered_list_packages \"$npm_install\")"

--- a/share/completions/yarn.fish
+++ b/share/completions/yarn.fish
@@ -7,7 +7,7 @@ set -l yarn_add "yarn global add"
 # because it won't be matched. But we can prevent the slowdown from getting
 # a list of all packages and filtering through it if we only do that when
 # completing what seems to be a package name.
-complete -f -c yarn -n '__fish_seen_subcommand_from remove; and not __fish_is_switch' -xa '(__yarn_installed_packages)'
+complete -f -c yarn -n '__fish_seen_subcommand_from remove; and not __fish_is_switch' -xa '(__yarn_installed_local_packages)'
 complete -f -c yarn -n '__fish_seen_subcommand_from add; and not __fish_is_switch' -xa "(__yarn_filtered_list_packages \"$yarn_add\")"
 
 complete -f -c yarn -n __fish_use_subcommand -a help -d 'Show available commands and flags'

--- a/share/completions/yarn.fish
+++ b/share/completions/yarn.fish
@@ -7,8 +7,8 @@ set -l yarn_add "yarn global add"
 # because it won't be matched. But we can prevent the slowdown from getting
 # a list of all packages and filtering through it if we only do that when
 # completing what seems to be a package name.
-complete -f -c yarn -n '__fish_seen_subcommand_from remove; and not __fish_is_switch' -xa '(__yarn_installed_local_packages)'
-complete -f -c yarn -n '__fish_seen_subcommand_from add; and not __fish_is_switch' -xa "(__yarn_filtered_list_packages \"$yarn_add\")"
+complete -f -c yarn -n '__fish_seen_subcommand_from remove; and not __fish_is_switch' -xa '(__npm_installed_local_packages)'
+complete -f -c yarn -n '__fish_seen_subcommand_from add; and not __fish_is_switch' -xa "(__npm_filtered_list_packages \"$yarn_add\")"
 
 complete -f -c yarn -n __fish_use_subcommand -a help -d 'Show available commands and flags'
 

--- a/share/functions/__fish_npm_helper.fish
+++ b/share/functions/__fish_npm_helper.fish
@@ -50,11 +50,22 @@ function __yarn_find_package_json
     return 1
 end
 
-function __yarn_installed_global_packages
-	set -l prefix (npm config get prefix)
-	set -l lib "$prefix/lib"
+function __npm_installed_global_packages
+	set -l prefix (npm prefix -g)
+	set -l node_modules "$prefix/lib/node_modules"
 
-	# todo recurse
+	for path in $node_modules/*
+		set -l mod (string split '/' $path)[-1]
+
+		if test (string match -r "^@" $mod)
+			for sub_path in $path/*
+				set -l sub_mod (string split '/' $sub_path)[-1]
+				echo $mod/$sub_mod
+			end
+		else
+			echo $mod
+		end
+	end
 end
 
 function __yarn_installed_local_packages

--- a/share/functions/__fish_npm_helper.fish
+++ b/share/functions/__fish_npm_helper.fish
@@ -55,9 +55,9 @@ function __npm_installed_global_packages
 	set -l node_modules "$prefix/lib/node_modules"
 
 	for path in $node_modules/*
-		set -l mod (string split '/' $path)[-1]
+		set -l mod (path basename -- $path)
 
-		if test (string match -r "^@" $mod)
+		if string match -rq "^@" $mod
 			for sub_path in $path/*
 				set -l sub_mod (string split '/' $sub_path)[-1]
 				echo $mod/$sub_mod

--- a/share/functions/__fish_npm_helper.fish
+++ b/share/functions/__fish_npm_helper.fish
@@ -50,7 +50,14 @@ function __yarn_find_package_json
     return 1
 end
 
-function __yarn_installed_packages
+function __yarn_installed_global_packages
+	set -l prefix (npm config get prefix)
+	set -l lib "$prefix/lib"
+
+	# todo recurse
+end
+
+function __yarn_installed_local_packages
     set -l package_json (__yarn_find_package_json)
     if not test $status -eq 0
         # no package.json in tree

--- a/share/functions/__fish_npm_helper.fish
+++ b/share/functions/__fish_npm_helper.fish
@@ -5,17 +5,17 @@
 
 # If all-the-package-names is installed, it will be used to generate npm completions.
 # Install globally with `sudo npm install -g all-the-package-names`. Keep it up to date.
-function __yarn_helper_installed
+function __npm_helper_installed
     # This function takes the command to globally install a package as $argv[1]
     if not type -q all-the-package-names
-        if not set -qg __fish_yarn_pkg_info_shown
+        if not set -qg __fish_npm_pkg_info_shown
             set -l old (commandline)
             commandline -r ""
             echo \nfish: Run `$argv[1] all-the-package-names` to gain intelligent \
                 package completion >&2
             commandline -f repaint
             commandline -r $old
-            set -g __fish_yarn_pkg_info_shown 1
+            set -g __fish_npm_pkg_info_shown 1
         end
         return 1
     end
@@ -23,9 +23,9 @@ end
 
 # Entire list of packages is too long to be used efficiently in a `complete` subcommand.
 # Search it for matches instead.
-function __yarn_filtered_list_packages
+function __npm_filtered_list_packages
     # This function takes the command to globally install a package as $argv[1]
-    if not __yarn_helper_installed $argv[1]
+    if not __npm_helper_installed $argv[1]
         return
     end
 
@@ -37,7 +37,7 @@ function __yarn_filtered_list_packages
     end
 end
 
-function __yarn_find_package_json
+function __npm_find_package_json
     set -l parents (__fish_parent_directories (pwd -P))
 
     for p in $parents
@@ -68,8 +68,8 @@ function __npm_installed_global_packages
 	end
 end
 
-function __yarn_installed_local_packages
-    set -l package_json (__yarn_find_package_json)
+function __npm_installed_local_packages
+    set -l package_json (__npm_find_package_json)
     if not test $status -eq 0
         # no package.json in tree
         return 1


### PR DESCRIPTION
## Description

fixes #9799

1. replaces the built-in `npm uninstall` completions (from `$ npm completion`) with the one that is already used by `yarn` for local packages and a new one for global packages (`npm uninstall -g`)
2. updates and remove outdated options and commands
3. adds missing command aliases, commands and options

### notes

the global completions are done [here](https://github.com/fish-shell/fish-shell/blob/84545861d030adc46a73e094d7ffcbbc584d1099/share/functions/__fish_npm_helper.fish#L53)

this is not fully done, i still need to update and complete for more npm commands

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
