### PR TITLE
Fix scp completion for WSL (with ssh.exe)

### DIFF
--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -45,7 +45,7 @@ complete -c scp -d "Local Path" -n "not string match @ -- (commandline -ct)"
 
 # Remote path
 # Get the list of remote files from the scp target.
-string match -rq 'OpenSSH_(?<major>\d+)\.*' -- (ssh -V 2>&1)
+string match -rq 'OpenSSH_\w*(?<major>\d+)\.*' -- (ssh -V 2>&1)
 if test "$major" -ge 9
     complete -c scp -d "Remote Path" -f -n "commandline -ct | string match -e ':'" -a "
     (__scp_remote_target):( \

--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -45,7 +45,7 @@ complete -c scp -d "Local Path" -n "not string match @ -- (commandline -ct)"
 
 # Remote path
 # Get the list of remote files from the scp target.
-string match -rq 'OpenSSH_\w*(?<major>\d+)\.*' -- (ssh -V 2>&1)
+string match -rq 'OpenSSH(_for_Windows)?_(?<major>\d+)\.*' -- (ssh -V 2>&1)
 if test "$major" -ge 9
     complete -c scp -d "Remote Path" -f -n "commandline -ct | string match -e ':'" -a "
     (__scp_remote_target):( \


### PR DESCRIPTION
## Description

On WSL, it is common to use ssh.exe (from the Windows part) to share the same `.ssh` folder with the host.

The completion script is not able to extract the version number from `ssh.exe`, which has this form:
```
OpenSSH_for_Windows_8.6p1, LibreSSL 3.4.3
```

This PR fixes this issue.