### PR TITLE
environment_impl: drop usage of lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,6 @@ dependencies = [
  "cc",
  "errno",
  "fish-printf",
- "lazy_static",
  "libc",
  "lru",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ pcre2 = { git = "https://github.com/fish-shell/rust-pcre2", tag = "0.2.9-utf32",
 
 bitflags = "2.5.0"
 errno = "0.3.0"
-lazy_static = "1.4.0"
 libc = "0.2.155"
 # lru pulls in hashbrown by default, which uses a faster (though less DoS resistant) hashing algo.
 # disabling default features uses the stdlib instead, but it doubles the time to rewrite the history


### PR DESCRIPTION
## Description

This change gets rid of `lazy_static` as direct dependency for good.

In order to make `once_cell` happy, the manual `Sync` marker needs to be moved below
the `Arc<...>` level, so I added a newtype wrapper for the `RefCell<EnvNode>` itself.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
