### PR TITLE
change cd to handle not readable directories: chdir+open instead of open+fchdir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -146,6 +146,7 @@ Other improvements
 - ``fish_indent`` will now collapse multiple successive empty lines into one (:issue:`10325`).
 - The HTML-based configuration UI (``fish_config``) now uses Alpine.js instead of AngularJS (:issue:`9554`).
 - ``fish_config`` now also works in a Windows MSYS environment (:issue:`10111`).
+- `cd` into a directory that is not readable but accessile (permissions `--x`) is now possible (:issue:`10432`).
 
 .. _rust-packaging:
 

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -2,15 +2,14 @@
 
 use super::prelude::*;
 use crate::{
+    common::wcs2zstring,
     env::{EnvMode, Environment},
-    fds::wopen_dir,
     path::path_apply_cdpath,
     wutil::{normalize_path, wperror, wreadlink},
 };
 use errno::Errno;
-use libc::{fchdir, EACCES, ELOOP, ENOENT, ENOTDIR, EPERM};
-use nix::sys::stat::Mode;
-use std::{os::fd::AsRawFd, sync::Arc};
+use libc::{EACCES, ELOOP, ENOENT, ENOTDIR, EPERM};
+use nix::unistd::chdir;
 
 // The cd builtin. Changes the current directory to the one specified or to $HOME if none is
 // specified. The directory can be relative to any directory in the CDPATH variable.
@@ -87,18 +86,10 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
 
         errno::set_errno(Errno(0));
 
-        let res = wopen_dir(&norm_dir, Mode::empty()).map_err(|err| err as i32);
+        let res = chdir(wcs2zstring(&norm_dir).as_c_str()).map_err(|e| e as i32);
 
-        let res = res.and_then(|fd| {
-            if unsafe { fchdir(fd.as_raw_fd()) } == 0 {
-                Ok(fd)
-            } else {
-                Err(errno::errno().0)
-            }
-        });
-
-        let fd = match res {
-            Ok(fd) => fd,
+        match res {
+            Ok(_) => {},
             Err(err) => {
                 // Some errors we skip and only report if nothing worked.
                 // ENOENT in particular is very low priority
@@ -122,13 +113,10 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
                 best_errno = err;
                 break;
             }
-        };
+        }
 
         // We need to keep around the fd for this directory, in the parser.
-        let dir_fd = Arc::new(fd);
-
-        // Stash the fd for the cwd in the parser.
-        parser.libdata_mut().cwd_fd = Some(dir_fd);
+        parser.libdata_mut().update_cwd_fd();
 
         parser.set_var_and_fire(L!("PWD"), EnvMode::EXPORT | EnvMode::GLOBAL, vec![norm_dir]);
         return STATUS_CMD_OK;

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -89,7 +89,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
         let res = chdir(wcs2zstring(&norm_dir).as_c_str()).map_err(|e| e as i32);
 
         match res {
-            Ok(_) => {},
+            Ok(_) => {}
             Err(err) => {
                 // Some errors we skip and only report if nothing worked.
                 // ENOENT in particular is very low priority

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -239,6 +239,17 @@ impl LibraryData {
             ..Default::default()
         }
     }
+
+    pub fn update_cwd_fd(&mut self) {
+        match open_dir(CStr::from_bytes_with_nul(b".\0").unwrap(), Mode::empty()) {
+            Ok(fd) => {
+                self.cwd_fd = Some(Arc::new(fd));
+            }
+            Err(_) => {
+                perror("Unable to open the current working directory");
+            }
+        }
+    }
 }
 
 impl Default for LoopStatus {
@@ -353,14 +364,7 @@ impl Parser {
             global_event_blocks: AtomicU64::new(0),
         });
 
-        match open_dir(CStr::from_bytes_with_nul(b".\0").unwrap(), Mode::empty()) {
-            Ok(fd) => {
-                result.libdata_mut().cwd_fd = Some(Arc::new(fd));
-            }
-            Err(_) => {
-                perror("Unable to open the current working directory");
-            }
-        }
+        result.libdata_mut().update_cwd_fd();
 
         result
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -247,6 +247,7 @@ impl LibraryData {
             }
             Err(_) => {
                 perror("Unable to open the current working directory");
+                self.cwd_fd = None;
             }
         }
     }

--- a/tests/checks/cd.fish
+++ b/tests/checks/cd.fish
@@ -280,7 +280,9 @@ begin
     mkdir -p a/b/c
     chmod -r a
 
-    cd a; pwd
+    cd a
+    # CHECKERR: Unable to open the current working directory: Permission denied
+    pwd
     # CHECK: {{.*}}/a
 
     cd b

--- a/tests/checks/cd.fish
+++ b/tests/checks/cd.fish
@@ -271,3 +271,25 @@ end
 complete -C'cd .'
 # CHECK: ../
 # CHECK: ./
+
+# Check that cd works with minimal permissions (issue #10432)
+begin
+    set -l oldpwd (pwd)
+    set -l tmp (mktemp -d)
+    cd $tmp
+    mkdir -p a/b/c
+    chmod -r a
+
+    cd a; pwd
+    # CHECK: {{.*}}/a
+
+    cd b
+    pwd
+    ls
+    # CHECK: {{.*}}/a/b
+    # CHECK: c
+
+    cd $oldpwd
+    chmod -R +rx $tmp # we must be able to list the directory to delete its children
+    rm -rf $tmp
+end


### PR DESCRIPTION
The previous code for the cd builtin used open(.., O_RDONLY) + fchdir to change the working directory. This fails, if the user has no read permission on the directory (but has the x permission). Now we first chdir and then try to open the new workin directory. this might fail, but in this case cd was already successful.

The alternative would be to use O_PATH instead of O_RDONLY, but this is not portable. As an improvement, we could use O_PATH for supported platforms later.

Fixes issue #10432

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages. (from the template, i think it does not apply here)
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
- [ ] Check for / discuss now unused code
