### PR TITLE
completions: fix wg-quick interface completions

### DIFF
--- a/share/completions/wg-quick.fish
+++ b/share/completions/wg-quick.fish
@@ -1,7 +1,7 @@
 set -l valid_subcmds up down strip save
 
 function __fish_wg_complete_interfaces
-    wg show interfaces
+    wg show interfaces | string split " "
 end
 
 complete -c wg-quick -f


### PR DESCRIPTION
wg outputs space separated list, so need to convert to newline separated for `complete`
