### PR TITLE
Return true if there was an autosuggestion to accept

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -155,6 +155,7 @@ Interactive improvements
 - ``read --help`` and friends no longer ignore redirections. This fixes a regression in version 3.1 (:issue:`10274`).
 - Measuring a command with ``time`` now considers the time taken for command substitution (:issue:`9100`).
 - ``fish_add_path`` now automatically enables verbose mode when used interactively (in the commandline), in an effort to be clearer about what it does (:issue:`10532`).
+- The `accept-autosuggestion` input function now returns true when there was something to accept.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -155,7 +155,7 @@ Interactive improvements
 - ``read --help`` and friends no longer ignore redirections. This fixes a regression in version 3.1 (:issue:`10274`).
 - Measuring a command with ``time`` now considers the time taken for command substitution (:issue:`9100`).
 - ``fish_add_path`` now automatically enables verbose mode when used interactively (in the commandline), in an effort to be clearer about what it does (:issue:`10532`).
-- The `accept-autosuggestion` input function now returns true when there was something to accept.
+- The `accept-autosuggestion` input function now returns false when there was nothing to accept.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -112,7 +112,7 @@ The following special input functions are available:
     only execute the next function if the previous succeeded (note: only some functions report success)
 
 ``accept-autosuggestion``
-    accept the current autosuggestion
+    accept the current autosuggestion. Returns true if there was a suggestion to accept.
 
 ``backward-char``
     move one character to the left.

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -112,7 +112,7 @@ The following special input functions are available:
     only execute the next function if the previous succeeded (note: only some functions report success)
 
 ``accept-autosuggestion``
-    accept the current autosuggestion. Returns true if there was a suggestion to accept.
+    accept the current autosuggestion. Returns false when there was nothing to accept.
 
 ``backward-char``
     move one character to the left.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2923,7 +2923,10 @@ impl<'a> Reader<'a> {
                 self.input_data.function_set_status(success);
             }
             rl::AcceptAutosuggestion => {
+                let success = !self.autosuggestion.is_empty();
                 self.accept_autosuggestion(true, false, MoveWordStyle::Punctuation);
+                // Return true if we had a suggestion to accept.
+                self.input_data.function_set_status(success);
             }
             rl::TransposeChars => {
                 let (elt, el) = self.active_edit_line();


### PR DESCRIPTION
## Description

Return true from `accept-autosuggestion` if there was an autosuggestion to accept, just like `suppress-autosuggestion`. 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
