### PR TITLE
Make alt-{b,f} move in directory history if commandline is empty

### DIFF
--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -364,6 +364,8 @@ To enable emacs mode, use :doc:`fish_default_key_bindings <cmds/fish_default_key
 
 - :kbd:`ctrl-b`, :kbd:`ctrl-f` move the cursor one character left or right or accept the autosuggestion just like the :kbd:`left` (``←``) and :kbd:`right` (``→``) shared bindings (which are available as well).
 
+- :kbd:`alt-b`, :kbd:`alt-f` move the cursor one word left or right, or accept one word of the autosuggestion. If the command line is empty, moves forward/backward in the directory history instead.
+
 - :kbd:`ctrl-n`, :kbd:`ctrl-p` move the cursor up/down or through history, like the up and down arrow shared bindings.
 
 - :kbd:`delete` or :kbd:`backspace` or :kbd:`ctrl-h` removes one character forwards or backwards respectively.

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -59,14 +59,8 @@ function fish_default_key_bindings -d "emacs-like key binds"
     bind --preset $argv ctrl-backspace backward-kill-word
     bind --preset $argv alt-delete kill-token
     bind --preset $argv ctrl-delete kill-word
-    bind --preset $argv alt-b backward-word
-    bind --preset $argv alt-f forward-word
-    if test "$TERM_PROGRAM" = Apple_Terminal
-        # Terminal.app sends \eb for alt+left, \ef for alt+right.
-        # Yeah.
-        $legacy_bind --preset $argv alt-b prevd-or-backward-word
-        $legacy_bind --preset $argv alt-f nextd-or-forward-word
-    end
+    bind --preset $argv alt-b prevd-or-backward-word
+    bind --preset $argv alt-f nextd-or-forward-word
 
     bind --preset $argv alt-\< beginning-of-buffer
     bind --preset $argv alt-\> end-of-buffer


### PR DESCRIPTION
`alt-{left,right}` move in the directory history (like in browsers). Arrow keys can be inconvenient to reach on some keyboards, so let's alias this to `alt-{b,f}`, which already have similar behavior. (historically the behavior was the same; we're considering changing that back on some platforms).

This happens to fix `alt-{left,right}` in Terminal.app (where we had a workaround for some cases), Ghostty and probably some versions of iTerm2, though that alone should not be the reason for this change.