### PR TITLE
Add support for OSC 133

### DIFF
--- a/src/curses.rs
+++ b/src/curses.rs
@@ -79,13 +79,6 @@ pub struct Term {
     pub clr_eol: Option<CString>,
     pub clr_eos: Option<CString>,
 
-    // OSC 133  docs: https://iterm2.com/documentation-escape-codes.html
-    pub prompt_start: Option<CString>,  // "\x1b133;A\x07"
-    pub prompt_end: Option<CString>,    // "\x1b133;B\x07"
-    pub command_start: Option<CString>, // "\x1b133;C\x07"
-    // pub command_end_before_status: Option<CString>, // "\x1b133;D;<exitcode>;\x07"
-    // pub command_end_after_status: Option<CString>,
-
     // Number capabilities
     pub max_colors: Option<usize>,
     pub init_tabs: Option<usize>,
@@ -244,10 +237,6 @@ impl Term {
             parm_right_cursor: get_str_cap(&db, "RI"),
             clr_eol: get_str_cap(&db, "ce"),
             clr_eos: get_str_cap(&db, "cd"),
-
-            prompt_start: if support_osc133 { Some(CString::new("\x1b]133;A\x1b\x5c").unwrap()) } else { None },
-            prompt_end: if support_osc133 { Some(CString::new("\x1b]133;B\x1b\x5c").unwrap()) } else { None },
-            command_start: if support_osc133 { Some(CString::new("\x1b]133;C\x1b\x5c").unwrap()) } else { None },
 
             // Number capabilities
             max_colors: get_num_cap(&db, "Co"),

--- a/src/curses.rs
+++ b/src/curses.rs
@@ -79,6 +79,13 @@ pub struct Term {
     pub clr_eol: Option<CString>,
     pub clr_eos: Option<CString>,
 
+    // OSC 133  docs: https://iterm2.com/documentation-escape-codes.html
+    pub prompt_start: Option<CString>,  // "\x1b133;A\x07"
+    pub prompt_end: Option<CString>,    // "\x1b133;B\x07"
+    pub command_start: Option<CString>, // "\x1b133;C\x07"
+    // pub command_end_before_status: Option<CString>, // "\x1b133;D;<exitcode>;\x07"
+    // pub command_end_after_status: Option<CString>,
+
     // Number capabilities
     pub max_colors: Option<usize>,
     pub init_tabs: Option<usize>,
@@ -201,6 +208,9 @@ impl Term {
     /// Initialize a new `Term` instance, prepopulating the values of all the curses string
     /// capabilities we care about in the process.
     fn new(db: terminfo::Database) -> Self {
+        // todo: how to do feature detection of OSC 133?
+        let support_osc133 = false;
+
         Term {
             // String capabilities
             enter_bold_mode: get_str_cap(&db, "md"),
@@ -234,6 +244,10 @@ impl Term {
             parm_right_cursor: get_str_cap(&db, "RI"),
             clr_eol: get_str_cap(&db, "ce"),
             clr_eos: get_str_cap(&db, "cd"),
+
+            prompt_start: if support_osc133 { Some(CString::new("\x1b]133;A\x1b\x5c").unwrap()) } else { None },
+            prompt_end: if support_osc133 { Some(CString::new("\x1b]133;B\x1b\x5c").unwrap()) } else { None },
+            command_start: if support_osc133 { Some(CString::new("\x1b]133;C\x1b\x5c").unwrap()) } else { None },
 
             // Number capabilities
             max_colors: get_num_cap(&db, "Co"),

--- a/src/output.rs
+++ b/src/output.rs
@@ -427,8 +427,12 @@ impl Outputter {
     /// Emit a terminfo string, like tputs.
     /// affcnt (number of lines affected) is assumed to be 1, i.e. not applicable.
     pub fn tputs(&mut self, str: &CStr) {
+        self.tputs_bytes(str.to_bytes());
+    }
+
+    pub fn tputs_bytes(&mut self, str: &[u8]) {
         self.begin_buffering();
-        let _ = self.write(str.to_bytes());
+        let _ = self.write(str);
         self.end_buffering();
     }
 

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -832,6 +832,7 @@ impl Screen {
         // Output the left prompt if it has changed.
         if left_prompt != zelf.actual_left_prompt {
             zelf.r#move(0, 0);
+            zelf.write_mbs_if_some(&term.and_then(|term| term.prompt_start.as_ref()));
             let mut start = 0;
             for line_break in left_prompt_layout.line_breaks {
                 zelf.write_str(&left_prompt[start..line_break]);
@@ -1031,6 +1032,7 @@ impl Screen {
                 let Cursor { x, y } = zelf.actual.cursor;
                 zelf.r#move(x - right_prompt_width, y);
                 zelf.write_str(L!("\r"));
+                zelf.write_mbs_if_some(&term.and_then(|term| term.prompt_end.as_ref()));
                 zelf.actual.cursor.x = 0;
             }
         }


### PR DESCRIPTION
## Description

Support marking prompts with OSC 133

Supercedes https://github.com/fish-shell/fish-shell/pull/10351.
## TODOs:
- [ ] Find out how feature detection is done
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
