### PR TITLE
Raw-quoting syntax

### DIFF
--- a/share/completions/ip.fish
+++ b/share/completions/ip.fish
@@ -401,7 +401,7 @@ function __fish_complete_ip
                             case netns
                             case link-netnsid
                             case vf mac
-                            case {{max,min}_tx_,}rate
+                            case {max,min}_tx_rate rate
                             case node_guid port_guid
                             case state
                                 echo auto

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -120,6 +120,16 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
         # Shift-space behaves like space because it's easy to mistype.
         bind --preset $argv shift-space 'commandline -i " "' expand-abbr-backtrack
 
+        bind --preset $argv "(" __fish_insert_subshell
+        function __fish_insert_subshell
+            if string match -qr '^\s*$' -- (commandline --current-process --cut-at-cursor | string collect) &&
+                    not string match -qr '\($' -- (commandline --cut-at-cursor)
+                commandline -i '$SHELL -c (( '
+            else
+                commandline -i "("
+            end
+        end
+
         bind --preset $argv enter execute
         bind --preset $argv ctrl-j execute
         bind --preset $argv ctrl-m execute

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3773,6 +3773,7 @@ impl<'s> Populator<'s> {
                 && [
                     TokenizerError::unterminated_quote,
                     TokenizerError::unterminated_subshell,
+                    TokenizerError::unterminated_raw_quote,
                 ]
                 .contains(&self.peek_token(0).tok_error)
             {
@@ -3809,6 +3810,7 @@ impl<'s> Populator<'s> {
                 && [
                     TokenizerError::unterminated_quote,
                     TokenizerError::unterminated_subshell,
+                    TokenizerError::unterminated_raw_quote,
                 ]
                 .contains(&self.peek_token(0).tok_error)
             {

--- a/src/parse_constants.rs
+++ b/src/parse_constants.rs
@@ -113,6 +113,7 @@ pub enum ParseErrorCode {
     // Tokenizer errors.
     tokenizer_unterminated_quote,
     tokenizer_unterminated_subshell,
+    tokenizer_unterminated_raw_quote,
     tokenizer_unterminated_slice,
     tokenizer_unterminated_escape,
     tokenizer_other,

--- a/src/parse_tree.rs
+++ b/src/parse_tree.rs
@@ -90,6 +90,9 @@ impl From<TokenizerError> for ParseErrorCode {
             TokenizerError::unterminated_subshell => {
                 ParseErrorCode::tokenizer_unterminated_subshell
             }
+            TokenizerError::unterminated_raw_quote => {
+                ParseErrorCode::tokenizer_unterminated_raw_quote
+            }
             TokenizerError::unterminated_slice => ParseErrorCode::tokenizer_unterminated_slice,
             TokenizerError::unterminated_escape => ParseErrorCode::tokenizer_unterminated_escape,
             _ => ParseErrorCode::tokenizer_other,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4550,6 +4550,7 @@ fn extract_tokens(s: &wstr) -> Vec<PositionedToken> {
                         result.push(t);
                     }
                 }
+                MaybeParentheses::QuotedCommand(_) => (),
             }
         }
 
@@ -5119,6 +5120,7 @@ fn replace_line_at_cursor(
     text[..start].to_owned() + replacement + &text[end..]
 }
 
+// TODO fix for raw quotes?
 pub(crate) fn get_quote(cmd_str: &wstr, len: usize) -> Option<char> {
     let cmd = cmd_str.as_char_slice();
     let mut i = 0;

--- a/src/tests/highlight.rs
+++ b/src/tests/highlight.rs
@@ -636,4 +636,17 @@ fn test_highlighting() {
         (">", fg(HighlightRole::error)),
         ("echo", fg(HighlightRole::error)),
     );
+
+    validate!(
+        ("echo", fg(HighlightRole::command)),
+        ("((", fg(HighlightRole::quote)),
+        ("echo", fg(HighlightRole::command)),
+        ("test/somewhere", fg(HighlightRole::param)),
+        ("))", fg(HighlightRole::quote)),
+    );
+
+    validate!(
+        ("echo", fg(HighlightRole::command)),
+        ("{{some raw  string}}", fg(HighlightRole::quote)),
+    );
 }

--- a/src/tests/parse_util.rs
+++ b/src/tests/parse_util.rs
@@ -435,5 +435,19 @@ fn test_indents() {
             0, "\n) line4",
             0, "\nline5\"",
         );
+
+        validate!(
+            0, "echo1 (", // )
+            1, "\necho2 ((" // ))
+        );
+        validate!(
+            0, "echo ((",
+            1, "\necho", // ))
+        );
+        validate!(
+            0, "echo ((",
+            1, "\necho",
+            0, ")" // )
+        );
     })();
 }

