### PR TITLE
Clarify block command documentation

### DIFF
--- a/doc_src/cmds/block.rst
+++ b/doc_src/cmds/block.rst
@@ -14,15 +14,11 @@ Synopsis
 Description
 -----------
 
-``block`` prevents events triggered by ``fish`` or the :doc:`emit <emit>` command from being delivered and acted upon while the block is in place.
-
-In functions, ``block`` can be useful while performing work that should not be interrupted by the shell.
-
-The block can be removed. Any events which triggered while the block was in place will then be delivered.
+``block`` delays delivery of all events triggered by ``fish`` or the :doc:`emit <emit>`, thus delaying the execution of any function registered ``--on-event``, ``--on-process-exit``, ``--on-job-exit``, ``--on-variable`` and ``--on-signal`` until after the block is removed.
 
 Event blocks should not be confused with code blocks, which are created with ``begin``, ``if``, ``while`` or ``for``
 
-Without options, the ``block`` command acts with function scope.
+Without options, ``block`` sets up a block that is released automatically at the end of the current function scope.
 
 The following options are available:
 
@@ -36,7 +32,7 @@ The following options are available:
     Release global block.
 
 **-h** or **--help**
-    Displays help about using this command.
+    Display help about using this command.
 
 Example
 -------
@@ -57,4 +53,4 @@ Example
 Notes
 -----
 
-Events are only received from the current fish process as there is no way to send events from one fish process to another (yet).
+Events are only received from the current fish process as there is no way to send events from one fish process to another.


### PR DESCRIPTION
## Description

This clarifies the effects of `block` (see #10383).

Since `block` is arguably useless (see #9030), this also removes the explanation of what it's useful for (which I feel was generic enough not to contribute much to the documentation anyways).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
