### PR TITLE
DNF5 completion support

### DIFF
--- a/share/completions/dnf.fish
+++ b/share/completions/dnf.fish
@@ -2,6 +2,11 @@
 # Completions for the dnf command
 #
 
+function __dnf_is_dnf5
+    set -l dnf_target (readlink (type -P dnf))
+    string match -q -- dnf5 $dnf_target
+end
+
 function __dnf_list_installed_packages
     dnf repoquery --cacheonly "$cur*" --qf "%{name}\n" --installed </dev/null
 end
@@ -15,9 +20,14 @@ function __dnf_list_available_packages
         return
     end
     set -l results
-    # dnf --cacheonly list --available gives a list of non-installed packages dnf is aware of,
-    # but it is slow as molasses. Unfortunately, sqlite3 is not available oob (Fedora Server 32).
-    if type -q sqlite3
+    if __dnf_is_dnf5
+        # dnf5 provides faster completions than repoquery, but does not maintain the
+        # same sqlite db as dnf4
+        set results (dnf --complete=2 dnf install "$tok*")
+    else if type -q sqlite3
+        # dnf --cacheonly list --available gives a list of non-installed packages dnf is aware of,
+        # but it is slow as molasses. Unfortunately, sqlite3 is not available oob (Fedora Server 32).
+
         # This schema is bad, there is only a "pkg" field with the full
         #    packagename-version-release.fedorarelease.architecture
         # tuple. We are only interested in the packagename.
@@ -37,7 +47,7 @@ function __dnf_list_available_packages
 end
 
 function __dnf_list_transactions
-    if type -q sqlite3
+    if not __dnf_is_dnf5 and type -q sqlite3
         sqlite3 /var/lib/dnf/history.sqlite "SELECT id, cmdline FROM trans" 2>/dev/null | string replace "|" \t
     end
 end

--- a/share/completions/dnf.fish
+++ b/share/completions/dnf.fish
@@ -3,8 +3,7 @@
 #
 
 function __dnf_is_dnf5
-    set -l dnf_target (readlink (type -P dnf))
-    string match -q -- dnf5 $dnf_target
+    path resolve -- $PATH/dnf | path filter | string match -q -- '*/dnf5'
 end
 
 function __dnf_list_installed_packages
@@ -47,7 +46,7 @@ function __dnf_list_available_packages
 end
 
 function __dnf_list_transactions
-    if not __dnf_is_dnf5 and type -q sqlite3
+    if not __dnf_is_dnf5 && type -q sqlite3
         sqlite3 /var/lib/dnf/history.sqlite "SELECT id, cmdline FROM trans" 2>/dev/null | string replace "|" \t
     end
 end


### PR DESCRIPTION
## Description

DNF5 does not create or update the `/var/cache/dnf/packages.db` sqlite file anymore. When sqlite3 is installed on the system, the current DNF completion for the install tries to access it, then fails and falls back to displaying file names instead of available packages.

Additionally, DNF5 added a `--complete` option for autocompletion, which is slightly faster than the existing `dnf repoquery`

Fixes issue #11002
