### PR TITLE
`<?` try-input redirection

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -168,6 +168,7 @@ Each stream has a number called the file descriptor (FD): 0 for stdin, 1 for std
 The destination of a stream can be changed using something called *redirection*. For example, ``echo hello > output.txt``, redirects the standard output of the ``echo`` command to a text file.
 
 - To read standard input from a file, use ``<SOURCE_FILE``.
+- To read standard input from a file or /dev/null if it can't be read, use ``<?SOURCE_FILE``.
 - To write standard output to a file, use ``>DESTINATION``.
 - To write standard error to a file, use ``2>DESTINATION``. [#]_
 - To append standard output to a file, use ``>>DESTINATION_FILE``.
@@ -187,6 +188,8 @@ Any arbitrary file descriptor can be used in a redirection by prefixing the redi
 - To redirect the input of descriptor N, use ``N<DESTINATION``.
 - To redirect the output of descriptor N, use ``N>DESTINATION``.
 - To append the output of descriptor N to a file, use ``N>>DESTINATION_FILE``.
+
+File descriptors cannot be used with a ``<?`` input redirection, only a regular ``<`` one.
 
 For example::
 
@@ -212,6 +215,9 @@ For example::
       echo stdout
       echo stderr >&2 # <- this goes to stderr!
   end >/dev/null # ignore stdout, so this prints "stderr"
+
+  # print all lines that include "foo" from myfile, or nothing if it doesn't exist.
+  string match '*foo*' <?myfile
 
 It is an error to redirect a builtin, function, or block to a file descriptor above 2. However this is supported for external commands.
 

--- a/share/functions/__fish_complete_groups.fish
+++ b/share/functions/__fish_complete_groups.fish
@@ -6,6 +6,6 @@ function __fish_complete_groups --description "Print a list of local groups, wit
     else
         while read -l line
             string split -f 1,4 : -- $line | string join \t
-        end </etc/group
+        end <?/etc/group
     end
 end

--- a/share/functions/__fish_complete_user_ids.fish
+++ b/share/functions/__fish_complete_user_ids.fish
@@ -1,7 +1,7 @@
 function __fish_complete_user_ids --description "Complete user IDs with user name as description"
     if command -sq getent
         getent passwd | string replace -f -r '^([[:alpha:]_][^:]*):[^:]*:(\d+).*' '$2\t$1'
-    else if test -r /etc/passwd
-        string replace -f -r '^([[:alpha:]_][^:]*):[^:]*:(\d+).*' '$2\t$1' </etc/passwd
+    else
+        string replace -f -r '^([[:alpha:]_][^:]*):[^:]*:(\d+).*' '$2\t$1' <?/etc/passwd
     end
 end

--- a/share/functions/__fish_complete_users.fish
+++ b/share/functions/__fish_complete_users.fish
@@ -10,8 +10,8 @@ function __fish_complete_users --description "Print a list of local users, with 
     else if command -sq dscl
         # This is the "Directory Service command line utility" used on macOS in place of getent.
         command dscl . -list /Users RealName | string match -r -v '^_' | string replace -r ' {2,}' \t
-    else if test -r /etc/passwd
-        string match -v -r '^\s*#' </etc/passwd | while read -l line
+    else
+        string match -v -r '^\s*#' <?/etc/passwd | while read -l line
             string split -f 1,5 : -- $line | string join \t | string replace -r ',.*' ''
         end
     end

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -18,10 +18,8 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
         string split ' '
 
     # Print nfs servers from /etc/fstab
-    if test -r /etc/fstab
-        string match -r '^\s*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:|^[a-zA-Z\.]*:' </etc/fstab |
-            string replace -r ':.*' ''
-    end
+    string match -r '^\s*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:|^[a-zA-Z\.]*:' <?/etc/fstab |
+    string replace -r ':.*' ''
 
     # Check hosts known to ssh.
     # Yes, seriously - the default specifies both with and without "2".
@@ -65,13 +63,11 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
         function _recursive --no-scope-shadowing
             set -l paths
             for config in $argv
-                if test -r "$config" -a -f "$config"
-                    set paths $paths (
-                    # Keep only Include lines and remove Include syntax
-                    string replace -rfi '^\s*Include\s+' '' <$config \
-                    # Normalize whitespace
-                    | string trim | string replace -r -a '\s+' ' ')
-                end
+                set paths $paths (
+                # Keep only Include lines and remove Include syntax
+                string replace -rfi '^\s*Include\s+' '' <?$config \
+                # Normalize whitespace
+                | string trim | string replace -r -a '\s+' ' ')
             end
 
             set -l new_paths
@@ -117,9 +113,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 
     # Read all files and operate on their combined content
     for file in $known_hosts
-        if test -r $file
-            read -z <$file
-        end
+        read -z <?$file
     end |
         # Ignore hosts that are hashed, commented or @-marked and strip the key
         # Handle multiple comma-separated hostnames sharing a key, too.

--- a/share/functions/__fish_set_locale.fish
+++ b/share/functions/__fish_set_locale.fish
@@ -26,15 +26,13 @@ function __fish_set_locale
     # but we operate under the assumption that the locale can't include whitespace. Other whitespace
     # shouldn't concern us, but a quoted "locale.LANG=SOMETHING" as a value to something else might.
     # Here the last definition of a variable takes precedence.
-    if test -r /proc/cmdline
-        for var in (string match -ra 'locale.[^=]+=\S+' < /proc/cmdline)
-            set -l kv (string replace 'locale.' '' -- $var | string split '=')
-            # Only set locale variables, not other stuff contained in these files - this also
-            # automatically ignores comments.
-            if contains -- $kv[1] $LOCALE_VARS
-                and set -q kv[2]
-                set -gx $kv[1] (string trim -c '\'"' -- $kv[2])
-            end
+    for var in (string match -ra 'locale.[^=]+=\S+' <?/proc/cmdline)
+        set -l kv (string replace 'locale.' '' -- $var | string split '=')
+        # Only set locale variables, not other stuff contained in these files - this also
+        # automatically ignores comments.
+        if contains -- $kv[1] $LOCALE_VARS
+            and set -q kv[2]
+            set -gx $kv[1] (string trim -c '\'"' -- $kv[2])
         end
     end
 
@@ -54,18 +52,16 @@ function __fish_set_locale
     # full POSIX-shell script.
     set -l user_cfg_dir (set -q XDG_CONFIG_HOME; and echo $XDG_CONFIG_HOME; or echo ~/.config)
     for f in $user_cfg_dir/locale.conf /etc/locale.conf /etc/env.d/02locale /etc/sysconfig/i18n /etc/default/locale
-        if test -r $f
-            while read -l kv
-                set kv (string split '=' -- $kv)
-                if contains -- $kv[1] $LOCALE_VARS
-                    and set -q kv[2]
-                    # Do not set already set variables again - this makes the merging happen.
-                    if not set -q $kv[1]
-                        set -gx $kv[1] (string trim -c '\'"' -- $kv[2])
-                    end
+        while read -l kv
+            set kv (string split '=' -- $kv)
+            if contains -- $kv[1] $LOCALE_VARS
+                and set -q kv[2]
+                # Do not set already set variables again - this makes the merging happen.
+                if not set -q $kv[1]
+                    set -gx $kv[1] (string trim -c '\'"' -- $kv[2])
                 end
-            end <$f
-        end
+            end
+        end <?$f
     end
 
     # If we really cannot get anything, at least set character encoding to UTF-8.

--- a/share/functions/fish_command_not_found.fish
+++ b/share/functions/fish_command_not_found.fish
@@ -5,11 +5,8 @@
 # This has a "ID=" line that defines the exact distribution,
 # and an "ID_LIKE=" line that defines what it is derived from or otherwise like.
 # For our purposes, we use both.
-set -l os
-if test -r /etc/os-release
-    set os (string match -r '^ID(?:_LIKE)?\s*=.*' < /etc/os-release | \
+set -l os (string match -r '^ID(?:_LIKE)?\s*=.*' <?/etc/os-release | \
     string replace -r '^ID(?:_LIKE)?\s*=(.*)' '$1' | string trim -c '\'"' | string split " ")
-end
 
 function __fish_default_command_not_found_handler
     printf (_ "fish: Unknown command: %s\n") (string escape -- $argv[1]) >&2

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -478,9 +478,9 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
     set -l total
 
     if test -d $git_dir/rebase-merge
-        set branch (cat $git_dir/rebase-merge/head-name 2>/dev/null)
-        set step (cat $git_dir/rebase-merge/msgnum 2>/dev/null)
-        set total (cat $git_dir/rebase-merge/end 2>/dev/null)
+        read branch <?$git_dir/rebase-merge/head-name
+        read step <?$git_dir/rebase-merge/msgnum
+        read total <?$git_dir/rebase-merge/end
         if test -f $git_dir/rebase-merge/interactive
             set operation "|REBASE-i"
         else
@@ -488,10 +488,10 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
         end
     else
         if test -d $git_dir/rebase-apply
-            set step (cat $git_dir/rebase-apply/next 2>/dev/null)
-            set total (cat $git_dir/rebase-apply/last 2>/dev/null)
+            read step <?$git_dir/rebase-apply/next
+            read total <?$git_dir/rebase-apply/last
             if test -f $git_dir/rebase-apply/rebasing
-                set branch (cat $git_dir/rebase-apply/head-name 2>/dev/null)
+                read branch <?$git_dir/rebase-apply/head-name
                 set operation "|REBASE"
             else if test -f $git_dir/rebase-apply/applying
                 set operation "|AM"

--- a/share/functions/help.fish
+++ b/share/functions/help.fish
@@ -79,8 +79,7 @@ function help --description 'Show help for the fish shell'
             #
             # We use this instead of xdg-open because that's useless without a backend
             # like wsl-open which we'll check in a minute.
-            if test -f /proc/version
-                and string match -riq 'Microsoft|WSL|MSYS|MINGW' </proc/version
+            if string match -riq 'Microsoft|WSL|MSYS|MINGW' <?/proc/version
                 and set -l cmd (command -s powershell.exe cmd.exe /mnt/c/Windows/System32/cmd.exe)
                 # Use the first of these.
                 set fish_browser $cmd[1]

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -1235,7 +1235,7 @@ impl<'s> Highlighter<'s> {
                             };
                         }
                     }
