### PR TITLE
Draft: cd without a file discriptor, patch out cwd_fd in Parser

### DIFF
--- a/src/fds.rs
+++ b/src/fds.rs
@@ -259,17 +259,6 @@ pub fn open_cloexec(path: &CStr, flags: OFlag, mode: nix::sys::stat::Mode) -> ni
     }
 }
 
-/// Wide character version of open_dir() that also sets the close-on-exec flag (atomically when
-/// possible).
-pub fn wopen_dir(pathname: &wstr, mode: nix::sys::stat::Mode) -> nix::Result<OwnedFd> {
-    open_dir(wcs2zstring(pathname).as_c_str(), mode)
-}
-
-/// Narrow version of wopen_dir().
-pub fn open_dir(path: &CStr, mode: nix::sys::stat::Mode) -> nix::Result<OwnedFd> {
-    open_cloexec(path, OFlag::O_RDONLY | OFlag::O_DIRECTORY, mode).map(OwnedFd::from)
-}
-
 /// Close a file descriptor \p fd, retrying on EINTR.
 pub fn exec_close(fd: RawFd) {
     assert!(fd >= 0, "Invalid fd");


### PR DESCRIPTION
Fixes issue #10432, but removes the (currently unused) functionality of having a working directory in the Parser.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
