### PR TITLE
Move push_timer to measure command substitution timing too

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -130,6 +130,7 @@ Interactive improvements
 - When exporting interactively defined functions (using ``type``, ``functions`` or ``funcsave``) the function body is now indented, same as in the interactive command line editor (:issue:`8603`).
 - :kbd:`ctrl-x` (``fish_clipboard_copy``) on multiline commands now includes indentation (:issue:`10437`).
 - When using :kbd:`ctrl-x` on Wayland in the VSCode terminal, the clipboard is no longer cleared on :kbd:`ctrl-c`.
+- Measuring a command with `time` now considers the time taken for command substitution (:issue:`9100`).
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -42,7 +42,6 @@ use crate::proc::{
 use crate::reader::{reader_run_count, restore_term_mode};
 use crate::redirection::{dup2_list_resolve_chain, Dup2List};
 use crate::threads::{iothread_perform_cant_wait, is_forked_child};
-use crate::timer::push_timer;
 use crate::trace::trace_if_enabled_with_args;
 use crate::wchar::{wstr, WString, L};
 use crate::wchar_ext::ToWString;
@@ -103,7 +102,6 @@ pub fn exec_job(parser: &Parser, job: &Job, block_io: IoChain) -> bool {
         }
         return false;
     }
-    let _timer = push_timer(job.wants_timing() && !no_exec());
 
     // Get the deferred process, if any. We will have to remember its pipes.
     let mut deferred_pipes = PartialPipes::default();

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -740,9 +740,6 @@ pub struct JobProperties {
     /// initial state should be.
     pub initial_background: bool,
 
-    /// Whether the job has the 'time' prefix and so we should print timing for this job.
-    pub wants_timing: bool,
-
     /// Whether this job was created as part of an event handler.
     pub from_event_handler: bool,
 }
@@ -882,11 +879,6 @@ impl Job {
     /// Access mutable job flags.
     pub fn mut_flags(&self) -> RefMut<JobFlags> {
         self.job_flags.borrow_mut()
-    }
-
-    // \return whether we should print timing information.
-    pub fn wants_timing(&self) -> bool {
-        self.properties.wants_timing
     }
 
     /// \return if we want job control.


### PR DESCRIPTION
## Description

I've moved the push timer to happen before where command substitution seems to occur, works correctly with the simple repro described on the ticket:

![image](https://github.com/fish-shell/fish-shell/assets/43611963/7e29662a-e7e2-4223-bcdc-24142ef0f53f)

Fixes #9100

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
