### PR TITLE
`ls` No Longer Sets `LS_COLORS`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ We have tried to keep these to a minimum, but in some cases it is unavoidable.
 - ``functions --handlers`` will now list handlers in a different order.
   Now it is definition order, first to last, where before it was last to first.
   This was never specifically defined, and we recommend not relying on a specific order (:issue:`9944`).
+- ``LS_COLORS`` is no longer set automatically by ``ls`` (:issue:`10080`). Users
+  that set ``.dircolors`` should manually import it using other means.
 
 Notable improvements and fixes
 ------------------------------

--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -1,22 +1,3 @@
-function __fish_set_lscolors --description 'Set $LS_COLORS if possible'
-    if ! set -qx LS_COLORS && set -l cmd (command -s {g,}dircolors)[1]
-        set -l colorfile
-        for file in ~/.dir_colors ~/.dircolors /etc/DIR_COLORS
-            if test -f $file
-                set colorfile $file
-                break
-            end
-        end
-        # Here we rely on the legacy behavior of `dircolors -c` producing output
-        # suitable for csh in order to extract just the data we're interested in.
-        set -gx LS_COLORS ($cmd -c $colorfile | string split ' ')[3]
-        # The value should always be quoted but be conservative and check first.
-        if string match -qr '^([\'"]).*\1$' -- $LS_COLORS
-            set LS_COLORS (string match -r '^.(.*).$' $LS_COLORS)[2]
-        end
-    end
-end
-
 function ls --description "List contents of directory"
     # Make ls use colors and show indicators if we are on a system that supports that feature and writing to stdout.
     #
@@ -34,10 +15,10 @@ function ls --description "List contents of directory"
         # Since that one's quite different, don't use it.
         if command -sq colorls
             and command colorls -GF >/dev/null 2>/dev/null
-            set -g __fish_ls_color_opt -GF
+            set -g __fish_ls_color_opt -G
             set -g __fish_ls_command colorls
         else
-            for opt in --color=auto -G --color -F
+            for opt in --color=auto -G --color
                 if command ls $opt / >/dev/null 2>/dev/null
                     set -g __fish_ls_color_opt $opt
                     break
@@ -45,9 +26,6 @@ function ls --description "List contents of directory"
             end
         end
     end
-
-    # Set the colors to the default via `dircolors` if none is given.
-    __fish_set_lscolors
 
     set -l opt
     isatty stdout

--- a/share/functions/ls.fish
+++ b/share/functions/ls.fish
@@ -7,16 +7,18 @@ function ls --description "List contents of directory"
     # Solaris 11's ls command takes a --color flag.
     # OpenBSD requires the separate colorls program for color support.
     # Also test -F because we'll want to define this function even with an ls that can't do colors (like NetBSD).
-    if not set -q __fish_ls_color_opt
-        set -g __fish_ls_color_opt
+    if not set -q __fish_ls_command
         set -g __fish_ls_command ls
+        set -g __fish_ls_color_opt
+        set -g __fish_ls_indicators_opt
         # OpenBSD ships a command called "colorls" that takes "-G" and "-F",
         # but there's also a ruby implementation that doesn't understand "-F".
         # Since that one's quite different, don't use it.
         if command -sq colorls
             and command colorls -GF >/dev/null 2>/dev/null
-            set -g __fish_ls_color_opt -G
             set -g __fish_ls_command colorls
+            set -g __fish_ls_color_opt -G
+            set -g __fish_ls_indicators_opt -F
         else
             for opt in --color=auto -G --color
                 if command ls $opt / >/dev/null 2>/dev/null
@@ -24,12 +26,16 @@ function ls --description "List contents of directory"
                     break
                 end
             end
+
+            if command ls -F / >/dev/null 2>/dev/null
+                set -g __fish_ls_indicators_opt -F
+            end
         end
     end
 
-    set -l opt
+    set -l indicators_opt
     isatty stdout
-    and set -a opt -F
+    and set -a indicators_opt $__fish_ls_indicators_opt
 
     # Terminal.app doesn't set $COLORTERM or $CLICOLOR,
     # but the new FreeBSD ls requires either to be set,
@@ -40,5 +46,5 @@ function ls --description "List contents of directory"
     test "$TERM_PROGRAM" = Apple_Terminal
     and set -lx CLICOLOR 1
 
-    command $__fish_ls_command $__fish_ls_color_opt $opt $argv
+    command $__fish_ls_command $__fish_ls_color_opt $indicators_opt $argv
 end


### PR DESCRIPTION
## Description

Fixes issue #10080

This PR changes the builtin `ls` function to no longer load `LS_COLORS` before executing `command ls`. See the aforementioned issue for more details.

Additionally, a small refactor was done to the computed `ls` flags WRT the `-F` flag. In particular, the `ls` function was documented to:

> Make ls [...] show indicators if we are on a system that supports that feature and writing to stdout.

In particular this wasn't really checked as:
- For `colorls` systems (OpenBSD), this would always append the `-F` flag regardless of whether or not it was printing to STDOUT
- For `ls` systems with support for a colour flag (`--color=auto`, `-G` or `--color`), it would append `-F` when printing to STDOUT regardless of whether or not it was supported by the system
- For `ls` that didn't support a colour flag (`--color=auto`, `-G` or `--color`) but that supported `-F`, it would append `-F` regardless of whether or not it was printing to STDOUT

## TODOs:

- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
