### PR TITLE
fish_vi_key_bindings: add bindings for semicolon and comma in visual mode

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -317,6 +317,8 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M visual t forward-jump-till
     bind -s --preset -M visual F backward-jump
     bind -s --preset -M visual T backward-jump-till
+    bind -s --preset -M visual ';' repeat-jump
+    bind -s --preset -M visual , repeat-jump-reverse
 
     for key in $eol_keys
         bind -s --preset -M visual $key end-of-line


### PR DESCRIPTION
fish_vi_key_bindings: add bindings for semicolon and comma in visual mode

They are already presented in normal mode, and I presume were forgotten to be added in visual mode

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
  No need to. It's expected to work out of the box
- [ ] Tests have been added for regressions fixed
  It's not a regression (at least, I'm not aware of)
- [ ] User-visible changes noted in CHANGELOG.rst
  I don't add it to `./CHANGELOG.rst` because it's a minor change that can be considered as a bug fix