### PR TITLE
Add `set --no-event` to change a variable without triggering an event

### DIFF
--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -9,7 +9,7 @@ Synopsis
 .. synopsis::
 
     set
-    set (-f | --function) (-l | --local) (-g | --global) (-U | --universal)
+    set (-f | --function) (-l | --local) (-g | --global) (-U | --universal) [--no-event]
     set [-Uflg] NAME [VALUE ...]
     set [-Uflg] NAME[[INDEX ...]] [VALUE ...]
     set (-a | --append) [-flgU] NAME VALUE ...
@@ -101,6 +101,11 @@ Further options:
     If no variable names are given then all variables are shown in sorted order.
     It shows the scopes the given variables are set in, along with the values in each and whether or not it is exported.
     No other flags can be used with this option.
+
+**--no-event**
+    Don't generate a variable change event when setting or erasing a variable.
+    We recommend using this carefully because the event handlers are usually set up for a reason.
+    Possible uses include modifying the variable inside a variable handler.
 
 **-L** or **--long**
     Do not abbreviate long values when printing set variables.

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -23,16 +23,22 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # and without this would then have subtly broken bindings.
     if test "$fish_key_bindings" != fish_vi_key_bindings
         and test "$rebind" = true
-        # Allow the user to set the variable universally.
+        # Allow the user to set the variable universally
+        set -l scope
         set -q fish_key_bindings
-        or set -g fish_key_bindings
-        # This triggers the handler, which calls us again and ensures the user_key_bindings
-        # are executed.
-        set fish_key_bindings fish_vi_key_bindings
-        # unless the handler somehow doesn't exist, which would leave us without bindings.
-        # this happens in no-config mode.
-        functions -q __fish_reload_key_bindings
-        and return
+        or set scope -g
+        true
+        # We try to use `set --no-event`, but to avoid leaving the user without bindings
+        # if they run this with an older version we fall back on setting the variable
+        # with an event.
+        if ! set --no-event $scope fish_key_bindings fish_vi_key_bindings 2>/dev/null
+            # This triggers the handler, which calls us again
+            set $scope fish_key_bindings fish_vi_key_bindings
+            # unless the handler somehow doesn't exist, which would leave us without bindings.
+            # this happens in no-config mode.
+            functions -q __fish_reload_key_bindings
+            and return
+        end
     end
 
     set -l init_mode insert

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -806,6 +806,11 @@ impl Parser {
         res
     }
 
+    /// Cover of vars().set(), without firing events
+    pub fn set_var(&self, key: &wstr, mode: EnvMode, vals: Vec<WString>) -> EnvStackSetResult {
+        self.vars().set(key, mode, vals)
+    }
+
     /// Update any universal variables and send event handlers.
     /// If \p always is set, then do it even if we have no pending changes (that is, look for
     /// changes from other fish instances); otherwise only sync if this instance has changed uvars.

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -965,4 +965,33 @@ set -e undefined[..1]
 set -l negative_oob 1 2 3
 set -q negative_oob[-10..1]
 
+# --no-event
+
+function onevent --on-variable nonevent
+    echo ONEVENT $argv $nonevent
+end
+
+set -g nonevent bar
+set -e nonevent
+
+# CHECK: ONEVENT VARIABLE SET nonevent bar
+# CHECK: ONEVENT VARIABLE ERASE nonevent
+
+set -g --no-event nonevent 2
+set -e --no-event nonevent
+set -S nonevent
+
+set -g --no-event nonevent 3
+set -e nonevent
+# CHECK: ONEVENT VARIABLE ERASE nonevent
+
+set -g nonevent 4
+# CHECK: ONEVENT VARIABLE SET nonevent 4
+set -e --no-event nonevent
+
+set -l nonevent 4
+set -e nonevent
+# CHECK: ONEVENT VARIABLE SET nonevent
+# CHECK: ONEVENT VARIABLE ERASE nonevent
+
 exit 0


### PR DESCRIPTION
## Description

As mentioned in #9030 this adds a `--no-event` option to `set`, so you can set or erase a variable without triggering the event.

Example:

```fish
function on-my-var --on-variable myvar
    echo myvar was changed!
end

set --no-event myvar foo # <- this will not print "myvar was changed!"
```

There is no short option because this is an advanced option that should be used with care.

This does what a potential use of the `block` builtin would do in a simpler way, and it can be used to remove one of the gnarliest parts of our key binding functions: They set the variable, causing the handler to be run, which then runs the function again.

This upgrades our functions to use `--no-event`, but notably in a way that it'll handle being run by older fishes. This is necessary because otherwise we'd be left with no bindings at all. Tho the binding functions have basically been rewritten to handle the new bind notation, I'm not entirely sure how an old fish accidentally running the new version would work?

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
