### PR TITLE
Fix completions for pactree, pkgfile

### DIFF
--- a/share/completions/pactree.fish
+++ b/share/completions/pactree.fish
@@ -1,4 +1,4 @@
-complete -c pactree -xa "(pacman -Sl | string replace -r '(\S+) *(\S+) *(.*)' '$2\t$3')"
+complete -c pactree -xa "(__fish_print_pacman_packages --installed)"
 complete -c pactree -s b -l dbpath -d 'Set an alternate database location' -xa '(__fish_complete_directories)'
 complete -c pactree -s c -l color -d 'Colorize output'
 complete -c pactree -s d -l depth -d 'Limit the depth of recursion' -x

--- a/share/completions/pkgfile.fish
+++ b/share/completions/pkgfile.fish
@@ -7,6 +7,6 @@ complete -c pkgfile -s r -l regex -d 'allow the use of regex in searches'
 complete -c pkgfile -s R -l repo -d 'search only in the specified repository' -xa '(__fish_print_pacman_repos)'
 complete -c pkgfile -s v -l verbose -d 'enable verbose output'
 complete -c pkgfile -s i -l info -d 'provides information about the package owning a file' -r
-complete -c pkgfile -s l -l list -d 'list files of a given package; similar to "pacman -Ql"' -xa "(pacman -Sl | string replace -r '(\S+) *(\S+) *(.*)' '$2\t$3')"
+complete -c pkgfile -s l -l list -d 'list files of a given package; similar to "pacman -Ql"' -xa "(__fish_print_pacman_packages)"
 complete -c pkgfile -s s -l search -d 'search which package owns a file' -r
 complete -c pkgfile -s u -l update -d 'update to the latest filelist. This requires write permission to /var/cache/pkgtools/lists'


### PR DESCRIPTION
## Description

BUG: `$` should be escaped.
```diff
-complete -c pactree -xa "(pacman -Sl | string replace -r '(\S+) *(\S+) *(.*)' '$2\t$3')"
+complete -c pactree -xa "(pacman -Sl | string replace -r '(\S+) *(\S+) *(.*)' '\$2\t\$3')"
```

Fix it by reusing some builtin functions.
