### PR TITLE
Add feature flag to turn off `%self`

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1987,6 +1987,7 @@ You can see the current list of features via ``status features``::
     qmark-noglob            on  3.0 ? no longer globs
     regex-easyesc           on  3.1 string replace -r needs fewer \\'s
     ampersand-nobg-in-token on  3.4 & only backgrounds if followed by a separating character
+    remove-percent-self     off 3.8 %self is no longer expanded (use $fish_pid)
 
 Here is what they mean:
 
@@ -1994,6 +1995,7 @@ Here is what they mean:
 - ``qmark-noglob`` was also introduced in fish 3.0 (and made the default in 3.8). It makes ``?`` an ordinary character instead of a single-character glob. Use a ``*`` instead (which will match multiple characters) or find other ways to match files like ``find``.
 - ``regex-easyesc`` was introduced in 3.1. It makes it so the replacement expression in ``string replace -r`` does one fewer round of escaping. Before, to escape a backslash you would have to use ``string replace -ra '([ab])' '\\\\\\\\$1'``. After, just ``'\\\\$1'`` is enough. Check your ``string replace`` calls if you use this anywhere.
 - ``ampersand-nobg-in-token`` was introduced in fish 3.4. It makes it so a ``&`` i no longer interpreted as the backgrounding operator in the middle of a token, so dealing with URLs becomes easier. Either put spaces or a semicolon after the ``&``. This is recommended formatting anyway, and ``fish_indent`` will have done it for you already.
+- ``remove-percent-self`` turns off the special ``%self`` expansion. It was introduced in 3.8. To get fish's pid, you can use the :envvar:`fish_pid` variable.
 
 
 These changes are introduced off by default. They can be enabled on a per session basis::

--- a/src/common.rs
+++ b/src/common.rs
@@ -475,6 +475,7 @@ fn unescape_string_internal(input: &wstr, flags: UnescapeFlags) -> Option<WStrin
     let unescape_special = flags.contains(UnescapeFlags::SPECIAL);
     let allow_incomplete = flags.contains(UnescapeFlags::INCOMPLETE);
     let ignore_backslashes = flags.contains(UnescapeFlags::NO_BACKSLASHES);
+    let allow_percent_self = !feature_test(FeatureFlag::remove_percent_self);
 
     // The positions of open braces.
     let mut braces = vec![];
