### PR TITLE
Reduce stat calls for wildcard

### DIFF
--- a/fish-rust/src/wutil/dir_iter.rs
+++ b/fish-rust/src/wutil/dir_iter.rs
@@ -45,6 +45,9 @@ pub struct DirEntry {
     // and the type is left as none(). Note this is an unavoidable race.
     typ: Cell<Option<DirEntryType>>,
 
+    // whether this could be a link, false if we know definitively it isn't.
+    possible_link: bool,
+
     // fd of the DIR*, used for fstatat().
     dirfd: Rc<DirFd>,
 }
@@ -71,6 +74,10 @@ impl DirEntry {
         self.check_type() == Some(DirEntryType::dir)
     }
 
+    /// \return false if we know this can't be a link via d_type, true if it could be.
+    pub fn is_possible_link(&self) -> bool {
+        self.possible_link
+    }
     /// \return the stat buff for this entry, invoking stat() if necessary.
     pub fn stat(&self) -> Option<libc::stat> {
         if self.stat.get().is_none() {
@@ -217,6 +224,7 @@ impl DirIter {
             stat: Cell::new(None),
             typ: Cell::new(None),
             dirfd: dir.clone(),
+            possible_link: false,
         };
         Ok(DirIter {
             withdot,
@@ -280,6 +288,8 @@ impl DirIter {
         if typ != Some(DirEntryType::lnk) {
             self.entry.typ.set(typ);
         }
+        // This entry could be a link if it is a link or unknown.
+        self.entry.possible_link = typ.unwrap_or(DirEntryType::lnk) == DirEntryType::lnk;
 
         Some(Ok(&self.entry))
     }

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -228,9 +228,12 @@ const dir_iter_t::entry_t *dir_iter_t::next() {
     entry_.inode = dent->d_ino;
 #ifdef HAVE_STRUCT_DIRENT_D_TYPE
     auto type = dirent_type_to_entry_type(dent->d_type);
-    // Do not store symlinks as we will need to resolve them.
+    // Do not store symlinks as type as we will need to resolve them.
     if (type != dir_entry_type_t::lnk) {
         entry_.type_ = type;
+        // But store if we know it can't be a link.
+        // If it is unknown, it could still be a link.
+        entry_.possible_link_ = !type.has_value();
     }
 #endif
     return &entry_;

--- a/src/wutil.cpp
+++ b/src/wutil.cpp
@@ -231,10 +231,9 @@ const dir_iter_t::entry_t *dir_iter_t::next() {
     // Do not store symlinks as type as we will need to resolve them.
     if (type != dir_entry_type_t::lnk) {
         entry_.type_ = type;
-        // But store if we know it can't be a link.
-        // If it is unknown, it could still be a link.
-        entry_.possible_link_ = !type.has_value();
     }
+    // This entry could be a link if it is a link or unknown.
+    entry_.possible_link_ = !type.has_value() || type == dir_entry_type_t::lnk;
 #endif
     return &entry_;
 }

--- a/src/wutil.h
+++ b/src/wutil.h
@@ -245,6 +245,9 @@ class dir_iter_t : noncopyable_t {
         /// \return whether this is a directory. This may call stat().
         bool is_dir() const { return check_type() == dir_entry_type_t::dir; }
 
+        /// \return false if we know this can't be a link via d_type, true if it could be.
+        bool is_possible_link() const { return possible_link_; }
+
         /// \return the stat buff for this entry, invoking stat() if necessary.
         const maybe_t<struct stat> &stat() const;
 
@@ -262,6 +265,9 @@ class dir_iter_t : noncopyable_t {
         // on some filesystems, or later via stat(). If stat() fails, the error is silently ignored
         // and the type is left as none(). Note this is an unavoidable race.
         mutable maybe_t<dir_entry_type_t> type_{};
+
+        /// whether this entry could be a link, false if we know definitively it isn't.
+        bool possible_link_ = true;
 
         // fd of the DIR*, used for fstatat().
         int dirfd_{-1};


### PR DESCRIPTION
## Description

This attempts to reduce the number of stat calls we do for wildcard in the case of a final `*/` component. That `*` is taken as an "intermediate" segment, followed by an empty final segment. This makes it so the intermediate segment expansion knows about it and stops the stat() calls we do for the purpose of symlink cycle detection (since we do not enter any symlinks we can't add any new cycles there!).

`true ~/complete_test/*/` with a `complete_test` directory with 10000 subdirectories is sped up by 1.60x relative to 35baa88334444c3f6778aa80b31ba3a65330ce69 by the first commit.

This is on ext4 with proper d_type support, so we get all the info via readdir, and can save 10k stat calls for 10k files

This is in C++ because that's the version that's currently used. If we decide it's a good approach, I'll port it to rust, and we can easily cherry-pick it for 3.7.0.

(I also had something for `ls ~/foo/<TAB>`, but that didn't end up saving anything and was kinda messy so I removed it - ignore the second commit)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] User-visible changes noted in CHANGELOG.rst
