### PR TITLE
Remove unnecessary clone when opening File for debug output

### DIFF
--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -773,7 +773,7 @@ fn throwing_main() -> i32 {
             .write(true)
             .truncate(true)
             .create(true)
-            .open(debug_path.clone())
+            .open(&debug_path)
         {
             Ok(dbg_file) => {
                 // Rust sets O_CLOEXEC by default


### PR DESCRIPTION
## Description

An unnecessary clone was being made when calling OpenOptions::open.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
