### PR TITLE
Improve documentation for `string escape`

### DIFF
--- a/doc_src/cmds/string-escape.rst
+++ b/doc_src/cmds/string-escape.rst
@@ -18,7 +18,9 @@ Description
 
 .. BEGIN DESCRIPTION
 
-``string escape`` escapes each *STRING* in one of three ways. The first is **--style=script**. This is the default. It alters the string such that it can be passed back to ``eval`` to produce the original argument again. By default, all special characters are escaped, and quotes are used to simplify the output when possible. If **-n** or **--no-quoted** is given, the simplifying quoted format is not used. Exit status: 0 if at least one string was escaped, or 1 otherwise.
+``string escape`` escapes each *STRING* in one of several ways.
+
+**--style=script** (default) alters the string such that it can be passed back to ``eval`` to produce the original argument again. By default, all special characters are escaped, and quotes are used to simplify the output when possible. If **-n** or **--no-quoted** is given, the simplifying quoted format is not used. Exit status: 0 if at least one string was escaped, or 1 otherwise.
 
 **--style=var** ensures the string can be used as a variable name by hex encoding any non-alphanumeric characters. The string is first converted to UTF-8 before being encoded.
 


### PR DESCRIPTION
Before, it unnecessarily stated that there are three `--style` options, when
there are actually four.

I also align the default `--style=script` argument to the beginning of the line
to match the other options visually for easier scanning.
