### PR TITLE
Fix unnecessary token expansion in sudo completion

### DIFF
--- a/share/completions/doas.fish
+++ b/share/completions/doas.fish
@@ -3,7 +3,7 @@
 #
 
 function __fish_doas_print_remaining_args
-    set -l tokens (commandline -xpc) (commandline -ct)
+    set -l tokens (commandline -xpc | string escape) (commandline -ct)
     set -e tokens[1]
     # These are all the options mentioned in the man page for openbsd's "doas" (in that order).
     set -l opts a= C= L n s u=

--- a/share/completions/env.fish
+++ b/share/completions/env.fish
@@ -62,7 +62,7 @@ end
 
 # Get the text after all env arguments and variables, so we can complete it as a regular command
 function __fish_env_remaining_args -V is_gnu
-    set -l argv (commandline -xpc) (commandline -ct)
+    set -l argv (commandline -xpc | string escape) (commandline -ct)
     if set -q is_gnu[1]
         argparse -s i/ignore-environment u/unset= help version -- $argv 2>/dev/null
         or return 0

--- a/share/completions/ip.fish
+++ b/share/completions/ip.fish
@@ -14,7 +14,7 @@ set -l ip_all_commands $ip_commands $ip_addr $ip_link $ip_neigh $ip_route $ip_ru
 
 function __fish_ip_commandwords
     set -l skip 0
-    set -l cmd (commandline -xpc)
+    set -l cmd (commandline -xpc | string escape)
     # Remove the first word because it's "ip" or an alias for it
     set -e cmd[1]
     set -l have_command 0

--- a/share/completions/sudo.fish
+++ b/share/completions/sudo.fish
@@ -3,7 +3,7 @@
 #
 
 function __fish_sudo_print_remaining_args
-    set -l tokens (commandline -xpc) (commandline -ct)
+    set -l tokens (commandline -xpc | string escape) (commandline -ct)
     set -e tokens[1]
     # These are all the options mentioned in the man page for Todd Miller's "sudo.ws" sudo (in that order).
     # If any other implementation has different options, this should be harmless, since they shouldn't be used anyway.

--- a/share/completions/svn.fish
+++ b/share/completions/svn.fish
@@ -1,6 +1,5 @@
 function __fish_complete_svn_diff --description 'Complete "svn diff" arguments'
-    set -l cmdl (commandline -cxp)
-    #set -l cmdl svn diff --diff-cmd diff --extensions '-a -b'
+    set -l cmdl (commandline -cxp | string escape)
     set -l diff diff
     set -l args
     while set -q cmdl[1]

--- a/share/completions/yadm.fish
+++ b/share/completions/yadm.fish
@@ -51,7 +51,7 @@ end
 # don't want to inherit all completions from git
 function __fish_complete_yadm_like_git
     # Remove the first word from the commandline because that is "yadm"
-    set -l cmdline (commandline -xpc; commandline -ct)[2..-1]
+    set -l cmdline (commandline -xpc | string escape; commandline -ct)[2..-1]
 
     # `yadm gitconfig` is same as `git config`
     if __fish_seen_subcommand_from gitconfig


### PR DESCRIPTION
## Description

Fixes issue #11041.

`commandline -x` expands strings so `__fish_complete_subcommand` recieve `mv b'ar` instead of `mv "b'ar"`.