### PR TITLE
Replace more escapes with quotes in man parser

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -260,8 +260,12 @@ def remove_groff_formatting(data):
     data = data.replace(r"\-", "-")
     data = data.replace(".I", "")
     data = data.replace("\f", "")
+    data = data.replace(r"\(oq", "'")
     data = data.replace(r"\(cq", "'")
     data = data.replace(r"\(aq", "'")
+    data = data.replace(r"\(dq", '"')
+    data = data.replace(r"\(lq", '"')
+    data = data.replace(r"\(rq", '"')
     return data
 
 

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -261,6 +261,7 @@ def remove_groff_formatting(data):
     data = data.replace(".I", "")
     data = data.replace("\f", "")
     data = data.replace(r"\(cq", "'")
+    data = data.replace(r"\(aq", "'")
     return data
 
 


### PR DESCRIPTION
## Description

Similar to #7086, which is about `\(cq`. At least one man page ([`df`](https://linux.die.net/man/1/df)) uses `\(aq`, so this PR replaces those with single quotes. I haven't found any examples other than `df`, though.

I don't understand roff, but looking at the [GNU Troff manual](https://www.gnu.org/software/groff/manual/groff.html#Character-Classes), `dq`, `lq`, `oq`, and `rq` may also have to be replaced with quotes, in addition to `cq` and `aq`. `dq` is a neutral double quote. `lq` seems to be used for left double quotes and `rq` for right double quotes, but I assume both can safely be replaced with neutral double quotes. I have no idea what `oq` is.

## TODOs:

- [x] Changes to fish usage are reflected in user documentation/manpages. <- Is this necessary?
- [x] Tests have been added for regressions fixed
- [x] <s>User-visible changes noted in CHANGELOG.rst</s> <- This change isn't particularly user-visible, right?
- [x] Try to find man pages that use `dq`, `lq`, `oq`, or `rq` and, if they exist, add them to this PR?
