### PR TITLE
Provide man and completion paths when running from build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,24 @@ add_definitions(-D_REENTRANT)
 # not run cargo, so we need to tell it *something*
 FILE(GLOB sources src/* src/*/* src/*/*/*)
 
+if(NOT FISH_IN_TREE_BUILD)
+  add_custom_target(data_dir ALL
+    COMMAND mkdir -p ${CMAKE_BINARY_DIR}/share
+    COMMAND # Don't run ln twice or it will create a new link in the link.
+            CreateLink() {
+                if ! test -e \"$$2\" ";" then
+                    ln -sf \"$$1\" \"$$2\" ";"
+                fi
+            }
+    COMMAND CreateLink ${CMAKE_SOURCE_DIR}/share/functions ${CMAKE_BINARY_DIR}/share/functions
+    COMMAND CreateLink ${CMAKE_SOURCE_DIR}/share/completions ${CMAKE_BINARY_DIR}/share/completions
+    COMMAND CreateLink ${CMAKE_SOURCE_DIR}/share/config.fish ${CMAKE_BINARY_DIR}/share/config.fish
+    COMMAND CreateLink ${CMAKE_SOURCE_DIR}/share/groff ${CMAKE_BINARY_DIR}/share/groff
+    COMMAND CreateLink ${CMAKE_SOURCE_DIR}/share/tools ${CMAKE_BINARY_DIR}/share/tools
+    COMMAND CreateLink ${CMAKE_BINARY_DIR}/user_doc/man ${CMAKE_BINARY_DIR}/share/man
+  )
+endif()
+
 # Define a function to link dependencies.
 function(FISH_LINK_DEPS_AND_SIGN target)
   add_custom_command(
@@ -115,11 +133,12 @@ function(FISH_LINK_DEPS_AND_SIGN target)
     USES_TERMINAL
     # Don't use VERBATIM here, to allow the generator expressions above to expand to nothing rather than an empty string
   )
+
   add_custom_target(${target} ALL
     COMMAND "${CMAKE_COMMAND}" -E copy
       "${rust_target_dir}/${rust_profile}/${target}"
       "${CMAKE_CURRENT_BINARY_DIR}"
-    DEPENDS ${rust_target_dir}/${rust_profile}/${target}
+    DEPENDS ${rust_target_dir}/${rust_profile}/${target} data_dir
   )
   codesign_on_mac(${target})
 endfunction(FISH_LINK_DEPS_AND_SIGN)

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -37,7 +37,7 @@ add_custom_target(fish_run_tests
           FISH_SOURCE_DIR=${CMAKE_SOURCE_DIR}
           ${CMAKE_CTEST_COMMAND} --force-new-ctest-process # --verbose
           --output-on-failure --progress
-  DEPENDS tests_dir funcs_dir tests_buildroot_target
+  DEPENDS tests_dir tests_buildroot_target
   USES_TERMINAL
 )
 
@@ -61,15 +61,6 @@ set(TEST_ROOT_DIR ${TEST_DIR}/root)
 
 # Copy needed directories for out-of-tree builds
 if(NOT FISH_IN_TREE_BUILD)
-  add_custom_target(funcs_dir)
-  add_custom_command(TARGET funcs_dir
-    COMMAND mkdir -p ${CMAKE_BINARY_DIR}/share
-    # Don't run ln twice or it will create a new link in the link.
-    COMMAND test -e ${CMAKE_BINARY_DIR}/share/functions || ln -sf
-                          ${CMAKE_SOURCE_DIR}/share/functions/ ${CMAKE_BINARY_DIR}/share/functions
-                       COMMENT "Symlinking fish functions to binary dir"
-                       VERBATIM)
-
   add_custom_target(tests_dir DEPENDS tests)
   add_custom_command(TARGET tests_dir
                        COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -94,7 +85,7 @@ set(CMAKE_XCODE_GENERATE_SCHEME 0)
 function(add_test_target NAME)
   string(REPLACE "/" "-" NAME ${NAME})
   add_custom_target("test_${NAME}" COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R "^${NAME}$$"
-    DEPENDS tests_dir funcs_dir tests_buildroot_target USES_TERMINAL )
+    DEPENDS tests_dir tests_buildroot_target USES_TERMINAL )
 endfunction()
 
 add_custom_target(tests_buildroot_target

--- a/debian/rules
+++ b/debian/rules
@@ -14,4 +14,4 @@ override_dh_auto_configure:
 # On CMake 3.5 (and possibly 3.6), the test target does not pick up its dependencies properly
 # Build tests_buildroot_target by hand (remove this once Ubuntu Xenial is out of support)
 override_dh_auto_build:
-	dh_auto_build -- all tests_dir funcs_dir tests_buildroot_target
+	dh_auto_build -- all tests_dir tests_buildroot_target

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -164,10 +164,11 @@ fn determine_config_directory_paths(argv0: impl AsRef<Path>) -> ConfigPaths {
                 manifest_dir.display()
             );
             done = true;
+            let build_path = exec_path.parent().unwrap();
             paths = ConfigPaths {
-                data: manifest_dir.join("share"),
+                data: build_path.join("share"),
                 sysconf: manifest_dir.join("etc"),
-                doc: manifest_dir.join("user_doc/html"),
+                doc: build_path.join("user_doc/html"),
                 bin: exec_path.clone(),
             }
         }


### PR DESCRIPTION
(EDIT: currently broken when using `-GMake` but works with `-GNinja`)

We offer the usual installation method of `make && make install`.  Since are
a leaf package, installation is not inherently necessary.  It would be nice
if instead of installing I could simply symlink `fish` into my `$PATH`.

This would lower the barrier to running (possibly multiple) forks.
I can imagine that users who just want to fix some completion scripts may
not want to clobber their system with a full install.

It already kind of works but there are two issues:

1. Documentation and completions and some scripts are not available
   For example `man path` will fail.

2. vendor completion/function/snippet directories will point to `PREFIX`

This PR is a quick and dirty fix for issue 1. Barely tested.

Issue 2 is tricky, but also sort of unrelated.
It also happens when using `make install`.
Let's say the system package manager installs 3rd party completions to `/usr/share/fish/vendor_completions.d/`.
By default, `make install` will install to `/usr/local/`, so only `/usr/local/share/fish/vendor_completions.d/` is guaranteed to be included.
We do include `$XDG_DATA_DIRS` at runtime as a non-fish-specific way to resolve this.
But it wold be nice if this didn't require manual intervention.

[*] Same for `fish_indent` and `fish_key_reader` but those rarely change,
so it's fine if they come from the system package manager.
