### PR TITLE
Add `status buildinfo`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,11 @@ fn main() {
             .unwrap(),
     );
 
+    // Some build info
+    rsconf::set_env_value("BUILD_TARGET_TRIPLE", &env::var("TARGET").unwrap());
+    rsconf::set_env_value("BUILD_HOST_TRIPLE", &env::var("HOST").unwrap());
+    rsconf::set_env_value("BUILD_PROFILE", &env::var("PROFILE").unwrap());
+
     let version = &get_version(&env::current_dir().unwrap());
     // Per https://doc.rust-lang.org/cargo/reference/build-scripts.html#inputs-to-the-build-script,
     // the source directory is the current working directory of the build script

--- a/cmake/Rust.cmake
+++ b/cmake/Rust.cmake
@@ -49,6 +49,8 @@ set(VARS_FOR_CARGO
     "PREFIX=${CMAKE_INSTALL_PREFIX}"
     # Temporary hack to propogate CMake flags/options to build.rs.
     "CMAKE_WITH_GETTEXT=${CMAKE_WITH_GETTEXT}"
+    # Cheesy so we can tell cmake was used to build
+    "CMAKE=1"
     "DOCDIR=${CMAKE_INSTALL_FULL_DOCDIR}"
     "DATADIR=${CMAKE_INSTALL_FULL_DATADIR}"
     "SYSCONFDIR=${CMAKE_INSTALL_FULL_SYSCONFDIR}"

--- a/doc_src/cmds/status.rst
+++ b/doc_src/cmds/status.rst
@@ -29,6 +29,7 @@ Synopsis
     status job-control CONTROL_TYPE
     status features
     status test-feature FEATURE
+    status buildinfo
 
 Description
 -----------
@@ -96,6 +97,10 @@ The following operations (subcommands) are available:
 
 **test-feature** *FEATURE*
     Returns 0 when FEATURE is enabled, 1 if it is disabled, and 2 if it is not recognized.
+
+**buildinfo**
+    This prints information on how fish was build - which architecture, which build system or profile was used, etc.
+    This is mainly useful for debugging.
 
 Notes
 -----

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -452,6 +452,8 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                 "gettext",
                 #[cfg(feature = "installable")]
                 "installable",
+                #[cfg(target_feature = "crt-static")]
+                "crt-static",
             ];
             streams
                 .out

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -447,16 +447,15 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
             streams.out.append(L!("Profile: "));
             streams.out.appendln(profile);
             streams.out.append(L!("Features: "));
-            streams.out.appendln(str2wcstring(
-                [
-                    #[cfg(gettext)]
-                    "gettext",
-                    #[cfg(feature = "installable")]
-                    "installable",
-                ]
-                .join(" ")
-                .as_bytes(),
-            ));
+            let features: &[&str] = &[
+                #[cfg(gettext)]
+                "gettext",
+                #[cfg(feature = "installable")]
+                "installable",
+            ];
+            streams
+                .out
+                .appendln(str2wcstring(features.join(" ").as_bytes()));
             streams.out.appendln("");
             return STATUS_CMD_OK;
         }

--- a/tests/checks/buildinfo.fish
+++ b/tests/checks/buildinfo.fish
@@ -1,0 +1,6 @@
+#RUN: %fish %s
+# THIS WILL FAIL ON CI
+# There is no real good way to match this other than
+# Version: {{.*}}
+# and so on (with some exceptions like build system being "Cargo" or "CMake")
+status buildinfo

--- a/tests/checks/buildinfo.fish
+++ b/tests/checks/buildinfo.fish
@@ -1,6 +1,14 @@
 #RUN: %fish %s
-# THIS WILL FAIL ON CI
-# There is no real good way to match this other than
-# Version: {{.*}}
-# and so on (with some exceptions like build system being "Cargo" or "CMake")
+# Example output:
+# Build system: CMake
+# Version: 3.7.1-2573-gea8301631-dirty
+# Target (and host): x86_64-unknown-linux-gnu
+# Profile: release
+# Features: gettext
+
 status buildinfo
+# CHECK: Build system: {{CMake|Cargo}}
+# CHECK: Version: {{.+}}
+# CHECK: Target (and host): {{.+}}
+# CHECK: Profile: {{release|debug}}
+# CHECK: Features:{{.*}}

--- a/tests/checks/buildinfo.fish
+++ b/tests/checks/buildinfo.fish
@@ -6,9 +6,10 @@
 # Profile: release
 # Features: gettext
 
-status buildinfo
+status buildinfo | grep -v 'Host:'
 # CHECK: Build system: {{CMake|Cargo}}
 # CHECK: Version: {{.+}}
-# CHECK: Target (and host): {{.+}}
+# (this could be "Target (and Host)" or "Target:" and a separate line "Host:")
+# CHECK: Target{{.*}}: {{.+}}
 # CHECK: Profile: {{release|debug}}
 # CHECK: Features:{{.*}}


### PR DESCRIPTION
This can be used to get some information on how fish was built - the version, the build system, the operating system and architecture, the features.

The idea is that we can tell people to run `status buildinfo | fish_clipboard_copy` and copy it into bug reports.

Example output:

```output
> ./fish -c 'status buildinfo'
Build system: CMake
Version: 3.7.1-2571-gaadcb292b
Target (and host): x86_64-unknown-linux-gnu
Profile: release
Features: gettext

> ../target/x86_64-unknown-linux-musl/debug/fish -c 'status buildinfo'
Build system: Cargo
Version: 3.7.1-2571-g79aee4d60
Target: x86_64-unknown-linux-musl
Host: x86_64-unknown-linux-gnu
Profile: debug
Features: installable
```

This seems like it might be useful especially since we have multiple build systems and the potential for cross-compilation now.

The exact set of things to print isn't set in stone, of course, this was just what I came up with.

An alternative is to make a `status debuginfo` command that is a bit broader in scope, and also prints e.g. terminal or locale information, possibly even the operating system.

Importantly, this should *not* collect information like the time it was compiled to not break build reproducability, nor should it (for obvious reasons) collect personal information.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
