### PR TITLE
Fully migrate string escaping

### DIFF
--- a/fish-rust/src/common.rs
+++ b/fish-rust/src/common.rs
@@ -338,7 +338,7 @@ fn escape_string_url(input: &wstr) -> WString {
             }
         }
         // All other chars need to have their UTF-8 representation encoded in hex.
-        out += &sprintf!("%%%02X"L, byte)[..];
+        sprintf!(=> &mut out, "%%%02X"L, byte);
     }
     out
 }
@@ -374,7 +374,7 @@ fn escape_string_var(input: &wstr) -> WString {
             continue;
         }
         // All other chars need to have their UTF-8 representation encoded in hex.
-        out += &sprintf!("_%02X"L, byte)[..];
+        sprintf!(=> &mut out, "_%02X"L, byte);
         prev_was_hex_encoded = true;
     }
     if prev_was_hex_encoded {

--- a/fish-rust/src/common.rs
+++ b/fish-rust/src/common.rs
@@ -2375,16 +2375,31 @@ mod common_ffi {
         type escape_string_style_t = crate::ffi::escape_string_style_t;
     }
     extern "Rust" {
-        fn rust_unescape_string(
+        #[cxx_name = "rust_unescape_string"]
+        fn unescape_string_ffi(
             input: *const wchar_t,
             len: usize,
             escape_special: u32,
             style: escape_string_style_t,
         ) -> UniquePtr<CxxWString>;
+
+        #[cxx_name = "rust_escape_string_script"]
+        fn escape_string_script_ffi(
+            input: *const wchar_t,
+            len: usize,
+            flags: u32,
+        ) -> UniquePtr<CxxWString>;
+
+        #[cxx_name = "rust_escape_string_url"]
+        fn escape_string_url_ffi(input: *const wchar_t, len: usize) -> UniquePtr<CxxWString>;
+
+        #[cxx_name = "rust_escape_string_var"]
+        fn escape_string_var_ffi(input: *const wchar_t, len: usize) -> UniquePtr<CxxWString>;
+
     }
 }
 
-fn rust_unescape_string(
+fn unescape_string_ffi(
     input: *const ffi::wchar_t,
     len: usize,
     escape_special: u32,
@@ -2404,4 +2419,27 @@ fn rust_unescape_string(
         Some(result) => result.to_ffi(),
         None => UniquePtr::null(),
     }
+}
+
+fn escape_string_script_ffi(
+    input: *const ffi::wchar_t,
+    len: usize,
+    flags: u32,
+) -> UniquePtr<CxxWString> {
+    let input = unsafe { slice::from_raw_parts(input, len) };
+    escape_string_script(
+        wstr::from_slice(input).unwrap(),
+        EscapeFlags::from_bits(flags).unwrap(),
+    )
+    .to_ffi()
+}
+
+fn escape_string_var_ffi(input: *const ffi::wchar_t, len: usize) -> UniquePtr<CxxWString> {
+    let input = unsafe { slice::from_raw_parts(input, len) };
+    escape_string_var(wstr::from_slice(input).unwrap()).to_ffi()
+}
+
+fn escape_string_url_ffi(input: *const ffi::wchar_t, len: usize) -> UniquePtr<CxxWString> {
+    let input = unsafe { slice::from_raw_parts(input, len) };
+    escape_string_url(wstr::from_slice(input).unwrap()).to_ffi()
 }

--- a/fish-rust/src/common.rs
+++ b/fish-rust/src/common.rs
@@ -2074,7 +2074,7 @@ mod tests {
     use rand::random;
 
     /// The number of tests to run.
-    const ESCAPE_TEST_COUNT: usize = 100_000;
+    const ESCAPE_TEST_COUNT: usize = 10_000;
     /// The average length of strings to unescape.
     const ESCAPE_TEST_LENGTH: usize = 100;
     /// The highest character number of character to try and escape.

--- a/fish-rust/src/tests/mod.rs
+++ b/fish-rust/src/tests/mod.rs
@@ -1,1 +1,13 @@
 mod fd_monitor;
+
+use std::ffi::CString;
+
+use libc::setlocale;
+use libc::LC_ALL;
+
+pub fn make_locale_sensitive() {
+    unsafe {
+        let locale = CString::new("").unwrap();
+        setlocale(LC_ALL, locale.as_ptr());
+    }
+}


### PR DESCRIPTION
This is an attempt at doing the uncontroversial part of https://github.com/fish-shell/fish-shell/pull/9763, as #9854 still "needs" it working. This first ports the tests, including testing _all_ escape styles instead of just script, and then some tests-cases that failed for the 'var'-style without the new fixes, and a port fix for script that was fairly clearly failing from running the tests.

- I was unable to find out how string_escape relies upon C++ code, and therefore could not write a non-ran-from-cpp version of the tests
- These functions are generally speaking very poorly tested.