### PR TITLE
Add forward-char-passive

### DIFF
--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -191,6 +191,10 @@ The following special input functions are available:
     move one character to the right; or if at the end of the commandline, accept the current autosuggestion.
     If the completion pager is active, select the next completion instead.
 
+``forward-char-passive``
+    move one character to the right, but do not trigger any non-movement-related operations. If the cursor is at the end of the
+    commandline, does not accept the current autosuggestion (if any). If the completion pager is active, does nothing.
+
 ``forward-single-char``
     move one character to the right; or if at the end of the commandline, accept a single char from the current autosuggestion.
 

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -100,6 +100,10 @@ The following special input functions are available:
     move one character to the left.
     If the completion pager is active, select the previous completion instead.
 
+``backward-char-passive``
+    move one character to the left, but do not trigger any non-movement-related operations. If the cursor is at the start of
+    the commandline, does nothing. Does not change the selected item in the completion pager UI when shown.
+
 ``backward-bigword``
     move one whitespace-delimited word to the left
 
@@ -193,7 +197,8 @@ The following special input functions are available:
 
 ``forward-char-passive``
     move one character to the right, but do not trigger any non-movement-related operations. If the cursor is at the end of the
-    commandline, does not accept the current autosuggestion (if any). If the completion pager is active, does nothing.
+    commandline, does not accept the current autosuggestion (if any). Does not change the selected item in the completion pager,
+    if shown.
 
 ``forward-single-char``
     move one character to the right; or if at the end of the commandline, accept a single char from the current autosuggestion.

