### PR TITLE
Swap variable overrides and time in not statement

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1644,16 +1644,16 @@ pub struct NotStatement {
     parent: Option<*const dyn Node>,
     /// Keyword, either not or exclam.
     pub kw: KeywordNot,
-    pub variables: VariableAssignmentList,
     pub time: Option<KeywordTime>,
+    pub variables: VariableAssignmentList,
     pub contents: Statement,
 }
 implement_node!(NotStatement, branch, not_statement);
 implement_acceptor_for_branch!(
     NotStatement,
     (kw: (KeywordNot)),
-    (variables: (VariableAssignmentList)),
     (time: (Option<KeywordTime>)),
+    (variables: (VariableAssignmentList)),
     (contents: (Statement)),
 );
 impl ConcreteNode for NotStatement {


### PR DESCRIPTION
This is allowed

	time a=b echo 123

but -- due to an oversight in 3de95038b0 (Make "time" a job prefix,
2019-12-21) -- this is not allowed:

	not time a=b echo 123

Instead, this one one works:

	not a=b time echo 123

which is weird because without the "not" this would run "/bin/time".

Swap the order for consistency.
