### PR TITLE
Force use of macOS's builtin `manpath`

### DIFF
--- a/share/functions/__fish_apropos.fish
+++ b/share/functions/__fish_apropos.fish
@@ -40,7 +40,7 @@ if test $status -eq 0 -a (count $sysver) -eq 3
 
         if test $age -ge $max_age
             test -d "$dir" || mkdir -m 700 -p $dir
-            /usr/libexec/makewhatis -o "$whatis" (manpath | string split :) >/dev/null 2>&1 </dev/null &
+            /usr/libexec/makewhatis -o "$whatis" (/usr/bin/manpath | string split :) >/dev/null 2>&1 </dev/null &
             disown $last_pid
         end
     end


### PR DESCRIPTION
## Description

This PR modifies `__fish_apropos` to call macOS's own `/usr/bin/manpath` directly.

Fixes an issue (which I didn't bother reporting separately) where, if the user has installed and configured the `man-db` package from Homebrew, `/usr/local/bin/manpath` will complain every time `__fish_apropos` runs:

    manpath: warning: $MANPATH set, ignoring /usr/local/etc/man_db.conf

The `>/dev/null 2>&1` later on line 43 doesn't suppress the message because of the subshell, I guess? Anyway, this prevents the needless warning and ensures more predictable behaviour.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
