### PR TITLE
Use Result<OwnedFd> for open_cloexec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ errno = "0.2.8"
 lazy_static = "1.4.0"
 libc = "0.2.137"
 lru = "0.10.0"
-nix = { version = "0.25.0", default-features = false, features = ["inotify", "resource"] }
+nix = { version = "0.25.0", default-features = false, features = ["inotify", "resource", "fs"] }
 num-traits = "0.2.15"
 once_cell = "1.17.0"
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -325,7 +325,7 @@ fn test_autoload() {
     use crate::common::{charptr2wcstring, wcs2zstring, write_loop};
     use crate::fds::wopen_cloexec;
     use crate::wutil::sprintf;
-    use libc::{O_CREAT, O_RDWR};
+    use nix::fcntl::OFlag;
 
     macro_rules! run {
         ( $fmt:expr $(, $arg:expr )* $(,)? ) => {
@@ -340,7 +340,7 @@ fn test_autoload() {
 
         let fd = wopen_cloexec(
             path,
-            O_RDWR | O_CREAT,
+            OFlag::O_RDWR | OFlag::O_CREAT,
             Mode::S_IRUSR
                 | Mode::S_IWUSR
                 | Mode::S_IRGRP

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -336,7 +336,19 @@ fn test_autoload() {
     }
 
     fn touch_file(path: &wstr) {
-        let fd = wopen_cloexec(path, O_RDWR | O_CREAT, 0o666).unwrap();
+        use nix::sys::stat::Mode;
+
+        let fd = wopen_cloexec(
+            path,
+            O_RDWR | O_CREAT,
+            Mode::S_IRUSR
+                | Mode::S_IWUSR
+                | Mode::S_IRGRP
+                | Mode::S_IWGRP
+                | Mode::S_IROTH
+                | Mode::S_IWOTH,
+        )
+        .unwrap();
         write_loop(&fd, "Hello".as_bytes()).unwrap();
         unsafe { libc::close(fd) };
     }

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -336,8 +336,7 @@ fn test_autoload() {
     }
 
     fn touch_file(path: &wstr) {
-        let fd = wopen_cloexec(path, O_RDWR | O_CREAT, 0o666);
-        assert!(fd >= 0);
+        let fd = wopen_cloexec(path, O_RDWR | O_CREAT, 0o666).unwrap();
         write_loop(&fd, "Hello".as_bytes()).unwrap();
         unsafe { libc::close(fd) };
     }

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -350,7 +350,6 @@ fn test_autoload() {
         )
         .unwrap();
         write_loop(&fd, "Hello".as_bytes()).unwrap();
-        unsafe { libc::close(fd) };
     }
 
     let mut t1 = "/tmp/fish_test_autoload.XXXXXX\0".as_bytes().to_vec();

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -341,12 +341,7 @@ fn test_autoload() {
         let fd = wopen_cloexec(
             path,
             OFlag::O_RDWR | OFlag::O_CREAT,
-            Mode::S_IRUSR
-                | Mode::S_IWUSR
-                | Mode::S_IRGRP
-                | Mode::S_IWGRP
-                | Mode::S_IROTH
-                | Mode::S_IWOTH,
+            Mode::from_bits(0o666).unwrap(),
         )
         .unwrap();
         write_loop(&fd, "Hello".as_bytes()).unwrap();

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use errno::{self, Errno};
 use libc::{fchdir, EACCES, ELOOP, ENOENT, ENOTDIR, EPERM, O_RDONLY};
+use nix::sys::stat::Mode;
 use std::{os::fd::AsRawFd, sync::Arc};
 
 // The cd builtin. Changes the current directory to the one specified or to $HOME if none is
@@ -86,7 +87,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
 
         errno::set_errno(Errno(0));
 
-        let res = wopen_cloexec(&norm_dir, O_RDONLY, 0)
+        let res = wopen_cloexec(&norm_dir, O_RDONLY, Mode::empty())
             .map(AutoCloseFd::new)
             .map_err(|err| err as i32);
 

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -8,8 +8,8 @@ use crate::{
     wutil::{normalize_path, wperror, wreadlink},
 };
 use errno::{self, Errno};
-use libc::{fchdir, EACCES, ELOOP, ENOENT, ENOTDIR, EPERM, O_RDONLY};
-use nix::sys::stat::Mode;
+use libc::{fchdir, EACCES, ELOOP, ENOENT, ENOTDIR, EPERM};
+use nix::{fcntl::OFlag, sys::stat::Mode};
 use std::{os::fd::AsRawFd, sync::Arc};
 
 // The cd builtin. Changes the current directory to the one specified or to $HOME if none is
@@ -87,7 +87,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
 
         errno::set_errno(Errno(0));
 
-        let res = wopen_cloexec(&norm_dir, O_RDONLY, Mode::empty())
+        let res = wopen_cloexec(&norm_dir, OFlag::O_RDONLY, Mode::empty())
             .map(AutoCloseFd::new)
             .map_err(|err| err as i32);
 

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -3,7 +3,7 @@
 use super::prelude::*;
 use crate::{
     env::{EnvMode, Environment},
-    fds::{wopen_cloexec, AutoCloseFd},
+    fds::wopen_cloexec,
     path::path_apply_cdpath,
     wutil::{normalize_path, wperror, wreadlink},
 };
@@ -87,9 +87,8 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
 
         errno::set_errno(Errno(0));
 
-        let res = wopen_cloexec(&norm_dir, OFlag::O_RDONLY, Mode::empty())
-            .map(AutoCloseFd::new)
-            .map_err(|err| err as i32);
+        let res =
+            wopen_cloexec(&norm_dir, OFlag::O_RDONLY, Mode::empty()).map_err(|err| err as i32);
 
         let res = res.and_then(|fd| {
             if unsafe { fchdir(fd.as_raw_fd()) } == 0 {
@@ -100,7 +99,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
         });
 
         let fd = match res {
-            Ok(raw_fd) => raw_fd,
+            Ok(fd) => fd,
             Err(err) => {
                 // Some errors we skip and only report if nothing worked.
                 // ENOENT in particular is very low priority

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -7,8 +7,8 @@ use crate::{
     parser::Block,
     reader::reader_read,
 };
-use libc::{c_int, O_RDONLY, S_IFMT, S_IFREG};
-use nix::sys::stat::Mode;
+use libc::{c_int, S_IFMT, S_IFREG};
+use nix::{fcntl::OFlag, sys::stat::Mode};
 
 use super::prelude::*;
 
@@ -51,7 +51,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
         func_filename = FilenameRef::new(L!("-").to_owned());
         fd = streams.stdin_fd;
     } else {
-        let Ok(raw_fd) = wopen_cloexec(args[optind], O_RDONLY, Mode::empty()) else {
+        let Ok(raw_fd) = wopen_cloexec(args[optind], OFlag::O_RDONLY, Mode::empty()) else {
             let esc = escape(args[optind]);
             streams.err.append(wgettext_fmt!(
                 "%ls: Error encountered while sourcing file '%ls':\n",

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -8,6 +8,7 @@ use crate::{
     reader::reader_read,
 };
 use libc::{c_int, O_RDONLY, S_IFMT, S_IFREG};
+use nix::sys::stat::Mode;
 
 use super::prelude::*;
 
@@ -50,7 +51,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
         func_filename = FilenameRef::new(L!("-").to_owned());
         fd = streams.stdin_fd;
     } else {
-        let Ok(raw_fd) = wopen_cloexec(args[optind], O_RDONLY, 0) else {
+        let Ok(raw_fd) = wopen_cloexec(args[optind], O_RDONLY, Mode::empty()) else {
             let esc = escape(args[optind]);
             streams.err.append(wgettext_fmt!(
                 "%ls: Error encountered while sourcing file '%ls':\n",

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -57,7 +57,7 @@ use nix::fcntl::OFlag;
 use nix::sys::stat;
 use std::ffi::CStr;
 use std::io::{Read, Write};
-use std::os::fd::{FromRawFd, RawFd};
+use std::os::fd::RawFd;
 use std::slice;
 use std::sync::atomic::Ordering;
 use std::sync::{atomic::AtomicUsize, Arc};
@@ -370,7 +370,7 @@ pub fn is_thompson_shell_script(path: &CStr) -> bool {
     let mut res = false;
     let fd = open_cloexec(path, OFlag::O_RDONLY | OFlag::O_NOCTTY, stat::Mode::empty());
     if let Ok(fd) = fd {
-        let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+        let mut file = std::fs::File::from(fd);
         let mut buf = [b'\0'; 256];
         if let Ok(got) = file.read(&mut buf) {
             if is_thompson_shell_payload(&buf[..got]) {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -53,6 +53,7 @@ use libc::{
     c_char, EACCES, ENOENT, ENOEXEC, ENOTDIR, EPIPE, EXIT_FAILURE, EXIT_SUCCESS, O_NOCTTY,
     O_RDONLY, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
 };
+use nix::sys::stat;
 use std::ffi::CStr;
 use std::io::{Read, Write};
 use std::os::fd::{FromRawFd, RawFd};
@@ -366,7 +367,7 @@ pub fn is_thompson_shell_script(path: &CStr) -> bool {
     }
     let e = errno();
     let mut res = false;
-    let fd = open_cloexec(path, O_RDONLY | O_NOCTTY, 0);
+    let fd = open_cloexec(path, O_RDONLY | O_NOCTTY, stat::Mode::empty());
     if let Ok(fd) = fd {
         let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
         let mut buf = [b'\0'; 256];

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -367,7 +367,7 @@ pub fn is_thompson_shell_script(path: &CStr) -> bool {
     let e = errno();
     let mut res = false;
     let fd = open_cloexec(path, O_RDONLY | O_NOCTTY, 0);
-    if fd != -1 {
+    if let Ok(fd) = fd {
         let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
         let mut buf = [b'\0'; 256];
         if let Ok(got) = file.read(&mut buf) {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -50,9 +50,10 @@ use crate::wutil::{fish_wcstol, perror};
 use crate::wutil::{wgettext, wgettext_fmt};
 use errno::{errno, set_errno};
 use libc::{
-    c_char, EACCES, ENOENT, ENOEXEC, ENOTDIR, EPIPE, EXIT_FAILURE, EXIT_SUCCESS, O_NOCTTY,
-    O_RDONLY, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
+    c_char, EACCES, ENOENT, ENOEXEC, ENOTDIR, EPIPE, EXIT_FAILURE, EXIT_SUCCESS, STDERR_FILENO,
+    STDIN_FILENO, STDOUT_FILENO,
 };
+use nix::fcntl::OFlag;
 use nix::sys::stat;
 use std::ffi::CStr;
 use std::io::{Read, Write};
@@ -367,7 +368,7 @@ pub fn is_thompson_shell_script(path: &CStr) -> bool {
     }
     let e = errno();
     let mut res = false;
-    let fd = open_cloexec(path, O_RDONLY | O_NOCTTY, stat::Mode::empty());
+    let fd = open_cloexec(path, OFlag::O_RDONLY | OFlag::O_NOCTTY, stat::Mode::empty());
     if let Ok(fd) = fd {
         let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
         let mut buf = [b'\0'; 256];

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -222,14 +222,17 @@ pub fn set_cloexec(fd: RawFd, should_set: bool /* = true */) -> c_int {
 
 /// Wide character version of open() that also sets the close-on-exec flag (atomically when
 /// possible).
-pub fn wopen_cloexec(pathname: &wstr, flags: i32, mode: libc::c_int) -> nix::Result<RawFd> {
+pub fn wopen_cloexec(
+    pathname: &wstr,
+    flags: i32,
+    mode: nix::sys::stat::Mode,
+) -> nix::Result<RawFd> {
     open_cloexec(wcs2zstring(pathname).as_c_str(), flags, mode)
 }
 
 /// Narrow versions of wopen_cloexec.
-pub fn open_cloexec(path: &CStr, flags: i32, mode: libc::c_int) -> nix::Result<RawFd> {
+pub fn open_cloexec(path: &CStr, flags: i32, mode: nix::sys::stat::Mode) -> nix::Result<RawFd> {
     let flags = unsafe { OFlag::from_bits_unchecked(flags) };
-    let mode = unsafe { nix::sys::stat::Mode::from_bits_unchecked(mode as u32) };
     // Port note: the C++ version of this function had a fallback for platforms where
     // O_CLOEXEC is not supported, using fcntl. In 2023, this is no longer needed.
     let saved_errno = errno();

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -224,15 +224,14 @@ pub fn set_cloexec(fd: RawFd, should_set: bool /* = true */) -> c_int {
 /// possible).
 pub fn wopen_cloexec(
     pathname: &wstr,
-    flags: i32,
+    flags: OFlag,
     mode: nix::sys::stat::Mode,
 ) -> nix::Result<RawFd> {
     open_cloexec(wcs2zstring(pathname).as_c_str(), flags, mode)
 }
 
 /// Narrow versions of wopen_cloexec.
-pub fn open_cloexec(path: &CStr, flags: i32, mode: nix::sys::stat::Mode) -> nix::Result<RawFd> {
-    let flags = unsafe { OFlag::from_bits_unchecked(flags) };
+pub fn open_cloexec(path: &CStr, flags: OFlag, mode: nix::sys::stat::Mode) -> nix::Result<RawFd> {
     // Port note: the C++ version of this function had a fallback for platforms where
     // O_CLOEXEC is not supported, using fcntl. In 2023, this is no longer needed.
     let saved_errno = errno();

--- a/src/io.rs
+++ b/src/io.rs
@@ -18,6 +18,7 @@ use crate::wchar::prelude::*;
 use crate::wutil::{perror, perror_io, wdirname, wstat, wwrite_to_fd};
 use errno::Errno;
 use libc::{EAGAIN, EINTR, ENOENT, ENOTDIR, EPIPE, EWOULDBLOCK, O_EXCL, STDOUT_FILENO};
+use nix::sys::stat::Mode;
 use std::cell::{RefCell, UnsafeCell};
 use std::os::fd::RawFd;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1006,7 +1007,12 @@ const FILE_ERROR: &wstr = L!("An error occurred while redirecting file '%ls'");
 const NOCLOB_ERROR: &wstr = L!("The file '%ls' already exists");
 
 /// Base open mode to pass to calls to open.
-const OPEN_MASK: libc::c_int = 0o666;
+const OPEN_MASK: Mode = Mode::S_IRUSR
+    .union(Mode::S_IWUSR)
+    .union(Mode::S_IRGRP)
+    .union(Mode::S_IWGRP)
+    .union(Mode::S_IROTH)
+    .union(Mode::S_IWOTH);
 
 /// Provide the fd monitor used for background fillthread operations.
 fn fd_monitor() -> &'static mut FdMonitor {

--- a/src/io.rs
+++ b/src/io.rs
@@ -17,7 +17,8 @@ use crate::topic_monitor::topic_t;
 use crate::wchar::prelude::*;
 use crate::wutil::{perror, perror_io, wdirname, wstat, wwrite_to_fd};
 use errno::Errno;
-use libc::{EAGAIN, EINTR, ENOENT, ENOTDIR, EPIPE, EWOULDBLOCK, O_EXCL, STDOUT_FILENO};
+use libc::{EAGAIN, EINTR, ENOENT, ENOTDIR, EPIPE, EWOULDBLOCK, STDOUT_FILENO};
+use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
 use std::cell::{RefCell, UnsafeCell};
 use std::os::fd::RawFd;
@@ -665,7 +666,7 @@ impl IoChain {
                             self.push(Arc::new(IoFile::new(spec.fd, file)));
                         }
                         Err(err) => {
-                            if (oflags & O_EXCL) != 0 && err == nix::Error::EEXIST {
+                            if oflags.intersects(OFlag::O_EXCL) && err == nix::Error::EEXIST {
                                 FLOGF!(warning, NOCLOB_ERROR, spec.target);
                             } else {
                                 if should_flog!(warning) {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1007,12 +1007,7 @@ const FILE_ERROR: &wstr = L!("An error occurred while redirecting file '%ls'");
 const NOCLOB_ERROR: &wstr = L!("The file '%ls' already exists");
 
 /// Base open mode to pass to calls to open.
-const OPEN_MASK: Mode = Mode::S_IRUSR
-    .union(Mode::S_IWUSR)
-    .union(Mode::S_IRGRP)
-    .union(Mode::S_IWGRP)
-    .union(Mode::S_IROTH)
-    .union(Mode::S_IWOTH);
+const OPEN_MASK: Mode = unsafe { Mode::from_bits_unchecked(0o666) };
 
 /// Provide the fd monitor used for background fillthread operations.
 fn fd_monitor() -> &'static mut FdMonitor {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,7 +33,7 @@ use crate::wait_handle::WaitHandleStore;
 use crate::wchar::{wstr, WString, L};
 use crate::wutil::{perror, wgettext, wgettext_fmt};
 use libc::c_int;
-use libc::O_RDONLY;
+use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
 use once_cell::sync::Lazy;
 use printf_compat::sprintf;
@@ -361,7 +361,7 @@ impl Parser {
 
         match open_cloexec(
             CStr::from_bytes_with_nul(b".\0").unwrap(),
-            O_RDONLY,
+            OFlag::O_RDONLY,
             Mode::empty(),
         ) {
             Ok(raw_fd) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,6 +34,7 @@ use crate::wchar::{wstr, WString, L};
 use crate::wutil::{perror, wgettext, wgettext_fmt};
 use libc::c_int;
 use libc::O_RDONLY;
+use nix::sys::stat::Mode;
 use once_cell::sync::Lazy;
 use printf_compat::sprintf;
 use std::cell::{Ref, RefCell, RefMut};
@@ -358,7 +359,11 @@ impl Parser {
             global_event_blocks: AtomicU64::new(0),
         });
 
-        match open_cloexec(CStr::from_bytes_with_nul(b".\0").unwrap(), O_RDONLY, 0) {
+        match open_cloexec(
+            CStr::from_bytes_with_nul(b".\0").unwrap(),
+            O_RDONLY,
+            Mode::empty(),
+        ) {
             Ok(raw_fd) => {
                 result.libdata_mut().cwd_fd = Some(Arc::new(AutoCloseFd::new(raw_fd)));
             }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -24,7 +24,7 @@ use std::cell::UnsafeCell;
 use std::io::BufReader;
 use std::num::NonZeroUsize;
 use std::ops::Range;
-use std::os::fd::{FromRawFd, RawFd};
+use std::os::fd::RawFd;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
@@ -4661,11 +4661,11 @@ impl ReaderData {
                 var.map_or_else(|| L!("~/.bash_history").to_owned(), |var| var.as_string());
             expand_tilde(&mut path, self.vars());
 
-            let Ok(raw_fd) = wopen_cloexec(&path, OFlag::O_RDONLY, Mode::empty()) else {
+            let Ok(fd) = wopen_cloexec(&path, OFlag::O_RDONLY, Mode::empty()) else {
                 return;
             };
 
-            let file = unsafe { std::fs::File::from_raw_fd(raw_fd) };
+            let file = std::fs::File::from(fd);
             self.history.populate_from_bash(BufReader::new(file));
         }
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -22,7 +22,7 @@ use std::cell::UnsafeCell;
 use std::io::BufReader;
 use std::num::NonZeroUsize;
 use std::ops::Range;
-use std::os::fd::RawFd;
+use std::os::fd::{FromRawFd, RawFd};
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
@@ -4658,10 +4658,12 @@ impl ReaderData {
             let mut path =
                 var.map_or_else(|| L!("~/.bash_history").to_owned(), |var| var.as_string());
             expand_tilde(&mut path, self.vars());
-            let file = AutoCloseFd::new(wopen_cloexec(&path, O_RDONLY, 0));
-            if !file.is_valid() {
+
+            let Ok(raw_fd) = wopen_cloexec(&path, O_RDONLY, 0) else {
                 return;
-            }
+            };
+
+            let file = unsafe { std::fs::File::from_raw_fd(raw_fd) };
             self.history.populate_from_bash(BufReader::new(file));
         }
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -17,6 +17,7 @@ use libc::{
     IXOFF, IXON, ONLCR, OPOST, O_NONBLOCK, O_RDONLY, SIGINT, SIGTTIN, STDIN_FILENO, STDOUT_FILENO,
     S_IFDIR, TCSANOW, VMIN, VQUIT, VSUSP, VTIME, _POSIX_VDISABLE,
 };
+use nix::sys::stat::Mode;
 use once_cell::sync::Lazy;
 use std::cell::UnsafeCell;
 use std::io::BufReader;
@@ -4659,7 +4660,7 @@ impl ReaderData {
                 var.map_or_else(|| L!("~/.bash_history").to_owned(), |var| var.as_string());
             expand_tilde(&mut path, self.vars());
 
-            let Ok(raw_fd) = wopen_cloexec(&path, O_RDONLY, 0) else {
+            let Ok(raw_fd) = wopen_cloexec(&path, O_RDONLY, Mode::empty()) else {
                 return;
             };
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -17,6 +17,7 @@ use libc::{
     IXOFF, IXON, ONLCR, OPOST, O_NONBLOCK, O_RDONLY, SIGINT, SIGTTIN, STDIN_FILENO, STDOUT_FILENO,
     S_IFDIR, TCSANOW, VMIN, VQUIT, VSUSP, VTIME, _POSIX_VDISABLE,
 };
+use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
 use once_cell::sync::Lazy;
 use std::cell::UnsafeCell;
@@ -4660,7 +4661,7 @@ impl ReaderData {
                 var.map_or_else(|| L!("~/.bash_history").to_owned(), |var| var.as_string());
             expand_tilde(&mut path, self.vars());
 
-            let Ok(raw_fd) = wopen_cloexec(&path, O_RDONLY, Mode::empty()) else {
+            let Ok(raw_fd) = wopen_cloexec(&path, OFlag::O_RDONLY, Mode::empty()) else {
                 return;
             };
 

--- a/src/redirection.rs
+++ b/src/redirection.rs
@@ -3,7 +3,7 @@
 use crate::io::IoChain;
 use crate::wchar::prelude::*;
 use crate::wutil::fish_wcstoi;
-use libc::{c_int, O_APPEND, O_CREAT, O_EXCL, O_RDONLY, O_TRUNC, O_WRONLY};
+use nix::fcntl::OFlag;
 use std::os::fd::RawFd;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -33,12 +33,12 @@ pub struct Dup2List {
 
 impl RedirectionMode {
     /// The open flags for this redirection mode.
-    pub fn oflags(self) -> Option<c_int> {
+    pub fn oflags(self) -> Option<OFlag> {
         match self {
-            RedirectionMode::append => Some(O_CREAT | O_APPEND | O_WRONLY),
-            RedirectionMode::overwrite => Some(O_CREAT | O_WRONLY | O_TRUNC),
-            RedirectionMode::noclob => Some(O_CREAT | O_EXCL | O_WRONLY),
-            RedirectionMode::input => Some(O_RDONLY),
+            RedirectionMode::append => Some(OFlag::O_CREAT | OFlag::O_APPEND | OFlag::O_WRONLY),
+            RedirectionMode::overwrite => Some(OFlag::O_CREAT | OFlag::O_WRONLY | OFlag::O_TRUNC),
+            RedirectionMode::noclob => Some(OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_WRONLY),
+            RedirectionMode::input => Some(OFlag::O_RDONLY),
             _ => None,
         }
     }
@@ -83,7 +83,7 @@ impl RedirectionSpec {
     }
 
     /// \return the open flags for this redirection.
-    pub fn oflags(&self) -> c_int {
+    pub fn oflags(&self) -> OFlag {
         match self.mode.oflags() {
             Some(flags) => flags,
             None => panic!("Not a file redirection"),

--- a/src/tests/history.rs
+++ b/src/tests/history.rs
@@ -1,6 +1,6 @@
 use crate::common::{is_windows_subsystem_for_linux, str2wcstring, wcs2osstring};
 use crate::env::{EnvMode, EnvStack};
-use crate::fds::{wopen_cloexec, AutoCloseFd};
+use crate::fds::wopen_cloexec;
 use crate::history::{self, History, HistoryItem, HistorySearch, PathList, SearchDirection};
 use crate::path::path_get_data;
 use crate::tests::prelude::*;
@@ -594,7 +594,7 @@ fn test_history_formats() {
         "echo foo".into(),
     ];
     let test_history_imported_from_bash = History::with_name(L!("bash_import"));
-    let file = AutoCloseFd::new(
+    let file = std::fs::File::from(
         wopen_cloexec(
             L!("tests/history_sample_bash"),
             OFlag::O_RDONLY,

--- a/src/tests/history.rs
+++ b/src/tests/history.rs
@@ -7,8 +7,7 @@ use crate::tests::prelude::*;
 use crate::tests::string_escape::ESCAPE_TEST_CHAR;
 use crate::wchar::prelude::*;
 use crate::wcstringutil::{string_prefixes_string, string_prefixes_string_case_insensitive};
-use libc::O_RDONLY;
-use nix::sys::stat::Mode;
+use nix::{fcntl::OFlag, sys::stat::Mode};
 use rand::random;
 use std::collections::VecDeque;
 use std::ffi::CString;
@@ -596,7 +595,12 @@ fn test_history_formats() {
     ];
     let test_history_imported_from_bash = History::with_name(L!("bash_import"));
     let file = AutoCloseFd::new(
-        wopen_cloexec(L!("tests/history_sample_bash"), O_RDONLY, Mode::empty()).unwrap(),
+        wopen_cloexec(
+            L!("tests/history_sample_bash"),
+            OFlag::O_RDONLY,
+            Mode::empty(),
+        )
+        .unwrap(),
     );
     test_history_imported_from_bash.populate_from_bash(BufReader::new(file));
     assert_eq!(test_history_imported_from_bash.get_history(), expected);

--- a/src/tests/history.rs
+++ b/src/tests/history.rs
@@ -8,6 +8,7 @@ use crate::tests::string_escape::ESCAPE_TEST_CHAR;
 use crate::wchar::prelude::*;
 use crate::wcstringutil::{string_prefixes_string, string_prefixes_string_case_insensitive};
 use libc::O_RDONLY;
+use nix::sys::stat::Mode;
 use rand::random;
 use std::collections::VecDeque;
 use std::ffi::CString;
@@ -594,8 +595,9 @@ fn test_history_formats() {
         "echo foo".into(),
     ];
     let test_history_imported_from_bash = History::with_name(L!("bash_import"));
-    let file =
-        AutoCloseFd::new(wopen_cloexec(L!("tests/history_sample_bash"), O_RDONLY, 0).unwrap());
+    let file = AutoCloseFd::new(
+        wopen_cloexec(L!("tests/history_sample_bash"), O_RDONLY, Mode::empty()).unwrap(),
+    );
     test_history_imported_from_bash.populate_from_bash(BufReader::new(file));
     assert_eq!(test_history_imported_from_bash.get_history(), expected);
     test_history_imported_from_bash.clear();

--- a/src/tests/history.rs
+++ b/src/tests/history.rs
@@ -594,8 +594,8 @@ fn test_history_formats() {
         "echo foo".into(),
     ];
     let test_history_imported_from_bash = History::with_name(L!("bash_import"));
-    let file = AutoCloseFd::new(wopen_cloexec(L!("tests/history_sample_bash"), O_RDONLY, 0));
-    assert!(file.is_valid());
+    let file =
+        AutoCloseFd::new(wopen_cloexec(L!("tests/history_sample_bash"), O_RDONLY, 0).unwrap());
     test_history_imported_from_bash.populate_from_bash(BufReader::new(file));
     assert_eq!(test_history_imported_from_bash.get_history(), expected);
     test_history_imported_from_bash.clear();

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -6,7 +6,8 @@ use crate::future_feature_flags::{feature_test, FeatureFlag};
 use crate::parse_constants::SOURCE_OFFSET_INVALID;
 use crate::redirection::RedirectionMode;
 use crate::wchar::prelude::*;
-use libc::{c_int, STDIN_FILENO, STDOUT_FILENO};
+use libc::{STDIN_FILENO, STDOUT_FILENO};
+use nix::fcntl::OFlag;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
 use std::os::fd::RawFd;
 
@@ -1036,8 +1037,8 @@ impl TryFrom<&wstr> for PipeOrRedir {
 
 impl PipeOrRedir {
     /// \return the oflags (as in open(2)) for this redirection.
-    pub fn oflags(&self) -> c_int {
-        self.mode.oflags().unwrap_or(-1)
+    pub fn oflags(&self) -> Option<OFlag> {
+        self.mode.oflags()
     }
 
     // \return if we are "valid". Here "valid" means only that the source fd did not overflow.


### PR DESCRIPTION
Rework of error handling for `w/open_cloexec` function. 

- Return `Result<T>` from `open_cloexec` instead of `RawFd(-1)`
- Return Rust's `OwnedFd` instead of `RawFd`
- Now that `open_cloexec` returns `OwnedFd` also remove some use of `AutoCloseFd`
  - `AutoCloseFd` is basically the same as std `OwnedFd`, except `OwnedFd` does not have a hidden invalid state, it is guarantied to always be valid. Perhaps in other parts of the codebase that's needed, but in cases where `open_cloexec` was being used the FDs were supposed to always be valid anyway, so I assume the type change is appropriate.
- Lastly, use nix's `OFlag` and `Mode` bitflags for `open_cloexec` attributes
  - I was not sure if you prefer the octal numeric mode notation or bitflag one, for now I did fully named flags, I can revert to octal representation as needed. (as that does not really matter that much, I'd rather focus on Result/OwnedFd stuff)