### PR TITLE
Make new ctrl-l logic more portable

### DIFF
--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -66,7 +66,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv alt-l __fish_list_current_token
     bind --preset $argv alt-o __fish_preview_current_file
     bind --preset $argv alt-w __fish_whatis_current_token
-    bind --preset $argv ctrl-l scrollback-push repaint
+    bind --preset $argv ctrl-l scrollback-push clear-screen
     bind --preset $argv ctrl-c cancel-commandline
     bind --preset $argv ctrl-u backward-kill-line
     bind --preset $argv ctrl-w backward-kill-path-component


### PR DESCRIPTION
The behavior of the new scrollback-push is not consistent across various terminals and the functionality of ctrl-l is too important to break in the default bindings. This hack should preserve the benefits of scrollback-push while keeping the portability of the old clear-screen: first we ask the terminal to scroll everything offscreen *then* we clear the screen. The addition of clear-screen should be a no-op on any terminal that fully supports the desired behavior of invoking the new scrollback-push.

(There are no real performance-related concerns with ctrl-l.)

This handles multiple possible issues (observed or otherwise) with scrollback-push:
* fish starts a new prompt at the top of the screen, scrollback is lost, screen is not cleared (observed under Prompt/iOS, FreeBSD console session, Linux 6.1 console session -- note that Linux kernel removed scrollback in 5.9)
* termcap SF isn't supported
* termcap UP isn't supported ("Only a few terminal descriptions provide these commands, and most programs do not use them.")

It still breaks in an ugly way if terminal position reporting isn't supported, but I'll address that separately.

Update:

As @krobelus mentioned, a number of terminal emulators map the old ctrl-l to scroll-then-clear. But the new implementation (both current and with this patch) actually *breaks* scrollback for these tty emulators (tested: conhost/Windows 11 and under gnome terminal 3.46), losing the last screen altogether.

Under FreeBSD console sessions, `scrollback-buffer` additionally causes fish to hang indefinitely until some time after ctrl-c is used (my random guess is that waiting for cursor position isn't being properly async?).

With these regressions in mind, I would prefer to close this PR and instead revert the default `ctrl-l` binding to `clear-screen` (keeping `scrollback-push` around for anyone that wants to manually opt into it).