### PR TITLE
Add completions for: `guile`, `guild`

### DIFF
--- a/share/completions/guild.fish
+++ b/share/completions/guild.fish
@@ -15,7 +15,6 @@ function __fish_guild__complete_optimizations
 end
 
 set -l command guild
-
 complete -c $command -f
 
 set -l compile_condition '__fish_seen_subcommand_from compile'

--- a/share/completions/guild.fish
+++ b/share/completions/guild.fish
@@ -1,0 +1,57 @@
+function __fish_guild__complete_warnings
+    guild compile -Whelp |
+        string replace --filter --regex '^\s+`([a-z\-]+)\'\s+(.+)' '$1\t$2'
+
+    printf '%s\n' 0 2 3
+    echo 1\tdefault
+end
+
+function __fish_guild__complete_optimizations
+    guild compile -Ohelp |
+        string replace --filter --regex '^\s+-O(.+)' '$1\nno-$1'
+
+    printf '%s\n' 0 1 3
+    echo 2\tdefault
+end
+
+set -l command guild
+
+complete -c $command -f
+
+complete -c $command -s h -l help -d 'Show help'
+complete -c $command -s v -l version -d 'Show version'
+
+complete -c $command -s L -l load-path -F \
+    -d 'Specify the directory to prepend to module load path'
+
+complete -c $command -s o -l output -F \
+    -d 'Specify the output file to put bytecode in'
+
+complete -c $command -s x -x \
+    -d 'Specify the extension to prepend to extension list'
+
+complete -c $command -s W -l warning \
+    -a '(__fish_complete_list , __fish_guild__complete_warnings)' \
+    -d 'Specify the warning level for a compilation'
+
+complete -c $command -s O -l optimize \
+    -a '(__fish_guild__complete_optimizations)' \
+    -d 'Specify the optimization level for a compilation'
+
+for standard in 6 7
+    set -l option r$standard"rc"
+
+    complete -c $command -l $option \
+        -d "Use $(string upper -- $option) compatible mode"
+end
+
+complete -c $command -s f -l from \
+    -a 'scheme\tdefault elisp ecmascript' \
+    -d 'Specify the language for sources'
+
+complete -c $command -s t -l to \
+    -a 'rtl\tdefault' \
+    -d 'Specify the language for an output'
+
+complete -c $command -s T -l target \
+    -d 'Specify the target for a code'

--- a/share/completions/guild.fish
+++ b/share/completions/guild.fish
@@ -18,40 +18,52 @@ set -l command guild
 
 complete -c $command -f
 
-complete -c $command -s h -l help -d 'Show help'
-complete -c $command -s v -l version -d 'Show version'
+set -l compile_condition '__fish_seen_subcommand_from compile'
+complete -c $command -a 'compile\tCompile scripts' -n "not $compile_condition"
+
+complete -c $command -s h -l help -d 'Show help' -n $compile_condition
+complete -c $command -l version -d 'Show version' -n $compile_condition
 
 complete -c $command -s L -l load-path -F \
-    -d 'Specify the directory to prepend to module load path'
+    -d 'Specify the directory to prepend to module load path' \
+    -n $compile_condition
 
 complete -c $command -s o -l output -F \
-    -d 'Specify the output file to put bytecode in'
+    -d 'Specify the output file to put bytecode in' \
+        -n $compile_condition
 
 complete -c $command -s x -x \
-    -d 'Specify the extension to prepend to extension list'
+    -d 'Specify the extension to prepend to extension list' \
+        -n $compile_condition
 
 complete -c $command -s W -l warning \
     -a '(__fish_complete_list , __fish_guild__complete_warnings)' \
-    -d 'Specify the warning level for a compilation'
+    -d 'Specify the warning level for a compilation' \
+        -n $compile_condition
 
 complete -c $command -s O -l optimize \
     -a '(__fish_guild__complete_optimizations)' \
-    -d 'Specify the optimization level for a compilation'
+    -d 'Specify the optimization level for a compilation' \
+        -n $compile_condition
 
 for standard in 6 7
     set -l option r$standard"rc"
 
     complete -c $command -l $option \
-        -d "Use $(string upper -- $option) compatible mode"
+        -d "Use $(string upper -- $option) compatible mode" \
+            -n $compile_condition
 end
 
 complete -c $command -s f -l from \
     -a 'scheme\tdefault elisp ecmascript' \
-    -d 'Specify the language for sources'
+    -d 'Specify the language for sources' \
+        -n $compile_condition
 
 complete -c $command -s t -l to \
     -a 'rtl\tdefault' \
-    -d 'Specify the language for an output'
+    -d 'Specify the language for an output' \
+        -n $compile_condition
 
 complete -c $command -s T -l target \
-    -d 'Specify the target for a code'
+    -d 'Specify the target for a code' \
+        -n $compile_condition

--- a/share/completions/guile.fish
+++ b/share/completions/guile.fish
@@ -58,7 +58,6 @@ function __fish_guile__complete_function_names
 end
 
 set -l command guile
-
 complete -c $command -f
 
 complete -c $command -s h -l help -d 'Show help'

