### PR TITLE
Add more convenient key bindings for VI mode

### DIFF
--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -73,6 +73,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv ctrl-l clear-screen
     bind --preset $argv ctrl-c cancel-commandline
     bind --preset $argv ctrl-u backward-kill-line
+    bind --preset $argv ctrl-k kill-line
     bind --preset $argv ctrl-w backward-kill-path-component
     bind --preset $argv end end-of-line
     bind --preset $argv home beginning-of-line

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -325,6 +325,9 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
         bind -s --preset -M visual $key beginning-of-line
     end
 
+    bind -s --preset -M visual -m default v end-selection repaint-mode
+    bind -s --preset -M visual -m insert i end-selection repaint-mode
+    bind -s --preset -M visual -m insert I end-selection beginning-of-line repaint-mode
     bind -s --preset -M visual -m insert c kill-selection end-selection repaint-mode
     bind -s --preset -M visual -m insert s kill-selection end-selection repaint-mode
     bind -s --preset -M visual -m default d kill-selection end-selection backward-char repaint-mode
@@ -334,6 +337,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset -M visual -m default '",*,y' "fish_clipboard_copy; commandline -f end-selection repaint-mode"
     bind -s --preset -M visual -m default '",+,y' "fish_clipboard_copy; commandline -f end-selection repaint-mode"
     bind -s --preset -M visual -m default '~' togglecase-selection end-selection repaint-mode
+    bind -s --preset -M visual -m default g,U togglecase-selection end-selection repaint-mode
 
     bind -s --preset -M visual -m default ctrl-c end-selection repaint-mode
     bind -s --preset -M visual -m default escape end-selection repaint-mode


### PR DESCRIPTION
To make it more familiar to vi/vim users.

In all mode, ctrl-k is bind to kill-line.

In Vi visual mode:
* press v or i turn into normal or insert mode respectively.
* press I turn to insert mode and move the cursor to beginning of line.
* because fish doesn't have upcase/locase-selection, and most people reach for g-U rather than g-u, g-U binds to togglecase-selection temporarily.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
