### PR TITLE
rclone.fish: assume a recent version if the version cannot be parsed

### DIFF
--- a/share/completions/rclone.fish
+++ b/share/completions/rclone.fish
@@ -1,10 +1,14 @@
-set -l rclone_version (rclone version | string match -rg 'rclone v?(.*)' | string split .)
-or return
-
-# Yes, rclone's parsing here has changed, now they *require* a `-` argument
-# where previously they required *not* having it.
-if test "$rclone_version[1]" -gt 1; or test "$rclone_version[2]" -gt 62
-    rclone completion fish - 2>/dev/null | source
+if set -l rclone_version (rclone version | string match -rg 'rclone v?(.*)' | string split .) &&
+        test "$rclone_version[1]" -lt 1 ||
+        test "$rclone_version[1]" -eq 1 &&
+        test "$rclone_version[2]" -le 62
+  # version is definitely <= 1.62, adding a `-` would be an error
+  rclone completion fish
 else
-    rclone completion fish 2>/dev/null | source
-end
+  # For newer versions, this requires an `-`. Without a `-`, it would
+  # try to write to /etc/completions/fish.
+  # If we can't determine the version, assume a recent one. An error
+  # is better than trying to write to /etc unexpectedly.
+  rclone completion fish -
+end 2>/dev/null | source
+


### PR DESCRIPTION
The version of rclone is set during compilation and could be any crazy string depending on the packager, whether it's a dev build, etc. If it cannot be parsed, let's assume a recent version.

Follows up on cc8fa0f7808130ece03f1c2ac0c95f9ede2aaa1d. Cc @faho 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
