### PR TITLE
Address new clippy lints

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2288,9 +2288,7 @@ impl<'a> Traversal<'a> {
 impl<'a> Iterator for Traversal<'a> {
     type Item = &'a dyn Node;
     fn next(&mut self) -> Option<&'a dyn Node> {
-        let Some(node) = self.stack.pop() else {
-            return None;
-        };
+        let node = self.stack.pop()?;
         // We want to visit in reverse order so the first child ends up on top of the stack.
         node.accept(self, true /* reverse */);
         Some(node)

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -140,9 +140,7 @@ impl Autoload {
         }
 
         // Do we have an entry to load?
-        let Some(file) = self.cache.check(cmd, false) else {
-            return None;
-        };
+        let file = self.cache.check(cmd, false)?;
 
         // Is this file the same as what we previously autoloaded?
         if let Some(loaded_file) = self.autoloaded_files.get(cmd) {

--- a/src/bin/fish_indent.rs
+++ b/src/bin/fish_indent.rs
@@ -2,6 +2,7 @@
 
 // Delete this once we require Rust 1.74.
 #![allow(unstable_name_collisions)]
+#![allow(unknown_lints)]
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::incompatible_msrv)] // false positive for is_some_and (we have a polyfill)
 

--- a/src/bin/fish_indent.rs
+++ b/src/bin/fish_indent.rs
@@ -3,6 +3,7 @@
 // Delete this once we require Rust 1.74.
 #![allow(unstable_name_collisions)]
 #![allow(clippy::uninlined_format_args)]
+#![allow(clippy::incompatible_msrv)] // false positive for is_some_and (we have a polyfill)
 
 use std::ffi::{CString, OsStr};
 use std::io::{stdin, Read, Write};

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -545,9 +545,7 @@ mod test_expressions {
             }
 
             // Parse a subexpression.
-            let Some(subexpr) = self.parse_expression(start + 1, end) else {
-                return None;
-            };
+            let subexpr = self.parse_expression(start + 1, end)?;
 
             // Parse a close paren.
             let close_index = subexpr.range().end;

--- a/src/env/environment_impl.rs
+++ b/src/env/environment_impl.rs
@@ -854,7 +854,7 @@ impl EnvStackImpl {
                 if val.exports() {
                     let mut node_ref = node.borrow_mut();
                     // Do NOT overwrite existing values, since we go from inner scopes outwards.
-                    if node_ref.env.get(key).is_none() {
+                    if !node_ref.env.contains_key(key) {
                         node_ref.env.insert(key.clone(), val.clone());
                     }
                     node_ref.changed_exported();

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -809,8 +809,6 @@ pub fn use_posix_spawn() -> bool {
 
 /// Whether or not we are running on an OS where we allow ourselves to use `posix_spawn()`.
 const fn allow_use_posix_spawn() -> bool {
-    #![allow(clippy::if_same_then_else)]
-    #![allow(clippy::needless_bool)]
     // OpenBSD's posix_spawn returns status 127 instead of erroring with ENOEXEC when faced with a
     // shebang-less script. Disable posix_spawn on OpenBSD.
     if cfg!(target_os = "openbsd") {

--- a/src/future_feature_flags.rs
+++ b/src/future_feature_flags.rs
@@ -4,6 +4,9 @@ use crate::wchar::prelude::*;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
+#[cfg(test)]
+use std::cell::RefCell;
+
 /// The list of flags.
 #[repr(u8)]
 #[derive(Clone, Copy)]
@@ -97,7 +100,7 @@ pub const METADATA: &[FeatureMetadata] = &[
 
 thread_local!(
     #[cfg(test)]
-    static LOCAL_FEATURES: std::cell::RefCell<Option<Features>> = std::cell::RefCell::new(None);
+    static LOCAL_FEATURES: RefCell<Option<Features>> = const { RefCell::new(None) };
 );
 
 /// The singleton shared feature set.

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -296,12 +296,8 @@ fn autosuggest_parse_command(
     );
 
     // Find the first statement.
-    let Some(jc) = ast.top().as_job_list().unwrap().get(0) else {
-        return None;
-    };
-    let Some(first_statement) = jc.job.statement.contents.as_decorated_statement() else {
-        return None;
-    };
+    let jc = ast.top().as_job_list().unwrap().get(0)?;
+    let first_statement = jc.job.statement.contents.as_decorated_statement()?;
 
     if let Some(expanded_command) = statement_get_expanded_command(buff, first_statement, ctx) {
         let mut arg = WString::new();
@@ -1491,9 +1487,7 @@ fn statement_get_expanded_command(
     ctx: &OperationContext<'_>,
 ) -> Option<WString> {
     // Get the command. Try expanding it. If we cannot, it's an error.
-    let Some(cmd) = stmt.command.try_source(src) else {
-        return None;
-    };
+    let cmd = stmt.command.try_source(src)?;
     let mut out_cmd = WString::new();
     let err = expand_to_command_and_args(cmd, ctx, &mut out_cmd, None, None, false);
     (err == ExpandResultCode::ok).then_some(out_cmd)

--- a/src/history.rs
+++ b/src/history.rs
@@ -205,9 +205,7 @@ fn history_filename(session_id: &wstr, suffix: &wstr) -> Option<WString> {
         return None;
     }
 
-    let Some(mut result) = path_get_data() else {
-        return None;
-    };
+    let mut result = path_get_data()?;
 
     result.push('/');
     result.push_utfstr(session_id);

--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -340,9 +340,7 @@ fn extract_prefix_and_unescape_yaml(line: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
 fn decode_item_fish_2_0(mut data: &[u8]) -> Option<HistoryItem> {
     let (advance, line) = read_line(data);
     let line = trim_start(line);
-    let Some((key, value)) = extract_prefix_and_unescape_yaml(line) else {
-        return None;
-    };
+    let (key, value) = extract_prefix_and_unescape_yaml(line)?;
 
     if key != b"- cmd" {
         return None;
@@ -432,17 +430,11 @@ pub fn time_to_seconds(ts: SystemTime) -> i64 {
 /// We know the string contains a newline, so stop when we reach it.
 fn parse_timestamp(s: &[u8]) -> Option<SystemTime> {
     let s = trim_start(s);
-
-    let Some(s) = s.strip_prefix(b"when:") else {
-        return None;
-    };
-
+    let s = s.strip_prefix(b"when:")?;
     let s = trim_start(s);
 
-    std::str::from_utf8(s)
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .map(time_from_seconds)
+    let t = std::str::from_utf8(s).ok()?.parse().ok()?;
+    Some(time_from_seconds(t))
 }
 
 fn complete_lines(s: &[u8]) -> impl Iterator<Item = &[u8]> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 #![allow(clippy::redundant_slicing)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::uninlined_format_args)]
+#![allow(clippy::assigning_clones)]
+#![allow(clippy::incompatible_msrv)] // false positive for is_some_and (1.70, but we have a polyfill)
 
 pub const BUILD_VERSION: &str = env!("FISH_BUILD_VERSION");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(unstable_name_collisions)]
+#![allow(unknown_lints)] // prevent stable from complaining about nightly-only lints
 #![allow(clippy::bool_assert_comparison)]
 #![allow(clippy::box_default)]
 #![allow(clippy::collapsible_if)]

--- a/src/tests/env.rs
+++ b/src/tests/env.rs
@@ -102,9 +102,9 @@ fn test_env_vars() {
         vec![L!("abc").to_owned(), L!("def").to_owned()],
         EnvVarFlags::EXPORT,
     );
-    assert!(v1 == v2 && !(v1 != v2));
-    assert!(v1 != v3 && !(v1 == v3));
-    assert!(v1 != v4 && !(v1 == v4));
+    assert_eq!(v1, v2);
+    assert_ne!(v1, v3);
+    assert_ne!(v1, v4);
 }
 
 #[test]

--- a/src/tests/highlight.rs
+++ b/src/tests/highlight.rs
@@ -34,7 +34,7 @@ fn test_is_potential_path() {
     std::fs::write("test/is_potential_path_test/gamma", []).unwrap();
 
     let wd = L!("test/is_potential_path_test/").to_owned();
-    let wds = vec![L!(".").to_owned(), wd];
+    let wds = [L!(".").to_owned(), wd];
 
     let vars = EnvStack::principal().clone();
     let ctx = OperationContext::background(&*vars, EXPANSION_LIMIT_DEFAULT);

--- a/src/tests/pager.rs
+++ b/src/tests/pager.rs
@@ -4,7 +4,6 @@ use crate::pager::{Pager, SelectionMotion};
 use crate::termsize::Termsize;
 use crate::tests::prelude::*;
 use crate::wchar::prelude::*;
-use crate::wchar_ext::WExt;
 use crate::wcstringutil::StringFuzzyMatch;
 
 #[test]

--- a/src/tests/parse_util.rs
+++ b/src/tests/parse_util.rs
@@ -8,7 +8,6 @@ use crate::parse_constants::{
 use crate::parse_util::{parse_util_detect_errors, BOOL_AFTER_BACKGROUND_ERROR_MSG};
 use crate::tests::prelude::*;
 use crate::wchar::prelude::*;
-use crate::wchar_ext::WExt;
 
 #[test]
 #[serial]

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -180,9 +180,7 @@ pub fn spawn<F: FnOnce() + Send + 'static>(callback: F) -> bool {
     // We don't have to port the PTHREAD_CREATE_DETACHED logic. Rust threads are detached
     // automatically if the returned join handle is dropped.
 
-    let result = match std::thread::Builder::new().spawn(move || {
-        (callback)();
-    }) {
+    let result = match std::thread::Builder::new().spawn(callback) {
         Ok(handle) => {
             let thread_id = handle.thread().id();
             FLOG!(iothread, "rust thread", thread_id, "spawned");

--- a/src/wutil/wcstod.rs
+++ b/src/wutil/wcstod.rs
@@ -197,10 +197,7 @@ where
 
 #[cfg(test)]
 mod test {
-    #![allow(overflowing_literals)]
-
     use super::{wcstod, Error};
-    use std::f64;
 
     #[test]
     #[allow(clippy::all)]


### PR DESCRIPTION
Changes should be largely self-explanatory - nightly added some new lints.
Fixes all clippy diagnostics except for `incompatible_msrv`: a few files use `Option::is_some_and` and `Result::is_ok_and`, which were stabilized in 1.70 vs the current MSRV of 1.67, and I wasn't sure whether to bump the MSRV to match reality, write a polyfill, or switch to something uglier.
I'm curious as to how these scattered `let`-`else` usages happened.