### PR TITLE
Check terminfo for ts capability to determine title setting support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,7 @@ Completions
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+- Fish now checks for the ``ts`` capability in terminfo to determine if a terminal supports setting the window title.
 
 Other improvements
 ------------------

--- a/fish-rust/src/curses.rs
+++ b/fish-rust/src/curses.rs
@@ -118,6 +118,7 @@ pub struct Term {
     pub set_a_background: Option<CString>,
     pub set_background: Option<CString>,
     pub exit_attribute_mode: Option<CString>,
+    pub set_title: Option<CString>,
 
     // Number capabilities
     pub max_colors: Option<i32>,
@@ -145,6 +146,7 @@ impl Term {
             set_a_background: get_str_cap("AB"),
             set_background: get_str_cap("Sb"),
             exit_attribute_mode: get_str_cap("me"),
+            set_title: get_str_cap("ts"),
 
             // Number capabilities
             max_colors: get_num_cap("Co"),

--- a/fish-rust/src/env_dispatch.rs
+++ b/fish-rust/src/env_dispatch.rs
@@ -612,7 +612,7 @@ fn does_term_support_setting_title(vars: &EnvStack) -> bool {
     };
     let term: &wstr = term.as_ref();
 
-    if curses::term().is_some_and(|term| term.set_title.is_some()) {
+    if curses::term().map(|term| term.set_title.is_some()) == Some(true) {
         return true;
     }
 

--- a/fish-rust/src/env_dispatch.rs
+++ b/fish-rust/src/env_dispatch.rs
@@ -612,6 +612,10 @@ fn does_term_support_setting_title(vars: &EnvStack) -> bool {
     };
     let term: &wstr = term.as_ref();
 
+    if curses::term().is_some_and(|term| term.set_title.is_some()) {
+        return true;
+    }
+
     let recognized = TITLE_TERMS.contains(&term)
         || term.starts_with(L!("xterm-"))
         || term.starts_with(L!("screen-"))


### PR DESCRIPTION
## Description

Check terminfo for the `ts` capability to determine if a terminal supports setting the window title.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
