### PR TITLE
give the two pages of the functions tab individual scrollbars

### DIFF
--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -54,7 +54,7 @@ body {
 }
 
 #tab_parent{
-		border: red 1px;
+    border: red 1px;
 }
 #tab_parent :first-child {
     border-top-left-radius: 8px;
@@ -99,13 +99,13 @@ body {
     margin-right: 12px;
     display: flex;
     flex-direction: row;
-    height: calc(100vh - 129px);
+    height: 90vh;
     overflow: hidden;
 }
 
 .function-list {
     text-align: right;
-    min-width: 200px;
+    min-width: 250px;
     font-size: 16pt;
     vertical-align: top;
     overflow-y: auto;

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -53,6 +53,9 @@ body {
     background-color: #DDE;
 }
 
+#tab_parent{
+		border: red 1px;
+}
 #tab_parent :first-child {
     border-top-left-radius: 8px;
     border-left: none;
@@ -91,25 +94,25 @@ body {
     height: 30px;
 }
 
-.master_detail_table {
-    display: table;
-    margin-top: 10px;
+.function_tab {
     margin-left: 12px;
     margin-right: 12px;
+    display: flex;
+    flex-direction: row;
+    height: calc(100vh - 129px);
+    overflow: hidden;
 }
 
-.master {
-    display: table-cell;
+.function-list {
     text-align: right;
     min-width: 200px;
     font-size: 16pt;
-    padding-bottom: 20px;
-    padding-top: 35px;
     vertical-align: top;
+    overflow-y: auto;
+    height: 100%;
 }
 
-.detail {
-    display: table-cell;
+.function-body {
     border: 1px solid #555;
     background-color: #ffffff;
     padding-top: 30px;
@@ -118,6 +121,8 @@ body {
     padding-right: 30px;
     border-radius: 5;
     width: 100%;
+    height: 100%;
+    overflow-y: auto;
 }
 
 .detail_function pre {

--- a/share/tools/web_config/index.html
+++ b/share/tools/web_config/index.html
@@ -237,8 +237,8 @@
             </template>
 
             <template x-if="currentTab === 'functions'" x-data="functions">
-                <div class="master_detail_table">
-                    <div class="master">
+                <div class="function_tab">
+                    <div class="function-list">
                         <template x-for="func in functions">
                             <!-- TODO use ul/li -->
                             <div>
@@ -250,7 +250,7 @@
                             </div>
                         </template>
                     </div>
-                    <div class="detail">
+                    <div class="function-body">
                         <div class="detail_function" x-html="functionDefinition"></div>
                     </div>
                 </div>


### PR DESCRIPTION
## Description
Added individual scrollbars for each page of the functions tab in the web interface. The existing version of the page is awkward to use if the user has hundreds of functions or is looking at a function that is hundreds of lines long because the you must scroll both of them at the same time.
With the function list pane and the function body pane each having an individual scrollbar, a user can scroll down to the bottom of their functions list without scrolling down in the function body, which is more convenient if the function only has a few lines. Conversely, if they are examining a function that is hundreds of lines long, they can scroll through it without scrolling the function list.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
