### PR TITLE
Fix typos in docs

### DIFF
--- a/doc_src/cmds/abbr.rst
+++ b/doc_src/cmds/abbr.rst
@@ -53,7 +53,7 @@ Combining these features, it is possible to create custom syntaxes, where a regu
 
      > abbr > ~/.config/fish/conf.d/myabbrs.fish
 
-   This will save all your abbrevations in "myabbrs.fish", overwriting the whole file so it doesn't leave any duplicates,
+   This will save all your abbreviations in "myabbrs.fish", overwriting the whole file so it doesn't leave any duplicates,
    or restore abbreviations you had erased.
    Of course any functions will have to be saved separately, see :doc:`funcsave <funcsave>`.
 

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -262,7 +262,7 @@ The following special input functions are available:
     search the history for the next matching argument
 
 ``forward-jump`` and ``backward-jump``
-    read another character and jump to its next occurence after/before the cursor
+    read another character and jump to its next occurrence after/before the cursor
 
 ``forward-jump-till`` and ``backward-jump-till``
     jump to right *before* the next occurrence
@@ -272,7 +272,7 @@ The following special input functions are available:
 
 ``jump-to-matching-bracket``
     jump to matching bracket if the character under the cursor is bracket;
-    otherwise, jump to the next occurence of *any right* bracket after the cursor.
+    otherwise, jump to the next occurrence of *any right* bracket after the cursor.
     The following brackets are considered: ``([{}])``
 
 ``jump-till-matching-bracket``
@@ -295,7 +295,7 @@ The following special input functions are available:
     move the selected text to the killring
 
 ``kill-whole-line``
-    move the line (including the following newline) to the killring. If the line is the last line, its preceeding newline is also removed
+    move the line (including the following newline) to the killring. If the line is the last line, its preceding newline is also removed
 
 ``kill-inner-line``
     move the line (without the following newline) to the killring

--- a/doc_src/cmds/commandline.rst
+++ b/doc_src/cmds/commandline.rst
@@ -116,7 +116,7 @@ The following options output metadata about the commandline state:
 **--is-valid**
     Returns true when the commandline is syntactically valid and complete.
     If it is, it would be executed when the ``execute`` bind function is called.
-    If the commandline is incomplete, return 2, if erroneus, return 1.
+    If the commandline is incomplete, return 2, if erroneous, return 1.
 
 **--showing-suggestion**
     Evaluates to true (i.e. returns 0) when the shell is currently showing an automatic history completion/suggestion, available to be consumed via one of the `forward-` bindings.

--- a/doc_src/cmds/string-repeat.rst
+++ b/doc_src/cmds/string-repeat.rst
@@ -19,7 +19,7 @@ Description
 
 .. BEGIN DESCRIPTION
 
-``string repeat`` repeats the *STRING* **-n** or **--count** times. The **-m** or **--max** option will limit the number of outputted characters (excluding the newline). This option can be used by itself or in conjunction with **--count**. If both **--count** and **--max** are present, max char will be outputed unless the final repeated string size is less than max, in that case, the string will repeat until count has been reached. Both **--count** and **--max** will accept a number greater than or equal to zero, in the case of zero, nothing will be outputed. The first argument is interpreted as *COUNT* if **--count** or **--max** are not explicilty specified. If **-N** or **--no-newline** is given, the output won't contain a newline character at the end. Exit status: 0 if yielded string is not empty, 1 otherwise.
+``string repeat`` repeats the *STRING* **-n** or **--count** times. The **-m** or **--max** option will limit the number of outputted characters (excluding the newline). This option can be used by itself or in conjunction with **--count**. If both **--count** and **--max** are present, max char will be outputted unless the final repeated string size is less than max, in that case, the string will repeat until count has been reached. Both **--count** and **--max** will accept a number greater than or equal to zero, in the case of zero, nothing will be outputted. The first argument is interpreted as *COUNT* if **--count** or **--max** are not explicitly specified. If **-N** or **--no-newline** is given, the output won't contain a newline character at the end. Exit status: 0 if yielded string is not empty, 1 otherwise.
 
 .. END DESCRIPTION
 

--- a/doc_src/cmds/string-shorten.rst
+++ b/doc_src/cmds/string-shorten.rst
@@ -34,7 +34,7 @@ If **-q** or **--quiet** is given, ``string shorten`` only runs for the return v
 
 The default ellipsis is ``…``. If fish thinks your system is incapable because of your locale, it will use ``...`` instead.
 
-The return value is 0 if any shortening occured, 1 otherwise.
+The return value is 0 if any shortening occurred, 1 otherwise.
 
 .. END DESCRIPTION
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -870,7 +870,7 @@ but if you need multiple or the command doesn't read from standard input, "proce
 
 This creates a temporary file, stores the output of the command in that file and prints the filename, so it is given to the outer command.
 
-Fish has a default limit of 100 MiB on the data it will read in a command sustitution. If that limit is reached the command (all of it, not just the command substitution - the outer command won't be executed at all) fails and ``$status`` is set to 122. This is so command substitutions can't cause the system to go out of memory, because typically your operating system has a much lower limit, so reading more than that would be useless and harmful. This limit can be adjusted with the ``fish_read_limit`` variable (`0` meaning no limit). This limit also affects the :doc:`read <cmds/read>` command.
+Fish has a default limit of 100 MiB on the data it will read in a command substitution. If that limit is reached the command (all of it, not just the command substitution - the outer command won't be executed at all) fails and ``$status`` is set to 122. This is so command substitutions can't cause the system to go out of memory, because typically your operating system has a much lower limit, so reading more than that would be useless and harmful. This limit can be adjusted with the ``fish_read_limit`` variable (`0` meaning no limit). This limit also affects the :doc:`read <cmds/read>` command.
 
 .. [#] One exception: Setting ``$IFS`` to empty will disable line splitting. This is deprecated, use :doc:`string split <cmds/string-split>` instead.
 
@@ -1845,7 +1845,7 @@ The "locale" of a program is its set of language and regional settings that depe
 
 .. envvar:: LC_MONETARY
 
-   Determines currency, how it is formated, and the symbols used.
+   Determines currency, how it is formatted, and the symbols used.
 
 .. envvar:: LC_NUMERIC
 


### PR DESCRIPTION
## Description

This PR fixes several typos in the documentation.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
