### PR TITLE
Docs: fix code block

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -91,7 +91,7 @@ searches for lines ending in ``enabled)`` in ``foo.txt`` (the ``$`` is special t
 
 ::
 
-   apt install "postgres-*"
+    apt install "postgres-*"
 
 installs all packages with a name starting with "postgres-", instead of looking through the current directory for files named "postgres-something".
 
@@ -265,7 +265,7 @@ Now let's see a few cases::
 
   # Show the "out" on stderr, silence the "err"
   print >&2 2>/dev/null
-  
+
   # Silence both
   print >/dev/null 2>&1
 


### PR DESCRIPTION
## Description

Attempt to fix a code block that did not render correctly in https://fishshell.com/docs/current/language.html#quotes. It looks like @faho already attempted this once in d239e26f6bb2d29f3f1f0098fc8050cf39efacfc. No idea why it isn't rendering.

## TODOs:

- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
