### PR TITLE
Create new base directories with mode 0700

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -667,7 +667,7 @@ fn make_base_directory(xdg_var: &wstr, non_xdg_homepath: &wstr) -> BaseDirectory
     let mut remoteness = DirRemoteness::unknown;
     if path.is_empty() {
         err = ENOENT;
-    } else if let Err(io_error) = std::fs::create_dir_all(wcs2osstring(&path)) {
+    } else if let Err(io_error) = create_dir_all_with_mode(wcs2osstring(&path), 0o700) {
         err = io_error.raw_os_error().unwrap_or_default();
     } else {
         err = 0;
@@ -683,6 +683,15 @@ fn make_base_directory(xdg_var: &wstr, non_xdg_homepath: &wstr) -> BaseDirectory
         err,
         used_xdg,
     }
+}
+
+// Like std::fs::create_dir_all, but new directories are created using the given mode (e.g. 0o700).
+fn create_dir_all_with_mode<P: AsRef<std::path::Path>>(path: P, mode: u32) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(mode)
+        .create(path.as_ref())
 }
 
 /// Return whether the given path is on a remote filesystem.

--- a/tests/checks/create-base-directories.fish
+++ b/tests/checks/create-base-directories.fish
@@ -1,0 +1,16 @@
+#RUN: %fish -C 'set -l fish %fish' %s
+
+# Set a XDG_CONFIG_HOME with both pre-existing and non-existing directories.
+set -l dir (mktemp -d)
+mkdir -m 0755 $dir/old
+set -gx XDG_CONFIG_HOME $dir/old/new
+
+# Launch fish so it will create all missing directories.
+$fish -c ''
+
+# Check that existing directories kept their permissions, and new directories
+# have the right permissions according to the XDG Base Directory Specification.
+ls -ld $dir/old $dir/old/new $dir/old/new/fish | awk '{print $1}'
+# CHECK: drwxr-xr-x
+# CHECK: drwx------
+# CHECK: drwx------


### PR DESCRIPTION
## Description

If base directories (e.g. $HOME/.config/fish) need to be created, create them with mode 0700 (i.e. restricted to the owner). This both keeps the behavior of old fish versions (e.g. [3.7.1](https://github.com/fish-shell/fish-shell/blob/80394ea4e38138e0ce0bf23b016dc931e22ff788/src/path.cpp#L323)) and is compliant with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/0.8/#referencing).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