--- a/src/input.rs
+++ b/src/input.rs
@@ -119,6 +119,7 @@ const INPUT_FUNCTION_METADATA: &[InputFunctionMetadata] = &[
     make_md(L!("and"), ReadlineCmd::FuncAnd),
     make_md(L!("backward-bigword"), ReadlineCmd::BackwardBigword),
     make_md(L!("backward-char"), ReadlineCmd::BackwardChar),
+    make_md(L!("backward-char-passive"), ReadlineCmd::BackwardCharPassive),
     make_md(L!("backward-delete-char"), ReadlineCmd::BackwardDeleteChar),
     make_md(L!("backward-jump"), ReadlineCmd::BackwardJump),
     make_md(L!("backward-jump-till"), ReadlineCmd::BackwardJumpTill),

--- a/src/input.rs
+++ b/src/input.rs
@@ -153,6 +153,7 @@ const INPUT_FUNCTION_METADATA: &[InputFunctionMetadata] = &[
     make_md(L!("force-repaint"), ReadlineCmd::ForceRepaint),
     make_md(L!("forward-bigword"), ReadlineCmd::ForwardBigword),
     make_md(L!("forward-char"), ReadlineCmd::ForwardChar),
+    make_md(L!("forward-char-passive"), ReadlineCmd::ForwardCharPassive),
     make_md(L!("forward-jump"), ReadlineCmd::ForwardJump),
     make_md(L!("forward-jump-till"), ReadlineCmd::ForwardJumpTill),
     make_md(L!("forward-single-char"), ReadlineCmd::ForwardSingleChar),

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -35,6 +35,7 @@ pub enum ReadlineCmd {
     ForwardChar,
     BackwardChar,
     ForwardSingleChar,
+    ForwardCharPassive,
     ForwardWord,
     BackwardWord,
     ForwardBigword,

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -34,6 +34,7 @@ pub enum ReadlineCmd {
     EndOfLine,
     ForwardChar,
     BackwardChar,
+    BackwardCharPassive,
     ForwardSingleChar,
     ForwardCharPassive,
     ForwardWord,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2511,6 +2511,16 @@ impl ReaderData {
                     self.update_buff_pos(elt, Some(el.position() + 1));
                 }
             }
+            rl::ForwardCharPassive => {
+                let (elt, el) = self.active_edit_line();
+                if self.is_navigating_pager_contents() {
+                    // Do nothing
+                } else if self.is_at_end(el) {
+                    // Do nothing
+                } else {
+                    self.update_buff_pos(elt, Some(el.position() + 1));
+                }
+            }
             rl::BackwardKillWord | rl::BackwardKillPathComponent | rl::BackwardKillBigword => {
                 let style = match c {
                     rl::BackwardKillBigword => MoveWordStyle::Whitespace,
@@ -4495,6 +4505,7 @@ fn command_ends_paging(c: ReadlineCmd, focused_on_search_field: bool) -> bool {
         | rl::HistoryPager
         | rl::BackwardChar
         | rl::ForwardChar
+        | rl::ForwardCharPassive
         | rl::ForwardSingleChar
         | rl::UpLine
         | rl::DownLine

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2497,6 +2497,14 @@ impl ReaderData {
                     self.update_buff_pos(elt, Some(el.position() - 1));
                 }
             }
+            rl::BackwardCharPassive => {
+                let (elt, el) = self.active_edit_line();
+                if el.position() != 0 {
+                    if elt == EditableLineTag::SearchField || !self.is_navigating_pager_contents() {
+                        self.update_buff_pos(elt, Some(el.position() - 1));
+                    }
+                }
+            }
             rl::ForwardChar | rl::ForwardSingleChar => {
                 let (elt, el) = self.active_edit_line();
                 if self.is_navigating_pager_contents() {
@@ -2513,12 +2521,10 @@ impl ReaderData {
             }
             rl::ForwardCharPassive => {
                 let (elt, el) = self.active_edit_line();
-                if self.is_navigating_pager_contents() {
-                    // Do nothing
-                } else if self.is_at_end(el) {
-                    // Do nothing
-                } else {
-                    self.update_buff_pos(elt, Some(el.position() + 1));
+                if !self.is_at_end(el) {
+                    if elt == EditableLineTag::SearchField || !self.is_navigating_pager_contents() {
+                        self.update_buff_pos(elt, Some(el.position() + 1));
+                    }
                 }
             }
             rl::BackwardKillWord | rl::BackwardKillPathComponent | rl::BackwardKillBigword => {
@@ -4504,6 +4510,7 @@ fn command_ends_paging(c: ReadlineCmd, focused_on_search_field: bool) -> bool {
         | rl::CompleteAndSearch
         | rl::HistoryPager
         | rl::BackwardChar
+        | rl::BackwardCharPassive
         | rl::ForwardChar
         | rl::ForwardCharPassive
         | rl::ForwardSingleChar

--- a/tests/checks/tmux-complete.fish
+++ b/tests/checks/tmux-complete.fish
@@ -104,13 +104,11 @@ isolated-tmux capture-pane -p
 # CHECK: prompt 7> echo suggest nothing
 
 isolated-tmux send-keys C-u 'bind \cs forward-char-passive' Enter C-l
-isolated-tmux send-keys C-u 'bind \cp backward-char' Enter C-l
+isolated-tmux send-keys C-u 'bind \cb backward-char-passive' Enter C-l
 isolated-tmux send-keys C-u 'echo do not accept this' Enter C-l
 tmux-sleep
-isolated-tmux send-keys 'echo do not accept thi' C-p C-p Delete C-p C-s 'h'
+isolated-tmux send-keys 'echo do not accept thi' C-b C-b Delete C-b C-s 'h'
 tmux-sleep
 isolated-tmux send-keys C-s C-s C-s 'x'
-tmux-sleep
 isolated-tmux capture-pane -p
-tmux-sleep
 # CHECK: prompt 10> echo do not accept thix

--- a/tests/checks/tmux-complete.fish
+++ b/tests/checks/tmux-complete.fish
@@ -102,3 +102,15 @@ isolated-tmux send-keys C-e M-f Space nothing
 tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 7> echo suggest nothing
+
+isolated-tmux send-keys C-u 'bind \cs forward-char-passive' Enter C-l
+isolated-tmux send-keys C-u 'bind \cp backward-char' Enter C-l
+isolated-tmux send-keys C-u 'echo do not accept this' Enter C-l
+tmux-sleep
+isolated-tmux send-keys 'echo do not accept thi' C-p C-p Delete C-p C-s 'h'
+tmux-sleep
+isolated-tmux send-keys C-s C-s C-s 'x'
+tmux-sleep
+isolated-tmux capture-pane -p
+tmux-sleep
+# CHECK: prompt 10> echo do not accept thix


### PR DESCRIPTION
Add a `forward-char-passive` binding. (Better suggestions for the name are being accepted!)

The idea is to add a "non-destructive" version of `forward-char` that strictly moves but does not change the "meta state" of the shell (does not accept auto completion, does not change completion pager selection). This has been requested by a terminal emulator developer and it makes sense to me at a high (enough) level.

I'm not going to pretend to be aware of where each binding is used, but it seems to me that *ideally* instead of adding something new to the existing `forward-char` and `forward-single-char` bindings, it would make more sense for one of them (`forward-single-char`) to not automatically accept suggestions. It seems `forward-single-char` is primarily used in the vi key bindings, and it isn't especially clear to me that accepting the autosuggestion makes sense there. But out of an abundance of precaution and to avoid breaking things, I am adding this as a new keybinding altogether.

Fixes issue #10397 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed (test is confirmed to fail if `forward-single-char` is used instead)
- [ ] User-visible changes noted in CHANGELOG.rst
