### PR TITLE
fix builtin help ignoring redirects

### DIFF
--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -1,7 +1,7 @@
 use super::prelude::*;
 use crate::builtins::*;
 use crate::common::{escape, get_by_sorted_name, str2wcstring, Named};
-use crate::io::{IoChain, IoFd, OutputStream};
+use crate::io::{IoFd, OutputStream};
 use crate::parse_constants::UNKNOWN_BUILTIN_ERR_MSG;
 use crate::parse_util::parse_util_argument_is_help;
 use crate::parser::{Block, BlockType, LoopStatus};
@@ -553,7 +553,7 @@ pub fn builtin_print_help_error(
     }
     let name_esc = escape(cmd);
     let mut cmd = sprintf!("__fish_print_help %ls ", &name_esc);
-    let mut ios = IoChain::new();
+    let mut ios = streams.io_chain.clone();
     if !error_message.is_empty() {
         cmd.push_utfstr(&escape(error_message));
         // If it's an error, redirect the output of __fish_print_help to stderr

--- a/tests/checks/print-help.fish
+++ b/tests/checks/print-help.fish
@@ -1,0 +1,15 @@
+# RUN: %fish %s
+# Test redirecting builtin help with a pipe
+
+set -lx __fish_data_dir (mktemp -d)
+mkdir -p $__fish_data_dir/man/man1
+# Create $__fish_data_dir/man/man1/and.1
+echo '.\" Test manpage for and (not real).
+.TH "AND" "1" "Feb 02, 2024" "3.7" "fish-shell"
+.SH NAME
+and \- conditionally execute a command' >$__fish_data_dir/man/man1/and.1
+
+# help should be redirected to grep instead of appearing on STDOUT
+builtin and --help | grep -q "and - conditionally execute a command"
+echo $status
+#CHECK: 0


### PR DESCRIPTION
## Description

Build on existing `IoChain` rather than starting with a blank slate when printing man pages for builtin commands.
Unsure how to test this in a way that will run in CI, since I think man pages will be unavailable.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages. _Probably not required?_
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Fixes #10274