### PR TITLE
Avoid segfaulting if user has invalid locale

### DIFF
--- a/tests/checks/broken-config.fish
+++ b/tests/checks/broken-config.fish
@@ -18,3 +18,7 @@ begin
     # CHECK: init
     # CHECK: normal command
 end
+
+# should not crash or segfault in the presence of an invalid locale
+LC_ALL=hello echo hello world
+# CHECK: hello world


### PR DESCRIPTION
- Don't segfault if user has an invalid locale

Some of the added `assert!`s are definitively not necessary, but that is a question of code style I would like answered in a review. I also realised I did not follow the comment-convention regarding full sentences...
