### PR TITLE
completions/git: extend --pretty/--format options

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -886,7 +886,12 @@ reference\t<abbrev-hash> (<title-line>, <short-author-date>)
 email\t<sha1> <date> / <author> / <author date> / <title> / <commit msg>
 mboxrd\tLike email, but lines in the commit message starting with \"From \" are quoted with \">\"
 raw\tShow the entire commit exactly as stored in the commit object
-format:\tSpecify which information to show"
+format:\tSpecify which information to show
+"
+            __fish_git config -z --get-regexp '^pretty\.' 2>/dev/null | while read -lz key value
+                set -l name (string replace -r '^.*\.' '' -- $key)
+                printf "%s\t%s\n" $name $value
+            end
     end
 end
 

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -882,7 +882,9 @@ short\t<sha1> / <author> / <title line>
 medium\t<sha1> / <author> / <author date> / <title> / <commit msg>
 full\t<sha1> / <author> / <committer> / <title> / <commit msg>
 fuller\t<sha1> / <author> / <author date> / <committer> / <committer date> / <title> / <commit msg>
+reference\t<abbrev-hash> (<title-line>, <short-author-date>)
 email\t<sha1> <date> / <author> / <author date> / <title> / <commit msg>
+mboxrd\tLike email, but lines in the commit message starting with \"From \" are quoted with \">\"
 raw\tShow the entire commit exactly as stored in the commit object
 format:\tSpecify which information to show"
     end


### PR DESCRIPTION
## Description

Add completions for "reference" and "mboxrd" builtin formats (added in git 2.25 and 2.27), as well as completions for custom format aliases. Custom format aliases can be added to the pretty section of git like so:
```gitconfig
[pretty]
        fixes = Fixes: %h (\"%s\")
```
(see: https://git-scm.com/docs/git-config#Documentation/git-config.txt-prettyltnamegt)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
