### PR TITLE
completions/magento: Fixes module aggregation for module related commands

### DIFF
--- a/share/completions/magento.fish
+++ b/share/completions/magento.fish
@@ -16,16 +16,9 @@ end
 
 function __fish_print_magento_modules -d "Lists all Magento modules"
     test -f app/etc/config.php; or return
-    command -q php; or return
+    command -q sed; or return
 
-    php -r '
-        $config  = include "app/etc/config.php";
-        
-        foreach ($config["modules"] as $module => $state) {
-            if ($module === "" || $module === "None") continue;
-            echo $module . PHP_EOL;
-        }
-    '
+    command sed -n '/modules.*\[/,/\]/p' app/etc/config.php | sed -E '1d;$d;s/^\s*|\s*=>.*$|"|\'//g'
 end
 
 function __fish_print_magento_i18n_packing_modes -d "Shows all available packing modes"

--- a/share/completions/magento.fish
+++ b/share/completions/magento.fish
@@ -15,13 +15,17 @@ end
 ###
 
 function __fish_print_magento_modules -d "Lists all Magento modules"
-    set -l modules (magento module:status)
+    test -f app/etc/config.php; or return
+    command -q php; or return
 
-    for i in $test
-        if test -n "$i" -a "$i" != None
-            echo $i
-        end
-    end
+    php -r '
+        $config  = include "app/etc/config.php";
+        
+        foreach ($config["modules"] as $module => $state) {
+            if ($module === "" || $module === "None") continue;
+            echo $module . PHP_EOL;
+        }
+    '
 end
 
 function __fish_print_magento_i18n_packing_modes -d "Shows all available packing modes"

--- a/share/completions/magento.fish
+++ b/share/completions/magento.fish
@@ -495,6 +495,13 @@ __fish_magento_register_command_option module:enable -f -l all -d "Enable all mo
 __fish_magento_register_command_option module:enable -f -s c -l clear-static-content -d "Clear generated static view files. Necessary if module(s) have static view files"
 
 #
+# module:status
+#
+__fish_magento_register_command_option module:status -f -a "(__fish_print_magento_modules)" -d "Module name"
+__fish_magento_register_command_option module:status -f -l enabled -d "Print only enabled modules"
+__fish_magento_register_command_option module:status -f -l disabled -d "Print only disabled modules"
+
+#
 # module:uninstall
 #
 __fish_magento_register_command_option module:uninstall -f -a "(__fish_print_magento_modules)" -d "Module name"


### PR DESCRIPTION
## Description

Previousely when attempting completion for commands `module:enable`, `mmodule:disable` and `module:uninstall` and error would be disaplyed, stating that "magento" was not found.
Upon inspection of the issue in the related completion script it became clear that:
1. The shell command `magento` does not exist as the CLI script of Magento resides under `bin/magento`.
2. The module aggregation would not work after referencing the appropriate CLI command as an undeclared variable was being introspected.
3. Using Magento's CLI command took too long to respond as it has to bootstrap the whole Magento stack in order to deliver modules.

Thus the whole aggregation was rewritten to a form that actually works and reduces the aggregation to reading the appropriate information directly from the configuration file, provided that the file exists and PHP is installed.

Note that no issue has been filed for this behaviour, yet the fix also removes `test -n` from the completion script thus contributing to #6520 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
