### PR TITLE
add /System/Applications/Utilities to `open` completions

### DIFF
--- a/share/completions/open.fish
+++ b/share/completions/open.fish
@@ -1,6 +1,6 @@
 if test (uname) = Darwin # OS X
-    complete -c open -s a -d 'specify app name' -r -a "(mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /System/Applications -onlyin /Developer/Applications 'kMDItemContentType==com.apple.application-*' | string replace -r '.+/(.+).app' '\$1')"
-    complete -c open -s b -d 'specify app bundle id' -x -a "(mdls (mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /System/Applications -onlyin /Developer/Applications 'kMDItemContentType==com.apple.application-*') -name kMDItemCFBundleIdentifier | string replace -rf 'kMDItemCFBundleIdentifier = \"(.+)\"' '\$1')"
+    complete -c open -s a -d 'specify app name' -r -a "(mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /System/Applications -onlyin /System/Applications/Utilities -onlyin /Developer/Applications 'kMDItemContentType==com.apple.application-*' | string replace -r '.+/(.+).app' '\$1')"
+    complete -c open -s b -d 'specify app bundle id' -x -a "(mdls (mdfind -onlyin /Applications -onlyin ~/Applications -onlyin /System/Applications -onlyin /System/Applications/Utilities -onlyin /Developer/Applications 'kMDItemContentType==com.apple.application-*') -name kMDItemCFBundleIdentifier | string replace -rf 'kMDItemCFBundleIdentifier = \"(.+)\"' '\$1')"
     complete -c open -s e -d 'open in TextEdit'
     complete -c open -s t -d 'open in default editor'
     complete -c open -s f -d 'open stdin with editor'


### PR DESCRIPTION
## Description

I noticed some applications such as `Activity Monitor` were missing from the completions since they are located in `/System/Applications/Utilities`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
