### PR TITLE
Make NULs work for builtins

### DIFF
--- a/fish-rust/src/builtins/shared.rs
+++ b/fish-rust/src/builtins/shared.rs
@@ -1,7 +1,7 @@
 use crate::builtins::{printf, wait};
 use crate::ffi::{self, parser_t, wcstring_list_ffi_t, Repin, RustBuiltin};
 use crate::wchar::{wstr, WString, L};
-use crate::wchar_ffi::{c_str, empty_wstring, WCharFromFFI};
+use crate::wchar_ffi::{c_str, empty_wstring, ToCppWString, WCharFromFFI};
 use crate::wgetopt::{wgetopter_t, wopt, woption, woption_argument_t};
 use libc::c_int;
 use std::os::fd::RawFd;
@@ -86,9 +86,9 @@ impl output_stream_t {
         unsafe { (*self.0).pin() }
     }
 
-    /// Append a &wtr or WString.
-    pub fn append<Str: AsRef<wstr>>(&mut self, s: Str) -> bool {
-        self.ffi().append1(c_str!(s))
+    /// Append a &wstr or WString.
+    pub fn append<Str: AsRef<wstr> + ToCppWString>(&mut self, s: Str) -> bool {
+        self.ffi().append(&s.into_cpp())
     }
 
     /// Append a char.

--- a/fish-rust/src/builtins/shared.rs
+++ b/fish-rust/src/builtins/shared.rs
@@ -87,8 +87,8 @@ impl output_stream_t {
     }
 
     /// Append a &wstr or WString.
-    pub fn append<Str: AsRef<wstr> + ToCppWString>(&mut self, s: Str) -> bool {
-        self.ffi().append(&s.into_cpp())
+    pub fn append<Str: AsRef<wstr>>(&mut self, s: Str) -> bool {
+        self.ffi().append(&s.as_ref().into_cpp())
     }
 
     /// Append a char.

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -955,3 +955,8 @@ string shorten -m0 foo bar asodjsaoidj
 # CHECK: foo
 # CHECK: bar
 # CHECK: asodjsaoidj
+
+echo foo\x00bar | string escape
+# CHECK: foo\x00bar
+echo foo\\x00bar | string escape
+# CHECK: foo\\x00bar


### PR DESCRIPTION
This switches from passing a c-string to output_stream_t::append to passing a proper string.

That means a builtin that prints a NUL no longer crashes with "thread '' panicked at 'String contained intermediate NUL character: ".

Instead, it will actually handle the NUL, even as an argument.

That means something like

`echo foo\x00bar` will now actually print a NUL instead of truncating after the `foo` because we passed c-strings around everywhere.

The former (not crashing) is *necessary* for e.g. `string`, the latter is a change that on the whole makes dealing with NULs easier, but it is a behavioral change.

To restore the c-string behavior we would have to truncate arguments at NUL.

See #9739.

The reason I am not outright declaring it *fixed* is because I would like consensus about this change in behavior.

For the record my opinion is that we *should* make it, that it is a good idea and that I don't believe there's a real concern about backwards-compatibility - accidental NULs basically don't happen.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
