### PR TITLE
Fix cursor position restore

### DIFF
--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -54,10 +54,7 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
                 end
                 set cursor_from_editor (mktemp)
                 set -a editor +$line "+norm! $col|" $f \
-                    '+autocmd VimLeave * ++once call writefile(
-                        [printf("%s %s %s", shellescape(bufname()), line("."), col("."))],
-                        "'$cursor_from_editor'"
-                     )'
+                    '+au VimLeave * ++once call writefile([printf("%s %s %s", shellescape(bufname()), line("."), col("."))], "'$cursor_from_editor'")'
             case emacs emacsclient gedit
                 set -a editor +$line:$col $f
             case kak


### PR DESCRIPTION
## Description
vim/nvim cannot restore cursor position now, the reason:
1. multi-line string cannot be handled correctly to create a valid autocmd.
2. I think the column number should +1 offset.
