### PR TITLE
Fix completions for `apt-build`, `htop` and `wget`

### DIFF
--- a/share/completions/apt-build.fish
+++ b/share/completions/apt-build.fish
@@ -2,7 +2,7 @@
 complete -c apt-build -l help -d "Display help and exit"
 complete -f -c apt-build -a update -d "Update list of packages"
 complete -f -c apt-build -a upgrade -d "Upgrade packages"
-complete -f -c apt-bulid -a world -d "Rebuild your system"
+complete -f -c apt-build -a world -d "Rebuild your system"
 complete -x -c apt-build -a install -d "Build and install a new package"
 complete -x -c apt-build -a source -d "Download and extract a source"
 complete -x -c apt-build -a info -d "Info on a package"

--- a/share/completions/htop.fish
+++ b/share/completions/htop.fish
@@ -15,7 +15,7 @@ complete -c htop -l readonly -d 'Disable all system and process changing feature
 complete -c htop -l version -s V -d 'Show version and exit'
 complete -c htop -l tree -s t -d 'Show processes in tree view'
 complete -c htop -l highlight-changes -s H -d 'Highlight new and old processes' -x
-complete -c htop -l drop-capabilites -d 'Drop unneeded Linux capabilites (Requires libpcap support)' -xka "
+complete -c htop -l drop-capabilities -d 'Drop unneeded Linux capabilities (Requires libpcap support)' -xka "
 		off
 		basic
 		strict

--- a/share/completions/wget.fish
+++ b/share/completions/wget.fish
@@ -55,7 +55,7 @@ complete -c wget -o nd -d "Do not create a hierarchy of directories"
 complete -c wget -s x -l force-directories -d "Force creation of a hierarchy of directories"
 complete -c wget -l no-host-directories -d "Disable generation of host-prefixed directories"
 complete -c wget -o nH -d "Disable generation of host-prefixed directories"
-complete -c wget -l protocal-directories -d "Use the protocol name as a directory component"
+complete -c wget -l protocol-directories -d "Use the protocol name as a directory component"
 complete -c wget -l cut-dirs -d "Ignore specified number of directory components" -xa "1 2 3 4 5"
 complete -c wget -s P -l directory-prefix -d "Set directory prefix" -r
 complete -c wget -s E -l html-extension -d "Force html files to have html extension"


### PR DESCRIPTION
## Description

This PR fixes incorrect completions caused by misspelled commands and parameters.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
