### PR TITLE
Move `getrusage` wrapper in `timer.rs` to shared `nix` wrapper module

### DIFF
--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -44,7 +44,7 @@ use fish::{
     fprintf, function, future_feature_flags as features,
     history::{self, start_private_mode},
     io::IoChain,
-    nix::{getpid, isatty},
+    nix::{getpid, getrusage, isatty, RUsage},
     panic::panic_handler,
     parse_constants::{ParseErrorList, ParseTreeFlags},
     parse_tree::ParsedSource,
@@ -237,13 +237,7 @@ fn tv_to_msec(tv: &libc::timeval) -> i64 {
 }
 
 fn print_rusage_self() {
-    let mut rs = MaybeUninit::uninit();
-    if unsafe { libc::getrusage(libc::RUSAGE_SELF, rs.as_mut_ptr()) } != 0 {
-        let s = CString::new("getrusage").unwrap();
-        unsafe { libc::perror(s.as_ptr()) }
-        return;
-    }
-    let rs: libc::rusage = unsafe { rs.assume_init() };
+    let rs = getrusage(RUsage::RSelf);
     let rss_kb = if cfg!(target_os = "macos") {
         // mac use bytes.
         rs.ru_maxrss / 1024

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -65,7 +65,6 @@ use fish::{
 };
 use std::ffi::{CString, OsStr, OsString};
 use std::fs::File;
-use std::mem::MaybeUninit;
 use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -47,7 +47,8 @@ pub enum RUsage {
     RChildren,
 }
 
-/// A safe wrapper around `libc::getrusage()`
+/// A safe wrapper around `libc::getrusage()`. If `libc::getrusage()` fails,
+/// `wutil::perror()` will be called and a zeroed struct will be returned.
 pub fn getrusage(resource: RUsage) -> libc::rusage {
     let mut rusage = std::mem::MaybeUninit::uninit();
     let result = unsafe {

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+use crate::wutil;
+
 #[allow(clippy::unnecessary_cast)]
 pub const fn timeval_to_duration(val: &libc::timeval) -> Duration {
     let micros = val.tv_sec as i64 * (1E6 as i64) + val.tv_usec as i64;
@@ -64,6 +66,9 @@ pub fn getrusage(resource: RUsage) -> libc::rusage {
     // return an empty value.
     match result {
         0 => unsafe { rusage.assume_init() },
-        _ => unsafe { std::mem::zeroed() },
+        _ => unsafe {
+            wutil::perror("getrusage");
+            std::mem::zeroed()
+        },
     }
 }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -37,3 +37,33 @@ pub fn isatty(fd: i32) -> bool {
     // No place we currently call it really cares about the difference.
     return unsafe { libc::isatty(fd) } == 1;
 }
+
+/// An enumeration of supported libc rusage types used by [`getrusage()`].
+/// NB: RUSAGE_THREAD is not supported on macOS.
+pub enum RUsage {
+    RSelf, // "Self" is a reserved keyword
+    RChildren,
+}
+
+/// A safe wrapper around `libc::getrusage()`
+pub fn getrusage(resource: RUsage) -> libc::rusage {
+    let mut rusage = std::mem::MaybeUninit::uninit();
+    let result = unsafe {
+        libc::getrusage(
+            match resource {
+                RUsage::RSelf => libc::RUSAGE_SELF,
+                RUsage::RChildren => libc::RUSAGE_CHILDREN,
+            },
+            rusage.as_mut_ptr(),
+        )
+    };
+
+    // getrusage(2) says the syscall can only fail if the dest address is invalid (EFAULT) or if the
+    // requested resource type is invalid. Since we're in control of both, we can assume it won't
+    // fail. In case it does anyway (e.g. OS where the syscall isn't implemented), we can just
+    // return an empty value.
+    match result {
+        0 => unsafe { rusage.assume_init() },
+        _ => unsafe { std::mem::zeroed() },
+    }
+}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -17,6 +17,8 @@
 use std::io::Write;
 use std::time::{Duration, Instant};
 
+use crate::nix;
+
 enum Unit {
     Minutes,
     Seconds,
@@ -38,38 +40,11 @@ pub fn push_timer() -> PrintElapsedOnDrop {
     }
 }
 
-/// An enumeration of supported libc rusage types used by [`getrusage()`].
-/// NB: RUSAGE_THREAD is not supported on macOS.
-enum RUsage {
-    RSelf, // "Self" is a reserved keyword
-    RChildren,
-}
-
-/// A safe wrapper around `libc::getrusage()`
-fn getrusage(resource: RUsage) -> libc::rusage {
-    let mut rusage = std::mem::MaybeUninit::uninit();
-    let result = unsafe {
-        match resource {
-            RUsage::RSelf => libc::getrusage(libc::RUSAGE_SELF, rusage.as_mut_ptr()),
-            RUsage::RChildren => libc::getrusage(libc::RUSAGE_CHILDREN, rusage.as_mut_ptr()),
-        }
-    };
-
-    // getrusage(2) says the syscall can only fail if the dest address is invalid (EFAULT) or if the
-    // requested resource type is invalid. Since we're in control of both, we can assume it won't
-    // fail. In case it does anyway (e.g. OS where the syscall isn't implemented), we can just
-    // return an empty value.
-    match result {
-        0 => unsafe { rusage.assume_init() },
-        _ => unsafe { std::mem::zeroed() },
-    }
-}
-
 impl TimerSnapshot {
     pub fn take() -> TimerSnapshot {
         TimerSnapshot {
-            cpu_fish: getrusage(RUsage::RSelf),
-            cpu_children: getrusage(RUsage::RChildren),
+            cpu_fish: nix::getrusage(nix::RUsage::RSelf),
+            cpu_children: nix::getrusage(nix::RUsage::RChildren),
             wall_time: Instant::now(),
         }
     }


### PR DESCRIPTION
## Description

There was a safe wrapper for `getrusage` in `timer.rs`, but it wasn't in the `nix` module. This change moves it there, and makes `bin/fish.rs` use it instead of `libc::getrusage`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
