### PR TITLE
Avoid traversing wait handle list if searching by PID

### DIFF
--- a/src/builtins/wait.rs
+++ b/src/builtins/wait.rs
@@ -36,13 +36,22 @@ fn find_wait_handles(
     handles: &mut Vec<WaitHandleRef>,
 ) -> bool {
     // Has a job already completed?
-    // TODO: we can avoid traversing this list if searching by pid.
     let mut matched = false;
     let wait_handles: &mut WaitHandleStore = &mut parser.mut_wait_handles();
-    for wh in wait_handles.iter() {
-        if wait_handle_matches(query, wh) {
-            handles.push(wh.clone());
-            matched = true;
+    match query {
+        WaitHandleQuery::Pid(pid) => {
+            if let Some(wh) = wait_handles.get_by_pid(pid) {
+                handles.push(wh);
+                matched = true;
+            }
+        }
+        _ => {
+            for wh in wait_handles.iter() {
+                if wait_handle_matches(query, wh) {
+                    handles.push(wh.clone());
+                    matched = true;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Previously, the wait handle list was iterated even if the query was by PID, which is unnecessary, as `WaitHandleStore` has a method `get_by_pid`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
