### PR TITLE
Assume files with all exec bits set are executable for completions

### DIFF
--- a/fish-rust/src/wildcard.rs
+++ b/fish-rust/src/wildcard.rs
@@ -426,17 +426,26 @@ fn wildcard_test_flags_then_complete(
         stat = None;
     }
 
-    let (file_size, is_directory, is_executable) = if let Some(Ok(md)) = &stat {
-        (md.len(), md.is_dir(), md.is_file())
+    let (file_size, is_directory, is_regular_file, perms) = if let Some(Ok(md)) = &stat {
+        (md.len(), md.is_dir(), md.is_file(), md.permissions().mode())
     } else {
-        (0, false, false)
+        (0, false, false, 0)
     };
 
     if need_directory && !is_directory {
         return false;
     }
 
-    if executables_only && (!is_executable || waccess(filepath, X_OK) != 0) {
+    // If the file has all executable bits set, we assume it is executable.
+    // This does not account for:
+    // 1. Capabilities (but neither does access!)
+    // 2. noexec filesystems (but then why add those to $PATH?)
+    // 3. MAC (SELinux etc)
+    // 4. ACLs
+    // Since this is for completions, that's fine.
+    let assume_executable = perms & (S_IXUSR | S_IXGRP | S_IXOTH) == (S_IXUSR | S_IXGRP | S_IXOTH);
+    if executables_only && !assume_executable && (!is_regular_file || waccess(filepath, X_OK) != 0)
+    {
         return false;
     }
 
@@ -453,7 +462,7 @@ fn wildcard_test_flags_then_complete(
         // so we tell file_get_desc that this file is definitely executable so it can skip the check.
         let mut desc = file_get_desc(filename, lstat, stat, executables_only).to_owned();
 
-        if !is_directory && !is_executable {
+        if !is_directory && !is_regular_file {
             if !desc.is_empty() {
                 desc.push_utfstr(L!(", "));
             }

--- a/fish-rust/src/wildcard.rs
+++ b/fish-rust/src/wildcard.rs
@@ -427,7 +427,12 @@ fn wildcard_test_flags_then_complete(
     }
 
     let (file_size, is_directory, is_regular_file, perms) = if let Some(Ok(md)) = &stat {
-        (md.len(), md.is_dir(), md.is_file(), md.permissions().mode())
+        (
+            md.len(),
+            md.is_dir(),
+            md.is_file(),
+            md.permissions().mode() as mode_t,
+        )
     } else {
         (0, false, false, 0)
     };


### PR DESCRIPTION
This checks the st_mode, which we need for other reasons. If it has the user, group *and* other exec bits set, i.e. a mode of 777 or 755 or similar, we assume it is executable and skip the waccess.

This can have false-positives (i.e. things offered as completion when they aren't executable) in some cases:

1. Capabilities
2. noexec filesystems
3. MAC like SELinux?
4. ACLs?

Of these, capabilities also aren't reflected in access. On a debian system:

```
sudo capsh --drop=CAP_NET_RAW --shell=/usr/bin/fish -- -c 'test -x /usr/bin/ping && echo is executable; ping 8.8.8.8'
```

prints

> is executable
> exec: Failed to execute process '/usr/bin/ping': No permission. Either suid/sgid is forbidden or you lack capabilities.

and strace confirms:

> faccessat(AT_FDCWD, "/usr/bin/ping", X_OK) = 0

Bash fails similarly, except the error is a more generic "Operation not permitted"

This leaves noexec filesystems and MAC.

Since this is for completions, it's probably okay to possibly be wrong in those cases, and *better* to have false-positives than the false-negatives of #9699 - if it is a false-positive, the user can just try to execute and will get an error. A false-negative will be invisible

Especially noexec filesystems shouldn't really be in completions because they'd have to be in $PATH.

I have been unable to test MAC, and from a cursory googling those would mostly fail the `stat` already.

This speeds up the common case by removing *most* access calls here - of the 2869 binaries in my $PATH, *1* (one) does not have a mode of 777, 555 or 755. It has 750.

Another system has 2170 files in $PATH, *none* of which doesn't have 777 or 755.

That means completing an empty command will have 2868/2170 fewer access() calls.

This regains all of the speed loss of #9699.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
