### PR TITLE
fix[completions]: Add set-timeout to bootctl

### DIFF
--- a/share/completions/bootctl.fish
+++ b/share/completions/bootctl.fish
@@ -1,4 +1,4 @@
-set -l commands status install update remove is-installed random-seed systemd-efi-options reboot-to-firmware list set-default set-oneshot
+set -l commands status install update remove is-installed random-seed systemd-efi-options reboot-to-firmware list set-default set-oneshot set-timeout set-timeout-oneshot
 
 complete -c bootctl -f
 complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a status -d 'Show status of EFI variables'
@@ -13,6 +13,8 @@ complete -c bootctl -n "__fish_seen_subcommand_from reboot-to-firmware" -a 'true
 complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a list -d 'List boot loader entries'
 complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a set-default -d 'Set default boot loader entry'
 complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a set-oneshot -d 'Set default boot loader entry (Once)'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a set-timeout -d 'Set default boot loader timeout'
+complete -c bootctl -n "not __fish_seen_subcommand_from $commands" -a set-timeout-oneshot -d 'Set default boot loader timeout (Once)'
 
 complete -c bootctl -s h -l help -d 'Show this help'
 complete -c bootctl -l version -d 'Print version'


### PR DESCRIPTION
Adds the set-timeout and set-timeout-oneshot subcommands to completions for bootctl
