### PR TITLE
fish_trace filters to avoid suppressing traces from binds etc

### DIFF
--- a/share/completions/set.fish
+++ b/share/completions/set.fish
@@ -54,7 +54,6 @@ function __fish_complete_special_vars
         FISH_DEBUG_OUTPUT "debug output path" \
         umask "current file creation mask" \
         fish_handle_reflow "if fish should repaint prompt when the term resizes" \
-        fish_trace "print cmds as they execute, like set -x" \
         fish_emoji_width "cols wide fish assumes emoji render as" \
         fish_key_bindings "name of function that sets binds" \
         fish_autosuggestion_enabled "turns autosuggestions on or off" \
@@ -62,7 +61,7 @@ function __fish_complete_special_vars
         fish_escape_delay_ms "How long fish waits to distinguish escape and alt" \
         fish_greeting "The message to display at start (also a function)" \
         fish_history "The session id to store history under" \
-        fish_trace "Enables execution tracing (if set to non-empty value)" \
+        fish_trace "Enables execution tracing, usually '1', or bind/event/prompt/title/all" \
         fish_user_paths "A list of dirs to prepend to PATH"
 end
 

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -352,7 +352,7 @@ fn handle_read_limit_change(vars: &EnvStack) {
 }
 
 fn handle_fish_trace(vars: &EnvStack) {
-    let enabled = vars.get_unless_empty(L!("fish_trace")).is_some();
+    let enabled = vars.get_unless_empty(L!("fish_trace"));
     crate::trace::trace_set_enabled(enabled);
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1286,8 +1286,8 @@ pub struct library_data_pod_t {
     /// Whether we are currently interactive.
     pub is_interactive: bool,
 
-    /// Whether to suppress fish_trace output. This occurs in the prompt, event handlers, and key
-    /// bindings.
+    /// Whether to suppress fish_trace output. This may occur in prompt, title, event handlers,
+    /// and key bindings.
     pub suppress_fish_trace: bool,
 
     /// Whether we should break or continue the current loop.


### PR DESCRIPTION
Today fish_trace=1 traces all fish script code except bind/events/prompt/title.
(Also fish_should_add_to_history which is part of bind).

Let's allow enabling these categories.  This is mainly to help debugging; I'm
not sure how useful this is to people who are not very familiar with fish. I'd
only list this in the changelog once we have a better design (reject typos
like "fish_trace=binds" and maybe allow turning off the default script trace).
