### PR TITLE
path: drop path_get_paths_ffi

### DIFF
--- a/fish-rust/src/builtins/command.rs
+++ b/fish-rust/src/builtins/command.rs
@@ -5,8 +5,8 @@ use crate::builtins::shared::{
     STATUS_CMD_OK, STATUS_CMD_UNKNOWN, STATUS_INVALID_ARGS,
 };
 use crate::ffi::parser_t;
-use crate::path::path_get_paths;
-use crate::wchar::{wstr, WString, L};
+use crate::path::{path_get_path, path_get_paths};
+use crate::wchar::{wstr, L};
 use crate::wgetopt::{wgetopter_t, wopt, woption, woption_argument_t};
 use crate::wutil::sprintf;
 
@@ -71,10 +71,14 @@ pub fn r#command(
     let mut res = false;
     let optind = w.woptind;
     for arg in argv.iter().take(argc).skip(optind) {
-        // TODO: This always gets all paths, and then skips a bunch.
-        // For the common case, we want to get just the one path.
-        // Port this over once path.cpp is.
-        let paths: Vec<WString> = path_get_paths(arg, &*parser.get_vars());
+        let paths = if opts.all {
+            path_get_paths(arg, &*parser.get_vars())
+        } else {
+            match path_get_path(arg, &*parser.get_vars()) {
+                Some(p) => vec![p],
+                None => vec![],
+            }
+        };
 
         for path in paths.iter() {
             res = true;

--- a/fish-rust/src/builtins/command.rs
+++ b/fish-rust/src/builtins/command.rs
@@ -5,9 +5,8 @@ use crate::builtins::shared::{
     STATUS_CMD_OK, STATUS_CMD_UNKNOWN, STATUS_INVALID_ARGS,
 };
 use crate::ffi::parser_t;
-use crate::ffi::path_get_paths_ffi;
+use crate::path::path_get_paths;
 use crate::wchar::{wstr, WString, L};
-use crate::wchar_ffi::{WCharFromFFI, WCharToFFI};
 use crate::wgetopt::{wgetopter_t, wopt, woption, woption_argument_t};
 use crate::wutil::sprintf;
 
@@ -75,7 +74,7 @@ pub fn r#command(
         // TODO: This always gets all paths, and then skips a bunch.
         // For the common case, we want to get just the one path.
         // Port this over once path.cpp is.
-        let paths: Vec<WString> = path_get_paths_ffi(&arg.to_ffi(), parser).from_ffi();
+        let paths: Vec<WString> = path_get_paths(arg, &*parser.get_vars());
 
         for path in paths.iter() {
             res = true;

--- a/fish-rust/src/builtins/type.rs
+++ b/fish-rust/src/builtins/type.rs
@@ -14,7 +14,7 @@ use crate::ffi::{
     function_get_definition_file, function_get_definition_lineno, function_get_props_autoload,
     function_is_copy,
 };
-use crate::path::path_get_paths;
+use crate::path::{path_get_path, path_get_paths};
 use crate::wchar::{wstr, WString, L};
 use crate::wchar_ffi::WCharFromFFI;
 use crate::wchar_ffi::WCharToFFI;
@@ -190,7 +190,14 @@ pub fn r#type(
             }
         }
 
-        let paths: Vec<WString> = path_get_paths(arg, &*parser.get_vars());
+        let paths = if opts.all {
+            path_get_paths(arg, &*parser.get_vars())
+        } else {
+            match path_get_path(arg, &*parser.get_vars()) {
+                Some(p) => vec![p],
+                None => vec![],
+            }
+        };
 
         for path in paths.iter() {
             found += 1;

--- a/fish-rust/src/builtins/type.rs
+++ b/fish-rust/src/builtins/type.rs
@@ -12,8 +12,9 @@ use crate::ffi::{
     builtin_exists, colorize_shell, function_get_annotated_definition,
     function_get_copy_definition_file, function_get_copy_definition_lineno,
     function_get_definition_file, function_get_definition_lineno, function_get_props_autoload,
-    function_is_copy, path_get_paths_ffi,
+    function_is_copy,
 };
+use crate::path::path_get_paths;
 use crate::wchar::{wstr, WString, L};
 use crate::wchar_ffi::WCharFromFFI;
 use crate::wchar_ffi::WCharToFFI;
@@ -189,7 +190,7 @@ pub fn r#type(
             }
         }
 
-        let paths: Vec<WString> = path_get_paths_ffi(&arg.to_ffi(), parser).from_ffi();
+        let paths: Vec<WString> = path_get_paths(arg, &*parser.get_vars());
 
         for path in paths.iter() {
             found += 1;

--- a/fish-rust/src/ffi.rs
+++ b/fish-rust/src/ffi.rs
@@ -132,7 +132,6 @@ include_cpp! {
     generate!("function_get_annotated_definition")
     generate!("function_is_copy")
     generate!("function_exists")
-    generate!("path_get_paths_ffi")
 
     generate!("rgb_color_t")
     generate_pod!("color24_t")

--- a/src/path.h
+++ b/src/path.h
@@ -63,12 +63,6 @@ struct get_path_result_t {
 };
 get_path_result_t path_try_get_path(const wcstring &cmd, const environment_t &vars);
 
-/// Return all the paths that match the given command.
-std::vector<wcstring> path_get_paths(const wcstring &cmd, const environment_t &vars);
-
-// Needed because of issues with vectors of wstring and environment_t.
-wcstring_list_ffi_t path_get_paths_ffi(const wcstring &cmd, const parser_t &parser);
-
 /// Returns the full path of the specified directory, using the CDPATH variable as a list of base
 /// directories for relative paths.
 ///


### PR DESCRIPTION
f77dc24 provides the pieces to call `path_get_paths` directly from Rust
code. Drop the C++ implementation and its FFI.

I'm not totally convinced the dereferencing of the `EnvStackRef` returned by
`get_vars()` here is right.
