### PR TITLE
Bump CTEST_PARALLEL_LEVEL to match CTEST_BUILD_PARALLEL_LEVEL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: make test
 on: [push, pull_request]
 
 env:
-  CTEST_PARALLEL_LEVEL: "1"
+  CTEST_PARALLEL_LEVEL: "4"
   CMAKE_BUILD_PARALLEL_LEVEL: "4"
 
 permissions:


### PR DESCRIPTION
This is an experiment to see if it causes any of the tests to flake and/or if it even appreciably speeds up CI to begin with.

I note that there are tests added in 8bf8b10 that mutate global terminal state but also note that local tests without CTEST_PARALLEL_LEVEL set at all have been running to completion just fine without any observed flakiness *and* that our Cirrus CI tests have this hard-coded to 6.

Closes #11006