### PR TITLE
fire fish_prompt on prompt repaint

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2115,6 +2115,9 @@ impl ReaderData {
                     }
                     // Else we repaint as normal.
                 }
+                if !self.conf.event.is_empty() {
+                    event::fire_generic(self.parser(), self.conf.event.to_owned(), vec![]);
+                }
                 self.exec_prompt();
                 self.screen.reset_line(/*repaint_prompt=*/ true);
                 self.layout_and_repaint(L!("readline"));


### PR DESCRIPTION
## Description

Now `commandline -f repaint` will emit the event `fish_prompt`. Probably some other ways will trigger this event too.

Fixes #10350 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] (N/A: not regression) Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
