### PR TITLE
Make translation string extraction work with rust

### DIFF
--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -1,18 +1,40 @@
 #!/usr/bin/env fish
 #
 # Tool to generate messages.pot
-# Extended to replace the old Makefile rule which did not port easily to CMake
 
-# This script was originally motivated to work around a quirk (or bug depending on your viewpoint)
-# of the xgettext command. See https://lists.gnu.org/archive/html/bug-gettext/2014-11/msg00006.html.
-# However, it turns out that even if that quirk did not exist we would still need something like
-# this script to properly extract descriptions. That's because we need to normalize the strings to
-# a format that xgettext will handle correctly. Also, `xgettext -LShell` doesn't correctly extract
-# all the strings we want translated. So we extract and normalize all such strings into a format
-# that `xgettext` can handle.
+# Create temporary directory for these operations. OS X `mktemp` is somewhat restricted, so this block
+# works around that - based on share/functions/funced.fish.
+set -q TMPDIR
+or set -l TMPDIR /tmp
+set -l tmpdir (mktemp -d $TMPDIR/fish.XXXXXX)
+or exit 1
 
-# Start with the C++ source
-xgettext -k -k_ -kN_ -LC++ --no-wrap -o messages.pot src/*.cpp src/*.h
+# This is a gigantic crime.
+# xgettext still does not support rust *at all*, so we use cargo-expand to get all our wgettext invocations.
+set -l expanded (cargo expand --lib; for f in fish{,_indent,_key_reader}; cargo expand --bin $f; end)
+
+# Extract any gettext call
+set -l strs (printf '%s\n' $expanded | grep -A1 wgettext_static_str |
+             grep 'widestring::internals::core::primitive::str =' |
+             string match -rg '"(.*)"' | string match -rv '^%ls$|^$' |
+             # escaping difference between gettext and cargo-expand: single-quotes
+             string replace -a "\'" "'" | sort -u)
+
+# Extract any constants
+set -a strs (string match -rv 'BUILD_VERSION:|PACKAGE_NAME' -- $expanded |
+             string match -rg 'const [A-Z_]*: &str = "(.*)"' | string replace -a "\'" "'")
+
+# We construct messages.pot ourselves instead of forcing this into msgmerge or whatever.
+# The escaping so far works out okay.
+for str in $strs
+    # grep -P needed for string escape to be compatible (PCRE-style),
+    # -H gives the filename, -n the line number.
+    # If you want to run this on non-GNU grep: Don't.
+    echo "#:" (grep -PHn -r -- (string escape --style=regex -- $str) src/ |
+    head -n1 | string replace -r ':\s.*' '')
+    echo "msgid \"$str\""
+    echo 'msgstr ""'
+end >messages.pot
 
 # This regex handles descriptions for `complete` and `function` statements. These messages are not
 # particularly important to translate. Hence the "implicit" label.
@@ -22,39 +44,22 @@ set -l implicit_regex '(?:^| +)(?:complete|function).*? (?:-d|--description) (([
 # than messages which should be implicitly translated.
 set -l explicit_regex '.*\( *_ (([\'"]).+?(?<!\\\\)\\2) *\).*'
 
-# Create temporary directory for these operations. OS X `mktemp` is somewhat restricted, so this block
-# works around that - based on share/functions/funced.fish.
-set -q TMPDIR
-or set -l TMPDIR /tmp
-set -l tmpdir (mktemp -d $TMPDIR/fish.XXXXXX)
-or exit 1
-
 mkdir -p $tmpdir/implicit/share/completions $tmpdir/implicit/share/functions
 mkdir -p $tmpdir/explicit/share/completions $tmpdir/explicit/share/functions
 
 for f in share/config.fish share/completions/*.fish share/functions/*.fish
     # Extract explicit attempts to translate a message. That is, those that are of the form
     # `(_ "message")`.
-    string replace --filter --regex $explicit_regex 'echo $1' <$f | fish >$tmpdir/explicit/$f.tmp 2>/dev/null
-    while read description
-        echo 'N_ "'(string replace --all '"' '\\"' -- $description)'"'
-    end <$tmpdir/explicit/$f.tmp >$tmpdir/explicit/$f
-    rm $tmpdir/explicit/$f.tmp
+    string replace --filter --regex $explicit_regex '$1' <$f | string unescape \
+        | string replace --all '"' '\\"' | string replace -r '(.*)' 'N_ "$1"' >$tmpdir/explicit/$f
 
     # Handle `complete` / `function` description messages. The `| fish` is subtle. It basically
     # avoids the need to use `source` with a command substitution that could affect the current
     # shell.
-    string replace --filter --regex $implicit_regex 'echo $1' <$f | fish >$tmpdir/implicit/$f.tmp 2>/dev/null
-    while read description
-        # We don't use `string escape` as shown in the next comment because it produces output that
-        # is not parsed correctly by xgettext. Instead just escape double-quotes and quote the
-        # resulting string.
-        echo 'N_ "'(string replace --all '"' '\\"' -- $description)'"'
-    end <$tmpdir/implicit/$f.tmp >$tmpdir/implicit/$f
-    rm $tmpdir/implicit/$f.tmp
+    string replace --filter --regex $implicit_regex '$1' <$f | string unescape \
+        | string replace --all '"' '\\"' | string replace -r '(.*)' 'N_ "$1"' >$tmpdir/implicit/$f
 end
 
-xgettext -j -k -kN_ -LShell --from-code=UTF-8 -cDescription --no-wrap -o messages.pot $tmpdir/explicit/share/*/*.fish
-xgettext -j -k -kN_ -LShell --from-code=UTF-8 -cDescription --no-wrap -o messages.pot $tmpdir/implicit/share/*/*.fish
+xgettext -j -k -kN_ -LShell --from-code=UTF-8 -cDescription --no-wrap -o messages.pot $tmpdir/{ex,im}plicit/share/*/*.fish
 
 rm -r $tmpdir

