### PR TITLE
completion: add more arguments for `rustc --print`

### DIFF
--- a/share/completions/rustc.fish
+++ b/share/completions/rustc.fish
@@ -1,14 +1,22 @@
 complete -c rustc -s h -l help
 
 complete -c rustc -x -l cfg
+complete -c rustc -x -l check-cfg -d "Provide list of expected cfgs for checking"
 complete -c rustc -r -s L -a 'dependency= crate= native= framework= all='
 complete -c rustc -x -s l -a 'dylib= static= framework='
-complete -c rustc -x -l crate-type -a 'bin lib rlib dylib staticlib proc-macro'
+complete -c rustc -x -l crate-type -a 'bin lib rlib dylib cdylib staticlib proc-macro'
 complete -c rustc -r -l crate-name
+complete -c rustc -x -l edition -a '2015 2018 2021' -d "Specify which edition of the compiler to use"
 complete -c rustc -x -l emit -a 'asm llvm-bc llvm-ir obj link dep-info metadata mir'
-complete -c rustc -x -l print -a 'crate-name file-names sysroot'
-complete -c rustc -s g
-complete -c rustc -s O
+set -l rustc_print_infos \
+    crate-name file-names sysroot target-libdir cfg calling-conventions \
+    target-list target-cpus target-features relocation-models code-models \
+    tls-models target-spec-json all-target-specs-json native-static-libs \
+    stack-protector-strategies link-args deployment-target
+complete -c rustc -x -l print -a "$rustc_print_infos" -d "print compiler information"
+complete -c rustc -s g -d "Equivalent to -C debuginfo=2"
+complete -c rustc -s O -d "Equivalent to -C opt-level=2"
+complete -c rustc -r -s o -d "Write output to <filename>"
 complete -c rustc -r -l out-dir
 complete -c rustc -x -l explain
 complete -c rustc -l test


### PR DESCRIPTION
Based on `rustc 1.80.0-nightly (9c9b56879 2024-05-05)`