### PR TITLE
Complete `cargo check` bin targets like `build`

### DIFF
--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -9,13 +9,13 @@ set -la __fish_cargo_subcommands (complete -C'cargo-' | string replace -rf '^car
 complete -c cargo -f -c cargo -n __fish_use_subcommand -a "$__fish_cargo_subcommands"
 complete -c cargo -x -c cargo -n '__fish_seen_subcommand_from help' -a "$__fish_cargo_subcommands"
 
-for x in bench b build rustc t test
+for x in bench b build c check rustc t test
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bench -a "(cargo bench --bench 2>&1 | string replace -rf '^\s+' '')"
     complete -c cargo -n "__fish_seen_subcommand_from $x" -l lib -d 'Only this package\'s library'
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l test -a "(cargo test --test 2>&1 | string replace -rf '^\s+' '')"
 end
 
-for x in bench b build r run rustc t test
+for x in bench b build c check r run rustc t test
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bin -a "(cargo run --bin 2>&1 | string replace -rf '^\s+' '')"
     complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l example -a "(cargo run --example 2>&1 | string replace -rf '^\s+' '')"
 end


### PR DESCRIPTION
## Description
Since `check` operates on basically the same things as `build`, it makes sense to complete binary targets the same way (i.e. tests, bins, examples)

Relates to #8429 — these completions already existed, just were being ignored for `check`.

<details>
<summary>Before</summary>

```
ianchamberlain@MacBook-Pro ~/D/D/fish-shell (fix/cargo-check-completions)> complete -C 'cargo check --bin '
benchmarks/
BSDmakefile
build.rs
build_tools/
Cargo.lock
Cargo.toml
CHANGELOG.rst
cmake/
CMakeLists.txt
CODE_OF_CONDUCT.md
CONTRIBUTING.rst
COPYING
debian/
docker/
Dockerfile
doc_internal/
doc_src/
etc/
fish.desktop
fish.pc.in
fish.png
fish.spec.in
GNUmakefile
osx/
po/
README.rst
share/
src/
target/
tests/
```
</details>

After:

```
ianchamberlain@MacBook-Pro ~/D/D/fish-shell (fix/cargo-check-completions)> complete -C 'cargo check --bin '
fish
fish_indent
fish_key_reader
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

Are any of these needed for such a small completion fix? Also, is this something that would make sense to backport to 3.7 or something (not sure what the release plan / versioning scheme is looking like at this point)?