### PR TITLE
Fix old history being momentarily forgotten after history file rewrite

### DIFF
--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -361,10 +361,7 @@ fn extract_prefix_and_unescape_yaml(line: &[u8]) -> Option<(Cow<[u8]>, Cow<[u8]>
 fn decode_item_fish_2_0(mut data: &[u8]) -> Option<HistoryItem> {
     let (advance, line) = read_line(data);
     let line = trim_start(line);
-    // Check this early *before* anything else.
-    if !line.starts_with(b"- cmd") {
-        return None;
-    }
+    assert!(line.starts_with(b"- cmd"));
 
     let (_key, value) = extract_prefix_and_unescape_yaml(line)?;
 


### PR DESCRIPTION
(Not yet sure which of the 3 approaches to take, maybe there is feedback)

Commit 1b9b89316 (After reading corrupted history entry, keep reading older
entries, 2024-10-06) made history search skip over corrupted history entries,
and try the next one.

This fixes some forms of on-disk corruption
However there is an easily reproducible, form of in-memory corruption.
Let the history be

    older-command
    some-newer-command

If fish runs a history search it will load the offsets of each item into
memory.

Now if another fish runs "older-command" (and up to 25 irrelevant commands), it
may vacuum (deduplicate) the history file, rewriting it in least-recently-used
order, which is:

    some-newer-command
    older-command

If the original fish re-runs the same history search, it will use stale
offsets to read from the memory-mapped file.  It actually wants to read from
a snapshot but mmap(3p) doesn't guarantee that:

> It is unspecified whether modifications to the underlying object done
> after the MAP_PRIVATE mapping is established are visible through the
> MAP_PRIVATE mapping.

It looks like on Linux we get the current version of the file contents,
hence history search fails because offsets don't point to valid items anymore.
This corruption goes away the next time fish vacuums the history file itself.

This commit fixes it by listening to history file changes.

Since this is a race between the notification system and the user performing
a history search, we can still hit it in theory, so we still need to check
lines for correctness and silently fail if they are broken in any way.

Alternative approaches (that don't have this imperfection).
1. take a shared lock before calling item_at_index().
   Haven't explored this very much; it seems like a reasonable approach.
2. create a private snapshot at startup (this would fix #6606):

    flock --shared ~/.local/share/fish_history
    cp ~/.local/share/fish_history ~/.local/share/fish_history.$fish_pid
    flock --shared ~/.local/share/fish_history --unlock

and then read old items only from that snapshot. It's only updated on
"history merge". We'll still write to the shared history file the same way.

Would be even better if we could keep the snapshot in memory.
Ideally we use copy-on-write for snapshots; I don't know if there are
portable implementations.

If we don't have copy-on-write we could compress the history (and still mmap+compress it on the fly).
Need to measure how much memory/disk space we want to spend...
