### PR TITLE
ctrl-l to scroll content instead of erasing screen

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Interactive improvements
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - :kbd:`ctrl-z` (undo) after executing a command will restore the previous cursor position instead of placing the cursor at the end of the command line.
+- :kbd:`ctrl-l` no longer clears the screen but only pushes all text before the prompt to the terminal's scrollback
+  (via a new special input function ``scrollback-push``).
+  You can restore previous behavior with `bind ctrl-l clear-screen`.
 - The OSC 133 prompt marking feature has learned about kitty's ``click_events=1`` flag, which allows moving fish's cursor by clicking.
 
 Completions

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -171,7 +171,10 @@ The following special input functions are available:
     make the current word begin with a capital letter
 
 ``clear-screen``
-    clears the screen and redraws the prompt. if the terminal doesn't support clearing the screen it is the same as ``repaint``.
+    clears the screen and redraws the prompt.
+
+``scrollback-push``
+    pushes earlier output to the terminal scrollback, positioning the prompt at the top.
 
 ``complete``
     guess the remainder of the current token

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -66,7 +66,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv alt-l __fish_list_current_token
     bind --preset $argv alt-o __fish_preview_current_file
     bind --preset $argv alt-w __fish_whatis_current_token
-    bind --preset $argv ctrl-l clear-screen
+    bind --preset $argv ctrl-l scrollback-push repaint
     bind --preset $argv ctrl-c cancel-commandline
     bind --preset $argv ctrl-u backward-kill-line
     bind --preset $argv ctrl-w backward-kill-path-component

--- a/tests/checks/tmux-commandline.fish
+++ b/tests/checks/tmux-commandline.fish
@@ -9,7 +9,9 @@ tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 1> echo foobar|cat
 
-isolated-tmux send-keys C-k C-u C-l 'commandline -i (seq $LINES) scroll_here' Enter
+isolated-tmux send-keys C-k C-u C-l
+tmux-sleep
+isolated-tmux send-keys 'commandline -i (seq $LINES) scroll_here' Enter
 tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: 2

--- a/tests/checks/tmux-complete.fish
+++ b/tests/checks/tmux-complete.fish
@@ -17,15 +17,17 @@ isolated-tmux capture-pane -p
 # CHECK: ~/file-1  ~/file-2
 
 # No pager on single smartcase completion (#7738).
-isolated-tmux send-keys C-u C-l 'mkdir cmake CMakeFiles' Enter C-l \
-    'cat cmake' Tab
+isolated-tmux send-keys C-u 'mkdir cmake CMakeFiles' Enter C-l
+tmux-sleep
+isolated-tmux send-keys 'cat cmake' Tab
 tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 1> cat cmake/
 
 # Correct case in pager when prefixes differ in case (#7743).
-isolated-tmux send-keys C-u C-l 'complete -c foo2 -a "aabc aaBd" -f' Enter C-l \
-    'foo2 A' Tab
+isolated-tmux send-keys C-u 'complete -c foo2 -a "aabc aaBd" -f' Enter C-l
+tmux-sleep
+isolated-tmux send-keys 'foo2 A' Tab
 tmux-sleep
 isolated-tmux capture-pane -p
 # The "bc" part is the autosuggestion - we could use "capture-pane -e" to check colors.
@@ -34,7 +36,9 @@ isolated-tmux capture-pane -p
 
 # Check that a larger-than-screen completion list does not stomp a multiline commandline (#8509).
 isolated-tmux send-keys C-u 'complete -c foo3 -fa "(seq $LINES)\t(string repeat -n $COLUMNS d)"' Enter \
-    C-l begin Enter foo3 Enter "echo some trailing line" \
+    C-l
+tmux-sleep
+isolated-tmux send-keys begin Enter foo3 Enter "echo some trailing line" \
     C-p C-e Space Tab Tab
 tmux-sleep
 isolated-tmux capture-pane -p | sed -n '1p;$p'
@@ -47,7 +51,9 @@ isolated-tmux capture-pane -p | sed -n '1p;$p'
 # The common prefix remains because it is inserted before the pager is shown.
 isolated-tmux send-keys C-c
 tmux-sleep
-isolated-tmux send-keys C-l foo2 Space BTab b BSpace b Escape
+isolated-tmux send-keys C-l
+tmux-sleep
+isolated-tmux send-keys foo2 Space BTab b BSpace b Escape
 tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 3> foo2 aa
@@ -65,7 +71,9 @@ isolated-tmux capture-pane -p
 # Check that a larger-than-screen completion does not break down-or-search.
 isolated-tmux send-keys C-u 'complete -c foo4 -f -a "
     a-long-arg-\"$(seq $LINES | string pad -c_ --width $COLUMNS)\"
