### PR TITLE
Add option to speed up `string match/replace` with `--max-matches`

### DIFF
--- a/doc_src/cmds/string-match.rst
+++ b/doc_src/cmds/string-match.rst
@@ -10,7 +10,7 @@ Synopsis
 
     string match [-a | --all] [-e | --entire] [-i | --ignore-case]
                  [-g | --groups-only] [-r | --regex] [-n | --index]
-                 [-q | --quiet] [-v | --invert]
+                 [-q | --quiet] [-v | --invert] [[-m | --max-matches] MAX]
                  PATTERN [STRING ...]
 
 .. END SYNOPSIS
@@ -35,6 +35,8 @@ If **--regex** or **-r** is given, *PATTERN* is interpreted as a Perl-compatible
 When matching via regular expressions, ``string match`` automatically sets variables for all named capturing groups (``(?<name>expression)``). It will create a variable with the name of the group, in the default scope, for each named capturing group, and set it to the value of the capturing group in the first matched argument. If a named capture group matched an empty string, the variable will be set to the empty string (like ``set var ""``). If it did not match, the variable will be set to nothing (like ``set var``).  When **--regex** is used with **--all**, this behavior changes. Each named variable will contain a list of matches, with the first match contained in the first element, the second match in the second, and so on. If the group was empty or did not match, the corresponding element will be an empty string.
 
 If **--invert** or **-v** is used the selected lines will be only those which do not match the given glob pattern or regular expression.
+
+If **--max-matches MAX** or **-m MAX** is used, ``string`` will stop checking for matches after MAX lines of input have matched. This can be used as an "early exit" optimization when processing long inputs but expecting a limited and fixed number of outputs that might be found considerably before the input stream has been exhausted. If combined with **--invert** or **-v**, considers only inverted matches.
 
 Exit status: 0 if at least one match was found, or 1 otherwise.
 

--- a/doc_src/cmds/string-replace.rst
+++ b/doc_src/cmds/string-replace.rst
@@ -9,7 +9,8 @@ Synopsis
 .. synopsis::
 
     string replace [-a | --all] [-f | --filter] [-i | --ignore-case]
-                   [-r | --regex] [-q | --quiet] PATTERN REPLACEMENT [STRING ...]
+                   [-r | --regex] [[-m | --max-matches] MAX] [-q | --quiet] 
+                   PATTERN REPLACEMENT [STRING ...]
 
 .. END SYNOPSIS
 
@@ -23,6 +24,8 @@ Description
 If **-r** or **--regex** is given, *PATTERN* is interpreted as a Perl-compatible regular expression, and *REPLACEMENT* can contain C-style escape sequences like **\t** as well as references to capturing groups by number or name as *$n* or *${n}*.
 
 If you specify the **-f** or **--filter** flag then each input string is printed only if a replacement was done. This is useful where you would otherwise use this idiom: ``a_cmd | string match pattern | string replace pattern new_pattern``. You can instead just write ``a_cmd | string replace --filter pattern new_pattern``.
+
+If **--max-matches MAX** or **-m MAX** is used, ``string replace`` will stop all processing after MAX lines of input have matched the specified pattern. In the event of ``--filter`` or ``-f``, this means the output will be MAX lines in length. This can be used as an "early exit" optimization when processing long inputs but expecting a limited and fixed number of outputs that might be found considerably before the input stream has been exhausted.
 
 Exit status: 0 if at least one replacement was performed, or 1 otherwise.
 

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -1148,3 +1148,17 @@ string shorten abc \aabc ab abcdef | string escape
 # CHECK: \cga…
 # CHECK: ab
 # CHECK: a…
+
+printf "dog\ncat\nbat\ngnat\n" | string match -m2 "*at"
+# CHECK: cat
+# CHECK: bat
+
+printf "dog\ncat\nbat\nhog\n" | string match -rvm1 'at$'
+# CHECK: dog
+
+printf "dog\ncat\nbat\n" | string replace -rf --max-matches 1 'at$' 'aught'
+# CHECK: caught
+
+printf "dog\ncat\nbat\n" | string replace -r --max-matches 1 '^c' 'h'
+# CHECK: dog
+# CHECK: hat


### PR DESCRIPTION
I've often needed a way to get the last bit of performance out of unwieldy completions that involve a lot of string processing (apt completions come to mind, and I ran into it just now with parsing man pages for kldload completions).

Since many times we are looking for just one exact string in the haystack, an easy optimization here is to introduce a way for `string match` or `string replace` to early exit after a specific number of matches (typically one) have been found.

Depending on the size of the input, this can be a huge boon. For example, parsing the description from FreeBSD kernel module man pages with

    zcat /usr/share/man/man4/zfs.4.gz | string match -m1 '.Nd *'

runs 35% faster with -m1 than without (bearing in mind that most of the time is taken just starting up `zcat`, parsing the compressed contents, and decompressing the file!), while processing all files under /usr/share/man/man4/*.4.gz in a loop (so a mix of files ranging from very short to moderately long) runs about 10% faster overall with -m1 (for context, in absolute terms that is 0.5s+ faster).

## TODOs:

- [x] Tests and docs to follow if no one has any objections to this feature.
