### PR TITLE
Port builtin count to rust

### DIFF
--- a/fish-rust/src/builtins/count.rs
+++ b/fish-rust/src/builtins/count.rs
@@ -21,7 +21,7 @@ pub fn count(
     // This means excluding lines that don't end in a newline!
     numargs += Arguments::new(&[] as _, &mut zero, streams, COUNT_CHUNK_SIZE)
         // second is "want_newline" - whether the line ended in a newline
-        .filter(|x| x.1)
+        .filter(|(_arg, has_trailing_newline)| has_trailing_newline)
         .count();
 
     streams.out.appendln(numargs.to_string());

--- a/fish-rust/src/builtins/count.rs
+++ b/fish-rust/src/builtins/count.rs
@@ -21,7 +21,7 @@ pub fn count(
     // This means excluding lines that don't end in a newline!
     numargs += Arguments::new(&[] as _, &mut zero, streams, COUNT_CHUNK_SIZE)
         // second is "want_newline" - whether the line ended in a newline
-        .filter(|(_arg, has_trailing_newline)| has_trailing_newline)
+        .filter(|x| x.1)
         .count();
 
     streams.out.appendln(numargs.to_string());

--- a/fish-rust/src/builtins/count.rs
+++ b/fish-rust/src/builtins/count.rs
@@ -1,0 +1,33 @@
+use super::prelude::*;
+
+// How many bytes we read() at once.
+// Since this is just for counting, it can be massive.
+const COUNT_CHUNK_SIZE: usize = 512 * 256;
+
+/// Implementation of the builtin count command, used to count the number of arguments sent to it.
+pub fn count(
+    _parser: &mut parser_t,
+    streams: &mut io_streams_t,
+    argv: &mut [&wstr],
+) -> Option<c_int> {
+    // Always add the size of argv (minus 0, which is "count").
+    // That means if you call `something | count a b c`, you'll get the count of something _plus 3_.
+    let mut numargs = argv.len() - 1;
+
+    // (silly variable for Arguments to do nothing with)
+    let mut zero = 0;
+
+    // Count the newlines coming in via stdin like `wc -l`.
+    // This means excluding lines that don't end in a newline!
+    numargs += Arguments::new(&[] as _, &mut zero, streams, COUNT_CHUNK_SIZE)
+        // second is "want_newline" - whether the line ended in a newline
+        .filter(|x| x.1)
+        .count();
+
+    streams.out.appendln(numargs.to_string());
+
+    if numargs == 0 {
+        return STATUS_CMD_ERROR;
+    }
+    STATUS_CMD_OK
+}

--- a/fish-rust/src/builtins/count.rs
+++ b/fish-rust/src/builtins/count.rs
@@ -24,7 +24,7 @@ pub fn count(
         .filter(|x| x.1)
         .count();
 
-    streams.out.appendln(numargs.to_string());
+    streams.out.appendln(numargs.to_wstring());
 
     if numargs == 0 {
         return STATUS_CMD_ERROR;

--- a/fish-rust/src/builtins/mod.rs
+++ b/fish-rust/src/builtins/mod.rs
@@ -8,6 +8,7 @@ pub mod builtin;
 pub mod cd;
 pub mod command;
 pub mod contains;
+pub mod count;
 pub mod echo;
 pub mod emit;
 pub mod exit;

--- a/fish-rust/src/builtins/shared.rs
+++ b/fish-rust/src/builtins/shared.rs
@@ -240,6 +240,7 @@ pub fn run_builtin(
         RustBuiltin::Cd => super::cd::cd(parser, streams, args),
         RustBuiltin::Contains => super::contains::contains(parser, streams, args),
         RustBuiltin::Command => super::command::command(parser, streams, args),
+        RustBuiltin::Count => super::count::count(parser, streams, args),
         RustBuiltin::Echo => super::echo::echo(parser, streams, args),
         RustBuiltin::Emit => super::emit::emit(parser, streams, args),
         RustBuiltin::Exit => super::exit::exit(parser, streams, args),

--- a/src/builtin.h
+++ b/src/builtin.h
@@ -120,6 +120,7 @@ enum class RustBuiltin : int32_t {
     Cd,
     Contains,
     Command,
+    Count,
     Echo,
     Emit,
     Exit,


### PR DESCRIPTION
## Description

This is one of the simpler builtins.

Not much to say, except that it punts the actual argument reading to "Arguments" - which presumably *could* be extended with modes to only use stdin, but this isn't *too* bad.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.rst
