### PR TITLE
Add libncurses-dev to apt install list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ On Debian or Ubuntu you want these packages:
 
 ::
 
-   sudo apt install build-essential cmake libpcre2-dev gettext
+   sudo apt install build-essential cmake libpcre2-dev gettext libncurses-dev
 
 On RedHat, CentOS, or Amazon EC2 everything should be preinstalled.
 


### PR DESCRIPTION
## Description

Very simple change to add `libncurses-dev` to `apt install` list. Apparently on some very old Ubuntu Docker images (e.g., Ubuntu 20.04), `libncurses-dev` isn't installed by default. Having it listed here ensures it gets installed successfully.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
