### PR TITLE
docs: Distinguish documents in sidebar

### DIFF
--- a/doc_src/python_docs_theme/static/pydoctheme.css
+++ b/doc_src/python_docs_theme/static/pydoctheme.css
@@ -53,7 +53,6 @@ body {
 div.related ul {
   margin: 0;
   padding: 0 0 0 10px;
-  list-style: none;
 }
 
 div.related {
@@ -581,7 +580,7 @@ div.document {
     }
 
     /* Reduce margins to save space */
-    div.sphinxsidebar ul ul, div.sphinxsidebar ul, div.bodywrapper, div.content {
+    div.sphinxsidebar ul ul, div.bodywrapper, div.content {
         margin-left: 0;
     }
 


### PR DESCRIPTION
## Description

#10942 is a great change, but also makes it hard to tell one document from another in the sidebar. Previously, each document are on their own line, but now a document with long title can span multiple lines.

This pull request restores the previously hidden list item marker to make it easier to distinguish the documents.

| | Before | After |
|--------|--------|--------|
| Wide | ![CleanShot 2024-12-28 at 15 25 38@2x](https://github.com/user-attachments/assets/7666c155-8264-43fe-9a15-1f00f1e8b129) | ![CleanShot 2024-12-28 at 15 27 16@2x](https://github.com/user-attachments/assets/30c9582c-8764-48d5-bc7f-82da0a353f81) |
| Narrow | ![CleanShot 2024-12-28 at 15 27 47@2x](https://github.com/user-attachments/assets/b12ce966-6afd-4890-8c5c-521d3845f4a2) |![CleanShot 2024-12-28 at 15 27 01@2x](https://github.com/user-attachments/assets/03ba4dd7-70f8-4df6-98ac-0891fe238002) | 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
