### PR TITLE
completions/tmux: dynamic completions for all `tmux` subcommands and flags using `tmux lscm`

### DIFF
--- a/share/completions/tmux.fish
+++ b/share/completions/tmux.fish
@@ -20,6 +20,10 @@ end
 #don't allow dirs in the completion list...
 complete -c tmux -x
 
+# Complete even commands not explicitly listed below, as long as `tmux list-commands` works
+set -l all_commands (tmux list-commands -F "#{command_list_name} #{command_list_alias}" 2>/dev/null)
+and complete -c tmux -n __fish_use_subcommand -a "$all_commands"
+
 ###############  Begin: Front  Flags ###############
 #these do not require parameters
 complete -c tmux -n __fish_use_subcommand -s 2 -d 'Force tmux to assume the terminal supports 256 colours'

--- a/share/completions/tmux.fish
+++ b/share/completions/tmux.fish
@@ -64,6 +64,10 @@ end
 __fish_tmux_parse_lscm_usage
 functions -e __fish_tmux_parse_lscm_usage
 
+# Completions for `tmux list-commands` itself
+set -l all_commands (tmux list-commands -F "#{command_list_name} #{command_list_alias}" 2>/dev/null)
+and complete -c tmux -n "__fish_seen_subcommand_from list-commands lscm" -x -a "$all_commands"
+
 ###############  End:   Dynamic Completions Using `tmux list-commands` ###############
 
 ###############  Begin: Front  Flags ###############


### PR DESCRIPTION
**Update:** This now completes all flags and all commands. So, `tmux if-shell -<TAB>` now works as well.

**Original description:** For example, `tmux shell<tab>` now completes to `if-shell` and `run-shell`, though
no additional information is provided.

This PR and #10854 complement each other, but either could be used independently from the other if necessary.

## TODOs:
- (n/a) Changes to fish usage are reflected in user documentation/manpages.
- (n/a) Tests have been added for regressions fixed
- (n/a) User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
