### PR TITLE
Implement FLOGF formatting

### DIFF
--- a/fish-rust/src/flog.rs
+++ b/fish-rust/src/flog.rs
@@ -191,10 +191,9 @@ macro_rules! FLOG {
     };
 }
 
-// TODO implement.
 macro_rules! FLOGF {
-    ($category:ident, $($elem:expr),+ $(,)*) => {
-        crate::flog::FLOG!($category, $($elem),*);
+    ($category:ident, $fmt: expr, $($elem:expr),+ $(,)*) => {
+        crate::flog::FLOG!($category, sprintf!($fmt, $($elem),*));
     }
 }
 

--- a/fish-rust/src/wcstringutil.rs
+++ b/fish-rust/src/wcstringutil.rs
@@ -4,7 +4,7 @@ use crate::common::{get_ellipsis_char, get_ellipsis_str};
 use crate::compat::MB_CUR_MAX;
 use crate::expand::INTERNAL_SEPARATOR;
 use crate::fallback::{fish_wcwidth, wcscasecmp};
-use crate::flog::FLOGF;
+use crate::flog::FLOG;
 use crate::wchar::{decode_byte_from_char, prelude::*};
 use crate::wutil::encoding::{wcrtomb, zero_mbstate, AT_LEAST_MB_LEN_MAX};
 
@@ -288,7 +288,7 @@ pub fn wcs2string_callback(input: &wstr, mut func: impl FnMut(&[u8]) -> bool) ->
 }
 
 fn wcs2string_bad_char(c: char) {
-    FLOGF!(
+    FLOG!(
         char_encoding,
         L!("Wide character U+%4X has no narrow representation"),
         c


### PR DESCRIPTION
## Description

As complained about in #9962, this adds the actual formatting capabilities to FLOGF, by just calling sprintf!.

Because of that some calls that didn't use a format string were no longer correct and I switched them to FLOG. I *think* I got all of them.

Mostly, I'm not sure that this actually is so simple?

One change from the C++ behavior is that `FLOGF!(category, string);` will refuse to compile - it *requires* some argument for the format string. I think that's probably correct because in that case you should use `FLOG!` and have probably made a mistake, that might be benign or might not.