### PR TITLE
Add warning about setting fish as login in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,25 +115,25 @@ The following optional features also have specific requirements:
 Switching to fish
 ~~~~~~~~~~~~~~~~~
 
-If you wish to use fish as your default shell, use the following command, from inside fish:
+If you wish to use fish as your default shell, the simplest method is to set your terminal emulator (eg GNOME Terminal, Apple's Terminal.app, or Konsole) to start fish directly. See its configuration and set the program to start to ``/usr/local/bin/fish`` (if that's where fish is installed - substitute another location as appropriate).
 
-::
+Alternatively, you can set fish as your login shell so that it will be started by all terminal logins, including SSH.
 
-   chsh -s (command -s fish)
+ .. warning::
 
-``chsh`` wants a full path, this will try to find where fish is installed. If that doesn't work, try to pass the path manually - it will usually be ``/usr/local/bin/fish`` if you built from source, or ``/usr/bin/fish`` if you installed a package.
+    Setting fish as your login shell may cause issues, such as an incorrect :envvar:`PATH`. Some operating systems, including a number of Linux distributions, require the login shell to be Bourne-compatible and to read configuration from ``/etc/profile``. fish may not be suitable as a login shell on these systems.
 
-``chsh`` will prompt you for your password and change your default shell. Log out, then log in again for the changes to take effect.
+To change your login shell to fish:
 
-Use the following command if fish isn’t already added to ``/etc/shells`` to permit fish to be your login shell (e.g. if ``chsh`` complains that it "doesn't exist" or similar):
+1. Add the shell to ``/etc/shells`` with::
 
-::
+    > echo /usr/local/bin/fish | sudo tee -a /etc/shells
 
-   command -s fish | sudo tee -a /etc/shells
+2. Change your default shell with::
 
-To switch your default shell back, you can run ``chsh -s /bin/bash``
-(substituting ``/bin/bash`` with ``/bin/tcsh`` or ``/bin/zsh`` as
-appropriate).
+    > chsh -s /usr/local/bin/fish
+
+Again, substitute the path to fish for ``/usr/local/bin/fish`` - see ``command -s fish`` inside fish. To change it back to another shell, just substitute ``/usr/local/bin/fish`` with ``/bin/bash``, ``/bin/tcsh`` or ``/bin/zsh`` as appropriate in the steps above.
 
 Building
 --------


### PR DESCRIPTION
In 5af1e64, a warning was added to the index of the documentation about setting up fish as your login shell. This PR also puts this warning in the Readme.

If the warning is no longer necessary and the problems mentionned in #328, #5394, and [on the debian forums](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1001584) have a workaround, do tell me, as I think this is the source of [a very weird situation in opam](https://github.com/ocaml/opam/issues/5761#issuecomment-1893943441).
