### PR TITLE
Use `memmap2` crate instead of hand-rolled memory mapping for history files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "lru",
+ "memmap2",
  "nix",
  "num-traits",
  "once_cell",
@@ -221,6 +222,15 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "minimal-lexical"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ errno = "0.2.8"
 lazy_static = "1.4.0"
 libc = "0.2.137"
 lru = "0.10.0"
+memmap2 = "0.9.4"
 nix = { version = "0.25.0", default-features = false, features = ["inotify", "resource", "fs"] }
 num-traits = "0.2.15"
 once_cell = "1.17.0"

--- a/src/history.rs
+++ b/src/history.rs
@@ -490,7 +490,7 @@ impl HistoryImpl {
             // as if it did not fail. The risk is that we may get an incomplete history item; this
             // is unlikely because we only treat an item as valid if it has a terminating newline.
             let locked = unsafe { Self::maybe_lock_file(&fd, LOCK_SH) };
-            self.file_contents = HistoryFileContents::create(fd.as_raw_fd());
+            self.file_contents = HistoryFileContents::create(&fd);
             self.history_file_id = if self.file_contents.is_some() {
                 file_id_for_fd(fd.as_raw_fd())
             } else {
@@ -564,7 +564,7 @@ impl HistoryImpl {
         // Read in existing items (which may have changed out from underneath us, so don't trust our
         // old file contents).
         if let Some(existing_fd) = existing_fd {
-            if let Some(local_file) = HistoryFileContents::create(existing_fd) {
+            if let Some(local_file) = HistoryFileContents::create(&existing_fd) {
                 let mut cursor = 0;
                 while let Some(offset) = local_file.offset_of_next_item(&mut cursor, None) {
                     // Try decoding an old item.


### PR DESCRIPTION
## Description

Replace the hand-rolled implementation of memory mapping with the `memmap2` crate. This allows enforcement within the type system that the memory-mapped file is read-only. Removes a bunch of `unsafe`-marked code as well and replaces the various remaining libc `lseek`s with safe `nix` versions.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
