### PR TITLE
remove $ from a $(command)

### DIFF
--- a/doc_src/tutorial.rst
+++ b/doc_src/tutorial.rst
@@ -386,7 +386,7 @@ Command Substitutions
 
 Command substitutions use the output of one command as an argument to another. Unlike other shells, fish does not use backticks `` for command substitutions. Instead, it uses parentheses with or without a dollar::
 
-    > echo In (pwd), running $(uname)
+    > echo In (pwd), running (uname)
     In /home/tutorial, running FreeBSD
 
 A common idiom is to capture the output of a command in a variable::


### PR DESCRIPTION
## Description

Fixes typo in Command Substitutions[¶](https://fishshell.com/docs/current/tutorial.html#command-substitutions) of Tutorial

Current example gives this:
> echo In (pwd), running $(uname)
fish: $(...) is not supported. In fish, please use '(uname)'.
echo In (pwd), running $(uname)
> echo In (pwd), running $uname
In /home, running
> echo In (pwd), running (uname)
In /home, running Linux


Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
