### PR TITLE
Convert builtin functions return type from Option<c_int> to Result<StatusOk, StatusError>.

### DIFF
--- a/src/bin/fish_indent.rs
+++ b/src/bin/fish_indent.rs
@@ -808,7 +808,7 @@ fn throwing_main() -> i32 {
             'P' => DUMP_PARSE_TREE.store(true),
             'h' => {
                 print_help("fish_indent");
-                return STATUS_CMD_OK.unwrap();
+                return STATUS_CMD_OK;
             }
             'v' => {
                 printf!(
@@ -819,7 +819,7 @@ fn throwing_main() -> i32 {
                         fish::BUILD_VERSION
                     )
                 );
-                return STATUS_CMD_OK.unwrap();
+                return STATUS_CMD_OK;
             }
             'w' => output_type = OutputType::File,
             'i' => do_indent = false,
@@ -844,7 +844,7 @@ fn throwing_main() -> i32 {
             'o' => {
                 debug_output = Some(w.woptarg.unwrap());
             }
-            _ => return STATUS_CMD_ERROR.unwrap(),
+            _ => return STATUS_CMD_ERROR,
         }
     }
 
@@ -882,11 +882,11 @@ fn throwing_main() -> i32 {
                         PROGRAM_NAME.get().unwrap()
                     )
                 );
-                return STATUS_CMD_ERROR.unwrap();
+                return STATUS_CMD_ERROR;
             }
             match read_file(stdin()) {
                 Ok(s) => src = s,
-                Err(()) => return STATUS_CMD_ERROR.unwrap(),
+                Err(()) => return STATUS_CMD_ERROR,
             }
         } else {
             let arg = args[i];
@@ -894,7 +894,7 @@ fn throwing_main() -> i32 {
                 Ok(file) => {
                     match read_file(file) {
                         Ok(s) => src = s,
-                        Err(()) => return STATUS_CMD_ERROR.unwrap(),
+                        Err(()) => return STATUS_CMD_ERROR,
                     }
                     output_location = arg;
                 }
@@ -903,7 +903,7 @@ fn throwing_main() -> i32 {
                         "%s",
                         wgettext_fmt!("Opening \"%s\" failed: %s\n", arg, err.to_string())
                     );
-                    return STATUS_CMD_ERROR.unwrap();
+                    return STATUS_CMD_ERROR;
                 }
             }
         }
@@ -987,7 +987,7 @@ fn throwing_main() -> i32 {
                                     err.to_string()
                                 )
                             );
-                            return STATUS_CMD_ERROR.unwrap();
+                            return STATUS_CMD_ERROR;
                         }
                     }
                 }

--- a/src/builtins/abbr.rs
+++ b/src/builtins/abbr.rs
@@ -124,7 +124,7 @@ fn join(list: &[&wstr], sep: &wstr) -> WString {
 }
 
 // Print abbreviations in a fish-script friendly way.
-fn abbr_show(streams: &mut IoStreams) -> Option<c_int> {
+fn abbr_show(streams: &mut IoStreams) -> Result<StatusOk, StatusError> {
     let style = EscapeStringStyle::Script(Default::default());
 
     abbrs::with_abbrs(|abbrs| {
@@ -174,11 +174,11 @@ fn abbr_show(streams: &mut IoStreams) -> Option<c_int> {
         }
     });
 
-    return STATUS_CMD_OK;
+    return Ok(StatusOk::OK);
 }
 
 // Print the list of abbreviation names.
-fn abbr_list(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
+fn abbr_list(opts: &Options, streams: &mut IoStreams) -> Result<StatusOk, StatusError> {
     const subcmd: &wstr = L!("--list");
     if !opts.args.is_empty() {
         streams.err.append(wgettext_fmt!(
@@ -187,7 +187,7 @@ fn abbr_list(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
             subcmd,
             &opts.args[0]
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
     abbrs::with_abbrs(|abbrs| {
         for abbr in abbrs.list() {
@@ -197,11 +197,11 @@ fn abbr_list(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
         }
     });
 
-    return STATUS_CMD_OK;
+    return Ok(StatusOk::OK);
 }
 
 // Rename an abbreviation, deleting any existing one with the given name.
-fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
+fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> Result<StatusOk, StatusError> {
     const subcmd: &wstr = L!("--rename");
 
     if opts.args.len() != 2 {
@@ -210,7 +210,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
             CMD,
             subcmd
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
     let old_name = &opts.args[0];
     let new_name = &opts.args[1];
@@ -220,7 +220,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
             CMD,
             subcmd
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if contains_whitespace(new_name) {
@@ -230,9 +230,9 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
             subcmd,
             new_name.as_utfstr()
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
-    abbrs::with_abbrs_mut(|abbrs| -> Option<c_int> {
+    abbrs::with_abbrs_mut(|abbrs| -> Result<StatusOk, StatusError> {
         if !abbrs.has_name(old_name) {
             streams.err.append(wgettext_fmt!(
                 "%ls %ls: No abbreviation named %ls\n",
@@ -240,7 +240,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
                 subcmd,
                 old_name.as_utfstr()
             ));
-            return STATUS_CMD_ERROR;
+            return Err(StatusError::STATUS_CMD_ERROR);
         }
         if abbrs.has_name(new_name) {
             streams.err.append(wgettext_fmt!(
@@ -250,10 +250,10 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
                 new_name.as_utfstr(),
                 old_name.as_utfstr()
             ));
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
         abbrs.rename(old_name, new_name);
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     })
 }
 
@@ -262,20 +262,20 @@ fn contains_whitespace(val: &wstr) -> bool {
 }
 
 // Test if any args is an abbreviation.
-fn abbr_query(opts: &Options) -> Option<c_int> {
+fn abbr_query(opts: &Options) -> Result<StatusOk, StatusError> {
     // Return success if any of our args matches an abbreviation.
     abbrs::with_abbrs(|abbrs| {
         for arg in opts.args.iter() {
             if abbrs.has_name(arg) {
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
         }
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     })
 }
 
 // Add a named abbreviation.
-fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
+fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Result<StatusOk, StatusError> {
     const subcmd: &wstr = L!("--add");
 
     if opts.args.len() < 2 && opts.function.is_none() {
@@ -284,7 +284,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
             CMD,
             subcmd
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if opts.args.is_empty() || opts.args[0].is_empty() {
@@ -293,7 +293,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
             CMD,
             subcmd
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
     let name = &opts.args[0];
     if name.chars().any(|c| c.is_whitespace()) {
@@ -303,7 +303,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
             subcmd,
             name.as_utfstr()
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     let key: &wstr;
@@ -331,7 +331,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
                     .err
                     .append(sprintf!("%ls: %*ls\n", CMD, offset, "^"));
             }
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
         let anchored = regex_make_anchored(regex_pattern);
         let re = Box::new(
@@ -352,7 +352,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
         streams
             .err
             .append(wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, L!("abbr")));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
     let replacement = if let Some(ref function) = opts.function {
         // Abbreviation function names disallow spaces.
@@ -363,7 +363,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
                 CMD,
                 function.as_utfstr()
             ));
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
         function.clone()
     } else {
@@ -390,7 +390,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
             "%ls: --command cannot be combined with --position command",
             CMD,
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     // Note historically we have allowed overwriting existing abbreviations.
@@ -408,22 +408,22 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> Option<c_int> {
         })
     });
 
-    return STATUS_CMD_OK;
+    return Ok(StatusOk::OK);
 }
 
 // Erase the named abbreviations.
-fn abbr_erase(opts: &Options, parser: &Parser) -> Option<c_int> {
+fn abbr_erase(opts: &Options, parser: &Parser) -> Result<StatusOk, StatusError> {
     if opts.args.is_empty() {
         // This has historically been a silent failure.
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     }
 
     // Erase each. If any is not found, return NotFound which is historical.
-    abbrs::with_abbrs_mut(|abbrs| -> Option<c_int> {
-        let mut result = STATUS_CMD_OK;
+    abbrs::with_abbrs_mut(|abbrs| -> Result<StatusOk, StatusError> {
+        let mut result: Result<StatusOk, StatusError> = Ok(StatusOk::OK);
         for arg in &opts.args {
             if !abbrs.erase(arg) {
-                result = Some(EnvStackSetResult::NotFound.into());
+                result = EnvStackSetResult::NotFound.into();
             }
             // Erase the old uvar - this makes `abbr -e` work.
             let esc_src = escape(arg);
@@ -432,7 +432,7 @@ fn abbr_erase(opts: &Options, parser: &Parser) -> Option<c_int> {
                 let ret = parser.vars().remove(&var_name, EnvMode::UNIVERSAL);
 
                 if ret == EnvStackSetResult::Ok {
-                    result = STATUS_CMD_OK
+                    result = Ok(StatusOk::OK)
                 };
             }
         }
@@ -440,7 +440,11 @@ fn abbr_erase(opts: &Options, parser: &Parser) -> Option<c_int> {
     })
 }
 
-pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Option<c_int> {
+pub fn abbr(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    argv: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let mut argv_read = Vec::with_capacity(argv.len());
     argv_read.extend_from_slice(argv);
 
@@ -504,7 +508,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                         "%ls: Cannot specify multiple positions\n",
                         CMD
                     ));
-                    return STATUS_INVALID_ARGS;
+                    return Err(StatusError::STATUS_INVALID_ARGS);
                 }
                 if w.woptarg == Some(L!("command")) {
                     opts.position = Some(Position::Command);
@@ -519,7 +523,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                     streams
                         .err
                         .append(L!("Position must be one of: command, anywhere.\n"));
-                    return STATUS_INVALID_ARGS;
+                    return Err(StatusError::STATUS_INVALID_ARGS);
                 }
             }
             'r' => {
@@ -528,7 +532,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                         "%ls: Cannot specify multiple regex patterns\n",
                         CMD
                     ));
-                    return STATUS_INVALID_ARGS;
+                    return Err(StatusError::STATUS_INVALID_ARGS);
                 }
                 opts.regex_pattern = w.woptarg.map(ToOwned::to_owned);
             }
@@ -538,7 +542,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                         "%ls: Cannot specify multiple set-cursor options\n",
                         CMD
                     ));
-                    return STATUS_INVALID_ARGS;
+                    return Err(StatusError::STATUS_INVALID_ARGS);
                 }
                 // The default set-cursor indicator is '%'.
                 let _ = opts
@@ -566,15 +570,15 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
             }
             'h' => {
                 builtin_print_help(parser, streams, cmd);
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, argv[w.wopt_index - 1], false);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => {
                 panic!("unexpected retval from wgeopter.next()");
@@ -587,7 +591,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
     }
 
     if !opts.validate(streams) {
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if opts.add {

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -86,7 +86,7 @@ const LONG_OPTIONS: &[WOption] = &[
 fn check_for_mutually_exclusive_flags(
     opts: &ArgParseCmdOpts,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     for opt_spec in opts.options.values() {
         if opt_spec.num_seen == 0 {
             continue;
@@ -143,19 +143,22 @@ fn check_for_mutually_exclusive_flags(
                             flag1,
                             flag2
                         ));
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
             }
         }
     }
 
-    return STATUS_CMD_OK;
+    Ok(StatusOk::OK)
 }
 
 // This should be called after all the option specs have been parsed. At that point we have enough
 // information to parse the values associated with any `--exclusive` flags.
-fn parse_exclusive_args(opts: &mut ArgParseCmdOpts, streams: &mut IoStreams) -> Option<c_int> {
+fn parse_exclusive_args(
+    opts: &mut ArgParseCmdOpts,
+    streams: &mut IoStreams,
+) -> Result<StatusOk, StatusError> {
     for raw_xflags in &opts.raw_exclusive_flags {
         let xflags: Vec<_> = raw_xflags.split(',').collect();
         if xflags.len() < 2 {
@@ -164,7 +167,7 @@ fn parse_exclusive_args(opts: &mut ArgParseCmdOpts, streams: &mut IoStreams) -> 
                 opts.name,
                 raw_xflags
             ));
-            return STATUS_CMD_ERROR;
+            return Err(StatusError::STATUS_CMD_ERROR);
         }
 
         let exclusive_set: &mut Vec<char> = &mut vec![];
@@ -182,14 +185,14 @@ fn parse_exclusive_args(opts: &mut ArgParseCmdOpts, streams: &mut IoStreams) -> 
                     opts.name,
                     flag
                 ));
-                return STATUS_CMD_ERROR;
+                return Err(StatusError::STATUS_CMD_ERROR);
             }
         }
 
         // Store the set of exclusive flags for use when parsing the supplied set of arguments.
         opts.exclusive_flag_sets.push(exclusive_set.to_vec());
     }
-    return STATUS_CMD_OK;
+    Ok(StatusOk::OK)
 }
 
 fn parse_flag_modifiers<'args>(
@@ -430,8 +433,11 @@ fn collect_option_specs<'args>(
     argc: usize,
     args: &[&'args wstr],
     streams: &mut IoStreams,
-) -> Option<c_int> {
-    let cmd: &wstr = args[0];
+) -> Result<StatusOk, StatusError> {
+    let cmd = match args.get(0) {
+        Some(cmd) => *cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
+    };
 
     // A counter to give short chars to long-only options because getopt needs that.
     // Luckily we have wgetopt so we can use wchars - this is one of the private use areas so we
@@ -443,7 +449,7 @@ fn collect_option_specs<'args>(
             streams
                 .err
                 .append(wgettext_fmt!("%ls: Missing -- separator\n", cmd));
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
 
         if "--" == args[*optind] {
@@ -452,7 +458,7 @@ fn collect_option_specs<'args>(
         }
 
         if !parse_option_spec(opts, args[*optind], &mut counter, streams) {
-            return STATUS_CMD_ERROR;
+            return Err(StatusError::STATUS_CMD_ERROR);
         }
 
         *optind += 1;
@@ -465,10 +471,10 @@ fn collect_option_specs<'args>(
         streams
             .err
             .append(wgettext_fmt!("%ls: Too many long-only options\n", cmd));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
-    return STATUS_CMD_OK;
+    return Ok(StatusOk::OK);
 }
 
 fn parse_cmd_opts<'args>(
@@ -478,8 +484,11 @@ fn parse_cmd_opts<'args>(
     args: &mut [&'args wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Option<c_int> {
-    let cmd = args[0];
+) -> Result<StatusOk, StatusError> {
+    let cmd = match args.get(0) {
+        Some(cmd) => *cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
+    };
 
     let mut args_read = Vec::with_capacity(args.len());
     args_read.extend_from_slice(args);
@@ -503,7 +512,7 @@ fn parse_cmd_opts<'args>(
                             cmd,
                             w.woptarg.unwrap()
                         ));
-                        return STATUS_INVALID_ARGS;
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     }
                     x.try_into().unwrap()
                 }
