### PR TITLE
Default bindings for token movement commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Notable backwards-incompatible changes
   See :ref:`below <changelog-new-bindings>` for details.
 - Fish no longer supports terminals that fail to ignore OSC or CSI sequences they don't recognize.
   The typical problem is that terminals echo the raw sequences sent by fish instead of silently ignoring them.
+- :kbd:`alt-left` and :kbd:`alt-right` will now move by one argument (which may contain quoted spaces), not just one word.
+- :kbd:`alt-backspace` will delete an entire argument, not just one word.
 - ``random`` now uses a different random number generator and so the values you get even with the same seed have changed.
   Notably, it will now work much more sensibly with very small seeds.
   The seed was never guaranteed to give the same result across systems,
@@ -162,6 +164,7 @@ New or improved bindings
 - During up-arrow history search, :kbd:`shift-delete` will delete the current search item and move to the next older item. Previously this was only supported in the history pager.
   Same for autosuggestions.
 - :kbd:`ctrl-Z` (also known as :kbd:`ctrl-shift-z`) is now bound to redo.
+- :kbd:`alt-delete` now deletes the argument (which may contain quoted spaces) right of the cursor.
 - Some improvements to the :kbd:`alt-e` binding which edits the commandline in an external editor:
   - The editor's cursor position is copied back to fish. This is currently supported for Vim and Kakoune.
   - Cursor position synchronization is only supported for a set of known editors. This has been extended by also resolving aliases. For example use ``complete --wraps my-vim vim`` to synchronize cursors when ``EDITOR=my-vim``.

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -303,7 +303,7 @@ Some bindings are common across Emacs and vi mode, because they aren't text edit
 
 - :kbd:`alt-enter` inserts a newline at the cursor position. This is useful to add a line to a commandline that's already complete.
 
-- :kbd:`alt-left` (``←``) and :kbd:`alt-right` (``→``) move the cursor one word left or right (to the next space or punctuation mark), or moves forward/backward in the directory history if the command line is empty. If the cursor is already at the end of the line, and an autosuggestion is available, :kbd:`alt-right` (``→``) (or :kbd:`alt-f`) accepts the first word in the suggestion.
+- :kbd:`alt-left` (``←``) and :kbd:`alt-right` (``→``) move the cursor one argument left or right, or moves forward/backward in the directory history if the command line is empty. If the cursor is already at the end of the line, and an autosuggestion is available, :kbd:`alt-right` (``→``) (or :kbd:`alt-f`) accepts the first argument in the suggestion.
 
 - :kbd:`ctrl-left` (``←``) and :kbd:`ctrl-right` (``→``) move the cursor one word left or right. These accept one word of the autosuggestion - the part they'd move over.
 
@@ -326,6 +326,8 @@ Some bindings are common across Emacs and vi mode, because they aren't text edit
 - :kbd:`ctrl-x` copies the current buffer to the system's clipboard, :kbd:`ctrl-v` inserts the clipboard contents. (see :doc:`fish_clipboard_copy <cmds/fish_clipboard_copy>` and :doc:`fish_clipboard_paste <cmds/fish_clipboard_paste>`)
 
 - :kbd:`alt-d` or :kbd:`ctrl-delete` moves the next word to the :ref:`killring`.
+
+- :kbd:`alt-delete` moves the next argument to the :ref:`killring`.
 
 - :kbd:`alt-h` (or :kbd:`f1`) shows the manual page for the current command, if one exists.
 
@@ -360,9 +362,9 @@ To enable emacs mode, use :doc:`fish_default_key_bindings <cmds/fish_default_key
 
 - :kbd:`ctrl-n`, :kbd:`ctrl-p` move the cursor up/down or through history, like the up and down arrow shared bindings.
 
-- :kbd:`delete` or :kbd:`backspace` removes one character forwards or backwards respectively. This also goes for :kbd:`ctrl-h`, which is indistinguishable from backspace.
+- :kbd:`delete` or :kbd:`backspace` or :kbd:`ctrl-h` removes one character forwards or backwards respectively.
 
-- :kbd:`alt-backspace` removes one word backwards. If supported by the terminal, :kbd:`ctrl-backspace` does the same.
+- :kbd:`ctrl-backspace` removes one word backwards and :kbd:`alt-backspace` removes one argument backwards.
 
 - :kbd:`alt-<` moves to the beginning of the commandline, :kbd:`alt->` moves to the end.
 

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -54,8 +54,8 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     $legacy_bind --preset $argv -k sright forward-bigword
     $legacy_bind --preset $argv -k sleft backward-bigword
 
-    bind --preset $argv alt-right nextd-or-forward-word
-    bind --preset $argv alt-left prevd-or-backward-word
+    bind --preset $argv alt-right nextd-or-forward-token
+    bind --preset $argv alt-left prevd-or-backward-token
 
     bind --preset $argv alt-up history-token-search-backward
     bind --preset $argv alt-down history-token-search-forward

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -74,9 +74,10 @@ function fish_default_key_bindings -d "emacs-like key binds"
     bind --preset $argv alt-u upcase-word
 
     bind --preset $argv alt-c capitalize-word
-    bind --preset $argv alt-backspace backward-kill-word
+    bind --preset $argv alt-backspace backward-kill-token
     bind --preset $argv ctrl-backspace backward-kill-word
     bind --preset $argv ctrl-delete kill-word
+    bind --preset $argv alt-delete kill-token
     bind --preset $argv alt-b backward-word
     bind --preset $argv alt-f forward-word
     if test "$TERM_PROGRAM" = Apple_Terminal

--- a/share/functions/nextd-or-forward-token.fish
+++ b/share/functions/nextd-or-forward-token.fish
@@ -1,0 +1,8 @@
+function nextd-or-forward-token --description "If commandline is empty, run nextd; else move one argument to the right"
+    if test "$(commandline; printf .)" = \n.
+        nextd
+        commandline -f repaint
+        return
+    end
+    commandline -f forward-token
+end

--- a/share/functions/prevd-or-backward-token.fish
+++ b/share/functions/prevd-or-backward-token.fish
@@ -1,0 +1,8 @@
+function prevd-or-backward-token --description "If commandline is empty, run prevd; else move one argument to the left"
+    if test "$(commandline; printf .)" = \n.
+        prevd
+        commandline -f repaint
+        return
+    end
+    commandline -f backward-token
+end


### PR DESCRIPTION
There is no natural default binding for token movements. Add
alt-{left,right,backspace,delete} bindings, breaking some existing behavior.

Many terminals don't support distinguishing ctrl-backspace from ctrl-h yet.
Add a special hack for those terminals, to keep the existing alt-backspace
behavior of killing a word, since that one seems more important to have
access to than kill-token.

I guess we could also add:

    bind alt-B backward-token
    bind alt-F forward-token
    bind ctrl-W backward-kill-token
    bind alt-D kill-token

Those might be intercepted by the terminal on Linux, but I don't know where
that happens.

Tested on foot, kitty, alacritty, xterm, tmux, konsole and gnome-terminal.
