### PR TITLE
Fix `man` completions on macOS with symlinked `manpath`

### DIFF
--- a/share/functions/__fish_apropos.fish
+++ b/share/functions/__fish_apropos.fish
@@ -40,7 +40,7 @@ if test $status -eq 0 -a (count $sysver) -eq 3
 
         if test $age -ge $max_age
             test -d "$dir" || mkdir -m 700 -p $dir
-            /usr/libexec/makewhatis -o "$whatis" (/usr/bin/manpath | string split :) >/dev/null 2>&1 </dev/null &
+            /usr/libexec/makewhatis -o "$whatis" (/usr/bin/manpath | string split : | xargs readlink -f) >/dev/null 2>&1 </dev/null &
             disown $last_pid
         end
     end


### PR DESCRIPTION
When `manpath` prints a symlink to a directory, `/usr/libexec/makewhatis` ignores the entire directory:

```
$ /usr/libexec/makewhatis -o /tmp/whatis \
    (/usr/bin/manpath | string split :)
makewhatis: /Users/wiggles/.nix-profile/share/man: Not a directory
```

This means that the built-in `man` completions will not index any commands in these directories.

If we pass the directories to `readlink -f` first, `makewhatis` correctly indexes the `man` pages.

```
$ /usr/libexec/makewhatis -o /tmp/whatis \
    (/usr/bin/manpath | string split : | xargs readlink -f)
```

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
