### PR TITLE
cd: open directory with O_PATH or O_SEARCH

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -159,6 +159,7 @@ Other improvements
 - ``fish_indent`` will now collapse multiple successive empty lines into one (:issue:`10325`).
 - The HTML-based configuration UI (``fish_config``) now uses Alpine.js instead of AngularJS (:issue:`9554`).
 - ``fish_config`` now also works in a Windows MSYS environment (:issue:`10111`).
+- `cd` into a directory that is not readable but accessile (permissions `--x`) is now possible (:issue:`10432`).
 
 .. _rust-packaging:
 

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -3,7 +3,7 @@
 use super::prelude::*;
 use crate::{
     env::{EnvMode, Environment},
-    fds::wopen_dir,
+    fds::{wopen_dir, BEST_O_SEARCH},
     path::path_apply_cdpath,
     wutil::{normalize_path, wperror, wreadlink},
 };
@@ -86,7 +86,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
 
         errno::set_errno(Errno(0));
 
-        let res = wopen_dir(&norm_dir).map_err(|err| err as i32);
+        let res = wopen_dir(&norm_dir, BEST_O_SEARCH).map_err(|err| err as i32);
 
         let res = res.and_then(|fd| {
             if unsafe { fchdir(fd.as_raw_fd()) } == 0 {

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use errno::Errno;
 use libc::{fchdir, EACCES, ELOOP, ENOENT, ENOTDIR, EPERM};
-use nix::sys::stat::Mode;
 use std::{os::fd::AsRawFd, sync::Arc};
 
 // The cd builtin. Changes the current directory to the one specified or to $HOME if none is
@@ -87,7 +86,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
 
         errno::set_errno(Errno(0));
 
-        let res = wopen_dir(&norm_dir, Mode::empty()).map_err(|err| err as i32);
+        let res = wopen_dir(&norm_dir).map_err(|err| err as i32);
 
         let res = res.and_then(|fd| {
             if unsafe { fchdir(fd.as_raw_fd()) } == 0 {

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -272,11 +272,19 @@ mod o_search {
     pub const BEST_O_SEARCH: OFlag = unsafe { OFlag::from_bits_unchecked(libc::O_SEARCH) };
     /// On Linux we can use O_PATH, it has nearly the same semantics. we can use the fd for openat / fchdir, with only requiring
     /// x permission on the directory.
-    #[cfg(all(not(any(target_os = "macos", target_os = "freebsd")), any(target_os = "linux", target_os = "android")))]
+    #[cfg(all(
+        not(any(target_os = "macos", target_os = "freebsd")),
+        any(target_os = "linux", target_os = "android")
+    ))]
     pub const BEST_O_SEARCH: OFlag = unsafe { OFlag::from_bits_unchecked(libc::O_PATH) };
 
     /// Fall back to O_RDONLY, this is what fish did before.
-    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "macos")))]
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "macos"
+    )))]
     pub const BEST_O_SEARCH: OFlag = OFlag::O_RDONLY;
 }
 
@@ -288,7 +296,8 @@ pub fn wopen_dir(pathname: &wstr, flags: OFlag) -> nix::Result<OwnedFd> {
 
 /// Narrow version of wopen_dir().
 pub fn open_dir(path: &CStr, flags: OFlag) -> nix::Result<OwnedFd> {
-    open_cloexec(path, flags | OFlag::O_DIRECTORY, nix::sys::stat::Mode::empty()).map(OwnedFd::from)
+    let mode = nix::sys::stat::Mode::empty();
+    open_cloexec(path, flags | OFlag::O_DIRECTORY, mode).map(OwnedFd::from)
 }
 
 /// Close a file descriptor \p fd, retrying on EINTR.

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -261,13 +261,13 @@ pub fn open_cloexec(path: &CStr, flags: OFlag, mode: nix::sys::stat::Mode) -> ni
 
 /// Wide character version of open_dir() that also sets the close-on-exec flag (atomically when
 /// possible).
-pub fn wopen_dir(pathname: &wstr, mode: nix::sys::stat::Mode) -> nix::Result<OwnedFd> {
-    open_dir(wcs2zstring(pathname).as_c_str(), mode)
+pub fn wopen_dir(pathname: &wstr) -> nix::Result<OwnedFd> {
+    open_dir(wcs2zstring(pathname).as_c_str())
 }
 
 /// Narrow version of wopen_dir().
-pub fn open_dir(path: &CStr, mode: nix::sys::stat::Mode) -> nix::Result<OwnedFd> {
-    open_cloexec(path, OFlag::O_RDONLY | OFlag::O_DIRECTORY, mode).map(OwnedFd::from)
+pub fn open_dir(path: &CStr) -> nix::Result<OwnedFd> {
+    open_cloexec(path, OFlag::O_RDONLY | OFlag::O_DIRECTORY, nix::sys::stat::Mode::empty()).map(OwnedFd::from)
 }
 
 /// Close a file descriptor \p fd, retrying on EINTR.

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -259,15 +259,36 @@ pub fn open_cloexec(path: &CStr, flags: OFlag, mode: nix::sys::stat::Mode) -> ni
     }
 }
 
+/// POSIX specifies an open option O_SEARCH for opening directories for later
+/// `fchdir` or `openat`, not for `readdir`. The read permission is not checked,
+/// and the x permission is checked on opening. Not all platforms have this,
+/// so we fall back to O_PATH or O_RDONLY according to the platform.
+pub use o_search::BEST_O_SEARCH;
+
+mod o_search {
+    use super::OFlag;
+    /// On FreeBSD or MacOS we have O_SEARCH.
+    #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+    pub const BEST_O_SEARCH: OFlag = unsafe { OFlag::from_bits_unchecked(libc::O_SEARCH) };
+    /// On Linux we can use O_PATH, it has nearly the same semantics. we can use the fd for openat / fchdir, with only requiring
+    /// x permission on the directory.
+    #[cfg(all(not(any(target_os = "macos", target_os = "freebsd")), any(target_os = "linux", target_os = "android")))]
+    pub const BEST_O_SEARCH: OFlag = unsafe { OFlag::from_bits_unchecked(libc::O_PATH) };
+
+    /// Fall back to O_RDONLY, this is what fish did before.
+    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "macos")))]
+    pub const BEST_O_SEARCH: OFlag = OFlag::O_RDONLY;
+}
+
 /// Wide character version of open_dir() that also sets the close-on-exec flag (atomically when
 /// possible).
