### PR TITLE
Add `path basename --no-extension`

### DIFF
--- a/doc_src/cmds/path.rst
+++ b/doc_src/cmds/path.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    path basename GENERAL_OPTIONS [PATH ...]
+    path basename GENERAL_OPTIONS [(-E | --no-extension)] [PATH ...]
     path dirname GENERAL_OPTIONS  [PATH ...]
     path extension GENERAL_OPTIONS [PATH ...]
     path filter GENERAL_OPTIONS [-v | --invert]
@@ -55,9 +55,11 @@ The following subcommands are available.
 
 ::
 
-    path basename [-z | --null-in] [-Z | --null-out] [-q | --quiet] [PATH ...]
+    path basename [-E | --no-extension] [-z | --null-in] [-Z | --null-out] [-q | --quiet] [PATH ...]
 
 ``path basename`` returns the last path component of the given path, by removing the directory prefix and removing trailing slashes. In other words, it is the part that is not the dirname. For files you might call it the "filename".
+
+If the ``-E`` or ``---no-extension`` option is used and the base name contained a period, the path is returned with the extension (or the last extension) removed, i.e. the "filename" without an extension (akin to calling ``path change-extension "" (path basename $path)``).
 
 It returns 0 if there was a basename, i.e. if the path wasn't empty or just slashes.
 

--- a/tests/checks/path.fish
+++ b/tests/checks/path.fish
@@ -318,5 +318,10 @@ path basename -Z foo bar baz | path sort
 # CHECK: baz
 # CHECK: foo
 
+path basename -E foo.txt /usr/local/foo.bar /foo.tar.gz
+# CHECK: foo
+# CHECK: foo
+# CHECK: foo.tar
+
 path basename --null-out bar baz | string escape
 # CHECK: bar\x00baz\x00


### PR DESCRIPTION
Add `path basename --no-extension`

This makes `path basename` a more useful replacement for the stock `basename`
command, which can be used with `-s .ext` to trim `.ext` from the base name.

Previously, this would have required the equivalent of

    path change-extension "" (path basename $path)

but now it can be just

    path basename -E $path


## TODOs:
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
