### PR TITLE
Update p4.fish

### DIFF
--- a/share/completions/p4.fish
+++ b/share/completions/p4.fish
@@ -45,7 +45,7 @@ function __fish_print_p4_changelists -d "Reformat output from `p4 changes` to si
             continue
         end
         # see output format ^^^
-        set -l change_match (string match -ar '^Change ([0-9]+) on [0-9/]+ by (\S+).*$' $line)
+        set -l change_match (string match -ar '^Change ([0-9]+) on [0-9/]+ by (\S+).*$' -- $line)
         if test -n "$change_match"
             if test -n "$result"
                 echo $result
@@ -56,7 +56,7 @@ function __fish_print_p4_changelists -d "Reformat output from `p4 changes` to si
                 set result $result $change_match[3]:
             end
         else
-            set result $result $line
+            set -a result $line
         end
     end
 


### PR DESCRIPTION
add `--` for the string match command, so that if the `$line` has any `-`'s in it will be ignored

## Description

Minor update fixing a issue during a completion of `p4 shelve -c <tab>`

Fixes issue #
Did not raise any issue. Basically fixes the following error when a change has description like `- Some change description`
```
string match: - Some change description : unknown option

<path-to-fish>/share/fish/completions/p4.fish (line 1):
in command substitution
        called on line 48 of file /depotbld/RHEL7.0/Fish/fish-3.6.1/share/fish/completions/p4.fish
in function '__fish_print_p4_changelists' with arguments '-c msip_madar_ddr5mrphy_m1_0 -s pending'
        called on line 129 of file /depotbld/RHEL7.0/Fish/fish-3.6.1/share/fish/completions/p4.fish
in function '__fish_print_p4_workspace_changelists' with arguments '-s pending'
        called on line 140 of file /depotbld/RHEL7.0/Fish/fish-3.6.1/share/fish/completions/p4.fish
in function '__fish_print_p4_pending_changelists'

(Type 'help string' for related documentation)

```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] ~~Changes to fish usage are reflected in user documentation/manpages.~~
- [ ] ~~Tests have been added for regressions fixed~~
- [ ] User-visible changes noted in CHANGELOG.rst