-pub fn wopen_dir(pathname: &wstr) -> nix::Result<OwnedFd> {
-    open_dir(wcs2zstring(pathname).as_c_str())
+pub fn wopen_dir(pathname: &wstr, flags: OFlag) -> nix::Result<OwnedFd> {
+    open_dir(wcs2zstring(pathname).as_c_str(), flags)
 }
 
 /// Narrow version of wopen_dir().
-pub fn open_dir(path: &CStr) -> nix::Result<OwnedFd> {
-    open_cloexec(path, OFlag::O_RDONLY | OFlag::O_DIRECTORY, nix::sys::stat::Mode::empty()).map(OwnedFd::from)
+pub fn open_dir(path: &CStr, flags: OFlag) -> nix::Result<OwnedFd> {
+    open_cloexec(path, flags | OFlag::O_DIRECTORY, nix::sys::stat::Mode::empty()).map(OwnedFd::from)
 }
 
 /// Close a file descriptor \p fd, retrying on EINTR.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -353,7 +353,7 @@ impl Parser {
             global_event_blocks: AtomicU64::new(0),
         });
 
-        match open_dir(CStr::from_bytes_with_nul(b".\0").unwrap(), Mode::empty()) {
+        match open_dir(CStr::from_bytes_with_nul(b".\0").unwrap()) {
             Ok(fd) => {
                 result.libdata_mut().cwd_fd = Some(Arc::new(fd));
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::event::{self, Event};
 use crate::expand::{
     expand_string, replace_home_directory_with_tilde, ExpandFlags, ExpandResultCode,
 };
-use crate::fds::open_dir;
+use crate::fds::{open_dir, BEST_O_SEARCH};
 use crate::global_safety::RelaxedAtomicBool;
 use crate::input_common::{terminal_protocols_disable_scoped, TERMINAL_PROTOCOLS};
 use crate::io::IoChain;
@@ -34,7 +34,6 @@ use crate::wchar::{wstr, WString, L};
 use crate::wutil::{perror, wgettext, wgettext_fmt};
 use crate::{function, FLOG};
 use libc::c_int;
-use nix::sys::stat::Mode;
 use once_cell::sync::Lazy;
 use printf_compat::sprintf;
 use std::cell::{Ref, RefCell, RefMut};
@@ -353,7 +352,7 @@ impl Parser {
             global_event_blocks: AtomicU64::new(0),
         });
 
-        match open_dir(CStr::from_bytes_with_nul(b".\0").unwrap()) {
+        match open_dir(CStr::from_bytes_with_nul(b".\0").unwrap(), BEST_O_SEARCH) {
             Ok(fd) => {
                 result.libdata_mut().cwd_fd = Some(Arc::new(fd));
             }

--- a/tests/checks/cd.fish
+++ b/tests/checks/cd.fish
@@ -271,3 +271,25 @@ end
 complete -C'cd .'
 # CHECK: ../
 # CHECK: ./
+
+# Check that cd works with minimal permissions (issue #10432)
+begin
+    set -l oldpwd (pwd)
+    set -l tmp (mktemp -d)
+    cd $tmp
+    mkdir -p a/b/c
+    chmod -r a
+
+    cd a; pwd
+    # CHECK: {{.*}}/a
+
+    cd b
+    pwd
+    ls
+    # CHECK: {{.*}}/a/b
+    # CHECK: c
+
+    cd $oldpwd
+    chmod -R +rx $tmp # we must be able to list the directory to delete its children
+    rm -rf $tmp
+end


### PR DESCRIPTION
## Description

fish implements the `cd` builtin using the system calls `open` and `fchdir`. On platforms where it is supported, this PR changes the flags argument for `open` to `O_SEARCH` or `O_PATH`, which does not require read permission on the directory we change into. This is more consistent with the behavior of `chdir` or `cd` in other shells.

also it cleans up the unused "mode" argument to `fds::[w]open_dir`.

Fixes issue #10432
Alternative to #10436 or #10433

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages. (no usage changes should appear)
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
