### PR TITLE
Restore terminal state better.

### DIFF
--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -484,7 +484,7 @@ impl Drop for TerminalProtocols {
         let sequences = concat!(
             "\x1b[?2004l",
             "\x1b[>4;0m",
-            "\x1b[<1u", // Konsole breaks unless we pass an explicit number of entries to pop.
+            "\x1b[<9u", // Pop a few number of entries as a best effort to disable kitty progressive enhancement.
             "\x1b>",
         );
         FLOG!(

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -484,7 +484,7 @@ impl Drop for TerminalProtocols {
         let sequences = concat!(
             "\x1b[?2004l",
             "\x1b[>4;0m",
-            "\x1b[<9u", // Pop a few number of entries as a best effort to disable kitty progressive enhancement.
+            "\x1b[=0u", // Clear kitty progressive enhancement.
             "\x1b>",
         );
         FLOG!(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3666,8 +3666,10 @@ pub fn term_copy_modes() {
 }
 
 /// Grab control of terminal.
-fn term_steal() {
-    term_copy_modes();
+fn term_steal(copy_modes: bool) {
+    if copy_modes {
+        term_copy_modes();
+    }
     while unsafe { libc::tcsetattr(STDIN_FILENO, TCSANOW, &*shell_modes()) } == -1 {
         if errno().0 == EIO {
             redirect_tty_output();
@@ -4971,7 +4973,7 @@ fn reader_run_command(parser: &Parser, cmd: &wstr) -> EvalRes {
         );
     }
 
-    term_steal();
+    term_steal(eval_res.status.is_success());
 
     // Provide value for `status current-command`
     parser.libdata_mut().status_vars.command = (*PROGRAM_NAME.get().unwrap()).to_owned();


### PR DESCRIPTION
## Description

Restore terminal state better when running commands.

1. Only update TTY_MODES_FOR_EXTERNAL_CMDS when the command finishes successfully.
2. Pop a few entries as a best effort to disable Kitty's progressive enhancement.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
