### PR TITLE
Always `source` file after `funced`

### DIFF
--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -115,7 +115,9 @@ function funced --description 'Edit function definition'
                 if test "$new_checksum" = "$checksum"
                     echo (_ "Editor exited but the function was not modified")
                     echo (_ "If the editor is still running, check if it waits for completion, maybe a '--wait' option?")
-                    # Don't source or save an unmodified file.
+                    # Source but don't save an unmodified file.
+                    # (Source in case the file changed externally since we first loaded it.)
+                    source "$writepath"
                     break
                 end
             end


### PR DESCRIPTION
... even if the file hasn't changed. This addresses an oddity in the following case:

* Shell is started,
* function `foo` is sourced from foo.fish
* foo.fish is *externally* edited and saved
* <Loaded definition of `foo` is now stale, but fish is unaware>
* `funced foo` loads `type -p foo` showing changed definition, user exits $EDITOR saving no changes (or with $status 0, more generally).
* Stale definition of `foo` remains
