### PR TITLE
Unescape strings for `__fish_complete_list`

### DIFF
--- a/share/functions/__fish_complete_list.fish
+++ b/share/functions/__fish_complete_list.fish
@@ -18,11 +18,11 @@ where:
     switch $pat
         case "*$div*"
             for i in (echo $pat | sed "s/^\(.\+$div\)$iprefix.*\$/\1/")$iprefix(eval $cmd)
-                echo $i
+                string unescape -- $i
             end
         case '*'
             for i in $prefix$iprefix(eval $cmd)
-                echo $i
+                string unescape -- $i
             end
     end
 


### PR DESCRIPTION
## Description

Unescape strings for `__fish_complete_list`.

Fixes issue #10726

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
