### PR TITLE
Update .editorconfig to use "unset" instead of "off"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,7 +22,7 @@ indent_size = 2
 indent_size = 2
 
 [share/{completions,functions}/**.fish]
-max_line_length = off
+max_line_length = unset
 
 [{COMMIT_EDITMSG,git-revise-todo}]
 max_line_length = 80


### PR DESCRIPTION
This is inline with the [EditorConfig spec](https://spec.editorconfig.org/). The [EditorConfig Wiki](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length) was outdated and misleading, but have corrected now.
