### PR TITLE
Un-hide documentation of non-fish shell builtins

### DIFF
--- a/doc_src/cmds/alias.rst
+++ b/doc_src/cmds/alias.rst
@@ -54,9 +54,11 @@ The following code will create ``rmi``, which runs ``rm`` with additional argume
     alias chrome='/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome banana'
 
 
-See more
+See Also
 --------
 
-1. The :doc:`function <function>` command this builds on.
-2. :ref:`Functions <syntax-function>`.
-3. :ref:`Defining aliases <syntax-aliases>`.
+- The :doc:`function <function>` command this builds on.
+- :ref:`Functions <syntax-function>`.
+- :ref:`Defining aliases <syntax-aliases>`.
+- ``command man alias`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/alias.html>

--- a/doc_src/cmds/bg.rst
+++ b/doc_src/cmds/bg.rst
@@ -45,3 +45,9 @@ If only 123 and 789 exist, it will still background them and print an error abou
 ``bg 123 banana`` or ``bg banana 123`` will complain that "banana" is not a valid job specifier.
 
 ``bg %2`` will background job 2.
+
+See Also
+--------
+
+- ``command man bg`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/bg.html>

--- a/doc_src/cmds/break.rst
+++ b/doc_src/cmds/break.rst
@@ -38,3 +38,5 @@ See Also
 --------
 
 - the :doc:`continue <continue>` command, to skip the remainder of the current iteration of the current inner loop
+- ``command man break`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#break>

--- a/doc_src/cmds/cd.rst
+++ b/doc_src/cmds/cd.rst
@@ -44,4 +44,6 @@ Examples
 See Also
 --------
 
-Navigate directories using the :ref:`directory history <directory-history>` or the :ref:`directory stack <directory-stack>`
+- Navigate directories using the :ref:`directory history <directory-history>` or the :ref:`directory stack <directory-stack>`
+- ``command man cd`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cd.html>

--- a/doc_src/cmds/command.rst
+++ b/doc_src/cmds/command.rst
@@ -40,3 +40,9 @@ Examples
 | ``command -s ls`` prints the path to the ``ls`` program.
 | ``command -q git; and command git log`` runs ``git log`` only if ``git`` exists.
 | ``command -sq git`` and ``command -q git`` and ``command -vq git`` return true (0) if a git command could be found and don't print anything.
+
+See Also
+--------
+
+- ``command man command`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html>

--- a/doc_src/cmds/continue.rst
+++ b/doc_src/cmds/continue.rst
@@ -36,3 +36,5 @@ See Also
 --------
 
 - the :doc:`break <break>` command, to stop the current inner loop
+- ``command man continue`` -- show docs for the non-fish variant.
+- <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#continue>

--- a/doc_src/cmds/echo.rst
+++ b/doc_src/cmds/echo.rst
@@ -79,3 +79,5 @@ See Also
 --------
 
 - the :doc:`printf <printf>` command, for more control over output formatting
+- ``command man echo`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html>

--- a/doc_src/cmds/exec.rst
+++ b/doc_src/cmds/exec.rst
@@ -21,3 +21,9 @@ Example
 -------
 
 ``exec emacs`` starts up the emacs text editor, and exits ``fish``. When emacs exits, the session will terminate.
+
+See Also
+--------
+
+- ``command man exec`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exec>

--- a/doc_src/cmds/exit.rst
+++ b/doc_src/cmds/exit.rst
@@ -20,3 +20,9 @@ Otherwise, the exit status will be that of the last command executed.
 If exit is called while sourcing a file (using the :doc:`source <source>` builtin) the rest of the file will be skipped, but the shell itself will not exit.
 
 The **--help** or **-h** option displays help about using this command.
+
+See Also
+--------
+
+- ``command man exit`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exit>

--- a/doc_src/cmds/false.rst
+++ b/doc_src/cmds/false.rst
@@ -20,3 +20,5 @@ See Also
 
 - :doc:`true <true>` command
 - :ref:`$status <variables-status>` variable
