### PR TITLE
Add completions for pnpm command

### DIFF
--- a/share/completions/pnpm.fish
+++ b/share/completions/pnpm.fish
@@ -1,0 +1,20 @@
+function _pnpm_completion
+  set cmd (commandline -o)
+  set cursor (commandline -C)
+  set words (count $cmd)
+
+  set completions (eval env DEBUG=\"" \"" COMP_CWORD=\""$words\"" COMP_LINE=\""$cmd \"" COMP_POINT=\""$cursor\"" pnpm completion -- $cmd)
+
+  if [ "$completions" = "__tabtab_complete_files__" ]
+    set -l matches (commandline -ct)*
+    if [ -n "$matches" ]
+      __fish_complete_path (commandline -ct)
+    end
+  else
+    for completion in $completions
+      echo -e $completion
+    end
+  end
+end
+
+complete -f -d 'pnpm' -c pnpm -a "(_pnpm_completion)"


### PR DESCRIPTION
## Description

This PR introduces completion support for pnpm in the fish shell. The completion script is based on the one provided by the pnpm/tabtab repository.
~https://github.com/pnpm/tabtab/blob/fish-script/lib/scripts/fish.sh~
https://github.com/pnpm/tabtab/blob/main/lib/scripts/fish.sh

Please review and let me know if any changes are required.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
