### PR TITLE
completions/tmux: some windows and panes boolean flag completions

### DIFF
--- a/share/completions/tmux.fish
+++ b/share/completions/tmux.fish
@@ -161,29 +161,54 @@ set -l swapw "swap-window swapw"
 set -l unlinkw "unlink-window unlinkw"
 
 complete -c tmux -n __fish_use_subcommand -a $breakp -d 'break pane off into a new window'
+
 complete -c tmux -n __fish_use_subcommand -a $capturep -d 'capture contents of a pane into a buffer'
+complete -c tmux -n "__fish_seen_subcommand_from $capturep" -xs a -d 'capture alternate screen'
+complete -c tmux -n "__fish_seen_subcommand_from $capturep" -xs p -d 'output to stdout'
+complete -c tmux -n "__fish_seen_subcommand_from $capturep" -xs e -d 'include color escapes'
+complete -c tmux -n "__fish_seen_subcommand_from $capturep" -xs C -d 'escape non-printable chars'
+
 complete -c tmux -n __fish_use_subcommand -a $chooseclient -d 'interactively choose client'
 complete -c tmux -n __fish_use_subcommand -a $choosetree -d 'interactively choose session/window/pane'
 complete -c tmux -n __fish_use_subcommand -a $customizemode -d 'interactively customize settings'
 complete -c tmux -n __fish_use_subcommand -a $displayp -d 'display a visible indicator for each pane'
 complete -c tmux -n __fish_use_subcommand -a $findw -d 'interactively choose window matching pattern'
+
 complete -c tmux -n __fish_use_subcommand -a $joinp -d 'split destination pane and move source pane into one of the halves'
+# $joinp takes a subset of $splitw arguments
+complete -c tmux -n "__fish_seen_subcommand_from $joinp $splitw" -xs b -d 'before target'
+complete -c tmux -n "__fish_seen_subcommand_from $joinp $splitw" -xs h -d 'horizontal'
+complete -c tmux -n "__fish_seen_subcommand_from $joinp $splitw" -xs v -d 'vertical'
+complete -c tmux -n "__fish_seen_subcommand_from $joinp $splitw" -xs l -d 'size in lines/cols'
+complete -c tmux -n "__fish_seen_subcommand_from $joinp $splitw" -xs f -d 'full height/width'
+
 complete -c tmux -n __fish_use_subcommand -a $killp -d 'destroy a pane'
 complete -c tmux -n __fish_use_subcommand -a $killw -d 'destroy a window'
 complete -c tmux -n __fish_use_subcommand -a $lastp -d 'select the previusly selected pane'
 complete -c tmux -n __fish_use_subcommand -a $lastw -d 'select the previusly selected window'
 complete -c tmux -n __fish_use_subcommand -a $linkw -d 'link source window to destination window'
+
 complete -c tmux -n __fish_use_subcommand -a $lsp -d 'list panes'
+complete -c tmux -n "__fish_seen_subcommand_from $lsp" -xs s -d 'all in session'
+
 complete -c tmux -n __fish_use_subcommand -a $lsw -d 'list windows'
 complete -c tmux -n __fish_use_subcommand -a $movew -d 'move window'
+
 complete -c tmux -n __fish_use_subcommand -a $neww -d 'create a new window'
+complete -c tmux -n "__fish_seen_subcommand_from $neww" -xs k -d 'replace if exists'
+complete -c tmux -n "__fish_seen_subcommand_from $neww" -xs S -d 'select if exists'
+
 complete -c tmux -n __fish_use_subcommand -a $nextl -d 'rearrange panes in a window according to the next layout'
 complete -c tmux -n __fish_use_subcommand -a $next -d 'move to the next window in the session'
 complete -c tmux -n __fish_use_subcommand -a $pipep -d 'pipe output from pane to a shell command'
 complete -c tmux -n __fish_use_subcommand -a $prevl -d 'rearrange panes in a window according to the previous layout'
 complete -c tmux -n __fish_use_subcommand -a $prev -d 'move to the previous window in the session'
 complete -c tmux -n __fish_use_subcommand -a $renamew -d 'rename a window'
+
 complete -c tmux -n __fish_use_subcommand -a $resizep -d 'resize a pane'
+complete -c tmux -n "__fish_seen_subcommand_from $resizep" -xs M -d 'begin mouse resize'
+complete -c tmux -n "__fish_seen_subcommand_from $resizep" -xs T -d 'trim below cursor'
+
 complete -c tmux -n __fish_use_subcommand -a $resizew -d 'resize a window'
 complete -c tmux -n __fish_use_subcommand -a $respawnp -d 'reactivate a pane where a command exited'
 complete -c tmux -n __fish_use_subcommand -a $respawnw -d 'reactivate a window where a command exited'
