### PR TITLE
completions/dnf: Fix completions for DNF5 (#9862)

### DIFF
--- a/share/completions/dnf.fish
+++ b/share/completions/dnf.fish
@@ -3,7 +3,7 @@
 #
 
 function __dnf_list_installed_packages
-    dnf repoquery --cacheonly "$cur*" --qf "%{name}" --installed </dev/null
+    dnf repoquery --cacheonly "$cur*" --qf "%{name}\n" --installed </dev/null
 end
 
 function __dnf_list_available_packages
@@ -26,7 +26,7 @@ function __dnf_list_available_packages
     else
         # In some cases dnf will ask for input (e.g. to accept gpg keys).
         # Connect it to /dev/null to try to stop it.
-        set results (dnf repoquery --cacheonly "$tok*" --qf "%{name}" --available </dev/null 2>/dev/null)
+        set results (dnf repoquery --cacheonly "$tok*" --qf "%{name}\n" --available </dev/null 2>/dev/null)
     end
     if set -q results[1]
         set results (string match -r -- '.*\\.rpm$' $files) $results


### PR DESCRIPTION
## Description

Since DNF5 there's no implicit \n in repoquery output. For DNF4 this change leaves blank lines in the output, but they are ignored anyway.

Fixes issue #9862

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
