### PR TITLE
Implement (and use) `string unescape --style=regex`

### DIFF
--- a/doc_src/cmds/string-escape.rst
+++ b/doc_src/cmds/string-escape.rst
@@ -26,7 +26,9 @@ Description
 
 **--style=regex** escapes an input string for literal matching within a regex expression. The string is first converted to UTF-8 before being encoded.
 
-``string unescape`` performs the inverse of the ``string escape`` command. If the string to be unescaped is not properly formatted it is ignored. For example, doing ``string unescape --style=var (string escape --style=var $str)`` will return the original string. There is no support for unescaping **--style=regex**.
+``string unescape`` performs the inverse of the ``string escape`` command. For example, doing ``string unescape --style=var (string escape --style=var $str)`` will return the original string. It assumes its input is valid and typically coming unmodified from the output of the matching ``string escape`` operation. If the string to be unescaped is not properly formatted, it is ignored.
+
+With regards to unescaping regex, in addition to reversing the effects of ``string escape --style=regex``, its counterpart ``string unescape --style=regex`` also unescapes *most* escape sequences that, in the most commonly used regex specs, *may* be escaped but are not in the current fish ``string escape`` implementation. For example, ``string escape --style=regex`` does not escape new lines or control characters and instead passes them through as-is (which is fine since they do not clash with any special regex syntax and *are* supported inputs to regex libraries), but to handle regex expressions formed from literal strings that were escaped outside of fish, ``string unescape --style=regex`` will also correctly detect and un-escape sequences like ``\n`` (literal backslash + n), mapping it to a new line. Note that ``string unescape --style=regex`` expects its input to be a string literal that has been previously escaped. Specifically, this means that it assumes all input is syntactically valid and well-formed regex and does not contain anything other than a literal regex pattern to match against (i.e. does not use special operators like ``|`` or ``(``/``)``, does not contain back references, does not make use of character classes, etc).
 
 .. END DESCRIPTION
 

--- a/share/functions/__fish_npm_helper.fish
+++ b/share/functions/__fish_npm_helper.fish
@@ -38,7 +38,7 @@ function __npm_filtered_list_packages
             test -f $path || continue
             # Using `string replace` directly is slow because it doesn't know to stop looking after a match cannot be
             # found in the alphabetically sorted list. Use `look` for its binary search support.
-            look '  "'(commandline -ct) $path | string replace -rf '^  "(.*?)".*' '$1'
+            look '  "'(commandline -ct) $path | string replace -rf '^  "(.*?)".*' '$1' | string unescape --style=regex
             break
         end
     end

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -307,11 +307,18 @@ string escape --style=var 中 | string unescape --style=var
 
 # test regex escaping
 string escape --style=regex ".ext"
-string escape --style=regex "bonjour, amigo"
-string escape --style=regex "^this is a literal string"
 # CHECK: \.ext
+string escape --style=regex "bonjour, amigo"
 # CHECK: bonjour, amigo
+string escape --style=regex "^this is a literal string"
 # CHECK: \^this is a literal string
+string escape --style=regex "not\n a line break"
+# CHECK: not\\n a line break
+
+# Escaping new lines in the input is /allowed/ but it would be a change that should be made carefully:
+string escape --style=regex "hello"\n"world"
+# CHECK: hello
+# CHECK: world
 
 ### Verify that we can correctly unescape the same strings
 #   we tested escaping above.
@@ -346,6 +353,18 @@ string unescape --style=var (string escape --style=var '_a_b_c_')
 
 string unescape --style=var -- (string escape --style=var -- -)
 # CHECK: -
+
+string unescape --style=regex -- (string escape --style=regex 'not\n a line break')
+# CHECK: not\n a line break
+
+# Test something that would be a character class (\w) if misinterpreted
+string unescape --style=regex -- (string escape --style=regex 'hello\world')
+# CHECK: hello\world
+
+# Test handling of optional escapes (not done by `string escape --style=regex`)
+string unescape --style=regex 'a\nb'
+# CHECK: a
+# CHECK: b
 
 ### Verify that we can correctly match strings.
 string match "*" a


### PR DESCRIPTION
Add support for `string unescape --style=regex`

    This complements existing support for `string escape --style=regex`.

    PCRE2's spec is rather extensive and supports a massive number of escape
    sequences, but we are only interested in those that are formed by escaping a
    literal string (i.e. not actually regexes).

    In addition to reversing the effects of `string escape --style=regex`, support
    for unescaping some common "in-the-wild" escape variants is also added. For
    example, `printf "hello\nworld\n"` is passed through unmodified by `string
    escape` but it's easy to imagine that a different regex escape library would
    encode that as the (fish-encoded) `hello\\nworld\\n` (escaping the new lines).
    We support both, since the goal here isn't to strictly unmap fish's `string
    escape` output (which would be of limited utility) but to also interact with
    regex expressions found in files or emitted by executables in the course of
    writing shell scripts (such as completions).

Closes #10611.
