### PR TITLE
Forbid subcommand keywords in variables-as-commands

### DIFF
--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -572,7 +572,12 @@ impl<'a> ParseExecutionContext {
         // This is an attempt to defeat function resolution.
         //
         // Make an exception for "time" because that is frequently used as a command and does fundamentally the same thing.
-        if parser_keywords_is_subcommand(out_cmd) && !unexp_cmd.starts_with(out_cmd.chars()) && out_cmd != L!("time") {
+        // (skipping in no-exec because we don't have the actual variable value)
+        if !no_exec()
+            && parser_keywords_is_subcommand(out_cmd)
+            && !unexp_cmd.starts_with(out_cmd.chars())
+            && out_cmd != L!("time")
+        {
             return report_error!(
                 self,
                 ctx,

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -568,15 +568,14 @@ impl<'a> ParseExecutionContext {
                 "The expanded command was empty."
             );
         }
-        // Complain if we've expanded to a subcommand keyword like "command" or "if".
-        // This is an attempt to defeat function resolution.
+        // Complain if we've expanded to a subcommand keyword like "command" or "if",
+        // because these will call the corresponding *builtin*,
+        // which won't be doing what the user asks for
         //
-        // Make an exception for "time" because that is frequently used as a command and does fundamentally the same thing.
         // (skipping in no-exec because we don't have the actual variable value)
         if !no_exec()
             && parser_keywords_is_subcommand(out_cmd)
-            && !unexp_cmd.starts_with(out_cmd.chars())
-            && out_cmd != L!("time")
+            && &unexp_cmd != out_cmd
         {
             return report_error!(
                 self,

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -573,10 +573,7 @@ impl<'a> ParseExecutionContext {
         // which won't be doing what the user asks for
         //
         // (skipping in no-exec because we don't have the actual variable value)
-        if !no_exec()
-            && parser_keywords_is_subcommand(out_cmd)
-            && &unexp_cmd != out_cmd
-        {
+        if !no_exec() && parser_keywords_is_subcommand(out_cmd) && &unexp_cmd != out_cmd {
             return report_error!(
                 self,
                 ctx,

--- a/tests/checks/expansion.fish
+++ b/tests/checks/expansion.fish
@@ -334,3 +334,9 @@ printf '<%s>\n' ($fish -c 'echo "$abc["' 2>&1)
 #CHECK: <fish: Invalid index value>
 #CHECK: <echo "$abc[">
 #CHECK: <           ^>
+
+set -l pager command less
+echo foo | $pager
+#CHECKERR: checks/expansion.fish (line 339): The expanded command is a keyword.
+#CHECKERR: echo foo | $pager
+#CHECKERR:            ^~~~~^


### PR DESCRIPTION
This stops you from doing e.g.

```fish
set pager command less
echo foo | $pager
```

Currently, it would run the command *builtin*, which can only do `--search` and similar, and would most likely end up printing its own help.

That means it very very likely won't work, and the code is misguided - it is trying to defeat function resolution in a way that won't do what the author wants it to.

The alternative would be to make the command *builtin* execute the command, *but*

1. That would require rearchitecting and rewriting a bunch of it and the parser
2. It would be a large footgun, in that `set EDITOR command foo` will only ever work inside fish, but $EDITOR is also used outside.

I don't want to add a feature that we would immediately have to discourage.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
- [ ] This reuses the "subcommand" keywords list, which should be *okay*. Alternatively we can restrict it to just "builtin", "command" and "function", but that would lack "if" and "while", which people could also be trying