@@ -194,8 +219,21 @@ set -l layouts 'even-horizontal even-vertical main-horizontal main-horizontal-mi
 complete -c tmux -n "__fish_seen_subcommand_from $selectl" -x -a "$layouts" -d 'predefined layout'
 
 complete -c tmux -n __fish_use_subcommand -a $selectp -d 'activate specific pane'
+complete -c tmux -n "__fish_seen_subcommand_from $selectp" -xs d -d 'disable input'
+complete -c tmux -n "__fish_seen_subcommand_from $selectp" -xs e -d 'enable input'
+complete -c tmux -n "__fish_seen_subcommand_from $selectp" -xs l -d 'previously selected'
+complete -c tmux -n "__fish_seen_subcommand_from $selectp" -xs m -d 'mark'
+complete -c tmux -n "__fish_seen_subcommand_from $selectp" -xs M -d 'unmark'
+
 complete -c tmux -n __fish_use_subcommand -a $selectw -d 'activate specific window'
+complete -c tmux -n "__fish_seen_subcommand_from $selectw" -xs l -d 'previously selected'
+complete -c tmux -n "__fish_seen_subcommand_from $selectw" -xs p -d 'previous'
+complete -c tmux -n "__fish_seen_subcommand_from $selectw" -xs n -d 'next'
+
 complete -c tmux -n __fish_use_subcommand -a $splitw -d 'create a new pane by splitting target-pane'
+# See also $joinp's arguments
+complete -c tmux -n "__fish_seen_subcommand_from $splitw" -xs I -d 'show stdin contents'
+
 complete -c tmux -n __fish_use_subcommand -a $swapp -d 'swap two panes'
 complete -c tmux -n __fish_use_subcommand -a $swapw -d 'swap two windows'
 complete -c tmux -n __fish_use_subcommand -a $unlinkw -d 'unlink target-window'
@@ -224,6 +262,29 @@ complete -c tmux -n "__fish_seen_subcommand_from $lsp" -xs t -d target
 #commands that take shell commands
 complete -c tmux -x -n "__fish_seen_subcommand_from $neww $pipep $respawnp $respawnw $splitw" \
           -a '(__fish_complete_subcommand --fcs-skip=2)'
+
+# Common boolean flags. TODO: -P for "print info", -Z for "zoom"
+complete -c tmux -n "__fish_seen_subcommand_from $breakp $joinp $linkw $neww $movew $splitw $swapp $swapp" -xs d -d 'do not activate'
+
+set -l updownleftright "$resizep $resizew $selectp "
+complete -c tmux -n "__fish_seen_subcommand_from $updownleftright" -xs D -d 'down'
+complete -c tmux -n "__fish_seen_subcommand_from $updownleftright" -xs U -d 'up'
+complete -c tmux -n "__fish_seen_subcommand_from $updownleftright" -xs L -d 'left'
+complete -c tmux -n "__fish_seen_subcommand_from $updownleftright" -xs R -d 'right'
+
+set -l before_after "$breakp $linkw $movew $neww "
+complete -c tmux -n "__fish_seen_subcommand_from $before_after" -xs a -d 'after'
+complete -c tmux -n "__fish_seen_subcommand_from $before_after" -xs b -d 'before'
+
+# Boolean flags, ct'd. Unclear why these are not -a/-b for after/before
+set -l updownnextprev "$rotatew $swapp "
+complete -c tmux -n "__fish_seen_subcommand_from $updownnextprev" -xs D -d 'down/next'
+complete -c tmux -n "__fish_seen_subcommand_from $updownnextprev" -xs U -d 'up/prev'
+
+# Boolean flags, ct'd. When `-a` does not mean "after"
+complete -c tmux -n "__fish_seen_subcommand_from $lsp $lsw" -xs a -d 'all on this server'
+complete -c tmux -n "__fish_seen_subcommand_from $killp $killw" -xs a -d 'all except chosen'
+complete -c tmux -n "__fish_seen_subcommand_from $prev $next" -xs a -d 'with alert'
 
 ###############  End:   Windows and Panes ###############
 


### PR DESCRIPTION
This documents some non-argument options for the window and panes commands. The choice of what to document is somewhat arbitrary, this commit is biased towards options that I find confusing or misleading without documentation (is `-a` "all" or "after"?) and the command that seem more useful to me.

I also didn't cover the options that would be covered by #10855 (though this PR can be used independently). I'm not sure how much difference this made, it might not matter at all.
