### PR TITLE
Vi mode: support `%` motion and `ib`/`ab` text objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -181,6 +181,7 @@ New or improved bindings
   - When the cursor is at the start of a line, escaping from insert mode no longer moves the cursor to the previous line.
   - Added bindings for clipboard interaction, like :kbd:`",+,p` and :kbd:`",+,y,y`.
   - Deleting in visual mode now moves the cursor back, matching vi (:issue:`10394`).
+  - Support :kbd:`%` motion.
 
 Completions
 ^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -182,6 +182,7 @@ New or improved bindings
   - Added bindings for clipboard interaction, like :kbd:`",+,p` and :kbd:`",+,y,y`.
   - Deleting in visual mode now moves the cursor back, matching vi (:issue:`10394`).
   - Support :kbd:`%` motion.
+  - Support `ab` and `ib` vi text objects. New input functions are introduced ``jump-{to,till}-matching-bracket`` (:issue:`1842`).
 
 Completions
 ^^^^^^^^^^^

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -258,6 +258,11 @@ The following special input functions are available:
 ``repeat-jump`` and ``repeat-jump-reverse``
     redo the last jump in the same/opposite direction
 
+``jump-to-matching-bracket``
+    jump to matching bracket if the character under the cursor is bracket;
+    otherwise, jump to the next occurence of *any right* bracket after the cursor.
+    The following brackets are considered: ``([{}])``
+
 ``kill-bigword``
     move the next whitespace-delimited word to the killring
 

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -263,6 +263,13 @@ The following special input functions are available:
     otherwise, jump to the next occurence of *any right* bracket after the cursor.
     The following brackets are considered: ``([{}])``
 
+``jump-till-matching-bracket``
+    the same as ``jump-to-matching-bracket`` but offset cursor to the right for left bracket, and offset cursor to the left for right bracket.
+    The offset is applied for both the position we jump from and position we jump to.
+    In other words, the cursor will continuously jump inside the brackets but won't reach them by 1 character.
+    The input function is useful to emulate ``ib`` vi text object.
+    The following brackets are considered: ``([{}])``
+
 ``kill-bigword``
     move the next whitespace-delimited word to the killring
 

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -238,6 +238,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset y,i backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection yank end-selection
     bind -s --preset y,a backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection yank end-selection
 
+    bind -s --preset % jump-to-matching-bracket
     bind -s --preset f forward-jump
     bind -s --preset F backward-jump
     bind -s --preset t forward-jump-till
@@ -305,6 +306,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M visual E 'set fish_cursor_end_mode exclusive' forward-single-char forward-bigword backward-char 'set fish_cursor_end_mode inclusive'
     bind -s --preset -M visual o swap-selection-start-stop repaint-mode
 
+    bind -s --preset -M visual % jump-to-matching-bracket
     bind -s --preset -M visual f forward-jump
     bind -s --preset -M visual t forward-jump-till
     bind -s --preset -M visual F backward-jump

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -169,6 +169,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset d,T begin-selection backward-jump forward-single-char kill-selection end-selection
     bind -s --preset d,h backward-char delete-char
     bind -s --preset d,l delete-char
+    bind -s --preset d,i,b jump-till-matching-bracket and jump-till-matching-bracket and begin-selection jump-till-matching-bracket kill-selection end-selection
+    bind -s --preset d,a,b jump-to-matching-bracket and jump-to-matching-bracket and begin-selection jump-to-matching-bracket kill-selection end-selection
     bind -s --preset d,i backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection
     bind -s --preset d,a backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection
     bind -s --preset 'd,;' begin-selection repeat-jump kill-selection end-selection
@@ -199,6 +201,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -m insert c,T begin-selection backward-jump forward-single-char kill-selection end-selection repaint-mode
     bind -s --preset -m insert c,h backward-char begin-selection kill-selection end-selection repaint-mode
     bind -s --preset -m insert c,l begin-selection kill-selection end-selection repaint-mode
+    bind -s --preset -m insert c,i,b jump-till-matching-bracket and jump-till-matching-bracket and begin-selection jump-till-matching-bracket kill-selection end-selection
+    bind -s --preset -m insert c,a,b jump-to-matching-bracket and jump-to-matching-bracket and begin-selection jump-to-matching-bracket kill-selection end-selection
     bind -s --preset -m insert c,i backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection repaint-mode
     bind -s --preset -m insert c,a backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection end-selection repaint-mode
 
