### PR TITLE
Fix out of scope opt variable

### DIFF
--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -50,7 +50,6 @@ function ls --description "List contents of directory"
     __fish_set_lscolors
 
     isatty stdout
-    and set -a opt -F
 
     # Terminal.app doesn't set $COLORTERM or $CLICOLOR,
     # but the new FreeBSD ls requires either to be set,
@@ -61,5 +60,5 @@ function ls --description "List contents of directory"
     test "$TERM_PROGRAM" = Apple_Terminal
     and set -lx CLICOLOR 1
 
-    command $__fish_ls_command $__fish_ls_color_opt $opt $argv
+    command $__fish_ls_command $__fish_ls_color_opt -F $argv
 end

--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -49,7 +49,9 @@ function ls --description "List contents of directory"
     # Set the colors to the default via `dircolors` if none is given.
     __fish_set_lscolors
 
+    set -l opt
     isatty stdout
+    and set -a opt -F
 
     # Terminal.app doesn't set $COLORTERM or $CLICOLOR,
     # but the new FreeBSD ls requires either to be set,
@@ -60,5 +62,5 @@ function ls --description "List contents of directory"
     test "$TERM_PROGRAM" = Apple_Terminal
     and set -lx CLICOLOR 1
 
-    command $__fish_ls_command $__fish_ls_color_opt -F $argv
+    command $__fish_ls_command $__fish_ls_color_opt $opt $argv
 end


### PR DESCRIPTION
## Description

I had a weird bug on a fresh fish install and I traced it back to this rather weird piece of code. The $opt variable is not set when the if at L29 fails and so just contained random junk from an earlier function call. Moreover, with every subsequent call of of ls it would grow an extra `-F`! I believe the following is the intended meaning of the author.

You can look at the blame of linet 53 and 66 to see that this state of things was caused by an old refactor of the ls function.

Fixes issue: if $opt is filled with some junk before calling ls it will result in unexpected behavior

~> set fish_trace on
~> set opt test
> set opt test
~> ls
> ls
(...)
--> ls --color=auto test -F
ls: cannot access 'test': No such file or directory