### PR TITLE
Enable globbing in history-pager

### DIFF
--- a/fish-rust/src/pager.rs
+++ b/fish-rust/src/pager.rs
@@ -15,7 +15,6 @@ use crate::fallback::{fish_wcswidth, fish_wcwidth};
 use crate::future::IsSomeAnd;
 use crate::highlight::{highlight_shell, HighlightRole, HighlightSpec};
 use crate::operation_context::OperationContext;
-use crate::parse_util::parse_util_contains_wildcard;
 use crate::screen::{Line, ScreenData};
 use crate::termsize::Termsize;
 use crate::wchar::prelude::*;
@@ -379,11 +378,6 @@ impl Pager {
         }
 
         let needle = self.search_field_line.text();
-
-        // Bypass glob pattern
-        if parse_util_contains_wildcard(needle) {
-            return true;
-        }
 
         // Match against the description.
         if string_fuzzy_match_string(needle, &info.desc, false).is_some() {

--- a/fish-rust/src/pager.rs
+++ b/fish-rust/src/pager.rs
@@ -589,7 +589,7 @@ impl Pager {
     }
 
     // Sets the set of completions.
-    pub fn set_completions(&mut self, raw_completions: &[Completion]) {
+    pub fn set_completions(&mut self, raw_completions: &[Completion], enable_refilter: bool) {
         self.selected_completion_idx = None;
         // Get completion infos out of it.
         self.unfiltered_completion_infos = process_completions_into_infos(raw_completions);
@@ -603,7 +603,11 @@ impl Pager {
         self.measure_completion_infos();
 
         // Refilter them.
-        self.refilter_completions();
+        if enable_refilter {
+            self.refilter_completions();
+        } else {
+            self.completion_infos = self.unfiltered_completion_infos.clone();
+        }
         self.have_unrendered_completions = true;
     }
 
@@ -1261,7 +1265,7 @@ mod pager_ffi {
         fn rendering_needs_update(&self, rendering: &PageRendering) -> bool;
         fn search_field_line(&mut self) -> *mut EditableLine;
         #[cxx_name = "set_completions"]
-        fn set_completions_ffi(&mut self, completions: &CompletionListFfi);
+        fn set_completions_ffi(&mut self, completions: &CompletionListFfi, enable_refilter: bool);
         fn set_fully_disclosed(&mut self);
         #[cxx_name = "set_prefix"]
         fn set_prefix_ffi(&mut self, prefix: &CxxWString, highlight: bool);
@@ -1324,8 +1328,8 @@ impl Pager {
     fn set_extra_progress_text(&mut self, text: &CxxWString) {
         self.extra_progress_text = text.from_ffi();
     }
-    fn set_completions_ffi(&mut self, completions: &CompletionListFfi) {
-        self.set_completions(&completions.0)
+    fn set_completions_ffi(&mut self, completions: &CompletionListFfi, enable_refilter: bool) {
+        self.set_completions(&completions.0, enable_refilter)
     }
     fn selected_completion_index_ffi(&self) -> usize {
         self.selected_completion_idx.unwrap_or(PAGER_SELECTION_NONE)

--- a/fish-rust/src/pager.rs
+++ b/fish-rust/src/pager.rs
@@ -15,6 +15,7 @@ use crate::fallback::{fish_wcswidth, fish_wcwidth};
 use crate::future::IsSomeAnd;
 use crate::highlight::{highlight_shell, HighlightRole, HighlightSpec};
 use crate::operation_context::OperationContext;
+use crate::parse_util::parse_util_contains_wildcard;
 use crate::screen::{Line, ScreenData};
 use crate::termsize::Termsize;
 use crate::wchar::prelude::*;
@@ -379,6 +380,11 @@ impl Pager {
 
         let needle = self.search_field_line.text();
 
+        // Bypass glob pattern
+        if parse_util_contains_wildcard(needle) {
+            return true;
+        }
+
         // Match against the description.
         if string_fuzzy_match_string(needle, &info.desc, false).is_some() {
             return true;
@@ -392,6 +398,7 @@ impl Pager {
                 return true;
             }
         }
+
         false // no match
     }
 

--- a/fish-rust/src/pager.rs
+++ b/fish-rust/src/pager.rs
@@ -102,9 +102,6 @@ pub struct Pager {
     // Whether we show the search field.
     pub search_field_shown: bool,
 
-    // Whether or not the pager should refilter the supplied completions.
-    pub refilter_disabled: bool,
-
     // The filtered list of completion infos.
     completion_infos: Vec<PagerComp>,
 
@@ -961,15 +958,6 @@ impl Pager {
 
     // Updates the completions list per the filter.
     pub fn refilter_completions(&mut self) {
-        // the result is already considered as filtered, we don't need
-        // to refine it again.
-        if self.refilter_disabled {
-            self.completion_infos = self.unfiltered_completion_infos.clone();
-            return;
-        }
-
-        // otherwise we need to filter through the completions
-        // according to the search field.
         self.completion_infos.clear();
         for i in 0..self.unfiltered_completion_infos.len() {
             if self.completion_info_passes_filter(&self.unfiltered_completion_infos[i]) {
@@ -1275,8 +1263,6 @@ mod pager_ffi {
         #[cxx_name = "set_completions"]
         fn set_completions_ffi(&mut self, completions: &CompletionListFfi);
         fn set_fully_disclosed(&mut self);
-        fn enable_refilter(&mut self);
-        fn disable_refilter(&mut self);
         #[cxx_name = "set_prefix"]
         fn set_prefix_ffi(&mut self, prefix: &CxxWString, highlight: bool);
         fn set_search_field_shown(&mut self, flag: bool);
@@ -1322,12 +1308,6 @@ impl Pager {
             Some(completion) => completion as *const Completion,
             None => std::ptr::null(),
         }
-    }
-    pub fn enable_refilter(&mut self) {
-        self.refilter_disabled = false;
-    }
-    pub fn disable_refilter(&mut self) {
-        self.refilter_disabled = true;
     }
     fn set_prefix_ffi(&mut self, prefix: &CxxWString, highlight: bool) {
         self.set_prefix(prefix.as_wstr(), highlight);

--- a/fish-rust/src/parse_util.rs
+++ b/fish-rust/src/parse_util.rs
@@ -570,6 +570,34 @@ pub fn parse_util_unescape_wildcards(s: &wstr) -> WString {
     result
 }
 
+/// Test if the given string contains any wildcard pattern
+pub fn parse_util_contains_wildcard(s: &wstr) -> bool {
+    let unesc_qmark = !feature_test(FeatureFlag::qmark_noglob);
+
+    let mut i = 0;
+    while i < s.len() {
+        let c = s.char_at(i);
+        if c == '*' {
+            return true;
+        } else if c == '?' && unesc_qmark {
+            return true;
+        }
+
+        if (c == '\\' && s.char_at(i + 1) == '*')
+            || (unesc_qmark && c == '\\' && s.char_at(i + 1) == '?')
+        {
+            i += 2;
+        } else if c == '\\' && s.char_at(i + 1) == '\\' {
+            // Not a wildcard, but ensure the next iteration doesn't see this escaped backslash.
+            i += 2;
+        } else {
+            i += 1
+        }
+    }
+
+    false
+}
+
 /// Checks if the specified string is a help option.
 #[widestrs]
 pub fn parse_util_argument_is_help(s: &wstr) -> bool {

--- a/fish-rust/src/parse_util.rs
+++ b/fish-rust/src/parse_util.rs
@@ -570,34 +570,6 @@ pub fn parse_util_unescape_wildcards(s: &wstr) -> WString {
     result
 }
 
-/// Test if the given string contains any wildcard pattern
-pub fn parse_util_contains_wildcard(s: &wstr) -> bool {
-    let unesc_qmark = !feature_test(FeatureFlag::qmark_noglob);
-
-    let mut i = 0;
-    while i < s.len() {
-        let c = s.char_at(i);
-        if c == '*' {
-            return true;
-        } else if c == '?' && unesc_qmark {
-            return true;
-        }
-
-        if (c == '\\' && s.char_at(i + 1) == '*')
-            || (unesc_qmark && c == '\\' && s.char_at(i + 1) == '?')
-        {
-            i += 2;
-        } else if c == '\\' && s.char_at(i + 1) == '\\' {
-            // Not a wildcard, but ensure the next iteration doesn't see this escaped backslash.
-            i += 2;
-        } else {
-            i += 1
-        }
-    }
-
-    false
-}
-
 /// Checks if the specified string is a help option.
 #[widestrs]
 pub fn parse_util_argument_is_help(s: &wstr) -> bool {

--- a/fish-rust/src/tests/pager.rs
+++ b/fish-rust/src/tests/pager.rs
@@ -24,7 +24,7 @@ add_test!("test_pager_navigation", || {
     }
 
     let mut pager = Pager::default();
-    pager.set_completions(&completions);
+    pager.set_completions(&completions, true);
     pager.set_term_size(&Termsize::defaults());
     let mut render = pager.render();
 
@@ -136,7 +136,7 @@ add_test!("test_pager_layout", || {
         StringFuzzyMatch::exact_match(),
         CompleteFlags::default(),
     )];
-    pager.set_completions(&c1s);
+    pager.set_completions(&c1s, true);
 
     validate!(&mut pager, 26, L!("abcdefghij  (1234567890)"));
     validate!(&mut pager, 25, L!("abcdefghij  (1234567890)"));
@@ -157,7 +157,7 @@ add_test!("test_pager_layout", || {
         StringFuzzyMatch::exact_match(),
         CompleteFlags::default(),
     )];
-    pager.set_completions(&c2s);
+    pager.set_completions(&c2s, true);
     validate!(&mut pager, 26, L!("abcdefghijklmnopqrs  (1)"));
     validate!(&mut pager, 25, L!("abcdefghijklmnopqrs  (1)"));
     validate!(&mut pager, 24, L!("abcdefghijklmnopqrs  (1)"));
@@ -177,7 +177,7 @@ add_test!("test_pager_layout", || {
         StringFuzzyMatch::exact_match(),
         CompleteFlags::default(),
     )];
-    pager.set_completions(&c3s);
+    pager.set_completions(&c3s, true);
     validate!(&mut pager, 26, L!("abcdefghijklmnopqrst"));
     validate!(&mut pager, 25, L!("abcdefghijklmnopqrst"));
     validate!(&mut pager, 24, L!("abcdefghijklmnopqrst"));

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -487,6 +487,26 @@ bool parse_util_contains_wildcards(const wcstring &str) {
     return false;
 }
 
+wcstring parse_util_escape_wildcards(const wcstring &str) {
+    wcstring result;
+    result.reserve(str.size());
+    bool unesc_qmark = !feature_test(feature_flag_t::qmark_noglob);
+
+    const wchar_t *const cs = str.c_str();
+    for (size_t i = 0; cs[i] != L'\0'; i++) {
+        if (cs[i] == L'*') {
+            result.append(L"\\*");
+        } else if (cs[i] == L'?' && unesc_qmark) {
+            result.append(L"\\?");
+        } else if (cs[i] == L'\\') {
+            result.append(L"\\\\");
+        } else {
+            result.push_back(cs[i]);
+        }
+    }
+    return result;
+}
+
 
 /// Find the outermost quoting style of current token. Returns 0 if token is not quoted.
 static wchar_t get_quote(const wcstring &cmd_str, size_t len) {

--- a/src/parse_util.cpp
+++ b/src/parse_util.cpp
@@ -466,6 +466,28 @@ wcstring parse_util_unescape_wildcards(const wcstring &str) {
     return result;
 }
 
+bool parse_util_contains_wildcards(const wcstring &str) {
+    bool unesc_qmark = !feature_test(feature_flag_t::qmark_noglob);
+
+    const wchar_t *const cs = str.c_str();
+    for (size_t i = 0; cs[i] != L'\0'; i++) {
+        if (cs[i] == L'*') {
+            return true;
+        } else if (cs[i] == L'?' && unesc_qmark) {
+            return true;
+        } else if (cs[i] == L'\\' && cs[i + 1] == L'*') {
+            i += 1;
+        } else if (cs[i] == L'\\' && cs[i + 1] == L'?' && unesc_qmark) {
+            i += 1;
+        } else if (cs[i] == L'\\' && cs[i + 1] == L'\\') {
+            // Not a wildcard, but ensure the next iteration doesn't see this escaped backslash.
+            i += 1;
+        }
+    }
+    return false;
+}
+
+
 /// Find the outermost quoting style of current token. Returns 0 if token is not quoted.
 static wchar_t get_quote(const wcstring &cmd_str, size_t len) {
     size_t i = 0;

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -99,6 +99,11 @@ wcstring parse_util_unescape_wildcards(const wcstring &str);
 /// Return if the given string contains wildcard characters.
 bool parse_util_contains_wildcards(const wcstring &str);
 
+/// Escape any wildcard characters in the given string. e.g. convert
+/// "a*b" to "a\*b".
+wcstring parse_util_escape_wildcards(const wcstring &str);
+
+
 /// Calculates information on the parameter at the specified index.
 ///
 /// \param cmd The command to be analyzed

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -96,6 +96,9 @@ size_t parse_util_get_offset(const wcstring &str, int line, long line_offset);
 /// transformation.
 wcstring parse_util_unescape_wildcards(const wcstring &str);
 
+/// Return if the given string contains wildcard characters.
+bool parse_util_contains_wildcards(const wcstring &str);
+
 /// Calculates information on the parameter at the specified index.
 ///
 /// \param cmd The command to be analyzed

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -3676,7 +3676,9 @@ void reader_data_t::handle_readline_command(readline_cmd_t c, readline_loop_stat
             pager.set_prefix(MB_CUR_MAX > 1 ? L"► " : L"> ", false /* highlight */);
             // Update the search field, which triggers the actual history search.
             if (!history_search.active() || history_search.search_string().empty()) {
-                insert_string(pager.search_field_line(), *command_line.text());
+                // Escape any wildcards the user may have in their input.
+                auto escaped_command_line = parse_util_escape_wildcards(*command_line.text());
+                insert_string(pager.search_field_line(), escaped_command_line);
             } else {
                 // If we have an actual history search already going, reuse that term
                 // - this is if the user looks around a bit and decides to switch to the pager.

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1204,7 +1204,7 @@ void reader_data_t::fill_history_pager(history_pager_invocation_t why,
             }
             shared_this->pager.set_extra_progress_text(
                 result.have_more_results ? _(L"Search again for more results") : L"");
-            shared_this->pager.set_completions(*result.matched_commands);
+            shared_this->pager.set_completions(*result.matched_commands, false);
             if (why == history_pager_invocation_t::Refresh) {
                 pager.set_selected_completion_index(*old_pager_index);
                 pager_selection_changed();
@@ -2285,7 +2285,7 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
 
     // Update the pager data.
     pager.set_prefix(prefix, true);
-    pager.set_completions(surviving_completions);
+    pager.set_completions(surviving_completions, true);
     // Modify the command line to reflect the new pager.
     pager_selection_changed();
     return false;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1202,7 +1202,6 @@ void reader_data_t::fill_history_pager(history_pager_invocation_t why,
                 shared_this->history_pager_history_index_start = index;
                 shared_this->history_pager_history_index_end = result.final_index;
             }
-            shared_this->pager.disable_refilter(); // skip extra filtering through pager's search field.
             shared_this->pager.set_extra_progress_text(
                 result.have_more_results ? _(L"Search again for more results") : L"");
             shared_this->pager.set_completions(*result.matched_commands);
@@ -2286,7 +2285,6 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
 
     // Update the pager data.
     pager.set_prefix(prefix, true);
-    pager.enable_refilter();
     pager.set_completions(surviving_completions);
     // Modify the command line to reflect the new pager.
     pager_selection_changed();

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1202,6 +1202,7 @@ void reader_data_t::fill_history_pager(history_pager_invocation_t why,
                 shared_this->history_pager_history_index_start = index;
                 shared_this->history_pager_history_index_end = result.final_index;
             }
+            shared_this->pager.disable_refilter(); // skip extra filtering through pager's search field.
             shared_this->pager.set_extra_progress_text(
                 result.have_more_results ? _(L"Search again for more results") : L"");
             shared_this->pager.set_completions(*result.matched_commands);
@@ -2285,6 +2286,7 @@ bool reader_data_t::handle_completions(const completion_list_t &comp, size_t tok
 
     // Update the pager data.
     pager.set_prefix(prefix, true);
+    pager.enable_refilter();
     pager.set_completions(surviving_completions);
     // Modify the command line to reflect the new pager.
     pager_selection_changed();

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1136,17 +1136,11 @@ static history_pager_result_t history_pager_search(const HistorySharedPtr &histo
     size_t page_size = std::max(termsize_last().height / 2 - 2, (rust::isize)12);
 
     rust::Box<completion_list_t> completions = new_completion_list();
+
     rust::Box<HistorySearch> search =
-        rust_history_search_new(history, search_string.c_str(), history_search_type_t::Contains,
+        rust_history_search_new(history, search_string.c_str(), history_search_type_t::ContainsGlob,
                                 smartcase_flags(search_string), history_index);
     bool next_match_found = search->go_to_next_match(direction);
-    if (!next_match_found) {
-        // If there were no matches, try again with subsequence search
-        search = rust_history_search_new(history, search_string.c_str(),
-                                         history_search_type_t::ContainsSubsequence,
-                                         smartcase_flags(search_string), history_index);
-        next_match_found = search->go_to_next_match(direction);
-    }
     while (completions->size() < page_size && next_match_found) {
         const history_item_t &item = search->current_item();
         completions->push_back(*new_completion_with(


### PR DESCRIPTION
## Description

I made an attempt to implement the feature described in #10131 to support search pattern in history-pager. From my limited manual testing it works as expected for me.

Now the question becomes whether or not we really want this feature, at all? Or if we do want this feature, should it be promoted to the default (or the only) behavior, or gated through feature flag, or a fish variable? I'm happy to try implement either one of the options.

Fixes issue #10131.

## TODOs:

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