@@ -517,7 +526,7 @@ fn parse_cmd_opts<'args>(
                             cmd,
                             w.woptarg.unwrap()
                         ));
-                        return STATUS_INVALID_ARGS;
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     }
                     x.try_into().unwrap()
                 }
@@ -530,18 +539,18 @@ fn parse_cmd_opts<'args>(
                     args[w.wopt_index - 1],
                     /* print_hints */ false,
                 );
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, args[w.wopt_index - 1], false);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => panic!("unexpected retval from next_opt"),
         }
     }
 
     if opts.print_help {
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     if "--" == args_read[w.wopt_index - 1] {
@@ -553,7 +562,7 @@ fn parse_cmd_opts<'args>(
         streams
             .err
             .append(wgettext_fmt!("%ls: Missing -- separator\n", cmd));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if opts.name.is_empty() {
@@ -607,10 +616,10 @@ fn validate_arg<'opts>(
     is_long_flag: bool,
     woptarg: &'opts wstr,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     // Obviously if there is no arg validation command we assume the arg is okay.
     if opt_spec.validation_command.is_empty() {
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     let vars = parser.vars();
@@ -648,7 +657,7 @@ fn validate_arg<'opts>(
         streams.err.append_char('\n');
     }
     vars.pop();
-    Some(retval)
+    retval
 }
 
 /// Return whether the option 'opt' is an implicit integer option.
@@ -670,13 +679,9 @@ fn validate_and_store_implicit_int<'args>(
     w: &mut WGetopter,
     is_long_flag: bool,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let opt_spec = opts.options.get_mut(&opts.implicit_int_flag).unwrap();
-    let retval = validate_arg(parser, &opts.name, opt_spec, is_long_flag, val, streams);
-
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    validate_arg(parser, &opts.name, opt_spec, is_long_flag, val, streams)?;
 
     // It's a valid integer so store it and return success.
     opt_spec.vals.clear();
@@ -684,7 +689,7 @@ fn validate_and_store_implicit_int<'args>(
     opt_spec.num_seen += 1;
     w.remaining_text = L!("");
 
-    return STATUS_CMD_OK;
+    Ok(StatusOk::OK)
 }
 
 fn handle_flag<'args>(
@@ -694,7 +699,7 @@ fn handle_flag<'args>(
     is_long_flag: bool,
     woptarg: Option<&'args wstr>,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let opt_spec = opts.options.get_mut(&opt).unwrap();
 
     opt_spec.num_seen += 1;
@@ -708,14 +713,11 @@ fn handle_flag<'args>(
             WString::from_chars(['-', opt_spec.short_flag])
         };
         opt_spec.vals.push(s);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     if let Some(woptarg) = woptarg {
-        let retval = validate_arg(parser, &opts.name, opt_spec, is_long_flag, woptarg, streams);
-        if retval != STATUS_CMD_OK {
-            return retval;
-        }
+        validate_arg(parser, &opts.name, opt_spec, is_long_flag, woptarg, streams)?;
     }
 
     match opt_spec.num_allowed {
@@ -733,7 +735,7 @@ fn handle_flag<'args>(
         }
     }
 
-    return STATUS_CMD_OK;
+    Ok(StatusOk::OK)
 }
 
 fn argparse_parse_flags<'args>(
@@ -743,7 +745,7 @@ fn argparse_parse_flags<'args>(
     args: &mut [&'args wstr],
     optind: &mut usize,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let mut args_read = Vec::with_capacity(args.len());
     args_read.extend_from_slice(args);
 
@@ -756,7 +758,7 @@ fn argparse_parse_flags<'args>(
     let mut w = WGetopter::new(&short_options, &long_options, args);
     while let Some((opt, longopt_idx)) = w.next_opt_indexed() {
         let is_long_flag = longopt_idx.is_some();
-        let retval = match opt {
+        let retval: Result<StatusOk, StatusError> = match opt {
             ':' => {
                 builtin_missing_argument(
                     parser,
@@ -765,7 +767,7 @@ fn argparse_parse_flags<'args>(
                     args_read[w.wopt_index - 1],
                     false,
                 );
-                STATUS_INVALID_ARGS
+                Err(StatusError::STATUS_INVALID_ARGS)
             }
             '?' => {
                 // It's not a recognized flag. See if it's an implicit int flag.
@@ -786,7 +788,7 @@ fn argparse_parse_flags<'args>(
                         opts.name,
                         args_read[w.wopt_index - 1]
                     ));
-                    STATUS_INVALID_ARGS
+                    Err(StatusError::STATUS_INVALID_ARGS)
                 } else {
                     // Any unrecognized option is put back if ignore_unknown is used.
                     // This allows reusing the same argv in multiple argparse calls,
@@ -799,7 +801,7 @@ fn argparse_parse_flags<'args>(
                     // Explain to wgetopt that we want to skip to the next arg,
                     // because we can't handle this opt group.
                     w.remaining_text = L!("");
-                    STATUS_CMD_OK
+                    Ok(StatusOk::OK)
                 }
             }
             NON_OPTION_CHAR => {
@@ -814,13 +816,15 @@ fn argparse_parse_flags<'args>(
             // It's a recognized flag.
             _ => handle_flag(parser, opts, opt, is_long_flag, w.woptarg, streams),
         };
-        if retval != STATUS_CMD_OK {
+        // clippy wants to use `?` here by using .as_ref() which doesn't exist for this Result type.
+        #[allow(clippy::question_mark)]
+        if retval.is_err() {
             return retval;
         }
     }
 
     *optind = w.wopt_index;
-    return STATUS_CMD_OK;
+    return Ok(StatusOk::OK);
 }
 
 // This function mimics the `next_opt()` usage found elsewhere in our other builtin commands.
@@ -832,31 +836,25 @@ fn argparse_parse_args<'args>(
     argc: usize,
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     if argc <= 1 {
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     let mut optind = 0usize;
-    let retval = argparse_parse_flags(parser, opts, argc, args, &mut optind, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    argparse_parse_flags(parser, opts, argc, args, &mut optind, streams)?;
 
-    let retval = check_for_mutually_exclusive_flags(opts, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    check_for_mutually_exclusive_flags(opts, streams)?;
 
     opts.args.extend_from_slice(&args[optind..]);
 
-    return STATUS_CMD_OK;
+    Ok(StatusOk::OK)
 }
 
 fn check_min_max_args_constraints(
     opts: &ArgParseCmdOpts,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let cmd = &opts.name;
 
     if opts.args.len() < opts.min_args {
@@ -866,7 +864,7 @@ fn check_min_max_args_constraints(
             opts.min_args,
             opts.args.len()
         ));
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     }
 
     if opts.max_args != usize::MAX && opts.args.len() > opts.max_args {
@@ -876,10 +874,10 @@ fn check_min_max_args_constraints(
             opts.max_args,
             opts.args.len()
         ));
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     }
 
-    return STATUS_CMD_OK;
+    Ok(StatusOk::OK)
 }
 
 /// Put the result of parsing the supplied args into the caller environment as local vars.
