### PR TITLE
Issue #10394

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -319,7 +319,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
 
     bind -s --preset -M visual -m insert c kill-selection end-selection repaint-mode
     bind -s --preset -M visual -m insert s kill-selection end-selection repaint-mode
-    bind -s --preset -M visual -m default d kill-selection end-selection repaint-mode
+    bind -s --preset -M visual -m default d kill-selection end-selection backward-char repaint-mode
     bind -s --preset -M visual -m default x kill-selection end-selection repaint-mode
     bind -s --preset -M visual -m default X kill-whole-line end-selection repaint-mode
     bind -s --preset -M visual -m default y kill-selection yank end-selection repaint-mode


### PR DESCRIPTION
## Description

Moves cursor backwards one space after vi mode visual deletion, just like in Vim.

Fixes issue #10394

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
