### PR TITLE
fix typo in set -U option

### DIFF
--- a/doc_src/cmds/read.rst
+++ b/doc_src/cmds/read.rst
@@ -26,7 +26,7 @@ The following options, like the corresponding ones in :doc:`set`, control variab
 
 **-U** or **--universal**
     Sets a universal variable.
-    The variable will be immediately available to all the user's ``fish`` instances on the machine, and will be persist across restarts of the shell.
+    The variable will be immediately available to all the user's ``fish`` instances on the machine, and will be persisted across restarts of the shell.
 
 **-f** or **--function**
     Sets a variable scoped to the executing function.

--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -38,7 +38,7 @@ The following options control variable scope:
 
 **-U** or **--universal**
     Sets a universal variable.
-    The variable will be immediately available to all the user's ``fish`` instances on the machine, and will be persist across restarts of the shell.
+    The variable will be immediately available to all the user's ``fish`` instances on the machine, and will be persisted across restarts of the shell.
 
 **-f** or **--function**
     Sets a variable scoped to the executing function.


### PR DESCRIPTION
## Description

Fixes a typo in the `set -U` descriptions:

Before

```
[... ]and will be persist across restarts of the shell.
```
After

```
[... ] and will be persisted across restarts of the shell.
```

I think

```
[...] and will persist across restarts of the shell.
```

would also be acceptable.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
