### PR TITLE
[doc]: fix --path description of set cmd

### DIFF
--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -63,7 +63,7 @@ These options modify how variables operate:
     Causes the specified shell variable to NOT be exported to child processes.
 
 **--path**
-    Treat specified variable as a :ref:`path variable <variables-path>`; variable will be split on colons (``:``) and will be displayed joined by colons colons when quoted (``echo "$PATH"``) or exported.
+    Treat specified variable as a :ref:`path variable <variables-path>`; variable will be split on colons (``:``) and will be displayed joined by colons when quoted (``echo "$PATH"``) or exported.
 
 **--unpath**
      Causes variable to no longer be treated as a :ref:`path variable <variables-path>`.


### PR DESCRIPTION
## Description

ix documentation of --path flag for the set cmd. Remove duplicated word colons.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