-    b-short-arg"' Enter C-l foo4 Space Tab Tab Down
+    b-short-arg"' Enter C-l
+tmux-sleep
+isolated-tmux send-keys foo4 Space Tab Tab Down
 tmux-sleep
 isolated-tmux capture-pane -p | head -1
 # The second one is the autosuggestion. Maybe we should turn them off for this test.
@@ -73,7 +81,9 @@ isolated-tmux capture-pane -p | head -1
 # CHECK: {{.*}} b-short-arg a-long-arg{{.*}}
 
 # Check that completion pager followed by token search search inserts two separate tokens.
-isolated-tmux send-keys C-u echo Space old-arg Enter C-l foo2 Space Tab Tab M-.
+isolated-tmux send-keys C-u echo Space old-arg Enter C-l
+tmux-sleep
+isolated-tmux send-keys foo2 Space Tab Tab M-.
 tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 5> foo2 aabc old-arg
@@ -86,6 +96,7 @@ isolated-tmux capture-pane -p
 # CHECK: prompt 6> echo suggest this
 
 isolated-tmux send-keys C-u 'bind ctrl-s forward-single-char' Enter C-l
+tmux-sleep
 isolated-tmux send-keys 'echo suggest thi'
 tmux-sleep
 isolated-tmux send-keys C-s
@@ -103,16 +114,19 @@ tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 7> echo suggest nothing
 
-isolated-tmux send-keys C-u 'bind \cs forward-char-passive' Enter C-l
-isolated-tmux send-keys C-u 'bind \cb backward-char-passive' Enter C-l
+isolated-tmux send-keys C-u 'bind \cs forward-char-passive' Enter
+isolated-tmux send-keys C-u 'bind \cb backward-char-passive' Enter
 isolated-tmux send-keys C-u 'echo do not accept this' Enter C-l
+tmux-sleep
 tmux-sleep
 isolated-tmux send-keys 'echo do not accept thi' C-b C-b DC C-b C-s 'h'
 tmux-sleep
 isolated-tmux send-keys C-s C-s C-s 'x'
 isolated-tmux capture-pane -p
 # CHECK: prompt 10> echo do not accept thix
-isolated-tmux send-keys C-u C-l ': {*,' Tab Tab Space ,
+isolated-tmux send-keys C-u C-l
+tmux-sleep
+isolated-tmux send-keys ': {*,' Tab Tab Space ,
 tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 10> : {*,cmake/ ,{{.*}}

--- a/tests/checks/tmux-signal.fish
+++ b/tests/checks/tmux-signal.fish
@@ -10,7 +10,9 @@ isolated-tmux send-keys '
         commandline -f repaint
     end
 ' Enter
-isolated-tmux send-keys C-l 'kill -SIGUSR1 $fish_pid' Enter
+isolated-tmux send-keys C-l
+tmux-sleep
+isolated-tmux send-keys 'kill -SIGUSR1 $fish_pid' Enter
 tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 1> kill -SIGUSR1 $fish_pid


### PR DESCRIPTION
On ctrl-l we send `\e[2J` (Erase in Display).  Some terminals interpret
this to scroll the screen content instead of clearing it. This happens
on VTE-based terminals like gnome-terminal for example.

The traditional behavior of ctrl-l erasing the screen (but not the
rest of the scrollback) is weird because:

1. `ctrl-l` is the easiest and most portable way to push the prompt
   to the top (and repaint after glitches I guess). But it's also a
   destructive action, truncating scrollback. I use it for scrolling
   and am frequently surprised when my scroll back is missing
   information.
2. the amount of lines erased depends on the window size.
   It would be more intuitive to erase by prompts, or erase the text
   in the terminal selection.

Let's use scrolling behavior on all terminals.

The new command could also be named "push-to-scrollback", for
consistency with others. But if we anticipate a want to add other
scrollback-related commands, "scrollback-push" is better.

This currently uses "CSI n A" for cursor movement, I guess to be safe
we could query for support for that as it's done in fa68c2619f (Use
parm_left_cursor and parm_right_cursor for bulk cursor motions. Fixes
#1448, 2014-05-09).

The implementation is currently async: keys sent immedately after
`ctrl-l` may be processed before the repaint completes.  We can
fix that.  For now change tests to reflect the new async behavior.

Ref: https://codeberg.org/dnkl/foot/wiki#how-do-i-make-ctrl-l-scroll-the-content-instead-of-erasing-it
as of wiki commit b57489e298f95d037fdf34da00ea60a5e8eafd6d
