### PR TITLE
Fix Vi mode autosuggestions and others

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ fish 3.8.0 (released ???)
    10198 10200 10201 10204 10210 10214 10219 10223 10227 10232 10235 10237 10243 10244 10245
    10246 10251 10260 10267 10281 10347 10366 10368 10370 10371 10263 10270 10272 10276 10277
    10278 10279 10291 10293 10305 10306 10309 10316 10317 10327 10328 10329 10330 10336 10340
-   10345 10346 10353 10354 10356 10372 10373
+   10345 10346 10353 10354 10356 10372 10373 3299 10360
 
 The entirety of fish's C++ code has been ported to Rust (:issue:`9512`).
 This means a large change in dependencies and how to build fish.
@@ -84,7 +84,12 @@ New or improved bindings
   - Cursor position synchronization is only supported for a set of known editors. This has been extended by also resolving aliases. For example use ``complete --wraps my-vim vim`` to synchronize cursors when `EDITOR=my-vim`.
 - ``backward-kill-path-component`` and friends now treat ``#`` as part of a path component (:issue:`10271`).
 - The ``E`` binding in vi mode now correctly handles the last character of the word, by jumping to the next word (:issue:`9700`).
-- Vi mode now binds :kbd:`Control-N`  to accept autosuggestions (:issue:`10339`).
+- Vi mode has seen some improvements although it continues to lack development.
+  - Insert-mode :kbd:`Control-N` accepts autosuggestions (:issue:`10339`).
+  - Outside insert mode, the cursor will no longer be placed beyond the last character on the commandline.
+  - When the cursor is at the end of the commandline, a single :kbd:`l` will accept an autosuggestion (:issue:`10286`)
+  - The cursor position after pasting (:kbd:`p`) has been corrected.
+  - When the cursor is at the start of a line, escaping from insert mode no longer moves the cursor to the previous line.
 
 Improved prompts
 ^^^^^^^^^^^^^^^^

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -56,7 +56,17 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # Add a way to switch from insert to normal (command) mode.
     # Note if we are paging, we want to stay in insert mode
     # See #2871
-    bind -s --preset -M insert \e "if commandline -P; commandline -f cancel; else; set fish_bind_mode default; commandline -f backward-char repaint-mode; end"
+    bind -s --preset -M insert \e '
+        if commandline -P
+            commandline -f cancel
+        else
+            set fish_bind_mode default
+            if test (count (commandline --cut-at-cursor | tail -c2)) != 2
+                commandline -f backward-char
+            end
+            commandline -f repaint-mode
+        end
+    '
 
     # Default (command) mode
     bind -s --preset :q exit

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -65,12 +65,12 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M default l forward-char
     bind -s --preset -m insert \n execute
     bind -s --preset -m insert \r execute
-    bind -s --preset -m insert o insert-line-under repaint-mode
-    bind -s --preset -m insert O insert-line-over repaint-mode
+    bind -s --preset -m insert o 'set fish_cursor_selection_mode exclusive' insert-line-under repaint-mode
+    bind -s --preset -m insert O 'set fish_cursor_selection_mode exclusive' insert-line-over repaint-mode
     bind -s --preset -m insert i repaint-mode
     bind -s --preset -m insert I beginning-of-line repaint-mode
-    bind -s --preset -m insert a forward-single-char repaint-mode
-    bind -s --preset -m insert A end-of-line repaint-mode
+    bind -s --preset -m insert a 'set fish_cursor_selection_mode exclusive' forward-single-char repaint-mode
+    bind -s --preset -m insert A 'set fish_cursor_selection_mode exclusive' end-of-line repaint-mode
     bind -s --preset -m visual v begin-selection repaint-mode
 
     bind -s --preset gg beginning-of-buffer
@@ -98,8 +98,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset gE backward-bigword
     bind -s --preset w forward-word forward-single-char
     bind -s --preset W forward-bigword forward-single-char
-    bind -s --preset e forward-single-char forward-word backward-char
-    bind -s --preset E forward-single-char forward-bigword backward-char
+    bind -s --preset e 'set fish_cursor_selection_mode exclusive' forward-single-char forward-word backward-char 'set fish_cursor_selection_mode inclusive'
+    bind -s --preset E 'set fish_cursor_selection_mode exclusive' forward-single-char forward-bigword backward-char 'set fish_cursor_selection_mode inclusive'
 
     bind -s --preset -M insert \cn accept-autosuggestion
 
@@ -112,10 +112,10 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # Vi moves the cursor back if, after deleting, it is at EOL.
     # To emulate that, move forward, then backward, which will be a NOP
     # if there is something to move forward to.
-    bind -s --preset -M default x delete-char forward-single-char backward-char
+    bind -s --preset -M default x delete-char 'set fish_cursor_selection_mode exclusive' forward-single-char backward-char 'set fish_cursor_selection_mode inclusive'
     bind -s --preset -M default X backward-delete-char
     bind -s --preset -M insert -k dc delete-char forward-single-char backward-char
