### PR TITLE
doc: expand &| reference to full example

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -266,8 +266,8 @@ Consider this helper function::
 Now let's see a few cases::
 
   # Redirect both stderr and stdout to less
-  # (can also be spelt as `&|`)
   print 2>&1 | less
+  print &| less       # equivalent using &|
 
   # Show the "out" on stderr, silence the "err"
   print >&2 2>/dev/null


### PR DESCRIPTION
## Description

I'm new to fish and wasn't aware of `|&` in bash. At this point in the tutorial I had to do a web search to understand what `&|` did.

FWIW at this point I tried `print &| | less` because I thought the comment was saying `&|` abbreviated `2>&1` rather than `2>&1 |`.

Built locally and verified with sphinx.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
