### PR TITLE
Add fish_termtitle variable to force window title support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,8 @@ Completions
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Add ``fish_termtitle`` variable to force fish to assume that the terminal is capable of setting the window title rather than relying on heuristics.
+
 Other improvements
 ------------------
 - A bug that prevented certain executables from being offered in tab-completions when root has been fixed (:issue:`9639`).

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1514,6 +1514,11 @@ You can change the settings of fish by changing the values of certain variables.
    If this is set to 1, fish will assume the terminal understands 256 colors, and won't translate matching colors down to the 16 color palette.
    This is usually autodetected.
 
+.. envvar:: fish_termtitle
+
+   If this is set to 1, fish will assume the terminal is capable of setting the window title.
+   This is usually autodetected.
+
 .. envvar:: fish_ambiguous_width
 
    controls the computed width of ambiguous-width characters. This should be set to 1 if your terminal renders these characters as single-width (typical), or 2 if double-width.

--- a/fish-rust/src/env_dispatch.rs
+++ b/fish-rust/src/env_dispatch.rs
@@ -601,6 +601,18 @@ fn apply_non_term_hacks(vars: &EnvStack) {
 /// terminal title if the underlying terminal does so, but will print garbage on terminals that
 /// don't. Since we can't see the underlying terminal below screen there is no way to fix this.
 fn does_term_support_setting_title(vars: &EnvStack) -> bool {
+    // If the user has told us their terminal supports setting the title then assume that it does
+    if let Some(fish_termtitle) = vars.get(L!("fish_termtitle")).map(|v| v.as_string()) {
+        // $fish_termtitle
+        if crate::wcstringutil::bool_from_string(&fish_termtitle) {
+            FLOG!(
+                term_support,
+                "$fish_termtitle set: assuming terminal can set title"
+            );
+            return true;
+        }
+    }
+
     #[rustfmt::skip]
     const TITLE_TERMS: &[&wstr] = &[
         L!("xterm"), L!("screen"),    L!("tmux"),    L!("nxterm"),


### PR DESCRIPTION
## Description

This provides an "escape hatch" for terminals that support setting the title,
but are not propertly detected by fish's heuristics.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
