### PR TITLE
Clear gettext cache on locale switch

### DIFF
--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -762,6 +762,7 @@ fn init_locale(vars: &EnvStack) {
                 _nl_msg_cat_cntr += 1;
             }
         }
+        crate::wutil::gettext::wgettext_clear_cache();
     }
 }
 

--- a/src/wutil/gettext.rs
+++ b/src/wutil/gettext.rs
@@ -64,6 +64,13 @@ enum MaybeStatic<'a> {
     Local(&'a wstr),
 }
 
+static WGETTEXT_MAP: Lazy<Mutex<HashMap<&'static wstr, &'static wstr>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub fn wgettext_clear_cache() {
+    WGETTEXT_MAP.lock().unwrap().clear();
+}
+
 /// Implementation detail for wgettext!.
 /// Wide character wrapper around the gettext function. For historic reasons, unlike the real
 /// gettext function, wgettext takes care of setting the correct domain, etc. using the textdomain
@@ -86,8 +93,6 @@ fn wgettext_impl(text: MaybeStatic) -> &'static wstr {
     );
 
     // Note that because entries are immortal, we simply leak non-static keys, and all values.
-    static WGETTEXT_MAP: Lazy<Mutex<HashMap<&'static wstr, &'static wstr>>> =
-        Lazy::new(|| Mutex::new(HashMap::new()));
     let mut wmap = WGETTEXT_MAP.lock().unwrap();
     let res = match wmap.get(key) {
         Some(v) => *v,


### PR DESCRIPTION
This fixes the issue where if you do `_ file` (which prints "file" in english) and then switch locale to e.g. de_DE.UTF-8 and do `_ file` again, it will still print "file" instead of the german "Datei".

CACHE INVALIDATION!!!111eleven!!! *shakes fist*

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

This is awkward to test because it needs to require a non-english locale, and I'm not sure how to do that (or do we do that anywhere?).
