### PR TITLE
Add appendln

### DIFF
--- a/fish-rust/src/builtins/argparse.rs
+++ b/fish-rust/src/builtins/argparse.rs
@@ -662,8 +662,7 @@ fn validate_arg<'opts>(
     let retval = exec_subshell(opt_spec.validation_command, parser, &mut cmd_output, false);
 
     for output in cmd_output {
-        streams.err.append(output);
-        streams.err.append1('\n');
+        streams.err.appendln(output);
     }
     vars.pop();
     return retval;

--- a/fish-rust/src/builtins/builtin.rs
+++ b/fish-rust/src/builtins/builtin.rs
@@ -78,7 +78,7 @@ pub fn r#builtin(
         // List is guaranteed to be sorted by name.
         let names: Vec<WString> = builtin_get_names_ffi().from_ffi();
         for name in names {
-            streams.out.append(name + L!("\n"));
+            streams.out.appendln(name);
         }
     }
 

--- a/fish-rust/src/builtins/command.rs
+++ b/fish-rust/src/builtins/command.rs
@@ -77,7 +77,7 @@ pub fn r#command(
                 return STATUS_CMD_OK;
             }
 
-            streams.out.append(sprintf!("%ls\n", path));
+            streams.out.appendln(path);
             if !opts.all {
                 break;
             }

