### PR TITLE
Fix formatting of abbr example

### DIFF
--- a/doc_src/cmds/abbr.rst
+++ b/doc_src/cmds/abbr.rst
@@ -125,6 +125,7 @@ This first creates a function ``vim_edit`` which prepends ``vim`` before its arg
 This creates an abbreviation "4DIRS" which expands to a multi-line loop "template." The template enters each directory and then leaves it. The cursor is positioned ready to enter the command to run in each directory, at the location of the ``!``, which is itself erased.
 
 ::
+
    abbr --command git co checkout
 
 Turns "co" as an argument to "git" into "checkout". Multiple commands are possible, ``--command={git,hg}`` would expand "co" to "checkout" for both git and hg.


### PR DESCRIPTION
## Description

I'm running fish 4.0b1 locally and I tried running `help abbr` and browsing the docs. I noticed one example which wasn't formatted correctly.

![CleanShot 2025-01-19 at 19 27 34](https://github.com/user-attachments/assets/03c41b6a-a2ae-46e3-b7f6-a9d2c853f730)


I'm not too familiar with rst, but based on looking at the file, it seems that this is how example code should be represented. Please advise if this does not look like the right fix!


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
