### PR TITLE
Compile in release mode for at least one CI runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     - name: cmake
       run: |
         mkdir build && cd build
-        cmake ..
+        cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
     - name: make
       run: |
         make VERBOSE=1


### PR DESCRIPTION
When we changed our default from RelWithDebInfo to Debug, we inadvertently ended up with all CI building and running in Debug mode. Change at least one of them back to Release to make sure we don't have any optimizations that cause funky stuff.

I'm changing the Ubuntu CI image because it's hopefully the fastest (since rust is relatively dog-slow to compile in release mode).
