### PR TITLE
fish_key_reader: Humanize key descriptions

### DIFF
--- a/doc_src/cmds/fish_key_reader.rst
+++ b/doc_src/cmds/fish_key_reader.rst
@@ -56,7 +56,7 @@ Example
    > fish_key_reader --verbose
    Press a key:
    # press alt+enter
-              hex:   1B  char: \c[  (or \e)
+              hex:   1B  char: \e
    (  0.027 ms)  hex:    D  char: \cM  (or \r)
    bind \e\r 'do something'
 

--- a/src/fish_key_reader.cpp
+++ b/src/fish_key_reader.cpp
@@ -138,7 +138,10 @@ static void ascii_printable_to_symbol(wchar_t *buf, int buf_len, wchar_t wc, boo
 static wchar_t *char_to_symbol(wchar_t wc, bool bind_friendly) {
     static wchar_t buf[64];
 
-    if (wc < L' ') {  // ASCII control character
+    if (wc == '\x1b') {
+        // Escape - this is *technically* also \c[
+        std::swprintf(buf, sizeof(buf) / sizeof(*buf), L"\\e");
+    } else if (wc < L' ') {  // ASCII control character
         ctrl_to_symbol(buf, sizeof(buf) / sizeof(*buf), wc, bind_friendly);
     } else if (wc == L' ') {  // the "space" character
         space_to_symbol(buf, sizeof(buf) / sizeof(*buf), wc, bind_friendly);
@@ -146,6 +149,8 @@ static wchar_t *char_to_symbol(wchar_t wc, bool bind_friendly) {
         del_to_symbol(buf, sizeof(buf) / sizeof(*buf), wc, bind_friendly);
     } else if (wc < 0x80) {  // ASCII characters that are not control characters
         ascii_printable_to_symbol(buf, sizeof(buf) / sizeof(*buf), wc, bind_friendly);
+    } else if (std::iswgraph(wc)) {
+        std::swprintf(buf, sizeof(buf) / sizeof(*buf), L"%lc", wc);
     }
 // Conditional handling of BMP Unicode characters depends on the encoding. Assume width of wchar_t
 // corresponds to the encoding, i.e. WCHAR_T_BITS == 16 implies UTF-16 and WCHAR_T_BITS == 32

--- a/tests/pexpects/fkr.py
+++ b/tests/pexpects/fkr.py
@@ -31,7 +31,7 @@ expect_str("char: \\cG\r\nbind \\cG 'do something'\r\n")
 sleep(0.020)
 # send "\x1B\xE1\x88\xB4"
 send("\x1B\u1234")
-expect_str("char: \\u1234\r\nbind \\e\\u1234 'do something'\r\n")
+expect_str("char: ሴ\r\nbind \\eሴ 'do something'\r\n")
 
 # Is a NULL char echoed correctly?
 sleep(0.020)


### PR DESCRIPTION
This used to print all codepoints outside of the ASCII range (i.e. above 0x80) in \uXXXX or \UYYYYYYYY notation.

That's quite awkward, considering that this is about keys that are being pressed, and many keyboards have actual symbols for these on them - I have an "ö" key, so I would like to use `bind ö` and not `bind \u00F6`. So we go by iswgraph.

On a slightly different note, `\e` was written as `\c[ (or \e)`. I do not believe anyone really uses `\c[` (the `[` would need to be escaped!), and it's confusing and unnecessary to even mention that.

PR for documentation, I don't need review on this.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
