### PR TITLE
Add wformat macro as non-localized peer to sprintf

### DIFF
--- a/fish-rust/src/ast.rs
+++ b/fish-rust/src/ast.rs
@@ -115,10 +115,10 @@ pub trait Node: Acceptor + ConcreteNode + std::fmt::Debug {
     fn describe(&self) -> WString {
         let mut res = ast_type_to_string(self.typ()).to_owned();
         if let Some(n) = self.as_token() {
-            let token_type: &'static wstr = n.token_type().into();
+            let token_type = n.token_type().to_wstr();
             res += &sprintf!(" '%ls'"L, token_type)[..];
         } else if let Some(n) = self.as_keyword() {
-            let keyword: &'static wstr = n.keyword().into();
+            let keyword = n.keyword().to_wstr();
             res += &sprintf!(" '%ls'"L, keyword)[..];
         }
         res
@@ -2341,7 +2341,7 @@ impl Ast {
                     result += &sprintf!(": '%ls'"L, argsrc)[..];
                 }
             } else if let Some(n) = node.as_keyword() {
-                result += &sprintf!("keyword: %ls"L, Into::<&'static wstr>::into(n.keyword()))[..];
+                result += &sprintf!("keyword: %ls"L, n.keyword().to_wstr())[..];
             } else if let Some(n) = node.as_token() {
                 let desc = match n.token_type() {
                     ParseTokenType::string => {
@@ -2754,7 +2754,9 @@ impl<'s> NodeVisitorMut for Populator<'s> {
         if self.unwinding {
             return;
         }
-        let VisitResult::Break(error) = flow else { return; };
+        let VisitResult::Break(error) = flow else {
+            return;
+        };
 
         /// We believe the node is some sort of block statement. Attempt to find a source range
         /// for the block's keyword (for, if, etc) and a user-presentable description. This

--- a/fish-rust/src/builtins/random.rs
+++ b/fish-rust/src/builtins/random.rs
@@ -162,6 +162,6 @@ pub fn random(
     // Safe because end was a valid i64 and the result here is in the range start..=end.
     let result: i64 = start.checked_add_unsigned(rand * step).unwrap();
 
-    streams.out.append(sprintf!(L!("%lld\n"), result));
+    streams.out.appendln(result.to_wstring());
     return STATUS_CMD_OK;
 }

--- a/fish-rust/src/color.rs
+++ b/fish-rust/src/color.rs
@@ -184,22 +184,6 @@ impl RgbColor {
         self.flags.reverse = reverse;
     }
 
-    /// Returns a description of the color.
-    #[widestrs]
-    pub fn description(self) -> WString {
-        match self.typ {
-            Type::None => WString::from_str("none"),
-            Type::Named { idx } => {
-                sprintf!("named(%d, %ls)"L, idx, name_for_color_idx(idx).unwrap())
-            }
-            Type::Rgb(c) => {
-                sprintf!("rgb(0x%02x%02x%02x"L, c.r, c.g, c.b)
-            }
-            Type::Normal => WString::from_str("normal"),
-            Type::Reset => WString::from_str("reset"),
-        }
-    }
-
     /// Returns the name index for the given color. Requires that the color be named or RGB.
     pub fn to_name_index(self) -> u8 {
         // TODO: This should look for the nearest color.
@@ -385,12 +369,6 @@ fn convert_color(color: Color24, colors: &[u32]) -> usize {
         })
         .expect("convert_color() called with empty color list")
         .0
-}
-
-fn name_for_color_idx(target_idx: u8) -> Option<&'static wstr> {
-    NAMED_COLORS
-        .iter()
-        .find_map(|&NamedColor { name, idx, .. }| (idx == target_idx).then_some(name))
 }
 
 fn term16_color_for_rgb(color: Color24) -> u8 {

--- a/fish-rust/src/parse_constants.rs
+++ b/fish-rust/src/parse_constants.rs
@@ -252,10 +252,11 @@ impl Default for ParseTokenType {
     }
 }
 
-impl From<ParseTokenType> for &'static wstr {
+impl ParseTokenType {
+    /// Return a string describing the token type.
     #[widestrs]
-    fn from(token_type: ParseTokenType) -> Self {
-        match token_type {
+    pub fn to_wstr(self) -> &'static wstr {
+        match self {
             ParseTokenType::comment => "ParseTokenType::comment"L,
             ParseTokenType::error => "ParseTokenType::error"L,
             ParseTokenType::tokenizer_error => "ParseTokenType::tokenizer_error"L,
@@ -279,10 +280,11 @@ impl Default for ParseKeyword {
     }
 }
 
-impl From<ParseKeyword> for &'static wstr {
+impl ParseKeyword {
+    /// Return the keyword as a string.
     #[widestrs]
-    fn from(keyword: ParseKeyword) -> Self {
-        match keyword {
+    pub fn to_wstr(self) -> &'static wstr {
+        match self {
             ParseKeyword::kw_exclam => "!"L,
             ParseKeyword::kw_and => "and"L,
             ParseKeyword::kw_begin => "begin"L,
@@ -308,7 +310,7 @@ impl From<ParseKeyword> for &'static wstr {
 
 impl printf_compat::args::ToArg<'static> for ParseKeyword {
     fn to_arg(self) -> printf_compat::args::Arg<'static> {
-        printf_compat::args::Arg::Str(self.into())
+        printf_compat::args::Arg::Str(self.to_wstr())
     }
 }
 
@@ -559,7 +561,7 @@ pub fn token_type_user_presentable_description(
     keyword: ParseKeyword,
 ) -> WString {
     if keyword != ParseKeyword::none {
-        return sprintf!("keyword: '%ls'"L, Into::<&'static wstr>::into(keyword));
+        return sprintf!("keyword: '%ls'"L, keyword.to_wstr());
     }
     match type_ {
         ParseTokenType::string => "a string"L.to_owned(),
@@ -573,7 +575,7 @@ pub fn token_type_user_presentable_description(
         ParseTokenType::error => "a parse error"L.to_owned(),
         ParseTokenType::tokenizer_error => "an incomplete token"L.to_owned(),
         ParseTokenType::comment => "a comment"L.to_owned(),
-        _ => sprintf!("a %ls"L, Into::<&'static wstr>::into(type_)),
+        _ => sprintf!("a %ls"L, type_.to_wstr()),
     }
 }
 

--- a/fish-rust/src/parse_tree.rs
+++ b/fish-rust/src/parse_tree.rs
@@ -73,9 +73,9 @@ impl ParseToken {
     }
     /// Returns a string description of the given parse token.
     pub fn describe(&self) -> WString {
-        let mut result = Into::<&'static wstr>::into(self.typ).to_owned();
+        let mut result = self.typ.to_wstr().to_owned();
         if self.keyword != ParseKeyword::none {
-            result += &sprintf!(L!(" <%ls>"), Into::<&'static wstr>::into(self.keyword))[..]
+            sprintf!(=> &mut result, " <%ls>", self.keyword.to_wstr())
         }
         result
     }

--- a/fish-rust/src/wutil/mod.rs
+++ b/fish-rust/src/wutil/mod.rs
@@ -508,7 +508,7 @@ pub fn fish_wcswidth(s: &wstr) -> libc::c_int {
 /// other things. While an inode / dev pair is sufficient to distinguish co-existing files, Linux
 /// seems to aggressively re-use inodes, so it cannot determine if a file has been deleted (ABA
 /// problem). Therefore we include richer information.
-#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct FileId {
     pub device: libc::dev_t,
     pub inode: libc::ino_t,
@@ -552,18 +552,6 @@ impl FileId {
         let lhs = (self.mod_seconds, self.mod_nanoseconds);
         let rhs = (rhs.mod_seconds, rhs.mod_nanoseconds);
         lhs.cmp(&rhs).is_lt()
-    }
-
-    pub fn dump(&self) -> WString {
-        let mut result = WString::new();
-        result += &sprintf!("     device: %lld\n", self.device)[..];
-        result += &sprintf!("      inode: %lld\n", self.inode)[..];
-        result += &sprintf!("       size: %lld\n", self.size)[..];
-        result += &sprintf!("     change: %lld\n", self.change_seconds)[..];
-        result += &sprintf!("change_nano: %lld\n", self.change_nanoseconds)[..];
-        result += &sprintf!("        mod: %lld\n", self.mod_seconds)[..];
-        result += &sprintf!("   mod_nano: %lld", self.mod_nanoseconds)[..];
-        result
     }
 }
 

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -178,18 +178,6 @@ bool rgb_color_t::try_parse_named(const wcstring &str) {
     return false;
 }
 
-static const wchar_t *name_for_color_idx(uint8_t idx) {
-    constexpr size_t colors_count = sizeof(named_colors) / sizeof(named_colors[0]);
-    if (idx < colors_count) {
-        for (auto &color : named_colors) {
-            if (idx == color.idx) {
-                return color.name;
-            }
-        }
-    }
-    return L"unknown";
-}
-
 rgb_color_t::rgb_color_t(uint8_t t, uint8_t i) : type(t), flags(), data() { data.name_idx = i; }
 
 rgb_color_t rgb_color_t::normal() { return rgb_color_t(type_normal); }
@@ -289,30 +277,4 @@ rgb_color_t::rgb_color_t(const wcstring &str) : type(), flags() { this->parse(st
 
 rgb_color_t::rgb_color_t(const std::string &str) : type(), flags() {
     this->parse(str2wcstring(str));
-}
-
-wcstring rgb_color_t::description() const {
-    switch (type) {
-        case type_none: {
-            return L"none";
-        }
-        case type_named: {
-            return format_string(L"named(%d: %ls)", static_cast<int>(data.name_idx),
-                                 name_for_color_idx(data.name_idx));
-        }
-        case type_rgb: {
-            return format_string(L"rgb(0x%02x%02x%02x)", data.color.rgb[0], data.color.rgb[1],
-                                 data.color.rgb[2]);
-        }
-        case type_reset: {
-            return L"reset";
-        }
-        case type_normal: {
-            return L"normal";
-        }
-        default: {
-            break;
-        }
-    }
-    DIE("unknown color type");
 }

--- a/src/color.h
+++ b/src/color.h
@@ -91,9 +91,6 @@ class rgb_color_t {
     /// Returns whether the color is special, that is, not rgb or named.
     bool is_special(void) const { return type != type_named && type != type_rgb; }
 
-    /// Returns a description of the color.
-    wcstring description() const;
-
     /// Returns the name index for the given color. Requires that the color be named or RGB.
     uint8_t to_name_index() const;
 


### PR DESCRIPTION
This is a change to add a macro `wformat!` analogous to `format!` but that produces a WString instead. This is used for formatting for *non-localized* strings, replacing `sprintf!` for those uses.

I've gone through our uses of sprintf to replace those cases which are not localized. I've also updated the Rust development guide.

The advantages of `wformat!` over `sprintf!` are:

1. Checked at compile time. `sprintf!("hello %s")` is broken but will compile, while `wformat!("hello {}")` will produce a compile-time error.
2. More familiar to Rust programmers. It uses the standard Rust formatting syntax, instead of the less-familiar printf syntax.
3. Much faster in debug and sanitizer builds. This is because it uses the Rust standard library, which is always compiled in release mode. This was a real issue in the string escape tests.

Disadvantages are:

1. Two string formatting mechanisms instead of one.
2. If we later decide to translate a `wformat!` string, we will have to convert to `sprintf!` format syntax first.

Thanks for any thoughts on this approach.