### PR TITLE
fix deno task completion for jsonc

### DIFF
--- a/share/completions/deno.fish
+++ b/share/completions/deno.fish
@@ -1,20 +1,4 @@
 deno completions fish | source
 
 # complete deno task
-set searchForDenoFilesCode '
-import * as JSONC from "https://deno.land/std@0.208.0/jsonc/mod.ts";
-// order matters
-const denoFile = ["deno.json", "deno.jsonc", "package.json"];
-for (const file of denoFile) {
-  try {
-    Deno.statSync(file);
-    // file exists
-    const props = file === "package.json" ? "scripts" : "tasks";
-    console.log(
-      Object.keys(JSONC.parse(Deno.readTextFileSync(file))[props]).join("\n"),
-    );
-    break;
-  } catch {}
-}
-'
-complete -f -c deno -n "__fish_seen_subcommand_from task" -n "__fish_is_nth_token 2" -a "(deno eval '$searchForDenoFilesCode')"
+complete -f -c deno -n "__fish_seen_subcommand_from task" -n "__fish_is_nth_token 2" -a "(NO_COLOR=1 deno task &| string match -rg '^- (\S*)')"

--- a/share/completions/deno.fish
+++ b/share/completions/deno.fish
@@ -2,6 +2,7 @@ deno completions fish | source
 
 # complete deno task
 set searchForDenoFilesCode '
+import * as JSONC from "https://deno.land/std@0.208.0/jsonc/mod.ts";
 // order matters
 const denoFile = ["deno.json", "deno.jsonc", "package.json"];
 for (const file of denoFile) {
@@ -10,7 +11,7 @@ for (const file of denoFile) {
     // file exists
     const props = file === "package.json" ? "scripts" : "tasks";
     console.log(
-      Object.keys(JSON.parse(Deno.readTextFileSync(file))[props]).join("\n"),
+      Object.keys(JSONC.parse(Deno.readTextFileSync(file))[props]).join("\n"),
     );
     break;
   } catch {}


### PR DESCRIPTION
The JSON parse doesn't work for jsonc files that actually contains comments (with //) , this fixes it by using jsonc parser from deno std.