### PR TITLE
Increase MSRV to 1.70

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,7 +103,7 @@ freebsd_task:
         - mkdir build && cd build
         - chown -R fish-user ..
         - sudo -u fish-user -s whoami
-        # FreeBSD's pkg currently has rust 1.66.0 while we need rust 1.67.0+. Use rustup to install
+        # FreeBSD's pkg currently has rust 1.66.0 while we need rust 1.70.0+. Use rustup to install
         # the latest, but note that it only installs rust per-user.
         - sudo -u fish-user -s fetch -qo - https://sh.rustup.rs > rustup.sh
         - sudo -u fish-user -s sh ./rustup.sh -y --profile=minimal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.67
+    - uses: dtolnay/rust-toolchain@1.70
     - name: Install deps
       run: |
         sudo apt install gettext libpcre2-dev python3-pip tmux
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.67
+    - uses: dtolnay/rust-toolchain@1.70
       with:
         targets: "i686-unknown-linux-gnu" # rust-toolchain wants this comma-separated
     - name: Install deps
@@ -127,7 +127,7 @@ jobs:
   #
   #   steps:
   #   - uses: actions/checkout@v4
-  #   - uses: dtolnay/rust-toolchain@1.67
+  #   - uses: dtolnay/rust-toolchain@1.70
   #   - name: Install deps
   #     run: |
   #       sudo apt install gettext libpcre2-dev python3-pip tmux
@@ -154,7 +154,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.67
+    - uses: dtolnay/rust-toolchain@1.70
     - name: Install deps
       run: |
         # --break-system-packages because homebrew has now declared itself "externally managed".

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,8 +26,8 @@ This will create a copy of the fish repository in the directory fish-shell in yo
 Also, for most changes you want to run the tests and so you'd get a setup to compile fish.
 For that, you'll require:
 
--  Rust (version 1.67 or later) - when in doubt, try rustup
--  CMake (version 3.5 or later)
+-  Rust - when in doubt, try rustup
+-  CMake
 -  PCRE2 (headers and libraries) - optional, this will be downloaded if missing
 -  gettext (headers and libraries) - optional, for translation support
 -  Sphinx - optional, to build the documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
 ]
 
 [workspace.package]
-rust-version = "1.67"
+rust-version = "1.70"
 edition = "2021"
 
 [profile.release]

--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,7 @@ Dependencies, git master
 
 Building from git master currently requires, in addition to the dependencies for a tarball:
 
--  Rust (version 1.67 or later)
+-  Rust (version 1.70 or later)
 -  CMake (version 3.19 or later)
 -  libclang, even if you are compiling with GCC
 -  an Internet connection

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Uploaders: David Adam <zanchey@ucc.gu.uwa.edu.au>
 # Debhelper should be bumped to >= 10 once Ubuntu Xenial is no longer supported
 Build-Depends: debhelper (>= 9.20160115), cmake (>= 3.5.0), gettext, libpcre2-dev,
 # Test dependencies
- locales-all, python3, rustc (>= 1.67) | rustc-mozilla (>= 1.67), cargo
+ locales-all, python3, rustc (>= 1.70) | rustc-mozilla (>= 1.70), cargo
 Standards-Version: 4.1.5
 Homepage: https://fishshell.com/
 Vcs-Git: https://github.com/fish-shell/fish-shell.git

