### PR TITLE
Improve apk completions for apk 3.x

### DIFF
--- a/share/completions/apk.fish
+++ b/share/completions/apk.fish
@@ -1,10 +1,10 @@
 # Completions for apk (Alpine Package Keeper)
 
 # Package name
-complete -c apk -n "__fish_seen_subcommand_from add" -a "(apk search -q)" -d Package
-complete -c apk -n "__fish_seen_subcommand_from manifest" -a "(apk info -q)" -d Package
-complete -f -c apk -n "__fish_seen_subcommand_from info fetch dot" -a "(apk search -q)" -d Package
-complete -f -c apk -n "__fish_seen_subcommand_from del fix version" -a "(apk info -q)" -d Package
+complete -c apk -n "__fish_seen_subcommand_from add" -a "(apk search -q 2>/dev/null)" -d Package
+complete -c apk -n "__fish_seen_subcommand_from manifest" -a "(apk info 2>/dev/null)" -d Package
+complete -f -c apk -n "__fish_seen_subcommand_from info fetch dot" -a "(apk search -q 2>/dev/null)" -d Package
+complete -f -c apk -n "__fish_seen_subcommand_from del fix version" -a "(apk info 2>/dev/null)" -d Package
 
 # Global options
 complete -f -c apk -s h -l help -d "Show help"


### PR DESCRIPTION
## Description
Improve completions for apk 3.x.

- -q silenced warnings in apk 2.x but not in in 3.x, so redirect stderr
  to /dev/null to avoid seeing warnings while completing (-q is still
  passed to `apk search` as it strips package versions and releases)
- Drop `-q` from `apk info`, as on apk 3.x it prevents apk info from
  outputting anything at all

I've tested these changes on both Chimera Linux (which uses apk 3.x)
and Alpine Linux (which is still using 2.x).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
