### PR TITLE
completions: make: respect line continuations in recipes

### DIFF
--- a/share/completions/make.fish
+++ b/share/completions/make.fish
@@ -12,9 +12,13 @@ function __fish_print_make_targets --argument-names directory file
     if make --version 2>/dev/null | string match -q 'GNU*'
         # https://stackoverflow.com/a/26339924
         make $makeflags -pRrq : 2>/dev/null |
-            awk -F: '/^# Files/,/^# Finished Make data base/ {
+            awk -F: -v 'bs_regex=\\\\\\\\' '/^# Files/,/^# Finished Make data base/ {
                 if ($1 == "# Not a target") skip = 1;
-                if ($1 !~ "^[#.\t]") { if (!skip) print $1; skip=0 }
+                if ($1 !~ "^[#.\t]" && !is_continuation ) {
+                    if (!skip) print $1;
+                    skip = 0
+                }
+                is_continuation = $0 ~ "^([^#]*[^#" bs_regex "])?(" bs_regex bs_regex ")*" bs_regex "$";
             }' 2>/dev/null
     else
         # BSD make


### PR DESCRIPTION
## Description

Without this, a recipe containing a trailing backslash followed by a line not beginning with tab (like any non-continued recipe lines would) would result in the continuation showing up in completions.

Whenever a line ends in a backslash, consider the next line invalid as a target.

Fixes #9976.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
