### PR TITLE
Add __fish_anypager helper

### DIFF
--- a/share/functions/__fish_anypager.fish
+++ b/share/functions/__fish_anypager.fish
@@ -1,0 +1,31 @@
+function __fish_anypager --description "Print a pager to use"
+    set -l pager
+    # We prefer $PAGER if we have it
+    set -q PAGER
+    and echo $PAGER | read -at pager
+
+    # or even $MANPAGER if we're allowed to
+    if test "$argv[1]" = "--with-manpager"
+        set -q MANPAGER
+        and echo $MANPAGER | read -at pager
+    end
+
+    # We use them if they *exist*
+    if command -q $pager[1]
+        printf %s\n $pager
+        return 0
+    end
+
+    # Cheesy hardcoded list of pagers.
+    for cmd in bat lv most less more
+        if command -q $cmd
+            echo -- $cmd
+            return 0
+        end
+    end
+
+    # We have no pager.
+    # We could fall back to "cat",
+    # but in some cases that's probably not helpful.
+    return 1
+end

--- a/share/functions/__fish_paginate.fish
+++ b/share/functions/__fish_paginate.fish
@@ -1,8 +1,6 @@
 function __fish_paginate -d "Paginate the current command using the users default pager"
-    set -l cmd less
-    if set -q PAGER
-        echo $PAGER | read -at cmd
-    end
+    set -l cmd (__fish_anypager)
+    or return 1
 
     fish_commandline_append " &| $cmd"
 end

--- a/share/functions/__fish_preview_current_file.fish
+++ b/share/functions/__fish_preview_current_file.fish
@@ -1,6 +1,6 @@
 function __fish_preview_current_file --description "Open the file at the cursor in a pager"
-    set -l pager less --
-    set -q PAGER && echo $PAGER | read -at pager
+    set -l pager (__fish_anypager)
+    or set pager cat
 
     # commandline -t will never return an empty list. However, the token
     # could comprise multiple lines, so join them into a single string.

--- a/share/functions/__fish_print_help.fish
+++ b/share/functions/__fish_print_help.fish
@@ -125,15 +125,10 @@ function __fish_print_help --description "Print help message for the specified f
         end
     end | string replace -ra '^       ' '' |
         begin
-            set -l pager less
-            # Try both PAGER and MANPAGER, last one wins
-            set -q PAGER
-            and echo -- $PAGER | read -at pager
-            set -q MANPAGER
-            and echo -- $MANPAGER | read -at pager
+            set -l pager (__fish_anypager --with-manpager)
+            and isatty stdout
+            or set pager cat # cannot use a builtin here
 
-            not isatty stdout
-            and set pager cat # cannot use a builtin here
             # similar to man, but add -F to quit paging when the help output is brief (#6227)
             # Also set -X for less < v530, see #8157.
             set -l lessopts isRF

--- a/share/functions/fish_delta.fish
+++ b/share/functions/fish_delta.fish
@@ -70,9 +70,9 @@ function fish_delta
 
     if isatty stdout
         set -f colors "$(set_color normal)" "$(set_color brblue)" "$(set_color bryellow)" "$(set_color green)" "$(set_color red)"
-        set -f pager less
-        set -q PAGER
-        and echo $PAGER | read -at pager
+        set -f pager (__fish_anypager)
+        or set pager cat
+
         if type -q less
             set -l lessopts isRF
             if test (less --version | string match -r 'less (\d+)')[2] -lt 530 2>/dev/null

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -86,9 +86,9 @@ function history --description "display or manipulate interactive command histor
             and set search_mode --contains
 
             if isatty stdout
-                set -l pager less
-                set -q PAGER
-                and echo $PAGER | read -at pager
+                set -l pager (__fish_anypager)
+                and isatty stdout
+                or set pager cat
 
                 # If the user hasn't preconfigured less with the $LESS environment variable,
                 # we do so to have it behave like cat if output fits on one screen.


### PR DESCRIPTION
This makes it easier to get *any pager* in the number of places we do.

Unfortunately:

1. It can't just execute the pager because that might block
2. We can't really set the necessary options for less here so they still need to be set outside.

This

Fixes #10074

by falling back to `cat` in that case. We could also decide to abort instead of using a non-pager, but for history that's probably fine.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