+- ``command man false`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/false.html>

--- a/doc_src/cmds/fg.rst
+++ b/doc_src/cmds/fg.rst
@@ -29,3 +29,9 @@ Example
 ``fg`` will put the last job in the foreground.
 
 ``fg %3`` will put job 3 into the foreground.
+
+See Also
+--------
+
+``command man fg``
+https://pubs.opengroup.org/onlinepubs/9699919799/utilities/fg.html

--- a/doc_src/cmds/jobs.rst
+++ b/doc_src/cmds/jobs.rst
@@ -54,3 +54,9 @@ Example
    Job Group   State   Command
    2   26012   running nc -l 55232 < /dev/random &
    1   26011   running python tests/test_11.py &
+
+See Also
+--------
+
+- ``command man jobs`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/jobs.html>

--- a/doc_src/cmds/not.rst
+++ b/doc_src/cmds/not.rst
@@ -34,5 +34,3 @@ The following code reports an error and exits if no file named spoon can be foun
         echo There is no spoon
         exit 1
     end
-
-

--- a/doc_src/cmds/not.rst
+++ b/doc_src/cmds/not.rst
@@ -9,12 +9,15 @@ Synopsis
 .. synopsis::
 
     not COMMAND [OPTIONS ...]
+    ! COMMAND [OPTIONS ...]
 
 
 Description
 -----------
 
 ``not`` negates the exit status of another command. If the exit status is zero, ``not`` returns 1. Otherwise, ``not`` returns 0.
+
+Most other shells only support the ``!`` variant.
 
 The **-h** or **--help** option displays help about using this command.
 

--- a/doc_src/cmds/printf.rst
+++ b/doc_src/cmds/printf.rst
@@ -100,6 +100,8 @@ See Also
 --------
 
 - the :doc:`echo <echo>` command, for simpler output
+- ``command man printf`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html>
 
 Footnotes
 ---------

--- a/doc_src/cmds/read.rst
+++ b/doc_src/cmds/read.rst
@@ -144,3 +144,8 @@ Delimiters given via "-d" are taken as one string::
     echo $c # nothing
 
 For an example on interactive use, see :ref:`Querying for user input <user-input>`.
+
+See Also
+--------
+- ``command man read`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/read.html>

--- a/doc_src/cmds/realpath.rst
+++ b/doc_src/cmds/realpath.rst
@@ -32,3 +32,8 @@ The following options are available:
 
 **-h** or **--help**
     Displays help about using this command.
+
+See Also
+--------
+
+- ``command man realpath`` -- show docs for the non-fish variant.

--- a/doc_src/cmds/return.rst
+++ b/doc_src/cmds/return.rst
@@ -34,3 +34,9 @@ An implementation of the false command as a fish function:
     function false
         return 1
     end
+
+See Also
+--------
+
+- ``command man return`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#return>

--- a/doc_src/cmds/source.rst
+++ b/doc_src/cmds/source.rst
@@ -44,3 +44,8 @@ Caveats
 -------
 
 In fish versions prior to 2.3.0, the :envvar:`argv` variable would have a single element (the name of the sourced file) if no arguments are present. Otherwise, it would contain arguments without the name of the sourced file. That behavior was very confusing and unlike other shells such as bash and zsh.
+
+See Also
+--------
+
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#dot>

--- a/doc_src/cmds/test.rst
+++ b/doc_src/cmds/test.rst
@@ -231,7 +231,7 @@ which is logically equivalent to the following:
 Standards
 ---------
 
-Unlike many things in fish, ``test`` implements a subset of the `IEEE Std 1003.1-2008 (POSIX.1) standard <https://www.unix.com/man-page/posix/1p/test/>`__. The following exceptions apply:
+Unlike many things in fish, ``test`` implements a subset of the `IEEE Std 1003.1-2008 (POSIX.1) standard <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html>`__. The following exceptions apply:
 
 - The ``<`` and ``>`` operators for comparing strings are not implemented.
 

--- a/doc_src/cmds/test.rst
+++ b/doc_src/cmds/test.rst
@@ -244,3 +244,9 @@ Other commands that may be useful as a condition, and are often easier to use:
 
 - :doc:`string`, which can do string operations including wildcard and regular expression matching
 - :doc:`path`, which can do file checks and operations, including filters on multiple paths at once
