### PR TITLE
README: use `cmake -B` to simplify build commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,10 +146,9 @@ To install into ``/usr/local``, run:
 
 .. code:: bash
 
-   mkdir build; cd build
-   cmake ..
-   cmake --build .
-   sudo cmake --install .
+   cmake -B build
+   cmake --build build
+   sudo cmake --install build
 
 The install directory can be changed using the
 ``-DCMAKE_INSTALL_PREFIX`` parameter for ``cmake``.


### PR DESCRIPTION
## Description
Note that `-B` was added in CMake 3.13 [1]
and CMake 3.15 or later is already required by fish. [2]

[1] https://cmake.org/cmake/help/latest/release/3.13.html#command-line
[2] commit 044cea1bf (update CMake requirement, 2024-12-26)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->