### PR TITLE
Pass indented commandline to editor on `alt-e`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -110,9 +110,10 @@ New or improved bindings
 - Special input functions run from bindings via ``commandline -f`` are now applied immediately instead of after the currently executing binding.
   For example, ``commandline -f yank -f yank-pop`` inserts the last-but-one entry from the kill ring.
 - When the cursor is on a command that resolves to an executable script, :kbd:`Alt-O` will now open that script in your editor (:issue:`10266`).
-- Two improvements to the :kbd:`Alt-E` binding which edits the commandline in an external editor:
+- Some improvements to the :kbd:`Alt-E` binding which edits the commandline in an external editor:
   - The editor's cursor position is copied back to fish. This is currently supported for Vim and Kakoune.
   - Cursor position synchronization is only supported for a set of known editors. This has been extended by also resolving aliases. For example use ``complete --wraps my-vim vim`` to synchronize cursors when `EDITOR=my-vim`.
+  - Multiline commands are indented before being sent to the editor, which matches the rendering in fish.
 - ``backward-kill-path-component`` and friends now treat ``#`` as part of a path component (:issue:`10271`).
 - The ``E`` binding in vi mode now correctly handles the last character of the word, by jumping to the next word (:issue:`9700`).
 - If the terminal supports shifted key codes from the [kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/), ``shift-enter`` now inserts a newline instead of executing the command line.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -103,6 +103,7 @@ Interactive improvements
 - fish no longer fails to open a fifo if interrupted by a terminal resize signal (:issue:`10250`).
 - ``read --help`` and friends no longer ignore redirections. This fixes a regression in version 3.1 (:issue:`10274`).
 - Command abbreviations (those with ``--position command`` or without a ``--position``) now also expand after decorators like ``command`` (:issue:`10396`).
+- When exporting interactively defined functions (using ``type``, ``functions`` or ``funcsave``) the function body is now indented, same as in command line editor (:issue:`8603`).
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc_src/cmds/fish_indent.rst
+++ b/doc_src/cmds/fish_indent.rst
@@ -25,6 +25,12 @@ The following options are available:
 **-i** or **--no-indent**
     Do not indent commands; only reformat to one job per line.
 
+**--only-indent**
+    Do not reformat, only indent each line.
+
+**--only-unindent**
+    Do not reformat, only unindent each line.
+
 **-c** or **--check**
     Do not indent, only return 0 if the code is already indented as fish_indent would, the number of failed files otherwise. Also print the failed filenames if not reading from standard input.
 

--- a/share/completions/fish_indent.fish
+++ b/share/completions/fish_indent.fish
@@ -1,6 +1,8 @@
 complete -c fish_indent -s h -l help -d 'Display help and exit'
 complete -c fish_indent -s v -l version -d 'Display version and exit'
 complete -c fish_indent -s i -l no-indent -d 'Do not indent output, only reformat into one job per line'
+complete -c fish_indent -l only-indent -d 'Do not reformat, only indent lines'
+complete -c fish_indent -l only-unindent -d 'Do not reformat, only unindent lines'
 complete -c fish_indent -l ansi -d 'Colorize the output using ANSI escape sequences'
 complete -c fish_indent -l html -d 'Output in HTML format'
 complete -c fish_indent -s w -l write -d 'Write to file'

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -47,16 +47,12 @@ function funced --description 'Edit function definition'
 
     if test "$editor" = fish
         if functions -q -- $funcname
-            command -q fish_indent
-            and functions --no-details -- $funcname | fish_indent --no-indent | read -z init
-            or functions --no-details -- $funcname | read -z init
+            functions --no-details -- $funcname | fish_indent --only-unindent | fish_indent --no-indent | read -z init
         end
 
         set -l prompt 'printf "%s%s%s> " (set_color green) '$funcname' (set_color normal)'
         if read -p $prompt -c "$init" --shell cmd
-            command -q fish_indent
-            and echo -n $cmd | fish_indent | read -lz cmd
-            or echo -n $cmd | read -lz cmd
+            echo -n $cmd | fish_indent --only-unindent | read -lz cmd
             eval "$cmd"
         end
         if set -q _flag_save

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -8,6 +8,8 @@ use crate::event::{self};
 use crate::function;
 use crate::highlight::colorize;
 use crate::highlight::highlight_shell;
