### PR TITLE
completions/git: don't offer files when running `git commit --fixup`

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1326,7 +1326,7 @@ complete -f -c git -n '__fish_git_using_command clone' -l recursive -d 'Initiali
 ### commit
 complete -c git -n __fish_git_needs_command -a commit -d 'Record changes to the repository'
 complete -c git -n '__fish_git_using_command commit' -l amend -d 'Amend the log message of the last commit'
-complete -f -c git -n '__fish_git_using_command commit' -a '(__fish_git_files modified deleted modified-staged-deleted untracked)'
+complete -f -c git -n '__fish_git_using_command commit' -n 'not __fish_git_contains_opt fixup squash' -a '(__fish_git_files modified deleted modified-staged-deleted untracked)'
 complete -c git -n '__fish_git_using_command commit' -s a -l all -d 'Automatically stage modified and deleted files'
 complete -c git -n '__fish_git_using_command commit' -s p -l patch -d 'Use interactive patch selection interface'
 complete -f -c git -n '__fish_git_using_command commit' -l fixup -d 'Fixup commit to be used with rebase --autosquash'


### PR DESCRIPTION
## Description

So I'm running fish 3.7 when I see this behaviour but it looks like the same problem should exist in master. Basically, when I run `git commit --fixup` I'm expecting to only see the recent commits, however before this change, I'd also see completions for untracked files in the repo. This should fix that (it seems to for 3.7 at least). I guess this isn't worth mentioning in the changelog?
