### PR TITLE
feat: adb completion cleared of awk

### DIFF
--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -74,7 +74,7 @@ function __fish_adb_list_files
     end
 
     # Return list of directories suffixed with '/'
-    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type d 2\>/dev/null | awk '{print $0"/"}'
+    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type d 2\>/dev/null | string -r '$' /
     # Return list of files
     __fish_adb_run_command find -H "$token*" -maxdepth 0 -type f 2\>/dev/null
 end


### PR DESCRIPTION
Ticks off adb in awk list in issue #6520

The latest available package on Archlinux also still doesn't have fixed `$1` to `$0` in the `awk command` that was replaced. It's fixed here already though, so I tried to make a small step forward in some other issue in hope for the next release to ship that adb completion fixed.