### PR TITLE
Run `cargo fmt` with Rustfmt 1.6.0

### DIFF
--- a/fish-rust/src/builtins/bg.rs
+++ b/fish-rust/src/builtins/bg.rs
@@ -73,9 +73,9 @@ pub fn bg(parser: &mut parser_t, streams: &mut io_streams_t, args: &mut [&wstr])
 
         let Some(job_pos) = job_pos else {
             streams
-                    .err
-                    .append(wgettext_fmt!("%ls: There are no suitable jobs\n", cmd));
-                return STATUS_CMD_ERROR;
+                .err
+                .append(wgettext_fmt!("%ls: There are no suitable jobs\n", cmd));
+            return STATUS_CMD_ERROR;
         };
 
         return send_to_bg(parser, streams, cmd, job_pos);

--- a/fish-rust/src/builtins/emit.rs
+++ b/fish-rust/src/builtins/emit.rs
@@ -21,7 +21,9 @@ pub fn emit(
     }
 
     let Some(event_name) = argv.get(opts.optind) else {
-        streams.err.append(&sprintf!("%ls: expected event name\n"L, cmd));
+        streams
+            .err
+            .append(&sprintf!("%ls: expected event name\n"L, cmd));
         return STATUS_INVALID_ARGS;
     };
 

--- a/fish-rust/src/builtins/function.rs
+++ b/fish-rust/src/builtins/function.rs
@@ -107,7 +107,11 @@ fn parse_cmd_opts(
             }
             's' => {
                 let Some(signal) = Signal::parse(w.woptarg.unwrap()) else {
-                    streams.err.append(wgettext_fmt!("%ls: Unknown signal '%ls'", cmd, w.woptarg.unwrap()));
+                    streams.err.append(wgettext_fmt!(
+                        "%ls: Unknown signal '%ls'",
+                        cmd,
+                        w.woptarg.unwrap()
+                    ));
                     return STATUS_INVALID_ARGS;
                 };
                 opts.events.push(EventDescription::Signal { signal });

--- a/fish-rust/src/builtins/status.rs
+++ b/fish-rust/src/builtins/status.rs
@@ -257,7 +257,11 @@ fn parse_cmd_opts(
                     return STATUS_CMD_ERROR;
                 }
                 let Ok(job_mode) = w.woptarg.unwrap().try_into() else {
-                    streams.err.append(wgettext_fmt!("%ls: Invalid job control mode '%ls'\n", cmd, w.woptarg.unwrap()));
+                    streams.err.append(wgettext_fmt!(
+                        "%ls: Invalid job control mode '%ls'\n",
+                        cmd,
+                        w.woptarg.unwrap()
+                    ));
                     return STATUS_CMD_ERROR;
                 };
                 opts.new_job_control_mode = Some(job_mode);
@@ -397,8 +401,12 @@ pub fn status(
                         ));
                         return STATUS_INVALID_ARGS;
                     }
-                    let Ok(new_mode)= args[0].try_into() else {
-                        streams.err.append(wgettext_fmt!("%ls: Invalid job control mode '%ls'\n", cmd, args[0]));
+                    let Ok(new_mode) = args[0].try_into() else {
+                        streams.err.append(wgettext_fmt!(
+                            "%ls: Invalid job control mode '%ls'\n",
+                            cmd,
+                            args[0]
+                        ));
                         return STATUS_CMD_ERROR;
                     };
                     new_mode

--- a/fish-rust/src/path.rs
+++ b/fish-rust/src/path.rs
@@ -224,7 +224,9 @@ fn path_is_executable(path: &wstr) -> bool {
         return false;
     }
     let narrow: Vec<u8> = narrow.into();
-    let Ok(md) = std::fs::metadata(OsStr::from_bytes(&narrow)) else { return false; };
+    let Ok(md) = std::fs::metadata(OsStr::from_bytes(&narrow)) else {
+        return false;
+    };
     md.is_file()
 }
 
@@ -240,7 +242,9 @@ pub fn path_get_paths(cmd: &wstr, vars: &dyn Environment) -> Vec<WString> {
         return paths;
     }
 
-    let Some(path_var) = vars.get(L!("PATH")) else { return paths; };
+    let Some(path_var) = vars.get(L!("PATH")) else {
+        return paths;
+    };
     for path in path_var.as_list() {
         if path.is_empty() {
             continue;

--- a/fish-rust/src/tests/string_escape.rs
+++ b/fish-rust/src/tests/string_escape.rs
@@ -151,7 +151,8 @@ fn test_escape_no_printables() {
         &random_string,
         EscapeStringStyle::Script(EscapeFlags::NO_PRINTABLES | EscapeFlags::NO_QUOTED),
     );
-    let Some(unescaped_string) = unescape_string(&escaped_string, UnescapeStringStyle::default()) else {
+    let Some(unescaped_string) = unescape_string(&escaped_string, UnescapeStringStyle::default())
+    else {
         panic!("Failed to unescape string <{escaped_string}>");
     };
 

--- a/fish-rust/src/wchar_ext.rs
+++ b/fish-rust/src/wchar_ext.rs
@@ -74,7 +74,9 @@ fn test_to_wstring() {
     let mut val: i64 = 1;
     loop {
         assert_eq!(val.to_wstring(), val.to_string());
-        let Some(next) = val.checked_mul(-3) else { break; };
+        let Some(next) = val.checked_mul(-3) else {
+            break;
+        };
         val = next;
     }
     assert_eq!(u64::MAX.to_wstring(), "18446744073709551615");

--- a/fish-rust/src/wutil/mod.rs
+++ b/fish-rust/src/wutil/mod.rs
@@ -169,7 +169,9 @@ pub fn wrealpath(pathname: &wstr) -> Option<WString> {
                 canonicalize(".")
             };
 
-            let Ok(narrow_result) = narrow_res else { return None; };
+            let Ok(narrow_result) = narrow_res else {
+                return None;
+            };
 
             let pathsep_idx = pathsep_idx.map_or(0, |idx| idx + 1);
 


### PR DESCRIPTION
- "1.6.0" now supports formatting let-else statements which we use liberally,
  and appears to have some fixes in regards to long-indented-lines with macros
  like `wgettext_fmt!`
- This commit updates the formatting so that devs with the latest stable don't
  see random format-fixes upon running `cargo fmt` (and so that CI can pass, we use always run clips and fmt with latest stable)


Release-notes for `rustfmt`: https://github.com/rust-lang/rustfmt/blob/master/CHANGELOG.md (the release-date in `rustup` says it was released yesterday along with Rust `1.72.0`)