### PR TITLE
fix python completion #10943

### DIFF
--- a/share/completions/python.fish
+++ b/share/completions/python.fish
@@ -1,23 +1,38 @@
-complete -c python -s B -d 'Don\'t write .py[co] files on import'
-complete -c python -s c -x -d "Execute argument as command"
-complete -c python -l check-hash-based-pycs -a "default always never" -d "Control validation behaviour of pyc files"
-complete -c python -s d -d "Debug on"
-complete -c python -s E -d "Ignore all PYTHON* env vars"
-complete -c python -s h -s '?' -l help -d "Display help and exit"
-complete -c python -s i -d "Interactive mode after executing commands"
-complete -c python -s m -d 'Run library module as a script (terminates option list)' -xa '(python -c "import pkgutil; print(\'\n\'.join([p[1] for p in pkgutil.iter_modules()]))")'
-complete -c python -s O -d "Enable optimizations"
-complete -c python -o OO -d "Remove doc-strings in addition to the -O optimizations"
-complete -c python -s s -d 'Don\'t add user site directory to sys.path'
-complete -c python -s S -d "Disable import of site module"
-complete -c python -s u -d "Unbuffered input and output"
-complete -c python -s v -d "Verbose mode"
-complete -c python -o vv -d "Even more verbose mode"
-complete -c python -s V -l version -d "Display version and exit"
-complete -c python -s W -x -d "Warning control" -a "ignore default all module once error"
-complete -c python -s x -d 'Skip first line of source, allowing use of non-Unix forms of #!cmd'
-complete -c python -f -n "__fish_is_nth_token 1" -k -a "(__fish_complete_suffix .py)"
-complete -c python -f -n "__fish_is_nth_token 1" -a - -d 'Read program from stdin'
+function __fish_python_no_arg
+    set -l num 1
+    set -l tokens (commandline -pxc)
+    set -l has_arg_list -X -W --check-hash-based-pycs
+    for has_arg in $has_arg_list
+        if contains -- $has_arg $tokens
+            set num (math $num + 1)
+        end
+    end
+    if test (__fish_number_of_cmd_args_wo_opts) -gt $num
+        return 1
+    end
+    return 0
+end
+
+complete -c python -n __fish_python_no_arg -s B -d 'Don\'t write .py[co] files on import'
+complete -c python -n __fish_python_no_arg -s c -x -d "Execute argument as command"
+complete -c python -n __fish_python_no_arg -l check-hash-based-pycs -a "default always never" -d "Control validation behaviour of pyc files"
+complete -c python -n __fish_python_no_arg -s d -d "Debug on"
+complete -c python -n __fish_python_no_arg -s E -d "Ignore all PYTHON* env vars"
+complete -c python -n __fish_python_no_arg -s h -s '?' -l help -d "Display help and exit"
+complete -c python -n __fish_python_no_arg -s i -d "Interactive mode after executing commands"
+complete -c python -n __fish_python_no_arg -s m -d 'Run library module as a script (terminates option list)' -xa '(python -c "import pkgutil; print(\'\n\'.join([p[1] for p in pkgutil.iter_modules()]))")'
+complete -c python -n __fish_python_no_arg -s O -d "Enable optimizations"
+complete -c python -n __fish_python_no_arg -o OO -d "Remove doc-strings in addition to the -O optimizations"
+complete -c python -n __fish_python_no_arg -s s -d 'Don\'t add user site directory to sys.path'
+complete -c python -n __fish_python_no_arg -s S -d "Disable import of site module"
+complete -c python -n __fish_python_no_arg -s u -d "Unbuffered input and output"
+complete -c python -n __fish_python_no_arg -s v -d "Verbose mode"
+complete -c python -n __fish_python_no_arg -o vv -d "Even more verbose mode"
+complete -c python -n __fish_python_no_arg -s V -l version -d "Display version and exit"
+complete -c python -n __fish_python_no_arg -s W -x -d "Warning control" -a "ignore default all module once error"
+complete -c python -n __fish_python_no_arg -s x -d 'Skip first line of source, allowing use of non-Unix forms of #!cmd'
+complete -c python -n __fish_python_no_arg -f -k -a "(__fish_complete_suffix .py)"
+complete -c python -n __fish_python_no_arg -f -a - -d 'Read program from stdin'
 
 # Version-specific completions
 # We have to detect this at runtime because pyenv etc can change
