### PR TITLE
completions/git: use `complete -C` for git aliases

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -623,88 +623,12 @@ function __fish_git_config_keys
     printf '%s\n' (__fish_git help --config)[1..-2] # Last line is a footer; ignore it
 end
 
-# HACK: Aliases
-# Git allows aliases, so we need to see what command the current command-token corresponds to
-# (so we can complete e.g. `lg` like `log`).
-# Checking `git config` for a lot of aliases can be quite slow if it is called
-# for every possible command.
-# Ideally, we'd `complete --wraps` this, but that is not currently possible, as is
-# using `complete -C` like
-# complete -c git -n '__fish_git_using_command lg' -a '(complete -C"git log ")'
-#
-# So instead, we store the aliases in global variables, named after the alias, containing the command.
-# This is because alias:command is an n:1 mapping (an alias can only have one corresponding command,
-#                                                  but a command can be aliased multiple times)
-
-# Approximately duplicates the logic from https://github.com/git/git/blob/d486ca60a51c9cb1fe068803c3f540724e95e83a/contrib/completion/git-completion.bash#L1130
-# The Git script also finds aliases that reference other aliases via a loop but this is fine for a PoC
-function __fish_git_aliased_command
-    for word in (string split ' ' -- $argv)
-        switch $word
-            case !gitk gitk
-                echo gitk
-                return
-                # Adding " to the list
-            case '!*' '-*' '*=*' git '()' '{' : '\'*' '"*'
-                continue
-            case '*'
-                echo $word
-                return
-        end
-    end
-end
-
-git config -z --get-regexp 'alias\..*' | while read -lz alias cmdline
-    set -l command (__fish_git_aliased_command $cmdline)
-    string match -q --regex '\w+' -- $command; or continue
-    # Git aliases can contain chars that variable names can't - escape them.
-    set -l alias (string replace 'alias.' '' -- $alias | string escape --style=var)
-    set -g __fish_git_alias_$alias $command $cmdline
-end
-
 function __fish_git_using_command
     set -l cmd (__fish_git_needs_command)
-    test -z "$cmd"
-    and return 1
-    contains -- $cmd $argv
-    and return 0
-
-    # Check aliases.
-    set -l varname __fish_git_alias_(string escape --style=var -- $cmd)
-    set -q $varname
-    and contains -- $$varname[1][1] $argv
-    and return 0
-    return 1
+    test -n "$cmd"
+    and contains -- $cmd $argv
 end
 
-function __fish_git_contains_opt
-    # Check if an option has been given
-    # First check the commandline normally
-    __fish_contains_opt $argv
-    and return
-
-    # Now check the alias
-    argparse s= -- $argv
-    set -l cmd (__fish_git_needs_command)
-    set -l varname __fish_git_alias_(string escape --style=var -- $cmd)
-    if set -q $varname
-        echo -- $$varname | read -lat toks
-        set toks (string replace -r '(-.*)=.*' '' -- $toks)
-        for i in $argv
-            if contains -- --$i $toks
-                return 0
-            end
-        end
-
-        for i in $_flag_s
-            if string match -qr -- "^-$i|^-[^-]*$i" $toks
-                return 0
-            end
-        end
-    end
-
-    return 1
-end
 function __fish_git_stash_using_command
     set -l cmd (commandline -opc)
     __fish_git_using_command stash
@@ -737,14 +661,37 @@ function __fish_git_complete_stashes
     __fish_git stash list --format=%gd:%gs 2>/dev/null | string replace ":" \t
 end
 
-function __fish_git_aliases
-    __fish_git config -z --get-regexp '^alias\.' 2>/dev/null | while read -lz key value
-        begin
-            set -l name (string replace -r '^.*\.' '' -- $key)
-            set -l val (string shorten --no-newline -m 36 -- $value)
-            printf "%s\t%s\n" $name "alias: $val"
+function __fish_git_get_aliases
+    # Get valid aliases - aliases for a builtin or custom commands are ignored
+    set -l non_aliases (__fish_git --list-cmds=main,others)
+    __fish_git config --get-regexp '^alias\.' 2>/dev/null | while read -l key value
+        set -l name (string replace -r '^alias\.' '' -- $key)
+        if not contains -- $name $non_aliases
+            printf "%s\t%s\n" $name $value
         end
     end
