### PR TITLE
Use CARGO_MANIFEST_DIR to see if we're running from build dir

### DIFF
--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -77,8 +77,6 @@ const DATA_DIR: &str = env!("DATADIR");
 const SYSCONF_DIR: &str = env!("SYSCONFDIR");
 const BIN_DIR: &str = env!("BINDIR");
 
-const OUT_DIR: &str = env!("FISH_BUILD_DIR");
-
 /// container to hold the options specified within the command line
 #[derive(Default, Debug)]
 struct FishCmdOpts {
@@ -160,7 +158,7 @@ fn determine_config_directory_paths(argv0: impl AsRef<Path>) -> ConfigPaths {
         // TODO: we should determine program_name from argv0 somewhere in this file
 
         // Detect if we're running right out of the CMAKE build directory
-        if exec_path.starts_with(OUT_DIR) {
+        if exec_path.starts_with(env!("CARGO_MANIFEST_DIR")) {
             let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             FLOG!(
                 config,
@@ -172,7 +170,7 @@ fn determine_config_directory_paths(argv0: impl AsRef<Path>) -> ConfigPaths {
                 data: manifest_dir.join("share"),
                 sysconf: manifest_dir.join("etc"),
                 doc: manifest_dir.join("user_doc/html"),
-                bin: OUT_DIR.into(),
+                bin: exec_path.clone(),
             }
         }
 


### PR DESCRIPTION
This allows running a fish built from `cargo build` *and* one built via cmake directly from the build directory, and it will pick up the functions in the repo. We do that by checking $CARGO_MANIFEST_DIR (which is the repo root) instead of the build directory, because this check only ever checked if the path to fish *starts with* that directory.

The difference is that now, when I build fish in ~/dev/fish-shell/build, it will still think it is "in the build directory" when I move it to ~/dev/fish-shell or ~/dev/fish-shell/share. It *won't* work if you have a build directory in an entirely different path, I am reasonably sure that didn't work before either.

The reason for this awkward compromise is that cargo *really* does not want us to know the target dir or profile. The alternative is to hard-code "target/debug" for the `cargo build` case, but that would break with checks in release-mode (e.g. for performance).

In future, we should make this an optional thing that's removed from installed builds. It is weird to keep the build directory in the compiled fish, and I've seen makepkg warn about it.

One way is to move all of `share/` to `share/fish` and then you could use `PREFIX=$PWD cargo build`, wich is probably not too odious.

----

One issue is that the history importing tests (test_history_formats) fail when run via `cargo test` because they look up the sample in `../tests` when they would have to use `../../tests`