### PR TITLE
ast: Require `--help` to parse more keywords as decorated statement

### DIFF
--- a/fish-rust/src/ast.rs
+++ b/fish-rust/src/ast.rs
@@ -3514,6 +3514,7 @@ impl<'s> Populator<'s> {
             // If we are one of these, then look for specifically help arguments. Otherwise, if the next token
             // looks like an option (starts with a dash), then parse it as a decorated statement.
             let help_only_kws = [
+                ParseKeyword::kw_begin,
                 ParseKeyword::kw_function,
                 ParseKeyword::kw_if,
                 ParseKeyword::kw_switch,

--- a/tests/checks/syntax-error-location.fish
+++ b/tests/checks/syntax-error-location.fish
@@ -78,3 +78,14 @@ $fish -c 'if -e; end'
 # CHECKERR: fish:
 # CHECKERR: if -e; end
 # CHECKERR:    ^^
+
+$fish -c 'begin --notanoption; end'
+# CHECKERR: fish: Unknown command: --notanoption
+# CHECKERR: fish:
+# CHECKERR: begin --notanoption; end
+# CHECKERR:       ^~~~~~~~~~~~^
+
+$fish -c 'begin --help'
+# CHECKERR: fish: begin: missing man page
+# CHECKERR: Documentation may not be installed.
+# CHECKERR: `help begin` will show an online version


### PR DESCRIPTION
This makes it so

```fish
if -e foo
    # do something
end
```

complains about `-e` not being a command instead of `end` being used outside of an if-block.

That means both that `-e` could now be used as a command name (it already can outside of `if`!) *and* that we get a better error!

The only way to get `if` to be a decorated statement now is to use `if -h` or `if --help` specifically (with a literal option).

The same goes for switch and while.

It would be possible, alternatively, to disallow `if -e` and point towards using `test` instead, but the "unknown command" message should already point towards using `test` more than pointing at the "end" (that might be quite far away).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
- [ ] The comments here confuse me quite a bit. Have I understood the intent correctly? Do we want to change this even more?