### PR TITLE
Don't execute off of buffered keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Scripting improvements
 Interactive improvements
 ------------------------
 - Autosuggestions are now also provided in  multi-line command lines. Like `ctrl-r`, autosuggestions operate only on the current line.
+- When typing a command while the previous one is still running, :kbd:`enter` will no longer execute the would-be command, and keys that are bound to shell commands will be ignored.
+  This mitigates a security issue where a command like ``cat malicious-file.txt`` could write terminal escape codes prompting the terminal to write arbitrary text to fish's standard input.
+  Such a malicious file can still potentially insert arbitrary text into the command line but can no longer execute it directly (:issue:`10987`).
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/input.rs
+++ b/src/input.rs
@@ -5,7 +5,7 @@ use crate::event;
 use crate::flog::FLOG;
 use crate::input_common::{
     CharEvent, CharInputStyle, ImplicitEvent, InputData, InputEventQueuer, ReadlineCmd,
-    WaitingForCursorPosition, R_END_INPUT_FUNCTIONS,
+    ReadlineCmdEvent, WaitingForCursorPosition, READING_BUFFERED_INPUT, R_END_INPUT_FUNCTIONS,
 };
 use crate::key::ViewportPosition;
 use crate::key::{self, canonicalize_raw_escapes, ctrl, Key, Modifiers};
@@ -873,6 +873,12 @@ impl<'a> Reader<'a> {
         }
         for cmd in m.commands.iter().rev() {
             let evt = match input_function_get_code(cmd) {
+                Some(ReadlineCmd::Execute) if READING_BUFFERED_INPUT.load() => {
+                    CharEvent::Readline(ReadlineCmdEvent {
+                        cmd: ReadlineCmd::SelfInsert,
+                        seq: WString::from_chars([key::Enter]),
+                    })
+                }
                 Some(code) => {
                     self.function_push_args(code);
                     // At this point, the sequence is only used for reinserting the keys into
@@ -886,7 +892,12 @@ impl<'a> Reader<'a> {
                             .collect(),
                     )
                 }
-                None => CharEvent::Command(cmd.clone()),
+                None => {
+                    if READING_BUFFERED_INPUT.load() {
+                        continue;
+                    }
+                    CharEvent::Command(cmd.clone())
+                }
             };
             self.push_front(evt);
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -77,7 +77,6 @@ use crate::history::{
     SearchType,
 };
 use crate::input::init_input;
-use crate::input_common::terminal_protocols_disable_ifn;
 use crate::input_common::ImplicitEvent;
 use crate::input_common::InputEventQueuer;
 use crate::input_common::WaitingForCursorPosition;
@@ -86,6 +85,7 @@ use crate::input_common::{
     terminal_protocol_hacks, terminal_protocols_enable_ifn, CharEvent, CharInputStyle, InputData,
     ReadlineCmd,
 };
+use crate::input_common::{terminal_protocols_disable_ifn, READING_BUFFERED_INPUT};
 use crate::io::IoChain;
 use crate::key::ViewportPosition;
 use crate::kill::{kill_add, kill_replace, kill_yank, kill_yank_rotate};
@@ -4072,6 +4072,7 @@ fn term_steal(copy_modes: bool) {
             break;
         }
     }
+    READING_BUFFERED_INPUT.store(true);
 
     termsize_invalidate_tty();
 }

--- a/tests/checks/tmux-bind2.fish
+++ b/tests/checks/tmux-bind2.fish
@@ -4,7 +4,9 @@
 isolated-tmux-start
 
 isolated-tmux send-keys "function prepend; commandline --cursor 0; commandline -i echo; end" Enter
+tmux-sleep
 isolated-tmux send-keys "bind ctrl-g prepend" Enter
+tmux-sleep
 isolated-tmux send-keys C-l
 isolated-tmux send-keys 'printf'
 isolated-tmux send-keys C-g Space


### PR DESCRIPTION
If I run "sleep 3", type a command and hit enter, then there is no
obvious way to cancel or edit the imminent command other than ctrl-c
but that also cancels sleep, and doesn't allow editing. (ctrl-z sort
of works, but also doesn't allow editing).

Let's limit ourselves to inserting the buffered command (translating
enter to a newline), and only execute once the user actually presses
enter after the previous command is done.

This seems more user-friendly in general, at the risk of breaking
expectations in some cases.

This also fixes a class of security issues where a command like
`cat malicious-file.txt` might output escape sequences, causing the
terminal to echo back a malicious command; such files can still insert
into the command line but at least not execute it directly.
(Since it's only fixed partially I'm not really sure if the security
issue is a good enough motivation for this particular change.)

Note that bracketed paste probably has similar motivation.

Part of #10987
See also https://codeberg.org/dnkl/foot/issues/1894#issuecomment-2562154