### PR TITLE
Remove share/completions/highlight.fish

### DIFF
--- a/share/completions/highlight.fish
+++ b/share/completions/highlight.fish
@@ -1,8 +1,0 @@
-
-complete -c highlight -s O -l out-format -d 'Output file in given format' -xa 'xterm256 latex tex rtf html xhtml ansi bbcode svg'
-complete -c highlight -s t -l tab -d 'Specify tab length' -x
-complete -c highlight -s i -l input -d 'Name of the input file' -r
-complete -c highlight -s o -l output -d 'Name of the output file' -r
-complete -c highlight -s d -l outdir -d 'Output directory' -r
-complete -c highlight -s S -l syntax -d 'Set type of the source code' -xa "(highlight -p | sed -r 's/^(.*[^[:space:]])[[:space:]]+:[[:space:]]*([^[:space:]]+).*\$/\2\t\1/; /^\$/d')"
-complete -c highlight -s s -l style -d 'Highlight style' -xa "(highlight --list-themes | sed '/^\$\| /d')"


### PR DESCRIPTION
Highlight ships its own completion script:
https://gitlab.com/saalen/highlight/-/blob/master/sh-completion/highlight.fish

I don't know if this requires a changelog entry.