### PR TITLE
Move generated completions to cache directory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -163,6 +163,7 @@ Completions
 ^^^^^^^^^^^
 - Added completions for:
 - Improved some completions
+- Generated completions are now stored in `$XDG_CACHE_HOME/fish` or `~/.cache/fish` by default (:issue:`10369`)
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc_src/completions.rst
+++ b/doc_src/completions.rst
@@ -155,7 +155,7 @@ By default, Fish searches the following for completions, using the first availab
 - A user-specified directory for third-party vendor completions, usually ``~/.local/share/fish/vendor_completions.d`` (controlled by the ``XDG_DATA_HOME`` environment variable);
 - A directory for third-party software vendors to ship their own completions for their software, usually ``/usr/share/fish/vendor_completions.d``;
 - The completions shipped with fish, usually installed in ``/usr/share/fish/completions``; and
-- Completions automatically generated from the operating system's manual, usually stored in ``~/.local/share/fish/generated_completions``.
+- Completions automatically generated from the operating system's manual, usually stored in ``~/.cache/fish/generated_completions`` (controlled by ``XDG_CACHE_HOME`` environment variable).
 
 These paths are controlled by parameters set at build, install, or run time, and may vary from the defaults listed above.
 

--- a/share/config.fish
+++ b/share/config.fish
@@ -80,7 +80,7 @@ else if not contains -- $__fish_data_dir/functions $fish_function_path
 end
 
 if not set -q fish_complete_path
-    set fish_complete_path $__fish_config_dir/completions $__fish_sysconf_dir/completions $__fish_vendor_completionsdirs $__fish_data_dir/completions $__fish_user_data_dir/generated_completions
+    set fish_complete_path $__fish_config_dir/completions $__fish_sysconf_dir/completions $__fish_vendor_completionsdirs $__fish_data_dir/completions $__fish_cache_dir/generated_completions
 else if not contains -- $__fish_data_dir/completions $fish_complete_path
     set -a fish_complete_path $__fish_data_dir/completions
 end

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -88,7 +88,7 @@ end" >$__fish_config_dir/config.fish
         # Check if our manpage completion script exists because some distros split it out.
         # (#7183)
         set -l script $__fish_data_dir/tools/create_manpage_completions.py
-        if not test -d $__fish_user_data_dir/generated_completions; and test -e "$script"
+        if not test -d $__fish_cache_dir/generated_completions; and test -e "$script"
             # Generating completions from man pages needs python (see issue #3588).
 
             # We cannot simply do `fish_update_completions &` because it is a function.
@@ -96,7 +96,7 @@ end" >$__fish_config_dir/config.fish
             # We don't want to call `fish -c` since that is unnecessary and sources config.fish again.
             # Hence we'll call python directly.
             # c_m_p.py should work with any python version.
-            set -l update_args -B $__fish_data_dir/tools/create_manpage_completions.py --manpath --cleanup-in '~/.config/fish/completions' --cleanup-in '~/.config/fish/generated_completions'
+            set -l update_args -B $__fish_data_dir/tools/create_manpage_completions.py --manpath --cleanup-in ~/.config/fish/completions --cleanup-in $__fish_config_dir/generated_completions --cleanup-in $__fish_cache_dir/generated_completions
             if set -l python (__fish_anypython)
                 # Run python directly in the background and swallow all output
                 $python $update_args >/dev/null 2>&1 &

--- a/share/functions/fish_delta.fish
+++ b/share/functions/fish_delta.fish
@@ -49,7 +49,7 @@ function fish_delta
         end
         # We don't care about generated completions.
         # They shouldn't be compared at all.
-        contains -- $dir $default_complete_path $__fish_user_data_dir/generated_completions
+        contains -- $dir $default_complete_path $__fish_cache_dir/generated_completions
         or set -a user_complete_path $dir
     end
 

--- a/share/functions/fish_update_completions.fish
+++ b/share/functions/fish_update_completions.fish
@@ -1,7 +1,7 @@
 function fish_update_completions --description "Update man-page based completions"
     # Don't write .pyc files, use the manpath, clean up old completions
     # display progress.
-    set -l update_args -B $__fish_data_dir/tools/create_manpage_completions.py --manpath --cleanup-in ~/.config/fish/generated_completions --progress $argv
+    set -l update_args -B $__fish_data_dir/tools/create_manpage_completions.py --manpath --cleanup-in $__fish_cache_dir/generated_completions --progress $argv
     if set -l python (__fish_anypython)
         $python $update_args
     else

--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -1136,11 +1136,11 @@ if __name__ == "__main__":
         sys.exit(0)
 
     if not args.stdout and not args.directory:
-        # Default to ~/.local/share/fish/generated_completions/
+        # Default to ~/.cache/fish/generated_completions
         # Create it if it doesn't exist
