### PR TITLE
Code cleanup in `src/bin/fish.rs` to make it more idiomatic

### DIFF
--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -873,16 +873,13 @@ fn throwing_main() -> i32 {
     // Stomp the exit status of any initialization commands (issue #635).
     parser.set_last_statuses(Statuses::just(STATUS_CMD_OK.unwrap()));
 
-    match (&opts.profile_startup_output, &opts.profile_output) {
-        (Some(profile_startup_output), Some(profile_output))
-            if profile_startup_output != profile_output =>
-        {
-            parser.emit_profiling(profile_startup_output);
-            // If we are profiling both, ensure the startup data only
-            // ends up in the startup file.
-            parser.clear_profiling();
-        }
-        _ => (),
+    // TODO: if-let-chains
+    if opts.profile_startup_output.is_some() && opts.profile_startup_output != opts.profile_output {
+        parser.emit_profiling(&opts.profile_startup_output.unwrap());
+
+        // If we are profiling both, ensure the startup data only
+        // ends up in the startup file.
+        parser.clear_profiling();
     }
 
     PROFILING_ACTIVE.store(opts.profile_output.is_some());

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -818,10 +818,9 @@ fn throwing_main() -> i32 {
         save_term_foreground_process_group();
     }
 
-    let mut paths: Option<ConfigPaths> = None;
     // If we're not executing, there's no need to find the config.
-    if !opts.no_exec {
-        paths = Some(determine_config_directory_paths(OsString::from_vec(
+    let paths: Option<ConfigPaths> = if !opts.no_exec {
+        let paths = Some(determine_config_directory_paths(OsString::from_vec(
             wcs2string(&args[0]),
         )));
         env_init(
@@ -829,7 +828,10 @@ fn throwing_main() -> i32 {
             /* do uvars */ !opts.no_config,
             /* default paths */ opts.no_config,
         );
-    }
+        paths
+    } else {
+        None
+    };
 
     // Set features early in case other initialization depends on them.
     // Start with the ones set in the environment, then those set on the command line (so the
@@ -846,7 +848,7 @@ fn throwing_main() -> i32 {
 
     // Construct the root parser!
     let env = Rc::new(EnvStack::globals().create_child(true /* dispatches_var_changes */));
-    let parser: &Parser = &Parser::new(env, CancelBehavior::Clear);
+    let parser = &Parser::new(env, CancelBehavior::Clear);
     parser.set_syncs_uvars(!opts.no_config);
 
     if !opts.no_exec && !opts.no_config {
@@ -871,13 +873,16 @@ fn throwing_main() -> i32 {
     // Stomp the exit status of any initialization commands (issue #635).
     parser.set_last_statuses(Statuses::just(STATUS_CMD_OK.unwrap()));
 
-    // TODO: if-let-chains
-    if opts.profile_startup_output.is_some() && opts.profile_startup_output != opts.profile_output {
-        parser.emit_profiling(&opts.profile_startup_output.unwrap());
-
-        // If we are profiling both, ensure the startup data only
-        // ends up in the startup file.
-        parser.clear_profiling();
+    match (&opts.profile_startup_output, &opts.profile_output) {
+        (Some(profile_startup_output), Some(profile_output))
+            if profile_startup_output != profile_output =>
+        {
+            parser.emit_profiling(profile_startup_output);
+            // If we are profiling both, ensure the startup data only
+            // ends up in the startup file.
+            parser.clear_profiling();
+        }
+        _ => (),
     }
 
     PROFILING_ACTIVE.store(opts.profile_output.is_some());
@@ -1009,7 +1014,6 @@ fn fish_xdm_login_hack_hack_hack_hack(cmds: &mut [OsString], args: &[WString]) -
         return false;
     }
 
-    let mut result = false;
     let cmd = &cmds[0];
     if cmd == "exec \"${@}\"" || cmd == "exec \"$@\"" {
         // We're going to construct a new command that starts with exec, and then has the
@@ -1021,7 +1025,8 @@ fn fish_xdm_login_hack_hack_hack_hack(cmds: &mut [OsString], args: &[WString]) -
         }
 
         cmds[0] = new_cmd;
-        result = true;
+        true
+    } else {
+        false
     }
-    result
 }


### PR DESCRIPTION
## Description
Updated some of the code in `src/bin/fish.rs` to make it more idiomatic, e.g. using if-expressions instead of:
```rust
let mut foo = None;
if (something) {
  foo = Some(something_else)
}
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
