### PR TITLE
Allow installable builds to be installed into a specific path

### DIFF
--- a/doc_src/cmds/fish.rst
+++ b/doc_src/cmds/fish.rst
@@ -40,9 +40,11 @@ The following options are available:
 **-i** or **--interactive**
     The shell is interactive.
 
-**--install**
+**--install[=PATH]**
     When built as self-installable (via cargo), this will unpack fish's datafiles and place them in ~/.local/share/fish/install/.
     Fish will also ask to do this automatically when run interactively.
+    If PATH is given, fish will install itself into a relocatable directory tree rooted at that path.
+    That means it will install the datafiles to PATH/share/fish and copy itself to PATH/bin/fish.
 
 **-l** or **--login**
     Act as if invoked as a login shell.

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -581,6 +581,9 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
             'h' => opts.batch_cmds.push("__fish_print_help fish".into()),
             'i' => opts.is_interactive_session = true,
             'I' => {
+                #[cfg(not(feature = "installable"))]
+                eprintln!("Fish was built without support for self-installation");
+                #[cfg(feature = "installable")]
                 if let Some(path) = w.woptarg {
                     // We were given an explicit path.
                     // Install us there as a relocatable install.

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -30,7 +30,7 @@ use fish::{
     },
     common::{
         escape, get_executable_path, save_term_foreground_process_group, scoped_push_replacer,
-        str2wcstring, wcs2string, PACKAGE_NAME, PROFILING_ACTIVE, PROGRAM_NAME,
+        str2wcstring, wcs2string, wcs2osstring, PACKAGE_NAME, PROFILING_ACTIVE, PROGRAM_NAME,
     },
     env::{
         environment::{env_init, EnvStack, Environment},
@@ -417,7 +417,7 @@ fn check_version_file(paths: &ConfigPaths, datapath: &wstr) -> Option<bool> {
         // When fish is installable, we write the version to a file,
         // now we check it.
         let verfile =
-            PathBuf::from(fish::common::wcs2osstring(datapath)).join("fish-install-version");
+            PathBuf::from(wcs2osstring(datapath)).join("fish-install-version");
         let version = std::fs::read_to_string(verfile).ok()?;
 
         return Some(version == fish::BUILD_VERSION);
@@ -453,7 +453,7 @@ fn read_init(parser: &Parser, paths: &ConfigPaths) {
                 );
             }
 
-            install(true, PathBuf::from(fish::common::wcs2osstring(&datapath)));
+            install(true, PathBuf::from(wcs2osstring(&datapath)));
             // We try to go on if installation failed (or was rejected) here
             // If the assets are missing, we will trigger a later error,
             // if they are outdated, things will probably (tm) work somewhat.


### PR DESCRIPTION
## Description

This reuses the "relocatable tree" idea to allow installable builds to be put into one.

So you do

```fish
fish --install=$HOME/.local
```

and it

- installs the data files into ~/.local/share/fish/install (that "install" part is still important so we don't clear out the data dir and blow away your history, ask me how I know)
- copies the fish binary to ~/.local/bin/fish

And if you then run ~/.local/bin/fish, it just finds the files.

The main weirdness here is that this picks up the relocatable idea of using PREFIX/etc as sysconfdir. I do not understand this, and it is what causes #10748. Personally, I would remove this, but it would mean fish would detect a relocatable tree as soon as ../share/fish exists (and we *also* allow fish next to share/).

When fish can't get the home directory (because we do not want to trust $HOME because that breaks with `sudo`), it will tell you to install it somewhere specific, so it

Fixes issue #10916

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed - I do not know how to test installable builds yet. Ideas welcome!
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
