### PR TITLE
docs: fix "theme choose None" command

### DIFF
--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -78,7 +78,7 @@ Fish also provides pre-made color themes you can pick with :doc:`fish_config <cm
 
 For example, to disable nearly all coloring::
 
-  fish_config theme choose none
+  fish_config theme choose None
 
 Or, to see all themes, right in your terminal::
 


### PR DESCRIPTION
The `fish_config theme choose` command needs an upper-case "None", not a lower case.
(sorry for the drive-by PR)

## Description

The docs say to use `none`, but it needs to be `None`.

```
harmen@ld ~ [127]> fish_config theme choose none
No such theme: none
Searched directories: /home/harmen/.config/fish/themes /usr/share/fish/tools/web_config/themes
harmen@ld ~ [1]> fish_config theme choose None
harmen@ld ~> 

```

At least with `fish, version 3.7.1` from Debian on Linux.

## TODOs:

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
