### PR TITLE
Add `set --keep` to avoid overwriting an existing variable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -121,6 +121,7 @@ Scripting improvements
 - ``string repeat`` now allows omission of ``-n`` when the first argument is an integer. (:issue:`10282`)
 - ``functions --handlers-type caller-exit`` once again lists functions defined as ``function --on-job-exit caller``, rather than them being listed by ``functions --handlers-type process-exit``.
 - ``set`` has a new ``--no-event`` flag, to set or erase variables without triggering a variable event. This is useful e.g. to change a variable in an event handler. (:issue:`10480`)
+- ``set`` has a new ``-keep`` flag, to keep an existing variable from being overwritten: ``set -k -g foo bar`` is equivalent to ``set -q foo or set -g foo bar``. (:issue:`10531`)
 - Commas in command substitution output are no longer used as separators in brace expansion, preventing a surprising expansion in rare cases (:issue:`5048`).
 - Universal variables can now store strings containing invalid Unicode codepoints (:issue:`10313`).
 

--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -93,7 +93,7 @@ Further options:
     If no variable was given, it also returns 255.
 
 **-k** or **--keep**
-    Only set the variable if it doesn't exist, so ``set -k name value`` is equivalent to  ``set -q name or set name value``.
+    Only set the variable if it doesn't exist, so ``set -k name value`` is equivalent to  ``set -q name; or set name value``.
 
 **-n** or **--names**
     List only the names of all defined variables, not their value.

--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -9,10 +9,10 @@ Synopsis
 .. synopsis::
 
     set
-    set (-f | --function) (-l | --local) (-g | --global) (-U | --universal) [--no-event]
-    set [-Uflg] NAME [VALUE ...]
-    set [-Uflg] NAME[[INDEX ...]] [VALUE ...]
-    set (-a | --append) [-flgU] NAME VALUE ...
+    set (-f | --function) (-l | --local) (-g | --global) (-U | --universal) (-k | --keep) [--no-event]
+    set [-Ufklg] NAME [VALUE ...]
+    set [-Ufklg] NAME[[INDEX ...]] [VALUE ...]
+    set (-a | --append) [-fklgU] NAME VALUE ...
     set (-q | --query) (-e | --erase) [-flgU] [NAME][[INDEX]] ...]
     set (-S | --show) [NAME ...]
 
@@ -91,6 +91,9 @@ Further options:
     If an *INDEX* is provided, check for items at that slot.
     Does not output anything, but the shell status is set to the number of variables specified that were not defined, up to a maximum of 255.
     If no variable was given, it also returns 255.
+
+**-k** or **--keep**
+    Only set the variable if it doesn't exist, so ``set -k name value`` is equivalent to  ``set -q name or set name value``.
 
 **-n** or **--names**
     List only the names of all defined variables, not their value.

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -994,6 +994,21 @@ set -e nonevent
 # CHECK: ONEVENT VARIABLE SET nonevent
 # CHECK: ONEVENT VARIABLE ERASE nonevent
 
+# --keep
+
+set -g -k keep bar
+echo $keep
+#CHECK: bar
+
+set -g -k keep baz
+echo $keep
+# CHECK: bar
+
+set -e keep
+set -g -k keep baz
+echo $keep
+# CHECK: baz
+
 mkdir -p empty
 env -u XDG_CONFIG_HOME HOME=$PWD/empty LC_ALL=en_US.UTF-8 $FISH -c 'set -Ux LC_ALL en_US.UTF-8'
 env -u XDG_CONFIG_HOME HOME=$PWD/empty LC_ALL=en_US.UTF-8 $FISH -c 'set -S LC_ALL'


### PR DESCRIPTION
## Description

This is my first time contributing to fish, so please point out any flaws in the procedure. Also, I would not consider myself a very power user of fish, so I might be missing something obvious, too.

This adds support for a `-k` or `--keep` option to the `set` command. When used in a `set` invokation that would set a variable to a value, the option turns the command into a no-op if a variable is already there.

I was looking at the changes in 3.7.1 after noticing a nice prompt in a fossil checkout of mine. This lead me to read the fossil prompt function and to stumble upon [this pattern](https://github.com/fish-shell/fish-shell/blob/7850142bef794db4d031fb6e1ec9dd7906a9f459/share/functions/fish_fossil_prompt.fish#L11-L47).

I thought there must be a better way... so here it is: `set -k -g foo bar` is (supposed to be) equivalent to `set -q foo or set -g foo bar`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
