### PR TITLE
Use OwnedFd in AutoClosePipes

### DIFF
--- a/src/builtins/eval.rs
+++ b/src/builtins/eval.rs
@@ -26,11 +26,11 @@ pub fn eval(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Opt
     let mut stdout_fill = None;
     if streams.out_is_piped {
         match IoBufferfill::create_opts(parser.libdata().pods.read_limit, STDOUT_FILENO) {
-            None => {
+            Err(_) => {
                 // We were unable to create a pipe, probably fd exhaustion.
                 return STATUS_CMD_ERROR;
             }
-            Some(buffer) => {
+            Ok(buffer) => {
                 stdout_fill = Some(buffer.clone());
                 ios.push(buffer);
             }
@@ -41,11 +41,11 @@ pub fn eval(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Opt
     let mut stderr_fill = None;
     if streams.err_is_piped {
         match IoBufferfill::create_opts(parser.libdata().pods.read_limit, STDERR_FILENO) {
-            None => {
+            Err(_) => {
                 // We were unable to create a pipe, probably fd exhaustion.
                 return STATUS_CMD_ERROR;
             }
-            Some(buffer) => {
+            Ok(buffer) => {
                 stderr_fill = Some(buffer.clone());
                 ios.push(buffer);
             }

--- a/src/fd_monitor.rs
+++ b/src/fd_monitor.rs
@@ -62,7 +62,7 @@ impl FdEventSignaller {
         #[cfg(not(HAVE_EVENTFD))]
         {
             // Implementation using pipes.
-            let Some(pipes) = make_autoclose_pipes() else {
+            let Ok(pipes) = make_autoclose_pipes() else {
                 perror("pipe");
                 exit_without_destructors(1);
             };


### PR DESCRIPTION
Static typing for invalid states in `AutoClosePipes`.

While at it, use nix pipe/pipe2 and Results.

Probably best reviewed per commit, as nix/result changes are unrelated.