### PR TITLE
Replaced double quotation marks with single in dnf.fish completions

### DIFF
--- a/share/completions/dnf.fish
+++ b/share/completions/dnf.fish
@@ -21,7 +21,7 @@ function __dnf_list_available_packages
         # This schema is bad, there is only a "pkg" field with the full
         #    packagename-version-release.fedorarelease.architecture
         # tuple. We are only interested in the packagename.
-        set results (sqlite3 /var/cache/dnf/packages.db "SELECT pkg FROM available WHERE pkg LIKE \"$tok%\"" 2>/dev/null |
+        set results (sqlite3 /var/cache/dnf/packages.db "SELECT pkg FROM available WHERE pkg LIKE '$tok%'" 2>/dev/null |
             string replace -r -- '-[^-]*-[^-]*$' '')
     else
         # In some cases dnf will ask for input (e.g. to accept gpg keys).


### PR DESCRIPTION
## Description

Replace double quotation marks in share/completions/dnf.fish with single.

Fixes issue #10096

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
