### PR TITLE
tab completions: avoid completing gpg --use-embedded-filename

### DIFF
--- a/share/functions/__fish_complete_gpg.fish
+++ b/share/functions/__fish_complete_gpg.fish
@@ -264,9 +264,6 @@ function __fish_complete_gpg -d "Internal function for gpg completion code dedup
     complete -c $__fish_complete_gpg_command -l for-your-eyes-only -d "Set the 'for your eyes only' flag in the message"
     complete -c $__fish_complete_gpg_command -l no-for-your-eyes-only -d "Clear the 'for your eyes only' flag in the message"
 
-    complete -c $__fish_complete_gpg_command -l use-embedded-filename -d "Create file with name as given in data"
-    complete -c $__fish_complete_gpg_command -l no-use-embedded-filename -d "Don't create file with name as given in data"
-
     complete -c $__fish_complete_gpg_command -l completes-needed -x -d "Number of completely trusted users to introduce a new key signer (defaults to 1)"
     complete -c $__fish_complete_gpg_command -l marginals-needed -x -d "Number of marginally trusted users to introduce a new key signer (defaults to 3)"
 


### PR DESCRIPTION
`gpg`'s `--use-embedded-filename` is a dangerous option that can cause `gpg` to write arbitrary content to arbitrary files.

According to the GnuPG maintainer, this is [not an option recommended for use](https://dev.gnupg.org/T4500).  Fish shouldn't encourage users to supply it.

I've offered https://dev.gnupg.org/T6972 to upstream to make it even more clear that this option is a bad idea.

While removing it, we might as well also remove `--no-use-embedded-filename`, since it is effectively a no-op.

## TODOs:

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

I don't think any of the templated checklist above are necessary, but i'm happy to supply them if they're desired.