### PR TITLE
Kill pure Vi key bindings, use hybrid behavior instead

### DIFF
--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -277,14 +277,11 @@ The fish editor features copy and paste, a :ref:`searchable history <history-sea
 Like bash and other shells, fish includes two sets of keyboard shortcuts (or key bindings): one inspired by the Emacs text editor, and one by the vi text editor. The default editing mode is Emacs. You can switch to vi mode by running :doc:`fish_vi_key_bindings <cmds/fish_vi_key_bindings>` and switch back with :doc:`fish_default_key_bindings <cmds/fish_default_key_bindings>`. You can also make your own key bindings by creating a function and setting the ``fish_key_bindings`` variable to its name. For example::
 
 
-    function fish_hybrid_key_bindings --description \
-    "Vi-style bindings that inherit emacs-style bindings in all modes"
-        for mode in default insert visual
-            fish_default_key_bindings -M $mode
-        end
-        fish_vi_key_bindings --no-erase
+    function my_key_bindings
+        fish_default_key_bindings_key_bindings # or fish_vi_key_bindings
+        bind \cg beginning-of-line 'commandline -i "# "'
     end
-    set -g fish_key_bindings fish_hybrid_key_bindings
+    set -g fish_key_bindings my_key_bindings
 
 While the key bindings included with fish include many of the shortcuts popular from the respective text editors, they are not a complete implementation. They include a shortcut to open the current command line in your preferred editor (:kbd:`Alt`\ +\ :kbd:`E` by default) if you need the full power of your editor.
 

--- a/share/functions/fish_hybrid_key_bindings.fish
+++ b/share/functions/fish_hybrid_key_bindings.fish
@@ -1,18 +1,3 @@
-function fish_hybrid_key_bindings --description "Vi-style bindings that inherit emacs-style bindings in all modes"
-    bind --erase --all --preset # clear earlier bindings, if any
-
-    if test "$fish_key_bindings" != fish_hybrid_key_bindings
-        # Allow the user to set the variable universally
-        set -q fish_key_bindings
-        or set -g fish_key_bindings
-        # This triggers the handler, which calls us again and ensures the user_key_bindings
-        # are executed.
-        set fish_key_bindings fish_hybrid_key_bindings
-        return
-    end
-
-    for mode in default insert visual
-        fish_default_key_bindings -M $mode
-    end
-    fish_vi_key_bindings --no-erase
+function fish_hybrid_key_bindings --description "Deprecated, use fish_vi_key_bindings"
+    fish_vi_key_bindings fish_hybrid_key_bindings
 end

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -1,4 +1,25 @@
-function fish_vi_key_bindings --description 'vi-like key bindings for fish'
+function fish_vi_key_bindings --description "Vi-style bindings that inherit emacs-style bindings in all modes"
+    set -l bindings_name $argv[1] fish_vi_key_bindings
+
+    bind --erase --all --preset # clear earlier bindings, if any
+
+    if test "$fish_key_bindings" != $bindings_name[1]
+        # Allow the user to set the variable universally
+        set -q fish_key_bindings
+        or set -g fish_key_bindings
+        # This triggers the handler, which calls us again and ensures the user_key_bindings
+        # are executed.
+        set fish_key_bindings $bindings_name[1]
+        return
+    end
+
+    for mode in default insert visual
+        fish_default_key_bindings -M $mode
+    end
+    __fish_vi_key_bindings --no-erase
+end
+
+function __fish_vi_key_bindings --description 'vi-like key bindings for fish'
     if contains -- -h $argv
         or contains -- --help $argv
         echo "Sorry but this function doesn't support -h or --help" >&2

--- a/share/tools/web_config/sample_prompts/nim.fish
+++ b/share/tools/web_config/sample_prompts/nim.fish
@@ -84,7 +84,6 @@ function fish_prompt
     end
 
     if test "$fish_key_bindings" = fish_vi_key_bindings
-        or test "$fish_key_bindings" = fish_hybrid_key_bindings
         set -l mode
         switch $fish_bind_mode
             case default


### PR DESCRIPTION
I find pure Vi mode very unpleasant to use because it doesn't define
shortcuts like Control-n and Control-f. Judging by the number of references
to "fish_vi_key_bindings" in public github repos, it seems that many users
don't know about "fish_hybrid_key_bindings" (unless they prefer the other
for some unknown reason?).

As far as I'm concerned, hybrid bindings are strictly better than Vi ones.
Let's avoid this easy user error and make both use the hybrid behavior.

Hybrid mode is nice because it reduces the friction of learning Vi mode,
because most Emacs key work the same way. Similarly, it reduces friction
caused by some of our bugs and missing features in Vi mode, because one
can simply fall back to the Emacs binding.
