### PR TITLE
Use strongly typed `Pid` and `Option<Pid>` types

### DIFF
--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -50,7 +50,7 @@ use fish::{
     printf,
     proc::{
         get_login, is_interactive_session, mark_login, mark_no_exec, proc_init,
-        set_interactive_session,
+        set_interactive_session, Pid,
     },
     reader::{reader_init, reader_read, term_copy_modes},
     signal::{signal_clear_cancel, signal_unblock_all},
@@ -695,7 +695,10 @@ fn throwing_main() -> i32 {
         parser.get_last_status()
     };
 
-    event::fire(parser, Event::process_exit(getpid(), exit_status));
+    event::fire(
+        parser,
+        Event::process_exit(Pid::new(getpid()).unwrap(), exit_status),
+    );
 
     // Trigger any exit handlers.
     event::fire_generic(

--- a/src/builtins/disown.rs
+++ b/src/builtins/disown.rs
@@ -24,7 +24,7 @@ fn disown_job(cmd: &wstr, streams: &mut IoStreams, j: &Job) {
     if j.is_stopped() {
         if let Some(pgid) = pgid {
             unsafe {
-                libc::killpg(pgid, SIGCONT);
+                libc::killpg(pgid.as_pid_t(), SIGCONT);
             }
         }
         streams.err.append(wgettext_fmt!(

--- a/src/builtins/jobs.rs
+++ b/src/builtins/jobs.rs
@@ -8,7 +8,7 @@ use crate::common::{escape_string, timef, EscapeFlags, EscapeStringStyle};
 use crate::io::IoStreams;
 use crate::job_group::{JobId, MaybeJobId};
 use crate::parser::Parser;
-use crate::proc::{clock_ticks_to_seconds, have_proc_stat, proc_get_jiffies, Job};
+use crate::proc::{clock_ticks_to_seconds, have_proc_stat, proc_get_jiffies, Job, Pid};
 use crate::wchar_ext::WExt;
 use crate::wgetopt::{wopt, ArgType, WGetopter, WOption};
 use crate::wutil::wgettext;
@@ -211,7 +211,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                     }
                 }
             } else {
-                match fish_wcstoi(arg).ok().filter(|&pid| pid >= 0) {
+                match fish_wcstoi(arg).ok().and_then(Pid::new) {
                     None => {
                         streams.err.append(wgettext_fmt!(
                             "%ls: '%ls' is not a valid process id\n",

--- a/src/builtins/jobs.rs
+++ b/src/builtins/jobs.rs
@@ -104,7 +104,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
             }
 
             for p in j.external_procs() {
-                out += &sprintf!("%d\n", p.pid.load().unwrap().get())[..];
+                out += &sprintf!("%d\n", p.pid.load().unwrap())[..];
             }
             streams.out.append(out);
         }

--- a/src/builtins/jobs.rs
+++ b/src/builtins/jobs.rs
@@ -37,7 +37,7 @@ fn cpu_use(j: &Job) -> f64 {
     let mut u = 0.0;
     for p in j.external_procs() {
         let now = timef();
-        let jiffies = proc_get_jiffies(p.pid.load().unwrap().as_pid_t());
+        let jiffies = proc_get_jiffies(p.pid.load().unwrap());
         let last_jiffies = p.last_times.get().jiffies;
         let since = now - last_jiffies as f64;
         if since > 0.0 && jiffies > last_jiffies {

--- a/src/event.rs
+++ b/src/event.rs
@@ -386,7 +386,7 @@ pub fn get_desc(parser: &Parser, evt: &Event) -> WString {
         }
         EventDescription::JobExit { pid, .. } => {
             if let Some(pid) = pid {
-                if let Some(job) = parser.job_get_from_pid(pid.as_pid_t()) {
+                if let Some(job) = parser.job_get_from_pid(*pid) {
                     format!("exit handler for job {}, '{}'", job.job_id(), job.command())
                 } else {
                     format!("exit handler for job with pid {pid}")

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -881,7 +881,7 @@ fn exec_external_command(
             exec_fork,
             "Fork #%d, pid %d: spawn external command '%s' from '%ls'",
             count,
-            pid.get(),
+            pid,
             p.actual_cmd,
             file.as_ref()
                 .map(|s| s.as_utfstr())

--- a/src/fork_exec/spawn.rs
+++ b/src/fork_exec/spawn.rs
@@ -105,7 +105,7 @@ impl PosixSpawner {
         // desired_pgid tracks the pgroup for the process. If it is none, the pgroup is left unchanged.
         // If it is zero, create a new pgroup from the pid. If it is >0, join that pgroup.
         let desired_pgid = if let Some(pgid) = j.get_pgid() {
-            Some(pgid)
+            Some(pgid.get())
         } else if j.processes()[0].leads_pgrp {
             Some(0)
         } else {

--- a/src/function.rs
+++ b/src/function.rs
@@ -442,9 +442,11 @@ impl FunctionProperties {
                     sprintf!(=> &mut out, " --on-variable %ls", name);
                 }
                 EventDescription::ProcessExit { pid } => {
-                    sprintf!(=> &mut out, " --on-process-exit %d", pid);
+                    let pid = pid.map(|p| p.get()).unwrap_or(0);
+                    sprintf!(=> &mut out, " --on-process-exit %d", pid)
                 }
                 EventDescription::JobExit { pid, .. } => {
+                    let pid = pid.map(|p| p.get()).unwrap_or(0);
                     sprintf!(=> &mut out, " --on-job-exit %d", pid);
                 }
                 EventDescription::CallerExit { .. } => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -23,7 +23,7 @@ use crate::parse_constants::{
 };
 use crate::parse_execution::{EndExecutionReason, ExecutionContext};
 use crate::parse_tree::{parse_source, LineCounter, ParsedSourceRef};
-use crate::proc::{job_reap, JobGroupRef, JobList, JobRef, ProcStatus};
+use crate::proc::{job_reap, JobGroupRef, JobList, JobRef, Pid, ProcStatus};
 use crate::signal::{signal_check_cancel, signal_clear_cancel, Signal};
 use crate::threads::assert_is_main_thread;
 use crate::util::get_time;
@@ -942,15 +942,15 @@ impl Parser {
     }
 
     /// Returns the job with the given pid.
-    pub fn job_get_from_pid(&self, pid: libc::pid_t) -> Option<JobRef> {
+    pub fn job_get_from_pid(&self, pid: Pid) -> Option<JobRef> {
         self.job_get_with_index_from_pid(pid).map(|t| t.1)
     }
 
     /// Returns the job and job index with the given pid.
-    pub fn job_get_with_index_from_pid(&self, pid: libc::pid_t) -> Option<(usize, JobRef)> {
+    pub fn job_get_with_index_from_pid(&self, pid: Pid) -> Option<(usize, JobRef)> {
         for (i, job) in self.jobs().iter().enumerate() {
             for p in job.external_procs() {
-                if p.pid.load().unwrap().get() == pid {
+                if p.pid.load().unwrap() == pid {
                     return Some((i, job.clone()));
                 }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -949,8 +949,8 @@ impl Parser {
     /// Returns the job and job index with the given pid.
     pub fn job_get_with_index_from_pid(&self, pid: libc::pid_t) -> Option<(usize, JobRef)> {
         for (i, job) in self.jobs().iter().enumerate() {
-            for p in job.processes().iter() {
-                if p.pid.load(Ordering::Relaxed) == pid {
+            for p in job.external_procs() {
+                if p.pid.load().unwrap().get() == pid {
                     return Some((i, job.clone()));
                 }
             }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -512,7 +512,7 @@ impl Drop for TtyTransfer {
 
 /// A type-safe equivalent to [`libc::pid_t`].
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Pid(NonZeroU32);
 
 impl Pid {
@@ -780,7 +780,7 @@ impl Process {
         } else {
             if self.wait_handle.borrow().is_none() {
                 self.wait_handle.replace(Some(WaitHandle::new(
-                    self.pid().unwrap().get(),
+                    self.pid().unwrap(),
                     jid,
                     wbasename(&self.actual_cmd.clone()).to_owned(),
                 )));

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1110,7 +1110,7 @@ impl Job {
                 } else {
                     charptr2wcstring(strsignal)
                 };
-                wperror(&sprintf!("killpg(%d, %s)", pgid.get(), strsignal));
+                wperror(&sprintf!("killpg(%d, %s)", pgid, strsignal));
                 return false;
             }
         } else {
@@ -1502,13 +1502,10 @@ fn process_mark_finished_children(parser: &Parser, block_ok: bool) {
                     WNOHANG | WUNTRACED | WCONTINUED,
                 )
             };
-            if pid <= 0 {
+            let Some(pid) = Pid::new(pid) else {
                 continue;
-            }
-            assert!(
-                pid == proc.pid().unwrap().get(),
-                "Unexpected waitpid() return"
-            );
+            };
+            assert!(pid == proc.pid().unwrap(), "Unexpected waitpid() return");
 
             // The process has stopped or exited! Update its status.
             let status = ProcStatus::from_waitpid(statusv);

--- a/tests/checks/basic.fish
+++ b/tests/checks/basic.fish
@@ -503,7 +503,7 @@ type --query cp
 echo $status
 #CHECK: 0
 
-jobs --query 0
+jobs --query 1
 echo $status
 #CHECK: 1
 


### PR DESCRIPTION
There's a separate `AtomicPid` type because relying on not storing zero or negative values into a `NonZeroI32` was not working. This found a number of bugs or unhandled cases in the codebase.

One thing I want to make sure of is that it is indeed an error to use `bg %0` or `jobs -q 0` in the sense that they can never match a job?

Closes #10832