-                    RedirectionMode::input => {
+                    RedirectionMode::input | RedirectionMode::try_input => {
                         // Input redirections must have a readable non-directory.
                         target_is_valid = waccess(&target_path, R_OK) == 0
                             && match wstat(&target_path) {

--- a/src/redirection.rs
+++ b/src/redirection.rs
@@ -11,6 +11,7 @@ pub enum RedirectionMode {
     overwrite, // normal redirection: > file.txt
     append,    // appending redirection: >> file.txt
     input,     // input redirection: < file.txt
+    try_input, // try-input redirection: <? file.txt
     fd,        // fd redirection: 2>&1
     noclob,    // noclobber redirection: >? file.txt
 }
@@ -38,7 +39,7 @@ impl RedirectionMode {
             RedirectionMode::append => Some(OFlag::O_CREAT | OFlag::O_APPEND | OFlag::O_WRONLY),
             RedirectionMode::overwrite => Some(OFlag::O_CREAT | OFlag::O_WRONLY | OFlag::O_TRUNC),
             RedirectionMode::noclob => Some(OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_WRONLY),
-            RedirectionMode::input => Some(OFlag::O_RDONLY),
+            RedirectionMode::input | RedirectionMode::try_input => Some(OFlag::O_RDONLY),
             _ => None,
         }
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -990,6 +990,9 @@ impl TryFrom<&wstr> for PipeOrRedir {
                 consume(&mut cursor, '<');
                 if try_consume(&mut cursor, '&') {
                     result.mode = RedirectionMode::fd;
+                } else if try_consume(&mut cursor, '?') {
+                    // <? foo try-input redirection (uses /dev/null if file can't be used).
+                    result.mode = RedirectionMode::try_input;
                 } else {
                     result.mode = RedirectionMode::input;
                 }

--- a/tests/checks/redirect.fish
+++ b/tests/checks/redirect.fish
@@ -142,3 +142,25 @@ echo "/bin/echo pipe 12 <&12 12<&-" | source 12<&0
 echo foo >/bin/echo/file
 #CHECKERR: warning: An error occurred while redirecting file '/bin/echo/file'
 #CHECKERR: warning: Path '/bin/echo' is not a directory
+
+echo foo <?nonexistent
+#CHECK: foo
+echo $status
+#CHECK: 0
+
+read -l foo <?nonexistent
+echo $status
+#CHECK: 1
+set -S foo
+#CHECK: $foo: set in local scope, unexported, with 0 elements
+
+set -l fish (status fish-path)
+$fish --no-config -c 'true <&?fail'
+#CHECKERR: fish: Requested redirection to '?fail', which is not a valid file descriptor
+#CHECKERR: true <&?fail
+#CHECKERR: ^~~~~~^
+
+$fish --no-config -c 'true <?&fail'
+#CHECKERR: fish: Expected a string, but found a '&'
+#CHECKERR: true <?&fail
+#CHECKERR: ^


### PR DESCRIPTION
## Description

This tries to open the given file to use as stdin, and if it fails, for any reason, it uses /dev/null instead.

This is useful in cases where we would otherwise do either of these:

```fish
test -r /path/to/file
and read -l foo < /path/to/file
# becomes 
read -l foo <? /path/to/file

cat /path/to/file 2>/dev/null | string match foo
# becomes
string match foo <? foo

```

This both makes it nicer and shorter, *and* helps with TOCTTOU - what if the file is removed/changed after the check?

The reason for reading /dev/null instead of a closed fd is that a closed fd will often cause an error.

In case opening /dev/null fails, it still skips the command. That's really a last resort for when the operating system has turned out to be a platypus and not a unix.

Fixes #4865

The main issue here, as discussed in 4865, is that this is arguably inconsistent with `>?` redirection - where that errors out, `<?` does *not* error out. Unfortunately the only solution I can come up with is to make `<` noclobber and make `<?` clobber, which also doesn't really seem right and would be an awkward change.

`<?` also currently cannot be combined with file descriptors - `<?&3` errors out. This could be lifted in future ("use this file descriptor if it is open"), tbh I'm fine with this at the moment because we don't have a way to globally open file descriptors anyway so you could really only use stdin, and that's pretty much always open.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Note: The second commit is for illustration, I'm not going to merge it because it's not really *necessary* and annoying for the people who want new scripts on old fish (which we don't "support" as such, but try not to gratuitously break).