### PR TITLE
Make default shell configuration more generic

### DIFF
--- a/doc_src/index.rst
+++ b/doc_src/index.rst
@@ -75,13 +75,13 @@ To change your login shell to fish:
 
 1. Add the shell to ``/etc/shells`` with::
 
-    > echo /usr/local/bin/fish | sudo tee -a /etc/shells
+    > echo $(which fish) | sudo tee -a /etc/shells
 
 2. Change your default shell with::
 
-    > chsh -s /usr/local/bin/fish
+    > chsh -s $(which fish)
 
-Again, substitute the path to fish for ``/usr/local/bin/fish`` - see ``command -s fish`` inside fish. To change it back to another shell, just substitute ``/usr/local/bin/fish`` with ``/bin/bash``, ``/bin/tcsh`` or ``/bin/zsh`` as appropriate in the steps above.
+If :command:`fish` was not installed in a directory included in your :envvar:`PATH`, substitute ``$(which fish)`` with its appropriate location. To change it back to another shell, just substitute ``$(which fish)`` with ``/bin/bash``, ``/bin/tcsh`` or ``/bin/zsh`` as appropriate in the steps above.
 
 Uninstalling
 ------------


### PR DESCRIPTION
## Description

Update command line instructions to use `$(which fish)` instead of hardcoded `/usr/local/bin/fish`


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed -> NA
- [ ] User-visible changes noted in CHANGELOG.rst -> NA?
