### PR TITLE
cmake: support building without C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 include(cmake/Mac.cmake)
 
-project(fish)
+# fish is mostly in rust, but a C compiler is needed for configure checks
+# in both CMake and build.rs
+project(fish LANGUAGES C)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# We are C++11.
-set(CMAKE_CXX_STANDARD 11)
 set(DEFAULT_BUILD_TYPE "Debug")
 
 # Generate Xcode schemas (but not for tests).
@@ -85,9 +85,6 @@ fish_link_deps_and_sign(fish_key_reader)
 
 # Set up the docs.
 include(cmake/Docs.cmake)
-
-# A helper for running tests.
-add_executable(fish_test_helper src/fish_test_helper.cpp)
 
 # Set up tests.
 include(cmake/Tests.cmake)

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -163,7 +163,6 @@ endif()
 
 # Group install targets into a InstallTargets folder
 set_property(TARGET build_fish_pc CHECK-FISH-BUILD-VERSION-FILE
-                    tests_buildroot_target
              PROPERTY FOLDER cmake/InstallTargets)
 
 # Make a target build_root that installs into the buildroot directory, for testing.

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -1,3 +1,19 @@
+# Running the integration tests requires a C++ compiler to build the helper
+include(CheckLanguage)
+check_language(CXX)
+
+add_feature_info(Tests CMAKE_CXX_COMPILER "unit and integration tests (require a C++ compiler)")
+if(CMAKE_CXX_COMPILER)
+    enable_language(CXX)
+    # Use C++11
+    set(CMAKE_CXX_STANDARD 11)
+else()
+    return()
+endif()
+
+# A helper for running tests.
+add_executable(fish_test_helper src/fish_test_helper.cpp)
+
 # This adds ctest support to the project
 enable_testing()
 
@@ -101,6 +117,10 @@ add_custom_target(tests_buildroot_target
                           ${TEST_INSTALL_DIR}/${CMAKE_INSTALL_PREFIX}
                           ${TEST_ROOT_DIR}
                   DEPENDS fish fish_test_helper)
+
+# Group install targets into a InstallTargets folder
+set_property(TARGET tests_buildroot_target
+             PROPERTY FOLDER cmake/InstallTargets)
 
 FILE(GLOB FISH_CHECKS CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/tests/checks/*.fish)
 foreach(CHECK ${FISH_CHECKS})


### PR DESCRIPTION
Closes #10549.

More work could be done to separate the integration and unit (Cargo) tests, allowing at least the latter to run without a C++ compiler.