+end
+
+function __fish_git_complete_aliases
+    # List the defined aliases when completing a command
+    __fish_git_get_aliases | while read -l -d\t name value
+        printf "%s\talias: %s\n" $name (string shorten --no-newline -m 36 -- $value)
+    end
+end
+
+function __fish_git_using_alias
+    # Check whether the current completion is for an alias
+    set -l cmd (__fish_git_needs_command)
+    test -n "$cmd"
+    and contains -- "$cmd" (__fish_git_get_aliases | string split -f 1 \t)
+end
+
+function __fish_git_complete_for_alias
+    # Resolve the alias and complete the command
+    # Assumes that __fish_git_using_alias is true
+    set -l alias (__fish_git_needs_command)
+    set -l value (git config --get "alias.$alias")
+    complete -C (commandline -p | string replace -- "$alias" "$value")
 end
 
 function __fish_git_custom_commands
@@ -1176,7 +1123,7 @@ complete -f -c git -n '__fish_git_using_command apply' -s 3 -l 3way -d 'Attempt 
 complete -F -c git -n '__fish_git_using_command apply' -l build-fake-ancestor -d 'Build a temporary index containing these blobs'
 complete -f -c git -n '__fish_git_using_command apply' -s R -l reverse -d 'Apply the patch in reverse'
 complete -f -c git -n '__fish_git_using_command apply' -l reject -d 'Leave rejected hunks in *.rej files'
-complete -f -c git -n '__fish_git_using_command apply' -n '__fish_git_contains_opt numstat' -s z -d 'Do not munge pathnames'
+complete -f -c git -n '__fish_git_using_command apply' -n '__fish_contains_opt numstat' -s z -d 'Do not munge pathnames'
 complete -x -c git -n '__fish_git_using_command apply am' -s p -d 'Remove n leading path components'
 complete -x -c git -n '__fish_git_using_command apply am' -s C -d 'Ensure n that lines of surrounding context match'
 complete -f -c git -n '__fish_git_using_command apply' -l unidiff-zero -d 'Do not break on diffs generated using --unified=0'
@@ -1319,7 +1266,7 @@ complete -x -c git -n '__fish_git_using_command commit' -s m -l message -d 'Use 
 complete -f -c git -n '__fish_git_using_command commit' -l no-edit -d 'Use the selected commit message without launching an editor'
 complete -f -c git -n '__fish_git_using_command commit' -l no-gpg-sign -d 'Do not sign commit'
 complete -f -c git -n '__fish_git_using_command commit' -s n -l no-verify -d 'Do not run pre-commit and commit-msg hooks'
-complete -f -c git -n '__fish_git_using_command commit' -n '__fish_git_contains_opt fixup squash' -ka '(__fish_git_recent_commits)'
+complete -f -c git -n '__fish_git_using_command commit' -n '__fish_contains_opt fixup squash' -ka '(__fish_git_recent_commits)'
 complete -f -c git -n '__fish_git_using_command commit' -l allow-empty -d 'Create a commit with no changes'
 complete -f -c git -n '__fish_git_using_command commit' -l allow-empty-message -d 'Create a commit with no commit message'
 complete -f -c git -n '__fish_git_using_command commit' -s s -l signoff -d 'Append Signed-off-by trailer to commit message'
@@ -1394,12 +1341,12 @@ complete -c git -n '__fish_git_using_command diff' -s 1 -l base -d 'Compare the 
 complete -c git -n '__fish_git_using_command diff' -s 2 -l ours -d 'Compare the working tree with the "our branch"'
 complete -c git -n '__fish_git_using_command diff' -s 3 -l theirs -d 'Compare the working tree with the "their branch"'
 complete -c git -n '__fish_git_using_command diff' -s 0 -d 'Omit diff output for unmerged entries and just show "Unmerged"'
-complete -c git -n '__fish_git_using_command diff' -n 'not __fish_git_contains_opt cached staged' -a '(
+complete -c git -n '__fish_git_using_command diff' -n 'not __fish_contains_opt cached staged' -a '(
     set -l kinds modified
     contains -- -- (commandline -opc) && set -a kinds deleted modified-staged-deleted
     __fish_git_files $kinds
 )'
-complete -c git -n '__fish_git_using_command diff' -n '__fish_git_contains_opt cached staged' -fa '(__fish_git_files all-staged)'
+complete -c git -n '__fish_git_using_command diff' -n '__fish_contains_opt cached staged' -fa '(__fish_git_files all-staged)'
 
 ### Function to list available tools for git difftool and mergetool
 
@@ -1966,9 +1913,9 @@ complete -f -c git -n '__fish_git_using_command restore' -l ignore-unmerged -d '
 complete -f -c git -n '__fish_git_using_command restore' -l ignore-skip-worktree-bits -d 'Ignore the sparse-checkout file and unconditionally restore any files in <pathspec>'
 complete -f -c git -n '__fish_git_using_command restore' -l overlay -d 'Never remove files when restoring'
 complete -f -c git -n '__fish_git_using_command restore' -l no-overlay -d 'Remove files when restoring (default)'
