### PR TITLE
Fix ctrl-r history search inconsistent ordering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Interactive improvements
   when typing a command and :kbd:`enter` while the previous one is still running, the new one will no longer execute immediately. Similarly, keys that are bound to shell commands will be ignored.
   This mitigates a security issue where a command like ``cat malicious-file.txt`` could write terminal escape codes prompting the terminal to write arbitrary text to fish's standard input.
   Such a malicious file can still potentially insert arbitrary text into the command line but can no longer execute it directly (:issue:`10987`).
+- The history search now preserves ordering between :kbd:`ctrl-s` forward and :kbd:`ctrl-r` backward searches.
 - Left mouse click now can select pager items.
 
 New or improved bindings

--- a/src/history.rs
+++ b/src/history.rs
@@ -1905,6 +1905,11 @@ impl HistorySearch {
 
             // We're done if it's empty or we cancelled.
             let Some(item) = self.history.item_at_index(index) else {
+                self.current_index = match direction {
+                    SearchDirection::Backward => self.history.size() + 1,
+                    SearchDirection::Forward => 0,
+                };
+                self.current_item = None;
                 return false;
             };
 
@@ -1923,6 +1928,12 @@ impl HistorySearch {
             self.current_index = index;
             return true;
         }
+    }
+
+    /// Move current index so there is `value` matches in between new and old indexes
+    pub fn search_forward(&mut self, value: usize) {
+        while self.go_to_next_match(SearchDirection::Forward) && self.deduper.len() <= value {}
+        self.deduper.clear();
     }
 
     /// Returns the current search result item.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5180,9 +5180,9 @@ impl ReaderData {
                 }
             }
             HistoryPagerInvocation::Refresh => {
-                // Redo the previous search previous direction.
+                // Make backward search from current position
                 let history_pager = self.history_pager.as_ref().unwrap();
-                direction = history_pager.direction;
+                direction = SearchDirection::Backward;
                 index = history_pager.history_index_start;
                 old_pager_index = Some(self.pager.selected_completion_index());
             }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1271,6 +1271,7 @@ impl ReaderData {
                 if self.history_pager.is_some() {
                     self.fill_history_pager(
                         HistoryPagerInvocation::Anew,
+                        Some(SelectionMotion::Next),
                         SearchDirection::Backward,
                     );
                     return;
@@ -2723,6 +2724,7 @@ impl<'a> Reader<'a> {
                     }
                     self.fill_history_pager(
                         HistoryPagerInvocation::Advance,
+                        Some(SelectionMotion::Next),
                         SearchDirection::Forward,
                     );
                     return;
@@ -2992,6 +2994,7 @@ impl<'a> Reader<'a> {
                     }
                     self.fill_history_pager(
                         HistoryPagerInvocation::Advance,
+                        Some(SelectionMotion::Next),
                         SearchDirection::Backward,
                     );
                     return;
@@ -3071,6 +3074,7 @@ impl<'a> Reader<'a> {
                     self.history.save();
                     self.fill_history_pager(
                         HistoryPagerInvocation::Refresh,
+                        None,
                         SearchDirection::Backward,
                     );
                 }
@@ -5151,6 +5155,7 @@ impl ReaderData {
     fn fill_history_pager(
         &mut self,
         why: HistoryPagerInvocation,
+        motion: Option<SelectionMotion>,
         mut direction: SearchDirection, /* = Backward */
     ) {
         let index;
@@ -5172,7 +5177,7 @@ impl ReaderData {
                 let history_pager = self.history_pager.as_ref().unwrap();
                 direction = SearchDirection::Backward;
                 index = history_pager.start;
-                old_pager_index = Some(self.pager.selected_completion_index());
+                old_pager_index = self.pager.selected_completion_index();
             }
         }
         let search_term = self.pager.search_field_line.text().to_owned();
@@ -5209,11 +5214,11 @@ impl ReaderData {
                 };
             zelf.pager.set_completions(&result.matched_commands, false);
             if why == HistoryPagerInvocation::Refresh {
-                zelf.pager
-                    .set_selected_completion_index(old_pager_index.unwrap());
+                zelf.pager.set_selected_completion_index(old_pager_index);
                 zelf.pager_selection_changed();
-            } else {
-                zelf.select_completion_in_direction(SelectionMotion::Next, true);
+            }
+            if let Some(motion) = motion {
+                zelf.select_completion_in_direction(motion, true);
             }
             zelf.super_highlight_me_plenty();
             zelf.layout_and_repaint(L!("history-pager"));

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5078,6 +5078,7 @@ impl<'a> Reader<'a> {
 struct HistoryPagerResult {
     matched_commands: Vec<Completion>,
     range: Range<usize>,
+    first_shown: usize,
 }
 
 #[derive(Eq, PartialEq)]
@@ -5127,6 +5128,7 @@ fn history_pager_search(
     });
     let first_index = search.current_index();
     let mut next_match_found = search.go_to_next_match(SearchDirection::Backward);
+    let first_shown = search.current_index();
     while completions.len() < page_size && next_match_found {
         let item = search.current_item();
         completions.push(Completion::new(
@@ -5141,6 +5143,7 @@ fn history_pager_search(
     HistoryPagerResult {
         matched_commands: completions,
         range: first_index..last_index,
+        first_shown,
     }
 }
 
@@ -5190,15 +5193,20 @@ impl ReaderData {
             let history_pager = zelf.history_pager.as_mut().unwrap();
             assert!(result.range.start < result.range.end);
             *history_pager = result.range;
-            zelf.pager.extra_progress_text = if direction == SearchDirection::Forward
-                && history_pager.start != 0
-                || direction == SearchDirection::Backward && history_pager.end != history_size + 1
-            {
-                wgettext!("Search again for more results")
-            } else {
-                L!("")
-            }
-            .to_owned();
+            zelf.pager.extra_progress_text =
+                if !result.matched_commands.is_empty() && *history_pager != (0..history_size + 1) {
+                    wgettext_fmt!(
+                        "Items %lu to %lu of %lu",
+                        match history_pager.start {
+                            0 => 1,
+                            _ => result.first_shown,
+                        },
+                        history_pager.end - 1,
+                        history_size
+                    )
+                } else {
+                    L!("").to_owned()
+                };
             zelf.pager.set_completions(&result.matched_commands, false);
             if why == HistoryPagerInvocation::Refresh {
                 zelf.pager

--- a/src/reader_history_search.rs
+++ b/src/reader_history_search.rs
@@ -81,10 +81,9 @@ impl ReaderHistorySearch {
 
     /// Move the history search in the given direction `dir`.
     pub fn move_in_direction(&mut self, dir: SearchDirection) -> bool {
-        if dir == SearchDirection::Forward {
-            self.move_forwards()
-        } else {
-            self.move_backwards()
+        match dir {
+            SearchDirection::Forward => self.move_forwards(),
+            SearchDirection::Backward => self.move_backwards(),
         }
     }
 

--- a/tests/checks/locale-numeric.fish
+++ b/tests/checks/locale-numeric.fish
@@ -2,7 +2,7 @@
 # musl currently does not have a `locale` command, so we skip this test there.
 # REQUIRES: command -v locale
 # We need a comma-using locale we know.
-# REQUIRES: locale -a | grep -i '(bg_BG\|de_DE\|es_ES\|fr_FR\|ru_RU).(UTF-8|utf8)'
+# REQUIRES: locale -a | grep -Ei '(bg_BG|de_DE|es_ES|fr_FR|ru_RU)\.(UTF-8|utf8)'
 # OpenBSD does not use LC_NUMERIC, this test is pointless there.
 # REQUIRES: test "$(uname)" != OpenBSD
 

--- a/tests/checks/tmux-history-pager.fish
+++ b/tests/checks/tmux-history-pager.fish
@@ -1,0 +1,142 @@
+# RUN: %fish %s
+# REQUIRES: command -v tmux
+
+# The default history-delete binding is shift-delete which
+# won't work on terminals that don't support CSI u, so rebind.
+set -g isolated_tmux_fish_extra_args -C '
+    set -g fish_autosuggestion_enabled 0
+    bind alt-d history-delete or backward-delete-char
+'
+isolated-tmux-start
+
+# Set up history
+for i in (seq 50 -1 1)
+    isolated-tmux send-keys "true $i$(if test $(math $i % 2) = 1; echo !; end)" Enter
+end
+
+isolated-tmux send-keys C-l
+isolated-tmux send-keys C-r
+isolated-tmux send-keys C-s
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 1!
+# CHECK: search:
+# CHECK: ► true 1!  ► true 3!  ► true 5!  ► true 7!  ► true 9!  ► true 11!
+# CHECK: ► true 2   ► true 4   ► true 6   ► true 8   ► true 10  ► true 12
+# CHECK: Items 1 to 12 of 50
+
+isolated-tmux send-keys C-r
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 13!
+# CHECK: search:
+# CHECK: ► true 13!  ► true 15!  ► true 17!  ► true 19!  ► true 21!  ► true 23!
+# CHECK: ► true 14   ► true 16   ► true 18   ► true 20   ► true 22   ► true 24
+# CHECK: Items 13 to 24 of 50
+
+isolated-tmux send-keys C-s
+isolated-tmux send-keys C-s
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 1!
+# CHECK: search:
+# CHECK: ► true 1!  ► true 3!  ► true 5!  ► true 7!  ► true 9!  ► true 11!
+# CHECK: ► true 2   ► true 4   ► true 6   ► true 8   ► true 10  ► true 12
+# CHECK: Items 1 to 12 of 50
+
+isolated-tmux send-keys C-r
+isolated-tmux send-keys C-r
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 25!
+# CHECK: search:
+# CHECK: ► true 25!  ► true 27!  ► true 29!  ► true 31!  ► true 33!  ► true 35!
+# CHECK: ► true 26   ► true 28   ► true 30   ► true 32   ► true 34   ► true 36
+# CHECK: Items 25 to 36 of 50
+
+isolated-tmux send-keys C-s
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 13!
+# CHECK: search:
+# CHECK: ► true 13!  ► true 15!  ► true 17!  ► true 19!  ► true 21!  ► true 23!
+# CHECK: ► true 14   ► true 16   ► true 18   ► true 20   ► true 22   ► true 24
+# CHECK: Items 13 to 24 of 50
+
+isolated-tmux send-keys !
+isolated-tmux send-keys C-s
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 1!
+# CHECK: search: !
+# CHECK: ► true 1!  ► true 5!  ► true 9!   ► true 13!  ► true 17!  ► true 21!
+# CHECK: ► true 3!  ► true 7!  ► true 11!  ► true 15!  ► true 19!  ► true 23!
+# CHECK: Items 1 to 24 of 50
+
+isolated-tmux send-keys C-r
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 25!
+# CHECK: search: !
+# CHECK: ► true 25!  ► true 29!  ► true 33!  ► true 37!  ► true 41!  ► true 45!
+# CHECK: ► true 27!  ► true 31!  ► true 35!  ► true 39!  ► true 43!  ► true 47!
+# CHECK: Items 25 to 48 of 50
+
+isolated-tmux send-keys C-r
+isolated-tmux send-keys C-r
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 49!
+# CHECK: search: !
+# CHECK: ► true 49!
+# CHECK: Items 49 to 50 of 50
+
+isolated-tmux send-keys M-d
+isolated-tmux send-keys C-r
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 47!
+# CHECK: search: !
+# CHECK: ► true 25!  ► true 29!  ► true 33!  ► true 37!  ► true 41!  ► true 45!
+# CHECK: ► true 27!  ► true 31!  ► true 35!  ► true 39!  ► true 43!  ► true 47!
+# CHECK: Items 25 to 49 of 49
+
+isolated-tmux send-keys C-s
+isolated-tmux send-keys C-r
+isolated-tmux send-keys M-d
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 27!
+# CHECK: search: !
+# CHECK: ► true 27!  ► true 31!  ► true 35!  ► true 39!  ► true 43!  ► true 47!
+# CHECK: ► true 29!  ► true 33!  ► true 37!  ► true 41!  ► true 45!
+# CHECK: Items 26 to 48 of 48
+
+for i in (seq 11)
+    isolated-tmux send-keys M-d
+end
+isolated-tmux send-keys Up
+isolated-tmux send-keys M-d
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 23!
+# CHECK: search: !
+# CHECK: ► true 1!  ► true 5!  ► true 9!   ► true 13!  ► true 17!  ► true 23!
+# CHECK: ► true 3!  ► true 7!  ► true 11!  ► true 15!  ► true 19!
+
+isolated-tmux send-keys !
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50>
+# CHECK: search: !!
+# CHECK: (no matches)
+
+isolated-tmux send-keys C-u
+isolated-tmux send-keys M-d
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50> true 2
+# CHECK: search:
+# CHECK: ► true 2   ► true 4   ► true 6   ► true 8   ► true 10   ► true 12
+# CHECK: ► true 3!  ► true 5!  ► true 7!  ► true 9!  ► true 11!  ► true 13!
+# CHECK: Items 1 to 12 of 35

--- a/tests/checks/tmux-multiline-prompt.fish
+++ b/tests/checks/tmux-multiline-prompt.fish
@@ -1,8 +1,6 @@
 #RUN: %fish %s
 #REQUIRES: command -v tmux && ! tmux -V | grep -qE '^tmux (next-3.4|3\.[0123][a-z]*($|[.-]))'
 #REQUIRES: command -v less && ! less --version 2>&1 | grep -q BusyBox
-# Disable on GitHub macOS CI because it fails more than it passes there
-#REQUIRES: uname -s | grep -qv Darwin || test -z "$CI"
 
 isolated-tmux-start
 
@@ -50,7 +48,7 @@ isolated-tmux capture-pane -p | tail -n 5
 # CHECK:
 
 # Test repainint after running an external program that uses the alternate screen.
-isolated-tmux send-keys 'bind ctrl-r "echo | less +q; commandline \'echo Hello World\'"' Enter C-l \
+isolated-tmux send-keys "bind ctrl-r 'echo | less +q; commandline \"echo Hello World\"'" Enter C-l
 isolated-tmux send-keys C-r
 tmux-sleep
 isolated-tmux send-keys Enter


### PR DESCRIPTION
## Description

When searching, `history_pager_search` returns elements in the order in which it encountered them. For example, given the sequence `(b, a, b, c)`, a backward search would return `(b, a, c)`, but a forward search would return `(a, b, c)`. This also causes `history_index_start` to be unequal to `0` when searching forward if the first element has a duplicate earlier in the searched interval.
Additionally, it skips every 13th element.

Now, when searching forward, `history_pager_search` finds a new `history_index_start` and only when searches backward. Also, `history_index_end` now points to an element outside the history that the search displays (like `history_index_start`).

I found this bugs in 3.7.1, 4.0b1 and current Git version.

PS: while debugging Fish with `lldb`, I found out that you can write your own summary providers, so I have written some for Fish types (mainly Utf32Str and Utf32String). Should I commit them to the main repo and maybe add a mention of them to `CONTRIBUTING.rst`, or is there a better place for this? 