### PR TITLE
Use git diff instead of git status if dirty and not untracked

### DIFF
--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -290,6 +290,9 @@ function fish_git_prompt --description "Prompt function for Git"
                 # Only untracked, ls-files is faster.
                 command git -c core.fsmonitor= ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- :/ >/dev/null 2>&1
                 and set untrackedfiles 1
+            else if test "$dirty" = true; and not test "$untracked" = true
+                # Only dirty, diff is faster
+                command git -c core.fsmonitor= diff --quiet HEAD; or set dirtystate 1
             else if test "$dirty" = true
                 # With both dirty and untracked, git status is ~10% faster.
                 # With just dirty, it's ~20%.


### PR DESCRIPTION
## Description

I found `git diff --quiet` to be significantly faster than `git status`. The difference is noticable on high latency storage (e.g. network share over internet).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
