### PR TITLE
Open command script in external editor on Alt+o

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Interactive improvements
 - :kbd:`Control-C` during command input no longer prints ``^C`` and a new prompt but merely clears the command line. This restores the behavior from version 2.2. To revert to the old behavior use ``bind \cc __fish_cancel_commandline`` (:issue:`10213`).
 - Command-specific tab completions may now offer results whose first character is a period. For example, it is now possible to tab-complete ``git add`` for files with leading periods. The default file completions hide these files, unless the token itself has a leading period (:issue:`3707`).
 - The :kbd:`Control-R` history search now uses glob syntax (:issue:`10131`).
+- When the cursor is on a command that resolves to a script, :kbd:`Alt-O` will now open that script in your editor.
 - :kbd:`Alt-E` now passes the cursor position to the external editor also if the editor aliases a supported editor (via ``complete --wraps``).
 
 New or improved bindings

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -331,13 +331,13 @@ Some bindings are common across Emacs and vi mode, because they aren't text edit
 
 - :kbd:`Alt`\ +\ :kbd:`L` lists the contents of the current directory, unless the cursor is over a directory argument, in which case the contents of that directory will be listed.
 
-- :kbd:`Alt`\ +\ :kbd:`O` opens the file at the cursor in a pager.
+- :kbd:`Alt`\ +\ :kbd:`O` opens the file at the cursor in a pager. If the cursor is in command position and the command is a script, it will instead open that script in your editor. The editor is chosen from the first available of the ``$VISUAL`` or ``$EDITOR`` variables.
 
 - :kbd:`Alt`\ +\ :kbd:`P` adds the string ``&| less;`` to the end of the job under the cursor. The result is that the output of the command will be paged.
 
 - :kbd:`Alt`\ +\ :kbd:`W` prints a short description of the command under the cursor.
 
-- :kbd:`Alt`\ +\ :kbd:`E` edits the current command line in an external editor. The editor is chosen from the first available of the ``$VISUAL`` or ``$EDITOR`` variables.
+- :kbd:`Alt`\ +\ :kbd:`E` edits the current command line in an external editor (as above, either ``$VISUAL`` or ``$EDITOR``).
 
 - :kbd:`Alt`\ +\ :kbd:`V` Same as :kbd:`Alt`\ +\ :kbd:`E`.
 

--- a/share/functions/__fish_anyeditor.fish
+++ b/share/functions/__fish_anyeditor.fish
@@ -1,0 +1,16 @@
+function __fish_anyeditor --description "Print a editor to use, or an error message"
+    set -l editor
+    if set -q VISUAL
+        echo $VISUAL | read -at editor
+    else if set -q EDITOR
+        echo $EDITOR | read -at editor
+    else
+        echo
+        echo (_ 'External editor requested but $VISUAL or $EDITOR not set.')
+        echo (_ 'Please set VISUAL or EDITOR to your preferred editor.')
+        commandline -f repaint
+        return 1
+    end
+    string join \n $editor
+    return 0
+end

--- a/share/functions/__fish_edit_command_if_at_cursor.fish
+++ b/share/functions/__fish_edit_command_if_at_cursor.fish
@@ -1,0 +1,24 @@
+function __fish_edit_command_if_at_cursor --description 'If cursor is at the command token, edit the command source file'
+    set -l editor $argv
+    set -l tokens (commandline -xpc)
+    set -l command
+    if not set -q tokens[1]
+        set command (commandline -xp)[1]
+    else if test (count $tokens) = 1 && test -z "$(commandline -t)"
+        set command $tokens[1]
+    end
+
+    set -q command[1]
+    or return 1
+    set -l command_path (command -v -- $command)
+    or return 1
+    test -w $command_path
+    or return 1
+    string match -q 'text/*' (file --brief --mime-type -- $command_path)
+    or return 1
+
+    __fish_disable_bracketed_paste
+    $editor $command_path
+    __fish_enable_bracketed_paste
+    return 0
+end

--- a/share/functions/__fish_preview_current_file.fish
+++ b/share/functions/__fish_preview_current_file.fish
@@ -1,4 +1,9 @@
 function __fish_preview_current_file --description "Open the file at the cursor in a pager"
+    if set -l editor (__fish_anyeditor) && __fish_edit_command_if_at_cursor $editor
+        return 0
+    end
+
+
     set -l pager (__fish_anypager)
     or set pager cat
 

--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -1,4 +1,15 @@
 function edit_command_buffer --description 'Edit the command buffer in an external editor'
+    set -l editor (__fish_anyeditor)
+    or begin
+        # Print the error message.
+        printf %s\n $editor
+        return 1
+    end
+
+    if test "$(commandline -p)" = "$(commandline)" && __fish_edit_command_if_at_cursor $editor
+        return 0
+    end
+
     set -l f (mktemp)
     or return 1
     if set -q f[1]
@@ -13,20 +24,6 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
         end
         command touch $f
         or return 1
-    end
-
-    # Edit the command line with the users preferred editor or vim or emacs.
-    set -l editor
-    if set -q VISUAL
-        echo $VISUAL | read -at editor
-    else if set -q EDITOR
-        echo $EDITOR | read -at editor
-    else
-        echo
-        echo (_ 'External editor requested but $VISUAL or $EDITOR not set.')
-        echo (_ 'Please set VISUAL or EDITOR to your preferred editor.')
-        commandline -f repaint
-        return 1
     end
 
     commandline -b >$f


### PR DESCRIPTION
Fish functions are great for configuring fish but they don't integrate
seamlessly with the rest of the system. For tasks that can run outside fish,
writing scripts is the natural approach.

To edit my scripts I frequently run

    $EDITOR (which my-script)

Would be great to reduce the amount typing for this common case (the names
of editor and scripts are usually short, so that's a lot of typing spent on
the boring part).

Our Alt+o binding opens the file at the cursor in a pager.  When the cursor
is in command position, it doesn't do anything (unless the command is actually
a valid file path). Let's make it open the resolved file path in an editor.

Also enable this functionality in Alt+e.  This is experimental, I will probably
drop it. The motivation is that when the cursor is on the command token of a
single-process commandline, the existing Alt+e behavior is probably not very
helpful. So maybe we can improve discoverability of this feature by plugging
it in here. Though I'm not sure how many users would even try Alt+e on the
command token.

In future, we should teach this binding to delegate to "funced" upon seeing
a function instead of a script. I didn't do it yet because funced prints
messages, so it will mess with the commandline rendering if used from
a binding.  (The fact that funced encourages overwriting functions that
ship with fish is worrysome. Also I'm not sure why funced doesn't open the
function's source file directly (if not sourced from stdin). Persisting the
function should probably be the default.)

Alternative approach: I think other shells expand "=my-script" to
"/path/to/my-script".  That is certainly an option -- if we do that we'd want
to teach fish to complete command names after "=".  Since I don't remember
scenarios where I care about the full path of a script beyond opening it in
my editor, I didn't look further into this.
