### PR TITLE
Improve flash

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1825,7 +1825,7 @@ impl ReaderData {
                 .as_ref()
                 .is_some_and(|saved_autosuggestion| {
                     self.conf.autosuggest_ok
-                        && self.history_search.is_at_end()
+                        && self.history_search.is_at_present()
                         && edit.replacement.is_empty()
                         && edit.range.start == saved_autosuggestion.search_string_range.end
                         && !edit.range.is_empty()
@@ -1873,7 +1873,7 @@ impl ReaderData {
 
     /// Apply the history search to the command line.
     fn update_command_line_from_history_search(&mut self) {
-        let new_text = if self.history_search.is_at_end() {
+        let new_text = if self.history_search.is_at_present() {
             self.history_search.search_string()
         } else {
             self.history_search.current_result()
@@ -2939,7 +2939,7 @@ impl<'a> Reader<'a> {
 
                 let was_active_before = self.history_search.active();
 
-                if self.history_search.is_at_end() {
+                if self.history_search.is_at_present() {
                     let el = &self.data.command_line;
                     if mode == SearchMode::Token {
                         // Searching by token.
@@ -2994,7 +2994,7 @@ impl<'a> Reader<'a> {
                 if !found && !was_active_before {
                     self.history_search.reset();
                 } else if found
-                    || (dir == SearchDirection::Forward && self.history_search.is_at_end())
+                    || (dir == SearchDirection::Forward && self.history_search.is_at_present())
                 {
                     self.update_command_line_from_history_search();
                 }
@@ -3053,7 +3053,7 @@ impl<'a> Reader<'a> {
             #[allow(deprecated)]
             rl::HistoryDelete | rl::HistoryPagerDelete => {
                 // Also applies to ordinary history search.
-                let is_history_search = !self.history_search.is_at_end();
+                let is_history_search = !self.history_search.is_at_present();
                 let is_autosuggestion = self.is_at_autosuggestion();
                 if is_history_search || is_autosuggestion {
                     self.input_data.function_set_status(true);
@@ -3290,9 +3290,9 @@ impl<'a> Reader<'a> {
                     );
                 } else {
                     if up {
-                        self.history_search.go_to_beginning();
+                        self.history_search.go_to_oldest();
                     } else {
-                        self.history_search.go_to_end();
+                        self.history_search.go_to_present();
                     }
                     if self.history_search.active() {
                         self.update_command_line_from_history_search();
@@ -4798,7 +4798,7 @@ impl<'a> Reader<'a> {
         let (elt, el) = self.active_edit_line();
         self.conf.autosuggest_ok
             && !self.suppress_autosuggestion
-            && self.history_search.is_at_end()
+            && self.history_search.is_at_present()
             && elt == EditableLineTag::Commandline
             && el
                 .text()

--- a/src/reader_history_search.rs
+++ b/src/reader_history_search.rs
@@ -88,16 +88,16 @@ impl ReaderHistorySearch {
         }
     }
 
-    /// Go to the beginning (earliest) of the search.
-    pub fn go_to_beginning(&mut self) {
+    /// Go to the oldest match (last match) of the search.
+    pub fn go_to_oldest(&mut self) {
         if self.matches.is_empty() {
             return;
         }
         self.match_index = self.matches.len() - 1;
     }
 
-    /// Go to the end (most recent) of the search.
-    pub fn go_to_end(&mut self) {
+    /// Go to the youngest match (original search string) of the search.
+    pub fn go_to_present(&mut self) {
         self.match_index = 0;
     }
 
@@ -119,7 +119,7 @@ impl ReaderHistorySearch {
 
     /// Return the range of the original search string in the new command line.
     pub fn search_range_if_active(&self) -> Option<SourceRange> {
-        if !self.active() || self.is_at_end() {
+        if !self.active() || self.is_at_present() {
             return None;
         }
         Some(SourceRange::new(
@@ -128,8 +128,8 @@ impl ReaderHistorySearch {
         ))
     }
 
-    /// Return whether we are at the end (most recent) of our search.
-    pub fn is_at_end(&self) -> bool {
+    /// Return whether we are at the youngest match (original search string) in our search.
+    pub fn is_at_present(&self) -> bool {
         self.match_index == 0
     }
 
@@ -140,7 +140,7 @@ impl ReaderHistorySearch {
     }
 
     pub fn handle_deletion(&mut self) {
-        assert!(!self.is_at_end());
+        assert!(!self.is_at_present());
         self.matches.remove(self.match_index);
         self.match_index -= 1;
         self.search_mut().prepare_to_search_after_deletion();


### PR DESCRIPTION
## Description

This pull request changes the behavior of flash in the following ways:
1. Failed history token search: now highlights the matched token if it isn't empty; otherwise, highlights the full command line.
2. Other failed history search: now highlights the full command line.
3. Failed deletion of autosuggestion: now highlights the autosuggestion.
4. Failed undo/redo: now highlights the full command line.
5. Failed completion: now highlights the completed token (#11050).

Other Changes:
- Converted `SourceRange` to use `usize` instead of `u32`.
- Made undo/redo not update autosuggestion if failed.
- Make `parse_util_token_extent` return its output instead of mutating input.
- Some other code refactoring.
