### PR TITLE
fix: add Ghostty to terminals that support vi cursors

### DIFF
--- a/share/functions/fish_vi_cursor.fish
+++ b/share/functions/fish_vi_cursor.fish
@@ -48,6 +48,7 @@ function fish_vi_cursor -d 'Set cursor shape for different vi modes'
             and not string match -q 'xterm-kitty*' -- $TERM
             and not string match -q 'rxvt*' -- $TERM
             and not string match -q 'alacritty*' -- $TERM
+            and not string match -q 'xterm-ghostty*' -- $TERM
             and not string match -q 'foot*' -- $TERM
             and not begin
                 set -q TMUX


### PR DESCRIPTION
## Description

There's a new terminal [Ghostty](https://mitchellh.com/ghostty) that is currently in closed beta but should go public until the end of this year. Ghostty supports shell integration features and custom cursors. However, the fish shell did not setup cursors for `vi` key bindings correctly, basically skipped Ghostty because of unknown `$TERM`.

Ghostty sets the `$TERM` to `xterm-ghostty`, so I just added it to the list in fish functions. This is my first contribution to fish shell, so I'm not really familiar with the code base. In any case, please let me know if I need to do some more changes for this.

I didn't create an issue for this, so no issue to be linked to. 

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
