### PR TITLE
Add `set --default`

### DIFF
--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -12,7 +12,8 @@ Synopsis
     set (-f | --function) (-l | --local) (-g | --global) (-U | --universal) [--no-event]
     set [-Uflg] NAME [VALUE ...]
     set [-Uflg] NAME[[INDEX ...]] [VALUE ...]
-    set (-a | --append) [-flgU] NAME VALUE ...
+    set (-a | --append) (-p | --prepend) [-flgU] NAME VALUE ...
+    set (-d | --default) [-ap] [-flgU] NAME VALUE ...
     set (-q | --query) (-e | --erase) [-flgU] [NAME][[INDEX]] ...]
     set (-S | --show) [NAME ...]
 
@@ -80,6 +81,13 @@ Further options:
     Prepends *VALUES* to the current set of values for variable **NAME**.
     This can be used with **--append** to both append and prepend at the same time.
     This cannot be used when assigning to a variable slice.
+
+**-d** or **--default** *NAME* *VALUE* ...
+    Sets the variable to VALUE if it isn't set yet, or uses the existing value if it is.
+    When used without a scope, nothing will happen if the variable already exists.
+    When it is used with a specified scope and another variable of the same name but different scope exists,
+    the variable will be created with the value of that other variable.
+    When used with **--append** or **--prepend**, the new VALUE will be appended or prepended to the existing value.
 
 **-e** or **--erase** *NAME*[*INDEX*]
     Causes the specified shell variables to be erased.

--- a/tests/checks/set.fish
+++ b/tests/checks/set.fish
@@ -1013,4 +1013,36 @@ set line[0] ""
 echo Still here
 # CHECK: Still here
 
+# --default
+set -e banana
+set -g banana global
+function on_banana --on-variable banana
+    echo POTASSIUM YUM YUM
+end
+
+# No variable event here:
+set --default banana not happening
+# One here:
+set -d --local banana local
+#CHECK: POTASSIUM YUM YUM
+set --show banana
+#CHECK: $banana: set in local scope, unexported, with 1 elements
+# It is still the value "global"!
+#CHECK: $banana[1]: |global|
+#CHECK: $banana: set in global scope, unexported, with 1 elements
+#CHECK: $banana[1]: |global|
+
+set --default pineapple pineappolis
+echo $pineapple
+#CHECK: pineappolis
+
+set --default --append pineapple appended
+echo $pineapple
+#CHECK: pineappolis appended
+
+set --default --append mango this is new
+echo $mango
+#CHECK: this is new
+
+
 exit 0


### PR DESCRIPTION
This allows quickly setting a variable to a value, or taking the existing value.

The simple use is this:

```fish
set --default foo bar
```

If $foo was already set, it stays. If $foo wasn't set, it is now set to "bar".

The trickier use is when it's combined with a scope or `--append` or `--prepend`. In those cases, it will ensure that:

1. The variable is now set with the given scope
2. If you use append/prepend, those values are included

These are nice properties to have to rely on.

In particular if you do `set --local foo bar`, you now have a *local* $foo, and so you can modify it without stepping on anyone's toes. If there was a global variable by that name, it still exists, but you've nicked the variable.

Alternative to #10531 
Fixes #2504 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
