### PR TITLE
Use ahash for our own HashMap and HashSet objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -98,6 +99,7 @@ source = "git+https://github.com/fish-shell/fast-float-rust?branch=fish#9590c33a
 name = "fish"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bitflags 2.5.0",
  "cc",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ once_cell = "1.17.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 widestring = "1.0.2"
 terminfo = "0.9.0"
+ahash = "0.8.11"
 
 [dev-dependencies]
 rand_pcg = "0.3.1"

--- a/src/abbrs.rs
+++ b/src/abbrs.rs
@@ -179,7 +179,7 @@ pub struct AbbreviationSet {
 
     /// Set of used abbrevation names.
     /// This is to avoid a linear scan when adding new abbreviations.
-    used_names: HashSet<WString>,
+    used_names: HashSet<WString, ahash::RandomState>,
 }
 
 impl AbbreviationSet {

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -26,10 +26,10 @@ pub struct Autoload {
     env_var_name: &'static wstr,
 
     /// A map from command to the files we have autoloaded.
-    autoloaded_files: HashMap<WString, FileId>,
+    autoloaded_files: HashMap<WString, FileId, ahash::RandomState>,
 
     /// The list of commands that we are currently autoloading.
-    current_autoloading: HashSet<WString>,
+    current_autoloading: HashSet<WString, ahash::RandomState>,
 
     /// The autoload cache.
     /// This is a unique_ptr because want to change it if the value of our environment variable
@@ -190,7 +190,7 @@ struct AutoloadFileCache {
 
     /// The set of files that we have returned to the caller, along with the time of the check.
     /// The key is the command (not the path).
-    known_files: HashMap<WString, KnownFile>,
+    known_files: HashMap<WString, KnownFile, ahash::RandomState>,
 }
 
 impl Default for AutoloadFileCache {
@@ -205,7 +205,7 @@ impl AutoloadFileCache {
         Self {
             dirs,
             misses_cache: MissesLruCache::new(NonZeroUsize::new(1024).unwrap()),
-            known_files: HashMap::new(),
+            known_files: HashMap::default(),
         }
     }
 

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -454,8 +454,8 @@ type CompletionEntryMap = BTreeMap<CompletionEntryIndex, CompletionEntry>;
 static COMPLETION_MAP: Mutex<CompletionEntryMap> = Mutex::new(BTreeMap::new());
 
 /// Completion "wrapper" support. The map goes from wrapping-command to wrapped-command-list.
-type WrapperMap = HashMap<WString, Vec<WString>>;
-static wrapper_map: Lazy<Mutex<WrapperMap>> = Lazy::new(|| Mutex::new(HashMap::new()));
+type WrapperMap = HashMap<WString, Vec<WString>, ahash::RandomState>;
+static wrapper_map: Lazy<Mutex<WrapperMap>> = Lazy::new(|| Mutex::new(HashMap::default()));
 
 /// Clear the [`CompleteFlags::AUTO_SPACE`] flag, and set [`CompleteFlags::NO_SPACE`] appropriately
 /// depending on the suffix of the string.
@@ -569,7 +569,7 @@ struct CustomArgData<'a> {
     /// When completing, variable assignments are really set in a local scope.
     var_assignments: &'a mut Vec<WString>,
     /// The set of wrapped commands which we have visited, and so should not be explored again.
-    visited_wrapped_commands: HashSet<WString>,
+    visited_wrapped_commands: HashSet<WString, ahash::RandomState>,
 }
 
 impl<'a> CustomArgData<'a> {
@@ -581,7 +581,7 @@ impl<'a> CustomArgData<'a> {
             do_file: true,
             wrap_depth: 0,
             var_assignments,
-            visited_wrapped_commands: HashSet::new(),
+            visited_wrapped_commands: HashSet::default(),
         }
     }
 }
@@ -598,7 +598,7 @@ struct Completer<'ctx> {
     needs_load: Vec<WString>,
     /// Table of completions conditions that have already been tested and the corresponding test
     /// results.
-    condition_cache: HashMap<WString, bool>,
+    condition_cache: HashMap<WString, bool, ahash::RandomState>,
 }
 
 static completion_autoloader: Lazy<Mutex<Autoload>> =
@@ -611,7 +611,7 @@ impl<'ctx> Completer<'ctx> {
             flags,
             completions: CompletionReceiver::new(ctx.expansion_limit),
             needs_load: vec![],
-            condition_cache: HashMap::new(),
+            condition_cache: HashMap::default(),
         }
     }
 

