### PR TITLE
Fix i586 floating point test failures

### DIFF
--- a/printf/src/tests.rs
+++ b/printf/src/tests.rs
@@ -342,6 +342,10 @@ fn test_ptr() {
 }
 
 #[test]
+#[cfg_attr(
+    all(target_arch = "x86", not(target_feature = "sse2")),
+    ignore = "i586 has inherent accuracy issues, see rust-lang/rust#114479"
+)]
 fn test_float() {
     // Basic form, handling of exponent/precision for 0
     assert_fmt1!("%a", 0.0, "0x0p+0");
@@ -448,6 +452,10 @@ fn test_float() {
 }
 
 #[test]
+#[cfg_attr(
+    all(target_arch = "x86", not(target_feature = "sse2")),
+    ignore = "i586 has inherent accuracy issues, see rust-lang/rust#114479"
+)]
 fn test_float_g() {
     // correctness in DBL_DIG places
     assert_fmt1!("%.15g", 1.23456789012345, "1.23456789012345");
@@ -583,8 +591,12 @@ fn test_prefixes() {
     assert_eq!(sprintf_check!("%ls", "cs"), "cs");
 }
 
-#[allow(clippy::approx_constant)]
 #[test]
+#[cfg_attr(
+    all(target_arch = "x86", not(target_feature = "sse2")),
+    ignore = "i586 has inherent accuracy issues, see rust-lang/rust#114479"
+)]
+#[allow(clippy::approx_constant)]
 fn negative_precision_width() {
     assert_fmt!("%*s", -10, "hello" => "hello     ");
     assert_fmt!("%*s", -5, "world" => "world");
@@ -692,6 +704,10 @@ fn test_errors() {
 }
 
 #[test]
+#[cfg_attr(
+    all(target_arch = "x86", not(target_feature = "sse2")),
+    ignore = "i586 has inherent accuracy issues, see rust-lang/rust#114479"
+)]
 fn test_locale() {
     fn test_printf_loc<'a>(expected: &str, locale: &Locale, format: &str, arg: impl ToArg<'a>) {
         let mut target = String::new();

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -72,9 +72,16 @@ math '-10^15'
 # CHECK: 100000000000000
 # CHECK: -1000000000000000
 
-math 3^0.5^2
+# Floating point operations under x86 without SSE2 have reduced accuracy!
+# This includes both i586 targets and i686 under Debian, where it's patched to remove SSE2.
+# As a result, some floating point tests use regular expressions to loosely match against
+# the shape of the expected result.
+
+# NB: The i586 case should also pass under other platforms, but not the other way around.
+math "3^0.5^2"
+# CHECK: {{1\.316074|1\.316\d+}}
+
 math -2^2
-# CHECK: 1.316074
 # CHECK: 4
 
 math -s0 '1.0 / 2.0'
@@ -280,7 +287,7 @@ math pow sin 3, 5 + 2
 # CHECKERR:             ^~~~^
 
 math sin pow 3, 5
-# CHECK: -0.890009
+# CHECK: {{-0\.890009|-0.890\d*}}
 
 math pow 2, cos -pi
 # CHECK: 0.5


### PR DESCRIPTION
This PR tries to find a balance between ignoring floating point tests/errors under i586 (i.e. x86 without SSE2) and ensuring that we still have somewhat reasonable results even when run with reduced accuracy. The printf unit tests are ignored under i586 but the littlecheck tests use prefix matching or reduced `math --scale` values to ensure that the results aren't ridiculous and the core preconditions are still being tested. The reduced accuracy tests are run under all platforms to ensure they don't rot, but the regular precision tests are only run if not i586.

This patch series includes the addition of a new and undocumented `status` builtin variants (`status target` and `status target-arch`) that are used to check at runtime if we should expect tests to run with reduced accuracy. There are obviously other ways to expose this information to the test environment, but I see a lot of (internal) use for this. 
(NB: I'm not saying "let's not document this" but rather just punting on the question of whether or not this will be a documented `status` interface for now.)