### PR TITLE
(WIP) Remove dependencies and use std ones instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "autocfg"
@@ -22,9 +22,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -64,9 +64,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys",
@@ -80,7 +80,6 @@ dependencies = [
  "cc",
  "errno",
  "fish-printf",
- "lazy_static",
  "libc",
  "lru",
  "nix",
@@ -123,9 +122,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -149,9 +148,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "lock_api"
@@ -175,7 +174,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -316,15 +315,15 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -443,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "widestring"
@@ -455,9 +454,9 @@ checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ pcre2 = { git = "https://github.com/fish-shell/rust-pcre2", tag = "0.2.9-utf32",
 
 bitflags = "2.5.0"
 errno = "0.3.0"
-lazy_static = "1.4.0"
 libc = "0.2.155"
 # lru pulls in hashbrown by default, which uses a faster (though less DoS resistant) hashing algo.
 # disabling default features uses the stdlib instead, but it doubles the time to rewrite the history
@@ -43,6 +42,7 @@ nix = { version = "0.29.0", default-features = false, features = [
     "fs",
 ] }
 num-traits = "0.2.19"
+# FIXME: Remove this dependency once it is unnecessary.
 once_cell = "1.19.0"
 fish-printf = { path = "./printf", features = ["widestring"] }
 

--- a/src/abbrs.rs
+++ b/src/abbrs.rs
@@ -1,18 +1,17 @@
 #![allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
 use std::{
     collections::HashSet,
-    sync::{Mutex, MutexGuard},
+    sync::{LazyLock, Mutex, MutexGuard},
 };
 
 use crate::wchar::prelude::*;
-use once_cell::sync::Lazy;
 
 use crate::parse_constants::SourceRange;
 #[cfg(test)]
 use crate::tests::prelude::*;
 use pcre2::utf32::Regex;
 
-static ABBRS: Lazy<Mutex<AbbreviationSet>> = Lazy::new(|| Mutex::new(Default::default()));
+static ABBRS: LazyLock<Mutex<AbbreviationSet>> = LazyLock::new(|| Mutex::new(Default::default()));
 
 pub fn with_abbrs<R>(cb: impl FnOnce(&AbbreviationSet) -> R) -> R {
     let abbrs_g = ABBRS.lock().unwrap();

--- a/src/builtins/random.rs
+++ b/src/builtins/random.rs
@@ -2,12 +2,11 @@ use super::prelude::*;
 
 use crate::util::get_rng;
 use crate::wutil;
-use once_cell::sync::Lazy;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-static RNG: Lazy<Mutex<SmallRng>> = Lazy::new(|| Mutex::new(get_rng()));
+static RNG: LazyLock<Mutex<SmallRng>> = LazyLock::new(|| Mutex::new(get_rng()));
 
 pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Option<c_int> {
     let cmd = argv[0];

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -11,9 +11,9 @@ mod test_expressions {
         file_id_for_path, fish_wcswidth, lwstat, waccess, wcstod::wcstod, wcstoi_opts, wstat,
         Error, Options,
     };
-    use once_cell::sync::Lazy;
     use std::collections::HashMap;
     use std::os::unix::prelude::*;
+    use std::sync::LazyLock;
 
     #[derive(Copy, Clone, PartialEq, Eq)]
     pub(super) enum Token {
@@ -183,7 +183,7 @@ mod test_expressions {
         TOKEN_INFOS.get(str).copied().unwrap_or(Token::Unknown)
     }
 
-    static TOKEN_INFOS: Lazy<HashMap<&'static wstr, Token>> = Lazy::new(|| {
+    static TOKEN_INFOS: LazyLock<HashMap<&'static wstr, Token>> = LazyLock::new(|| {
         let pairs = [
             (L!(""), Token::Unknown),
             (L!("!"), Token::UnaryBoolean(UnaryBooleanToken::Bang)),

--- a/src/builtins/ulimit.rs
+++ b/src/builtins/ulimit.rs
@@ -1,8 +1,8 @@
 use std::cmp::Ordering;
+use std::sync::LazyLock;
 
 use libc::{c_uint, rlim_t, RLIM_INFINITY};
 use nix::errno::Errno;
-use once_cell::sync::Lazy;
 
 use crate::fallback::{fish_wcswidth, wcscasecmp};
 use crate::libc::*;
@@ -353,7 +353,7 @@ impl Resource {
 }
 
 /// Array of resource_t structs, describing all known resource types.
-static RESOURCE_ARR: Lazy<Box<[Resource]>> = Lazy::new(|| {
+static RESOURCE_ARR: LazyLock<Box<[Resource]>> = LazyLock::new(|| {
     let resources_info = [
         (
             RLIMIT_SBSIZE(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -20,14 +20,13 @@ use crate::wutil::fish_iswalnum;
 use bitflags::bitflags;
 use core::slice;
 use libc::{EIO, O_WRONLY, SIGTTOU, SIG_IGN, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
-use once_cell::sync::OnceCell;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI32, AtomicU32, Ordering};
-use std::sync::{Arc, MutexGuard};
+use std::sync::{Arc, MutexGuard, OnceLock};
 use std::time;
 use std::{env, process};
 
@@ -1073,7 +1072,7 @@ pub fn get_obfuscation_read_char() -> char {
 pub static PROFILING_ACTIVE: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
 
 /// Name of the current program. Should be set at startup. Used by the debug function.
-pub static PROGRAM_NAME: OnceCell<&'static wstr> = OnceCell::new();
+pub static PROGRAM_NAME: OnceLock<&'static wstr> = OnceLock::new();
 
 /// MS Windows tty devices do not currently have either a read or write timestamp - those respective
 /// fields of `struct stat` are always set to the current time, which means we can't rely on them.
@@ -1831,7 +1830,7 @@ pub const fn assert_sync<T: Sync>() {}
 /// session. We err on the side of assuming it's not a console session. This approach isn't
 /// bullet-proof and that's OK.
 pub fn is_console_session() -> bool {
-    static IS_CONSOLE_SESSION: OnceCell<bool> = OnceCell::new();
+    static IS_CONSOLE_SESSION: OnceLock<bool> = OnceLock::new();
     *IS_CONSOLE_SESSION.get_or_init(|| {
         const PATH_MAX: usize = libc::PATH_MAX as usize;
         let mut tty_name = [0u8; PATH_MAX];

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -4,7 +4,7 @@ use std::{
     mem,
     sync::{
         atomic::{self, AtomicUsize},
-        Mutex, MutexGuard,
+        LazyLock, Mutex, MutexGuard,
     },
     time::{Duration, Instant},
 };
@@ -16,7 +16,6 @@ use crate::{
     wutil::sprintf,
 };
 use bitflags::bitflags;
-use once_cell::sync::Lazy;
 
 use crate::{
     abbrs::with_abbrs,
@@ -61,13 +60,13 @@ use crate::{
 // description strings should be defined in the same file?
 
 /// Description for ~USER completion.
-static COMPLETE_USER_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Home for %ls"));
+static COMPLETE_USER_DESC: LazyLock<&wstr> = LazyLock::new(|| wgettext!("Home for %ls"));
 
 /// Description for short variables. The value is concatenated to this description.
-static COMPLETE_VAR_DESC_VAL: Lazy<&wstr> = Lazy::new(|| wgettext!("Variable: %ls"));
+static COMPLETE_VAR_DESC_VAL: LazyLock<&wstr> = LazyLock::new(|| wgettext!("Variable: %ls"));
 
 /// Description for abbreviations.
-static ABBR_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Abbreviation: %ls"));
+static ABBR_DESC: LazyLock<&wstr> = LazyLock::new(|| wgettext!("Abbreviation: %ls"));
 
 /// The special cased translation macro for completions. The empty string needs to be special cased,
 /// since it can occur, and should not be translated. (Gettext returns the version information as
@@ -456,7 +455,7 @@ static COMPLETION_TOMBSTONES: Mutex<BTreeSet<WString>> = Mutex::new(BTreeSet::ne
 
 /// Completion "wrapper" support. The map goes from wrapping-command to wrapped-command-list.
 type WrapperMap = HashMap<WString, Vec<WString>>;
-static wrapper_map: Lazy<Mutex<WrapperMap>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static wrapper_map: LazyLock<Mutex<WrapperMap>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Clear the [`CompleteFlags::AUTO_SPACE`] flag, and set [`CompleteFlags::NO_SPACE`] appropriately
 /// depending on the suffix of the string.
@@ -611,8 +610,8 @@ struct Completer<'ctx> {
     condition_cache: HashMap<WString, bool>,
 }
 
-static completion_autoloader: Lazy<Mutex<Autoload>> =
-    Lazy::new(|| Mutex::new(Autoload::new(L!("fish_complete_path"))));
+static completion_autoloader: LazyLock<Mutex<Autoload>> =
+    LazyLock::new(|| Mutex::new(Autoload::new(L!("fish_complete_path"))));
 
 impl<'ctx> Completer<'ctx> {
     pub fn new(ctx: &'ctx OperationContext<'ctx>, flags: CompletionRequestOptions) -> Self {

--- a/src/env/environment.rs
+++ b/src/env/environment.rs
@@ -28,13 +28,12 @@ use crate::wutil::{fish_wcstol, wgetcwd, wgettext};
 use std::sync::atomic::Ordering;
 
 use libc::{c_int, uid_t, STDOUT_FILENO, _IONBF};
-use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::io::Write;
 use std::mem::MaybeUninit;
 use std::os::unix::prelude::*;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// Set when a universal variable has been modified but not yet been written to disk via sync().
 static UVARS_LOCALLY_MODIFIED: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
@@ -561,7 +560,7 @@ fn setup_path() {
 
 /// The originally inherited variables and their values.
 /// This is a simple key->value map and not e.g. cut into paths.
-pub static INHERITED_VARS: OnceCell<HashMap<WString, WString>> = OnceCell::new();
+pub static INHERITED_VARS: OnceLock<HashMap<WString, WString>> = OnceLock::new();
 
 pub fn env_init(paths: Option<&ConfigPaths>, do_uvars: bool, default_paths: bool) {
     let vars = EnvStack::globals();

--- a/src/env/environment_impl.rs
+++ b/src/env/environment_impl.rs
@@ -14,8 +14,7 @@ use crate::threads::{is_forked_child, is_main_thread};
 use crate::wchar::prelude::*;
 use crate::wutil::fish_wcstol_radix;
 
-use lazy_static::lazy_static;
-use std::cell::{RefCell, UnsafeCell};
+use std::cell::UnsafeCell;
 use std::collections::HashSet;
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -26,7 +25,7 @@ use std::ops::{Deref, DerefMut};
 use portable_atomic::AtomicU64;
 #[cfg(target_has_atomic = "64")]
 use std::sync::atomic::AtomicU64;
-use std::sync::{atomic::Ordering, Arc, Mutex, MutexGuard};
+use std::sync::{atomic::Ordering, Arc, LazyLock, Mutex, MutexGuard, RwLock};
 
 /// Getter for universal variables.
 /// This is typically initialized in env_init(), and is considered empty before then.
@@ -202,12 +201,11 @@ impl EnvNode {
 }
 
 /// EnvNodeRef is a reference to an EnvNode. It may be shared between different environments.
-/// The type Arc<RefCell<...>> may look suspicious, but all accesses to the EnvNode are protected by a global lock.
 #[derive(Clone)]
-struct EnvNodeRef(Arc<RefCell<EnvNode>>);
+struct EnvNodeRef(Arc<RwLock<EnvNode>>);
 
 impl Deref for EnvNodeRef {
-    type Target = RefCell<EnvNode>;
+    type Target = RwLock<EnvNode>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -219,7 +217,7 @@ impl EnvNodeRef {
         // Accesses are protected by the global lock.
         #[allow(unknown_lints)]
         #[allow(clippy::arc_with_non_send_sync)]
-        EnvNodeRef(Arc::new(RefCell::new(EnvNode {
+        EnvNodeRef(Arc::new(RwLock::new(EnvNode {
             env: VarTable::new(),
             new_scope: is_new_scope,
             export_gen: 0,
@@ -234,12 +232,12 @@ impl EnvNodeRef {
 
     /// Cover over find_entry.
     fn find_entry(&self, key: &wstr) -> Option<EnvVar> {
-        self.borrow().find_entry(key)
+        self.read().unwrap().find_entry(key)
     }
 
     /// Cover over next.
     fn next(&self) -> Option<EnvNodeRef> {
-        self.borrow().next.clone()
+        self.read().unwrap().next.clone()
     }
 
     /// Helper to get an iterator over the chain of EnvNodeRefs.
@@ -276,15 +274,13 @@ impl Iterator for EnvNodeIter {
     }
 }
 
-lazy_static! {
-    // All accesses to the EnvNode are protected by a global lock.
-    static ref GLOBAL_NODE: EnvNodeRef = EnvNodeRef::new(false, None);
-}
+// All accesses to the EnvNode are protected by a global lock.
+static GLOBAL_NODE: LazyLock<EnvNodeRef> = LazyLock::new(|| EnvNodeRef::new(false, None));
 
 /// Recursive helper to snapshot a series of nodes.
 fn copy_node_chain(node: &EnvNodeRef) -> EnvNodeRef {
     let next = node.next().as_ref().map(copy_node_chain);
-    let node = node.borrow();
+    let node = node.read().unwrap();
     let new_node = EnvNode {
         env: node.env.clone(),
         export_gen: node.export_gen,
@@ -293,7 +289,7 @@ fn copy_node_chain(node: &EnvNodeRef) -> EnvNodeRef {
     };
     #[allow(unknown_lints)]
     #[allow(clippy::arc_with_non_send_sync)]
-    EnvNodeRef(Arc::new(RefCell::new(new_node)))
+    EnvNodeRef(Arc::new(RwLock::new(new_node)))
 }
 
 /// A struct wrapping up parser-local variables. These are conceptually variables that differ in
@@ -432,7 +428,7 @@ impl EnvScopedImpl {
             // The first node that introduces a new scope is ours.
             // If this doesn't happen, we go on until we've reached the
             // topmost local scope.
-            if node.borrow().new_scope {
+            if node.read().unwrap().new_scope {
                 break;
             }
         }
@@ -499,12 +495,12 @@ impl EnvScopedImpl {
 
         if query.local {
             for cur in self.locals.iter() {
-                add_keys(&cur.borrow().env, &mut names);
+                add_keys(&cur.read().unwrap().env, &mut names);
             }
         }
 
         if query.global {
-            add_keys(&self.globals.borrow().env, &mut names);
+            add_keys(&self.globals.read().unwrap().env, &mut names);
             // Add electrics.
             for ev in ELECTRIC_VARIABLES {
                 let matches = if ev.exports() {
@@ -559,12 +555,12 @@ impl EnvScopedImpl {
         // Our uvars generation count doesn't come from next_export_generation(), so always supply
         // it even if it's 0.
         func(uvars().get_export_generation());
-        if self.globals.borrow().exports() {
-            func(self.globals.borrow().export_gen);
+        if self.globals.read().unwrap().exports() {
+            func(self.globals.read().unwrap().export_gen);
         }
         for node in self.locals.iter() {
-            if node.borrow().exports() {
-                func(node.borrow().export_gen);
+            if node.read().unwrap().exports() {
+                func(node.read().unwrap().export_gen);
             }
         }
     }
@@ -593,7 +589,7 @@ impl EnvScopedImpl {
 
     /// Get the exported variables into a variable table.
     fn get_exported(n: &EnvNodeRef, table: &mut VarTable) {
-        let n = n.borrow();
+        let n = n.read().unwrap();
 
         // Allow parent scopes to populate first, since we may want to overwrite those results.
         if let Some(next) = n.next.as_ref() {
@@ -768,7 +764,7 @@ impl EnvStackImpl {
                     // The first node that introduces a new scope is ours.
                     // If this doesn't happen, we go on until we've reached the
                     // topmost local scope.
-                    if node.borrow().new_scope {
+                    if node.read().unwrap().new_scope {
                         break;
                     }
                 }
@@ -833,7 +829,7 @@ impl EnvStackImpl {
                 let mut node = self.base.locals.clone();
                 while node.next().is_some() {
                     node = node.next().unwrap();
-                    if node.borrow().new_scope {
+                    if node.read().unwrap().new_scope {
                         break;
                     }
                 }
@@ -858,9 +854,9 @@ impl EnvStackImpl {
         // Propagate local exported variables.
         let node = EnvNodeRef::new(true, None);
         for cursor in self.base.locals.iter() {
-            for (key, val) in cursor.borrow().env.iter() {
+            for (key, val) in cursor.read().unwrap().env.iter() {
                 if val.exports() {
-                    let mut node_ref = node.borrow_mut();
+                    let mut node_ref = node.write().unwrap();
                     // Do NOT overwrite existing values, since we go from inner scopes outwards.
                     if !node_ref.env.contains_key(key) {
                         node_ref.env.insert(key.clone(), val.clone());
@@ -895,7 +891,7 @@ impl EnvStackImpl {
                 panic!("Attempt to pop last local scope")
             }
         }
-        let var_names = popped.borrow().env.keys().cloned().collect();
+        let var_names = popped.read().unwrap().env.keys().cloned().collect();
         var_names
     }
 
@@ -903,7 +899,7 @@ impl EnvStackImpl {
     fn find_in_chain(node: &EnvNodeRef, key: &wstr) -> Option<EnvNodeRef> {
         #[allow(clippy::manual_find)]
         for cur in node.iter() {
-            if cur.borrow().env.contains_key(key) {
+            if cur.read().unwrap().env.contains_key(key) {
                 return Some(cur);
             }
         }
@@ -914,7 +910,7 @@ impl EnvStackImpl {
     /// Return true if the variable was found and removed.
     fn remove_from_chain(node: &mut EnvNodeRef, key: &wstr) -> bool {
         for cur in node.iter() {
-            let mut cur_ref = cur.borrow_mut();
+            let mut cur_ref = cur.write().unwrap();
             if let Some(var) = cur_ref.env.remove(key) {
                 if var.exports() {
                     cur_ref.changed_exported();
@@ -967,7 +963,7 @@ impl EnvStackImpl {
             let pwd = val.pop().unwrap();
             if pwd != self.base.perproc_data.pwd {
                 self.base.perproc_data.pwd = pwd;
-                self.base.globals.borrow_mut().changed_exported();
+                self.base.globals.write().unwrap().changed_exported();
             }
             return Some(EnvStackSetResult::Ok);
         }
@@ -1026,7 +1022,7 @@ impl EnvStackImpl {
     /// Set a variable in a given node `node`.
     fn set_in_node(node: &mut EnvNodeRef, key: &wstr, mut val: Vec<WString>, flags: VarFlags) {
         // Read the var from the node. In C++ this was node->env[key] which establishes a default.
-        let mut node_ref = node.borrow_mut();
+        let mut node_ref = node.write().unwrap();
         let var = node_ref.env.entry(key.to_owned()).or_default();
 
         // Use an explicit exports, or inherit from the existing variable.
@@ -1059,7 +1055,7 @@ impl EnvStackImpl {
     // Implement the default behavior of 'set' by finding the node for an unspecified scope.
     fn resolve_unspecified_scope(&mut self) -> EnvNodeRef {
         for cursor in self.base.locals.iter() {
-            if cursor.borrow().new_scope {
+            if cursor.read().unwrap().new_scope {
                 return cursor;
             }
         }
@@ -1074,7 +1070,7 @@ impl EnvStackImpl {
             node = Self::find_in_chain(&self.base.globals, key);
         }
         if let Some(node) = node {
-            let iter = node.borrow().env.get(key).cloned();
+            let iter = node.read().unwrap().env.get(key).cloned();
             assert!(iter.is_some(), "Node should contain key");
             return iter;
         }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -6,11 +6,11 @@
 use crate::widecharwidth::{WcLookupTable, WcWidth};
 use crate::{common::is_console_session, wchar::prelude::*};
 use errno::{errno, Errno};
-use once_cell::sync::Lazy;
 use std::cmp;
 use std::fs::File;
 use std::os::fd::FromRawFd;
 use std::sync::atomic::{AtomicIsize, Ordering};
+use std::sync::LazyLock;
 use std::{ffi::CString, mem};
 
 /// Width of ambiguous East Asian characters and, as of TR11, all private-use characters.
@@ -29,7 +29,7 @@ pub static FISH_AMBIGUOUS_WIDTH: AtomicIsize = AtomicIsize::new(1);
 // For some reason, this is declared here and exposed here, but is set in `env_dispatch`.
 pub static FISH_EMOJI_WIDTH: AtomicIsize = AtomicIsize::new(1);
 
-static WC_LOOKUP_TABLE: Lazy<WcLookupTable> = Lazy::new(WcLookupTable::new);
+static WC_LOOKUP_TABLE: LazyLock<WcLookupTable> = LazyLock::new(WcLookupTable::new);
 
 /// A safe wrapper around the system `wcwidth()` function
 pub fn wcwidth(c: char) -> isize {

--- a/src/function.rs
+++ b/src/function.rs
@@ -14,10 +14,9 @@ use crate::parser::Parser;
 use crate::parser_keywords::parser_keywords_is_reserved;
 use crate::wchar::prelude::*;
 use crate::wutil::{dir_iter::DirIter, sprintf};
-use once_cell::sync::Lazy;
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroU32;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 #[derive(Clone)]
 pub struct FunctionProperties {
@@ -100,7 +99,7 @@ impl FunctionSet {
 }
 
 /// The big set of all functions.
-static FUNCTION_SET: Lazy<Mutex<FunctionSet>> = Lazy::new(|| {
+static FUNCTION_SET: LazyLock<Mutex<FunctionSet>> = LazyLock::new(|| {
     Mutex::new(FunctionSet {
         funcs: HashMap::new(),
         autoload_tombstones: HashSet::new(),

--- a/src/input.rs
+++ b/src/input.rs
@@ -14,11 +14,10 @@ use crate::reader::{
 use crate::signal::signal_clear_cancel;
 use crate::threads::{assert_is_main_thread, iothread_service_main};
 use crate::wchar::prelude::*;
-use once_cell::sync::{Lazy, OnceCell};
 use std::ffi::CString;
 use std::sync::{
     atomic::{AtomicU32, Ordering},
-    Mutex, MutexGuard,
+    LazyLock, Mutex, MutexGuard, OnceLock,
 };
 
 pub const FISH_BIND_MODE_VAR: &wstr = L!("fish_bind_mode");
@@ -246,13 +245,13 @@ pub struct InputMappingSet {
 
 /// Access the singleton input mapping set.
 pub fn input_mappings() -> MutexGuard<'static, InputMappingSet> {
-    static INPUT_MAPPINGS: Lazy<Mutex<InputMappingSet>> =
-        Lazy::new(|| Mutex::new(InputMappingSet::default()));
+    static INPUT_MAPPINGS: LazyLock<Mutex<InputMappingSet>> =
+        LazyLock::new(|| Mutex::new(InputMappingSet::default()));
     INPUT_MAPPINGS.lock().unwrap()
 }
 
 /// Terminfo map list.
-static TERMINFO_MAPPINGS: OnceCell<Box<[TerminfoMapping]>> = OnceCell::new();
+static TERMINFO_MAPPINGS: OnceLock<Box<[TerminfoMapping]>> = OnceLock::new();
 
 /// Return the current bind mode.
 fn input_get_bind_mode(vars: &dyn Environment) -> WString {

--- a/src/io.rs
+++ b/src/io.rs
@@ -20,7 +20,6 @@ use errno::Errno;
 use libc::{EAGAIN, EINTR, ENOENT, ENOTDIR, EPIPE, EWOULDBLOCK, STDOUT_FILENO};
 use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
-use once_cell::sync::Lazy;
 #[cfg(not(target_has_atomic = "64"))]
 use portable_atomic::AtomicU64;
 use std::cell::RefCell;
@@ -30,7 +29,7 @@ use std::os::fd::{AsRawFd, IntoRawFd, OwnedFd, RawFd};
 #[cfg(target_has_atomic = "64")]
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
-use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::sync::{Arc, Condvar, LazyLock, Mutex, MutexGuard};
 
 /// separated_buffer_t represents a buffer of output from commands, prepared to be turned into a
 /// variable. For example, command substitutions output into one of these. Most commands just
@@ -1034,7 +1033,7 @@ const NOCLOB_ERROR: &wstr = L!("The file '%ls' already exists");
 const OPEN_MASK: Mode = Mode::from_bits_truncate(0o666);
 
 /// Provide the fd monitor used for background fillthread operations.
-static FD_MONITOR: Lazy<FdMonitor> = Lazy::new(FdMonitor::new);
+static FD_MONITOR: LazyLock<FdMonitor> = LazyLock::new(FdMonitor::new);
 
 pub fn fd_monitor() -> &'static FdMonitor {
     &FD_MONITOR

--- a/src/kill.rs
+++ b/src/kill.rs
@@ -3,15 +3,14 @@
 //! Works like the killring in emacs and readline. The killring is cut and paste with a memory of
 //! previous cuts.
 
-use once_cell::sync::Lazy;
 use std::collections::VecDeque;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 use crate::wchar::prelude::*;
 
 struct KillRing(VecDeque<WString>);
 
-static KILL_RING: Lazy<Mutex<KillRing>> = Lazy::new(|| Mutex::new(KillRing::new()));
+static KILL_RING: LazyLock<Mutex<KillRing>> = LazyLock::new(|| Mutex::new(KillRing::new()));
 
 impl KillRing {
     /// Create a new killring.

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -1,14 +1,14 @@
 use std::sync::atomic::AtomicPtr;
+use std::sync::LazyLock;
 
 use libc::{c_char, c_int};
-use once_cell::sync::Lazy;
 
 pub static _PATH_BSHELL: AtomicPtr<c_char> = AtomicPtr::new(std::ptr::null_mut());
 extern "C" {
     pub fn C_PATH_BSHELL() -> *const c_char;
 }
 
-pub static _PC_CASE_SENSITIVE: Lazy<c_int> = Lazy::new(|| unsafe { C_PC_CASE_SENSITIVE() });
+pub static _PC_CASE_SENSITIVE: LazyLock<c_int> = LazyLock::new(|| unsafe { C_PC_CASE_SENSITIVE() });
 extern "C" {
     fn C_PC_CASE_SENSITIVE() -> c_int;
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,11 +1,11 @@
 use std::{
     panic::{set_hook, take_hook, UnwindSafe},
     sync::atomic::{AtomicBool, Ordering},
+    sync::OnceLock,
     time::Duration,
 };
 
 use libc::STDIN_FILENO;
-use once_cell::sync::OnceCell;
 
 use crate::{
     common::{read_blocked, PROGRAM_NAME},
@@ -13,7 +13,7 @@ use crate::{
     threads::{asan_maybe_exit, is_main_thread},
 };
 
-pub static AT_EXIT: OnceCell<Box<dyn Fn(bool) + Send + Sync>> = OnceCell::new();
+pub static AT_EXIT: OnceLock<Box<dyn Fn(bool) + Send + Sync>> = OnceLock::new();
 
 pub fn panic_handler(main: impl FnOnce() -> i32 + UnwindSafe) -> ! {
     // The isatty() check will stop us from hanging in most fish tests, but not those

--- a/src/path.rs
+++ b/src/path.rs
@@ -12,10 +12,10 @@ use crate::wchar::prelude::*;
 use crate::wutil::{normalize_path, path_normalize_for_cd, waccess, wdirname, wstat};
 use errno::{errno, set_errno, Errno};
 use libc::{EACCES, ENOENT, ENOTDIR, F_OK, X_OK};
-use once_cell::sync::Lazy;
 use std::ffi::OsStr;
 use std::io::ErrorKind;
 use std::os::unix::prelude::*;
+use std::sync::LazyLock;
 
 /// Returns the user configuration directory for fish. If the directory or one of its parents
 /// doesn't exist, they are first created.
@@ -198,7 +198,7 @@ pub fn path_get_path(cmd: &wstr, vars: &dyn Environment) -> Option<WString> {
 }
 
 // PREFIX is defined at build time.
-pub static DEFAULT_PATH: Lazy<[WString; 3]> = Lazy::new(|| {
+pub static DEFAULT_PATH: LazyLock<[WString; 3]> = LazyLock::new(|| {
     [
         WString::from_str(env!("PREFIX")) + L!("/bin"),
         L!("/usr/bin").to_owned(),
@@ -759,20 +759,20 @@ fn path_remoteness(path: &wstr) -> DirRemoteness {
 }
 
 fn get_data_directory() -> &'static BaseDirectory {
-    static DIR: Lazy<BaseDirectory> =
-        Lazy::new(|| make_base_directory(L!("XDG_DATA_HOME"), L!("/.local/share/fish")));
+    static DIR: LazyLock<BaseDirectory> =
+        LazyLock::new(|| make_base_directory(L!("XDG_DATA_HOME"), L!("/.local/share/fish")));
     &DIR
 }
 
 fn get_cache_directory() -> &'static BaseDirectory {
-    static DIR: Lazy<BaseDirectory> =
-        Lazy::new(|| make_base_directory(L!("XDG_CACHE_HOME"), L!("/.cache/fish")));
+    static DIR: LazyLock<BaseDirectory> =
+        LazyLock::new(|| make_base_directory(L!("XDG_CACHE_HOME"), L!("/.cache/fish")));
     &DIR
 }
 
 fn get_config_directory() -> &'static BaseDirectory {
-    static DIR: Lazy<BaseDirectory> =
-        Lazy::new(|| make_base_directory(L!("XDG_CONFIG_HOME"), L!("/.config/fish")));
+    static DIR: LazyLock<BaseDirectory> =
+        LazyLock::new(|| make_base_directory(L!("XDG_CONFIG_HOME"), L!("/.config/fish")));
     &DIR
 }
 

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -31,7 +31,6 @@ use libc::{
     WCONTINUED, WEXITSTATUS, WIFCONTINUED, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WNOHANG, WTERMSIG,
     WUNTRACED, _SC_CLK_TCK,
 };
-use once_cell::sync::Lazy;
 #[cfg(not(target_has_atomic = "64"))]
 use portable_atomic::AtomicU64;
 use std::cell::{Cell, Ref, RefCell, RefMut};
@@ -43,7 +42,7 @@ use std::rc::Rc;
 #[cfg(target_has_atomic = "64")]
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 /// Types of processes.
 #[derive(Default, Eq, PartialEq)]
@@ -1866,8 +1865,8 @@ fn process_clean_after_marking(parser: &Parser, allow_interactive: bool) -> bool
 
 pub fn have_proc_stat() -> bool {
     // Check for /proc/self/stat to see if we are running with Linux-style procfs.
-    static HAVE_PROC_STAT_RESULT: Lazy<bool> =
-        Lazy::new(|| fs::metadata("/proc/self/stat").is_ok());
+    static HAVE_PROC_STAT_RESULT: LazyLock<bool> =
+        LazyLock::new(|| fs::metadata("/proc/self/stat").is_ok());
     *HAVE_PROC_STAT_RESULT
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -37,11 +37,11 @@ pub mod prelude {
     use crate::topic_monitor::topic_monitor_init;
     use crate::wutil::wgetcwd;
     use crate::{env::EnvStack, proc::proc_init};
-    use once_cell::sync::OnceCell;
     use std::cell::RefCell;
     use std::env::set_current_dir;
     use std::ffi::CString;
     use std::rc::Rc;
+    use std::sync::OnceLock;
 
     /// A wrapper around a Parser with some test helpers.
     pub struct TestParser {
@@ -85,7 +85,7 @@ pub mod prelude {
     }
 
     pub fn test_init() -> impl ScopeGuarding<Target = ()> {
-        static DONE: OnceCell<()> = OnceCell::new();
+        static DONE: OnceLock<()> = OnceLock::new();
         DONE.get_or_init(|| {
             // If we are building with `cargo build` and have build w/ `cmake`, FISH_BUILD_DIR might
             // not yet exist.

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -6,7 +6,7 @@ use crate::reader::Reader;
 use std::marker::PhantomData;
 use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 impl FloggableDebug for std::thread::ThreadId {}
@@ -30,8 +30,8 @@ const IO_WAIT_FOR_WORK_DURATION: Duration = Duration::from_millis(500);
 static IO_THREAD_POOL: OnceLock<Mutex<ThreadPool>> = OnceLock::new();
 
 /// The event signaller singleton used for completions and queued main thread requests.
-static NOTIFY_SIGNALLER: once_cell::sync::Lazy<crate::fd_monitor::FdEventSignaller> =
-    once_cell::sync::Lazy::new(crate::fd_monitor::FdEventSignaller::new);
+static NOTIFY_SIGNALLER: LazyLock<crate::fd_monitor::FdEventSignaller> =
+    LazyLock::new(crate::fd_monitor::FdEventSignaller::new);
 
 /// A [`ThreadPool`] work request.
 type WorkItem = Box<dyn FnOnce() + 'static + Send>;

--- a/src/universal_notifier/mod.rs
+++ b/src/universal_notifier/mod.rs
@@ -1,5 +1,5 @@
-use once_cell::sync::OnceCell;
 use std::os::fd::RawFd;
+use std::sync::OnceLock;
 
 #[cfg(target_os = "macos")]
 mod notifyd;
@@ -69,7 +69,7 @@ pub fn create_notifier() -> Box<dyn UniversalNotifier> {
 }
 
 // Default instance. Other instances are possible for testing.
-static DEFAULT_NOTIFIER: OnceCell<Box<dyn UniversalNotifier>> = OnceCell::new();
+static DEFAULT_NOTIFIER: OnceLock<Box<dyn UniversalNotifier>> = OnceLock::new();
 
 pub fn default_notifier() -> &'static dyn UniversalNotifier {
     DEFAULT_NOTIFIER.get_or_init(create_notifier).as_ref()

--- a/src/wildcard.rs
+++ b/src/wildcard.rs
@@ -4,6 +4,7 @@ use libc::X_OK;
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fs;
+use std::sync::LazyLock;
 
 use crate::common::{
     char_offset, is_windows_subsystem_for_linux, unescape_string, UnescapeFlags,
@@ -20,14 +21,14 @@ use crate::wcstringutil::{
 };
 use crate::wutil::dir_iter::DirEntryType;
 use crate::wutil::{dir_iter::DirEntry, lwstat, waccess};
-use once_cell::sync::Lazy;
 
-static COMPLETE_EXEC_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("command"));
-static COMPLETE_EXEC_LINK_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("command link"));
-static COMPLETE_FILE_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("file"));
-static COMPLETE_SYMLINK_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("symlink"));
-static COMPLETE_DIRECTORY_SYMLINK_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("dir symlink"));
-static COMPLETE_DIRECTORY_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("directory"));
+static COMPLETE_EXEC_DESC: LazyLock<&wstr> = LazyLock::new(|| wgettext!("command"));
+static COMPLETE_EXEC_LINK_DESC: LazyLock<&wstr> = LazyLock::new(|| wgettext!("command link"));
+static COMPLETE_FILE_DESC: LazyLock<&wstr> = LazyLock::new(|| wgettext!("file"));
+static COMPLETE_SYMLINK_DESC: LazyLock<&wstr> = LazyLock::new(|| wgettext!("symlink"));
+static COMPLETE_DIRECTORY_SYMLINK_DESC: LazyLock<&wstr> =
+    LazyLock::new(|| wgettext!("dir symlink"));
+static COMPLETE_DIRECTORY_DESC: LazyLock<&wstr> = LazyLock::new(|| wgettext!("directory"));
 
 /// Character representing any character except '/' (slash).
 pub const ANY_CHAR: char = char_offset(WILDCARD_RESERVED_BASE, 0);


### PR DESCRIPTION
## Description

Some of containers, like `Lazy` and `OnceCell` which are provided by third-party crate `once_cell`, have their equivalent implementation in standard library: `LazyLock` and `OnceLock`.

Use std rather than third-party crates seems better because std can provide safer and more stable implementations.

The only thing that should be noticed is that the MSRV will be `1.80.0`, because it was this version that first introduced `LazyLock` in std.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
