### PR TITLE
fish_vi_cursor: Remove terminal checks

### DIFF
--- a/share/functions/fish_vi_cursor.fish
+++ b/share/functions/fish_vi_cursor.fish
@@ -10,60 +10,6 @@ function fish_vi_cursor -d 'Set cursor shape for different vi modes'
         return
     end
 
-    # If this variable is set, skip all checks
-    if not set -q fish_vi_force_cursor
-
-        # Emacs Makes All Cursors Suck
-        if set -q INSIDE_EMACS
-            return
-        end
-
-        # vte-based terms set $TERM = xterm*, but only gained support in 2015.
-        # From https://bugzilla.gnome.org/show_bug.cgi?id=720821, it appears it was version 0.40.0
-        if set -q VTE_VERSION
-            and test "$VTE_VERSION" -lt 4000 2>/dev/null
-            return
-        end
-
-        # Similarly, genuine XTerm can do it since v280.
-        if set -q XTERM_VERSION
-            and not test (string replace -r "XTerm\((\d+)\)" '$1' -- "$XTERM_VERSION") -ge 280 2>/dev/null
-            return
-        end
-
-        # We need one of these terms.
-        # It would be lovely if we could rely on terminfo, but:
-        # - The "Ss" entry isn't a thing in macOS' old and crusty terminfo
-        # - It is set for xterm, and everyone and their dog claims to be xterm
-        #
-        # So we just don't care about $TERM, unless it is one of the few terminals that actually have their own entry.
-        if not set -q KONSOLE_PROFILE_NAME
-            and not test -n "$KONSOLE_VERSION" -a "$KONSOLE_VERSION" -ge 200400 # konsole, but new.
-            and not set -q ITERM_PROFILE
-            and not set -q VTE_VERSION # which version is already checked above
-            and not set -q WT_PROFILE_ID
-            and not set -q XTERM_VERSION
-            and not string match -q Apple_Terminal -- $TERM_PROGRAM
-            and not string match -rq '^st(-.*)$' -- $TERM
-            and not string match -q 'xterm-kitty*' -- $TERM
-            and not string match -q 'rxvt*' -- $TERM
-            and not string match -q 'alacritty*' -- $TERM
-            and not string match -q 'xterm-ghostty*' -- $TERM
-            and not string match -q 'foot*' -- $TERM
-            and not begin
-                set -q TMUX
-                and string match -qr '^screen|^tmux' -- $TERM
-            end
-            return
-        end
-    end
-
-    set -l terminal $argv[1]
-    set -q terminal[1]
-    or set terminal auto
-
-    set -l function __fish_cursor_xterm
-
     set -q fish_cursor_unknown
     or set -g fish_cursor_unknown block
 
@@ -73,7 +19,7 @@ function fish_vi_cursor -d 'Set cursor shape for different vi modes'
               if not set -q \$varname
                 set varname fish_cursor_unknown
               end
-              $function \$\$varname
+              __fish_cursor_xterm \$\$varname
           end
          " | source
 
@@ -86,7 +32,7 @@ function fish_vi_cursor -d 'Set cursor shape for different vi modes'
               if not set -q \$varname
                 set varname fish_cursor_unknown
               end
-              $function \$\$varname
+              __fish_cursor_xterm \$\$varname
           end
          " | source
 end


### PR DESCRIPTION
We keep having to extend these with new terminals, and I can no longer find a terminal that fails this.

Even emacs' ansi-term can now at least reliably ignore the sequence.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
