### PR TITLE
Add horcrux completion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Completions
 - ``krita`` (:issue:`9903`).
 - ``blender`` (:issue:`9905`).
 - ``gimp`` (:issue:`9904`).
+- ``horcrux`` (:issue:`9922`).
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/share/completions/horcrux.fish
+++ b/share/completions/horcrux.fish
@@ -1,0 +1,8 @@
+set -l subcommands 'bind split'
+set -l subcommand_show_condition "not __fish_seen_subcommand_from $subcommands"
+set -l split_option_show_condition "contains -- split (commandline -po)"
+
+complete -c horcrux -a bind -n "$subcommand_show_condition" -f -d 'Bind directory'
+complete -c horcrux -a split -n "$subcommand_show_condition" -f -d 'Split file'
+complete -c horcrux -s n -r -n "$split_option_show_condition" -d 'Count of horcruxes to make'
+complete -c horcrux -s t -r -n "$split_option_show_condition" -d 'Count of horcruxes required to resurrect the original file'

--- a/share/completions/horcrux.fish
+++ b/share/completions/horcrux.fish
@@ -1,6 +1,6 @@
 set -l subcommands 'bind split'
 set -l subcommand_show_condition "not __fish_seen_subcommand_from $subcommands"
-set -l split_option_show_condition "contains -- split (commandline -po)"
+set -l split_option_show_condition "__fish_seen_subcommand_from split"
 
 complete -c horcrux -a bind -n "$subcommand_show_condition" -f -d 'Bind directory'
 complete -c horcrux -a split -n "$subcommand_show_condition" -f -d 'Split file'


### PR DESCRIPTION
## Description

https://github.com/jesseduffield/horcrux

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst

## Notes

For some reason, options are passed [before](https://github.com/jesseduffield/horcrux/blob/master/main.go#L63) `split` subcommand. As @faho [responded](https://matrix.to/#/!YLTeaulxSDauOOxBoR:matrix.org/$BzgD3RM1W8EmYv05mAshWP_bmoncGhFdHRReq1dZIbQ?via=gitter.im&via=matrix.org&via=tchncs.de) in Gitter it's not the way Fish completions should work.