### PR TITLE
Docs: correct small grammatical error in read.rst

### DIFF
--- a/doc_src/cmds/read.rst
+++ b/doc_src/cmds/read.rst
@@ -106,7 +106,7 @@ The following code stores the value 'hello' in the shell variable :envvar:`foo`.
 
     echo hello|read foo
 
-While this is a neat way to handle command output line-by-line::
+The :doc:`while <while>` command is a neat way to handle command output line-by-line::
 
     printf '%s\n' line1 line2 line3 line4 | while read -l foo
                       echo "This is another line: $foo"


### PR DESCRIPTION
## Description

Just noticed this sentence doesn't make sense (the construct is typically used as  'while something, something else' but we just end the sentence early); I assumed it intended to reference the `while` command, so I attempted to link to it to help the reader to read more if they wished so.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
