### PR TITLE
completions: add `unbuffer` completions

### DIFF
--- a/share/completions/unbuffer.fish
+++ b/share/completions/unbuffer.fish
@@ -1,0 +1,2 @@
+complete -c unbuffer -a "(__fish_complete_subcommand)" -x
+complete -c unbuffer -s p -d "Read from stdin for pipeline use, exit when stdin closes"


### PR DESCRIPTION
unbuffer is sometimes bundled with `expect` (which fish already ships
completions for), and sometimes is bundled separately. It's often recommended for forcing colors to have color output.

https://manpages.debian.org/bookworm/expect/unbuffer.1.en.html

Ads for `unbuffer`:

https://wiki.archlinux.org/title/Color_output_in_console#Reading_from_stdin

https://jvns.ca/blog/2024/10/01/terminal-colours/

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
