### PR TITLE
Make fish_add_path more transparent

### DIFF
--- a/doc_src/cmds/fish_add_path.rst
+++ b/doc_src/cmds/fish_add_path.rst
@@ -52,7 +52,8 @@ Options
     Move already-existing components to the place they would be added - by default they would be left in place and not added again.
 
 **-v** or **--verbose**
-    Print the :doc:`set <set>` command used.
+    Print the :doc:`set <set>` command used, and some more warnings, like when a path is skipped because it doesn't exist or is not a directory.
+    Verbose mode is automatically enabled when fish_add_path is used interactively and the output goes to the terminal.
 
 **-n** or **--dry-run**
     Print the ``set`` command that would be used without executing it.

--- a/share/functions/fish_add_path.fish
+++ b/share/functions/fish_add_path.fish
@@ -70,6 +70,8 @@ function fish_add_path --description "Add paths to the PATH"
             if set -q _flag_move; and not contains -- $p $newpaths
                 set -a indexes $ind
                 set -a newpaths $p
+            else if set -q _flag_verbose
+                printf (_ "Skipping already included path: %s\n") "$p"
             end
         else if not contains -- $p $newpaths
             # Without move, we only add it if it's not in.
@@ -99,6 +101,10 @@ function fish_add_path --description "Add paths to the PATH"
         and set $scope $var $newvar
         return 0
     else
+        if set -q _flag_verbose
+            # print a message in verbose mode
+            printf (_ "No paths to add, not setting anything.\n") "$p"
+        end
         return 1
     end
 end

--- a/share/functions/fish_add_path.fish
+++ b/share/functions/fish_add_path.fish
@@ -36,6 +36,11 @@ function fish_add_path --description "Add paths to the PATH"
     set -l mode $_flag_prepend $_flag_append
     set -q mode[1]; or set mode -p
 
+    # Enable verbose mode if we're interactively used
+    status current-command | string match -rq '^fish_add_path$'
+    and isatty stdout
+    and set -l _flag_verbose yes
+
     # To keep the order of our arguments, go through and save the ones we want to keep.
     set -l newpaths
     set -l indexes

--- a/tests/checks/fish_add_path.fish
+++ b/tests/checks/fish_add_path.fish
@@ -25,6 +25,8 @@ function checkpath --on-variable PATH --on-variable fish_user_paths; echo CHECKP
 set PATH $PATH
 # CHECK: CHECKPATH: VARIABLE SET PATH
 fish_add_path -v $tmpdir/bin
+# CHECK: Skipping already included path: {{.*}}
+# CHECK: No paths to add, not setting anything.
 # Nothing happened, so the status failed.
 echo $status
 # CHECK: 1


### PR DESCRIPTION
## Description

fish_add_path has a pretty tricky dual nature:

- It's usable in config.fish - you throw it in there and it does The Right Thing
- It's usable in the commandline

These two have different needs - scripted use needs it to be as quiet as possible. If a path wasn't added because it's already included, that's probably because it already ran. If a path wasn't added because it's a file, that's probably because it was a directory on another system.

Interactive use, on the other hand, suffers a bit from a lack of feedback - you do something and it either silently returns true or false, without explaining *why*.

We have "verbose" mode - `fish_add_path -v`, but that's something people need to know about, and it currently does not explain enough.

So, what this does is:

1. It makes verbose mode more informative by printing a message for each path that was eliminated and also if no path was left
2. (the spicy part) It automatically enables verbose mode if fish_add_path is used interactively, from the commandline - if you run `fish_add_path /foo` at your prompt, you'll get messages

That latter part is a bit naughty - numerous CLI guidelines don't like this. But I do believe it's helpful, and I don't really see an alternative - anything else requires adding a flag to get messages interactively, or adding a flag to suppress them noninteractively.

I see people on the internet fail regularly by trying to add a *file* instead of the directory it contains:

```fish
fish_add_path /opt/bin/texlive # <- should be /opt/bin!
```

and we currently have no warning about this - it will just silently return false. You'll have to run `fish_add_path -v /opt/bin/texlive` to get "Skipping path because it is a file instead of a directory".

Adding this means they'll get the feedback, which should make their mistake obvious - add the directory. (an alternative for this specific case is to automatically dirname any file, but the lack of information hurts in other cases as well)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
