### PR TITLE
Add fish_cmd_entered event for modifying commandline after user hits enter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Deprecations and removed features
 
 Scripting improvements
 ----------------------
+- `fish_cmd_entered` event emitted after the user hits enter
 
 Interactive improvements
 ------------------------

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -2083,6 +2083,8 @@ Fish already has the following named events for the ``--on-event`` switch:
 
 - ``fish_prompt`` is emitted whenever a new fish prompt is about to be displayed.
 
+- ``fish_cmd_entered`` is emitted after the user finishes entering a command.
+
 - ``fish_preexec`` is emitted right before executing an interactive command. The commandline is passed as the first parameter. Not emitted if command is empty.
 
 - ``fish_posterror`` is emitted right after executing a command with syntax errors. The commandline is passed as the first parameter.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1960,6 +1960,7 @@ impl<'a> Reader<'a> {
                 break;
             }
         }
+        event::fire_generic(zelf.parser, L!("fish_cmd_entered").to_owned(), vec![]);
 
         // Redraw the command line. This is what ensures the autosuggestion is hidden, etc. after the
         // user presses enter.


### PR DESCRIPTION
## Description

As I was hacking on some scripts I tried to use `fish_preexec` to alter the `commandline` prior to execution. I quickly realized that's not possible, and in fact it seems `fish_preexec` might not be the actual event I was looking for.

To enable such an operation (commandline editing prior to execution) I've added a new event that occurs earlier on, once the `Reader` determines that it's finished reading.

With this new event it's possible to define the following function (N.B. this may, and probably is, bad code):
```
function remap_foo --on-event fish_cmd_entered
  set cli (commandline --tokens-raw)
  set n (count $cli)
  test $n -eq 0; and return
  for i in (seq 1 $n)
    test "$cli[$i]" = foo; and set cli[$i] bar
  end
  commandline --replace "$cli"
end
```
and then
```
echo foo<enter>
```
would get replaced just before execution with
```
echo bar
```

---

This event is essentially enabling `abbr --regex '...' --position anywhere --function '...'`, but for the full commandline instead of just the matched token. I'm not sure if this is the correct way of going about this, or if modifying `abbr` is a better route.

Or, there's also the possibility that this sort of feature is out of scope for fish, which is ok too!

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
