### PR TITLE
completions: improved xxd completions

### DIFF
--- a/share/completions/xxd.fish
+++ b/share/completions/xxd.fish
@@ -1,34 +1,20 @@
-function __fish_seen_any_argument
-    # Returns true if none of the switch names appear in the command line.
-    for arg in $argv
-        switch (string length $arg)
-            case 2
-                __fish_seen_argument -o $arg; and return 1
-            case 1
-                __fish_seen_argument -s $arg; and return 1
-            case '*'
-                __fish_seen_argument -l $arg; and return 1
-        end
-    end
-end
-
-set -l xxd_exclusive_args b e i ps r
-
-complete -c xxd -s a -d 'Toggle autoskip'
-complete -c xxd -s b -n "__fish_seen_any_argument $xxd_exclusive_args" -d 'Binary digit dump'
-complete -c xxd -s C -n '__fish_seen_argument -s i' -d 'Capitalize variable names'
-complete -c xxd -s c -xa '(seq 8 8 64)' -d 'Format COLS octets per line, default 16'
-complete -c xxd -s E -d 'Show characters in EBCDIC'
-complete -c xxd -s e -n "__fish_seen_any_argument $xxd_exclusive_args" -d 'Little-endian dump'
-complete -c xxd -s g -xa '1 2 4' -d 'Octets per group in normal output, default 2'
-complete -c xxd -s h -d 'Print help summary'
-complete -c xxd -s i -n "__fish_seen_any_argument $xxd_exclusive_args" -d 'Output C-include file style'
-complete -c xxd -s l -d 'Stop after NUM octets'
-complete -c xxd -s o -x -d 'Add OFFSET to the displayed file position'
-complete -c xxd -o ps -n "__fish_seen_any_argument $xxd_exclusive_args" -d 'Output PostScript/plain hexdump style'
-complete -c xxd -s r -d 'Reverse operation: convert hexdump into binary'
-complete -c xxd -s s -xa '-32 -8 +8 +32' -n 'not __fish_seen_argument -s r' -d 'Start at SEEK bytes offset in file'
-complete -c xxd -s s -xa '-32 -8 +8 +32' -n '__fish_seen_argument -s r' -d 'Add OFFSET to file positions in hexdump'
-complete -c xxd -s d -d 'Show offset in decimal, not hex'
-complete -c xxd -s u -d 'Use uppercase hex letters'
-complete -c xxd -s v -d 'Show version'
+complete -c xxd -o a -o autoskip -d 'Toggle autoskip'
+complete -c xxd -o b -o bits -d 'Binary digit dump'
+complete -c xxd -o c -o cols -x -d 'Number of octets per line'
+complete -c xxd -o C -o capitalize -n '__fish_seen_argument -o i' -d 'Capitalize variable names'
+complete -c xxd -o d -d 'Show offset in decimal, not hex'
+complete -c xxd -o E -o EBCDIC -d 'Show characters in EBCDIC'
+complete -c xxd -o e -d 'Little-endian hex dump'
+complete -c xxd -o g -o groupsize -xa '0 1 2 4' -d 'Octets per group'
+complete -c xxd -o h -o help -d 'Print help summary'
+complete -c xxd -o i -o include -d 'Output in C include file style'
+complete -c xxd -o l -o len -x -d 'Stop after NUM octets'
+complete -c xxd -o n -o name -x -n '__fish_seen_argument -o i' -d 'Set variable name'
+complete -c xxd -o o -x -d 'Add OFFSET to displayed file position'
+complete -c xxd -o p -o ps -o postscript -o plain -d 'Output PostScript/plain hexdump style'
+complete -c xxd -o r -o revert -d 'Convert hexdump to binary'
+complete -c xxd -o R -xa 'never always auto' -d 'Output coloring mode'
+complete -c xxd -o s -xa '-32 -8 +8 +32' -n 'not __fish_seen_argument -o r' -d 'Start at SEEK bytes offset in file'
+complete -c xxd -o s -xa '-32 -8 +8 +32' -n '__fish_seen_argument -o r' -d 'Add OFFSET to file positions in hexdump'
+complete -c xxd -o u -d 'Use uppercase hex letters'
+complete -c xxd -o v -o version -d 'Show version'


### PR DESCRIPTION
## Description

Improved the completions for `xxd` because they had a few deficiencies.

- The `__fish_seen_any_argument` function did not work at all, resulting in some options never being displayed.
- The related `xxd_exclusive_args` list was not correct, e.g. combining `-r` and `-b` is totally fine plus there are other cases which are more complicated. In the end I decided to drop the entire logic. Most other completion scripts also don't do this.
- The longer old-style options were missing.
- Technically, short options in xxd are also old-style options, you cannot combine them like `-rp`.
- Two options were missing.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
