### PR TITLE
Port fish_test_helper to C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 include(cmake/Mac.cmake)
 
-project(fish)
+project(fish LANGUAGES C)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# We are C++11.
-set(CMAKE_CXX_STANDARD 11)
 set(DEFAULT_BUILD_TYPE "Debug")
 
 # Generate Xcode schemas (but not for tests).
@@ -87,8 +85,7 @@ fish_link_deps_and_sign(fish_key_reader)
 include(cmake/Docs.cmake)
 
 # A helper for running tests.
-add_executable(fish_test_helper src/fish_test_helper.cpp)
-
+add_executable(fish_test_helper src/fish_test_helper.c)
 # Set up tests.
 include(cmake/Tests.cmake)
 

--- a/README.rst
+++ b/README.rst
@@ -140,11 +140,10 @@ Building from git master currently requires:
 
 -  Rust (version 1.70 or later)
 -  CMake (version 3.19 or later)
--  a C compiler (for system feature detection)
+-  a C compiler (for system feature detection and the test helper binary)
 -  PCRE2 (headers and libraries) - optional, this will be downloaded if missing
 -  gettext (headers and libraries) - optional, for translation support
 -  an Internet connection, as other dependencies will be downloaded automatically
--  For tests: a C++11 compiler
 
 
 Building from source (all platforms) - Makefile generator


### PR DESCRIPTION
This is the last piece of C++, so now we can remove the need for a C++ compiler.

We need one for C anyway (libc.c).

Fixes #10549

Alternative to #10563

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
