### PR TITLE
Use `fish_color_at` to decide the colour of the @ (if present) in the prompt

### DIFF
--- a/share/functions/prompt_login.fish
+++ b/share/functions/prompt_login.fish
@@ -24,5 +24,5 @@ function prompt_login --description "display user name for the prompt"
         set color_host $fish_color_host_remote
     end
 
-    echo -n -s (set_color $fish_color_user) "$USER" (set_color normal) @ (set_color $color_host) (prompt_hostname) (set_color normal)
+    echo -n -s (set_color $fish_color_user) "$USER" (set_color $fish_color_at) @ (set_color $color_host) (prompt_hostname) (set_color normal)
 end

--- a/share/tools/web_config/themes/fish default.theme
+++ b/share/tools/web_config/themes/fish default.theme
@@ -33,3 +33,4 @@ fish_color_option cyan
 fish_color_keyword blue
 fish_color_host_remote yellow
 fish_color_status red
+fish_color_at normal

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -1489,6 +1489,7 @@ class FishConfigHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                     "fish_color_autosuggestion",
                     "fish_color_cwd",
                     "fish_color_user",
+                    "fish_color_at",
                     "fish_color_host",
                     "fish_color_host_remote",
                     "fish_color_cancel",


### PR DESCRIPTION
## Description

As discussed [here](https://github.com/fish-shell/fish-shell/issues/7186), you can't easily change the colour of the `@` in the prompt (if present).

This draft proposes a fix.

## TODOs:

- [ ] Discuss if this is the correct way to do it.
- [ ] Update all themes, adding `fish_color_at=normal`, so that they all render the same if the user doesn't specify.
- [ ] Do something similar for any trailing prompt character? (in the linked issue, the user can't change the colour of the `>`)