### PR TITLE
reader: Use existing search string when opening the history pager

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -3837,7 +3837,13 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             pager.set_search_field_shown(true);
             pager.set_prefix(MB_CUR_MAX > 1 ? L"► " : L"> ", false /* highlight */);
             // Update the search field, which triggers the actual history search.
-            insert_string(&pager.search_field_line, command_line.text());
+            if (!history_search.active() || history_search.search_string().empty()) {
+                insert_string(&pager.search_field_line, command_line.text());
+            } else {
+                // If we have an actual history search already going, reuse that term
+                // - this is if the user looks around a bit and decides to switch to the pager.
+                insert_string(&pager.search_field_line, history_search.search_string());
+            }
             break;
         }
         case rl::history_pager_delete: {


### PR DESCRIPTION
I sometimes find myself doing something like this:

- Look for a commandline that includes "echo" (as an example)
- Type echo, press up a few times
- I can't immediately find what I'm looking for
- Press ctrl-r to open up the history pager
- It uses the current commandline as the search string, so now I'm looking for "echo foobar"

This makes it so if the search string already is in use, that's what the history-pager picks as the initial search string.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

I am entirely fine with shelving this if it gets in the way of anyone's porting. On the other hand it's pretty trivial.