### PR TITLE
Ask to install installable builds on interactive launch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,10 +55,7 @@ Notable improvements and fixes
     cargo install --path . # in a clone of the fish repository
     # or `cargo build --release` and copy target/release/fish{,_indent,_key_reader} wherever you want
 
-    # and then, wherever you use it, run
-    /path/to/fish --install # or --install=noconfirm for non-interactive use
-
-  This will extract all the data files to (currently) ~/.local/share/fish/install/. To uninstall, remove the fish binaries and that directory.
+  The first time it runs interactively, it will extract all the data files to (currently) ~/.local/share/fish/install/. To uninstall, remove the fish binaries and that directory.
 
   This configuration is experimental.
   It does not affect the main configuration, which is a regular install via ``cmake``.

--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ You can also build fish as a self-installing binary.
 
 This will include all the datafiles like the included functions or web configuration tool in the main ``fish`` binary.
 
-On the first interactive run, and whenever it notices they are out of date, it will extract the datafiles to ~/.local/share/fish/install/ (currently, subject to change). You can do this manually by running ``fish --install`` (or ``fish --install=noconfirm`` to skip the confirmation).
+On the first interactive run, and whenever it notices they are out of date, it will extract the datafiles to ~/.local/share/fish/install/ (currently, subject to change). You can do this manually by running ``fish --install``.
 
 To install fish as self-installable, just use ``cargo``, like::
 

--- a/README.rst
+++ b/README.rst
@@ -171,10 +171,9 @@ Building fish as self-installable (experimental)
 
 You can also build fish as a self-installing binary.
 
-This will include all the datafiles like the included functions or web configuration tool in the main ``fish`` binary,
-and you can unpack them to ~/.local/share/fish/install/ (currently, subject to change) by running ``fish --install`` (or ``fish --install=noconfirm`` to skip the confirmation).
+This will include all the datafiles like the included functions or web configuration tool in the main ``fish`` binary.
 
-You will have to use ``--install`` once per user and you will have to run it again when you upgrade fish. It will tell you to.
+On the first interactive run, and whenever it notices they are out of date, it will extract the datafiles to ~/.local/share/fish/install/ (currently, subject to change). You can do this manually by running ``fish --install`` (or ``fish --install=noconfirm`` to skip the confirmation).
 
 To install fish as self-installable, just use ``cargo``, like::
 

--- a/doc_src/cmds/fish.rst
+++ b/doc_src/cmds/fish.rst
@@ -43,6 +43,7 @@ The following options are available:
 **--install[=noconfirm]**
     When built as self-installable (via cargo), this will unpack fish's datafiles and place them in ~/.local/share/fish/install/.
     Using ``--install=noconfirm`` will skip the confirmation step.
+    Fish will also do this automatically when run interactively.
 
 **-l** or **--login**
     Act as if invoked as a login shell.

--- a/doc_src/cmds/fish.rst
+++ b/doc_src/cmds/fish.rst
@@ -40,10 +40,9 @@ The following options are available:
 **-i** or **--interactive**
     The shell is interactive.
 
-**--install[=noconfirm]**
+**--install**
     When built as self-installable (via cargo), this will unpack fish's datafiles and place them in ~/.local/share/fish/install/.
-    Using ``--install=noconfirm`` will skip the confirmation step.
-    Fish will also do this automatically when run interactively.
+    Fish will also ask to do this automatically when run interactively.
 
 **-l** or **--login**
     Act as if invoked as a login shell.

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -540,7 +540,7 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
         wopt(L!("no-config"), NoArgument, 'N'),
         wopt(L!("no-execute"), NoArgument, 'n'),
         wopt(L!("print-rusage-self"), NoArgument, RUSAGE_ARG),
-        wopt(L!("install"), OptionalArgument, 'I'),
+        wopt(L!("install"), NoArgument, 'I'),
         wopt(
             L!("print-debug-categories"),
             NoArgument,
@@ -576,20 +576,7 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
             'h' => opts.batch_cmds.push("__fish_print_help fish".into()),
             'i' => opts.is_interactive_session = true,
             'I' => {
-                let noconfirm = match w.woptarg {
-                    None => false,
-                    Some(n) if n == L!("noconfirm") => true,
-                    _ => {
-                        FLOGF!(
-                            error,
-                            "Unknown argument to --install: '%ls'",
-                            w.woptarg.unwrap()
-                        );
-                        std::process::exit(1);
-                    }
-                };
-                let ret = install(!noconfirm);
-                std::process::exit(if ret { 0 } else { 1 });
+                install(false);
             }
             'l' => opts.is_login = true,
             'N' => {


### PR DESCRIPTION
## Description

One downside installable builds currently have is the need to run `fish --install` every so often.

This makes it so interactive runs (real interactive runs, `fish -i` doesn't suffice, you need a terminal so we can ask) do that automatically, including asking for it.

That means you can do

```terminal
> ~/.cargo/bin/fish
Warning: Fish's asset files are missing or out of date. Trying to install them.
This will write fish's data files to '/home/alfa/.local/share/fish/install'.
Please enter 'yes' to continue.
> yes
# and the prompt shows, we're in a session
```

You can still decline (by entering anything other than "yes"). If the files are missing, it will run without reading any config - this is quite uncomfortable, it won't even have the regular keybindings. (if they are outdated, things will "most likely" work out okay, but it will ask again next run)

Notably, for non-interactive runs, this won't install automatically, and it won't even complain about *outdated* files anymore.

If the files don't exist, on the other hand, it will print an error and then run.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
