### PR TITLE
doc_src: add print media support to the Sphinx theme

### DIFF
--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -611,6 +611,68 @@ div.documentwrapper {
     }
 }
 
+/* On print media remove anything non-essential. */
+@media print {
+    .inline-search {
+        display: none;
+    }
+
+    div.sphinxsidebar {
+        display: none;
+    }
+
+    div.bodywrapper {
+        margin-left: 0;
+    }
+
+    div.sphinxsidebar ul {
+        flex-basis: content;
+        flex-wrap: wrap;
+    }
+
+    div.sphinxsidebarwrapper {
+        display: flex;
+    }
+
+    div#searchbox {
+        display: none !important;
+    }
+
+    div.body {
+        padding: 1rem;
+    }
+
+    div#fmain {
+        border-radius: 0px;
+        margin: 0;
+        box-shadow: 0;
+        width: 100%;
+        padding: 0;
+        /* We have some padding/margins that would overflow - just remove it */
+        overflow: clip;
+    }
+
+    div.footer {
+        margin: 0;
+    }
+
+    /* Avoid splitting code blocks across multiple pages. */
+    pre {
+        page-break-inside: avoid;
+    }
+
+    /* Show section numbers. */
+    .body {
+        counter-reset: section;
+    }
+
+    h2::before {
+        counter-increment: section;
+        content: counter(section) ". ";
+        font-weight: normal;
+    }
+}
+
 .sphinxsidebar ul.current > li.current { font-weight: bold }
 
 .gray { color: #777 }


### PR DESCRIPTION
## Description

Update the pydoctheme.css file to add support for print media.

The code was adapted from the existing support for screens that are less than 700px wide, with the following changes:

  - Remove the documents and sections index
  - Remove the quick search
  - Remove dead CSS code

Additionally, add section numbers and ensure that code blocks are never split across multiple pages.

Since it is now possible to generate good PDF documents using the browser, maybe #5063 can be closed.  This PR **does not** close it.

## NOTES

While reading the existing code I found that:
  - The `div.content` selector does not match any element
  - The `div.sphinxsidebarwrapper > h3:nth-child(5)` also seems to be dead code

I checked the generated files, and I'm quite sure (but not 100%).