--- a/fish-rust/src/builtins/contains.rs
+++ b/fish-rust/src/builtins/contains.rs
@@ -69,7 +69,7 @@ pub fn contains(
         for (i, arg) in args[optind..].iter().enumerate().skip(1) {
             if needle == arg {
                 if opts.print_index {
-                    streams.out.append(wgettext_fmt!("%d\n", i));
+                    streams.out.appendln(i.to_wstring());
                 }
                 return STATUS_CMD_OK;
             }

--- a/fish-rust/src/builtins/functions.rs
+++ b/fish-rust/src/builtins/functions.rs
@@ -211,7 +211,7 @@ pub fn functions(
         } else {
             L!("n/a").to_owned()
         };
-        streams.out.append(def_file + L!("\n"));
+        streams.out.appendln(def_file);
 
         if opts.verbose {
             let copy_place = match props.as_ref() {
@@ -226,20 +226,20 @@ pub fn functions(
                 Some(p) if !p.is_autoload.load() => L!("not-autoloaded").to_owned(),
                 _ => L!("n/a").to_owned(),
             };
-            streams.out.append(copy_place + L!("\n"));
+            streams.out.appendln(copy_place);
             let line = if let Some(p) = props.as_ref() {
                 p.definition_lineno()
             } else {
                 0
             };
-            streams.out.append(sprintf!("%d\n", line));
+            streams.out.appendln(line.to_wstring());
 
             let shadow = match props.as_ref() {
                 Some(p) if p.shadow_scope => L!("scope-shadowing").to_owned(),
                 Some(p) if !p.shadow_scope => L!("no-scope-shadowing").to_owned(),
                 _ => L!("n/a").to_owned(),
             };
-            streams.out.append(shadow + L!("\n"));
+            streams.out.appendln(shadow);
 
             let desc = match props.as_ref() {
                 Some(p) if !p.description.is_empty() => escape_string(
@@ -249,7 +249,7 @@ pub fn functions(
                 Some(p) if p.description.is_empty() => L!("").to_owned(),
                 _ => L!("n/a").to_owned(),
             };
-            streams.out.append(desc + L!("\n"));
+            streams.out.appendln(desc);
         }
         // Historical - this never failed?
         return STATUS_CMD_OK;
@@ -292,7 +292,7 @@ pub fn functions(
                 .append(reformat_for_screen(&buff, &termsize_last()));
         } else {
             for name in names {
-                streams.out.append(name + "\n");
+                streams.out.appendln(name);
             }
         }
         return STATUS_CMD_OK;

--- a/fish-rust/src/builtins/pwd.rs
+++ b/fish-rust/src/builtins/pwd.rs
@@ -62,6 +62,6 @@ pub fn pwd(parser: &mut parser_t, streams: &mut io_streams_t, argv: &mut [&wstr]
     if pwd.is_empty() {
         return STATUS_CMD_ERROR;
     }
-    streams.out.append(pwd + L!("\n"));
+    streams.out.appendln(pwd);
     return STATUS_CMD_OK;
 }

--- a/fish-rust/src/builtins/random.rs
+++ b/fish-rust/src/builtins/random.rs
@@ -55,9 +55,7 @@ pub fn random(
         }
 
         let rand = RNG.lock().unwrap().gen_range(0..arg_count - 1);
-        streams
-            .out
-            .append(sprintf!(L!("%ls\n"), argv[i + 1 + rand]));
+        streams.out.appendln(argv[i + 1 + rand]);
         return STATUS_CMD_OK;
     }
     fn parse_ll(streams: &mut io_streams_t, cmd: &wstr, num: &wstr) -> Result<i64, wutil::Error> {

--- a/fish-rust/src/builtins/shared.rs
+++ b/fish-rust/src/builtins/shared.rs
@@ -114,6 +114,12 @@ impl output_stream_t {
         self.ffi().append(&s.as_ref().into_cpp())
     }
 
+    /// Append a &wstr or WString with a newline
+    pub fn appendln(&mut self, s: impl Into<WString>) -> bool {
+        let s = s.into() + L!("\n");
+        self.ffi().append(&s.into_cpp())
+    }
+
     /// Append a char.
     pub fn append1(&mut self, c: char) -> bool {
         self.append(wstr::from_char_slice(&[c]))

--- a/fish-rust/src/builtins/status.rs
+++ b/fish-rust/src/builtins/status.rs
@@ -450,22 +450,20 @@ pub fn status(
                         (true, _) => wgettext!("Standard input"),
                         (false, _) => &res,
                     };
-                    streams.out.append(wgettext_fmt!("%ls\n", f));
+                    streams.out.appendln(f);
                 }
                 STATUS_FUNCTION => {
                     let f = match parser.get_func_name(opts.level) {
                         Some(f) => f,
                         None => wgettext!("Not a function").to_owned(),
                     };
-                    streams.out.append(wgettext_fmt!("%ls\n", f));
+                    streams.out.appendln(f);
                 }
                 STATUS_LINE_NUMBER => {
                     // TBD is how to interpret the level argument when fetching the line number.
                     // See issue #4161.
                     // streams.out.append_format(L"%d\n", parser.get_lineno(opts.level));
-                    streams
-                        .out
-                        .append(wgettext_fmt!("%d\n", parser.get_lineno().0));
+                    streams.out.appendln(parser.get_lineno().0.to_wstring());
                 }
                 STATUS_IS_INTERACTIVE => {
                     if is_interactive_session() {
@@ -529,12 +527,11 @@ pub fn status(
                 STATUS_CURRENT_CMD => {
                     let var = parser.pin().libdata().get_status_vars_command().from_ffi();
                     if !var.is_empty() {
-                        streams.out.append(var);
+                        streams.out.appendln(var);
                     } else {
                         // FIXME: C++ used `program_name` here, no clue where it's from
-                        streams.out.append(L!("fish"));
+                        streams.out.appendln(L!("fish"));
                     }
-                    streams.out.append1('\n');
                 }
                 STATUS_CURRENT_COMMANDLINE => {
                     let var = parser
@@ -542,8 +539,7 @@ pub fn status(
                         .libdata()
                         .get_status_vars_commandline()
                         .from_ffi();
-                    streams.out.append(var);
-                    streams.out.append1('\n');
+                    streams.out.appendln(var);
                 }
                 STATUS_FISH_PATH => {
                     let path = get_executable_path("fish");
@@ -564,13 +560,11 @@ pub fn status(
                             _ => path,
                         };
 
-                        streams.out.append(real);
-                        streams.out.append1('\n');
+                        streams.out.appendln(real);
                     } else {
                         // This is a relative path, we can't canonicalize it
                         let path = str2wcstring(path.as_os_str().as_bytes());
-                        streams.out.append(path);
-                        streams.out.append1('\n');
+                        streams.out.appendln(path);
                     }
                 }
                 STATUS_SET_JOB_CONTROL | STATUS_FEATURES | STATUS_TEST_FEATURE => {

--- a/fish-rust/src/builtins/string/length.rs
+++ b/fish-rust/src/builtins/string/length.rs
@@ -48,7 +48,7 @@ impl StringSubCommand<'_> for Length {
                         nnonempty += 1;
                     }
                     if !self.quiet {
-                        streams.out.append(max.to_wstring() + L!("\n"));
+                        streams.out.appendln(max.to_wstring());
                     } else if nnonempty > 0 {
                         return STATUS_CMD_OK;
                     }
@@ -59,7 +59,7 @@ impl StringSubCommand<'_> for Length {
                     nnonempty += 1;
                 }
                 if !self.quiet {
-                    streams.out.append(n.to_wstring() + L!("\n"));
+                    streams.out.appendln(n.to_wstring());
                 } else if nnonempty > 0 {
                     return STATUS_CMD_OK;
                 }

--- a/fish-rust/src/builtins/string/match.rs
+++ b/fish-rust/src/builtins/string/match.rs
@@ -315,8 +315,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
                 if self.opts.index {
                     streams.out.append(sprintf!("1 %lu\n", arg.len()));
                 } else {
-                    streams.out.append(arg);
-                    streams.out.append1('\n');
+                    streams.out.appendln(arg);
                 }
             }
             return match self.opts.invert_match {
@@ -334,8 +333,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
         }
 
         if self.opts.entire {
-            streams.out.append(arg);
-            streams.out.append1('\n');
+            streams.out.appendln(arg);
         }
 
         let start = (self.opts.entire || self.opts.groups_only) as usize;
@@ -346,8 +344,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
                     .out
                     .append(sprintf!("%lu %lu\n", m.start() + 1, m.end() - m.start()));
             } else {
-                streams.out.append(&arg[m.start()..m.end()]);
-                streams.out.append1('\n');
+                streams.out.appendln(&arg[m.start()..m.end()]);
             }
         }
 
@@ -397,8 +394,7 @@ impl<'opts, 'args> WildCardMatcher<'opts, 'args> {
                 if self.opts.index {
                     streams.out.append(sprintf!("1 %lu\n", arg.len()));
                 } else {
-                    streams.out.append(arg);
-                    streams.out.append1('\n');
+                    streams.out.appendln(arg);
                 }
             }
         }

--- a/fish-rust/src/builtins/string/shorten.rs
+++ b/fish-rust/src/builtins/string/shorten.rs
@@ -84,8 +84,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
             //     echo whatever
             // end
             for (arg, _) in iter {
-                streams.out.append(arg);
-                streams.out.append1('\n');
+                streams.out.appendln(arg);
             }
             return STATUS_CMD_OK;
         }
@@ -184,8 +183,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
                         res
                     }
                 };