--- a/share/completions/guile.fish
+++ b/share/completions/guile.fish
@@ -1,0 +1,116 @@
+function __fish_guile__complete_srfis
+    printf '%s\n' 0\t'cond-expand' \
+        1\t'List library' \
+        2\t'and-let*' \
+        4\t'Homogeneous numeric vector datatypes' \
+        6\t'Basic String Ports' \
+        8\t'receive' \
+        9\t'define-record-type' \
+        10\t'Hash-Comma Reader Extension' \
+        11\t'let-values' \
+        13\t'String Library' \
+        14\t'Character-set Library' \
+        16\t'case-lambda' \
+        17\t'Generalized set!' \
+        18\t'Multithreading support' \
+        19\t'Time/Date Library' \
+        23\t'Error Reporting' \
+        26\t'specializing parameters' \
+        27\t'Sources of Random Bits' \
+        28\t'Basic Format Strings' \
+        30\t'Nested Multi-line Comments' \
+        31\t'A special form ‘rec’ for recursive evaluation' \
+        34\t'Exception handling for programs' \
+        35\t'Conditions' \
+        37\t'args-fold' \
+        38\t'External Representation for Data With Shared Structure' \
+        39\t'Parameters' \
+        41\t'Streams' \
+        42\t'Eager Comprehensions' \
+        43\t'Vector Library' \
+        45\t'Primitives for Expressing Iterative Lazy Algorithms' \
+        46\t'Basic syntax-rules Extensions' \
+        55\t'Requiring Features' \
+        60\t'Integers as Bits' \
+        61\t'A more general cond clause' \
+        62\t'S-expression comments' \
+        64\t'A Scheme API for test suites' \
+        67\t'Compare procedures' \
+        69\t'Basic hash tables' \
+        71\t'Extended let-syntax for multiple values' \
+        87\t'in case clauses' \
+        88\t'Keyword Objects' \
+        98\t'Accessing environment variables' \
+        105\t'Curly-infix expressions' \
+        111\t'Boxes' \
+        119\t'Wisp: simpler indentation-sensitive Scheme'
+end
+
+function __fish_guile__complete_function_names
+    set -l path (commandline -poc |
+        string match --regex '.*\\.scm$' |
+        sed -n 1p)
+
+    test -e "$path" && begin
+        cat $path |
+            string match --all --groups-only --regex '\(\s*define\s+\(\s*(\w+)'
+    end
+end
+
+set -l command guile
+
+complete -c $command -f
+
+complete -c $command -s h -l help -d 'Show help'
+complete -c $command -s v -l version -d 'Show version'
+complete -c $command -s s -F -r -d 'Specify the script to run'
+complete -c $command -s c -x -d 'Specify the code to run'
+
+complete -c $command -s L -F -r \
+    -d 'Specify the directory to prepend to module load path'
+
+complete -c $command -s C -F -r \
+    -d 'Specify the directory to prepend to module load path for compiled files'
+
+complete -c $command -s x -x \
+    -a '.scm\tdefault' \
+    -d 'Specify the extension to prepend to extension list'
+
+complete -c $command -s l -F -r -d 'Specify the script to load'
+
+complete -c $command -s e -x \
+    -a '(__fish_guile__complete_function_names)' \
+    -d 'Specify the entry point of a script'
+
+complete -c $command -o ds \
+    -d 'Treat the last -s option as if it occurred at this point'
+
+complete -c $command -l use-srfi \
+    -a '(__fish_complete_list , __fish_guile__complete_srfis)' \
+    -d 'Specify the SRFI modules to load'
+
+for standard in 6 7
+    set -l option r$standard"rc"
+
+    complete -c $command -l $option \
+        -d "Use $(string upper -- $option) compatible mode"
+end
+
+complete -c $command -l debug -d 'Use debug mode'
+complete -c $command -l no-debug -d "Don't use debug mode"
+complete -c $command -s q -d "Don't load .guile file"
+
+complete -c $command -l listen \
+    -a '37146\tdefault' \
+    -d 'Specify the port to list to'
+
+complete -c $command -l auto-compile -d 'Compile scripts automatically'
+
+complete -c $command -l fresh-auto-compile \
+    -d 'Compile scripts automatically forcefully'
+
+complete -c $command -l no-auto-compile -d "Don't compile scripts automatically"
+
+complete -c $command -l language \
+    -a 'scheme\tdefault elisp ecmascript' \
+    -d 'Specify the language for sources'


### PR DESCRIPTION
## Description

Add completions for:

- [x] [`guile`](https://www.gnu.org/software/guile/manual/html_node/Command_002dline-Options.html)
- [x] [`guild`](https://www.gnu.org/software/guile/manual/html_node/Compilation.html)

## Notes

I have no clue how to extract all function names from the current file purely from Scheme code, that's why for now I use [regular expressions](https://github.com/fish-shell/fish-shell/pull/10792/files#diff-8bc0c9a2375d402b31006ee4100d542f6b5779d0ad50354b5ba924ce284af3f4R49) to find function names.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
