### PR TITLE
Fix rounding error on math docs

### DIFF
--- a/doc_src/cmds/math.rst
+++ b/doc_src/cmds/math.rst
@@ -190,7 +190,7 @@ Examples
 
 ``math -s0 10.0 / 6.0`` outputs ``1``.
 
-``math -s3 10 / 6`` outputs ``1.666``.
+``math -s3 10 / 6`` outputs ``1.667``.
 
 ``math "sin(pi)"`` outputs ``0``.
 


### PR DESCRIPTION
## Description

Just noticed this minor error on the math builtin docs.

This affects both the 3.7 version and the Rust rewrite. I'm opening this PR for `master`, but if it makes more sense to merge it into a 3.7.x branch please let me know.

I'm not adding a test for this because [there's already a check](https://github.com/fish-shell/fish-shell/blob/cb46396b677cde80c654c1e89903f1c193d82ca5/tests/checks/math.fish#L14-L15) for exactly this case. It was just the docs that were wrong.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] ~Tests have been added for regressions fixed~
- [ ] User-visible changes noted in CHANGELOG.rst
