### PR TITLE
Restore NUL truncation for builtin arguments

### DIFF
--- a/tests/checks/nuls.fish
+++ b/tests/checks/nuls.fish
@@ -1,0 +1,7 @@
+#RUN: %fish %s
+# NUL-handling
+
+echo foo\x00bar | string escape
+# CHECK: foo\x00bar
+echo foo\\x00bar | string escape
+# CHECK: foo\\x00bar

--- a/tests/checks/nuls.fish
+++ b/tests/checks/nuls.fish
@@ -1,7 +1,12 @@
 #RUN: %fish %s
 # NUL-handling
 
+# This one actually prints a NUL
+echo (printf '%s\x00' foo bar | string escape)
+# CHECK: foo\x00bar\x00
+# This one is truncated
 echo foo\x00bar | string escape
-# CHECK: foo\x00bar
+# CHECK: foo
+# This one is just escaped
 echo foo\\x00bar | string escape
 # CHECK: foo\\x00bar

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -955,8 +955,3 @@ string shorten -m0 foo bar asodjsaoidj
 # CHECK: foo
 # CHECK: bar
 # CHECK: asodjsaoidj
-
-echo foo\x00bar | string escape
-# CHECK: foo\x00bar
-echo foo\\x00bar | string escape
-# CHECK: foo\\x00bar


### PR DESCRIPTION
## Description

This makes it so builtins can no longer see NUL (0x00) again. `echo foo\x00bar` will only see `foo`.

We do this by explicitly truncating the string ourselves, because of course rust no longer passes nul-terminated wchar_t* around.

This is likely to not be the final word on the issue, but until we have a good design for how working with NULs should work, this is the safest choice.

Fixes issue #9739 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.rst
