### PR TITLE
Replace some direct uses of libc with wrappers

### DIFF
--- a/fish-rust/src/builtins/complete.rs
+++ b/fish-rust/src/builtins/complete.rs
@@ -6,6 +6,7 @@ use crate::complete::{complete_add_wrapper, complete_remove_wrapper, CompletionR
 use crate::ffi;
 use crate::highlight::colorize;
 use crate::highlight::highlight_shell;
+use crate::nix::isatty;
 use crate::parse_constants::ParseErrorList;
 use crate::parse_util::parse_util_detect_errors_in_argument_list;
 use crate::parse_util::{parse_util_detect_errors, parse_util_token_extent};
@@ -201,7 +202,7 @@ fn builtin_complete_print(cmd: &wstr, streams: &mut IoStreams, parser: &Parser) 
     let repr = complete_print(cmd);
 
     // colorize if interactive
-    if !streams.out_is_redirected && unsafe { libc::isatty(STDOUT_FILENO) } != 0 {
+    if !streams.out_is_redirected && isatty(STDOUT_FILENO) {
         let mut colors = vec![];
         highlight_shell(&repr, &mut colors, &parser.context(), false, None);
         streams

--- a/fish-rust/src/builtins/function.rs
+++ b/fish-rust/src/builtins/function.rs
@@ -7,6 +7,7 @@ use crate::event::{self, EventDescription, EventHandler};
 use crate::function;
 use crate::global_safety::RelaxedAtomicBool;
 use crate::io::IoStreams;
+use crate::nix::getpid;
 use crate::parse_tree::NodeRef;
 use crate::parser::Parser;
 use crate::parser_keywords::parser_keywords_is_reserved;
@@ -148,8 +149,7 @@ fn parse_cmd_opts(
                     }
                     e = EventDescription::CallerExit { caller_id };
                 } else if opt == 'p' && woptarg == "%self" {
-                    // Safety: getpid() is always successful.
-                    let pid = unsafe { libc::getpid() };
+                    let pid: i32 = getpid();
                     e = EventDescription::ProcessExit { pid };
                 } else {
                     let pid = fish_wcstoi(woptarg);

--- a/fish-rust/src/builtins/path.rs
+++ b/fish-rust/src/builtins/path.rs
@@ -4,6 +4,7 @@ use std::os::unix::prelude::{FileTypeExt, MetadataExt};
 use std::time::SystemTime;
 
 use super::prelude::*;
+use crate::nix::{getegid, geteuid};
 use crate::path::path_apply_working_directory;
 use crate::util::wcsfilecmp_glob;
 use crate::wcstringutil::split_string_tok;
@@ -12,7 +13,7 @@ use crate::wutil::{
     INVALID_FILE_ID,
 };
 use bitflags::bitflags;
-use libc::{getegid, geteuid, mode_t, uid_t, F_OK, PATH_MAX, R_OK, S_ISGID, S_ISUID, W_OK, X_OK};
+use libc::{mode_t, F_OK, PATH_MAX, R_OK, S_ISGID, S_ISUID, W_OK, X_OK};
 
 use super::shared::BuiltinCmd;
 
@@ -808,11 +809,9 @@ fn filter_path(opts: &Options, path: &wstr) -> bool {
                 return false;
             } else if perm.contains(PermFlags::SGID) && (md.mode() as mode_t & S_ISGID) == 0 {
                 return false;
-            } else if perm.contains(PermFlags::USER) && (unsafe { geteuid() } != md.uid() as uid_t)
-            {
+            } else if perm.contains(PermFlags::USER) && geteuid() != md.uid() {
                 return false;
-            } else if perm.contains(PermFlags::GROUP) && (unsafe { getegid() } != md.gid() as uid_t)
-            {
+            } else if perm.contains(PermFlags::GROUP) && getegid() != md.gid() {
                 return false;
             }
         }

--- a/fish-rust/src/builtins/read.rs
+++ b/fish-rust/src/builtins/read.rs
@@ -15,6 +15,7 @@ use crate::env::Environment;
 use crate::env::READ_BYTE_LIMIT;
 use crate::env::{EnvVar, EnvVarFlags};
 use crate::ffi;
+use crate::nix::isatty;
 use crate::reader::ReaderConfig;
 use crate::reader::{reader_pop, reader_push, reader_readline};
 use crate::tokenizer::Tokenizer;
@@ -592,7 +593,7 @@ pub fn read(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
     loop {
         buff.clear();
 
-        let stream_stdin_is_a_tty = unsafe { libc::isatty(streams.stdin_fd) } != 0;
+        let stream_stdin_is_a_tty = isatty(streams.stdin_fd);
         if stream_stdin_is_a_tty && !opts.split_null {
             // Read interactively using reader_readline(). This does not support splitting on null.
             exit_res = read_interactive(

--- a/fish-rust/src/builtins/source.rs
+++ b/fish-rust/src/builtins/source.rs
@@ -3,6 +3,7 @@ use crate::{
     fds::{wopen_cloexec, AutoCloseFd},
     ffi::reader_read_ffi,
     io::IoChain,
+    nix::isatty,
     parser::Block,
 };
 use libc::{c_int, O_RDONLY, S_IFMT, S_IFREG};
@@ -41,7 +42,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
             return STATUS_CMD_ERROR;
         }
         // Either a bare `source` which means to implicitly read from stdin or an explicit `-`.
-        if argc == optind && unsafe { libc::isatty(streams.stdin_fd) } != 0 {
+        if argc == optind && isatty(streams.stdin_fd) {
             // Don't implicitly read from the terminal.
             return STATUS_CMD_ERROR;
         }

--- a/fish-rust/src/builtins/test.rs
+++ b/fish-rust/src/builtins/test.rs
@@ -84,8 +84,7 @@ mod test_expressions {
         // Return true if the number is a tty().
         fn isatty(&self, streams: &mut IoStreams) -> bool {
             fn istty(fd: libc::c_int) -> bool {
-                // Safety: isatty cannot crash.
-                unsafe { libc::isatty(fd) > 0 }
+                crate::nix::isatty(fd)
             }
             if self.delta != 0.0 || self.base > i32::MAX as i64 || self.base < i32::MIN as i64 {
                 return false;
@@ -928,8 +927,7 @@ mod test_expressions {
             }
             Token::filetype_G => {
                 // "-G", for check effective group id
-                // Safety: getegid cannot fail.
-                stat_and(arg, |buf| unsafe { libc::getegid() } == buf.gid())
+                stat_and(arg, |buf| crate::nix::getegid() == buf.gid())
             }
             Token::filetype_g => {
                 // "-g", for set-group-id
@@ -946,10 +944,9 @@ mod test_expressions {
             }
             Token::filetype_O => {
                 // "-O", for check effective user id
-                stat_and(
-                    arg,
-                    |buf: std::fs::Metadata| unsafe { libc::geteuid() } == buf.uid(),
-                )
+                stat_and(arg, |buf: std::fs::Metadata| {
+                    crate::nix::geteuid() == buf.uid()
+                })
             }
             Token::filetype_p => {
                 // "-p", for FIFO

--- a/fish-rust/src/builtins/test.rs
+++ b/fish-rust/src/builtins/test.rs
@@ -4,6 +4,7 @@ use crate::common;
 mod test_expressions {
     use super::*;
 
+    use crate::nix::isatty;
     use crate::wutil::{
         file_id_for_path, fish_wcswidth, lwstat, waccess, wcstod::wcstod, wcstoi_opts, wstat,
         Error, Options,
@@ -83,9 +84,6 @@ mod test_expressions {
 
         // Return true if the number is a tty().
         fn isatty(&self, streams: &mut IoStreams) -> bool {
-            fn istty(fd: libc::c_int) -> bool {
-                crate::nix::isatty(fd)
-            }
             if self.delta != 0.0 || self.base > i32::MAX as i64 || self.base < i32::MIN as i64 {
                 return false;
             }
@@ -93,14 +91,14 @@ mod test_expressions {
             if bint == 0 {
                 match streams.stdin_fd {
                     -1 => false,
-                    fd => istty(fd),
+                    fd => isatty(fd),
                 }
             } else if bint == 1 {
-                !streams.out_is_redirected && istty(libc::STDOUT_FILENO)
+                !streams.out_is_redirected && isatty(libc::STDOUT_FILENO)
             } else if bint == 2 {
-                !streams.err_is_redirected && istty(libc::STDERR_FILENO)
+                !streams.err_is_redirected && isatty(libc::STDERR_FILENO)
             } else {
-                istty(bint)
+                isatty(bint)
             }
         }
     }

--- a/fish-rust/src/exec.rs
+++ b/fish-rust/src/exec.rs
@@ -30,6 +30,7 @@ use crate::io::{
     BufferedOutputStream, FdOutputStream, IoBufferfill, IoChain, IoClose, IoMode, IoPipe,
     IoStreams, OutputStream, SeparatedBuffer, StringOutputStream,
 };
+use crate::nix::isatty;
 use crate::null_terminated_array::{
     null_terminated_array_length, AsNullTerminatedArray, OwningNullTerminatedArray,
 };
@@ -54,7 +55,7 @@ use cxx::{CxxWString, UniquePtr};
 use errno::{errno, set_errno};
 use libc::c_int;
 use libc::{
-    c_char, isatty, EACCES, ENOENT, ENOEXEC, ENOTDIR, EPIPE, EXIT_FAILURE, EXIT_SUCCESS, O_NOCTTY,
+    c_char, EACCES, ENOENT, ENOEXEC, ENOTDIR, EPIPE, EXIT_FAILURE, EXIT_SUCCESS, O_NOCTTY,
     O_RDONLY, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
 };
 use std::ffi::CStr;
@@ -1383,7 +1384,7 @@ fn allow_exec_with_background_jobs(parser: &Parser) -> bool {
     // Compare run counts, so we only warn once.
     let current_run_count = reader_run_count();
     let last_exec_run_count = &mut parser.libdata_mut().pods.last_exec_run_counter;
-    if unsafe { isatty(STDIN_FILENO) } != 0 && current_run_count - 1 != *last_exec_run_count {
+    if isatty(STDIN_FILENO) && current_run_count - 1 != *last_exec_run_count {
         print_exit_warning_for_jobs(&bgs);
         *last_exec_run_count = current_run_count;
         false

--- a/fish-rust/src/fork_exec/postfork.rs
+++ b/fish-rust/src/fork_exec/postfork.rs
@@ -3,6 +3,7 @@
 // That means no locking, no allocating, no freeing memory, etc!
 use super::flog_safe::FLOG_SAFE;
 use crate::common::exit_without_destructors;
+use crate::nix::getpid;
 use crate::redirection::Dup2List;
 use crate::signal::signal_reset_handlers;
 use libc::{c_char, c_int, pid_t};
@@ -189,7 +190,7 @@ pub fn child_setup_process(
         unsafe {
             libc::signal(libc::SIGTTIN, libc::SIG_IGN);
             libc::signal(libc::SIGTTOU, libc::SIG_IGN);
-            let _ = libc::tcsetpgrp(libc::STDIN_FILENO, libc::getpid());
+            let _ = libc::tcsetpgrp(libc::STDIN_FILENO, getpid());
         }
     }
     if let Some(sigmask) = sigmask {

--- a/fish-rust/src/io.rs
+++ b/fish-rust/src/io.rs
@@ -8,6 +8,7 @@ use crate::fds::{
 };
 use crate::flog::{should_flog, FLOG, FLOGF};
 use crate::global_safety::RelaxedAtomicBool;
+use crate::nix::isatty;
 use crate::path::path_apply_working_directory;
 use crate::proc::JobGroupRef;
 use crate::redirection::{RedirectionMode, RedirectionSpecList};
@@ -1018,7 +1019,7 @@ impl<'a> IoStreams<'a> {
         }
     }
     pub fn out_is_terminal(&self) -> bool {
-        !self.out_is_redirected && unsafe { libc::isatty(STDOUT_FILENO) == 1 }
+        !self.out_is_redirected && isatty(STDOUT_FILENO)
     }
 }
 

--- a/fish-rust/src/nix.rs
+++ b/fish-rust/src/nix.rs
@@ -22,3 +22,18 @@ impl TimevalExt for libc::timeval {
         timeval_to_duration(self)
     }
 }
+
+pub fn geteuid() -> u32 {
+    unsafe { libc::geteuid() }
+}
+pub fn getegid() -> u32 {
+    unsafe { libc::getegid() }
+}
+pub fn getpid() -> i32 {
+    unsafe { libc::getpid() }
+}
+pub fn isatty(fd: i32) -> bool {
+    // This returns false if the fd is valid but not a tty, or is invalid.
+    // No place we currently call it really cares about the difference.
+    return unsafe { libc::isatty(fd) } == 1;
+}


### PR DESCRIPTION
## Description

EDIT: Switched to our own wrappers, nix has problems compiling on FreeBSD with the "fs" feature.

This replaces our uses of libc's geteuid, getegid, getpid and isatty with the corresponding functions from the nix crate.

The main advantage is that it removes a bunch of awkward `unsafe` blocks. In turn nix has made some type choices like wrap pid_t in a Pid newtype that we then need to cast into an i32 again so we can use it.

This isn't the only solution. Alternatively we could:

- Make our own wrappers, possibly more direct
- Live with the unsafes
- Use nix *more*, integrating it more fully (e.g. add to_wstring to Pid)

Fundamentally, I would like for `unsafe` to be a rare thing that's easy to audit. In this case libc gets in the way because it defaults to marking things as unsafe, which includes things like getpid where I do not understand what the unsafety is supposed to be.

So I would like to wrap these things away, and these four functions were an easy start.

There are some other rust "style" things that I would like to change, including our uses of .unwrap(), which scares me (it's effectively an "assert"!), and I would like to remove a bunch of them.