-complete -f -c git -n '__fish_git_using_command restore' -n 'not __fish_git_contains_opt -s S staged' -a '(__fish_git_files modified deleted modified-staged-deleted unmerged)'
-complete -f -c git -n '__fish_git_using_command restore' -n '__fish_git_contains_opt -s S staged' -a '(__fish_git_files added modified-staged deleted-staged renamed copied)'
-complete -F -c git -n '__fish_git_using_command restore' -n '__fish_git_contains_opt -s s source'
+complete -f -c git -n '__fish_git_using_command restore' -n 'not __fish_contains_opt -s S staged' -a '(__fish_git_files modified deleted modified-staged-deleted unmerged)'
+complete -f -c git -n '__fish_git_using_command restore' -n '__fish_contains_opt -s S staged' -a '(__fish_git_files added modified-staged deleted-staged renamed copied)'
+complete -F -c git -n '__fish_git_using_command restore' -n '__fish_contains_opt -s s source'
 # switch options
 complete -f -c git -n __fish_git_needs_command -a switch -d 'Switch to a branch'
 complete -f -c git -n '__fish_git_using_command switch' -ka '(__fish_git_unique_remote_branches)' -d 'Unique Remote Branch'
@@ -2018,7 +1965,7 @@ complete -f -c git -n '__fish_git_using_command revert' -l no-rerere-autoupdate 
 ### rm
 complete -c git -n __fish_git_needs_command -a rm -d 'Remove files from the working tree and/or staging area'
 complete -c git -n '__fish_git_using_command rm' -l cached -d 'Unstage files from the index'
-complete -c git -n '__fish_git_using_command rm' -n '__fish_git_contains_opt cached' -f -a '(__fish_git_files all-staged)'
+complete -c git -n '__fish_git_using_command rm' -n '__fish_contains_opt cached' -f -a '(__fish_git_files all-staged)'
 complete -c git -n '__fish_git_using_command rm' -l ignore-unmatch -d 'Exit with a zero status even if no files matched'
 complete -c git -n '__fish_git_using_command rm' -s r -d 'Allow recursive removal'
 complete -c git -n '__fish_git_using_command rm' -s q -l quiet -d 'Be quiet'
@@ -2056,7 +2003,7 @@ complete -f -c git -n '__fish_git_using_command tag' -s v -l verify -d 'Verify s
 complete -f -c git -n '__fish_git_using_command tag' -s f -l force -d 'Force overwriting existing tag'
 complete -f -c git -n '__fish_git_using_command tag' -s l -l list -d 'List tags'
 complete -f -c git -n '__fish_git_using_command tag' -l contains -xka '(__fish_git_commits)' -d 'List tags that contain a commit'
-complete -f -c git -n '__fish_git_using_command tag' -n '__fish_git_contains_opt -s d delete -s v verify -s f force' -ka '(__fish_git_tags)' -d Tag
+complete -f -c git -n '__fish_git_using_command tag' -n '__fish_contains_opt -s d delete -s v verify -s f force' -ka '(__fish_git_tags)' -d Tag
 # TODO options
 
 ### update-index
@@ -2233,7 +2180,8 @@ complete -f -c git -n '__fish_git_using_command submodule' -n '__fish_seen_subco
 complete -f -c git -n __fish_git_needs_command -a whatchanged -d 'Show logs with difference each commit introduces'
 
 ## Aliases (custom user-defined commands)
-complete -c git -n __fish_git_needs_command -a '(__fish_git_aliases)'
+complete -f -c git -n __fish_git_needs_command -a '(__fish_git_complete_aliases)'
+complete -f -c git -n __fish_git_using_alias -ka '(__fish_git_complete_for_alias)'
 
 ### git clean
 complete -f -c git -n __fish_git_needs_command -a clean -d 'Remove untracked files from the working tree'


### PR DESCRIPTION
## Description

This PR refactors the git completion for aliases. With these changes, completion just works for recursive aliases, and aliased commands are transparently completed as if the alias were resolved.

I made these changes because of issues I was running into with git-branchless and the aliases it sets up. I had set up completion for the `git-branchless` commands which worked correctly, but the completion would not work when using the aliases. I have been using these changes locally for the past few months, and they work great.

## TODOs:

<!-- Just check off what what we know been done so far. We can help you with this stuff. -->

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
