### PR TITLE
docs: Update synopsis for 'set'

### DIFF
--- a/doc_src/cmds/set.rst
+++ b/doc_src/cmds/set.rst
@@ -12,9 +12,10 @@ Synopsis
     set (-f | --function) (-l | --local) (-g | --global) (-U | --universal) [--no-event]
     set [-Uflg] NAME [VALUE ...]
     set [-Uflg] NAME[[INDEX ...]] [VALUE ...]
-    set (-a | --append) [-flgU] NAME VALUE ...
-    set (-q | --query) (-e | --erase) [-flgU] [NAME][[INDEX]] ...]
-    set (-S | --show) [NAME ...]
+    set (-x | --export) (-u | --unexport) [-Uflg] NAME [VALUE ...]
+    set (-a | --append) (-p | --prepend) [-Uflg] NAME VALUE ...
+    set (-q | --query) (-e | --erase) [-Uflg] [NAME][[INDEX]] ...]
+    set (-S | --show) (-L | --long) [NAME ...]
 
 Description
 -----------


### PR DESCRIPTION
- Include --export flag
- Include --prepend flag
- Make -Uflg order consistent

## Description

I noticed that the synopsis for `set` wasn't complete nor consistent. The synopsis is useful as a quick TLDR;, so I updated it with a more useful blurb.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed (N/A???)
- [ ] User-visible changes noted in CHANGELOG.rst
