### PR TITLE
completions: add airmon-ng

### DIFF
--- a/share/completions/airmon-ng.fish
+++ b/share/completions/airmon-ng.fish
@@ -1,0 +1,6 @@
+#airmon-ng
+
+set -l commands "start stop check"
+complete -c airmon-ng -x -n "not __fish_seen_subcommand_from $commands" -a "$commands"
+complete -c airmon-ng -x -n "__fish_seen_subcommand_from $commands; and not __fish_seen_subcommand_from (__fish_print_interfaces)" -a "(__fish_print_interfaces)"
+complete -c airmon-ng -f


### PR DESCRIPTION
## Description

I added completions for the `airmon-ng` command. I am not familiar with the related commands so I have not added completions for them.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