@@ -25,10 +40,10 @@ complete -c python -f -n "__fish_is_nth_token 1" -a - -d 'Read program from stdi
 complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s2"' -s 3 -d 'Warn about Python 3.x incompatibilities that 2to3 cannot trivially fix'
 complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s2"' -s t -d "Warn on mixed tabs and spaces"
 complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s2"' -s Q -x -a "old new warn warnall" -d "Division control"
-complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3"' -s q -d 'Don\'t print version and copyright messages on interactive startup'
-complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3"' -s X -x -d 'Set implementation-specific option'
-complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3"' -s b -d 'Warn when comparing bytes with str or int'
-complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3"' -o bb -d 'Error when comparing bytes with str or int'
-complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3"' -s R -d 'Turn on hash randomization'
-complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3"' -s I -d 'Run in isolated mode'
-complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3"' -o VV -d 'Print further version info'
+complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3" && __fish_python_no_arg' -s q -d 'Don\'t print version and copyright messages on interactive startup'
+complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3" && __fish_python_no_arg' -s X -x -d 'Set implementation-specific option'
+complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3" && __fish_python_no_arg' -s b -d 'Warn when comparing bytes with str or int'
+complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3" && __fish_python_no_arg' -o bb -d 'Error when comparing bytes with str or int'
+complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3" && __fish_python_no_arg' -s R -d 'Turn on hash randomization'
+complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3" && __fish_python_no_arg' -s I -d 'Run in isolated mode'
+complete -c python -n 'python -V 2>&1 | string match -rq "^.*\s3" && __fish_python_no_arg' -o VV -d 'Print further version info'

