### PR TITLE
fix the show example in the complete command document.

### DIFF
--- a/doc_src/cmds/complete.rst
+++ b/doc_src/cmds/complete.rst
@@ -149,7 +149,7 @@ Now hub inherits all of the completions from git. Note this can also be specifie
 
 ::
 
-   complete -c git
+   complete -C git
 
 Shows all completions for ``git``.
 


### PR DESCRIPTION
## Description
Sorry for the 1-character PR. It just annoyed me that the man page (rst page) example didn't work, so I fixed the example in the `doc_src/cmds/complete.rst` file. (by changing `-c` to `-C` )

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] ~~Tests have been added for regressions fixed~~
- [ ] User-visible changes noted in CHANGELOG.rst
