### PR TITLE
Add completions for: `test-spice` and `validate-spice`

### DIFF
--- a/share/completions/test-spice.fish
+++ b/share/completions/test-spice.fish
@@ -1,0 +1,4 @@
+complete -c test-spice -l help -d 'Show help'
+
+complete -c test-spice -s r -l remove -d 'Remove all test spices'
+complete -c test-spice -s s -l skip -d 'Skip validation with `validate-spice`'

--- a/share/completions/validate-spice.fish
+++ b/share/completions/validate-spice.fish
@@ -1,0 +1,1 @@
+complete -c validate-spice -l all -d 'Validate all spices'


### PR DESCRIPTION
## Description

Add support for [test-spice](https://github.com/linuxmint/cinnamon-spices-desklets/blob/master/test-spice) and [validate-spice](https://github.com/linuxmint/cinnamon-spices-desklets/blob/master/validate-spice) scripts for Cinnamon spices developers.

Reason: the upstream project seems to be [against](https://github.com/linuxmint/cinnamon-spices-desklets/pull/1271) these completions, but I see a benefit in them, although completions are pretty simple.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
