### PR TITLE
Add a clear-screen bind function to clear the screen

### DIFF
--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -142,6 +142,9 @@ The following special input functions are available:
 ``capitalize-word``
     make the current word begin with a capital letter
 
+``clear-screen``
+    clears the screen and redraws the prompt. if the terminal doesn't support clearing the screen it does nothing.
+
 ``complete``
     guess the remainder of the current token
 

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -143,7 +143,7 @@ The following special input functions are available:
     make the current word begin with a capital letter
 
 ``clear-screen``
-    clears the screen and redraws the prompt. if the terminal doesn't support clearing the screen it does nothing.
+    clears the screen and redraws the prompt. if the terminal doesn't support clearing the screen it is the same as ``repaint``.
 
 ``complete``
     guess the remainder of the current token

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -87,9 +87,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv \el __fish_list_current_token
     bind --preset $argv \eo __fish_preview_current_file
     bind --preset $argv \ew __fish_whatis_current_token
-    # ncurses > 6.0 sends a "delete scrollback" sequence along with clear.
-    # This string replace removes it.
-    bind --preset $argv \cl 'echo -n (clear | string replace \e\[3J ""); commandline -f repaint'
+    bind --preset $argv \cl clear-screen
     bind --preset $argv \cc cancel-commandline
     bind --preset $argv \cu backward-kill-line
     bind --preset $argv \cw backward-kill-path-component

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -107,6 +107,7 @@ static constexpr const input_function_metadata_t input_function_metadata[] = {
     {L"cancel", readline_cmd_t::cancel},
     {L"cancel-commandline", readline_cmd_t::cancel_commandline},
     {L"capitalize-word", readline_cmd_t::capitalize_word},
+    {L"clear-screen", readline_cmd_t::clear_screen_and_repaint},
     {L"complete", readline_cmd_t::complete},
     {L"complete-and-search", readline_cmd_t::complete_and_search},
     {L"delete-char", readline_cmd_t::delete_char},

--- a/src/input_common.h
+++ b/src/input_common.h
@@ -92,6 +92,8 @@ enum class readline_cmd_t {
     end_undo_group,
     repeat_jump,
     disable_mouse_tracking,
+    // ncurses uses the obvious name
+    clear_screen_and_repaint,
     // NOTE: This one has to be last.
     reverse_repeat_jump
 };

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -4340,6 +4340,7 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             break;
         }
         case rl::clear_screen_and_repaint: {
+            parser().libdata().is_repaint = true;
             auto clear = screen_clear();
             if (!clear.empty()) {
                 // Clear the screen if we can.
@@ -4349,15 +4350,14 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
                 // while keeping the prompt up-to-date.
                 outputter_t &outp = stdoutput();
                 outp.writestr(clear.c_str());
-                parser().libdata().is_repaint = true;
                 screen.reset_line(true /* redraw prompt */);
                 this->layout_and_repaint(L"readline");
-                exec_prompt();
-                screen.reset_line(true /* redraw prompt */);
-                this->layout_and_repaint(L"readline");
-                force_exec_prompt_and_repaint = false;
-                parser().libdata().is_repaint = false;
             }
+            exec_prompt();
+            screen.reset_line(true /* redraw prompt */);
+            this->layout_and_repaint(L"readline");
+            force_exec_prompt_and_repaint = false;
+            parser().libdata().is_repaint = false;
             break;
         }
         // Some commands should have been handled internally by inputter_t::readch().

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -4339,6 +4339,27 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             outp.writestr(L"\x1B[?1000l");
             break;
         }
+        case rl::clear_screen_and_repaint: {
+            auto clear = screen_clear();
+            if (!clear.empty()) {
+                // Clear the screen if we can.
+                // This is subtle: We first clear, draw the old prompt,
+                // and *then* reexecute the prompt and overdraw it.
+                // This removes the flicker,
+                // while keeping the prompt up-to-date.
+                outputter_t &outp = stdoutput();
+                outp.writestr(clear.c_str());
+                parser().libdata().is_repaint = true;
+                screen.reset_line(true /* redraw prompt */);
+                this->layout_and_repaint(L"readline");
+                exec_prompt();
+                screen.reset_line(true /* redraw prompt */);
+                this->layout_and_repaint(L"readline");
+                force_exec_prompt_and_repaint = false;
+                parser().libdata().is_repaint = false;
+            }
+            break;
+        }
         // Some commands should have been handled internally by inputter_t::readch().
         case rl::self_insert:
         case rl::self_insert_notfirst:

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -267,7 +267,10 @@ maybe_t<size_t> escape_code_length(const wchar_t *code) {
 }
 
 wcstring screen_clear() {
-    return str2wcstring(clear_screen);
+    if (clear_screen) {
+        return str2wcstring(clear_screen);
+    }
+    return wcstring{};
 }
 
 long escape_code_length_ffi(const wchar_t *code) {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -266,6 +266,10 @@ maybe_t<size_t> escape_code_length(const wchar_t *code) {
     return found ? maybe_t<size_t>{esc_seq_len} : none();
 }
 
+wcstring screen_clear() {
+    return str2wcstring(clear_screen);
+}
+
 long escape_code_length_ffi(const wchar_t *code) {
     auto found = escape_code_length(code);
     return found.has_value() ? (long)*found : -1;

--- a/src/screen.h
+++ b/src/screen.h
@@ -335,5 +335,6 @@ maybe_t<size_t> escape_code_length(const wchar_t *code);
 // Always return a value, by moving checking of sequence start to the caller.
 long escape_code_length_ffi(const wchar_t *code);
 
+wcstring screen_clear();
 void screen_set_midnight_commander_hack();
 #endif


### PR DESCRIPTION
## Description

This adds a bind function called `clear-screen` and binds it to ctrl+l by default, removing the rather awkward invocation of the `clear` command.

What that does is:

1. Print the "clear_screen" escape sequence, if possible
2. Redraw with the old prompt
3. Reexecute the prompt
4. Repaint again

This makes for a smooth experience removing any flicker, and still leaves an up-to-date prompt (eventually, once it comes through).

I've tested this with TERM=dumb (it'll do nothing) and with an awkwardly slow prompt - it will show the old prompt, won't react to input and then update the prompt and the commandline.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
