### PR TITLE
fix: #10184 causes adb file completion failures

### DIFF
--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -73,7 +73,7 @@ function __fish_adb_list_files
     end
 
     # Return list of directories suffixed with '/'
-    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type d 2\>/dev/null | awk '{print $0"/"}'
+    __fish_adb_run_command find -H "$token*" -maxdepth 0 -type d 2\>/dev/null | string replace -r '$' /
     # Return list of files
     __fish_adb_run_command find -H "$token*" -maxdepth 0 -type f 2\>/dev/null
 end


### PR DESCRIPTION
Signed-off-by: NextAlone <12210746+NextAlone@users.noreply.github.com>

## Description

Fixes adb files completions failures caused by #10184

Fixes issue #10184

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