--- a/src/builtins/abbr.rs
+++ b/src/builtins/abbr.rs
@@ -324,7 +324,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
                     .append(wgettext_fmt!("%ls: %ls\n", CMD, regex_pattern.as_utfstr()));
                 streams
                     .err
-                    .append(wgettext_fmt!("%ls: %*ls\n", CMD, offset, "^"));
+                    .append(sprintf!("%ls: %*ls\n", CMD, offset, "^"));
             }
             return STATUS_INVALID_ARGS;
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -962,7 +962,7 @@ impl Parser {
                     &wgettext_fmt!(
                         "Could not write profiling information to file '%s': %s",
                         &String::from_utf8_lossy(path),
-                        format!("{}", err)
+                        err.to_string()
                     )
                 );
                 return;


### PR DESCRIPTION
## Description

This extracts the strings we pass to wgettext! and friends into the po files.

The usual way to do this is xgettext. Unfortunately, while there is a patch to add rust support, it appears to have been [stuck in limbo for almost 2 years](https://savannah.gnu.org/bugs/?56774).

Since we already have a script to work around xgettext issues, let's just create some issues of our own!

This uses [cargo-expand](https://github.com/dtolnay/cargo-expand) to extract the strings from uses of wgettext.

For obvious reasons, that's a bit brittle, so I'm not about to call this the absolute greatest solution ever.

However, cargo-expand means we get nested macros etc for free - anything that expands to "pass this string literal to gettext" will work. Additionally, we assume any string constant (except for BUILD_VERSION and PACKAGE_NAME (why do we even have PACKAGE_NAME)) could be translated. Worst case it's useless guff in the po file.

I have not included the generated po-files in this because those are about ~250k lines changed.

Here are the statistics on what would change in them in terms of "translated" (has msgid and msgstr) vs untranslated strings:

```
OLD po/de.po 1458 translated messages, 1 fuzzy translation, 21680 untranslated messages.
NEW po/de.po 1439 translated messages, 23474 untranslated messages.

OLD po/en.po 2335 translated messages, 20804 untranslated messages.
NEW po/en.po 2330 translated messages, 22583 untranslated messages.

OLD po/fr.po 7469 translated messages, 15670 untranslated messages.
NEW po/fr.po 7334 translated messages, 17579 untranslated messages.

OLD po/pl.po 86 translated messages, 23053 untranslated messages.
NEW po/pl.po 103 translated messages, 24810 untranslated messages.

OLD po/pt_BR.po 1146 translated messages, 21993 untranslated messages.
NEW po/pt_BR.po 1152 translated messages, 23761 untranslated messages.

OLD po/sv.po 1590 translated messages, 21549 untranslated messages.
NEW po/sv.po 1586 translated messages, 23327 untranslated messages.

OLD po/zh_CN.po 35 translated messages, 23104 untranslated messages.
NEW po/zh_CN.po 73 translated messages, 24840 untranslated messages.
```

Note that a lot of these are bound to be unused strings, we have *not* kept up well with translations.

The *increase* in translated messages is due to unused translations being matched to msgids - I believe in some cases the old code did not correctly figure out the location. I have compared some of the zh_CN ones and they seem plausible (in terms of format specifiers and google translate).


---------

To be quite honest, I'm pretty sure the future direction would take us off gettext.

The tools aren't good, development isn't quick, and it's tying us to the C-world.

But this seems like a necessary step in order to get the strings out.

As an important note: Only 434 of the 25000 messages are in the core src/. That means french is at about 40%, german is at about 30%. These numbers aren't *good*, but it is possible to improve them.

It is much too easy to feel like this work is useless because of the staggering number of messages we have. But I do believe that one dedicated translator for a language might be capable of translating 100% of src/ - but they would have to keep at it, because we keep changing and adding and removing these messages.