### PR TITLE
refactor: remove unnecessary `copied()` for Utf32Str reference

### DIFF
--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -86,12 +86,8 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
     // Construct argv from our null-terminated list.
     // This is slightly subtle. If this is a bare `source` with no args then `argv + optind` already
     // points to the end of argv. Otherwise we want to skip the file name to get to the args if any.
-    let mut argv_list: Vec<WString> = vec![];
     let remaining_args = &args[optind + if argc == optind { 0 } else { 1 }..];
-    #[allow(clippy::unnecessary_to_owned)]
-    for arg in remaining_args.iter().copied() {
-        argv_list.push(arg.to_owned());
-    }
+    let argv_list = remaining_args.iter().map(|&arg| arg.to_owned()).collect();
     parser.vars().set_argv(argv_list);
 
     let mut retval = reader_read(parser, fd, streams.io_chain);


### PR DESCRIPTION
## Description

- Build `argv_list` as an immutable vec.
- Use `map` iterator pattern to deref a `&Utf32Str` and copy the string.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
