### PR TITLE
Use `string shorten` in `fish_title`

### DIFF
--- a/share/functions/fish_title.fish
+++ b/share/functions/fish_title.fish
@@ -4,18 +4,18 @@ function fish_title
         # If we're connected via ssh, we print the hostname.
         set -l ssh
         set -q SSH_TTY
-        and set ssh "["(prompt_hostname | string sub -l 10 | string collect)"]"
+        and set ssh "["(prompt_hostname | string shorten -l 10 | string collect)"]"
         # An override for the current command is passed as the first parameter.
         # This is used by `fg` to show the true process name, among others.
         if set -q argv[1]
-            echo -- $ssh (string sub -l 20 -- $argv[1]) (prompt_pwd -d 1 -D 1)
+            echo -- $ssh (string shorten -l 20 -- $argv[1]) (prompt_pwd -d 1 -D 1)
         else
             # Don't print "fish" because it's redundant
             set -l command (status current-command)
             if test "$command" = fish
                 set command
             end
-            echo -- $ssh (string sub -l 20 -- $command) (prompt_pwd -d 1 -D 1)
+            echo -- $ssh (string shorten -l 20 -- $command) (prompt_pwd -d 1 -D 1)
         end
     end
 end


### PR DESCRIPTION
## Description

`string shorten` indicates shortened string with an ellipsis, making it self-evident and less ambiguous.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
