### PR TITLE
Add completions for: `termux-*`

### DIFF
--- a/share/completions/termux-call-log.fish
+++ b/share/completions/termux-call-log.fish
@@ -15,5 +15,5 @@ complete -c $command \
 complete -c $command \
     -a '0\tdefault' \
     -s o \
-    -d 'Start listing calls with a specific one' \
+    -d 'Start listing calls with the specified one' \
     -x

--- a/share/completions/termux-call-log.fish
+++ b/share/completions/termux-call-log.fish
@@ -4,12 +4,12 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a '10\tdefault' \
     -s l \
-    -d '[l]imit the amount of listed calls' \
+    -d 'Limit the amount of listed calls' \
     -x
 
 complete -c $command \

--- a/share/completions/termux-call-log.fish
+++ b/share/completions/termux-call-log.fish
@@ -1,5 +1,7 @@
 set command termux-call-log
 
+complete -c $command -f
+
 complete -c $command \
     -s h \
     -d 'Show [h]elp'

--- a/share/completions/termux-call-log.fish
+++ b/share/completions/termux-call-log.fish
@@ -1,19 +1,13 @@
-set command termux-call-log
+set -l command termux-call-log
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
+complete -c $command -s l -x \
     -a '10\tdefault' \
-    -s l \
-    -d 'Limit the amount of listed calls' \
-    -x
+    -d 'Limit the amount of listed calls'
 
-complete -c $command \
+complete -c $command -s o -x \
     -a '0\tdefault' \
-    -s o \
-    -d 'Start listing calls with the specified one' \
-    -x
+    -d 'Start listing calls with the specified one'

--- a/share/completions/termux-call-log.fish
+++ b/share/completions/termux-call-log.fish
@@ -1,0 +1,17 @@
+set command termux-call-log
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a '10\tdefault' \
+    -s l \
+    -d '[l]imit the amount of listed calls' \
+    -x
+
+complete -c $command \
+    -a '0\tdefault' \
+    -s o \
+    -d 'Start listing calls with a specific one' \
+    -x

--- a/share/completions/termux-camera-photo.fish
+++ b/share/completions/termux-camera-photo.fish
@@ -1,13 +1,9 @@
-set command termux-camera-photo
+set -l command termux-camera-photo
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
+complete -c $command -s c -x \
     -a '(__fish_termux_api__complete_camera_ids)' \
-    -s c \
-    -d 'Specify the ID of a camera' \
-    -x
+    -d 'Specify the ID of a camera'

--- a/share/completions/termux-camera-photo.fish
+++ b/share/completions/termux-camera-photo.fish
@@ -9,5 +9,5 @@ complete -c $command \
 complete -c $command \
     -a '(__fish_termux_api__complete_camera_ids)' \
     -s c \
-    -d 'Specify a [c]amera ID' \
+    -d 'Specify the ID of a [c]amera' \
     -x

--- a/share/completions/termux-camera-photo.fish
+++ b/share/completions/termux-camera-photo.fish
@@ -1,0 +1,23 @@
+function __fish_termux_api__complete_camera_ids
+    set -l command termux-camera-info
+    set ids ($command | jq --raw-output '.[].id')
+    set types ($command | jq --raw-output '.[].facing')
+
+    printf "0\tdefault\n"
+
+    for index in (seq (count $ids))
+        printf "%s\t%s\n" $ids[$index] $types[$index]
+    end
+end
+
+set command termux-camera-photo
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a '(__fish_termux_api__complete_camera_ids)' \
+    -s c \
+    -d 'Specify a [c]amera ID' \
+    -x

--- a/share/completions/termux-camera-photo.fish
+++ b/share/completions/termux-camera-photo.fish
@@ -12,6 +12,8 @@ end
 
 set command termux-camera-photo
 
+complete -c $command -f
+
 complete -c $command \
     -s h \
     -d 'Show [h]elp'

--- a/share/completions/termux-camera-photo.fish
+++ b/share/completions/termux-camera-photo.fish
@@ -4,10 +4,10 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a '(__fish_termux_api__complete_camera_ids)' \
     -s c \
-    -d 'Specify the ID of a [c]amera' \
+    -d 'Specify the ID of a camera' \
     -x

--- a/share/completions/termux-camera-photo.fish
+++ b/share/completions/termux-camera-photo.fish
@@ -1,15 +1,3 @@
-function __fish_termux_api__complete_camera_ids
-    set -l command termux-camera-info
-    set ids ($command | jq --raw-output '.[].id')
-    set types ($command | jq --raw-output '.[].facing')
-
-    printf "0\tdefault\n"
-
-    for index in (seq (count $ids))
-        printf "%s\t%s\n" $ids[$index] $types[$index]
-    end
-end
-
 set command termux-camera-photo
 
 complete -c $command -f

--- a/share/completions/termux-dialog.fish
+++ b/share/completions/termux-dialog.fish
@@ -7,7 +7,7 @@ complete -c $command -s h -d 'Show help'
 complete -c $command -s l -l list -d 'List all widgets and their options'
 complete -c $command -s t -l title -x -d 'Specify the title of a dialog'
 
-set subcommands_with_descriptions 'confirm\t"Show a confirmation"' \
+set -l subcommands_with_descriptions 'confirm\t"Show a confirmation"' \
     'checkbox\t"Select multiple values using checkboxes"' \
     'counter\t"Pick a number in specific range"' \
     'date\t"Pick a date"' \
@@ -18,7 +18,7 @@ set subcommands_with_descriptions 'confirm\t"Show a confirmation"' \
     'text\t"Input text"' \
     'time\t"Pick a time value"'
 
-set subcommands (string replace --regex '\\\t.+' '' -- $subcommands_with_descriptions)
+set -l subcommands (string replace --regex '\\\t.+' '' -- $subcommands_with_descriptions)
 
 complete -c $command -a "$subcommands_with_descriptions" \
     -n "not __fish_seen_subcommand_from $subcommands"

--- a/share/completions/termux-dialog.fish
+++ b/share/completions/termux-dialog.fish
@@ -33,7 +33,7 @@ complete -c $command -s v -x \
 
 complete -c $command -s r -x \
     -d "Specify the number range of a dialog" \
-    -n "__fish_seen_subcommand_from counter"    
+    -n "__fish_seen_subcommand_from counter"
 
 complete -c $command -s d -x \
     -a '"dd-MM-yyyy k:m:s"\tdefault' \

--- a/share/completions/termux-dialog.fish
+++ b/share/completions/termux-dialog.fish
@@ -1,7 +1,3 @@
-function __fish_termux_api__complete_date_formats
-    printf 'dd-MM-yyyy k:m:s\tdefault'
-end
-
 set command termux-dialog
 
 complete -c $command -f
@@ -56,7 +52,7 @@ complete -c $command \
     -x
 
 complete -c $command \
-    -a '(__fish_termux_api__complete_date_formats)' \
+    -a '"dd-MM-yyyy k:m:s"\tdefault' \
     -s d \
     -d "Specify a [d]ate format" \
     -n "__fish_seen_subcommand_from date" \

--- a/share/completions/termux-dialog.fish
+++ b/share/completions/termux-dialog.fish
@@ -4,17 +4,17 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s l \
     -l list \
-    -d '[l]ist all widgets and their options'
+    -d 'List all widgets and their options'
 
 complete -c $command \
     -s t \
     -l title \
-    -d 'Specify the [t]itle of a dialog' \
+    -d 'Specify the title of a dialog' \
     -x
 
 set subcommands_with_descriptions 'confirm\t"Show a confirmation"' \
@@ -36,7 +36,7 @@ complete -c $command \
 
 complete -c $command \
     -s i \
-    -d "Specify the text h[i]nt of a dialog" \
+    -d "Specify the text hint of a dialog" \
     -n "__fish_seen_subcommand_from confirm speech text" \
     -x
 
@@ -48,14 +48,14 @@ complete -c $command \
 
 complete -c $command \
     -s r \
-    -d "Specify the number [r]ange of a dialog" \
+    -d "Specify the number range of a dialog" \
     -n "__fish_seen_subcommand_from counter" \
     -x
 
 complete -c $command \
     -a '"dd-MM-yyyy k:m:s"\tdefault' \
     -s d \
-    -d "Specify the [d]ate format of a dialog" \
+    -d "Specify the date format of a dialog" \
     -n "__fish_seen_subcommand_from date" \
     -x
 
@@ -63,15 +63,15 @@ set text_condition "__fish_seen_subcommand_from text"
 
 complete -c $command \
     -s m \
-    -d "Enable the [m]ultiline input mode in a dialog" \
+    -d "Enable the multiline input mode in a dialog" \
     -n "$text_condition; and not __fish_seen_argument -s n"
 
 complete -c $command \
     -s n \
-    -d "Enable the [n]umber input mode in a dialog" \
+    -d "Enable the number input mode in a dialog" \
     -n "$text_condition; and not __fish_seen_argument -s m"
 
 complete -c $command \
     -s p \
-    -d "Enable the [p]assword input mode in a dialog" \
+    -d "Enable the password input mode in a dialog" \
     -n $text_condition

--- a/share/completions/termux-dialog.fish
+++ b/share/completions/termux-dialog.fish
@@ -14,7 +14,8 @@ complete -c $command \
 complete -c $command \
     -s t \
     -l title \
-    -d 'Specify a dialog [t]itle'
+    -d 'Specify a dialog [t]itle' \
+    -x
 
 set subcommands_with_descriptions 'confirm\t"Show a confirmation"' \
     'checkbox\t"Select multiple values using checkboxes"' \
@@ -63,17 +64,14 @@ set text_condition "__fish_seen_subcommand_from text"
 complete -c $command \
     -s m \
     -d "Enable [m]ultiline input mode" \
-    -n "$text_condition; and not __fish_seen_argument -s n" \
-    -x
+    -n "$text_condition; and not __fish_seen_argument -s n"
 
 complete -c $command \
     -s n \
     -d "Enable [n]umber input mode" \
-    -n "$text_condition; and not __fish_seen_argument -s m" \
-    -x
+    -n "$text_condition; and not __fish_seen_argument -s m"
 
 complete -c $command \
     -s p \
     -d "Enable [p]assword input mode" \
-    -n $text_condition \
-    -x
+    -n $text_condition

