### PR TITLE
Fix `cd ..` to the root directory

### DIFF
--- a/src/wutil/mod.rs
+++ b/src/wutil/mod.rs
@@ -319,8 +319,12 @@ pub fn path_normalize_for_cd(wd: &wstr, path: &wstr) -> WString {
     paths.extend(path_comps);
     let mut result =
         WString::with_capacity(paths.iter().fold(0, |sum, s| sum + s.len()) + paths.len() + 1);
-    for p in &paths {
-        result.push(SEP);
+    result.push(SEP);
+    // TODO: intersperse() https://github.com/rust-lang/rust/issues/79524
+    for (i, p) in paths.iter().enumerate() {
+        if i != 0 {
+            result.push(SEP);
+        }
         result.push_utfstr(*p);
     }
     result
@@ -388,6 +392,14 @@ mod path_cd_tests {
         let path = L!("..");
         eprintln!("({}, {})", wd, path);
         assert_eq!(path_normalize_for_cd(wd, path), L!("/.."));
+    }
+
+    #[test]
+    fn up_to_root_directory() {
+        let wd = L!("/foo/");
+        let path = L!("..");
+        eprintln!("({}, {})", wd, path);
+        assert_eq!(path_normalize_for_cd(wd, path), L!("/"));
     }
 
     #[test]

--- a/tests/checks/cd.fish
+++ b/tests/checks/cd.fish
@@ -194,6 +194,12 @@ cd $old_path
 cd file
 cd $old_path
 
+# Test that going up to the root directory using .. works
+cd /(string split --no-empty -f 1 / (pwd))
+cd ..
+pwd
+#CHECK: /
+
 # cd back before removing the test directory again.
 cd $oldpwd
 rm -Rf $base


### PR DESCRIPTION
The leading slash always needs to be present, even if there aren't any other components. This was introduced by the Rust port.

Fixes #10636

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
