### PR TITLE
Remove `lazy_static!` and Use `Lazy` Instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,6 @@ dependencies = [
  "cc",
  "errno",
  "fish-printf",
- "lazy_static",
  "libc",
  "lru",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ pcre2 = { git = "https://github.com/fish-shell/rust-pcre2", tag = "0.2.9-utf32",
 
 bitflags = "2.5.0"
 errno = "0.3.0"
-lazy_static = "1.4.0"
 libc = "0.2.155"
 # lru pulls in hashbrown by default, which uses a faster (though less DoS resistant) hashing algo.
 # disabling default features uses the stdlib instead, but it doubles the time to rewrite the history

--- a/src/env/environment_impl.rs
+++ b/src/env/environment_impl.rs
@@ -287,8 +287,6 @@ fn copy_node_chain(node: &EnvNodeRef) -> EnvNodeRef {
         new_scope: node.new_scope,
         next,
     };
-    #[allow(unknown_lints)]
-    #[allow(clippy::arc_with_non_send_sync)]
     EnvNodeRef(Arc::new(RwLock::new(new_node)))
 }
 


### PR DESCRIPTION
## Description

`Arc<RefCell<T>>` isn't thread-safe and should be replaced with `Arc<RwLock<T>>`, but `lazy_static!` bypassed this check so that it could probably cause a vulnerability. This PR aims to fix this protential issue.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
