### PR TITLE
Fix build on NetBSD

### DIFF
--- a/src/libc.c
+++ b/src/libc.c
@@ -182,6 +182,8 @@ int C_RLIMIT_NTHR() {
 #endif
 }
 
+#ifdef LC_GLOBAL_LOCALE
 locale_t C_LC_GLOBAL_LOCALE() {
     return LC_GLOBAL_LOCALE;
 }
+#endif

--- a/src/libc.c
+++ b/src/libc.c
@@ -1,3 +1,4 @@
+#include <locale.h>
 #include <paths.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -179,4 +180,8 @@ int C_RLIMIT_NTHR() {
 #else
     return -1;
 #endif
+}
+
+locale_t C_LC_GLOBAL_LOCALE() {
+    return LC_GLOBAL_LOCALE;
 }

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -102,3 +102,8 @@ extern "C" {
     fn C_RLIMIT_NPTS() -> i32; // ifndef: -1
     fn C_RLIMIT_NTHR() -> i32; // ifndef: -1
 }
+
+#[cfg(target_os = "netbsd")]
+extern "C" {
+    pub fn C_LC_GLOBAL_LOCALE() -> libc::locale_t;
+}

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -60,12 +60,17 @@ unsafe fn lconv_to_locale(lconv: &libc::lconv) -> Locale {
 
 /// Read the numeric locale, or None on any failure.
 #[cfg(localeconv_l)]
+#[allow(non_snake_case)]
 unsafe fn read_locale() -> Option<Locale> {
     extern "C" {
         fn localeconv_l(loc: libc::locale_t) -> *const libc::lconv;
     }
-    /// Rust libc does not provide LC_GLOBAL_LOCALE, but it appears to be -1 everywhere.
+    /// Rust libc does not provide LC_GLOBAL_LOCALE, but it is usually -1.
+    #[cfg(not(target_os = "netbsd"))]
     const LC_GLOBAL_LOCALE: libc::locale_t = (-1_isize) as libc::locale_t;
+    // On NetBSD it's not.
+    #[cfg(target_os = "netbsd")]
+    let LC_GLOBAL_LOCALE: libc::locale_t = unsafe { crate::libc::C_LC_GLOBAL_LOCALE() };
 
     const empty: [libc::c_char; 1] = [0];
     let cur = libc::duplocale(LC_GLOBAL_LOCALE);

--- a/src/path.rs
+++ b/src/path.rs
@@ -684,14 +684,14 @@ fn path_remoteness(path: &wstr) -> DirRemoteness {
         }
         let mnt_local = MNT_LOCAL();
         if mnt_local != 0 {
-            let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
-            if unsafe { libc::statfs(narrow.as_ptr(), &mut buf) } < 0 {
+            let mut buf: libc::statvfs = unsafe { std::mem::zeroed() };
+            if unsafe { libc::statvfs(narrow.as_ptr(), &mut buf) } < 0 {
                 return DirRemoteness::unknown;
             }
             // statfs::f_flag is hard-coded as 64-bits on 32/64-bit FreeBSD but it's a (4-byte)
             // long on 32-bit NetBSD.. and always 4-bytes on macOS (even on 64-bit builds).
             #[allow(clippy::useless_conversion)]
-            return if u64::from(buf.f_flags) & mnt_local != 0 {
+            return if u64::from(buf.f_flag) & mnt_local != 0 {
                 DirRemoteness::local
             } else {
                 DirRemoteness::remote

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -601,10 +601,17 @@ impl Screen {
         unsafe { libc::fstat(STDOUT_FILENO, &mut post_buff_1) };
         unsafe { libc::fstat(STDERR_FILENO, &mut post_buff_2) };
 
+        // Yes these differ in one `_`. I hate it.
+        #[cfg(not(target_os = "netbsd"))]
         let changed = self.prev_buff_1.st_mtime != post_buff_1.st_mtime
             || self.prev_buff_1.st_mtime_nsec != post_buff_1.st_mtime_nsec
             || self.prev_buff_2.st_mtime != post_buff_2.st_mtime
             || self.prev_buff_2.st_mtime_nsec != post_buff_2.st_mtime_nsec;
+        #[cfg(target_os = "netbsd")]
+        let changed = self.prev_buff_1.st_mtime != post_buff_1.st_mtime
+            || self.prev_buff_1.st_mtimensec != post_buff_1.st_mtimensec
+            || self.prev_buff_2.st_mtime != post_buff_2.st_mtime
+            || self.prev_buff_2.st_mtimensec != post_buff_2.st_mtimensec;
 
         if changed {
             // Ok, someone has been messing with our screen. We will want to repaint. However, we do not

--- a/src/wutil/mod.rs
+++ b/src/wutil/mod.rs
@@ -537,9 +537,15 @@ impl FileId {
         result.change_seconds = buf.st_ctime;
         result.mod_seconds = buf.st_mtime;
         #[allow(clippy::unnecessary_cast)] // platform-dependent
+        #[cfg(not(target_os = "netbsd"))]
         {
             result.change_nanoseconds = buf.st_ctime_nsec as _;
             result.mod_nanoseconds = buf.st_mtime_nsec as _;
+        }
+        #[cfg(target_os = "netbsd")]
+        {
+            result.change_nanoseconds = buf.st_ctimensec as _;
+            result.mod_nanoseconds = buf.st_mtimensec as _;
         }
         result
     }


### PR DESCRIPTION
Notably:

1. A typo in `f_flag` vs `f_flags` - this was probably never tested. I don't know if we couldn't use the ST_LOCAL path everywhere?
2. Some pointless name differences  - `st_mtimensec` vs `st_mtime_nsec`
3. The big one: This said that LC_GLOBAL_LOCALE was -1 "everywhere". Well, not on NetBSD.

Does anyone have a better idea for how to solve these? This works, but it's quite ugly, and hard to keep up-to-date given that we have no CI and, to be honest, not a lot of users on NetBSD.

Especially the name difference is one I just find fudging annoying. I had hoped we could get away from pointless stuff like that.
