### PR TITLE
Add support for the fish_config command in the Windows MSYS environment.

### DIFF
--- a/share/functions/fish_config.fish
+++ b/share/functions/fish_config.fish
@@ -19,6 +19,14 @@ function fish_config --description "Launch fish's web based configuration"
         set -lx __fish_bin_dir $__fish_bin_dir
         if set -l python (__fish_anypython)
             $python "$__fish_data_dir/tools/web_config/webconfig.py" $argv
+
+            # If the execution of 'webconfig.py' fails, display python location and return.
+            if test $status -ne 0
+                echo "Please check if Python has been installed successfully."
+                echo "You can find the location of Python by executing the 'command -s $python' command."
+                return 1
+            end
+
         else
             echo (set_color $fish_color_error)Cannot launch the web configuration tool:(set_color normal)
             echo (set_color -o)"fish_config browse"(set_color normal) requires Python.


### PR DESCRIPTION
## Description
This PR adds support for the fish_config command in the Windows MSYS environment.

## share/functions/fish_config.fish
Windows 11 comes with a default python.exe, but it's merely an empty installation package. It doesn't executing .py files via the command line, so add a detection to display a prompt message when script failed.

## share/tools/web_config/webconfig.py
- Under Windows fish_bin_name will append the .exe extension, and replace '\\' with '/' in the filepath. 
- Because the select function is not supported on Windows for sys.stdin, I use a socket as a replacement. I couldn't find any other solution here. Using multiple processes would add a lot of complexity and result in extensive code changes.
- To fix https://github.com/python/cpython/issues/112277, on Windows, the temporary file is closed after writing and flushing, set delete to True to ensure cleanup when program exit.
- To fix https://github.com/zephyrproject-rtos/windows-curses/issues/49, use empty string when get_tparm return None


