### PR TITLE
Use nix read/write

### DIFF
--- a/src/fds.rs
+++ b/src/fds.rs
@@ -33,23 +33,13 @@ pub struct AutoCloseFd {
 
 impl Read for AutoCloseFd {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        unsafe {
-            match libc::read(self.as_raw_fd(), buf.as_mut_ptr() as *mut _, buf.len()) {
-                -1 => Err(std::io::Error::from_raw_os_error(errno::errno().0)),
-                bytes => Ok(bytes as usize),
-            }
-        }
+        nix::unistd::read(self.as_raw_fd(), buf).map_err(std::io::Error::from)
     }
 }
 
 impl Write for AutoCloseFd {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        unsafe {
-            match libc::write(self.as_raw_fd(), buf.as_ptr() as *const _, buf.len()) {
-                -1 => Err(std::io::Error::from_raw_os_error(errno::errno().0)),
-                bytes => Ok(bytes as usize),
-            }
-        }
+        nix::unistd::write(self.as_raw_fd(), buf).map_err(std::io::Error::from)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {

--- a/src/fork_exec/flog_safe.rs
+++ b/src/fork_exec/flog_safe.rs
@@ -84,9 +84,7 @@ pub fn flog_impl_async_safe(fd: i32, s: impl FloggableDisplayAsyncSafe) {
     let bytes: &[u8] = s.to_flog_str_async_safe(&mut storage);
     // Note we deliberately do not retry on signals, etc.
     // This is used to report error messages after fork() in the child process.
-    unsafe {
-        let _ = libc::write(fd, bytes.as_ptr() as *const libc::c_void, bytes.len());
-    }
+    let _ = nix::unistd::write(fd, bytes);
 }
 
 /// Variant of FLOG which is async-safe to use after fork().

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -294,7 +294,7 @@ fn readb(in_fd: RawFd) -> ReadbResult {
         // Check stdin.
         if fdset.test(in_fd) {
             let mut arr: [u8; 1] = [0];
-            if read_blocked(in_fd, &mut arr) != 1 {
+            if read_blocked(in_fd, &mut arr) != Ok(1) {
                 // The terminal has been closed.
                 return ReadbResult::Eof;
             }

--- a/src/tests/fd_monitor.rs
+++ b/src/tests/fd_monitor.rs
@@ -76,9 +76,8 @@ impl ItemMaker {
             }
             ItemWakeReason::Readable => {
                 let mut buf = [0u8; 1024];
-                let amt =
-                    unsafe { libc::read(fd.as_raw_fd(), buf.as_mut_ptr() as *mut _, buf.len()) };
-                assert_ne!(amt, -1, "read error!");
+                let res = nix::unistd::read(fd.as_raw_fd(), &mut buf);
+                let amt = res.expect("read error!");
                 self.length_read.fetch_add(amt as usize, Ordering::Relaxed);
                 was_closed = amt == 0;
             }

--- a/src/universal_notifier/notifyd.rs
+++ b/src/universal_notifier/notifyd.rs
@@ -123,6 +123,7 @@ impl UniversalNotifier for NotifydNotifier {
             match res {
                 Ok(amt_read) if amt_read != buff.len() => break,
                 Err(_) => break,
+                _ => continue,
             }
         }
         FLOGF!(

--- a/src/universal_notifier/notifyd.rs
+++ b/src/universal_notifier/notifyd.rs
@@ -114,16 +114,15 @@ impl UniversalNotifier for NotifydNotifier {
         let mut read_something = false;
         let mut buff: [u8; 64] = [0; 64];
         loop {
-            let amt_read = unsafe {
-                libc::read(
-                    self.notify_fd,
-                    buff.as_mut_ptr() as *mut libc::c_void,
-                    buff.len(),
-                )
-            };
-            read_something = read_something || amt_read > 0;
-            if amt_read != buff.len() as isize {
-                break;
+            let res = nix::unistd::read(self.notify_fd, &mut buff);
+
+            if let Ok(amt_read) = res {
+                read_something |= amt_read > 0;
+            }
+
+            match res {
+                Ok(amt_read) if amt_read != buff.len() => break,
+                Err(_) => break,
             }
         }
         FLOGF!(

--- a/src/wutil/mod.rs
+++ b/src/wutil/mod.rs
@@ -401,12 +401,8 @@ pub fn wrename(old_name: &wstr, new_name: &wstr) -> libc::c_int {
     unsafe { libc::rename(old_narrow.as_ptr(), new_narrow.as_ptr()) }
 }
 
-pub fn write_to_fd(input: &[u8], fd: RawFd) -> std::io::Result<usize> {
-    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
-    let amt = file.write(input);
-    // Ensure the file is not closed.
-    file.into_raw_fd();
-    amt
+pub fn write_to_fd(input: &[u8], fd: RawFd) -> nix::Result<usize> {
+    nix::unistd::write(fd, input)
 }
 
 /// Write a wide string to a file descriptor. This avoids doing any additional allocation.


### PR DESCRIPTION
## Description

Moving from libc::read/write to nix read/write with Result types instead of -1 whenever possible.

---
Somewhat related to work in #10196

