### PR TITLE
commandline: Add "--current-command"

### DIFF
--- a/doc_src/cmds/commandline.rst
+++ b/doc_src/cmds/commandline.rst
@@ -70,6 +70,9 @@ The following options change what part of the commandline is printed or updated:
 **-t** or **--current-token**
     Selects the current token
 
+**-m** or **--current-command**
+    Selects just the command token in the current process, without any decorators like ``exec`` or ``and``, unless they are the only thing in the process. This can be empty if the commandline doesn't currently have one. Note that it is *not* expanded, so e.g. ``$PAGER foo`` has a command of ``$PAGER``.
+
 The following options change the way ``commandline`` prints the current commandline buffer:
 
 **-c** or **--cut-at-cursor**

--- a/tests/checks/commandline.fish
+++ b/tests/checks/commandline.fish
@@ -17,3 +17,15 @@ or echo Invalid $status
 commandline --input 'echo $$' --is-valid
 or echo Invalid $status
 # CHECK: Invalid 1
+
+commandline --input 'echo $$' --current-command
+# CHECK: echo
+
+commandline --input 'foo=bar ' --current-command
+# CHECK:
+
+commandline --input 'boo; and foo=bar git' --current-command
+# CHECK: git
+
+commandline --input 'cat boo | foo=bar less' --current-command
+# CHECK: less

--- a/tests/pexpects/abbrs.py
+++ b/tests/pexpects/abbrs.py
@@ -154,3 +154,21 @@ sendline(r"""abbr LLL --position anywhere --set-cursor=!HERE! '!HERE! | less'"""
 expect_prompt()
 send(r"""echo LLL derp?""")
 expect_str(r"<echo derp | less >")
+
+sendline(r"""
+function abbr_echo_commit
+    test "$(commandline -m)" = echo
+    or return
+    echo commit
+end
+abbr c --position anywhere --function abbr_echo_commit""")
+expect_prompt()
+
+sendline(r"""echo c""")
+expect_prompt("commit")
+
+sendline(r"""true; and builtin echo c; and false""")
+expect_prompt("commit")
+
+sendline(r"""printf '%s\n' c""")
+expect_prompt("c")


### PR DESCRIPTION
This can be used to get the current command, even following decorators like `command` or `exec` or `and`.

That makes it useful e.g. to make abbrs only apply to a specific command.

You can also do `commandline --replace --current-command foo` to change

```
echo bar | git commit
```

to

```
echo bar | foo commit
```

For example, to make an abbreviation expand only for `git` as the command:

```fish
function abbr_git_commit
    test "$(commandline -m)" = git
    or return
    echo commit
end
abbr c --position anywhere --function abbr_git_commit
```

It would still be possible to implement a shortcut for abbr - `abbr --command git c commit`, but this is a nice building block for other things regardless.

We could already claim this handles #9411.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
- [ ] The ast-parsing I added to commandline is mostly duplicated with highlight::autosuggest_parse_command(). We should put it somewhere it can be shared, but I'm not sure where - ast directly?
- [ ] I didn't have this expand the command on purpose, pending #10212. We should follow what happens there (and adjust the docs).
- [ ] I'm not sure I caught all the edge-cases, there's weirdness with foo=bar variable assignments.