@@ -529,7 +530,11 @@ fn unescape_string_internal(input: &wstr, flags: UnescapeFlags) -> Option<WStrin
                 '%' => {
                     // Note that this only recognizes %self if the string is literally %self.
                     // %self/foo will NOT match this.
-                    if unescape_special && input_position == 0 && input == PROCESS_EXPAND_SELF_STR {
+                    if allow_percent_self
+                        && unescape_special
+                        && input_position == 0
+                        && input == PROCESS_EXPAND_SELF_STR
+                    {
                         to_append_or_none = Some(PROCESS_EXPAND_SELF);
                         input_position += PROCESS_EXPAND_SELF_STR.len() - 1; // skip over 'self's
                     }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -15,6 +15,7 @@ use crate::common::{
 use crate::complete::{CompleteFlags, Completion, CompletionList, CompletionReceiver};
 use crate::env::{EnvVar, Environment};
 use crate::exec::exec_subshell_for_expand;
+use crate::future_feature_flags::{feature_test, FeatureFlag};
 use crate::history::{history_session_id, History};
 use crate::operation_context::OperationContext;
 use crate::parse_constants::{ParseError, ParseErrorCode, ParseErrorList, SOURCE_LOCATION_UNKNOWN};
@@ -1386,7 +1387,9 @@ impl<'a, 'b, 'c> Expander<'a, 'b, 'c> {
         out: &mut CompletionReceiver,
     ) -> ExpandResult {
         expand_home_directory(&mut input, self.ctx.vars());
-        expand_percent_self(&mut input);
+        if !feature_test(FeatureFlag::remove_percent_self) {
+            expand_percent_self(&mut input);
+        }
         if !out.add(input) {
             return append_overflow_error(self.errors, None);
         }

--- a/src/future_feature_flags.rs
+++ b/src/future_feature_flags.rs
@@ -19,6 +19,8 @@ pub enum FeatureFlag {
 
     /// Whether "&" is not-special if followed by a word character.
     ampersand_nobg_in_token,
+    /// Whether "%self" is expanded to fish's pid
+    remove_percent_self,
 }
 
 struct Features {
@@ -83,6 +85,14 @@ pub const METADATA: &[FeatureMetadata] = &[
         default_value: true,
         read_only: false,
     },
+    FeatureMetadata {
+        flag: FeatureFlag::remove_percent_self,
+        name: L!("remove-percent-self"),
+        groups: L!("3.8"),
+        description: L!("%self is no longer expanded (use $fish_pid)"),
+        default_value: false,
+        read_only: false,
+    },
 ];
 
 thread_local!(
@@ -142,6 +152,7 @@ impl Features {
                 AtomicBool::new(METADATA[1].default_value),
                 AtomicBool::new(METADATA[2].default_value),
                 AtomicBool::new(METADATA[3].default_value),
+                AtomicBool::new(METADATA[4].default_value),
             ],
         }
     }

--- a/tests/checks/features-percent-self1.fish
+++ b/tests/checks/features-percent-self1.fish
@@ -1,4 +1,4 @@
-#RUN: %fish --features=remove-percent-self -C 'set -g fish_indent %fish_indent' %s
+#RUN: %fish --features=remove-percent-self %s
 
 echo %self
 # CHECK: %self

--- a/tests/checks/features-percent-self1.fish
+++ b/tests/checks/features-percent-self1.fish
@@ -1,0 +1,4 @@
+#RUN: %fish --features=remove-percent-self -C 'set -g fish_indent %fish_indent' %s
+
+echo %self
+# CHECK: %self

--- a/tests/checks/features-percent-self2.fish
+++ b/tests/checks/features-percent-self2.fish
@@ -1,0 +1,2 @@
+#RUN: %fish --features    'remove-percent-self' -c 'status test-feature remove-percent-self; echo remove-percent-self: $status'
+# CHECK: remove-percent-self: 0

--- a/tests/checks/status.fish
+++ b/tests/checks/status.fish
@@ -57,6 +57,7 @@ status features
 #CHECK: qmark-noglob            on  3.0 ? no longer globs
 #CHECK: regex-easyesc           on  3.1 string replace -r needs fewer \'s
 #CHECK: ampersand-nobg-in-token on  3.4 & only backgrounds if followed by a separator
+#CHECK: remove-percent-self     off 3.8 %self is no longer expanded (use $fish_pid)
 status test-feature stderr-nocaret
 echo $status
 #CHECK: 0


### PR DESCRIPTION
This is the last remnant of the old percent expansion.

It has the downsides of it, in that it is annoying to combine with anything:

```fish
echo %self/foo
```

prints "%self/foo", not fish's pid.

We have introduced $fish_pid in 3.0, which is much easier to use - just like a variable, because it is one.

If you need backwards-compatibility for < 3.0, you can use the following shim:

```fish
set -q fish_pid
or set -g fish_pid %self
```

So we introduce a feature-flag called "remove-percent-self" to turn it off.

"%self" will simply not be special, e.g. `echo %self` will print "%self".

## Current uses of %self:

Here's a few notable uses of %self I can still find in the wild:

- Oh-my-fish's [installer](https://github.com/oh-my-fish/oh-my-fish/blob/d427501b2c3003599bc09502e9d9535b5317c677/bin/install#L140) (last commit to oh-my-fish/oh-my-fish was a year ago)
- The [await plugin](https://github.com/oh-my-fish/plugin-await/blob/master/functions/await.fish#L5) (last commit 5 years ago)
- [theme-budspencer](https://github.com/oh-my-fish/theme-budspencer/blob/eb3bf2919014fc33c136667bf3ae7b0c5b195d3c/functions/fish_prompt.fish#L58) (last commit 2 years ago)

There are in total [386 matches on Github](https://github.com/search?q=%25self+language%3Afish+&type=code) I can find. These are all easily, almost mechanically replaced with `$fish_pid`, with optional backwards-compatibility by setting the variable yourself if it doesn't exist (see above).

It is worth pointing out that $fish_pid was introduced in fish 3.0, which is 45% of commits up to 3.7.0 behind. It was released 5 years ago.