### PR TITLE
fix: give up after some specified attempts of repainting the prompt

### DIFF
--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -11,7 +11,6 @@ use crate::proc::is_interactive_session;
 use crate::reader::{
     reader_change_cursor_end_mode, reader_change_cursor_selection_mode, reader_change_history,
     reader_schedule_prompt_repaint, reader_set_autosuggestion_enabled,
-    reader_set_handle_redraw_attempts_change,
 };
 use crate::screen::screen_set_midnight_commander_hack;
 use crate::screen::LAYOUT_CACHE_SHARED;
@@ -74,7 +73,6 @@ static VAR_DISPATCH_TABLE: once_cell::sync::Lazy<VarDispatchTable> =
             L!("fish_autosuggestion_enabled"),
             handle_autosuggestion_change,
         );
-        table.add_anon(L!("fish_redraw_attempts"), handle_redraw_attempts_change);
         table.add_anon(
             L!("fish_use_posix_spawn"),
             handle_fish_use_posix_spawn_change,
@@ -278,10 +276,6 @@ fn handle_fish_cursor_end_mode_change(vars: &EnvStack) {
     };
 
     reader_change_cursor_end_mode(mode);
-}
-
-fn handle_redraw_attempts_change(vars: &EnvStack) {
-    reader_set_handle_redraw_attempts_change(vars);
 }
 fn handle_autosuggestion_change(vars: &EnvStack) {
     reader_set_autosuggestion_enabled(vars);

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -11,6 +11,7 @@ use crate::proc::is_interactive_session;
 use crate::reader::{
     reader_change_cursor_end_mode, reader_change_cursor_selection_mode, reader_change_history,
     reader_schedule_prompt_repaint, reader_set_autosuggestion_enabled,
+    reader_set_handle_redraw_attempts_change,
 };
 use crate::screen::screen_set_midnight_commander_hack;
 use crate::screen::LAYOUT_CACHE_SHARED;
@@ -73,6 +74,7 @@ static VAR_DISPATCH_TABLE: once_cell::sync::Lazy<VarDispatchTable> =
             L!("fish_autosuggestion_enabled"),
             handle_autosuggestion_change,
         );
+        table.add_anon(L!("fish_redraw_attempts"), handle_redraw_attempts_change);
         table.add_anon(
             L!("fish_use_posix_spawn"),
             handle_fish_use_posix_spawn_change,
@@ -278,6 +280,9 @@ fn handle_fish_cursor_end_mode_change(vars: &EnvStack) {
     reader_change_cursor_end_mode(mode);
 }
 
+fn handle_redraw_attempts_change(vars: &EnvStack) {
+    reader_set_handle_redraw_attempts_change(vars);
+}
 fn handle_autosuggestion_change(vars: &EnvStack) {
     reader_set_autosuggestion_enabled(vars);
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -942,24 +942,6 @@ pub fn reader_set_autosuggestion_enabled(vars: &dyn Environment) {
     }
 }
 
-/// Change the number of attempts to redraw a prompt before giving up.
-pub fn reader_set_handle_redraw_attempts_change(vars: &dyn Environment) {
-    // We don't need to _change_ if we're not initialized yet.
-    let Some(data) = current_data() else {
-        return;
-    };
-    let attempts: usize = vars
-        .get(L!("fish_redraw_attempts"))
-        .and_then(|v| v.as_string().to_string().parse().ok())
-        .unwrap_or(3);
-    if data.redraw_attempt.threshold != attempts {
-        data.redraw_attempt.threshold = attempts;
-        data.force_exec_prompt_and_repaint = true;
-        data.input_data
-            .queue_char(CharEvent::from_readline(ReadlineCmd::Repaint));
-    }
-}
-
 /// Tell the reader that it needs to re-exec the prompt and repaint.
 /// This may be called in response to e.g. a color variable change.
 pub fn reader_schedule_prompt_repaint() {
@@ -4219,7 +4201,7 @@ impl<'a> Reader<'a> {
                     },
                     zelf.parser,
                     Some(&mut prompt_list),
-                    /*apply_exit_status=*/ true,
+                    /*apply_exit_status=*/ false,
                 );
                 if status != 0 {
                     zelf.redraw_attempt.record();


### PR DESCRIPTION
## Description

- Adds a repaint attempts counter to `ReaderData` struct
- The number of retries can bet set using a newly introduced `fish_redraw_attempts` environment variable
- The default value is set to 3
- If the subshell exit status of the prompt command is not zero for `threshold` number of times,
`redraw_attempt.exceeded()` is true and we paint the default prompt

Fixes issue #9796

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
