### PR TITLE
fix documentation for `path normalize`

### DIFF
--- a/doc_src/cmds/path.rst
+++ b/doc_src/cmds/path.rst
@@ -279,7 +279,7 @@ Examples
 
     path normalize [-z | --null-in] [-Z | --null-out] [-q | --quiet] [PATH ...]
 
-``path normalize`` returns the normalized versions of all paths. That means it squashes duplicate "/" (except for two leading "//"), collapses "../" with earlier components and removes "." components.
+``path normalize`` returns the normalized versions of all paths. That means it squashes duplicate "/", collapses "../" with earlier components and removes "." components.
 
 Unlike ``realpath`` or ``path resolve``, it does not make the paths absolute. It also does not resolve any symlinks. As such it can operate on non-existent paths.
 


### PR DESCRIPTION
## Description

This removes `(except for two leading "//")` from the documentation of `path normalize`, since `path normalize` does actually squash leading "//" (I tested the current HEAD and 3.7.1 and both behave the same)


> `path normalize` returns the normalized versions of all paths. That means it squashes duplicate "/" ~~(except for two leading "//")~~, collapses "../" with earlier components and removes "." components.


Please verify by running

```fish
❱ path normalize //usr/bin
/usr/bin 
```

NB: this should probably be merged both on master and on the branch for the next non-rust release

## TODOs:

*(none applies, so I am checking all off as done)*

<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
