### PR TITLE
string repeat: allow omission of `-n`

### DIFF
--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -468,8 +468,20 @@ string repeat -n 2 foo
 string repeat --count 2 foo
 # CHECK: foofoo
 
+string repeat 2 foo
+# CHECK: foofoo
+
+string repeat 2 -n 3
+# CHECK: 222
+
 echo foo | string repeat -n 2
 # CHECK: foofoo
+
+echo foo | string repeat 2
+# CHECK: foofoo
+
+string repeat foo
+# CHECKERR: string repeat: Invalid count value 'foo'
 
 string repeat -n2 -q foo; and echo "exit 0"
 # CHECK: exit 0
@@ -566,8 +578,7 @@ string repeat -n; and echo "exit 0"
 # DONTCHECKERR: string repeat: Unknown option '-l'
 
 string repeat ""
-or echo string repeat empty string failed
-# CHECK: string repeat empty string failed
+# CHECKERR: string repeat: Invalid count value ''
 
 string repeat -n3 ""
 or echo string repeat empty string failed


### PR DESCRIPTION
## Description

`string repeat` will expect the first positional argument as the count if it is not supplied through the `-n` flag.

Fixes issue #9332

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
