### PR TITLE
Turn off release-mode overflow checks again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ rust-version = "1.70"
 edition = "2021"
 
 [profile.release]
-overflow-checks = true
 lto = true
 
 [package]


### PR DESCRIPTION
Not sure about this but "no overflow checks" is the status quo, so
if we want to keep the checks beyond the port, this should be stated
explicitly, as implied by e616de544 (Enable rust overflow checks in
release mode, at least for now, 2023-02-20).
