### PR TITLE
docs: test drive fish section to Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,17 @@ The following optional features also have specific requirements:
 -  ``colorls`` is used, if installed, to add color when running ``ls`` on platforms
    that do not have color support (such as OpenBSD)
 
+
+Test driving fish
+~~~~~~~~~~~~~~~~~
+
+If you want to try fish but want to have a fallback to your old workflow, you can use the following trick:
+Let assume without loss of generality that your default shell is bash. Just add``fish`` at the end of 
+your ``.bashrc`` file. Then, when you open a new terminal, you will be in fish. If you want to go back 
+to bash, press ``Ctrl-D``. This way all configuration from your ``.bashrc`` will be inherited by fish
+as well.
+
+
 Switching to fish
 ~~~~~~~~~~~~~~~~~
 
@@ -134,6 +145,7 @@ Use the following command if fish isn’t already added to ``/etc/shells`` to pe
 To switch your default shell back, you can run ``chsh -s /bin/bash``
 (substituting ``/bin/bash`` with ``/bin/tcsh`` or ``/bin/zsh`` as
 appropriate).
+
 
 Building
 --------


### PR DESCRIPTION
## Description

For somebody like me who like to use fish in their daily workflow, but also have a convenient fallback to a more traditional shell, I converged to the trick described in this PR (adding "fish" to last line of ".bashrc").

I'm not sure this is a common workflow, or whether it has serious shortcomings. If this is not the right place for such a workflow recommendation/proposal, feel free to just close the PR!