### PR TITLE
Extend diskutil eject to suggest volumes

### DIFF
--- a/share/completions/diskutil.fish
+++ b/share/completions/diskutil.fish
@@ -52,8 +52,8 @@ complete -f -c diskutil -n __fish_use_subcommand -a umountDisk -d 'Unmount an en
 complete -f -c diskutil -n '__fish_diskutil_using_not_subcommand umountDisk' -a '(__fish_diskutil_mounted_volumes)'
 
 # eject
-complete -f -c diskutil -n __fish_use_subcommand -a eject -d 'Eject a disk'
-complete -f -c diskutil -n '__fish_diskutil_using_not_subcommand eject' -a '(__fish_diskutil_devices)'
+complete -f -c diskutil -n __fish_use_subcommand -a eject -d 'Eject a volume or disk'
+complete -f -c diskutil -n '__fish_diskutil_using_not_subcommand eject' -a '(__fish_diskutil_mounted_volumes) (__fish_diskutil_devices)'
 
 # mount
 complete -f -c diskutil -n __fish_use_subcommand -a mount -d 'Mount a single volume'

--- a/share/completions/diskutil.fish
+++ b/share/completions/diskutil.fish
@@ -14,6 +14,11 @@ function __fish_diskutil_mounted_volumes
     printf '%s\n' $mountpoints
 end
 
+function __fish_diskutil_writeable_volumes
+    set -l mountpoints (path filter -w /Volumes/*)
+    printf '%s\n' $mountpoints
+end
+
 function __fish_diskutil_using_not_subcommand
     not __fish_seen_subcommand_from apfs
     and not __fish_seen_subcommand_from appleRAID
@@ -53,7 +58,7 @@ complete -f -c diskutil -n '__fish_diskutil_using_not_subcommand umountDisk' -a 
 
 # eject
 complete -f -c diskutil -n __fish_use_subcommand -a eject -d 'Eject a volume or disk'
-complete -f -c diskutil -n '__fish_diskutil_using_not_subcommand eject' -a '(__fish_diskutil_mounted_volumes) (__fish_diskutil_devices)'
+complete -f -c diskutil -n '__fish_diskutil_using_not_subcommand eject' -a '(__fish_diskutil_writeable_volumes ; __fish_diskutil_devices)'
 
 # mount
 complete -f -c diskutil -n __fish_use_subcommand -a mount -d 'Mount a single volume'


### PR DESCRIPTION
Extend `diskutil eject` completion to also suggest mounted volumes.

Fixes #10573

## Description

<img width="1060" alt="image" src="https://github.com/fish-shell/fish-shell/assets/101384/f41869ea-032b-4a36-8b7b-892a613056c1">

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst (mentioned already improved completions
