### PR TITLE
Fix should_add_to_history

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5692,7 +5692,7 @@ impl<'a> Reader<'a> {
             return text.as_char_slice()[0] != ' ';
         }
 
-        let mut cmd: WString = L!("fish_should_add_to_history ").into();
+        let mut cmd: WString = L!("fish_should_add_to_history").into();
         cmd.push_utfstr(&escape(text));
         let _not_interactive = scoped_push_replacer(
             |new_value| std::mem::replace(&mut parser.libdata_mut().is_interactive, new_value),


### PR DESCRIPTION
## Description

Fixing an extra space typo in this line:
https://github.com/fish-shell/fish-shell/blob/f139d8ebedb98099334573d5f4772d5fea60ddaf/src/reader.rs#L5695

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
