### PR TITLE
Emit only sane pgid value for `jobs` output

### DIFF
--- a/src/builtins/jobs.rs
+++ b/src/builtins/jobs.rs
@@ -50,8 +50,10 @@ fn cpu_use(j: &Job) -> f64 {
 
 /// Print information about the specified job.
 fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut IoStreams) {
-    // TODO: Breaking change, but don't print meaningless -2 for jobs without a pgid
-    let pgid = j.get_pgid().unwrap_or(-2); // the old INVALID_PGID value
+    let pgid = match j.get_pgid() {
+        Some(pgid) => pgid.to_string(),
+        None => "-".to_string(),
+    };
 
     let mut out = WString::new();
     match mode {
@@ -66,7 +68,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
                 out += wgettext!("State\tCommand\n");
             }
 
-            sprintf!(=> &mut out, "%d\t%d\t", j.job_id(), pgid);
+            sprintf!(=> &mut out, "%d\t%s\t", j.job_id(), pgid);
 
             if have_proc_stat() {
                 sprintf!(=> &mut out, "%.0f%%\t", 100.0 * cpu_use(j));
@@ -93,7 +95,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
                 // Print table header before first job.
                 out += wgettext!("Group\n");
             }
-            out += &sprintf!("%d\n", pgid)[..];
+            out += &sprintf!("%s\n", pgid)[..];
             streams.out.append(out);
         }
         JobsPrintMode::PrintPid => {


### PR DESCRIPTION
We were previously printing the internal INVALID_PID value (since removed), which was a meaningless `-2` constant, when there was no pgid associated with a job.

This PR changes that to `-` to indicate no pgid available, which I prefer over something like `0` or `-1`, but will cause problems for any code out there that is hardcoded to convert this field to an integral value (do we have any code like that ourselves?).

Other options include 0 or -1 as mentioned above, or printing fish's own pgid.

EDIT:

I don't recommend printing 0 or fish's own pgid because if those get through validation we could end up killing ourself or something equally disasterous.