### PR TITLE
completions/jj: use dynamic completions by default, also fix them

### DIFF
--- a/share/completions/jj.fish
+++ b/share/completions/jj.fish
@@ -1,1 +1,10 @@
-jj util completion fish | source
+# The reason for `__this-command-does-not-exist` is that, if dynamic completion
+# is not implemented, we'd like to get an error reliably. However, the
+# behavior of `jj` without arguments depends on the value of a config, see
+# https://jj-vcs.github.io/jj/latest/config/#default-command
+if set -l completion (COMPLETE=fish jj __this-command-does-not-exist 2>/dev/null)
+    # jj is new enough for dynamic completions to be implemented
+    printf %s\n $completion | source
+else
+    jj util completion fish | source
+end


### PR DESCRIPTION
This uses jj's dynamic completions when possible.

This avoids an annoying problem. Because of 04a4e5c4 (so, in fish 4.0beta, but not in fish 3.7.1), jj's dynamic completions (added to jj recently, see the second paragraph of <https://jj-vcs.github.io/jj/latest/install-and-setup/#command-line-completion>) do not work very well in fish if the user puts `COMPLETE=fish jj | source` in their `~/.config/fish/config.fish`. When the user types `jj <TAB>`, they are instead overridden by fish's built-in non-dynamic completions.

The difference is subtle. One problem I saw is that `jj new <TAB>` works as expected (and shows revisions) while `jj new -A <TAB>` becomes broken (and shows files).

If the user puts `COMPLETE=fish jj | source` in `~/.config/fish/completions/jj.fish` there is no problem. However, users might be confused if they run `COMPLETE=fish jj | source` or put it in their config and it works in a broken fashion. I certainly was, this took a while to debug.

Meanwhile, I checked that if the user has `jj completion fish | source` in their `config.fish`, executing `COMPLETE=fish jj __this_command_does_not_exist | source` afterwards still seems to work correctly. So, this PR should not cause the opposite
problem to the one it tries to solve.

Let me know if there's a better approach to this problem.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
