### PR TITLE
Make `cargo install` only mostly instead of entirely broken

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -208,7 +208,14 @@ fn setup_paths() {
         var
     }
 
-    let prefix = PathBuf::from(env::var("PREFIX").unwrap_or("/usr/local".to_string()));
+    let prefix = if let Ok(pre) = env::var("PREFIX") {
+        PathBuf::from(pre)
+    } else if let Ok(home) = env::var("HOME") {
+        PathBuf::from(home).join(".local/")
+    } else {
+        panic!("Need either $PREFIX or $HOME");
+    };
+
     if prefix.is_relative() {
         panic!("Can't have relative prefix");
     }

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -287,7 +287,9 @@ fn read_init(parser: &Parser, paths: &ConfigPaths) {
         let escaped_pathname = escape(&datapath);
         FLOGF!(
             error,
-            "Fish cannot find its asset files in '%ls'. Refusing to read configuration.",
+            "Fish cannot find its asset files in '%ls'.\n\
+             Please copy the share/ directory from the fish repository there and restart fish.\n\
+             Refusing to read configuration because of this.",
             escaped_pathname
         );
         return;


### PR DESCRIPTION
## Description

(title is a bit of an overstatement, I don't want anyone to post this to HN with "fish can now be installed with `cargo install`!!!111eleven!!!")

Currently, if someone downloads the fish source and goes "It's a rust project, I know this!", they'll run `cargo install --path .` and end up with a fish install that is almost entirely broken in non-obvious ways.

As far as I know, it is impossible to disable `cargo install` officially. We could break it on purpose by setting an environment variable in cmake and check it in build.rs, but this would also break `cargo build`.

So this goes a different path:

1. If we can't read share/config.fish (that would be /usr/share/fish/config.fish in a typical package-managed install, or /usr/local/share/fish/config.fish with classical `sudo make install`), it prints an error and refuses to read the rest of the configuration - which would most likely throw more errors. At that point, fish is running in basically emergency mode.
2. It tells you where the data path is and to copy share/ there. If we did decide to support this, this could be a link to a "fish-4.0-share.tar.xz" that you would extract instead.
3. It defaults $PREFIX to ~/.local

The first change is split out because I believe it to be good on its own, regardless of the rest. Without it, with my own configuration, running a not-fully-installed fish would complain about `fish_add_path` not existing.

Together, this means the experience would be sort of like the following:

1. Run `cargo install --path .`
2. Fish ended up in ~/.cargo/bin/fish, run that
3. Fish tells us:
> error: Fish cannot find its asset files in '/home/alfa/.local/share/fish'.
Please copy the share/ directory from the fish repository there and restart fish.
Refusing to read configuration because of this.
4. `cp -r share/* ~/.local/share/fish`
5. Restart fish
6. It works, with some caveats! `help` will just open the online documentation, which is fine. fish_config *almost* works if we can finagle $__fish_bin_dir (or use `status fish-path`, but I know that's broken on OpenBSD). man pages won't be there, so `builtin --help` will tell you to run `help builtin`.

Of course this isn't exactly ideal. It involves annoying manual steps, and especially upgrading would be a pain - you would have to install the assets again, and it's not obvious that you would have to! (we could theoretically compare mtime of config.fish vs the fish binary)

But it's simple enough to add, reasonably obvious to use, and allows people to install fish locally for themselves, which is something we historically struggled with (see our attempts at an appimage).

If cargo ever learned to install assets, we could extend this to build on that.