### PR TITLE
add completions for crc and oc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,7 @@ Completions
 - ``horcrux`` (:issue:`9922`).
 - ``java_home`` (:issue:`9998`).
 - ``crc`` (:issue:`10034`).
+- ``oc`` (:issue:`10034`).
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,7 @@ Completions
 - ``gimp`` (:issue:`9904`).
 - ``horcrux`` (:issue:`9922`).
 - ``java_home`` (:issue:`9998`).
+- ``crc`` (:issue:`10034`).
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/share/completions/crc.fish
+++ b/share/completions/crc.fish
@@ -1,0 +1,1 @@
+crc completion fish | source

--- a/share/completions/oc.fish
+++ b/share/completions/oc.fish
@@ -1,0 +1,1 @@
+oc completion fish | source


### PR DESCRIPTION
## Description

This PR adds completions for `crc` to fish. `crc` (Code Ready Containers) is a RedHat tool for using OpenShift locally. It provides autogenerated and (as far as I've been able to tell so far) accurate completions. This PR merely sources those completions.

~~I'll add the issue number to the Changelog once the PR is created.~~ Done

EDIT: after seeing that the `oc` completions are missing I've added those as well.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst
