### PR TITLE
Include the target of bad redirects in the error

### DIFF
--- a/fish-rust/src/ast.rs
+++ b/fish-rust/src/ast.rs
@@ -3192,6 +3192,15 @@ impl<'s> Populator<'s> {
                     }
                 }
             }
+            ParseTokenType::redirection if self.peek_type(0) == ParseTokenType::string => {
+                let next = self.tokens.pop();
+                parse_error_range!(
+                    self,
+                    next.range().combine(tok.range()),
+                    ParseErrorCode::generic,
+                    "Expected a string, but found a redirection"
+                );
+            }
             ParseTokenType::pipe
             | ParseTokenType::redirection
             | ParseTokenType::background

--- a/fish-rust/src/parse_constants.rs
+++ b/fish-rust/src/parse_constants.rs
@@ -237,6 +237,18 @@ impl SourceRange {
             .try_into()
             .unwrap()
     }
+    pub fn combine(&self, other: Self) -> Self {
+        let start = std::cmp::min(self.start, other.start);
+        SourceRange {
+            start,
+            length: std::cmp::max(self.end(), other.end())
+                .checked_sub(start.try_into().unwrap())
+                .expect("Overflow")
+                .try_into()
+                .unwrap(),
+        }
+    }
+
     fn end_ffi(&self) -> u32 {
         self.start.checked_add(self.length).expect("Overflow")
     }

--- a/src/fish_tests.cpp
+++ b/src/fish_tests.cpp
@@ -4883,6 +4883,11 @@ static void test_highlighting() {
     });
 #endif
 
+    highlight_tests.push_back({
+        {L">", highlight_role_t::error},
+        {L"echo", highlight_role_t::error},
+    });
+
     bool saved_flag = feature_test(feature_flag_t::ampersand_nobg_in_token);
     feature_set(feature_flag_t::ampersand_nobg_in_token, true);
     for (const highlight_component_list_t &components : highlight_tests) {


### PR DESCRIPTION
## Description

When a redirect generates an error, peek at the next token, and if it is a string, consume it, and include it in the error range; the latter is done by adding a method `combine` to `SourceRange` that merges two of them. Test was from @krobelus.


Fixes issue #8877

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
