### PR TITLE
completions: add ssh -D option

### DIFF
--- a/share/completions/ssh.fish
+++ b/share/completions/ssh.fish
@@ -13,6 +13,7 @@ complete -c ssh -n 'test (__fish_number_of_cmd_args_wo_opts) -ge 2' -d "Command 
 complete -c ssh -s a -d "Disables forwarding of the authentication agent"
 complete -c ssh -s B -d "Bind to the address of that interface" -xa '(__fish_print_interfaces)'
 complete -c ssh -s b -d "Local address to bind to" -xa '(__fish_print_addresses)'
+complete -c ssh -s D -d "Specify dynamic port forwarding" -x
 complete -c ssh -s E -d "Append debug logs to log_file" -rF
 complete -c ssh -s e -d "Escape character" -xa "\^ none"
 complete -c ssh -s f -d "Go to background"


### PR DESCRIPTION
From `man ssh` of OpenSSH_9.6p1:

```
       -D [bind_address:]port
               Specifies a local “dynamic” application-level port forwarding.  This works by allocating a socket to listen to port on the local  side,  optionally bound to the specified bind_address.  Whenever a connection is made to this port, the connection is forwarded over the secure channel,  and  the  application protocol is then used to determine where to connect to from the remote machine.  Currently the SOCKS4 and SOCKS5 protocols are supported, and ssh will act as a SOCKS server.  Only root can forward privileged ports.  Dynamic port forwardings can also  be specified in the configuration file.

               IPv6  addresses can be specified by enclosing the address in square brackets.  Only the superuser can forward privileged ports.  By default, the local port is bound in accordance with the GatewayPorts setting.  However, an explicit bind_address may be used to bind  the  connection to  a  specific  address.  The bind_address of “localhost” indicates that the listening port be bound for local use only, while an empty address or ‘*’ indicates that the port should be available from all interfaces.
```