### PR TITLE
posix_spawn: Unconditionally default all signals (except HUP)

### DIFF
--- a/src/fork_exec/spawn.rs
+++ b/src/fork_exec/spawn.rs
@@ -3,7 +3,7 @@
 use super::blocked_signals_for_job;
 use crate::proc::Job;
 use crate::redirection::Dup2List;
-use crate::signal::get_signals_with_handlers;
+use crate::signal::get_signals_to_default;
 use crate::{exec::is_thompson_shell_script, libc::_PATH_BSHELL};
 use errno::Errno;
 use libc::{c_char, posix_spawn_file_actions_t, posix_spawnattr_t};
@@ -126,8 +126,7 @@ impl PosixSpawner {
         }
 
         // Everybody gets default handlers.
-        let mut sigdefault: libc::sigset_t = unsafe { std::mem::zeroed() };
-        get_signals_with_handlers(&mut sigdefault);
+        let sigdefault = get_signals_to_default();
         attr.set_sigdefault(&sigdefault)?;
 
         // Reset the sigmask.


### PR DESCRIPTION
As I understand it, we want all signals for processes we spawn (except for HUP, because of nohup) to have the default signal handlers.

So I don't know why we need to check what action a specific signal currently has, we can just default it anyway.

This saves ~30 syscalls *per process* we spawn, so:

```fish
for f in (seq 1000)
    command true
end
```

has ~30000 fewer rt_sigaction calls. These take up about ~30% of the total time spent in syscalls according to strace.

We could also compute this set once at startup and then reuse it.