### PR TITLE
Support command for jumping to word location based on key

### DIFF
--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -111,6 +111,7 @@ pub enum ReadlineCmd {
     DisableMouseTracking,
     // ncurses uses the obvious name
     ClearScreenAndRepaint,
+    MoveJumpAnchor,
     // NOTE: This one has to be last.
     ReverseRepeatJump,
 }


### PR DESCRIPTION
## Description

I have added a command that can be used to jump to a word in the command line. Each word is represented with a letter and pressing that letter jumps to that word. It can also be combined with visual mode to select to that word.  I have made a quick video outlining its operation.

[recording.webm](https://github.com/fish-shell/fish-shell/assets/60908/601b34d7-7061-46ab-bb66-e90a73740635)

I have implemented something similar for my fork of the helix editor (it uses partly the same code and is available on my github account)  and used it for a few moths now. I find it very useful instead of using vim like find to command when the character in question is repeated (like the / in paths).

I am adding this pull request as a start of a discussion on how to implement this and I am open to adapting it more to match the architecture of the reader subsystem of fish if necessary.

I use the following fish config with the command (since i use colemak the default variables are set up for that, but I have tried to make a qwerty variant for users of less esoteric keyboard layouts)

```
set fish_jump_anchors_before 'tsradpfwvcxgqbz54321TSRADPFWVCXGQBZ!@#$%'
set fish_jump_anchors_after 'neiohluym,.kj;09876NEIOHLUYM<?KJ:^&*()'
set fish_jump_anchors_before_qwerty 'fdsagrewcxztqvz54321FDSAGREWCXZTQVZ%$#@!'
set fish_jump_anchors_after_qwerty 'jkl;hoiu.,mpyn/09876-=JKL:HOIU><MPYN)(*&^_+'

bind -M default \co 'move-jump-anchor'
bind -M insert \co 'move-jump-anchor'
bind -M visual \co 'move-jump-anchor'
bind \co 'move-jump-anchor'
```

I can help adding documentation and changelog once I know that this is something that is found worthwhile and that the shape of the feature won't change too much.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
- [ ] 


