### PR TITLE
docs: correct insert mode key

### DIFF
--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -453,7 +453,7 @@ Command mode is also known as normal mode.
 
 - :kbd:`i` enters :ref:`insert mode <vi-mode-insert>` at the current cursor position.
 
-- :kbd:`Shift`\ +\ :kbd:`R` enters :ref:`insert mode <vi-mode-insert>` at the beginning of the line.
+- :kbd:`Shift`\ +\ :kbd:`I` enters :ref:`insert mode <vi-mode-insert>` at the beginning of the line.
 
 - :kbd:`v` enters :ref:`visual mode <vi-mode-visual>` at the current cursor position.
 


### PR DESCRIPTION
## Description

Shift+I is the correct mapping for inserting at the begginning of the line :grin: 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
