### PR TITLE
docs: use fish_vi_key_bindings in the example section

### DIFF
--- a/doc_src/cmds/fish_default_key_bindings.rst
+++ b/doc_src/cmds/fish_default_key_bindings.rst
@@ -24,4 +24,4 @@ Examples
 
 To start using vi key bindings::
 
-  fish_default_key_bindings
+  fish_vi_key_bindings


### PR DESCRIPTION
## Description

In order to start using vi key bindings, `fish_vi_key_bindings` needs to be used.
