### PR TITLE
Enable OSC 0 when running in Rio and Foot terminal

### DIFF
--- a/fish-rust/src/env_dispatch.rs
+++ b/fish-rust/src/env_dispatch.rs
@@ -594,7 +594,7 @@ fn does_term_support_setting_title(vars: &EnvStack) -> bool {
     #[rustfmt::skip]
     const TITLE_TERMS: &[&wstr] = &[
         L!("xterm"), L!("screen"),    L!("tmux"),    L!("nxterm"),
-        L!("rxvt"),  L!("alacritty"), L!("wezterm"),
+        L!("rxvt"),  L!("alacritty"), L!("wezterm"), L!("rio"),
     ];
 
     let Some(term) = vars.get_unless_empty(L!("TERM")).map(|v| v.as_string()) else {

--- a/fish-rust/src/env_dispatch.rs
+++ b/fish-rust/src/env_dispatch.rs
@@ -595,6 +595,7 @@ fn does_term_support_setting_title(vars: &EnvStack) -> bool {
     const TITLE_TERMS: &[&wstr] = &[
         L!("xterm"), L!("screen"),    L!("tmux"),    L!("nxterm"),
         L!("rxvt"),  L!("alacritty"), L!("wezterm"), L!("rio"),
+        L!("foot"),
     ];
 
     let Some(term) = vars.get_unless_empty(L!("TERM")).map(|v| v.as_string()) else {


### PR DESCRIPTION
## Description

[Rio terminal](https://github.com/raphamorim/rio) has [support](https://github.com/raphamorim/rio/blob/558e8ebbb3f0594d039d98a05d5416aab4db81ba/docs/docs/escape-sequence-support.md?plain=1#L96) for OSC 0 (dynamic titles).

[Foot terminal](https://github.com/DanteAlighierin/foot) has [support](https://github.com/DanteAlighierin/foot/blob/master/README.md?plain=1#L440) for OSC 0 (dynamic titles).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
