### PR TITLE
completions: add chezmoi completions

### DIFF
--- a/share/completions/chezmoi.fish
+++ b/share/completions/chezmoi.fish
@@ -1,0 +1,1 @@
+chezmoi completion fish | source


### PR DESCRIPTION
## Description

Added completions for [chezmoi](https://chezmoi.io).

I used the completions for kubectl as an inspiration, which means that it's up to chezmoi to always
generate the correct fish completions.

If this is not intended and the actual output should be committed instead,
I'd change this. Furthermore, there were no guidelines about commit messages
inside the CONTRIBUTING.rst, therefore I've oriented after the commit history of the master
branch.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
