### PR TITLE
add stash completions to git show and git diff

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1040,6 +1040,7 @@ complete -f -c git -n __fish_git_needs_command -a show -d 'Show the last commit 
 complete -f -c git -n '__fish_git_using_command show' -n 'not contains -- -- (commandline -opc)' -ka '(__fish_git_branches)'
 complete -f -c git -n '__fish_git_using_command show' -n 'not contains -- -- (commandline -opc)' -ka '(__fish_git_tags)' -d Tag
 complete -f -c git -n '__fish_git_using_command show' -n 'not contains -- -- (commandline -opc)' -ka '(__fish_git_commits)'
+complete -f -c git -n '__fish_git_using_command show' -n 'not contains -- -- (commandline -opc)' -ka '(__fish_git_complete_stashes)'
 complete -f -c git -n __fish_git_needs_rev_files -n 'not contains -- -- (commandline -opc)' -xa '(__fish_git_complete_rev_files)'
 complete -F -c git -n '__fish_git_using_command show' -n 'contains -- -- (commandline -opc)'
 complete -f -c git -n '__fish_git_using_command show' -l format -d 'Pretty-print the contents of the commit logs in a given format' -a '(__fish_git_show_opt format)'
@@ -1369,6 +1370,7 @@ complete -f -c git -n '__fish_git_using_command describe' -l first-parent -d 'Fo
 ### diff
 complete -c git -n __fish_git_needs_command -a diff -d 'Show changes between commits and working tree'
 complete -c git -n '__fish_git_using_command diff' -n 'not contains -- -- (commandline -opc)' -ka '(__fish_git_ranges)'
+complete -c git -n '__fish_git_using_command diff' -n 'not contains -- -- (commandline -opc)' -ka '(__fish_git_complete_stashes)'
 complete -c git -n '__fish_git_using_command diff' -l cached -d 'Show diff of changes in the index'
 complete -c git -n '__fish_git_using_command diff' -l staged -d 'Show diff of changes in the index'
 complete -c git -n '__fish_git_using_command diff' -l no-index -d 'Compare two paths on the filesystem'


### PR DESCRIPTION
## Description

you can use `git show` and `git diff` with stashes

```
$ git show stash@{1}
$ git diff stash@{0} stash@{1}
$ git diff stash@{0}
```

this adds completions to those  
especially the former (`git show`) is fairly useful because `git stash show` only shows like with `--stat`

#### notes:
* you can also `git checkout` and `git switch --detach` (to) stashes, but i didn't want to encourage that, as you should probably use `git stash apply` or `git stash pop`, so you aren't missing new commits you added since creating the stash. if you want me to i can add that as well
* technically this should also apply to `git cherry-pick` (and probably `git cherry`) but that should probably be done via `git stash apply`, so i didn't add it
```
$ git cherry-pick stash@{1} -m 1
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
