### PR TITLE
Add a missing space after a comma

### DIFF
--- a/doc_src/cmds/function.rst
+++ b/doc_src/cmds/function.rst
@@ -30,7 +30,7 @@ The following options are available:
     Inherit completions from the given *WRAPPED_COMMAND*. See the documentation for :doc:`complete <complete>` for more information.
 
 **-e** *EVENT_NAME* or **--on-event** *EVENT_NAME*
-    Run this function when the specified named event is emitted. Fish internally generates named events, for example,when showing the prompt. Custom events can be emitted using the :doc:`emit <emit>` command.
+    Run this function when the specified named event is emitted. Fish internally generates named events, for example, when showing the prompt. Custom events can be emitted using the :doc:`emit <emit>` command.
 
 **-v** *VARIABLE_NAME* or **--on-variable** *VARIABLE_NAME*
     Run this function when the variable *VARIABLE_NAME* changes value. Note that :program:`fish` makes no guarantees on any particular timing or even that the function will be run for every single ``set``. Rather it will be run when the variable has been set at least once, possibly skipping some values or being run when the variable has been set to the same value (except for universal variables set in other shells - only changes in the value will be picked up for those).


### PR DESCRIPTION
This is a tiny typo I spotted while reading the docs.