### PR TITLE
Replace rust toolchain setup in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: SetupRust
-      uses: ATiltedTree/setup-rust@v1
-      with:
-        rust-version: 1.67
+    - uses: dtolnay/rust-toolchain@1.67
     - name: Install deps
       run: |
         sudo apt install gettext libncurses5-dev libpcre2-dev python3-pip tmux
@@ -46,11 +43,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: SetupRust
-      uses: ATiltedTree/setup-rust@v1
+    - uses: dtolnay/rust-toolchain@1.67
       with:
-        rust-version: 1.67
-        targets: "i686-unknown-linux-gnu" # setup-rust wants this space-separated
+        targets: "i686-unknown-linux-gnu" # rust-toolchain wants this comma-separated
     - name: Install deps
       run: |
         sudo apt update
@@ -84,12 +79,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: SetupRust
-      uses: ATiltedTree/setup-rust@v1
+    # All -Z options require running nightly
+    - uses: dtolnay/rust-toolchain@nightly
       with:
-        # All -Z options require running nightly
-        rust-version: nightly
         # ASAN uses `cargo build -Zbuild-std` which requires the rust-src component
+        # this is comma-separated
         components: rust-src
     - name: Install deps
       run: |
@@ -135,10 +129,7 @@ jobs:
   #
   #   steps:
   #   - uses: actions/checkout@v3
-  #   - name: SetupRust
-  #     uses: ATiltedTree/setup-rust@v1
-  #     with:
-  #       rust-version: 1.67
+  #   - uses: dtolnay/rust-toolchain@1.67
   #   - name: Install deps
   #     run: |
   #       sudo apt install gettext libncurses5-dev libpcre2-dev python3-pip tmux
@@ -165,10 +156,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: SetupRust
-      uses: ATiltedTree/setup-rust@v1
-      with:
-        rust-version: 1.67
+    - uses: dtolnay/rust-toolchain@1.67
     - name: Install deps
       run: |
         sudo pip3 install pexpect

--- a/.github/workflows/rust_checks.yml
+++ b/.github/workflows/rust_checks.yml
@@ -11,10 +11,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: SetupRust
-      uses: ATiltedTree/setup-rust@v1
-      with:
-        rust-version: stable
+    - uses: dtolnay/rust-toolchain@stable
     - name: cargo fmt
       run: cargo fmt --check --all
 
@@ -23,10 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: SetupRust
-      uses: ATiltedTree/setup-rust@v1
-      with:
-        rust-version: stable
+    - uses: dtolnay/rust-toolchain@stable
     - name: Install deps
       run: |
         sudo apt install gettext libncurses5-dev libpcre2-dev python3-pip tmux


### PR DESCRIPTION
- Replace ATiltedTree/setup-rust with rust-toolchain

This hopefully makes it not necessary to delete the cache on every new Rust release, see https://github.com/fish-shell/fish-shell/pull/9980, https://github.com/fish-shell/fish-shell/commit/5c29ff52fb76ad360c2e1078289f4a30022875d5, and https://github.com/fish-shell/fish-shell/commit/54fa1ad6ec7adb0d9c14076843ef5e51c18ecc7a, likely at the cost of not caching, but this is network-limited regardless, so I don't think it should be that much of a slowdown

EDIT: there is also a warning with every [ATiltedTree/setup-rust](https://github.com/ATiltedTree/setup-rust) use:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: ATiltedTree/setup-rust@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```