### PR TITLE
Add `commandline --showing-suggestion`

### DIFF
--- a/doc_src/cmds/commandline.rst
+++ b/doc_src/cmds/commandline.rst
@@ -113,6 +113,10 @@ The following options output metadata about the commandline state:
     If it is, it would be executed when the ``execute`` bind function is called.
     If the commandline is incomplete, return 2, if erroneus, return 1.
 
+**--showing-suggestion**
+    Evaluates to true (i.e. returns 0) when the shell is currently showing an automatic history completion/suggestion, available to be consumed via one of the `forward-` bindings.
+    For example, can be used to determine if moving the cursor to the right when already at the end of the line would have no effect or if it would cause a completion to be accepted (note that `forward-char-passive` does this automatically).
+
 Example
 -------
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -942,6 +942,18 @@ pub fn reader_execute_readline_cmd(parser: &Parser, ch: CharEvent) {
     }
 }
 
+pub fn reader_showing_suggestion(parser: &Parser) -> bool {
+    if !is_interactive_session() {
+        return false;
+    }
+    if let Some(data) = current_data() {
+        let reader = Reader { parser, data };
+        !reader.autosuggestion.is_empty()
+    } else {
+        false
+    }
+}
+
 /// Return the value of the interrupted flag, which is set by the sigint handler, and clear it if it
 /// was set. If the current reader is interruptible, mark the reader as exit_loop_requested.
 pub fn reader_reading_interrupted(data: &mut ReaderData) -> i32 {

--- a/tests/pexpects/commandline.py
+++ b/tests/pexpects/commandline.py
@@ -12,6 +12,28 @@ send, sendline, sleep, expect_prompt, expect_re, expect_str = (
 )
 expect_prompt()
 
+# Test --showing-suggestion before we dirty the history
+sendline("echo hello")
+expect_prompt()
+sendline("function debug; commandline --showing-suggestion; set -g cmd_status $status; end")
+expect_prompt()
+sendline("bind ctrl-p debug");
+expect_prompt()
+send("echo hell")
+sleep(0.1) # wait for suggestion to appear under CI
+send(control("p"))
+sendline("")
+expect_prompt("hell")
+sendline("echo cmd_status: $cmd_status")
+expect_prompt("cmd_status: 0")
+send("echo goodb")
+sleep(0.1) # wait for suggestion to appear under CI
+send(control("p"))
+sendline("")
+expect_prompt("goodb")
+sendline("echo cmd_status: $cmd_status")
+expect_prompt("cmd_status: 1")
+
 sendline("bind '~' 'handle_tilde'")
 expect_prompt()
 


### PR DESCRIPTION
Returns 0 (true) in case an autosuggestion is currently being displayed.

This was first requested in #5000 then again in #10580 after the existing workaround for this missing functionality was broken as part of a change to the overall behavior of `commandline` (for the better).

~~I haven't written the documentation or put in much work besides adding it and checking it more or less works as I would like to see if anyone has any objections to this.~~