### PR TITLE
Rustify O_NONBLOCK operations

### DIFF
--- a/fish-rust/src/ffi.rs
+++ b/fish-rust/src/ffi.rs
@@ -55,7 +55,6 @@ include_cpp! {
 
     generate_pod!("wcharz_t")
     generate!("wcstring_list_ffi_t")
-    generate!("make_fd_nonblocking")
     generate!("wperror")
 
     generate_pod!("pipes_ffi_t")

--- a/fish-rust/src/topic_monitor.rs
+++ b/fish-rust/src/topic_monitor.rs
@@ -21,8 +21,7 @@ set. This is the real power of topics: you can wait for a sigchld signal OR a th
 */
 
 use crate::fd_readable_set::fd_readable_set_t;
-use crate::fds::{self, AutoClosePipes};
-use crate::ffi::{self as ffi, c_int};
+use crate::fds::{self, make_fd_nonblocking, AutoClosePipes};
 use crate::flog::{FloggableDebug, FLOG};
 use crate::wchar::WString;
 use crate::wutil::perror;
@@ -213,7 +212,7 @@ impl binary_semaphore_t {
             // receive SIGCHLD and so deadlock. So if tsan is enabled, we mark our fd as non-blocking
             // (so reads will never block) and use select() to poll it.
             if cfg!(feature = "FISH_TSAN_WORKAROUNDS") {
-                ffi::make_fd_nonblocking(c_int(pipes_.read.fd()));
+                let _ = make_fd_nonblocking(&pipes_.read.fd());
             }
         }
         binary_semaphore_t {

--- a/fish-rust/src/wutil/mod.rs
+++ b/fish-rust/src/wutil/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use gettext::{wgettext, wgettext_fmt, wgettext_str};
 pub(crate) use printf::sprintf;
 use std::ffi::OsStr;
 use std::fs::{self, canonicalize};
-use std::io::Write;
+use std::io::{self, Write};
 use std::os::fd::{FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::prelude::{OsStrExt, OsStringExt};
 
@@ -79,6 +79,10 @@ pub fn perror(s: &str) {
     };
     let _ = stderr.write_all(slice);
     let _ = stderr.write_all(b"\n");
+}
+
+pub fn perror_io(s: &str, e: &io::Error) {
+    eprintln!("{}: {}", s, e);
 }
 
 /// Wide character version of getcwd().


### PR DESCRIPTION
Add & adopt Rust implementations of `make_fd_blocking` and `make_fd_nonblocking`.

I've tried to make these more Rust idiomatic than the C++ versions. I don't like the naming of `perror_io` and would appreciate any other suggestions.