### PR TITLE
functions: handle hostname starting with dash

### DIFF
--- a/share/functions/prompt_hostname.fish
+++ b/share/functions/prompt_hostname.fish
@@ -1,3 +1,3 @@
 function prompt_hostname --description 'short hostname for the prompt'
-    string replace -r "\..*" "" $hostname
+    string replace -r -- "\..*" "" $hostname
 end


### PR DESCRIPTION
## Description

If a hostname starts with a dash `-` character, the prompt_hostname function fails because the `string` function interprets it as an option instead of an argument.

Related to #4959 
