### PR TITLE
Fix rclone autocompletion script sourcing issue in fish shell

### DIFF
--- a/share/completions/rclone.fish
+++ b/share/completions/rclone.fish
@@ -1,1 +1,1 @@
-rclone completion fish 2>/dev/null | source
+rclone completion fish - | source


### PR DESCRIPTION
## Description

This pull request addresses the issue of the `rclone completion fish 2>/dev/null | source` command not properly sourcing the generated autocompletion script in the fish shell.

## Changes Made

Modified the `rclone completion fish` command to write the autocompletion script to stdout using the `-` option: `rclone completion fish - | source`.

## Documentation

The rclone completion fish command documentation can be found [here](https://rclone.org/commands/rclone_completion_fish/). This pull request ensures that the provided documentation reflects the correct usage of the command.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
