### PR TITLE
Automatic vi normal mode on paging

### DIFF
--- a/share/functions/fish_vi_on_paging.fish
+++ b/share/functions/fish_vi_on_paging.fish
@@ -1,0 +1,11 @@
+function fish_vi_on_paging
+    function _fish_open_pager
+        commandline -f complete
+        if commandline --paging-mode
+            commandline -f repaint
+            set fish_bind_mode default
+        end
+
+    end
+    bind --mode insert \t _fish_open_pager
+end


### PR DESCRIPTION
I added a function that makes fish automatically enter vi normal mode when opening pager.
To enable simply add this to your fish.config:

```shell
fish_vi_on_paging
``` 