--- a/share/completions/termux-dialog.fish
+++ b/share/completions/termux-dialog.fish
@@ -1,0 +1,80 @@
+set command termux-dialog
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s l \
+    -l list \
+    -d '[l]ist all widgets and their options'
+
+complete -c $command \
+    -s t \
+    -l title \
+    -d 'Specify a dialog [t]itle'
+
+set subcommands_with_descriptions 'confirm\t"Show a confirmation"' \
+    'checkbox\t"Select multiple values using checkboxes"' \
+    'counter\t"Pick a number in specific range"' \
+    'date\t"Pick a date"' \
+    'radio\t"Pick a single value from radio buttons"' \
+    'sheet\t"Pick a value from sliding bottom sheet"' \
+    'spinner\t"Pick a single value from a dropdown spinner"' \
+    'speech\t"Obtain speech using device microphone"' \
+    'text\t"Input text"' \
+    'time\t"Pick a time value"'
+
+set subcommands (string replace --regex '\\\t.+' '' -- $subcommands_with_descriptions)
+
+complete -c $command \
+    -a "$subcommands_with_descriptions" \
+    -n "not __fish_seen_subcommand_from $subcommands" \
+    -f
+
+complete -c $command \
+    -s i \
+    -d "Specify a text h[i]nt" \
+    -n "__fish_seen_subcommand_from confirm speech text" \
+    -x
+
+complete -c $command \
+    -s v \
+    -d "Specify comma delimited choices" \
+    -n "__fish_seen_subcommand_from checkbox radio sheet spinner" \
+    -x
+
+complete -c $command \
+    -s r \
+    -d "Specify a number [r]ange" \
+    -n "__fish_seen_subcommand_from counter" \
+    -x
+
+complete -c $command \
+    -a '"dd-MM-yyyy k:m:s"\tdefault' \
+    -s d \
+    -d "Specify a [d]ate format" \
+    -n "__fish_seen_subcommand_from date" \
+    -x
+
+set text_condition "__fish_seen_subcommand_from text"
+
+complete -c $command \
+    -s m \
+    -d "Enable [m]ultiline input mode" \
+    -n "$text_condition; and not __fish_seen_argument -s n" \
+    -x
+
+complete -c $command \
+    -s n \
+    -d "Enable [n]umber input mode" \
+    -n "$text_condition; and not __fish_seen_argument -s m" \
+    -x
+
+complete -c $command \
+    -s p \
+    -d "Enable [p]assword input mode" \
+    -n $text_condition \
+    -x

--- a/share/completions/termux-dialog.fish
+++ b/share/completions/termux-dialog.fish
@@ -14,7 +14,7 @@ complete -c $command \
 complete -c $command \
     -s t \
     -l title \
-    -d 'Specify a dialog [t]itle' \
+    -d 'Specify the [t]itle of a dialog' \
     -x
 
 set subcommands_with_descriptions 'confirm\t"Show a confirmation"' \
@@ -36,26 +36,26 @@ complete -c $command \
 
 complete -c $command \
     -s i \
-    -d "Specify a text h[i]nt" \
+    -d "Specify the text h[i]nt of a dialog" \
     -n "__fish_seen_subcommand_from confirm speech text" \
     -x
 
 complete -c $command \
     -s v \
-    -d "Specify comma delimited choices" \
+    -d "Specify the comma delimited choices of a dialog" \
     -n "__fish_seen_subcommand_from checkbox radio sheet spinner" \
     -x
 
 complete -c $command \
     -s r \
-    -d "Specify a number [r]ange" \
+    -d "Specify the number [r]ange of a dialog" \
     -n "__fish_seen_subcommand_from counter" \
     -x
 
 complete -c $command \
     -a '"dd-MM-yyyy k:m:s"\tdefault' \
     -s d \
-    -d "Specify a [d]ate format" \
+    -d "Specify the [d]ate format of a dialog" \
     -n "__fish_seen_subcommand_from date" \
     -x
 
@@ -63,15 +63,15 @@ set text_condition "__fish_seen_subcommand_from text"
 
 complete -c $command \
     -s m \
-    -d "Enable [m]ultiline input mode" \
+    -d "Enable the [m]ultiline input mode in a dialog" \
     -n "$text_condition; and not __fish_seen_argument -s n"
 
 complete -c $command \
     -s n \
-    -d "Enable [n]umber input mode" \
+    -d "Enable the [n]umber input mode in a dialog" \
     -n "$text_condition; and not __fish_seen_argument -s m"
 
 complete -c $command \
     -s p \
-    -d "Enable [p]assword input mode" \
+    -d "Enable the [p]assword input mode in a dialog" \
     -n $text_condition

--- a/share/completions/termux-dialog.fish
+++ b/share/completions/termux-dialog.fish
@@ -1,3 +1,7 @@
+function __fish_termux_api__complete_date_formats
+    printf 'dd-MM-yyyy k:m:s\tdefault'
+end
+
 set command termux-dialog
 
 complete -c $command -f
