### PR TITLE
Move from errno crate to nix errno

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ printf-compat = { git = "https://github.com/fish-shell/printf-compat.git", branc
 autocxx = "0.23.1"
 bitflags = "2.4.0"
 cxx = "1.0"
-errno = "0.2.8"
+_errno = { package="errno", version = "0.2.8" }
 lazy_static = "1.4.0"
 libc = "0.2.137"
 lru = "0.10.0"

--- a/fish-rust/src/builtins/pwd.rs
+++ b/fish-rust/src/builtins/pwd.rs
@@ -1,5 +1,5 @@
 //! Implementation of the pwd builtin.
-use errno::errno;
+use nix::errno::Errno;
 
 use super::prelude::*;
 use crate::{env::Environment, wutil::wrealpath};
@@ -51,7 +51,7 @@ pub fn pwd(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opti
             streams.err.append(wgettext_fmt!(
                 "%ls: realpath failed: %s\n",
                 cmd,
-                errno().to_string()
+                Errno::last().desc()
             ));
             return STATUS_CMD_ERROR;
         }

--- a/fish-rust/src/builtins/shared.rs
+++ b/fish-rust/src/builtins/shared.rs
@@ -9,8 +9,8 @@ use crate::proc::{no_exec, ProcStatus};
 use crate::reader::reader_read;
 use crate::wchar::{wstr, WString, L};
 use crate::wgetopt::{wgetopter_t, wopt, woption, woption_argument_t};
-use errno::errno;
 use libc::{c_int, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
+use nix::errno::Errno;
 
 use std::borrow::Cow;
 use std::fs::File;
@@ -638,11 +638,11 @@ pub fn builtin_print_error_trailer(parser: &Parser, b: &mut OutputStream, cmd: &
 /// This function works like perror, but it prints its result into the streams.err string instead
 /// to stderr. Used by the builtin commands.
 pub fn builtin_wperror(program_name: &wstr, streams: &mut IoStreams) {
-    let err = errno();
+    let err = Errno::last();
     streams.err.append(program_name);
     streams.err.append(L!(": "));
-    if err.0 != 0 {
-        let werr = WString::from_str(&err.to_string());
+    if err != Errno::from_i32(0) {
+        let werr = WString::from_str(&err.desc());
         streams.err.append(werr);
         streams.err.push('\n');
     }

--- a/fish-rust/src/fork_exec/spawn.rs
+++ b/fish-rust/src/fork_exec/spawn.rs
@@ -5,8 +5,8 @@ use crate::exec::is_thompson_shell_script;
 use crate::proc::Job;
 use crate::redirection::Dup2List;
 use crate::signal::get_signals_with_handlers;
-use errno::{self, Errno};
 use libc::{self, c_char, posix_spawn_file_actions_t, posix_spawnattr_t};
+use nix::errno::Errno;
 use std::ffi::{CStr, CString};
 
 // The posix_spawn family of functions is unusual in that it returns errno codes directly in the return value, not via errno.
@@ -14,7 +14,7 @@ use std::ffi::{CStr, CString};
 fn check_fail(res: i32) -> Result<(), Errno> {
     match res {
         0 => Ok(()),
-        err => Err(Errno(err)),
+        err => Err(Errno::from_i32(err)),
     }
 }
 
@@ -181,7 +181,7 @@ impl PosixSpawner {
         // after performing a binary safety check, recommended by POSIX: a
         // line needs to exist before the first \0 with a lowercase letter.
         let cmdcstr = unsafe { CStr::from_ptr(cmd) };
-        if spawn_err.0 == libc::ENOEXEC && is_thompson_shell_script(cmdcstr) {
+        if spawn_err == Errno::ENOEXEC && is_thompson_shell_script(cmdcstr) {
             // Create a new argv with /bin/sh prepended.
             let interp = get_path_bshell();
             let mut argv2 = vec![interp.as_ptr() as *mut c_char];

--- a/fish-rust/src/history.rs
+++ b/fish-rust/src/history.rs
@@ -36,6 +36,7 @@ use libc::{
     O_RDONLY, O_WRONLY, SEEK_SET,
 };
 use lru::LruCache;
+use nix::errno::Errno;
 use rand::Rng;
 use widestring_suffix::widestrs;
 
@@ -718,7 +719,7 @@ impl HistoryImpl {
                     FLOGF!(
                         history_file,
                         "Error %d when truncating temporary history file",
-                        errno::errno().0
+                        Errno::last() as i32,
                     );
                 }
             } else {
@@ -738,14 +739,14 @@ impl HistoryImpl {
                         FLOGF!(
                             history_file,
                             "Error %d when changing ownership of history file",
-                            errno::errno().0
+                            Errno::last() as i32,
                         );
                     }
                     if unsafe { fchmod(tmp_fd, sbuf.st_mode) } == -1 {
                         FLOGF!(
                             history_file,
                             "Error %d when changing mode of history file",
-                            errno::errno().0,
+                            Errno::last() as i32,
                         );
                     }
                 }
@@ -754,10 +755,7 @@ impl HistoryImpl {
                 if wrename(&tmp_name, &target_name) == -1 {
                     FLOG!(
                         error,
-                        wgettext_fmt!(
-                            "Error when renaming history file: %s",
-                            errno::errno().to_string()
-                        )
+                        wgettext_fmt!("Error when renaming history file: %s", Errno::last().desc())
                     );
                 }
 

--- a/fish-rust/src/history/file.rs
+++ b/fish-rust/src/history/file.rs
@@ -7,11 +7,11 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use errno::errno;
 use libc::{
-    c_void, lseek, mmap, munmap, EINTR, MAP_ANONYMOUS, MAP_FAILED, MAP_PRIVATE, PROT_READ,
-    PROT_WRITE, SEEK_END, SEEK_SET,
+    c_void, lseek, mmap, munmap, MAP_ANONYMOUS, MAP_FAILED, MAP_PRIVATE, PROT_READ, PROT_WRITE,
+    SEEK_END, SEEK_SET,
 };
+use nix::errno::Errno;
 
 use super::{HistoryItem, PersistenceMode};
 use crate::{
@@ -237,7 +237,7 @@ fn read_from_fd(fd: RawFd, dest: &mut [u8]) -> bool {
         let amt =
             unsafe { libc::read(fd, (&mut dest[nread]) as *mut u8 as *mut c_void, remaining) };
         if amt < 0 {
-            if errno().0 != EINTR {
+            if Errno::last() != Errno::EINTR {
                 return false;
             }
         } else if amt == 0 {

--- a/fish-rust/src/input.rs
+++ b/fish-rust/src/input.rs
@@ -11,12 +11,13 @@ use crate::proc::job_reap;
 use crate::reader::{
     reader_reading_interrupted, reader_reset_interrupted, reader_schedule_prompt_repaint,
 };
+use crate::set_errno;
 use crate::signal::signal_clear_cancel;
 #[cfg(test)]
 use crate::tests::prelude::*;
 use crate::threads::assert_is_main_thread;
 use crate::wchar::prelude::*;
-use errno::{set_errno, Errno};
+use nix::errno::Errno;
 use once_cell::sync::{Lazy, OnceCell};
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -1136,7 +1137,7 @@ pub fn input_terminfo_get_sequence(name: &wstr, out_seq: &mut WString) -> bool {
         if name == m.name {
             // Found the mapping.
             if m.seq.is_none() {
-                set_errno(Errno(libc::EILSEQ));
+                set_errno(Errno::EILSEQ);
                 return false;
             } else {
                 *out_seq = str2wcstring(m.seq.as_ref().unwrap());
@@ -1144,7 +1145,7 @@ pub fn input_terminfo_get_sequence(name: &wstr, out_seq: &mut WString) -> bool {
             }
         }
     }
-    set_errno(Errno(libc::ENOENT));
+    set_errno(Errno::ENOENT);
     false
 }
 

--- a/fish-rust/src/input_common.rs
+++ b/fish-rust/src/input_common.rs
@@ -8,6 +8,7 @@ use crate::universal_notifier::default_notifier;
 use crate::wchar::prelude::*;
 use crate::wutil::encoding::{mbrtowc, zero_mbstate};
 use crate::wutil::fish_wcstol;
+use nix::errno::Errno;
 use std::collections::VecDeque;
 use std::os::fd::RawFd;
 use std::ptr;
@@ -272,8 +273,8 @@ fn readb(in_fd: RawFd) -> ReadbResult {
         // Here's where we call select().
         let select_res = fdset.check_readable(FdReadableSet::kNoTimeout);
         if select_res < 0 {
-            let err = errno::errno().0;
-            if err == libc::EINTR || err == libc::EAGAIN {
+            let err = Errno::last();
+            if err == Errno::EINTR || err == Errno::EAGAIN {
                 // A signal.
                 return ReadbResult::Interrupted;
             } else {

--- a/fish-rust/src/lib.rs
+++ b/fish-rust/src/lib.rs
@@ -111,3 +111,9 @@ mod wutil;
 #[cfg(test)]
 #[allow(unused_imports)] // Easy way to suppress warnings while we have two testing modes.
 mod tests;
+
+// TODO: Remove once nix is updated to include set_errno
+// https://github.com/nix-rust/nix/pull/2283
+fn set_errno(errno: ::nix::errno::Errno) {
+    ::errno::set_errno(::errno::Errno(errno as i32))
+}

--- a/fish-rust/src/lib.rs
+++ b/fish-rust/src/lib.rs
@@ -115,5 +115,5 @@ mod tests;
 // TODO: Remove once nix is updated to include set_errno
 // https://github.com/nix-rust/nix/pull/2283
 fn set_errno(errno: ::nix::errno::Errno) {
-    ::errno::set_errno(::errno::Errno(errno as i32))
+    ::_errno::set_errno(::_errno::Errno(errno as i32))
 }

--- a/fish-rust/src/parse_execution.rs
+++ b/fish-rust/src/parse_execution.rs
@@ -797,7 +797,7 @@ impl<'a> ParseExecutionContext {
                             &external_cmd.path
                         },
                         statement,
-                        std::io::Error::from_raw_os_error(external_cmd.err.unwrap().into()),
+                        std::io::Error::from(external_cmd.err.unwrap()),
                     );
                 }
             };

--- a/fish-rust/src/signal.rs
+++ b/fish-rust/src/signal.rs
@@ -4,11 +4,12 @@ use crate::common::{exit_without_destructors, restore_term_foreground_process_gr
 use crate::event::{enqueue_signal, is_signal_observed};
 use crate::nix::getpid;
 use crate::reader::{reader_handle_sigint, reader_sighup};
+use crate::set_errno;
 use crate::termsize::TermsizeContainer;
 use crate::topic_monitor::{generation_t, topic_monitor_principal, topic_t, GenerationsList};
 use crate::wchar::prelude::*;
 use crate::wutil::{fish_wcstoi, perror};
-use errno::{errno, set_errno};
+use nix::errno::Errno;
 use std::sync::atomic::{AtomicI32, Ordering};
 
 /// Store the "main" pid. This allows us to reliably determine if we are in a forked child.
@@ -57,7 +58,7 @@ extern "C" fn fish_signal_handler(
     _context: *mut libc::c_void,
 ) {
     // Ensure we preserve errno.
-    let saved_errno = errno();
+    let saved_errno = Errno::last();
 
     // Check if we are a forked child.
     if reraise_if_forked_child(sig) {

--- a/fish-rust/src/threads.rs
+++ b/fish-rust/src/threads.rs
@@ -3,6 +3,7 @@
 
 use crate::flog::{FloggableDebug, FLOG};
 use crate::reader::ReaderData;
+use nix::errno::Errno;
 use once_cell::race::OnceBox;
 use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -77,7 +78,7 @@ pub fn init() {
     }
     unsafe {
         let result = libc::pthread_atfork(None, None, Some(child_post_fork));
-        assert_eq!(result, 0, "pthread_atfork() failure: {}", errno::errno());
+        assert_eq!(result, 0, "pthread_atfork() failure: {}", Errno::last());
     }
 
     IO_THREAD_POOL

--- a/fish-rust/src/wutil/gettext.rs
+++ b/fish-rust/src/wutil/gettext.rs
@@ -8,10 +8,11 @@ use std::sync::Mutex;
 use crate::common::{charptr2wcstring, wcs2zstring};
 use crate::ffi::wchar_t;
 use crate::fish::PACKAGE_NAME;
+use crate::set_errno;
 #[cfg(test)]
 use crate::tests::prelude::*;
 use crate::wchar::prelude::*;
-use errno::{errno, set_errno};
+use nix::errno::Errno;
 use once_cell::sync::{Lazy, OnceCell};
 use widestring::U32CString;
 
@@ -72,7 +73,7 @@ fn wgettext_init_if_necessary() {
 pub fn wgettext_impl_do_not_use_directly(text: Cow<'static, [wchar_t]>) -> &'static wstr {
     assert_eq!(text.last(), Some(&0), "should be nul-terminated");
     // Preserve errno across this since this is often used in printing error messages.
-    let err = errno();
+    let err = Errno::last();
 
     wgettext_init_if_necessary();
     #[allow(clippy::type_complexity)]


### PR DESCRIPTION
## Description

`nix` crate already has rusty errno API backed in, without a need for any additional feature flags, so there is no need to depend on extra crate for that.

There was no way to set errno via `nix`, but I [submitted a patch for that already](https://github.com/nix-rust/nix/pull/2283), once it lands `errno` crate can be removed all together just by swapping set functions.
In the meantime I used a small wrapper for setting the errnos, just to make this mergable if you wish to.

Not sure if those sorts of changes are even wanted, but yeah I guess I'm asking after the fact :smile: 

If using more of nix is welcome, then let me know if enabling more of its feature flags like `fs`/`signals`/`user` is also fine, as I'd love to work on porting more stuff from raw libc calls to nix equivalents in the future. (obviously that would be in smaller, more review friendly portions)
