### PR TITLE
Add completion for pstree

### DIFF
--- a/share/completions/pstree.fish
+++ b/share/completions/pstree.fish
@@ -1,0 +1,22 @@
+complete -c pstree -f
+complete -c pstree -s a -l arguments -d 'Show command line arguments'
+complete -c pstree -s A -l ascii -d 'use ASCII line drawing characters'
+complete -c pstree -s c -l compact -d 'don\'t compact identical subtrees'
+complete -c pstree -s h -l highlight-all -d 'highlight current process and its ancestors'
+complete -c pstree -s H -l highlight-pid -d 'highlight this process and its ancestors' -a '(ps -Ao pid | string trim)'
+complete -c pstree -s g -l show-pgids -d 'show process group ids; implies -c'
+complete -c pstree -s G -l vt100 -d 'use VT100 line drawing characters'
+complete -c pstree -s l -l long -d 'don\'t truncate long lines'
+complete -c pstree -s n -l numeric-sort -d 'sort output by PID'
+complete -c pstree -s N -l ns-sort -d 'sort by namespace type' -xa 'cgroup ipc mnt net pid user uts'
+complete -c pstree -s p -l show-pids -d 'show PIDs; implies -c'
+complete -c pstree -s s -l show-parents -d 'show parents of the selected process'
+complete -c pstree -s S -l ns-changes -d 'show namespace transitions'
+complete -c pstree -s t -l thread-names -d 'show full thread names'
+complete -c pstree -s T -l hide-threads -d 'hide threads, show only processes'
+complete -c pstree -s u -l uid-changes -d 'show uid transitions'
+complete -c pstree -s U -l unicode -d 'use UTF-8 line drawing characters'
+complete -c pstree -s V -l version -d 'display version information'
+complete -c pstree -s Z -l security-context -d 'show SELinux security contexts'
+complete -c pstree -a '(ps -Ao pid | string trim)' -d PID
+complete -c pstree -a '(cut -d: -f1 /etc/passwd)' -d USER

--- a/share/completions/pstree.fish
+++ b/share/completions/pstree.fish
@@ -3,7 +3,7 @@ complete -c pstree -s a -l arguments -d 'Show command line arguments'
 complete -c pstree -s A -l ascii -d 'use ASCII line drawing characters'
 complete -c pstree -s c -l compact -d 'don\'t compact identical subtrees'
 complete -c pstree -s h -l highlight-all -d 'highlight current process and its ancestors'
-complete -c pstree -s H -l highlight-pid -d 'highlight this process and its ancestors' -a '(ps -Ao pid | string trim)'
+complete -c pstree -s H -l highlight-pid -d 'highlight this process and its ancestors' -a '(__fish_complete_pids)'
 complete -c pstree -s g -l show-pgids -d 'show process group ids; implies -c'
 complete -c pstree -s G -l vt100 -d 'use VT100 line drawing characters'
 complete -c pstree -s l -l long -d 'don\'t truncate long lines'
@@ -18,5 +18,5 @@ complete -c pstree -s u -l uid-changes -d 'show uid transitions'
 complete -c pstree -s U -l unicode -d 'use UTF-8 line drawing characters'
 complete -c pstree -s V -l version -d 'display version information'
 complete -c pstree -s Z -l security-context -d 'show SELinux security contexts'
-complete -c pstree -a '(ps -Ao pid | string trim)' -d PID
-complete -c pstree -a '(cut -d: -f1 /etc/passwd)' -d USER
+complete -c pstree -a '(__fish_complete_pids)' -d PID
+complete -c pstree -a '(__fish_complete_users)' -d USER


### PR DESCRIPTION
## Description

Add completion for pstree <https://www.man7.org/linux/man-pages/man1/pstree.1.html>.

Is it possible to show a custom description for each argument value? Here I want to complete PIDs, it would be nice to show the process name in the tab options/search, but only complete with the PID.

pstree help for reference:

```
Usage: pstree [-acglpsStuZ] [ -h | -H PID ] [ -n | -N type ]
              [ -A | -G | -U ] [ PID | USER ]
       pstree -V
Display a tree of processes.

  -a, --arguments     show command line arguments
  -A, --ascii         use ASCII line drawing characters
  -c, --compact       don't compact identical subtrees
  -h, --highlight-all highlight current process and its ancestors
  -H PID,
  --highlight-pid=PID highlight this process and its ancestors
  -g, --show-pgids    show process group ids; implies -c
  -G, --vt100         use VT100 line drawing characters
  -l, --long          don't truncate long lines
  -n, --numeric-sort  sort output by PID
  -N type,
  --ns-sort=type      sort by namespace type (cgroup, ipc, mnt, net, pid,
                                              user, uts)
  -p, --show-pids     show PIDs; implies -c
  -s, --show-parents  show parents of the selected process
  -S, --ns-changes    show namespace transitions
  -t, --thread-names  show full thread names
  -T, --hide-threads  hide threads, show only processes
  -u, --uid-changes   show uid transitions
  -U, --unicode       use UTF-8 (Unicode) line drawing characters
  -V, --version       display version information
  -Z, --security-context
                      show SELinux security contexts
  PID    start at this PID; default is 1 (init)
  USER   show only trees rooted at processes of this user
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