--- a/doc_internal/rust-devel.md
+++ b/doc_internal/rust-devel.md
@@ -18,7 +18,7 @@ We use forks of the last two - see the [FFI section](#ffi) below. No special act
 
 ### Build Dependencies
 
-fish-shell currently depends on Rust 1.67 or later. To install Rust, follow https://rustup.rs.
+fish-shell currently depends on Rust 1.70 or later. To install Rust, follow https://rustup.rs.
 
 ### Build via CMake
 

--- a/fish.spec.in
+++ b/fish.spec.in
@@ -10,7 +10,7 @@ URL:                    https://fishshell.com/
 
 Source0:                %{name}_@VERSION@.orig.tar.xz
 BuildRequires:          cargo gettext gcc-c++ xz pcre2-devel
-BuildRequires:          rust >= 1.67
+BuildRequires:          rust >= 1.70
 
 %if 0%{?rhel} && 0%{?rhel} < 8
 BuildRequires: cmake3

--- a/src/bin/fish_indent.rs
+++ b/src/bin/fish_indent.rs
@@ -30,7 +30,7 @@ use fish::expand::INTERNAL_SEPARATOR;
 use fish::fds::set_cloexec;
 use fish::fprintf;
 #[allow(unused_imports)]
-use fish::future::{IsOkAnd, IsSomeAnd, IsSorted};
+use fish::future::{IsSomeAnd, IsSorted};
 use fish::global_safety::RelaxedAtomicBool;
 use fish::highlight::{colorize, highlight_shell, HighlightRole, HighlightSpec};
 use fish::libc::setlinebuf;

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -6,7 +6,6 @@ use crate::should_flog;
 mod test_expressions {
     use super::*;
 
-    #[allow(unused_imports)]
     use crate::nix::isatty;
     use crate::wutil::{
         file_id_for_path, fish_wcswidth, lwstat, waccess, wcstod::wcstod, wcstoi_opts, wstat,

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -7,7 +7,6 @@ mod test_expressions {
     use super::*;
 
     #[allow(unused_imports)]
-    use crate::future::IsOkAnd;
     use crate::nix::isatty;
     use crate::wutil::{
         file_id_for_path, fish_wcswidth, lwstat, waccess, wcstod::wcstod, wcstoi_opts, wstat,

--- a/src/future.rs
+++ b/src/future.rs
@@ -3,47 +3,14 @@
 pub trait IsSomeAnd {
     type Type;
     #[allow(clippy::wrong_self_convention)]
-    fn is_some_and(self, s: impl FnOnce(Self::Type) -> bool) -> bool;
-    #[allow(clippy::wrong_self_convention)]
     fn is_none_or(self, s: impl FnOnce(Self::Type) -> bool) -> bool;
 }
 impl<T> IsSomeAnd for Option<T> {
     type Type = T;
-    fn is_some_and(self, f: impl FnOnce(T) -> bool) -> bool {
-        match self {
-            Some(v) => f(v),
-            None => false,
-        }
-    }
     fn is_none_or(self, f: impl FnOnce(T) -> bool) -> bool {
         match self {
             Some(v) => f(v),
             None => true,
-        }
-    }
-}
-
-pub trait IsOkAnd {
-    type Type;
-    type Error;
-    #[allow(clippy::wrong_self_convention)]
-    fn is_ok_and(self, s: impl FnOnce(Self::Type) -> bool) -> bool;
-    #[allow(clippy::wrong_self_convention)]
-    fn is_err_and(self, s: impl FnOnce(Self::Error) -> bool) -> bool;
-}
-impl<T, E> IsOkAnd for Result<T, E> {
-    type Type = T;
-    type Error = E;
-    fn is_ok_and(self, f: impl FnOnce(T) -> bool) -> bool {
-        match self {
-            Ok(v) => f(v),
-            Err(_) => false,
-        }
-    }
-    fn is_err_and(self, f: impl FnOnce(E) -> bool) -> bool {
-        match self {
-            Ok(_) => false,
-            Err(e) => f(e),
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -60,7 +60,7 @@ use crate::fd_readable_set::poll_fd_readable;
 use crate::fds::{make_fd_blocking, wopen_cloexec, AutoCloseFd};
 use crate::flog::{FLOG, FLOGF};
 #[allow(unused_imports)]
-use crate::future::{IsOkAnd, IsSomeAnd};
+use crate::future::IsSomeAnd;
 use crate::global_safety::RelaxedAtomicBool;
 use crate::highlight::{
     autosuggest_validate_from_history, highlight_shell, HighlightRole, HighlightSpec,


### PR DESCRIPTION
## Description

This increases the minimum supported rust version to 1.70, from 1.67.

In this case it allows us remove a few backports - "is_some_and" and "is_ok_and" and "is_err_and". I could not find "is_none_or", so I kept it in.

The reason for increasing it is mostly that 1.67 does not *gain* us anything. According to https://repology.org/project/rust/versions, none of the distros we build packages for are on 1.67, 1.68 or 1.69 in supported releases.

Here are the distributions on those versions in supported releases:

- Gobolinux on 1.68 - which currently ships [fish 3.1.2](https://github.com/gobolinux/Recipes/tree/master/Fish), so I don't believe they have a lot of fish users
- ArchLinux 32 (an unofficial port of Arch to 32-bit intel arches) on 1.69, which has [1.77 in staging](https://archlinux32.org/packages/i686/extra-staging/rust/), so hopefully they'll upgrade soon

it also lists Buildroot and YiffOS, but that appears to be outdated information - Buildroot 2024.02 has rust 1.74, YiffOS lists 1.70 in [the online package browser](https://packages.yiffos.gay/rust) (and frankly seems to be pretty dead).

-------------------

We have never really "formalized" an MSRV policy. I would like it to be roughly "we try to enable distro packages with distro compilers".

Basically we don't increase MSRV willy-nilly (no "last X releases" policy), but we also don't keep it lower where it doesn't help. We're not going to support Debian 11's 1.48, so keeping 1.67 doesn't help there.