### PR TITLE
Revert and then actually fix macOS build warning

### DIFF
--- a/cmake/Mac.cmake
+++ b/cmake/Mac.cmake
@@ -1,5 +1,3 @@
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum OS X deployment version")
-
 # Code signing ID on Mac.
 # If this is falsey, codesigning is disabled.
 # '-' is ad-hoc codesign.

--- a/cmake/Rust.cmake
+++ b/cmake/Rust.cmake
@@ -1,7 +1,3 @@
-if (APPLE)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum OS X deployment version")
-endif()
-
 if(EXISTS "${CMAKE_SOURCE_DIR}/corrosion-vendor/")
     add_subdirectory("${CMAKE_SOURCE_DIR}/corrosion-vendor/")
 else()


### PR DESCRIPTION
- Revert "Fix built for newer than linked macOS warning"
- Don't specify a min macOS version when not needed

This PR does not specify `MACOSX_DEPLOYMENT_TARGET` in any release script, as I don't know what should be changed

CI now does not warn about Rust-objects being built for newer macOS-versions than being linked