### PR TITLE
Enable PWD reporting for iTerm2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,7 @@ Other improvements
 - An integer overflow in `string repeat` leading to a near-infinite loop has been fixed (:issue:`9899`).
 - `string shorten` behaves better in the presence of non-printable characters, including fixing an integer overflow that shortened strings more than intended. (:issue:`9854`)
 - `string pad` no longer allows non-printable characters as padding. (:issue:`9854`)
+- PWD reporting via OSC 7 is now enabled by default for iTerm2.
 
 For distributors
 ----------------

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -267,7 +267,7 @@ end" >$__fish_config_dir/config.fish
     end
 
     # Notify terminals when $PWD changes (issue #906).
-    # VTE based terminals, Terminal.app, iTerm.app (TODO), foot, and kitty support this.
+    # VTE based terminals, Terminal.app, iTerm.app, foot, and kitty support this.
     if not set -q FISH_UNIT_TESTS_RUNNING
         and begin
             string match -q -- 'foot*' $TERM
@@ -275,6 +275,7 @@ end" >$__fish_config_dir/config.fish
             or test 0"$VTE_VERSION" -ge 3405
             or test "$TERM_PROGRAM" = Apple_Terminal && test (string match -r '\d+' 0"$TERM_PROGRAM_VERSION") -ge 309
             or test "$TERM_PROGRAM" = WezTerm
+            or test "$TERM_PROGRAM" = iTerm.app
         end
         function __update_cwd_osc --on-variable PWD --description 'Notify capable terminals when $PWD changes'
             if status --is-command-substitution || set -q INSIDE_EMACS


### PR DESCRIPTION
## Description

iTerm2 supports reporting PWD changes via OSC 7 (and has for quite some time). Remove the `TODO` comment and enable OSC 7 on iTerm2.

I am not sure why this was left as a TODO for so long. I searched the issue tracker, but didn't find anything.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] User-visible changes noted in CHANGELOG.rst
