### PR TITLE
Add feature flag for turning off keyboard protocols

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -2024,6 +2024,7 @@ You can see the current list of features via ``status features``::
     ampersand-nobg-in-token on  3.4 & only backgrounds if followed by a separating character
     remove-percent-self     off 4.0 %self is no longer expanded (use $fish_pid)
     test-require-arg        off 4.0 builtin test requires an argument
+    keyboard-protocols      on  4.0 Use keyboard protocols (kitty, xterm's modifyotherkeys
 
 Here is what they mean:
 
@@ -2033,6 +2034,9 @@ Here is what they mean:
 - ``ampersand-nobg-in-token`` was introduced in fish 3.4. It makes it so a ``&`` i no longer interpreted as the backgrounding operator in the middle of a token, so dealing with URLs becomes easier. Either put spaces or a semicolon after the ``&``. This is recommended formatting anyway, and ``fish_indent`` will have done it for you already.
 - ``remove-percent-self`` turns off the special ``%self`` expansion. It was introduced in 4.0. To get fish's pid, you can use the :envvar:`fish_pid` variable.
 - ``test-require-arg`` removes :doc:`builtin test <cmds/test>`'s one-argument form (``test "string"``. It was introduced in 4.0. To test if a string is non-empty, use ``test -n "string"``. If disabled, any call to ``test`` that would change sends a :ref:`debug message <debugging-fish>` of category "deprecated-test", so starting fish with ``fish --debug=deprecated-test`` can be used to find offending calls.
+- ``keyboard-protocols`` lets fish turn on various keyboard protocols including the kitty keyboard protocol.
+  It was introduced in 4.0 and is on by default.
+  Disable it with ``no-keyboard-protocols`` to work around bugs in your terminal.
 
 
 These changes are introduced off by default. They can be enabled on a per session basis::

--- a/src/future_feature_flags.rs
+++ b/src/future_feature_flags.rs
@@ -27,6 +27,9 @@ pub enum FeatureFlag {
 
     /// Remove `test`'s one and zero arg mode (make `test -n` return false etc)
     test_require_arg,
+
+    /// Whether keyboard protocols (kitty's CSI x u, xterm's modifyOtherKeys) are used
+    keyboard_protocols,
 }
 
 struct Features {
@@ -107,6 +110,14 @@ pub const METADATA: &[FeatureMetadata] = &[
         default_value: false,
         read_only: false,
     },
+    FeatureMetadata {
+        flag: FeatureFlag::keyboard_protocols,
+        name: L!("keyboard-protocols"),
+        groups: L!("4.0"),
+        description: L!("Use keyboard protocols (kitty, xterm's modifyotherkeys"),
+        default_value: true,
+        read_only: false,
+    },
 ];
 
 thread_local!(
@@ -168,6 +179,7 @@ impl Features {
                 AtomicBool::new(METADATA[3].default_value),
                 AtomicBool::new(METADATA[4].default_value),
                 AtomicBool::new(METADATA[5].default_value),
+                AtomicBool::new(METADATA[6].default_value),
             ],
         }
     }

--- a/tests/checks/status.fish
+++ b/tests/checks/status.fish
@@ -59,6 +59,7 @@ status features
 #CHECK: ampersand-nobg-in-token on  3.4 & only backgrounds if followed by a separator
 #CHECK: remove-percent-self     off 4.0 %self is no longer expanded (use $fish_pid)
 #CHECK: test-require-arg        off 4.0 builtin test requires an argument
+#CHECK: keyboard-protocols      on  4.0 Use keyboard protocols (kitty, xterm's modifyotherkeys
 status test-feature stderr-nocaret
 echo $status
 #CHECK: 0


### PR DESCRIPTION
To work around terminal bugs.

The flag "keyboard-protocols" defaults to "on" and enables keyboard protocols, but can be turned off by setting "no-keyboard-protocols".

This has downsides as a feature flag - if you use multiple terminals and one of them can't do it you'll have to disable it in all, but anything else would require us to hook this up to env-dispatch, and ensure that we turn the protocols *off* when the flag is disabled.

Since this is a temporary inconvenience, this would be okay to ask zellij and Jetbrains-with-WSL users.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
