### PR TITLE
abbr: expand command abbrs after decorators

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4337,7 +4337,7 @@ fn expand_replacer(
     ))
 }
 
-// Extract all the token ranges in \p str, along with whether they are an undecorated command.
+// Extract all the token ranges in \p str, along with whether they are a command.
 // Tokens containing command substitutions are skipped; this ensures tokens are non-overlapping.
 struct PositionedToken {
     range: SourceRange,
@@ -4350,7 +4350,7 @@ fn extract_tokens(s: &wstr) -> Vec<PositionedToken> {
         | ParseTreeFlags::LEAVE_UNTERMINATED;
     let ast = Ast::parse(s, ast_flags, None);
 
-    // Helper to check if a node is the command portion of an undecorated statement.
+    // Helper to check if a node is the command portion of a decorated statement.
     let is_command = |node: &dyn ast::Node| {
         let mut cursor = Some(node);
         while let Some(cur) = cursor {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4355,7 +4355,7 @@ fn extract_tokens(s: &wstr) -> Vec<PositionedToken> {
         let mut cursor = Some(node);
         while let Some(cur) = cursor {
             if let Some(stmt) = cur.as_decorated_statement() {
-                if stmt.opt_decoration.is_none() && node.pointer_eq(&stmt.command) {
+                if node.pointer_eq(&stmt.command) {
                     return true;
                 }
             }

--- a/src/tests/abbrs.rs
+++ b/src/tests/abbrs.rs
@@ -131,7 +131,7 @@ fn test_abbreviations() {
     // Others should not be.
     validate!("of gc", None);
 
-    // Others should not be.
+    // Other decorations generally should be.
     validate!("command gc", None, "command git checkout");
 
     // yin/yang expands everywhere.

--- a/src/tests/abbrs.rs
+++ b/src/tests/abbrs.rs
@@ -132,7 +132,7 @@ fn test_abbreviations() {
     validate!("of gc", None);
 
     // Others should not be.
-    validate!("command gc", None);
+    validate!("command gc", None, "command git checkout");
 
     // yin/yang expands everywhere.
     validate!("command yin", None, "command yang");


### PR DESCRIPTION
Currently, we expand command-abbrs (those with `--position command`) after `if`, but not after `command` or `builtin` or `time`:

```fish
abbr --add gc "git checkout"
```

will expand as `if gc` but not as `command gc`.

This was explicitly tested, but I have no idea why it shouldn't be?

Looking at the git history nothing really springs up as explanation.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
