### PR TITLE
don't error if only dependencies or devDependencies are present

### DIFF
--- a/share/functions/__fish_npm_helper.fish
+++ b/share/functions/__fish_npm_helper.fish
@@ -77,7 +77,7 @@ function __npm_installed_local_packages
 
     if set -l python (__fish_anypython)
         $python -S -c 'import json, sys; data = json.load(sys.stdin);
-print("\n".join(data["dependencies"])); print("\n".join(data["devDependencies"]))' <$package_json 2>/dev/null
+print("\n".join(data.get("dependencies", []))); print("\n".join(data.get("devDependencies", [])))' <$package_json 2>/dev/null
     else if type -q jq
         jq -r '.dependencies as $a1 | .devDependencies as $a2 | ($a1 + $a2) | to_entries[] | .key' $package_json
     else


### PR DESCRIPTION
## Description

`package.json` may not have both `dependencies` and `devDependencies`. right now, the completion fails due to a keyerror if this is the case. this fixes it by falling back to an empty array.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