-        xdg_data_home = os.getenv("XDG_DATA_HOME", "~/.local/share")
+        xdg_cache_home = os.getenv("XDG_CACHE_HOME", "~/.cache")
         args.directory = os.path.expanduser(
-            xdg_data_home + "/fish/generated_completions/"
+            xdg_cache_home + "/fish/generated_completions/"
         )
         try:
             os.makedirs(args.directory)

--- a/src/env/environment.rs
+++ b/src/env/environment.rs
@@ -16,8 +16,8 @@ use crate::libc::{stdout_stream, C_PATH_BSHELL, _PATH_BSHELL};
 use crate::nix::{geteuid, getpid, isatty};
 use crate::null_terminated_array::OwningNullTerminatedArray;
 use crate::path::{
-    path_emit_config_directory_messages, path_get_config, path_get_data, path_make_canonical,
-    paths_are_same_file,
+    path_emit_config_directory_messages, path_get_cache, path_get_config, path_get_data,
+    path_make_canonical, paths_are_same_file,
 };
 use crate::proc::is_interactive_session;
 use crate::termsize;
@@ -429,6 +429,7 @@ const FISH_HELPDIR_VAR: &wstr = L!("__fish_help_dir");
 const FISH_BIN_DIR: &wstr = L!("__fish_bin_dir");
 const FISH_CONFIG_DIR: &wstr = L!("__fish_config_dir");
 const FISH_USER_DATA_DIR: &wstr = L!("__fish_user_data_dir");
+const FISH_CACHE_DIR: &wstr = L!("__fish_cache_dir");
 
 /// Maximum length of hostname. Longer hostnames are truncated.
 const HOSTNAME_LEN: usize = 255;
@@ -648,6 +649,12 @@ pub fn env_init(paths: Option<&ConfigPaths>, do_uvars: bool, default_paths: bool
         user_data_dir.unwrap_or_default(),
     );
 
+    let user_cache_dir = path_get_cache();
+    vars.set_one(
+        FISH_CACHE_DIR,
+        EnvMode::GLOBAL,
+        user_cache_dir.unwrap_or_default(),
+    );
     // Set up a default PATH
     setup_path();
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -34,13 +34,29 @@ pub fn path_get_config() -> Option<WString> {
 /// Returns the user data directory for fish. If the directory or one of its parents doesn't exist,
 /// they are first created.
 ///
-/// Volatile files presumed to be local to the machine, such as the fish_history and all the
-/// generated_completions, will be stored in this directory.
+/// Volatile files presumed to be local to the machine, such as the fish_history will be stored in this directory.
 ///
 /// \param path The directory as an out param
 /// \return whether the directory was returned successfully
 pub fn path_get_data() -> Option<WString> {
     let dir = get_data_directory();
+    if dir.success() {
+        Some(dir.path.to_owned())
+    } else {
+        None
+    }
+}
+
+/// Returns the user cache directory for fish. If the directory or one of its parents doesn't exist,
+/// they are first created.
+///
+/// Volatile files presumed to be local to the machine such as all the
+/// generated_completions, will be stored in this directory.
+///
+/// \param path The directory as an out param
+/// \return whether the directory was returned successfully
+pub fn path_get_cache() -> Option<WString> {
+    let dir = get_cache_directory();
     if dir.success() {
         Some(dir.path.to_owned())
     } else {
@@ -704,6 +720,12 @@ fn path_remoteness(path: &wstr) -> DirRemoteness {
 fn get_data_directory() -> &'static BaseDirectory {
     static DIR: Lazy<BaseDirectory> =
         Lazy::new(|| make_base_directory(L!("XDG_DATA_HOME"), L!("/.local/share/fish")));
+    &DIR
+}
+
+fn get_cache_directory() -> &'static BaseDirectory {
+    static DIR: Lazy<BaseDirectory> =
+        Lazy::new(|| make_base_directory(L!("XDG_CACHE_HOME"), L!("/.cache/fish")));
     &DIR
 }
 

--- a/tests/test_env.sh
+++ b/tests/test_env.sh
@@ -50,6 +50,10 @@ export XDG_RUNTIME_DIR
 mkdir -p $XDG_RUNTIME_DIR/fish || die
 chmod 700 "$XDG_RUNTIME_DIR"
 
+XDG_CACHE_HOME="$homedir/xdg_cache_home"
+export XDG_CACHE_HOME
+mkdir -p $XDG_CACHE_HOME/fish || die
+
 # Create a temp/scratch directory for tests to use, if they want (tests shouldn't write to a
 # shared temp folder).
 TMPDIR="$homedir/temp"


### PR DESCRIPTION
## Description

Generates completions in `XDG_CACHE_HOME` or `~/.cache` by default and loads them from there.

Not sure what we want to about existing generated completions? This PR basically updates the paths and ignores the old ones, not sure if this change is considered breaking in that way...

Fixes #10369

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
