### PR TITLE
Prevent loading of `psqlrc` when listing databases for completion

### DIFF
--- a/share/functions/__fish_complete_pg_database.fish
+++ b/share/functions/__fish_complete_pg_database.fish
@@ -1,3 +1,3 @@
 function __fish_complete_pg_database
-    psql -AtqwlF \t 2>/dev/null | awk 'NF > 1 { print $1 }'
+    psql -AtqwlXF \t 2>/dev/null | awk 'NF > 1 { print $1 }'
 end

--- a/share/functions/__fish_complete_pg_user.fish
+++ b/share/functions/__fish_complete_pg_user.fish
@@ -1,3 +1,3 @@
 function __fish_complete_pg_user
-    psql -Atqwc 'select usename from pg_user' template1 2>/dev/null
+    psql -AtqwXc 'select usename from pg_user' template1 2>/dev/null
 end


### PR DESCRIPTION
## Description

Users have the ability to override the way records are displayed in psql by changing the [format](https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-META-COMMAND-PSET-FORMAT) and [linestyle](https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-META-COMMAND-PSET-LINESTYLE) settings. These settings also affect the output of psql commands used for autocompletion, like listing databases and users - so they inadvertently break Fish's completion

If we [suppress the loading of psqlrc](https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-OPTION-NO-PSQLRC) the default settings are used instead.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

## Example output

I can't see any tests associated with this functionality but here's a screenshot demonstrating the problem outlined above. The fancy tables in the first command (adhering to my `~/.psqlrc`) break completion, which looks like this:

![image](https://github.com/fish-shell/fish-shell/assets/128088/41d2e06c-521f-4964-8146-d177525817e7)

If we run with/without the `-X` it's clear what's going on.


![image](https://github.com/fish-shell/fish-shell/assets/128088/37f6e0bb-b935-48c6-9e25-f1abcdb9e1f3)
