### PR TITLE
completions/pkill: use locals.

### DIFF
--- a/share/completions/pkill.fish
+++ b/share/completions/pkill.fish
@@ -2,7 +2,7 @@
 __fish_complete_pgrep pkill
 __fish_make_completion_signals
 for i in $__kill_signals
-    echo $i | read number name
+    echo $i | read -l number name
     complete -c pkill -o $number -d $name
     complete -c pkill -o $name -d $name
 end


### PR DESCRIPTION
## Description

Use `read -l` to not (over)write `number` and `name` in the shell context.

## TODOs:

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

I don't know that I feel any of the above is necessary for a change of this minority, but I'm happy to be guided otherwise.