### PR TITLE
Add completion for `curl`'s `--output-dir` 

### DIFF
--- a/share/completions/curl.fish
+++ b/share/completions/curl.fish
@@ -116,6 +116,7 @@ complete -c curl -l ntlm-wb -d '(HTTP) Enable NTLM, but hand over auth to separa
 complete -c curl -l ntlm -d '(HTTP) Enable NTLM authentication'
 complete -c curl -l oauth2-bearer -d '(IMAP POP3 SMTP) Specify the Bearer Token for OAUTH 2'
 complete -c curl -s o -l output -d 'Write output to <file> instead of stdout'
+complete -c curl -l output-dir -d 'Directory in which files should be stored when used with -o/--output'
 complete -c curl -l pass -d '(SSH TLS) Passphrase for the private key'
 complete -c curl -l path-as-is -d 'Do not handle sequences of /../ or /./ in the given URL path'
 complete -c curl -l pinnedpubkey -d '(TLS) Use the specified public key file (or hashes)'

--- a/share/completions/curl.fish
+++ b/share/completions/curl.fish
@@ -116,7 +116,7 @@ complete -c curl -l ntlm-wb -d '(HTTP) Enable NTLM, but hand over auth to separa
 complete -c curl -l ntlm -d '(HTTP) Enable NTLM authentication'
 complete -c curl -l oauth2-bearer -d '(IMAP POP3 SMTP) Specify the Bearer Token for OAUTH 2'
 complete -c curl -s o -l output -d 'Write output to <file> instead of stdout'
-complete -c curl -l output-dir -d 'Directory in which files should be stored when used with -o/--output'
+complete -c curl -l output-dir -xa "(__fish_complete_directories)" -d 'Directory in which files should be stored when used with -o/--output'
 complete -c curl -l pass -d '(SSH TLS) Passphrase for the private key'
 complete -c curl -l path-as-is -d 'Do not handle sequences of /../ or /./ in the given URL path'
 complete -c curl -l pinnedpubkey -d '(TLS) Use the specified public key file (or hashes)'


### PR DESCRIPTION
## Description
This add the completion for curl's [`--output-dir`](https://curl.se/docs/manpage.html#--output-dir) option.


## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
