### PR TITLE
fix: don't make assumptions about signedness of libc::c_char

### DIFF
--- a/fish-rust/src/common.rs
+++ b/fish-rust/src/common.rs
@@ -1467,10 +1467,10 @@ pub fn fish_setlocale() {
 
 /// Test if the character can be encoded using the current locale.
 fn can_be_encoded(wc: char) -> bool {
-    let mut converted = [0_i8; AT_LEAST_MB_LEN_MAX];
+    let mut converted: [libc::c_char; AT_LEAST_MB_LEN_MAX] = [0; AT_LEAST_MB_LEN_MAX];
     let mut state = zero_mbstate();
     unsafe {
-        wcrtomb(&mut converted[0], wc as libc::wchar_t, &mut state) != 0_usize.wrapping_sub(1)
+        wcrtomb(converted.as_mut_ptr(), wc as libc::wchar_t, &mut state) != 0_usize.wrapping_sub(1)
     }
 }
 


### PR DESCRIPTION
## Description

Pass mut pointer of ``[libc::c_char; AT_LEAST_MB_LEN_MAX]`` to first arg of ``wcrtomb`` instead of mut reference of first element of ``[0_i8; AT_LEAST_MB_LEN_MAX]``.

**Fixes:**

Compilation on arm linux. The particular flavor is 

```
Linux version 6.5.4-403.asahi.fc39.aarch64+16k (mockbuild@6e169ab400a24fc0ac23648bc274e6e0) (gcc (GCC) 13.2.1 20230728 (Red Hat 13.2.1-1), GNU ld version 2.40-13.fc39) #1 SMP PREEMPT_DYNAMIC Fri Sep 22 21:02:30 UTC 2023
```

On master(10d91b0249f57a5269ee5e1c0517da095fe3c820), I get the following compilation error:

```
error[E0308]: mismatched types
    --> fish-rust/src/common.rs:1473:17
     |
1473 | ...   wcrtomb(&mut converted[0], wc as libc::wchar_t, &mut state) != 0...
     |       ------- ^^^^^^^^^^^^^^^^^ expected `*mut u8`, found `&mut i8`
     |       |
     |       arguments to this function are incorrect
     |
     = note:    expected raw pointer `*mut u8`
             found mutable reference `&mut i8`
note: function defined here
    --> fish-rust/src/wutil/encoding.rs:2:12
     |
2    |     pub fn wcrtomb(s: *mut libc::c_char, wc: libc::wchar_t, ps: *mut m...
     |            ^^^^^^^

For more information about this error, try `rustc --explain E0308`.

```

## Disclaimer:

This fix is rather mechanical (naive approach to make compiler happy), and my knowledge of unsafe rust is rather limited.