+use crate::parse_util::apply_indents;
+use crate::parse_util::parse_util_compute_indents;
 use crate::parser_keywords::parser_keywords_is_reserved;
 use crate::termsize::termsize_last;
 
@@ -405,6 +407,10 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
             ));
         } else {
             def = props.annotated_definition(arg);
+        }
+
+        if props.definition_file().is_none() {
+            def = apply_indents(&def, &parse_util_compute_indents(&def));
         }
 
         if streams.out_is_terminal() {

--- a/src/builtins/type.rs
+++ b/src/builtins/type.rs
@@ -3,6 +3,7 @@ use crate::common::str2wcstring;
 use crate::function;
 use crate::highlight::{colorize, highlight_shell};
 
+use crate::parse_util::{apply_indents, parse_util_compute_indents};
 use crate::path::{path_get_path, path_get_paths};
 
 #[derive(Default)]
@@ -128,6 +129,9 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> O
                             comment,
                             props.annotated_definition(arg)
                         ));
+                        if props.definition_file().is_none() {
+                            def = apply_indents(&def, &parse_util_compute_indents(&def));
+                        }
 
                         if streams.out_is_terminal() {
                             let mut color = vec![];

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -85,6 +85,7 @@ use crate::pager::{PageRendering, Pager, SelectionMotion};
 use crate::parse_constants::SourceRange;
 use crate::parse_constants::{ParseTreeFlags, ParserTestErrorBits};
 use crate::parse_tree::ParsedSource;
+use crate::parse_util::SPACES_PER_INDENT;
 use crate::parse_util::{
     parse_util_cmdsubst_extent, parse_util_compute_indents, parse_util_contains_wildcards,
     parse_util_detect_errors, parse_util_detect_errors_in_ast, parse_util_escape_string_with_quote,
@@ -2770,7 +2771,9 @@ impl ReaderData {
                         let total_offset_new = parse_util_get_offset(
                             el.text(),
                             line_new,
-                            line_offset_old - 4 * (indent_new - indent_old),
+                            line_offset_old
+                                - isize::try_from(SPACES_PER_INDENT).unwrap()
+                                    * (indent_new - indent_old),
                         );
                         self.update_buff_pos(elt, total_offset_new);
                     }

--- a/tests/checks/indent.fish
+++ b/tests/checks/indent.fish
@@ -464,3 +464,35 @@ echo "
 echo this file starts late
 " | $fish_indent
 #CHECK: echo this file starts late
+
+echo 'foo|bar; begin
+echo' | $fish_indent --only-indent
+# CHECK: foo|bar; begin
+# CHECK: {{^}}    echo
+
+echo 'begin
+    echo
+end' | $fish_indent --only-unindent
+# CHECK: {{^}}begin
+# CHECK: {{^}}echo
+# CHECK: {{^}}end
+
+echo 'if true
+    begin
+        echo
+    end
+end' | $fish_indent --only-unindent
+# CHECK: {{^}}if true
+# CHECK: {{^}}begin
+# CHECK: {{^}}echo
+# CHECK: {{^}}end
+# CHECK: {{^}}end
+
+echo 'begin
+    echo
+  not indented properly
+end' | $fish_indent --only-unindent
+# CHECK: {{^}}begin
+# CHECK: {{^}}    echo
+# CHECK: {{^}}  not indented properly
+# CHECK: {{^}}end


### PR DESCRIPTION
Indented multiline commandlines look ugly in an external editor.  Also,
fish doesn't properly handle the case when the editor runs fish_indent.
Fix is by indenting when exporting the commandline and un-indenting when
importing the commandline again.

Unindent only if the file is properly indented (meaning at least by the
amount fish would use).  Another complication is that we need to offset
cursor positions by the indentation.

This approach exposes "fish_indent --only-indent" and "--only-unindent"
though I don't imagine they are useful for others so I'm not sure if this
is the right place and whether we should even document it.

One alternative is to add "commandline --indented" to handle indentation
transparently.
So  "commandline --indented" would print a indented lines,
and "commandline --indented 'if true' '    echo'" would remove the unecessary
indentation before replacing the commandline.
That would probably simplify the logic for the cursor position offset.

---

Last commit is a related fix:

builtins type/functions: indent interactively-defined functions

This means that in case no editor is defined, "fish_indent" is now required.

Fixes #8603
