### PR TITLE
Log original exit code used when a builtin returns a negative exit code

### DIFF
--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -475,13 +475,13 @@ proc_status_t builtin_run(parser_t &parser, const wcstring_list_t &argv, io_stre
             return proc_status_t::empty();
         }
         if (code < 0) {
+            FLOGF(warning, "builtin %ls returned invalid exit code %d", cmdname.c_str(), code);
             // If the code is below 0, constructing a proc_status_t
             // would assert() out, which is a terrible failure mode
             // So instead, what we do is we get a positive code,
             // and we avoid 0.
             code = abs((256 + code) % 256);
             if (code == 0) code = 255;
-            FLOGF(warning, "builtin %ls returned invalid exit code %d", cmdname.c_str(), code);
         }
         return proc_status_t::from_exit_code(code);
     }

--- a/tests/checks/status-value.fish
+++ b/tests/checks/status-value.fish
@@ -26,22 +26,22 @@ echo $status
 # CHECKERR:      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 
 $fish -c 'exit -5'
-# CHECKERR: warning: builtin exit returned invalid exit code 251
+# CHECKERR: warning: builtin exit returned invalid exit code -5
 echo $status
 # CHECK: 251
 
 $fish -c 'exit -1'
-# CHECKERR: warning: builtin exit returned invalid exit code 255
+# CHECKERR: warning: builtin exit returned invalid exit code -1
 echo $status
 # CHECK: 255
 
 # (we avoid 0, so this is turned into 255 again)
 $fish -c 'exit -256'
-# CHECKERR: warning: builtin exit returned invalid exit code 255
+# CHECKERR: warning: builtin exit returned invalid exit code -256
 echo $status
 # CHECK: 255
 
 $fish -c 'exit -512'
-# CHECKERR: warning: builtin exit returned invalid exit code 255
+# CHECKERR: warning: builtin exit returned invalid exit code -512
 echo $status
 # CHECK: 255


### PR DESCRIPTION
## Description

In fish 3.7.0 executing `exit` with a negative argument results in:
```
$ fish -c 'exit -123'
warning: builtin exit returned invalid exit code 133
```

It would make more sense if the error was:
```
$ fish -c 'exit -123'
warning: builtin exit returned invalid exit code -123
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
