### PR TITLE
docs: Correct default value of `read` function in `read.rst`

### DIFF
--- a/doc_src/cmds/read.rst
+++ b/doc_src/cmds/read.rst
@@ -59,7 +59,7 @@ The following options control the interactive mode:
     Masks characters written to the terminal, replacing them with asterisks. This is useful for reading things like passwords or other sensitive information.
 
 **-p** or **--prompt** *PROMPT_CMD*
-    Uses the output of the shell command *PROMPT_CMD* as the prompt for the interactive mode. The default prompt command is ``set_color green; echo read; set_color normal; echo "> "``
+    Uses the output of the shell command *PROMPT_CMD* as the prompt for the interactive mode. The default prompt command is ``set_color green; echo -n read; set_color normal; echo -n "> "``
 
 **-P** or **--prompt-str** *PROMPT_STR*
     Uses the literal *PROMPT_STR* as the prompt for the interactive mode.


### PR DESCRIPTION
## Description

Hi, I found the documentation about the default value of `read` function is a bit different from the actual implementation (no `-n` in the documentation). 

ref. 
- https://github.com/fish-shell/fish-shell/blob/33a7172ee8f99a32a18ac627642831bbf9ac8523/src/builtins/read.rs#L453
- https://github.com/fish-shell/fish-shell/blob/master/src/builtins/shared.rs#L22

Fixes issue N/A

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