--- a/src/env/environment_impl.rs
+++ b/src/env/environment_impl.rs
@@ -483,11 +483,11 @@ impl EnvScopedImpl {
 
     pub fn get_names(&self, flags: EnvMode) -> Vec<WString> {
         let query = Query::new(flags);
-        let mut names: HashSet<WString> = HashSet::new();
+        let mut names: HashSet<WString, ahash::RandomState> = HashSet::default();
 
         // Helper to add the names of variables from `envs` to names, respecting show_exported and
         // show_unexported.
-        let add_keys = |envs: &VarTable, names: &mut HashSet<WString>| {
+        let add_keys = |envs: &VarTable, names: &mut HashSet<WString, ahash::RandomState>| {
             for (key, val) in envs.iter() {
                 if query.export_matches(val) {
                     names.insert(key.clone());

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -100,7 +100,7 @@ enum EnvCallback {
 
 #[derive(Default)]
 struct VarDispatchTable {
-    table: HashMap<&'static wstr, EnvCallback>,
+    table: HashMap<&'static wstr, EnvCallback, ahash::RandomState>,
 }
 
 impl VarDispatchTable {

--- a/src/env_universal_common.rs
+++ b/src/env_universal_common.rs
@@ -75,7 +75,7 @@ pub struct EnvUniversal {
 
     // Keys that have been modified, and need to be written. A value here that is not present in
     // vars indicates a deleted value.
-    modified: HashSet<WString>,
+    modified: HashSet<WString, ahash::RandomState>,
 
     // A generation count which is incremented every time an exported variable is modified.
     export_generation: u64,

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -120,8 +120,8 @@ pub fn highlight_shell(
 /// one screen redraw.
 #[derive(Default)]
 pub struct HighlightColorResolver {
-    fg_cache: HashMap<HighlightSpec, RgbColor>,
-    bg_cache: HashMap<HighlightSpec, RgbColor>,
+    fg_cache: HashMap<HighlightSpec, RgbColor, ahash::RandomState>,
+    bg_cache: HashMap<HighlightSpec, RgbColor, ahash::RandomState>,
 }
 
 /// highlight_color_resolver_t resolves highlight specs (like "a command") to actual RGB colors.
@@ -773,7 +773,7 @@ pub fn is_potential_path(
     let mut checked_paths = HashSet::new();
 
     // Keep a cache of which paths / filesystems are case sensitive.
-    let mut case_sensitivity_cache = CaseSensitivityCache::new();
+    let mut case_sensitivity_cache = CaseSensitivityCache::default();
 
     for wd in directories {
         if ctx.check_cancel() {
@@ -1550,7 +1550,7 @@ fn get_fallback(role: HighlightRole) -> HighlightRole {
 /// Returns:
 ///     false: the filesystem is not case insensitive
 ///     true: the file system is case insensitive
-pub type CaseSensitivityCache = HashMap<WString, bool>;
+pub type CaseSensitivityCache = HashMap<WString, bool, ahash::RandomState>;
 fn fs_is_case_insensitive(
     path: &wstr,
     fd: RawFd,

--- a/src/history.rs
+++ b/src/history.rs
@@ -359,7 +359,7 @@ struct HistoryImpl {
     /// Deleted item contents.
     /// Boolean describes if it should be deleted only in this session or in all
     /// (used in deduplication).
-    deleted_items: HashMap<WString, bool>,
+    deleted_items: HashMap<WString, bool, ahash::RandomState>,
     /// The buffer containing the history file contents.
     file_contents: Option<HistoryFileContents>,
     /// The file ID of the history file.
@@ -970,7 +970,7 @@ impl HistoryImpl {
             first_unwritten_new_item_index: 0,
             has_pending_item: false,
             disable_automatic_save_counter: 0,
-            deleted_items: HashMap::new(),
+            deleted_items: HashMap::default(),
             file_contents: None,
             history_file_id: INVALID_FILE_ID,
             boundary_timestamp: SystemTime::now(),
@@ -1212,8 +1212,8 @@ impl HistoryImpl {
     fn items_at_indexes(
         &mut self,
         indexes: impl IntoIterator<Item = usize>,
-    ) -> HashMap<usize, WString> {
-        let mut result = HashMap::new();
+    ) -> HashMap<usize, WString, ahash::RandomState> {
+        let mut result = HashMap::default();
         for idx in indexes {
             // If this is the first time the index is encountered, we have to go fetch the item.
             #[allow(clippy::map_entry)] // looks worse
@@ -1753,7 +1753,7 @@ impl History {
     pub fn items_at_indexes(
         &self,
         indexes: impl IntoIterator<Item = usize>,
-    ) -> HashMap<usize, WString> {
+    ) -> HashMap<usize, WString, ahash::RandomState> {
         self.imp().items_at_indexes(indexes)
     }
 
@@ -1798,7 +1798,7 @@ pub struct HistorySearch {
     /// Index of the current history item.
     current_index: usize, // 0
     /// If deduping, the items we've seen.
-    deduper: HashSet<WString>,
+    deduper: HashSet<WString, ahash::RandomState>,
 }
 
 impl HistorySearch {
@@ -1827,7 +1827,7 @@ impl HistorySearch {
             flags,
             current_item: None,
             current_index: starting_index,
-            deduper: HashSet::new(),
+            deduper: HashSet::default(),
         };
 
         if search.ignores_case() {

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -1146,7 +1146,7 @@ fn mangle_1_completion_description(s: &mut WString) {
 fn join_completions(comps: &mut Vec<PagerComp>) {
     // A map from description to index in the completion list of the element with that description.
     // The indexes are stored +1.
-    let mut desc_table: HashMap<WString, usize> = HashMap::new();
+    let mut desc_table: HashMap<WString, usize, ahash::RandomState> = HashMap::default();
 
     // Note that we mutate the completion list as we go, so the size changes.
     let mut i = 0;

--- a/src/reader_history_search.rs
+++ b/src/reader_history_search.rs
@@ -56,7 +56,7 @@ pub struct ReaderHistorySearch {
     matches: Vec<SearchMatch>,
 
     /// A set of new items to skip, corresponding to matches_ and anything added in skip().
-    skips: HashSet<WString>,
+    skips: HashSet<WString, ahash::RandomState>,
 
     /// Index into our matches list.
     match_index: usize,
@@ -153,7 +153,7 @@ impl ReaderHistorySearch {
             mode != SearchMode::Inactive,
             "mode cannot be inactive in this setter"
         );
-        self.skips = HashSet::from([text.clone()]);
+        self.skips = ahash::AHashSet::from([text.clone()]).into();
         self.matches = vec![SearchMatch::new(text.clone(), 0)];
         self.match_index = 0;
         self.mode = mode;

--- a/src/wildcard.rs
+++ b/src/wildcard.rs
@@ -459,9 +459,9 @@ mod expander {
         /// The working directory to resolve paths against
         working_directory: &'e wstr,
         /// The set of items we have resolved, used to efficiently avoid duplication.
-        completion_set: HashSet<WString>,
+        completion_set: HashSet<WString, ahash::RandomState>,
         /// The set of file IDs we have visited, used to avoid symlink loops.
-        visited_files: HashSet<FileId>,
+        visited_files: HashSet<FileId, ahash::RandomState>,
         /// Flags controlling expansion.
         flags: ExpandFlags,
         /// Resolved items get inserted into here. This is transient of course.
@@ -492,7 +492,7 @@ mod expander {
                     .iter()
                     .map(|c| c.completion.to_owned())
                     .collect(),
-                visited_files: HashSet::new(),
+                visited_files: HashSet::default(),
                 flags,
                 resolved_completions,
                 did_add: false,
@@ -895,7 +895,7 @@ mod expander {
             // Ensure we don't fall into a symlink loop.
             // Ideally we would compare both devices and inodes, but devices require a stat call, so we
             // use inodes exclusively.
-            let mut visited_inodes: HashSet<libc::ino_t> = HashSet::new();
+            let mut visited_inodes: HashSet<libc::ino_t, ahash::RandomState> = HashSet::default();
 
             loop {
                 let mut unique_entry = WString::new();


### PR DESCRIPTION
We already transitively take a dependency on the ahash crate, so might as well use it. While not all of our HashMap/HashSet objects are performance-sensitive, some of them are and there's no cost to migrating them all over.

By default, rust uses a DoS-resistant, cryptographic hash (SipHash) to hash the keys for HashMap/HashSet entries into buckets, which is slower than what we used to use in the C++ world. We don't use any of it in a security-sensitive context or based off of unvalidated/untrusted/remote input, so there are no security reasons to continue to use SipHash.

Some of fish's HashMap/HashSet instances could benefit from being faster, e.g. the functions cache, various completion caches, environment variable tables, and history lookups, so this isn't just a "use it because it's there" kind of thing.