### PR TITLE
docs: Use grid in the CSS

### DIFF
--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -71,12 +71,10 @@ div.related h3 {
 }
 
 div.related li.right {
-  float: right;
   margin-right: 5px;
 }
 
 div.sphinxsidebar {
-  width: 230px;
   overflow-wrap: break-word;
 }
 
@@ -548,10 +546,6 @@ div.sphinxsidebar ul {
 }
 
 
-div.bodywrapper {
-    margin-left: 230px;
-}
-
 aside.footnote > .label {
     display: inline;
 }
@@ -565,14 +559,32 @@ div.documentwrapper {
     width: 100%;
 }
 
+div.document {
+    display: grid;
+    grid-template: 1fr min-content / 12rem minmax(0,1fr);
+}
+
 /* On screens that are less than 700px wide remove anything non-essential
    - the sidebar, the gradient background, ... */
 @media screen and (max-width: 700px) {
+    div.document {
+        display: grid;
+        grid-template: 30vh min-content / 100%;
+    }
     div.sphinxsidebar {
         font-size: 16px;
         width: 100%;
         height: auto;
         position: relative;
+        /* To separate the "side"bar from the content below */
+        border-bottom: 1px solid;
+        border-color: var(--sidebar-border-color);
+    }
+
+    div.sphinxsidebar h3, div.sphinxsidebar h4 {
+        margin-top: 0;
+        /* "Sections" div has no identifiable class or id */
+        /* margin-left: 0.5em; */
     }
     div.bodywrapper {
         margin-left: 0;
@@ -585,11 +597,12 @@ div.documentwrapper {
     }
     div.sphinxsidebarwrapper {
         display: flex;
+        gap: 1em;
     }
     div.sphinxsidebarwrapper > h3:nth-child(5) {
         display: none;
     }
-    div#searchbox {
+    #searchbox {
         display: none !important;
     }
     div.content {margin-left: 0;}

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -111,7 +111,6 @@ div.sphinxsidebar ul {
   margin: 10px;
   padding: 0;
   color: var(--secondary-link-color);
-  margin: 10px;
   list-style: none;
 }
 
@@ -581,15 +580,14 @@ div.document {
         border-color: var(--sidebar-border-color);
     }
 
-    div.sphinxsidebar h3, div.sphinxsidebar h4 {
-        margin-top: 0;
-        /* "Sections" div has no identifiable class or id */
-        /* margin-left: 0.5em; */
-    }
-    div.bodywrapper {
+    /* Reduce margins to save space */
+    div.sphinxsidebar ul ul, div.sphinxsidebar ul, div.bodywrapper, div.content {
         margin-left: 0;
     }
 
+    div.sphinxsidebar h3, div.sphinxsidebar h4 {
+        margin-top: 0;
+    }
 
     div.sphinxsidebar ul {
         flex-basis: content;
@@ -598,6 +596,7 @@ div.document {
     div.sphinxsidebarwrapper {
         display: flex;
         gap: 1em;
+        justify-content: space-between;
     }
     div.sphinxsidebarwrapper > h3:nth-child(5) {
         display: none;
@@ -605,7 +604,6 @@ div.document {
     #searchbox {
         display: none !important;
     }
-    div.content {margin-left: 0;}
     div.body {
         padding: 1rem;
     }

--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -626,6 +626,9 @@ div.document {
 
 /* On print media remove anything non-essential. */
 @media print {
+    div.document {
+        display: block;
+    }
     .inline-search {
         display: none;
     }


### PR DESCRIPTION
Instead of hardcoded 230px margin.

This also makes the ToC only take up a third of the screen when narrow, and lets you scroll the rest.

Without, you'd have to scroll past the *entire* ToC, which is awkward.

Remaining issue is the search box up top. Since this disables the one in the sidebar again once the window gets too narrow, that one is important, and it isn't *great*.

(we had disabled the search box before but sphinx changed it from a `<div>` to a `<search>`)

## Screenshots

These are from Firefox, with the "Galaxy S20 Android 11" view (800 x 360). Chromium looks similar, and moving it around feels okay - it's nice and responsive, switching to the "narrow" view with the sidebar up top at the correct point.

Old:
![Bildschirmfoto am 2024-12-25 um 11 06 42](https://github.com/user-attachments/assets/f321740a-b8de-4b14-a2ba-deb40faa6104)
![Bildschirmfoto am 2024-12-25 um 11 06 46](https://github.com/user-attachments/assets/b4b2e4d1-e455-49c4-8232-db00e8d5c448)

Note the "quick search" in the middle and the fact that the *entire screen* is table of contents, no actual content.

New:

![Bildschirmfoto am 2024-12-25 um 11 06 58](https://github.com/user-attachments/assets/1381b297-9f40-4feb-872d-5586c8202be2)
![Bildschirmfoto am 2024-12-25 um 11 07 00](https://github.com/user-attachments/assets/929b855a-a480-4018-97d7-bc34013d0a5d)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
