### PR TITLE
feat: improve completion for konsole

### DIFF
--- a/share/completions/konsole.fish
+++ b/share/completions/konsole.fish
@@ -1,35 +1,36 @@
-# Completion for `konsole
+# Completion for konsole
 
-complete -c konsole -l help -d 'Show help and exit'
-complete -c konsole -s v -d 'Show version and exit'
-complete -c konsole -l version -d 'Show version and exit'
-complete -c konsole -l help-qt -d 'Show Qt specific options and exit'
-complete -c konsole -l help-kde -d 'Show KDE specific options and exit'
+complete -c konsole -f
+
+complete -c konsole -l help -xs h -d 'Show help and exit'
 complete -c konsole -l help-all -d 'Show all options and exit'
-complete -c konsole -l author -d 'Show author information and exit'
-complete -c konsole -l license -d 'Show license information and exit'
-complete -c konsole -l name -d 'Window class'
-complete -c konsole -l ls -d 'Login shell'
-complete -c konsole -s T -d 'Window name'
-complete -c konsole -l tn -d 'Terminal type'
-complete -c konsole -l noclose -d 'Do not close when command exists'
-complete -c konsole -l nohist -d 'Do not save history'
-complete -c konsole -l nomenubar -d 'Hide menu bar'
-complete -c konsole -l notabbar -d 'Hide tab bar'
-complete -c konsole -l notoolbar -d 'Hide tab bar'
-complete -c konsole -l noframe -d 'Hide frame bar'
-complete -c konsole -l noscrollbar -d 'Hide scrollbar'
-complete -c konsole -l noxft -d 'Do not use atni-aliasing'
-complete -c konsole -l noresize -d 'Do not allow window to be resized'
-complete -c konsole -l vt_sz -d 'Window size'
-complete -c konsole -l type -d 'Session type'
-complete -c konsole -l types -d 'List session types'
-complete -c konsole -l keytab -d 'Keytab name'
-complete -c konsole -l keytabs -d 'List keytabs'
-complete -c konsole -l profile -d Profile
-complete -c konsole -l profiles -d 'List profiles'
-complete -c konsole -l schema -d Schema
-complete -c konsole -l schemas -d 'List schemas'
-complete -c konsole -l script -d 'Enable extended DCOP Qt functions'
-complete -c konsole -l workdir -d 'Working directory'
-complete -c konsole -s e -d 'Command to execute'
+complete -c konsole -l version -xs v -d 'Show version and exit'
+complete -c konsole -l author -d 'Show author info and exit'
+complete -c konsole -l license -d 'Show license info and exit'
+complete -c konsole -l desktopfile -d 'Base file name of desktop entry'
+
+set -l profiles (konsole --list-profiles)
+complete -c konsole -l profile -d 'Name of profile to use'
+for p in $profiles
+    complete -c konsole -n "__fish_seen_subcommand_from --profile; and not __fish_seen_subcommand_from $profiles" -a $p
+end
+
+complete -c konsole -l layout -rF -d 'json layoutfile to be loaded'
+complete -c konsole -l builtin-profile -d 'Use the built-in profile'
+complete -c konsole -l workdir -d 'Set initial working dir' -xa "(__fish_complete_directories)"
+complete -c konsole -l hold -l noclose -d 'Do not close when command exists'
+complete -c konsole -l new-tab -d 'Create a new tab'
+complete -c konsole -l tabs-from-file -rF -d 'Create tabs from tabs config'
+complete -c konsole -l background-mode -d 'Start Konsole in the background'
+complete -c konsole -l separate -l nofork -d 'Run in a separate process'
+complete -c konsole -l show-menubar -d 'Show the menubar'
+complete -c konsole -l hide-menubar -d 'Hide the menubar'
+complete -c konsole -l show-tabbar -d 'Show the tabbar'
+complete -c konsole -l hide-tabbar -d 'Hide the tabbar'
+complete -c konsole -l fullscreen -d 'Start Konsole in fullscreen mode'
+complete -c konsole -l notransparency -d 'Disable transparent backgrounds'
+complete -c konsole -l list-profiles -x -d 'List the available profiles'
+complete -c konsole -l list-profile-properties -x -d 'List all the profile properties'
+complete -c konsole -s p -x -d '<P=V> Change profile property'
+complete -c konsole -s e -x -d '<CMD> Command to execute'
+complete -c konsole -l force-reuse -d 'Force re-using existing instance'


### PR DESCRIPTION
## Description

Improve the existing completion for konsole, as the current version is outdated. Similar to the current version, the improved version only contains options from --help, but not from --help-all, which includes more Qt-specific options that are less likely to be used by users.
Additionally, it can complete --profile based on existing profiles, provided the profile name does not contain any space. (Please let me know if there is a better way to implement this. Thank you in advance.)

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