@@ -918,14 +916,22 @@ fn set_argparse_result_vars(vars: &EnvStack, opts: &ArgParseCmdOpts) {
 /// an external command also means its output has to be in a form that can be eval'd. Because our
 /// version is a builtin it can directly set variables local to the current scope (e.g., a
 /// function). It doesn't need to write anything to stdout that then needs to be eval'd.
-pub fn argparse(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
-    let cmd = args[0];
+pub fn argparse(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
+    let cmd = match args.get(0) {
+        Some(cmd) => *cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
+    };
+
     let argc = args.len();
 
     let mut opts = ArgParseCmdOpts::new();
     let mut optind = 0usize;
     let retval = parse_cmd_opts(&mut opts, &mut optind, argc, args, parser, streams);
-    if retval != STATUS_CMD_OK {
+    if retval.is_err() {
         // This is an error in argparse usage, so we append the error trailer with a stack trace.
         // The other errors are an error in using *the command* that is using argparse,
         // so our help doesn't apply.
@@ -935,34 +941,25 @@ pub fn argparse(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
 
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
-    let retval = parse_exclusive_args(&mut opts, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    parse_exclusive_args(&mut opts, streams)?;
 
     // wgetopt expects the first argument to be the command, and skips it.
     // if optind was 0 we'd already have returned.
     assert!(optind > 0, "Optind is 0?");
-    let retval = argparse_parse_args(
+    argparse_parse_args(
         &mut opts,
         &mut args[optind - 1..],
         argc - optind + 1,
         parser,
         streams,
-    );
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    )?;
 
-    let retval = check_min_max_args_constraints(&opts, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    check_min_max_args_constraints(&opts, streams)?;
 
     set_argparse_result_vars(parser.vars(), &opts);
 
-    return retval;
+    Ok(StatusOk::OK)
 }

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -448,7 +448,7 @@ fn parse_cmd_opts(
     argv: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Option<i32> {
+) -> Result<StatusOk, StatusError> {
     let cmd = argv[0];
     let short_options = L!(":aehkKfM:Lm:s");
     const long_options: &[WOption] = &[
@@ -477,7 +477,7 @@ fn parse_cmd_opts(
             'K' => opts.mode = BIND_KEY_NAMES,
             'L' => {
                 opts.list_modes = true;
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
             'M' => {
                 if !valid_var_name(w.woptarg.unwrap()) {
@@ -486,7 +486,7 @@ fn parse_cmd_opts(
                         cmd,
                         w.woptarg.unwrap()
                     ));
-                    return STATUS_INVALID_ARGS;
+                    return Err(StatusError::STATUS_INVALID_ARGS);
                 }
                 opts.bind_mode = w.woptarg.unwrap().to_owned();
                 opts.bind_mode_given = true;
@@ -497,7 +497,7 @@ fn parse_cmd_opts(
                     streams
                         .err
                         .append(wgettext_fmt!(BUILTIN_ERR_BIND_MODE, cmd, new_mode));
-                    return STATUS_INVALID_ARGS;
+                    return Err(StatusError::STATUS_INVALID_ARGS);
                 }
                 opts.sets_bind_mode = Some(new_mode.to_owned());
             }
@@ -512,11 +512,11 @@ fn parse_cmd_opts(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, argv[w.wopt_index - 1], true);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => {
                 panic!("unexpected retval from WGetopter")
@@ -524,7 +524,7 @@ fn parse_cmd_opts(
         }
     }
     *optind = w.wopt_index;
-    return STATUS_CMD_OK;
+    return Ok(StatusOk::OK);
 }
 
 impl BuiltinBind {
@@ -534,22 +534,19 @@ impl BuiltinBind {
         parser: &Parser,
         streams: &mut IoStreams,
         argv: &mut [&wstr],
-    ) -> Option<c_int> {
+    ) -> Result<StatusOk, StatusError> {
         let cmd = argv[0];
         let mut optind = 0;
-        let retval = parse_cmd_opts(&mut self.opts, &mut optind, argv, parser, streams);
-        if retval != STATUS_CMD_OK {
-            return retval;
-        }
+        parse_cmd_opts(&mut self.opts, &mut optind, argv, parser, streams)?;
 
         if self.opts.list_modes {
             self.list_modes(streams);
-            return STATUS_CMD_OK;
+            return Ok(StatusOk::OK);
         }
 
         if self.opts.print_help {
             builtin_print_help(parser, streams, cmd);
-            return STATUS_CMD_OK;
+            return Ok(StatusOk::OK);
         }
 
         // Default to user mode
@@ -567,7 +564,7 @@ impl BuiltinBind {
                         true, /* user */
                         streams,
                     ) {
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
                 if self.opts.preset {
@@ -577,13 +574,13 @@ impl BuiltinBind {
                         false, /* user */
                         streams,
                     ) {
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
             }
             BIND_INSERT => {
                 if self.insert(optind, argv, parser, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             BIND_KEY_NAMES => self.key_names(self.opts.all, streams),
@@ -592,13 +589,17 @@ impl BuiltinBind {
                 streams
                     .err
                     .append(wgettext_fmt!("%ls: Invalid state\n", cmd));
-                return STATUS_CMD_ERROR;
+                return Err(StatusError::STATUS_CMD_ERROR);
             }
         }
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     }
 }
 
-pub fn bind(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+pub fn bind(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     BuiltinBind::new().bind(parser, streams, args)
 }

--- a/src/builtins/block.rs
+++ b/src/builtins/block.rs
@@ -27,7 +27,7 @@ fn parse_options(
     args: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Result<(Options, usize), Option<c_int>> {
+) -> Result<(Options, usize), StatusError> {
     let cmd = args[0];
 
     const SHORT_OPTS: &wstr = L!(":eghl");
@@ -57,11 +57,11 @@ fn parse_options(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
-                return Err(STATUS_INVALID_ARGS);
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, args[w.wopt_index - 1], false);
-                return Err(STATUS_INVALID_ARGS);
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => {
                 panic!("unexpected retval from WGetopter");
@@ -73,18 +73,18 @@ fn parse_options(
 }
 
 /// The block builtin, used for temporarily blocking events.
-pub fn block(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+pub fn block(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let cmd = args[0];
 
-    let opts = match parse_options(args, parser, streams) {
-        Ok((opts, _)) => opts,
-        Err(err @ Some(_)) if err != STATUS_CMD_OK => return err,
-        Err(err) => panic!("Illogical exit code from parse_options(): {err:?}"),
-    };
+    let (opts, _) = parse_options(args, parser, streams)?;
 
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     if opts.erase {
@@ -93,17 +93,17 @@ pub fn block(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Op
                 "%ls: Can not specify scope when removing block\n",
                 cmd
             ));
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
 
         if parser.global_event_blocks.load(Ordering::Relaxed) == 0 {
             streams
                 .err
                 .append(wgettext_fmt!("%ls: No blocks defined\n", cmd));
-            return STATUS_CMD_ERROR;
+            return Err(StatusError::STATUS_CMD_ERROR);
         }
         parser.global_event_blocks.fetch_sub(1, Ordering::Relaxed);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     let mut block_idx = 0;
@@ -144,5 +144,5 @@ pub fn block(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Op
         parser.global_event_blocks.fetch_add(1, Ordering::Relaxed);
     }
 
-    return STATUS_CMD_OK;
+    return Ok(StatusOk::OK);
 }

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -13,18 +13,21 @@ use std::{os::fd::AsRawFd, sync::Arc};
 
 // The cd builtin. Changes the current directory to the one specified or to $HOME if none is
 // specified. The directory can be relative to any directory in the CDPATH variable.
-pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
-    let cmd = args[0];
-
-    let opts = match HelpOnlyCmdOpts::parse(args, parser, streams) {
-        Ok(opts) => opts,
-        Err(err @ Some(_)) if err != STATUS_CMD_OK => return err,
-        Err(err) => panic!("Illogical exit code from parse_options(): {err:?}"),
+pub fn cd(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
+    let cmd = match args.get(0) {
+        Some(cmd) => *cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
     };
+
+    let opts = HelpOnlyCmdOpts::parse(args, parser, streams)?;
 
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     let vars = parser.vars();
@@ -42,7 +45,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
                 streams
                     .err
                     .append(wgettext_fmt!("%ls: Could not find home directory\n", cmd));
-                return STATUS_CMD_ERROR;
+                return Err(StatusError::STATUS_CMD_ERROR);
             }
         }
     };
@@ -57,7 +60,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
         if !parser.is_interactive() {
             streams.err.append(parser.current_line());
         };
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     }
 
     let pwd = vars.get_pwd_slash();
@@ -74,7 +77,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
             streams.err.append(parser.current_line());
         }
 
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     }
 
     let mut best_errno = 0;
@@ -130,7 +133,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
         parser.libdata_mut().cwd_fd = Some(dir_fd);
 
         parser.set_var_and_fire(L!("PWD"), EnvMode::EXPORT | EnvMode::GLOBAL, vec![norm_dir]);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     if best_errno == ENOTDIR {
@@ -178,5 +181,5 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Optio
         streams.err.append(parser.current_line());
     }
 
-    return STATUS_CMD_ERROR;
+    return Err(StatusError::STATUS_CMD_ERROR);
 }

--- a/src/builtins/command.rs
+++ b/src/builtins/command.rs
@@ -8,7 +8,11 @@ struct command_cmd_opts_t {
     find_path: bool,
 }
 
-pub fn r#command(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Option<c_int> {
+pub fn r#command(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    argv: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let cmd = argv[0];
     let argc = argv.len();
     let print_hints = false;
@@ -33,15 +37,15 @@ pub fn r#command(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
             'v' => opts.find_path = true,
             'h' => {
                 builtin_print_help(parser, streams, cmd);
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => {
                 panic!("unexpected retval from wgeopter.next()");
@@ -52,7 +56,7 @@ pub fn r#command(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     // Quiet implies find_path.
     if !opts.find_path && !opts.all && !opts.quiet {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     let mut res = false;
@@ -69,7 +73,7 @@ pub fn r#command(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
         for path in paths.iter() {
             res = true;
             if opts.quiet {
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
 
             streams.out.appendln(path);
@@ -80,8 +84,8 @@ pub fn r#command(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     }
 
     if res {
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     } else {
-        STATUS_CMD_UNKNOWN
+        Err(StatusError::STATUS_CMD_UNKNOWN)
     }
 }

--- a/src/builtins/contains.rs
+++ b/src/builtins/contains.rs
@@ -11,7 +11,7 @@ fn parse_options(
     args: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Result<(Options, usize), Option<c_int>> {
+) -> Result<(Options, usize), StatusError> {
     let cmd = args[0];
 
     const SHORT_OPTS: &wstr = L!("+:hi");
@@ -29,11 +29,11 @@ fn parse_options(
             'i' => opts.print_index = true,
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
-                return Err(STATUS_INVALID_ARGS);
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, args[w.wopt_index - 1], false);
-                return Err(STATUS_INVALID_ARGS);
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => {
                 panic!("unexpected retval from WGetopter");
@@ -46,18 +46,18 @@ fn parse_options(
 
 /// Implementation of the builtin contains command, used to check if a specified string is part of
 /// a list.
-pub fn contains(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+pub fn contains(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let cmd = args[0];
 
-    let (opts, optind) = match parse_options(args, parser, streams) {
-        Ok((opts, optind)) => (opts, optind),
-        Err(err @ Some(_)) if err != STATUS_CMD_OK => return err,
-        Err(err) => panic!("Illogical exit code from parse_options(): {err:?}"),
-    };
+    let (opts, optind) = parse_options(args, parser, streams)?;
 
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     let needle = args.get(optind);
@@ -67,7 +67,7 @@ pub fn contains(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
                 if opts.print_index {
                     streams.out.appendln(i.to_wstring());
                 }
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
         }
     } else {
@@ -76,5 +76,5 @@ pub fn contains(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
             .append(wgettext_fmt!("%ls: Key not specified\n", cmd));
     }
 
-    return STATUS_CMD_ERROR;
+    return Err(StatusError::STATUS_CMD_ERROR);
 }

--- a/src/builtins/count.rs
+++ b/src/builtins/count.rs
@@ -5,7 +5,11 @@ use super::prelude::*;
 const COUNT_CHUNK_SIZE: usize = 512 * 256;
 
 /// Implementation of the builtin count command, used to count the number of arguments sent to it.
-pub fn count(_parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Option<c_int> {
+pub fn count(
+    _parser: &Parser,
+    streams: &mut IoStreams,
+    argv: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     // Always add the size of argv (minus 0, which is "count").
     // That means if you call `something | count a b c`, you'll get the count of something _plus 3_.
     let mut numargs = argv.len() - 1;
@@ -22,8 +26,8 @@ pub fn count(_parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> O
 
     streams.out.appendln(numargs.to_wstring());
 
-    if numargs == 0 {
-        return STATUS_CMD_ERROR;
+    match numargs {
+        0 => Err(StatusError::STATUS_CMD_ERROR),
+        _ => Ok(StatusOk::OK),
     }
-    STATUS_CMD_OK
 }

--- a/src/builtins/emit.rs
+++ b/src/builtins/emit.rs
@@ -1,25 +1,28 @@
 use super::prelude::*;
 use crate::event;
 
-pub fn emit(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Option<c_int> {
-    let cmd = argv[0];
-
-    let opts = match HelpOnlyCmdOpts::parse(argv, parser, streams) {
-        Ok(opts) => opts,
-        Err(err @ Some(_)) if err != STATUS_CMD_OK => return err,
-        Err(err) => panic!("Illogical exit code from parse_options(): {err:?}"),
+pub fn emit(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    argv: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
+    let cmd = match argv.get(0) {
+        Some(cmd) => *cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
     };
+
+    let opts = HelpOnlyCmdOpts::parse(argv, parser, streams)?;
 
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     let Some(event_name) = argv.get(opts.optind) else {
         streams
             .err
             .append(sprintf!(L!("%ls: expected event name\n"), cmd));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     };
 
     event::fire_generic(
@@ -31,5 +34,5 @@ pub fn emit(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
             .collect(),
     );
 
-    STATUS_CMD_OK
+    Ok(StatusOk::OK)
 }

--- a/src/builtins/eval.rs
+++ b/src/builtins/eval.rs
@@ -6,10 +6,14 @@ use crate::parser::BlockType;
 use crate::wcstringutil::join_strings;
 use libc::{STDERR_FILENO, STDOUT_FILENO};
 
-pub fn eval(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+pub fn eval(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let argc = args.len();
     if argc <= 1 {
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     let new_cmd = join_strings(&args[1..], ' ');
@@ -28,7 +32,7 @@ pub fn eval(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Opt
         match IoBufferfill::create_opts(parser.libdata().read_limit, STDOUT_FILENO) {
             Err(_) => {
                 // We were unable to create a pipe, probably fd exhaustion.
-                return STATUS_CMD_ERROR;
+                return Err(StatusError::STATUS_CMD_ERROR);
             }
             Ok(buffer) => {
                 stdout_fill = Some(buffer.clone());
@@ -43,7 +47,7 @@ pub fn eval(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Opt
         match IoBufferfill::create_opts(parser.libdata().read_limit, STDERR_FILENO) {
             Err(_) => {
                 // We were unable to create a pipe, probably fd exhaustion.
-                return STATUS_CMD_ERROR;
+                return Err(StatusError::STATUS_CMD_ERROR);
             }
             Ok(buffer) => {
                 stderr_fill = Some(buffer.clone());
@@ -56,9 +60,12 @@ pub fn eval(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Opt
     let status = if res.was_empty {
         // Issue #5692, in particular, to catch `eval ""`, `eval "begin; end;"`, etc.
         // where we have an argument but nothing is executed.
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     } else {
-        Some(res.status.status_value())
+        match res.status.status_value() {
+            0 => Ok(StatusOk::OK),
+            code => Err(StatusError::from(code)),
+        }
     };
 
     // Finish the bufferfills - exhaust and close our pipes.

--- a/src/builtins/exit.rs
+++ b/src/builtins/exit.rs
@@ -2,11 +2,12 @@ use super::prelude::*;
 use super::r#return::parse_return_value;
 
 /// Function for handling the exit builtin.
-pub fn exit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
-    let retval = match parse_return_value(args, parser, streams) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
+pub fn exit(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
+    let result = parse_return_value(args, parser, streams);
 
     // Mark that we are exiting in the parser.
     // TODO: in concurrent mode this won't successfully exit a pipeline, as there are other parsers
@@ -14,5 +15,5 @@ pub fn exit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Opt
     // behavior we want here.
     parser.libdata_mut().exit_current_script = true;
 
-    return Some(retval);
+    result
 }

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -77,7 +77,7 @@ fn parse_cmd_opts(
     argv: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> c_int {
     let cmd = L!("function");
     let print_hints = false;
     let mut handling_named_arguments = false;
@@ -231,7 +231,7 @@ fn validate_function_name(
     function_name: &mut WString,
     cmd: &wstr,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> c_int {
     if argv.len() < 2 {
         // This is currently impossible but let's be paranoid.
         streams
@@ -267,7 +267,7 @@ pub fn function(
     streams: &mut IoStreams,
     c_args: &mut [&wstr],
     func_node: NodeRef<BlockStatement>,
-) -> Option<c_int> {
+) -> c_int {
     // The wgetopt function expects 'function' as the first argument. Make a new vec with
     // that property. This is needed because this builtin has a different signature than the other
     // builtins.

--- a/src/builtins/history.rs
+++ b/src/builtins/history.rs
@@ -139,34 +139,38 @@ fn parse_cmd_opts(
     argv: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Option<c_int> {
-    let cmd = argv[0];
+) -> Result<StatusOk, StatusError> {
+    let cmd = match argv.get(0) {
+        Some(cmd) => *cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
+    };
+
     let mut w = WGetopter::new(short_options, longopts, argv);
     while let Some(opt) = w.next_opt() {
         match opt {
             '\x01' => {
                 if !set_hist_cmd(cmd, &mut opts.hist_cmd, HistCmd::Delete, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             '\x02' => {
                 if !set_hist_cmd(cmd, &mut opts.hist_cmd, HistCmd::Search, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             '\x03' => {
                 if !set_hist_cmd(cmd, &mut opts.hist_cmd, HistCmd::Save, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             '\x04' => {
                 if !set_hist_cmd(cmd, &mut opts.hist_cmd, HistCmd::Clear, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             '\x05' => {
                 if !set_hist_cmd(cmd, &mut opts.hist_cmd, HistCmd::Merge, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             'C' => {
@@ -195,7 +199,7 @@ fn parse_cmd_opts(
                         cmd,
                         w.woptarg.unwrap()
                     ));
-                    return STATUS_INVALID_ARGS;
+                    return Err(StatusError::STATUS_INVALID_ARGS);
                 }
             },
             'z' => {
@@ -206,7 +210,7 @@ fn parse_cmd_opts(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 // Try to parse it as a number; e.g., "-123".
@@ -214,7 +218,7 @@ fn parse_cmd_opts(
                     Ok(x) => opts.max_items = Some(x as _), // todo!("historical behavior is to cast")
                     Err(_) => {
                         builtin_unknown_option(parser, streams, cmd, argv[w.wopt_index - 1], true);
-                        return STATUS_INVALID_ARGS;
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     }
                 }
                 w.remaining_text = L!("");
@@ -226,22 +230,28 @@ fn parse_cmd_opts(
     }
 
     *optind = w.wopt_index;
-    STATUS_CMD_OK
+    Ok(StatusOk::OK)
 }
 
 /// Manipulate history of interactive commands executed by the user.
-pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+pub fn history(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let mut opts = HistoryCmdOpts::default();
     let mut optind = 0;
-    let retval = parse_cmd_opts(&mut opts, &mut optind, args, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
-    let cmd = &args[0];
+
+    parse_cmd_opts(&mut opts, &mut optind, args, parser, streams)?;
+
+    let cmd = match args.get(0) {
+        Some(cmd) => *cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
+    };
 
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     // Use the default history if we have none (which happens if invoked non-interactively, e.g.
@@ -256,7 +266,7 @@ pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> 
     if optind < args.len() {
         if let Ok(subcmd) = HistCmd::try_from(args[optind]) {
             if !set_hist_cmd(cmd, &mut opts.hist_cmd, subcmd, streams) {
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             optind += 1;
         }
@@ -266,7 +276,7 @@ pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> 
     // search term).
     let args = &args[optind..];
 
-    let mut status = STATUS_CMD_OK;
+    let mut status = Ok(StatusOk::OK);
     match opts.hist_cmd {
         HistCmd::None | HistCmd::Search => {
             if !history.search(
@@ -281,7 +291,7 @@ pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> 
                 &parser.context().cancel_checker,
                 streams,
             ) {
-                status = STATUS_CMD_ERROR;
+                status = Err(StatusError::STATUS_CMD_ERROR);
             }
         }
         HistCmd::Delete => {
@@ -293,13 +303,13 @@ pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> 
                 streams
                     .err
                     .append(wgettext!("builtin history delete only supports --exact\n"));
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             if !opts.case_sensitive {
                 streams.err.append(wgettext!(
                     "builtin history delete --exact requires --case-sensitive\n"
                 ));
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
 
             for delete_string in args {
@@ -308,21 +318,21 @@ pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> 
         }
         HistCmd::Clear => {
             if check_for_unexpected_hist_args(&opts, cmd, args, streams) {
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             history.clear();
             history.save();
         }
         HistCmd::ClearSession => {
             if check_for_unexpected_hist_args(&opts, cmd, args, streams) {
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             history.clear_session();
             history.save();
         }
         HistCmd::Merge => {
             if check_for_unexpected_hist_args(&opts, cmd, args, streams) {
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
 
             if in_private_mode(parser.vars()) {
@@ -330,13 +340,13 @@ pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> 
                     "%ls: can't merge history in private mode\n",
                     cmd
                 ));
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             history.incorporate_external_changes();
         }
         HistCmd::Save => {
             if check_for_unexpected_hist_args(&opts, cmd, args, streams) {
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             history.save();
         }

--- a/src/builtins/jobs.rs
+++ b/src/builtins/jobs.rs
@@ -1,8 +1,7 @@
 // Functions for executing the jobs builtin.
 
 use super::shared::{
-    builtin_missing_argument, builtin_print_help, builtin_unknown_option, STATUS_CMD_ERROR,
-    STATUS_INVALID_ARGS,
+    builtin_missing_argument, builtin_print_help, builtin_unknown_option, StatusError, StatusOk,
 };
 use crate::common::{escape_string, timef, EscapeFlags, EscapeStringStyle};
 use crate::io::IoStreams;
@@ -13,11 +12,9 @@ use crate::wchar_ext::WExt;
 use crate::wgetopt::{wopt, ArgType, WGetopter, WOption};
 use crate::wutil::wgettext;
 use crate::{
-    builtins::shared::STATUS_CMD_OK,
     wchar::{wstr, WString, L},
     wutil::{fish_wcstoi, sprintf, wgettext_fmt},
 };
-use libc::c_int;
 use std::num::NonZeroU32;
 
 /// Print modes for the jobs builtin.
@@ -134,8 +131,16 @@ const LONG_OPTIONS: &[WOption] = &[
 ];
 
 /// The jobs builtin. Used for printing running jobs. Defined in builtin_jobs.c.
-pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Option<c_int> {
-    let cmd = argv[0];
+pub fn jobs(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    argv: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
+    let cmd = match argv.get(0) {
+        Some(cmd) => *cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
+    };
+
     let argc = argv.len();
     let mut found = false;
     let mut mode = JobsPrintMode::Default;
@@ -161,15 +166,15 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
             }
             'h' => {
                 builtin_print_help(parser, streams, cmd);
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, argv[w.wopt_index - 1], true);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => panic!("unexpected retval from WGetopter"),
         }
@@ -180,10 +185,10 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
         for j in &parser.jobs()[..] {
             if j.is_visible() {
                 builtin_jobs_print(j, mode, !streams.out_is_redirected, streams);
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
         }
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     }
 
     if w.wopt_index < argc {
@@ -197,7 +202,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                             cmd,
                             arg
                         ));
-                        return STATUS_INVALID_ARGS;
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     }
                     Some(job_id) => {
                         let job_id = if job_id == 0 {
@@ -218,7 +223,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                             cmd,
                             arg
                         ));
-                        return STATUS_INVALID_ARGS;
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     }
                     Some(job_id) => {
                         j = parser.job_get_from_pid(job_id);
@@ -235,7 +240,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                         .err
                         .append(wgettext_fmt!("%ls: No suitable job: %ls\n", cmd, arg));
                 }
-                return STATUS_CMD_ERROR;
+                return Err(StatusError::STATUS_CMD_ERROR);
             }
         }
     } else {
@@ -255,8 +260,8 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                 .out
                 .append(wgettext_fmt!("%ls: There are no jobs\n", argv[0]));
         }
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     }
 
-    STATUS_CMD_OK
+    Ok(StatusOk::OK)
 }

--- a/src/builtins/path.rs
+++ b/src/builtins/path.rs
@@ -229,7 +229,7 @@ fn parse_opts<'args>(
     args: &mut [&'args wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let cmd = args[0];
     let mut args_read = Vec::with_capacity(args.len());
     args_read.extend_from_slice(args);
@@ -242,11 +242,11 @@ fn parse_opts<'args>(
             ':' => {
                 streams.err.append(L!("path ")); // clone of string_error
                 builtin_missing_argument(parser, streams, cmd, args_read[w.wopt_index - 1], false);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 path_unknown_option(parser, streams, cmd, args_read[w.wopt_index - 1]);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             'q' => {
                 opts.quiet = true;
@@ -270,7 +270,7 @@ fn parse_opts<'args>(
                 for t in types_args {
                     let Ok(r#type) = t.try_into() else {
                         path_error!(streams, "%ls: Invalid type '%ls'\n", "path", t);
-                        return STATUS_INVALID_ARGS;
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     };
                     *types |= r#type;
                 }
@@ -282,7 +282,7 @@ fn parse_opts<'args>(
                 for p in perms_args {
                     let Ok(perm) = p.try_into() else {
                         path_error!(streams, "%ls: Invalid permission '%ls'\n", "path", p);
-                        return STATUS_INVALID_ARGS;
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     };
                     *perms |= perm;
                 }
@@ -341,7 +341,7 @@ fn parse_opts<'args>(
             }
             _ => {
                 path_unknown_option(parser, streams, cmd, args_read[w.wopt_index - 1]);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
         }
     }
@@ -357,17 +357,17 @@ fn parse_opts<'args>(
 
         if opts.arg1.is_none() && n_req_args == 1 {
             path_error!(streams, BUILTIN_ERR_ARG_COUNT0, cmd);
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
     }
 
     // At this point we should not have optional args and be reading args from stdin.
     if streams.stdin_is_directly_redirected && args.len() > *optind {
         path_error!(streams, BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
-    STATUS_CMD_OK
+    Ok(StatusOk::OK)
 }
 
 fn path_transform(
@@ -376,14 +376,12 @@ fn path_transform(
     args: &mut [&wstr],
     func: impl Fn(&wstr) -> WString,
     custom_opts: impl Fn(&mut Options),
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let mut opts = Options::default();
     custom_opts(&mut opts);
     let mut optind = 0;
-    let retval = parse_opts(&mut opts, &mut optind, 0, args, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+
+    parse_opts(&mut opts, &mut optind, 0, args, parser, streams)?;
 
     let mut n_transformed = 0;
     let arguments = arguments(args, &mut optind, streams).with_split_behavior(match opts.null_in {
@@ -406,20 +404,24 @@ fn path_transform(
             // Return okay if path wasn't already in this form
             // TODO: Is that correct?
             if opts.quiet {
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             };
         }
         path_out(streams, &opts, transformed);
     }
 
     if n_transformed > 0 {
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     } else {
-        STATUS_CMD_ERROR
+        Err(StatusError::STATUS_CMD_ERROR)
     }
 }
 
-fn path_basename(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+fn path_basename(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     path_transform(
         parser,
         streams,
@@ -431,7 +433,11 @@ fn path_basename(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
     )
 }
 
-fn path_dirname(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+fn path_dirname(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     path_transform(parser, streams, args, |s| wdirname(s).to_owned(), |_| {})
 }
 
@@ -443,18 +449,24 @@ fn normalize_help(path: &wstr) -> WString {
     np
 }
 
-fn path_normalize(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+fn path_normalize(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     path_transform(parser, streams, args, normalize_help, |_| {})
 }
 
-fn path_mtime(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+fn path_mtime(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let mut opts = Options::default();
     opts.relative_valid = true;
     let mut optind = 0;
-    let retval = parse_opts(&mut opts, &mut optind, 0, args, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+
+    parse_opts(&mut opts, &mut optind, 0, args, parser, streams)?;
 
     let mut n_transformed = 0;
 
@@ -472,7 +484,7 @@ fn path_mtime(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
 
         if ret != INVALID_FILE_ID {
             if opts.quiet {
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
             n_transformed += 1;
             if !opts.relative {
@@ -487,9 +499,9 @@ fn path_mtime(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
     }
 
     if n_transformed > 0 {
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     } else {
-        STATUS_CMD_ERROR
+        Err(StatusError::STATUS_CMD_ERROR)
     }
 }
 
@@ -531,13 +543,15 @@ fn test_find_extension() {
     }
 }
 
-fn path_extension(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+fn path_extension(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let mut opts = Options::default();
     let mut optind = 0;
-    let retval = parse_opts(&mut opts, &mut optind, 0, args, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+
+    parse_opts(&mut opts, &mut optind, 0, args, parser, streams)?;
 
     let mut n_transformed = 0;
     let arguments = arguments(args, &mut optind, streams).with_split_behavior(match opts.null_in {
@@ -555,16 +569,16 @@ fn path_extension(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) 
 
         let ext = arg.slice_from(pos);
         if opts.quiet && !ext.is_empty() {
-            return STATUS_CMD_OK;
+            return Ok(StatusOk::OK);
         }
         path_out(streams, &opts, ext);
         n_transformed += 1;
     }
 
     if n_transformed > 0 {
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     } else {
-        STATUS_CMD_ERROR
+        Err(StatusError::STATUS_CMD_ERROR)
     }
 }
 
@@ -572,13 +586,11 @@ fn path_change_extension(
     parser: &Parser,
     streams: &mut IoStreams,
     args: &mut [&wstr],
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let mut opts = Options::default();
     let mut optind = 0;
-    let retval = parse_opts(&mut opts, &mut optind, 1, args, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+
+    parse_opts(&mut opts, &mut optind, 1, args, parser, streams)?;
 
     let mut n_transformed = 0usize;
     let arguments = arguments(args, &mut optind, streams).with_split_behavior(match opts.null_in {
@@ -611,19 +623,21 @@ fn path_change_extension(
     }
 
     if n_transformed > 0 {
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     } else {
-        STATUS_CMD_ERROR
+        Err(StatusError::STATUS_CMD_ERROR)
     }
 }
 
-fn path_resolve(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+fn path_resolve(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let mut opts = Options::default();
     let mut optind = 0;
-    let retval = parse_opts(&mut opts, &mut optind, 0, args, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+
+    parse_opts(&mut opts, &mut optind, 0, args, parser, streams)?;
 
     let mut n_transformed = 0usize;
     let arguments = arguments(args, &mut optind, streams).with_split_behavior(match opts.null_in {
@@ -669,28 +683,30 @@ fn path_resolve(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
 
         // Return 0 if we found a realpath.
         if opts.quiet {
-            return STATUS_CMD_OK;
+            return Ok(StatusOk::OK);
         }
         path_out(streams, &opts, real);
         n_transformed += 1;
     }
 
     if n_transformed > 0 {
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     } else {
-        STATUS_CMD_ERROR
+        Err(StatusError::STATUS_CMD_ERROR)
     }
 }
 
-fn path_sort(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+fn path_sort(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let mut opts = Options::default();
     opts.reverse_valid = true;
     opts.unique_valid = true;
     let mut optind = 0;
-    let retval = parse_opts(&mut opts, &mut optind, 0, args, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+
+    parse_opts(&mut opts, &mut optind, 0, args, parser, streams)?;
 
     let keyfunc: fn(&wstr) -> &wstr = match &opts.key {
         Some(k) if k == "basename" => wbasename,
@@ -703,7 +719,7 @@ fn path_sort(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Op
         None => wbasename,
         Some(k) => {
             path_error!(streams, "%ls: Invalid sort key '%ls'\n", args[0], k);
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
     };
 
@@ -744,7 +760,7 @@ fn path_sort(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Op
     }
 
     /* TODO: Return true only if already sorted? */
-    STATUS_CMD_OK
+    Ok(StatusOk::OK)
 }
 
 fn filter_path(opts: &Options, path: &wstr, uid: Option<u32>, gid: Option<u32>) -> bool {
@@ -853,16 +869,14 @@ fn path_filter_maybe_is(
     streams: &mut IoStreams,
     args: &mut [&wstr],
     is_is: bool,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let mut opts = Options::default();
     opts.types_valid = true;
     opts.perms_valid = true;
     opts.invert_valid = true;
     let mut optind = 0;
-    let retval = parse_opts(&mut opts, &mut optind, 0, args, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+
+    parse_opts(&mut opts, &mut optind, 0, args, parser, streams)?;
 
     // If we have been invoked as "path is", which is "path filter -q".
     if is_is {
@@ -911,28 +925,43 @@ fn path_filter_maybe_is(
         }
         n_transformed += 1;
         if opts.quiet {
-            return STATUS_CMD_OK;
+            return Ok(StatusOk::OK);
         };
     }
 
     if n_transformed > 0 {
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     } else {
-        STATUS_CMD_ERROR
+        Err(StatusError::STATUS_CMD_ERROR)
     }
 }
 
-fn path_filter(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+fn path_filter(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     path_filter_maybe_is(parser, streams, args, false)
 }
 
-fn path_is(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+fn path_is(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     path_filter_maybe_is(parser, streams, args, true)
 }
 
 /// The path builtin, for handling paths.
-pub fn path(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
-    let cmd = args[0];
+pub fn path(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
+    let cmd = match args.get(0) {
+        Some(&cmd) => cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
+    };
     let argc = args.len();
 
     if argc <= 1 {
@@ -940,12 +969,12 @@ pub fn path(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Opt
             .err
             .append(wgettext_fmt!(BUILTIN_ERR_MISSING_SUBCMD, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if args[1] == "-h" || args[1] == "--help" {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     let subcmd_name = args[1];
@@ -966,14 +995,14 @@ pub fn path(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Opt
                 .err
                 .append(wgettext_fmt!(BUILTIN_ERR_INVALID_SUBCMD, cmd, subcmd_name));
             builtin_print_error_trailer(parser, streams.err, cmd);
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
     };
 
     if argc >= 3 && (args[2] == "-h" || args[2] == "--help") {
         // Unlike string, we don't have separate docs (yet)
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
     let args = &mut args[1..];
     return subcmd(parser, streams, args);

--- a/src/builtins/printf.rs
+++ b/src/builtins/printf.rs
@@ -79,7 +79,7 @@ struct builtin_printf_state_t<'a, 'b> {
     streams: &'a mut IoStreams<'b>,
 
     // The status of the operation.
-    exit_code: c_int,
+    exit_code: Result<StatusOk, StatusError>,
 
     // Whether we should stop outputting. This gets set in the case of an error, and also with the
     // \c escape.
@@ -588,7 +588,7 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
 
         // We set the exit code to error, because one occurred,
         // but we don't do an early exit so we still print what we can.
-        self.exit_code = STATUS_CMD_ERROR.unwrap();
+        self.exit_code = Err(StatusError::STATUS_CMD_ERROR);
     }
 
     fn fatal_error<Str: AsRef<wstr>>(&mut self, errstr: Str) {
@@ -610,7 +610,7 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
             self.streams.err.push('\n');
         }
 
-        self.exit_code = STATUS_CMD_ERROR.unwrap();
+        self.exit_code = Err(StatusError::STATUS_CMD_ERROR);
         self.early_exit = true;
     }
 
@@ -767,19 +767,23 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
 }
 
 /// The printf builtin.
-pub fn printf(_parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Option<c_int> {
+pub fn printf(
+    _parser: &Parser,
+    streams: &mut IoStreams,
+    argv: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let mut argc = argv.len();
 
     // Rebind argv as immutable slice (can't rearrange its elements), skipping the command name.
     let mut argv: &[&wstr] = &argv[1..];
     argc -= 1;
     if argc < 1 {
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     let mut state = builtin_printf_state_t {
         streams,
-        exit_code: STATUS_CMD_OK.unwrap(),
+        exit_code: Ok(StatusOk::OK),
         early_exit: false,
         buff: WString::new(),
         locale: get_numeric_locale(),
@@ -799,5 +803,5 @@ pub fn printf(_parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> 
             break;
         }
     }
-    return Some(state.exit_code);
+    return state.exit_code;
 }

--- a/src/builtins/pwd.rs
+++ b/src/builtins/pwd.rs
@@ -12,7 +12,11 @@ const long_options: &[WOption] = &[
     wopt(L!("physical"), NoArgument, 'P'),
 ];
 
-pub fn pwd(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Option<c_int> {
+pub fn pwd(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    argv: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let cmd = argv[0];
     let argc = argv.len();
     let mut resolve_symlinks = false;
@@ -23,11 +27,11 @@ pub fn pwd(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opti
             'P' => resolve_symlinks = true,
             'h' => {
                 builtin_print_help(parser, streams, cmd);
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, argv[w.wopt_index - 1], false);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => panic!("unexpected retval from WGetopter"),
         }
@@ -37,7 +41,7 @@ pub fn pwd(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opti
         streams
             .err
             .append(wgettext_fmt!(BUILTIN_ERR_ARG_COUNT1, cmd, 0, argc - 1));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     let mut pwd = WString::new();
@@ -53,12 +57,12 @@ pub fn pwd(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opti
                 cmd,
                 errno().to_string()
             ));
-            return STATUS_CMD_ERROR;
+            return Err(StatusError::STATUS_CMD_ERROR);
         }
     }
     if pwd.is_empty() {
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     }
     streams.out.appendln(pwd);
-    return STATUS_CMD_OK;
+    Ok(StatusOk::OK)
 }

--- a/src/builtins/read.rs
+++ b/src/builtins/read.rs
@@ -88,7 +88,7 @@ fn parse_cmd_opts(
     args: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Result<(Options, usize), Option<c_int>> {
+) -> Result<(Options, usize), StatusError> {
     let cmd = args[0];
     let mut opts = Options::new();
     let mut w = WGetopter::new(SHORT_OPTIONS, LONG_OPTIONS, args);
@@ -111,7 +111,7 @@ fn parse_cmd_opts(
                     ),
                     cmd
                 ));
-                return Err(STATUS_INVALID_ARGS);
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             'f' => {
                 opts.place |= EnvMode::FUNCTION;
@@ -138,7 +138,7 @@ fn parse_cmd_opts(
                             w.woptarg.unwrap()
                         ));
                         builtin_print_error_trailer(parser, streams.err, cmd);
-                        return Err(STATUS_INVALID_ARGS);
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     }
                     _ => {
                         streams.err.append(wgettext_fmt!(
@@ -147,7 +147,7 @@ fn parse_cmd_opts(
                             w.woptarg.unwrap()
                         ));
                         builtin_print_error_trailer(parser, streams.err, cmd);
-                        return Err(STATUS_INVALID_ARGS);
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     }
                 }
             }
@@ -183,11 +183,11 @@ fn parse_cmd_opts(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], true);
-                return Err(STATUS_INVALID_ARGS);
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, args[w.wopt_index - 1], true);
-                return Err(STATUS_INVALID_ARGS);
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => {
                 panic!("unexpected retval from WGetopter");
@@ -210,8 +210,8 @@ fn read_interactive(
     right_prompt: &wstr,
     commandline: &wstr,
     inputfd: RawFd,
-) -> Option<c_int> {
-    let mut exit_res = STATUS_CMD_OK;
+) -> Result<StatusOk, StatusError> {
+    let mut exit_res = Ok(StatusOk::OK);
 
     // Construct a configuration.
     let mut conf = ReaderConfig::default();
@@ -255,7 +255,7 @@ fn read_interactive(
             buff.truncate(nchars);
         }
     } else {
-        exit_res = STATUS_CMD_ERROR;
+        exit_res = Err(StatusError::STATUS_CMD_ERROR);
     }
     reader_pop();
     exit_res
@@ -271,8 +271,13 @@ const READ_CHUNK_SIZE: usize = 128;
 /// of chars.
 ///
 /// Returns an exit status.
-fn read_in_chunks(fd: RawFd, buff: &mut WString, split_null: bool, do_seek: bool) -> Option<c_int> {
-    let mut exit_res = STATUS_CMD_OK;
+fn read_in_chunks(
+    fd: RawFd,
+    buff: &mut WString,
+    split_null: bool,
+    do_seek: bool,
+) -> Result<StatusOk, StatusError> {
+    let mut exit_res = Ok(StatusOk::OK);
     let mut narrow_buff = vec![];
     let mut eof = false;
     let mut finished = false;
@@ -310,18 +315,18 @@ fn read_in_chunks(fd: RawFd, buff: &mut WString, split_null: bool, do_seek: bool
                 } == -1
             {
                 perror("lseek");
-                return STATUS_CMD_ERROR;
+                return Err(StatusError::STATUS_CMD_ERROR);
             }
             finished = true;
         } else if narrow_buff.len() > READ_BYTE_LIMIT.load(Ordering::Relaxed) {
-            exit_res = STATUS_READ_TOO_MUCH;
+            exit_res = Err(StatusError::STATUS_READ_TOO_MUCH);
             finished = true;
         }
     }
 
     *buff = str2wcstring(&narrow_buff);
     if buff.is_empty() && eof {
-        exit_res = STATUS_CMD_ERROR;
+        exit_res = Err(StatusError::STATUS_CMD_ERROR);
     }
 
     exit_res
@@ -335,8 +340,8 @@ fn read_one_char_at_a_time(
     buff: &mut WString,
     nchars: usize,
     split_null: bool,
-) -> Option<c_int> {
-    let mut exit_res = STATUS_CMD_OK;
+) -> Result<StatusOk, StatusError> {
+    let mut exit_res = Ok(StatusOk::OK);
     let mut eof = false;
     let mut nbytes = 0;
 
@@ -378,7 +383,7 @@ fn read_one_char_at_a_time(
         }
 
         if nbytes > READ_BYTE_LIMIT.load(Ordering::Relaxed) {
-            exit_res = STATUS_READ_TOO_MUCH;
+            exit_res = Err(StatusError::STATUS_READ_TOO_MUCH);
             break;
         }
         if eof {
@@ -398,7 +403,7 @@ fn read_one_char_at_a_time(
     }
 
     if buff.is_empty() && eof {
-        exit_res = STATUS_CMD_ERROR;
+        exit_res = Err(StatusError::STATUS_CMD_ERROR);
     }
 
     exit_res
@@ -411,7 +416,7 @@ fn validate_read_args(
     argv: &[&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     if opts.prompt.is_some() && opts.prompt_str.is_some() {
         streams.err.append(wgettext_fmt!(
             "%ls: Options %ls and %ls cannot be used together\n",
@@ -420,7 +425,7 @@ fn validate_read_args(
             "-P",
         ));
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if opts.delimiter.is_some() && opts.one_line {
@@ -430,7 +435,7 @@ fn validate_read_args(
             "--delimiter",
             "--line"
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
     if opts.one_line && opts.split_null {
         streams.err.append(wgettext_fmt!(
@@ -439,7 +444,7 @@ fn validate_read_args(
             "-z",
             "--line"
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if let Some(prompt_str) = opts.prompt_str.as_ref() {
@@ -451,7 +456,7 @@ fn validate_read_args(
     if opts.place.contains(EnvMode::UNEXPORT) && opts.place.contains(EnvMode::EXPORT) {
         streams.err.append(wgettext_fmt!(BUILTIN_ERR_EXPUNEXP, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if opts
@@ -463,7 +468,7 @@ fn validate_read_args(
     {
         streams.err.append(wgettext_fmt!(BUILTIN_ERR_GLOCAL, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     let argc = argv.len();
@@ -471,21 +476,21 @@ fn validate_read_args(
         streams
             .err
             .append(wgettext_fmt!(BUILTIN_ERR_MIN_ARG_COUNT1, cmd, 1, argc));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if opts.array && argc != 1 {
         streams
             .err
             .append(wgettext_fmt!(BUILTIN_ERR_ARG_COUNT1, cmd, 1, argc));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if opts.to_stdout && argc > 0 {
         streams
             .err
             .append(wgettext_fmt!(BUILTIN_ERR_MAX_ARG_COUNT1, cmd, 0, argc));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if opts.tokenize && opts.delimiter.is_some() {
@@ -495,7 +500,7 @@ fn validate_read_args(
             "--delimiter",
             "--tokenize"
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     if opts.tokenize && opts.one_line {
@@ -505,7 +510,7 @@ fn validate_read_args(
             "--line",
             "--tokenize"
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     // Verify all variable names.
@@ -515,7 +520,7 @@ fn validate_read_args(
                 .err
                 .append(wgettext_fmt!(BUILTIN_ERR_VARNAME, cmd, arg));
             builtin_print_error_trailer(parser, streams.err, cmd);
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
         if EnvVar::flags_for(arg).contains(EnvVarFlags::READ_ONLY) {
             streams.err.append(wgettext_fmt!(
@@ -524,22 +529,24 @@ fn validate_read_args(
                 arg
             ));
             builtin_print_error_trailer(parser, streams.err, cmd);
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         }
     }
 
-    STATUS_CMD_OK
+    Ok(StatusOk::OK)
 }
 
 /// The read builtin. Reads from stdin and stores the values in environment variables.
-pub fn read(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Option<c_int> {
+pub fn read(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    argv: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let mut buff = WString::new();
-    let mut exit_res;
+    let mut exit_res: Result<StatusOk, StatusError>;
 
-    let (mut opts, optind) = match parse_cmd_opts(argv, parser, streams) {
-        Ok(res) => res,
-        Err(retval) => return retval,
-    };
+    let (mut opts, optind) = parse_cmd_opts(argv, parser, streams)?;
+
     let cmd = argv[0];
     let mut argv: &[&wstr] = argv;
     if !opts.to_stdout {
@@ -553,20 +560,17 @@ pub fn read(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
 
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
-    let retval = validate_read_args(cmd, &mut opts, argv, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    validate_read_args(cmd, &mut opts, argv, parser, streams)?;
 
     // stdin may have been explicitly closed
     if streams.stdin_fd < 0 {
         streams
             .err
             .append(wgettext_fmt!("%ls: stdin is closed\n", cmd));
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     }
 
     if opts.one_line {
@@ -633,7 +637,7 @@ pub fn read(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Opt
                 read_one_char_at_a_time(streams.stdin_fd, &mut buff, opts.nchars, opts.split_null);
         }
 
-        if exit_res != STATUS_CMD_OK {
+        if exit_res.is_err() {
             clear_remaining_vars(&mut var_ptr);
             return exit_res;
         }

--- a/src/builtins/return.rs
+++ b/src/builtins/return.rs
@@ -11,7 +11,7 @@ fn parse_options(
     args: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Result<(Options, usize), Option<c_int>> {
+) -> Result<(Options, usize), StatusError> {
     let cmd = args[0];
 
     const SHORT_OPTS: &wstr = L!(":h");
@@ -26,7 +26,7 @@ fn parse_options(
             'h' => opts.print_help = true,
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], true);
-                return Err(STATUS_INVALID_ARGS);
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 // We would normally invoke builtin_unknown_option() and return an error.
@@ -44,11 +44,12 @@ fn parse_options(
 }
 
 /// Function for handling the return builtin.
-pub fn r#return(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
-    let mut retval = match parse_return_value(args, parser, streams) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
+pub fn r#return(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
+    let mut retval = parse_return_value(args, parser, streams);
 
     let has_function_block = parser.blocks_iter_rev().any(|b| b.is_function_call());
 
@@ -58,9 +59,11 @@ pub fn r#return(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
     // evaluating to a `$status` of 0 and keeps us from running into undefined behavior by trying to
     // left shift a negative value in W_EXITCODE().
     // Note in Rust, dividend % divisor has the same sign as the dividend.
-    if retval < 0 {
-        retval = 256 - (retval % 256).abs();
-    }
+    if let Err(ref err) = retval {
+        if err.get_code() < 0 {
+            retval = Err(StatusError::from(256 - (err.get_code() % 256).abs()));
+        }
+    };
 
     // If we're not in a function, exit the current script (but not an interactive shell).
     if !has_function_block {
@@ -68,48 +71,48 @@ pub fn r#return(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
         if !ld.is_interactive {
             ld.exit_current_script = true;
         }
-        return Some(retval);
+        return retval;
     }
 
     // Mark a return in the libdata.
     parser.libdata_mut().returning = true;
 
-    return Some(retval);
+    return retval;
 }
 
 pub fn parse_return_value(
     args: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Result<i32, Option<c_int>> {
+) -> Result<StatusOk, StatusError> {
     let cmd = args[0];
-    let (opts, optind) = match parse_options(args, parser, streams) {
-        Ok((opts, optind)) => (opts, optind),
-        Err(err @ Some(_)) if err != STATUS_CMD_OK => return Err(err),
-        Err(err) => panic!("Illogical exit code from parse_options(): {err:?}"),
-    };
+    let (opts, optind) = parse_options(args, parser, streams)?;
+
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return Err(STATUS_CMD_OK);
+        return Ok(StatusOk::OK);
     }
     if optind + 1 < args.len() {
         streams
             .err
             .append(wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return Err(STATUS_INVALID_ARGS);
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
     if optind == args.len() {
-        Ok(parser.get_last_status())
+        Err(StatusError::from(parser.get_last_status()))
     } else {
         match fish_wcstoi(args[optind]) {
-            Ok(i) => Ok(i),
+            Ok(i) => match i {
+                0 => Ok(StatusOk::OK),
+                code => Err(StatusError::from(code)),
+            },
             Err(_e) => {
                 streams
                     .err
                     .append(wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, args[1]));
                 builtin_print_error_trailer(parser, streams.err, cmd);
-                return Err(STATUS_INVALID_ARGS);
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
         }
     }

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -13,18 +13,22 @@ use super::prelude::*;
 
 /// The  source builtin, sometimes called `.`. Evaluates the contents of a file in the current
 /// context.
-pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+pub fn source(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let argc = args.len();
 
-    let opts = match HelpOnlyCmdOpts::parse(args, parser, streams) {
-        Ok(opts) => opts,
-        Err(err) => return err,
+    let opts = HelpOnlyCmdOpts::parse(args, parser, streams)?;
+    let cmd = match args.get(0) {
+        Some(&cmd) => cmd,
+        None => return Err(StatusError::STATUS_INVALID_ARGS),
     };
-    let cmd = args[0];
 
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     // If we open a file, this ensures it stays open until the end of scope.
@@ -40,7 +44,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
             streams
                 .err
                 .append(wgettext_fmt!("%ls: stdin is closed\n", cmd));
-            return STATUS_CMD_ERROR;
+            return Err(StatusError::STATUS_CMD_ERROR);
         }
         // Either a bare `source` which means to implicitly read from stdin or an explicit `-`.
         if argc == optind && isatty(streams.stdin_fd) {
@@ -49,7 +53,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                 "%ls: missing filename argument or input redirection\n",
                 cmd
             ));
-            return STATUS_CMD_ERROR;
+            return Err(StatusError::STATUS_CMD_ERROR);
         }
         func_filename = FilenameRef::new(L!("-").to_owned());
         fd = streams.stdin_fd;
@@ -66,7 +70,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                     &esc
                 ));
                 builtin_wperror(cmd, streams);
-                return STATUS_CMD_ERROR;
+                return Err(StatusError::STATUS_CMD_ERROR);
             }
         };
 
@@ -90,20 +94,23 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
     let argv_list = remaining_args.iter().map(|&arg| arg.to_owned()).collect();
     parser.vars().set_argv(argv_list);
 
-    let mut retval = reader_read(parser, fd, streams.io_chain);
+    let retval = reader_read(parser, fd, streams.io_chain);
 
     parser.pop_block(sb);
 
-    if retval != STATUS_CMD_OK.unwrap() {
-        let esc = escape(&func_filename);
-        streams.err.append(wgettext_fmt!(
-            "%ls: Error while reading file '%ls'\n",
-            cmd,
-            if esc == "-" { L!("<stdin>") } else { &esc }
-        ));
-    } else {
-        retval = parser.get_last_status();
+    match retval {
+        Ok(_) => match parser.get_last_status() {
+            0 => Ok(StatusOk::OK),
+            code => Err(StatusError::from(code)),
+        },
+        Err(err) => {
+            let esc = escape(&func_filename);
+            streams.err.append(wgettext_fmt!(
+                "%ls: Error while reading file '%ls'\n",
+                cmd,
+                if esc == "-" { L!("<stdin>") } else { &esc }
+            ));
+            Err(err)
+        }
     }
-
-    Some(retval)
 }

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -201,7 +201,7 @@ fn parse_cmd_opts(
     args: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let cmd = args[0];
 
     let mut args_read = Vec::with_capacity(args.len());
@@ -221,13 +221,13 @@ fn parse_cmd_opts(
                                 cmd,
                                 arg
                             ));
-                            return STATUS_INVALID_ARGS;
+                            return Err(StatusError::STATUS_INVALID_ARGS);
                         }
                         _ => {
                             streams
                                 .err
                                 .append(wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, arg));
-                            return STATUS_INVALID_ARGS;
+                            return Err(StatusError::STATUS_INVALID_ARGS);
                         }
                     }
                 };
@@ -244,12 +244,12 @@ fn parse_cmd_opts(
                     _ => unreachable!(),
                 };
                 if !opts.try_set_status_cmd(subcmd, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             'j' => {
                 if !opts.try_set_status_cmd(STATUS_SET_JOB_CONTROL, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
                 let Ok(job_mode) = w.woptarg.unwrap().try_into() else {
                     streams.err.append(wgettext_fmt!(
@@ -257,38 +257,38 @@ fn parse_cmd_opts(
                         cmd,
                         w.woptarg.unwrap()
                     ));
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 };
                 opts.new_job_control_mode = Some(job_mode);
             }
             IS_FULL_JOB_CTRL_SHORT => {
                 if !opts.try_set_status_cmd(STATUS_IS_FULL_JOB_CTRL, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             IS_INTERACTIVE_JOB_CTRL_SHORT => {
                 if !opts.try_set_status_cmd(STATUS_IS_INTERACTIVE_JOB_CTRL, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             IS_NO_JOB_CTRL_SHORT => {
                 if !opts.try_set_status_cmd(STATUS_IS_NO_JOB_CTRL, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             FISH_PATH_SHORT => {
                 if !opts.try_set_status_cmd(STATUS_FISH_PATH, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
             }
             'h' => opts.print_help = true,
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, args[w.wopt_index - 1], false);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => panic!("unexpected retval from WGetopter"),
         }
@@ -296,23 +296,24 @@ fn parse_cmd_opts(
 
     *optind = w.wopt_index;
 
-    return STATUS_CMD_OK;
+    return Ok(StatusOk::OK);
 }
 
-pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+pub fn status(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let cmd = args[0];
     let argc = args.len();
 
     let mut opts = StatusCmdOpts::default();
     let mut optind = 0usize;
-    let retval = parse_cmd_opts(&mut opts, &mut optind, args, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    parse_cmd_opts(&mut opts, &mut optind, args, parser, streams)?;
 
     if opts.print_help {
         builtin_print_help(parser, streams, cmd);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     }
 
     // If a status command hasn't already been specified via a flag check the first word.
@@ -321,7 +322,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
         match StatusCmd::from_wstr(args[optind].to_string().as_str()) {
             Some(s) => {
                 if !opts.try_set_status_cmd(s, streams) {
-                    return STATUS_CMD_ERROR;
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
                 optind += 1;
             }
@@ -329,7 +330,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                 streams
                     .err
                     .append(wgettext_fmt!(BUILTIN_ERR_INVALID_SUBCMD, cmd, args[1]));
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
         }
     }
@@ -354,7 +355,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
             .append(wgettext_fmt!("Job control: %ls\n", job_control_mode));
         streams.out.append(parser.stack_trace());
 
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     };
 
     match subcmd {
@@ -370,7 +371,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                             0,
                             args.len()
                         ));
-                        return STATUS_INVALID_ARGS;
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     }
                     j
                 }
@@ -383,7 +384,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                             1,
                             args.len()
                         ));
-                        return STATUS_INVALID_ARGS;
+                        return Err(StatusError::STATUS_INVALID_ARGS);
                     }
                     let Ok(new_mode) = args[0].try_into() else {
                         streams.err.append(wgettext_fmt!(
@@ -391,7 +392,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                             cmd,
                             args[0]
                         ));
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     };
                     new_mode
                 }
@@ -408,19 +409,18 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                     1,
                     args.len()
                 ));
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
-            use TestFeatureRetVal::*;
-            let mut retval = Some(TEST_FEATURE_NOT_RECOGNIZED as c_int);
+            let mut retval = TestFeatureRetVal::TEST_FEATURE_NOT_RECOGNIZED;
             for md in features::METADATA {
                 if md.name == args[0] {
                     retval = match feature_test(md.flag) {
-                        true => Some(TEST_FEATURE_ON as c_int),
-                        false => Some(TEST_FEATURE_OFF as c_int),
+                        true => TestFeatureRetVal::TEST_FEATURE_ON,
+                        false => TestFeatureRetVal::TEST_FEATURE_OFF,
                     };
                 }
             }
-            return retval;
+            return Err(StatusError::from(retval as i32));
         }
         STATUS_BUILDINFO => {
             let version = str2wcstring(crate::BUILD_VERSION.as_bytes());
@@ -459,7 +459,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                 .out
                 .appendln(str2wcstring(features.join(" ").as_bytes()));
             streams.out.appendln("");
-            return STATUS_CMD_OK;
+            return Ok(StatusOk::OK);
         }
         ref s => {
             if !args.is_empty() {
@@ -470,7 +470,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                     0,
                     args.len()
                 ));
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             match s {
                 STATUS_BASENAME | STATUS_DIRNAME | STATUS_FILENAME => {
@@ -501,58 +501,57 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                 }
                 STATUS_IS_INTERACTIVE => {
                     if is_interactive_session() {
-                        return STATUS_CMD_OK;
-                    } else {
-                        return STATUS_CMD_ERROR;
+                        return Ok(StatusOk::OK);
                     }
+                    return Err(StatusError::STATUS_CMD_ERROR);
                 }
                 STATUS_IS_COMMAND_SUB => {
                     if parser.libdata().is_subshell {
-                        return STATUS_CMD_OK;
+                        return Ok(StatusOk::OK);
                     } else {
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
                 STATUS_IS_BLOCK => {
                     if parser.is_block() {
-                        return STATUS_CMD_OK;
+                        return Ok(StatusOk::OK);
                     } else {
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
                 STATUS_IS_BREAKPOINT => {
                     if parser.is_breakpoint() {
-                        return STATUS_CMD_OK;
+                        return Ok(StatusOk::OK);
                     } else {
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
                 STATUS_IS_LOGIN => {
                     if get_login() {
-                        return STATUS_CMD_OK;
+                        return Ok(StatusOk::OK);
                     } else {
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
                 STATUS_IS_FULL_JOB_CTRL => {
                     if get_job_control_mode() == JobControl::all {
-                        return STATUS_CMD_OK;
+                        return Ok(StatusOk::OK);
                     } else {
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
                 STATUS_IS_INTERACTIVE_JOB_CTRL => {
                     if get_job_control_mode() == JobControl::interactive {
-                        return STATUS_CMD_OK;
+                        return Ok(StatusOk::OK);
                     } else {
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
                 STATUS_IS_NO_JOB_CTRL => {
                     if get_job_control_mode() == JobControl::none {
-                        return STATUS_CMD_OK;
+                        return Ok(StatusOk::OK);
                     } else {
-                        return STATUS_CMD_ERROR;
+                        return Err(StatusError::STATUS_CMD_ERROR);
                     }
                 }
                 STATUS_STACK_TRACE => {
@@ -609,5 +608,5 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
         }
     };
 
-    return retval;
+    Ok(StatusOk::OK)
 }

--- a/src/builtins/string/collect.rs
+++ b/src/builtins/string/collect.rs
@@ -60,9 +60,9 @@ impl StringSubCommand<'_> for Collect {
         }
 
         if appended > 0 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/escape.rs
+++ b/src/builtins/string/escape.rs
@@ -57,9 +57,9 @@ impl StringSubCommand<'_> for Escape {
         }
 
         if escaped_any {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/join.rs
+++ b/src/builtins/string/join.rs
@@ -41,17 +41,17 @@ impl<'args> StringSubCommand<'args> for Join<'args> {
         streams: &mut IoStreams,
     ) -> Option<libc::c_int> {
         if self.is_join0 {
-            return STATUS_CMD_OK;
+            return Some(STATUS_CMD_OK);
         }
 
         let Some(arg) = args.get(*optind).copied() else {
             string_error!(streams, BUILTIN_ERR_ARG_COUNT0, args[0]);
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         };
         *optind += 1;
         self.sep = arg;
 
-        STATUS_CMD_OK
+        Some(STATUS_CMD_OK)
     }
 
     fn handle(
@@ -76,7 +76,7 @@ impl<'args> StringSubCommand<'args> for Join<'args> {
 
                 streams.out.append(arg);
             } else if nargs > 1 {
-                return STATUS_CMD_OK;
+                return Some(STATUS_CMD_OK);
             }
             nargs += 1;
             print_trailing_newline = want_newline;
@@ -91,9 +91,9 @@ impl<'args> StringSubCommand<'args> for Join<'args> {
         }
 
         if nargs > 1 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/length.rs
+++ b/src/builtins/string/length.rs
@@ -54,7 +54,7 @@ impl StringSubCommand<'_> for Length {
                     if !self.quiet {
                         streams.out.appendln(max.to_wstring());
                     } else if nnonempty > 0 {
-                        return STATUS_CMD_OK;
+                        return Some(STATUS_CMD_OK);
                     }
                 }
             } else {
@@ -65,14 +65,14 @@ impl StringSubCommand<'_> for Length {
                 if !self.quiet {
                     streams.out.appendln(n.to_wstring());
                 } else if nnonempty > 0 {
-                    return STATUS_CMD_OK;
+                    return Some(STATUS_CMD_OK);
                 }
             }
         }
         if nnonempty > 0 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/match.rs
+++ b/src/builtins/string/match.rs
@@ -76,11 +76,11 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
         let cmd = args[0];
         let Some(arg) = args.get(*optind).copied() else {
             string_error!(streams, BUILTIN_ERR_ARG_COUNT0, cmd);
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         };
         *optind += 1;
         self.pattern = arg;
-        STATUS_CMD_OK
+        Some(STATUS_CMD_OK)
     }
 
     fn handle(
@@ -98,7 +98,7 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
                 cmd,
                 wgettext!("--entire and --index are mutually exclusive")
             ));
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         }
 
         if self.invert_match && self.groups_only {
@@ -107,7 +107,7 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
                 cmd,
                 wgettext!("--invert and --groups-only are mutually exclusive")
             ));
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         }
 
         if self.entire && self.groups_only {
@@ -116,14 +116,14 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
                 cmd,
                 wgettext!("--entire and --groups-only are mutually exclusive")
             ));
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         }
 
         let mut matcher = match StringMatcher::new(self.pattern, self) {
             Ok(m) => m,
             Err(e) => {
                 e.print_error(args, streams);
-                return STATUS_INVALID_ARGS;
+                return Some(STATUS_INVALID_ARGS);
             }
         };
 
@@ -152,9 +152,9 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
         }
 
         if match_count > 0 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/pad.rs
+++ b/src/builtins/string/pad.rs
@@ -105,6 +105,6 @@ impl StringSubCommand<'_> for Pad {
             streams.out.append(padded);
         }
 
-        STATUS_CMD_OK
+        Some(STATUS_CMD_OK)
     }
 }

--- a/src/builtins/string/repeat.rs
+++ b/src/builtins/string/repeat.rs
@@ -46,24 +46,24 @@ impl StringSubCommand<'_> for Repeat {
         streams: &mut IoStreams,
     ) -> Option<c_int> {
         if self.count.is_some() || self.max.is_some() {
-            return STATUS_CMD_OK;
+            return Some(STATUS_CMD_OK);
         }
 
         let name = args[0];
 
         let Some(arg) = args.get(*optind) else {
             string_error!(streams, BUILTIN_ERR_ARG_COUNT0, name);
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         };
         *optind += 1;
 
         let Ok(Ok(count)) = fish_wcstol(arg).map(|count| count.try_into()) else {
             string_error!(streams, "%ls: Invalid count value '%ls'\n", name, arg);
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         };
 
         self.count = Some(count);
-        return STATUS_CMD_OK;
+        return Some(STATUS_CMD_OK);
     }
 
     fn handle(
@@ -80,7 +80,7 @@ impl StringSubCommand<'_> for Repeat {
             // XXX: This used to be allowed, but returned 1.
             // Keep it that way for now instead of adding an error.
             // streams.err.append(L"Count or max must be greater than zero");
-            return STATUS_CMD_ERROR;
+            return Some(STATUS_CMD_ERROR);
         }
 
         let mut all_empty = true;
@@ -97,7 +97,7 @@ impl StringSubCommand<'_> for Repeat {
 
             if self.quiet {
                 // Early out if we can - see #7495.
-                return STATUS_CMD_OK;
+                return Some(STATUS_CMD_OK);
             }
 
             if !first {
@@ -147,8 +147,8 @@ impl StringSubCommand<'_> for Repeat {
                         // so we need to check every so often if the pipe has been closed.
                         // If we didn't, running `string repeat -n LARGENUMBER foo | pv`
                         // and pressing ctrl-c seems to hang.
-                        if streams.out.flush_and_check_error() != STATUS_CMD_OK.unwrap() {
-                            return STATUS_CMD_ERROR;
+                        if streams.out.flush_and_check_error() != STATUS_CMD_OK {
+                            return Some(STATUS_CMD_ERROR);
                         }
                         i -= chunk.len();
                     }
@@ -168,9 +168,9 @@ impl StringSubCommand<'_> for Repeat {
         }
 
         if all_empty {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         } else {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         }
     }
 }

--- a/src/builtins/string/replace.rs
+++ b/src/builtins/string/replace.rs
@@ -65,18 +65,18 @@ impl<'args> StringSubCommand<'args> for Replace<'args> {
         let cmd = args[0];
         let Some(pattern) = args.get(*optind).copied() else {
             string_error!(streams, BUILTIN_ERR_ARG_COUNT0, cmd);
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         };
         *optind += 1;
         let Some(replacement) = args.get(*optind).copied() else {
             string_error!(streams, BUILTIN_ERR_ARG_COUNT1, cmd, 1, 2);
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         };
         *optind += 1;
 
         self.pattern = pattern;
         self.replacement = replacement;
-        return STATUS_CMD_OK;
+        return Some(STATUS_CMD_OK);
     }
 
     fn handle(
@@ -92,7 +92,7 @@ impl<'args> StringSubCommand<'args> for Replace<'args> {
             Ok(x) => x,
             Err(e) => {
                 e.print_error(args, streams);
-                return STATUS_INVALID_ARGS;
+                return Some(STATUS_INVALID_ARGS);
             }
         };
 
@@ -108,7 +108,7 @@ impl<'args> StringSubCommand<'args> for Replace<'args> {
                         cmd,
                         e.error_message()
                     );
-                    return STATUS_INVALID_ARGS;
+                    return Some(STATUS_INVALID_ARGS);
                 }
             };
             replace_count += replaced as usize;
@@ -121,20 +121,20 @@ impl<'args> StringSubCommand<'args> for Replace<'args> {
             }
 
             if self.quiet && replace_count > 0 {
-                return STATUS_CMD_OK;
+                return Some(STATUS_CMD_OK);
             }
             if self
                 .max_matches
                 .is_some_and(|max| max.get() == replace_count)
             {
-                return STATUS_CMD_OK;
+                return Some(STATUS_CMD_OK);
             }
         }
 
         if replace_count > 0 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/shorten.rs
+++ b/src/builtins/string/shorten.rs
@@ -84,7 +84,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
             for (arg, _) in iter {
                 streams.out.appendln(arg);
             }
-            return STATUS_CMD_OK;
+            return Some(STATUS_CMD_OK);
         }
 
         for (arg, _) in iter {
@@ -168,7 +168,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
                     pos += skip_escapes(&line, pos).max(1);
                 }
                 if self.quiet && pos != 0 {
-                    return STATUS_CMD_OK;
+                    return Some(STATUS_CMD_OK);
                 }
 
                 let output = match pos {
@@ -217,7 +217,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
             }
 
             if self.quiet && pos != line.len() {
-                return STATUS_CMD_OK;
+                return Some(STATUS_CMD_OK);
             }
 
             if pos == line.len() {
@@ -235,9 +235,9 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
 
         // Return true if we have shortened something and false otherwise.
         if nsub > 0 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/split.rs
+++ b/src/builtins/string/split.rs
@@ -147,15 +147,15 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
         streams: &mut IoStreams,
     ) -> Option<libc::c_int> {
         if self.is_split0 {
-            return STATUS_CMD_OK;
+            return Some(STATUS_CMD_OK);
         }
         let Some(arg) = args.get(*optind).copied() else {
             string_error!(streams, BUILTIN_ERR_ARG_COUNT0, args[0]);
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         };
         *optind += 1;
         self.sep = arg;
-        return STATUS_CMD_OK;
+        return Some(STATUS_CMD_OK);
     }
 
     fn handle(
@@ -171,7 +171,7 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
                 args[0],
                 wgettext!("--allow-empty is only valid with --fields")
             ));
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         }
 
         let sep = self.sep;
@@ -216,7 +216,7 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
 
             // If we're quiet, we return early if we've found something to split.
             if self.quiet && splits.len() > 1 {
-                return STATUS_CMD_OK;
+                return Some(STATUS_CMD_OK);
             }
             split_count += splits.len();
             arg_count += 1;
@@ -225,9 +225,9 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
 
         if self.quiet {
             return if split_count > arg_count {
-                STATUS_CMD_OK
+                Some(STATUS_CMD_OK)
             } else {
-                STATUS_CMD_ERROR
+                Some(STATUS_CMD_ERROR)
             };
         }
 
@@ -251,7 +251,7 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
                     for field in self.fields.iter() {
                         // we already have checked the start
                         if *field >= splits.len() {
-                            return STATUS_CMD_ERROR;
+                            return Some(STATUS_CMD_ERROR);
                         }
                     }
                 }
@@ -273,9 +273,9 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
 
         // We split something if we have more split values than args.
         return if split_count > arg_count {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         };
     }
 }

--- a/src/builtins/string/sub.rs
+++ b/src/builtins/string/sub.rs
@@ -60,7 +60,7 @@ impl StringSubCommand<'_> for Sub {
                 cmd,
                 wgettext!("--end and --length are mutually exclusive")
             ));
-            return STATUS_INVALID_ARGS;
+            return Some(STATUS_INVALID_ARGS);
         }
 
         let mut nsub = 0;
@@ -101,14 +101,14 @@ impl StringSubCommand<'_> for Sub {
             }
             nsub += 1;
             if self.quiet {
-                return STATUS_CMD_OK;
+                return Some(STATUS_CMD_OK);
             }
         }
 
         if nsub > 0 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/transform.rs
+++ b/src/builtins/string/transform.rs
@@ -36,14 +36,14 @@ impl StringSubCommand<'_> for Transform {
                     streams.out.append1('\n');
                 }
             } else if n_transformed > 0 {
-                return STATUS_CMD_OK;
+                return Some(STATUS_CMD_OK);
             }
         }
 
         if n_transformed > 0 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/trim.rs
+++ b/src/builtins/string/trim.rs
@@ -86,14 +86,14 @@ impl<'args> StringSubCommand<'args> for Trim<'args> {
                     streams.out.append1('\n');
                 }
             } else if ntrim > 0 {
-                return STATUS_CMD_OK;
+                return Some(STATUS_CMD_OK);
             }
         }
 
         if ntrim > 0 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/string/unescape.rs
+++ b/src/builtins/string/unescape.rs
@@ -49,9 +49,9 @@ impl StringSubCommand<'_> for Unescape {
         }
 
         if nesc > 0 {
-            STATUS_CMD_OK
+            Some(STATUS_CMD_OK)
         } else {
-            STATUS_CMD_ERROR
+            Some(STATUS_CMD_ERROR)
         }
     }
 }

--- a/src/builtins/tests/string_tests.rs
+++ b/src/builtins/tests/string_tests.rs
@@ -1,3 +1,4 @@
+use crate::builtins::shared::get_code;
 use crate::io::IoChain;
 use crate::tests::prelude::*;
 use crate::wchar::prelude::*;
@@ -21,7 +22,7 @@ fn test_string() {
     }
 
     // TODO: these should be individual tests, not all in one, port when we can run these with `cargo test`
-    fn string_test(mut args: Vec<&wstr>, expected_rc: Option<i32>, expected_out: &wstr) {
+    fn string_test(mut args: Vec<&wstr>, expected_rc: i32, expected_out: &wstr) {
         let parser = TestParser::new();
         let mut outs = OutputStream::String(StringOutputStream::new());
         let mut errs = OutputStream::Null;
@@ -29,7 +30,7 @@ fn test_string() {
         let mut streams = IoStreams::new(&mut outs, &mut errs, &io_chain);
         streams.stdin_is_directly_redirected = false; // read from argv instead of stdin
 
-        let rc = string(&parser, &mut streams, args.as_mut_slice()).expect("string failed");
+        let rc = string(&parser, &mut streams, args.as_mut_slice());
 
         let actual = escape(outs.contents());
         let expected = escape(expected_out);
@@ -40,8 +41,8 @@ fn test_string() {
 
         // Check return code after so we get a chance to identify the difference first
         assert_eq!(
-            expected_rc.unwrap(),
-            rc,
+            expected_rc,
+            get_code(&rc),
             "string builtin returned unexpected return code"
         );
     }

--- a/src/builtins/tests/test_tests.rs
+++ b/src/builtins/tests/test_tests.rs
@@ -25,19 +25,17 @@ fn run_one_test_test_mbracket(expected: i32, lst: &[&str], bracket: bool) -> boo
     let io_chain = IoChain::new();
     let mut streams = IoStreams::new(&mut out, &mut err, &io_chain);
 
-    let result: Option<i32> = builtin_test(&parser, &mut streams, &mut argv);
+    let result = builtin_test(&parser, &mut streams, &mut argv);
 
-    if result != Some(expected) {
-        let got = match result {
-            Some(r) => r.to_wstring(),
-            None => L!("nothing").to_owned(),
-        };
+    let result = get_code(&result);
+
+    if result != expected {
         eprintln!(
             "expected builtin_test() to return {}, got {}",
-            expected, got
+            expected, result
         );
     }
-    result == Some(expected)
+    result == expected
 }
 
 fn run_test_test(expected: i32, lst: &[&str]) -> bool {
@@ -58,16 +56,19 @@ fn test_test_brackets() {
 
     let args1 = &mut [L!("["), L!("foo")];
     assert_eq!(
-        builtin_test(&parser, &mut streams, args1),
+        get_code(&builtin_test(&parser, &mut streams, args1)),
         STATUS_INVALID_ARGS
     );
 
     let args2 = &mut [L!("["), L!("foo"), L!("]")];
-    assert_eq!(builtin_test(&parser, &mut streams, args2), STATUS_CMD_OK);
+    assert_eq!(
+        get_code(&builtin_test(&parser, &mut streams, args2)),
+        STATUS_CMD_OK
+    );
 
     let args3 = &mut [L!("["), L!("foo"), L!("]"), L!("bar")];
     assert_eq!(
-        builtin_test(&parser, &mut streams, args3),
+        get_code(&builtin_test(&parser, &mut streams, args3)),
         STATUS_INVALID_ARGS
     );
 }

--- a/src/builtins/ulimit.rs
+++ b/src/builtins/ulimit.rs
@@ -101,9 +101,9 @@ fn set_limit(
     soft: bool,
     value: rlim_t,
     streams: &mut IoStreams,
-) -> Option<c_int> {
+) -> Result<StatusOk, StatusError> {
     let Some((mut rlim_cur, mut rlim_max)) = getrlimit(resource) else {
-        return STATUS_CMD_ERROR;
+        return Err(StatusError::STATUS_CMD_ERROR);
     };
     if hard {
         rlim_max = value;
@@ -127,9 +127,9 @@ fn set_limit(
             builtin_wperror(L!("ulimit"), streams);
         }
 
-        STATUS_CMD_ERROR
+        Err(StatusError::STATUS_CMD_ERROR)
     } else {
-        STATUS_CMD_OK
+        Ok(StatusOk::OK)
     }
 }
 
@@ -168,7 +168,11 @@ impl Default for Options {
     }
 }
 
-pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Option<c_int> {
+pub fn ulimit(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    args: &mut [&wstr],
+) -> Result<StatusOk, StatusError> {
     let cmd = args[0];
 
     const SHORT_OPTS: &wstr = L!(":HSabcdefilmnqrstuvwyKPTh");
@@ -231,15 +235,15 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
             'T' => opts.what = RLIMIT_NTHR(),
             'h' => {
                 builtin_print_help(parser, streams, cmd);
-                return STATUS_CMD_OK;
+                return Ok(StatusOk::OK);
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, w.argv[w.wopt_index - 1], true);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, w.argv[w.wopt_index - 1], true);
-                return STATUS_INVALID_ARGS;
+                return Err(StatusError::STATUS_INVALID_ARGS);
             }
             _ => {
                 panic!("unexpected retval from WGetopter");
@@ -258,7 +262,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
         ));
 
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     let what: c_uint = opts.what.try_into().unwrap();
@@ -267,14 +271,14 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
     let arg_count = argc - w.wopt_index;
     if arg_count == 0 {
         print(what, opts.hard, streams);
-        return STATUS_CMD_OK;
+        return Ok(StatusOk::OK);
     } else if arg_count != 1 {
         streams
             .err
             .append(wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
 
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     }
 
     let mut hard = opts.hard;
@@ -291,18 +295,18 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
             cmd
         ));
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     } else if wcscasecmp(w.argv[w.wopt_index], L!("unlimited")) == Ordering::Equal {
         RLIM_INFINITY
     } else if wcscasecmp(w.argv[w.wopt_index], L!("hard")) == Ordering::Equal {
         match get(what, true) {
             Some(limit) => limit,
-            None => return STATUS_CMD_ERROR,
+            None => return Err(StatusError::STATUS_CMD_ERROR),
         }
     } else if wcscasecmp(w.argv[w.wopt_index], L!("soft")) == Ordering::Equal {
         match get(what, soft) {
             Some(limit) => limit,
-            None => return STATUS_CMD_ERROR,
+            None => return Err(StatusError::STATUS_CMD_ERROR),
         }
     } else if let Ok(limit) = fish_wcstol(w.argv[w.wopt_index]) {
         let Some(x) = get_multiplier(what).checked_mul(limit as rlim_t) else {
@@ -312,7 +316,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                 w.argv[w.wopt_index]
             ));
             builtin_print_error_trailer(parser, streams.err, cmd);
-            return STATUS_INVALID_ARGS;
+            return Err(StatusError::STATUS_INVALID_ARGS);
         };
         x
     } else {
@@ -322,7 +326,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
             w.argv[w.wopt_index]
         ));
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return STATUS_INVALID_ARGS;
+        return Err(StatusError::STATUS_INVALID_ARGS);
     };
 
     set_limit(what, hard, soft, new_limit, streams)

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -880,7 +880,8 @@ impl<'ctx> Completer<'ctx> {
             // Compute new value and reinsert it.
             let test_res = exec_subshell(
                 condition, parser, None, false, /* don't apply exit status */
-            ) == 0;
+            )
+            .is_ok();
             self.condition_cache.insert(condition.to_owned(), test_res);
             test_res
         }
@@ -998,7 +999,7 @@ impl<'ctx> Completer<'ctx> {
         // search if we know the location of the whatis database. This can take some time on slower
         // systems with a large set of manuals, but it should be ok since apropos is only called once.
         let mut list = vec![];
-        exec_subshell(
+        let _ = exec_subshell(
             &lookup_cmd,
             parser,
             Some(&mut list),

--- a/src/env/environment.rs
+++ b/src/env/environment.rs
@@ -4,6 +4,7 @@ use super::environment_impl::{
 };
 use super::{ConfigPaths, ElectricVar};
 use crate::abbrs::{abbrs_get_set, Abbreviation, Position};
+use crate::builtins::shared::{StatusError, StatusOk};
 use crate::common::{str2wcstring, unescape_string, wcs2zstring, UnescapeStringStyle};
 use crate::env::{EnvMode, EnvVar, Statuses};
 use crate::env_dispatch::{env_dispatch_init, env_dispatch_var_change};
@@ -63,6 +64,18 @@ impl From<EnvStackSetResult> for c_int {
             EnvStackSetResult::Scope => 2,
             EnvStackSetResult::Invalid => 3,
             EnvStackSetResult::NotFound => 4,
+        }
+    }
+}
+
+impl From<EnvStackSetResult> for Result<StatusOk, StatusError> {
+    fn from(r: EnvStackSetResult) -> Self {
+        match r {
+            EnvStackSetResult::Ok => Ok(StatusOk::OK),
+            EnvStackSetResult::Perm => Err(StatusError::STATUS_ENV_STACK_PERM),
+            EnvStackSetResult::Scope => Err(StatusError::STATUS_ENV_STACK_SCOPE),
+            EnvStackSetResult::Invalid => Err(StatusError::STATUS_ENV_STACK_INVALID),
+            EnvStackSetResult::NotFound => Err(StatusError::STATUS_ENV_STACK_NOT_FOUND),
         }
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -668,7 +668,7 @@ impl OutputStream {
         match self {
             OutputStream::Fd(stream) => stream.flush_and_check_error(),
             OutputStream::Buffered(stream) => stream.flush_and_check_error(),
-            OutputStream::Null | OutputStream::String(_) => STATUS_CMD_OK.unwrap(),
+            OutputStream::Null | OutputStream::String(_) => STATUS_CMD_OK,
         }
     }
 
@@ -794,7 +794,6 @@ impl FdOutputStream {
         } else {
             STATUS_CMD_OK
         }
-        .unwrap()
     }
 }
 
@@ -839,7 +838,7 @@ impl BufferedOutputStream {
     }
     fn flush_and_check_error(&mut self) -> libc::c_int {
         if self.buffer.discarded() {
-            return STATUS_READ_TOO_MUCH.unwrap();
+            return STATUS_READ_TOO_MUCH;
         }
         0
     }

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -189,7 +189,7 @@ impl<'a> ExecutionContext {
             return report_error!(
                 self,
                 ctx,
-                STATUS_CMD_ERROR.unwrap(),
+                STATUS_CMD_ERROR,
                 infinite_recursive_node,
                 INFINITE_FUNC_RECURSION_ERR_MSG,
                 func_name
@@ -205,7 +205,7 @@ impl<'a> ExecutionContext {
             return report_error!(
                 self,
                 ctx,
-                STATUS_CMD_ERROR.unwrap(),
+                STATUS_CMD_ERROR,
                 job_list,
                 CALL_STACK_LIMIT_EXCEEDED_ERR_MSG
             );
@@ -284,7 +284,7 @@ impl<'a> ExecutionContext {
                     return report_error!(
                         self,
                         ctx,
-                        STATUS_NOT_EXECUTABLE.unwrap(),
+                        STATUS_NOT_EXECUTABLE,
                         &statement.command,
                         concat!(
                             "Unknown command. A component of '%ls' is not a ",
@@ -296,7 +296,7 @@ impl<'a> ExecutionContext {
                     return report_error!(
                         self,
                         ctx,
-                        STATUS_NOT_EXECUTABLE.unwrap(),
+                        STATUS_NOT_EXECUTABLE,
                         &statement.command,
                         "Unknown command. A component of '%ls' is not a directory.",
                         cmd
@@ -307,7 +307,7 @@ impl<'a> ExecutionContext {
             return report_error!(
                 self,
                 ctx,
-                STATUS_NOT_EXECUTABLE.unwrap(),
+                STATUS_NOT_EXECUTABLE,
                 &statement.command,
                 "Unknown command. '%ls' exists but is not an executable file.",
                 cmd
@@ -369,13 +369,7 @@ impl<'a> ExecutionContext {
 
         // Here we want to report an error (so it shows a backtrace).
         // If the handler printed text, that's already shown, so error will be empty.
-        report_error_formatted!(
-            self,
-            ctx,
-            STATUS_CMD_UNKNOWN.unwrap(),
-            &statement.command,
-            error
-        )
+        report_error_formatted!(self, ctx, STATUS_CMD_UNKNOWN, &statement.command, error)
     }
 
     // Utilities.
@@ -506,13 +500,13 @@ impl<'a> ExecutionContext {
                 // This means that the error positions are relative to the beginning
                 // of the token; we need to make them relative to the original source.
                 parse_error_offset_source_start(&mut errors, pos_of_command_token);
-                return self.report_errors(ctx, STATUS_ILLEGAL_CMD.unwrap(), &errors);
+                return self.report_errors(ctx, STATUS_ILLEGAL_CMD, &errors);
             }
             ExpandResultCode::wildcard_no_match => {
                 return report_error!(
                     self,
                     ctx,
-                    STATUS_UNMATCHED_WILDCARD.unwrap(),
+                    STATUS_UNMATCHED_WILDCARD,
                     statement,
                     WILDCARD_ERR_MSG,
                     &self.node_source(statement)
@@ -530,7 +524,7 @@ impl<'a> ExecutionContext {
             return report_error!(
                 self,
                 ctx,
-                STATUS_ILLEGAL_CMD.unwrap(),
+                STATUS_ILLEGAL_CMD,
                 &statement.command,
                 "The expanded command was empty."
             );
@@ -544,7 +538,7 @@ impl<'a> ExecutionContext {
             return report_error!(
                 self,
                 ctx,
-                STATUS_ILLEGAL_CMD.unwrap(),
+                STATUS_ILLEGAL_CMD,
                 &statement.command,
                 "The expanded command is a keyword."
             );
@@ -903,7 +897,7 @@ impl<'a> ExecutionContext {
             return report_error!(
                 self,
                 ctx,
-                STATUS_EXPAND_ERROR.unwrap(),
+                STATUS_EXPAND_ERROR,
                 &header.var_name,
                 FAILED_EXPANSION_VARIABLE_NAME_ERR_MSG,
                 for_var_name
@@ -914,7 +908,7 @@ impl<'a> ExecutionContext {
             return report_error!(
                 self,
                 ctx,
-                STATUS_INVALID_ARGS.unwrap(),
+                STATUS_INVALID_ARGS,
                 header.var_name,
                 BUILTIN_ERR_VARNAME,
                 "for",
@@ -935,7 +929,7 @@ impl<'a> ExecutionContext {
             return report_error!(
                 self,
                 ctx,
-                STATUS_INVALID_ARGS.unwrap(),
+                STATUS_INVALID_ARGS,
                 header.var_name,
                 "%ls: %ls: cannot overwrite read-only variable",
                 "for",
@@ -1061,7 +1055,7 @@ impl<'a> ExecutionContext {
                 // 'if' condition failed, no else clause, return 0, we're done.
                 // No job list means no successful conditions, so return 0 (issue #1443).
                 ctx.parser()
-                    .set_last_statuses(Statuses::just(STATUS_CMD_OK.unwrap()));
+                    .set_last_statuses(Statuses::just(STATUS_CMD_OK));
             }
             Some(job_list_to_execute) => {
                 // Execute the job list we got.
@@ -1115,7 +1109,7 @@ impl<'a> ExecutionContext {
                 return report_error!(
                     self,
                     ctx,
-                    STATUS_UNMATCHED_WILDCARD.unwrap(),
+                    STATUS_UNMATCHED_WILDCARD,
                     &statement.argument,
                     WILDCARD_ERR_MSG,
                     &self.node_source(&statement.argument)
@@ -1126,7 +1120,7 @@ impl<'a> ExecutionContext {
                     return report_error!(
                         self,
                         ctx,
-                        STATUS_INVALID_ARGS.unwrap(),
+                        STATUS_INVALID_ARGS,
                         &statement.argument,
                         "switch: Expected at most one argument, got %lu\n",
                         switch_values_expanded.len()
@@ -1317,7 +1311,7 @@ impl<'a> ExecutionContext {
                 statement as *const ast::BlockStatement,
             ),
         );
-        let err_code = err_code.unwrap();
+
         ctx.parser().libdata_mut().status_count += 1;
         ctx.parser().set_last_statuses(Statuses::just(err_code));
 
@@ -1404,7 +1398,7 @@ impl<'a> ExecutionContext {
                         return report_error!(
                             self,
                             ctx,
-                            STATUS_UNMATCHED_WILDCARD.unwrap(),
+                            STATUS_UNMATCHED_WILDCARD,
                             arg_node,
                             WILDCARD_ERR_MSG,
                             &self.node_source(*arg_node)
@@ -1455,7 +1449,7 @@ impl<'a> ExecutionContext {
                     return report_error!(
                         self,
                         ctx,
-                        STATUS_INVALID_ARGS.unwrap(),
+                        STATUS_INVALID_ARGS,
                         redir_node,
                         "Invalid redirection: %ls",
                         &self.node_source(redir_node)
@@ -1480,7 +1474,7 @@ impl<'a> ExecutionContext {
                 return report_error!(
                     self,
                     ctx,
-                    STATUS_INVALID_ARGS.unwrap(),
+                    STATUS_INVALID_ARGS,
                     redir_node,
                     "Invalid redirection target: %ls",
                     target
@@ -1499,7 +1493,7 @@ impl<'a> ExecutionContext {
                 return report_error!(
                     self,
                     ctx,
-                    STATUS_INVALID_ARGS.unwrap(),
+                    STATUS_INVALID_ARGS,
                     redir_node,
                     "Requested redirection to '%ls', which is not a valid file descriptor",
                     &spec.target
@@ -1560,7 +1554,7 @@ impl<'a> ExecutionContext {
                 return report_error!(
                     self,
                     ctx,
-                    STATUS_INVALID_ARGS.unwrap(),
+                    STATUS_INVALID_ARGS,
                     job_node,
                     ERROR_TIME_BACKGROUND
                 );
@@ -1826,7 +1820,7 @@ impl<'a> ExecutionContext {
                 result = report_error!(
                     self,
                     ctx,
-                    STATUS_INVALID_ARGS.unwrap(),
+                    STATUS_INVALID_ARGS,
                     &jc.pipe,
                     ILLEGAL_FD_ERR_MSG,
                     &self.node_source(&jc.pipe)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -505,10 +505,10 @@ impl Parser {
         eprintf!("%s\n", backtrace_and_desc);
 
         // Set a valid status.
-        self.set_last_statuses(Statuses::just(STATUS_ILLEGAL_CMD.unwrap()));
+        self.set_last_statuses(Statuses::just(STATUS_ILLEGAL_CMD));
         let break_expand = true;
         EvalRes {
-            status: ProcStatus::from_exit_code(STATUS_ILLEGAL_CMD.unwrap()),
+            status: ProcStatus::from_exit_code(STATUS_ILLEGAL_CMD),
             break_expand,
             ..Default::default()
         }
@@ -810,7 +810,7 @@ impl Parser {
         &self.variables
     }
 
-    /// Get the variables as an Arc.
+    /// Get the variables as an Rc.
     pub fn vars_ref(&self) -> Rc<EnvStack> {
         Rc::clone(&self.variables)
     }

--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -648,16 +648,10 @@ fn test_eval_illegal_exit_code() {
     parser.pushd("test/temp");
     validate!(L!("echo -n"), STATUS_CMD_OK.unwrap());
     validate!(L!("pwd"), STATUS_CMD_OK.unwrap());
-    validate!(
-        L!("UNMATCHABLE_WILDCARD*"),
-        STATUS_UNMATCHED_WILDCARD.unwrap()
-    );
-    validate!(
-        L!("UNMATCHABLE_WILDCARD**"),
-        STATUS_UNMATCHED_WILDCARD.unwrap()
-    );
-    validate!(L!("?"), STATUS_UNMATCHED_WILDCARD.unwrap());
-    validate!(L!("abc?def"), STATUS_UNMATCHED_WILDCARD.unwrap());
+    validate!(L!("UNMATCHABLE_WILDCARD*"), STATUS_UNMATCHED_WILDCARD);
+    validate!(L!("UNMATCHABLE_WILDCARD**"), STATUS_UNMATCHED_WILDCARD);
+    validate!(L!("?"), STATUS_UNMATCHED_WILDCARD);
+    validate!(L!("abc?def"), STATUS_UNMATCHED_WILDCARD);
     parser.popd();
 }
 

--- a/tests/checks/create-base-directories.fish
+++ b/tests/checks/create-base-directories.fish
@@ -10,7 +10,8 @@ $fish -c ''
 
 # Check that existing directories kept their permissions, and new directories
 # have the right permissions according to the XDG Base Directory Specification.
-ls -ld $dir/old $dir/old/new $dir/old/new/fish | awk '{print $1}'
+# depending on your environment, there might be a '.' printed at the end of the permissions
+ls -ld $dir/old $dir/old/new $dir/old/new/fish | awk '{gsub(/\.$/, "", $1); print $1}'
 # CHECK: drwxr-xr-x
 # CHECK: drwx------
 # CHECK: drwx------


### PR DESCRIPTION
## Description

Talk about your changes here.

Currently all error codes are wrapped in an Option type, this is not a causes the Option type to leak into a lot of function return types when it's not needed. 

In this PR I removed all these Options around the static variables aswell as reworked all `Option<c_int>` return types to be `Result<StatusOk, StatusError>`. `StatusOk` is an enum that can be a regular `OK` or an `OK_PRESERVE_ERROR_CODE`. There's a lot of small improvements that are now possible for example you can now use `?` to handle errors a lot easier.

There's still a lot more places that could be improved but this PR is limited to replacing all the builtin functions.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
