### PR TITLE
fix: check whether a function is tombstoned during highlight

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -241,7 +241,8 @@ pub fn exists_no_autoload(cmd: &wstr) -> bool {
     }
     let mut funcset = FUNCTION_SET.lock().unwrap();
     // Check if we either have the function, or it could be autoloaded.
-    funcset.get_props(cmd).is_some() || funcset.autoloader.can_autoload(cmd)
+    !(funcset.autoload_tombstones.contains(cmd) && !funcset.funcs.contains_key(cmd))
+        && (funcset.get_props(cmd).is_some() || funcset.autoloader.can_autoload(cmd))
 }
 
 /// Remove the function with the specified name.


### PR DESCRIPTION
## Description
To check whether a function exists in the current context without invoking autoload, we check two things:
- Is the function tombstoned *and* the current `funcset` does not contain the name? Then it does not exists.
- If not, can we get its props or autoload it? Then it exists.

Fixes issue #10866

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
