### PR TITLE
Import portable_atomic::AtomicU64 when std does not provide it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pcre2",
+ "portable-atomic",
  "rand",
  "rand_pcg",
  "rsconf",
@@ -318,6 +319,12 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 widestring = "1.1.0"
 terminfo = "0.9.0"
 
+[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
+portable-atomic = { version = "1", default-features = false, features = ["fallback"] }
+
 [dev-dependencies]
 rand_pcg = "0.3.1"
 serial_test = { version = "1.0.0", default-features = false }

--- a/src/env/environment_impl.rs
+++ b/src/env/environment_impl.rs
@@ -22,7 +22,11 @@ use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 
-use std::sync::{atomic::AtomicU64, atomic::Ordering, Arc, Mutex, MutexGuard};
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+use std::sync::{atomic::Ordering, Arc, Mutex, MutexGuard};
 
 /// Getter for universal variables.
 /// This is typically initialized in env_init(), and is considered empty before then.

--- a/src/fd_monitor.rs
+++ b/src/fd_monitor.rs
@@ -1,5 +1,9 @@
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 use std::os::unix::prelude::*;
-use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -20,11 +20,15 @@ use errno::Errno;
 use libc::{EAGAIN, EINTR, ENOENT, ENOTDIR, EPIPE, EWOULDBLOCK, STDOUT_FILENO};
 use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 use std::cell::{RefCell, UnsafeCell};
 use std::fs::File;
 use std::io;
 use std::os::fd::{AsRawFd, IntoRawFd, OwnedFd, RawFd};
-use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 
 /// separated_buffer_t represents a buffer of output from commands, prepared to be turned into a

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,14 +33,18 @@ use crate::wutil::{perror, wgettext, wgettext_fmt};
 use crate::{function, FLOG};
 use fish_printf::sprintf;
 use libc::c_int;
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 use std::cell::{Ref, RefCell, RefMut};
 use std::ffi::{CStr, OsStr};
 use std::num::NonZeroU32;
 use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::os::unix::prelude::OsStrExt;
 use std::rc::Rc;
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
 use std::sync::{
-    atomic::{AtomicIsize, AtomicU64, Ordering},
+    atomic::{AtomicIsize, Ordering},
     Arc,
 };
 

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -33,12 +33,16 @@ use libc::{
     WUNTRACED, _SC_CLK_TCK,
 };
 use once_cell::sync::Lazy;
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::fs;
 use std::io::{Read, Write};
 use std::os::fd::RawFd;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicU8, Ordering};
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU8, Ordering};
 use std::sync::Arc;
 
 /// Types of processes.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -20,6 +20,8 @@ use libc::{
 use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
 use once_cell::sync::Lazy;
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 use std::cell::UnsafeCell;
 use std::cmp;
 use std::io::BufReader;
@@ -30,8 +32,10 @@ use std::ops::Range;
 use std::os::fd::RawFd;
 use std::pin::Pin;
 use std::rc::Rc;
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
-use std::sync::atomic::{AtomicI32, AtomicU32, AtomicU64, AtomicU8};
+use std::sync::atomic::{AtomicI32, AtomicU32, AtomicU8};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 

--- a/src/tests/fd_monitor.rs
+++ b/src/tests/fd_monitor.rs
@@ -1,7 +1,11 @@
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 use std::fs::File;
 use std::io::Write;
 use std::os::fd::{AsRawFd, IntoRawFd};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 

--- a/src/tests/topic_monitor.rs
+++ b/src/tests/topic_monitor.rs
@@ -1,7 +1,11 @@
 use crate::tests::prelude::*;
 use crate::topic_monitor::{GenerationsList, Topic, TopicMonitor};
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
 use std::sync::{
-    atomic::{AtomicU32, AtomicU64, Ordering},
+    atomic::{AtomicU32, Ordering},
     Arc,
 };
 


### PR DESCRIPTION

Congrats for getting close to a release!

I dedicate my contribution to the public domain.

## Description

Restores support for 32-bit powerpc and mips. I am using this build in an openwrt-rust-1.80 toolchain. I intend to add mipsel+rust-nightly check if it makes sense.

I will run a branch on top of faho's installer PR in a few days too.

Fixes issue #10415.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
