### PR TITLE
Fix typo in `read` doc

### DIFF
--- a/doc_src/cmds/read.rst
+++ b/doc_src/cmds/read.rst
@@ -137,7 +137,7 @@ Delimiters given via "-d" are taken as one string::
     echo $first # outputs "a b", $second is empty
 
     echo 'a"foo bar"b (command echo wurst)*" "{a,b}' | read -lt -l a b c
-    echo $a # outputs 'afoo bar' (without the quotes)
+    echo $a # outputs 'afoo barb' (without the quotes)
     echo $b # outputs '(command echo wurst)* {a,b}' (without the quotes)
     echo $c # nothing
 


### PR DESCRIPTION
## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
