### PR TITLE
Add `--verbose` completion to `fish_key_reader`

### DIFF
--- a/share/completions/fish_key_reader.fish
+++ b/share/completions/fish_key_reader.fish
@@ -1,3 +1,4 @@
 complete -c fish_key_reader -s h -l help -d 'Display help and exit'
 complete -c fish_key_reader -s v -l version -d 'Display version and exit'
 complete -c fish_key_reader -s c -l continuous -d 'Start a continuous session'
+complete -c fish_key_reader -s V -l verbose -d 'Output timing and explain sequence'


### PR DESCRIPTION
## Description

This was missing from #8467.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
