### PR TITLE
Fix a typo in `language.rst`

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1951,7 +1951,7 @@ To specify a signal handler for the WINCH signal, write::
         echo Got WINCH signal!
     end
 
-Fish already the following named events for the ``--on-event`` switch:
+Fish already has the following named events for the ``--on-event`` switch:
 
 - ``fish_prompt`` is emitted whenever a new fish prompt is about to be displayed.
 


### PR DESCRIPTION
## Description

added a missing `has`