--- a/share/completions/python3.fish
+++ b/share/completions/python3.fish
@@ -1,24 +1,40 @@
-complete -c python3 -s B -d 'Don\'t write .py[co] files on import'
-complete -c python3 -s c -x -d "Execute argument as command"
-complete -c python3 -s d -d "Debug on"
-complete -c python3 -s E -d "Ignore environment variables"
-complete -c python3 -s h -s '?' -l help -d "Display help and exit"
-complete -c python3 -s i -d "Interactive mode after executing commands"
-complete -c python3 -s O -d "Enable optimizations"
-complete -c python3 -o OO -d "Remove doc-strings in addition to the -O optimizations"
-complete -c python3 -s s -d 'Don\'t add user site directory to sys.path'
-complete -c python3 -s S -d "Disable import of site module"
-complete -c python3 -s u -d "Unbuffered input and output"
-complete -c python3 -s v -d "Verbose mode"
-complete -c python3 -s V -l version -d "Display version and exit"
-complete -c python3 -s W -x -d "Warning control" -a "ignore default all module once error"
-complete -c python3 -s x -d 'Skip first line of source, allowing use of non-Unix forms of #!cmd'
-complete -c python3 -n "__fish_is_nth_token 1" -k -fa "(__fish_complete_suffix .py)"
-complete -c python3 -f -n "__fish_is_nth_token 1" -a - -d 'Read program from stdin'
-complete -c python3 -s q -d 'Don\'t print version and copyright messages on interactive startup'
-complete -c python3 -s X -x -d 'Set implementation-specific option' -a 'faulthandler showrefcount tracemalloc showalloccount importtime dev utf8 pycache_prefex=PATH:'
-complete -c python3 -s b -d 'Issue warnings for possible misuse of `bytes` with `str`'
-complete -c python3 -o bb -d 'Issue errors for possible misuse of `bytes` with `str`'
-complete -c python3 -s m -d 'Run library module as a script (terminates option list)' -xa '(python3 -c "import pkgutil; print(\'\n\'.join([p[1] for p in pkgutil.iter_modules()]))")'
-complete -c python3 -l check-hash-based-pycs -d 'Set pyc hash check mode' -xa "default always never"
-complete -c python3 -s I -d 'Run in isolated mode'
+function __fish_python_no_arg
+    set -l num 1
+    set -l tokens (commandline -pxc)
+    set -l has_arg_list -X -W --check-hash-based-pycs
+    for has_arg in $has_arg_list
+        if contains -- $has_arg $tokens
+            set num (math $num + 1)
+        end
+    end
+    if test (__fish_number_of_cmd_args_wo_opts) -gt $num
+        return 1
+    end
+    return 0
+end
+
+complete -c python3 -n __fish_python_no_arg -s B -d 'Don\'t write .py[co] files on import'
+complete -c python3 -n __fish_python_no_arg -s c -x -d "Execute argument as command"
+complete -c python3 -n __fish_python_no_arg -s d -d "Debug on"
+complete -c python3 -n __fish_python_no_arg -s E -d "Ignore environment variables"
+complete -c python3 -n __fish_python_no_arg -s h -s '?' -l help -d "Display help and exit"
+complete -c python3 -n __fish_python_no_arg -s i -d "Interactive mode after executing commands"
+complete -c python3 -n __fish_python_no_arg -s O -d "Enable optimizations"
+complete -c python3 -n __fish_python_no_arg -o OO -d "Remove doc-strings in addition to the -O optimizations"
+complete -c python3 -n __fish_python_no_arg -s s -d 'Don\'t add user site directory to sys.path'
+complete -c python3 -n __fish_python_no_arg -s S -d "Disable import of site module"
+complete -c python3 -n __fish_python_no_arg -s u -d "Unbuffered input and output"
+complete -c python3 -n __fish_python_no_arg -s v -d "Verbose mode"
+complete -c python3 -n __fish_python_no_arg -s V -l version -d "Display version and exit"
+complete -c python3 -n __fish_python_no_arg -s W -x -d "Warning control" -a "ignore default all module once error"
+complete -c python3 -n __fish_python_no_arg -s x -d 'Skip first line of source, allowing use of non-Unix forms of #!cmd'
+complete -c python3 -n __fish_python_no_arg -k -fa "(__fish_complete_suffix .py)"
+complete -c python3 -n __fish_python_no_arg -fa - -d 'Read program from stdin'
+complete -c python3 -n __fish_python_no_arg -s q -d 'Don\'t print version and copyright messages on interactive startup'
+complete -c python3 -n __fish_python_no_arg -s X -x -d 'Set implementation-specific option' -a 'faulthandler showrefcount tracemalloc showalloccount importtime dev utf8 pycache_prefex=PATH:'
+complete -c python3 -n __fish_python_no_arg -s b -d 'Issue warnings for possible misuse of `bytes` with `str`'
+complete -c python3 -n __fish_python_no_arg -o bb -d 'Issue errors for possible misuse of `bytes` with `str`'
+complete -c python3 -n __fish_python_no_arg -s m -d 'Run library module as a script (terminates option list)' -xa '(python3 -c "import pkgutil; print(\'\n\'.join([p[1] for p in pkgutil.iter_modules()]))")'
+complete -c python3 -n __fish_python_no_arg -l check-hash-based-pycs -d 'Set pyc hash check mode' -xa "default always never"
+complete -c python3 -n __fish_python_no_arg -s I -d 'Run in isolated mode'
+


### PR DESCRIPTION
## Description

Make the new autocompletion more suitable for Python 3. Avoid autocomplete when the script is given.

```
python3 [option] ... [-c cmd | -m mod | file | -] [arg] ...
```

Fixes issue #10943 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