--- a/src/tests/tokenizer.rs
+++ b/src/tests/tokenizer.rs
@@ -94,6 +94,22 @@ fn test_tokenizer() {
         assert_eq!(token.error_offset_within_token, 4);
     }
 
+    {
+        let mut t = Tokenizer::new(L!(r#"(( echo \ " ' \xyz ))"#), TokFlags(0));
+        let token = t.next().unwrap();
+        assert_eq!(token.type_, TokenType::string);
+        let next = t.next();
+        assert!(t.next().is_none(), "Unexpected token: {:?}", next.unwrap());
+    }
+
+    {
+        let mut t = Tokenizer::new(L!(r#"{{ echo \ " ' \xyz }}"#), TokFlags(0));
+        let token = t.next().unwrap();
+        assert_eq!(token.type_, TokenType::string);
+        let next = t.next();
+        assert!(t.next().is_none(), "Unexpected token: {:?}", next.unwrap());
+    }
+
     // Test some redirection parsing.
     macro_rules! pipe_or_redir {
         ($s:literal) => {

--- a/tests/checks/braces.fish
+++ b/tests/checks/braces.fish
@@ -1,5 +1,7 @@
 #RUN: %fish %s
 
+set -l fish (status fish-path)
+
 echo x-{1}
 #CHECK: x-{1}
 
@@ -12,11 +14,10 @@ echo foo-{1,2{3,4}}
 echo foo-{} # literal "{}" expands to itself
 #CHECK: foo-{}
 
-echo foo-{{},{}} # the inner "{}" expand to themselves, the outer pair expands normally.
-#CHECK: foo-{} foo-{}
-
-echo foo-{{a},{}} # also works with something in the braces.
-#CHECK: foo-{a} foo-{}
+$fish -c 'echo foo-{{},{}}'
+#CHECKERR: fish: Unexpected '}' for unopened brace expansion
+#CHECKERR: echo foo-{{^|\{\{\},\{\}\}|^}}
+#CHECKERR:            ^
 
 echo foo-{""} # still expands to foo-{}
 #CHECK: foo-{}
@@ -51,3 +52,9 @@ end
 
 echo {a(echo ,)b}
 #CHECK: {a,b}
+
+echo {{\xyz}}
+#CHECK: \xyz
+
+echo {{a,b}}
+#CHECK: a,b

--- a/tests/checks/expansion.fish
+++ b/tests/checks/expansion.fish
@@ -66,7 +66,7 @@ end
 #CHECK: Amy
 
 echo {{a,b}}
-#CHECK: {a} {b}
+#CHECK: a,b
 
 # Test expansion of variables
 


### PR DESCRIPTION
TL;DR: this makes it so that typing `(` at the start of a command opens a subshell;
completions, quoting etc. work just like inside command substitutions.
This is enabled by the first commit that adds raw quoting syntax.

---

Other shells allow to create subshells using `(cd somewhere && do-something)`.
Our answer to this is to create a subshell like a regular process (#1439):

	$SHELL -c 'cd somewhere && do-something'

This syntax works the same way for non-shell programs

	watch 'ps aux | grep foo'
	git bisect run $SHELL -c 'make || exit 125; make test'
	hyperfine '...'

Issues with our solution are:
- the argument has no command-highlighting, completions (#9406) or indentation
- the  user may need to escape the argument multiple times ("quoting hell").
This primarily affects arguments containing backslashes and quotes
(for example `$SHELL -c 'printf %s\\\n *'`).
In many other cases backslash escaping is not necessary however the rules
can be confusing.

One workaround is to compose the subcommand in a separate shell prompt and
copy-paste it (inside quotes for automatic escaping).
That's not ideal because it breaks the writer's flow, and it doesn't work
well if the command needs to be refined.

Add a `(( ))` raw quoting syntax for subshells and deferred commands.
Syntax highlighting, completion and indentation work the same as in top-level
commands. No expansion/unescaping takes place:

	$SHELL -c ((printf %s\\n *))

Nested parentheses are okay, similar to Tcl's braced strings.
Imbalanced quotation marks are an error.
This means that the quoted string cannot contain an imbalance of its quote
characters.
(The good side is that, in many cases, imbalance is not intentional).

If we stick to this syntax, it would be good to also support `(< >)` and
`({ })` with the same meaning as `(( ))`, to make it easier to use when the
quoted content contains an unmatched `(`.

---

Also add a `{{ }}` raw quoting syntax that does not get shell highlighting,
completion and indentation.
This is meant for languages like Perl, awk, Python and regex dialects (no
more need to escape backslashes).
The would be a breaking change, we might want to avoid that by picking a
different syntax.

To-do:
- figure out how we want to tweak syntax, possibly find something that can
be added to Bash.
- adjust __fish_tokenizer_state
- docs/changelog/tests
