### PR TITLE
refactor: replace PathBuf with Path avoid unnecessary heap allocation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -222,7 +222,7 @@ fn has_small_stack(_: &Target) -> Result<bool, Box<dyn Error>> {
 }
 
 fn setup_paths() {
-    fn get_path(name: &str, default: &str, onvar: PathBuf) -> PathBuf {
+    fn get_path(name: &str, default: &str, onvar: &Path) -> PathBuf {
         let mut var = PathBuf::from(env::var(name).unwrap_or(default.to_string()));
         if var.is_relative() {
             var = onvar.join(var);
@@ -245,7 +245,7 @@ fn setup_paths() {
     rsconf::rebuild_if_env_changed("PREFIX");
     rsconf::set_env_value("PREFIX", prefix.to_str().unwrap());
 
-    let datadir = get_path("DATADIR", "share/", prefix.clone());
+    let datadir = get_path("DATADIR", "share/", &prefix);
     rsconf::set_env_value("DATADIR", datadir.to_str().unwrap());
     rsconf::rebuild_if_env_changed("DATADIR");
 
@@ -256,7 +256,7 @@ fn setup_paths() {
     };
     rsconf::set_env_value("DATADIR_SUBDIR", datadir_subdir);
 
-    let bindir = get_path("BINDIR", "bin/", prefix.clone());
+    let bindir = get_path("BINDIR", "bin/", &prefix);
     rsconf::set_env_value("BINDIR", bindir.to_str().unwrap());
     rsconf::rebuild_if_env_changed("BINDIR");
 
@@ -265,16 +265,16 @@ fn setup_paths() {
         // If we get our prefix from $HOME, we should use the system's /etc/
         // ~/.local/share/etc/ makes no sense
         if prefix_from_home { "/etc/" } else { "etc/" },
-        datadir.clone(),
+        &datadir,
     );
     rsconf::set_env_value("SYSCONFDIR", sysconfdir.to_str().unwrap());
     rsconf::rebuild_if_env_changed("SYSCONFDIR");
 
-    let localedir = get_path("LOCALEDIR", "locale/", datadir.clone());
+    let localedir = get_path("LOCALEDIR", "locale/", &datadir);
     rsconf::set_env_value("LOCALEDIR", localedir.to_str().unwrap());
     rsconf::rebuild_if_env_changed("LOCALEDIR");
 
-    let docdir = get_path("DOCDIR", "doc/fish", datadir.clone());
+    let docdir = get_path("DOCDIR", "doc/fish", &datadir);
     rsconf::set_env_value("DOCDIR", docdir.to_str().unwrap());
     rsconf::rebuild_if_env_changed("DOCDIR");
 }
@@ -287,7 +287,7 @@ fn get_version(src_dir: &Path) -> String {
         return var;
     }
 
-    let path = PathBuf::from(src_dir).join("version");
+    let path = src_dir.join("version");
     if let Ok(strver) = read_to_string(path) {
         return strver.to_string();
     }
@@ -316,7 +316,7 @@ fn get_version(src_dir: &Path) -> String {
     // or because it refused (safe.directory applies to `git describe`!)
     // So we read the SHA ourselves.
     fn get_git_hash() -> Result<String, Box<dyn std::error::Error>> {
-        let gitdir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".git");
+        let gitdir = Path::new(env!("CARGO_MANIFEST_DIR")).join(".git");
 
         // .git/HEAD contains ref: refs/heads/branch
         let headpath = gitdir.join("HEAD");

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -284,7 +284,7 @@ fn determine_config_directory_paths(argv0: impl AsRef<Path>) -> ConfigPaths {
 
         // Detect if we're running right out of the CMAKE build directory
         if exec_path.starts_with(env!("CARGO_MANIFEST_DIR")) {
-            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
             FLOG!(
                 config,
                 "Running out of target directory, using paths relative to CARGO_MANIFEST_DIR:\n",
@@ -346,7 +346,7 @@ fn determine_config_directory_paths(argv0: impl AsRef<Path>) -> ConfigPaths {
 
             PathBuf::from(home).join(DATA_DIR).join(DATA_DIR_SUBDIR)
         } else {
-            PathBuf::from(DATA_DIR).join(DATA_DIR_SUBDIR)
+            Path::new(DATA_DIR).join(DATA_DIR_SUBDIR)
         };
         let bin = if cfg!(feature = "installable") {
             exec_path.parent().map(|x| x.to_path_buf())
@@ -357,7 +357,7 @@ fn determine_config_directory_paths(argv0: impl AsRef<Path>) -> ConfigPaths {
         FLOG!(config, "Using compiled in paths:");
         paths = ConfigPaths {
             data,
-            sysconf: PathBuf::from(SYSCONF_DIR).join("fish"),
+            sysconf: Path::new(SYSCONF_DIR).join("fish"),
             doc: DOC_DIR.into(),
             bin,
         }


### PR DESCRIPTION
## Description

- When `PathBuf` is not actually needed, using `Path` can avoid unnecessary overhead of heap allocation.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
