### PR TITLE
Add completions for Google Cloud commands.

### DIFF
--- a/share/completions/gcloud.fish
+++ b/share/completions/gcloud.fish
@@ -1,0 +1,1 @@
+complete -c gcloud -f -a '(__fish_argcomplete_complete gcloud)'

--- a/share/completions/gsutil.fish
+++ b/share/completions/gsutil.fish
@@ -1,0 +1,1 @@
+complete -c gsutil -f -a '(__fish_argcomplete_complete gsutil)'


### PR DESCRIPTION
## Description

The `gcloud` and `gsutil` Google Cloud commands use argcomplete, so integrating them is easy with the `__fish_argcomplete_complete` function.