### PR TITLE
Fixed typo in French translations

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -2239,7 +2239,7 @@ msgstr "%s : Pile de dossiers vide…\\n"
 
 #: share/functions/psub.fish:1
 msgid "%s: Not inside of command substitution"
-msgstr "%s : hors de laa substitution de commande"
+msgstr "%s : hors de la substitution de commande"
 
 #: share/functions/realpath.fish:1
 msgid "%s: These flags are not allowed by fish realpath: '%s'"


### PR DESCRIPTION
## Description

There was a duplicated 'a' in one of the French strings.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
