### PR TITLE
remove unnecessarily silenced lint in history

### DIFF
--- a/src/builtins/history.rs
+++ b/src/builtins/history.rs
@@ -306,8 +306,8 @@ pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> 
                 ));
                 return STATUS_INVALID_ARGS;
             }
-            #[allow(clippy::unnecessary_to_owned)]
-            for delete_string in args.iter().copied() {
+
+            for &delete_string in args {
                 history.remove(delete_string.to_owned());
             }
         }


### PR DESCRIPTION
## Description

This was raised on https://github.com/fish-shell/fish-shell/pull/10439#discussion_r1563958398 for addition of the history `append` command but the removal of the silenced lint applies to `delete` as well, to keep the other PR on topic, I've raised this small change as a separate PR

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
