### PR TITLE
Upgrade to Alpine v3.19 and add cargo as dependency

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.19
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
 ENV LANG C.UTF-8
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
   ninja \
   pcre2-dev \
   python3 \
-  py3-pexpect
+  py3-pexpect \
+  cargo
 
 RUN addgroup -g 1000 fishuser
 


### PR DESCRIPTION
## Description

Alpine v3.13 is out-of-date since 2021-01-14 and is not getting any security updates anymore: https://alpinelinux.org/releases/

Cargo and rustc seems to be required in order to pass tests.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
