### PR TITLE
In .editorconfig replace `max_line_length: none` with `off`.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,7 +22,7 @@ indent_size = 2
 indent_size = 2
 
 [share/{completions,functions}/**.fish]
-max_line_length = none
+max_line_length = off
 
 [{COMMIT_EDITMSG,git-revise-todo}]
 max_line_length = 80


### PR DESCRIPTION
## Description
According to
https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length
that is the correct value to disable this property.
