### PR TITLE
completions: Add object files to ninja completions

### DIFF
--- a/share/completions/ninja.fish
+++ b/share/completions/ninja.fish
@@ -13,6 +13,7 @@ end
 
 function __fish_print_ninja_targets
     __fish_ninja -t targets 2>/dev/null | string replace -r ':.*' ''
+    __fish_ninja -t targets all 2>/dev/null | string replace -r ':.*' '' | string match -e -r '\.(?:o|so|a)$'
 end
 complete -c ninja -f -a '(__fish_print_ninja_targets)' -d target
 complete -x -c ninja -s t -x -a "(__fish_print_ninja_tools)" -d subtool


### PR DESCRIPTION
## Description

When working on a C or C++ projects, it is often handy to compile a single file (e.g. large refactoring where many files fail to compile so compiling a single file results in less compiler errors making the compiler output significantly easier to read and navigate). Current completion offers only ninja targets which are usually just top level binaries. This commit makes object files and library files offer in the ninja completion.

The change is inspired by the [zsh ninja completion](https://github.com/zchee/zsh-completions/blob/c828f06e08ba96c0cf2fc626bb62be932ea112ab/src/zsh/_ninja#L30), but aims to reduce noise by only matching for entries ending in ".o", ".so" or ".a".

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