+
+See Also
+--------
+
+- ``command man test`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html>

--- a/doc_src/cmds/time.rst
+++ b/doc_src/cmds/time.rst
@@ -79,3 +79,9 @@ Inline variable assignments need to follow the ``time`` keyword::
    Executed in   90.00 secs      fish           external
       usr time    4.62 millis    4.62 millis    0.00 millis
       sys time    2.35 millis    0.41 millis    1.95 millis
+
+See Also
+--------
+
+- ``command man time`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/time.html>

--- a/doc_src/cmds/trap.rst
+++ b/doc_src/cmds/trap.rst
@@ -52,3 +52,8 @@ Example
     trap "status --print-stack-trace" SIGUSR1
     # Prints a stack trace each time the SIGUSR1 signal is sent to the shell.
 
+See Also
+--------
+
+- ``command man trap`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#trap>

--- a/doc_src/cmds/true.rst
+++ b/doc_src/cmds/true.rst
@@ -22,3 +22,5 @@ See Also
 
 - :doc:`false <false>` command
 - :ref:`$status <variables-status>` variable
+- ``command man true`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/true.html>

--- a/doc_src/cmds/type.rst
+++ b/doc_src/cmds/type.rst
@@ -53,3 +53,9 @@ Example
     >_ type fg
     fg is a builtin
 
+
+See Also
+--------
+
+- ``command man type`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/type.html>

--- a/doc_src/cmds/umask.rst
+++ b/doc_src/cmds/umask.rst
@@ -50,3 +50,9 @@ Example
 -------
 
 ``umask 177`` or ``umask u=rw`` sets the file creation mask to read and write for the owner and no permissions at all for any other users.
+
+See Also
+--------
+
+- ``command man umask`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/umask.html>

--- a/doc_src/cmds/wait.rst
+++ b/doc_src/cmds/wait.rst
@@ -51,3 +51,9 @@ spawns five jobs in the background, and then waits until all of them finishes.
     wait sleep
 
 spawns five jobs and ``hoge`` in the background, and then waits until all ``sleep``\s finish, and doesn't wait for ``hoge`` finishing.
+
+See Also
+--------
+
+- ``command man wait`` -- show docs for the non-fish variant.
+- The POSIX variant: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/wait.html>

--- a/doc_src/conf.py
+++ b/doc_src/conf.py
@@ -178,6 +178,8 @@ def get_command_description(path, name):
 # Unbreak it (#7996)
 man_make_section_directory = False
 
+man_show_urls = True
+
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [

--- a/doc_src/fish_synopsis.py
+++ b/doc_src/fish_synopsis.py
@@ -53,7 +53,7 @@ lexer_rules = [
         # Hack: treat the "[ expr ]" alias of builtin test as command token (not as grammar
         # metacharacter).  This works because we write it without spaces in the grammar (like
         # "[OPTIONS]").
-        (r"\[ | \]", Name.Constant),
+        (r"! |\[ | \]", Name.Constant),
         # Statement separators.
         (r"\n", Text.Whitespace),
         (r";", Punctuation),


### PR DESCRIPTION
When writing scripts for other shells, it can be confusing and annoying
that our `man` function shadows other manual pages, for example `exec(1p)`
from [Linux man-pages]. I almost never want to see the fish variant for such
contended cases (which obviuosly don't include fish-specific commands like
`string`, only widely-known shell builtins).

For the contented cases like `exec`, the POSIX documentation is more
substantial and useful, since it describes a (sub)set of languages widely
used for scripting.

Because of this I think we should stop overriding the system's man pages.
Nowadays we offer `exec -h` as intuitive way to show the documentation for
the fish-specific command (note that `help` is not a good replacement because
it uses a web browser).

Looking through the contended commands, it seems like for most of them,
the fish version is not substantially different from the system version.
A notable exception is `read` but I don't think it's a very important one.

So I'm saying: we can sacrifice a bit of the native fish-scripting experience
in exchange for playing nicer with the outside world.  I think the latter
is more important because scripting is not our focus, the way I see it.
So maybe put our manpath at the end.

In lieu of that, we should at least have `exec.rst` reference the system or
POSIX variants, which is what this draft patch does, to set the stage.

[Linux man-pages]: https://www.kernel.org/doc/man-pages/
