### PR TITLE
Fix grammar in completion docs

### DIFF
--- a/doc_src/cmds/complete.rst
+++ b/doc_src/cmds/complete.rst
@@ -1,6 +1,6 @@
 .. _cmd-complete:
 
-complete - edit command specific tab-completions
+complete - edit command-specific tab-completions
 ================================================
 
 Synopsis
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    complete ((-c | --command) | (-p | --path)) COMMAND [OPTIONS] 
+    complete ((-c | --command) | (-p | --path)) COMMAND [OPTIONS]
     complete (-C | --do-complete) [--escape] STRING
 
 Description
@@ -72,7 +72,7 @@ The following options are available:
 **-h** or **--help**
     Displays help about using this command.
 
-Command specific tab-completions in ``fish`` are based on the notion of options and arguments. An option is a parameter which begins with a hyphen, such as ``-h``, ``-help`` or ``--help``. Arguments are parameters that do not begin with a hyphen. Fish recognizes three styles of options, the same styles as the GNU getopt library. These styles are:
+Command-specific tab-completions in ``fish`` are based on the notion of options and arguments. An option is a parameter which begins with a hyphen, such as ``-h``, ``-help`` or ``--help``. Arguments are parameters that do not begin with a hyphen. Fish recognizes three styles of options, the same styles as the GNU getopt library. These styles are:
 
 - Short options, like ``-a``. Short options are a single character long, are preceded by a single hyphen and can be grouped together (like ``-la``, which is equivalent to ``-l -a``). Option arguments may be specified by appending the option with the value (``-w32``), or, if ``--require-parameter`` is given, in the following parameter (``-w 32``).
 

--- a/doc_src/completions.rst
+++ b/doc_src/completions.rst
@@ -26,7 +26,7 @@ By default, option arguments are *optional*, so the candidates are only offered 
   > myprog -o <TAB>
 
 Usually options *require* a parameter, so you would give ``--require-parameter`` / ``-r``::
-  
+
   complete -c myprog -s o -l output -ra "yes no"
 
 which offers yes/no in these cases::
@@ -119,7 +119,7 @@ For examples of how to write your own complex completions, study the completions
 Useful functions for writing completions
 ----------------------------------------
 
-``fish`` ships with several functions that are very useful when writing command specific completions. Most of these functions name begins with the string ``__fish_``. Such functions are internal to ``fish`` and their name and interface may change in future fish versions. Still, some of them may be very useful when writing completions. A few of these functions are described here. Be aware that they may be removed or changed in future versions of fish.
+``fish`` ships with several functions that may be useful when writing command-specific completions. Most of these function names begin with the string ``__fish_``. Such functions are internal to ``fish`` and their name and interface may change in future fish versions. A few of these functions are described here.
 
 Functions beginning with the string ``__fish_print_`` print a newline separated list of strings. For example, ``__fish_print_filesystems`` prints a list of all known file systems. Functions beginning with ``__fish_complete_`` print out a newline separated list of completions with descriptions. The description is separated from the completion by a tab character.
 
@@ -161,7 +161,7 @@ These paths are controlled by parameters set at build, install, or run time, and
 
 This wide search may be confusing. If you are unsure, your completions probably belong in ``~/.config/fish/completions``.
 
-If you have written new completions for a common Unix command, please consider sharing your work by submitting it via the instructions in :ref:`Further help and development <more-help>`
+If you have written new completions for a common Unix command, please consider sharing your work by submitting it via the instructions in :ref:`Further help and development <more-help>`.
 
 If you are developing another program and would like to ship completions with your program, install them to the "vendor" completions directory. As this path may vary from system to system, the ``pkgconfig`` framework should be used to discover this path with the output of ``pkg-config --variable completionsdir fish``.
 


### PR DESCRIPTION
## Description

A few minor grammar mistakes I found while perusing the docs.

## TODOs:

- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
