### PR TITLE
Fix crash when running ELF w/ interpreter missing

### DIFF
--- a/src/postfork.cpp
+++ b/src/postfork.cpp
@@ -463,7 +463,7 @@ void safe_report_exec_error(int err, const char *actual_cmd, const char *const *
             const char *interpreter =
                 get_interpreter(actual_cmd, interpreter_buff, sizeof interpreter_buff);
             struct stat buf;
-            auto statret = stat(interpreter, &buf);
+            auto statret = !interpreter || stat(interpreter, &buf);
             if (interpreter && (0 != statret || access(interpreter, X_OK))) {
                 // Detect Windows line endings and complain specifically about them.
                 auto len = strlen(interpreter);


### PR DESCRIPTION
## Description

The function `stat` as defined in `include/x86_64-linux-gnu/sys/stat.h` marks its arguments as nonnull as in below. This UB causes crash in release builds with variable `interpreter` assumed to be nonnull. Along with failing `stat` returning nonzero value, this ultimately causes `strlen` to be called with NULL as argument. This PR fixes the problem by prefixing `stat` call with a check to avoid calling it with NULL argument.

Definition of `stat`:
```c
extern int stat (const char *__restrict __file,
		 struct stat *__restrict __buf) __THROW __nonnull ((1, 2));
```
Reproduce:
```fish
> # interp.c is any vaild single file C source
> gcc ./interp.c -Wl,--dynamic-linker=/bad -o interp
> echo './interp' > in.txt
> ./fish < in.txt
'./fish < in.txt' terminated by signal SIGSEGV (Address boundary error)
```

Problem identified and fixed together with @moodyhunter

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
  - No change to usage
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
  - No user-visible change