### PR TITLE
Use aws_completer in aws completions

### DIFF
--- a/share/completions/aws.fish
+++ b/share/completions/aws.fish
@@ -1,3 +1,10 @@
+# AWS CLI comes bundled with a completion command.
+# https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-completion.html
+if type -q aws_completer
+    complete -c aws -f -a "(env COMP_LINE=(commandline -pc) aws_completer)"
+    exit 0
+end
+
 # These are very much incomplete completions for the aws-cli suite.
 # In addition to a complete list of services, the `aws s3` completions are mostly complete
 # (and are the primary reason this file exists). The automatically generated completions

--- a/share/completions/aws.fish
+++ b/share/completions/aws.fish
@@ -1,7 +1,7 @@
 # AWS CLI comes bundled with a completion command.
 # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-completion.html
 if type -q aws_completer
-    complete -c aws -f -a "(env COMP_LINE=(commandline -pc) aws_completer)"
+    complete -c aws -f -a "(COMP_LINE=(commandline -pc) aws_completer)"
     exit 0
 end
 

--- a/share/completions/aws.fish
+++ b/share/completions/aws.fish
@@ -1,7 +1,13 @@
 # AWS CLI comes bundled with a completion command.
 # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-completion.html
 if type -q aws_completer
-    complete -c aws -f -a "(COMP_LINE=(commandline -pc) aws_completer)"
+    function __aws_completer
+        set -lx COMP_LINE (commandline -pc)
+        set -lx COMP_POINT (string length $COMP_LINE)
+        aws_completer
+    end
+
+    complete -c aws -f -a "(__aws_completer)"
     exit 0
 end
 


### PR DESCRIPTION
## Description

This updates the AWS CLI completions to use `aws_completer`, which [it comes bundled with](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-completion.html) nowadays.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
