### PR TITLE
Simplify and fix `__fish_is_zfs_feature_enabled`

### DIFF
--- a/share/functions/__fish_is_zfs_feature_enabled.fish
+++ b/share/functions/__fish_is_zfs_feature_enabled.fish
@@ -1,17 +1,7 @@
-function __fish_is_zfs_feature_enabled -a feature target -d "Returns 0 if the given ZFS feature is available or enabled for the given full-path target (zpool or dataset), or any target if none given"
-    type -q zpool
-    or return
-    set -l pool (string replace -r '/.*' '' -- $target)
-    set -l feature_name ""
-    if test -z "$pool"
-        set feature_name (zpool get -H all 2>/dev/null | string match -r "\s$feature\s")
-    else
-        set feature_name (zpool get -H all $pool 2>/dev/null | string match -r "$pool\s$feature\s")
-    end
-    if test $status -ne 0 # No such feature
-        return 1
-    end
-    set -l state (echo $feature_name | cut -f3)
-    string match -qr '(active|enabled)' -- $state
-    return $status
+function __fish_is_zfs_feature_enabled \
+    -a feature pool \
+    -d "Returns 0 if the given ZFS pool feature is active or enabled for the given pool or for any pool if none specified"
+
+    type -q zpool && \
+    zpool get -H -o value $feature $pool 2> /dev/null | string match -rq '^(enabled|active)$'
 end

--- a/share/functions/__fish_is_zfs_feature_enabled.fish
+++ b/share/functions/__fish_is_zfs_feature_enabled.fish
@@ -3,5 +3,5 @@ function __fish_is_zfs_feature_enabled \
     -d "Returns 0 if the given ZFS pool feature is active or enabled for the given pool or for any pool if none specified"
 
     type -q zpool || return
-    zpool get -H -o value $feature $pool 2> /dev/null | string match -rq '^(enabled|active)$'
+    zpool get -H -o value $feature $pool 2>/dev/null | string match -rq '^(enabled|active)$'
 end

--- a/share/functions/__fish_is_zfs_feature_enabled.fish
+++ b/share/functions/__fish_is_zfs_feature_enabled.fish
@@ -2,6 +2,6 @@ function __fish_is_zfs_feature_enabled \
     -a feature pool \
     -d "Returns 0 if the given ZFS pool feature is active or enabled for the given pool or for any pool if none specified"
 
-    type -q zpool && \
+    type -q zpool || return
     zpool get -H -o value $feature $pool 2> /dev/null | string match -rq '^(enabled|active)$'
 end


### PR DESCRIPTION
## Description

Previously `__fish_is_zfs_feature_enabled` was doing
`<whitespace>$queried_feature<whitespace>` pattern matching which
was skipping the state part expected in the follow-up checking code.

Passing the dataset/snapshot in a `target` argument is pointless. As
none of the existing code attempts to do this plus it is also a
private function (`__` prefix), rename of the argument and removal
of extra text replacement should not be considered a breaking change.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