@@ -235,6 +239,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset y,T begin-selection backward-jump-till kill-selection yank end-selection
     bind -s --preset y,h backward-char begin-selection kill-selection yank end-selection
     bind -s --preset y,l begin-selection kill-selection yank end-selection
+    bind -s --preset y,i,b jump-till-matching-bracket and jump-till-matching-bracket and begin-selection jump-till-matching-bracket kill-selection yank end-selection
+    bind -s --preset y,a,b jump-to-matching-bracket and jump-to-matching-bracket and begin-selection jump-to-matching-bracket kill-selection yank end-selection
     bind -s --preset y,i backward-jump-till and repeat-jump-reverse and begin-selection repeat-jump kill-selection yank end-selection
     bind -s --preset y,a backward-jump and repeat-jump-reverse and begin-selection repeat-jump kill-selection yank end-selection
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -178,6 +178,7 @@ const INPUT_FUNCTION_METADATA: &[InputFunctionMetadata] = &[
     make_md(L!("history-token-search-forward"), ReadlineCmd::HistoryTokenSearchForward),
     make_md(L!("insert-line-over"), ReadlineCmd::InsertLineOver),
     make_md(L!("insert-line-under"), ReadlineCmd::InsertLineUnder),
+    make_md(L!("jump-till-matching-bracket"), ReadlineCmd::JumpTillMatchingBracket),
     make_md(L!("jump-to-matching-bracket"), ReadlineCmd::JumpToMatchingBracket),
     make_md(L!("kill-bigword"), ReadlineCmd::KillBigword),
     make_md(L!("kill-inner-line"), ReadlineCmd::KillInnerLine),

--- a/src/input.rs
+++ b/src/input.rs
@@ -178,6 +178,7 @@ const INPUT_FUNCTION_METADATA: &[InputFunctionMetadata] = &[
     make_md(L!("history-token-search-forward"), ReadlineCmd::HistoryTokenSearchForward),
     make_md(L!("insert-line-over"), ReadlineCmd::InsertLineOver),
     make_md(L!("insert-line-under"), ReadlineCmd::InsertLineUnder),
+    make_md(L!("jump-to-matching-bracket"), ReadlineCmd::JumpToMatchingBracket),
     make_md(L!("kill-bigword"), ReadlineCmd::KillBigword),
     make_md(L!("kill-inner-line"), ReadlineCmd::KillInnerLine),
     make_md(L!("kill-line"), ReadlineCmd::KillLine),

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -110,6 +110,7 @@ pub enum ReadlineCmd {
     ForwardJumpTill,
     BackwardJumpTill,
     JumpToMatchingBracket,
+    JumpTillMatchingBracket,
     FuncAnd,
     FuncOr,
     ExpandAbbr,

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -109,6 +109,7 @@ pub enum ReadlineCmd {
     BackwardJump,
     ForwardJumpTill,
     BackwardJumpTill,
+    JumpToMatchingBracket,
     FuncAnd,
     FuncOr,
     ExpandAbbr,


### PR DESCRIPTION
## Description

I didn't add new tests, since I didn't find that fish has any existing tests for input functions.

It's my first time writing in Rust, so I might did some noob mistakes. I tried to stick with the existing code style as much as possible, but I might made mistakes.

I understand that I introduce a new API, which could be a reason to reject the PR.

The implementation is obviously not 100% the same as in VIM, but it should cover the major cases. ~~The biggest missing part is real matching of "matching brackets", I just scan the text to find next the first occurence of the bracket, but I think it's good enough.~~ (UPD: supported)

My commits don't cover `ci(`, `ci{`, `ci[`, and friends (The introduced `jump-to-matching-bracket` can't help here, because it would match any bracket). I think that if fish supported `jump-to-matching-char` (brackets match their respecitve brackets, regular chars match themselves), mentioned bindings could be added (by changing existing `b,i` binding). If you are ok with the proposal, I can implement it in the next PR

Makes progress in issue #1842

Thank you for checking the PR regardless of your decision! And thank for the great shell!

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed. 
  It's not a regression. So I guess check?
- [x] User-visible changes noted in CHANGELOG.rst
- [x] I read `CONTRIBUTING.rst`