### PR TITLE
completion(apt-mark): Add missing minimize-manual command & --color options

### DIFF
--- a/share/completions/apt-mark.fish
+++ b/share/completions/apt-mark.fish
@@ -2,7 +2,7 @@
 
 function __fish_apt_no_subcommand -d 'Test if apt has yet to be given the subcommand'
     for i in (commandline -xpc)
-        if contains -- $i auto manual hold unhold showauto showmanual showhold
+        if contains -- $i auto manual minimize-manual hold unhold showauto showmanual showhold
             return 1
         end
     end
@@ -23,6 +23,7 @@ complete -c apt-mark -n __fish_apt_use_package -a '(__fish_print_apt_packages)' 
 complete -c apt-mark -s h -l help -d 'Display help and exit'
 complete -f -n __fish_apt_no_subcommand -c apt-mark -a auto -d 'Mark a package as automatically installed'
 complete -f -n __fish_apt_no_subcommand -c apt-mark -a manual -d 'Mark a package as manually installed'
+complete -f -n __fish_apt_no_subcommand -c apt-mark -a minimize-manual -d 'Mark all dependencies of meta packages as auto'
 complete -f -n __fish_apt_no_subcommand -c apt-mark -a hold -d 'Hold a package, prevent automatic installation or removal'
 complete -f -n __fish_apt_no_subcommand -c apt-mark -a unhold -d 'Cancel a hold on a package'
 complete -f -n __fish_apt_no_subcommand -c apt-mark -a showauto -d 'Show automatically installed packages'
@@ -31,4 +32,6 @@ complete -f -n __fish_apt_no_subcommand -c apt-mark -a showhold -d 'Show held pa
 complete -c apt-mark -s v -l version -d 'Display version and exit'
 complete -r -c apt-mark -s c -l config-file -d 'Specify a config file'
 complete -r -c apt-mark -s o -l option -d 'Set a config option'
+complete -r -c apt-mark -l color -d 'Turn colors on'
+complete -r -c apt-mark -l no-color -d 'Turn colors off'
 complete -r -c apt-mark -s f -l file -d 'Write package statistics to a file'

--- a/share/completions/apt-mark.fish
+++ b/share/completions/apt-mark.fish
@@ -32,6 +32,6 @@ complete -f -n __fish_apt_no_subcommand -c apt-mark -a showhold -d 'Show held pa
 complete -c apt-mark -s v -l version -d 'Display version and exit'
 complete -r -c apt-mark -s c -l config-file -d 'Specify a config file'
 complete -r -c apt-mark -s o -l option -d 'Set a config option'
-complete -r -c apt-mark -l color -d 'Turn colors on'
-complete -r -c apt-mark -l no-color -d 'Turn colors off'
+complete -c apt-mark -l color -d 'Turn colors on'
+complete -c apt-mark -l no-color -d 'Turn colors off'
 complete -r -c apt-mark -s f -l file -d 'Write package statistics to a file'


### PR DESCRIPTION
## Description

Minor improvement to completions.

<!-- Fixes issue # -->

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages. _(No changes to `fish` usage)_
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst _Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits_
