### PR TITLE
Enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 
 [profile.release]
 overflow-checks = true
+lto = true
+codegen-units = 1
 
 [package]
 name = "fish"


### PR DESCRIPTION
## Description

This PR enables LTO in Cargo.toml. It could shrink the binary size significantly and improve performance (in theory).

The original C++ version binary size is ~1.6MB (stripped). Before LTO, the Rust version is ~4.2MB (stripped). After enabling LTO, the Rust version is ~3.7MB (stripped). If you could accept `opt-level="z"`, the size will be ~2.9MB (stripped).