-                streams.out.append(output);
-                streams.out.append1('\n');
+                streams.out.appendln(output);
                 continue;
             } else {
                 /* shorten the right side */
@@ -224,8 +222,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
             }
 
             if pos == line.len() {
-                streams.out.append(line);
-                streams.out.append1('\n');
+                streams.out.appendln(line);
                 continue;
             }
 

--- a/fish-rust/src/builtins/test.rs
+++ b/fish-rust/src/builtins/test.rs
@@ -1026,7 +1026,9 @@ pub fn test(
             // Ignore the closing bracket from now on.
             argc -= 1;
         } else {
-            streams.err.append(L!("[: the last argument must be ']'\n"));
+            streams
+                .err
+                .appendln(wgettext!("[: the last argument must be ']'"));
             builtin_print_error_trailer(parser, streams, program_name);
             return STATUS_INVALID_ARGS;
         }
@@ -1064,8 +1066,7 @@ pub fn test(
     if !eval_errors.is_empty() {
         if !common::should_suppress_stderr_for_tests() {
             for eval_error in eval_errors {
-                streams.err.append(eval_error);
-                streams.err.append1('\n');
+                streams.err.appendln(eval_error);
             }
             // Add a backtrace but not the "see help" message
             // because this isn't about passing the wrong options.

--- a/fish-rust/src/builtins/type.rs
+++ b/fish-rust/src/builtins/type.rs
@@ -119,15 +119,13 @@ pub fn r#type(
                     }
                     if opts.path {
                         if let Some(orig_path) = props.copy_definition_file() {
-                            streams.out.append(orig_path);
+                            streams.out.appendln(orig_path);
                         } else {
-                            streams.out.append(path);
+                            streams.out.appendln(path);
                         }
-                        streams.out.append1('\n');
                     } else if !opts.short_output {
                         streams.out.append(wgettext_fmt!("%ls is a function", arg));
-                        streams.out.append(wgettext_fmt!(" with definition"));
-                        streams.out.append1('\n');
+                        streams.out.appendln(wgettext!(" with definition"));
                         let mut def = WString::new();
                         def.push_utfstr(&sprintf!(
                             "# %ls\n%ls",
@@ -146,7 +144,7 @@ pub fn r#type(
                         streams.out.append(wgettext_fmt!(" (%ls)\n", comment));
                     }
                 } else if opts.get_type {
-                    streams.out.append(L!("function\n"));
+                    streams.out.appendln("function");
                 }
                 if !opts.all {
                     continue;
@@ -187,12 +185,12 @@ pub fn r#type(
             }
             if !opts.get_type {
                 if opts.path || opts.force_path {
-                    streams.out.append(sprintf!("%ls\n", path));
+                    streams.out.appendln(path);
                 } else {
                     streams.out.append(wgettext_fmt!("%ls is %ls\n", arg, path));
                 }
             } else if opts.get_type {
-                streams.out.append(L!("file\n"));
+                streams.out.appendln("file");
                 break;
             }
             if !opts.all {


### PR DESCRIPTION
- Add an appenln method to output_stream_t
- Adopt appendln

- I did remove a couple instances of what I determined "untranslatable" uses of `wgettext`

```diff
- streams.out.append(wgettext_fmt!("%ls\n", f));
+ streams.out.appendln(f);
```