### PR TITLE
Fix missing of builtin token description

### DIFF
--- a/share/functions/__fish_whatis_current_token.fish
+++ b/share/functions/__fish_whatis_current_token.fish
@@ -18,7 +18,7 @@ function __fish_whatis_current_token -d "Show man page entries or function descr
             and set desc "$token - $funcinfo[5]"
 
         case builtin
-            set desc (__fish_print_help $token | awk "/./ {print; exit}")
+            set desc (__fish_print_help $token | awk "/./ { getline; print; exit }" | string trim)
 
         case file
             set -l tmpdesc (whatis $token 2>/dev/null)


### PR DESCRIPTION
## Description

With default config, press alt-w on a builtin function, e.g.
```sh
builtin
```

It will show `NAME` only rather than a brief description for the `builtin`.
