### PR TITLE
completions/insmod: Add support for insmod command

### DIFF
--- a/share/completions/insmod.fish
+++ b/share/completions/insmod.fish
@@ -1,0 +1,9 @@
+function _insmod_complete
+    # List all .ko files in the current directory for completion.
+    for file in (ls *.ko)
+        echo $file
+    end
+end
+
+complete -c insmod -a '(_insmod_complete)' -f
+


### PR DESCRIPTION
## Description

This commit introduces a new completion script for the `insmod` command, enabling Fish shell users to autocomplete file for `.ko` (kernel module) files in the current directory.