### PR TITLE
Begin switching to `File` from `OwnedFd` in a few places

### DIFF
--- a/src/env_universal_common.rs
+++ b/src/env_universal_common.rs
@@ -22,6 +22,7 @@ use nix::{fcntl::OFlag, sys::stat::Mode};
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
 use std::ffi::CString;
+use std::fs::File;
 use std::mem::MaybeUninit;
 use std::os::fd::{AsFd, AsRawFd, OwnedFd, RawFd};
 use std::os::unix::prelude::MetadataExt;
@@ -496,7 +497,7 @@ impl EnvUniversal {
         &mut self,
         directory: &wstr,
         out_path: &mut WString,
-    ) -> Result<OwnedFd, Errno> {
+    ) -> Result<File, Errno> {
         // Create and open a temporary file for writing within the given directory. Try to create a
         // temporary file, up to 10 times. We don't use mkstemps because we want to open it CLO_EXEC.
         // This should almost always succeed on the first try.

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -8,7 +8,8 @@ use crate::{common::is_console_session, wchar::prelude::*};
 use errno::{errno, Errno};
 use once_cell::sync::Lazy;
 use std::cmp;
-use std::os::fd::{FromRawFd, OwnedFd};
+use std::fs::File;
+use std::os::fd::FromRawFd;
 use std::sync::atomic::{AtomicIsize, Ordering};
 use std::{ffi::CString, mem};
 
@@ -102,7 +103,7 @@ pub fn fish_wcswidth(s: &wstr) -> isize {
 // Replacement for mkostemp(str, O_CLOEXEC)
 // This uses mkostemp if available,
 // otherwise it uses mkstemp followed by fcntl
-pub fn fish_mkstemp_cloexec(name_template: CString) -> Result<(OwnedFd, CString), Errno> {
+pub fn fish_mkstemp_cloexec(name_template: CString) -> Result<(File, CString), Errno> {
     let name = name_template.into_raw();
     #[cfg(not(target_os = "macos"))]
     let fd = {
@@ -121,7 +122,7 @@ pub fn fish_mkstemp_cloexec(name_template: CString) -> Result<(OwnedFd, CString)
     if fd == -1 {
         Err(errno())
     } else {
-        unsafe { Ok((OwnedFd::from_raw_fd(fd), CString::from_raw(name))) }
+        unsafe { Ok((File::from_raw_fd(fd), CString::from_raw(name))) }
     }
 }
 


### PR DESCRIPTION
This is a step towards converting `wopen_cloexec()` to return `File` instead of `OwnedFd`/`AutocloseFd`.¹

In addition to letting us use native standard library functions instead of unsafe libc calls, we gain additional semantic safety because `File` operations that manipulate the state of the fd (e.g. `File::seek()`) require a `&mut` reference to the `File`, whereas using `RawFd` or `OwnedFd` everywhere leaves us in a position where it's not clear whether or not other references to the same fd will manipulate its underlying state.

¹ We actually wouldn't even need `wopen_cloexec()` at all (just a widechar wrapper) as Rust's native `File::open()`/`File::create()` functionality uses `FD_CLOEXEC` internally.

The patch itself is fine, tests pass, etc. but I would like to open the floor for any discussions on the nature of the change itself (moving more code from our libc wrappers to rust std). As you can see, this change also uses native `File` functionality as exposed via the rust standard library (seek, etc) instead of calling libc operations on the raw fd itself, reducing our ffi code and removing a number of `unsafe` calls.

The idea is that after all call sites have been converted to use `File`, we can go back in and change `wopen_cloexec()` to return a `File` directly.