-    bind -s --preset -M default -k dc delete-char forward-single-char backward-char
+    bind -s --preset -M default -k dc delete-char 'set fish_cursor_selection_mode exclusive' forward-single-char backward-char 'set fish_cursor_selection_mode inclusive'
 
     # Backspace deletes a char in insert mode, but not in normal/default mode.
     bind -s --preset -M insert -k backspace backward-delete-char
@@ -225,13 +225,13 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # in vim p means paste *after* current character, so go forward a char before pasting
     # also in vim, P means paste *at* current position (like at '|' with cursor = line),
     # \ so there's no need to go back a char, just paste it without moving
-    bind -s --preset p forward-char yank
+    bind -s --preset p 'set -g fish_cursor_selection_mode exclusive' forward-char 'set -g fish_cursor_selection_mode inclusive' yank
     bind -s --preset P yank
     bind -s --preset gp yank-pop
 
     # same vim 'pasting' note as upper
-    bind -s --preset '"*p' forward-char "commandline -i ( xsel -p; echo )[1]"
-    bind -s --preset '"*P' "commandline -i ( xsel -p; echo )[1]"
+    bind -s --preset '"*p' 'set -g fish_cursor_selection_mode exclusive' forward-char 'set -g fish_cursor_selection_mode inclusive' fish_clipboard_paste
+    bind -s --preset '"*P' fish_clipboard_paste
 
     #
     # Lowercase r, enters replace_one mode
@@ -267,8 +267,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M visual gE backward-bigword
     bind -s --preset -M visual w forward-word
     bind -s --preset -M visual W forward-bigword
-    bind -s --preset -M visual e forward-word
-    bind -s --preset -M visual E forward-bigword
+    bind -s --preset -M visual e 'set fish_cursor_selection_mode exclusive' forward-single-char forward-word backward-char 'set fish_cursor_selection_mode inclusive'
+    bind -s --preset -M visual E 'set fish_cursor_selection_mode exclusive' forward-single-char forward-bigword backward-char 'set fish_cursor_selection_mode inclusive'
     bind -s --preset -M visual o swap-selection-start-stop repaint-mode
 
     bind -s --preset -M visual f forward-jump
@@ -305,8 +305,21 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # After executing once, this will have defined functions listening for the variable.
     # Therefore it needs to be before setting fish_bind_mode.
     fish_vi_cursor
-    set -g fish_cursor_selection_mode inclusive
+    function __fish_vi_key_bindings_on_mode_change --on-variable fish_bind_mode
+        switch $fish_bind_mode
+            case insert
+                set -g fish_cursor_selection_mode exclusive
+            case '*'
+                set -g fish_cursor_selection_mode inclusive
+        end
+    end
+    function __fish_vi_key_bindings_remove_handlers --on-variable __fish_active_key_bindings
+        functions --erase __fish_vi_key_bindings_remove_handlers
+        functions --erase __fish_vi_key_bindings_on_mode_change
+        functions --erase fish_vi_cursor_handle
+        functions --erase fish_vi_cursor_handle_preexec
+        set -e -g fish_cursor_selection_mode
+    end
 
     set fish_bind_mode $init_mode
-
 end

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -73,9 +73,6 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert A end-of-line repaint-mode
     bind -s --preset -m visual v begin-selection repaint-mode
 
-    #bind -s --preset -m insert o "commandline -a \n" down-line repaint-mode
-    #bind -s --preset -m insert O beginning-of-line "commandline -i \n" up-line repaint-mode # doesn't work
-
     bind -s --preset gg beginning-of-buffer
     bind -s --preset G end-of-buffer
 

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -232,6 +232,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # same vim 'pasting' note as upper
     bind -s --preset '"*p' 'set -g fish_cursor_selection_mode exclusive' forward-char 'set -g fish_cursor_selection_mode inclusive' fish_clipboard_paste
     bind -s --preset '"*P' fish_clipboard_paste
+    bind -s --preset '"+p' 'set -g fish_cursor_selection_mode exclusive' forward-char 'set -g fish_cursor_selection_mode inclusive' fish_clipboard_paste
+    bind -s --preset '"+P' fish_clipboard_paste
 
     #
     # Lowercase r, enters replace_one mode
@@ -290,6 +292,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M visual -m default X kill-whole-line end-selection repaint-mode
     bind -s --preset -M visual -m default y kill-selection yank end-selection repaint-mode
     bind -s --preset -M visual -m default '"*y' "fish_clipboard_copy; commandline -f end-selection repaint-mode"
+    bind -s --preset -M visual -m default '"+y' "fish_clipboard_copy; commandline -f end-selection repaint-mode"
     bind -s --preset -M visual -m default '~' togglecase-selection end-selection repaint-mode
 
     bind -s --preset -M visual -m default \cc end-selection repaint-mode

--- a/src/editable_line.rs
+++ b/src/editable_line.rs
@@ -123,6 +123,7 @@ impl EditableLine {
         self.position
     }
     pub fn set_position(&mut self, position: usize) {
+        assert!(position <= self.len());
         self.position = position;
     }
 


### PR DESCRIPTION
Add a hack to Vi mode to avoid placing the cursor beyond the last character.
This fixes an issue with autosuggestions.  Also fix some other issues.

Vi mode has lots of issues remaining but with hybrid mode it seems usable
to me.

Closes #10286
Closes #3299