### PR TITLE
Retry open_cloexec for signals other than SIGINT

### DIFF
--- a/tests/pexpects/signals.py
+++ b/tests/pexpects/signals.py
@@ -63,6 +63,15 @@ subprocess.call(["pkill", "-TERM", "-P", str(sp.spawn.pid), "sleep"])
 expect_str("fish_kill_signal 15")
 expect_prompt()
 
+# See that open() is only interruptible by SIGINT.
+sendline("mkfifo fifoo")
+expect_prompt()
+sendline("cat >fifoo")
+subprocess.call(["kill", "-WINCH", str(sp.spawn.pid)])
+expect_re("open: ", shouldfail=True, timeout=10)
+subprocess.call(["kill", "-INT", str(sp.spawn.pid)])
+expect_prompt()
+
 # Verify that sending SIGHUP to the shell, such as will happen when the tty is
 # closed by the terminal, terminates the shell and the foreground command and
 # any background commands run from that shell.


### PR DESCRIPTION
This retries {w,}open_cloexec if it gets EINTR, unless it got a cancel signal (i.e. SIGINT).

That means if you do `cat >fifo` (where "fifo" is a fifo without a reader), you can only stop it if you ctrl-c, not if you e.g. resize the terminal.

It also no longer prints the warning when you press ctrl-c - SIGINT is expected, we don't print anything in a lot of cases.

This affects *all* uses of open_cloexec, e.g. in `cd`. Most probably won't see a difference, the man page for open(2) on my system claims:

> While blocked waiting to complete an open of a slow device (e.g., a FIFO; see fifo(7))

Fixes #10250

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
