### PR TITLE
Improve mouse support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Interactive improvements
   when typing a command and :kbd:`enter` while the previous one is still running, the new one will no longer execute immediately. Similarly, keys that are bound to shell commands will be ignored.
   This mitigates a security issue where a command like ``cat malicious-file.txt`` could write terminal escape codes prompting the terminal to write arbitrary text to fish's standard input.
   Such a malicious file can still potentially insert arbitrary text into the command line but can no longer execute it directly (:issue:`10987`).
+- Left mouse click now can select pager items.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1392,6 +1392,7 @@ impl ReaderData {
         assert!(self.cursor_position_wait == CursorPositionWait::None);
         self.cursor_position_wait = cursor_position_wait;
         let _ = out.write(b"\x1b[6n");
+        self.save_screen_state();
     }
 
     pub fn mouse_left_click(&mut self, cursor: ViewportPosition, click_position: ViewportPosition) {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -418,7 +418,7 @@ impl Screen {
             i += 1;
         };
 
-        let full_line_count = self.desired.cursor.y + 1;
+        let full_line_count = self.desired.cursor.y + calc_prompt_lines(&layout.left_prompt);
         let pager_available_height = std::cmp::max(
             1,
             curr_termsize


### PR DESCRIPTION
## Description
Currently, using a mouse leads to crashes when clicking on the pager, autosuggestions, multi-line prompts, or the command line when the pager search field is open. Additionally, clicking past the command line moves the cursor to the start of the command if it is a single line.

This pull request fixes these crashes, makes cursor position changes consistent when clicking and adds the ability to select pager elements by clicking.

Other fixes:
- https://github.com/fish-shell/fish-shell/commit/2ba662be8c3f4b811aacd565f9632583c8468a30 fixes the issue where the screen height could exceed the terminal height when using a multi-line prompt. This would result in KiTTY no longer reporting mouse clicks.

- https://github.com/fish-shell/fish-shell/commit/25f242cc11a252d52aaf3a813970217cdd513d7b fixes unsaved screen modifications that would trigger a prompt redraw when clicking with a mouse or calling scrollback-push. This would led to duplication of prompt lines in multi-line prompts.
