### PR TITLE
Adding forward-*next*-[big]word movements.

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -126,6 +126,8 @@ static constexpr const input_function_metadata_t input_function_metadata[] = {
     {L"forward-char", readline_cmd_t::forward_char},
     {L"forward-jump", readline_cmd_t::forward_jump},
     {L"forward-jump-till", readline_cmd_t::forward_jump_till},
+    {L"forward-next-bigword", readline_cmd_t::forward_next_bigword},
+    {L"forward-next-word", readline_cmd_t::forward_next_word},
     {L"forward-single-char", readline_cmd_t::forward_single_char},
     {L"forward-word", readline_cmd_t::forward_word},
     {L"history-pager", readline_cmd_t::history_pager},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -22,6 +22,8 @@ enum class readline_cmd_t {
     backward_word,
     forward_bigword,
     backward_bigword,
+    forward_next_word,
+    forward_next_bigword,
     nextd_or_forward_word,
     prevd_or_backward_word,
     history_search_backward,


### PR DESCRIPTION
## Description

Fish's movements, particularly in vim mode, are hindered by the lack of a movement that allows one to move to the start of the next word.

Currently, the shortcomings of fish's `forward-word` and `forward-bigword` can be easily seen in the case of the following, where both `forward-word` and `forward-bigword` take one from `1` to `2` and then `2` to `3`.
```
foo     bar      baz
^   ^       ^
1   2       3
```
Instead, we want the behaviour of 
```
foo     bar      baz
^       ^        ^
1       2        3
```

We want to leave `forward-word` and `forward-bigword` as they are as they're currently used plenty, but we should add a new `forward-next-word` and `forward-next-bigword` (alternative names welcome) to give us this functionality, and then I'll add a separate PR for integrating these into vim mode.

The case of having multiple spaces between arguments may seem rather specific, but I believe the functionality can actually be quite important to have reliable vim keybindings, as they otherwise include fragile workarounds to get this same behaviour.

At this stage, I want a thumbs-up from an owner that they're happy with this addition, and/or receive suggestions for changes such that such an owner _would_ be, and then I will work on documentation, testing, and the like.