### PR TITLE
Cache sourced completions

### DIFF
--- a/share/completions/pip.fish
+++ b/share/completions/pip.fish
@@ -1,1 +1,2 @@
-pip completion --fish 2>/dev/null | source
+__fish_cache_sourced_completions pip completion --fish 2>/dev/null
+or pip completion --fish 2>/dev/null | source

--- a/share/completions/pip2.fish
+++ b/share/completions/pip2.fish
@@ -1,5 +1,2 @@
-# pip[2|3] emits (or emitted) completions with the wrong command name
-# See discussion at https://github.com/fish-shell/fish-shell/pull/4448
-# and pip bug at https://github.com/pypa/pip/pull/4755
-# Keep this even after pip fix is upstreamed for users not on the latest pip
-pip2 completion --fish 2>/dev/null | string replace -r -- " -c\s+pip\b" " -c pip2" | source
+__fish_cache_sourced_completions pip2 completion --fish 2>/dev/null
+or pip2 completion --fish 2>/dev/null | source

--- a/share/completions/pip3.fish
+++ b/share/completions/pip3.fish
@@ -1,5 +1,2 @@
-# pip[2|3] emits (or emitted) completions with the wrong command name
-# See discussion at https://github.com/fish-shell/fish-shell/pull/4448
-# and pip bug at https://github.com/pypa/pip/pull/4755
-# Keep this even after pip fix is upstreamed for users not on the latest pip
-pip3 completion --fish 2>/dev/null | string replace -r -- " -c\s+pip\b" " -c pip3" | source
+__fish_cache_sourced_completions pip3 completion --fish 2>/dev/null
+or pip3 completion --fish 2>/dev/null | source

--- a/share/completions/pipenv.fish
+++ b/share/completions/pipenv.fish
@@ -1,12 +1,5 @@
-# try new completion generation of click first
-set -l comps (_PIPENV_COMPLETE=fish_source pipenv 2>/dev/null)
-if test -z "$comps" || string match -q 'Usage:*' -- $comps
-    # fall back to older click-completion used in prior versions
-    set comps (_PIPENV_COMPLETE=source-fish pipenv --completion 2>/dev/null)
-end
-
-set -q comps[1] && printf %s\n $comps | source
-
+_PIPENV_COMPLETE=fish_source __fish_cache_sourced_completions pipenv 2>/dev/null
+or _PIPENV_COMPLETE=fish_source pipenv 2>/dev/null | source
 
 # manual workaround for pipenv run command completion until this is supported by the built-in mechanism
 complete -c pipenv -n "__fish_seen_subcommand_from run" -a "(__fish_complete_subcommand --fcs-skip=2)" -x

--- a/share/completions/ykman.fish
+++ b/share/completions/ykman.fish
@@ -1,1 +1,2 @@
-_YKMAN_COMPLETE=fish_source ykman | source
+_YKMAN_COMPLETE=fish_source __fish_cache_sourced_completions ykman
+or _YKMAN_COMPLETE=fish_source ykman | source

--- a/share/functions/__fish_cache_sourced_completions.fish
+++ b/share/functions/__fish_cache_sourced_completions.fish
@@ -1,0 +1,45 @@
+function __fish_cache_sourced_completions
+    # Allow a `--name=foo` option which ends up in the filename.
+    argparse -s name= -- $argv
+    or return
+
+    set -q argv[1]
+    or return 1
+    
+    set -l cmd (command -s $argv[1])
+    or begin
+        # If we have no command, we can't get an mtime
+        # and so we can't cache
+        # The caller can more easily retry
+        return 127
+    end
+
+    set -l cachedir (__fish_make_cache_dir completions)
+    or return
+
+    set -l stampfile $cachedir/$argv[1].stamp
+    set -l compfile $cachedir/$argv[1].fish
+
+    set -l mtime (path mtime -- $cmd)
+
+    set -l cmtime 0
+    path is -rf -- $stampfile
+    and read cmtime < $stampfile
+
+    # If either the timestamp or the completion file don't exist,
+    # or the mtime differs, we rerun.
+    #
+    # That means we'll rerun if the command was up- or downgraded.
+    if path is -vrf -- $stampfile $compfile || test "$cmtime" -ne "$mtime" 2>/dev/null
+        $argv > $compfile
+        # If the command exited unsuccessfully, we assume it didn't work.
+        or return 2
+        echo -- $mtime > $stampfile
+    end
+
+    if path is -rf -- $compfile
+        source $compfile
+        return 0
+    end
+    return 3
+end

--- a/share/functions/__fish_make_cache_dir.fish
+++ b/share/functions/__fish_make_cache_dir.fish
@@ -3,6 +3,10 @@ function __fish_make_cache_dir --description "Create and return XDG_CACHE_HOME"
     if test -z "$xdg_cache_home"; or string match -qv '/*' -- $xdg_cache_home; or set -q xdg_cache_home[2]
         set xdg_cache_home $HOME/.cache
     end
-    mkdir -m 700 -p $xdg_cache_home
-    and echo $xdg_cache_home
+
+    # If we get an argument, we try to create that as a subdirectory.
+    # So if you call `__fish_make_cache_dir completions`,
+    # this creates e.g. ~/.cache/fish/completions
+    mkdir -m 700 -p $xdg_cache_home/fish/"$argv[1]"
+    and echo $xdg_cache_home/fish/"$argv[1]"
 end

