### PR TITLE
Simplify Parser's shared-from-this pattern

### DIFF
--- a/src/global_safety.rs
+++ b/src/global_safety.rs
@@ -1,6 +1,5 @@
 use crate::flog::FLOG;
-use std::cell::{Ref, RefCell, RefMut};
-use std::rc::{Rc, Weak};
+use std::cell::{Ref, RefMut};
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::sync::MutexGuard;
 
@@ -50,30 +49,6 @@ impl<T: ?Sized> AtomicRef<T> {
             value as *const &'static T as *mut &'static T,
             Ordering::Relaxed,
         )
-    }
-}
-
-pub struct SharedFromThisBase<T> {
-    weak: RefCell<Weak<T>>,
-}
-
-impl<T> SharedFromThisBase<T> {
-    pub fn new() -> SharedFromThisBase<T> {
-        SharedFromThisBase {
-            weak: RefCell::new(Weak::new()),
-        }
-    }
-
-    pub fn initialize(&self, r: &Rc<T>) {
-        *self.weak.borrow_mut() = Rc::downgrade(r);
-    }
-}
-
-pub trait SharedFromThis<T> {
-    fn get_base(&self) -> &SharedFromThisBase<T>;
-
-    fn shared_from_this(&self) -> Rc<T> {
-        self.get_base().weak.borrow().upgrade().unwrap()
     }
 }
 


### PR DESCRIPTION
## Description
Rust 1.60.0 added `Rc::new_cyclic`, which makes it a lot easier to set up an intentional reference cycle. Ideally we'd completely remove this oddity, especially because it looks like only one `Parser` is ever constructed or passed around (and it lives in a static variable!). However, that's a more disruptive change than I'm comfortable attempting as a complete newcomer.

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages. (N/A)
- [x] Tests have been added for regressions fixed (N/A)
- [x] User-visible changes noted in CHANGELOG.rst (N/A)
