### PR TITLE
Flush stdout when control returns to shell

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -202,6 +202,7 @@ Other improvements
 - ``fish_config`` now also works in a Windows MSYS environment (:issue:`10111`).
 - Performance and interactivity under WSL has been improved with a workaround for Windows-specific locations being appended to ``$PATH`` by default (:issue:`10506`).
 - Additional filesystems such as AFS are properly detected as remote, which avoids certain hangs due to expensive filesystem locks (:issue:`10818`).
+- Standard output is flushed if external commands exit w/ a signal, in an attempt to reduce interleaving process output with the prompt (:issue:`10861`).
 
 .. _rust-packaging:
 


### PR DESCRIPTION
This prevents kernel-buffered stdout contents from being written to the terminal after the prompt itself, which can happen when the external process is terminated with a signal and hasn't executed the libc/runtime-provided exit handlers that flush stdout.

Screenshots of afl-fuzz being terminated by `^C` before and after the change:

Before:

![image](https://github.com/user-attachments/assets/00a2dbf8-32f9-4ca0-94b7-aae94daa2f0b)

After:

![image](https://github.com/user-attachments/assets/54af62ea-bd7c-46b7-9fa4-0c218d585ed7)

I tried to minimize any performance impact by trying to reduce the number of times this is called (by placing it as high up as possible, but bubbling up reap status) and by not performing the call in non-interactive mode (where fish shouldn't be painting to the shell bypassing stdout). stderr isn't flushed because it's typically unbuffered.

Let me know if you think this should be included in the changelog afterwards.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