@@ -32,7 +36,6 @@ set subcommands (string replace --regex '\\\t.+' '' -- $subcommands_with_descrip
 complete -c $command \
     -a "$subcommands_with_descriptions" \
     -n "not __fish_seen_subcommand_from $subcommands" \
-    -f
 
 complete -c $command \
     -s i \
@@ -53,7 +56,7 @@ complete -c $command \
     -x
 
 complete -c $command \
-    -a '"dd-MM-yyyy k:m:s"\tdefault' \
+    -a '(__fish_termux_api__complete_date_formats)' \
     -s d \
     -d "Specify a [d]ate format" \
     -n "__fish_seen_subcommand_from date" \

--- a/share/completions/termux-dialog.fish
+++ b/share/completions/termux-dialog.fish
@@ -1,21 +1,11 @@
-set command termux-dialog
+set -l command termux-dialog
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -s l \
-    -l list \
-    -d 'List all widgets and their options'
-
-complete -c $command \
-    -s t \
-    -l title \
-    -d 'Specify the title of a dialog' \
-    -x
+complete -c $command -s l -l list -d 'List all widgets and their options'
+complete -c $command -s t -l title -x -d 'Specify the title of a dialog'
 
 set subcommands_with_descriptions 'confirm\t"Show a confirmation"' \
     'checkbox\t"Select multiple values using checkboxes"' \
@@ -30,48 +20,36 @@ set subcommands_with_descriptions 'confirm\t"Show a confirmation"' \
 
 set subcommands (string replace --regex '\\\t.+' '' -- $subcommands_with_descriptions)
 
-complete -c $command \
-    -a "$subcommands_with_descriptions" \
-    -n "not __fish_seen_subcommand_from $subcommands" \
+complete -c $command -a "$subcommands_with_descriptions" \
+    -n "not __fish_seen_subcommand_from $subcommands"
 
-complete -c $command \
-    -s i \
+complete -c $command -s i -x \
     -d "Specify the text hint of a dialog" \
-    -n "__fish_seen_subcommand_from confirm speech text" \
-    -x
+    -n "__fish_seen_subcommand_from confirm speech text"
 
-complete -c $command \
-    -s v \
+complete -c $command -s v -x \
     -d "Specify the comma delimited choices of a dialog" \
-    -n "__fish_seen_subcommand_from checkbox radio sheet spinner" \
-    -x
+    -n "__fish_seen_subcommand_from checkbox radio sheet spinner"
 
-complete -c $command \
-    -s r \
+complete -c $command -s r -x \
     -d "Specify the number range of a dialog" \
-    -n "__fish_seen_subcommand_from counter" \
-    -x
+    -n "__fish_seen_subcommand_from counter"    
 
-complete -c $command \
+complete -c $command -s d -x \
     -a '"dd-MM-yyyy k:m:s"\tdefault' \
-    -s d \
     -d "Specify the date format of a dialog" \
-    -n "__fish_seen_subcommand_from date" \
-    -x
+    -n "__fish_seen_subcommand_from date"
 
 set text_condition "__fish_seen_subcommand_from text"
 
-complete -c $command \
-    -s m \
+complete -c $command -s m \
     -d "Enable the multiline input mode in a dialog" \
     -n "$text_condition; and not __fish_seen_argument -s n"
 
-complete -c $command \
-    -s n \
+complete -c $command -s n \
     -d "Enable the number input mode in a dialog" \
     -n "$text_condition; and not __fish_seen_argument -s m"
 
-complete -c $command \
-    -s p \
+complete -c $command -s p \
     -d "Enable the password input mode in a dialog" \
     -n $text_condition

--- a/share/completions/termux-download.fish
+++ b/share/completions/termux-download.fish
@@ -8,11 +8,13 @@ complete -c $command \
 
 complete -c $command \
     -s d \
-    -d 'Specify a [d]escription for a download notification'
+    -d 'Specify a [d]escription for a download notification' \
+    -x
 
 complete -c $command \
     -s t \
-    -d 'Specify a [t]itle for a download notification'
+    -d 'Specify a [t]itle for a download notification' \
+    -x
 
 complete -c $command \
     -s p \

--- a/share/completions/termux-download.fish
+++ b/share/completions/termux-download.fish
@@ -1,22 +1,11 @@
-set command termux-download
+set -l command termux-download
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -s d \
-    -d 'Specify the description for a download notification' \
-    -x
+complete -c $command -s d -x \
+    -d 'Specify the description for a download notification'
 
-complete -c $command \
-    -s t \
-    -d 'Specify the title for a download notification' \
-    -x
-
-complete -c $command \
-    -s p \
-    -d 'Specify the path for a download' \
-    -F -r
+complete -c $command -s t -x -d 'Specify the title for a download notification'
+complete -c $command -s p -F -r -d 'Specify the path for a download'

--- a/share/completions/termux-download.fish
+++ b/share/completions/termux-download.fish
@@ -1,0 +1,20 @@
+set command termux-download
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s d \
+    -d 'Specify a [d]escription for a download notification'
+
+complete -c $command \
+    -s t \
+    -d 'Specify a [t]itle for a download notification'
+
+complete -c $command \
+    -s p \
+    -d 'Specify a [p]ath for a download' \
+    -F -r

--- a/share/completions/termux-download.fish
+++ b/share/completions/termux-download.fish
@@ -8,15 +8,15 @@ complete -c $command \
 
 complete -c $command \
     -s d \
-    -d 'Specify a [d]escription for a download notification' \
+    -d 'Specify the [d]escription for a download notification' \
     -x
 
 complete -c $command \
     -s t \
-    -d 'Specify a [t]itle for a download notification' \
+    -d 'Specify the [t]itle for a download notification' \
     -x
 
 complete -c $command \
     -s p \
-    -d 'Specify a [p]ath for a download' \
+    -d 'Specify the [p]ath for a download' \
     -F -r

--- a/share/completions/termux-download.fish
+++ b/share/completions/termux-download.fish
@@ -4,19 +4,19 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s d \
-    -d 'Specify the [d]escription for a download notification' \
+    -d 'Specify the description for a download notification' \
     -x
 
 complete -c $command \
     -s t \
-    -d 'Specify the [t]itle for a download notification' \
+    -d 'Specify the title for a download notification' \
     -x
 
 complete -c $command \
     -s p \
-    -d 'Specify the [p]ath for a download' \
+    -d 'Specify the path for a download' \
     -F -r

--- a/share/completions/termux-infrared-transmit.fish
+++ b/share/completions/termux-infrared-transmit.fish
@@ -8,4 +8,5 @@ complete -c $command \
 
 complete -c $command \
     -s f \
-    -d 'Specify IR carrier [f]requency'
+    -d 'Specify IR carrier [f]requency' \
+    -x

--- a/share/completions/termux-infrared-transmit.fish
+++ b/share/completions/termux-infrared-transmit.fish
@@ -8,5 +8,5 @@ complete -c $command \
 
 complete -c $command \
     -s f \
-    -d 'Specify IR carrier [f]requency' \
+    -d 'Specify the IR carrier [f]requency' \
     -x

--- a/share/completions/termux-infrared-transmit.fish
+++ b/share/completions/termux-infrared-transmit.fish
@@ -1,0 +1,11 @@
+set command termux-infrared-transmit
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s f \
+    -d 'Specify IR carrier [f]requency'

--- a/share/completions/termux-infrared-transmit.fish
+++ b/share/completions/termux-infrared-transmit.fish
@@ -4,9 +4,9 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s f \
-    -d 'Specify the IR carrier [f]requency' \
+    -d 'Specify the IR carrier frequency' \
     -x

--- a/share/completions/termux-infrared-transmit.fish
+++ b/share/completions/termux-infrared-transmit.fish
@@ -1,12 +1,7 @@
-set command termux-infrared-transmit
+set -l command termux-infrared-transmit
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -s f \
-    -d 'Specify the IR carrier frequency' \
-    -x
+complete -c $command -s f -x -d 'Specify the IR carrier frequency'

--- a/share/completions/termux-job-scheduler.fish
+++ b/share/completions/termux-job-scheduler.fish
@@ -23,19 +23,19 @@ complete -c $command \
 
 complete -c $command \
     -l job-id \
-    -d 'Specify a job id' \
+    -d 'Specify the ID of a job' \
     -x
 
 complete -c $command \
     -a '0\tdefault' \
     -l period-ms \
-    -d 'Specify an interval between script runs' \
+    -d 'Specify the interval between script runs' \
     -x
 
 complete -c $command \
     -a 'any\tdefault unmetered cellular not_roaming none' \
     -l network \
-    -d 'Require a network of a specific type to be available' \
+    -d 'Require the network of a specific type to be available' \
     -x
 
 complete -c $command \

--- a/share/completions/termux-job-scheduler.fish
+++ b/share/completions/termux-job-scheduler.fish
@@ -1,72 +1,37 @@
-set command termux-job-scheduler
+set -l command termux-job-scheduler
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -s p \
-    -l pending \
-    -d 'List pending jobs'
+complete -c $command -s p -l pending -d 'List pending jobs'
+complete -c $command -l cancel-all -d 'Cancel all pending jobs'
+complete -c $command -s s -l script -r -d 'Specify a script path to schedule'
+complete -c $command -l job-id -x -d 'Specify the ID of a job'
 
-complete -c $command \
-    -l cancel-all \
-    -d 'Cancel all pending jobs'
-
-complete -c $command \
-    -s s \
-    -l script \
-    -d 'Specify a script path to schedule' \
-    -r
-
-complete -c $command \
-    -l job-id \
-    -d 'Specify the ID of a job' \
-    -x
-
-complete -c $command \
+complete -c $command -l period-ms -x \
     -a '0\tdefault' \
-    -l period-ms \
-    -d 'Specify the interval between script runs' \
-    -x
+    -d 'Specify the interval between script runs'
 
-complete -c $command \
+complete -c $command -l network -x \
     -a 'any\tdefault unmetered cellular not_roaming none' \
-    -l network \
-    -d 'Require the network of a specific type to be available' \
-    -x
+    -d 'Require the network of a specific type to be available'
 
-complete -c $command \
+complete -c $command -l battery-not-low -x \
     -a 'true\tdefault false' \
-    -l battery-not-low \
-    -d 'Whether run a script when a battery is low' \
-    -x
+    -d 'Whether run a script when a battery is low'
 
-complete -c $command \
+complete -c $command -l storage-not-low -x \
     -a 'false\tdefault true' \
-    -l storage-not-low \
-    -d 'Whether run a script when a storage is low' \
-    -x
+    -d 'Whether run a script when a storage is low'
 
-complete -c $command \
+complete -c $command -l charging -x \
     -a 'false\tdefault true' \
-    -l charging \
-    -d 'Whether run a script when the device is charging' \
-    -x
+    -d 'Whether run a script when the device is charging'
 
-complete -c $command \
+complete -c $command -l persisted -x \
     -a 'false\tdefault true' \
-    -l persisted \
-    -d 'Whether unschedule script on reboots' \
-    -x
+    -d 'Whether unschedule script on reboots'
 
-complete -c $command \
-    -l trigger-content-uri \
-    -x
-
-complete -c $command \
-    -a '1\tdefault' \
-    -l trigger-content-flag \
-    -x
+complete -c $command -l trigger-content-uri -x
+complete -c $command -l trigger-content-flag -x -a '1\tdefault'

--- a/share/completions/termux-job-scheduler.fish
+++ b/share/completions/termux-job-scheduler.fish
@@ -1,0 +1,72 @@
+set command termux-job-scheduler
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s p \
+    -l pending \
+    -d 'List [p]ending jobs'
+
+complete -c $command \
+    -l cancel-all \
+    -d 'Cancel all pending jobs'
+
+complete -c $command \
+    -s s \
+    -l script \
+    -d 'Specify a [s]cript path to schedule' \
+    -r
+
+complete -c $command \
+    -l job-id \
+    -d 'Specify a job id' \
+    -x
+
+complete -c $command \
+    -a '0\tdefault' \
+    -l period-ms \
+    -d 'Specify an interval between script runs' \
+    -x
+
+complete -c $command \
+    -a 'any\tdefault unmetered cellular not_roaming none' \
+    -l network \
+    -d 'Require a network of a specific type to be available' \
+    -x
+
+complete -c $command \
+    -a 'true\tdefault false' \
+    -l battery-not-low \
+    -d 'Whether run a script when a battery is low' \
+    -x
+
+complete -c $command \
+    -a 'false\tdefault true' \
+    -l storage-not-low \
+    -d 'Whether run a script when a storage is low' \
+    -x
+
+complete -c $command \
+    -a 'false\tdefault true' \
+    -l charging \
+    -d 'Whether run a script when the device is charging' \
+    -x
+
+complete -c $command \
+    -a 'false\tdefault true' \
+    -l persisted \
+    -d 'Whether run un-schedule script on reboots' \
+    -x
+
+complete -c $command \
+    -l trigger-content-uri \
+    -x
+
+complete -c $command \
+    -a '1\tdefault' \
+    -l trigger-content-flag \
+    -x

--- a/share/completions/termux-job-scheduler.fish
+++ b/share/completions/termux-job-scheduler.fish
@@ -4,12 +4,12 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s p \
     -l pending \
-    -d 'List [p]ending jobs'
+    -d 'List pending jobs'
 
 complete -c $command \
     -l cancel-all \
@@ -18,7 +18,7 @@ complete -c $command \
 complete -c $command \
     -s s \
     -l script \
-    -d 'Specify a [s]cript path to schedule' \
+    -d 'Specify a script path to schedule' \
     -r
 
 complete -c $command \

--- a/share/completions/termux-job-scheduler.fish
+++ b/share/completions/termux-job-scheduler.fish
@@ -59,7 +59,7 @@ complete -c $command \
 complete -c $command \
     -a 'false\tdefault true' \
     -l persisted \
-    -d 'Whether run un-schedule script on reboots' \
+    -d 'Whether unschedule script on reboots' \
     -x
 
 complete -c $command \

--- a/share/completions/termux-location.fish
+++ b/share/completions/termux-location.fish
@@ -1,19 +1,13 @@
-set command termux-location
+set -l command termux-location
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
+complete -c $command -s p -x \
     -a 'gps\tdefault network passive' \
-    -s p \
-    -d 'Specify the provider of a location' \
-    -x
+    -d 'Specify the provider of a location'
 
-complete -c $command \
+complete -c $command -s r -x \
     -a 'once\tdefault last updates' \
-    -s r \
-    -d 'Specify the request type for a location' \
-    -x
+    -d 'Specify the request type for a location'

--- a/share/completions/termux-location.fish
+++ b/share/completions/termux-location.fish
@@ -9,11 +9,11 @@ complete -c $command \
 complete -c $command \
     -a 'gps\tdefault network passive' \
     -s p \
-    -d 'Specify a location provider' \
+    -d 'Specify the provider of a location' \
     -x
 
 complete -c $command \
     -a 'once\tdefault last updates' \
     -s r \
-    -d 'Specify a request type' \
+    -d 'Specify the request type for a location' \
     -x

--- a/share/completions/termux-location.fish
+++ b/share/completions/termux-location.fish
@@ -1,0 +1,19 @@
+set command termux-location
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a 'gps\tdefault network passive' \
+    -s p \
+    -d 'Specify a location provider' \
+    -x
+
+complete -c $command \
+    -a 'once\tdefault last updates' \
+    -s r \
+    -d 'Specify a request type' \
+    -x

--- a/share/completions/termux-location.fish
+++ b/share/completions/termux-location.fish
@@ -4,7 +4,7 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a 'gps\tdefault network passive' \

--- a/share/completions/termux-media-player.fish
+++ b/share/completions/termux-media-player.fish
@@ -4,7 +4,7 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 set subcommands_with_descriptions 'info\t"Show a current playback information"' \
     'play\t"Resume a playback if paused | Play a specific media file"' \

--- a/share/completions/termux-media-player.fish
+++ b/share/completions/termux-media-player.fish
@@ -19,4 +19,4 @@ complete -c $command \
 
 complete -c $command \
     -n "__fish_seen_subcommand_from play" \
-    -F
+    -F -r

--- a/share/completions/termux-media-player.fish
+++ b/share/completions/termux-media-player.fish
@@ -1,0 +1,22 @@
+set command termux-media-player
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+set subcommands_with_descriptions 'info\t"Show a current playback information"' \
+    'play\t"Resume a playback if paused | Play a specific media file"' \
+    'pause\t"Pause a playback"' \
+    'stop\t"Quit a playback"'
+
+set subcommands (string replace --regex '\\\t.+' '' -- $subcommands_with_descriptions)
+
+complete -c $command \
+    -a "$subcommands_with_descriptions" \
+    -n "not __fish_seen_subcommand_from $subcommands"
+
+complete -c $command \
+    -n "__fish_seen_subcommand_from play" \
+    -F

--- a/share/completions/termux-media-player.fish
+++ b/share/completions/termux-media-player.fish
@@ -9,7 +9,7 @@ set subcommands_with_descriptions 'info\t"Show a current playback information"' 
     'pause\t"Pause a playback"' \
     'stop\t"Quit a playback"'
 
-set subcommands (string replace --regex '\\\t.+' '' -- $subcommands_with_descriptions)
+set -l subcommands (string replace --regex '\\\t.+' '' -- $subcommands_with_descriptions)
 
 complete -c $command -a "$subcommands_with_descriptions" \
     -n "not __fish_seen_subcommand_from $subcommands"

--- a/share/completions/termux-media-player.fish
+++ b/share/completions/termux-media-player.fish
@@ -1,10 +1,8 @@
-set command termux-media-player
+set -l command termux-media-player
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
 set subcommands_with_descriptions 'info\t"Show a current playback information"' \
     'play\t"Resume a playback if paused | Play a specific media file"' \
@@ -13,10 +11,8 @@ set subcommands_with_descriptions 'info\t"Show a current playback information"' 
 
 set subcommands (string replace --regex '\\\t.+' '' -- $subcommands_with_descriptions)
 
-complete -c $command \
-    -a "$subcommands_with_descriptions" \
+complete -c $command -a "$subcommands_with_descriptions" \
     -n "not __fish_seen_subcommand_from $subcommands"
 
-complete -c $command \
-    -n "__fish_seen_subcommand_from play" \
-    -F -r
+complete -c $command -F -r \
+    -n "__fish_seen_subcommand_from play"

--- a/share/completions/termux-media-scan.fish
+++ b/share/completions/termux-media-scan.fish
@@ -2,12 +2,12 @@ set command termux-media-scan
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s r \
-    -d 'Scan directories [r]ecursively'
+    -d 'Scan directories recursively'
 
 complete -c $command \
     -s v \
-    -d 'Show [v]erbose messages'
+    -d 'Show verbose messages'

--- a/share/completions/termux-media-scan.fish
+++ b/share/completions/termux-media-scan.fish
@@ -1,0 +1,13 @@
+set command termux-media-scan
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s r \
+    -d 'Scan directories [r]ecursively'
+
+complete -c $command \
+    -s v \
+    -d 'Show [v]erbose messages'

--- a/share/completions/termux-media-scan.fish
+++ b/share/completions/termux-media-scan.fish
@@ -1,13 +1,6 @@
-set command termux-media-scan
+set -l command termux-media-scan
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -s r \
-    -d 'Scan directories recursively'
-
-complete -c $command \
-    -s v \
-    -d 'Show verbose messages'
+complete -c $command -s r -d 'Scan directories recursively'
+complete -c $command -s v -d 'Show verbose messages'

--- a/share/completions/termux-microphone-record.fish
+++ b/share/completions/termux-microphone-record.fish
@@ -1,0 +1,51 @@
+set command termux-microphone-record
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s d \
+    -d Record
+
+complete -c $command \
+    -s f \
+    -d 'Specify a [f]ile to save recording to' \
+    -F -r
+
+complete -c $command \
+    -a '0\tdefault' \
+    -s l \
+    -d 'Specify a recording length [l]imit' \
+    -x
+
+complete -c $command \
+    -a 'aac amr_wb amr_nb' \
+    -s e \
+    -d 'Specify a recording [e]ncoder' \
+    -x
+
+complete -c $command \
+    -s b \
+    -d 'Specify a recording [b]itrate' \
+    -x
+
+complete -c $command \
+    -s r \
+    -d 'Specify a recording sampling [r]ate' \
+    -x
+
+complete -c $command \
+    -s c \
+    -d 'Specify a recording [c]hannel count' \
+    -x
+
+complete -c $command \
+    -s i \
+    -d 'Show [i]nformation about the current recording'
+
+complete -c $command \
+    -s q \
+    -d '[q]uit the current recording'

--- a/share/completions/termux-microphone-record.fish
+++ b/share/completions/termux-microphone-record.fish
@@ -4,7 +4,7 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s d \
@@ -12,40 +12,40 @@ complete -c $command \
 
 complete -c $command \
     -s f \
-    -d 'Specify a [f]ile to save recording to' \
+    -d 'Specify a file to save recording to' \
     -F -r
 
 complete -c $command \
     -a '0\tdefault' \
     -s l \
-    -d 'Specify the length [l]imit of a recording' \
+    -d 'Specify the length limit of a recording' \
     -x
 
 complete -c $command \
     -a 'aac amr_wb amr_nb' \
     -s e \
-    -d 'Specify the [e]ncoder of a recording' \
+    -d 'Specify the encoder of a recording' \
     -x
 
 complete -c $command \
     -s b \
-    -d 'Specify the [b]itrate of a recording' \
+    -d 'Specify the bitrate of a recording' \
     -x
 
 complete -c $command \
     -s r \
-    -d 'Specify the sampling [r]ate of a recording' \
+    -d 'Specify the sampling rate of a recording' \
     -x
 
 complete -c $command \
     -s c \
-    -d 'Specify the [c]hannel count of a recording' \
+    -d 'Specify the channel count of a recording' \
     -x
 
 complete -c $command \
     -s i \
-    -d 'Show [i]nformation about the current recording'
+    -d 'Show information about the current recording'
 
 complete -c $command \
     -s q \
-    -d '[q]uit the current recording'
+    -d 'Quit the current recording'

--- a/share/completions/termux-microphone-record.fish
+++ b/share/completions/termux-microphone-record.fish
@@ -18,28 +18,28 @@ complete -c $command \
 complete -c $command \
     -a '0\tdefault' \
     -s l \
-    -d 'Specify a recording length [l]imit' \
+    -d 'Specify the length [l]imit of a recording' \
     -x
 
 complete -c $command \
     -a 'aac amr_wb amr_nb' \
     -s e \
-    -d 'Specify a recording [e]ncoder' \
+    -d 'Specify the [e]ncoder of a recording' \
     -x
 
 complete -c $command \
     -s b \
-    -d 'Specify a recording [b]itrate' \
+    -d 'Specify the [b]itrate of a recording' \
     -x
 
 complete -c $command \
     -s r \
-    -d 'Specify a recording sampling [r]ate' \
+    -d 'Specify the sampling [r]ate of a recording' \
     -x
 
 complete -c $command \
     -s c \
-    -d 'Specify a recording [c]hannel count' \
+    -d 'Specify the [c]hannel count of a recording' \
     -x
 
 complete -c $command \

--- a/share/completions/termux-microphone-record.fish
+++ b/share/completions/termux-microphone-record.fish
@@ -1,51 +1,22 @@
-set command termux-microphone-record
+set -l command termux-microphone-record
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -s d \
-    -d Record
+complete -c $command -s d -d Record
+complete -c $command -s f -F -r -d 'Specify a file to save recording to'
 
-complete -c $command \
-    -s f \
-    -d 'Specify a file to save recording to' \
-    -F -r
-
-complete -c $command \
+complete -c $command -s l -x \
     -a '0\tdefault' \
-    -s l \
-    -d 'Specify the length limit of a recording' \
-    -x
+    -d 'Specify the length limit of a recording'
 
-complete -c $command \
+complete -c $command -s e -x \
     -a 'aac amr_wb amr_nb' \
-    -s e \
-    -d 'Specify the encoder of a recording' \
-    -x
+    -d 'Specify the encoder of a recording'
 
-complete -c $command \
-    -s b \
-    -d 'Specify the bitrate of a recording' \
-    -x
-
-complete -c $command \
-    -s r \
-    -d 'Specify the sampling rate of a recording' \
-    -x
-
-complete -c $command \
-    -s c \
-    -d 'Specify the channel count of a recording' \
-    -x
-
-complete -c $command \
-    -s i \
-    -d 'Show information about the current recording'
-
-complete -c $command \
-    -s q \
-    -d 'Quit the current recording'
+complete -c $command -s b -x -d 'Specify the bitrate of a recording'
+complete -c $command -s r -x -d 'Specify the sampling rate of a recording'
+complete -c $command -s c -x -d 'Specify the channel count of a recording'
+complete -c $command -s i -d 'Show information about the current recording'
+complete -c $command -s q -d 'Quit the current recording'

--- a/share/completions/termux-notification-remove.fish
+++ b/share/completions/termux-notification-remove.fish
@@ -1,0 +1,12 @@
+set command termux-notification-remove
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -l help \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a '(__fish_termux_api__complete_group_ids)' \
+    -x

--- a/share/completions/termux-notification-remove.fish
+++ b/share/completions/termux-notification-remove.fish
@@ -1,12 +1,7 @@
-set command termux-notification-remove
+set -l command termux-notification-remove
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -l help \
-    -d 'Show help'
+complete -c $command -s h -l help -d 'Show help'
 
-complete -c $command \
-    -a '(__fish_termux_api__complete_group_ids)' \
-    -x
+complete -c $command -a '(__fish_termux_api__complete_group_ids)' -x

--- a/share/completions/termux-notification-remove.fish
+++ b/share/completions/termux-notification-remove.fish
@@ -5,7 +5,7 @@ complete -c $command -f
 complete -c $command \
     -s h \
     -l help \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a '(__fish_termux_api__complete_group_ids)' \

--- a/share/completions/termux-notification.fish
+++ b/share/completions/termux-notification.fish
@@ -1,19 +1,3 @@
-function __fish_termux_api__complete_group_ids
-    set -l command termux-notification-list
-    set ids ($command | jq --raw-output '.[].group')
-    set titles ($command | jq --raw-output '.[].title')
-
-    for index in (seq (count $ids))
-        set -l id $ids[$index]
-        set -l title $titles[$index]
-
-        test -z "$id" && continue
-        test -z "$title" && set title "Unknown title"
-
-        printf "%s\t%s\n" $id $title
-    end
-end
-
 set command termux-notification
 
 complete -c $command -f

--- a/share/completions/termux-notification.fish
+++ b/share/completions/termux-notification.fish
@@ -1,123 +1,80 @@
-set command termux-notification
+set -l command termux-notification
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -l help \
-    -d 'Show help'
+complete -c $command -s h -l help -d 'Show help'
 
-complete -c $command \
-    -l action \
-    -d 'Specify the action when pressing a notification' \
-    -F -r
+complete -c $command -l action -F -r \
+    -d 'Specify the action when pressing a notification'
 
-complete -c $command \
-    -l alert-once \
+complete -c $command -l alert-once \
     -d 'Do not alert when a notification is edited'
 
 set button_names first second third
 set index 1
 
 while test $index -le (count $button_names)
-    complete -c $command \
-        -l button$index \
-        -d "Specify the text of a $button_names[$index] notification button" \
-        -x
+    complete -c $command -l button$index -x \
+        -d "Specify the text of a $button_names[$index] notification button"
 
-    complete -c $command \
-        -l button$index-action \
-        -d "Specify the action of a $button_names[$index] notification button" \
-        -F -r
+    complete -c $command -l button$index-action -F -r \
+        -d "Specify the action of a $button_names[$index] notification button"
 
     set index (math $index + 1)
 end
 
-complete -c $command \
-    -s c \
-    -l content \
-    -d 'Specify the content of a notification' \
-    -x
+complete -c $command -s c -l content -x \
+    -d 'Specify the content of a notification'
 
-complete -c $command \
+complete -c $command -l group -x \
     -a '(__fish_termux_api__complete_group_ids)' \
-    -l group \
-    -d 'Specify the group of a notification' \
-    -x
+    -d 'Specify the group of a notification'
 
-complete -c $command \
-    -l help-actions \
+complete -c $command -l help-actions \
     -d 'Show help for the actions of a notification'
 
-complete -c $command \
-    -s i \
-    -l id \
-    -d 'Specify the identifier of a notification' \
-    -x
+complete -c $command -s i -l id -x \
+    -d 'Specify the identifier of a notification'
 
-complete -c $command \
-    -l image-path \
-    -d 'Specify the image of a notification' \
-    -F -r
+complete -c $command -l image-path -F -r \
+    -d 'Specify the image of a notification'
 
-complete -c $command \
+complete -c $command -l led-color -x \
     -a 'none\tdefault' \
-    -l led-color \
-    -d 'Specify the LED color of a notification' \
-    -x
+    -d 'Specify the LED color of a notification'
 
 set led_states on off
 
 for state in $led_states
-    complete -c $command \
+    complete -c $command -l led-$state -x \
         -a '800\tdefault' \
-        -l led-$state \
-        -d "Specify the time for the LED to be $state while flashing of a notification" \
-        -x
+        -d "Specify the time for the LED to be $state while flashing of a notification"
 end
 
-complete -c $command \
-    -l on-delete \
-    -d 'Specify the action when a notification is cleared' \
-    -F -r
+complete -c $command -l on-delete -F -r \
+    -d 'Specify the action when a notification is cleared'
 
-complete -c $command \
-    -l ongoing \
-    -d 'Pin a notification'
+complete -c $command -l ongoing -d 'Pin a notification'
 
-complete -c $command \
+complete -c $command -l priority -x \
     -a 'default\tdefault high low max min' \
-    -l priority \
-    -d 'Specify the priority of a notification' \
-    -x
+    -d 'Specify the priority of a notification'
 
-complete -c $command \
-    -l sound \
-    -d 'Play the sound with a notification'
+complete -c $command -l sound -d 'Play the sound with a notification'
+complete -c $command -s t -l title -x -d 'Specify the title of a notification'
+    
 
-complete -c $command \
-    -s t \
-    -l title \
-    -d 'Specify the title of a notification' \
-    -x
+complete -c $command -l vibrate -x \
+    -d 'Specify the vibrate pattern of a notification'
 
-complete -c $command \
-    -l vibrate \
-    -d 'Specify the vibrate pattern of a notification' \
-    -x
-
-complete -c $command \
+complete -c $command -l type -x \
     -a 'default\tdefault media' \
-    -l type \
-    -d 'Specify the style of a notification' \
-    -x
+    -d 'Specify the style of a notification'
 
 set media_options next pause play previous
 
 for option in $media_options
-    complete -c $command \
-        -l media-$option \
+    complete -c $command -l media-$option -F -r \
         -d "Specify the action for $option button a notification" \
-        -n '__fish_seen_argument -l type' \
-        -F -r
+        -n '__fish_seen_argument -l type'
 end

--- a/share/completions/termux-notification.fish
+++ b/share/completions/termux-notification.fish
@@ -10,8 +10,8 @@ complete -c $command -l action -F -r \
 complete -c $command -l alert-once \
     -d 'Do not alert when a notification is edited'
 
-set button_names first second third
-set index 1
+set -l button_names first second third
+set -l index 1
 
 while test $index -le (count $button_names)
     complete -c $command -l button$index -x \
@@ -43,7 +43,7 @@ complete -c $command -l led-color -x \
     -a 'none\tdefault' \
     -d 'Specify the LED color of a notification'
 
-set led_states on off
+set -l led_states on off
 
 for state in $led_states
     complete -c $command -l led-$state -x \
@@ -63,7 +63,6 @@ complete -c $command -l priority -x \
 complete -c $command -l sound -d 'Play the sound with a notification'
 complete -c $command -s t -l title -x -d 'Specify the title of a notification'
 
-
 complete -c $command -l vibrate -x \
     -d 'Specify the vibrate pattern of a notification'
 
@@ -71,7 +70,7 @@ complete -c $command -l type -x \
     -a 'default\tdefault media' \
     -d 'Specify the style of a notification'
 
-set media_options next pause play previous
+set -l media_options next pause play previous
 
 for option in $media_options
     complete -c $command -l media-$option -F -r \

--- a/share/completions/termux-notification.fish
+++ b/share/completions/termux-notification.fish
@@ -5,7 +5,7 @@ complete -c $command -f
 complete -c $command \
     -s h \
     -l help \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -l action \
@@ -36,7 +36,7 @@ end
 complete -c $command \
     -s c \
     -l content \
-    -d 'Specify the [c]ontent of a notification' \
+    -d 'Specify the content of a notification' \
     -x
 
 complete -c $command \
@@ -47,12 +47,12 @@ complete -c $command \
 
 complete -c $command \
     -l help-actions \
-    -d 'Show [h]elp for the actions of a notification'
+    -d 'Show help for the actions of a notification'
 
 complete -c $command \
     -s i \
     -l id \
-    -d 'Specify the [i]dentifier of a notification' \
+    -d 'Specify the identifier of a notification' \
     -x
 
 complete -c $command \
@@ -98,7 +98,7 @@ complete -c $command \
 complete -c $command \
     -s t \
     -l title \
-    -d 'Specify the [t]itle of a notification' \
+    -d 'Specify the title of a notification' \
     -x
 
 complete -c $command \

--- a/share/completions/termux-notification.fish
+++ b/share/completions/termux-notification.fish
@@ -22,12 +22,12 @@ set index 1
 while test $index -le (count $button_names)
     complete -c $command \
         -l button$index \
-        -d "Specify the text of the $button_names[$index] notification button" \
+        -d "Specify the text of a $button_names[$index] notification button" \
         -x
 
     complete -c $command \
         -l button$index-action \
-        -d "Specify the action of the $button_names[$index] notification button" \
+        -d "Specify the action of a $button_names[$index] notification button" \
         -F -r
 
     set index (math $index + 1)
@@ -72,7 +72,7 @@ for state in $led_states
     complete -c $command \
         -a '800\tdefault' \
         -l led-$state \
-        -d 'Specify the time for the LED to be $state while flashing of a notification' \
+        -d "Specify the time for the LED to be $state while flashing of a notification" \
         -x
 end
 

--- a/share/completions/termux-notification.fish
+++ b/share/completions/termux-notification.fish
@@ -1,0 +1,139 @@
+function __fish_termux_api__complete_group_ids
+    set -l command termux-notification-list
+    set ids ($command | jq --raw-output '.[].group')
+    set titles ($command | jq --raw-output '.[].title')
+
+    for index in (seq (count $ids))
+        set -l id $ids[$index]
+        set -l title $titles[$index]
+
+        test -z "$id" && continue
+        test -z "$title" && set title "Unknown title"
+
+        printf "%s\t%s\n" $id $title
+    end
+end
+
+set command termux-notification
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -l help \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -l action \
+    -d 'Specify the action when pressing a notification' \
+    -F -r
+
+complete -c $command \
+    -l alert-once \
+    -d 'Do not alert when a notification is edited'
+
+set button_names first second third
+set index 1
+
+while test $index -le (count $button_names)
+    complete -c $command \
+        -l button$index \
+        -d "Specify the text of the $button_names[$index] notification button" \
+        -x
+
+    complete -c $command \
+        -l button$index-action \
+        -d "Specify the action of the $button_names[$index] notification button" \
+        -F -r
+
+    set index (math $index + 1)
+end
+
+complete -c $command \
+    -s c \
+    -l content \
+    -d 'Specify the [c]ontent of a notification' \
+    -x
+
+complete -c $command \
+    -a '(__fish_termux_api__complete_group_ids)' \
+    -l group \
+    -d 'Specify the group of a notification' \
+    -x
+
+complete -c $command \
+    -l help-actions \
+    -d 'Show [h]elp for the actions of a notification'
+
+complete -c $command \
+    -s i \
+    -l id \
+    -d 'Specify the [i]dentifier of a notification' \
+    -x
+
+complete -c $command \
+    -l image-path \
+    -d 'Specify the image of a notification' \
+    -F -r
+
+complete -c $command \
+    -a 'none\tdefault' \
+    -l led-color \
+    -d 'Specify the LED color of a notification' \
+    -x
+
+set led_states on off
+
+for state in $led_states
+    complete -c $command \
+        -a '800\tdefault' \
+        -l led-$state \
+        -d 'Specify the time for the LED to be $state while flashing of a notification' \
+        -x
+end
+
+complete -c $command \
+    -l on-delete \
+    -d 'Specify the action when a notification is cleared' \
+    -F -r
+
+complete -c $command \
+    -l ongoing \
+    -d 'Pin a notification'
+
+complete -c $command \
+    -a 'default\tdefault high low max min' \
+    -l priority \
+    -d 'Specify the priority of a notification' \
+    -x
+
+complete -c $command \
+    -l sound \
+    -d 'Play the sound with a notification'
+
+complete -c $command \
+    -s t \
+    -l title \
+    -d 'Specify the [t]itle of a notification' \
+    -x
+
+complete -c $command \
+    -l vibrate \
+    -d 'Specify the vibrate pattern of a notification' \
+    -x
+
+complete -c $command \
+    -a 'default\tdefault media' \
+    -l type \
+    -d 'Specify the style of a notification' \
+    -x
+
+set media_options next pause play previous
+
+for option in $media_options
+    complete -c $command \
+        -l media-$option \
+        -d "Specify the action for $option button a notification" \
+        -n '__fish_seen_argument -l type' \
+        -F -r
+end

--- a/share/completions/termux-notification.fish
+++ b/share/completions/termux-notification.fish
@@ -62,7 +62,7 @@ complete -c $command -l priority -x \
 
 complete -c $command -l sound -d 'Play the sound with a notification'
 complete -c $command -s t -l title -x -d 'Specify the title of a notification'
-    
+
 
 complete -c $command -l vibrate -x \
     -d 'Specify the vibrate pattern of a notification'

--- a/share/completions/termux-sensor.fish
+++ b/share/completions/termux-sensor.fish
@@ -1,61 +1,20 @@
-function __fish_termux_api__complete_sensor_ids_as_list
-    set ids (__fish_termux_api__complete_sensor_ids)
-    set token (commandline -t -c)
-
-    set delimiter ,
-
-    switch "$token"
-        case '*,'
-            set delimiter
-    end
-
-    test -z "$token" && set delimiter
-
-    for id in $ids
-        string unescape -- "$token$delimiter$id"
-    end
-end
-
-set command termux-sensor
+set -l command termux-sensor
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -l help \
-    -d 'Show help'
+complete -c $command -s h -l help -d 'Show help'
 
-complete -c $command \
-    -s a \
-    -l all \
-    -d 'Listen to all sensors'
+complete -c $command -s a -l all -d 'Listen to all sensors'
+complete -c $command -s c -l cleanup -d 'Release sensor resources'
+complete -c $command -s l -l list -d 'List sensors'
 
-complete -c $command \
-    -s c \
-    -l cleanup \
-    -d 'Release sensor resources'
+complete -c $command -s s -l sensors -x \
+    -a '(__fish_complete_list , __fish_termux_api__complete_sensor_ids)' \
+    -d 'Specify comma-separated sensors to listen to'
 
-complete -c $command \
-    -s l \
-    -l list \
-    -d 'List sensors'
+complete -c $command -s d -l delay -x \
+    -d 'Specify the delay between sensor updates'
 
-complete -c $command \
-    -a '(__fish_termux_api__complete_sensor_ids_as_list)' \
-    -s s \
-    -l sensors \
-    -d 'Specify comma-separated sensors to listen to' \
-    -x
-
-complete -c $command \
-    -s d \
-    -l delay \
-    -d 'Specify the delay between sensor updates' \
-    -x
-
-complete -c $command \
+complete -c $command -s n -l limit -x \
     -a 'continuous\tdefault' \
-    -s n \
-    -l limit \
-    -d 'Specify a number of times to read senors' \
-    -x
+    -d 'Specify a number of times to read senors'

--- a/share/completions/termux-sensor.fish
+++ b/share/completions/termux-sensor.fish
@@ -1,0 +1,61 @@
+function __fish_termux_api__complete_sensor_ids_as_list
+    set ids (__fish_termux_api__complete_sensor_ids)
+    set token (commandline -t -c)
+
+    set delimiter ,
+
+    switch "$token"
+        case '*,'
+            set delimiter
+    end
+
+    test -z "$token" && set delimiter
+
+    for id in $ids
+        string unescape -- "$token$delimiter$id"
+    end
+end
+
+set command termux-sensor
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -l help \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s a \
+    -l all \
+    -d 'Listen to all sensors'
+
+complete -c $command \
+    -s c \
+    -l cleanup \
+    -d 'Release sensor resources'
+
+complete -c $command \
+    -s l \
+    -l list \
+    -d '[l]ist sensors'
+
+complete -c $command \
+    -a '(__fish_termux_api__complete_sensor_ids_as_list)' \
+    -s s \
+    -l sensors \
+    -d 'Specify comma-separated [s]ensors to listen to' \
+    -x
+
+complete -c $command \
+    -s d \
+    -l delay \
+    -d 'Specify an interval between sensor updates' \
+    -x
+
+complete -c $command \
+    -a 'continuous\tdefault' \
+    -s n \
+    -l limit \
+    -d 'Specify a number of times to read senors' \
+    -x

--- a/share/completions/termux-sensor.fish
+++ b/share/completions/termux-sensor.fish
@@ -28,7 +28,7 @@ complete -c $command \
 complete -c $command \
     -s a \
     -l all \
-    -d 'Listen to all sensors'
+    -d 'Listen to [a]ll sensors'
 
 complete -c $command \
     -s c \
@@ -50,12 +50,12 @@ complete -c $command \
 complete -c $command \
     -s d \
     -l delay \
-    -d 'Specify an interval between sensor updates' \
+    -d 'Specify the [d]elay between sensor updates' \
     -x
 
 complete -c $command \
     -a 'continuous\tdefault' \
     -s n \
     -l limit \
-    -d 'Specify a number of times to read senors' \
+    -d 'Specify a [n]umber of times to read senors' \
     -x

--- a/share/completions/termux-sensor.fish
+++ b/share/completions/termux-sensor.fish
@@ -23,12 +23,12 @@ complete -c $command -f
 complete -c $command \
     -s h \
     -l help \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s a \
     -l all \
-    -d 'Listen to [a]ll sensors'
+    -d 'Listen to all sensors'
 
 complete -c $command \
     -s c \
@@ -38,24 +38,24 @@ complete -c $command \
 complete -c $command \
     -s l \
     -l list \
-    -d '[l]ist sensors'
+    -d 'List sensors'
 
 complete -c $command \
     -a '(__fish_termux_api__complete_sensor_ids_as_list)' \
     -s s \
     -l sensors \
-    -d 'Specify comma-separated [s]ensors to listen to' \
+    -d 'Specify comma-separated sensors to listen to' \
     -x
 
 complete -c $command \
     -s d \
     -l delay \
-    -d 'Specify the [d]elay between sensor updates' \
+    -d 'Specify the delay between sensor updates' \
     -x
 
 complete -c $command \
     -a 'continuous\tdefault' \
     -s n \
     -l limit \
-    -d 'Specify a [n]umber of times to read senors' \
+    -d 'Specify a number of times to read senors' \
     -x

--- a/share/completions/termux-share.fish
+++ b/share/completions/termux-share.fish
@@ -14,4 +14,3 @@ complete -c $command -s c \
 
 complete -c $command -s d -d 'Specify the receiver of a content'
 complete -c $command -s t -x -d 'Specify the title of a content'
-    

--- a/share/completions/termux-share.fish
+++ b/share/completions/termux-share.fish
@@ -5,18 +5,18 @@ complete -c $command -f
 complete -c $command \
     -s h \
     -l help \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a 'view\tdefault edit send' \
     -s a \
-    -d 'Specify the [a]ction to perform on a content' \
+    -d 'Specify the action to perform on a content' \
     -x
 
 complete -c $command \
     -a 'text/plain\tdefault' \
     -s c \
-    -d 'Specify the type of a [c]ontent'
+    -d 'Specify the type of a content'
 
 complete -c $command \
     -s d \
@@ -24,5 +24,5 @@ complete -c $command \
 
 complete -c $command \
     -s t \
-    -d 'Specify the [t]itle of a content' \
+    -d 'Specify the title of a content' \
     -x

--- a/share/completions/termux-share.fish
+++ b/share/completions/termux-share.fish
@@ -1,0 +1,28 @@
+set command termux-share
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -l help \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a 'view\tdefault edit send' \
+    -s a \
+    -d 'Specify the [a]ction to perform on a content' \
+    -x
+
+complete -c $command \
+    -a 'text/plain\tdefault' \
+    -s c \
+    -d 'Specify the type of a [c]ontent'
+
+complete -c $command \
+    -s d \
+    -d 'Specify the receiver of a content'
+
+complete -c $command \
+    -s t \
+    -d 'Specify the [t]itle of a content' \
+    -x

--- a/share/completions/termux-share.fish
+++ b/share/completions/termux-share.fish
@@ -1,28 +1,17 @@
-set command termux-share
+set -l command termux-share
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -l help \
-    -d 'Show help'
+complete -c $command -s h -l help -d 'Show help'
 
-complete -c $command \
+complete -c $command -s a -x \
     -a 'view\tdefault edit send' \
-    -s a \
-    -d 'Specify the action to perform on a content' \
-    -x
+    -d 'Specify the action to perform on a content'
 
-complete -c $command \
+complete -c $command -s c \
     -a 'text/plain\tdefault' \
-    -s c \
     -d 'Specify the type of a content'
 
-complete -c $command \
-    -s d \
-    -d 'Specify the receiver of a content'
-
-complete -c $command \
-    -s t \
-    -d 'Specify the title of a content' \
-    -x
+complete -c $command -s d -d 'Specify the receiver of a content'
+complete -c $command -s t -x -d 'Specify the title of a content'
+    

--- a/share/completions/termux-sms-list.fish
+++ b/share/completions/termux-sms-list.fish
@@ -1,33 +1,21 @@
-set command termux-sms-list
+set -l command termux-sms-list
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -s d \
-    -d 'Show the creation dates of listed messages'
+complete -c $command -s d -d 'Show the creation dates of listed messages'
 
-complete -c $command \
+complete -c $command -s l -x \
     -a '10\tdefault' \
-    -s l \
-    -d 'Limit the amount of listed messages' \
-    -x
+    -d 'Limit the amount of listed messages'
 
-complete -c $command \
-    -s n \
-    -d 'Show the phone numbers of listed messages'
+complete -c $command -s n -d 'Show the phone numbers of listed messages'
 
-complete -c $command \
+complete -c $command -s o -x \
     -a '0\tdefault' \
-    -s o \
-    -d 'Start listing calls with the specificed one' \
-    -x
+    -d 'Start listing calls with the specificed one'
 
-complete -c $command \
+complete -c $command -s t -x \
     -a 'inbox\tdefault all sent draft outbox' \
-    -s t \
-    -d 'Filter listed messages by the type' \
-    -x
+    -d 'Filter listed messages by the type'

--- a/share/completions/termux-sms-list.fish
+++ b/share/completions/termux-sms-list.fish
@@ -1,0 +1,33 @@
+set command termux-sms-list
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s d \
+    -d 'Show the creation [d]ates of listed messages'
+
+complete -c $command \
+    -a '10\tdefault' \
+    -s l \
+    -d '[l]imit the amount of listed messages' \
+    -x
+
+complete -c $command \
+    -s n \
+    -d 'Show the phone [n]umbers of listed messages'
+
+complete -c $command \
+    -a '0\tdefault' \
+    -s o \
+    -d 'Start listing calls with the specificed one' \
+    -x
+
+complete -c $command \
+    -a 'inbox\tdefault all sent draft outbox' \
+    -s t \
+    -d 'Filter listed messages by the [t]ype' \
+    -x

--- a/share/completions/termux-sms-list.fish
+++ b/share/completions/termux-sms-list.fish
@@ -4,21 +4,21 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s d \
-    -d 'Show the creation [d]ates of listed messages'
+    -d 'Show the creation dates of listed messages'
 
 complete -c $command \
     -a '10\tdefault' \
     -s l \
-    -d '[l]imit the amount of listed messages' \
+    -d 'Limit the amount of listed messages' \
     -x
 
 complete -c $command \
     -s n \
-    -d 'Show the phone [n]umbers of listed messages'
+    -d 'Show the phone numbers of listed messages'
 
 complete -c $command \
     -a '0\tdefault' \
@@ -29,5 +29,5 @@ complete -c $command \
 complete -c $command \
     -a 'inbox\tdefault all sent draft outbox' \
     -s t \
-    -d 'Filter listed messages by the [t]ype' \
+    -d 'Filter listed messages by the type' \
     -x

--- a/share/completions/termux-sms-send.fish
+++ b/share/completions/termux-sms-send.fish
@@ -1,0 +1,18 @@
+set command termux-sms-list
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a '(__fish_complete_list , __fish_termux_api__complete_phone_numbers)' \
+    -s n \
+    -d 'Specify the recipient [n]umbers of a message' \
+    -x
+
+complete -c $command \
+    -s s \
+    -d 'Specify the sim [s]lot to use for a message' \
+    -x

--- a/share/completions/termux-sms-send.fish
+++ b/share/completions/termux-sms-send.fish
@@ -4,15 +4,15 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a '(__fish_complete_list , __fish_termux_api__complete_phone_numbers)' \
     -s n \
-    -d 'Specify the recipient [n]umbers of a message' \
+    -d 'Specify the recipient numbers of a message' \
     -x
 
 complete -c $command \
     -s s \
-    -d 'Specify the sim [s]lot to use for a message' \
+    -d 'Specify the sim slot to use for a message' \
     -x

--- a/share/completions/termux-sms-send.fish
+++ b/share/completions/termux-sms-send.fish
@@ -1,18 +1,11 @@
-set command termux-sms-list
+set -l command termux-sms-list
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
+complete -c $command -s n -x \
     -a '(__fish_complete_list , __fish_termux_api__complete_phone_numbers)' \
-    -s n \
-    -d 'Specify the recipient numbers of a message' \
-    -x
+    -d 'Specify the recipient numbers of a message'
 
-complete -c $command \
-    -s s \
-    -d 'Specify the sim slot to use for a message' \
-    -x
+complete -c $command -s s -x -d 'Specify the sim slot to use for a message'

--- a/share/completions/termux-telephony-call.fish
+++ b/share/completions/termux-telephony-call.fish
@@ -4,7 +4,7 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a '(__fish_termux_api__complete_phone_numbers)'

--- a/share/completions/termux-telephony-call.fish
+++ b/share/completions/termux-telephony-call.fish
@@ -1,10 +1,7 @@
-set command termux-telephony-call
+set -l command termux-telephony-call
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -a '(__fish_termux_api__complete_phone_numbers)'
+complete -c $command -a '(__fish_termux_api__complete_phone_numbers)'

--- a/share/completions/termux-telephony-call.fish
+++ b/share/completions/termux-telephony-call.fish
@@ -1,0 +1,10 @@
+set command termux-telephony-call
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a '(__fish_termux_api__complete_phone_numbers)'

--- a/share/completions/termux-toast.fish
+++ b/share/completions/termux-toast.fish
@@ -1,29 +1,19 @@
-set command termux-toast
+set -l command termux-toast
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
+complete -c $command -s b -x \
     -a '(__fish_termux_api__complete_colors)' \
-    -s b \
-    -d 'Specify the background color of a message' \
-    -x
+    -d 'Specify the background color of a message'
 
-complete -c $command \
+complete -c $command -s c -x \
     -a '(__fish_termux_api__complete_colors)' \
-    -s c \
-    -d 'Specify the text color of a message' \
-    -x
+    -d 'Specify the text color of a message'
 
-complete -c $command \
+complete -c $command -s g -x \
     -a 'middle\tdefault top bottom' \
-    -s g \
-    -d 'Specify the position of a message' \
-    -x
+    -d 'Specify the position of a message'
 
-complete -c $command \
-    -s s \
-    -d 'Show a message for the short period of time'
+complete -c $command -s s -d 'Show a message for the short period of time'

--- a/share/completions/termux-toast.fish
+++ b/share/completions/termux-toast.fish
@@ -4,18 +4,18 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a '(__fish_termux_api__complete_colors)' \
     -s b \
-    -d 'Specify the [b]ackground color of a message' \
+    -d 'Specify the background color of a message' \
     -x
 
 complete -c $command \
     -a '(__fish_termux_api__complete_colors)' \
     -s c \
-    -d 'Specify the text [c]olor of a message' \
+    -d 'Specify the text color of a message' \
     -x
 
 complete -c $command \
@@ -26,4 +26,4 @@ complete -c $command \
 
 complete -c $command \
     -s s \
-    -d 'Show a message for the [s]hort period of time'
+    -d 'Show a message for the short period of time'

--- a/share/completions/termux-toast.fish
+++ b/share/completions/termux-toast.fish
@@ -1,0 +1,29 @@
+set command termux-toast
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a '(__fish_termux_api__complete_colors)' \
+    -s b \
+    -d 'Specify the [b]ackground color of a message' \
+    -x
+
+complete -c $command \
+    -a '(__fish_termux_api__complete_colors)' \
+    -s c \
+    -d 'Specify the text [c]olor of a message' \
+    -x
+
+complete -c $command \
+    -a 'middle\tdefault top bottom' \
+    -s g \
+    -d 'Specify the position of a message' \
+    -x
+
+complete -c $command \
+    -s s \
+    -d 'Show a message for the [s]hort period of time'

--- a/share/completions/termux-torch.fish
+++ b/share/completions/termux-torch.fish
@@ -1,11 +1,7 @@
-set command termux-torch
+set -l command termux-torch
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -a 'on off' \
-    -d 'Toggle the LED torch of a device' \
+complete -c $command -a 'on off' -d 'Toggle the LED torch of a device'

--- a/share/completions/termux-torch.fish
+++ b/share/completions/termux-torch.fish
@@ -4,7 +4,7 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a 'on off' \

--- a/share/completions/termux-torch.fish
+++ b/share/completions/termux-torch.fish
@@ -1,0 +1,11 @@
+set command termux-torch
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a 'on off' \
+    -d 'Toggle the LED torch of a device' \

--- a/share/completions/termux-tts-speak.fish
+++ b/share/completions/termux-tts-speak.fish
@@ -38,7 +38,7 @@ complete -c $command \
     -x
 
 complete -c $command \
-    -a 'notification\tdefault alarm music ring system voice_call' \
+    -a '(__fish_termux_api__complete_stream_ids | string replace --regex "(notification)" "\$1\tdefault")' \
     -s s \
     -d 'Specify the [s]tream for a speech' \
     -x

--- a/share/completions/termux-tts-speak.fish
+++ b/share/completions/termux-tts-speak.fish
@@ -1,44 +1,19 @@
-set command termux-tts-speak
+set -l command termux-tts-speak
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
+complete -c $command -s e -x \
     -a '(__fish_termux_api__complete_tts_engines)' \
-    -s e \
-    -d 'Specify the TTS engine for a speech' \
-    -x
+    -d 'Specify the TTS engine for a speech'
 
-complete -c $command \
-    -s l \
-    -d 'Specify the language of a speech' \
-    -x
+complete -c $command -s l -x -d 'Specify the language of a speech'
+complete -c $command -s n -x -d 'Specify the region of a speech'
+complete -c $command -s v -x -d 'Specify the language variant of a speech'
+complete -c $command -s p -x -d 'Specify the pitch of a speech'
+complete -c $command -s r -x -d 'Specify the rate of a speech'
 
-complete -c $command \
-    -s n \
-    -d 'Specify the region of a speech' \
-    -x
-
-complete -c $command \
-    -s v \
-    -d 'Specify the language variant of a speech' \
-    -x
-
-complete -c $command \
-    -s p \
-    -d 'Specify the pitch of a speech' \
-    -x
-
-complete -c $command \
-    -s r \
-    -d 'Specify the rate of a speech' \
-    -x
-
-complete -c $command \
+complete -c $command -s s -x \
     -a '(__fish_termux_api__complete_stream_ids | string replace --regex "(notification)" "\$1\tdefault")' \
-    -s s \
-    -d 'Specify the stream for a speech' \
-    -x
+    -d 'Specify the stream for a speech'

--- a/share/completions/termux-tts-speak.fish
+++ b/share/completions/termux-tts-speak.fish
@@ -4,41 +4,41 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a '(__fish_termux_api__complete_tts_engines)' \
     -s e \
-    -d 'Specify the TTS [e]ngine for a speech' \
+    -d 'Specify the TTS engine for a speech' \
     -x
 
 complete -c $command \
     -s l \
-    -d 'Specify the [l]anguage of a speech' \
+    -d 'Specify the language of a speech' \
     -x
 
 complete -c $command \
     -s n \
-    -d 'Specify the regio[n] of a speech' \
+    -d 'Specify the region of a speech' \
     -x
 
 complete -c $command \
     -s v \
-    -d 'Specify the language [v]ariant of a speech' \
+    -d 'Specify the language variant of a speech' \
     -x
 
 complete -c $command \
     -s p \
-    -d 'Specify the [p]itch of a speech' \
+    -d 'Specify the pitch of a speech' \
     -x
 
 complete -c $command \
     -s r \
-    -d 'Specify the [r]ate of a speech' \
+    -d 'Specify the rate of a speech' \
     -x
 
 complete -c $command \
     -a '(__fish_termux_api__complete_stream_ids | string replace --regex "(notification)" "\$1\tdefault")' \
     -s s \
-    -d 'Specify the [s]tream for a speech' \
+    -d 'Specify the stream for a speech' \
     -x

--- a/share/completions/termux-tts-speak.fish
+++ b/share/completions/termux-tts-speak.fish
@@ -1,0 +1,44 @@
+set command termux-tts-speak
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a '(__fish_termux_api__complete_tts_engines)' \
+    -s e \
+    -d 'Specify the TTS [e]ngine for a speech' \
+    -x
+
+complete -c $command \
+    -s l \
+    -d 'Specify the [l]anguage of a speech' \
+    -x
+
+complete -c $command \
+    -s n \
+    -d 'Specify the regio[n] of a speech' \
+    -x
+
+complete -c $command \
+    -s v \
+    -d 'Specify the language [v]ariant of a speech' \
+    -x
+
+complete -c $command \
+    -s p \
+    -d 'Specify the [p]itch of a speech' \
+    -x
+
+complete -c $command \
+    -s r \
+    -d 'Specify the [r]ate of a speech' \
+    -x
+
+complete -c $command \
+    -a 'NOTIFICATION\tdefault ALARM MUSIC RING SYSTEM VOICE_CALL' \
+    -s s \
+    -d 'Specify the [s]tream for a speech' \
+    -x

--- a/share/completions/termux-tts-speak.fish
+++ b/share/completions/termux-tts-speak.fish
@@ -38,7 +38,7 @@ complete -c $command \
     -x
 
 complete -c $command \
-    -a 'NOTIFICATION\tdefault ALARM MUSIC RING SYSTEM VOICE_CALL' \
+    -a 'notification\tdefault alarm music ring system voice_call' \
     -s s \
     -d 'Specify the [s]tream for a speech' \
     -x

--- a/share/completions/termux-usb.fish
+++ b/share/completions/termux-usb.fish
@@ -1,0 +1,21 @@
+set command termux-usb
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s l \
+    -d '[l]ist all devices'
+
+complete -c $command \
+    -s r \
+    -d 'Show the permission [r]equest dialog for a device'
+
+complete -c $command \
+    -s e \
+    -d '[e]xecute the specified command for a device' \
+    -x
+    

--- a/share/completions/termux-usb.fish
+++ b/share/completions/termux-usb.fish
@@ -4,18 +4,18 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s l \
-    -d '[l]ist all devices'
+    -d 'List all devices'
 
 complete -c $command \
     -s r \
-    -d 'Show the permission [r]equest dialog for a device'
+    -d 'Show the permission request dialog for a device'
 
 complete -c $command \
     -s e \
-    -d '[e]xecute the specified command for a device' \
+    -d 'execute the specified command for a device' \
     -x
     

--- a/share/completions/termux-usb.fish
+++ b/share/completions/termux-usb.fish
@@ -1,21 +1,9 @@
-set command termux-usb
+set -l command termux-usb
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -s l \
-    -d 'List all devices'
-
-complete -c $command \
-    -s r \
-    -d 'Show the permission request dialog for a device'
-
-complete -c $command \
-    -s e \
-    -d 'execute the specified command for a device' \
-    -x
-    
+complete -c $command -s l -d 'List all devices'
+complete -c $command -s r -d 'Show the permission request dialog for a device'
+complete -c $command -s e -x -d 'Execute the specified command for a device'

--- a/share/completions/termux-vibrate.fish
+++ b/share/completions/termux-vibrate.fish
@@ -1,0 +1,17 @@
+set command termux-vibrate
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a '1000\tdefault' \
+    -s d \
+    -d 'Specify the [d]uration of a vibration' \
+    -x
+
+complete -c $command \
+    -s f \
+    -d 'Vibrate in a silent mode too'

--- a/share/completions/termux-vibrate.fish
+++ b/share/completions/termux-vibrate.fish
@@ -4,12 +4,12 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a '1000\tdefault' \
     -s d \
-    -d 'Specify the [d]uration of a vibration' \
+    -d 'Specify the duration of a vibration' \
     -x
 
 complete -c $command \

--- a/share/completions/termux-vibrate.fish
+++ b/share/completions/termux-vibrate.fish
@@ -1,17 +1,11 @@
-set command termux-vibrate
+set -l command termux-vibrate
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
+complete -c $command -s d -x \
     -a '1000\tdefault' \
-    -s d \
-    -d 'Specify the duration of a vibration' \
-    -x
+    -d 'Specify the duration of a vibration'
 
-complete -c $command \
-    -s f \
-    -d 'Vibrate in a silent mode too'
+complete -c $command -s f -d 'Vibrate in a silent mode too'

--- a/share/completions/termux-volume.fish
+++ b/share/completions/termux-volume.fish
@@ -1,0 +1,7 @@
+set command termux-volume
+
+complete -c $command -f
+
+complete -c $command \
+    -a '(__fish_termux_api__complete_stream_ids)' \
+    -d 'Specify the [s]tream for a volume'

--- a/share/completions/termux-volume.fish
+++ b/share/completions/termux-volume.fish
@@ -4,4 +4,4 @@ complete -c $command -f
 
 complete -c $command \
     -a '(__fish_termux_api__complete_stream_ids)' \
-    -d 'Specify the [s]tream for a volume'
+    -d 'Specify the stream for a volume'

--- a/share/completions/termux-volume.fish
+++ b/share/completions/termux-volume.fish
@@ -1,7 +1,6 @@
-set command termux-volume
+set -l command termux-volume
 
 complete -c $command -f
 
-complete -c $command \
-    -a '(__fish_termux_api__complete_stream_ids)' \
+complete -c $command -a '(__fish_termux_api__complete_stream_ids)' \
     -d 'Specify the stream for a volume'

--- a/share/completions/termux-wallpaper.fish
+++ b/share/completions/termux-wallpaper.fish
@@ -4,18 +4,18 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -s f \
-    -d 'Specify the [f]ile of a wallpaper' \
+    -d 'Specify the file of a wallpaper' \
     -F -r
 
 complete -c $command \
     -s u \
-    -d 'Specify the [u]RL of a wallpaper' \
+    -d 'Specify the uRL of a wallpaper' \
     -F -r
 
 complete -c $command \
     -s l \
-    -d 'Set a wallpaper for the [l]ockscreen'
+    -d 'Set a wallpaper for the lockscreen'

--- a/share/completions/termux-wallpaper.fish
+++ b/share/completions/termux-wallpaper.fish
@@ -1,0 +1,21 @@
+set command termux-wallpaper
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -s f \
+    -d 'Specify the [f]ile of a wallpaper' \
+    -F -r
+
+complete -c $command \
+    -s u \
+    -d 'Specify the [u]RL of a wallpaper' \
+    -F -r
+
+complete -c $command \
+    -s l \
+    -d 'Set a wallpaper for the [l]ockscreen'

--- a/share/completions/termux-wallpaper.fish
+++ b/share/completions/termux-wallpaper.fish
@@ -1,21 +1,9 @@
-set command termux-wallpaper
+set -l command termux-wallpaper
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -s f \
-    -d 'Specify the file of a wallpaper' \
-    -F -r
-
-complete -c $command \
-    -s u \
-    -d 'Specify the uRL of a wallpaper' \
-    -F -r
-
-complete -c $command \
-    -s l \
-    -d 'Set a wallpaper for the lockscreen'
+complete -c $command -s f -F -r -d 'Specify the file of a wallpaper'
+complete -c $command -s u -F -r -d 'Specify the uRL of a wallpaper'
+complete -c $command -s l -d 'Set a wallpaper for the lockscreen'

--- a/share/completions/termux-wifi-enable.fish
+++ b/share/completions/termux-wifi-enable.fish
@@ -4,7 +4,7 @@ complete -c $command -f
 
 complete -c $command \
     -s h \
-    -d 'Show [h]elp'
+    -d 'Show help'
 
 complete -c $command \
     -a 'true false' \

--- a/share/completions/termux-wifi-enable.fish
+++ b/share/completions/termux-wifi-enable.fish
@@ -1,11 +1,8 @@
-set command termux-wifi-enable
+set -l command termux-wifi-enable
 
 complete -c $command -f
 
-complete -c $command \
-    -s h \
-    -d 'Show help'
+complete -c $command -s h -d 'Show help'
 
-complete -c $command \
-    -a 'true false' \
+complete -c $command -a 'true false' \
     -d 'Toggle the WiFi availability of a device'

--- a/share/completions/termux-wifi-enable.fish
+++ b/share/completions/termux-wifi-enable.fish
@@ -1,0 +1,11 @@
+set command termux-wifi-enable
+
+complete -c $command -f
+
+complete -c $command \
+    -s h \
+    -d 'Show [h]elp'
+
+complete -c $command \
+    -a 'true false' \
+    -d 'Toggle the WiFi availability of a device'

--- a/share/functions/__fish_termux_api__complete_camera_ids.fish
+++ b/share/functions/__fish_termux_api__complete_camera_ids.fish
@@ -1,0 +1,11 @@
+function __fish_termux_api__complete_camera_ids
+    set -l command termux-camera-info
+    set ids ($command | jq --raw-output '.[].id')
+    set types ($command | jq --raw-output '.[].facing')
+
+    printf "0\tdefault\n"
+
+    for index in (seq (count $ids))
+        printf "%s\t%s\n" $ids[$index] $types[$index]
+    end
+end

--- a/share/functions/__fish_termux_api__complete_colors.fish
+++ b/share/functions/__fish_termux_api__complete_colors.fish
@@ -1,0 +1,3 @@
+function __fish_termux_api__complete_colors
+    set_color --print-colors | string match --invert --regex '^(br.*|normal)$'
+end

--- a/share/functions/__fish_termux_api__complete_group_ids.fish
+++ b/share/functions/__fish_termux_api__complete_group_ids.fish
@@ -1,0 +1,15 @@
+function __fish_termux_api__complete_group_ids
+    set -l command termux-notification-list
+    set ids ($command | jq --raw-output '.[].group')
+    set titles ($command | jq --raw-output '.[].title')
+
+    for index in (seq (count $ids))
+        set -l id $ids[$index]
+        set -l title $titles[$index]
+
+        test -z "$id" && continue
+        test -z "$title" && set title "Unknown title"
+
+        printf "%s\t%s\n" $id $title
+    end
+end

--- a/share/functions/__fish_termux_api__complete_phone_numbers.fish
+++ b/share/functions/__fish_termux_api__complete_phone_numbers.fish
@@ -1,0 +1,15 @@
+function __fish_termux_api__complete_phone_numbers
+    set -l command termux-contact-list
+    set numbers ($command | jq --raw-output '.[].number')
+    set names ($command | jq --raw-output '.[].name')
+
+    for index in (seq (count $numbers))
+        set -l number $numbers[$index]
+        set -l name $names[$index]
+
+        test -z "$number" && continue
+        test -z "$name" && set name "Unknown name"
+
+        printf "%s\t%s\n" $number $name
+    end
+end

--- a/share/functions/__fish_termux_api__complete_sensor_ids.fish
+++ b/share/functions/__fish_termux_api__complete_sensor_ids.fish
@@ -1,0 +1,6 @@
+function __fish_termux_api__complete_sensor_ids
+    set -l command termux-sensor -l
+    set ids ($command | jq --raw-output '.sensors[]')
+
+    string join \n -- $ids
+end

--- a/share/functions/__fish_termux_api__complete_stream_ids.fish
+++ b/share/functions/__fish_termux_api__complete_stream_ids.fish
@@ -1,0 +1,3 @@
+function __fish_termux_api__complete_stream_ids
+    string join \n -- notification alarm music ring system voice_call
+end

--- a/share/functions/__fish_termux_api__complete_tts_engines.fish
+++ b/share/functions/__fish_termux_api__complete_tts_engines.fish
@@ -1,0 +1,9 @@
+function __fish_termux_api__complete_tts_engines
+    set -l command termux-tts-engines
+    set ids ($command | jq --raw-output '.[].name')
+    set labels ($command | jq --raw-output '.[].label')
+
+    for index in (seq (count $ids))
+        printf "%s\t%s\n" $ids[$index] $labels[$index]
+    end
+end


### PR DESCRIPTION
## Description

Add completions for: [`termux-*`](https://wiki.termux.com/wiki/Termux:API).

Fixes issue #

## Features

- [x] Positional and option arguments are completed in cases documentation clearly states what valid values are
- [x] Default values for switches are suggested
- [x] File completion is disabled where appropriate

## Progress

- [x] Completions are created for all Termux commands where help page includes at least one positional argument or switch
- [x] Completion descriptions are standardized
- [x] Code is refactored

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