--- a/share/functions/__fish_print_eopkg_packages.fish
+++ b/share/functions/__fish_print_eopkg_packages.fish
@@ -11,7 +11,7 @@ function __fish_print_eopkg_packages
     # Determine whether to print installed/available packages
 
     if set -q _flag_installed
-        set -l cache_file $xdg_cache_home/.eopkg-installed-cache.$USER
+        set -l cache_file $xdg_cache_home/eopkg-installed
         if test -f $cache_file
             cat $cache_file
             set -l age (path mtime -R -- $cache_file)
@@ -25,7 +25,7 @@ function __fish_print_eopkg_packages
         eopkg list-installed -N | cut -d ' ' -f 1 >$cache_file &
         return 0
     else
-        set -l cache_file $xdg_cache_home/.eopkg-available-cache.$USER
+        set -l cache_file $xdg_cache_home/eopkg-available
         if test -f $cache_file
             cat $cache_file
             set -l age (path mtime -R -- $cache_file)

--- a/share/functions/__fish_print_pacman_packages.fish
+++ b/share/functions/__fish_print_pacman_packages.fish
@@ -9,7 +9,7 @@ function __fish_print_pacman_packages
     or return
 
     if not set -q _flag_installed
-        set -l cache_file $xdg_cache_home/.pac-cache.$USER
+        set -l cache_file $xdg_cache_home/pacman
         if test -f $cache_file
             cat $cache_file
             set -l age (path mtime -R -- $cache_file)

--- a/share/functions/__fish_print_port_packages.fish
+++ b/share/functions/__fish_print_port_packages.fish
@@ -5,7 +5,7 @@ function __fish_print_port_packages
     set -l xdg_cache_home (__fish_make_cache_dir)
     or return
 
-    set -l cache_file $xdg_cache_home/.port-cache.$USER
+    set -l cache_file $xdg_cache_home/port
     if test -f $cache_file
         cat $cache_file
         set -l age (path mtime -R -- $cache_file)

--- a/share/functions/__fish_print_rpm_packages.fish
+++ b/share/functions/__fish_print_rpm_packages.fish
@@ -10,7 +10,7 @@ function __fish_print_rpm_packages
 
     if type -q -f /usr/share/yum-cli/completion-helper.py
         # If the cache is less than six hours old, we do not recalculate it
-        set -l cache_file $xdg_cache_home/.yum-cache.$USER
+        set -l cache_file $xdg_cache_home/yum
         if test -f $cache_file
             cat $cache_file
             set -l age (path mtime -R -- $cache_file)
@@ -29,7 +29,7 @@ function __fish_print_rpm_packages
     # as a background job and cache the results.
     if type -q -f rpm
         # If the cache is less than five minutes old, we do not recalculate it
-        set -l cache_file $xdg_cache_home/.rpm-cache.$USER
+        set -l cache_file $xdg_cache_home/rpm
         if test -f $cache_file
             cat $cache_file
             set -l age (path mtime -R -- $cache_file)

--- a/share/functions/__fish_print_xbps_packages.fish
+++ b/share/functions/__fish_print_xbps_packages.fish
@@ -9,7 +9,7 @@ function __fish_print_xbps_packages
     or return
 
     if not set -q _flag_installed
-        set -l cache_file $xdg_cache_home/.xbps-cache.$USER
+        set -l cache_file $xdg_cache_home/xbps
         if test -f $cache_file
             set -l age (path mtime -R -- $cache_file)
             set -l max_age 300


### PR DESCRIPTION
## Description

We have a lot of completions that look like

```fish
pip completion --fish 2>/dev/null | source
```

That's *fine*, upstream gives us some support.

However, the scripts they provide change very rarely, usually not even every release, and so running them again for every shell is extremely wasteful.

In particular the python tools are very slow, `pip completion --fish` takes about 180ms on my system with a hot cache, which is quite noticeable every time you write "pip" in a fresh shell.

So this does two things:

1. It moves our cache to ~/.cache/fish (insert $XDG_CACHE_HOME as appropriate) and allows easily creating subdirectories
2. It caches these completions by running them once, and storing them in a file in our cache
directory

The first one will also move all pre-existing cached completions - this is basically exclusively package managers, so people will have one awkward hidden file in ~/.cache called something like ".pac-cache.alfa" that is ~300K in size that they'd have to remove. We don't try to because running `rm` like that is iffy.

The second one does cache invalidation via the command's mtime.

We store the mtime of the command we ran, and compare against that for
future runs. If the mtime differs - so if the command was up or
downgraded, we run it again.

But if there is no command, no file to compare mtime to, we can't use the cache.

This PR adopts the cache for all egregious offenders I could find. Mostly those are the python tools - pipenv takes a whopping 320ms on my system just to print 18 lines.

I have tested a lot of the other tools (basically everything I could find in the arch repos), and most are more like ~30ms (starship takes 3ms, deno takes 15ms), in which case the cache is probably better avoided.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [?] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
- [ ] This removes a few old workarounds for pip{,env}. Do we still need them? My research tells me pip's bug was fixed in 2017 and pipenv's behavior changed in 2019. Given that these are packaging tools that do cryptography and such... do we still need these?
- [ ] Do we need to remove the old cache files? Or do we add a note in the release notes? At worst this is ~300K of wasted space.
- [x] We should rename the package manager cache files to be without a "." - `~/.cache/fish/pac-cache` would be fine (tbh they never should have been hidden, this is what .cache is *for*!)
- [ ] Are there any edgecases I did not think through?
- [ ] Alternatively: Do we just ship the output ourselves? This is of course awkward to keep up-to-date and may have licensing issues.